### PR TITLE
implement system2 interfaces on top of descriptors

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -1,6 +1,8 @@
 package descriptors
 
 import (
+	"encoding/json"
+
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -63,5 +65,6 @@ type DevnetEnvironment struct {
 	L1   *Chain     `json:"l1"`
 	L2   []*L2Chain `json:"l2"`
 
-	Features []string `json:"features,omitempty"`
+	Features []string        `json:"features,omitempty"`
+	DepSet   json.RawMessage `json:"dep_set,omitempty"`
 }

--- a/devnet-sdk/shell/env/env_test.go
+++ b/devnet-sdk/shell/env/env_test.go
@@ -16,6 +16,7 @@ func TestLoadDevnetEnv(t *testing.T) {
 	content := `{
 		"l1": {
 			"name": "l1",
+			"id": "1",
 			"nodes": [{
 				"services": {
 					"el": {
@@ -35,6 +36,7 @@ func TestLoadDevnetEnv(t *testing.T) {
 		},
 		"l2": [{
 			"name": "op",
+			"id": "2",
 			"nodes": [{
 				"services": {
 					"el": {

--- a/devnet-sdk/system2/orchestrator.go
+++ b/devnet-sdk/system2/orchestrator.go
@@ -61,11 +61,12 @@ func (setup *Setup) CommonConfig() CommonConfig {
 // Option is used to define a function that inspects and/or changes a System.
 type Option func(setup *Setup)
 
-// Append constructs a new Option that that first applies the receiver, and then the remaining options.
+// Add adds changes the option into a new Option that that first applies the receiver, and then the remaining options.
 // This is a convenience for bundling options together.
-func (fn Option) Append(other ...Option) Option {
-	return func(setup *Setup) {
-		fn(setup)
+func (fn *Option) Add(other ...Option) {
+	inner := *fn
+	*fn = func(setup *Setup) {
+		inner(setup)
 		for _, oFn := range other {
 			oFn(setup)
 		}

--- a/devnet-sdk/system2/orchestrator.go
+++ b/devnet-sdk/system2/orchestrator.go
@@ -61,7 +61,7 @@ func (setup *Setup) CommonConfig() CommonConfig {
 // Option is used to define a function that inspects and/or changes a System.
 type Option func(setup *Setup)
 
-// Add adds changes the option into a new Option that that first applies the receiver, and then the remaining options.
+// Add changes the option into a new Option that that first applies the receiver, and then the other options.
 // This is a convenience for bundling options together.
 func (fn *Option) Add(other ...Option) {
 	inner := *fn

--- a/devnet-sdk/systemext/addrbook.go
+++ b/devnet-sdk/systemext/addrbook.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -21,9 +20,9 @@ type l1AddressBook struct {
 
 func newL1AddressBook(setup *system2.Setup, addresses descriptors.AddressMap) *l1AddressBook {
 	protocolVersions, ok := addresses[ProtocolVersionsAddressName]
-	require.True(setup.T, ok)
+	setup.Require.True(ok)
 	superchainConfig, ok := addresses[SuperchainConfigAddressName]
-	require.True(setup.T, ok)
+	setup.Require.True(ok)
 
 	book := &l1AddressBook{
 		protocolVersions: protocolVersions,
@@ -49,7 +48,7 @@ type l2AddressBook struct {
 
 func newL2AddressBook(setup *system2.Setup, addresses descriptors.AddressMap) *l2AddressBook {
 	systemConfig, ok := addresses[SystemConfigAddressName]
-	require.True(setup.T, ok)
+	setup.Require.True(ok)
 
 	return &l2AddressBook{
 		systemConfig: systemConfig,

--- a/devnet-sdk/systemext/addrbook.go
+++ b/devnet-sdk/systemext/addrbook.go
@@ -46,8 +46,8 @@ type l2AddressBook struct {
 	systemConfig common.Address
 }
 
-func newL2AddressBook(setup *system2.Setup, addresses descriptors.AddressMap) *l2AddressBook {
-	systemConfig, ok := addresses[SystemConfigAddressName]
+func newL2AddressBook(setup *system2.Setup, l1Addresses descriptors.AddressMap) *l2AddressBook {
+	systemConfig, ok := l1Addresses[SystemConfigAddressName]
 	setup.Require.True(ok)
 
 	return &l2AddressBook{

--- a/devnet-sdk/systemext/addrbook.go
+++ b/devnet-sdk/systemext/addrbook.go
@@ -1,0 +1,63 @@
+package systemext
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ProtocolVersionsAddressName = "protocolVersionsProxy"
+	SuperchainConfigAddressName = "superchainConfigProxy"
+
+	SystemConfigAddressName = "systemConfigProxy"
+)
+
+type l1AddressBook struct {
+	protocolVersions common.Address
+	superchainConfig common.Address
+}
+
+func newL1AddressBook(setup *system2.Setup, addresses descriptors.AddressMap) *l1AddressBook {
+	protocolVersions, ok := addresses[ProtocolVersionsAddressName]
+	require.True(setup.T, ok)
+	superchainConfig, ok := addresses[SuperchainConfigAddressName]
+	require.True(setup.T, ok)
+
+	book := &l1AddressBook{
+		protocolVersions: protocolVersions,
+		superchainConfig: superchainConfig,
+	}
+
+	return book
+}
+
+func (a *l1AddressBook) ProtocolVersionsAddr() common.Address {
+	return a.protocolVersions
+}
+
+func (a *l1AddressBook) SuperchainConfigAddr() common.Address {
+	return a.superchainConfig
+}
+
+var _ system2.SuperchainDeployment = (*l1AddressBook)(nil)
+
+type l2AddressBook struct {
+	systemConfig common.Address
+}
+
+func newL2AddressBook(setup *system2.Setup, addresses descriptors.AddressMap) *l2AddressBook {
+	systemConfig, ok := addresses[SystemConfigAddressName]
+	require.True(setup.T, ok)
+
+	return &l2AddressBook{
+		systemConfig: systemConfig,
+	}
+}
+
+func (a *l2AddressBook) SystemConfigProxyAddr() common.Address {
+	return a.systemConfig
+}
+
+var _ system2.L2Deployment = (*l2AddressBook)(nil)

--- a/devnet-sdk/systemext/helpers.go
+++ b/devnet-sdk/systemext/helpers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
 	"github.com/ethereum-optimism/optimism/op-service/client"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -34,7 +33,7 @@ func rpcClient(setup *system2.Setup, endpoint string) client.RPC {
 		opts = append(opts, client.WithLazyDial())
 	}
 	cl, err := client.NewRPC(setup.Ctx, setup.Log, endpoint, opts...)
-	require.NoError(setup.T, err)
+	setup.Require.NoError(err)
 	return cl
 }
 

--- a/devnet-sdk/systemext/helpers.go
+++ b/devnet-sdk/systemext/helpers.go
@@ -1,0 +1,58 @@
+package systemext
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ELServiceName = "el"
+	CLServiceName = "cl"
+
+	HTTPProtocol    = "http"
+	RPCProtocol     = "rpc"
+	MetricsProtocol = "metrics"
+
+	FeatureInterop = "interop"
+)
+
+func getOrchestrator(setup *system2.Setup) *Orchestrator {
+	o, ok := setup.Orchestrator.(*Orchestrator)
+	setup.Require.True(ok, "orchestrator is not a valid Orchestrator")
+	return o
+}
+
+func rpcClient(setup *system2.Setup, endpoint string) client.RPC {
+	orchestrator := getOrchestrator(setup)
+
+	opts := []client.RPCOption{}
+	if !orchestrator.useEagerRPCClients {
+		opts = append(opts, client.WithLazyDial())
+	}
+	cl, err := client.NewRPC(setup.Ctx, setup.Log, endpoint, opts...)
+	require.NoError(setup.T, err)
+	return cl
+}
+
+func findProtocolService(setup *system2.Setup, svc string, protocol string, services map[string]descriptors.Service) (string, error) {
+	orchestrator := getOrchestrator(setup)
+
+	for name, service := range services {
+		if name == svc {
+			for proto, endpoint := range service.Endpoints {
+				if proto == protocol {
+					port := endpoint.Port
+					if orchestrator.usePrivatePorts {
+						port = endpoint.PrivatePort
+					}
+					return fmt.Sprintf("http://%s:%d", endpoint.Host, port), nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("%s not found", svc)
+}

--- a/devnet-sdk/systemext/helpers.go
+++ b/devnet-sdk/systemext/helpers.go
@@ -1,11 +1,14 @@
 package systemext
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -37,7 +40,7 @@ func rpcClient(setup *system2.Setup, endpoint string) client.RPC {
 	return cl
 }
 
-func findProtocolService(setup *system2.Setup, svc string, protocol string, services map[string]descriptors.Service) (string, error) {
+func findProtocolService(setup *system2.Setup, svc string, protocol string, services descriptors.ServiceMap) (string, error) {
 	orchestrator := getOrchestrator(setup)
 
 	for name, service := range services {
@@ -54,4 +57,9 @@ func findProtocolService(setup *system2.Setup, svc string, protocol string, serv
 		}
 	}
 	return "", fmt.Errorf("%s not found", svc)
+}
+
+func decodePrivateKey(key string) (*ecdsa.PrivateKey, error) {
+	b := common.FromHex(key)
+	return crypto.ToECDSA(b)
 }

--- a/devnet-sdk/systemext/ids.go
+++ b/devnet-sdk/systemext/ids.go
@@ -1,0 +1,60 @@
+package systemext
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func collectSystemExtIDs(env *descriptors.DevnetEnvironment) DefaultSystemExtIDs {
+	l1ID := eth.ChainIDFromBig(env.L1.Config.ChainID)
+	l1Nodes := make([]DefaultSystemExtL1NodeIDs, len(env.L1.Nodes))
+	for i := range env.L1.Nodes {
+		l1Nodes[i] = DefaultSystemExtL1NodeIDs{
+			EL: system2.L1ELNodeID{Key: fmt.Sprintf("el-%d", i), ChainID: l1ID},
+			CL: system2.L1CLNodeID{Key: fmt.Sprintf("cl-%d", i), ChainID: l1ID},
+		}
+	}
+
+	l2s := make([]DefaultSystemExtL2IDs, len(env.L2))
+	for idx, l2 := range env.L2 {
+		l2ID := eth.ChainIDFromBig(l2.Config.ChainID)
+		id := system2.L2NetworkID{Key: l2.Name, ChainID: l2ID}
+
+		nodes := make([]DefaultSystemExtL2NodeIDs, len(l2.Nodes))
+		for i := range l2.Nodes {
+			nodes[i] = DefaultSystemExtL2NodeIDs{
+				EL: system2.L2ELNodeID{Key: fmt.Sprintf("el-%s-%d", l2.Name, i), ChainID: l2ID},
+				CL: system2.L2CLNodeID{Key: fmt.Sprintf("cl-%s-%d", l2.Name, i), ChainID: l2ID},
+			}
+		}
+
+		l2s[idx] = DefaultSystemExtL2IDs{
+			L2:    id,
+			Nodes: nodes,
+
+			L2Batcher:    system2.L2BatcherID{Key: fmt.Sprintf("batcher-%s", l2.Name), ChainID: l2ID},
+			L2Proposer:   system2.L2ProposerID{Key: fmt.Sprintf("proposer-%s", l2.Name), ChainID: l2ID},
+			L2Challenger: system2.L2ChallengerID{Key: fmt.Sprintf("challenger-%s", l2.Name), ChainID: l2ID},
+		}
+	}
+
+	ids := DefaultSystemExtIDs{
+		L1: system2.L1NetworkID{
+			Key:     env.L1.Name,
+			ChainID: eth.ChainIDFromBig(env.L1.Config.ChainID),
+		},
+		Nodes:      l1Nodes,
+		Superchain: system2.SuperchainID(env.Name),
+		Cluster:    system2.ClusterID(env.Name),
+		L2s:        l2s,
+	}
+
+	if isInterop(env) {
+		ids.Supervisor = system2.SupervisorID(env.Name)
+	}
+
+	return ids
+}

--- a/devnet-sdk/systemext/ids.go
+++ b/devnet-sdk/systemext/ids.go
@@ -44,7 +44,7 @@ func collectSystemExtIDs(env *descriptors.DevnetEnvironment) DefaultSystemExtIDs
 	ids := DefaultSystemExtIDs{
 		L1: system2.L1NetworkID{
 			Key:     env.L1.Name,
-			ChainID: eth.ChainIDFromBig(env.L1.Config.ChainID),
+			ChainID: l1ID,
 		},
 		Nodes:      l1Nodes,
 		Superchain: system2.SuperchainID(env.Name),

--- a/devnet-sdk/systemext/keyring.go
+++ b/devnet-sdk/systemext/keyring.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 )
 
 type keyring struct {
@@ -18,12 +17,12 @@ var _ system2.L2Keys = (*keyring)(nil)
 
 func (k *keyring) Secret(key devkeys.Key) *ecdsa.PrivateKey {
 	pk, err := k.keys.Secret(key)
-	require.NoError(k.setup.T, err)
+	k.setup.Require.NoError(err)
 	return pk
 }
 
 func (k *keyring) Address(key devkeys.Key) common.Address {
 	addr, err := k.keys.Address(key)
-	require.NoError(k.setup.T, err)
+	k.setup.Require.NoError(err)
 	return addr
 }

--- a/devnet-sdk/systemext/keyring.go
+++ b/devnet-sdk/systemext/keyring.go
@@ -1,0 +1,29 @@
+package systemext
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+type keyring struct {
+	keys  *devkeys.MnemonicDevKeys
+	setup *system2.Setup
+}
+
+var _ system2.L2Keys = (*keyring)(nil)
+
+func (k *keyring) Secret(key devkeys.Key) *ecdsa.PrivateKey {
+	pk, err := k.keys.Secret(key)
+	require.NoError(k.setup.T, err)
+	return pk
+}
+
+func (k *keyring) Address(key devkeys.Key) common.Address {
+	addr, err := k.keys.Address(key)
+	require.NoError(k.setup.T, err)
+	return addr
+}

--- a/devnet-sdk/systemext/l1.go
+++ b/devnet-sdk/systemext/l1.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/require"
 )
 
 func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.Option {
@@ -29,7 +28,7 @@ func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.O
 			ids := nodes[idx]
 
 			elRPC, err := findProtocolService(setup, ELServiceName, RPCProtocol, node.Services)
-			require.NoError(setup.T, err)
+			setup.Require.NoError(err)
 			elClient := rpcClient(setup, elRPC)
 			l1.AddL1ELNode(system2.NewL1ELNode(system2.L1ELNodeConfig{
 				ELNodeConfig: system2.ELNodeConfig{
@@ -41,7 +40,7 @@ func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.O
 			}))
 
 			clHTTP, err := findProtocolService(setup, CLServiceName, HTTPProtocol, node.Services)
-			require.NoError(setup.T, err)
+			setup.Require.NoError(err)
 			l1.AddL1CLNode(system2.NewL1CLNode(system2.L1CLNodeConfig{
 				ID:           ids.CL,
 				CommonConfig: commonConfig,
@@ -51,7 +50,7 @@ func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.O
 
 		for name, wallet := range env.L1.Wallets {
 			priv, err := crypto.HexToECDSA(wallet.PrivateKey)
-			require.NoError(setup.T, err)
+			setup.Require.NoError(err)
 			l1.AddUser(system2.NewUser(system2.UserConfig{
 				CommonConfig: commonConfig,
 				ID:           system2.UserID{Key: name, ChainID: l1ID},

--- a/devnet-sdk/systemext/l1.go
+++ b/devnet-sdk/systemext/l1.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.Option {
@@ -49,12 +48,13 @@ func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.O
 		}
 
 		for name, wallet := range env.L1.Wallets {
-			priv, err := crypto.HexToECDSA(wallet.PrivateKey)
+			priv, err := decodePrivateKey(wallet.PrivateKey)
 			setup.Require.NoError(err)
 			l1.AddUser(system2.NewUser(system2.UserConfig{
 				CommonConfig: commonConfig,
 				ID:           system2.UserID{Key: name, ChainID: l1ID},
 				Priv:         priv,
+				EL:           l1.L1ELNode(l1.L1ELNodes()[0]),
 			}))
 		}
 

--- a/devnet-sdk/systemext/l1.go
+++ b/devnet-sdk/systemext/l1.go
@@ -1,0 +1,64 @@
+package systemext
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func WithL1(id system2.L1NetworkID, nodes []DefaultSystemExtL1NodeIDs) system2.Option {
+	return func(setup *system2.Setup) {
+		env := getOrchestrator(setup).env
+
+		commonConfig := setup.CommonConfig()
+		l1ID := eth.ChainIDFromBig(env.L1.Config.ChainID)
+		l1 := system2.NewL1Network(system2.L1NetworkConfig{
+			NetworkConfig: system2.NetworkConfig{
+				CommonConfig: commonConfig,
+				ChainConfig:  env.L1.Config,
+			},
+			ID: system2.L1NetworkID{
+				Key:     env.L1.Name,
+				ChainID: l1ID,
+			},
+		})
+
+		for idx, node := range env.L1.Nodes {
+			ids := nodes[idx]
+
+			elRPC, err := findProtocolService(setup, ELServiceName, RPCProtocol, node.Services)
+			require.NoError(setup.T, err)
+			elClient := rpcClient(setup, elRPC)
+			l1.AddL1ELNode(system2.NewL1ELNode(system2.L1ELNodeConfig{
+				ELNodeConfig: system2.ELNodeConfig{
+					CommonConfig: commonConfig,
+					Client:       elClient,
+					ChainID:      l1ID,
+				},
+				ID: ids.EL,
+			}))
+
+			clHTTP, err := findProtocolService(setup, CLServiceName, HTTPProtocol, node.Services)
+			require.NoError(setup.T, err)
+			l1.AddL1CLNode(system2.NewL1CLNode(system2.L1CLNodeConfig{
+				ID:           ids.CL,
+				CommonConfig: commonConfig,
+				Client:       client.NewBasicHTTPClient(clHTTP, setup.Log),
+			}))
+		}
+
+		for name, wallet := range env.L1.Wallets {
+			priv, err := crypto.HexToECDSA(wallet.PrivateKey)
+			require.NoError(setup.T, err)
+			l1.AddUser(system2.NewUser(system2.UserConfig{
+				CommonConfig: commonConfig,
+				ID:           system2.UserID{Key: name, ChainID: l1ID},
+				Priv:         priv,
+			}))
+		}
+
+		setup.System.AddL1Network(l1)
+	}
+}

--- a/devnet-sdk/systemext/l2.go
+++ b/devnet-sdk/systemext/l2.go
@@ -1,0 +1,148 @@
+package systemext
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs, l1ID system2.L1NetworkID) system2.Option {
+	return func(setup *system2.Setup) {
+		commonConfig := setup.CommonConfig()
+		orchestrator := getOrchestrator(setup)
+		env := orchestrator.env
+		net := env.L2[idx]
+
+		l1 := setup.System.L1Network(l1ID)
+		l1ChainID := l1.ChainID()
+		l2ID := eth.ChainIDFromBig(net.Config.ChainID)
+
+		cfg := system2.L2NetworkConfig{
+			NetworkConfig: system2.NetworkConfig{
+				CommonConfig: commonConfig,
+				ChainConfig:  net.Config,
+			},
+			ID: system2.L2NetworkID{
+				Key:     net.Name,
+				ChainID: l2ID,
+			},
+			RollupConfig: &rollup.Config{
+				L1ChainID: l1ChainID.ToBig(),
+				L2ChainID: l2ID.ToBig(),
+			},
+			Deployment: newL2AddressBook(setup, net.Addresses),
+			Keys:       defineSystemKeys(setup),
+			Superchain: setup.System.Superchain(system2.SuperchainID(env.Name)),
+			L1:         l1,
+		}
+		if orchestrator.isInterop() {
+			cfg.Cluster = setup.System.Cluster(system2.ClusterID(env.Name))
+		}
+
+		l2 := system2.NewL2Network(cfg)
+
+		for idx, node := range net.Nodes {
+			ids := nodeIDs[idx]
+
+			elRPC, err := findProtocolService(setup, ELServiceName, RPCProtocol, node.Services)
+			require.NoError(setup.T, err)
+			elClient := rpcClient(setup, elRPC)
+			l2.AddL2ELNode(system2.NewL2ELNode(system2.L2ELNodeConfig{
+				ELNodeConfig: system2.ELNodeConfig{
+					CommonConfig: commonConfig,
+					Client:       elClient,
+					ChainID:      l2ID,
+				},
+				ID: ids.EL,
+			}))
+
+			clRPC, err := findProtocolService(setup, CLServiceName, RPCProtocol, node.Services)
+			require.NoError(setup.T, err)
+			clClient := rpcClient(setup, clRPC)
+			l2.AddL2CLNode(system2.NewL2CLNode(system2.L2CLNodeConfig{
+				ID:           ids.CL,
+				CommonConfig: commonConfig,
+				Client:       clClient,
+			}))
+		}
+
+		for name, wallet := range net.Wallets {
+			priv, err := crypto.HexToECDSA(wallet.PrivateKey)
+			require.NoError(setup.T, err)
+			l2.AddUser(system2.NewUser(system2.UserConfig{
+				CommonConfig: commonConfig,
+				ID:           system2.UserID{Key: name, ChainID: l2ID},
+				Priv:         priv,
+			}))
+		}
+
+		setup.System.AddL2Network(l2)
+	}
+}
+
+func WithBatcher(idx int, l2ID system2.L2NetworkID, id system2.L2BatcherID) system2.Option {
+	return func(setup *system2.Setup) {
+		commonConfig := setup.CommonConfig()
+		env := getOrchestrator(setup).env
+		net := env.L2[idx]
+
+		l2 := setup.System.L2Network(l2ID)
+
+		batcherRPC, err := findProtocolService(setup, "batcher", RPCProtocol, net.Services)
+		require.NoError(setup.T, err)
+		l2.(system2.ExtensibleL2Network).AddL2Batcher(system2.NewL2Batcher(system2.L2BatcherConfig{
+			CommonConfig: commonConfig,
+			ID:           id,
+			Client:       rpcClient(setup, batcherRPC),
+		}))
+	}
+}
+
+func WithProposer(idx int, l2ID system2.L2NetworkID, id system2.L2ProposerID) system2.Option {
+	return func(setup *system2.Setup) {
+		commonConfig := setup.CommonConfig()
+		env := getOrchestrator(setup).env
+		net := env.L2[idx]
+
+		l2 := setup.System.L2Network(l2ID)
+
+		proposerRPC, err := findProtocolService(setup, "proposer", RPCProtocol, net.Services)
+		require.NoError(setup.T, err)
+		l2.(system2.ExtensibleL2Network).AddL2Proposer(system2.NewL2Proposer(system2.L2ProposerConfig{
+			CommonConfig: commonConfig,
+			ID:           id,
+			Client:       rpcClient(setup, proposerRPC),
+		}))
+	}
+}
+
+func WithChallenger(idx int, l2ID system2.L2NetworkID, id system2.L2ChallengerID) system2.Option {
+	return func(setup *system2.Setup) {
+		commonConfig := setup.CommonConfig()
+		env := getOrchestrator(setup).env
+		net := env.L2[idx]
+
+		l2 := setup.System.L2Network(l2ID)
+
+		_, err := findProtocolService(setup, "challenger", MetricsProtocol, net.Services)
+		require.NoError(setup.T, err)
+		l2.(system2.ExtensibleL2Network).AddL2Challenger(system2.NewL2Challenger(system2.L2ChallengerConfig{
+			CommonConfig: commonConfig,
+			ID:           id,
+		}))
+	}
+}
+
+func defineSystemKeys(setup *system2.Setup) system2.L2Keys {
+	// TODO: get actual mnemonic from Kurtosis
+	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(setup.T, err)
+
+	return &keyring{
+		keys:  keys,
+		setup: setup,
+	}
+}

--- a/devnet-sdk/systemext/l2.go
+++ b/devnet-sdk/systemext/l2.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs, l1ID system2.L1NetworkID) system2.Option {
@@ -32,7 +31,7 @@ func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs
 				L1ChainID: l1ChainID.ToBig(),
 				L2ChainID: l2ID.ToBig(),
 			},
-			Deployment: newL2AddressBook(setup, net.Addresses),
+			Deployment: newL2AddressBook(setup, net.L1Addresses),
 			Keys:       defineSystemKeys(setup),
 			Superchain: setup.System.Superchain(system2.SuperchainID(env.Name)),
 			L1:         l1,
@@ -58,7 +57,7 @@ func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs
 				ID: ids.EL,
 			}))
 
-			clRPC, err := findProtocolService(setup, CLServiceName, RPCProtocol, node.Services)
+			clRPC, err := findProtocolService(setup, CLServiceName, HTTPProtocol, node.Services)
 			setup.Require.NoError(err)
 			clClient := rpcClient(setup, clRPC)
 			l2.AddL2CLNode(system2.NewL2CLNode(system2.L2CLNodeConfig{
@@ -69,12 +68,13 @@ func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs
 		}
 
 		for name, wallet := range net.Wallets {
-			priv, err := crypto.HexToECDSA(wallet.PrivateKey)
+			priv, err := decodePrivateKey(wallet.PrivateKey)
 			setup.Require.NoError(err)
 			l2.AddUser(system2.NewUser(system2.UserConfig{
 				CommonConfig: commonConfig,
 				ID:           system2.UserID{Key: name, ChainID: l2ID},
 				Priv:         priv,
+				EL:           l2.L2ELNode(l2.L2ELNodes()[0]),
 			}))
 		}
 
@@ -90,7 +90,7 @@ func WithBatcher(idx int, l2ID system2.L2NetworkID, id system2.L2BatcherID) syst
 
 		l2 := setup.System.L2Network(l2ID)
 
-		batcherRPC, err := findProtocolService(setup, "batcher", RPCProtocol, net.Services)
+		batcherRPC, err := findProtocolService(setup, "batcher", HTTPProtocol, net.Services)
 		setup.Require.NoError(err)
 		l2.(system2.ExtensibleL2Network).AddL2Batcher(system2.NewL2Batcher(system2.L2BatcherConfig{
 			CommonConfig: commonConfig,
@@ -108,7 +108,7 @@ func WithProposer(idx int, l2ID system2.L2NetworkID, id system2.L2ProposerID) sy
 
 		l2 := setup.System.L2Network(l2ID)
 
-		proposerRPC, err := findProtocolService(setup, "proposer", RPCProtocol, net.Services)
+		proposerRPC, err := findProtocolService(setup, "proposer", HTTPProtocol, net.Services)
 		setup.Require.NoError(err)
 		l2.(system2.ExtensibleL2Network).AddL2Proposer(system2.NewL2Proposer(system2.L2ProposerConfig{
 			CommonConfig: commonConfig,

--- a/devnet-sdk/systemext/l2.go
+++ b/devnet-sdk/systemext/l2.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/require"
 )
 
 func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs, l1ID system2.L1NetworkID) system2.Option {
@@ -48,7 +47,7 @@ func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs
 			ids := nodeIDs[idx]
 
 			elRPC, err := findProtocolService(setup, ELServiceName, RPCProtocol, node.Services)
-			require.NoError(setup.T, err)
+			setup.Require.NoError(err)
 			elClient := rpcClient(setup, elRPC)
 			l2.AddL2ELNode(system2.NewL2ELNode(system2.L2ELNodeConfig{
 				ELNodeConfig: system2.ELNodeConfig{
@@ -60,7 +59,7 @@ func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs
 			}))
 
 			clRPC, err := findProtocolService(setup, CLServiceName, RPCProtocol, node.Services)
-			require.NoError(setup.T, err)
+			setup.Require.NoError(err)
 			clClient := rpcClient(setup, clRPC)
 			l2.AddL2CLNode(system2.NewL2CLNode(system2.L2CLNodeConfig{
 				ID:           ids.CL,
@@ -71,7 +70,7 @@ func WithL2(idx int, id system2.L2NetworkID, nodeIDs []DefaultSystemExtL2NodeIDs
 
 		for name, wallet := range net.Wallets {
 			priv, err := crypto.HexToECDSA(wallet.PrivateKey)
-			require.NoError(setup.T, err)
+			setup.Require.NoError(err)
 			l2.AddUser(system2.NewUser(system2.UserConfig{
 				CommonConfig: commonConfig,
 				ID:           system2.UserID{Key: name, ChainID: l2ID},
@@ -92,7 +91,7 @@ func WithBatcher(idx int, l2ID system2.L2NetworkID, id system2.L2BatcherID) syst
 		l2 := setup.System.L2Network(l2ID)
 
 		batcherRPC, err := findProtocolService(setup, "batcher", RPCProtocol, net.Services)
-		require.NoError(setup.T, err)
+		setup.Require.NoError(err)
 		l2.(system2.ExtensibleL2Network).AddL2Batcher(system2.NewL2Batcher(system2.L2BatcherConfig{
 			CommonConfig: commonConfig,
 			ID:           id,
@@ -110,7 +109,7 @@ func WithProposer(idx int, l2ID system2.L2NetworkID, id system2.L2ProposerID) sy
 		l2 := setup.System.L2Network(l2ID)
 
 		proposerRPC, err := findProtocolService(setup, "proposer", RPCProtocol, net.Services)
-		require.NoError(setup.T, err)
+		setup.Require.NoError(err)
 		l2.(system2.ExtensibleL2Network).AddL2Proposer(system2.NewL2Proposer(system2.L2ProposerConfig{
 			CommonConfig: commonConfig,
 			ID:           id,
@@ -128,7 +127,7 @@ func WithChallenger(idx int, l2ID system2.L2NetworkID, id system2.L2ChallengerID
 		l2 := setup.System.L2Network(l2ID)
 
 		_, err := findProtocolService(setup, "challenger", MetricsProtocol, net.Services)
-		require.NoError(setup.T, err)
+		setup.Require.NoError(err)
 		l2.(system2.ExtensibleL2Network).AddL2Challenger(system2.NewL2Challenger(system2.L2ChallengerConfig{
 			CommonConfig: commonConfig,
 			ID:           id,
@@ -137,9 +136,9 @@ func WithChallenger(idx int, l2ID system2.L2NetworkID, id system2.L2ChallengerID
 }
 
 func defineSystemKeys(setup *system2.Setup) system2.L2Keys {
-	// TODO: get actual mnemonic from Kurtosis
+	// TODO(#15040): get actual mnemonic from Kurtosis
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
-	require.NoError(setup.T, err)
+	setup.Require.NoError(err)
 
 	return &keyring{
 		keys:  keys,

--- a/devnet-sdk/systemext/orchestrator.go
+++ b/devnet-sdk/systemext/orchestrator.go
@@ -29,13 +29,13 @@ func (o *Orchestrator) isInterop() bool {
 	return isInterop(o.env) && len(o.env.L2) > 0
 }
 
-func (o *Orchestrator) WithPrivatePorts() OrchestratorOption {
+func WithPrivatePorts() OrchestratorOption {
 	return func(orchestrator *Orchestrator) {
 		orchestrator.usePrivatePorts = true
 	}
 }
 
-func (o *Orchestrator) WithEagerRPCClients() OrchestratorOption {
+func WithEagerRPCClients() OrchestratorOption {
 	return func(orchestrator *Orchestrator) {
 		orchestrator.useEagerRPCClients = true
 	}

--- a/devnet-sdk/systemext/orchestrator.go
+++ b/devnet-sdk/systemext/orchestrator.go
@@ -1,0 +1,44 @@
+package systemext
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+)
+
+type OrchestratorOption func(*Orchestrator)
+
+type Orchestrator struct {
+	env *descriptors.DevnetEnvironment
+
+	usePrivatePorts    bool
+	useEagerRPCClients bool
+}
+
+func isInterop(env *descriptors.DevnetEnvironment) bool {
+	for _, feature := range env.Features {
+		if feature == FeatureInterop {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Orchestrator) isInterop() bool {
+	// Ugly hack to ensure we can use L2[0] for supervisor
+	// Ultimately this should be removed.
+	return isInterop(o.env) && len(o.env.L2) > 0
+}
+
+func (o *Orchestrator) WithPrivatePorts() OrchestratorOption {
+	return func(orchestrator *Orchestrator) {
+		orchestrator.usePrivatePorts = true
+	}
+}
+
+func (o *Orchestrator) WithEagerRPCClients() OrchestratorOption {
+	return func(orchestrator *Orchestrator) {
+		orchestrator.useEagerRPCClients = true
+	}
+}
+
+var _ system2.Orchestrator = (*Orchestrator)(nil)

--- a/devnet-sdk/systemext/system.go
+++ b/devnet-sdk/systemext/system.go
@@ -46,7 +46,13 @@ func DefaultSystemExt(env *descriptors.DevnetEnvironment, opts ...OrchestratorOp
 	opt := system2.Option(func(setup *system2.Setup) {
 		setup.Log.Info("Mapping descriptor")
 
-		orchestrator := setup.Orchestrator.(*Orchestrator)
+		var orchestrator *Orchestrator
+		if setup.Orchestrator == nil {
+			orchestrator = &Orchestrator{}
+			setup.Orchestrator = orchestrator
+		} else {
+			orchestrator = setup.Orchestrator.(*Orchestrator)
+		}
 		setup.Require.Nil(orchestrator.env, "orchestrator env should be nil")
 		setup.Require.NotNil(env, "env should not be nil")
 		orchestrator.env = env

--- a/devnet-sdk/systemext/system.go
+++ b/devnet-sdk/systemext/system.go
@@ -55,18 +55,18 @@ func DefaultSystemExt(env *descriptors.DevnetEnvironment, opts ...OrchestratorOp
 		}
 	})
 
-	opt.Append(WithL1(ids.L1, ids.Nodes))
-	opt.Append(WithSuperchain(ids.Superchain))
-	opt.Append(WithSupervisor(ids.Supervisor))
-	opt.Append(WithCluster(ids.Cluster))
+	opt.Add(WithL1(ids.L1, ids.Nodes))
+	opt.Add(WithSuperchain(ids.Superchain))
+	opt.Add(WithSupervisor(ids.Supervisor))
+	opt.Add(WithCluster(ids.Cluster))
 
 	for idx := range env.L2 {
 		l2IDs := ids.L2s[idx]
-		opt.Append(WithL2(idx, l2IDs.L2, l2IDs.Nodes, ids.L1))
+		opt.Add(WithL2(idx, l2IDs.L2, l2IDs.Nodes, ids.L1))
 
-		opt.Append(WithBatcher(idx, l2IDs.L2, l2IDs.L2Batcher))
-		opt.Append(WithProposer(idx, l2IDs.L2, l2IDs.L2Proposer))
-		opt.Append(WithChallenger(idx, l2IDs.L2, l2IDs.L2Challenger))
+		opt.Add(WithBatcher(idx, l2IDs.L2, l2IDs.L2Batcher))
+		opt.Add(WithProposer(idx, l2IDs.L2, l2IDs.L2Proposer))
+		opt.Add(WithChallenger(idx, l2IDs.L2, l2IDs.L2Challenger))
 	}
 
 	return ids, opt

--- a/devnet-sdk/systemext/system.go
+++ b/devnet-sdk/systemext/system.go
@@ -1,0 +1,124 @@
+package systemext
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system2"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+type DefaultSystemExtIDs struct {
+	L1    system2.L1NetworkID
+	Nodes []DefaultSystemExtL1NodeIDs
+
+	Superchain system2.SuperchainID
+	Cluster    system2.ClusterID
+
+	Supervisor system2.SupervisorID
+
+	L2s []DefaultSystemExtL2IDs
+}
+
+type DefaultSystemExtL1NodeIDs struct {
+	EL system2.L1ELNodeID
+	CL system2.L1CLNodeID
+}
+
+type DefaultSystemExtL2NodeIDs struct {
+	EL system2.L2ELNodeID
+	CL system2.L2CLNodeID
+}
+
+type DefaultSystemExtL2IDs struct {
+	L2 system2.L2NetworkID
+
+	Nodes []DefaultSystemExtL2NodeIDs
+
+	L2Batcher    system2.L2BatcherID
+	L2Proposer   system2.L2ProposerID
+	L2Challenger system2.L2ChallengerID
+}
+
+func DefaultSystemExt(env *descriptors.DevnetEnvironment, opts ...OrchestratorOption) (DefaultSystemExtIDs, system2.Option) {
+	ids := collectSystemExtIDs(env)
+
+	opt := system2.Option(func(setup *system2.Setup) {
+		setup.Log.Info("Mapping descriptor")
+
+		orchestrator := setup.Orchestrator.(*Orchestrator)
+		setup.Require.Nil(orchestrator.env, "orchestrator env should be nil")
+		setup.Require.NotNil(env, "env should not be nil")
+		orchestrator.env = env
+		for _, o := range opts {
+			o(orchestrator)
+		}
+	})
+
+	opt.Append(WithL1(ids.L1, ids.Nodes))
+	opt.Append(WithSuperchain(ids.Superchain))
+	opt.Append(WithSupervisor(ids.Supervisor))
+	opt.Append(WithCluster(ids.Cluster))
+
+	for idx := range env.L2 {
+		l2IDs := ids.L2s[idx]
+		opt.Append(WithL2(idx, l2IDs.L2, l2IDs.Nodes, ids.L1))
+
+		opt.Append(WithBatcher(idx, l2IDs.L2, l2IDs.L2Batcher))
+		opt.Append(WithProposer(idx, l2IDs.L2, l2IDs.L2Proposer))
+		opt.Append(WithChallenger(idx, l2IDs.L2, l2IDs.L2Challenger))
+	}
+
+	return ids, opt
+}
+
+func WithSuperchain(id system2.SuperchainID) system2.Option {
+	return func(setup *system2.Setup) {
+		commonConfig := setup.CommonConfig()
+		env := getOrchestrator(setup).env
+
+		setup.System.AddSuperchain(system2.NewSuperchain(system2.SuperchainConfig{
+			CommonConfig: commonConfig,
+			ID:           id,
+			Deployment:   newL1AddressBook(setup, env.L1.Addresses),
+		}))
+	}
+}
+
+func WithSupervisor(id system2.SupervisorID) system2.Option {
+	return func(setup *system2.Setup) {
+		orchestrator := getOrchestrator(setup)
+		if !orchestrator.isInterop() {
+			return
+		}
+
+		// ideally we should check supervisor is consistent across all L2s
+		// but that's what Kurtosis does.
+		supervisorRPC, err := findProtocolService(setup, "supervisor", RPCProtocol, orchestrator.env.L2[0].Services)
+		setup.Require.NoError(err)
+		supervisorClient := rpcClient(setup, supervisorRPC)
+		setup.System.AddSupervisor(system2.NewSupervisor(system2.SupervisorConfig{
+			CommonConfig: setup.CommonConfig(),
+			ID:           id,
+			Client:       supervisorClient,
+		}))
+	}
+}
+
+func WithCluster(id system2.ClusterID) system2.Option {
+	return func(setup *system2.Setup) {
+		orchestrator := getOrchestrator(setup)
+		if !orchestrator.isInterop() {
+			return
+		}
+
+		var depSet depset.StaticConfigDependencySet
+		setup.Require.NoError(json.Unmarshal(orchestrator.env.DepSet, &depSet))
+
+		setup.System.AddCluster(system2.NewCluster(system2.ClusterConfig{
+			CommonConfig:  setup.CommonConfig(),
+			ID:            id,
+			DependencySet: &depSet,
+		}))
+	}
+}

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@f57f766d3902c5044a055d09ac2136da1de38f98
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@1cf76907eaa437ee9fcf902167714fece027962a
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173

--- a/kurtosis-devnet/pkg/kurtosis/adapters.go
+++ b/kurtosis-devnet/pkg/kurtosis/adapters.go
@@ -2,9 +2,11 @@ package kurtosis
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/deployer"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/depset"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/interfaces"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/jwt"
@@ -42,3 +44,11 @@ func (a *enclaveJWTAdapter) ExtractData(ctx context.Context, enclave string) (*j
 }
 
 var _ interfaces.JWTExtractor = (*enclaveJWTAdapter)(nil)
+
+type enclaveDepsetAdapter struct{}
+
+func (a *enclaveDepsetAdapter) ExtractData(ctx context.Context, enclave string) (json.RawMessage, error) {
+	return depset.NewExtractor(enclave).ExtractData(ctx)
+}
+
+var _ interfaces.DepsetExtractor = (*enclaveDepsetAdapter)(nil)

--- a/kurtosis-devnet/pkg/kurtosis/sources/depset/depset.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/depset/depset.go
@@ -1,0 +1,50 @@
+package depset
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
+)
+
+const (
+	depsetFileName = "dependency_set.json"
+)
+
+// extractor implements the interfaces.DepsetExtractor interface
+type extractor struct {
+	enclave string
+}
+
+// NewExtractor creates a new dependency set extractor
+func NewExtractor(enclave string) *extractor {
+	return &extractor{
+		enclave: enclave,
+	}
+}
+
+// ExtractData extracts dependency set from its respective artifact
+func (e *extractor) ExtractData(ctx context.Context) (json.RawMessage, error) {
+	fs, err := ktfs.NewEnclaveFS(ctx, e.enclave)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractDepsetFromArtifact(ctx, fs, depsetFileName)
+}
+
+func extractDepsetFromArtifact(ctx context.Context, fs *ktfs.EnclaveFS, artifactName string) (json.RawMessage, error) {
+	a, err := fs.GetArtifact(ctx, artifactName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get artifact: %w", err)
+	}
+
+	buffer := &bytes.Buffer{}
+	if err := a.ExtractFiles(ktfs.NewArtifactFileWriter(depsetFileName, buffer)); err != nil {
+		return nil, fmt.Errorf("failed to extract dependency set: %w", err)
+	}
+
+	return json.RawMessage(buffer.Bytes()), nil
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/interfaces/interfaces.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/interfaces/interfaces.go
@@ -2,6 +2,7 @@ package interfaces
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/deployer"
@@ -24,4 +25,8 @@ type EnclaveObserver interface {
 
 type JWTExtractor interface {
 	ExtractData(context.Context, string) (*jwt.Data, error)
+}
+
+type DepsetExtractor interface {
+	ExtractData(context.Context, string) (json.RawMessage, error)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This change makes devnet-sdk's existing devnet descriptor a valid provide of system2 interfaces.
As a prerequisite, it bubbles up the interop  depset information through the descriptor.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
