### PR TITLE
op-chain-ops: Introduce check-prestate

### DIFF
--- a/op-chain-ops/README.md
+++ b/op-chain-ops/README.md
@@ -34,6 +34,7 @@ cmd/
 ├── check-derivation              - Check that transactions can be confirmed and safety can be consolidated
 ├── check-ecotone                 - Checks for Ecotone network upgrade
 ├── check-fjord                   - Checks for Fjord network upgrade
+├── check-prestate                - Checks a fault proof absolute prestate's chain compatibility
 ├── deposit-hash                  - Determine the L2 deposit tx hash, based on log event(s) emitted by a L1 tx.
 ├── ecotone-scalar                - Translate between serialized and human-readable L1 fee scalars (introduced in Ecotone upgrade).
 ├── op-simulate                   - Simulate a remote transaction in a local Geth EVM for block-processing debugging.

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-program/prestates"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/mattn/go-isatty"
+	"golang.org/x/mod/modfile"
+)
+
+type PrestateInfo struct {
+	Hash    common.Hash `json:"hash"`
+	Version string      `json:"version"`
+	Type    string      `json:"type"`
+
+	OpProgram          CommitInfo `json:"op-program"`
+	OpGeth             CommitInfo `json:"op-geth"`
+	SuperchainRegistry CommitInfo `json:"superchain-registry"`
+}
+
+type CommitInfo struct {
+	Commit  string `json:"commit"`
+	DiffUrl string `json:"diff-url"`
+	DiffCmd string `json:"diff-cmd"`
+}
+
+func main() {
+	color := isatty.IsTerminal(os.Stderr.Fd())
+	handler := log.NewTerminalHandler(os.Stderr, color)
+	oplog.SetGlobalLogHandler(handler)
+	log := log.NewLogger(handler)
+
+	// Define the flag variables
+	var (
+		prestateHashStr string
+	)
+
+	// Define and parse the command-line flags
+	flag.StringVar(&prestateHashStr, "prestate-hash", "", "Specify the absolute prestate hash to verify")
+
+	// Parse the command-line arguments
+	flag.Parse()
+	if prestateHashStr == "" {
+		log.Crit("--prestate-hash is required")
+	}
+	prestateHash := common.HexToHash(prestateHashStr)
+	if prestateHash == (common.Hash{}) {
+		log.Crit("--prestate-hash is invalid")
+	}
+
+	prestateReleases, err := prestates.LoadReleases("")
+	if err != nil {
+		log.Crit("Failed to load prestate releases list", "err", err)
+	}
+
+	var prestateVersion string
+	var prestateType string
+	for version, prestates := range prestateReleases.Prestates {
+		for _, prestate := range prestates {
+			if common.HexToHash(prestate.Hash) == prestateHash {
+				prestateVersion = version
+				prestateType = prestate.Type
+				break
+			}
+		}
+	}
+	if prestateVersion == "" {
+		log.Crit("Failed to find a prestate release with hash", "hash", prestateHash)
+	}
+	prestateTag := fmt.Sprintf("op-program/v%s", prestateVersion)
+	log.Info("Found prestate", "version", prestateVersion, "type", prestateType, "tag", prestateTag)
+
+	modFile, err := fetchMonorepoGoMod(prestateTag)
+	if err != nil {
+		log.Crit("Failed to fetch go mod", "err", err)
+	}
+	var gethVersion string
+	for _, replace := range modFile.Replace {
+		if replace.Old.Path == "github.com/ethereum/go-ethereum" {
+			gethVersion = replace.New.Version
+			break
+		}
+	}
+	if gethVersion == "" {
+		log.Crit("Failed to find op-geth replace in go.mod")
+	}
+	log.Info("Found op-geth version", "version", gethVersion)
+
+	registryCommitBytes, err := fetch(fmt.Sprintf("https://github.com/ethereum-optimism/op-geth/raw/%s/superchain-registry-commit.txt", gethVersion))
+	if err != nil {
+		log.Crit("Failed to fetch superchain registry commit info", "err", err)
+	}
+	commit := string(registryCommitBytes)
+	log.Info("Found superchain registry commit info", "commit", commit)
+
+	report := PrestateInfo{
+		Hash:               prestateHash,
+		Version:            prestateVersion,
+		Type:               prestateType,
+		OpProgram:          commitInfo("optimism", prestateTag, "develop", ""),
+		OpGeth:             commitInfo("op-geth", gethVersion, "optimism", ""),
+		SuperchainRegistry: commitInfo("superchain-registry", commit, "main", "superchain"),
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(report); err != nil {
+		log.Crit("Failed to encode report", "err", err)
+	}
+}
+
+func commitInfo(repository string, commit string, mainBranch string, dir string) CommitInfo {
+	return CommitInfo{
+		Commit:  commit,
+		DiffUrl: fmt.Sprintf("https://github.com/ethereum-optimism/%s/compare/%s...%s", repository, commit, mainBranch),
+		DiffCmd: fmt.Sprintf("git fetch && git diff %s...origin/%s %s", commit, mainBranch, dir),
+	}
+}
+
+func fetchMonorepoGoMod(opProgramTag string) (*modfile.File, error) {
+	goModUrl := fmt.Sprintf("https://github.com/ethereum-optimism/optimism/raw/refs/tags/%s/go.mod", opProgramTag)
+	goMod, err := fetch(goModUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch go.mod: %w", err)
+	}
+
+	return modfile.Parse("go.mod", goMod, nil)
+}
+
+func fetch(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %v: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch %v: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/op-program/prestates/fetcher.go
+++ b/op-program/prestates/fetcher.go
@@ -1,0 +1,51 @@
+package prestates
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// standardPrestatesUrl is the URL to the TOML file in superchain registry that defines the list of standard prestates
+// Note that this explicitly points to the main branch and is not pinned to a specific version. The verification check
+// intends to
+const standardPrestatesUrl = "https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-prestates.toml"
+
+func LoadReleases(overrideFile string) (*Prestates, error) {
+	var data []byte
+	if overrideFile != "" {
+		d, err := os.ReadFile(overrideFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read override file (%v): %w", overrideFile, err)
+		}
+		data = d
+	} else {
+		resp, err := http.Get(standardPrestatesUrl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download standard prestates from %v: %w", standardPrestatesUrl, err)
+		}
+		defer resp.Body.Close()
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read standard prestates from %v: %w", standardPrestatesUrl, err)
+		}
+	}
+	var standardPrestates Prestates
+	err := toml.Unmarshal(data, &standardPrestates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse standard prestates from %v: %w", standardPrestatesUrl, err)
+	}
+	return &standardPrestates, nil
+}
+
+type Prestates struct {
+	Prestates map[string][]Prestate `toml:"prestates"`
+}
+
+type Prestate struct {
+	Type string `toml:"type"`
+	Hash string `toml:"hash"`
+}


### PR DESCRIPTION
**Description**

Introduces a check-prestate script to op-chain-ops which, given a prestate hash, finds the op-program version it's from and the op-geth and superchain-registry commits that it uses.  It then outputs this information along with convenient links and commands to view the diff between the commit used and the latest commit.

This is just a starting point to gather the relevant information, we will need to keep building on this over time to automatically verify specific things.