### PR TITLE
op-e2e: Interop FP devnet

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -4,7 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 
+	"golang.org/x/exp/maps"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/interop"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
@@ -70,6 +74,12 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 		}
 		deployments.L2s[l2ChainID] = l2Deployment
 	}
+
+	interopDeployment, err := MigrateInterop(l1Host, uint64(cfg.L1.L1GenesisBlockTimestamp), cfg.Superchain, superDeployment, cfg.L2s, deployments.L2s)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to migrate interop: %w", err)
+	}
+	deployments.Interop = interopDeployment
 
 	out := &WorldOutput{
 		L2s: make(map[string]*L2Output),
@@ -199,7 +209,7 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 	l1Host.SetTxOrigin(cfg.Deployer)
 
 	output, err := opcm.DeployOPChain(l1Host, opcm.DeployOPChainInput{
-		OpChainProxyAdminOwner:  cfg.ProxyAdminOwner,
+		OpChainProxyAdminOwner:  superCfg.ProxyAdminOwner,
 		SystemConfigOwner:       cfg.SystemConfigOwner,
 		Batcher:                 cfg.BatchSenderAddress,
 		UnsafeBlockSigner:       cfg.P2PSequencerAddress,
@@ -225,6 +235,50 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 	// Collect deployment addresses
 	return &L2Deployment{
 		L2OpchainDeployment: L2OpchainDeployment(output),
+	}, nil
+}
+
+func MigrateInterop(
+	l1Host *script.Host, l1GenesisTimestamp uint64, superCfg *SuperchainConfig, superDeployment *SuperchainDeployment, l2Cfgs map[string]*L2Config, l2Deployments map[string]*L2Deployment,
+) (*InteropDeployment, error) {
+	l2ChainIDs := maps.Keys(l2Deployments)
+	sort.Strings(l2ChainIDs)
+	chainConfigs := make([]interop.OPChainConfig, len(l2Deployments))
+	for i, l2ChainID := range l2ChainIDs {
+		l2Deployment := l2Deployments[l2ChainID]
+		chainConfigs[i] = interop.OPChainConfig{
+			SystemConfigProxy: l2Deployment.SystemConfigProxy,
+			ProxyAdmin:        superDeployment.ProxyAdmin,
+			AbsolutePrestate:  l2Cfgs[l2ChainID].DisputeAbsolutePrestate,
+		}
+	}
+
+	// For now get the fault game parameters from the first chain
+	l2ChainID := l2ChainIDs[0]
+	// We don't have a super root at genesis. But stub the starting anchor root anyways to facilitate super DG testing.
+	startingAnchorRoot := common.Hash(opcm.PermissionedGameStartingAnchorRoot)
+	imi := interop.InteropMigrationInput{
+		Prank:                          superCfg.ProxyAdminOwner,
+		Opcm:                           superDeployment.Opcm,
+		UsePermissionlessGame:          true,
+		StartingAnchorRoot:             startingAnchorRoot,
+		StartingAnchorL2SequenceNumber: big.NewInt(int64(l1GenesisTimestamp)),
+		Proposer:                       l2Cfgs[l2ChainID].Proposer,
+		Challenger:                     l2Cfgs[l2ChainID].Challenger,
+		MaxGameDepth:                   l2Cfgs[l2ChainID].DisputeMaxGameDepth,
+		SplitDepth:                     l2Cfgs[l2ChainID].DisputeSplitDepth,
+		InitBond:                       big.NewInt(0),
+		ClockExtension:                 l2Cfgs[l2ChainID].DisputeClockExtension,
+		MaxClockDuration:               l2Cfgs[l2ChainID].DisputeMaxClockDuration,
+		EncodedChainConfigs:            chainConfigs,
+	}
+	output, err := interop.Migrate(l1Host, imi)
+	if err != nil {
+		return nil, fmt.Errorf("failed to migrate interop: %w", err)
+	}
+
+	return &InteropDeployment{
+		DisputeGameFactory: output.DisputeGameFactory,
 	}, nil
 }
 

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -69,8 +69,13 @@ type L2Deployment struct {
 	// e.g. a Safe that will own the L2 chain contracts
 }
 
+type InteropDeployment struct {
+	DisputeGameFactory common.Address `json:"DisputeGameFactory"`
+}
+
 type WorldDeployment struct {
 	L1         *L1Deployment            `json:"L1"`
 	Superchain *SuperchainDeployment    `json:"Superchain"`
 	L2s        map[string]*L2Deployment `json:"L2s"`
+	Interop    *InteropDeployment       `json:"Interop"`
 }

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -75,7 +75,7 @@ func (recipe *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, er
 				ChallengePeriodSeconds:          big.NewInt(120),
 				ProofMaturityDelaySeconds:       big.NewInt(12),
 				DisputeGameFinalityDelaySeconds: big.NewInt(6),
-				MipsVersion:                     big.NewInt(1),
+				MipsVersion:                     big.NewInt(2),
 			},
 			UseInterop: true,
 		},

--- a/op-deployer/pkg/deployer/interop/migrate.go
+++ b/op-deployer/pkg/deployer/interop/migrate.go
@@ -1,0 +1,61 @@
+package interop
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lmittmann/w3"
+)
+
+type InteropMigrationInput struct {
+	Prank common.Address `json:"prank"`
+	Opcm  common.Address `json:"opcm"`
+
+	UsePermissionlessGame          bool           `json:"usePermissionlessGame"`
+	StartingAnchorRoot             common.Hash    `json:"startingAnchorRoot"`
+	StartingAnchorL2SequenceNumber *big.Int       `json:"startingAnchorL2SequenceNumber"`
+	Proposer                       common.Address `json:"proposer"`
+	Challenger                     common.Address `json:"challenger"`
+	MaxGameDepth                   uint64         `json:"maxGameDepth"`
+	SplitDepth                     uint64         `json:"splitDepth"`
+	InitBond                       *big.Int       `json:"initBond"`
+	ClockExtension                 uint64         `json:"clockExtension"`
+	MaxClockDuration               uint64         `json:"maxClockDuration"`
+
+	EncodedChainConfigs []OPChainConfig `evm:"-" json:"chainConfigs"`
+}
+
+func (u *InteropMigrationInput) OpChainConfigs() ([]byte, error) {
+	data, err := opChainConfigEncoder.EncodeArgs(u.EncodedChainConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode chain configs: %w", err)
+	}
+	return data[4:], nil
+}
+
+type OPChainConfig struct {
+	SystemConfigProxy common.Address `json:"systemConfigProxy"`
+	ProxyAdmin        common.Address `json:"proxyAdmin"`
+	AbsolutePrestate  common.Hash    `json:"absolutePrestate"`
+}
+
+type InteropMigrationOutput struct {
+	DisputeGameFactory common.Address `json:"disputeGameFactory"`
+}
+
+func (output *InteropMigrationOutput) CheckOutput(input common.Address) error {
+	return nil
+}
+
+var opChainConfigEncoder = w3.MustNewFunc("dummy((address systemConfigProxy,address proxyAdmin,bytes32 absolutePrestate)[])", "")
+
+type InteropMigration struct {
+	Run func(input common.Address)
+}
+
+func Migrate(host *script.Host, input InteropMigrationInput) (InteropMigrationOutput, error) {
+	return opcm.RunScriptSingle[InteropMigrationInput, InteropMigrationOutput](host, input, "InteropMigration.s.sol", "InteropMigration")
+}

--- a/op-deployer/pkg/deployer/interop/migrate_test.go
+++ b/op-deployer/pkg/deployer/interop/migrate_test.go
@@ -1,0 +1,80 @@
+package interop
+
+import (
+	"context"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropMigration(t *testing.T) {
+	t.Skip("Skipped until the sepolia opcm supports the interop migration")
+
+	lgr := testlog.Logger(t, slog.LevelDebug)
+
+	forkedL1, stopL1, err := devnet.NewForkedSepolia(lgr)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, stopL1())
+	})
+	l1RPC := forkedL1.RPCUrl()
+
+	_, afactsFS := testutil.LocalArtifacts(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	rpcClient, err := rpc.Dial(l1RPC)
+	require.NoError(t, err)
+
+	bcast := new(broadcaster.CalldataBroadcaster)
+	host, err := env.DefaultForkedScriptHost(
+		ctx,
+		bcast,
+		lgr,
+		common.Address{'D'},
+		afactsFS,
+		rpcClient,
+	)
+	require.NoError(t, err)
+
+	pao := common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2")
+	input := InteropMigrationInput{
+		Prank:                          pao,
+		Opcm:                           common.HexToAddress("0xaf334f4537e87f5155d135392ff6d52f1866465e"),
+		UsePermissionlessGame:          true,
+		StartingAnchorL2SequenceNumber: big.NewInt(1),
+		Proposer:                       common.Address{'A'},
+		Challenger:                     common.Address{'B'},
+		MaxGameDepth:                   10,
+		SplitDepth:                     10,
+		InitBond:                       big.NewInt(1000),
+		ClockExtension:                 10,
+		MaxClockDuration:               10,
+		EncodedChainConfigs: []OPChainConfig{
+			{
+				SystemConfigProxy: common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+				ProxyAdmin:        common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"),
+				AbsolutePrestate:  common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000abc"),
+			},
+		},
+	}
+	output, err := Migrate(host, input)
+	require.NoError(t, err)
+	require.NotEqual(t, common.Address{}, output.DisputeGameFactory)
+
+	dump, err := bcast.Dump()
+	require.NoError(t, err)
+	require.True(t, dump[0].Value.ToInt().Cmp(common.Big0) == 0)
+	require.Equal(t, *dump[0].To, pao)
+}

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -215,6 +215,8 @@ func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node 
 }
 
 func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, timestamp uint64, rootClaim common.Hash, opts ...GameOpt) *SuperCannonGameHelper {
+	// Can't create a game at L1 genesis!
+	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1))
 	return h.startSuperCannonGameOfType(ctx, timestamp, rootClaim, superCannonGameType, opts...)
 }
 

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -214,10 +214,12 @@ func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node 
 	return NewOutputCannonGameHelper(h.T, h.Client, h.Opts, h.PrivKey, game, h.FactoryAddr, createdEvent.DisputeProxy, provider, h.System)
 }
 
-func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, timestamp uint64, rootClaim common.Hash, opts ...GameOpt) *SuperCannonGameHelper {
+func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, rootClaim common.Hash, opts ...GameOpt) *SuperCannonGameHelper {
 	// Can't create a game at L1 genesis!
 	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1))
-	return h.startSuperCannonGameOfType(ctx, timestamp, rootClaim, superCannonGameType, opts...)
+	b, err := h.Client.BlockByNumber(ctx, nil)
+	require.NoError(h.T, err)
+	return h.startSuperCannonGameOfType(ctx, b.Time(), rootClaim, superCannonGameType, opts...)
 }
 
 func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestamp uint64, rootClaim common.Hash, gameType uint32, opts ...GameOpt) *SuperCannonGameHelper {

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -3,6 +3,7 @@ package faultproofs
 import (
 	"context"
 	"testing"
+	"time"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
@@ -10,11 +11,10 @@ import (
 )
 
 func TestCreateSuperCannonGame(t *testing.T) {
-	t.Skip("Super cannon game can't yet be deployed with SuperSystem")
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
 	sys.L2IDs()
-	game := disputeGameFactory.StartSuperCannonGame(ctx, 4, common.Hash{0x01})
+	game := disputeGameFactory.StartSuperCannonGame(ctx, uint64(time.Now().Unix())+3, common.Hash{0x01})
 	game.LogGameData(ctx)
 }

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -3,7 +3,6 @@ package faultproofs
 import (
 	"context"
 	"testing"
-	"time"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
@@ -15,6 +14,6 @@ func TestCreateSuperCannonGame(t *testing.T) {
 	ctx := context.Background()
 	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
 	sys.L2IDs()
-	game := disputeGameFactory.StartSuperCannonGame(ctx, uint64(time.Now().Unix())+3, common.Hash{0x01})
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
 	game.LogGameData(ctx)
 }

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -151,9 +151,7 @@ func (s *interopE2ESystem) AdvanceL1Time(duration time.Duration) {
 }
 
 func (s *interopE2ESystem) DisputeGameFactoryAddr() common.Address {
-	// Currently uses the dispute game factory for the first L2 chain.
-	// Ultimately this should be a factory shared by all chains in the dependency set
-	return s.worldDeployment.L2s[s.L2IDs()[0]].DisputeGameFactoryProxy
+	return s.worldDeployment.Interop.DisputeGameFactory
 }
 
 // prepareHDWallet creates a new HD wallet to derive keys from

--- a/packages/contracts-bedrock/scripts/deploy/InteropMigration.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/InteropMigration.s.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
+import { IOPContractsManagerInteropMigrator, IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { Duration, Proposal, Hash } from "src/dispute/lib/Types.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+
+contract InteropMigrationInput is BaseDeployIO {
+    address internal _prank;
+    IOPContractsManager internal _opcm;
+
+    bool internal _usePermissionlessGame;
+
+    // starting anchor proposal
+    bytes32 internal _startingAnchorRoot;
+    uint256 internal _startingAnchorL2SequenceNumber;
+
+    // game parameters
+    address internal _proposer;
+    address internal _challenger;
+    uint256 internal _maxGameDepth;
+    uint256 internal _splitDepth;
+    uint256 internal _initBond;
+    uint256 internal _clockExtension;
+    uint256 internal _maxClockDuration;
+
+    bytes internal _opChainConfigs;
+
+    function set(bytes4 _sel, address _value) public {
+        require(address(_value) != address(0), "InteropMigrationInput: cannot set zero address");
+
+        if (_sel == this.prank.selector) _prank = _value;
+        else if (_sel == this.opcm.selector) _opcm = IOPContractsManager(_value);
+        else if (_sel == this.proposer.selector) _proposer = _value;
+        else if (_sel == this.challenger.selector) _challenger = _value;
+        else revert("InteropMigrationInput: unknown selector");
+    }
+
+    function set(bytes4 _sel, bool _value) public {
+        if (_sel == this.usePermissionlessGame.selector) _usePermissionlessGame = _value;
+        else revert("InteropMigrationInput: unknown selector");
+    }
+
+    function set(bytes4 _sel, uint256 _value) public {
+        if (_sel == this.maxGameDepth.selector) {
+            require(_value != 0, "InteropMigrationInput: maxGameDepth cannot be 0");
+            _maxGameDepth = _value;
+        } else if (_sel == this.splitDepth.selector) {
+            require(_value != 0, "InteropMigrationInput: splitDepth cannot be 0");
+            _splitDepth = _value;
+        } else if (_sel == this.initBond.selector) {
+            require(_value != 0, "InteropMigrationInput: initBond cannot be 0");
+            _initBond = _value;
+        } else if (_sel == this.clockExtension.selector) {
+            require(_value <= type(uint64).max, "InteropMigrationInput: clockExtension must fit inside uint64");
+            require(_value != 0, "InteropMigrationInput: clockExtension cannot be 0");
+            _clockExtension = _value;
+        } else if (_sel == this.maxClockDuration.selector) {
+            require(_value <= type(uint64).max, "InteropMigrationInput: maxClockDuration must fit inside uint64");
+            require(_value != 0, "InteropMigrationInput: maxClockDuration cannot be 0");
+            _maxClockDuration = _value;
+        } else if (_sel == this.startingAnchorL2SequenceNumber.selector) {
+            require(_value != 0, "InteropMigrationInput: startingAnchorL2SequenceNumber cannot be 0");
+            _startingAnchorL2SequenceNumber = _value;
+        } else {
+            revert("InteropMigrationInput: unknown selector");
+        }
+    }
+
+    function set(bytes4 _sel, bytes32 _value) public {
+        if (_sel == this.startingAnchorRoot.selector) {
+            require(_value != bytes32(0), "InteropMigrationInput: startingAnchorRoot cannot be 0");
+            _startingAnchorRoot = _value;
+        } else {
+            revert("InteropMigrationInput: unknown selector");
+        }
+    }
+
+    function set(bytes4 _sel, IOPContractsManager.OpChainConfig[] memory _value) public {
+        require(_value.length > 0, "InteropMigrationInput: cannot set empty array");
+
+        if (_sel == this.opChainConfigs.selector) _opChainConfigs = abi.encode(_value);
+        else revert("InteropMigrationInput: unknown selector");
+    }
+
+    function prank() public view returns (address) {
+        require(address(_prank) != address(0), "InteropMigrationInput: prank not set");
+        return _prank;
+    }
+
+    function opcm() public view returns (IOPContractsManager) {
+        require(address(_opcm) != address(0), "InteropMigrationInput: not set");
+        return _opcm;
+    }
+
+    function usePermissionlessGame() public view returns (bool) {
+        return _usePermissionlessGame;
+    }
+
+    function proposer() public view returns (address) {
+        require(address(_proposer) != address(0), "InteropMigrationInput: proposer not set");
+        return _proposer;
+    }
+
+    function challenger() public view returns (address) {
+        require(address(_challenger) != address(0), "InteropMigrationInput: challenger not set");
+        return _challenger;
+    }
+
+    function maxGameDepth() public view returns (uint256) {
+        require(_maxGameDepth > 0, "InteropMigrationInput: maxGameDepth not set");
+        return _maxGameDepth;
+    }
+
+    function splitDepth() public view returns (uint256) {
+        require(_splitDepth > 0, "InteropMigrationInput: splitDepth not set");
+        return _splitDepth;
+    }
+
+    function initBond() public view returns (uint256) {
+        require(_initBond > 0, "InteropMigrationInput: initBond not set");
+        return _initBond;
+    }
+
+    function clockExtension() public view returns (uint256) {
+        require(_clockExtension > 0, "InteropMigrationInput: clockExtension not set");
+        return _clockExtension;
+    }
+
+    function maxClockDuration() public view returns (uint256) {
+        require(_maxClockDuration > 0, "InteropMigrationInput: maxClockDuration not set");
+        return _maxClockDuration;
+    }
+
+    function startingAnchorRoot() public view returns (bytes32) {
+        require(_startingAnchorRoot != bytes32(0), "InteropMigrationInput: startingAnchorRoot not set");
+        return _startingAnchorRoot;
+    }
+
+    function startingAnchorL2SequenceNumber() public view returns (uint256) {
+        require(_startingAnchorL2SequenceNumber > 0, "InteropMigrationInput: startingAnchorL2SequenceNumber not set");
+        return _startingAnchorL2SequenceNumber;
+    }
+
+    function opChainConfigs() public view returns (bytes memory) {
+        require(_opChainConfigs.length > 0, "InteropMigrationInput: not set");
+        return _opChainConfigs;
+    }
+}
+
+contract InteropMigrationOutput is BaseDeployIO {
+    IDisputeGameFactory internal _disputeGameFactory;
+
+    function set(bytes4 _sel, IDisputeGameFactory _value) public {
+        if (_sel == this.disputeGameFactory.selector) _disputeGameFactory = _value;
+        else revert("InteropMigrationOutput: unknown selector");
+    }
+
+    function disputeGameFactory() public view returns (IDisputeGameFactory) {
+        require(address(_disputeGameFactory) != address(0), "InteropMigrationOutput: not set");
+        DeployUtils.assertValidContractAddress(address(_disputeGameFactory));
+        return _disputeGameFactory;
+    }
+}
+
+contract InteropMigration is Script {
+    function run(InteropMigrationInput _imi, InteropMigrationOutput _imo) public {
+        IOPContractsManager opcm = _imi.opcm();
+        IOPContractsManager.OpChainConfig[] memory opChainConfigs =
+            abi.decode(_imi.opChainConfigs(), (IOPContractsManager.OpChainConfig[]));
+
+        IOPContractsManagerInteropMigrator.MigrateInput memory inputs = IOPContractsManagerInteropMigrator.MigrateInput({
+            usePermissionlessGame: _imi.usePermissionlessGame(),
+            startingAnchorRoot: Proposal({
+                root: Hash.wrap(_imi.startingAnchorRoot()),
+                l2SequenceNumber: _imi.startingAnchorL2SequenceNumber()
+            }),
+            gameParameters: IOPContractsManagerInteropMigrator.GameParameters({
+                proposer: _imi.proposer(),
+                challenger: _imi.challenger(),
+                maxGameDepth: _imi.maxGameDepth(),
+                splitDepth: _imi.splitDepth(),
+                initBond: _imi.initBond(),
+                clockExtension: Duration.wrap(uint64(_imi.clockExtension())),
+                maxClockDuration: Duration.wrap(uint64(_imi.maxClockDuration()))
+            }),
+            opChainConfigs: opChainConfigs
+        });
+        // Etch DummyCaller contract. This contract is used to mimic the contract that is used
+        // as the source of the delegatecall to the OPCM. In practice this will be the governance
+        // 2/2 or similar.
+        address prank = _imi.prank();
+        bytes memory code = vm.getDeployedCode("InteropMigration.s.sol:DummyCaller");
+        vm.etch(prank, code);
+        vm.store(prank, bytes32(0), bytes32(uint256(uint160(address(opcm)))));
+        vm.label(prank, "DummyCaller");
+
+        // Call into the DummyCaller. This will perform the delegatecall under the hood and
+        // return the result.
+        vm.broadcast(msg.sender);
+        (bool success,) = DummyCaller(prank).migrate(inputs);
+        require(success, "InteropMigration: migrate failed");
+
+        // After migration all portals will have the same DGF
+        IOptimismPortal portal = IOptimismPortal(payable(opChainConfigs[0].systemConfigProxy.optimismPortal()));
+        _imo.set(_imo.disputeGameFactory.selector, portal.disputeGameFactory());
+
+        checkOutput(_imi, _imo);
+    }
+
+    function checkOutput(InteropMigrationInput _imi, InteropMigrationOutput _imo) public view {
+        IOPContractsManager.OpChainConfig[] memory opChainConfigs =
+            abi.decode(_imi.opChainConfigs(), (IOPContractsManager.OpChainConfig[]));
+
+        for (uint256 i = 0; i < opChainConfigs.length; i++) {
+            IOptimismPortal portal = IOptimismPortal(payable(opChainConfigs[i].systemConfigProxy.optimismPortal()));
+            require(
+                IDisputeGameFactory(portal.disputeGameFactory()) == _imo.disputeGameFactory(),
+                "InteropMigration: disputeGameFactory mismatch"
+            );
+        }
+    }
+}
+
+contract DummyCaller {
+    address internal _opcmAddr;
+
+    function migrate(IOPContractsManagerInteropMigrator.MigrateInput memory _migrateInput)
+        external
+        returns (bool, bytes memory)
+    {
+        bytes memory data = abi.encodeCall(DummyCaller.migrate, _migrateInput);
+        (bool success, bytes memory result) = _opcmAddr.delegatecall(data);
+        return (success, result);
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
+++ b/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { InteropMigrationInput, InteropMigration, InteropMigrationOutput } from "scripts/deploy/InteropMigration.s.sol";
+import { IOPContractsManagerInteropMigrator, IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { Claim } from "src/dispute/lib/Types.sol";
+
+contract InteropMigrationInput_Test is Test {
+    InteropMigrationInput input;
+
+    function setUp() public {
+        input = new InteropMigrationInput();
+    }
+
+    function test_getters_whenNotSet_reverts() public {
+        vm.expectRevert("InteropMigrationInput: prank not set");
+        input.prank();
+
+        vm.expectRevert("InteropMigrationInput: not set");
+        input.opcm();
+
+        vm.expectRevert("InteropMigrationInput: proposer not set");
+        input.proposer();
+
+        vm.expectRevert("InteropMigrationInput: challenger not set");
+        input.challenger();
+
+        vm.expectRevert("InteropMigrationInput: maxGameDepth not set");
+        input.maxGameDepth();
+
+        vm.expectRevert("InteropMigrationInput: splitDepth not set");
+        input.splitDepth();
+
+        vm.expectRevert("InteropMigrationInput: initBond not set");
+        input.initBond();
+
+        vm.expectRevert("InteropMigrationInput: clockExtension not set");
+        input.clockExtension();
+
+        vm.expectRevert("InteropMigrationInput: maxClockDuration not set");
+        input.maxClockDuration();
+
+        vm.expectRevert("InteropMigrationInput: startingAnchorL2SequenceNumber not set");
+        input.startingAnchorL2SequenceNumber();
+
+        vm.expectRevert("InteropMigrationInput: startingAnchorRoot not set");
+        input.startingAnchorRoot();
+
+        vm.expectRevert("InteropMigrationInput: not set");
+        input.opChainConfigs();
+    }
+
+    function test_setAddress_succeeds() public {
+        address mockPrank = makeAddr("prank");
+        address mockOPCM = makeAddr("opcm");
+
+        // Create mock contract at OPCM address
+        vm.etch(mockOPCM, hex"01");
+
+        input.set(input.prank.selector, mockPrank);
+        input.set(input.opcm.selector, mockOPCM);
+
+        assertEq(input.prank(), mockPrank);
+        assertEq(address(input.opcm()), mockOPCM);
+    }
+
+    function test_setOpChainConfigs_succeeds() public {
+        // Create sample OpChainConfig array
+        IOPContractsManager.OpChainConfig[] memory configs = new IOPContractsManager.OpChainConfig[](2);
+
+        // Setup mock addresses and contracts for first config
+        address systemConfig1 = makeAddr("systemConfig1");
+        address proxyAdmin1 = makeAddr("proxyAdmin1");
+        vm.etch(systemConfig1, hex"01");
+        vm.etch(proxyAdmin1, hex"01");
+
+        configs[0] = IOPContractsManager.OpChainConfig({
+            systemConfigProxy: ISystemConfig(systemConfig1),
+            proxyAdmin: IProxyAdmin(proxyAdmin1),
+            absolutePrestate: Claim.wrap(bytes32(uint256(1)))
+        });
+
+        // Setup mock addresses and contracts for second config
+        address systemConfig2 = makeAddr("systemConfig2");
+        address proxyAdmin2 = makeAddr("proxyAdmin2");
+        vm.etch(systemConfig2, hex"01");
+        vm.etch(proxyAdmin2, hex"01");
+
+        configs[1] = IOPContractsManager.OpChainConfig({
+            systemConfigProxy: ISystemConfig(systemConfig2),
+            proxyAdmin: IProxyAdmin(proxyAdmin2),
+            absolutePrestate: Claim.wrap(bytes32(uint256(2)))
+        });
+
+        input.set(input.opChainConfigs.selector, configs);
+
+        bytes memory storedConfigs = input.opChainConfigs();
+        assertEq(storedConfigs, abi.encode(configs));
+
+        // Additional verification of stored claims if needed
+        IOPContractsManager.OpChainConfig[] memory decodedConfigs =
+            abi.decode(storedConfigs, (IOPContractsManager.OpChainConfig[]));
+        assertEq(Claim.unwrap(decodedConfigs[0].absolutePrestate), bytes32(uint256(1)));
+        assertEq(Claim.unwrap(decodedConfigs[1].absolutePrestate), bytes32(uint256(2)));
+    }
+
+    function test_setAddress_withZeroAddress_reverts() public {
+        vm.expectRevert("InteropMigrationInput: cannot set zero address");
+        input.set(input.prank.selector, address(0));
+
+        vm.expectRevert("InteropMigrationInput: cannot set zero address");
+        input.set(input.opcm.selector, address(0));
+
+        vm.expectRevert("InteropMigrationInput: cannot set zero address");
+        input.set(input.proposer.selector, address(0));
+
+        vm.expectRevert("InteropMigrationInput: cannot set zero address");
+        input.set(input.challenger.selector, address(0));
+    }
+
+    function test_setOpChainConfigs_withEmptyArray_reverts() public {
+        IOPContractsManager.OpChainConfig[] memory emptyConfigs = new IOPContractsManager.OpChainConfig[](0);
+
+        vm.expectRevert("InteropMigrationInput: cannot set empty array");
+        input.set(input.opChainConfigs.selector, emptyConfigs);
+    }
+
+    function test_set_withInvalidSelector_reverts() public {
+        vm.expectRevert("InteropMigrationInput: unknown selector");
+        input.set(bytes4(0xdeadbeef), makeAddr("test"));
+
+        // Create a single config for testing invalid selector
+        IOPContractsManager.OpChainConfig[] memory configs = new IOPContractsManager.OpChainConfig[](1);
+        address mockSystemConfig = makeAddr("systemConfig");
+        address mockProxyAdmin = makeAddr("proxyAdmin");
+        vm.etch(mockSystemConfig, hex"01");
+        vm.etch(mockProxyAdmin, hex"01");
+
+        configs[0] = IOPContractsManager.OpChainConfig({
+            systemConfigProxy: ISystemConfig(mockSystemConfig),
+            proxyAdmin: IProxyAdmin(mockProxyAdmin),
+            absolutePrestate: Claim.wrap(bytes32(uint256(1)))
+        });
+
+        vm.expectRevert("InteropMigrationInput: unknown selector");
+        input.set(bytes4(0xdeadbeef), configs);
+    }
+}
+
+contract MockOPCM {
+    event MigrateCalled(address indexed sysCfgProxy, address indexed proxyAdmin, bytes32 indexed absolutePrestate);
+
+    function migrate(IOPContractsManagerInteropMigrator.MigrateInput memory _input) public {
+        emit MigrateCalled(
+            address(_input.opChainConfigs[0].systemConfigProxy),
+            address(_input.opChainConfigs[0].proxyAdmin),
+            Claim.unwrap(_input.opChainConfigs[0].absolutePrestate)
+        );
+    }
+}
+
+contract InteropMigration_Test is Test {
+    MockOPCM mockOPCM;
+    InteropMigrationInput input;
+    IOPContractsManager.OpChainConfig config;
+    InteropMigration migration;
+    address prank;
+
+    event MigrateCalled(address indexed sysCfgProxy, address indexed proxyAdmin, bytes32 indexed absolutePrestate);
+
+    function setUp() public {
+        mockOPCM = new MockOPCM();
+        input = new InteropMigrationInput();
+        input.set(input.opcm.selector, address(mockOPCM));
+        config = IOPContractsManager.OpChainConfig({
+            systemConfigProxy: ISystemConfig(makeAddr("systemConfigProxy")),
+            proxyAdmin: IProxyAdmin(makeAddr("proxyAdmin")),
+            absolutePrestate: Claim.wrap(keccak256("absolutePrestate"))
+        });
+        IOPContractsManager.OpChainConfig[] memory configs = new IOPContractsManager.OpChainConfig[](1);
+        configs[0] = config;
+        input.set(input.opChainConfigs.selector, configs);
+        prank = makeAddr("prank");
+        input.set(input.prank.selector, prank);
+
+        input.set(input.usePermissionlessGame.selector, true);
+        input.set(input.startingAnchorL2SequenceNumber.selector, 1);
+        input.set(input.startingAnchorRoot.selector, bytes32(uint256(1)));
+        input.set(input.proposer.selector, makeAddr("proposer"));
+        input.set(input.challenger.selector, makeAddr("challenger"));
+        input.set(input.maxGameDepth.selector, 100);
+        input.set(input.splitDepth.selector, 10);
+        input.set(input.initBond.selector, 1000);
+        input.set(input.clockExtension.selector, 100);
+        input.set(input.maxClockDuration.selector, 1000);
+
+        migration = new InteropMigration();
+    }
+
+    function test_migrate_succeeds() public {
+        // MigrateCalled should be emitted by the prank since it's a delegatecall.
+        vm.expectEmit(address(prank));
+        emit MigrateCalled(
+            address(config.systemConfigProxy), address(config.proxyAdmin), Claim.unwrap(config.absolutePrestate)
+        );
+
+        // mocks for post-migration checks
+        address portal = makeAddr("optimismPortal");
+        address dgf = makeAddr("disputeGameFactory");
+        IOPContractsManager.OpChainConfig[] memory opChainConfigs =
+            abi.decode(input.opChainConfigs(), (IOPContractsManager.OpChainConfig[]));
+        vm.mockCall(
+            address(opChainConfigs[0].systemConfigProxy),
+            abi.encodeCall(ISystemConfig.optimismPortal, ()),
+            abi.encode(portal)
+        );
+        vm.etch(dgf, hex"01");
+        vm.mockCall(portal, abi.encodeCall(IOptimismPortal.disputeGameFactory, ()), abi.encode(dgf));
+
+        InteropMigrationOutput output = new InteropMigrationOutput();
+        migration.run(input, output);
+    }
+}


### PR DESCRIPTION
Wires up an interop-compatible devnet using OPCM. The result is an interop supersystem that can be used to create super dispute games.