### PR TITLE
docs: migrate build instructions from make to just in op-dispute-mon README

### DIFF
--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -1,4 +1,4 @@
-"# op-dispute-mon
+# op-dispute-mon
 
 The `op-dispute-mon` is an off-chain service to monitor dispute games.
 
@@ -27,4 +27,3 @@ shows the available config options and can be accessed by running `./bin/op-disp
   --rollup-rpc <Optimism-Rollup-RPC-URL>
 
 ```
-"

--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -1,4 +1,4 @@
-# op-dispute-mon
+"# op-dispute-mon
 
 The `op-dispute-mon` is an off-chain service to monitor dispute games.
 
@@ -7,7 +7,7 @@ The `op-dispute-mon` is an off-chain service to monitor dispute games.
 Clone this repo. Then run:
 
 ```shell
-make op-dispute-mon
+just op-dispute-mon
 ```
 
 This will build the `op-dispute-mon` binary which can be run with
@@ -27,3 +27,4 @@ shows the available config options and can be accessed by running `./bin/op-disp
   --rollup-rpc <Optimism-Rollup-RPC-URL>
 
 ```
+"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR updates the build instructions in the op-dispute-mon README.md file to use `just` instead of `make`. The project has been migrating from Makefile-based builds to just-based builds, and this documentation change ensures that users are directed to use the preferred build method.

The following components have been updated:
- op-dispute-mon

**Tests**

No tests were added as this is a documentation-only change.

**Additional context**

The project has been migrating from Makefile to justfile for build instructions. The Makefiles now include DEPRECATED_TARGETS and import the justfiles/deprecated.mk file, which shows a deprecation warning when make is used and redirects to the just command.

This PR follows the pattern of similar documentation updates like PR #14627.

**Metadata**

<!-- No specific issues are being fixed by this PR -->