### PR TITLE
check-prestates: Load and compare the chain configs with the latest versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.2.0.20250324042408-5a259f9eece0
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.3.0.20250327000707-c3a989eb882d
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.5
 	golang.org/x/crypto v0.32.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
+	golang.org/x/mod v0.22.0
 	golang.org/x/sync v0.10.0
 	golang.org/x/term v0.28.0
 	golang.org/x/time v0.10.0
@@ -259,7 +260,6 @@ require (
 	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
@@ -275,7 +275,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.2
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.2.0.20250324042408-5a259f9eece0
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101503.2-rc.2 h1:SihKdvBN4G0yW6pKb96CzXchq0NiHgetAoPqkZ8tYQA=
-github.com/ethereum-optimism/op-geth v1.101503.2-rc.2/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
+github.com/ethereum-optimism/op-geth v1.101503.2-rc.2.0.20250324042408-5a259f9eece0 h1:ksHK+2w95aWBFD8Q64kcLYeaQVMDoLOkO2XGNZTfoHs=
+github.com/ethereum-optimism/op-geth v1.101503.2-rc.2.0.20250324042408-5a259f9eece0/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101503.2-rc.2.0.20250324042408-5a259f9eece0 h1:ksHK+2w95aWBFD8Q64kcLYeaQVMDoLOkO2XGNZTfoHs=
-github.com/ethereum-optimism/op-geth v1.101503.2-rc.2.0.20250324042408-5a259f9eece0/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
+github.com/ethereum-optimism/op-geth v1.101503.2-rc.3.0.20250327000707-c3a989eb882d h1:IJ3e42kR96bCBWZHH3zXmPzGcgQdCsOZgX1CwKITU/8=
+github.com/ethereum-optimism/op-geth v1.101503.2-rc.3.0.20250327000707-c3a989eb882d/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/op-chain-ops/README.md
+++ b/op-chain-ops/README.md
@@ -34,7 +34,7 @@ cmd/
 ├── check-derivation              - Check that transactions can be confirmed and safety can be consolidated
 ├── check-ecotone                 - Checks for Ecotone network upgrade
 ├── check-fjord                   - Checks for Fjord network upgrade
-├── check-prestate                - Checks a fault proof absolute prestate's chain compatibility
+├── check-prestate                - Checks a fault proof absolute prestate's chain compatibility. e.g: go run cmd/check-prestate --prestate-hash <HASH>
 ├── deposit-hash                  - Determine the L2 deposit tx hash, based on log event(s) emitted by a L1 tx.
 ├── ecotone-scalar                - Translate between serialized and human-readable L1 fee scalars (introduced in Ecotone upgrade).
 ├── op-simulate                   - Simulate a remote transaction in a local Geth EVM for block-processing debugging.

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -1,18 +1,25 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-program/prestates"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/mattn/go-isatty"
+	"golang.org/x/exp/maps"
 	"golang.org/x/mod/modfile"
 )
 
@@ -24,6 +31,15 @@ type PrestateInfo struct {
 	OpProgram          CommitInfo `json:"op-program"`
 	OpGeth             CommitInfo `json:"op-geth"`
 	SuperchainRegistry CommitInfo `json:"superchain-registry"`
+
+	UpToDateChains []string        `json:"up-to-date-chains"`
+	OutdatedChains []OutdatedChain `json:"outdated-chains"`
+	MissingChains  []string        `json:"missing-chains"`
+}
+
+type OutdatedChain struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type CommitInfo struct {
@@ -98,8 +114,49 @@ func main() {
 	if err != nil {
 		log.Crit("Failed to fetch superchain registry commit info", "err", err)
 	}
-	commit := string(registryCommitBytes)
+	commit := strings.TrimSpace(string(registryCommitBytes))
 	log.Info("Found superchain registry commit info", "commit", commit)
+
+	prestateConfigData, err := fetch(fmt.Sprintf("https://github.com/ethereum-optimism/op-geth/raw/refs/tags/%s/superchain/superchain-configs.zip", gethVersion))
+	if err != nil {
+		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
+	}
+	prestateConfigs, err := superchain.NewChainConfigReader(prestateConfigData)
+	if err != nil {
+		log.Crit("Failed to parse prestate's superchain registry config zip", "err", err)
+	}
+	prestateNames := prestateConfigs.ChainNames()
+
+	latestConfigs, err := latestSuperchainConfigs()
+	if err != nil {
+		log.Crit("Failed to get latest superchain configs", "err", err)
+	}
+
+	knownChains := make(map[string]bool)
+	var supportedChains []string
+	outdatedChains := make(map[string]OutdatedChain)
+	for _, name := range prestateNames {
+		knownChains[name] = true
+		msg, err := checkConfig(name, prestateConfigs, latestConfigs)
+		if err != nil {
+			log.Crit("Failed to check config", "chain", name, "err", err)
+		}
+		if msg != "" {
+			outdatedChains[name] = OutdatedChain{
+				Name:   name,
+				Reason: msg,
+			}
+		} else {
+			supportedChains = append(supportedChains, name)
+		}
+	}
+
+	var missingChains []string
+	for _, chainName := range latestConfigs.ChainNames() {
+		if !knownChains[chainName] {
+			missingChains = append(missingChains, chainName)
+		}
+	}
 
 	report := PrestateInfo{
 		Hash:               prestateHash,
@@ -108,6 +165,9 @@ func main() {
 		OpProgram:          commitInfo("optimism", prestateTag, "develop", ""),
 		OpGeth:             commitInfo("op-geth", gethVersion, "optimism", ""),
 		SuperchainRegistry: commitInfo("superchain-registry", commit, "main", "superchain"),
+		UpToDateChains:     supportedChains,
+		OutdatedChains:     maps.Values(outdatedChains),
+		MissingChains:      missingChains,
 	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
@@ -115,6 +175,107 @@ func main() {
 	if err := encoder.Encode(report); err != nil {
 		log.Crit("Failed to encode report", "err", err)
 	}
+}
+
+func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (string, error) {
+	actualChainID, err := actual.ChainIDByName(network)
+	if err != nil {
+		return "", fmt.Errorf("failed to get actual chain ID for %v: %w", network, err)
+	}
+	expectedChainID, err := expected.ChainIDByName(network)
+	if err != nil {
+		return "", fmt.Errorf("failed to get expected chain ID for %v: %w", network, err)
+	}
+	if actualChainID != expectedChainID {
+		return fmt.Sprintf("Chain ID mismatch, prestate=%v, latest=%v", actualChainID, expectedChainID), nil
+	}
+	actualChain, err := actual.GetChain(actualChainID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get actual chain for %v: %w", network, err)
+	}
+	expectedChain, err := expected.GetChain(expectedChainID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get expected chain for %v: %w", network, err)
+	}
+	actualConfig, err := actualChain.Config()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config for actual chain %v: %w", network, err)
+	}
+	expectedConfig, err := expectedChain.Config()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config for expected chain %v: %w", network, err)
+	}
+	configMsg, err := checkChainConfig(actualConfig, expectedConfig)
+	if err != nil {
+		return "", err
+	}
+	if configMsg != "" {
+		return configMsg, nil
+	}
+	actualGenesis, err := actualChain.GenesisData()
+	if err != nil {
+		return "", fmt.Errorf("failed to get genesis for actual chain %v: %w", network, err)
+	}
+	expectedGenesis, err := expectedChain.GenesisData()
+	if err != nil {
+		return "", fmt.Errorf("failed to get genesis for expected chain %v: %w", network, err)
+	}
+	if !bytes.Equal(actualGenesis, expectedGenesis) {
+		return "Genesis mismatch", nil
+	}
+	return "", nil
+}
+
+func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.ChainConfig) (string, error) {
+	actualStr, err := toml.Marshal(actual)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal actual chain config: %w", err)
+	}
+	expectedStr, err := toml.Marshal(expected)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal expected chain config: %w", err)
+	}
+	if !bytes.Equal(actualStr, expectedStr) {
+		return "Chain config mismatch", nil
+	}
+	return "", nil
+}
+
+// latestSuperchainConfigs loads the latest config from the superchain-registry main branch using the
+// sync-superchain.sh script from op-geth to create a zip of configs that can be read by op-geth's ChainConfigLoader.
+func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
+	// Download the op-geth script to build the superchain config
+	script, err := fetch("https://github.com/ethereum-optimism/op-geth/raw/refs/heads/optimism/sync-superchain.sh")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch sync-superchain.sh script: %w", err)
+	}
+	dir, err := os.MkdirTemp("", "checkprestate")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+	if err := os.Mkdir(filepath.Join(dir, "superchain"), 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create superchain dir: %w", err)
+	}
+	scriptPath := filepath.Join(dir, "sync-superchain.sh")
+	if err := os.WriteFile(scriptPath, script, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to write sync-superchain.sh: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "superchain-registry-commit.txt"), []byte("main"), 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write superchain-registry-commit.txt: %w", err)
+	}
+	cmd := exec.Command(scriptPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to build superchain config zip: %w", err)
+	}
+	configBytes, err := os.ReadFile(filepath.Join(dir, "superchain/superchain-configs.zip"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read generated superchain-configs.zip: %w", err)
+	}
+	return superchain.NewChainConfigReader(configBytes)
 }
 
 func commitInfo(repository string, commit string, mainBranch string, dir string) CommitInfo {

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -265,7 +265,7 @@ func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
 		return nil, fmt.Errorf("failed to write superchain-registry-commit.txt: %w", err)
 	}
 	cmd := exec.Command(scriptPath)
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -70,15 +70,31 @@ func main() {
 	// Define the flag variables
 	var (
 		prestateHashStr string
+		chainsStr       string
 	)
 
 	// Define and parse the command-line flags
 	flag.StringVar(&prestateHashStr, "prestate-hash", "", "Specify the absolute prestate hash to verify")
+	flag.StringVar(&chainsStr, "chains", "", "List of chains to consider in the report. Comma separated. Default: all chains in the superchain-registry")
 
 	// Parse the command-line arguments
 	flag.Parse()
 	if prestateHashStr == "" {
 		log.Crit("--prestate-hash is required")
+	}
+	chainFilter := func(chainName string) bool {
+		return true
+	}
+	var filteredChainNames []string
+	if chainsStr != "" {
+		chains := make(map[string]bool)
+		for _, chain := range strings.Split(chainsStr, ",") {
+			chains[strings.TrimSpace(chain)] = true
+		}
+		chainFilter = func(chainName string) bool {
+			return chains[chainName]
+		}
+		filteredChainNames = maps.Keys(chains)
 	}
 	prestateHash := common.HexToHash(prestateHashStr)
 	if prestateHash == (common.Hash{}) {
@@ -149,6 +165,9 @@ func main() {
 	var supportedChains []string
 	outdatedChains := make(map[string]OutdatedChain)
 	for _, name := range prestateNames {
+		if !chainFilter(name) {
+			continue
+		}
 		knownChains[name] = true
 		diff, err := checkConfig(name, prestateConfigs, latestConfigs)
 		if err != nil {
@@ -164,8 +183,15 @@ func main() {
 		}
 	}
 
-	var missingChains []string
-	for _, chainName := range latestConfigs.ChainNames() {
+	missingChains := make([]string, 0) // Not null for json serialization
+	expectedChainNames := filteredChainNames
+	if len(expectedChainNames) == 0 {
+		expectedChainNames = latestConfigs.ChainNames()
+	}
+	for _, chainName := range expectedChainNames {
+		if !chainFilter(chainName) {
+			continue
+		}
 		if !knownChains[chainName] {
 			missingChains = append(missingChains, chainName)
 		}

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -45,14 +45,20 @@ type PrestateInfo struct {
 }
 
 type OutdatedChain struct {
-	Name   string `json:"name"`
-	Reason string `json:"reason,omitempty"`
+	Name string `json:"name"`
+	Diff *Diff  `json:"diff,omitempty"`
 }
 
 type CommitInfo struct {
 	Commit  string `json:"commit"`
 	DiffUrl string `json:"diff-url"`
 	DiffCmd string `json:"diff-cmd"`
+}
+
+type Diff struct {
+	Msg      string `json:"message"`
+	Prestate any    `json:"prestate"`
+	Latest   any    `json:"latest"`
 }
 
 func main() {
@@ -128,7 +134,7 @@ func main() {
 	if err != nil {
 		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
 	}
-	prestateConfigs, err := superchain.NewChainConfigReader(prestateConfigData)
+	prestateConfigs, err := superchain.NewChainConfigLoader(prestateConfigData)
 	if err != nil {
 		log.Crit("Failed to parse prestate's superchain registry config zip", "err", err)
 	}
@@ -144,14 +150,14 @@ func main() {
 	outdatedChains := make(map[string]OutdatedChain)
 	for _, name := range prestateNames {
 		knownChains[name] = true
-		msg, err := checkConfig(name, prestateConfigs, latestConfigs)
+		diff, err := checkConfig(name, prestateConfigs, latestConfigs)
 		if err != nil {
 			log.Crit("Failed to check config", "chain", name, "err", err)
 		}
-		if msg != "" {
+		if diff != nil {
 			outdatedChains[name] = OutdatedChain{
-				Name:   name,
-				Reason: msg,
+				Name: name,
+				Diff: diff,
 			}
 		} else {
 			supportedChains = append(supportedChains, name)
@@ -184,68 +190,80 @@ func main() {
 	}
 }
 
-func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (string, error) {
+func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (*Diff, error) {
 	actualChainID, err := actual.ChainIDByName(network)
 	if err != nil {
-		return "", fmt.Errorf("failed to get actual chain ID for %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get actual chain ID for %v: %w", network, err)
 	}
 	expectedChainID, err := expected.ChainIDByName(network)
 	if err != nil {
-		return "", fmt.Errorf("failed to get expected chain ID for %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get expected chain ID for %v: %w", network, err)
 	}
 	if actualChainID != expectedChainID {
-		return fmt.Sprintf("Chain ID mismatch, prestate=%v, latest=%v", actualChainID, expectedChainID), nil
+		return &Diff{
+			Msg:      "Chain ID mismatch",
+			Prestate: actualChainID,
+			Latest:   expectedChainID,
+		}, nil
 	}
 	actualChain, err := actual.GetChain(actualChainID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get actual chain for %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get actual chain for %v: %w", network, err)
 	}
 	expectedChain, err := expected.GetChain(expectedChainID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get expected chain for %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get expected chain for %v: %w", network, err)
 	}
 	actualConfig, err := actualChain.Config()
 	if err != nil {
-		return "", fmt.Errorf("failed to get config for actual chain %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get config for actual chain %v: %w", network, err)
 	}
 	expectedConfig, err := expectedChain.Config()
 	if err != nil {
-		return "", fmt.Errorf("failed to get config for expected chain %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get config for expected chain %v: %w", network, err)
 	}
-	configMsg, err := checkChainConfig(actualConfig, expectedConfig)
+	configDiff, err := checkChainConfig(actualConfig, expectedConfig)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if configMsg != "" {
-		return configMsg, nil
+	if configDiff != nil {
+		return configDiff, nil
 	}
 	actualGenesis, err := actualChain.GenesisData()
 	if err != nil {
-		return "", fmt.Errorf("failed to get genesis for actual chain %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get genesis for actual chain %v: %w", network, err)
 	}
 	expectedGenesis, err := expectedChain.GenesisData()
 	if err != nil {
-		return "", fmt.Errorf("failed to get genesis for expected chain %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get genesis for expected chain %v: %w", network, err)
 	}
 	if !bytes.Equal(actualGenesis, expectedGenesis) {
-		return "Genesis mismatch", nil
+		return &Diff{
+			Msg:      "Genesis mismatch",
+			Prestate: string(actualGenesis),
+			Latest:   string(expectedGenesis),
+		}, nil
 	}
-	return "", nil
+	return nil, nil
 }
 
-func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.ChainConfig) (string, error) {
+func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.ChainConfig) (*Diff, error) {
 	actualStr, err := toml.Marshal(actual)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal actual chain config: %w", err)
+		return nil, fmt.Errorf("failed to marshal actual chain config: %w", err)
 	}
 	expectedStr, err := toml.Marshal(expected)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal expected chain config: %w", err)
+		return nil, fmt.Errorf("failed to marshal expected chain config: %w", err)
 	}
 	if !bytes.Equal(actualStr, expectedStr) {
-		return "Chain config mismatch", nil
+		return &Diff{
+			Msg:      "Chain config mismatch",
+			Prestate: actual,
+			Latest:   expected,
+		}, nil
 	}
-	return "", nil
+	return nil, nil
 }
 
 // latestSuperchainConfigs loads the latest config from the superchain-registry main branch using the
@@ -282,7 +300,7 @@ func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read generated superchain-configs.zip: %w", err)
 	}
-	return superchain.NewChainConfigReader(configBytes)
+	return superchain.NewChainConfigLoader(configBytes)
 }
 
 func commitInfo(repository string, commit string, mainBranch string, dir string) CommitInfo {

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -23,6 +23,13 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+const (
+	monorepoGoModAtTag            = "https://github.com/ethereum-optimism/optimism/raw/refs/tags/%s/go.mod"
+	superchainRegistryCommitAtRef = "https://github.com/ethereum-optimism/op-geth/raw/%s/superchain-registry-commit.txt"
+	superchainConfigsZipAtTag     = "https://github.com/ethereum-optimism/op-geth/raw/refs/tags/%s/superchain/superchain-configs.zip"
+	syncSuperchainScript          = "https://github.com/ethereum-optimism/op-geth/raw/refs/heads/optimism/sync-superchain.sh"
+)
+
 type PrestateInfo struct {
 	Hash    common.Hash `json:"hash"`
 	Version string      `json:"version"`
@@ -110,14 +117,14 @@ func main() {
 	}
 	log.Info("Found op-geth version", "version", gethVersion)
 
-	registryCommitBytes, err := fetch(fmt.Sprintf("https://github.com/ethereum-optimism/op-geth/raw/%s/superchain-registry-commit.txt", gethVersion))
+	registryCommitBytes, err := fetch(fmt.Sprintf(superchainRegistryCommitAtRef, gethVersion))
 	if err != nil {
 		log.Crit("Failed to fetch superchain registry commit info", "err", err)
 	}
 	commit := strings.TrimSpace(string(registryCommitBytes))
 	log.Info("Found superchain registry commit info", "commit", commit)
 
-	prestateConfigData, err := fetch(fmt.Sprintf("https://github.com/ethereum-optimism/op-geth/raw/refs/tags/%s/superchain/superchain-configs.zip", gethVersion))
+	prestateConfigData, err := fetch(fmt.Sprintf(superchainConfigsZipAtTag, gethVersion))
 	if err != nil {
 		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
 	}
@@ -245,7 +252,7 @@ func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.Chain
 // sync-superchain.sh script from op-geth to create a zip of configs that can be read by op-geth's ChainConfigLoader.
 func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
 	// Download the op-geth script to build the superchain config
-	script, err := fetch("https://github.com/ethereum-optimism/op-geth/raw/refs/heads/optimism/sync-superchain.sh")
+	script, err := fetch(syncSuperchainScript)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch sync-superchain.sh script: %w", err)
 	}
@@ -287,7 +294,7 @@ func commitInfo(repository string, commit string, mainBranch string, dir string)
 }
 
 func fetchMonorepoGoMod(opProgramTag string) (*modfile.File, error) {
-	goModUrl := fmt.Sprintf("https://github.com/ethereum-optimism/optimism/raw/refs/tags/%s/go.mod", opProgramTag)
+	goModUrl := fmt.Sprintf(monorepoGoModAtTag, opProgramTag)
 	goMod, err := fetch(goModUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch go.mod: %w", err)

--- a/op-program/prestates/fetcher.go
+++ b/op-program/prestates/fetcher.go
@@ -10,8 +10,7 @@ import (
 )
 
 // standardPrestatesUrl is the URL to the TOML file in superchain registry that defines the list of standard prestates
-// Note that this explicitly points to the main branch and is not pinned to a specific version. The verification check
-// intends to
+// Note that this explicitly points to the main branch and is not pinned to a specific version.
 const standardPrestatesUrl = "https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-prestates.toml"
 
 func LoadReleases(overrideFile string) (*Prestates, error) {


### PR DESCRIPTION
**Description**

Loads the configs included in the prestate from the superchain-registry and compares them with the latest version of configs from the superchain registry.  Final report includes the list of up to date chains, list of outdated chains and list of missing chains (that have been added to the superchain-registry but aren't in the prestate).

Example:
```
go run ./check-prestate/ --prestate-hash 0x03f83792f653160f3274b0888e998077a27e1f74cb35bcb20d86021e769340aa
```

```json
{
  "hash": "0x03f83792f653160f3274b0888e998077a27e1f74cb35bcb20d86021e769340aa",
  "version": "1.5.0-rc.1",
  "type": "cannon64",
  "op-program": {
    "commit": "op-program/v1.5.0-rc.1",
    "diff-url": "https://github.com/ethereum-optimism/optimism/compare/op-program/v1.5.0-rc.1...develop",
    "diff-cmd": "git fetch && git diff op-program/v1.5.0-rc.1...origin/develop "
  },
  "op-geth": {
    "commit": "v1.101500.0-rc.1",
    "diff-url": "https://github.com/ethereum-optimism/op-geth/compare/v1.101500.0-rc.1...optimism",
    "diff-cmd": "git fetch && git diff v1.101500.0-rc.1...origin/optimism "
  },
  "superchain-registry": {
    "commit": "644fd6b0a440760c02b64ce9d9610f2ac31e66a5",
    "diff-url": "https://github.com/ethereum-optimism/superchain-registry/compare/644fd6b0a440760c02b64ce9d9610f2ac31e66a5...main",
    "diff-cmd": "git fetch && git diff 644fd6b0a440760c02b64ce9d9610f2ac31e66a5...origin/main superchain"
  },
  "up-to-date-chains": [
    "arena-z-testnet-sepolia",
    "automata-mainnet",
    "base-mainnet",
    "bob-mainnet",
    "cyber-mainnet",
    "cyber-sepolia",
    "ethernity-mainnet",
    "funki-mainnet",
    "funki-sepolia",
    "hashkeychain-mainnet",
    "lisk-mainnet",
    "lisk-sepolia",
    "lyra-mainnet",
    "metal-mainnet",
    "mint-mainnet",
    "mode-mainnet",
    "op-mainnet",
    "orderly-mainnet",
    "pivotal-sepolia",
    "polynomial-mainnet",
    "race-mainnet",
    "race-sepolia",
    "redstone-mainnet",
    "shape-mainnet",
    "shape-sepolia",
    "soneium-mainnet",
    "sseed-mainnet",
    "swan-mainnet",
    "swell-mainnet",
    "tbn-mainnet",
    "tbn-sepolia",
    "worldchain-mainnet",
    "worldchain-sepolia",
    "xterio-eth-mainnet",
    "zora-mainnet"
  ],
  "outdated-chains": [
    {
      "name": "ink-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "op-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "soneium-minato-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "unichain-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "creator-chain-testnet-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "ethernity-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "mode-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "metal-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "oplabs-devnet-0-sepolia-dev-0",
      "reason": "Chain config mismatch"
    },
    {
      "name": "zora-sepolia",
      "reason": "Chain config mismatch"
    },
    {
      "name": "ink-mainnet",
      "reason": "Chain config mismatch"
    },
    {
      "name": "arena-z-mainnet",
      "reason": "Chain config mismatch"
    },
    {
      "name": "base-devnet-0-sepolia-dev-0",
      "reason": "Chain config mismatch"
    },
    {
      "name": "base-sepolia",
      "reason": "Chain config mismatch"
    }
  ],
  "missing-chains": [
    "settlus-sepolia-sepolia",
    "snax-mainnet",
    "unichain-mainnet"
  ]
}
```

**Additional context**

Builds on #14997 
Uses https://github.com/ethereum-optimism/op-geth/pull/556 which is merged so it pulls in the latest op-geth optimism branch.

**Metadata**

Closes #14980 