### PR TITLE
refactor: use the built-in min to simplify the code

### DIFF
--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -247,8 +247,5 @@ func padGasLimit(data []byte, gasUsed uint64, creation bool, blockGasLimit uint6
 	}
 
 	limit := uint64(float64(gas) * GasPadFactor)
-	if limit > blockGasLimit {
-		return blockGasLimit
-	}
-	return limit
+	return min(limit, blockGasLimit)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

In Go 1.21, the standard library includes built-in [min](https://pkg.go.dev/builtin@go1.21.0#min) function, which can greatly simplify the code.



<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
