### PR TITLE
Provide withdrawalDelaySeconds as input to SV

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/validator.go
+++ b/op-deployer/pkg/deployer/bootstrap/validator.go
@@ -56,6 +56,7 @@ type ValidatorInput struct {
 	AnchorStateRegistryImpl          common.Address `json:"anchorStateRegistryImpl"`
 	DelayedWETHImpl                  common.Address `json:"delayedWETHImpl"`
 	MIPSImpl                         common.Address `json:"mipsImpl" evm:"mipsImpl"`
+	WithdrawalDelaySeconds           uint64         `json:"withdrawalDelaySeconds"`
 }
 
 type ValidatorOutput struct {

--- a/op-deployer/pkg/deployer/bootstrap/validator_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/validator_test.go
@@ -71,6 +71,7 @@ func testValidator(t *testing.T, forkRPCURL string, loc *artifacts.Locator, rele
 		AnchorStateRegistryImpl:          common.Address{'A'},
 		DelayedWETHImpl:                  common.Address{'B'},
 		MIPSImpl:                         common.Address{'D'},
+		WithdrawalDelaySeconds:           302400,
 	}
 
 	out, err := Validator(ctx, ValidatorConfig{

--- a/packages/contracts-bedrock/interfaces/L1/IStandardValidator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IStandardValidator.sol
@@ -49,6 +49,7 @@ interface IStandardValidatorBase {
     function superchainConfigVersion() external pure returns (string memory);
     function systemConfigImpl() external view returns (address);
     function systemConfigVersion() external pure returns (string memory);
+    function withdrawalDelaySeconds() external view returns (uint256);
 }
 
 interface IStandardValidatorV180 is IStandardValidatorBase {
@@ -66,7 +67,8 @@ interface IStandardValidatorV180 is IStandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     ) external;
 }
 
@@ -85,7 +87,8 @@ interface IStandardValidatorV200 is IStandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     ) external;
 }
 
@@ -104,6 +107,7 @@ interface IStandardValidatorV300 is IStandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     ) external;
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployStandardValidator.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployStandardValidator.s.sol
@@ -27,6 +27,7 @@ contract DeployStandardValidatorInput is BaseDeployIO {
     address internal _l1PAOMultisig;
     address internal _mips;
     address internal _challenger;
+    uint256 internal _withdrawalDelaySeconds;
 
     // Implementation addresses
     address internal _superchainConfigImpl;
@@ -99,6 +100,15 @@ contract DeployStandardValidatorInput is BaseDeployIO {
     function set(bytes4 _sel, string memory _value) public {
         if (_sel == this.release.selector) {
             _release = _value;
+        } else {
+            revert("DeployStandardValidator: unknown selector");
+        }
+    }
+
+    function set(bytes4 _sel, uint256 _value) public {
+        if (_sel == this.withdrawalDelaySeconds.selector) {
+            require(_value > 0, "DeployStandardValidator: withdrawalDelaySeconds must be greater than 0");
+            _withdrawalDelaySeconds = _value;
         } else {
             revert("DeployStandardValidator: unknown selector");
         }
@@ -193,6 +203,11 @@ contract DeployStandardValidatorInput is BaseDeployIO {
         require(_mipsImpl != address(0), "DeployStandardValidator: mipsImpl not set");
         return _mipsImpl;
     }
+
+    function withdrawalDelaySeconds() public view returns (uint256) {
+        require(_withdrawalDelaySeconds > 0, "DeployStandardValidator: withdrawalDelaySeconds not set");
+        return _withdrawalDelaySeconds;
+    }
 }
 
 /// @title DeployStandardValidatorOutput
@@ -261,7 +276,14 @@ contract DeployStandardValidator is Script {
             _args: DeployUtils.encodeConstructor(
                 abi.encodeCall(
                     IStandardValidatorV180.__constructor__,
-                    (getImplementations(_si), _si.superchainConfig(), _si.l1PAOMultisig(), _si.mips(), _si.challenger())
+                    (
+                        getImplementations(_si),
+                        _si.superchainConfig(),
+                        _si.l1PAOMultisig(),
+                        _si.mips(),
+                        _si.challenger(),
+                        _si.withdrawalDelaySeconds()
+                    )
                 )
             ),
             _salt: DeployUtils.DEFAULT_SALT
@@ -277,7 +299,14 @@ contract DeployStandardValidator is Script {
             _args: DeployUtils.encodeConstructor(
                 abi.encodeCall(
                     IStandardValidatorV200.__constructor__,
-                    (getImplementations(_si), _si.superchainConfig(), _si.l1PAOMultisig(), _si.mips(), _si.challenger())
+                    (
+                        getImplementations(_si),
+                        _si.superchainConfig(),
+                        _si.l1PAOMultisig(),
+                        _si.mips(),
+                        _si.challenger(),
+                        _si.withdrawalDelaySeconds()
+                    )
                 )
             ),
             _salt: DeployUtils.DEFAULT_SALT
@@ -293,7 +322,14 @@ contract DeployStandardValidator is Script {
             _args: DeployUtils.encodeConstructor(
                 abi.encodeCall(
                     IStandardValidatorV300.__constructor__,
-                    (getImplementations(_si), _si.superchainConfig(), _si.l1PAOMultisig(), _si.mips(), _si.challenger())
+                    (
+                        getImplementations(_si),
+                        _si.superchainConfig(),
+                        _si.l1PAOMultisig(),
+                        _si.mips(),
+                        _si.challenger(),
+                        _si.withdrawalDelaySeconds()
+                    )
                 )
             ),
             _salt: DeployUtils.DEFAULT_SALT
@@ -324,6 +360,7 @@ contract DeployStandardValidator is Script {
         require(v180.l1PAOMultisig() == _si.l1PAOMultisig(), "SV180-20");
         require(v180.mips() == _si.mips(), "SV180-30");
         require(v180.challenger() == _si.challenger(), "SV180-40");
+        require(v180.withdrawalDelaySeconds() == _si.withdrawalDelaySeconds(), "SV180-50");
     }
 
     function assertValidValidatorV200(DeployStandardValidatorInput _si, address _validator) internal view {
@@ -332,5 +369,6 @@ contract DeployStandardValidator is Script {
         require(v200.l1PAOMultisig() == _si.l1PAOMultisig(), "SV200-20");
         require(v200.mips() == _si.mips(), "SV200-30");
         require(v200.challenger() == _si.challenger(), "SV200-40");
+        require(v200.withdrawalDelaySeconds() == _si.withdrawalDelaySeconds(), "SV200-50");
     }
 }

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorBase.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorBase.json
@@ -77,6 +77,11 @@
         "internalType": "address",
         "name": "_challenger",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_withdrawalDelaySeconds",
+        "type": "uint256"
       }
     ],
     "stateMutability": "nonpayable",
@@ -418,6 +423,19 @@
       }
     ],
     "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalDelaySeconds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorV180.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorV180.json
@@ -77,6 +77,11 @@
         "internalType": "address",
         "name": "_challenger",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_withdrawalDelaySeconds",
+        "type": "uint256"
       }
     ],
     "stateMutability": "nonpayable",
@@ -461,6 +466,19 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalDelaySeconds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorV200.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorV200.json
@@ -77,6 +77,11 @@
         "internalType": "address",
         "name": "_challenger",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_withdrawalDelaySeconds",
+        "type": "uint256"
       }
     ],
     "stateMutability": "nonpayable",
@@ -461,6 +466,19 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalDelaySeconds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorV300.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorV300.json
@@ -77,6 +77,11 @@
         "internalType": "address",
         "name": "_challenger",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_withdrawalDelaySeconds",
+        "type": "uint256"
       }
     ],
     "stateMutability": "nonpayable",
@@ -461,6 +466,19 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalDelaySeconds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorBase.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorBase.json
@@ -28,73 +28,80 @@
     "type": "address"
   },
   {
-    "bytes": "20",
-    "label": "l1ERC721BridgeImpl",
+    "bytes": "32",
+    "label": "withdrawalDelaySeconds",
     "offset": 0,
     "slot": "4",
-    "type": "address"
+    "type": "uint256"
   },
   {
     "bytes": "20",
-    "label": "optimismPortalImpl",
+    "label": "l1ERC721BridgeImpl",
     "offset": 0,
     "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "systemConfigImpl",
+    "label": "optimismPortalImpl",
     "offset": 0,
     "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "optimismMintableERC20FactoryImpl",
+    "label": "systemConfigImpl",
     "offset": 0,
     "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1CrossDomainMessengerImpl",
+    "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
     "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1StandardBridgeImpl",
+    "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
     "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "disputeGameFactoryImpl",
+    "label": "l1StandardBridgeImpl",
     "offset": 0,
     "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "anchorStateRegistryImpl",
+    "label": "disputeGameFactoryImpl",
     "offset": 0,
     "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "delayedWETHImpl",
+    "label": "anchorStateRegistryImpl",
     "offset": 0,
     "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "mipsImpl",
+    "label": "delayedWETHImpl",
     "offset": 0,
     "slot": "13",
+    "type": "address"
+  },
+  {
+    "bytes": "20",
+    "label": "mipsImpl",
+    "offset": 0,
+    "slot": "14",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV180.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV180.json
@@ -28,73 +28,80 @@
     "type": "address"
   },
   {
-    "bytes": "20",
-    "label": "l1ERC721BridgeImpl",
+    "bytes": "32",
+    "label": "withdrawalDelaySeconds",
     "offset": 0,
     "slot": "4",
-    "type": "address"
+    "type": "uint256"
   },
   {
     "bytes": "20",
-    "label": "optimismPortalImpl",
+    "label": "l1ERC721BridgeImpl",
     "offset": 0,
     "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "systemConfigImpl",
+    "label": "optimismPortalImpl",
     "offset": 0,
     "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "optimismMintableERC20FactoryImpl",
+    "label": "systemConfigImpl",
     "offset": 0,
     "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1CrossDomainMessengerImpl",
+    "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
     "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1StandardBridgeImpl",
+    "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
     "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "disputeGameFactoryImpl",
+    "label": "l1StandardBridgeImpl",
     "offset": 0,
     "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "anchorStateRegistryImpl",
+    "label": "disputeGameFactoryImpl",
     "offset": 0,
     "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "delayedWETHImpl",
+    "label": "anchorStateRegistryImpl",
     "offset": 0,
     "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "mipsImpl",
+    "label": "delayedWETHImpl",
     "offset": 0,
     "slot": "13",
+    "type": "address"
+  },
+  {
+    "bytes": "20",
+    "label": "mipsImpl",
+    "offset": 0,
+    "slot": "14",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV200.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV200.json
@@ -28,73 +28,80 @@
     "type": "address"
   },
   {
-    "bytes": "20",
-    "label": "l1ERC721BridgeImpl",
+    "bytes": "32",
+    "label": "withdrawalDelaySeconds",
     "offset": 0,
     "slot": "4",
-    "type": "address"
+    "type": "uint256"
   },
   {
     "bytes": "20",
-    "label": "optimismPortalImpl",
+    "label": "l1ERC721BridgeImpl",
     "offset": 0,
     "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "systemConfigImpl",
+    "label": "optimismPortalImpl",
     "offset": 0,
     "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "optimismMintableERC20FactoryImpl",
+    "label": "systemConfigImpl",
     "offset": 0,
     "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1CrossDomainMessengerImpl",
+    "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
     "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1StandardBridgeImpl",
+    "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
     "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "disputeGameFactoryImpl",
+    "label": "l1StandardBridgeImpl",
     "offset": 0,
     "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "anchorStateRegistryImpl",
+    "label": "disputeGameFactoryImpl",
     "offset": 0,
     "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "delayedWETHImpl",
+    "label": "anchorStateRegistryImpl",
     "offset": 0,
     "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "mipsImpl",
+    "label": "delayedWETHImpl",
     "offset": 0,
     "slot": "13",
+    "type": "address"
+  },
+  {
+    "bytes": "20",
+    "label": "mipsImpl",
+    "offset": 0,
+    "slot": "14",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV300.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV300.json
@@ -28,73 +28,80 @@
     "type": "address"
   },
   {
-    "bytes": "20",
-    "label": "l1ERC721BridgeImpl",
+    "bytes": "32",
+    "label": "withdrawalDelaySeconds",
     "offset": 0,
     "slot": "4",
-    "type": "address"
+    "type": "uint256"
   },
   {
     "bytes": "20",
-    "label": "optimismPortalImpl",
+    "label": "l1ERC721BridgeImpl",
     "offset": 0,
     "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "systemConfigImpl",
+    "label": "optimismPortalImpl",
     "offset": 0,
     "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "optimismMintableERC20FactoryImpl",
+    "label": "systemConfigImpl",
     "offset": 0,
     "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1CrossDomainMessengerImpl",
+    "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
     "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "l1StandardBridgeImpl",
+    "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
     "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "disputeGameFactoryImpl",
+    "label": "l1StandardBridgeImpl",
     "offset": 0,
     "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "anchorStateRegistryImpl",
+    "label": "disputeGameFactoryImpl",
     "offset": 0,
     "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "delayedWETHImpl",
+    "label": "anchorStateRegistryImpl",
     "offset": 0,
     "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
-    "label": "mipsImpl",
+    "label": "delayedWETHImpl",
     "offset": 0,
     "slot": "13",
+    "type": "address"
+  },
+  {
+    "bytes": "20",
+    "label": "mipsImpl",
+    "offset": 0,
+    "slot": "14",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -178,7 +178,7 @@ contract StandardValidatorBase {
     {
         ISemver _semver = ISemver(address(_sysCfg));
         _errors = internalRequire(stringEq(_semver.version(), systemConfigVersion()), "SYSCON-10", _errors);
-        _errors = internalRequire(_sysCfg.gasLimit() == uint64(60_000_000), "SYSCON-20", _errors);
+        _errors = internalRequire(_sysCfg.gasLimit() <= uint64(200_000_000), "SYSCON-20", _errors);
         _errors = internalRequire(_sysCfg.scalar() >> 248 == 1, "SYSCON-30", _errors);
         _errors =
             internalRequire(_admin.getProxyImplementation(address(_sysCfg)) == systemConfigImpl, "SYSCON-40", _errors);

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -29,6 +29,7 @@ contract StandardValidatorBase {
     address public l1PAOMultisig;
     address public mips;
     address public challenger;
+    uint256 public withdrawalDelaySeconds;
 
     // Implementation addresses as state variables
     address public l1ERC721BridgeImpl;
@@ -60,12 +61,14 @@ contract StandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     ) {
         superchainConfig = _superchainConfig;
         l1PAOMultisig = _l1PAOMultisig;
         mips = _mips;
         challenger = _challenger;
+        withdrawalDelaySeconds = _withdrawalDelaySeconds;
 
         // Set implementation addresses from struct
         l1ERC721BridgeImpl = _implementations.l1ERC721BridgeImpl;
@@ -460,7 +463,7 @@ contract StandardValidatorBase {
             _errors
         );
         _errors = internalRequire(_weth.owner() == l1PAOMultisig, string.concat(_errorPrefix, "-30"), _errors);
-        _errors = internalRequire(_weth.delay() == 1 weeks, string.concat(_errorPrefix, "-40"), _errors);
+        _errors = internalRequire(_weth.delay() == withdrawalDelaySeconds, string.concat(_errorPrefix, "-40"), _errors);
         return _errors;
     }
 
@@ -551,9 +554,17 @@ contract StandardValidatorV180 is StandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     )
-        StandardValidatorBase(_implementations, _superchainConfig, _l1PAOMultisig, _mips, _challenger)
+        StandardValidatorBase(
+            _implementations,
+            _superchainConfig,
+            _l1PAOMultisig,
+            _mips,
+            _challenger,
+            _withdrawalDelaySeconds
+        )
     { }
 
     function validate(InputV180 memory _input, bool _allowFailure) public view returns (string memory) {
@@ -582,9 +593,17 @@ contract StandardValidatorV200 is StandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     )
-        StandardValidatorBase(_implementations, _superchainConfig, _l1PAOMultisig, _mips, _challenger)
+        StandardValidatorBase(
+            _implementations,
+            _superchainConfig,
+            _l1PAOMultisig,
+            _mips,
+            _challenger,
+            _withdrawalDelaySeconds
+        )
     { }
 
     function validate(InputV200 memory _input, bool _allowFailure) public view returns (string memory) {
@@ -683,9 +702,17 @@ contract StandardValidatorV300 is StandardValidatorBase {
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
         address _mips,
-        address _challenger
+        address _challenger,
+        uint256 _withdrawalDelaySeconds
     )
-        StandardValidatorBase(_implementations, _superchainConfig, _l1PAOMultisig, _mips, _challenger)
+        StandardValidatorBase(
+            _implementations,
+            _superchainConfig,
+            _l1PAOMultisig,
+            _mips,
+            _challenger,
+            _withdrawalDelaySeconds
+        )
     { }
 
     function validate(InputV300 memory _input, bool _allowFailure) public view returns (string memory) {

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -1007,6 +1007,7 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
 
         vm.createSelectFork(rpcUrl);
 
+        // When OP Mainnet is updated this will need to be updated to the current validator version.
         StandardValidatorV180 mainnetValidator = new StandardValidatorV180(
             StandardValidatorBase.ImplementationsBase({
                 systemConfigImpl: address(0xAB9d6cB7A427c0765163A7f45BB91cAfe5f2D375),
@@ -1024,7 +1025,7 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
             address(0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A), // l1PAOMultisig
             address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C), // mips
             address(0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A), // challenger
-            302400
+            604800
         );
 
         StandardValidatorV180.InputV180 memory input = StandardValidatorV180.InputV180({

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -148,7 +148,7 @@ abstract contract StandardValidatorTest is Test {
 
         // Test invalid gas limit
         _mockValidationCalls();
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.gasLimit, ()), abi.encode(uint64(1_000_000)));
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.gasLimit, ()), abi.encode(uint64(200_000_001)));
         assertEq("SYSCON-20", validate(true));
 
         // Test invalid scalar

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -953,7 +953,7 @@ abstract contract StandardValidatorTest is Test {
     function _mockDelayedWETH(address _weth) public {
         vm.mockCall(address(_weth), abi.encodeCall(ISemver.version, ()), abi.encode("1.1.0"));
         vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.owner, ()), abi.encode(l1PAOMultisig));
-        vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(1 weeks));
+        vm.mockCall(address(_weth), abi.encodeCall(IDelayedWETH.delay, ()), abi.encode(1 weeks / 2));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -994,7 +994,8 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
             superchainConfig,
             l1PAOMultisig,
             mips,
-            challenger
+            challenger,
+            302400
         );
     }
 
@@ -1022,7 +1023,8 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
             ISuperchainConfig(address(0x95703e0982140D16f8ebA6d158FccEde42f04a4C)),
             address(0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A), // l1PAOMultisig
             address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C), // mips
-            address(0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A) // challenger
+            address(0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A), // challenger
+            302400
         );
 
         StandardValidatorV180.InputV180 memory input = StandardValidatorV180.InputV180({
@@ -1094,7 +1096,8 @@ contract StandardValidatorV200_Test is StandardValidatorTest {
             superchainConfig,
             l1PAOMultisig,
             mips,
-            challenger
+            challenger,
+            302400
         );
     }
 
@@ -1195,7 +1198,8 @@ contract StandardValidatorV300_Test is StandardValidatorTest {
             superchainConfig,
             l1PAOMultisig,
             mips,
-            challenger
+            challenger,
+            302400
         );
     }
 

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -916,6 +916,7 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "StandardValidator", _sel: _getSel("l1StandardBridgeVersion()") });
         _addSpec({ _name: "StandardValidator", _sel: _getSel("optimismMintableERC20FactoryVersion()") });
         _addSpec({ _name: "StandardValidator", _sel: _getSel("preimageOracleVersion()") });
+        _addSpec({ _name: "StandardValidator", _sel: _getSel("withdrawalDelaySeconds()") });
     }
 
     /// @dev Computes the selector from a function signature.


### PR DESCRIPTION
**Description**

Two things: 
1. Adds a configurable value for setting the DelayedWeth withdrawal value.
2. Changes the gas limit check to accept anything under [200_000_000](https://specs.optimism.io/protocol/configurability.html#gas-limit)

