### PR TITLE
fix FORK_BLOCK_NUMBER

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -117,8 +117,11 @@ anvil-fork:
 # Helpful for debugging.
 test-upgrade-against-anvil *ARGS: build-go-ffi
   #!/bin/bash
-  echo "Running upgrade tests at block $pinnedBlockNumber"
-  export FORK_BLOCK_NUMBER=$pinnedBlockNumber
+  if [ -z "$FORK_BLOCK_NUMBER" ]; then
+    export FORK_BLOCK_NUMBER=$pinnedBlockNumber
+  fi
+  echo "Running upgrade tests at block $FORK_BLOCK_NUMBER"
+
   export FORK_RPC_URL=http://127.0.0.1:8545
   export FORK_TEST=true
   forge test {{ARGS}} \

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -91,7 +91,9 @@ print-pinned-block-number:
 #   when the L1 chain is upgraded.
 prepare-upgrade-env *ARGS : build-go-ffi
   #!/bin/bash
-  export FORK_BLOCK_NUMBER=$pinnedBlockNumber
+  if [ -z "$FORK_BLOCK_NUMBER" ]; then
+    export FORK_BLOCK_NUMBER=$pinnedBlockNumber
+  fi
   echo "Running upgrade tests at block $FORK_BLOCK_NUMBER"
   export FORK_RPC_URL=$ETH_RPC_URL
   export FORK_TEST=true


### PR DESCRIPTION
The comment says:

`# - FORK_BLOCK_NUMBER can be set in the env, or else will fallback to the default block number.`

This PR makes the code consistent with the comment.