### PR TITLE
fix(op-deployer): ManagerImplementationAddrFor handle unproxied opcm

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -143,7 +143,15 @@ func ManagerImplementationAddrFor(chainID uint64, tag string) (common.Address, e
 	if !ok {
 		return common.Address{}, fmt.Errorf("unsupported tag for chain ID %d: %s", chainID, tag)
 	}
-	return common.Address(*versionData.OPContractsManager.Address), nil
+	if versionData.OPContractsManager.Address != nil {
+		// op-contracts/v1.8.0 and earlier use proxied opcm
+		return common.Address(*versionData.OPContractsManager.Address), nil
+	}
+	if versionData.OPContractsManager.ImplementationAddress != nil {
+		// op-contracts/v2.0.0-rc.1 and later use non-proxied opcm
+		return common.Address(*versionData.OPContractsManager.ImplementationAddress), nil
+	}
+	return common.Address{}, fmt.Errorf("OPContractsManager address is nil for tag %s", tag)
 }
 
 // SuperchainProxyAdminAddrFor returns the address of the Superchain ProxyAdmin for the given chain ID.

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -137,11 +137,11 @@ func SuperchainFor(chainID uint64) (superchain.Superchain, error) {
 func ManagerImplementationAddrFor(chainID uint64, tag string) (common.Address, error) {
 	versionsData, err := L1VersionsFor(chainID)
 	if err != nil {
-		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+		return common.Address{}, fmt.Errorf("unsupported chainID: %d", chainID)
 	}
 	versionData, ok := versionsData[validation.Semver(tag)]
 	if !ok {
-		return common.Address{}, fmt.Errorf("unsupported tag for chain ID %d: %s", chainID, tag)
+		return common.Address{}, fmt.Errorf("unsupported tag for chainID %d: %s", chainID, tag)
 	}
 	if versionData.OPContractsManager.Address != nil {
 		// op-contracts/v1.8.0 and earlier use proxied opcm

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -99,3 +99,56 @@ func TestL2ProxyAdminOwner(t *testing.T) {
 		require.Equal(t, common.Address(test.expAddr), addr)
 	}
 }
+
+func TestManagerImplementationAddrFor(t *testing.T) {
+	testCases := []struct {
+		name          string
+		chainID       uint64
+		tag           string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "proxied opcm",
+			chainID:     1,
+			tag:         "op-contracts/v1.8.0",
+			expectError: false,
+		},
+		{
+			name:        "non-proxied opcm",
+			chainID:     1,
+			tag:         "op-contracts/v2.0.0-rc.1",
+			expectError: false,
+		},
+		{
+			name:          "unsupported chainID",
+			chainID:       999999,
+			tag:           "op-contracts/v1.8.0",
+			expectError:   true,
+			errorContains: "unsupported chainID",
+		},
+		{
+			name:          "unsupported tag",
+			chainID:       1,
+			tag:           "op-contracts/v999.999.999",
+			expectError:   true,
+			errorContains: "unsupported tag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, err := ManagerImplementationAddrFor(tc.chainID, tc.tag)
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorContains != "" {
+					require.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotEqual(t, common.Address{}, addr, "address should not be empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Bug fix: between [op-contracts/v1.8.0](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml#L82) and [op-contracts/v2.0.0-rc.1](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml#L60) `op_contracts_manager` changed from having `implementation_address` (proxied) specified to having `address` (non-proxied) specified. This led to a nil dereference error on [this line](https://github.com/ethereum-optimism/optimism/blob/develop/op-deployer/pkg/deployer/standard/standard.go#L146) when using tags > op-contracts/v1.8.0

op-deployer should now be able to gracefully handle both situations