### PR TITLE
op-acceptance-tests: interop: execute message with invalid attributes

### DIFF
--- a/op-acceptance-tests/tests/interop/interop_txplan_test.go
+++ b/op-acceptance-tests/tests/interop/interop_txplan_test.go
@@ -291,7 +291,7 @@ const (
 	invalidChainID     invalidType = "invalidChainID"
 )
 
-// executeIndexedFault builds on top of txintent.ExecuteIndexed to inject a fault for the identifer of message
+// executeIndexedFault builds on top of txintent.ExecuteIndexed to inject a fault for the identifier of message
 func executeIndexedFault(executor common.Address, events *plan.Lazy[*txintent.InteropOutput], index int, rng *rand.Rand, faults []invalidType) func(ctx context.Context) (*txintent.ExecTrigger, error) {
 	return func(ctx context.Context) (*txintent.ExecTrigger, error) {
 		execTrigger, err := txintent.ExecuteIndexed(executor, events, index)(ctx)

--- a/op-acceptance-tests/tests/interop/interop_txplan_test.go
+++ b/op-acceptance-tests/tests/interop/interop_txplan_test.go
@@ -1,13 +1,21 @@
 package interop
 
 import (
+	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/plan"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -273,6 +281,108 @@ func execMsgDifferEventIndexInSingleTx(
 	}
 }
 
+type invalidType string
+
+const (
+	invalidOrigin      invalidType = "invalidOrigin"
+	invalidBlockNumber invalidType = "invalidBlockNumber"
+	invalidLogIndex    invalidType = "invalidLogIndex"
+	invalidTimestamp   invalidType = "invalidTimestamp"
+	invalidChainID     invalidType = "invalidChainID"
+)
+
+// executeIndexedFault builds on top of txintent.ExecuteIndexed to inject a fault for the identifer of message
+func executeIndexedFault(executor common.Address, events *plan.Lazy[*txintent.InteropOutput], index int, rng *rand.Rand, faults []invalidType) func(ctx context.Context) (*txintent.ExecTrigger, error) {
+	return func(ctx context.Context) (*txintent.ExecTrigger, error) {
+		execTrigger, err := txintent.ExecuteIndexed(executor, events, index)(ctx)
+		if err != nil {
+			return nil, err
+		}
+		newMsg := execTrigger.Msg
+		for _, fault := range faults {
+			switch fault {
+			case invalidOrigin:
+				newMsg.Identifier.Origin = testutils.RandomAddress(rng)
+			case invalidBlockNumber:
+				// make sure that the faulty blockNumber does not exceed type(uint64).max for CrossL2Inbox check
+				newMsg.Identifier.BlockNumber = rng.Uint64() / 2
+			case invalidLogIndex:
+				// make sure that the faulty logIndex does not exceed type(uint32).max for CrossL2Inbox check
+				newMsg.Identifier.LogIndex = rng.Uint32() / 2
+			case invalidTimestamp:
+				// make sure that the faulty Timestamp does not exceed type(uint64).max for CrossL2Inbox check
+				newMsg.Identifier.Timestamp = rng.Uint64() / 2
+			case invalidChainID:
+				newMsg.Identifier.ChainID = eth.ChainIDFromBytes32([32]byte(testutils.RandomData(rng, 32)))
+			default:
+				panic("invalid type")
+			}
+		}
+		return &txintent.ExecTrigger{
+			Executor: executor,
+			Msg:      newMsg,
+		}, nil
+	}
+}
+
+// executeMessageInvalidAttributes tests below scenario:
+// Execute message, but with one or more invalid attributes inside identifiers
+func executeMessageInvalidAttributes(
+	l2ChainNums int,
+	walletGetters []validators.WalletGetter,
+) systest.InteropSystemTestFunc {
+	return func(t systest.T, sys system.InteropSystem) {
+		ctx, rng, logger, _, wallets, opts := DefaultInteropSetup(t, sys, l2ChainNums, walletGetters)
+
+		eventLoggerAddress, err := DeployEventLogger(ctx, wallets[0], logger)
+		require.NoError(t, err)
+
+		// Intent to initiate message(or emit event) on chain A
+		txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](opts[0])
+		randomInitTrigger := RandomInitTrigger(rng, eventLoggerAddress, 3, 10)
+		txA.Content.Set(randomInitTrigger)
+
+		// Trigger single event
+		receiptA, err := txA.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		logger.Info("initiate message included", "block", receiptA.BlockHash)
+
+		// construct txplan opts for testing failed validating messages
+		optsForFail := txplan.Combine(
+			DefaultTxSubmitOptions(wallets[1]),
+			txplan.WithRetryInclusion(wallets[1].Client(), 5, retry.Exponential()),
+			// does not fetch the included block info
+		)
+		faultsLists := [][]invalidType{
+			// we test each identifier attributes to be faulty
+			{invalidOrigin}, {invalidBlockNumber}, {invalidLogIndex}, {invalidTimestamp}, {invalidChainID},
+			// at last test for every attributes to be faulty
+			{invalidOrigin, invalidBlockNumber, invalidLogIndex, invalidTimestamp, invalidChainID},
+		}
+		for _, faults := range faultsLists {
+			logger.Info("attempt to validate message with invalid attribute", "faults", faults)
+			// Intent to validate message on chain B
+			txB := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsForFail)
+			txB.Content.DependOn(&txA.Result)
+
+			// Single event in tx so index is 0, and also inject faults
+			txB.Content.Fn(executeIndexedFault(constants.CrossL2Inbox, &txA.Result, 0, rng, faults))
+
+			// make sure that the transaction is not reverted by CrossL2Inbox...
+			gas, err := txB.PlannedTx.Gas.Eval(ctx)
+			require.NoError(t, err)
+			require.Greater(t, gas, uint64(0))
+
+			// but rather not included at chain B because of supervisor check
+			// chain B L2 EL will query supervisor to check whether given message is valid
+			// supervisor will throw ErrConflict(conflicting data), and L2 EL will drop tx
+			_, err = txB.PlannedTx.Included.Eval(ctx)
+			require.Error(t, err)
+			logger.Info("validate message not included")
+		}
+	}
+}
+
 func TestInteropTxTest(t *testing.T) {
 	l2ChainNums := 2
 	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
@@ -281,6 +391,7 @@ func TestInteropTxTest(t *testing.T) {
 		name     string
 		testFunc systest.InteropSystemTestFunc
 	}{
+		// success case
 		{"initAndExecMsg", initAndExecMsg(l2ChainNums, walletGetters)},
 		{"initAndExecMultipleMsg", initAndExecMultipleMsg(l2ChainNums, walletGetters)},
 		{"execSameMsgTwice", execSameMsgTwice(l2ChainNums, walletGetters)},
@@ -288,6 +399,9 @@ func TestInteropTxTest(t *testing.T) {
 		{"execMsgDifferentTopicCount", execMsgDifferentTopicCount(l2ChainNums, walletGetters)},
 		{"execMsgOpagueData", execMsgOpagueData(l2ChainNums, walletGetters)},
 		{"execMsgDifferEventIndexInSingleTx", execMsgDifferEventIndexInSingleTx(l2ChainNums, walletGetters)},
+
+		// failure case
+		{"executeMessageInvalidAttributes", executeMessageInvalidAttributes(l2ChainNums, walletGetters)},
 	}
 
 	for _, test := range tests {

--- a/op-acceptance-tests/tests/interop/interop_txplan_test.go
+++ b/op-acceptance-tests/tests/interop/interop_txplan_test.go
@@ -281,18 +281,28 @@ func execMsgDifferEventIndexInSingleTx(
 	}
 }
 
-type invalidType string
+type invalidAttributeType string
 
 const (
-	invalidOrigin      invalidType = "invalidOrigin"
-	invalidBlockNumber invalidType = "invalidBlockNumber"
-	invalidLogIndex    invalidType = "invalidLogIndex"
-	invalidTimestamp   invalidType = "invalidTimestamp"
-	invalidChainID     invalidType = "invalidChainID"
+	randomOrigin        invalidAttributeType = "randomOrigin"
+	randomBlockNumber   invalidAttributeType = "randomBlockNumber"
+	randomLogIndex      invalidAttributeType = "randomLogIndex"
+	randomTimestamp     invalidAttributeType = "randomTimestamp"
+	randomChainID       invalidAttributeType = "randomChainID"
+	mismatchedLogIndex  invalidAttributeType = "mismatchedLogIndex"
+	mismatchedTimestamp invalidAttributeType = "mismatchedTimestamp"
+	msgNotPresent       invalidAttributeType = "msgNotPresent"
 )
 
 // executeIndexedFault builds on top of txintent.ExecuteIndexed to inject a fault for the identifier of message
-func executeIndexedFault(executor common.Address, events *plan.Lazy[*txintent.InteropOutput], index int, rng *rand.Rand, faults []invalidType) func(ctx context.Context) (*txintent.ExecTrigger, error) {
+func executeIndexedFault(
+	executor common.Address,
+	events *plan.Lazy[*txintent.InteropOutput],
+	index int,
+	rng *rand.Rand,
+	faults []invalidAttributeType,
+	sys system.InteropSystem,
+) func(ctx context.Context) (*txintent.ExecTrigger, error) {
 	return func(ctx context.Context) (*txintent.ExecTrigger, error) {
 		execTrigger, err := txintent.ExecuteIndexed(executor, events, index)(ctx)
 		if err != nil {
@@ -301,19 +311,30 @@ func executeIndexedFault(executor common.Address, events *plan.Lazy[*txintent.In
 		newMsg := execTrigger.Msg
 		for _, fault := range faults {
 			switch fault {
-			case invalidOrigin:
+			case randomOrigin:
 				newMsg.Identifier.Origin = testutils.RandomAddress(rng)
-			case invalidBlockNumber:
+			case randomBlockNumber:
 				// make sure that the faulty blockNumber does not exceed type(uint64).max for CrossL2Inbox check
 				newMsg.Identifier.BlockNumber = rng.Uint64() / 2
-			case invalidLogIndex:
+			case randomLogIndex:
 				// make sure that the faulty logIndex does not exceed type(uint32).max for CrossL2Inbox check
 				newMsg.Identifier.LogIndex = rng.Uint32() / 2
-			case invalidTimestamp:
+			case randomTimestamp:
 				// make sure that the faulty Timestamp does not exceed type(uint64).max for CrossL2Inbox check
 				newMsg.Identifier.Timestamp = rng.Uint64() / 2
-			case invalidChainID:
+			case randomChainID:
 				newMsg.Identifier.ChainID = eth.ChainIDFromBytes32([32]byte(testutils.RandomData(rng, 32)))
+			case mismatchedLogIndex:
+				// valid msg within block, but mismatchging event index
+				newMsg.Identifier.LogIndex += 1
+			case mismatchedTimestamp:
+				// within time window, but mismatching block
+				newMsg.Identifier.Timestamp += 2
+			case msgNotPresent:
+				// valid chain but msg not there
+				// use destination chain ID because initiating message is not present in dest chain
+				destChainID := sys.L2s()[1].ID().Uint64()
+				newMsg.Identifier.ChainID = eth.ChainID{destChainID}
 			default:
 				panic("invalid type")
 			}
@@ -353,11 +374,13 @@ func executeMessageInvalidAttributes(
 			txplan.WithRetryInclusion(wallets[1].Client(), 5, retry.Exponential()),
 			// does not fetch the included block info
 		)
-		faultsLists := [][]invalidType{
-			// we test each identifier attributes to be faulty
-			{invalidOrigin}, {invalidBlockNumber}, {invalidLogIndex}, {invalidTimestamp}, {invalidChainID},
-			// at last test for every attributes to be faulty
-			{invalidOrigin, invalidBlockNumber, invalidLogIndex, invalidTimestamp, invalidChainID},
+		faultsLists := [][]invalidAttributeType{
+			// test each identifier attributes to be faulty for upper bound tests
+			{randomOrigin}, {randomBlockNumber}, {randomLogIndex}, {randomTimestamp}, {randomChainID},
+			// test for every attributes to be faulty for upper bound tests
+			{randomOrigin, randomBlockNumber, randomLogIndex, randomTimestamp, randomChainID},
+			// test for non-random invalid attributes
+			{mismatchedLogIndex}, {mismatchedTimestamp}, {msgNotPresent},
 		}
 		for _, faults := range faultsLists {
 			logger.Info("attempt to validate message with invalid attribute", "faults", faults)
@@ -366,7 +389,7 @@ func executeMessageInvalidAttributes(
 			txB.Content.DependOn(&txA.Result)
 
 			// Single event in tx so index is 0, and also inject faults
-			txB.Content.Fn(executeIndexedFault(constants.CrossL2Inbox, &txA.Result, 0, rng, faults))
+			txB.Content.Fn(executeIndexedFault(constants.CrossL2Inbox, &txA.Result, 0, rng, faults, sys))
 
 			// make sure that the transaction is not reverted by CrossL2Inbox...
 			gas, err := txB.PlannedTx.Gas.Eval(ctx)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

This test adds partial implementation for https://github.com/ethereum-optimism/optimism/issues/15023, all the upper bounds and random address.

  - [ ] Execute message, but with one or more invalid attributes:
    - [x] `origin`
      - changed with different addr
    - [x] `blocknumber`
      - upper bound: contract allows `uint64`
    - [x] `logIndex`
      - [x] valid msg within block, but different event index
      - [x] upper bound: contract allows `uint32`
    - [x] `timestamp`
      - [x] within time window, but not matching block
      - [x] upper bound: contract allows `uint64`
    - [ ] `chainid`
      - [x] valid chain, msg not there
      - [ ] chain not in dependency set
      - [x] upper bound: random 32byte value.

Did not test the `chain not in dependency set` because current kt devnet does not support multiple depsets.

**Test**

Passing via targeting the local interop devnet

First failure case for txplan alpha testing added. Example test log:

```
=== RUN   TestInteropTxTest
=== RUN   TestInteropTxTest/executeMessageInvalidAttributes
DEBUG[03-26|21:25:15.646] checking balance                         wallet=0xcd3B766CCDd6AE721141F452C550Ca635964ce71 balance="10000 ETH" needed="1 ETH"
DEBUG[03-26|21:25:15.648] checking balance                         wallet=0x90F79bf6EB2c4f870365E785982E1f101E93b906 balance="10000 ETH" needed="1 ETH"
    interop_test_helpers.go:84: INFO [03-26|21:25:15.648] Deploying EventLogger
    interop_test_helpers.go:93: INFO [03-26|21:25:18.975] Deployed EventLogger                     address=0x162459Bb429a63D2e31Fe2d1cdb5b058f2D31AdF
    interop_txplan_test.go:369: INFO [03-26|21:25:22.254] initiate message included                block=845a25..bbea93
    interop_txplan_test.go:386: INFO [03-26|21:25:22.254] attempt to validate message with invalid attribute faults=[randomOrigin]
    interop_txplan_test.go:404: INFO [03-26|21:25:37.674] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:25:37.675] attempt to validate message with invalid attribute faults=[randomBlockNumber]
    interop_txplan_test.go:404: INFO [03-26|21:25:53.243] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:25:53.244] attempt to validate message with invalid attribute faults=[randomLogIndex]
    interop_txplan_test.go:404: INFO [03-26|21:26:08.807] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:26:08.807] attempt to validate message with invalid attribute faults=[randomTimestamp]
    interop_txplan_test.go:404: INFO [03-26|21:26:24.081] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:26:24.081] attempt to validate message with invalid attribute faults=[randomChainID]
    interop_txplan_test.go:404: INFO [03-26|21:26:39.779] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:26:39.779] attempt to validate message with invalid attribute faults="[randomOrigin randomBlockNumber randomLogIndex randomTimestamp randomChainID]"
    interop_txplan_test.go:404: INFO [03-26|21:26:55.260] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:26:55.260] attempt to validate message with invalid attribute faults=[mismatchedLogIndex]
    interop_txplan_test.go:404: INFO [03-26|21:27:10.799] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:27:10.799] attempt to validate message with invalid attribute faults=[mismatchedTimestamp]
    interop_txplan_test.go:404: INFO [03-26|21:27:26.394] validate message not included
    interop_txplan_test.go:386: INFO [03-26|21:27:26.395] attempt to validate message with invalid attribute faults=[msgNotPresent]
    interop_txplan_test.go:404: INFO [03-26|21:27:41.854] validate message not included
--- PASS: TestInteropTxTest (146.22s)
    --- PASS: TestInteropTxTest/executeMessageInvalidAttributes (146.22s)
PASS
ok      github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop 146.651s
```

For the relevant logs that L2 EL node which receives transaction that includes validating messages:
```
$ docker logs -f 6b8311cd0b6c 2>&1 | grep conflict
WARN [03-25|16:56:27.015] Transaction was rejected during block-building hash=4d8b18..9d397a err="conflicting data"
WARN [03-25|16:56:43.019] Transaction was rejected during block-building hash=378e65..99e9e0 err="conflicting data"
WARN [03-25|16:56:57.007] Transaction was rejected during block-building hash=11c2bd..ffecbe err="conflicting data"
WARN [03-25|16:57:13.007] Transaction was rejected during block-building hash=fa45ff..4c3ee6 err="conflicting data"
WARN [03-25|16:57:29.083] Transaction was rejected during block-building hash=03423f..61f486 err="conflicting data"
WARN [03-25|16:57:45.019] Transaction was rejected during block-building hash=5f94a9..3d2874 err="conflicting data"
...
```
all txs that include invalid validating messages are rejected as intended.
