### PR TITLE
op-e2e: Add the initial set of Super DG e2e tests

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -100,6 +100,66 @@ type Config struct {
 	PprofConfig   oppprof.CLIConfig
 }
 
+func NewInteropConfig(
+	gameFactoryAddress common.Address,
+	l1EthRpc string,
+	l1BeaconApi string,
+	supervisorRpc string,
+	l2Rpcs []string,
+	datadir string,
+	supportedTraceTypes ...types.TraceType,
+) Config {
+	return Config{
+		L1EthRpc:           l1EthRpc,
+		L1Beacon:           l1BeaconApi,
+		SupervisorRPC:      supervisorRpc,
+		L2Rpcs:             l2Rpcs,
+		GameFactoryAddress: gameFactoryAddress,
+		MaxConcurrency:     uint(runtime.NumCPU()),
+		PollInterval:       DefaultPollInterval,
+
+		TraceTypes: supportedTraceTypes,
+
+		MaxPendingTx: DefaultMaxPendingTx,
+
+		TxMgrConfig:   txmgr.NewCLIConfig(l1EthRpc, txmgr.DefaultChallengerFlagValues),
+		MetricsConfig: opmetrics.DefaultCLIConfig(),
+		PprofConfig:   oppprof.DefaultCLIConfig(),
+
+		Datadir: datadir,
+
+		Cannon: vm.Config{
+			VmType:          types.TraceTypeCannon,
+			L1:              l1EthRpc,
+			L1Beacon:        l1BeaconApi,
+			L2s:             l2Rpcs,
+			SnapshotFreq:    DefaultCannonSnapshotFreq,
+			InfoFreq:        DefaultCannonInfoFreq,
+			DebugInfo:       true,
+			BinarySnapshots: true,
+		},
+		Asterisc: vm.Config{
+			VmType:          types.TraceTypeAsterisc,
+			L1:              l1EthRpc,
+			L1Beacon:        l1BeaconApi,
+			L2s:             l2Rpcs,
+			SnapshotFreq:    DefaultAsteriscSnapshotFreq,
+			InfoFreq:        DefaultAsteriscInfoFreq,
+			BinarySnapshots: true,
+		},
+		AsteriscKona: vm.Config{
+			VmType:          types.TraceTypeAsteriscKona,
+			L1:              l1EthRpc,
+			L1Beacon:        l1BeaconApi,
+			L2s:             l2Rpcs,
+			SnapshotFreq:    DefaultAsteriscSnapshotFreq,
+			InfoFreq:        DefaultAsteriscInfoFreq,
+			BinarySnapshots: true,
+		},
+		GameWindow: DefaultGameWindow,
+	}
+}
+
 func NewConfig(
 	gameFactoryAddress common.Address,
 	l1EthRpc string,

--- a/op-e2e/e2eutils/disputegame/claim_helper.go
+++ b/op-e2e/e2eutils/disputegame/claim_helper.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -81,15 +79,7 @@ func (c *ClaimHelper) WaitForCounterClaim(ctx context.Context, ignoreClaims ...*
 
 // WaitForCountered waits until the claim is countered either by a child claim or by a step call.
 func (c *ClaimHelper) WaitForCountered(ctx context.Context) {
-	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-	err := wait.For(timedCtx, time.Second, func() (bool, error) {
-		latestData := c.game.getClaim(ctx, c.Index)
-		return latestData.CounteredBy != common.Address{}, nil
-	})
-	if err != nil { // Avoid waiting time capturing game data when there's no error
-		c.require.NoErrorf(err, "Claim %v was not countered\n%v", c.Index, c.game.GameData(ctx))
-	}
+	c.game.WaitForCountered(ctx, c.Index)
 }
 
 func (c *ClaimHelper) RequireCorrectOutputRoot(ctx context.Context) {

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -24,8 +24,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -77,12 +79,15 @@ type DisputeSystem interface {
 	L1BeaconEndpoint() endpoint.RestHTTP
 	SupervisorClient() *sources.SupervisorClient
 	NodeEndpoint(name string) endpoint.RPC
+	L2NodeEndpoints() []endpoint.RPC
 	NodeClient(name string) *ethclient.Client
 	RollupEndpoint(name string) endpoint.RPC
+	SupervisorEndpoint() endpoint.RPC
 	RollupClient(name string) *sources.RollupClient
-
+	IsSupersystem() bool
 	DisputeGameFactoryAddr() common.Address
 	RollupCfgs() []*rollup.Config
+	DependencySet() *depset.StaticConfigDependencySet
 	L2Geneses() []*core.Genesis
 	PrestateVariant() challenger.PrestateVariant
 
@@ -212,6 +217,18 @@ func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node 
 	provider := outputs.NewTraceProvider(logger, prestateProvider, rollupClient, l2Client, l1Head, splitDepth, prestateBlock, poststateBlock)
 
 	return NewOutputCannonGameHelper(h.T, h.Client, h.Opts, h.PrivKey, game, h.FactoryAddr, createdEvent.DisputeProxy, provider, h.System)
+}
+
+func (h *FactoryHelper) StartSuperCannonGameWithCorrectRoot(ctx context.Context, opts ...GameOpt) *SuperCannonGameHelper {
+	cfg := NewGameCfg(opts...)
+	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1))
+	b, err := h.Client.BlockByNumber(ctx, nil)
+	require.NoError(h.T, err)
+	l2Timestamp := b.Time()
+	h.WaitForSuperTimestamp(l2Timestamp, cfg)
+	output, err := h.System.SupervisorClient().SuperRootAtTimestamp(ctx, hexutil.Uint64(l2Timestamp))
+	h.Require.NoErrorf(err, "Failed to get output at timestamp %v", l2Timestamp)
+	return h.startSuperCannonGameOfType(ctx, l2Timestamp, common.Hash(output.SuperRoot), superCannonGameType, opts...)
 }
 
 func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, rootClaim common.Hash, opts ...GameOpt) *SuperCannonGameHelper {
@@ -353,6 +370,54 @@ func (h *FactoryHelper) WaitForBlock(l2Node string, l2BlockNumber uint64, cfg *G
 		_, err := geth.WaitForBlockToBeSafe(new(big.Int).SetUint64(l2BlockNumber), l2Client, 1*time.Minute)
 		h.Require.NoErrorf(err, "Block number %v did not become safe", l2BlockNumber)
 	}
+}
+
+func (h *FactoryHelper) WaitForSuperTimestamp(l2Timestamp uint64, cfg *GameCfg) {
+	if cfg.allowFuture {
+		// Proposing a timestamp that doesn't exist yet, so don't perform any checks
+		return
+	}
+
+	client := h.System.SupervisorClient()
+	absoluteTimeout := 3 * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), absoluteTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	lastLog := time.Now()
+	for {
+		select {
+		case <-ticker.C:
+			status, err := client.SyncStatus(ctx)
+			h.Require.NoError(err, "Failed to get sync status")
+			if cfg.allowUnsafe {
+				localUnsafeAtTimestamp := true
+				for _, chain := range status.Chains {
+					if chain.LocalUnsafe.Time < l2Timestamp {
+						localUnsafeAtTimestamp = false
+						break
+					}
+				}
+				if !localUnsafeAtTimestamp {
+					return
+				}
+			} else {
+				if status.SafeTimestamp >= l2Timestamp {
+					return
+				}
+			}
+			// log every 30 seconds
+			if time.Since(lastLog) > 30*time.Second {
+				h.T.Logf("Waiting for super timestamp %v", l2Timestamp)
+				lastLog = time.Now()
+			}
+		case <-ctx.Done():
+			h.Require.NoError(ctx.Err(), "Safe head did not reach proposal timestamp")
+		}
+	}
+
 }
 
 func (h *FactoryHelper) StartChallenger(ctx context.Context, name string, options ...challenger.Option) *challenger.Helper {

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -241,7 +241,7 @@ func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, rootClaim comm
 
 func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestamp uint64, rootClaim common.Hash, gameType uint32, opts ...GameOpt) *SuperCannonGameHelper {
 	cfg := NewGameCfg(opts...)
-	logger := testlog.Logger(h.T, log.LevelInfo).New("role", "OutputCannonGameHelper")
+	logger := testlog.Logger(h.T, log.LevelInfo).New("role", "CannonGameHelper")
 	rootProvider := h.System.SupervisorClient()
 
 	extraData := h.CreateSuperGameExtraData(ctx, rootProvider, timestamp, cfg)

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -221,8 +221,7 @@ func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node 
 
 func (h *FactoryHelper) StartSuperCannonGameWithCorrectRoot(ctx context.Context, opts ...GameOpt) *SuperCannonGameHelper {
 	cfg := NewGameCfg(opts...)
-	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1))
-	b, err := h.Client.BlockByNumber(ctx, nil)
+	b, err := wait.ForNextSafeBlock(ctx, h.Client)
 	require.NoError(h.T, err)
 	l2Timestamp := b.Time()
 	h.WaitForSuperTimestamp(l2Timestamp, cfg)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -41,16 +41,16 @@ func NewOutputCannonGameHelper(t *testing.T, client *ethclient.Client, opts *bin
 }
 
 type HonestActorConfig struct {
-	PrestateBlock  uint64
-	PoststateBlock uint64
-	ChallengerOpts []challenger.Option
+	PrestateSequenceNumber  uint64
+	PoststateSequenceNumber uint64
+	ChallengerOpts          []challenger.Option
 }
 
 type HonestActorOpt func(cfg *HonestActorConfig)
 
 func WithClaimedL2BlockNumber(num uint64) HonestActorOpt {
 	return func(cfg *HonestActorConfig) {
-		cfg.PoststateBlock = num
+		cfg.PoststateSequenceNumber = num
 	}
 }
 
@@ -69,9 +69,9 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 	splitDepth := g.SplitDepth(ctx)
 	rollupClient := g.System.RollupClient(l2Node)
 	actorCfg := &HonestActorConfig{
-		PrestateBlock:  realPrestateBlock,
-		PoststateBlock: realPostStateBlock,
-		ChallengerOpts: g.defaultChallengerOptions(),
+		PrestateSequenceNumber:  realPrestateBlock,
+		PoststateSequenceNumber: realPostStateBlock,
+		ChallengerOpts:          g.defaultChallengerOptions(),
 	}
 	for _, option := range options {
 		option(actorCfg)
@@ -79,10 +79,10 @@ func (g *OutputCannonGameHelper) CreateHonestActor(ctx context.Context, l2Node s
 
 	cfg := challenger.NewChallengerConfig(g.T, g.System, l2Node, actorCfg.ChallengerOpts...)
 	dir := filepath.Join(cfg.Datadir, "honest")
-	prestateProvider := outputs.NewPrestateProvider(rollupClient, actorCfg.PrestateBlock)
+	prestateProvider := outputs.NewPrestateProvider(rollupClient, actorCfg.PrestateSequenceNumber)
 	l1Head := g.GetL1Head(ctx)
 	accessor, err := outputs.NewOutputCannonTraceAccessor(
-		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramServerExecutor(logger), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, actorCfg.PrestateBlock, actorCfg.PoststateBlock)
+		logger, metrics.NoopMetrics, cfg.Cannon, vm.NewOpProgramServerExecutor(logger), l2Client, prestateProvider, cfg.CannonAbsolutePreState, rollupClient, dir, l1Head, splitDepth, actorCfg.PrestateSequenceNumber, actorCfg.PoststateSequenceNumber)
 	g.Require.NoError(err, "Failed to create output cannon trace accessor")
 	return NewOutputHonestHelper(g.T, g.Require, &g.OutputGameHelper.SplitGameHelper, g.Game, accessor)
 }

--- a/op-e2e/e2eutils/disputegame/split_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/split_game_helper.go
@@ -27,17 +27,18 @@ import (
 const defaultTimeout = 20 * time.Minute
 
 type SplitGameHelper struct {
-	T                     *testing.T
-	Require               *require.Assertions
-	Client                *ethclient.Client
-	Opts                  *bind.TransactOpts
-	PrivKey               *ecdsa.PrivateKey
-	Game                  contracts.FaultDisputeGameContract
-	FactoryAddr           common.Address
-	Addr                  common.Address
-	CorrectOutputProvider types.TraceProvider
-	System                DisputeSystem
-	DescribePosition      func(pos types.Position, splitDepth types.Depth) string
+	T                       *testing.T
+	Require                 *require.Assertions
+	Client                  *ethclient.Client
+	Opts                    *bind.TransactOpts
+	PrivKey                 *ecdsa.PrivateKey
+	Game                    contracts.FaultDisputeGameContract
+	FactoryAddr             common.Address
+	Addr                    common.Address
+	CorrectOutputProvider   types.TraceProvider
+	System                  DisputeSystem
+	DescribePosition        func(pos types.Position, splitDepth types.Depth) string
+	ClaimedL2SequenceNumber func(pos types.Position) (uint64, error)
 }
 
 type moveCfg struct {
@@ -279,6 +280,18 @@ func (g *SplitGameHelper) WaitForAllClaimsCountered(ctx context.Context) {
 		})
 }
 
+func (g *SplitGameHelper) WaitForCountered(ctx context.Context, claimIdx int64) {
+	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		claim := g.getClaim(ctx, claimIdx)
+		return claim.CounteredBy != common.Address{}, nil
+	})
+	if err != nil { // Avoid waiting time capturing game data when there's no error
+		g.Require.NoErrorf(err, "Claim %v was not countered\n%v", claimIdx, g.GameData(ctx))
+	}
+}
+
 func (g *SplitGameHelper) Resolve(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
@@ -416,6 +429,25 @@ func WithoutWaitingForStep() DefendClaimOpt {
 	return func(cfg *defendClaimCfg) {
 		cfg.skipWaitingForStep = true
 	}
+}
+
+func (g *SplitGameHelper) SupportClaim(ctx context.Context, claim *ClaimHelper, performMove Mover, attemptStep Stepper) {
+	g.T.Logf("Supporting claim %v at depth %v", claim.Index, claim.Depth())
+	for !claim.IsMaxDepth(ctx) {
+		g.LogGameData(ctx)
+		// Wait for the challenger to counter
+		claim = claim.WaitForCounterClaim(ctx)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+		g.LogGameData(ctx)
+
+		// Respond with our own move
+		claim = performMove(claim)
+	}
+
+	g.LogGameData(ctx)
+	attemptStep(claim.Index)
 }
 
 // DefendClaim uses the supplied Mover to perform moves in an attempt to defend the supplied claim.
@@ -564,4 +596,53 @@ func (g *SplitGameHelper) ResolveClaim(ctx context.Context, claimIdx int64) {
 	candidate, err := g.Game.ResolveClaimTx(uint64(claimIdx))
 	g.Require.NoError(err, "Failed to create resolve claim candidate tx")
 	transactions.RequireSendTx(g.T, ctx, g.Client, candidate, g.PrivKey)
+}
+
+func (g *SplitGameHelper) DisputeLastBlock(ctx context.Context) *ClaimHelper {
+	return g.DisputeBlock(ctx, g.L2BlockNum(ctx))
+}
+
+// DisputeBlock posts claims from both the honest and dishonest actor to progress the output root part of the game
+// through to the split depth and the claims are setup such that the last block in the game range is the block
+// to execute cannon on. ie the first block the honest and dishonest actors disagree about is the l2 block of the game.
+func (g *SplitGameHelper) DisputeBlock(ctx context.Context, disputeBlockNum uint64) *ClaimHelper {
+	dishonestValue := g.GetClaimValue(ctx, 0)
+	correctRootClaim := g.correctClaimValue(ctx, types.NewPositionFromGIndex(big.NewInt(1)))
+	rootIsValid := dishonestValue == correctRootClaim
+	if rootIsValid {
+		// Ensure that the dishonest actor is actually posting invalid roots.
+		// Otherwise, the honest challenger will defend our counter and ruin everything.
+		dishonestValue = common.Hash{0xff, 0xff, 0xff}
+	}
+	pos := types.NewPositionFromGIndex(big.NewInt(1))
+	getClaimValue := func(parentClaim *ClaimHelper, claimPos types.Position) common.Hash {
+		claimBlockNum, err := g.ClaimedL2SequenceNumber(claimPos)
+		g.Require.NoError(err, "failed to calculate claim block number")
+		if claimBlockNum < disputeBlockNum {
+			// Use the correct output root for all claims prior to the dispute block number
+			// This pushes the game to dispute the last block in the range
+			return g.correctClaimValue(ctx, claimPos)
+		}
+		if rootIsValid == parentClaim.AgreesWithOutputRoot() {
+			// We are responding to a parent claim that agrees with a valid root, so we're being dishonest
+			return dishonestValue
+		} else {
+			// Otherwise we must be the honest actor so use the correct root
+			return g.correctClaimValue(ctx, claimPos)
+		}
+	}
+
+	claim := g.RootClaim(ctx)
+	for !claim.IsOutputRootLeaf(ctx) {
+		parentClaimBlockNum, err := g.ClaimedL2SequenceNumber(pos)
+		g.Require.NoError(err, "failed to calculate parent claim block number")
+		if parentClaimBlockNum >= disputeBlockNum {
+			pos = pos.Attack()
+			claim = claim.Attack(ctx, getClaimValue(claim, pos))
+		} else {
+			pos = pos.Defend()
+			claim = claim.Defend(ctx, getClaimValue(claim, pos))
+		}
+	}
+	return claim
 }

--- a/op-e2e/e2eutils/disputegame/split_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/split_game_helper.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultTimeout = 5 * time.Minute
+const defaultTimeout = 20 * time.Minute
 
 type SplitGameHelper struct {
 	T                     *testing.T
@@ -372,7 +372,7 @@ func (g *SplitGameHelper) GameData(ctx context.Context) string {
 		pos := claim.Position
 		extra := g.DescribePosition(pos, splitDepth)
 		info = info + fmt.Sprintf("%v - Position: %v, Depth: %v, IndexAtDepth: %v Trace Index: %v, ClaimHash: %v, Countered By: %v, ParentIndex: %v Claimant: %v Bond: %v %v\n",
-			i, claim.Position.ToGIndex().Int64(), pos.Depth(), pos.IndexAtDepth(), pos.TraceIndex(maxDepth), claim.Value.Hex(), claim.CounteredBy, claim.ParentContractIndex, claim.Claimant, claim.Bond, extra)
+			i, claim.Position.ToGIndex(), pos.Depth(), pos.IndexAtDepth(), pos.TraceIndex(maxDepth), claim.Value.Hex(), claim.CounteredBy, claim.ParentContractIndex, claim.Claimant, claim.Bond, extra)
 	}
 	l2BlockNum := g.L2BlockNum(ctx)
 	status, err := g.Game.GetStatus(ctx)
@@ -555,7 +555,7 @@ func (g *SplitGameHelper) StepFails(ctx context.Context, claimIdx int64, isAttac
 	validStepErr := "0xfb4e40dd"
 	invalidPrestateErr := "0x696550ff"
 	if !strings.Contains(err.Error(), validStepErr) && !strings.Contains(err.Error(), invalidPrestateErr) {
-		g.Require.Failf("Revert reason should be abi encoded ValidStep() or InvalidPrestate() but was: %v", err.Error())
+		g.Require.Failf("Revert reason should be abi encoded ValidStep() or InvalidPrestate()", "err is %v", err.Error())
 	}
 }
 

--- a/op-e2e/e2eutils/disputegame/super_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/super_cannon_helper.go
@@ -1,15 +1,21 @@
 package disputegame
 
 import (
+	"context"
 	"crypto/ecdsa"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +28,7 @@ func NewSuperCannonGameHelper(t *testing.T, client *ethclient.Client, opts *bind
 	superGameHelper := NewSuperGameHelper(t, require.New(t), client, opts, key, game, factoryAddr, gameAddr, provider, system)
 	defaultChallengerOptions := func() []challenger.Option {
 		return []challenger.Option{
-			challenger.WithCannon(t, system),
+			challenger.WithSuperCannon(t, system),
 			challenger.WithFactoryAddress(factoryAddr),
 			challenger.WithGameAddress(gameAddr),
 		}
@@ -31,4 +37,43 @@ func NewSuperCannonGameHelper(t *testing.T, client *ethclient.Client, opts *bind
 		SuperGameHelper: *superGameHelper,
 		CannonHelper:    *NewCannonHelper(&superGameHelper.SplitGameHelper, defaultChallengerOptions),
 	}
+}
+
+func (g *SuperCannonGameHelper) CreateHonestActor(ctx context.Context, options ...HonestActorOpt) *OutputHonestHelper {
+	logger := testlog.Logger(g.T, log.LevelInfo).New("role", "HonestHelper", "game", g.Addr)
+
+	realPrestateBlock, realPostStateBlock, err := g.Game.GetGameRange(ctx)
+	g.Require.NoError(err, "Failed to load block range")
+	splitDepth := g.SplitDepth(ctx)
+	supervisorClient := g.System.SupervisorClient()
+	actorCfg := &HonestActorConfig{
+		PrestateSequenceNumber:  realPrestateBlock,
+		PoststateSequenceNumber: realPostStateBlock,
+		ChallengerOpts:          g.defaultChallengerOptions(),
+	}
+	for _, option := range options {
+		option(actorCfg)
+	}
+
+	cfg := challenger.NewChallengerConfig(g.T, g.System, "", actorCfg.ChallengerOpts...)
+	dir := filepath.Join(cfg.Datadir, "honest")
+	prestateProvider := super.NewSuperRootPrestateProvider(supervisorClient, actorCfg.PrestateSequenceNumber)
+	l1Head := g.GetL1Head(ctx)
+	accessor, err := super.NewSuperCannonTraceAccessor(
+		logger,
+		metrics.NoopMetrics,
+		cfg.Cannon,
+		vm.NewOpProgramServerExecutor(logger),
+		prestateProvider,
+		supervisorClient,
+		cfg.CannonAbsolutePreState,
+		dir,
+		l1Head,
+		splitDepth,
+		actorCfg.PrestateSequenceNumber,
+		actorCfg.PoststateSequenceNumber,
+	)
+	g.Require.NoError(err, "Failed to create output cannon trace accessor")
+	return NewOutputHonestHelper(g.T, g.Require, &g.SuperGameHelper.SplitGameHelper, g.Game, accessor)
+
 }

--- a/op-e2e/e2eutils/disputegame/super_dispute_system.go
+++ b/op-e2e/e2eutils/disputegame/super_dispute_system.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -47,6 +48,19 @@ func (s *SuperDisputeSystem) NodeEndpoint(name string) endpoint.RPC {
 	return s.sys.L2GethEndpoint(network, node)
 }
 
+func (s *SuperDisputeSystem) L2NodeEndpoints() []endpoint.RPC {
+	networks := s.sys.L2IDs()
+	endpoints := make([]endpoint.RPC, len(networks))
+	for i, network := range networks {
+		endpoints[i] = s.sys.L2GethEndpoint(network, "sequencer")
+	}
+	return endpoints
+}
+
+func (s *SuperDisputeSystem) SupervisorEndpoint() endpoint.RPC {
+	return endpoint.URL(s.sys.Supervisor().RPC())
+}
+
 func (s *SuperDisputeSystem) NodeClient(name string) *ethclient.Client {
 	if name == "l1" {
 		return s.sys.L1GethClient()
@@ -78,6 +92,10 @@ func (s *SuperDisputeSystem) RollupCfgs() []*rollup.Config {
 	return cfgs
 }
 
+func (s *SuperDisputeSystem) DependencySet() *depset.StaticConfigDependencySet {
+	return s.sys.DependencySet()
+}
+
 func (s *SuperDisputeSystem) L2Geneses() []*core.Genesis {
 	networks := s.sys.L2IDs()
 	cfgs := make([]*core.Genesis, len(networks))
@@ -93,6 +111,10 @@ func (s *SuperDisputeSystem) PrestateVariant() challenger.PrestateVariant {
 
 func (s *SuperDisputeSystem) AdvanceTime(duration time.Duration) {
 	s.sys.AdvanceL1Time(duration)
+}
+
+func (s *SuperDisputeSystem) IsSupersystem() bool {
+	return true
 }
 
 var _ DisputeSystem = (*SuperDisputeSystem)(nil)

--- a/op-e2e/e2eutils/disputegame/super_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/super_game_helper.go
@@ -33,7 +33,6 @@ func NewSuperGameHelper(t *testing.T, require *require.Assertions, client *ethcl
 			CorrectOutputProvider: correctOutputProvider,
 			System:                system,
 			DescribePosition: func(pos types.Position, splitDepth types.Depth) string {
-
 				if pos.Depth() > splitDepth {
 					return ""
 				}
@@ -42,6 +41,10 @@ func NewSuperGameHelper(t *testing.T, require *require.Assertions, client *ethcl
 					return ""
 				}
 				return fmt.Sprintf("Timestamp: %v, Step: %v", timestamp, step)
+			},
+			ClaimedL2SequenceNumber: func(pos types.Position) (uint64, error) {
+				timestamp, _, err := correctOutputProvider.ComputeStep(pos)
+				return timestamp, err
 			},
 		},
 	}

--- a/op-e2e/faultproofs/arenas.go
+++ b/op-e2e/faultproofs/arenas.go
@@ -1,0 +1,98 @@
+package faultproofs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/interop"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+)
+
+type gameArena interface {
+	AdvanceTime(duration time.Duration)
+	L1Client() *ethclient.Client
+	GetProposalRoot(ctx context.Context, l2SequenceNumber uint64) common.Hash
+	CreateChallenger(ctx context.Context)
+	CreateHonestActor(ctx context.Context) *disputegame.OutputHonestHelper
+}
+
+type outputGameArena struct {
+	t    *testing.T
+	sys  *e2esys.System
+	game *disputegame.OutputCannonGameHelper
+}
+
+func (o *outputGameArena) AdvanceTime(duration time.Duration) {
+	o.sys.AdvanceTime(duration)
+}
+
+func (o *outputGameArena) L1Client() *ethclient.Client {
+	return o.sys.NodeClient("l1")
+}
+
+func (o *outputGameArena) GetProposalRoot(ctx context.Context, l2SequenceNumber uint64) common.Hash {
+	output, err := o.sys.RollupClient("sequencer").OutputAtBlock(ctx, l2SequenceNumber)
+	require.NoError(o.t, err)
+	return common.Hash(output.OutputRoot)
+}
+
+func (o *outputGameArena) CreateChallenger(ctx context.Context) {
+	o.game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(o.sys.Cfg.Secrets.Alice))
+}
+
+func (o *outputGameArena) CreateHonestActor(ctx context.Context) *disputegame.OutputHonestHelper {
+	return o.game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(o.sys.Cfg.Secrets.Mallory))
+}
+
+func createOutputGameArena(t *testing.T, sys *e2esys.System, game *disputegame.OutputCannonGameHelper) gameArena {
+	return &outputGameArena{
+		t:    t,
+		sys:  sys,
+		game: game,
+	}
+}
+
+type superGameArena struct {
+	t    *testing.T
+	sys  interop.SuperSystem
+	game *disputegame.SuperCannonGameHelper
+}
+
+func (s *superGameArena) AdvanceTime(duration time.Duration) {
+	s.sys.AdvanceL1Time(duration)
+}
+
+func (s *superGameArena) L1Client() *ethclient.Client {
+	return s.sys.L1GethClient()
+}
+
+func (s *superGameArena) GetProposalRoot(ctx context.Context, l2SequenceNumber uint64) common.Hash {
+	output, err := s.sys.SupervisorClient().SuperRootAtTimestamp(ctx, hexutil.Uint64(l2SequenceNumber))
+	require.NoError(s.t, err)
+	return common.Hash(output.SuperRoot)
+}
+
+func (s *superGameArena) CreateChallenger(ctx context.Context) {
+	s.game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(s.t)), challenger.WithDepset(s.t, s.sys.DependencySet()))
+}
+
+func (s *superGameArena) CreateHonestActor(ctx context.Context) *disputegame.OutputHonestHelper {
+	return s.game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(s.t)), func(c *disputegame.HonestActorConfig) {
+		c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(s.t, s.sys.DependencySet()))
+	})
+}
+
+func createSuperGameArena(t *testing.T, sys interop.SuperSystem, game *disputegame.SuperCannonGameHelper) gameArena {
+	return &superGameArena{
+		t:    t,
+		sys:  sys,
+		game: game,
+	}
+}

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -38,7 +38,6 @@ func testCannonGame(t *testing.T, ctx context.Context, arena gameArena, game *di
 
 	// Attack the root of the cannon trace subgame
 	claim = claim.Attack(ctx, common.Hash{0x00, 0xcc})
-	lastDishonestClaim := claim
 	for !claim.IsMaxDepth(ctx) {
 		if claim.AgreesWithOutputRoot() {
 			// If the latest claim supports the output root, wait for the honest challenger to respond
@@ -47,26 +46,247 @@ func testCannonGame(t *testing.T, ctx context.Context, arena gameArena, game *di
 		} else {
 			// Otherwise we need to counter the honest claim
 			claim = claim.Defend(ctx, common.Hash{0x00, 0xdd})
-			lastDishonestClaim = claim
 			game.LogGameData(ctx)
 		}
 	}
 
-	if expectChallengerToStep := game.MaxDepth(ctx)%2 == 0; expectChallengerToStep {
-		t.Log("Waiting for challenger to step...")
-		claim.WaitForCountered(ctx)
-	} else {
-		t.Log("Calling step on challenger's claim...")
-		require.NotEqual(t, lastDishonestClaim.Position, claim.Position, "sanity checking challenger claim failed")
-		honestActor := arena.CreateHonestActor(ctx)
-		honestActor.StepFails(ctx, claim.Index, false)
-		honestActor.StepFails(ctx, claim.Index, true)
-	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
 	game.LogGameData(ctx)
 
 	arena.AdvanceTime(game.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
 	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func testCannonChallengeAllZeroClaim(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	game.LogGameData(ctx)
+
+	claim := game.DisputeLastBlock(ctx)
+	arena.CreateChallenger(ctx)
+
+	game.SupportClaim(ctx, claim, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		if parent.IsBottomGameRoot(ctx) {
+			return parent.Attack(ctx, common.Hash{})
+		}
+		return parent.Defend(ctx, common.Hash{})
+	}, verifyFinalStepper(t, ctx, arena, game))
+	game.LogGameData(ctx)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	game.LogGameData(ctx)
+}
+
+func testCannonDefendStep(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	outputRootClaim := game.DisputeLastBlock(ctx)
+	game.LogGameData(ctx)
+	arena.CreateChallenger(ctx)
+
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	maxDepth := game.MaxDepth(ctx)
+	game.SupportClaim(ctx, outputRootClaim, func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		// Post invalid claims for most steps to get down into the early part of the trace
+		if claim.Depth() < maxDepth-3 {
+			return claim.Attack(ctx, common.Hash{0xaa})
+		} else {
+			// Post our own counter but using the correct hash in low levels to force a defense step
+			return correctTrace.AttackClaim(ctx, claim)
+		}
+	}, verifyFinalStepper(t, ctx, arena, game))
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func testCannonPoisonedPostState(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	// Honest first attack at "honest" level
+	claim := correctTrace.AttackClaim(ctx, game.RootClaim(ctx))
+
+	// Honest defense at "dishonest" level
+	claim = correctTrace.DefendClaim(ctx, claim)
+
+	// Dishonest attack at "honest" level - honest move would be to ignore
+	claimToIgnore1 := claim.Attack(ctx, common.Hash{0x03, 0xaa})
+
+	// Honest attack at "dishonest" level - honest move would be to ignore
+	claimToIgnore2 := correctTrace.AttackClaim(ctx, claimToIgnore1)
+	game.LogGameData(ctx)
+
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	// Start dishonest challenger that posts correct claims
+	for {
+		game.LogGameData(ctx)
+		// Wait for the challenger to counter
+		// Note that we need to ignore claimToIgnore1 which already counters this...
+		claim = claim.WaitForCounterClaim(ctx, claimToIgnore1)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+
+		// Respond with our own move
+		if claim.IsBottomGameRoot(ctx) {
+			// Root of the cannon game must have the right VM status code (so it can't be honest).
+			// Note this occurs when there are splitDepth + 4 claims because there are multiple forks in this game.
+			claim = claim.Attack(ctx, common.Hash{0x01})
+		} else {
+			claim = correctTrace.DefendClaim(ctx, claim)
+		}
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	// Verify that the challenger didn't challenge our poisoned claims
+	claimToIgnore1.RequireOnlyCounteredBy(ctx, claimToIgnore2)
+	claimToIgnore2.RequireOnlyCounteredBy(ctx /* nothing */)
+
+	// Time travel past when the game will be resolvable.
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.LogGameData(ctx)
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func testDisputeRootBeyondProposedBlockValidOutputRoot(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, rootIsCorrect(t, ctx, arena, game), "This test must be run with a correct proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	claim := game.RootClaim(ctx)
+	// Attack the output root
+	claim = correctTrace.AttackClaim(ctx, claim)
+	// Wait for the challenger to respond
+	claim = claim.WaitForCounterClaim(ctx)
+	// Then defend until the split depth to force the game into the extension part of the output root bisection
+	// ie. the output root we wind up disputing is theoretically for a block after block number 1
+	for !claim.IsOutputRootLeaf(ctx) {
+		claim = correctTrace.DefendClaim(ctx, claim)
+		claim = claim.WaitForCounterClaim(ctx)
+	}
+	game.LogGameData(ctx)
+	// At this point we've reached the bottom of the output root bisection and every claim
+	// will have the same, valid, output root. We now need to post a cannon trace root that claims its invalid.
+	claim = claim.Defend(ctx, common.Hash{0x01, 0xaa})
+	// Now defend with the correct trace
+	for {
+		game.LogGameData(ctx)
+		claim = claim.WaitForCounterClaim(ctx)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+		claim = correctTrace.DefendClaim(ctx, claim)
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	// Time travel past when the game will be resolvable.
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
+	game.LogGameData(ctx)
+}
+
+func testDisputeRootBeyondProposedBlockInvalidOutputRoot(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	claim := game.RootClaim(ctx)
+	// Wait for the honest challenger to counter the root
+	claim = claim.WaitForCounterClaim(ctx)
+	// Then defend until the split depth to force the game into the extension part of the output root bisection
+	// ie. the output root we wind up disputing is theoretically for a block after block number 1
+	// The dishonest actor challenges with the correct roots
+	for claim.IsOutputRoot(ctx) {
+		claim = correctTrace.DefendClaim(ctx, claim)
+		claim = claim.WaitForCounterClaim(ctx)
+	}
+	game.LogGameData(ctx)
+	// Now defend with the correct trace
+	for !claim.IsMaxDepth(ctx) {
+		game.LogGameData(ctx)
+		if claim.IsBottomGameRoot(ctx) {
+			claim = correctTrace.AttackClaim(ctx, claim)
+		} else {
+			claim = correctTrace.DefendClaim(ctx, claim)
+		}
+		if !claim.IsMaxDepth(ctx) {
+			// Have to attack the root of the cannon trace
+			claim = claim.WaitForCounterClaim(ctx)
+		}
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	// Time travel past when the game will be resolvable.
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	game.LogGameData(ctx)
+}
+
+func testDisputeRootChangeClaimedRoot(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	claim := game.RootClaim(ctx)
+	// Wait for the honest challenger to counter the root
+	claim = claim.WaitForCounterClaim(ctx)
+
+	// Then attack every claim until the leaf of output root bisection
+	for {
+		claim = claim.Attack(ctx, common.Hash{0xbb})
+		claim = claim.WaitForCounterClaim(ctx)
+		if claim.Depth() == game.SplitDepth(ctx)-1 {
+			// Post the correct output root as the leaf.
+			// This is for epoch 1 which is what the original root proposal was for too
+			claim = correctTrace.AttackClaim(ctx, claim)
+			// Challenger should post the first cannon trace
+			claim = claim.WaitForCounterClaim(ctx)
+			break
+		}
+	}
+
+	game.LogGameData(ctx)
+
+	// Now defend with the correct trace
+	for !claim.IsMaxDepth(ctx) {
+		game.LogGameData(ctx)
+		if claim.IsBottomGameRoot(ctx) {
+			claim = correctTrace.AttackClaim(ctx, claim)
+		} else {
+			claim = correctTrace.DefendClaim(ctx, claim)
+		}
+		if !claim.IsMaxDepth(ctx) {
+			// Have to attack the root of the cannon trace
+			claim = claim.WaitForCounterClaim(ctx)
+		}
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	game.LogGameData(ctx)
 }
 
 func rootIsCorrect(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) bool {
@@ -76,4 +296,37 @@ func rootIsCorrect(t *testing.T, ctx context.Context, arena gameArena, game *dis
 	require.NoError(t, err)
 	output := arena.GetProposalRoot(ctx, l2SequenceNumber)
 	return output == root.Value
+}
+
+func verifyFinalStepper(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) disputegame.Stepper {
+	return func(parentClaimIdx int64) {
+		validRoot := rootIsCorrect(t, ctx, arena, game)
+		maxDepth := game.MaxDepth(ctx)
+		expectChallengerToStep := validRoot == (maxDepth%2 == 1)
+		if expectChallengerToStep {
+			t.Log("Waiting for challenger to step on dishonest claim...")
+			game.WaitForCountered(ctx, parentClaimIdx)
+		} else {
+			t.Log("Calling step on challenger's claim...")
+			honestActor := arena.CreateHonestActor(ctx)
+			honestActor.StepFails(ctx, parentClaimIdx, false)
+			honestActor.StepFails(ctx, parentClaimIdx, true)
+		}
+	}
+}
+
+func verifyFinalStepExecution(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper, claim *disputegame.ClaimHelper) {
+	validRoot := rootIsCorrect(t, ctx, arena, game)
+	maxDepth := game.MaxDepth(ctx)
+	expectChallengerToStep := validRoot == (maxDepth%2 == 1)
+
+	if expectChallengerToStep {
+		t.Log("Waiting for challenger to step on dishonest claim...")
+		claim.WaitForCountered(ctx)
+	} else {
+		t.Log("Calling step on challenger's claim...")
+		honestActor := arena.CreateHonestActor(ctx)
+		honestActor.StepFails(ctx, claim.Index, false)
+		honestActor.StepFails(ctx, claim.Index, true)
+	}
 }

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -1,0 +1,79 @@
+package faultproofs
+
+import (
+	"context"
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func testCannonGame(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	game.LogGameData(ctx)
+	arena.CreateChallenger(ctx)
+
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+
+	// Challenger should post an output root to counter claims down to the leaf level of the top game
+	claim := game.RootClaim(ctx)
+	for claim.IsOutputRoot(ctx) && !claim.IsOutputRootLeaf(ctx) {
+		if claim.AgreesWithOutputRoot() {
+			// If the latest claim agrees with the output root, expect the honest challenger to counter it
+			claim = claim.WaitForCounterClaim(ctx)
+			game.LogGameData(ctx)
+			claim.RequireCorrectOutputRoot(ctx)
+		} else {
+			// Otherwise we should counter
+			claim = claim.Attack(ctx, common.Hash{0xaa})
+			game.LogGameData(ctx)
+		}
+	}
+
+	// Wait for the challenger to post the first claim in the cannon trace
+	claim = claim.WaitForCounterClaim(ctx)
+	game.LogGameData(ctx)
+
+	// Attack the root of the cannon trace subgame
+	claim = claim.Attack(ctx, common.Hash{0x00, 0xcc})
+	lastDishonestClaim := claim
+	for !claim.IsMaxDepth(ctx) {
+		if claim.AgreesWithOutputRoot() {
+			// If the latest claim supports the output root, wait for the honest challenger to respond
+			claim = claim.WaitForCounterClaim(ctx)
+			game.LogGameData(ctx)
+		} else {
+			// Otherwise we need to counter the honest claim
+			claim = claim.Defend(ctx, common.Hash{0x00, 0xdd})
+			lastDishonestClaim = claim
+			game.LogGameData(ctx)
+		}
+	}
+
+	if expectChallengerToStep := game.MaxDepth(ctx)%2 == 0; expectChallengerToStep {
+		t.Log("Waiting for challenger to step...")
+		claim.WaitForCountered(ctx)
+	} else {
+		t.Log("Calling step on challenger's claim...")
+		require.NotEqual(t, lastDishonestClaim.Position, claim.Position, "sanity checking challenger claim failed")
+		honestActor := arena.CreateHonestActor(ctx)
+		honestActor.StepFails(ctx, claim.Index, false)
+		honestActor.StepFails(ctx, claim.Index, true)
+	}
+	game.LogGameData(ctx)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func rootIsCorrect(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) bool {
+	root, err := game.Game.GetClaim(ctx, 0)
+	require.NoError(t, err)
+	_, l2SequenceNumber, err := game.Game.GetGameRange(ctx)
+	require.NoError(t, err)
+	output := arena.GetProposalRoot(ctx, l2SequenceNumber)
+	return output == root.Value
+}

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -188,6 +188,9 @@ func testDisputeRootBeyondProposedBlockValidOutputRoot(t *testing.T, ctx context
 			break
 		}
 		claim = correctTrace.DefendClaim(ctx, claim)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
 	}
 	verifyFinalStepExecution(t, ctx, arena, game, claim)
 

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -29,56 +29,15 @@ func TestOutputCannonGame_Multithreaded(t *testing.T) {
 func testOutputCannonGame(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 4, common.Hash{0x01})
 	game.LogGameData(ctx)
 
-	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	game.LogGameData(ctx)
-
-	// Challenger should post an output root to counter claims down to the leaf level of the top game
-	claim := game.RootClaim(ctx)
-	for claim.IsOutputRoot(ctx) && !claim.IsOutputRootLeaf(ctx) {
-		if claim.AgreesWithOutputRoot() {
-			// If the latest claim agrees with the output root, expect the honest challenger to counter it
-			claim = claim.WaitForCounterClaim(ctx)
-			game.LogGameData(ctx)
-			claim.RequireCorrectOutputRoot(ctx)
-		} else {
-			// Otherwise we should counter
-			claim = claim.Attack(ctx, common.Hash{0xaa})
-			game.LogGameData(ctx)
-		}
-	}
-
-	// Wait for the challenger to post the first claim in the cannon trace
-	claim = claim.WaitForCounterClaim(ctx)
-	game.LogGameData(ctx)
-
-	// Attack the root of the cannon trace subgame
-	claim = claim.Attack(ctx, common.Hash{0x00, 0xcc})
-	for !claim.IsMaxDepth(ctx) {
-		if claim.AgreesWithOutputRoot() {
-			// If the latest claim supports the output root, wait for the honest challenger to respond
-			claim = claim.WaitForCounterClaim(ctx)
-			game.LogGameData(ctx)
-		} else {
-			// Otherwise we need to counter the honest claim
-			claim = claim.Defend(ctx, common.Hash{0x00, 0xdd})
-			game.LogGameData(ctx)
-		}
-	}
-	// Challenger should be able to call step and counter the leaf claim.
-	claim.WaitForCountered(ctx)
-	game.LogGameData(ctx)
-
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonGame(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestOutputCannon_ChallengeAllZeroClaim_Standard(t *testing.T) {

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -34,8 +34,6 @@ func testOutputCannonGame(t *testing.T, allocType config.AllocType) {
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 4, common.Hash{0x01})
-	game.LogGameData(ctx)
-
 	arena := createOutputGameArena(t, sys, game)
 	testCannonGame(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -52,29 +50,13 @@ func testOutputCannonChallengeAllZeroClaim(t *testing.T, allocType config.AllocT
 	// The dishonest actor always posts claims with all zeros.
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, common.Hash{})
-	game.LogGameData(ctx)
-
-	claim := game.DisputeLastBlock(ctx)
-	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	game.DefendClaim(ctx, claim, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
-		if parent.IsBottomGameRoot(ctx) {
-			return parent.Attack(ctx, common.Hash{})
-		}
-		return parent.Defend(ctx, common.Hash{})
-	})
-
-	game.LogGameData(ctx)
-
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonChallengeAllZeroClaim(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestOutputCannon_PublishCannonRootClaim_Standard(t *testing.T) {
@@ -184,34 +166,13 @@ func testOutputCannonDefendStep(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
-	require.NotNil(t, game)
-	outputRootClaim := game.DisputeLastBlock(ctx)
-	game.LogGameData(ctx)
-
-	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Mallory))
-
-	maxDepth := game.MaxDepth(ctx)
-	game.DefendClaim(ctx, outputRootClaim, func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
-		// Post invalid claims for most steps to get down into the early part of the trace
-		if claim.Depth() < maxDepth-3 {
-			return claim.Attack(ctx, common.Hash{0xaa})
-		} else {
-			// Post our own counter but using the correct hash in low levels to force a defense step
-			return correctTrace.AttackClaim(ctx, claim)
-		}
-	})
-
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonDefendStep(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestOutputCannonStepWithLargePreimage_Standard(t *testing.T) {
@@ -476,64 +437,14 @@ func testOutputCannonPoisonedPostState(t *testing.T, allocType config.AllocType)
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	// Honest first attack at "honest" level
-	claim := correctTrace.AttackClaim(ctx, game.RootClaim(ctx))
-
-	// Honest defense at "dishonest" level
-	claim = correctTrace.DefendClaim(ctx, claim)
-
-	// Dishonest attack at "honest" level - honest move would be to ignore
-	claimToIgnore1 := claim.Attack(ctx, common.Hash{0x03, 0xaa})
-
-	// Honest attack at "dishonest" level - honest move would be to ignore
-	claimToIgnore2 := correctTrace.AttackClaim(ctx, claimToIgnore1)
-	game.LogGameData(ctx)
-
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	// Start dishonest challenger that posts correct claims
-	for {
-		game.LogGameData(ctx)
-		// Wait for the challenger to counter
-		// Note that we need to ignore claimToIgnore1 which already counters this...
-		claim = claim.WaitForCounterClaim(ctx, claimToIgnore1)
-
-		// Respond with our own move
-		if claim.IsBottomGameRoot(ctx) {
-			// Root of the cannon game must have the right VM status code (so it can't be honest).
-			// Note this occurs when there are splitDepth + 4 claims because there are multiple forks in this game.
-			claim = claim.Attack(ctx, common.Hash{0x01})
-		} else {
-			claim = correctTrace.DefendClaim(ctx, claim)
-		}
-
-		// Defender moves last. If we're at max depth, then we're done
-		if claim.IsMaxDepth(ctx) {
-			break
-		}
-	}
-
-	// Wait for the challenger to call step
-	claim.WaitForCountered(ctx)
-	// Verify that the challenger didn't challenge our poisoned claims
-	claimToIgnore1.RequireOnlyCounteredBy(ctx, claimToIgnore2)
-	claimToIgnore2.RequireOnlyCounteredBy(ctx /* nothing */)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.LogGameData(ctx)
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonPoisonedPostState(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot_Standard(t *testing.T) {
@@ -548,50 +459,14 @@ func testDisputeOutputRootBeyondProposedBlockValidOutputRoot(t *testing.T, alloc
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	claim := game.RootClaim(ctx)
-	// Attack the output root
-	claim = correctTrace.AttackClaim(ctx, claim)
-	// Wait for the challenger to respond
-	claim = claim.WaitForCounterClaim(ctx)
-	// Then defend until the split depth to force the game into the extension part of the output root bisection
-	// ie. the output root we wind up disputing is theoretically for a block after block number 1
-	for !claim.IsOutputRootLeaf(ctx) {
-		claim = correctTrace.DefendClaim(ctx, claim)
-		claim = claim.WaitForCounterClaim(ctx)
-	}
-	game.LogGameData(ctx)
-	// At this point we've reached the bottom of the output root bisection and every claim
-	// will have the same, valid, output root. We now need to post a cannon trace root that claims its invalid.
-	claim = claim.Defend(ctx, common.Hash{0x01, 0xaa})
-	// Now defend with the correct trace
-	for {
-		game.LogGameData(ctx)
-		claim = claim.WaitForCounterClaim(ctx)
-		if claim.IsMaxDepth(ctx) {
-			break
-		}
-		claim = correctTrace.DefendClaim(ctx, claim)
-	}
-	// Should not be able to step either attacking or defending
-	correctTrace.StepClaimFails(ctx, claim, true)
-	correctTrace.StepClaimFails(ctx, claim, false)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testDisputeRootBeyondProposedBlockValidOutputRoot(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot_Standard(t *testing.T) {
@@ -606,51 +481,14 @@ func testDisputeOutputRootBeyondProposedBlockInvalidOutputRoot(t *testing.T, all
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	claim := game.RootClaim(ctx)
-	// Wait for the honest challenger to counter the root
-	claim = claim.WaitForCounterClaim(ctx)
-	// Then defend until the split depth to force the game into the extension part of the output root bisection
-	// ie. the output root we wind up disputing is theoretically for a block after block number 1
-	// The dishonest actor challenges with the correct roots
-	for claim.IsOutputRoot(ctx) {
-		claim = correctTrace.DefendClaim(ctx, claim)
-		claim = claim.WaitForCounterClaim(ctx)
-	}
-	game.LogGameData(ctx)
-	// Now defend with the correct trace
-	for !claim.IsMaxDepth(ctx) {
-		game.LogGameData(ctx)
-		if claim.IsBottomGameRoot(ctx) {
-			claim = correctTrace.AttackClaim(ctx, claim)
-		} else {
-			claim = correctTrace.DefendClaim(ctx, claim)
-		}
-		if !claim.IsMaxDepth(ctx) {
-			// Have to attack the root of the cannon trace
-			claim = claim.WaitForCounterClaim(ctx)
-		}
-	}
-
-	// Wait for our final claim to be countered by the challenger calling step
-	claim.WaitForCountered(ctx)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testDisputeRootBeyondProposedBlockInvalidOutputRoot(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestTestDisputeOutputRoot_ChangeClaimedOutputRoot_Standard(t *testing.T) {
@@ -665,60 +503,14 @@ func testTestDisputeOutputRootChangeClaimedOutputRoot(t *testing.T, allocType co
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	claim := game.RootClaim(ctx)
-	// Wait for the honest challenger to counter the root
-	claim = claim.WaitForCounterClaim(ctx)
-
-	// Then attack every claim until the leaf of output root bisection
-	for {
-		claim = claim.Attack(ctx, common.Hash{0xbb})
-		claim = claim.WaitForCounterClaim(ctx)
-		if claim.Depth() == game.SplitDepth(ctx)-1 {
-			// Post the correct output root as the leaf.
-			// This is for block 1 which is what the original output root was for too
-			claim = correctTrace.AttackClaim(ctx, claim)
-			// Challenger should post the first cannon trace
-			claim = claim.WaitForCounterClaim(ctx)
-			break
-		}
-	}
-
-	game.LogGameData(ctx)
-
-	// Now defend with the correct trace
-	for !claim.IsMaxDepth(ctx) {
-		game.LogGameData(ctx)
-		if claim.IsBottomGameRoot(ctx) {
-			claim = correctTrace.AttackClaim(ctx, claim)
-		} else {
-			claim = correctTrace.DefendClaim(ctx, claim)
-		}
-		if !claim.IsMaxDepth(ctx) {
-			// Have to attack the root of the cannon trace
-			claim = claim.WaitForCounterClaim(ctx)
-		}
-	}
-
-	// Wait for our final claim to be countered by the challenger calling step
-	claim.WaitForCountered(ctx)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testDisputeRootChangeClaimedRoot(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestInvalidateUnsafeProposal_Standard(t *testing.T) {

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -28,37 +28,7 @@ func TestSuperCannonGame(t *testing.T) {
 	ctx := context.Background()
 	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
 	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
-	game.LogGameData(ctx)
-
-	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
-	correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
-		c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
-	})
-	game.LogGameData(ctx)
-
-	invalidRoot := game.RootClaim(ctx)
-	honestCounter := invalidRoot.WaitForCounterClaim(ctx)
-	game.ChallengeClaim(ctx, honestCounter, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
-		// ordered top to bottom
-		switch {
-		case parent.IsOutputRoot(ctx):
-			parent.RequireCorrectOutputRoot(ctx)
-			return parent.Attack(ctx, common.Hash{0x01, 0xaa})
-		case parent.IsBottomGameRoot(ctx):
-			return parent.Attack(ctx, common.Hash{0x01, 0xaa})
-		default:
-			return parent.Defend(ctx, common.Hash{0x01, 0xaa})
-		}
-	}, func(idx int64) {
-		correctTrace.StepFails(ctx, idx, false)
-		correctTrace.StepFails(ctx, idx, true)
-	})
-
-	game.LogGameData(ctx)
-
-	sys.AdvanceL1Time(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	testCannonGame(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
 }
 
 func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"testing"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateSuperCannonGame(t *testing.T) {
@@ -16,4 +21,77 @@ func TestCreateSuperCannonGame(t *testing.T) {
 	sys.L2IDs()
 	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
 	game.LogGameData(ctx)
+}
+
+func TestSuperCannonGame(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	game.LogGameData(ctx)
+
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+	correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+		c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+	})
+	game.LogGameData(ctx)
+
+	invalidRoot := game.RootClaim(ctx)
+	honestCounter := invalidRoot.WaitForCounterClaim(ctx)
+	game.ChallengeClaim(ctx, honestCounter, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		// ordered top to bottom
+		switch {
+		case parent.IsOutputRoot(ctx):
+			parent.RequireCorrectOutputRoot(ctx)
+			return parent.Attack(ctx, common.Hash{0x01, 0xaa})
+		case parent.IsBottomGameRoot(ctx):
+			return parent.Attack(ctx, common.Hash{0x01, 0xaa})
+		default:
+			return parent.Defend(ctx, common.Hash{0x01, 0xaa})
+		}
+	}, func(idx int64) {
+		correctTrace.StepFails(ctx, idx, false)
+		correctTrace.StepFails(ctx, idx, true)
+	})
+
+	game.LogGameData(ctx)
+
+	sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRoot(ctx)
+	game.LogGameData(ctx)
+
+	correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+		c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+	})
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+	rootAttack := correctTrace.AttackClaim(ctx, game.RootClaim(ctx))
+	game.DefendClaim(ctx, rootAttack, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		switch {
+		case parent.IsOutputRoot(ctx):
+			parent.RequireCorrectOutputRoot(ctx)
+			if parent.IsOutputRootLeaf(ctx) {
+				return parent.Attack(ctx, common.Hash{0x01, 0xaa})
+			} else {
+				return correctTrace.DefendClaim(ctx, parent)
+			}
+		case parent.IsBottomGameRoot(ctx):
+			return correctTrace.AttackClaim(ctx, parent)
+		default:
+			return correctTrace.DefendClaim(ctx, parent)
+		}
+	})
+	game.LogGameData(ctx)
+
+	sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
 }

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -31,6 +31,54 @@ func TestSuperCannonGame(t *testing.T) {
 	testCannonGame(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
 }
 
+func TestSuperCannonGame_ChallengeAllZeroClaim(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testCannonChallengeAllZeroClaim(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonDefendStep(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testCannonDefendStep(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonPoisonedPostState(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testCannonPoisonedPostState(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonRootBeyondProposedBlock_ValidRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRoot(ctx)
+	testDisputeRootBeyondProposedBlockValidOutputRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonRootBeyondProposedBlock_InvalidRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testDisputeRootBeyondProposedBlockInvalidOutputRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testDisputeRootChangeClaimedRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
 func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()

--- a/op-e2e/faultproofs/util_interop.go
+++ b/op-e2e/faultproofs/util_interop.go
@@ -49,12 +49,12 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 	// wait for the supervisor to sync genesis
 	var lastError error
 	err = wait.For(ctx, 1*time.Minute, func() (bool, error) {
-		_, err := s2.SupervisorClient().SyncStatus(ctx)
+		status, err := s2.SupervisorClient().SyncStatus(ctx)
 		if err != nil {
 			lastError = err
 			return false, nil
 		}
-		return true, nil
+		return status.SafeTimestamp != 0, nil
 	})
 	require.NoErrorf(t, err, "failed to wait for supervisor to sync genesis: %v", lastError)
 

--- a/op-e2e/faultproofs/util_interop.go
+++ b/op-e2e/faultproofs/util_interop.go
@@ -2,6 +2,7 @@ package faultproofs
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
@@ -9,10 +10,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/interop"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
+
+var InteropL1ChainID = new(big.Int).SetUint64(900100)
 
 func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts) (interop.SuperSystem, *disputegame.FactoryHelper, *ethclient.Client) {
 	fdc := new(faultDisputeConfig)
@@ -20,7 +24,7 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 		opt(fdc)
 	}
 	recipe := interopgen.InteropDevRecipe{
-		L1ChainID:        900100,
+		L1ChainID:        InteropL1ChainID.Uint64(),
 		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
 		GenesisTimestamp: uint64(time.Now().Unix() + 3), // start chain 3 seconds from now
 	}
@@ -40,5 +44,35 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 	s2 := interop.NewSuperSystem(t, &recipe, worldResources, superCfg)
 	factory := disputegame.NewFactoryHelper(t, context.Background(), disputegame.NewSuperDisputeSystem(s2),
 		disputegame.WithFactoryPrivKey(privKey))
+
+	ctx := context.Background()
+	// wait for the supervisor to sync genesis
+	var lastError error
+	err = wait.For(ctx, 1*time.Minute, func() (bool, error) {
+		_, err := s2.SupervisorClient().SyncStatus(ctx)
+		if err != nil {
+			lastError = err
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoErrorf(t, err, "failed to wait for supervisor to sync genesis: %v", lastError)
+
 	return s2, factory, s2.L1GethClient()
+}
+
+func aliceKey(t *testing.T) *ecdsa.PrivateKey {
+	hdWallet, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+	challengerKey, err := hdWallet.Secret(devkeys.ChainUserKeys(InteropL1ChainID)(1))
+	require.NoError(t, err)
+	return challengerKey
+}
+
+func malloryKey(t *testing.T) *ecdsa.PrivateKey {
+	hdWallet, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+	malloryKey, err := hdWallet.Secret(devkeys.ChainUserKeys(InteropL1ChainID)(2))
+	require.NoError(t, err)
+	return malloryKey
 }

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -398,7 +399,8 @@ func (sys *System) DisputeGameFactoryAddr() common.Address {
 }
 
 func (sys *System) SupervisorClient() *sources.SupervisorClient {
-	panic("supervisor not supported for single chain system")
+	sys.t.Fatal("supervisor client is not available for single chain system")
+	return nil
 }
 
 func (sys *System) Config() SystemConfig { return sys.Cfg }
@@ -426,6 +428,24 @@ func (sys *System) NodeEndpoint(name string) endpoint.RPC {
 		sys.t.Fatalf("unknown eth instance: %s", name)
 	}
 	return ethInst.UserRPC()
+}
+
+func (sys *System) L2NodeEndpoints() []endpoint.RPC {
+	return []endpoint.RPC{sys.NodeEndpoint("sequencer")}
+}
+
+func (sys *System) SupervisorEndpoint() endpoint.RPC {
+	sys.t.Fatalf("supervisor endpoint is not supported for pre-interop System")
+	return nil
+}
+
+func (sys *System) DependencySet() *depset.StaticConfigDependencySet {
+	sys.t.Fatalf("dependency set source is not supported for pre-interop System")
+	return nil
+}
+
+func (sys *System) IsSupersystem() bool {
+	return false
 }
 
 func (sys *System) RollupEndpoint(name string) endpoint.RPC {


### PR DESCRIPTION
Setup `SuperSystem` for e2e testing of the op-challenger for `SuperFaultDisputeGames`. This is done to ensure the system works as expected.

The output root e2e test cases will be migrated for the Super DG in a later PR. Observe the refactor of `TestOutputCannonGame` for a preview of how the migration will be done.

part of https://github.com/ethereum-optimism/optimism/issues/14974