### PR TITLE
systest: Introduce AcquireSystem

### DIFF
--- a/devnet-sdk/testing/systest/systest.go
+++ b/devnet-sdk/testing/systest/systest.go
@@ -119,13 +119,14 @@ func (h *basicSystemTestHelper) AcquireSystem(t BasicT, validators ...Preconditi
 	sys, err := tryAcquirers(t, h.acquirers)
 	if err != nil {
 		h.handlePreconditionError(t, err)
-		return nil, nil
+		return nil, nil // handlePreconditionError already skipped or failed but make it clear we don't continue
 	}
 
 	for _, validator := range validators {
 		ctx, err := validator(wt, sys)
 		if err != nil {
 			h.handlePreconditionError(t, err)
+			return nil, nil // handlePreconditionError already skipped or failed but make it clear we don't continue
 		}
 		wt = wt.WithContext(ctx)
 	}
@@ -139,7 +140,7 @@ func (h *basicSystemTestHelper) AcquireInteropSystem(t BasicT, validators ...Pre
 		return wt, sys
 	} else {
 		h.handlePreconditionError(t, fmt.Errorf("interop test requested, but system is not an interop system"))
-		return nil, nil
+		return nil, nil // handlePreconditionError already skipped or failed but make it clear we don't continue
 	}
 }
 

--- a/devnet-sdk/testing/systest/systest.go
+++ b/devnet-sdk/testing/systest/systest.go
@@ -70,8 +70,8 @@ type InteropSystemTestFunc func(t T, sys system.InteropSystem)
 
 // systemTestHelper defines the interface for system test functionality
 type systemTestHelper interface {
-	SystemTest(t BasicT, f SystemTestFunc, validators ...PreconditionValidator)
-	InteropSystemTest(t BasicT, f InteropSystemTestFunc, validators ...PreconditionValidator)
+	AcquireSystem(t BasicT, validators ...PreconditionValidator) (T, system.System)
+	AcquireInteropSystem(t BasicT, validators ...PreconditionValidator) (T, system.InteropSystem)
 	WithAcquirers(acquirers []SystemAcquirer) *basicSystemTestHelper
 	WithProvider(provider systemProvider) *basicSystemTestHelper
 }
@@ -107,19 +107,19 @@ func (h *basicSystemTestHelper) handlePreconditionError(t BasicT, err error) {
 	}
 }
 
-func (h *basicSystemTestHelper) SystemTest(t BasicT, f SystemTestFunc, validators ...PreconditionValidator) {
+func (h *basicSystemTestHelper) AcquireSystem(t BasicT, validators ...PreconditionValidator) (T, system.System) {
 	wt := NewT(t)
 	wt.Helper()
 
 	ctx, cancel := context.WithCancel(wt.Context())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	wt = wt.WithContext(ctx)
 
 	sys, err := tryAcquirers(t, h.acquirers)
 	if err != nil {
 		h.handlePreconditionError(t, err)
-		return
+		return nil, nil
 	}
 
 	for _, validator := range validators {
@@ -129,19 +129,18 @@ func (h *basicSystemTestHelper) SystemTest(t BasicT, f SystemTestFunc, validator
 		}
 		wt = wt.WithContext(ctx)
 	}
-
-	f(wt, sys)
+	return wt, sys
 }
 
-func (h *basicSystemTestHelper) InteropSystemTest(t BasicT, f InteropSystemTestFunc, validators ...PreconditionValidator) {
+func (h *basicSystemTestHelper) AcquireInteropSystem(t BasicT, validators ...PreconditionValidator) (T, system.InteropSystem) {
 	t.Helper()
-	h.SystemTest(t, func(t T, sys system.System) {
-		if sys, ok := sys.(system.InteropSystem); ok {
-			f(t, sys)
-		} else {
-			h.handlePreconditionError(t, fmt.Errorf("interop test requested, but system is not an interop system"))
-		}
-	}, validators...)
+	wt, sys := h.AcquireSystem(t, validators...)
+	if sys, ok := sys.(system.InteropSystem); ok {
+		return wt, sys
+	} else {
+		h.handlePreconditionError(t, fmt.Errorf("interop test requested, but system is not an interop system"))
+		return nil, nil
+	}
 }
 
 // newBasicSystemTestHelper creates a new basicSystemTestHelper using environment variables
@@ -180,12 +179,24 @@ func (h *basicSystemTestHelper) WithProvider(provider systemProvider) *basicSyst
 	return &newHelper
 }
 
+// AcquireSystem delegates to the default helper
+func AcquireSystem(t BasicT, validators ...PreconditionValidator) (T, system.System) {
+	return defaultHelper.AcquireSystem(t, validators...)
+}
+
+// AcquireInteropSystem delegates to the default helper
+func AcquireInteropSystem(t BasicT, validators ...PreconditionValidator) (T, system.InteropSystem) {
+	return defaultHelper.AcquireInteropSystem(t, validators...)
+}
+
 // SystemTest delegates to the default helper
 func SystemTest(t BasicT, f SystemTestFunc, validators ...PreconditionValidator) {
-	defaultHelper.SystemTest(t, f, validators...)
+	wt, sys := defaultHelper.AcquireSystem(t, validators...)
+	f(wt, sys)
 }
 
 // InteropSystemTest delegates to the default helper
 func InteropSystemTest(t BasicT, f InteropSystemTestFunc, validators ...PreconditionValidator) {
-	defaultHelper.InteropSystemTest(t, f, validators...)
+	wt, sys := defaultHelper.AcquireInteropSystem(t, validators...)
+	f(wt, sys)
 }

--- a/devnet-sdk/testing/systest/systest_test.go
+++ b/devnet-sdk/testing/systest/systest_test.go
@@ -28,7 +28,7 @@ func (h *mockSystemTestHelper) handlePreconditionError(t BasicT, err error) {
 	}
 }
 
-func (h *mockSystemTestHelper) SystemTest(t BasicT, f SystemTestFunc, validators ...PreconditionValidator) {
+func (h *mockSystemTestHelper) AcquireSystem(t BasicT, validators ...PreconditionValidator) (T, system.System) {
 	h.systemTestCalls++
 	wt := NewT(t)
 
@@ -39,30 +39,30 @@ func (h *mockSystemTestHelper) SystemTest(t BasicT, f SystemTestFunc, validators
 	sys, err := h.systemAcquirer()
 	if err != nil {
 		h.handlePreconditionError(t, err)
-		return
+		return nil, nil
 	}
 
 	for _, validator := range validators {
 		ctx, err := validator(wt, sys)
 		if err != nil {
 			h.handlePreconditionError(t, err)
-			return
+			return nil, nil
 		}
 		wt = wt.WithContext(ctx)
 	}
 
-	f(wt, sys)
+	return wt, sys
 }
 
-func (h *mockSystemTestHelper) InteropSystemTest(t BasicT, f InteropSystemTestFunc, validators ...PreconditionValidator) {
+func (h *mockSystemTestHelper) AcquireInteropSystem(t BasicT, validators ...PreconditionValidator) (T, system.InteropSystem) {
 	h.interopTestCalls++
-	h.SystemTest(t, func(t T, sys system.System) {
-		if sys, ok := sys.(system.InteropSystem); ok {
-			f(t, sys)
-		} else {
-			h.handlePreconditionError(t, fmt.Errorf("interop test requested, but system is not an interop system"))
-		}
-	}, validators...)
+	wt, sys := h.AcquireSystem(t, validators...)
+	if sys, ok := sys.(system.InteropSystem); ok {
+		return wt, sys
+	} else {
+		h.handlePreconditionError(t, fmt.Errorf("interop test requested, but system is not an interop system"))
+	}
+	return nil, nil
 }
 
 // mockEnvGetter implements envGetter for testing
@@ -145,9 +145,9 @@ func TestSystemTest(t *testing.T) {
 				}
 
 				recorder := &mockTBRecorder{mockTB: mockTB{name: "test"}}
-				helper.SystemTest(recorder, func(t T, sys system.System) {
-					t.Fatal("test function should not be called")
-				})
+				wt, sys := helper.AcquireSystem(recorder)
+				require.Nil(t, wt, "should not return wt")
+				require.Nil(t, sys, "should not return system")
 
 				require.Equal(t, tc.expectSkip, recorder.skipped, "unexpected skip state")
 				require.Equal(t, tc.expectFatal, recorder.failed, "unexpected fatal state")
@@ -164,12 +164,9 @@ func TestSystemTest(t *testing.T) {
 			},
 		}
 
-		called := false
-		helper.SystemTest(t, func(t T, sys system.System) {
-			called = true
-			require.NotNil(t, sys)
-		})
-		require.True(t, called)
+		wt, sys := helper.AcquireSystem(t)
+		require.NotNil(t, wt)
+		require.NotNil(t, sys)
 	})
 
 	t.Run("with validator", func(t *testing.T) {
@@ -180,19 +177,16 @@ func TestSystemTest(t *testing.T) {
 		}
 
 		validatorCalled := false
-		testCalled := false
 
 		validator := func(t T, sys system.System) (context.Context, error) {
 			validatorCalled = true
 			return t.Context(), nil
 		}
 
-		helper.SystemTest(t, func(t T, sys system.System) {
-			testCalled = true
-		}, validator)
-
+		wt, sys := helper.AcquireSystem(t, validator)
+		require.NotNil(t, wt)
+		require.NotNil(t, sys)
 		require.True(t, validatorCalled)
-		require.True(t, testCalled)
 	})
 
 	t.Run("multiple validators", func(t *testing.T) {
@@ -208,7 +202,9 @@ func TestSystemTest(t *testing.T) {
 			return t.Context(), nil
 		}
 
-		helper.SystemTest(t, func(t T, sys system.System) {}, validator, validator, validator)
+		wt, sys := helper.AcquireSystem(t, validator, validator, validator)
+		require.NotNil(t, wt)
+		require.NotNil(t, sys)
 		require.Equal(t, 3, validatorCount)
 	})
 }
@@ -223,11 +219,9 @@ func TestInteropSystemTest(t *testing.T) {
 		}
 
 		recorder := &mockTBRecorder{mockTB: mockTB{name: "test"}}
-		called := false
-		helper.InteropSystemTest(recorder, func(t T, sys system.InteropSystem) {
-			called = true
-		})
-		require.False(t, called)
+		wt, sys := helper.AcquireInteropSystem(recorder)
+		require.Nil(t, wt, "should not return wt")
+		require.Nil(t, sys, "should not return interop system")
 		require.Len(t, helper.preconditionErrors, 1)
 		require.Contains(t, helper.preconditionErrors[0].Error(), "interop test requested")
 	})
@@ -239,12 +233,10 @@ func TestInteropSystemTest(t *testing.T) {
 			},
 		}
 
-		called := false
-		helper.InteropSystemTest(t, func(t T, sys system.InteropSystem) {
-			called = true
-			require.NotNil(t, sys.InteropSet())
-		})
-		require.True(t, called)
+		wt, sys := helper.AcquireInteropSystem(t)
+		require.NotNil(t, wt)
+		require.NotNil(t, sys)
+		require.NotNil(t, sys.InteropSet())
 		require.Empty(t, helper.preconditionErrors)
 	})
 }
@@ -294,9 +286,11 @@ func TestPreconditionHandling(t *testing.T) {
 			recorder := &mockTBRecorder{mockTB: mockTB{name: "test"}}
 			testErr := fmt.Errorf("test precondition error")
 
-			helper.SystemTest(recorder, func(t T, sys system.System) {}, func(t T, sys system.System) (context.Context, error) {
+			wt, sys := helper.AcquireSystem(recorder, func(t T, sys system.System) (context.Context, error) {
 				return t.Context(), testErr
 			})
+			require.Nil(t, wt)
+			require.Nil(t, sys)
 
 			require.Equal(t, tc.expectSkip, recorder.skipped, "unexpected skip state")
 			require.Equal(t, tc.expectFatal, recorder.failed, "unexpected fatal state")

--- a/devnet-sdk/testing/systest/testing_test.go
+++ b/devnet-sdk/testing/systest/testing_test.go
@@ -347,10 +347,7 @@ func TestSystemAcquisition(t *testing.T) {
 		helper := newBasicSystemTestHelper(&mockEnvGetter{}).
 			WithAcquirers(acquirers)
 
-		var acquiredSys system.System
-		helper.SystemTest(t, func(t T, sys system.System) {
-			acquiredSys = sys
-		})
+		_, acquiredSys := helper.AcquireSystem(t)
 		require.Equal(t, sys1, acquiredSys)
 	})
 
@@ -389,9 +386,9 @@ func TestSystemAcquisition(t *testing.T) {
 				helper.expectPreconditionsMet = tc.expectMet
 
 				recorder := &mockTBRecorder{mockTB: mockTB{name: "test"}}
-				helper.SystemTest(recorder, func(t T, sys system.System) {
-					require.Fail(t, "should not reach here")
-				})
+				wt, sys := helper.AcquireSystem(recorder)
+				require.Nil(t, wt)
+				require.Nil(t, sys)
 
 				require.Equal(t, tc.expectSkip, recorder.skipped, "unexpected skip state")
 				require.Equal(t, tc.expectFatal, recorder.failed, "unexpected fatal state")
@@ -439,9 +436,9 @@ func TestSystemAcquisition(t *testing.T) {
 				helper.expectPreconditionsMet = tc.expectMet
 
 				recorder := &mockTBRecorder{mockTB: mockTB{name: "test"}}
-				helper.SystemTest(recorder, func(t T, sys system.System) {
-					require.Fail(t, "should not reach here")
-				})
+				wt, sys := helper.AcquireSystem(recorder)
+				require.Nil(t, wt)
+				require.Nil(t, sys)
 
 				require.Equal(t, tc.expectSkip, recorder.skipped, "unexpected skip state")
 				require.Equal(t, tc.expectFatal, recorder.failed, "unexpected fatal state")


### PR DESCRIPTION
**Description**

Support having a system returned rather than having to supply a callback.  To avoid adjusting all tests at once (and potentially causing a lot of conflicts), the callback approach is still supported.  Will follow up with converting tests if we're happy with this change.

**Tests**

Updated `systest_test.go` but it appears to just be testing the mock.
Converted isthmus/fees_test.go to use the acquire approach.
