### PR TITLE
op-deployer: remove unnecessary type argument for `WithPrecompileAtAddress`

### DIFF
--- a/op-deployer/book/src/reference-guide/engine.md
+++ b/op-deployer/book/src/reference-guide/engine.md
@@ -28,7 +28,7 @@ Solidity scripts are much more ergonomic than Go code for complex on-chain inter
 - Simple ABI encoding/decoding.
 - Clear separation of concerns between inter-contract calls, and the underlying RPC calls that drive them.
 
-The alternative is to encode all on-chain interactions in Go code. This is possible, but it is much more verbose and 
+The alternative is to encode all on-chain interactions in Go code. This is possible, but it is much more verbose and
 requires writing bindings between Go and the Solidity ABI. These bindings are error-prone and difficult to maintain.
 
 ## Engine Implementation
@@ -39,9 +39,9 @@ hooks that drive most of the engine's behavior. The best way to understand these
 
 ## Using the Engine
 
-OP Deployer uses the etching tooling described above to communicate between OP Deployer and the scripting engine. 
-Most Solidity scripts define an input contract, an output contract, and the script itself. The script reads data 
-from fields on the input contract, then sets fields on the output contract as it runs. OP Deployer defines the input 
+OP Deployer uses the etching tooling described above to communicate between OP Deployer and the scripting engine.
+Most Solidity scripts define an input contract, an output contract, and the script itself. The script reads data
+from fields on the input contract, then sets fields on the output contract as it runs. OP Deployer defines the input
 and output contracts as Go structs, like this:
 
 ```go
@@ -68,30 +68,30 @@ package foo_script
 func Run(host *script.Host, input FooInput) (FooOutput, error) {
 	// Create a variable to hold our output
 	var output FooOutput
-	
+
 	// Make new addresses for our input/output contracts
 	inputAddr := host.NewScriptAddress()
 	outputAddr := host.NewScriptAddress()
 
 	// Inject the input/output contracts into the EVM as precompiles
-	cleanupInput, err := script.WithPrecompileAtAddress[*FooInput](host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
 	if err != nil {
 		return output, fmt.Errorf("failed to insert input precompile: %w", err)
 	}
 	defer cleanupInput()
 
-	cleanupOutput, err := script.WithPrecompileAtAddress[*FooOutput](host, outputAddr, &output,
+	cleanupOutput, err := script.WithPrecompileAtAddress(host, outputAddr, &output,
 		script.WithFieldSetter[*FooOutput])
 	if err != nil {
 		return output, fmt.Errorf("failed to insert output precompile: %w", err)
 	}
 	defer cleanupOutput()
-	
+
 	// ... do stuff with the input/output contracts ...
 }
 ```
 
-The script engine will automatically generate getters and setters for the fields on the input and output contracts. 
+The script engine will automatically generate getters and setters for the fields on the input and output contracts.
 You can use the `evm:` struct tag to customize the behavior of these getters and setters.
 
 Finally, the script itself gets etched into the EVM's memory and executed, like this:
@@ -120,6 +120,6 @@ func Run(host *script.Host, input FooInput) (FooOutput, error) {
 }
 ```
 
-You may notice that the script is loaded from a file. To run the scripting engine, contract artifacts (**not** 
-source code) must exist somewhere on disk for the scripting engine to use. For more information on that, see the 
+You may notice that the script is loaded from a file. To run the scripting engine, contract artifacts (**not**
+source code) must exist somewhere on disk for the scripting engine to use. For more information on that, see the
 chapter on artifacts locators.

--- a/op-deployer/book/src/reference-guide/engine.md
+++ b/op-deployer/book/src/reference-guide/engine.md
@@ -28,7 +28,7 @@ Solidity scripts are much more ergonomic than Go code for complex on-chain inter
 - Simple ABI encoding/decoding.
 - Clear separation of concerns between inter-contract calls, and the underlying RPC calls that drive them.
 
-The alternative is to encode all on-chain interactions in Go code. This is possible, but it is much more verbose and
+The alternative is to encode all on-chain interactions in Go code. This is possible, but it is much more verbose and 
 requires writing bindings between Go and the Solidity ABI. These bindings are error-prone and difficult to maintain.
 
 ## Engine Implementation
@@ -39,9 +39,9 @@ hooks that drive most of the engine's behavior. The best way to understand these
 
 ## Using the Engine
 
-OP Deployer uses the etching tooling described above to communicate between OP Deployer and the scripting engine.
-Most Solidity scripts define an input contract, an output contract, and the script itself. The script reads data
-from fields on the input contract, then sets fields on the output contract as it runs. OP Deployer defines the input
+OP Deployer uses the etching tooling described above to communicate between OP Deployer and the scripting engine. 
+Most Solidity scripts define an input contract, an output contract, and the script itself. The script reads data 
+from fields on the input contract, then sets fields on the output contract as it runs. OP Deployer defines the input 
 and output contracts as Go structs, like this:
 
 ```go
@@ -68,30 +68,30 @@ package foo_script
 func Run(host *script.Host, input FooInput) (FooOutput, error) {
 	// Create a variable to hold our output
 	var output FooOutput
-
+	
 	// Make new addresses for our input/output contracts
 	inputAddr := host.NewScriptAddress()
 	outputAddr := host.NewScriptAddress()
 
 	// Inject the input/output contracts into the EVM as precompiles
-	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress[*FooInput](host, inputAddr, &input)
 	if err != nil {
 		return output, fmt.Errorf("failed to insert input precompile: %w", err)
 	}
 	defer cleanupInput()
 
-	cleanupOutput, err := script.WithPrecompileAtAddress(host, outputAddr, &output,
+	cleanupOutput, err := script.WithPrecompileAtAddress[*FooOutput](host, outputAddr, &output,
 		script.WithFieldSetter[*FooOutput])
 	if err != nil {
 		return output, fmt.Errorf("failed to insert output precompile: %w", err)
 	}
 	defer cleanupOutput()
-
+	
 	// ... do stuff with the input/output contracts ...
 }
 ```
 
-The script engine will automatically generate getters and setters for the fields on the input and output contracts.
+The script engine will automatically generate getters and setters for the fields on the input and output contracts. 
 You can use the `evm:` struct tag to customize the behavior of these getters and setters.
 
 Finally, the script itself gets etched into the EVM's memory and executed, like this:
@@ -120,6 +120,6 @@ func Run(host *script.Host, input FooInput) (FooOutput, error) {
 }
 ```
 
-You may notice that the script is loaded from a file. To run the scripting engine, contract artifacts (**not**
-source code) must exist somewhere on disk for the scripting engine to use. For more information on that, see the
+You may notice that the script is loaded from a file. To run the scripting engine, contract artifacts (**not** 
+source code) must exist somewhere on disk for the scripting engine to use. For more information on that, see the 
 chapter on artifacts locators.

--- a/op-deployer/pkg/deployer/opcm/alt_da.go
+++ b/op-deployer/pkg/deployer/opcm/alt_da.go
@@ -35,13 +35,13 @@ func DeployAltDA(
 	inputAddr := host.NewScriptAddress()
 	outputAddr := host.NewScriptAddress()
 
-	cleanupInput, err := script.WithPrecompileAtAddress[*DeployAltDAInput](host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
 	if err != nil {
 		return output, fmt.Errorf("failed to insert DeployAltDAInput precompile: %w", err)
 	}
 	defer cleanupInput()
 
-	cleanupOutput, err := script.WithPrecompileAtAddress[*DeployAltDAOutput](host, outputAddr, &output,
+	cleanupOutput, err := script.WithPrecompileAtAddress(host, outputAddr, &output,
 		script.WithFieldSetter[*DeployAltDAOutput])
 	if err != nil {
 		return output, fmt.Errorf("failed to insert DeployAltDAOutput precompile: %w", err)

--- a/op-deployer/pkg/deployer/opcm/implementations.go
+++ b/op-deployer/pkg/deployer/opcm/implementations.go
@@ -68,13 +68,13 @@ func DeployImplementations(
 	inputAddr := host.NewScriptAddress()
 	outputAddr := host.NewScriptAddress()
 
-	cleanupInput, err := script.WithPrecompileAtAddress[*DeployImplementationsInput](host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
 	if err != nil {
 		return output, fmt.Errorf("failed to insert DeployImplementationsInput precompile: %w", err)
 	}
 	defer cleanupInput()
 
-	cleanupOutput, err := script.WithPrecompileAtAddress[*DeployImplementationsOutput](host, outputAddr, &output,
+	cleanupOutput, err := script.WithPrecompileAtAddress(host, outputAddr, &output,
 		script.WithFieldSetter[*DeployImplementationsOutput])
 	if err != nil {
 		return output, fmt.Errorf("failed to insert DeployImplementationsOutput precompile: %w", err)

--- a/op-deployer/pkg/deployer/opcm/l2genesis.go
+++ b/op-deployer/pkg/deployer/opcm/l2genesis.go
@@ -47,7 +47,7 @@ func L2Genesis(l2Host *script.Host, input *L2GenesisInput) error {
 	deployConfig := &genesis.DeployConfig{
 		L2InitializationConfig: input.L2Config,
 	}
-	cleanupDeployConfig, err := script.WithPrecompileAtAddress[*genesis.DeployConfig](l2Host, deployConfigAddr, deployConfig, script.WithFieldsOnly[*genesis.DeployConfig])
+	cleanupDeployConfig, err := script.WithPrecompileAtAddress(l2Host, deployConfigAddr, deployConfig, script.WithFieldsOnly[*genesis.DeployConfig])
 	if err != nil {
 		return fmt.Errorf("failed to insert DeployConfig precompile: %w", err)
 	}

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -113,14 +113,14 @@ func ReadImplementationAddresses(host *script.Host, input ReadImplementationAddr
 	inputAddr := host.NewScriptAddress()
 	outputAddr := host.NewScriptAddress()
 
-	cleanupInput, err := script.WithPrecompileAtAddress[*ReadImplementationAddressesInput](host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
 	if err != nil {
 		return rio, fmt.Errorf("failed to insert ReadImplementationAddressesInput precompile: %w", err)
 	}
 	defer cleanupInput()
 	host.Label(inputAddr, "ReadImplementationAddressesInput")
 
-	cleanupOutput, err := script.WithPrecompileAtAddress[*ReadImplementationAddressesOutput](host, outputAddr, &rio,
+	cleanupOutput, err := script.WithPrecompileAtAddress(host, outputAddr, &rio,
 		script.WithFieldSetter[*ReadImplementationAddressesOutput])
 	if err != nil {
 		return rio, fmt.Errorf("failed to insert ReadImplementationAddressesOutput precompile: %w", err)

--- a/op-deployer/pkg/deployer/opcm/script.go
+++ b/op-deployer/pkg/deployer/opcm/script.go
@@ -21,13 +21,13 @@ func RunScriptSingle[I any, O any](
 	inputAddr := host.NewScriptAddress()
 	outputAddr := host.NewScriptAddress()
 
-	cleanupInput, err := script.WithPrecompileAtAddress[*I](host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
 	if err != nil {
 		return output, fmt.Errorf("failed to insert input precompile: %w", err)
 	}
 	defer cleanupInput()
 
-	cleanupOutput, err := script.WithPrecompileAtAddress[*O](host, outputAddr, &output,
+	cleanupOutput, err := script.WithPrecompileAtAddress(host, outputAddr, &output,
 		script.WithFieldSetter[*O])
 	if err != nil {
 		return output, fmt.Errorf("failed to insert output precompile: %w", err)
@@ -59,7 +59,7 @@ func RunScriptVoid[I any](
 ) error {
 	inputAddr := host.NewScriptAddress()
 
-	cleanupInput, err := script.WithPrecompileAtAddress[*I](host, inputAddr, &input)
+	cleanupInput, err := script.WithPrecompileAtAddress(host, inputAddr, &input)
 	if err != nil {
 		return fmt.Errorf("failed to insert input precompile: %w", err)
 	}


### PR DESCRIPTION
This PR removes type argument for `script.WithPrecompileAtAddress` since it's inferable.