### PR TITLE
feat(op-e2e): State validation failure in EVM

### DIFF
--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -15,7 +15,7 @@ const (
 	NotEnoughBalance
 )
 
-func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
 	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
 
@@ -96,7 +96,7 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
 }
 
-func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
 	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
 
@@ -182,7 +182,7 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 }
 
 func Test_ProgramAction_BadTxInBatch(gt *testing.T) {
-	matrix := helpers.NewMatrix[any]()
+	matrix := helpers.NewMatrix[int64]()
 	defer matrix.Run(gt)
 
 	matrix.AddDefaultTestCasesWithName(

--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -5,10 +5,14 @@ import (
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-	"github.com/ethereum-optimism/optimism/op-program/client/claim"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	BadSignature int64 = iota
+	NotEnoughBalance
 )
 
 func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
@@ -29,9 +33,25 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
-		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+
+		var newTx *types.Transaction
+		if testCfg.Custom == BadSignature {
+			txCopy, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+			require.NoError(t, err)
+
+			newTx = txCopy
+		} else if testCfg.Custom == NotEnoughBalance {
+			pkey, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			signer := types.LatestSigner(env.Sd.L2Cfg.Config)
+
+			txCopy, err := types.SignTx(txs[1], signer, pkey)
+			require.NoError(t, err)
+
+			newTx = txCopy
+		}
+
 		txs[1] = newTx
-		require.NoError(t, err)
 		return block
 	})
 	env.Batcher.ActL2ChannelClose(t)
@@ -47,26 +67,30 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
 
-	// Ensure the safe head has not advanced - the batch is invalid.
+	// Ensure the safe head has not advanced if pre-Holocene - the batch is invalid.
+	// If post-holocene, the block should be reduced to deposits only.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	if !env.Sd.RollupCfg.IsHolocene(l2SafeHead.Time) {
+		require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
 
-	// Reset the batcher and submit a valid batch.
-	env.Batcher.Reset()
-	env.Batcher.ActSubmitAll(t)
-	env.Miner.ActL1StartBlock(12)(t)
-	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
-	env.Miner.ActL1EndBlock(t)
-	env.Miner.ActL1SafeNext(t)
+		// Reset the batcher and submit a valid batch.
+		env.Batcher.Reset()
+		env.Batcher.ActSubmitAll(t)
+		env.Miner.ActL1StartBlock(12)(t)
+		env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+		env.Miner.ActL1EndBlock(t)
+		env.Miner.ActL1SafeNext(t)
 
-	// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
-	env.Sequencer.ActL1HeadSignal(t)
-	env.Sequencer.ActL2PipelineFull(t)
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l1Head := env.Miner.L1Chain().CurrentBlock()
+		require.Equal(t, uint64(2), l1Head.Number.Uint64())
+	}
 
 	// Ensure the safe head has advanced.
-	l1Head := env.Miner.L1Chain().CurrentBlock()
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(2), l1Head.Number.Uint64())
 	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
 
 	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
@@ -92,11 +116,26 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	// within the span batch.
 	env.Batcher.ActL2BatchBuffer(t)
 	err := env.Batcher.Buffer(t, func(block *types.Block) *types.Block {
-		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
-		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+
+		var newTx *types.Transaction
+		if testCfg.Custom == BadSignature {
+			txCopy, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+			require.NoError(t, err)
+
+			newTx = txCopy
+		} else if testCfg.Custom == NotEnoughBalance {
+			pkey, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			signer := types.LatestSigner(env.Sd.L2Cfg.Config)
+
+			txCopy, err := types.SignTx(txs[1], signer, pkey)
+			require.NoError(t, err)
+
+			newTx = txCopy
+		}
+
 		txs[1] = newTx
-		require.NoError(t, err)
 		return block
 	})
 	require.NoError(t, err)
@@ -113,26 +152,30 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
 
-	// Ensure the safe head has not advanced - the batch is invalid.
+	// Ensure the safe head has not advanced if pre-Holocene - the batch is invalid.
+	// If post-holocene, the block should be reduced to deposits only.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	if !env.Sd.RollupCfg.IsHolocene(l2SafeHead.Time) {
+		require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
 
-	// Reset the batcher and submit a valid batch.
-	env.Batcher.Reset()
-	env.Batcher.ActSubmitAll(t)
-	env.Miner.ActL1StartBlock(12)(t)
-	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
-	env.Miner.ActL1EndBlock(t)
-	env.Miner.ActL1SafeNext(t)
+		// Reset the batcher and submit a valid batch.
+		env.Batcher.Reset()
+		env.Batcher.ActSubmitAll(t)
+		env.Miner.ActL1StartBlock(12)(t)
+		env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+		env.Miner.ActL1EndBlock(t)
+		env.Miner.ActL1SafeNext(t)
 
-	// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
-	env.Sequencer.ActL1HeadSignal(t)
-	env.Sequencer.ActL2PipelineFull(t)
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l1Head := env.Miner.L1Chain().CurrentBlock()
+		require.Equal(t, uint64(2), l1Head.Number.Uint64())
+	}
 
 	// Ensure the safe head has advanced.
-	l1Head := env.Miner.L1Chain().CurrentBlock()
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(2), l1Head.Number.Uint64())
 	require.Equal(t, uint64(2), l2SafeHead.Number.Uint64())
 
 	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()-1, testCfg.CheckResult, testCfg.InputParams...)
@@ -142,34 +185,28 @@ func Test_ProgramAction_BadTxInBatch(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	matrix.AddTestCase(
-		"HonestClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"BadSignature",
+		BadSignature,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatchTest,
-		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"JunkClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"NotEnoughBalance",
+		NotEnoughBalance,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatchTest,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
 	)
-	matrix.AddTestCase(
-		"ResubmitBadFirstFrame-HonestClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"ResubmitBadFirstFrame-BadSignature",
+		BadSignature,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatch_ResubmitBadFirstFrame_Test,
-		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"ResubmitBadFirstFrame-JunkClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"ResubmitBadFirstFrame-NotEnoughBalance",
+		NotEnoughBalance,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatch_ResubmitBadFirstFrame_Test,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
 	)
 }


### PR DESCRIPTION
## Overview

Adds an action test for Isthmus that asserts the EVM's transaction pre-validation routine successfully rejects a transaction signed by an account that cannot afford the transaction.

This test uses a signer with 0 balance - an extension to this case, where the signer can afford the transaction pre-Isthmus, but not post-Isthmus, is added in #15061