### PR TITLE
feat(op-e2e): Pre-Isthmus fee - Operator fee

### DIFF
--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -210,6 +210,18 @@ func (s *BasicUser[B]) ActSetTxGasLimit(limit uint64) Action {
 	}
 }
 
+func (s *BasicUser[B]) ActSetGasTipCap(feeCap *big.Int) Action {
+	return func(t Testing) {
+		s.txOpts.GasTipCap = feeCap
+	}
+}
+
+func (s *BasicUser[B]) ActSetGasFeeCap(feeCap *big.Int) Action {
+	return func(t Testing) {
+		s.txOpts.GasFeeCap = feeCap
+	}
+}
+
 func (s *BasicUser[B]) ActRandomTxData(t Testing) {
 	t.Helper()
 	dataLen := s.rng.Intn(128_000)

--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -15,7 +15,7 @@ const (
 	NotEnoughBalance
 )
 
-func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
 	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
 
@@ -96,7 +96,7 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
 }
 
-func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
 	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
 
@@ -182,7 +182,7 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 }
 
 func Test_ProgramAction_BadTxInBatch(gt *testing.T) {
-	matrix := helpers.NewMatrix[any]()
+	matrix := helpers.NewMatrix[int64]()
 	defer matrix.Run(gt)
 
 	matrix.AddDefaultTestCasesWithName(

--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -5,10 +5,14 @@ import (
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-	"github.com/ethereum-optimism/optimism/op-program/client/claim"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	BadSignature int64 = iota
+	NotEnoughBalance
 )
 
 func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
@@ -29,9 +33,25 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
 		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
-		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+
+		var newTx *types.Transaction
+		if testCfg.Custom == BadSignature {
+			txCopy, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+			require.NoError(t, err)
+
+			newTx = txCopy
+		} else if testCfg.Custom == NotEnoughBalance {
+			pkey, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			signer := types.LatestSigner(env.Sd.L2Cfg.Config)
+
+			txCopy, err := types.SignTx(txs[1], signer, pkey)
+			require.NoError(t, err)
+
+			newTx = txCopy
+		}
+
 		txs[1] = newTx
-		require.NoError(t, err)
 		return block
 	})
 	env.Batcher.ActL2ChannelClose(t)
@@ -47,26 +67,30 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
 
-	// Ensure the safe head has not advanced - the batch is invalid.
+	// Ensure the safe head has not advanced if pre-Holocene - the batch is invalid.
+	// If post-holocene, the block should be reduced to deposits only.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	if !env.Sd.RollupCfg.IsHolocene(l2SafeHead.Time) {
+		require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
 
-	// Reset the batcher and submit a valid batch.
-	env.Batcher.Reset()
-	env.Batcher.ActSubmitAll(t)
-	env.Miner.ActL1StartBlock(12)(t)
-	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
-	env.Miner.ActL1EndBlock(t)
-	env.Miner.ActL1SafeNext(t)
+		// Reset the batcher and submit a valid batch.
+		env.Batcher.Reset()
+		env.Batcher.ActSubmitAll(t)
+		env.Miner.ActL1StartBlock(12)(t)
+		env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+		env.Miner.ActL1EndBlock(t)
+		env.Miner.ActL1SafeNext(t)
 
-	// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
-	env.Sequencer.ActL1HeadSignal(t)
-	env.Sequencer.ActL2PipelineFull(t)
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l1Head := env.Miner.L1Chain().CurrentBlock()
+		require.Equal(t, uint64(2), l1Head.Number.Uint64())
+	}
 
 	// Ensure the safe head has advanced.
-	l1Head := env.Miner.L1Chain().CurrentBlock()
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(2), l1Head.Number.Uint64())
 	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
 
 	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
@@ -92,11 +116,26 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	// within the span batch.
 	env.Batcher.ActL2BatchBuffer(t)
 	err := env.Batcher.Buffer(t, func(block *types.Block) *types.Block {
-		// Replace the tx with one that has a bad signature.
 		txs := block.Transactions()
-		newTx, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+
+		var newTx *types.Transaction
+		if testCfg.Custom == BadSignature {
+			txCopy, err := txs[1].WithSignature(env.Alice.L2.Signer(), make([]byte, 65))
+			require.NoError(t, err)
+
+			newTx = txCopy
+		} else if testCfg.Custom == NotEnoughBalance {
+			pkey, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			signer := types.LatestSigner(env.Sd.L2Cfg.Config)
+
+			txCopy, err := types.SignTx(txs[1], signer, pkey)
+			require.NoError(t, err)
+
+			newTx = txCopy
+		}
+
 		txs[1] = newTx
-		require.NoError(t, err)
 		return block
 	})
 	require.NoError(t, err)
@@ -113,26 +152,30 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
 
-	// Ensure the safe head has not advanced - the batch is invalid.
+	// Ensure the safe head has not advanced if pre-Holocene - the batch is invalid.
+	// If post-holocene, the block should be reduced to deposits only.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	if !env.Sd.RollupCfg.IsHolocene(l2SafeHead.Time) {
+		require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
 
-	// Reset the batcher and submit a valid batch.
-	env.Batcher.Reset()
-	env.Batcher.ActSubmitAll(t)
-	env.Miner.ActL1StartBlock(12)(t)
-	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
-	env.Miner.ActL1EndBlock(t)
-	env.Miner.ActL1SafeNext(t)
+		// Reset the batcher and submit a valid batch.
+		env.Batcher.Reset()
+		env.Batcher.ActSubmitAll(t)
+		env.Miner.ActL1StartBlock(12)(t)
+		env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+		env.Miner.ActL1EndBlock(t)
+		env.Miner.ActL1SafeNext(t)
 
-	// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
-	env.Sequencer.ActL1HeadSignal(t)
-	env.Sequencer.ActL2PipelineFull(t)
+		// Instruct the sequencer to derive the L2 chain from the data on L1 that the batcher just posted.
+		env.Sequencer.ActL1HeadSignal(t)
+		env.Sequencer.ActL2PipelineFull(t)
+
+		l1Head := env.Miner.L1Chain().CurrentBlock()
+		require.Equal(t, uint64(2), l1Head.Number.Uint64())
+	}
 
 	// Ensure the safe head has advanced.
-	l1Head := env.Miner.L1Chain().CurrentBlock()
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(2), l1Head.Number.Uint64())
 	require.Equal(t, uint64(2), l2SafeHead.Number.Uint64())
 
 	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()-1, testCfg.CheckResult, testCfg.InputParams...)
@@ -142,34 +185,28 @@ func Test_ProgramAction_BadTxInBatch(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	matrix.AddTestCase(
-		"HonestClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"BadSignature",
+		BadSignature,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatchTest,
-		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"JunkClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"NotEnoughBalance",
+		NotEnoughBalance,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatchTest,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
 	)
-	matrix.AddTestCase(
-		"ResubmitBadFirstFrame-HonestClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"ResubmitBadFirstFrame-BadSignature",
+		BadSignature,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatch_ResubmitBadFirstFrame_Test,
-		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"ResubmitBadFirstFrame-JunkClaim",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
+	matrix.AddDefaultTestCasesWithName(
+		"ResubmitBadFirstFrame-NotEnoughBalance",
+		NotEnoughBalance,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Holocene, helpers.Isthmus),
 		runBadTxInBatch_ResubmitBadFirstFrame_Test,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
 	)
 }

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -8,12 +8,17 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,11 +29,10 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 		NormalTx testCase = iota
 		DepositTx
 		StateRefund
+		NotEnoughFundsInBatchMissingOpFee
 		IsthmusTransitionBlock
 	)
 
-	const testOperatorFeeScalar = uint32(100e6)
-	const testOperatorFeeConstant = uint64(500)
 	testStorageUpdateContractAddress := common.HexToAddress("0xffffffff")
 	// contract TestSetter {
 	//   uint x;
@@ -40,6 +44,16 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 	runIsthmusDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
 		t := actionsHelpers.NewDefaultTesting(gt)
 		deployConfigOverrides := func(dp *genesis.DeployConfig) {}
+
+		var testOperatorFeeScalar uint32
+		var testOperatorFeeConstant uint64
+		if testCfg.Custom == NotEnoughFundsInBatchMissingOpFee {
+			testOperatorFeeScalar = 0
+			testOperatorFeeConstant = 0xffff
+		} else {
+			testOperatorFeeScalar = 100e6
+			testOperatorFeeConstant = 500
+		}
 
 		if testCfg.Custom == StateRefund {
 			testCfg.Allocs = actionsHelpers.DefaultAlloc
@@ -92,8 +106,6 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 			require.Equal(t, types.ReceiptStatusSuccessful, r.Status, "tx unsuccessful")
 		}
 
-		t.Logf("L2 Genesis Time: %d, IsthmusTime: %d ", env.Sequencer.RollupCfg.Genesis.L2Time, *env.Sequencer.RollupCfg.IsthmusTime)
-
 		sysCfgContract, err := bindings.NewSystemConfig(env.Sd.RollupCfg.L1SystemConfigAddress, env.Miner.EthClient())
 		require.NoError(t, err)
 
@@ -132,7 +144,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 			// Send an L2 tx
 			env.Sequencer.ActL2StartBlock(t)
 			env.Alice.L2.ActResetTxOpts(t)
-			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)
+			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
 			env.Alice.L2.ActMakeTx(t)
 			// we usually don't include txs in the transition block, so we force-include it
 			env.Engine.ActL2IncludeTxIgnoreForcedEmpty(env.Alice.Address())(t)
@@ -172,9 +184,105 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 
 			receipt, err = env.Alice.GetLastDepositL2Receipt(t)
 			require.NoError(t, err)
+		case NotEnoughFundsInBatchMissingOpFee:
+			pkey, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			address := crypto.PubkeyToAddress(pkey.PublicKey)
+
+			// Send `address` just enough ETH to cover the gas costs of the transaction, sans the operator fee.
+			// Since we're just doing a simple call to `Bob`, that should be 21000 gas at the current gas price
+			// plus the L1 data fee.
+
+			// Craft a transaction from Alice -> Bob (just to compute L1 cost, not to send.)
+			env.Alice.L2.ActResetTxOpts(t)
+			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
+			tx := env.Alice.L2.MakeTransaction(t)
+
+			rlp, err := tx.MarshalBinary()
+			require.NoError(t, err, "failed to RLP encode transaction")
+
+			unsafeHeader := env.Engine.L2Chain().CurrentHeader()
+			unsafeBlock := env.Engine.L2Chain().GetBlockByHash(unsafeHeader.Hash())
+			nextBaseFee := eip1559.CalcBaseFee(
+				env.Sd.L2Cfg.Config,
+				unsafeHeader,
+				unsafeHeader.Time+env.Sd.RollupCfg.BlockTime,
+			)
+
+			l1BlockInfo, err := derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, unsafeHeader.Time, unsafeBlock.Transactions()[0].Data())
+			require.NoError(t, err)
+
+			daCost := fjordL1Cost(l1BlockInfo, types.NewRollupCostData(rlp))
+			expectedFeePreIsthmus := nextBaseFee.Mul(nextBaseFee, big.NewInt(int64(params.TxGas)))
+			expectedFeePreIsthmus.Add(expectedFeePreIsthmus, daCost)
+
+			// Include an L2 tx, from Bob -> mock signer
+			env.Bob.L2.ActResetTxOpts(t)
+			env.Bob.L2.ActSetTxToAddr(&address)(t)
+			env.Bob.L2.ActSetTxValue(expectedFeePreIsthmus)(t)
+			env.Bob.L2.ActMakeTx(t)
+
+			env.Sequencer.ActL2StartBlock(t)
+			env.Engine.ActL2IncludeTx(env.Bob.Address())(t)
+			env.Sequencer.ActL2EndBlock(t)
+			env.Bob.L2.ActCheckReceiptStatusOfLastTx(true)(t)
+
+			// Ensure the mock signer received the funds
+			require.Equal(t, expectedFeePreIsthmus, balanceAt(address))
+
+			// Buffer the L2 block we just included
+			env.Batcher.ActL2BatchBuffer(t)
+
+			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
+			if testCfg.Custom != NotEnoughFundsInBatchMissingOpFee {
+				require.Equal(t, operatorFeeVaultInitialBalance.Sign(), 0)
+			}
+
+			// Craft a transaction from Alice -> Bob
+			env.Alice.L2.ActResetTxOpts(t)
+			env.Alice.L2.ActSetTxToAddr(&env.Dp.Addresses.Bob)(t)
+			env.Alice.L2.ActSetTxGasLimit(params.TxGas)(t)
+			env.Alice.L2.ActSetGasFeeCap(big.NewInt(1))(t)
+			env.Alice.L2.ActSetGasTipCap(big.NewInt(1))(t)
+			env.Alice.L2.ActMakeTx(t)
+
+			// Include an L2 tx, from Alice -> Bob
+			env.Sequencer.ActL2StartBlock(t)
+			env.Engine.ActL2IncludeTx(env.Alice.Address())(t)
+			env.Sequencer.ActL2EndBlock(t)
+			env.Alice.L2.ActCheckReceiptStatusOfLastTx(true)(t)
+
+			// Instruct the batcher to submit a faulty channel, with Alice's tx re-signed by a new private key.
+			// This key will have 0 balance.
+			env.Batcher.ActL2BatchBuffer(t, func(block *types.Block) *types.Block {
+				txs := block.Transactions()
+
+				// Skip over any L2 blocks that don't contain user-space txs.
+				if len(txs) == 1 {
+					return block
+				}
+
+				// Re-sign Alice's tx with a random key.
+				require.NoError(t, err, "error generating random private key")
+				signer := types.LatestSigner(env.Sd.L2Cfg.Config)
+				newSignedTx, err := types.SignTx(txs[1], signer, pkey)
+				require.NoError(t, err, "error re-signing Alice's transaction")
+
+				// Replace Alice's tx with the re-signed one.
+				txs[1] = newSignedTx
+				return block
+			})
+			env.Batcher.ActL2ChannelClose(t)
+			env.Batcher.ActL2BatchSubmit(t)
+
+			// Include the batcher transaction.
+			env.Miner.ActL1StartBlock(12)(t)
+			env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+			env.Miner.ActL1EndBlock(t)
 		}
 
 		aliceFinalBalance, l1FeeVaultFinalBalance, baseFeeVaultFinalBalance, sequencerFeeVaultFinalBalance, operatorFeeVaultFinalBalance := getCurrentBalances()
+		l2UnsafeHead := env.Engine.L2Chain().CurrentHeader()
 
 		if receipt == nil {
 			receipt = env.Alice.L2.LastTxReceipt(t)
@@ -186,7 +294,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 
 			// Nothing should has been sent to operator fee vault
 			require.Equal(t, operatorFeeVaultInitialBalance, operatorFeeVaultFinalBalance)
-		} else {
+		} else if env.Sd.RollupCfg.IsIsthmus(l2UnsafeHead.Time) {
 			// Check that the operator fee was applied
 			require.Equal(t, testOperatorFeeScalar, uint32(*receipt.OperatorFeeScalar))
 			require.Equal(t, testOperatorFeeConstant, *receipt.OperatorFeeConstant)
@@ -230,15 +338,39 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 
 		require.Equal(t, aliceInitialBalance, finalTotalBalance)
 
-		l2UnsafeHead := env.Engine.L2Chain().CurrentHeader()
-
-		env.BatchAndMine(t)
+		// The NotEnoughFundsInBatchMissingOpFee case is special, as it submits its own invalid batch.
+		if testCfg.Custom != NotEnoughFundsInBatchMissingOpFee {
+			env.BatchAndMine(t)
+		}
 		env.Sequencer.ActL1HeadSignal(t)
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 
-		require.Equal(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation leads to the same block")
+		if testCfg.Custom == NotEnoughFundsInBatchMissingOpFee {
+			// The unsafe block prior to derivation should be different from the safe block after derivation. The
+			// batcher posted the block but with a different transaction, signed by a key that has no balance. This
+			// should cause a reorg in the unsafe chain, and the original block should be reduced to deposits only
+			// if Isthmus is active.
+			require.NotEqual(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation leads to the same block")
+
+			reorgedUnsafe := env.Engine.L2Chain().CurrentHeader()
+			require.Equal(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(reorgedUnsafe), "reorged unsafe block is the same")
+
+			safeHeadBlock := env.Engine.L2Chain().GetBlockByHash(l2SafeHead.Hash())
+			if env.Sd.RollupCfg.IsIsthmus(l2SafeHead.Time) {
+				require.Equal(t, len(safeHeadBlock.Transactions()), 1)
+
+				// Ensure that the logs contain a mention of the block being replaced _due to the signer not having enough
+				// balance_.
+				require.NotNil(t, env.Logs.FindLog(testlog.NewAttributesContainsFilter("err", "insufficient funds for gas * price + value")))
+				require.NotNil(t, env.Logs.FindLog(testlog.NewAttributesContainsFilter("err", "have 1400000021000 want 1400000086535")))
+			} else {
+				require.Equal(t, len(safeHeadBlock.Transactions()), 2)
+			}
+		} else {
+			require.Equal(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation leads to the same block")
+		}
 
 		env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
 	}
@@ -247,8 +379,20 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 	matrix.AddDefaultTestCasesWithName("NormalTx", NormalTx, helpers.NewForkMatrix(helpers.Isthmus), runIsthmusDerivationTest)
 	matrix.AddDefaultTestCasesWithName("DepositTx", DepositTx, helpers.NewForkMatrix(helpers.Isthmus), runIsthmusDerivationTest)
 	matrix.AddDefaultTestCasesWithName("StateRefund", StateRefund, helpers.NewForkMatrix(helpers.Isthmus), runIsthmusDerivationTest)
+	matrix.AddDefaultTestCasesWithName("NotEnoughFundsInBatchMissingOpFee", NotEnoughFundsInBatchMissingOpFee, helpers.NewForkMatrix(helpers.Holocene, helpers.Isthmus), runIsthmusDerivationTest)
 	matrix.AddDefaultTestCasesWithName("IsthmusTransitionBlock", IsthmusTransitionBlock, helpers.NewForkMatrix(helpers.Holocene), runIsthmusDerivationTest)
 	matrix.Run(gt)
+}
+
+func fjordL1Cost(l1BlockInfo *derive.L1BlockInfo, rollupCostData types.RollupCostData) *big.Int {
+	costFunc := types.NewL1CostFuncFjord(
+		l1BlockInfo.BaseFee,
+		l1BlockInfo.BlobBaseFee,
+		new(big.Int).SetUint64(uint64(l1BlockInfo.BaseFeeScalar)),
+		new(big.Int).SetUint64(uint64(l1BlockInfo.BlobBaseFeeScalar)))
+
+	fee, _ := costFunc(rollupCostData)
+	return fee
 }
 
 func ptr[T any](v T) *T {

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -352,7 +352,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 			// batcher posted the block but with a different transaction, signed by a key that has no balance. This
 			// should cause a reorg in the unsafe chain, and the original block should be reduced to deposits only
 			// if Isthmus is active.
-			require.NotEqual(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation leads to the same block")
+			require.NotEqual(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation should not lead to the same block")
 
 			reorgedUnsafe := env.Engine.L2Chain().CurrentHeader()
 			require.Equal(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(reorgedUnsafe), "reorged unsafe block is the same")


### PR DESCRIPTION
## Overview

Adds an action test that asserts that an L2 batch with a transaction whose sender can _exactly_ afford a transaction pre-Isthmus, but not post-Isthmus (with non-zero operator fee configured,) is correctly handled.

**Expected Behavior**:
1. In Holocene, a transaction that can afford the L1 fee + gas fee is accepted by the EVM.
2. In Isthmus, a transaction that can't afford the L1 fee + operator fee + gas fee is rejected by the EVM. The block is then reduced to deposits only per Holocene rules.