### PR TITLE
feat(kt-devnet): Option to clean up existing enclave

### DIFF
--- a/kurtosis-devnet/README.md
+++ b/kurtosis-devnet/README.md
@@ -168,3 +168,9 @@ Potentially you'll also need to cleanup dangling docker networks:
 ```shell
 docker network rm -f $(docker network ls -qf "name=kt-*")
 ```
+
+### `just devnet *` kills an existing enclave
+
+By default, `jusfile` recipes derived from the `devnet` recipe will attempt to destroy an existing
+enclave with the same name. This can be disabled by setting the `SKIP_ENCL_CLEAN` envvar, and the
+existing enclave will be preserved.

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -82,6 +82,13 @@ devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE:
         fi
     fi
     export ENCL_NAME="$DEVNET_NAME"-devnet
+
+    if [[ -z "$SKIP_ENCL_CLEAN" ]]; then
+        # clear out any existing enclaves with the same name.
+        # this can fail and it doesn't matter.
+        kurtosis enclave rm "$ENCL_NAME" --force 2&>/dev/null || true
+    fi
+
     go run cmd/main.go -kurtosis-package {{PACKAGE}} \
         -environment "tests/$ENCL_NAME.json" \
         -template "{{TEMPLATE_FILE}}" \

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -39,7 +39,7 @@ acceptance-test devnet="simple" gate="holocene":
         # Run the appropriate devnet from the kurtosis-devnet directory if needed.
         # Note: For now, due to a known bug, we ignore failures here
         #       because if the devnet is already running then this command will fail.
-        just {{KURTOSIS_DIR}}/{{ devnet }}-devnet || true
+        SKIP_ENCL_CLEAN="${SKIP_ENCL_CLEAN:-true}" just {{KURTOSIS_DIR}}/{{ devnet }}-devnet || true
 
         # Print which binary is being used (for debugging)
         BINARY_PATH=$(mise which op-acceptor)


### PR DESCRIPTION
## Overview

Adds an optional envvar to the `just devnet SPEC` recipe base that automatically attempts to clean up an existing enclave with the same name prior to starting if set. Failures are silent in the event that the envvar is set, but the enclave doesn't exist already.