### PR TITLE
kurtosis-devnet: fix dependency set fetcher logic

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go
@@ -7,16 +7,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	FeatureInterop = "interop"
+)
+
 // ChainSpec represents the network parameters for a chain
 type ChainSpec struct {
 	Name      string
 	NetworkID string
 }
 
+type FeatureList []string
+
+func (fl FeatureList) Contains(feature string) bool {
+	for _, f := range fl {
+		if f == feature {
+			return true
+		}
+	}
+	return false
+}
+
 // EnclaveSpec represents the parsed chain specifications from the YAML
 type EnclaveSpec struct {
 	Chains   []ChainSpec
-	Features []string
+	Features FeatureList
 }
 
 // NetworkParams represents the network parameters section in the YAML
@@ -61,7 +76,7 @@ func NewSpec(opts ...SpecOption) *Spec {
 type featureExtractor func(YAMLSpec, string) bool
 
 var featuresMap = map[string]featureExtractor{
-	"interop": interopExtractor,
+	FeatureInterop: interopExtractor,
 }
 
 func interopExtractor(yamlSpec YAMLSpec, chainName string) bool {


### PR DESCRIPTION
**Description**

The Kurtosis package outputs the json file only when interop is
enabled, so mirror this logic when assembling the system
specification.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
