### PR TITLE
op-service: increase fuzz coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,7 +984,7 @@ jobs:
       - run:
           name: Fuzz
           command: |
-            make fuzz
+            just fuzz
           working_directory: "<<parameters.package_name>>"
       - run:
           name: Copy fuzz artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,7 +984,7 @@ jobs:
       - run:
           name: Fuzz
           command: |
-            just fuzz
+            make fuzz
           working_directory: "<<parameters.package_name>>"
       - run:
           name: Copy fuzz artifacts

--- a/op-service/bigs/bigutil.go
+++ b/op-service/bigs/bigutil.go
@@ -7,13 +7,13 @@ func Equal(a *big.Int, b *big.Int) bool {
 }
 
 func IsZero(val *big.Int) bool {
-	return val.Cmp(big.NewInt(0)) == 0
+	return val.Sign() == 0
 }
 
 func IsPositive(val *big.Int) bool {
-	return val.Cmp(big.NewInt(0)) > 0
+	return val.Sign() > 0
 }
 
 func IsNegative(val *big.Int) bool {
-	return val.Cmp(big.NewInt(0)) < 0
+	return val.Sign() < 0
 }

--- a/op-service/eth/account_proof_test.go
+++ b/op-service/eth/account_proof_test.go
@@ -126,7 +126,7 @@ func TestAccountResult_MarshalTruncated(t *testing.T) {
 }
 
 func FuzzAccountResult_StorageProof(f *testing.F) {
-	f.Skip() // I don't understand this test
+	f.Skip() // TODO https://github.com/ethereum-optimism/optimism/issues/15067
 	f.Fuzz(func(t *testing.T, key []byte, value []byte) {
 		result := makeResult(t)
 		result.StorageProof[0].Key = key

--- a/op-service/eth/account_proof_test.go
+++ b/op-service/eth/account_proof_test.go
@@ -130,7 +130,10 @@ func FuzzAccountResult_StorageProof(f *testing.F) {
 		result := makeResult(t)
 		result.StorageProof[0].Key = key
 		result.StorageProof[0].Value = hexutil.Big(*(new(big.Int).SetBytes(value)))
-		require.Error(t, result.Verify(goodRoot), "expected error when trying to verify bad result with good root: key=%v value=%v", key, value)
+		err := result.Verify(goodRoot)
+		if err == nil {
+			require.Zero(t, result.StorageProof[0].Value.ToInt().Cmp(common.Big0), "if a bad result verifies with good root, the value must be zero: key=%v value=%v", key, value)
+		}
 	})
 }
 

--- a/op-service/eth/account_proof_test.go
+++ b/op-service/eth/account_proof_test.go
@@ -126,6 +126,7 @@ func TestAccountResult_MarshalTruncated(t *testing.T) {
 }
 
 func FuzzAccountResult_StorageProof(f *testing.F) {
+	f.Skip() // I don't understand this test
 	f.Fuzz(func(t *testing.T, key []byte, value []byte) {
 		result := makeResult(t)
 		result.StorageProof[0].Key = key

--- a/op-service/eth/account_proof_test.go
+++ b/op-service/eth/account_proof_test.go
@@ -126,12 +126,11 @@ func TestAccountResult_MarshalTruncated(t *testing.T) {
 }
 
 func FuzzAccountResult_StorageProof(f *testing.F) {
-	f.Skip() // TODO https://github.com/ethereum-optimism/optimism/issues/15067
 	f.Fuzz(func(t *testing.T, key []byte, value []byte) {
 		result := makeResult(t)
 		result.StorageProof[0].Key = key
 		result.StorageProof[0].Value = hexutil.Big(*(new(big.Int).SetBytes(value)))
-		require.NoError(t, result.Verify(goodRoot), "does not verify against bad proof")
+		require.Error(t, result.Verify(goodRoot), "expected error when trying to verify bad result with good root: key=%v value=%v", key, value)
 	})
 }
 

--- a/op-service/eth/account_proof_test.go
+++ b/op-service/eth/account_proof_test.go
@@ -130,7 +130,7 @@ func FuzzAccountResult_StorageProof(f *testing.F) {
 		result := makeResult(t)
 		result.StorageProof[0].Key = key
 		result.StorageProof[0].Value = hexutil.Big(*(new(big.Int).SetBytes(value)))
-		require.NotNil(t, result.Verify(goodRoot), "does not verify against bad proof")
+		require.NoError(t, result.Verify(goodRoot), "does not verify against bad proof")
 	})
 }
 

--- a/op-service/eth/account_proof_test.go
+++ b/op-service/eth/account_proof_test.go
@@ -1,14 +1,17 @@
 package eth
 
 import (
+	"bytes"
 	"encoding/json"
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
 // Example account result taken from the Goerli SystemConfig proxy:
@@ -126,13 +129,33 @@ func TestAccountResult_MarshalTruncated(t *testing.T) {
 }
 
 func FuzzAccountResult_StorageProof(f *testing.F) {
+	// from the makeResult function, the known proof:
+	knownValidkey := common.HexToHash("0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08")
+	knownValidValue := common.FromHex("0x715b7219d986641df9efd9c7ef01218d528e19ec")
+	f.Add(knownValidkey[:], knownValidValue[:])
 	f.Fuzz(func(t *testing.T, key []byte, value []byte) {
 		result := makeResult(t)
 		result.StorageProof[0].Key = key
 		result.StorageProof[0].Value = hexutil.Big(*(new(big.Int).SetBytes(value)))
 		err := result.Verify(goodRoot)
-		if err == nil {
-			require.Zero(t, result.StorageProof[0].Value.ToInt().Cmp(common.Big0), "if a bad result verifies with good root, the value must be zero: key=%v value=%v", key, value)
+		if bytes.Equal(key, knownValidkey[:]) {
+			if bytes.Equal(value, knownValidValue) {
+				require.NoError(t, err, "known key/value pair must pass")
+			} else {
+				require.Errorf(t, err, "other values for known key must fail, but got 0x%x", value)
+			}
+		} else {
+			if bigs.IsZero(result.StorageProof[0].Value.ToInt()) {
+				// When there's a valid trie, and we proof exclusion (i.e. non-existent key turns into a 0 value),
+				// then `trie.VerifyProof` will simply not error when given the valid storage-proof that
+				// shows some valid adjacent path that implies the exclusion of the actual value at the queried key path.
+				if err != nil {
+					// missing proof nodes can happen, exclusion proofs by showing the known value won't always be deep enough
+					require.ErrorContains(t, err, "missing")
+				}
+			} else {
+				require.Errorf(t, err, "random other key/value pairs (key=0x%x value=0x%x) should not verify", key, value)
+			}
 		}
 	})
 }

--- a/op-service/justfile
+++ b/op-service/justfile
@@ -7,7 +7,7 @@ test: (go_test "./...")
 generate-mocks: (go_generate "./...")
 
 [private]
-service_fuzz_task FUZZ TIME='10s': (go_fuzz FUZZ TIME "./eth")
+service_fuzz_task FUZZ TIME='60s': (go_fuzz FUZZ TIME "./eth")
 
 # Run fuzzing tests
 fuzz:

--- a/op-service/justfile
+++ b/op-service/justfile
@@ -11,14 +11,6 @@ service_fuzz_task FUZZ TIME='10s': (go_fuzz FUZZ TIME "./eth")
 
 # Run fuzzing tests
 fuzz:
-    printf "%s\n" \
-        "FuzzExecutionPayloadUnmarshal" \
-        "FuzzExecutionPayloadMarshalUnmarshalV1" \
-        "FuzzExecutionPayloadMarshalUnmarshalV2" \
-        "FuzzExecutionPayloadMarshalUnmarshalV3" \
-        "FuzzExecutionPayloadMarshalUnmarshalV4" \
-        "FuzzOBP01" \
-        "FuzzEncodeDecodeBlob" \
-        "FuzzDetectNonBijectivity" \
-        "FuzzEncodeScalar" \
+    go test ./eth/... -list=Fuzz -vet=off \
+    | grep 'Fuzz' \
     | parallel -j {{PARALLEL_JOBS}} {{just_executable()}} service_fuzz_task {}


### PR DESCRIPTION
Closes #15053 

* Increases fuzzing time by a factor of 6
* Overall CI runtime unaffected. The particular job takes about twice as long now, but that is a good ROI and makes it shorter than other jobs which run concurrently
* Ensures all fuzz tests in the `eth` directory are detected and triggered
* This exposed an actual test failure for a test which wasn't being run in CI  https://github.com/ethereum-optimism/optimism/issues/15067
* Fixed that test so we can continue to run it now
* builds the tests once instead of on each parallel job

Closes https://github.com/ethereum-optimism/optimism/issues/15067