### PR TITLE
Bump op-acceptor version to v0.1.6

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -37,7 +37,7 @@ anvil = "v1.0.0"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
 kurtosis = "1.6.0"
-op-acceptor = "op-acceptor/v0.1.5"
+op-acceptor = "op-acceptor/v0.1.6"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v0.1.5")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v0.1.6")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 


### PR DESCRIPTION
Updates the op-acceptance-tests to rely on [op-acceptor v0.1.6](https://github.com/ethereum-optimism/infra/releases/tag/op-acceptor%2Fv0.1.6). This should fix the [corresponding post-merge CI failures](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/85608/workflows/2b3675d2-36db-43f8-81c3-2d4d3842e88f/jobs/3392773).