### PR TITLE
op-{dispute-mon,challenger}: Fix metrics setup

### DIFF
--- a/op-challenger/runner/metrics.go
+++ b/op-challenger/runner/metrics.go
@@ -37,6 +37,7 @@ var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
 func NewMetrics(runConfigs []RunConfig) *Metrics {
 	registry := opmetrics.NewRegistry()
 	factory := opmetrics.With(registry)
+	rpcClientMetrics := opmetrics.MakeRPCClientMetrics(Namespace, factory)
 
 	metrics := &Metrics{
 		ns:       Namespace,
@@ -45,7 +46,7 @@ func NewMetrics(runConfigs []RunConfig) *Metrics {
 
 		ContractMetrics:  contractMetrics.MakeContractMetrics(Namespace, factory),
 		VmMetrics:        metrics.NewVmMetrics(Namespace, factory),
-		RPCClientMetrics: &opmetrics.RPCClientMetrics{},
+		RPCClientMetrics: &rpcClientMetrics,
 
 		up: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace,

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -242,6 +242,7 @@ var _ Metricer = (*Metrics)(nil)
 func NewMetrics() *Metrics {
 	registry := opmetrics.NewRegistry()
 	factory := opmetrics.With(registry)
+	rpcClientMetrics := opmetrics.MakeRPCClientMetrics(Namespace, factory)
 
 	return &Metrics{
 		ns:       Namespace,
@@ -250,7 +251,7 @@ func NewMetrics() *Metrics {
 
 		CacheMetrics:     opmetrics.NewCacheMetrics(factory, Namespace, "provider_cache", "Provider cache"),
 		ContractMetrics:  contractMetrics.MakeContractMetrics(Namespace, factory),
-		RPCClientMetrics: &opmetrics.RPCClientMetrics{},
+		RPCClientMetrics: &rpcClientMetrics,
 		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "info",


### PR DESCRIPTION
It's unsafe to use the underlying type uninitialized to setup `RPCClientMetrics`.