### PR TITLE
op-e2e/system: add test for minting to a delegated account

### DIFF
--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -84,7 +84,15 @@ func TestMintOnRevertedDeposit(t *testing.T) {
 	require.Equal(t, startNonce+1, endNonce, "Nonce of deposit sender should increment on L2, even if the deposit fails")
 }
 
-func TestMintToDelegatedAccount(t *testing.T) {
+func TestMintCallToDelegatedAccount(t *testing.T) {
+	// This test:
+	// 1. Deploys a contract on L2 that stores the first word of the call data to storage
+	// 2. Sets the delegation designation for an account on L2 to the new contract
+	// 3. Sends a deposit to the account with the delegation code
+	// 4. Ensures the deposit properly calls the contract and stores the first word of the call data to storage
+	// 5. Ensures the deposit sender's nonce is incremented on L2
+	// 6. Ensures the deposit sender's balance is incremented on L2
+
 	op_e2e.InitParallel(t)
 	cfg := e2esys.DefaultSystemConfig(t)
 	cfg.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
@@ -249,7 +257,7 @@ func TestMintToDelegatedAccount(t *testing.T) {
 	diff = diff.Sub(endBalance, startBalance)
 	require.Equal(t, mintAmount, diff, "Did not get expected balance change")
 
-	// Bob slot 0 should not be 0x42
+	// Bob slot 0 should be 0x42
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	slot0, err = l2Seq.StorageAt(ctx, cfg.Secrets.Addresses().Bob, common.Hash{0x00}, nil)
 	cancel()

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -95,6 +95,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 
 	op_e2e.InitParallel(t)
 	cfg := e2esys.DefaultSystemConfig(t)
+	cfg.DeployConfig = cfg.DeployConfig.Copy()
 	cfg.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
 	delete(cfg.Nodes, "verifier")
 	sys, err := cfg.Start(t)

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -84,6 +84,40 @@ func TestMintOnRevertedDeposit(t *testing.T) {
 	require.Equal(t, startNonce+1, endNonce, "Nonce of deposit sender should increment on L2, even if the deposit fails")
 }
 
+var (
+	deployPrefixSize = byte(16)
+	deployPrefix     = []byte{
+		// Copy input data after this prefix into memory starting at address 0x00
+		// CODECOPY arg size
+		byte(vm.PUSH1), deployPrefixSize,
+		byte(vm.CODESIZE),
+		byte(vm.SUB),
+		// CODECOPY arg offset
+		byte(vm.PUSH1), deployPrefixSize,
+		// CODECOPY arg destOffset
+		byte(vm.PUSH1), 0x00,
+		byte(vm.CODECOPY),
+
+		// Return code from memory
+		// RETURN arg size
+		byte(vm.PUSH1), deployPrefixSize,
+		byte(vm.CODESIZE),
+		byte(vm.SUB),
+		// RETURN arg offset
+		byte(vm.PUSH1), 0x00,
+		byte(vm.RETURN),
+	}
+	sstoreContract = []byte{
+		// Load first word from call data
+		byte(vm.PUSH1), 0x00,
+		byte(vm.CALLDATALOAD),
+
+		// Store it to slot 0
+		byte(vm.PUSH1), 0x00,
+		byte(vm.SSTORE),
+	}
+)
+
 func TestMintCallToDelegatedAccount(t *testing.T) {
 	// This test:
 	// 1. Deploys a contract on L2 that stores the first word of the call data to storage
@@ -106,39 +140,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 
 	// Simple constructor that is prefixed to the actual contract code
 	// Results in the contract code being returned as the code for the new contract
-	deployPrefixSize := byte(16)
-	deployPrefix := []byte{
-		// Copy input data after this prefix into memory starting at address 0x00
-		// CODECOPY arg size
-		byte(vm.PUSH1), deployPrefixSize,
-		byte(vm.CODESIZE),
-		byte(vm.SUB),
-		// CODECOPY arg offset
-		byte(vm.PUSH1), deployPrefixSize,
-		// CODECOPY arg destOffset
-		byte(vm.PUSH1), 0x00,
-		byte(vm.CODECOPY),
-
-		// Return code from memory
-		// RETURN arg size
-		byte(vm.PUSH1), deployPrefixSize,
-		byte(vm.CODESIZE),
-		byte(vm.SUB),
-		// RETURN arg offset
-		byte(vm.PUSH1), 0x00,
-		byte(vm.RETURN),
-	}
-	// first deploy a contract that stores the first word of the call data to storage
-	storeFirstWordProgram := []byte{
-		// Load first word from call data
-		byte(vm.PUSH1), 0x00,
-		byte(vm.CALLDATALOAD),
-
-		// Store it to slot 0
-		byte(vm.PUSH1), 0x00,
-		byte(vm.SSTORE),
-	}
-	deployStore := append(deployPrefix, storeFirstWordProgram...)
+	deployData := append(deployPrefix, sstoreContract...)
 	signer := types.NewIsthmusSigner(cfg.L2ChainIDBig())
 
 	tx := types.MustSignNewTx(cfg.Secrets.Alice, signer, &types.DynamicFeeTx{
@@ -149,7 +151,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 		Gas:       500000,
 		GasFeeCap: big.NewInt(5000000000),
 		GasTipCap: big.NewInt(2),
-		Data:      deployStore,
+		Data:      deployData,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -170,8 +172,8 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	code, err := l2Seq.PendingCodeAt(ctx, contractAddr)
 	cancel()
 	require.NoError(t, err, "Failed to get code at contract address")
-	if !bytes.Equal(code, storeFirstWordProgram) {
-		t.Fatalf("Code at contract address is incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(storeFirstWordProgram))
+	if !bytes.Equal(code, sstoreContract) {
+		t.Fatalf("Code at contract address is incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(sstoreContract))
 	}
 
 	// set delegation designation for an account on L2 to new contract
@@ -286,41 +288,6 @@ func TestDepositTxCreateContract(t *testing.T) {
 
 	opts, err := bind.NewKeyedTransactorWithChainID(cfg.Secrets.Alice, cfg.L1ChainIDBig())
 	require.NoError(t, err)
-
-	// Simple constructor that is prefixed to the actual contract code
-	// Results in the contract code being returned as the code for the new contract
-	deployPrefixSize := byte(16)
-	deployPrefix := []byte{
-		// Copy input data after this prefix into memory starting at address 0x00
-		// CODECOPY arg size
-		byte(vm.PUSH1), deployPrefixSize,
-		byte(vm.CODESIZE),
-		byte(vm.SUB),
-		// CODECOPY arg offset
-		byte(vm.PUSH1), deployPrefixSize,
-		// CODECOPY arg destOffset
-		byte(vm.PUSH1), 0x00,
-		byte(vm.CODECOPY),
-
-		// Return code from memory
-		// RETURN arg size
-		byte(vm.PUSH1), deployPrefixSize,
-		byte(vm.CODESIZE),
-		byte(vm.SUB),
-		// RETURN arg offset
-		byte(vm.PUSH1), 0x00,
-		byte(vm.RETURN),
-	}
-	// Stores the first word from call data code to storage slot 0
-	sstoreContract := []byte{
-		// Load first word from call data
-		byte(vm.PUSH1), 0x00,
-		byte(vm.CALLDATALOAD),
-
-		// Store it to slot 0
-		byte(vm.PUSH1), 0x00,
-		byte(vm.SSTORE),
-	}
 
 	deployData := append(deployPrefix, sstoreContract...)
 

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -157,7 +157,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	})
 
 	err = l2Seq.SendTransaction(ctx, tx)
-	require.NoError(t, err, "Failed to send set code transaction")
+	require.NoError(t, err, "Failed to send contract deployment transaction")
 
 	_, err = wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
 	require.NoError(t, err, "Failed to get receipt for set code transaction")

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/core/vm/program"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -95,11 +95,44 @@ func TestMintToDelegatedAccount(t *testing.T) {
 	l1Client := sys.NodeClient("l1")
 	l2Seq := sys.NodeClient("sequencer")
 
-	// first deploy a contract that does nothing
-	store42Program := program.New().Sstore(0x42, 0x42)
+	// Simple constructor that is prefixed to the actual contract code
+	// Results in the contract code being returned as the code for the new contract
+	deployPrefixSize := byte(16)
+	deployPrefix := []byte{
+		// Copy input data after this prefix into memory starting at address 0x00
+		// CODECOPY arg size
+		byte(vm.PUSH1), deployPrefixSize,
+		byte(vm.CODESIZE),
+		byte(vm.SUB),
+		// CODECOPY arg offset
+		byte(vm.PUSH1), deployPrefixSize,
+		// CODECOPY arg destOffset
+		byte(vm.PUSH1), 0x00,
+		byte(vm.CODECOPY),
+
+		// Return code from memory
+		// RETURN arg size
+		byte(vm.PUSH1), deployPrefixSize,
+		byte(vm.CODESIZE),
+		byte(vm.SUB),
+		// RETURN arg offset
+		byte(vm.PUSH1), 0x00,
+		byte(vm.RETURN),
+	}
+	// first deploy a contract that stores the first word of the call data to storage
+	storeFirstWordProgram := []byte{
+		// Load first word from call data
+		byte(vm.PUSH1), 0x00,
+		byte(vm.CALLDATALOAD),
+
+		// Store it to slot 0
+		byte(vm.PUSH1), 0x00,
+		byte(vm.SSTORE),
+	}
+	deployStore := append(deployPrefix, storeFirstWordProgram...)
 	signer := types.NewIsthmusSigner(cfg.L2ChainIDBig())
 
-	tx := types.MustSignNewTx(cfg.Secrets.Bob, signer, &types.DynamicFeeTx{
+	tx := types.MustSignNewTx(cfg.Secrets.Alice, signer, &types.DynamicFeeTx{
 		ChainID:   cfg.L2ChainIDBig(),
 		Nonce:     0,
 		To:        nil,
@@ -107,7 +140,7 @@ func TestMintToDelegatedAccount(t *testing.T) {
 		Gas:       500000,
 		GasFeeCap: big.NewInt(5000000000),
 		GasTipCap: big.NewInt(2),
-		Data:      store42Program.Bytes(),
+		Data:      deployStore,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -116,28 +149,39 @@ func TestMintToDelegatedAccount(t *testing.T) {
 	require.NoError(t, err, "Failed to send set code transaction")
 
 	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
-	_, err = wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
+	r, err := wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
 	cancel()
 	require.NoError(t, err, "Failed to get receipt for set code transaction")
 
-	contractAddr := crypto.CreateAddress(cfg.Secrets.Addresses().Bob, 0)
+	contractAddr := crypto.CreateAddress(cfg.Secrets.Addresses().Alice, 0)
+	fmt.Println(r.Status, r.ContractAddress, contractAddr)
+
+	// validate codeat
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	code, err := l2Seq.PendingCodeAt(ctx, contractAddr)
+	cancel()
+	require.NoError(t, err, "Failed to get code at contract address")
+	if !bytes.Equal(code, storeFirstWordProgram) {
+		t.Fatalf("Code at contract address is incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(storeFirstWordProgram))
+	}
 
 	// set delegation designation for an account on L2 to new contract
 	auth1, err := types.SignSetCode(cfg.Secrets.Bob, types.SetCodeAuthorization{
 		Address: contractAddr,
-		Nonce:   2,
+		Nonce:   1,
 	})
 
 	require.NoError(t, err, "Failed to sign set code authorization")
 
 	txdata := &types.SetCodeTx{
 		ChainID:   uint256.MustFromBig(cfg.L2ChainIDBig()),
-		Nonce:     1,
+		Nonce:     0,
 		To:        cfg.Secrets.Addresses().Bob,
 		Gas:       500000,
 		GasFeeCap: uint256.NewInt(5000000000),
 		GasTipCap: uint256.NewInt(2),
 		AuthList:  []types.SetCodeAuthorization{auth1},
+		Data:      []byte{1},
 	}
 
 	tx = types.MustSignNewTx(cfg.Secrets.Bob, signer, txdata)
@@ -154,7 +198,7 @@ func TestMintToDelegatedAccount(t *testing.T) {
 
 	// ensure the delegation was set
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	delegation, err := l2Seq.PendingCodeAt(ctx, cfg.Secrets.Addresses().Bob)
+	delegation, err := l2Seq.CodeAt(ctx, cfg.Secrets.Addresses().Bob, nil)
 	if err != nil {
 		t.Fatalf("Failed to get delegation code: %v", err)
 	}
@@ -163,6 +207,13 @@ func TestMintToDelegatedAccount(t *testing.T) {
 	if !bytes.Equal(delegation, want) {
 		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(delegation), common.Bytes2Hex(want))
 	}
+
+	// ensure the code was executed correctly
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	slot0, err := l2Seq.StorageAt(ctx, cfg.Secrets.Addresses().Bob, common.Hash{0x00}, nil)
+	cancel()
+	require.NoError(t, err, "Failed to get storage at slot 0")
+	require.Equal(t, byte(0x01), slot0[0], "The first word of the call data should be stored in slot 0")
 
 	aliceKey := cfg.Secrets.Alice
 	opts, err := bind.NewKeyedTransactorWithChainID(aliceKey, cfg.L1ChainIDBig())
@@ -185,6 +236,7 @@ func TestMintToDelegatedAccount(t *testing.T) {
 	opts.Value = mintAmount
 	helpers.SendDepositTx(t, cfg, l1Client, l2Seq, opts, func(l2Opts *helpers.DepositTxOpts) {
 		l2Opts.ToAddr = toAddr
+		l2Opts.Data = []byte{0x42}
 	})
 
 	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
@@ -196,6 +248,13 @@ func TestMintToDelegatedAccount(t *testing.T) {
 	diff := new(big.Int)
 	diff = diff.Sub(endBalance, startBalance)
 	require.Equal(t, mintAmount, diff, "Did not get expected balance change")
+
+	// Bob slot 0 should not be 0x42
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	slot0, err = l2Seq.StorageAt(ctx, cfg.Secrets.Addresses().Bob, common.Hash{0x00}, nil)
+	cancel()
+	require.NoError(t, err, "Failed to get storage at slot 0")
+	require.Equal(t, byte(0x42), slot0[0], "The first word of the call data should be stored in slot 0")
 
 	// From nonce should have increased as a result
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -3,7 +3,6 @@ package bridge
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -125,7 +124,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	// 3. Sends a deposit tx (using the L1 bridge) to the L2 account with the delegation code
 	// 4. Ensures the deposit properly calls the contract and stores the first word of the call data to storage
 	// 5. Ensures the deposit sender's nonce is incremented on L2
-	// 6. Ensures the deposit sender's balance is incremented on L2
+	// 6. Ensures the deposit recipient's balance is incremented on L2
 
 	op_e2e.InitParallel(t)
 	cfg := e2esys.DefaultSystemConfig(t)
@@ -137,6 +136,9 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 
 	l1Client := sys.NodeClient("l1")
 	l2Seq := sys.NodeClient("sequencer")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
 	// Simple constructor that is prefixed to the actual contract code
 	// Results in the contract code being returned as the code for the new contract
@@ -154,27 +156,25 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 		Data:      deployData,
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	err = l2Seq.SendTransaction(ctx, tx)
-	cancel()
 	require.NoError(t, err, "Failed to send set code transaction")
 
-	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
-	r, err := wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
-	cancel()
+	_, err = wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
 	require.NoError(t, err, "Failed to get receipt for set code transaction")
 
 	contractAddr := crypto.CreateAddress(cfg.Secrets.Addresses().Alice, 0)
-	fmt.Println(r.Status, r.ContractAddress, contractAddr)
 
 	// validate codeat
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	code, err := l2Seq.PendingCodeAt(ctx, contractAddr)
-	cancel()
 	require.NoError(t, err, "Failed to get code at contract address")
 	if !bytes.Equal(code, sstoreContract) {
 		t.Fatalf("Code at contract address is incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(sstoreContract))
 	}
+
+	// validate slot 0 is empty
+	slot0, err := l2Seq.StorageAt(ctx, contractAddr, common.Hash{0x00}, nil)
+	require.NoError(t, err, "Failed to get storage at slot 0")
+	require.Equal(t, make([]byte, 32), slot0, "Slot 0 should be empty")
 
 	// set delegation designation for an account on L2 to new contract
 	auth1, err := types.SignSetCode(cfg.Secrets.Bob, types.SetCodeAuthorization{
@@ -184,6 +184,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 
 	require.NoError(t, err, "Failed to sign set code authorization")
 
+	// Set slot0 to 0x01 first
 	txdata := &types.SetCodeTx{
 		ChainID:   uint256.MustFromBig(cfg.L2ChainIDBig()),
 		Nonce:     0,
@@ -192,37 +193,27 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 		GasFeeCap: uint256.NewInt(5000000000),
 		GasTipCap: uint256.NewInt(2),
 		AuthList:  []types.SetCodeAuthorization{auth1},
-		Data:      []byte{1},
+		Data:      []byte{0x01},
 	}
 
 	tx = types.MustSignNewTx(cfg.Secrets.Bob, signer, txdata)
 
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	err = l2Seq.SendTransaction(ctx, tx)
-	cancel()
 	require.NoError(t, err, "Failed to send set code transaction")
 
-	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
 	_, err = wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
-	cancel()
 	require.NoError(t, err, "Failed to get receipt for set code transaction")
 
 	// ensure the delegation was set
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	delegation, err := l2Seq.CodeAt(ctx, cfg.Secrets.Addresses().Bob, nil)
-	if err != nil {
-		t.Fatalf("Failed to get delegation code: %v", err)
-	}
-	cancel()
+	require.NoError(t, err, "Failed to get delegation code")
 	want := types.AddressToDelegation(auth1.Address)
 	if !bytes.Equal(delegation, want) {
 		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(delegation), common.Bytes2Hex(want))
 	}
 
 	// ensure the code was executed correctly
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	slot0, err := l2Seq.StorageAt(ctx, cfg.Secrets.Addresses().Bob, common.Hash{0x00}, nil)
-	cancel()
+	slot0, err = l2Seq.StorageAt(ctx, cfg.Secrets.Addresses().Bob, common.Hash{0x00}, nil)
 	require.NoError(t, err, "Failed to get storage at slot 0")
 	require.Equal(t, byte(0x01), slot0[0], "The first word of the call data should be stored in slot 0")
 
@@ -231,17 +222,13 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	require.NoError(t, err)
 	fromAddr := opts.From
 
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	startBalance, err := l2Seq.BalanceAt(ctx, cfg.Secrets.Addresses().Bob, nil)
-	cancel()
 	require.NoError(t, err)
 
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	startNonce, err := l2Seq.NonceAt(ctx, fromAddr, nil)
 	require.NoError(t, err)
-	cancel()
 
-	// send a deposit to bob with the delegation code
+	// send a deposit to bob with the delegation code and setting slot 0 to 0x42
 	toAddr := cfg.Secrets.Addresses().Bob
 	mintAmount := big.NewInt(9_000_000)
 	opts.Value = mintAmount
@@ -250,9 +237,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 		l2Opts.Data = []byte{0x42}
 	})
 
-	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
 	endBalance, err := wait.ForBalanceChange(ctx, l2Seq, toAddr, startBalance)
-	cancel()
 	require.NoError(t, err)
 
 	// Bob balance should have increased by the mint amount
@@ -261,17 +246,13 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	require.Equal(t, mintAmount, diff, "Did not get expected balance change")
 
 	// Bob slot 0 should be 0x42
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	slot0, err = l2Seq.StorageAt(ctx, cfg.Secrets.Addresses().Bob, common.Hash{0x00}, nil)
-	cancel()
 	require.NoError(t, err, "Failed to get storage at slot 0")
 	require.Equal(t, byte(0x42), slot0[0], "The first word of the call data should be stored in slot 0")
 
 	// From nonce should have increased as a result
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	endNonce, err := l2Seq.NonceAt(ctx, fromAddr, nil)
 	require.NoError(t, err)
-	cancel()
 	require.Equal(t, startNonce+1, endNonce, "Nonce of deposit sender should increment on L2, even if the deposit fails")
 }
 

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -121,7 +121,7 @@ var (
 func TestMintCallToDelegatedAccount(t *testing.T) {
 	// This test:
 	// 1. Deploys a contract on L2 that stores the first word of the call data to storage
-	// 2. Sets the delegation designation for an account on L2 to the new contract
+	// 2. Sets the delegation designation for an account on L2 to the new contract with nonzero calldata and ensures this is set in the contract
 	// 3. Sends a deposit tx (using the L1 bridge) to the L2 account with the delegation code
 	// 4. Ensures the deposit properly calls the contract and stores the first word of the call data to storage
 	// 5. Ensures the deposit sender's nonce is incremented on L2

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -122,7 +122,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	// This test:
 	// 1. Deploys a contract on L2 that stores the first word of the call data to storage
 	// 2. Sets the delegation designation for an account on L2 to the new contract
-	// 3. Sends a deposit to the account with the delegation code
+	// 3. Sends a deposit tx (using the L1 bridge) to the L2 account with the delegation code
 	// 4. Ensures the deposit properly calls the contract and stores the first word of the call data to storage
 	// 5. Ensures the deposit sender's nonce is incremented on L2
 	// 6. Ensures the deposit sender's balance is incremented on L2

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -1,12 +1,15 @@
 package bridge
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 	"testing"
 	"time"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
@@ -17,6 +20,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/core/vm/program"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,6 +79,127 @@ func TestMintOnRevertedDeposit(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	endNonce, err := l2Verif.NonceAt(ctx, fromAddr, nil)
+	require.NoError(t, err)
+	cancel()
+	require.Equal(t, startNonce+1, endNonce, "Nonce of deposit sender should increment on L2, even if the deposit fails")
+}
+
+func TestMintToDelegatedAccount(t *testing.T) {
+	op_e2e.InitParallel(t)
+	cfg := e2esys.DefaultSystemConfig(t)
+	cfg.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
+	delete(cfg.Nodes, "verifier")
+	sys, err := cfg.Start(t)
+	require.NoError(t, err, "Error starting up system")
+
+	l1Client := sys.NodeClient("l1")
+	l2Seq := sys.NodeClient("sequencer")
+
+	// first deploy a contract that does nothing
+	store42Program := program.New().Sstore(0x42, 0x42)
+	signer := types.NewIsthmusSigner(cfg.L2ChainIDBig())
+
+	tx := types.MustSignNewTx(cfg.Secrets.Bob, signer, &types.DynamicFeeTx{
+		ChainID:   cfg.L2ChainIDBig(),
+		Nonce:     0,
+		To:        nil,
+		Value:     big.NewInt(0),
+		Gas:       500000,
+		GasFeeCap: big.NewInt(5000000000),
+		GasTipCap: big.NewInt(2),
+		Data:      store42Program.Bytes(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	err = l2Seq.SendTransaction(ctx, tx)
+	cancel()
+	require.NoError(t, err, "Failed to send set code transaction")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+	_, err = wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
+	cancel()
+	require.NoError(t, err, "Failed to get receipt for set code transaction")
+
+	contractAddr := crypto.CreateAddress(cfg.Secrets.Addresses().Bob, 0)
+
+	// set delegation designation for an account on L2 to new contract
+	auth1, err := types.SignSetCode(cfg.Secrets.Bob, types.SetCodeAuthorization{
+		Address: contractAddr,
+		Nonce:   2,
+	})
+
+	require.NoError(t, err, "Failed to sign set code authorization")
+
+	txdata := &types.SetCodeTx{
+		ChainID:   uint256.MustFromBig(cfg.L2ChainIDBig()),
+		Nonce:     1,
+		To:        cfg.Secrets.Addresses().Bob,
+		Gas:       500000,
+		GasFeeCap: uint256.NewInt(5000000000),
+		GasTipCap: uint256.NewInt(2),
+		AuthList:  []types.SetCodeAuthorization{auth1},
+	}
+
+	tx = types.MustSignNewTx(cfg.Secrets.Bob, signer, txdata)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	err = l2Seq.SendTransaction(ctx, tx)
+	cancel()
+	require.NoError(t, err, "Failed to send set code transaction")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+	_, err = wait.ForReceipt(ctx, l2Seq, tx.Hash(), 1)
+	cancel()
+	require.NoError(t, err, "Failed to get receipt for set code transaction")
+
+	// ensure the delegation was set
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	delegation, err := l2Seq.PendingCodeAt(ctx, cfg.Secrets.Addresses().Bob)
+	if err != nil {
+		t.Fatalf("Failed to get delegation code: %v", err)
+	}
+	cancel()
+	want := types.AddressToDelegation(auth1.Address)
+	if !bytes.Equal(delegation, want) {
+		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(delegation), common.Bytes2Hex(want))
+	}
+
+	aliceKey := cfg.Secrets.Alice
+	opts, err := bind.NewKeyedTransactorWithChainID(aliceKey, cfg.L1ChainIDBig())
+	require.NoError(t, err)
+	fromAddr := opts.From
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	startBalance, err := l2Seq.BalanceAt(ctx, cfg.Secrets.Addresses().Bob, nil)
+	cancel()
+	require.NoError(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	startNonce, err := l2Seq.NonceAt(ctx, fromAddr, nil)
+	require.NoError(t, err)
+	cancel()
+
+	// send a deposit to bob with the delegation code
+	toAddr := cfg.Secrets.Addresses().Bob
+	mintAmount := big.NewInt(9_000_000)
+	opts.Value = mintAmount
+	helpers.SendDepositTx(t, cfg, l1Client, l2Seq, opts, func(l2Opts *helpers.DepositTxOpts) {
+		l2Opts.ToAddr = toAddr
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+	endBalance, err := wait.ForBalanceChange(ctx, l2Seq, toAddr, startBalance)
+	cancel()
+	require.NoError(t, err)
+
+	// Bob balance should have increased by the mint amount
+	diff := new(big.Int)
+	diff = diff.Sub(endBalance, startBalance)
+	require.Equal(t, mintAmount, diff, "Did not get expected balance change")
+
+	// From nonce should have increased as a result
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	endNonce, err := l2Seq.NonceAt(ctx, fromAddr, nil)
 	require.NoError(t, err)
 	cancel()
 	require.Equal(t, startNonce+1, endNonce, "Nonce of deposit sender should increment on L2, even if the deposit fails")


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a test for minting to a delegated account.