### PR TITLE
devnet-sdk/op-acceptance-tests: introduce `RequireNoChainFork` and use in `withdrawal_root_test.go`

### DIFF
--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -4,15 +4,47 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"math/big"
 	"strings"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 )
+
+// RequireNoChainFork checks that the L2 chain has not forked now, and returns a
+// function that check again (to be called at the end of the test).
+func RequireNoChainFork(t T, chain system.L2Chain, logger log.Logger) func() {
+	ctx := t.Context()
+
+	clients := make([]*ethclient.Client, len(chain.Nodes()))
+	for _, node := range chain.Nodes() {
+		client, err := node.GethClient()
+		require.NoError(t, err)
+		clients = append(clients, client)
+	}
+	// We use a multiclient where feasible to automatically check for consistency
+	// between the nodes.
+	l2MultiClient := NewMultiClient(clients)
+
+	// Setup chain fork detection
+	logger.Info("Setting up chain fork detection")
+	l2StartHeader, err := l2MultiClient.HeaderByNumber(ctx, nil)
+	require.NoError(t, err)
+	logger.Debug("Got L2 head block", "number", l2StartHeader.Number)
+	return func() {
+		l2EndHeader, err := l2MultiClient.HeaderByNumber(ctx, nil)
+		require.NoError(t, err)
+		require.True(t, l2EndHeader.Number.Cmp(l2StartHeader.Number) > 0, "L2 chain should have progressed")
+		logger.Debug("Got L2 end block", "number", l2EndHeader.Number)
+	}
+}
 
 // MultiClient is a simple client that checks hash consistency between underlying clients
 type MultiClient struct {

--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -23,12 +23,13 @@ import (
 func RequireNoChainFork(t T, chain system.L2Chain, logger log.Logger) func() {
 	ctx := t.Context()
 
-	clients := make([]*ethclient.Client, len(chain.Nodes()))
+	clients := make([]*ethclient.Client, 0, len(chain.Nodes()))
 	for _, node := range chain.Nodes() {
 		client, err := node.GethClient()
 		require.NoError(t, err)
 		clients = append(clients, client)
 	}
+
 	// We use a multiclient where feasible to automatically check for consistency
 	// between the nodes.
 	l2MultiClient := NewMultiClient(clients)
@@ -140,6 +141,7 @@ func (mc *MultiClient) fetchWithConsistencyCheck(
 	queryFn func(*ethclient.Client, *big.Int) (interface{}, *big.Int, common.Hash, error),
 ) (interface{}, error) {
 	// Get from primary client
+	// print whether mc.clients[0] is nil
 	primaryItem, blockNum, primaryHash, err := queryFn(mc.clients[0], number)
 	if err != nil {
 		return nil, err

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -31,7 +31,7 @@ optimism_package:
         tolerations: []
         count: 1
       - el_type: op-reth
-        el_image: ""
+        el_image: "ghcr.io/paradigmxyz/op-reth:nightly@sha256:cc2fce901755783b42f5c76b8adc81375c7a80b8ca080b76b6e35cfb4d3e41a7"
         el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}

--- a/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
+++ b/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
@@ -47,25 +46,15 @@ func withdrawalRootTestScenario(chainIdx uint64, walletGetter validators.WalletG
 		ctx := t.Context()
 
 		chain := sys.L2s()[chainIdx]
+		gethCl, err := chain.Nodes()[0].GethClient()
+		require.NoError(t, err)
 
 		logger := testlog.Logger(t, log.LevelInfo)
 		logger.Info("Started test")
 
 		user := walletGetter(ctx)
 
-		clients := make([]*ethclient.Client, len(chain.Nodes()))
-		for _, node := range chain.Nodes() {
-			client, err := node.GethClient()
-			require.NoError(t, err)
-			clients = append(clients, client)
-		}
-		// We use a multiclient where feasible to automatically check for consistency
-		// between the nodes.
-		multiClient := systest.NewMultiClient(clients)
-
-		// MultiClient does not yet support all RPC methods, and so we single one out to use
-		// for now:
-		gethCl := clients[0]
+		defer systest.RequireNoChainFork(t, chain, logger)()
 
 		rpcCl, err := client.NewRPC(ctx, logger, chain.Nodes()[0].RPCURL())
 		require.NoError(t, err)
@@ -74,7 +63,7 @@ func withdrawalRootTestScenario(chainIdx uint64, walletGetter validators.WalletG
 		require.NoError(t, err)
 
 		// Determine pre-state
-		preBlock, err := multiClient.BlockByNumber(ctx, nil)
+		preBlock, err := gethCl.BlockByNumber(ctx, nil)
 		require.NoError(t, err)
 		logger.Info("Got pre-state block", "hash", preBlock.Hash(), "number", preBlock.Number())
 

--- a/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
+++ b/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
@@ -46,15 +47,26 @@ func withdrawalRootTestScenario(chainIdx uint64, walletGetter validators.WalletG
 		ctx := t.Context()
 
 		chain := sys.L2s()[chainIdx]
-		gethCl, err := chain.Nodes()[0].GethClient()
-		require.NoError(t, err)
 
 		logger := testlog.Logger(t, log.LevelInfo)
 		logger.Info("Started test")
 
 		user := walletGetter(ctx)
 
-		// Sad eth clients
+		clients := make([]*ethclient.Client, len(chain.Nodes()))
+		for _, node := range chain.Nodes() {
+			client, err := node.GethClient()
+			require.NoError(t, err)
+			clients = append(clients, client)
+		}
+		// We use a multiclient where feasible to automatically check for consistency
+		// between the nodes.
+		multiClient := systest.NewMultiClient(clients)
+
+		// MultiClient does not yet support all RPC methods, and so we single one out to use
+		// for now:
+		gethCl := clients[0]
+
 		rpcCl, err := client.NewRPC(ctx, logger, chain.Nodes()[0].RPCURL())
 		require.NoError(t, err)
 		t.Cleanup(rpcCl.Close)
@@ -62,7 +74,7 @@ func withdrawalRootTestScenario(chainIdx uint64, walletGetter validators.WalletG
 		require.NoError(t, err)
 
 		// Determine pre-state
-		preBlock, err := gethCl.BlockByNumber(ctx, nil)
+		preBlock, err := multiClient.BlockByNumber(ctx, nil)
 		require.NoError(t, err)
 		logger.Info("Got pre-state block", "hash", preBlock.Hash(), "number", preBlock.Number())
 


### PR DESCRIPTION
This introduces a helper which can be invoked in one line in any acceptance test. It checks all clients agree on the block hash when called, and then checks again when the test is done (also requiring the chain progressed). 

These are very basic sanity checks which are good to add to essentially any test to give us convenient cross-client consensus checks. 

Unfortunately I haven't been able to test this yet, the isthmus devnet is not currently working due to a known issue. 