### PR TITLE
op-service: set implicit empty requests hash post-Isthmus

### DIFF
--- a/op-e2e/actions/upgrades/isthmus_fork_test.go
+++ b/op-e2e/actions/upgrades/isthmus_fork_test.go
@@ -82,7 +82,6 @@ func TestIsthmusActivationAtGenesis(gt *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, genesisPayload.ExecutionPayload.WithdrawalsRoot)
 	require.Equal(t, genesisPayload.ExecutionPayload.WithdrawalsRoot, genesisBlock.WithdrawalsRoot())
-	require.Equal(t, types.EmptyRequestsHash, *genesisPayload.RequestsHash)
 	got, ok := genesisPayload.CheckBlockHash()
 	require.Equal(t, got, reproduced.Hash())
 	require.True(t, ok, "CheckBlockHash must pass")

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -133,11 +133,10 @@ func createExecutionPayload(w types.Withdrawals, withdrawalsRoot *common.Hash, e
 	}
 }
 
-func createEnvelope(h *common.Hash, w types.Withdrawals, withdrawalsRoot *common.Hash, excessGas, gasUsed *uint64, requestsHash *common.Hash) *eth.ExecutionPayloadEnvelope {
+func createEnvelope(h *common.Hash, w types.Withdrawals, withdrawalsRoot *common.Hash, excessGas, gasUsed *uint64) *eth.ExecutionPayloadEnvelope {
 	return &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload:      createExecutionPayload(w, withdrawalsRoot, excessGas, gasUsed),
 		ParentBeaconBlockRoot: h,
-		RequestsHash:          requestsHash,
 	}
 }
 
@@ -192,12 +191,11 @@ func TestBlockValidator(t *testing.T) {
 		result    pubsub.ValidationResult
 		payload   *eth.ExecutionPayloadEnvelope
 	}{
-		{"V3RejectNonZeroExcessGas", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &one, &zero, nil)},
-		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one, nil)},
-		{"V3Valid", v3Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero, nil)},
-		{"V4Valid", v4Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, &withdrawalsRoot, &zero, &zero, &types.EmptyRequestsHash)},
-		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero, &types.EmptyRequestsHash)},
-		{"V4RejectNoRequestsHash", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, &common.Hash{}, &zero, &zero, nil)},
+		{"V3RejectNonZeroExcessGas", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &one, &zero)},
+		{"V3RejectNonZeroBlobGasUsed", v3Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &one)},
+		{"V3Valid", v3Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero)},
+		{"V4Valid", v4Validator, pubsub.ValidationAccept, createEnvelope(&beaconHash, types.Withdrawals{}, &withdrawalsRoot, &zero, &zero)},
+		{"V4RejectNoWithdrawalRoot", v4Validator, pubsub.ValidationReject, createEnvelope(&beaconHash, types.Withdrawals{}, nil, &zero, &zero)},
 	}
 
 	for _, tt := range envelopeTests {

--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -85,11 +85,6 @@ func (v BlockVersion) HasWithdrawalsRoot() bool {
 	return v == BlockV4
 }
 
-// ImpliesRequestsRoot returns whether an empty requests-root should be assumed to be there, but not encoded.
-func (v BlockVersion) ImpliesRequestsRoot() bool {
-	return v == BlockV4
-}
-
 func executionPayloadFixedPart(version BlockVersion) uint32 {
 	if version == BlockV4 {
 		return blockV4FixedPart
@@ -493,11 +488,6 @@ func (envelope *ExecutionPayloadEnvelope) UnmarshalSSZ(version BlockVersion, sco
 	err = payload.UnmarshalSSZ(version, scope-32, r)
 	if err != nil {
 		return err
-	}
-
-	if version.ImpliesRequestsRoot() {
-		h := types.EmptyRequestsHash
-		envelope.RequestsHash = &h
 	}
 
 	envelope.ExecutionPayload = &payload

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -234,7 +234,6 @@ type (
 type ExecutionPayloadEnvelope struct {
 	ParentBeaconBlockRoot *common.Hash      `json:"parentBeaconBlockRoot,omitempty"`
 	ExecutionPayload      *ExecutionPayload `json:"executionPayload"`
-	RequestsHash          *common.Hash      `json:"requestsHash,omitempty"`
 }
 
 func (env *ExecutionPayloadEnvelope) ID() BlockID {
@@ -332,12 +331,12 @@ func (envelope *ExecutionPayloadEnvelope) CheckBlockHash() (actual common.Hash, 
 		BlobGasUsed:      (*uint64)(payload.BlobGasUsed),
 		ExcessBlobGas:    (*uint64)(payload.ExcessBlobGas),
 		ParentBeaconRoot: envelope.ParentBeaconBlockRoot,
-		RequestsHash:     envelope.RequestsHash,
 	}
 
-	if payload.WithdrawalsRoot != nil {
+	if payload.WithdrawalsRoot != nil { // Isthmus
 		header.WithdrawalsHash = payload.WithdrawalsRoot
-	} else if payload.Withdrawals != nil {
+		header.RequestsHash = &types.EmptyRequestsHash
+	} else if payload.Withdrawals != nil { // Canyon
 		withdrawalHash := types.DeriveSha(*payload.Withdrawals, hasher)
 		header.WithdrawalsHash = &withdrawalHash
 	}
@@ -401,7 +400,6 @@ func BlockAsPayloadEnv(bl *types.Block, config *params.ChainConfig) (*ExecutionP
 	return &ExecutionPayloadEnvelope{
 		ExecutionPayload:      payload,
 		ParentBeaconBlockRoot: bl.BeaconRoot(),
-		RequestsHash:          bl.RequestsHash(),
 	}, nil
 }
 
@@ -649,7 +647,6 @@ func DecodeOperatorFeeParams(scalar [32]byte) OperatorFeeParams {
 
 // EncodeOperatorFeeParams encodes the OperatorFeeParams into a 32-byte value
 func EncodeOperatorFeeParams(params OperatorFeeParams) (scalar [32]byte) {
-
 	binary.BigEndian.PutUint32(scalar[20:24], params.Scalar)
 	binary.BigEndian.PutUint64(scalar[24:32], params.Constant)
 	return

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -280,7 +280,6 @@ func (block *RPCBlock) ExecutionPayloadEnvelope(trustCache bool) (*eth.Execution
 	return &eth.ExecutionPayloadEnvelope{
 		ParentBeaconBlockRoot: block.ParentBeaconRoot,
 		ExecutionPayload:      payload,
-		RequestsHash:          block.RequestsHash,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This fixes https://github.com/ethereum-optimism/optimism/pull/14361/files and removes the `RequestsHash` field again from the envelope, and instead implicitly sets it inside `CheckBlockHash()`.

**Tests**

Existing tests fixed.

**Additional context**

The req hash is already set in the engine to the empty req hash for Isthmus.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/15099
