### PR TITLE
op-program: Fix flaky miner test

### DIFF
--- a/op-program/client/l2/test/miner.go
+++ b/op-program/client/l2/test/miner.go
@@ -63,8 +63,7 @@ func NewMiner(t *testing.T, logger log.Logger, isthmusTime uint64) (*Miner, *cor
 		NoPruning:   true,
 	}
 	nodeCfg := &node.Config{
-		Name:    "l2-geth",
-		DataDir: t.TempDir(),
+		Name: "l2-geth",
 	}
 	n, err := node.New(nodeCfg)
 	require.NoError(t, err)


### PR DESCRIPTION
The op-program miner test setup flakes for some unknown reason. Based on this [stacktrace](https://github.com/ethereum-optimism/optimism/issues/15095#issue-2956153020), there is a bug in the op-geth logger as the panic doesn't seem to stem from API misuse either in the test or op-geth itself.
However, we don't need a disk-backed DB for the miner test. So this patch modifies the test setup to use the in-memory DB instead, which avoids the codepath causing the flake. A faster test is a nice bonus.

fixes: https://github.com/ethereum-optimism/optimism/issues/15095