### PR TITLE
devnet-sdk/systemgo: deployer integration

### DIFF
--- a/devnet-sdk/devstack/devtest/package.go
+++ b/devnet-sdk/devstack/devtest/package.go
@@ -156,17 +156,14 @@ func (t *implP) _PackageOnly() {
 	panic("do not use - this method only forces the interface to be unique")
 }
 
-func NewP(logger log.Logger) P {
+func NewP(logger log.Logger, onFail func()) P {
 	ctx, cancel := context.WithCancel(context.Background())
 	out := &implP{
 		scopeName: "pkg",
 		logger:    logger,
-		fail: func() {
-			logger.Error("Exiting now...")
-			os.Exit(1)
-		},
-		ctx:    ctx,
-		cancel: cancel,
+		fail:      onFail,
+		ctx:       ctx,
+		cancel:    cancel,
 	}
 	out.req = require.New(out)
 	return out

--- a/devnet-sdk/devstack/presets/interop.go
+++ b/devnet-sdk/devstack/presets/interop.go
@@ -29,10 +29,8 @@ func NewSimpleInterop(dest *TestSetup[*SimpleInterop]) stack.Option {
 
 // startInProcessSimpleInterop starts a new system that meets the simple interop criteria
 func startInProcessSimpleInterop(orch stack.Orchestrator) {
-	contracts, err := contractPaths()
-	orch.P().Require().NoError(err, "could not get contract paths")
 	var ids sysgo.DefaultInteropSystemIDs
-	opt := sysgo.DefaultInteropSystem(contracts, &ids)
+	opt := sysgo.DefaultInteropSystem(&ids)
 	opt(orch)
 }
 

--- a/devnet-sdk/devstack/shim/l1_network.go
+++ b/devnet-sdk/devstack/shim/l1_network.go
@@ -24,8 +24,8 @@ type presetL1Network struct {
 var _ stack.ExtensibleL1Network = (*presetL1Network)(nil)
 
 func NewL1Network(cfg L1NetworkConfig) stack.ExtensibleL1Network {
-	require.Equal(cfg.T, cfg.ID.ChainID, eth.ChainIDFromBig(cfg.NetworkConfig.ChainConfig.ChainID), "chain config must match expected chain")
-	cfg.Log = cfg.Log.New("chainID", cfg.ID.ChainID, "id", cfg.ID)
+	require.Equal(cfg.T, cfg.ID.ChainID(), eth.ChainIDFromBig(cfg.NetworkConfig.ChainConfig.ChainID), "chain config must match expected chain")
+	cfg.Log = cfg.Log.New("chainID", cfg.ID.ChainID(), "id", cfg.ID)
 	return &presetL1Network{
 		id:            cfg.ID,
 		presetNetwork: newNetwork(cfg.NetworkConfig),

--- a/devnet-sdk/devstack/shim/l2_network.go
+++ b/devnet-sdk/devstack/shim/l2_network.go
@@ -45,10 +45,10 @@ var _ stack.L2Network = (*presetL2Network)(nil)
 
 func NewL2Network(cfg L2NetworkConfig) stack.ExtensibleL2Network {
 	// sanity-check the configs match the expected chains
-	require.Equal(cfg.T, cfg.ID.ChainID, eth.ChainIDFromBig(cfg.NetworkConfig.ChainConfig.ChainID), "chain config must match expected chain")
+	require.Equal(cfg.T, cfg.ID.ChainID(), eth.ChainIDFromBig(cfg.NetworkConfig.ChainConfig.ChainID), "chain config must match expected chain")
 	require.Equal(cfg.T, cfg.L1.ChainID(), eth.ChainIDFromBig(cfg.RollupConfig.L1ChainID), "rollup config must match expected L1 chain")
-	require.Equal(cfg.T, cfg.ID.ChainID, eth.ChainIDFromBig(cfg.RollupConfig.L2ChainID), "rollup config must match expected L2 chain")
-	cfg.Log = cfg.Log.New("chainID", cfg.ID.ChainID, "id", cfg.ID)
+	require.Equal(cfg.T, cfg.ID.ChainID(), eth.ChainIDFromBig(cfg.RollupConfig.L2ChainID), "rollup config must match expected L2 chain")
+	cfg.Log = cfg.Log.New("chainID", cfg.ID.ChainID(), "id", cfg.ID)
 	return &presetL2Network{
 		id:            cfg.ID,
 		presetNetwork: newNetwork(cfg.NetworkConfig),

--- a/devnet-sdk/devstack/shim/system.go
+++ b/devnet-sdk/devstack/shim/system.go
@@ -72,8 +72,8 @@ func (p *presetSystem) L1Network(id stack.L1NetworkID) stack.L1Network {
 
 func (p *presetSystem) AddL1Network(v stack.L1Network) {
 	id := v.ID()
-	p.require().True(p.networks.SetIfMissing(id.ChainID, v), "chain with id %s must not already exist", id.ChainID)
-	p.require().True(p.l1ChainIDs.SetIfMissing(id.ChainID, id), "l1 chain id %s mapping must not already exist", id)
+	p.require().True(p.networks.SetIfMissing(id.ChainID(), v), "chain with id %s must not already exist", id.ChainID())
+	p.require().True(p.l1ChainIDs.SetIfMissing(id.ChainID(), id), "l1 chain id %s mapping must not already exist", id)
 	p.require().True(p.l1Networks.SetIfMissing(id, v), "l1 chain %s must not already exist", id)
 }
 
@@ -85,8 +85,8 @@ func (p *presetSystem) L2Network(id stack.L2NetworkID) stack.L2Network {
 
 func (p *presetSystem) AddL2Network(v stack.L2Network) {
 	id := v.ID()
-	p.require().True(p.networks.SetIfMissing(id.ChainID, v), "chain with id %s must not already exist", id.ChainID)
-	p.require().True(p.l2ChainIDs.SetIfMissing(id.ChainID, id), "l2 chain id %s mapping must not already exist", id)
+	p.require().True(p.networks.SetIfMissing(id.ChainID(), v), "chain with id %s must not already exist", id.ChainID())
+	p.require().True(p.l2ChainIDs.SetIfMissing(id.ChainID(), id), "l2 chain id %s mapping must not already exist", id)
 	p.require().True(p.l2Networks.SetIfMissing(id, v), "l2 chain %s must not already exist", id)
 }
 

--- a/devnet-sdk/devstack/stack/l1_network.go
+++ b/devnet-sdk/devstack/stack/l1_network.go
@@ -1,25 +1,31 @@
 package stack
 
+import "github.com/ethereum-optimism/optimism/op-service/eth"
+
 // L1NetworkID identifies a L1Network by name and chainID, is type-safe, and can be value-copied and used as map key.
-type L1NetworkID idWithChain
+type L1NetworkID idOnlyChainID
 
 const L1NetworkKind Kind = "L1Network"
 
+func (id L1NetworkID) ChainID() eth.ChainID {
+	return idOnlyChainID(id).ChainID()
+}
+
 func (id L1NetworkID) String() string {
-	return idWithChain(id).string(L1NetworkKind)
+	return idOnlyChainID(id).string(L1NetworkKind)
 }
 
 func (id L1NetworkID) MarshalText() ([]byte, error) {
-	return idWithChain(id).marshalText(L1NetworkKind)
+	return idOnlyChainID(id).marshalText(L1NetworkKind)
 }
 
 func (id *L1NetworkID) UnmarshalText(data []byte) error {
-	return (*idWithChain)(id).unmarshalText(L1NetworkKind, data)
+	return (*idOnlyChainID)(id).unmarshalText(L1NetworkKind, data)
 }
 
 func SortL1NetworkIDs(ids []L1NetworkID) []L1NetworkID {
 	return copyAndSort(ids, func(a, b L1NetworkID) bool {
-		return lessIDWithChain(idWithChain(a), idWithChain(b))
+		return lessIDOnlyChainID(idOnlyChainID(a), idOnlyChainID(b))
 	})
 }
 

--- a/devnet-sdk/devstack/stack/l2_network.go
+++ b/devnet-sdk/devstack/stack/l2_network.go
@@ -7,28 +7,33 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // L2NetworkID identifies a L2Network by name and chainID, is type-safe, and can be value-copied and used as map key.
-type L2NetworkID idWithChain
+type L2NetworkID idOnlyChainID
 
 const L2NetworkKind Kind = "L2Network"
 
+func (id L2NetworkID) ChainID() eth.ChainID {
+	return idOnlyChainID(id).ChainID()
+}
+
 func (id L2NetworkID) String() string {
-	return idWithChain(id).string(L2NetworkKind)
+	return idOnlyChainID(id).string(L2NetworkKind)
 }
 
 func (id L2NetworkID) MarshalText() ([]byte, error) {
-	return idWithChain(id).marshalText(L2NetworkKind)
+	return idOnlyChainID(id).marshalText(L2NetworkKind)
 }
 
 func (id *L2NetworkID) UnmarshalText(data []byte) error {
-	return (*idWithChain)(id).unmarshalText(L2NetworkKind, data)
+	return (*idOnlyChainID)(id).unmarshalText(L2NetworkKind, data)
 }
 
 func SortL2NetworkIDs(ids []L2NetworkID) []L2NetworkID {
 	return copyAndSort(ids, func(a, b L2NetworkID) bool {
-		return lessIDWithChain(idWithChain(a), idWithChain(b))
+		return lessIDOnlyChainID(idOnlyChainID(a), idOnlyChainID(b))
 	})
 }
 

--- a/devnet-sdk/devstack/sysext/l1.go
+++ b/devnet-sdk/devstack/sysext/l1.go
@@ -19,7 +19,7 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 			CommonConfig: commonConfig,
 			ChainConfig:  env.L1.Config,
 		},
-		ID: stack.L1NetworkID{Key: "main", ChainID: l1ID},
+		ID: stack.L1NetworkID(l1ID),
 	})
 
 	for idx, node := range env.L1.Nodes {

--- a/devnet-sdk/devstack/sysext/l2.go
+++ b/devnet-sdk/devstack/sysext/l2.go
@@ -11,10 +11,7 @@ import (
 )
 
 func getL2ID(net *descriptors.L2Chain) stack.L2NetworkID {
-	return stack.L2NetworkID{
-		Key:     net.ID,
-		ChainID: eth.ChainIDFromBig(net.Config.ChainID),
-	}
+	return stack.L2NetworkID(eth.ChainIDFromBig(net.Config.ChainID))
 }
 
 func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.ExtensibleSystem) {
@@ -35,8 +32,8 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 		},
 		ID: l2ID,
 		RollupConfig: &rollup.Config{
-			L1ChainID: l1ID.ChainID.ToBig(),
-			L2ChainID: l2ID.ChainID.ToBig(),
+			L1ChainID: l1ID.ChainID().ToBig(),
+			L2ChainID: l2ID.ChainID().ToBig(),
 			// TODO this rollup config should be loaded from kurtosis artifacts
 		},
 		Deployment: newL2AddressBook(system.T(), net.L1Addresses),
@@ -62,7 +59,7 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 		require.NoError(err)
 		l2.AddUser(shim.NewUser(shim.UserConfig{
 			CommonConfig: commonConfig,
-			ID:           stack.UserID{Key: name, ChainID: l2ID.ChainID},
+			ID:           stack.UserID{Key: name, ChainID: l2ID.ChainID()},
 			Priv:         priv,
 			EL:           l2.L2ELNode(l2.L2ELNodes()[0]),
 		}))
@@ -84,11 +81,11 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 		ELNodeConfig: shim.ELNodeConfig{
 			CommonConfig: shim.NewCommonConfig(l2Net.T()),
 			Client:       elClient,
-			ChainID:      l2ID.ChainID,
+			ChainID:      l2ID.ChainID(),
 		},
 		ID: stack.L2ELNodeID{
 			Key:     elService.Name,
-			ChainID: l2ID.ChainID,
+			ChainID: l2ID.ChainID(),
 		},
 	}))
 
@@ -102,7 +99,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 	l2Net.AddL2CLNode(shim.NewL2CLNode(shim.L2CLNodeConfig{
 		ID: stack.L2CLNodeID{
 			Key:     clService.Name,
-			ChainID: l2ID.ChainID,
+			ChainID: l2ID.ChainID(),
 		},
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),
 		Client:       clClient,
@@ -127,7 +124,7 @@ func (o *Orchestrator) hydrateBatcherMaybe(net *descriptors.L2Chain, l2Net stack
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),
 		ID: stack.L2BatcherID{
 			Key:     batcherService.Name,
-			ChainID: l2ID.ChainID,
+			ChainID: l2ID.ChainID(),
 		},
 		Client: o.rpcClient(l2Net.T(), batcherRPC),
 	}))
@@ -152,7 +149,7 @@ func (o *Orchestrator) hydrateProposerMaybe(net *descriptors.L2Chain, l2Net stac
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),
 		ID: stack.L2ProposerID{
 			Key:     proposerService.Name,
-			ChainID: l2ID.ChainID,
+			ChainID: l2ID.ChainID(),
 		},
 		Client: o.rpcClient(l2Net.T(), proposerRPC),
 	}))
@@ -173,7 +170,7 @@ func (o *Orchestrator) hydrateChallengerMaybe(net *descriptors.L2Chain, l2Net st
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),
 		ID: stack.L2ChallengerID{
 			Key:     challengerService.Name,
-			ChainID: l2ID.ChainID,
+			ChainID: l2ID.ChainID(),
 		},
 	}))
 }

--- a/devnet-sdk/devstack/sysgo/contracts.go
+++ b/devnet-sdk/devstack/sysgo/contracts.go
@@ -1,23 +1,32 @@
-package presets
+package sysgo
 
 import (
 	"errors"
 	"fmt"
 	"os"
-
-	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/sysgo"
 )
 
-func contractPaths() (sysgo.ContractPaths, error) {
+func contractPaths() (ContractPaths, error) {
 	contractsBedrockPath := "packages/contracts-bedrock"
 	root, err := findMonorepoRoot(contractsBedrockPath)
 	if err != nil {
-		return sysgo.ContractPaths{}, err
+		return ContractPaths{}, err
 	}
-	return sysgo.ContractPaths{
+	return ContractPaths{
 		FoundryArtifacts: root + contractsBedrockPath + "/forge-artifacts",
 		SourceMap:        root + contractsBedrockPath,
 	}, nil
+}
+
+func ensureDir(dirPath string) error {
+	stat, err := os.Stat(dirPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat path: %w", err)
+	}
+	if !stat.IsDir() {
+		return fmt.Errorf("path is not a directory")
+	}
+	return nil
 }
 
 // findMonorepoRoot finds the relative path to the monorepo root

--- a/devnet-sdk/devstack/sysgo/deployer.go
+++ b/devnet-sdk/devstack/sysgo/deployer.go
@@ -1,0 +1,280 @@
+package sysgo
+
+import (
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type DeployerOption func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder)
+
+func WithDeployer(opts ...DeployerOption) stack.Option {
+	return func(o stack.Orchestrator) {
+		orch := o.(*Orchestrator)
+		require := o.P().Require()
+
+		wb := &worldBuilder{
+			p:       o.P(),
+			logger:  o.P().Logger(),
+			require: o.P().Require(),
+			keys:    orch.keys,
+			builder: intentbuilder.New(),
+		}
+		for _, opt := range opts {
+			opt(o.P(), orch.keys, wb.builder)
+		}
+		wb.Build()
+
+		l1ID := stack.L1NetworkID(eth.ChainIDFromUInt64(wb.output.AppliedIntent.L1ChainID))
+		superchainID := stack.SuperchainID("main")
+		clusterID := stack.ClusterID("main")
+
+		l1Net := &L1Network{
+			id:        l1ID,
+			genesis:   wb.outL1Genesis,
+			blockTime: 6,
+		}
+		orch.l1Nets.Set(l1ID.ChainID(), l1Net)
+
+		orch.superchains.Set(superchainID, &Superchain{
+			id:         superchainID,
+			deployment: wb.outSuperchainDeployment,
+		})
+		orch.clusters.Set(clusterID, &Cluster{
+			id:     clusterID,
+			depset: wb.outDepset,
+		})
+
+		for _, chainID := range wb.l2Chains {
+			l2Genesis, ok := wb.outL2Genesis[chainID]
+			require.True(ok, "L2 genesis must exist")
+			l2RollupCfg, ok := wb.outL2RollupCfg[chainID]
+			require.True(ok, "L2 rollup config must exist")
+			l2Dep, ok := wb.outL2Deployment[chainID]
+			require.True(ok, "L2 deployment must exist")
+
+			l2ID := stack.L2NetworkID(chainID)
+			l2Net := &L2Network{
+				id:         l2ID,
+				l1ChainID:  l1ID.ChainID(),
+				genesis:    l2Genesis,
+				rollupCfg:  l2RollupCfg,
+				deployment: l2Dep,
+				keys:       orch.keys,
+			}
+			orch.l2Nets.Set(l2ID.ChainID(), l2Net)
+		}
+	}
+}
+
+type worldBuilder struct {
+	p devtest.P
+
+	logger  log.Logger
+	require *require.Assertions
+	keys    devkeys.Keys
+
+	builder intentbuilder.Builder
+
+	output                  *state.State
+	outL1Genesis            *core.Genesis
+	l2Chains                []eth.ChainID
+	outL2Genesis            map[eth.ChainID]*core.Genesis
+	outL2RollupCfg          map[eth.ChainID]*rollup.Config
+	outL2Deployment         map[eth.ChainID]*L2Deployment
+	outDepset               *depset.StaticConfigDependencySet
+	outSuperchainDeployment *SuperchainDeployment
+}
+
+var (
+	oneEth     = uint256.NewInt(1e18)
+	millionEth = new(uint256.Int).Mul(uint256.NewInt(1e6), oneEth)
+)
+
+func WithLocalContractSources() DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		paths, err := contractPaths()
+		p.Require().NoError(err)
+		wd, err := os.Getwd()
+		p.Require().NoError(err)
+		artifactsPath := filepath.Join(wd, paths.FoundryArtifacts)
+		p.Require().NoError(ensureDir(artifactsPath))
+		contractArtifacts, err := artifacts.NewFileLocator(artifactsPath)
+		p.Require().NoError(err)
+		builder.WithL1ContractsLocator(contractArtifacts)
+		builder.WithL2ContractsLocator(contractArtifacts)
+	}
+}
+
+func WithCommons(l1ChainID eth.ChainID) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		_, l1Config := builder.WithL1(l1ChainID)
+
+		l1StartTimestamp := uint64(time.Now().Unix()) + 1
+		l1Config.WithTimestamp(l1StartTimestamp)
+
+		l1Config.WithPragueOffset(0) // activate pectra on L1
+
+		// We use the L1 chain ID to identify the superchain-wide roles.
+		addrFor := intentbuilder.RoleToAddrProvider(p, keys, l1ChainID)
+		_, superCfg := builder.WithSuperchain()
+		intentbuilder.WithDevkeySuperRoles(p, keys, l1ChainID, superCfg)
+		l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainProxyAdminOwner), *millionEth)
+		l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainProtocolVersionsOwner), *millionEth)
+		l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainConfigGuardianKey), *millionEth)
+	}
+}
+
+func WithPrefundedL2(chainID eth.ChainID) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		_, l2Config := builder.WithL2(chainID)
+		l2Config.ChainID()
+
+		intentbuilder.WithDevkeyVaults(p, keys, l2Config)
+		intentbuilder.WithDevkeyRoles(p, keys, l2Config)
+
+		{
+			addrFor := intentbuilder.KeyToAddrProvider(p, keys)
+			// unique key for this L2
+			l2Config.WithPrefundedAccount(addrFor(devkeys.ChainUserKeys(chainID.ToBig())(0)), *millionEth)
+		}
+		{
+			addrFor := intentbuilder.RoleToAddrProvider(p, keys, chainID)
+			l1Config := l2Config.L1Config()
+			l1Config.WithPrefundedAccount(addrFor(devkeys.BatcherRole), *millionEth)
+			l1Config.WithPrefundedAccount(addrFor(devkeys.ProposerRole), *millionEth)
+			l1Config.WithPrefundedAccount(addrFor(devkeys.ChallengerRole), *millionEth)
+			l1Config.WithPrefundedAccount(addrFor(devkeys.SystemConfigOwner), *millionEth)
+			l1Config.WithPrefundedAccount(addrFor(devkeys.L1ProxyAdminOwnerRole), *millionEth)
+		}
+	}
+}
+
+func (wb *worldBuilder) buildL1Genesis() {
+	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
+	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")
+
+	genesisOuter := wb.output.L1DevGenesis
+	genesisAlloc := wb.output.L1StateDump.Data.Accounts
+	genesisCfg := *genesisOuter
+	genesisCfg.StateHash = nil
+	genesisCfg.Alloc = genesisAlloc
+
+	wb.outL1Genesis = &genesisCfg
+}
+
+func (wb *worldBuilder) buildL2Genesis() {
+	wb.outL2Genesis = make(map[eth.ChainID]*core.Genesis)
+	wb.outL2RollupCfg = make(map[eth.ChainID]*rollup.Config)
+	for _, ch := range wb.output.Chains {
+		l2Genesis, l2RollupCfg, err := inspect.GenesisAndRollup(wb.output, ch.ID)
+		wb.require.NoError(err, "need L2 genesis and rollup")
+		id := eth.ChainIDFromBytes32(ch.ID)
+		wb.outL2Genesis[id] = l2Genesis
+		wb.outL2RollupCfg[id] = l2RollupCfg
+	}
+}
+
+func (wb *worldBuilder) buildDepSet() {
+	if wb.output.InteropDepSet == nil {
+		return
+	}
+	// Deployer uses a different type than the dependency-set itself, so we have to convert
+	depSetContents := make(map[eth.ChainID]*depset.StaticConfigDependency)
+	for _, ch := range wb.output.Chains {
+		id := eth.ChainIDFromBytes32(ch.ID)
+		deployerDep, ok := wb.output.InteropDepSet.Dependencies[id.String()]
+		wb.require.True(ok, "expecting deployer to use stringified chain IDs")
+		depSetContents[id] = &depset.StaticConfigDependency{
+			ChainIndex:     supervisortypes.ChainIndex(deployerDep.ChainIndex),
+			ActivationTime: deployerDep.ActivationTime,
+			HistoryMinTime: deployerDep.HistoryMinTime,
+		}
+	}
+	staticDepSet, err := depset.NewStaticConfigDependencySet(depSetContents)
+	wb.require.NoError(err)
+	wb.outDepset = staticDepSet
+}
+
+func (wb *worldBuilder) buildL2DeploymentOutputs() {
+	wb.outL2Deployment = make(map[eth.ChainID]*L2Deployment)
+	for _, ch := range wb.output.Chains {
+		chainID := eth.ChainIDFromBytes32(ch.ID)
+		wb.outL2Deployment[chainID] = &L2Deployment{
+			systemConfigProxyAddr:   ch.SystemConfigProxyAddress,
+			disputeGameFactoryProxy: ch.DisputeGameFactoryProxyAddress,
+		}
+	}
+	wb.outSuperchainDeployment = &SuperchainDeployment{
+		protocolVersionsAddr: wb.output.SuperchainDeployment.ProtocolVersionsProxyAddress,
+		superchainConfigAddr: wb.output.SuperchainDeployment.SuperchainConfigProxyAddress,
+	}
+}
+
+func (wb *worldBuilder) Build() {
+	st := &state.State{
+		Version: 1,
+	}
+
+	// Work-around of op-deployer design issue.
+	// We use the same deployer key for all L1 and L2 chains we deploy here.
+	deployerKey, err := wb.keys.Secret(devkeys.DeployerRole.Key(big.NewInt(0)))
+	wb.require.NoError(err, "need deployer key")
+
+	intent, err := wb.builder.Build()
+	wb.require.NoError(err)
+
+	if len(intent.Chains) > 1 { // multiple L2s implies interop
+		intent.UseInterop = true
+	}
+
+	pipelineOpts := deployer.ApplyPipelineOpts{
+		DeploymentTarget:   deployer.DeploymentTargetGenesis,
+		L1RPCUrl:           "",
+		DeployerPrivateKey: deployerKey,
+		Intent:             intent,
+		State:              st,
+		Logger:             wb.logger,
+		StateWriter:        wb, // direct output back here
+	}
+	err = deployer.ApplyPipeline(wb.p.Ctx(), pipelineOpts)
+	wb.require.NoError(err)
+
+	wb.require.NotNil(wb.output, "expected state-write to output")
+
+	for _, id := range wb.output.Chains {
+		chainID := eth.ChainIDFromBytes32(id.ID)
+		wb.l2Chains = append(wb.l2Chains, chainID)
+	}
+
+	wb.buildL1Genesis()
+	wb.buildL2Genesis()
+	wb.buildL2DeploymentOutputs()
+	wb.buildDepSet()
+}
+
+// WriteState is a callback used by deployer.ApplyPipeline to write the output
+func (wb *worldBuilder) WriteState(st *state.State) error {
+	wb.output = st
+	return nil
+}

--- a/devnet-sdk/devstack/sysgo/l2_batcher.go
+++ b/devnet-sdk/devstack/sysgo/l2_batcher.go
@@ -56,7 +56,7 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 		l1Net, ok := orch.l1Nets.Get(l1ELID.ChainID)
 		require.True(ok)
 
-		require.Equal(l2Net.l1ChainID, l1Net.id.ChainID, "expecting L1EL on L1 of L2CL")
+		require.Equal(l2Net.l1ChainID, l1Net.id.ChainID(), "expecting L1EL on L1 of L2CL")
 
 		require.Equal(l2CLID.ChainID, l2ELID.ChainID, "L2 CL and EL must be on same L2 chain")
 

--- a/devnet-sdk/devstack/sysgo/system.go
+++ b/devnet-sdk/devstack/sysgo/system.go
@@ -32,21 +32,21 @@ type DefaultInteropSystemIDs struct {
 	L2BProposer stack.L2ProposerID
 }
 
-func DefaultInteropSystem(contractPaths ContractPaths, dest *DefaultInteropSystemIDs) stack.Option {
+func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2AID := eth.ChainIDFromUInt64(901)
 	l2BID := eth.ChainIDFromUInt64(902)
 	ids := DefaultInteropSystemIDs{
-		L1:          stack.L1NetworkID{Key: "l1", ChainID: l1ID},
+		L1:          stack.L1NetworkID(l1ID),
 		L1EL:        stack.L1ELNodeID{Key: "l1", ChainID: l1ID},
 		L1CL:        stack.L1CLNodeID{Key: "l1", ChainID: l1ID},
-		Superchain:  "dev",
-		Cluster:     "dev",
+		Superchain:  "main", // TODO(#15244): hardcoded to match the deployer default ID
+		Cluster:     "main",
 		Supervisor:  "dev",
-		L2A:         stack.L2NetworkID{Key: "l2A", ChainID: l2AID},
+		L2A:         stack.L2NetworkID(l2AID),
 		L2ACL:       stack.L2CLNodeID{Key: "sequencer", ChainID: l2AID},
 		L2AEL:       stack.L2ELNodeID{Key: "sequencer", ChainID: l2AID},
-		L2B:         stack.L2NetworkID{Key: "l2B", ChainID: l2BID},
+		L2B:         stack.L2NetworkID(l2BID),
 		L2BCL:       stack.L2CLNodeID{Key: "sequencer", ChainID: l2BID},
 		L2BEL:       stack.L2ELNodeID{Key: "sequencer", ChainID: l2BID},
 		L2ABatcher:  stack.L2BatcherID{Key: "main", ChainID: l2AID},
@@ -61,8 +61,14 @@ func DefaultInteropSystem(contractPaths ContractPaths, dest *DefaultInteropSyste
 
 	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
 
-	opt.Add(WithInteropGen(ids.L1, ids.Superchain, ids.Cluster,
-		[]stack.L2NetworkID{ids.L2A, ids.L2B}, contractPaths))
+	opt.Add(WithDeployer(
+		WithLocalContractSources(),
+		WithCommons(ids.L1.ChainID()),
+		WithPrefundedL2(ids.L2A.ChainID()),
+		WithPrefundedL2(ids.L2B.ChainID())))
+
+	//opt.Add(WithInteropGen(ids.L1, ids.Superchain, ids.Cluster,
+	//	[]stack.L2NetworkID{ids.L2A, ids.L2B}, contractPaths))
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 

--- a/devnet-sdk/devstack/sysgo/system_test.go
+++ b/devnet-sdk/devstack/sysgo/system_test.go
@@ -17,14 +17,14 @@ import (
 
 func TestSystem(gt *testing.T) {
 	var ids DefaultInteropSystemIDs
-	opt := DefaultInteropSystem(ContractPaths{
-		FoundryArtifacts: "../../../packages/contracts-bedrock/forge-artifacts",
-		SourceMap:        "../../../packages/contracts-bedrock",
-	}, &ids)
+	opt := DefaultInteropSystem(&ids)
 
 	logger := testlog.Logger(gt, log.LevelInfo)
 
-	p := devtest.NewP(logger)
+	p := devtest.NewP(logger, func() {
+		gt.Helper()
+		gt.FailNow()
+	})
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p)

--- a/op-chain-ops/genesis/helpers.go
+++ b/op-chain-ops/genesis/helpers.go
@@ -72,11 +72,6 @@ func GetBlockFromTag(chain ethereum.ChainReader, tag *rpc.BlockNumberOrHash) (*t
 	}
 }
 
-// uint642Big creates a new *big.Int from a uint64.
-func uint642Big(in uint64) *big.Int {
-	return new(big.Int).SetUint64(in)
-}
-
 func newHexBig(in uint64) *hexutil.Big {
 	b := new(big.Int).SetUint64(in)
 	hb := hexutil.Big(*b)

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -305,6 +306,9 @@ func CompleteL1(l1Host *script.Host, cfg *L1Config) (*L1Output, error) {
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
 				L1ChainID: cfg.ChainID.Uint64(),
+			},
+			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
+				L1CancunTimeOffset: new(hexutil.Uint64),
 			},
 		},
 		DevL1DeployConfig: cfg.DevL1DeployConfig,

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -8,10 +8,6 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/interop"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -21,8 +17,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis/beacondeposit"
-	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen/deployers"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/interop"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var (
@@ -153,7 +151,7 @@ func CreateL2(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceM
 func PrepareInitialL1(l1Host *script.Host, cfg *L1Config) (*L1Deployment, error) {
 	l1Host.SetTxOrigin(sysGenesisDeployer)
 
-	if err := deployers.InsertPreinstalls(l1Host); err != nil {
+	if err := opcm.InsertPreinstalls(l1Host); err != nil {
 		return nil, fmt.Errorf("failed to install preinstalls in L1: %w", err)
 	}
 	// No global contracts inserted at this point.

--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -442,6 +442,11 @@ func (h *Host) Wipe(addr common.Address) {
 	h.state.SetBalance(addr, uint256.NewInt(0), tracing.BalanceChangeUnspecified)
 }
 
+// SetBalance sets an account's balance in state.
+func (h *Host) SetBalance(addr common.Address, balance *uint256.Int) {
+	h.state.SetBalance(addr, balance, tracing.BalanceChangeUnspecified)
+}
+
 // SetNonce sets an account's nonce in state.
 func (h *Host) SetNonce(addr common.Address, nonce uint64) {
 	h.state.SetNonce(addr, nonce, tracing.NonceChangeUnspecified)

--- a/op-deployer/pkg/deployer/opcm/preinstalls.go
+++ b/op-deployer/pkg/deployer/opcm/preinstalls.go
@@ -1,4 +1,4 @@
-package deployers
+package opcm
 
 import (
 	"fmt"
@@ -10,6 +10,8 @@ type PreinstallsScript struct {
 	SetPreinstalls func() error
 }
 
+// InsertPreinstalls inserts preinstalls in the given host.
+// This is part of the L2Genesis already, but is isolated to be reused for L1 dev genesis.
 func InsertPreinstalls(host *script.Host) error {
 	l2GenesisScript, cleanupL2Genesis, err := script.WithScript[PreinstallsScript](host, "SetPreinstalls.s.sol", "SetPreinstalls")
 	if err != nil {

--- a/op-deployer/pkg/deployer/pipeline/prefund_l1_dev_genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/prefund_l1_dev_genesis.go
@@ -1,0 +1,28 @@
+package pipeline
+
+import (
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+)
+
+// PrefundL1DevGenesis pre-funds accounts in the L1 dev genesis for testing purposes
+func PrefundL1DevGenesis(env *Env, intent *state.Intent, st *state.State) error {
+	lgr := env.Logger.New("stage", "prefund-l1-dev-genesis")
+	lgr.Info("Prefunding accounts in L1 dev genesis")
+
+	if intent.L1DevGenesisParams == nil {
+		lgr.Warn("No L1 dev params, will not prefund any accounts")
+		return nil
+	}
+	prefundMap := intent.L1DevGenesisParams.Prefund
+	if len(prefundMap) == 0 {
+		lgr.Warn("Not prefunding any L1 dev accounts. L1 dev genesis may not be usable.")
+		return nil
+	}
+	for addr, amount := range prefundMap {
+		env.L1ScriptHost.SetBalance(addr, (*uint256.Int)(amount))
+	}
+	lgr.Info("Prefunded dev accounts on L1", "accounts", len(prefundMap))
+	return nil
+}

--- a/op-deployer/pkg/deployer/pipeline/prefund_l2_dev_genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/prefund_l2_dev_genesis.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+)
+
+// PrefundL2DevGenesis pre-funds accounts in the L2 dev genesis for testing purposes
+func PrefundL2DevGenesis(env *Env, intent *state.Intent, st *state.State, chainID common.Hash) error {
+	lgr := env.Logger.New("stage", "prefund-l2-dev-genesis")
+	lgr.Info("Prefunding accounts in L2 dev genesis")
+
+	thisIntent, err := intent.Chain(chainID)
+	if err != nil {
+		return fmt.Errorf("failed to get chain intent: %w", err)
+	}
+
+	thisChainState, err := st.Chain(chainID)
+	if err != nil {
+		return fmt.Errorf("failed to get chain state: %w", err)
+	}
+
+	if thisIntent.L2DevGenesisParams == nil {
+		lgr.Warn("No L2 dev params, will not prefund any accounts")
+		return nil
+	}
+	prefundMap := thisIntent.L2DevGenesisParams.Prefund
+	if len(prefundMap) == 0 {
+		lgr.Warn("Not prefunding any L2 dev accounts. L2 dev genesis may not be usable.")
+		return nil
+	}
+
+	for addr, amount := range prefundMap {
+		acc := thisChainState.Allocs.Data.Accounts[addr]
+		acc.Balance = (*uint256.Int)(amount).ToBig()
+		thisChainState.Allocs.Data.Accounts[addr] = acc
+	}
+	lgr.Info("Prefunded dev accounts on L2", "accounts", len(prefundMap))
+	return nil
+}

--- a/op-deployer/pkg/deployer/pipeline/preinstall_l1_dev_genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/preinstall_l1_dev_genesis.go
@@ -1,0 +1,20 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen/deployers"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+)
+
+func PreinstallL1DevGenesis(env *Env, intent *state.Intent, st *state.State) error {
+	lgr := env.Logger.New("stage", "preinstall-l1-dev-genesis")
+	lgr.Info("Adding preinstalls to L1 dev genesis")
+
+	if err := deployers.InsertPreinstalls(env.L1ScriptHost); err != nil {
+		return fmt.Errorf("failed to add preinstalls to L1 dev state: %w", err)
+	}
+	env.L1ScriptHost.Wipe(env.Deployer)
+
+	return nil
+}

--- a/op-deployer/pkg/deployer/pipeline/preinstall_l1_dev_genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/preinstall_l1_dev_genesis.go
@@ -3,7 +3,7 @@ package pipeline
 import (
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen/deployers"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 )
 
@@ -11,7 +11,7 @@ func PreinstallL1DevGenesis(env *Env, intent *state.Intent, st *state.State) err
 	lgr := env.Logger.New("stage", "preinstall-l1-dev-genesis")
 	lgr.Info("Adding preinstalls to L1 dev genesis")
 
-	if err := deployers.InsertPreinstalls(env.L1ScriptHost); err != nil {
+	if err := opcm.InsertPreinstalls(env.L1ScriptHost); err != nil {
 		return fmt.Errorf("failed to add preinstalls to L1 dev state: %w", err)
 	}
 	env.L1ScriptHost.Wipe(env.Deployer)

--- a/op-deployer/pkg/deployer/pipeline/seal_l1_dev_genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/seal_l1_dev_genesis.go
@@ -1,0 +1,66 @@
+package pipeline
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func SealL1DevGenesis(env *Env, intent *state.Intent, st *state.State) error {
+	lgr := env.Logger.New("stage", "seal-l1-dev-genesis")
+	lgr.Info("Sealing L1 dev genesis")
+
+	l1DevParams := intent.L1DevGenesisParams
+	if l1DevParams == nil {
+		env.Logger.Warn("Using dev L1 genesis without any customization")
+		l1DevParams = &state.L1DevGenesisParams{}
+	}
+	// Create a state-dump
+	dump, err := env.L1ScriptHost.StateDump()
+	if err != nil {
+		return fmt.Errorf("failed to dump L1 state: %w", err)
+	}
+	st.L1StateDump = &state.GzipData[foundry.ForgeAllocs]{
+		Data: dump,
+	}
+
+	bp := &l1DevParams.BlockParams
+	timestamp := bp.Timestamp
+	if timestamp == 0 {
+		timestamp = uint64(time.Now().Unix())
+		env.Logger.Warn("Dynamically determined dev L1 genesis timestamp", "timestamp", timestamp)
+	}
+	excessBlobGas := bp.ExcessBlobGas
+
+	// Create a genesis configuration template
+	genesisTemplate, err := genesis.NewL1GenesisMinimal(&genesis.DevL1DeployConfigMinimal{
+		DevL1DeployConfig: genesis.DevL1DeployConfig{
+			L1GenesisBlockTimestamp:     hexutil.Uint64(timestamp),
+			L1GenesisBlockGasLimit:      hexutil.Uint64(bp.GasLimit),
+			L1GenesisBlockExcessBlobGas: (*hexutil.Uint64)(&excessBlobGas),
+			// The rest is left to defaults
+		},
+		L1ChainID:          eth.ChainIDFromUInt64(intent.L1ChainID),
+		L1PragueTimeOffset: l1DevParams.PragueTimeOffset,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create dev L1 genesis template: %w", err)
+	}
+	// Combine the two into a valid genesis
+	genesisTemplate.Alloc = dump.Accounts
+	// Compute the genesis state root (by turning it into a block, which will apply the defaults, chain-config, etc.)
+	l1GenesisBlock := genesisTemplate.ToBlock()
+	// Cache the genesis state-root, and de-dup the state-copy we maintain, by using the state-hash attribute.
+	h := l1GenesisBlock.Root()
+	genesisTemplate.Alloc = nil
+	genesisTemplate.StateHash = &h
+	st.L1DevGenesis = genesisTemplate
+	lgr.Info("Sealed L1 dev genesis", "blockHash", l1GenesisBlock.Hash(), "stateRoot", h)
+	return nil
+}

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 )
 
 type VMType string
@@ -35,6 +37,12 @@ type AdditionalDisputeGame struct {
 	MakeRespected                bool
 }
 
+type L2DevGenesisParams struct {
+	// Prefund is a map of addresses to balances (in wei), to prefund in the L2 dev genesis state.
+	// This is independent of the "Prefund" functionality that may fund a default 20 test accounts.
+	Prefund map[common.Address]*hexutil.U256 `json:"prefund" toml:"prefund"`
+}
+
 type ChainIntent struct {
 	ID                         common.Hash               `json:"id" toml:"id"`
 	BaseFeeVaultRecipient      common.Address            `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
@@ -50,6 +58,9 @@ type ChainIntent struct {
 	OperatorFeeScalar          uint32                    `json:"operatorFeeScalar,omitempty" toml:"operatorFeeScalar,omitempty"`
 	OperatorFeeConstant        uint64                    `json:"operatorFeeConstant,omitempty" toml:"operatorFeeConstant,omitempty"`
 	L1StartBlockHash           *common.Hash              `json:"l1StartBlockHash,omitempty" toml:"l1StartBlockHash,omitempty"`
+
+	// Optional. For development purposes only. Only enabled if the operation mode targets a genesis-file output.
+	L2DevGenesisParams *L2DevGenesisParams `json:"l2DevGenesisParams,omitempty" toml:"l2DevGenesisParams,omitempty"`
 }
 
 type ChainRoles struct {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -7,15 +7,14 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/ethereum-optimism/superchain-registry/validation"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
-
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
-
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum-optimism/superchain-registry/validation"
 )
 
 type IntentType string
@@ -38,6 +37,28 @@ type SuperchainProofParams struct {
 	MIPSVersion                     uint64 `json:"mipsVersion" toml:"mipsVersion"`
 }
 
+type L1DevGenesisBlockParams struct {
+	// Warning: the genesis timestamp will default to time.Now().
+	Timestamp uint64 `json:"timestamp"`
+	// Gas limit, uses default if 0
+	GasLimit uint64 `json:"gasLimit"`
+	// Optional. Dencun is always active in L1 dev genesis, so 0 is used as-is if not modified.
+	// This may be used to start the chain with high blob fees.
+	ExcessBlobGas uint64 `json:"excessBlobGas"`
+}
+
+type L1DevGenesisParams struct {
+	// BlockParams is the set of genesis-block parameters to use.
+	BlockParams L1DevGenesisBlockParams `json:"blockParams" toml:"blockParams"`
+
+	// PragueTimeOffset configures Prague (aka Pectra) to be activated at the given time after L1 dev genesis time.
+	PragueTimeOffset *uint64 `json:"pragueTimeOffset" toml:"pragueTimeOffset"`
+
+	// Prefund is a map of addresses to balances (in wei), to prefund in the L1 dev genesis state.
+	// This is independent of the "Prefund" functionality that may fund a default 20 test accounts.
+	Prefund map[common.Address]*hexutil.U256 `json:"prefund" toml:"prefund"`
+}
+
 type Intent struct {
 	ConfigType            IntentType         `json:"configType" toml:"configType"`
 	L1ChainID             uint64             `json:"l1ChainID" toml:"l1ChainID"`
@@ -49,7 +70,10 @@ type Intent struct {
 	L2ContractsLocator    *artifacts.Locator `json:"l2ContractsLocator" toml:"l2ContractsLocator"`
 	Chains                []*ChainIntent     `json:"chains" toml:"chains"`
 	GlobalDeployOverrides map[string]any     `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
-	L1StartTimestamp      *uint64            `json:"l1StartTimestamp" toml:"l1StartTimestamp"`
+
+	// L1DevGenesisParams is optional. This may be used to customize the L1 genesis when
+	// the deployer output is directed to produce a L1 genesis state for development.
+	L1DevGenesisParams *L1DevGenesisParams `json:"l1DevGenesisParams"`
 }
 
 type SuperchainRoles struct {

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -3,6 +3,8 @@ package state
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/core"
+
 	"github.com/ethereum-optimism/optimism/devnet-sdk/proofs/prestate"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 
@@ -50,6 +52,12 @@ type State struct {
 
 	// L1StateDump contains the complete L1 state dump of the deployment.
 	L1StateDump *GzipData[foundry.ForgeAllocs] `json:"l1StateDump"`
+
+	// L1DevGenesis contains the dev L1 genesis, and may be nil if this is not a genesis-strategy deployment.
+	// Warning: the Allocs part of the genesis is not included. Instead, the stateHash attribute is set.
+	// The allocs are included in L1StateDump.
+	// The stateHash can be used for consistency checks and faster block-hash computation.
+	L1DevGenesis *core.Genesis `json:"-"`
 
 	// DeploymentCalldata contains the calldata of each transaction in the deployment. This is only
 	// populated if apply is called with --deployment-target=calldata.

--- a/op-e2e/actions/helpers/l1_replica_test.go
+++ b/op-e2e/actions/helpers/l1_replica_test.go
@@ -47,7 +47,6 @@ func TestL1Replica_ActL1RPCFail(gt *testing.T) {
 func TestL1Replica_ActL1Sync(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, DefaultRollupTestParams())
-	dp.DeployConfig.L1CancunTimeOffset = nil
 	sd := e2eutils.Setup(t, dp, DefaultAlloc)
 	log := testlog.Logger(t, log.LevelDebug)
 	genesisBlock := sd.L1Cfg.ToBlock()

--- a/op-e2e/actions/upgrades/dencun_fork_test.go
+++ b/op-e2e/actions/upgrades/dencun_fork_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestDencunL1ForkAfterGenesis(gt *testing.T) {
+	gt.Skip("Cancun is activated in the contracts-build, rendering this test technically invalid")
+
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	offset := hexutil.Uint64(24)

--- a/op-e2e/actions/upgrades/ecotone_fork_test.go
+++ b/op-e2e/actions/upgrades/ecotone_fork_test.go
@@ -240,6 +240,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 
 // TestEcotoneBeforeL1 tests that the L2 Ecotone fork can activate before L1 Dencun does
 func TestEcotoneBeforeL1(gt *testing.T) {
+	gt.Skip("L1 contracts depend on Cancun, this test is legacy")
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	offset := hexutil.Uint64(0)

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -272,4 +272,6 @@ func ApplyDeployConfigForks(deployConfig *genesis.DeployConfig) {
 	// Canyon and lower is activated by default
 	deployConfig.L2GenesisCanyonTimeOffset = new(hexutil.Uint64)
 	deployConfig.L2GenesisRegolithTimeOffset = new(hexutil.Uint64)
+	// Activated by default, contracts depend on it
+	deployConfig.L1CancunTimeOffset = new(hexutil.Uint64)
 }

--- a/op-program/client/l2/engine_backend_test.go
+++ b/op-program/client/l2/engine_backend_test.go
@@ -332,6 +332,9 @@ func setupOracle(t *testing.T, blockCount int, headBlockNumber int, enableEcoton
 				L2ChainID:   901,
 				L2BlockTime: 2,
 			},
+			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
+				L1CancunTimeOffset: new(hexutil.Uint64),
+			},
 		},
 	}
 	if enableEcotone {

--- a/op-service/eth/chain_id.go
+++ b/op-service/eth/chain_id.go
@@ -64,8 +64,8 @@ func EvilChainIDToUInt64(id ChainID) uint64 {
 	return v.Uint64()
 }
 
-func (id *ChainID) ToBig() *big.Int {
-	return (*uint256.Int)(id).ToBig()
+func (id ChainID) ToBig() *big.Int {
+	return (*uint256.Int)(&id).ToBig()
 }
 
 // MarshalText marshals into the decimal representation of the chainID


### PR DESCRIPTION
**Description**

Changes:
- `devstack/devtest`: improve devtest to handle failure case during setup better
- `devstack/presets`: update presets package to register setup error exit code properly
- `devstack/{shim,stack,sysext}`: make the L1 and L2 network IDs just typed chain IDs, no additional key string content. This simplifies integration.
- `devstack/sysgo`:
  - move contracts loading into sysgo package, closer to the actual usage
  - `deployer.go`: creates in-process go test L1/L2 chains, using the genesis strategy, based on what the intent-builder declared as L1/L2 chains.
  - Misc updates to handle the above
- `op-chain-ops/genesis`:
  - split `NewL1Genesis` to allow for more direct instantiation of L1 genesis, and warn in godocs about the quirks
  - Enforce L1 cancun offset to be set. The smart-contracts build already depends on the cancun evm version. Any test that didn't use L1 cancun already has been updated now.
- `op-chain-ops/script`: add balance setter, for the deployer dev pipeline to use
- `op-deployer/pipeline`:
  - new pipeline steps to:
    - prefund L1
    - prefund L2
    - preinstall L1
  - updated L1 dev pipeline, to seal L1 genesis once, and have 1 reference then for L2 genesis-strategy deployments to build against, so we don't re-build the L1 dev genesis multiple times, and can be more sure of the sealing and resulting block hash.
  - simplified start block genesis strategy code: just use the block from the known sealed L1. Don't repeat building it per L2.
- `op-deployer/state`:
    - add L2 dev genesis params, with prefunding map attribute. We may add more in the future.
    - add L1 dev genesis params, with prefunding, genesis block params, prague fork config
    - persist the L1 genesis (minus the allocs) in the output state, for easy reconstruction of the L1 genesis, without re-running through op-chain-ops legacy code again
- op-e2e: fix tests that didn't run against L1 cancun
- e2eutils/intentbuilder: add new options to configure the L1 and L2
- op-service: minor tweak to `ChainID.ToBig()`, so it can be used on values, and doesn't become a multi-line go statement just to convert a chain ID.

**Tests**

op-deployer integration is now the default in the new devnet-sdk devstack.
The interopgen code is still there, usage in interop system setup example is commented. We'll remove interopgen once the deployer integration is trusted to be stable.
 
**Additional context**

This allows pre-intentop testing in the devstack

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15059