### PR TITLE
feat: Simplify op-deployer scripts: Add runtime ABI validation [2/N]

### DIFF
--- a/op-chain-ops/script/abi.go
+++ b/op-chain-ops/script/abi.go
@@ -121,6 +121,21 @@ func matchArguments(args abi.Arguments, goTypes ...reflect.Type) error {
 	return nil
 }
 
+// matchMethod ensures that a method ABI matches the provided GO input & output types
+func matchMethod(method abi.Method, inputGoTypes []reflect.Type, outputGoTypes []reflect.Type) error {
+	err := matchArguments(method.Inputs, inputGoTypes...)
+	if err != nil {
+		return fmt.Errorf("method %s does not have matching inputs: %w", method.RawName, err)
+	}
+
+	err = matchArguments(method.Outputs, outputGoTypes...)
+	if err != nil {
+		return fmt.Errorf("method %s does not have matching outputs: %w", method.RawName, err)
+	}
+
+	return nil
+}
+
 func abiTypeErr(abiType abi.Type, goType reflect.Type) error {
 	return fmt.Errorf("ABI type %s (represented by %s) is not assignable to Go type %s", abiType, abiType.GetType(), goType)
 }

--- a/op-chain-ops/script/abi.go
+++ b/op-chain-ops/script/abi.go
@@ -80,8 +80,21 @@ func matchTypes(abiType abi.Type, goType reflect.Type) error {
 			//
 			// This is important since ABI encoding and decoding specifically has issues
 			// with misordered fields and can place values in wrong places
-			if field.Name != goField.Name {
-				return fmt.Errorf("%w: ABI field name %s at index %d does not match Go field name %s. Please make sure to match the Go structs with Solidity structs", abiTypeErr(abiType, goType), field.Name, index, goField.Name)
+			//
+			// Here we need to take `abi:` tags into consideration since if present,
+			// they will dictate the ABI <-> Go field mapping instead of the struct names
+			goFieldTagName, ok := goField.Tag.Lookup("abi")
+			if ok {
+				// If the tag is present, we'll match it with the corresponding ABI tuple type name
+				abiFieldRawName := abiType.TupleRawNames[index]
+				if goFieldTagName != abiFieldRawName {
+					return fmt.Errorf("%w: ABI field name %s at index %d does not match Go field name %s. Please make sure to match the Go structs with Solidity structs", abiTypeErr(abiType, goType), field.Name, index, goField.Name)
+				}
+			} else {
+				// If there is no `abi:` tag, we'll match the field names themselves
+				if field.Name != goField.Name {
+					return fmt.Errorf("%w: ABI field name %s at index %d does not match Go field name %s. Please make sure to match the Go structs with Solidity structs", abiTypeErr(abiType, goType), field.Name, index, goField.Name)
+				}
 			}
 
 			// Now we ensure that the types match

--- a/op-chain-ops/script/abi.go
+++ b/op-chain-ops/script/abi.go
@@ -121,21 +121,6 @@ func matchArguments(args abi.Arguments, goTypes ...reflect.Type) error {
 	return nil
 }
 
-// matchMethod ensures that a method ABI matches the provided GO input & output types
-func matchMethod(method abi.Method, inputGoTypes []reflect.Type, outputGoTypes []reflect.Type) error {
-	err := matchArguments(method.Inputs, inputGoTypes...)
-	if err != nil {
-		return fmt.Errorf("method %s does not have matching inputs: %w", method.RawName, err)
-	}
-
-	err = matchArguments(method.Outputs, outputGoTypes...)
-	if err != nil {
-		return fmt.Errorf("method %s does not have matching outputs: %w", method.RawName, err)
-	}
-
-	return nil
-}
-
 func abiTypeErr(abiType abi.Type, goType reflect.Type) error {
 	return fmt.Errorf("ABI type %s (represented by %s) is not assignable to Go type %s", abiType, abiType.GetType(), goType)
 }

--- a/op-chain-ops/script/abi.go
+++ b/op-chain-ops/script/abi.go
@@ -1,0 +1,126 @@
+package script
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// matchTypes is a runtime ABI type check utility that ensures that compile-time structs
+// match the ABI definition loaded from an artifact at runtime
+//
+// This verification is important since even with abigen-generated types the ABI can deviate
+// which would cause a lot of headache and e.g. partially successful deployments or configurations
+func matchTypes(abiType abi.Type, goType reflect.Type) error {
+	// If the types are convertible, we're good
+	if goType.AssignableTo(abiType.GetType()) {
+		return nil
+	}
+
+	// We check for arrays first (i.e. fixed length slices like uint256[2])
+	if abiType.T == abi.ArrayTy {
+		// First a basic check
+		if goType.Kind() != reflect.Array {
+			return abiTypeErr(abiType, goType)
+		}
+
+		// Now make sure the lengths match
+		if abiType.Size != goType.Len() {
+			return fmt.Errorf("%w: expected an array of length %d, got length %d", abiTypeErr(abiType, goType), abiType.Size, goType.Len())
+		}
+
+		// Finally we check the element types
+		err := matchTypes(*abiType.Elem, goType.Elem())
+		if err != nil {
+			return fmt.Errorf("%w: %w", abiTypeErr(abiType, goType), err)
+		}
+
+		// If all the checks above succeeded, it means the array is safe to be used
+		return nil
+	}
+
+	// Now we check for slice type (i.e. variable length slices like uint256[])
+	if abiType.T == abi.SliceTy {
+		// First a basic check
+		if goType.Kind() != reflect.Slice {
+			return abiTypeErr(abiType, goType)
+		}
+
+		// Then check the element types
+		err := matchTypes(*abiType.Elem, goType.Elem())
+		if err != nil {
+			return fmt.Errorf("%w: %w", abiTypeErr(abiType, goType), err)
+		}
+
+		// If all the checks above succeeded, it means the slice is safe to be used
+		return nil
+	}
+
+	// Finally the most complex ones, tuples
+	if abiType.T == abi.TupleTy {
+		// First a basic check
+		if goType.Kind() != reflect.Struct {
+			return abiTypeErr(abiType, goType)
+		}
+
+		// Then we compare the number of fields
+		numAbiFields := abiType.TupleType.NumField()
+		numGoFields := goType.NumField()
+		if numAbiFields != numGoFields {
+			return fmt.Errorf("%w: the number of struct fields doesn't match: ABI type has %d, Go type has %d", abiTypeErr(abiType, goType), numAbiFields, numGoFields)
+		}
+
+		// And finally we check each field
+		for index := range numAbiFields {
+			field := abiType.TupleType.Field(index)
+			goField := goType.Field(index)
+
+			// First we make sure that the names are sorted in the correct order
+			//
+			// This is important since ABI encoding and decoding specifically has issues
+			// with misordered fields and can place values in wrong places
+			if field.Name != goField.Name {
+				return fmt.Errorf("%w: ABI field name %s at index %d does not match Go field name %s. Please make sure to match the Go structs with Solidity structs", abiTypeErr(abiType, goType), field.Name, index, goField.Name)
+			}
+
+			// Now we ensure that the types match
+			err := matchTypes(*abiType.TupleElems[index], goField.Type)
+			if err != nil {
+				return fmt.Errorf("%w: ABI field %s does not match Go field %s: %w", abiTypeErr(abiType, goType), field.Name, goField.Name, err)
+			}
+		}
+
+		// If all the checks above succeeded, it means the tuple is safe to be used
+		return nil
+	}
+
+	// We'll return a default error
+	return abiTypeErr(abiType, goType)
+}
+
+// matchArguments ensures that an argument list (e.g. function argument or return values)
+// match the provided Go types
+func matchArguments(args abi.Arguments, goTypes ...reflect.Type) error {
+	// First we make sure that the argument lengths match
+	numAbiArgs := len(args)
+	numGoTypes := len(goTypes)
+	if numAbiArgs != numGoTypes {
+		return fmt.Errorf("ABI arguments don't match Go types: ABI has %d arguments, Go has %d", numAbiArgs, numGoTypes)
+	}
+
+	for index, abiArg := range args {
+		goType := goTypes[index]
+
+		err := matchTypes(abiArg.Type, goType)
+		if err != nil {
+			return fmt.Errorf("ABI argument %s at index %d doesn't match Go type: %w", abiArg.Name, index, err)
+		}
+	}
+
+	return nil
+}
+
+func abiTypeErr(abiType abi.Type, goType reflect.Type) error {
+	return fmt.Errorf("ABI type %s (represented by %s) is not assignable to Go type %s", abiType, abiType.GetType(), goType)
+}

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -1,0 +1,247 @@
+package script
+
+import (
+	_ "embed"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func die[O any](value O, err error) O {
+	if err != nil {
+		panic(err)
+	}
+
+	return value
+}
+
+func TestMatchTypes(t *testing.T) {
+	type matchTypesTest struct {
+		abiType abi.Type
+		goType  reflect.Type
+		err     string
+	}
+
+	type StructWithPrimitiveFields struct {
+		AddressField common.Address
+		BoolField    bool
+		UintField    *big.Int
+	}
+
+	type StructWithPrimitiveFieldsWrapper struct {
+		Nested StructWithPrimitiveFields
+	}
+
+	structWithPrimitiveFieldsMarshalling := []abi.ArgumentMarshaling{{Name: "addressField", Type: "address"}, {Name: "boolField", Type: "bool"}, {Name: "uintField", Type: "uint256"}}
+
+	matchTypesTests := []matchTypesTest{
+		{
+			abiType: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(new(big.Int)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("uint128", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(new(big.Int)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("uint64", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new(uint64)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("uint8", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new(uint8)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("string", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new(string)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("bool", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new(bool)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("bytes", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([]byte)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("bytes", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([32]byte)),
+			err:     `ABI type bytes (represented by []uint8) is not assignable to Go type [32]uint8`,
+		},
+		{
+			abiType: die(abi.NewType("bytes32", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([32]byte)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("bytes32", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([]byte)),
+			err:     `ABI type bytes32 (represented by [32]uint8) is not assignable to Go type []uint8`,
+		},
+		{
+			abiType: die(abi.NewType("bytes32", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([64]byte)),
+			err:     `ABI type bytes32 (represented by [32]uint8) is not assignable to Go type [64]uint8`,
+		},
+		{
+			abiType: die(abi.NewType("address", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new(common.Address)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("address", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([]byte)),
+			err:     `ABI type address (represented by common.Address) is not assignable to Go type []uint8`,
+		},
+		{
+			abiType: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new(struct{})),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("tuple", "", structWithPrimitiveFieldsMarshalling)),
+			goType:  reflect.TypeOf(*new(StructWithPrimitiveFields)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "boolField", Type: "bool"}, {Name: "addressField", Type: "address"}, {Name: "uintField", Type: "uint256"}})),
+			goType:  reflect.TypeOf(*new(StructWithPrimitiveFields)),
+			err:     `ABI type (bool,address,uint256) (represented by struct { BoolField bool "json:\"boolField\""; AddressField common.Address "json:\"addressField\""; UintField *big.Int "json:\"uintField\"" }) is not assignable to Go type script.StructWithPrimitiveFields: ABI field name BoolField at index 0 does not match Go field name AddressField. Please make sure to match the Go structs with Solidity structs`,
+		},
+		{
+			abiType: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "addressField", Type: "bool"}, {Name: "boolField", Type: "bool"}, {Name: "uintField", Type: "uint256"}})),
+			goType:  reflect.TypeOf(*new(StructWithPrimitiveFields)),
+			err:     `ABI type (bool,bool,uint256) (represented by struct { AddressField bool "json:\"addressField\""; BoolField bool "json:\"boolField\""; UintField *big.Int "json:\"uintField\"" }) is not assignable to Go type script.StructWithPrimitiveFields: ABI field AddressField does not match Go field AddressField: ABI type bool (represented by bool) is not assignable to Go type common.Address`,
+		},
+		{
+			abiType: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "nested", Type: "tuple", Components: structWithPrimitiveFieldsMarshalling}})),
+			goType:  reflect.TypeOf(*new(StructWithPrimitiveFieldsWrapper)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "nested", Type: "tuple", Components: []abi.ArgumentMarshaling{{Name: "addressField", Type: "bool"}, {Name: "boolField", Type: "bool"}, {Name: "uintField", Type: "uint256"}}}})),
+			goType:  reflect.TypeOf(*new(StructWithPrimitiveFieldsWrapper)),
+			err:     `ABI type ((bool,bool,uint256)) (represented by struct { Nested struct { AddressField bool "json:\"addressField\""; BoolField bool "json:\"boolField\""; UintField *big.Int "json:\"uintField\"" } "json:\"nested\"" }) is not assignable to Go type script.StructWithPrimitiveFieldsWrapper: ABI field Nested does not match Go field Nested: ABI type (bool,bool,uint256) (represented by struct { AddressField bool "json:\"addressField\""; BoolField bool "json:\"boolField\""; UintField *big.Int "json:\"uintField\"" }) is not assignable to Go type script.StructWithPrimitiveFields: ABI field AddressField does not match Go field AddressField: ABI type bool (represented by bool) is not assignable to Go type common.Address`,
+		},
+		{
+			abiType: die(abi.NewType("tuple[]", "", []abi.ArgumentMarshaling{})),
+			goType:  reflect.TypeOf(*new([]struct{})),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("tuple[]", "", structWithPrimitiveFieldsMarshalling)),
+			goType:  reflect.TypeOf(*new([]StructWithPrimitiveFields)),
+			err:     ``,
+		},
+		{
+			abiType: die(abi.NewType("tuple[]", "", []abi.ArgumentMarshaling{{Name: "boolField", Type: "bool"}, {Name: "addressField", Type: "address"}, {Name: "uintField", Type: "uint256"}})),
+			goType:  reflect.TypeOf(*new([]StructWithPrimitiveFields)),
+			err:     `ABI type (bool,address,uint256)[] (represented by []struct { BoolField bool "json:\"boolField\""; AddressField common.Address "json:\"addressField\""; UintField *big.Int "json:\"uintField\"" }) is not assignable to Go type []script.StructWithPrimitiveFields: ABI type (bool,address,uint256) (represented by struct { BoolField bool "json:\"boolField\""; AddressField common.Address "json:\"addressField\""; UintField *big.Int "json:\"uintField\"" }) is not assignable to Go type script.StructWithPrimitiveFields: ABI field name BoolField at index 0 does not match Go field name AddressField. Please make sure to match the Go structs with Solidity structs`,
+		},
+		{
+			abiType: die(abi.NewType("tuple[2]", "", structWithPrimitiveFieldsMarshalling)),
+			goType:  reflect.TypeOf(*new([3]StructWithPrimitiveFields)),
+			err:     `ABI type (address,bool,uint256)[2] (represented by [2]struct { AddressField common.Address "json:\"addressField\""; BoolField bool "json:\"boolField\""; UintField *big.Int "json:\"uintField\"" }) is not assignable to Go type [3]script.StructWithPrimitiveFields: expected an array of length 2, got length 3`,
+		},
+	}
+
+	for _, test := range matchTypesTests {
+		t.Run(fmt.Sprintf("%s <-> %s", test.abiType, test.goType), func(t *testing.T) {
+			err := matchTypes(test.abiType, test.goType)
+
+			if test.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.err)
+			}
+		})
+	}
+}
+
+func TestMatchArguments(t *testing.T) {
+	type matchArgumentsTest struct {
+		abiArguments abi.Arguments
+		goTypes      []reflect.Type
+		err          string
+	}
+
+	matchArgumentsTests := []matchArgumentsTest{
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(new(big.Int))},
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256[]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new([]*big.Int))},
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256[]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{},
+			err:     `ABI arguments don't match Go types: ABI has 1 arguments, Go has 0`,
+		},
+		{
+			abiArguments: abi.Arguments{},
+			goTypes:      []reflect.Type{reflect.TypeOf(*new([]*big.Int))},
+			err:          `ABI arguments don't match Go types: ABI has 0 arguments, Go has 1`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new([]*big.Int))},
+			err:     `ABI argument  at index 0 doesn't match Go type: ABI type uint256[2] (represented by [2]*big.Int) is not assignable to Go type []*big.Int`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "address"}})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(struct{ Field *big.Int }))},
+			err:     `ABI argument  at index 0 doesn't match Go type: ABI type (address) (represented by struct { Field common.Address "json:\"field\"" }) is not assignable to Go type struct { Field *big.Int }: ABI field Field does not match Go field Field: ABI type address (represented by common.Address) is not assignable to Go type *big.Int`,
+		},
+	}
+
+	for _, test := range matchArgumentsTests {
+		t.Run(fmt.Sprintf("%v <-> %v", test.abiArguments, test.goTypes), func(t *testing.T) {
+			err := matchArguments(test.abiArguments, test.goTypes...)
+
+			if test.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.err)
+			}
+		})
+	}
+}

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -245,3 +245,72 @@ func TestMatchArguments(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchMethod(t *testing.T) {
+	type matchMethodTest struct {
+		abiMethod     abi.Method
+		goInputTypes  []reflect.Type
+		goOutputTypes []reflect.Type
+		err           string
+	}
+
+	matchMethodTests := []matchMethodTest{
+		{
+			abiMethod:     abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{}),
+			goInputTypes:  []reflect.Type{},
+			goOutputTypes: []reflect.Type{},
+			err:           ``,
+		},
+		{
+			abiMethod: abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
+				},
+			}, abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("string", "", []abi.ArgumentMarshaling{})),
+				},
+			}),
+			goInputTypes:  []reflect.Type{reflect.TypeOf(new(big.Int))},
+			goOutputTypes: []reflect.Type{reflect.TypeOf(*new(string))},
+			err:           ``,
+		},
+		{
+			abiMethod:     abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{}),
+			goInputTypes:  []reflect.Type{reflect.TypeOf(new(big.Int))},
+			goOutputTypes: []reflect.Type{},
+			err:           `method run does not have matching inputs: ABI arguments don't match Go types: ABI has 0 arguments, Go has 1`,
+		},
+		{
+			abiMethod:     abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{}),
+			goInputTypes:  []reflect.Type{},
+			goOutputTypes: []reflect.Type{reflect.TypeOf(new(big.Int))},
+			err:           `method run does not have matching outputs: ABI arguments don't match Go types: ABI has 0 arguments, Go has 1`,
+		},
+		{
+			abiMethod: abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
+				},
+			}),
+			goInputTypes:  []reflect.Type{},
+			goOutputTypes: []reflect.Type{reflect.TypeOf(*new(string))},
+			err:           `method run does not have matching outputs: ABI argument  at index 0 doesn't match Go type: ABI type uint256 (represented by *big.Int) is not assignable to Go type string`,
+		},
+	}
+
+	for _, test := range matchMethodTests {
+		t.Run(fmt.Sprintf("%v <-> (%v) -> (%v)", test.abiMethod, test.goInputTypes, test.goOutputTypes), func(t *testing.T) {
+			err := matchMethod(test.abiMethod, test.goInputTypes, test.goOutputTypes)
+
+			if test.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.err)
+			}
+		})
+	}
+}

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -237,6 +237,16 @@ func TestMatchArguments(t *testing.T) {
 					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
 				},
 			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new([2]*big.Int))},
+			err:     ``,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
 			goTypes: []reflect.Type{reflect.TypeOf(*new([]*big.Int))},
 			err:     `ABI argument  at index 0 doesn't match Go type: ABI type uint256[2] (represented by [2]*big.Int) is not assignable to Go type []*big.Int`,
 		},

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -200,11 +200,30 @@ func TestMatchArguments(t *testing.T) {
 			abiArguments: abi.Arguments{
 				{
 					Name: "",
+					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new([2]*big.Int))},
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
 					Type: die(abi.NewType("uint256[]", "", []abi.ArgumentMarshaling{})),
 				},
 			},
 			goTypes: []reflect.Type{},
 			err:     `ABI arguments don't match Go types: ABI has 1 arguments, Go has 0`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256[]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(big.Int))},
+			err:     `ABI argument  at index 0 doesn't match Go type: ABI type uint256[] (represented by []*big.Int) is not assignable to Go type big.Int`,
 		},
 		{
 			abiArguments: abi.Arguments{},
@@ -235,11 +254,70 @@ func TestMatchArguments(t *testing.T) {
 			abiArguments: abi.Arguments{
 				{
 					Name: "",
+					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "uint256"}, {Name: "otherField", Type: "address"}})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(struct {
+				FieldRenamed      *big.Int       `abi:"field"`
+				OtherFieldRenamed common.Address `abi:"otherField"`
+			}))},
+			err: ``,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "uint256"}, {Name: "otherField", Type: "address"}})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(struct {
+				Field      *big.Int       `abi:"otherField"`
+				OtherField common.Address `abi:"field"`
+			}))},
+			err: `ABI argument  at index 0 doesn't match Go type: ABI type (uint256,address) (represented by struct { Field *big.Int "json:\"field\""; OtherField common.Address "json:\"otherField\"" }) is not assignable to Go type struct { Field *big.Int "abi:\"otherField\""; OtherField common.Address "abi:\"field\"" }: ABI field name Field at index 0 does not match Go field name Field. Please make sure to match the Go structs with Solidity structs`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "address"}})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(uint8))},
+			err:     `ABI argument  at index 0 doesn't match Go type: ABI type (address) (represented by struct { Field common.Address "json:\"field\"" }) is not assignable to Go type uint8`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
 					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "address"}})),
 				},
 			},
 			goTypes: []reflect.Type{reflect.TypeOf(*new(struct{ Field *big.Int }))},
 			err:     `ABI argument  at index 0 doesn't match Go type: ABI type (address) (represented by struct { Field common.Address "json:\"field\"" }) is not assignable to Go type struct { Field *big.Int }: ABI field Field does not match Go field Field: ABI type address (represented by common.Address) is not assignable to Go type *big.Int`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "address"}, {Name: "otherField", Type: "uint256"}})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(struct{ Field common.Address }))},
+			err:     `ABI argument  at index 0 doesn't match Go type: ABI type (address,uint256) (represented by struct { Field common.Address "json:\"field\""; OtherField *big.Int "json:\"otherField\"" }) is not assignable to Go type struct { Field common.Address }: the number of struct fields doesn't match: ABI type has 2, Go type has 1`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "address"}, {Name: "otherField", Type: "uint256"}})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new(struct {
+				OtherField *big.Int
+				Field      common.Address
+			}))},
+			err: `ABI argument  at index 0 doesn't match Go type: ABI type (address,uint256) (represented by struct { Field common.Address "json:\"field\""; OtherField *big.Int "json:\"otherField\"" }) is not assignable to Go type struct { OtherField *big.Int; Field common.Address }: ABI field name Field at index 0 does not match Go field name OtherField. Please make sure to match the Go structs with Solidity structs`,
 		},
 	}
 

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -247,6 +247,16 @@ func TestMatchArguments(t *testing.T) {
 					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
 				},
 			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new([2]*big.Int))},
+			err:     ``,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
+					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
 			goTypes: []reflect.Type{reflect.TypeOf(*new([]*big.Int))},
 			err:     `ABI argument  at index 0 doesn't match Go type: ABI type uint256[2] (represented by [2]*big.Int) is not assignable to Go type []*big.Int`,
 		},

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -225,6 +225,16 @@ func TestMatchArguments(t *testing.T) {
 			abiArguments: abi.Arguments{
 				{
 					Name: "",
+					Type: die(abi.NewType("uint256[2]", "", []abi.ArgumentMarshaling{})),
+				},
+			},
+			goTypes: []reflect.Type{reflect.TypeOf(*new([2]*string))},
+			err:     `ABI argument  at index 0 doesn't match Go type: ABI type uint256[2] (represented by [2]*big.Int) is not assignable to Go type [2]*string: ABI type uint256 (represented by *big.Int) is not assignable to Go type *string`,
+		},
+		{
+			abiArguments: abi.Arguments{
+				{
+					Name: "",
 					Type: die(abi.NewType("tuple", "", []abi.ArgumentMarshaling{{Name: "field", Type: "address"}})),
 				},
 			},
@@ -236,75 +246,6 @@ func TestMatchArguments(t *testing.T) {
 	for _, test := range matchArgumentsTests {
 		t.Run(fmt.Sprintf("%v <-> %v", test.abiArguments, test.goTypes), func(t *testing.T) {
 			err := matchArguments(test.abiArguments, test.goTypes...)
-
-			if test.err == "" {
-				require.NoError(t, err)
-			} else {
-				require.EqualError(t, err, test.err)
-			}
-		})
-	}
-}
-
-func TestMatchMethod(t *testing.T) {
-	type matchMethodTest struct {
-		abiMethod     abi.Method
-		goInputTypes  []reflect.Type
-		goOutputTypes []reflect.Type
-		err           string
-	}
-
-	matchMethodTests := []matchMethodTest{
-		{
-			abiMethod:     abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{}),
-			goInputTypes:  []reflect.Type{},
-			goOutputTypes: []reflect.Type{},
-			err:           ``,
-		},
-		{
-			abiMethod: abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{
-				{
-					Name: "",
-					Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
-				},
-			}, abi.Arguments{
-				{
-					Name: "",
-					Type: die(abi.NewType("string", "", []abi.ArgumentMarshaling{})),
-				},
-			}),
-			goInputTypes:  []reflect.Type{reflect.TypeOf(new(big.Int))},
-			goOutputTypes: []reflect.Type{reflect.TypeOf(*new(string))},
-			err:           ``,
-		},
-		{
-			abiMethod:     abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{}),
-			goInputTypes:  []reflect.Type{reflect.TypeOf(new(big.Int))},
-			goOutputTypes: []reflect.Type{},
-			err:           `method run does not have matching inputs: ABI arguments don't match Go types: ABI has 0 arguments, Go has 1`,
-		},
-		{
-			abiMethod:     abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{}),
-			goInputTypes:  []reflect.Type{},
-			goOutputTypes: []reflect.Type{reflect.TypeOf(new(big.Int))},
-			err:           `method run does not have matching outputs: ABI arguments don't match Go types: ABI has 0 arguments, Go has 1`,
-		},
-		{
-			abiMethod: abi.NewMethod("Run", "run", abi.Function, "", false, false, abi.Arguments{}, abi.Arguments{
-				{
-					Name: "",
-					Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
-				},
-			}),
-			goInputTypes:  []reflect.Type{},
-			goOutputTypes: []reflect.Type{reflect.TypeOf(*new(string))},
-			err:           `method run does not have matching outputs: ABI argument  at index 0 doesn't match Go type: ABI type uint256 (represented by *big.Int) is not assignable to Go type string`,
-		},
-	}
-
-	for _, test := range matchMethodTests {
-		t.Run(fmt.Sprintf("%v <-> (%v) -> (%v)", test.abiMethod, test.goInputTypes, test.goOutputTypes), func(t *testing.T) {
-			err := matchMethod(test.abiMethod, test.goInputTypes, test.goOutputTypes)
 
 			if test.err == "" {
 				require.NoError(t, err)

--- a/op-chain-ops/script/abi_test.go
+++ b/op-chain-ops/script/abi_test.go
@@ -1,7 +1,6 @@
 package script
 
 import (
-	_ "embed"
 	"fmt"
 	"math/big"
 	"reflect"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

ABI runtime validation utilities to be used when loading deploy scripts:

- `matchTypes` ensures that a given ABI type matches a Go type
- `matchArguments` ensures that a list of ABI arguments (function params or return values) matches Go types

These validators will be executed when a script ABI is loaded in runtime and will halt any execution if the Go types do not match the loaded ABI.

Unfortunately, this kind of validation is not provided out of the box by `go-ethereum`.

**Considered alternatives**

A notable alternative is to use `Pack` and `Unpack` methods to validate the ABI <-> Go type mapping. Unfortunately, this means that besides the struct types, the consumer of this code would need to provide two additional values per every ABI method to be validated - an example input and an example output.

**Besides the additional code required, the validation would only be correct if all the example fields provided had different values.** This is due to a quirk of the ABI decoding - the fields will be decoded in the order of definition and their names might not match. As an example:

```go
// With a go struct defined like this
type MyStruct struct {
  FieldB common.Address // Notice this field being defined first
  FieldA common.Address
}
```

```solidity
struct MyStruct {
  address fieldA;
  address fieldB;
}
```

Using these two as an example, the ABI decoder would place the solidity value of `fieldA` into `FieldB` of the go struct. If this was not the case (which it might not be after we pull upstream), we could simplify this validation code to minimum since this peculiarity is the only reason this code has been introduced.

Relates to #14976