### PR TITLE
chore(op-acceptance-tests): increase circleci job timeout.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1738,6 +1738,7 @@ workflows:
       - op-acceptance-tests:
           devnet: isthmus
           gate: isthmus
+          no_output_timeout: 60m
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -50,7 +50,7 @@ acceptance-test devnet="simple" gate="holocene":
             --testdir "{{REPO_ROOT}}" \
             --gate {{gate}} \
             --validators ./acceptance-tests.yaml \
-            --log.level info
+            --log.level debug
     else
         echo "Mise not installed, falling back to Docker..."
         just acceptance-test-docker {{devnet}} {{gate}}


### PR DESCRIPTION
**Description**

Increase the timeout of the CircleCI job which runs acceptance tests. Also increase the output verbosity to further reduce the chance we'll timeout due to no output being detected by CircleCI.
