### PR TITLE
op-acceptance-tests, kt-devnet: Pin L2 EL versions for isthmus NAT tests

### DIFF
--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -29,7 +29,8 @@ optimism_package:
         tolerations: []
         count: 1
       - el_type: op-reth
-        el_image: "ghcr.io/paradigmxyz/op-reth:nightly"
+        # Pinning op-reth nightly image: "Created": "2025-03-31T02:09:09.704214502Z"
+        el_image: "ghcr.io/paradigmxyz/op-reth@sha256:7d83174c900a623897d5cf3a42764f19047ca47034f9726f5a9fad2c7ed32fee"
         el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -1,5 +1,3 @@
-# Non-functional right now, just here for reference
-
 optimism_package:
   chains:
     - participants:

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -4,7 +4,7 @@ optimism_package:
   chains:
     - participants:
       - el_type: op-geth
-        el_image: ""
+        el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3"
         el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}
@@ -31,7 +31,7 @@ optimism_package:
         tolerations: []
         count: 1
       - el_type: op-reth
-        el_image: "ghcr.io/paradigmxyz/op-reth:nightly@sha256:cc2fce901755783b42f5c76b8adc81375c7a80b8ca080b76b6e35cfb4d3e41a7"
+        el_image: "ghcr.io/paradigmxyz/op-reth:nightly"
         el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -24,7 +24,7 @@ gates:
     description: "Isthmus network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
-        timeout: 20m
+        timeout: 6h
 
   - id: interop
     inherits:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Intends to fix develop branch's op-acceptance tests failing, by pinning working versions of L2 EL reth and geth.

Locally tested that all tests are passing using below two testing methods
- `go test ./... -v -count=1 -timeout=6h at op-acceptance-tests/tests/isthmus`
- `just acceptance-test "isthmus" "isthmus"` 

Note that the second command is run in CI.

This is a temporary measure, all isthmus changes must be landed on `latest` tagged image of `op-geth` and `op-reth`. After that we can remove the hardcoded versions at `kurtosis-devnet/isthmus.yaml`.

