### PR TITLE
Parallelize Kurtosis Devnet Local Docker Builds (23% faster)

### DIFF
--- a/kurtosis-devnet/pkg/build/docker_test.go
+++ b/kurtosis-devnet/pkg/build/docker_test.go
@@ -1,115 +1,520 @@
 package build
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-// mockDockerClient implements the dockerClient interface for testing
+// --- Mocks ---
+
+// mockCmdRunner is a mock implementation of cmdRunner
+type mockCmdRunner struct {
+	mock.Mock
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+	runErr error // Error to return from Run()
+}
+
+func (m *mockCmdRunner) CombinedOutput() ([]byte, error) {
+	args := m.Called()
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *mockCmdRunner) SetOutput(stdout, stderr *bytes.Buffer) {
+	m.Called(stdout, stderr)
+	m.stdout = stdout
+	m.stderr = stderr
+}
+
+func (m *mockCmdRunner) Run() error {
+	m.Called()
+	// Simulate writing output if configured
+	if m.stdout != nil {
+		m.stdout.WriteString("mock stdout output\n")
+	}
+	if m.stderr != nil {
+		m.stderr.WriteString("mock stderr output\n")
+	}
+	return m.runErr // Return the pre-configured error
+}
+
+// mockCmdFactory is a mock implementation of cmdFactory
+type mockCmdFactory struct {
+	mock.Mock
+}
+
+func (m *mockCmdFactory) Create(name string, arg ...string) cmdRunner {
+	args := m.Called(name, arg)
+	return args.Get(0).(cmdRunner)
+}
+
+// mockDockerClient is a mock implementation of dockerClient
 type mockDockerClient struct {
-	inspectFunc func(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
-	tagFunc     func(ctx context.Context, source, target string) error
+	mock.Mock
 }
 
 func (m *mockDockerClient) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
-	return m.inspectFunc(ctx, imageID)
+	args := m.Called(ctx, imageID)
+	return args.Get(0).(types.ImageInspect), args.Get(1).([]byte), args.Error(2)
 }
 
 func (m *mockDockerClient) ImageTag(ctx context.Context, source, target string) error {
-	return m.tagFunc(ctx, source, target)
+	args := m.Called(ctx, source, target)
+	return args.Error(0)
 }
 
-// mockDockerProvider implements the dockerProvider interface for testing
+// mockDockerProvider is a mock implementation of dockerProvider
 type mockDockerProvider struct {
-	client dockerClient
+	mock.Mock
 }
 
-func (p *mockDockerProvider) newClient() (dockerClient, error) {
-	return p.client, nil
-}
-
-// mockCmd is a mock for command execution that always succeeds
-type mockCmd struct {
-	output []byte
-}
-
-func (m *mockCmd) CombinedOutput() ([]byte, error) {
-	return m.output, nil
-}
-
-// mockCmdFactory creates mock commands for testing
-func mockCmdFactory(output []byte) cmdFactory {
-	return func(name string, arg ...string) cmdRunner {
-		return &mockCmd{output: output}
+func (m *mockDockerProvider) newClient() (dockerClient, error) {
+	args := m.Called()
+	// Return nil for the client if an error is configured
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
 	}
+	return args.Get(0).(dockerClient), args.Error(1)
 }
 
-// TestDockerBuilderNaming tests the image naming logic in the DockerBuilder
-func TestDockerBuilderNaming(t *testing.T) {
-	tests := []struct {
-		name        string
-		projectName string
-		imageTag    string
-		mockInspect types.ImageInspect
-		mockTagErr  error
-		wantTag     string
-		wantErr     bool
-	}{
-		{
-			name:        "successful image build and tag",
-			projectName: "test-project",
-			imageTag:    "test-image:latest",
-			mockInspect: types.ImageInspect{
-				ID: "sha256:abcdef123456789abcdef123456789abcdef1234",
-			},
-			wantTag: "test-project:abcdef123456",
-			wantErr: false,
-		},
-		{
-			name:        "tag error",
-			projectName: "test-project",
-			imageTag:    "test-image:latest",
-			mockInspect: types.ImageInspect{
-				ID: "sha256:abcdef123456789abcdef123456789abcdef1234",
-			},
-			mockTagErr: assert.AnError,
-			wantErr:    true,
-		},
+// --- Helper to capture log output ---
+func captureLogs(t *testing.T) (*bytes.Buffer, func()) {
+	var logBuf bytes.Buffer
+	originalLogger := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() {
+		log.SetOutput(originalLogger)
+	})
+	return &logBuf, func() { log.SetOutput(originalLogger) }
+}
+
+// --- Tests ---
+
+func TestDockerBuilder_Build_Success(t *testing.T) {
+	logBuf, cleanup := captureLogs(t)
+	defer cleanup()
+
+	projectName := "test-project"
+	initialTag := "test-project:enclave1"
+	imageID := "sha256:1234567890abcdef1234567890abcdef"
+	shortID := "1234567890ab"
+	finalTag := fmt.Sprintf("%s:%s", projectName, shortID)
+
+	// --- Mock Setup ---
+	mockRunner := &mockCmdRunner{}
+	mockRunner.On("SetOutput", mock.AnythingOfType("*bytes.Buffer"), mock.AnythingOfType("*bytes.Buffer")).Return()
+	mockRunner.On("Run").Return(nil) // Simulate successful command execution
+
+	mockFactory := &mockCmdFactory{}
+	mockFactory.On("Create", "sh", []string{"-c", fmt.Sprintf("just %s-image %s", projectName, initialTag)}).Return(mockRunner)
+
+	mockClient := &mockDockerClient{}
+	mockClient.On("ImageInspectWithRaw", mock.Anything, initialTag).Return(types.ImageInspect{ID: imageID}, []byte{}, nil)
+	mockClient.On("ImageTag", mock.Anything, initialTag, finalTag).Return(nil)
+
+	mockProvider := &mockDockerProvider{}
+	mockProvider.On("newClient").Return(mockClient, nil)
+
+	// --- Builder Setup ---
+	builder := NewDockerBuilder(
+		WithDockerDryRun(false), // Ensure not dry run
+		withCmdFactory(mockFactory.Create),
+		withDockerProvider(mockProvider),
+		WithDockerConcurrency(1), // Explicitly set concurrency
+	)
+
+	// --- Execute ---
+	resultTag, err := builder.Build(projectName, initialTag)
+
+	// --- Assertions ---
+	require.NoError(t, err)
+	assert.Equal(t, finalTag, resultTag)
+
+	// Verify mocks were called
+	mockFactory.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
+	mockProvider.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
+
+	// Verify log output
+	logs := logBuf.String()
+	assert.Contains(t, logs, fmt.Sprintf("Build started for project: %s (tag: %s)", projectName, initialTag))
+	assert.Contains(t, logs, fmt.Sprintf("Executing build command for %s", projectName))
+	assert.Contains(t, logs, fmt.Sprintf("Build successful for project: %s. Tagged as: %s", projectName, finalTag))
+	assert.NotContains(t, logs, "mock stdout output") // Output should be hidden on success
+	assert.NotContains(t, logs, "mock stderr output")
+	assert.NotContains(t, logs, "Build failed for") // Should not contain failure messages
+	assert.NotContains(t, logs, "--- Start Output") // Should not contain detailed output logs
+}
+
+func TestDockerBuilder_Build_CommandFailure(t *testing.T) {
+	logBuf, cleanup := captureLogs(t)
+	defer cleanup()
+
+	projectName := "fail-project"
+	initialTag := "fail-project:enclave1"
+	expectedError := errors.New("command execution failed")
+
+	// --- Mock Setup ---
+	mockRunner := &mockCmdRunner{runErr: expectedError} // Simulate command failure
+	mockRunner.On("SetOutput", mock.AnythingOfType("*bytes.Buffer"), mock.AnythingOfType("*bytes.Buffer")).Return()
+	mockRunner.On("Run").Return(expectedError) // Use the specific error
+
+	mockFactory := &mockCmdFactory{}
+	mockFactory.On("Create", "sh", []string{"-c", fmt.Sprintf("just %s-image %s", projectName, initialTag)}).Return(mockRunner)
+
+	// Docker client/provider mocks are not strictly needed here as the failure happens before,
+	// but we include the provider mock for completeness if NewDockerBuilder tried to create one early.
+	mockProvider := &mockDockerProvider{}
+
+	// --- Builder Setup ---
+	builder := NewDockerBuilder(
+		WithDockerDryRun(false),
+		withCmdFactory(mockFactory.Create),
+		withDockerProvider(mockProvider), // Pass the mock provider
+		WithDockerConcurrency(1),
+	)
+
+	// --- Execute ---
+	resultTag, err := builder.Build(projectName, initialTag)
+
+	// --- Assertions ---
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build command failed")
+	assert.Equal(t, "", resultTag) // No tag should be returned on failure
+
+	// Verify mocks
+	mockFactory.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
+	// No Docker client calls should have happened
+	mockProvider.AssertNotCalled(t, "newClient")
+
+	// Verify log output
+	logs := logBuf.String()
+	assert.Contains(t, logs, fmt.Sprintf("Build started for project: %s", projectName))
+	assert.Contains(t, logs, fmt.Sprintf("Executing build command for %s", projectName))
+	assert.Contains(t, logs, fmt.Sprintf("Build failed for %s", projectName))
+	assert.Contains(t, logs, expectedError.Error()) // Check if the specific error message is logged
+	assert.Contains(t, logs, "--- Start Output (stdout) for failed fail-project ---")
+	assert.Contains(t, logs, "mock stdout output") // Output SHOULD be visible on failure
+	assert.Contains(t, logs, "--- End Output (stdout) for failed fail-project ---")
+	assert.Contains(t, logs, "--- Start Output (stderr) for failed fail-project ---")
+	assert.Contains(t, logs, "mock stderr output") // Output SHOULD be visible on failure
+	assert.Contains(t, logs, "--- End Output (stderr) for failed fail-project ---")
+	assert.NotContains(t, logs, "Build successful for project") // Should not log success
+}
+
+func TestDockerBuilder_Build_ConcurrencyLimit(t *testing.T) {
+	logBuf, cleanup := captureLogs(t)
+	defer cleanup()
+
+	concurrencyLimit := 2
+	numBuilds := 5
+	buildDuration := 50 * time.Millisecond // Short duration for test speed
+
+	// --- Mock Setup ---
+	mockRunners := make([]*mockCmdRunner, numBuilds)
+	mockFactory := &mockCmdFactory{}
+	mockClient := &mockDockerClient{}
+	mockProvider := &mockDockerProvider{}
+	mockProvider.On("newClient").Return(mockClient, nil) // Assume client creation works
+
+	buildStartTimes := make([]time.Time, numBuilds)
+	buildEndTimes := make([]time.Time, numBuilds)
+	completionOrder := make([]int, 0, numBuilds)
+	var mu sync.Mutex // Protect shared slices
+
+	for i := 0; i < numBuilds; i++ {
+		projectName := fmt.Sprintf("concurrent-project-%d", i)
+		initialTag := fmt.Sprintf("%s:enclave1", projectName)
+		imageID := fmt.Sprintf("sha256:conc%dabcdef1234567890abcdef", i)
+
+		// --- Calculate expected final tag based on actual logic ---
+		shortID := TruncateID(imageID)                         // Simulate truncation
+		finalTag := fmt.Sprintf("%s:%s", projectName, shortID) // Correct expectation
+
+		runner := &mockCmdRunner{}
+		runnerIdx := i // Capture loop variable
+
+		runner.On("SetOutput", mock.AnythingOfType("*bytes.Buffer"), mock.AnythingOfType("*bytes.Buffer")).Return()
+		runner.On("Run").Run(func(args mock.Arguments) {
+			mu.Lock()
+			buildStartTimes[runnerIdx] = time.Now()
+			mu.Unlock()
+			time.Sleep(buildDuration) // Simulate build time
+			mu.Lock()
+			buildEndTimes[runnerIdx] = time.Now()
+			completionOrder = append(completionOrder, runnerIdx)
+			mu.Unlock()
+		}).Return(nil) // Simulate successful command execution
+
+		mockRunners[i] = runner
+		mockFactory.On("Create", "sh", []string{"-c", fmt.Sprintf("just %s-image %s", projectName, initialTag)}).Return(runner)
+		mockClient.On("ImageInspectWithRaw", mock.Anything, initialTag).Return(types.ImageInspect{ID: imageID}, []byte{}, nil)
+		mockClient.On("ImageTag", mock.Anything, initialTag, finalTag).Return(nil)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockClient := &mockDockerClient{
-				inspectFunc: func(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
-					return tt.mockInspect, nil, nil
-				},
-				tagFunc: func(ctx context.Context, source, target string) error {
-					return tt.mockTagErr
-				},
-			}
+	// --- Builder Setup ---
+	builder := NewDockerBuilder(
+		withCmdFactory(mockFactory.Create),
+		withDockerProvider(mockProvider),
+		WithDockerConcurrency(concurrencyLimit), // Set the limit
+	)
 
-			mockProvider := &mockDockerProvider{
-				client: mockClient,
-			}
+	// --- Execute Concurrently ---
+	var wg sync.WaitGroup
+	wg.Add(numBuilds)
+	startTime := time.Now()
 
-			// Create a builder with our mocks
-			builder := NewDockerBuilder(
-				withDockerProvider(mockProvider),
-				withCmdFactory(mockCmdFactory([]byte("mock build output"))),
-			)
-
-			tag, err := builder.Build(tt.projectName, tt.imageTag)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantTag, tag)
-		})
+	for i := 0; i < numBuilds; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			projectName := fmt.Sprintf("concurrent-project-%d", idx)
+			initialTag := fmt.Sprintf("%s:enclave1", projectName)
+			_, err := builder.Build(projectName, initialTag)
+			assert.NoError(t, err, "Build %d failed", idx)
+		}(i)
 	}
+
+	wg.Wait() // Wait for all builds to complete
+	totalDuration := time.Since(startTime)
+
+	// --- Assertions ---
+	mockFactory.AssertExpectations(t)
+	mockProvider.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
+	for _, runner := range mockRunners {
+		runner.AssertExpectations(t)
+	}
+
+	// Basic check: total time should be roughly (numBuilds / concurrencyLimit) * buildDuration
+	minExpectedDuration := time.Duration(numBuilds/concurrencyLimit) * buildDuration
+	assert.GreaterOrEqual(t, totalDuration, minExpectedDuration, "Total duration too short, indicates lack of proper concurrency limiting")
+
+	// More detailed check: At no point should more than 'concurrencyLimit' builds be running simultaneously.
+	maxConcurrent := 0
+	for i := 0; i < numBuilds; i++ {
+		concurrentCount := 0
+		for j := 0; j < numBuilds; j++ {
+			// Check if build j overlaps with the start time of build i
+			if buildStartTimes[j].Before(buildStartTimes[i]) && buildEndTimes[j].After(buildStartTimes[i]) {
+				concurrentCount++
+			}
+			// Also count builds starting exactly at the same time (within tolerance)
+			if buildStartTimes[j].Equal(buildStartTimes[i]) && i <= j {
+				concurrentCount++
+			}
+		}
+		if concurrentCount > maxConcurrent {
+			maxConcurrent = concurrentCount
+		}
+	}
+	assert.LessOrEqual(t, maxConcurrent, concurrencyLimit, "More builds ran concurrently than the limit")
+
+	// Verify logs indicate success for all
+	logs := logBuf.String()
+	for i := 0; i < numBuilds; i++ {
+		projectName := fmt.Sprintf("concurrent-project-%d", i)
+		assert.Contains(t, logs, fmt.Sprintf("Build successful for project: %s", projectName))
+	}
+	assert.NotContains(t, logs, "Build failed for")
+}
+
+func TestDockerBuilder_Build_DryRun(t *testing.T) {
+	logBuf, cleanup := captureLogs(t)
+	defer cleanup()
+
+	projectName := "dry-run-project"
+	initialTag := "dry-run-project:enclave-dry"
+
+	// --- Mock Setup ---
+	// No mocks for command execution or docker client should be needed/called in dry run
+	mockFactory := &mockCmdFactory{}
+	mockProvider := &mockDockerProvider{}
+
+	// --- Builder Setup ---
+	builder := NewDockerBuilder(
+		WithDockerDryRun(true), // Enable dry run
+		withCmdFactory(mockFactory.Create),
+		withDockerProvider(mockProvider),
+		WithDockerConcurrency(1),
+	)
+
+	// --- Execute ---
+	resultTag, err := builder.Build(projectName, initialTag)
+
+	// --- Assertions ---
+	require.NoError(t, err)
+	// In dry run mode, the builder currently returns the *initial* tag provided.
+	assert.Equal(t, initialTag, resultTag)
+
+	// Verify mocks were NOT called
+	mockFactory.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+	mockProvider.AssertNotCalled(t, "newClient")
+
+	// Verify log output for dry run
+	logs := logBuf.String()
+	assert.Contains(t, logs, fmt.Sprintf("Build started for project: %s", projectName))
+	assert.Contains(t, logs, fmt.Sprintf("Dry run: Skipping build for project %s", projectName))
+	assert.NotContains(t, logs, "Executing build command")
+	assert.NotContains(t, logs, "Build successful")
+	assert.NotContains(t, logs, "Build failed")
+}
+
+func TestDockerBuilder_Build_DuplicateCalls(t *testing.T) {
+	logBuf, cleanup := captureLogs(t)
+	defer cleanup()
+
+	projectName := "duplicate-project"
+	initialTag := "duplicate:enclave1"
+	imageID := "sha256:dup1234567890abcdef1234567890abcdef"
+
+	// --- Calculate expected final tag based on actual logic ---
+	shortID := TruncateID(imageID)                         // Simulate truncation
+	finalTag := fmt.Sprintf("%s:%s", projectName, shortID) // Correct expectation
+	buildDuration := 30 * time.Millisecond
+
+	// --- Mock Setup ---
+	mockRunner := &mockCmdRunner{}
+	mockRunner.On("SetOutput", mock.AnythingOfType("*bytes.Buffer"), mock.AnythingOfType("*bytes.Buffer")).Return()
+	// Simulate build time only on the first call to Run
+	runCallCount := 0
+	mockRunner.On("Run").Run(func(args mock.Arguments) {
+		runCallCount++
+		if runCallCount == 1 {
+			time.Sleep(buildDuration)
+		}
+	}).Return(nil).Once() // Expect Run to be called ONLY ONCE
+
+	mockFactory := &mockCmdFactory{}
+	// Expect Create to be called ONLY ONCE
+	mockFactory.On("Create", "sh", []string{"-c", fmt.Sprintf("just %s-image %s", projectName, initialTag)}).Return(mockRunner).Once()
+
+	mockClient := &mockDockerClient{}
+	// Expect Inspect and Tag to be called ONLY ONCE
+	mockClient.On("ImageInspectWithRaw", mock.Anything, initialTag).Return(types.ImageInspect{ID: imageID}, []byte{}, nil).Once()
+	mockClient.On("ImageTag", mock.Anything, initialTag, finalTag).Return(nil).Once()
+
+	mockProvider := &mockDockerProvider{}
+	mockProvider.On("newClient").Return(mockClient, nil).Once() // Expect newClient ONLY ONCE
+
+	// --- Builder Setup ---
+	builder := NewDockerBuilder(
+		withCmdFactory(mockFactory.Create),
+		withDockerProvider(mockProvider),
+		WithDockerConcurrency(2), // Allow multiple goroutines to proceed to Build if needed
+	)
+
+	// --- Execute Concurrently ---
+	var wg sync.WaitGroup
+	numCalls := 3
+	results := make([]string, numCalls)
+	errors := make([]error, numCalls)
+	wg.Add(numCalls)
+
+	for i := 0; i < numCalls; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errors[idx] = builder.Build(projectName, initialTag)
+		}(i)
+	}
+
+	wg.Wait() // Wait for all calls to Build to return
+
+	// --- Assertions ---
+	// Verify mocks were called exactly once, despite multiple calls to Build
+	mockFactory.AssertExpectations(t)
+	mockRunner.AssertExpectations(t)
+	mockProvider.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
+
+	// Check results from all calls
+	for i := 0; i < numCalls; i++ {
+		require.NoError(t, errors[i], "Call %d returned an error", i)
+		assert.Equal(t, finalTag, results[i], "Call %d returned wrong tag", i)
+	}
+
+	// Verify logs show only one build execution sequence
+	logs := logBuf.String()
+	assert.Equal(t, 1, strings.Count(logs, fmt.Sprintf("Build started for project: %s", projectName)), "Expected build start log only once")
+	assert.Equal(t, 1, strings.Count(logs, fmt.Sprintf("Executing build command for %s", projectName)), "Expected command execution log only once")
+	assert.Equal(t, 1, strings.Count(logs, fmt.Sprintf("Build successful for project: %s", projectName)), "Expected success log only once")
+	assert.NotContains(t, logs, "Build failed")
+
+	fmt.Println("Captured logs for duplicate calls test:\n", logs) // Optional: print logs for manual inspection if test fails
+}
+
+// --- Test Default Command Runner ---
+// This test ensures the real exec.Command interaction works as expected
+// It's more of an integration test for the defaultCmdRunner wrapper.
+func TestDefaultCmdRunner_Run_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping command runner test in short mode.")
+	}
+
+	cmdRunner := defaultCmdFactory("echo", "hello world")
+	var stdout, stderr bytes.Buffer
+	cmdRunner.SetOutput(&stdout, &stderr)
+
+	err := cmdRunner.Run()
+	require.NoError(t, err)
+	assert.Equal(t, "hello world\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestDefaultCmdRunner_Run_Failure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping command runner test in short mode.")
+	}
+
+	// Use a command guaranteed to fail and write to stderr
+	cmdRunner := defaultCmdFactory("sh", "-c", "echo 'stdout message' && >&2 echo 'stderr message' && exit 1")
+	var stdout, stderr bytes.Buffer
+	cmdRunner.SetOutput(&stdout, &stderr)
+
+	err := cmdRunner.Run()
+	require.Error(t, err)
+	// Check if it's an ExitError which is expected for command failures
+	var exitErr *exec.ExitError
+	assert.ErrorAs(t, err, &exitErr, "Error should be an exec.ExitError")
+	assert.Equal(t, "stdout message\n", stdout.String())
+	assert.Equal(t, "stderr message\n", stderr.String())
+}
+
+func TestDefaultCmdRunner_CombinedOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping command runner test in short mode.")
+	}
+
+	// Test when SetOutput hasn't been called (internal buffering)
+	cmdRunner1 := defaultCmdFactory("sh", "-c", "echo 'stdout' && >&2 echo 'stderr'")
+	output1, err1 := cmdRunner1.CombinedOutput()
+	require.NoError(t, err1)
+	// Order isn't guaranteed, but both should be present
+	assert.Contains(t, string(output1), "stdout")
+	assert.Contains(t, string(output1), "stderr")
+
+	// Test when SetOutput *has* been called
+	cmdRunner2 := defaultCmdFactory("sh", "-c", "echo 'stdout2' && >&2 echo 'stderr2'")
+	var stdout, stderr bytes.Buffer
+	cmdRunner2.SetOutput(&stdout, &stderr)
+	output2, err2 := cmdRunner2.CombinedOutput() // This should now call Run() internally and combine buffers
+	require.NoError(t, err2)
+	assert.Equal(t, "stdout2\n", stdout.String()) // Buffers should be populated
+	assert.Equal(t, "stderr2\n", stderr.String())
+	combined := "stdout2\n" + "stderr2\n"
+	assert.Equal(t, combined, string(output2)) // Combined output should match concatenated buffers
 }

--- a/kurtosis-devnet/pkg/deploy/prestate.go
+++ b/kurtosis-devnet/pkg/deploy/prestate.go
@@ -45,6 +45,10 @@ func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
 	}
 
 	if h.dryRun {
+		// In dry run, populate with placeholder keys to avoid template errors during first pass
+		info.Hashes["prestate"] = "dry_run_placeholder"
+		info.Hashes["prestate_mt64"] = "dry_run_placeholder"
+		info.Hashes["prestate_interop"] = "dry_run_placeholder"
 		h.info = info
 		return info, nil
 	}

--- a/kurtosis-devnet/pkg/deploy/template.go
+++ b/kurtosis-devnet/pkg/deploy/template.go
@@ -7,9 +7,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/build"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/tmpl"
+)
+
+var (
+	dockerBuildConcurrency = 8
 )
 
 type Templater struct {
@@ -20,20 +25,58 @@ type Templater struct {
 	dataFile     string
 	buildDir     string
 	urlBuilder   func(path ...string) string
+
+	// Common state across template functions
+	buildJobsMux sync.Mutex
+	buildJobs    map[string]*dockerBuildJob
+}
+
+// dockerBuildJob helps collect and group build jobs
+type dockerBuildJob struct {
+	projectName string
+	imageTag    string
+	result      string
+	err         error
+	done        chan struct{}
 }
 
 func (f *Templater) localDockerImageOption() tmpl.TemplateContextOptions {
-	dockerBuilder := build.NewDockerBuilder(
-		build.WithDockerBaseDir(f.baseDir),
-		build.WithDockerDryRun(f.dryRun),
-	)
+	// Initialize the build jobs map if it's nil
+	if f.buildJobs == nil {
+		f.buildJobs = make(map[string]*dockerBuildJob)
+	}
 
 	imageTag := func(projectName string) string {
 		return fmt.Sprintf("%s:%s", projectName, f.enclave)
 	}
 
+	// Function that gets called during template rendering
 	return tmpl.WithFunction("localDockerImage", func(projectName string) (string, error) {
-		return dockerBuilder.Build(projectName, imageTag(projectName))
+		tag := imageTag(projectName)
+
+		// First, check if we already have this build job
+		f.buildJobsMux.Lock()
+		job, exists := f.buildJobs[projectName]
+		if !exists {
+			// If not, create a new job but don't start it yet
+			job = &dockerBuildJob{
+				projectName: projectName,
+				imageTag:    tag,
+				done:        make(chan struct{}),
+			}
+			f.buildJobs[projectName] = job
+		}
+		f.buildJobsMux.Unlock()
+
+		// If the job is already done, return its result
+		select {
+		case <-job.done:
+			return job.result, job.err
+		default:
+			// Just collect the build request for now and return a placeholder
+			// The actual build will happen in Render() before final template evaluation
+			return fmt.Sprintf("__PLACEHOLDER_DOCKER_IMAGE_%s__", projectName), nil
+		}
 	})
 }
 
@@ -78,6 +121,11 @@ func (f *Templater) localPrestateOption() tmpl.TemplateContextOptions {
 }
 
 func (f *Templater) Render() (*bytes.Buffer, error) {
+	// Initialize the build jobs map if it's nil
+	if f.buildJobs == nil {
+		f.buildJobs = make(map[string]*dockerBuildJob)
+	}
+
 	opts := []tmpl.TemplateContextOptions{
 		f.localDockerImageOption(),
 		f.localContractArtifactsOption(),
@@ -110,7 +158,58 @@ func (f *Templater) Render() (*bytes.Buffer, error) {
 	// Create template context
 	tmplCtx := tmpl.NewTemplateContext(opts...)
 
-	// Process template
+	// First pass: Collect all build jobs without executing them
+	prelimBuf := bytes.NewBuffer(nil)
+	if err := tmplCtx.InstantiateTemplate(tmplFile, prelimBuf); err != nil {
+		return nil, fmt.Errorf("error in first-pass template processing: %w", err)
+	}
+
+	// Find all docker build jobs and execute them concurrently
+	var dockerJobs []*dockerBuildJob
+	f.buildJobsMux.Lock()
+	for _, job := range f.buildJobs {
+		dockerJobs = append(dockerJobs, job)
+	}
+	f.buildJobsMux.Unlock()
+
+	if len(dockerJobs) > 0 {
+		// Create a single Docker builder for all builds using the factory
+		dockerBuilder := build.NewDockerBuilder(
+			build.WithDockerBaseDir(f.baseDir),
+			build.WithDockerDryRun(f.dryRun),
+			build.WithDockerConcurrency(dockerBuildConcurrency), // Set concurrency
+		)
+
+		// Start all the builds
+		var wg sync.WaitGroup
+		wg.Add(len(dockerJobs))
+		for _, job := range dockerJobs {
+			go func(j *dockerBuildJob) {
+				defer wg.Done()
+				log.Printf("Starting build for %s (tag: %s)", j.projectName, j.imageTag)
+				j.result, j.err = dockerBuilder.Build(j.projectName, j.imageTag)
+				close(j.done) // Mark this job as done
+			}(job)
+		}
+		wg.Wait() // Wait for all builds to complete
+
+		// Check for any build errors
+		for _, job := range dockerJobs {
+			if job.err != nil {
+				return nil, fmt.Errorf("error building docker image for %s: %w", job.projectName, job.err)
+			}
+		}
+
+		// Now reopen the template file for the second pass
+		tmplFile.Close()
+		tmplFile, err = os.Open(f.templateFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reopening template file: %w", err)
+		}
+		defer tmplFile.Close()
+	}
+
+	// Second pass: Render with actual build results
 	buf := bytes.NewBuffer(nil)
 	if err := tmplCtx.InstantiateTemplate(tmplFile, buf); err != nil {
 		return nil, fmt.Errorf("error processing template: %w", err)

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -52,3 +52,88 @@ artifacts: {{localContractArtifacts "l1"}}`
 	assert.Contains(t, buf.String(), "test-deployment")
 	assert.Contains(t, buf.String(), "test-project:test-enclave")
 }
+
+func TestRenderTemplate_DryRun(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir, err := os.MkdirTemp("", "template-test-dryrun")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a test template file with multiple docker image requests, including duplicates
+	templateContent := `
+name: {{.name}}
+imageA1: {{ localDockerImage "project-a" }}
+imageB: {{ localDockerImage "project-b" }}
+imageA2: {{ localDockerImage "project-a" }}
+contracts: {{ localContractArtifacts "l1" }}
+prestateHash: {{ (localPrestate).Hashes.prestate }}`
+
+	templatePath := filepath.Join(tmpDir, "template.yaml")
+	err = os.WriteFile(templatePath, []byte(templateContent), 0644)
+	require.NoError(t, err)
+
+	// Create a test data file
+	dataContent := `{"name": "test-deployment"}`
+	dataPath := filepath.Join(tmpDir, "data.json")
+	err = os.WriteFile(dataPath, []byte(dataContent), 0644)
+	require.NoError(t, err)
+
+	// Create dummy prestate and contract files for dry run build simulation
+	prestateDir := filepath.Join(tmpDir, "prestate_build")
+	contractsDir := filepath.Join(tmpDir, "contracts_build")
+	require.NoError(t, os.MkdirAll(prestateDir, 0755))
+	require.NoError(t, os.MkdirAll(contractsDir, 0755))
+	// Note: The actual content doesn't matter for dry run, just existence might
+	// depending on how the builders are implemented, but our current focus is docker build flow.
+
+	// Create a Templater instance in dryRun mode
+	enclaveName := "test-enclave-dryrun"
+	templater := &Templater{
+		enclave:      enclaveName,
+		dryRun:       true,
+		baseDir:      tmpDir, // Needs a valid base directory
+		templateFile: templatePath,
+		dataFile:     dataPath,
+		buildDir:     tmpDir, // Used by contract/prestate builders
+		urlBuilder: func(path ...string) string {
+			return "http://fileserver.test/" + strings.Join(path, "/")
+		},
+	}
+
+	buf, err := templater.Render()
+	require.NoError(t, err)
+
+	// --- Assertions ---
+	output := buf.String()
+	t.Logf("Rendered output (dry run):\n%s", output)
+
+	// 1. Verify template data is rendered
+	assert.Contains(t, output, "name: test-deployment")
+
+	// 2. Verify Docker images are replaced with their *initial* tags (due to dryRun)
+	//    and NOT the placeholder values.
+	expectedTagA := "project-a:" + enclaveName
+	expectedTagB := "project-b:" + enclaveName
+	assert.Contains(t, output, "imageA1: "+expectedTagA)
+	assert.Contains(t, output, "imageB: "+expectedTagB)
+	assert.Contains(t, output, "imageA2: "+expectedTagA) // Duplicate uses the same tag
+	assert.NotContains(t, output, "__PLACEHOLDER_DOCKER_IMAGE_")
+
+	// 3. Verify contract artifacts URL is present (uses dry run logic of that builder)
+	assert.Contains(t, output, "contracts: http://fileserver.test/contracts-bundle-"+enclaveName+".tar.gz")
+
+	// 4. Verify prestate hash placeholder is present (dry run for prestate needs specific setup)
+	//    In dry run, the prestate builder might return zero values or specific placeholders.
+	//    Based on `localPrestateHolder` implementation, it might error if files don't exist,
+	//    or return default values. Let's assume it returns empty/default for dry run.
+	//    Adjust this assertion based on the actual dry-run behavior of PrestateBuilder.
+	//    For now, let's check if the key exists, assuming the dry run might produce an empty hash.
+	assert.Contains(t, output, "prestateHash:") // Check if the key is rendered
+
+	// 5. Check that buildJobs map was populated (indirectly verifying first pass)
+	templater.buildJobsMux.Lock()
+	assert.Contains(t, templater.buildJobs, "project-a")
+	assert.Contains(t, templater.buildJobs, "project-b")
+	assert.Len(t, templater.buildJobs, 2, "Should only have jobs for unique project names")
+	templater.buildJobsMux.Unlock()
+}


### PR DESCRIPTION
## Objective

The primary goal of this change is to significantly speed up the local development workflow within `kurtosis-devnet` when using local artifacts (specifically Docker images). Previously, when a Kurtosis template required multiple local Docker images (e.g., `op-node`, `op-batcher`, `op-proposer`), these images were built sequentially, leading to long wait times. This PR introduces parallel execution for these Docker builds.

## Problem

Initial investigation revealed that despite setting concurrency limits within the Docker building logic, builds were still executing one after another. This was because the Kurtosis templating engine evaluated template functions like `localDockerImage` sequentially. Each call triggered its respective build immediately, blocking further template evaluation until completion.

## Solution

This PR implements a two-pass template rendering strategy to enable true parallel builds:

1.  **First Pass (Collection):** The template is rendered once. During this pass, calls to `localDockerImage` don't trigger builds immediately. Instead, they register the required build jobs (project name, tag) and return a temporary placeholder string.
2.  **Concurrent Build Execution:** After the first pass, all unique collected Docker build jobs are executed concurrently using a shared `DockerBuilder` instance, respecting the configured concurrency limit (defaulting to 8). Build results (final image tags or errors) are stored.
3.  **Second Pass (Final Rendering):** The template is rendered again. This time, the `localDockerImage` function returns the *actual* results (the final image tag) obtained from the completed concurrent builds.

## Key Changes

*   **`pkg/build/docker.go`:**
    *   Refactored `DockerBuilder` to support concurrent builds using `golang.org/x/sync/semaphore`.
    *   Added `WithDockerConcurrency(limit)` option to configure the maximum number of parallel builds.
    *   Improved logging: Logs build start/success/failure, suppresses stdout/stderr during execution, and only outputs logs on failure.
    *   Ensured build de-duplication: Builds for the same project name are only executed once per `Render` cycle.
*   **`pkg/deploy/template.go`:**
    *   Refactored `Templater.Render` to perform the two-pass rendering logic described above.
    *   Modified `localDockerImageOption` to register build jobs instead of executing them immediately during the first pass.
    *   Introduced shared state (`buildJobs`, `buildJobsMu`) within `Templater` to manage build requests across template function calls and rendering passes.
    *   Set the default Docker build concurrency to 8 when creating the builder for the execution phase.
*   **`pkg/deploy/prestate.go`:**
    *   Adjusted `localPrestateHolder.GetPrestateInfo` to return placeholder hash keys during `dryRun` mode. This prevents errors during the first template rendering pass when prestate information is accessed.
*   **Tests:**
    *   Added comprehensive tests for `DockerBuilder` (`docker_test.go`) covering concurrency limits, logging, dry runs, and duplicate build handling.
    *   Added a new test (`TestRenderTemplate_DryRun` in `template_test.go`) to specifically verify the two-pass rendering logic in `Templater`.
    *   Fixed existing tests to align with the new logic (e.g., correct expected image tag calculation).

## Outcome

Deploying Kurtosis devnets that utilize multiple local Docker images (like `isthmus-devnet`) are now faster due to the parallel execution of the underlying `just ...-image` commands. In local testing the `just isthmus-devnet` runtime went from `5:05` to `3:53.26`, a 23.6% speedup!