### PR TITLE
Update acceptance test configuration to include fork subpackages

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -9,21 +9,21 @@ gates:
     description: "Sanity checks for the acceptance tests."
     tests:
       - name: TestFindRPCEndpoints
-        package: github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis
+        package: github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/...
 
   - id: holocene
     inherits:
       - sanitychecks
     description: "Holocene network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord/...
 
   - id: isthmus
     inherits:
       - sanitychecks
     description: "Isthmus network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/...
         timeout: 6h
 
   - id: interop
@@ -31,4 +31,4 @@ gates:
       - sanitychecks
     description: "Interop network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/...

--- a/op-acceptance-tests/tests/isthmus/operator_fee/balance_reader.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/balance_reader.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"context"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/balance_snapshot.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/balance_snapshot.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"fmt"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/balance_snapshot_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/balance_snapshot_test.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"math/big"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/fee_checker.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/fee_checker.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"context"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"log/slog"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/system_config_contract_utils.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/system_config_contract_utils.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"context"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/test_case_generator.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/test_case_generator.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	cryptoRand "crypto/rand"

--- a/op-acceptance-tests/tests/isthmus/operator_fee/tx_utils.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/tx_utils.go
@@ -1,4 +1,4 @@
-package isthmus
+package operatorfee
 
 import (
 	"context"


### PR DESCRIPTION
Currently the operator fee NAT test is not run as part of post-merge CI because its directory is not specified in the acceptance-tests.yaml file. By updating this file to add the recursive `...` syntax, this ensures that all subpackages of the test directory in question are included in the gate.

At the same time, I am updating the package name within files in `op-acceptance-tests/tests/isthmus/operator_fee/` to `operatorfee`. I had previously mistakenly believed that by setting the package name to the parent directory had merged the child directory's package with the parent directory's. This is not the case, if you declare a child directory golang file to have the same package name as the parent, then you are declaring a nested package of the same name.