### PR TITLE
op-batcher: disallow blobs when Alt-DA is enabled

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -260,6 +260,10 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("unknown data availability type: %v", cfg.DataAvailabilityType)
 	}
 
+	if bs.UseAltDA && cc.UseBlobs {
+		return fmt.Errorf("cannot use blobs with Alt-DA")
+	}
+
 	if bs.UseAltDA && cc.MaxFrameSize > altda.MaxInputSize {
 		return fmt.Errorf("max frame size %d exceeds altDA max input size %d", cc.MaxFrameSize, altda.MaxInputSize)
 	}

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -261,7 +261,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 	}
 
 	if bs.UseAltDA && cc.UseBlobs {
-		return fmt.Errorf("cannot use blobs with Alt-DA")
+		return fmt.Errorf("cannot use data availability type blobs or auto with Alt-DA")
 	}
 
 	if bs.UseAltDA && cc.MaxFrameSize > altda.MaxInputSize {


### PR DESCRIPTION
In `publishToAltDAAndL1`, it's clear that blob is not allowed when Alt-DA is enabled according to [here](https://github.com/ethereum-optimism/optimism/blob/0e6ad65f779660c76e2a99e1957789322e22cd22/op-batcher/batcher/driver.go#L815).

However, in `initChannelConfig` there's no such check.

This PR adds the missing check.

This issue is reported as the 9th finding in celo's audit report [here](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/security-reviews/2024_12-Cel2-TrailOfBits.pdf).