### PR TITLE
fix: ProtocolVersion should be bytes32

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IProtocolVersions.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IProtocolVersions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-type ProtocolVersion is uint256;
+type ProtocolVersion is bytes32;
 
 interface IProtocolVersions {
     enum UpdateType {

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -77,8 +77,8 @@ contract DeployConfig is Script {
     uint256 public preimageOracleMinProposalSize;
     uint256 public preimageOracleChallengePeriod;
     uint256 public systemConfigStartBlock;
-    uint256 public requiredProtocolVersion;
-    uint256 public recommendedProtocolVersion;
+    bytes32 public requiredProtocolVersion;
+    bytes32 public recommendedProtocolVersion;
     uint256 public proofMaturityDelaySeconds;
     uint256 public disputeGameFinalityDelaySeconds;
     uint256 public respectedGameType;
@@ -150,8 +150,8 @@ contract DeployConfig is Script {
         eip1559Denominator = stdJson.readUint(_json, "$.eip1559Denominator");
         eip1559Elasticity = stdJson.readUint(_json, "$.eip1559Elasticity");
         systemConfigStartBlock = stdJson.readUint(_json, "$.systemConfigStartBlock");
-        requiredProtocolVersion = stdJson.readUint(_json, "$.requiredProtocolVersion");
-        recommendedProtocolVersion = stdJson.readUint(_json, "$.recommendedProtocolVersion");
+        requiredProtocolVersion = stdJson.readBytes32(_json, "$.requiredProtocolVersion");
+        recommendedProtocolVersion = stdJson.readBytes32(_json, "$.recommendedProtocolVersion");
 
         proofMaturityDelaySeconds = _readOr(_json, "$.proofMaturityDelaySeconds", 0);
         disputeGameFinalityDelaySeconds = _readOr(_json, "$.disputeGameFinalityDelaySeconds", 0);

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -89,17 +89,17 @@ contract ProtocolVersions_Setters_Test is ProtocolVersions_Init {
         emit ConfigUpdate(0, IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(_version));
 
         vm.prank(protocolVersions.owner());
-        protocolVersions.setRequired(ProtocolVersion.wrap(_version));
-        assertEq(ProtocolVersion.unwrap(protocolVersions.required()), _version);
+        protocolVersions.setRequired(ProtocolVersion.wrap(bytes32(_version)));
+        assertEq(ProtocolVersion.unwrap(protocolVersions.required()), bytes32(_version));
     }
 
     /// @dev Tests that `setRecommended` updates the recommended protocol version successfully.
     function testFuzz_setRecommended_succeeds(uint256 _version) external {
         vm.expectEmit(true, true, true, true);
-        emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(_version));
+        emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(bytes32(_version)));
 
         vm.prank(protocolVersions.owner());
-        protocolVersions.setRecommended(ProtocolVersion.wrap(_version));
-        assertEq(ProtocolVersion.unwrap(protocolVersions.recommended()), _version);
+        protocolVersions.setRecommended(ProtocolVersion.wrap(bytes32(_version)));
+        assertEq(ProtocolVersion.unwrap(protocolVersions.recommended()), bytes32(_version));
     }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -300,8 +300,8 @@ contract DeployOPChain_TestBase is Test {
     address protocolVersionsOwner = makeAddr("defaultProtocolVersionsOwner");
     address guardian = makeAddr("defaultGuardian");
     bool paused = false;
-    ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(1);
-    ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(2);
+    ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(bytes32(uint256(1)));
+    ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(bytes32(uint256(2)));
 
     // Define default inputs for DeployImplementations.
     // `superchainConfigProxy` and `protocolVersionsProxy` are set during `setUp` since they are

--- a/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
@@ -17,8 +17,8 @@ contract DeploySuperchainInput_Test is Test {
     address protocolVersionsOwner = makeAddr("defaultProtocolVersionsOwner");
     address guardian = makeAddr("defaultGuardian");
     bool paused = false;
-    ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(1);
-    ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(2);
+    ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(bytes32(uint256(1)));
+    ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(bytes32(uint256(2)));
 
     function setUp() public {
         dsi = new DeploySuperchainInput();
@@ -131,15 +131,15 @@ contract DeploySuperchain_Test is Test {
     address defaultProtocolVersionsOwner = makeAddr("defaultProtocolVersionsOwner");
     address defaultGuardian = makeAddr("defaultGuardian");
     bool defaultPaused = false;
-    ProtocolVersion defaultRequiredProtocolVersion = ProtocolVersion.wrap(1);
-    ProtocolVersion defaultRecommendedProtocolVersion = ProtocolVersion.wrap(2);
+    ProtocolVersion defaultRequiredProtocolVersion = ProtocolVersion.wrap(bytes32(uint256(1)));
+    ProtocolVersion defaultRecommendedProtocolVersion = ProtocolVersion.wrap(bytes32(uint256(2)));
 
     function setUp() public {
         deploySuperchain = new DeploySuperchain();
         (dsi, dso) = deploySuperchain.etchIOContracts();
     }
 
-    function unwrap(ProtocolVersion _pv) internal pure returns (uint256) {
+    function unwrap(ProtocolVersion _pv) internal pure returns (bytes32) {
         return ProtocolVersion.unwrap(_pv);
     }
 
@@ -155,8 +155,8 @@ contract DeploySuperchain_Test is Test {
         address protocolVersionsOwner = address(uint160(uint256(hash(_seed, 1))));
         address guardian = address(uint160(uint256(hash(_seed, 2))));
         bool paused = bool(uint8(uint256(hash(_seed, 3))) % 2 == 0);
-        ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(uint256(hash(_seed, 4)));
-        ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(uint256(hash(_seed, 5)));
+        ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(hash(_seed, 4));
+        ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(hash(_seed, 5));
 
         // Set the input values on the input contract.
         dsi.set(dsi.superchainProxyAdminOwner.selector, superchainProxyAdminOwner);

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -215,7 +215,7 @@ contract Initializer_Test is CommonTest {
                 name: "ProtocolVersionsImpl",
                 target: EIP1967Helper.getImplementation(address(protocolVersions)),
                 initCalldata: abi.encodeCall(
-                    protocolVersions.initialize, (address(0), ProtocolVersion.wrap(1), ProtocolVersion.wrap(2))
+                    protocolVersions.initialize, (address(0), ProtocolVersion.wrap(bytes32(uint256(1))), ProtocolVersion.wrap(bytes32(uint256(2))))
                 )
             })
         );
@@ -225,7 +225,7 @@ contract Initializer_Test is CommonTest {
                 name: "ProtocolVersionsProxy",
                 target: address(protocolVersions),
                 initCalldata: abi.encodeCall(
-                    protocolVersions.initialize, (address(0), ProtocolVersion.wrap(1), ProtocolVersion.wrap(2))
+                    protocolVersions.initialize, (address(0), ProtocolVersion.wrap(bytes32(uint256(1))), ProtocolVersion.wrap(bytes32(uint256(2))))
                 )
             })
         );


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

According to the [OP Stack Specification](https://specs.optimism.io/protocol/superchain-upgrades.html#protocol-version-format), `ProtocolVersion` should be encoded as `bytes32`.

Although `uint256` and `bytes32` occupy the same space and have the same data layout, this inconsistency causes issues downstream where e.g. `ProtocolVersion` from `op-geth` (based on `[32]byte`) clashes with the `uint256` values. Automation, code generation and ABI validation become messy and/or impossible without special cases to work around this inconsistency.