### PR TITLE
op-e2e: interop action test txplan poc

### DIFF
--- a/devnet-sdk/system/walletV2.go
+++ b/devnet-sdk/system/walletV2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -39,19 +38,7 @@ func NewWalletV2FromWalletAndChain(ctx context.Context, wallet Wallet, chain Cha
 
 func NewWalletV2(ctx context.Context, rpcURL string, priv *ecdsa.PrivateKey, clCfg *sources.EthClientConfig, log log.Logger) (*walletV2, error) {
 	if clCfg == nil {
-		clCfg = &sources.EthClientConfig{
-			MaxRequestsPerBatch:   10,
-			MaxConcurrentRequests: 10,
-			ReceiptsCacheSize:     10,
-			TransactionsCacheSize: 10,
-			HeadersCacheSize:      10,
-			PayloadsCacheSize:     10,
-			BlockRefsCacheSize:    10,
-			TrustRPC:              false,
-			MustBePostMerge:       true,
-			RPCProviderKind:       sources.RPCKindStandard,
-			MethodResetDuration:   time.Minute,
-		}
+		clCfg = sources.DefaultEthClientConfig(10)
 	}
 	rpcClient, err := rpc.DialContext(ctx, rpcURL)
 	if err != nil {

--- a/op-e2e/actions/helpers/l2_engine.go
+++ b/op-e2e/actions/helpers/l2_engine.go
@@ -179,6 +179,12 @@ func (e *L2Engine) EngineClient(t Testing, cfg *rollup.Config) *sources.EngineCl
 	return l2Cl
 }
 
+func (e *L2Engine) SourceClient(t Testing, cacheSize int) *sources.EthClient {
+	l2sc, err := sources.NewEthClient(e.RPCClient(), e.log, nil, sources.DefaultEthClientConfig(cacheSize))
+	require.NoError(t, err)
+	return l2sc
+}
+
 // ActL2RPCFail makes the next L2 RPC request fail with given error
 func (e *L2Engine) ActL2RPCFail(t Testing, err error) {
 	if e.FailL2RPC != nil { // already set to fail?

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -1,0 +1,121 @@
+package interop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+type txSubmitter struct {
+	t       helpers.Testing
+	chain   *dsl.Chain
+	from    common.Address
+	receipt *types.Receipt
+}
+
+func (ts *txSubmitter) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	// we need low level interaction here
+	// do not submit transactions via RPC, instead directly interact with block builder
+	receipt, err := ts.chain.SequencerEngine.EngineApi.IncludeTx(tx, ts.from)
+	if err == nil {
+		// be aware that this receipt is not finalized...
+		// which means its info may be incorrect, such as block hash
+		// you must call ActL2EndBlock to seal the L2 block
+		ts.receipt = receipt
+	}
+	return err
+}
+
+type receiptGetter struct {
+	t     helpers.Testing
+	chain *dsl.Chain
+	sc    *sources.EthClient
+}
+
+func (rg *receiptGetter) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	// close l2 block before fetching actual receipt
+	rg.chain.Sequencer.ActL2EndBlock(rg.t)
+	return rg.sc.TransactionReceipt(ctx, txHash)
+}
+
+func TestTxPlanDeployEventLogger(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+
+	aliceA := setupUser(t, is, actors.ChainA, 0)
+
+	l2sc := actors.ChainA.SequencerEngine.SourceClient(t, 10)
+
+	submitter1 := &txSubmitter{t: t, chain: actors.ChainA, from: aliceA.address}
+	// txplan options for only tx submission, not ensuring block inclusion
+	opts1 := txplan.Combine(
+		txplan.WithPrivateKey(aliceA.secret),
+		txplan.WithChainID(l2sc),
+		txplan.WithAgainstLatestBlock(l2sc),
+		txplan.WithPendingNonce(l2sc),
+		txplan.WithEstimator(l2sc, false),
+		txplan.WithTransactionSubmitter(submitter1),
+	)
+
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+
+	deployCalldata := common.FromHex(bindings.EventloggerBin)
+	// tx submitted but not sealed in block
+	deployTxWithoutSeal := txplan.NewPlannedTx(opts1, txplan.WithData(deployCalldata))
+	_, err := deployTxWithoutSeal.Submitted.Eval(t.Ctx())
+	require.NoError(t, err)
+	latestBlock, err := deployTxWithoutSeal.AgainstBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	getter := &receiptGetter{t: t, chain: actors.ChainA, sc: l2sc}
+	submitter2 := &txSubmitter{t: t, chain: actors.ChainA, from: aliceA.address}
+	// txplan options for tx submission and ensuring block inclusion
+	opts2 := txplan.Combine(
+		txplan.WithPrivateKey(aliceA.secret),
+		txplan.WithChainID(l2sc),
+		txplan.WithAgainstLatestBlock(l2sc),
+		// no pending nonce
+		txplan.WithEstimator(l2sc, false),
+		txplan.WithTransactionSubmitter(submitter2),
+		txplan.WithAssumedInclusion(getter),
+		txplan.WithBlockInclusionInfo(l2sc),
+	)
+	deployTx := txplan.NewPlannedTx(opts2, txplan.WithData(deployCalldata))
+	// manually set nonce because we cannot use the pending nonce
+	nonce, err := deployTxWithoutSeal.Nonce.Get()
+	require.NoError(t, err)
+	deployTx.Nonce.Set(nonce + 1)
+
+	// tx submitted and sealed in block
+	// now the tx is actually included in L2 block, as well as included the tx submitted before
+	receipt, err := deployTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// all intermediate receipts / finalized receipt must contain the contractAddress field
+	// because they all deployed contract
+	require.NotNil(t, receipt.ContractAddress)
+	require.NotNil(t, submitter1.receipt.ContractAddress)
+	require.NotNil(t, submitter2.receipt.ContractAddress)
+
+	// different nonce so different contract address
+	require.NotEqual(t, submitter1.receipt.ContractAddress, submitter2.receipt.ContractAddress)
+	// second and the finalized contract address must be equal
+	require.Equal(t, submitter2.receipt.ContractAddress, receipt.ContractAddress)
+
+	includedBlock, err := deployTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// single block advanced
+	require.Equal(t, latestBlock.NumberU64()+1, includedBlock.Number)
+}

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -102,6 +102,9 @@ func (c *EthClientConfig) Check() error {
 	if c.PayloadsCacheSize < 0 {
 		return fmt.Errorf("invalid payloads cache size: %d", c.PayloadsCacheSize)
 	}
+	if c.BlockRefsCacheSize < 0 {
+		return fmt.Errorf("invalid blockrefs cache size: %d", c.BlockRefsCacheSize)
+	}
 	if c.MaxConcurrentRequests < 1 {
 		return fmt.Errorf("expected at least 1 concurrent request, but max is %d", c.MaxConcurrentRequests)
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR includes the PoC for observing how txplan will be integrated to the op-e2e interop action test. We need this because for interop tx alpha message passing tests, we need block builder support. Details at https://github.com/ethereum-optimism/optimism/issues/15092. 

**Tests**

Added `TestTxPlanDeployEventLogger` which deploys `EventLogger` contract by combining the existing block building functionality of action test + txplan.
