### PR TITLE
feat: Simplify op-deployer scripts: DeploySuperchain2 [4/N]

### DIFF
--- a/op-chain-ops/script/deploy.go
+++ b/op-chain-ops/script/deploy.go
@@ -94,6 +94,26 @@ func NewForgeScriptFromArtifact(artifact *foundry.Artifact, name string, backend
 	}
 }
 
+// NewDeployScriptWithoutOutputFromFile is a syntactic sugar around NewForgeScriptFromFile and NewDeployScriptWithoutOutput
+func NewDeployScriptWithoutOutputFromFile[I any](host *Host, fileName string, name string) (DeployScriptWithoutOutput[I], error) {
+	script, err := NewForgeScriptFromFile(host, fileName, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDeployScriptWithoutOutput[I](script, "run")
+}
+
+// NewDeployScriptWithOutputFromFile is a syntactic sugar around NewForgeScriptFromFile and NewDeployScriptWithOutput
+func NewDeployScriptWithOutputFromFile[I any, O any](host *Host, fileName string, name string) (DeployScriptWithOutput[I, O], error) {
+	script, err := NewForgeScriptFromFile(host, fileName, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDeployScriptWithOutput[I, O](script, "run")
+}
+
 // NewDeployScriptWithoutOutput creates an instance of DeployScriptWithoutOutput[I], a void-returning deploy script
 func NewDeployScriptWithoutOutput[I any](script ForgeScript, methodName string) (DeployScriptWithoutOutput[I], error) {
 	return newDeployScriptWithoutOutput[I](script, methodName)

--- a/op-chain-ops/script/deploy_test.go
+++ b/op-chain-ops/script/deploy_test.go
@@ -398,11 +398,7 @@ func TestNewForgeScriptFromFile(t *testing.T) {
 		host := NewHost(logger, af, nil, DefaultContext)
 
 		// We'll use an example script that returns the input data, just mapped to a different struct
-		script, err := NewForgeScriptFromFile(host, "DeployScriptExample.s.sol", "DeployScriptExample")
-		require.NoError(t, err)
-
-		// We wrap the script with a strongly-typed wrapper
-		deploySuperchain, err := NewDeployScriptWithOutput[DeployScriptExampleInput, DeployScriptExampleOutput](script, "run")
+		deploySuperchain, err := NewDeployScriptWithOutputFromFile[DeployScriptExampleInput, DeployScriptExampleOutput](host, "DeployScriptExample.s.sol", "DeployScriptExample")
 		require.NoError(t, err)
 
 		// Put some input & expected output together

--- a/op-chain-ops/script/deploy_test.go
+++ b/op-chain-ops/script/deploy_test.go
@@ -398,7 +398,7 @@ func TestNewForgeScriptFromFile(t *testing.T) {
 		host := NewHost(logger, af, nil, DefaultContext)
 
 		// We'll use an example script that returns the input data, just mapped to a different struct
-		deploySuperchain, err := NewDeployScriptWithOutputFromFile[DeployScriptExampleInput, DeployScriptExampleOutput](host, "DeployScriptExample.s.sol", "DeployScriptExample")
+		deployExampleScript, err := NewDeployScriptWithOutputFromFile[DeployScriptExampleInput, DeployScriptExampleOutput](host, "DeployScriptExample.s.sol", "DeployScriptExample")
 		require.NoError(t, err)
 
 		// Put some input & expected output together
@@ -412,7 +412,7 @@ func TestNewForgeScriptFromFile(t *testing.T) {
 		}
 
 		// And make sure that we get what we would expect
-		output, err := deploySuperchain.Run(input)
+		output, err := deployExampleScript.Run(input)
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, output)
 
@@ -421,7 +421,7 @@ func TestNewForgeScriptFromFile(t *testing.T) {
 			InputFieldA: common.BigToAddress(big.NewInt(0)),
 			InputFieldB: common.BigToAddress(big.NewInt(0)),
 		}
-		_, err = deploySuperchain.Run(zeroInput)
+		_, err = deployExampleScript.Run(zeroInput)
 		require.ErrorContains(t, err, "failed to call script DeployScriptExample using data 0xfc61915400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000: failed to call backend: execution reverted at")
 	})
 }

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -1,6 +1,12 @@
 build:
     go build -o bin/op-deployer cmd/op-deployer/main.go
 
+build-contracts:
+    just ../packages/contracts-bedrock/forge-build
+
+test args='./...': build-contracts
+    go test -v {{args}}
+
 download-artifacts checksum outfile:
     curl -o {{outfile}} -L https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-{{checksum}}.tar.gz
 

--- a/op-deployer/pkg/deployer/opcm/bootstrap_test.go
+++ b/op-deployer/pkg/deployer/opcm/bootstrap_test.go
@@ -1,0 +1,32 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestHost is a helper function for testing deploy script wrappers
+func createTestHost(t *testing.T) *script.Host {
+	// Create a logger
+	logger, _ := testlog.CaptureLogger(t, log.LevelInfo)
+
+	// Create an artifact filesystem pointing to the bedrock contracts artifact directory
+	af := foundry.OpenArtifactsDir("../../../../packages/contracts-bedrock/forge-artifacts")
+
+	// Now put a host together
+	host := script.NewHost(logger, af, nil, script.DefaultContext, script.WithCreate2Deployer())
+	host.SetTxOrigin(common.BigToAddress(big.NewInt(6)))
+
+	// And enable cheats
+	err := host.EnableCheats()
+	require.NoError(t, err)
+
+	return host
+}

--- a/op-deployer/pkg/deployer/opcm/bootstrap_test.go
+++ b/op-deployer/pkg/deployer/opcm/bootstrap_test.go
@@ -14,8 +14,8 @@ import (
 
 // createTestHost is a helper function for testing deploy script wrappers
 func createTestHost(t *testing.T) *script.Host {
-    t.Helper()
-    
+	t.Helper()
+
 	// Create a logger
 	logger, _ := testlog.CaptureLogger(t, log.LevelInfo)
 

--- a/op-deployer/pkg/deployer/opcm/bootstrap_test.go
+++ b/op-deployer/pkg/deployer/opcm/bootstrap_test.go
@@ -14,6 +14,8 @@ import (
 
 // createTestHost is a helper function for testing deploy script wrappers
 func createTestHost(t *testing.T) *script.Host {
+    t.Helper()
+    
 	// Create a logger
 	logger, _ := testlog.CaptureLogger(t, log.LevelInfo)
 

--- a/op-deployer/pkg/deployer/opcm/superchain2.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2.go
@@ -29,15 +29,3 @@ type DeploySuperchainScript script.DeployScriptWithOutput[DeploySuperchain2Input
 func NewDeploySuperchainScript(host *script.Host) (DeploySuperchainScript, error) {
 	return script.NewDeployScriptWithOutputFromFile[DeploySuperchain2Input, DeploySuperchain2Output](host, "DeploySuperchain2.s.sol", "DeploySuperchain2")
 }
-
-// DeploySuperchain2 exists for backwards compatibility and migration period
-//
-// Eventually the script loading and validation should occur before any scripts are run to avoid errors being thrown in the middle of the deployment
-func DeploySuperchain2(host *script.Host, input DeploySuperchain2Input) (output DeploySuperchain2Output, err error) {
-	script, err := NewDeploySuperchainScript(host)
-	if err != nil {
-		return output, err
-	}
-
-	return script.Run(input)
-}

--- a/op-deployer/pkg/deployer/opcm/superchain2.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2.go
@@ -1,0 +1,44 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeploySuperchain2Input struct {
+	Guardian                   common.Address `toml:"guardian"`
+	ProtocolVersionsOwner      common.Address `toml:"protocolVersionsOwner"`
+	SuperchainProxyAdminOwner  common.Address `toml:"superchainProxyAdminOwner"`
+	Paused                     bool           `toml:"paused"`
+	RecommendedProtocolVersion *big.Int       `toml:"recommendedProtocolVersion"`
+	RequiredProtocolVersion    *big.Int       `toml:"requiredProtocolVersion"`
+}
+
+type DeploySuperchain2Output struct {
+	ProtocolVersionsImpl  common.Address `json:"protocolVersionsImplAddress"`
+	ProtocolVersionsProxy common.Address `json:"protocolVersionsProxyAddress"`
+	SuperchainConfigImpl  common.Address `json:"superchainConfigImplAddress"`
+	SuperchainConfigProxy common.Address `json:"superchainConfigProxyAddress"`
+	SuperchainProxyAdmin  common.Address `json:"proxyAdminAddress"`
+}
+
+type DeploySuperchainScript script.DeployScriptWithOutput[DeploySuperchain2Input, DeploySuperchain2Output]
+
+// NewDeploySuperchainScript loads and validates the DeploySuperchain2 script contract
+func NewDeploySuperchainScript(host *script.Host) (DeploySuperchainScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeploySuperchain2Input, DeploySuperchain2Output](host, "DeploySuperchain2.s.sol", "DeploySuperchain2")
+}
+
+// DeploySuperchain2 exists for backwards compatibility and migration period
+//
+// Eventually the script loading and validation should occur before any scripts are run to avoid errors being thrown in the middle of the deployment
+func DeploySuperchain2(host *script.Host, input DeploySuperchain2Input) (output DeploySuperchain2Output, err error) {
+	script, err := NewDeploySuperchainScript(host)
+	if err != nil {
+		return output, err
+	}
+
+	return script.Run(input)
+}

--- a/op-deployer/pkg/deployer/opcm/superchain2.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2.go
@@ -1,19 +1,18 @@
 package opcm
 
 import (
-	"math/big"
-
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 type DeploySuperchain2Input struct {
-	Guardian                   common.Address `toml:"guardian"`
-	ProtocolVersionsOwner      common.Address `toml:"protocolVersionsOwner"`
-	SuperchainProxyAdminOwner  common.Address `toml:"superchainProxyAdminOwner"`
-	Paused                     bool           `toml:"paused"`
-	RecommendedProtocolVersion *big.Int       `toml:"recommendedProtocolVersion"`
-	RequiredProtocolVersion    *big.Int       `toml:"requiredProtocolVersion"`
+	Guardian                   common.Address         `toml:"guardian"`
+	ProtocolVersionsOwner      common.Address         `toml:"protocolVersionsOwner"`
+	SuperchainProxyAdminOwner  common.Address         `toml:"superchainProxyAdminOwner"`
+	Paused                     bool                   `toml:"paused"`
+	RecommendedProtocolVersion params.ProtocolVersion `toml:"recommendedProtocolVersion"`
+	RequiredProtocolVersion    params.ProtocolVersion `toml:"requiredProtocolVersion"`
 }
 
 type DeploySuperchain2Output struct {

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -1,0 +1,31 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploySuperchain2(t *testing.T) {
+	t.Run("should not fail with current version of DeploySuperchain2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host := createTestHost(t)
+
+		// Then we deploy
+		output, err := opcm.DeploySuperchain2(host, opcm.DeploySuperchain2Input{
+			Guardian:                   common.BigToAddress(big.NewInt(1)),
+			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
+			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
+			Paused:                     true,
+			RecommendedProtocolVersion: big.NewInt(2),
+			RequiredProtocolVersion:    big.NewInt(1),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+	})
+}

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -15,8 +15,14 @@ func TestDeploySuperchain2(t *testing.T) {
 		// First we grab a test host
 		host1 := createTestHost(t)
 
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deploySuperchain, err := opcm.NewDeploySuperchainScript(host1)
+		require.NoError(t, err)
+
 		// Then we deploy
-		output, err := opcm.DeploySuperchain2(host1, opcm.DeploySuperchain2Input{
+		output, err := deploySuperchain.Run(opcm.DeploySuperchain2Input{
 			Guardian:                   common.BigToAddress(big.NewInt(1)),
 			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
 			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeploySuperchain2(t *testing.T) {
+func TestNewDeploySuperchainScript(t *testing.T) {
 	t.Run("should not fail with current version of DeploySuperchain2 contract", func(t *testing.T) {
 		// First we grab a test host
 		host1 := createTestHost(t)

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -13,10 +13,10 @@ import (
 func TestDeploySuperchain2(t *testing.T) {
 	t.Run("should not fail with current version of DeploySuperchain2 contract", func(t *testing.T) {
 		// First we grab a test host
-		host := createTestHost(t)
+		host1 := createTestHost(t)
 
 		// Then we deploy
-		output, err := opcm.DeploySuperchain2(host, opcm.DeploySuperchain2Input{
+		output, err := opcm.DeploySuperchain2(host1, opcm.DeploySuperchain2Input{
 			Guardian:                   common.BigToAddress(big.NewInt(1)),
 			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
 			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
@@ -30,7 +30,11 @@ func TestDeploySuperchain2(t *testing.T) {
 		require.NotNil(t, output)
 
 		// Now we run the old deployer
-		deprecatedOutput, err := opcm.DeploySuperchain(host, opcm.DeploySuperchainInput{
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		deprecatedOutput, err := opcm.DeploySuperchain(host2, opcm.DeploySuperchainInput{
 			Guardian:                   common.BigToAddress(big.NewInt(1)),
 			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
 			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
@@ -43,11 +47,18 @@ func TestDeploySuperchain2(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, deprecatedOutput)
 
-		// And make sure that the basics match
+		// Now make sure the addresses are the same
 		require.Equal(t, deprecatedOutput.ProtocolVersionsImpl, output.ProtocolVersionsImpl)
 		require.Equal(t, deprecatedOutput.SuperchainConfigImpl, output.SuperchainConfigImpl)
-		require.Equal(t, host.GetCode(deprecatedOutput.SuperchainConfigProxy), host.GetCode(output.SuperchainConfigProxy))
-		require.Equal(t, host.GetCode(deprecatedOutput.ProtocolVersionsProxy), host.GetCode(output.ProtocolVersionsProxy))
-		require.Equal(t, host.GetCode(deprecatedOutput.SuperchainProxyAdmin), host.GetCode(output.SuperchainProxyAdmin))
+		require.Equal(t, deprecatedOutput.ProtocolVersionsProxy, output.ProtocolVersionsProxy)
+		require.Equal(t, deprecatedOutput.SuperchainConfigProxy, output.SuperchainConfigProxy)
+		require.Equal(t, deprecatedOutput.SuperchainProxyAdmin, output.SuperchainProxyAdmin)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.ProtocolVersionsImpl), host1.GetCode(output.ProtocolVersionsImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.SuperchainConfigImpl), host1.GetCode(output.SuperchainConfigImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.SuperchainConfigProxy), host1.GetCode(output.SuperchainConfigProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.ProtocolVersionsProxy), host1.GetCode(output.ProtocolVersionsProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.SuperchainProxyAdmin), host1.GetCode(output.SuperchainProxyAdmin))
 	})
 }

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,8 +21,8 @@ func TestDeploySuperchain2(t *testing.T) {
 			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
 			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
 			Paused:                     true,
-			RecommendedProtocolVersion: big.NewInt(2),
-			RequiredProtocolVersion:    big.NewInt(1),
+			RecommendedProtocolVersion: params.ProtocolVersion{1},
+			RequiredProtocolVersion:    params.ProtocolVersion{2},
 		})
 
 		// And do some simple asserts

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -28,5 +28,26 @@ func TestDeploySuperchain2(t *testing.T) {
 		// And do some simple asserts
 		require.NoError(t, err)
 		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		deprecatedOutput, err := opcm.DeploySuperchain(host, opcm.DeploySuperchainInput{
+			Guardian:                   common.BigToAddress(big.NewInt(1)),
+			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
+			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
+			Paused:                     true,
+			RecommendedProtocolVersion: params.ProtocolVersion{1},
+			RequiredProtocolVersion:    params.ProtocolVersion{2},
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// And make sure that the basics match
+		require.Equal(t, deprecatedOutput.ProtocolVersionsImpl, output.ProtocolVersionsImpl)
+		require.Equal(t, deprecatedOutput.SuperchainConfigImpl, output.SuperchainConfigImpl)
+		require.Equal(t, host.GetCode(deprecatedOutput.SuperchainConfigProxy), host.GetCode(output.SuperchainConfigProxy))
+		require.Equal(t, host.GetCode(deprecatedOutput.ProtocolVersionsProxy), host.GetCode(output.ProtocolVersionsProxy))
+		require.Equal(t, host.GetCode(deprecatedOutput.SuperchainProxyAdmin), host.GetCode(output.SuperchainProxyAdmin))
 	})
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR pulls together the previous changes to create a `NewDeploySuperchainScript` factory function for `DeploySuperchain2` deploy script. This function is not yet being used, that will be included in a PR to follow.

In addition to `NewDeploySuperchainScript`, two syntactic-sugar functions have been added to minimize the code a dev needs to write (one line should be all it takes):

- `NewDeployScriptWithoutOutputFromFile` combines `NewForgeScriptFromFile` and `NewDeployScriptWithoutOutput`
- `NewDeployScriptWithOutputFromFile` combines `NewForgeScriptFromFile` and `NewDeployScriptWithOutput`

To ensure we're not breaking anything, we introduce a test suite that compares the outputs of the old & the new script. By using a fresh host (with identical deployer address & nonce), we can just make sure that the outputs are identical.

(small thing: there also was a variable name typo and `deploySuperchain` has been renamed to `deployExampleScript` since it deploys an example script)

Relates to #14976