### PR TITLE
Replace ethclient.Client with HeaderProvider interface in NewClientRegistry

### DIFF
--- a/devnet-sdk/contracts/contracts.go
+++ b/devnet-sdk/contracts/contracts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewClientRegistry creates a new Registry that uses the provided client
-func NewClientRegistry(c *ethclient.Client) interfaces.ContractsRegistry {
+func NewClientRegistry(c HeaderProvider) interfaces.ContractsRegistry {
 	return &client.ClientRegistry{Client: c}
 }
 


### PR DESCRIPTION
This PR refactors the NewClientRegistry function to accept a HeaderProvider interface instead of a concrete ethclient.Client type. This change improves code flexibility and testability by allowing any implementation that can provide block headers to be used with the ContractsRegistry.

