### PR TITLE
op-service: cleanup eth.ChainID type, remove uint32 index legacy, add sort method

### DIFF
--- a/op-service/eth/chain_id_test.go
+++ b/op-service/eth/chain_id_test.go
@@ -39,3 +39,25 @@ func TestChainID_String(t *testing.T) {
 		})
 	}
 }
+
+func TestSortChainIDs(t *testing.T) {
+	ids := []ChainID{
+		ChainIDFromUInt64(123),
+		ChainIDFromUInt64(16),
+		ChainIDFromBytes32([32]byte{0: 1}),
+		ChainIDFromUInt64(1),
+		ChainIDFromUInt64(2),
+		ChainIDFromUInt64(0xdeadbeef),
+	}
+	expected := []ChainID{
+		ChainIDFromUInt64(1),
+		ChainIDFromUInt64(2),
+		ChainIDFromUInt64(16),
+		ChainIDFromUInt64(123),
+		ChainIDFromUInt64(0xdeadbeef),
+		ChainIDFromBytes32([32]byte{0: 1}),
+	}
+	require.NotEqual(t, expected, ids)
+	SortChainID(ids)
+	require.Equal(t, expected, ids)
+}

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -2,6 +2,7 @@ package cross
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -195,12 +196,12 @@ func (m mockDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID
 }
 
 func (m mockDependencySet) ChainIndexFromID(chain eth.ChainID) (types.ChainIndex, error) {
-	v, err := chain.ToUInt32()
-	if err != nil {
-		return 0, err
+	v := chain.ToBig()
+	if v.BitLen() > 20 {
+		return 0, fmt.Errorf("chain ID is too large for mock dependency set: %s", chain)
 	}
-	// offset, so we catch improper manual conversion that doesn't apply this offset
-	return types.ChainIndex(v + 1000), nil
+	// offset, so we catch improper manual conversion that doesn't apply this arbitrary offset
+	return types.ChainIndex(v.Uint64() + 1000), nil
 }
 
 func (m mockDependencySet) Chains() []eth.ChainID {


### PR DESCRIPTION
**Description**

Just some quick cleanup of the chain ID type. Docs / sort method / methods for convenience.

**Tests**

Added test for the sorting

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
