### PR TITLE
op e2e: interop action test: same timestamp + invalid timestamp invariant

### DIFF
--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -278,12 +278,7 @@ func TestBreakTimestampInvariant(gt *testing.T) {
 	// BUT we intentionally break the timestamp invariant
 	require.Greater(t, includedA.Time, includedB.Time)
 
-	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
-	assertHeads(t, actors.ChainB, 2, 0, 0, 0)
-
-	blockToBeReorged, err := actors.ChainB.SequencerEngine.SourceClient(t, 10).BlockRefByLabel(t.Ctx(), "latest")
-	require.NoError(t, err)
-	require.Equal(t, uint64(2), blockToBeReorged.Number)
+	assertHeads(t, actors.ChainB, 1, 0, 0, 0)
 
 	actors.ChainB.Batcher.ActSubmitAll(t)
 	actors.L1Miner.ActL1StartBlock(12)(t)
@@ -299,16 +294,30 @@ func TestBreakTimestampInvariant(gt *testing.T) {
 	t.Log("awaiting node to sync")
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 
-	require.Equal(t, uint64(2), actors.ChainB.Sequencer.SyncStatus().LocalSafeL2.Number)
+	reorgedOutBlock := actors.ChainB.Sequencer.SyncStatus().LocalSafeL2
+	require.Equal(t, uint64(1), reorgedOutBlock.Number)
 
 	t.Log("Expecting supervisor to sync and catch local-safe dependency issue")
 	actors.ChainB.Sequencer.SyncSupervisor(t)
 	actors.Supervisor.ProcessFull(t)
 
-	assertHeads(t, actors.ChainB, 2, 2, 0, 0)
+	assertHeads(t, actors.ChainB, 1, 1, 0, 0)
 
 	// check supervisor head, expect it to be rewound
 	localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), localUnsafe.Number, "unsafe chain needs to be rewound")
+
+	// Make the op-node do the processing to build the replacement
+	t.Log("Expecting op-node to build replacement block")
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+
+	// Make sure the replaced block has different blockhash
+	replacedBlock := actors.ChainB.Sequencer.SyncStatus().LocalSafeL2
+	require.NotEqual(t, reorgedOutBlock.Hash, replacedBlock.Hash)
+
+	// but reached block number as 1
+	assertHeads(t, actors.ChainB, 1, 1, 1, 1)
 }

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -2,12 +2,16 @@ package interop
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -118,4 +122,193 @@ func TestTxPlanDeployEventLogger(gt *testing.T) {
 
 	// single block advanced
 	require.Equal(t, latestBlock.NumberU64()+1, includedBlock.Number)
+}
+
+func DefaultTxOpts(t helpers.Testing, user *userWithKeys, chain *dsl.Chain) txplan.Option {
+	sc := chain.SequencerEngine.SourceClient(t, 10)
+	getter := &receiptGetter{t: t, chain: chain, sc: sc}
+	submitter := &txSubmitter{t: t, chain: chain, from: user.address}
+	// txplan options for tx submission and ensuring block inclusion
+	return txplan.Combine(
+		txplan.WithPrivateKey(user.secret),
+		txplan.WithChainID(sc),
+		txplan.WithAgainstLatestBlock(sc),
+		txplan.WithPendingNonce(sc),
+		txplan.WithEstimator(sc, false),
+		txplan.WithTransactionSubmitter(submitter),
+		txplan.WithAssumedInclusion(getter),
+		txplan.WithBlockInclusionInfo(sc),
+	)
+}
+
+func DeployEventLogger(t helpers.Testing, opts txplan.Option) common.Address {
+	deployCalldata := common.FromHex(bindings.EventloggerBin)
+	deployTx := txplan.NewPlannedTx(opts, txplan.WithData(deployCalldata))
+	receipt, err := deployTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.NotNil(t, receipt.ContractAddress)
+	eventLoggerAddress := receipt.ContractAddress
+	return eventLoggerAddress
+}
+func TestInitAndExecMsg(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	rng := rand.New(rand.NewSource(1234))
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+	alice := setupUser(t, is, actors.ChainA, 0)
+	bob := setupUser(t, is, actors.ChainB, 0)
+
+	optsA := DefaultTxOpts(t, alice, actors.ChainA)
+	optsB := DefaultTxOpts(t, bob, actors.ChainB)
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+
+	// chain A progressed single unsafe block
+	eventLoggerAddress := DeployEventLogger(t, optsA)
+	// Also match chain B
+	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
+
+	// Intent to initiate message(or emit event) on chain A
+	txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsA)
+	randomInitTrigger := interop.RandomInitTrigger(rng, eventLoggerAddress, 3, 10)
+	txA.Content.Set(randomInitTrigger)
+
+	// Trigger single event
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	_, err := txA.PlannedTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
+
+	// Ingest the new unsafe-block event
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	// Verify as cross-unsafe with supervisor
+	actors.Supervisor.ProcessFull(t)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, actors.ChainA, 2, 0, 2, 0)
+	assertHeads(t, actors.ChainB, 1, 0, 0, 0)
+
+	// Ingest the new unsafe-block event
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	// Verify as cross-unsafe with supervisor
+	actors.Supervisor.ProcessFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, actors.ChainB, 1, 0, 1, 0)
+
+	// Intent to validate message on chain B
+	txB := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsB)
+	txB.Content.DependOn(&txA.Result)
+
+	// Single event in tx so index is 0
+	txB.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &txA.Result, 0))
+
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+	_, err = txB.PlannedTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	includedA, err := txA.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	includedB, err := txB.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// initating messages time <= executing message time
+	require.LessOrEqual(t, includedA.Time, includedB.Time)
+
+	assertHeads(t, actors.ChainB, 2, 0, 1, 0)
+
+	// Ingest the new unsafe-block event
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	// Verify as cross-unsafe with supervisor
+	actors.Supervisor.ProcessFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
+	assertHeads(t, actors.ChainB, 2, 0, 2, 0)
+}
+
+func TestBreakTimestampInvariant(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	rng := rand.New(rand.NewSource(1234))
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+
+	alice := setupUser(t, is, actors.ChainA, 0)
+	bob := setupUser(t, is, actors.ChainB, 0)
+
+	optsA := DefaultTxOpts(t, alice, actors.ChainA)
+	optsB := DefaultTxOpts(t, bob, actors.ChainB)
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	// chain A progressed single unsafe block
+	eventLoggerAddress := DeployEventLogger(t, optsA)
+
+	// Intent to initiate message(or emit event) on chain A
+	txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsA)
+	randomInitTrigger := interop.RandomInitTrigger(rng, eventLoggerAddress, 3, 10)
+	txA.Content.Set(randomInitTrigger)
+
+	// Trigger single event
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	_, err := txA.PlannedTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
+
+	// make supervisor know chainA's unsafe blocks
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+
+	// Intent to validate message on chain B
+	txB := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsB)
+	txB.Content.DependOn(&txA.Result)
+
+	// Single event in tx so index is 0
+	txB.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &txA.Result, 0))
+
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+	_, err = txB.PlannedTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, actors.ChainB, 1, 0, 0, 0)
+
+	includedA, err := txA.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	includedB, err := txB.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// initating messages time <= executing message time
+	// BUT we intentionally break the timestamp invariant
+	require.Greater(t, includedA.Time, includedB.Time)
+
+	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
+	assertHeads(t, actors.ChainB, 2, 0, 0, 0)
+
+	blockToBeReorged, err := actors.ChainB.SequencerEngine.SourceClient(t, 10).BlockRefByLabel(t.Ctx(), "latest")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), blockToBeReorged.Number)
+
+	actors.ChainB.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+
+	actors.Supervisor.SignalLatestL1(t)
+	t.Log("awaiting L1-exhaust event")
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	t.Log("awaiting supervisor to provide L1 data")
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+	t.Log("awaiting node to sync")
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
+	require.Equal(t, uint64(2), actors.ChainB.Sequencer.SyncStatus().LocalSafeL2.Number)
+
+	t.Log("Expecting supervisor to sync and catch local-safe dependency issue")
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+
+	assertHeads(t, actors.ChainB, 2, 2, 0, 0)
+
+	// check supervisor head, expect it to be rewound
+	localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), localUnsafe.Number, "unsafe chain needs to be rewound")
 }

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -150,6 +150,7 @@ func DeployEventLogger(t helpers.Testing, opts txplan.Option) common.Address {
 	eventLoggerAddress := receipt.ContractAddress
 	return eventLoggerAddress
 }
+
 func TestInitAndExecMsg(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -151,7 +151,7 @@ func DeployEventLogger(t helpers.Testing, opts txplan.Option) common.Address {
 	return eventLoggerAddress
 }
 
-func TestInitAndExecMsg(gt *testing.T) {
+func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))
 	is := dsl.SetupInterop(t)

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -213,7 +213,7 @@ func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	require.NoError(t, err)
 
 	// initating messages time <= executing message time
-	require.LessOrEqual(t, includedA.Time, includedB.Time)
+	require.Equal(t, includedA.Time, includedB.Time)
 
 	assertHeads(t, actors.ChainB, 2, 0, 1, 0)
 

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -178,7 +178,7 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 					})
 				}
 			} else {
-				return fmt.Errorf("executing message %s in %s breaks timestamp invariant", msg, candidate)
+				return fmt.Errorf("executing message %s in %s breaks timestamp invariant: %w", msg, candidate, types.ErrConflict)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds op-e2e interop action test using txintent. Checks that 

- [x] Transaction executes message within same block (same timestamp)
    -  `TestInitAndExecMsgSameTimestamp`
- [x] Execute message with timestamp > current timestamp
    - `TestBreakTimestampInvariant`

which are part of https://github.com/ethereum-optimism/optimism/issues/15092

**Additional context**

AFAIK when
- timestamp invariant broken txs are included in unsafe block...
- and they are batched and written to L1, becoming safe block...
- and they are detected by supervisor, supervisor asks the op-node to rewind.

To make this, when timestamp invariant fault is detected, we must bubble up `ErrConflict` to make below codeline to be triggered.

https://github.com/ethereum-optimism/optimism/blob/af091dcc2cae1bbe13206d78e633b0090f95b772/op-supervisor/supervisor/backend/cross/safe_update.go#L48-L52

Function trace:
- CrossSafeUpdate ->  scopedCrossSafeUpdate -> CrossSafeHazards -> NewHazardSet -> build -> `<invalid timestamp>` error thrown.
