### PR TITLE
feat: Simplify op-deployer scripts: DeployImplementations [5/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/implementations2.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2.go
@@ -51,15 +51,3 @@ type DeployImplementations2Script script.DeployScriptWithOutput[DeployImplementa
 func NewDeployImplementationsScript(host *script.Host) (DeployImplementations2Script, error) {
 	return script.NewDeployScriptWithOutputFromFile[DeployImplementations2Input, DeployImplementations2Output](host, "DeployImplementations2.s.sol", "DeployImplementations2")
 }
-
-// DeploySuperchain2 exists for backwards compatibility and migration period
-//
-// Eventually the script loading and validation should occur before any scripts are run to avoid errors being thrown in the middle of the deployment
-func DeployImplementations2(host *script.Host, input DeployImplementations2Input) (output DeployImplementations2Output, err error) {
-	script, err := NewDeployImplementationsScript(host)
-	if err != nil {
-		return output, err
-	}
-
-	return script.Run(input)
-}

--- a/op-deployer/pkg/deployer/opcm/implementations2.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2.go
@@ -1,0 +1,65 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployImplementations2Input struct {
+	WithdrawalDelaySeconds          *big.Int
+	MinProposalSizeBytes            *big.Int
+	ChallengePeriodSeconds          *big.Int
+	ProofMaturityDelaySeconds       *big.Int
+	DisputeGameFinalityDelaySeconds *big.Int
+	MipsVersion                     *big.Int
+	// Release version to set OPCM implementations for, of the format `op-contracts/vX.Y.Z`.
+	L1ContractsRelease    string
+	SuperchainConfigProxy common.Address
+	ProtocolVersionsProxy common.Address
+	SuperchainProxyAdmin  common.Address
+	UpgradeController     common.Address
+}
+
+type DeployImplementations2Output struct {
+	Opcm                             common.Address `json:"opcmAddress"`
+	OpcmContractsContainer           common.Address `json:"opcmContractsContainerAddress"`
+	OpcmGameTypeAdder                common.Address `json:"opcmGameTypeAdderAddress"`
+	OpcmDeployer                     common.Address `json:"opcmDeployerAddress"`
+	OpcmUpgrader                     common.Address `json:"opcmUpgraderAddress"`
+	OpcmInteropMigrator              common.Address `json:"opcmInteropMigratorAddress"`
+	DelayedWETHImpl                  common.Address `json:"delayedWETHImplAddress"`
+	OptimismPortalImpl               common.Address `json:"optimismPortalImplAddress"`
+	ETHLockboxImpl                   common.Address `json:"ethLockboxImplAddress" abi:"ethLockboxImpl"`
+	PreimageOracleSingleton          common.Address `json:"preimageOracleSingletonAddress"`
+	MipsSingleton                    common.Address `json:"mipsSingletonAddress"`
+	SystemConfigImpl                 common.Address `json:"systemConfigImplAddress"`
+	L1CrossDomainMessengerImpl       common.Address `json:"l1CrossDomainMessengerImplAddress"`
+	L1ERC721BridgeImpl               common.Address `json:"l1ERC721BridgeImplAddress"`
+	L1StandardBridgeImpl             common.Address `json:"l1StandardBridgeImplAddress"`
+	OptimismMintableERC20FactoryImpl common.Address `json:"optimismMintableERC20FactoryImplAddress"`
+	DisputeGameFactoryImpl           common.Address `json:"disputeGameFactoryImplAddress"`
+	AnchorStateRegistryImpl          common.Address `json:"anchorStateRegistryImplAddress"`
+	SuperchainConfigImpl             common.Address `json:"superchainConfigImplAddress"`
+	ProtocolVersionsImpl             common.Address `json:"protocolVersionsImplAddress"`
+}
+
+type DeployImplementations2Script script.DeployScriptWithOutput[DeployImplementations2Input, DeployImplementations2Output]
+
+// NewDeploySuperchainScript loads and validates the DeploySuperchain2 script contract
+func NewDeployImplementationsScript(host *script.Host) (DeployImplementations2Script, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployImplementations2Input, DeployImplementations2Output](host, "DeployImplementations2.s.sol", "DeployImplementations2")
+}
+
+// DeploySuperchain2 exists for backwards compatibility and migration period
+//
+// Eventually the script loading and validation should occur before any scripts are run to avoid errors being thrown in the middle of the deployment
+func DeployImplementations2(host *script.Host, input DeployImplementations2Input) (output DeployImplementations2Output, err error) {
+	script, err := NewDeployImplementationsScript(host)
+	if err != nil {
+		return output, err
+	}
+
+	return script.Run(input)
+}

--- a/op-deployer/pkg/deployer/opcm/implementations2.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2.go
@@ -47,7 +47,7 @@ type DeployImplementations2Output struct {
 
 type DeployImplementations2Script script.DeployScriptWithOutput[DeployImplementations2Input, DeployImplementations2Output]
 
-// NewDeploySuperchainScript loads and validates the DeploySuperchain2 script contract
+// NewDeployImplementationsScript loads and validates the DeploySuperchain2 script contract
 func NewDeployImplementationsScript(host *script.Host) (DeployImplementations2Script, error) {
 	return script.NewDeployScriptWithOutputFromFile[DeployImplementations2Input, DeployImplementations2Output](host, "DeployImplementations2.s.sol", "DeployImplementations2")
 }

--- a/op-deployer/pkg/deployer/opcm/implementations2_test.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeployImplementations2(t *testing.T) {
+func TestNewDeployImplementationsScript(t *testing.T) {
 	deployDependencies := func(host *script.Host) (proxyAdminAddress common.Address, proxyAddress common.Address, protocolVersionsAddress common.Address) {
 		proxyAdminArtifact, err := host.Artifacts().ReadArtifact("ProxyAdmin.sol", "ProxyAdmin")
 		require.NoError(t, err)

--- a/op-deployer/pkg/deployer/opcm/implementations2_test.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
@@ -11,20 +12,14 @@ import (
 )
 
 func TestDeployImplementations2(t *testing.T) {
-	t.Run("should not fail with current version of DeployImplementations2 contract", func(t *testing.T) {
-		// First we grab a test host
-		host := createTestHost(t)
-
-		// Get some artifacts going
-
-		// First we get the proxy admin deployed
+	deployDependencies := func(host *script.Host) (proxyAdminAddress common.Address, proxyAddress common.Address, protocolVersionsAddress common.Address) {
 		proxyAdminArtifact, err := host.Artifacts().ReadArtifact("ProxyAdmin.sol", "ProxyAdmin")
 		require.NoError(t, err)
 
 		encodedProxyAdmin, err := proxyAdminArtifact.ABI.Pack("", addresses.ScriptDeployer)
 		require.NoError(t, err)
 
-		proxyAdminAddress, err := host.Create(addresses.ScriptDeployer, append(proxyAdminArtifact.Bytecode.Object, encodedProxyAdmin...))
+		proxyAdminAddress, err = host.Create(addresses.ScriptDeployer, append(proxyAdminArtifact.Bytecode.Object, encodedProxyAdmin...))
 		require.NoError(t, err)
 
 		// Then we get a proxy deployed
@@ -34,7 +29,7 @@ func TestDeployImplementations2(t *testing.T) {
 		encodedProxy, err := proxyArtifact.ABI.Pack("", proxyAdminAddress)
 		require.NoError(t, err)
 
-		proxyAddress, err := host.Create(addresses.ScriptDeployer, append(proxyArtifact.Bytecode.Object, encodedProxy...))
+		proxyAddress, err = host.Create(addresses.ScriptDeployer, append(proxyArtifact.Bytecode.Object, encodedProxy...))
 		require.NoError(t, err)
 
 		// Then we get ProtocolVersions deployed
@@ -44,11 +39,24 @@ func TestDeployImplementations2(t *testing.T) {
 		encodedProtocolVersions, err := protocolVersionsArtifact.ABI.Pack("")
 		require.NoError(t, err)
 
-		protocolVersionsAddress, err := host.Create(addresses.ScriptDeployer, append(protocolVersionsArtifact.Bytecode.Object, encodedProtocolVersions...))
+		protocolVersionsAddress, err = host.Create(addresses.ScriptDeployer, append(protocolVersionsArtifact.Bytecode.Object, encodedProtocolVersions...))
 		require.NoError(t, err)
 
-		// Then we run the deploy script
-		output, err := opcm.DeployImplementations2(host, opcm.DeployImplementations2Input{
+		return proxyAdminAddress, proxyAddress, protocolVersionsAddress
+	}
+
+	t.Run("should not fail with current version of DeployImplementations2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// We'll need some contracts already deployed for this to work
+		proxyAdminAddress, proxyAddress, protocolVersionsAddress := deployDependencies(host1)
+
+		deployImplementations, err := opcm.NewDeployImplementationsScript(host1)
+		require.NoError(t, err)
+
+		// Now we run the deploy script
+		output, err := deployImplementations.Run(opcm.DeployImplementations2Input{
 			WithdrawalDelaySeconds:          big.NewInt(1),
 			MinProposalSizeBytes:            big.NewInt(2),
 			ChallengePeriodSeconds:          big.NewInt(3),
@@ -66,5 +74,77 @@ func TestDeployImplementations2(t *testing.T) {
 		// And do some simple asserts
 		require.NoError(t, err)
 		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+
+		// We'll need some contracts already deployed for this to work
+		proxyAdminAddress, proxyAddress, protocolVersionsAddress = deployDependencies(host2)
+
+		deprecatedOutput, err := opcm.DeployImplementations(host2, opcm.DeployImplementationsInput{
+			WithdrawalDelaySeconds:          big.NewInt(1),
+			MinProposalSizeBytes:            big.NewInt(2),
+			ChallengePeriodSeconds:          big.NewInt(3),
+			ProofMaturityDelaySeconds:       big.NewInt(4),
+			DisputeGameFinalityDelaySeconds: big.NewInt(5),
+			MipsVersion:                     big.NewInt(1),
+			// Release version to set OPCM implementations for, of the format `op-contracts/vX.Y.Z`.
+			L1ContractsRelease:    "dev-release",
+			SuperchainConfigProxy: proxyAddress,
+			ProtocolVersionsProxy: protocolVersionsAddress,
+			SuperchainProxyAdmin:  proxyAdminAddress,
+			UpgradeController:     common.BigToAddress(big.NewInt(13)),
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.AnchorStateRegistryImpl, output.AnchorStateRegistryImpl)
+		require.Equal(t, deprecatedOutput.DelayedWETHImpl, output.DelayedWETHImpl)
+		require.Equal(t, deprecatedOutput.DisputeGameFactoryImpl, output.DisputeGameFactoryImpl)
+		require.Equal(t, deprecatedOutput.ETHLockboxImpl, output.ETHLockboxImpl)
+		require.Equal(t, deprecatedOutput.L1CrossDomainMessengerImpl, output.L1CrossDomainMessengerImpl)
+		require.Equal(t, deprecatedOutput.L1ERC721BridgeImpl, output.L1ERC721BridgeImpl)
+		require.Equal(t, deprecatedOutput.L1StandardBridgeImpl, output.L1StandardBridgeImpl)
+		require.Equal(t, deprecatedOutput.MipsSingleton, output.MipsSingleton)
+		require.Equal(t, deprecatedOutput.Opcm, output.Opcm)
+		require.Equal(t, deprecatedOutput.OpcmContractsContainer, output.OpcmContractsContainer)
+		require.Equal(t, deprecatedOutput.OpcmDeployer, output.OpcmDeployer)
+		require.Equal(t, deprecatedOutput.OpcmGameTypeAdder, output.OpcmGameTypeAdder)
+		require.Equal(t, deprecatedOutput.OpcmInteropMigrator, output.OpcmInteropMigrator)
+		require.Equal(t, deprecatedOutput.OpcmUpgrader, output.OpcmUpgrader)
+		require.Equal(t, deprecatedOutput.OptimismMintableERC20FactoryImpl, output.OptimismMintableERC20FactoryImpl)
+		require.Equal(t, deprecatedOutput.OptimismPortalImpl, output.OptimismPortalImpl)
+		require.Equal(t, deprecatedOutput.PreimageOracleSingleton, output.PreimageOracleSingleton)
+		require.Equal(t, deprecatedOutput.ProtocolVersionsImpl, output.ProtocolVersionsImpl)
+		require.Equal(t, deprecatedOutput.SuperchainConfigImpl, output.SuperchainConfigImpl)
+		require.Equal(t, deprecatedOutput.SystemConfigImpl, output.SystemConfigImpl)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.AnchorStateRegistryImpl), host1.GetCode(output.AnchorStateRegistryImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.DelayedWETHImpl), host1.GetCode(output.DelayedWETHImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.DisputeGameFactoryImpl), host1.GetCode(output.DisputeGameFactoryImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.ETHLockboxImpl), host1.GetCode(output.ETHLockboxImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.L1CrossDomainMessengerImpl), host1.GetCode(output.L1CrossDomainMessengerImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.L1ERC721BridgeImpl), host1.GetCode(output.L1ERC721BridgeImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.L1StandardBridgeImpl), host1.GetCode(output.L1StandardBridgeImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.MipsSingleton), host1.GetCode(output.MipsSingleton))
+		require.Equal(t, host2.GetCode(deprecatedOutput.Opcm), host1.GetCode(output.Opcm))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OpcmContractsContainer), host1.GetCode(output.OpcmContractsContainer))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OpcmDeployer), host1.GetCode(output.OpcmDeployer))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OpcmGameTypeAdder), host1.GetCode(output.OpcmGameTypeAdder))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OpcmInteropMigrator), host1.GetCode(output.OpcmInteropMigrator))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OpcmUpgrader), host1.GetCode(output.OpcmUpgrader))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OptimismMintableERC20FactoryImpl), host1.GetCode(output.OptimismMintableERC20FactoryImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OptimismPortalImpl), host1.GetCode(output.OptimismPortalImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.PreimageOracleSingleton), host1.GetCode(output.PreimageOracleSingleton))
+		require.Equal(t, host2.GetCode(deprecatedOutput.ProtocolVersionsImpl), host1.GetCode(output.ProtocolVersionsImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.SuperchainConfigImpl), host1.GetCode(output.SuperchainConfigImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.SystemConfigImpl), host1.GetCode(output.SystemConfigImpl))
 	})
 }

--- a/op-deployer/pkg/deployer/opcm/implementations2_test.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2_test.go
@@ -1,0 +1,70 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployImplementations2(t *testing.T) {
+	t.Run("should not fail with current version of DeployImplementations2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host := createTestHost(t)
+
+		// Get some artifacts going
+
+		// First we get the proxy admin deployed
+		proxyAdminArtifact, err := host.Artifacts().ReadArtifact("ProxyAdmin.sol", "ProxyAdmin")
+		require.NoError(t, err)
+
+		encodedProxyAdmin, err := proxyAdminArtifact.ABI.Pack("", addresses.ScriptDeployer)
+		require.NoError(t, err)
+
+		proxyAdminAddress, err := host.Create(addresses.ScriptDeployer, append(proxyAdminArtifact.Bytecode.Object, encodedProxyAdmin...))
+		require.NoError(t, err)
+
+		// Then we get a proxy deployed
+		proxyArtifact, err := host.Artifacts().ReadArtifact("Proxy.sol", "Proxy")
+		require.NoError(t, err)
+
+		encodedProxy, err := proxyArtifact.ABI.Pack("", proxyAdminAddress)
+		require.NoError(t, err)
+
+		proxyAddress, err := host.Create(addresses.ScriptDeployer, append(proxyArtifact.Bytecode.Object, encodedProxy...))
+		require.NoError(t, err)
+
+		// Then we get ProtocolVersions deployed
+		protocolVersionsArtifact, err := host.Artifacts().ReadArtifact("ProtocolVersions.sol", "ProtocolVersions")
+		require.NoError(t, err)
+
+		encodedProtocolVersions, err := protocolVersionsArtifact.ABI.Pack("")
+		require.NoError(t, err)
+
+		protocolVersionsAddress, err := host.Create(addresses.ScriptDeployer, append(protocolVersionsArtifact.Bytecode.Object, encodedProtocolVersions...))
+		require.NoError(t, err)
+
+		// Then we run the deploy script
+		output, err := opcm.DeployImplementations2(host, opcm.DeployImplementations2Input{
+			WithdrawalDelaySeconds:          big.NewInt(1),
+			MinProposalSizeBytes:            big.NewInt(2),
+			ChallengePeriodSeconds:          big.NewInt(3),
+			ProofMaturityDelaySeconds:       big.NewInt(4),
+			DisputeGameFinalityDelaySeconds: big.NewInt(5),
+			MipsVersion:                     big.NewInt(1),
+			// Release version to set OPCM implementations for, of the format `op-contracts/vX.Y.Z`.
+			L1ContractsRelease:    "dev-release",
+			SuperchainConfigProxy: proxyAddress,
+			ProtocolVersionsProxy: protocolVersionsAddress,
+			SuperchainProxyAdmin:  proxyAdminAddress,
+			UpgradeController:     common.BigToAddress(big.NewInt(13)),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations2.s.sol
@@ -1,0 +1,741 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+// Libraries
+import { Chains } from "scripts/libraries/Chains.sol";
+import { LibString } from "@solady/utils/LibString.sol";
+
+// Interfaces
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { IMIPS } from "interfaces/cannon/IMIPS.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import {
+    IOPContractsManager,
+    IOPContractsManagerGameTypeAdder,
+    IOPContractsManagerDeployer,
+    IOPContractsManagerUpgrader,
+    IOPContractsManagerContractsContainer,
+    IOPContractsManagerInteropMigrator
+} from "interfaces/L1/IOPContractsManager.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+
+contract DeployImplementations2 is Script {
+    struct Input {
+        uint256 withdrawalDelaySeconds;
+        uint256 minProposalSizeBytes;
+        uint256 challengePeriodSeconds;
+        uint256 proofMaturityDelaySeconds;
+        uint256 disputeGameFinalityDelaySeconds;
+        uint256 mipsVersion;
+        // This is used in opcm to signal which version of the L1 smart contracts is deployed.
+        // It takes the format of `op-contracts/v*.*.*`.
+        string l1ContractsRelease;
+        // Outputs from DeploySuperchain.s.sol.
+        ISuperchainConfig superchainConfigProxy;
+        IProtocolVersions protocolVersionsProxy;
+        IProxyAdmin superchainProxyAdmin;
+        address upgradeController;
+    }
+
+    struct Output {
+        IOPContractsManager opcm;
+        IOPContractsManagerContractsContainer opcmContractsContainer;
+        IOPContractsManagerGameTypeAdder opcmGameTypeAdder;
+        IOPContractsManagerDeployer opcmDeployer;
+        IOPContractsManagerUpgrader opcmUpgrader;
+        IOPContractsManagerInteropMigrator opcmInteropMigrator;
+        IDelayedWETH delayedWETHImpl;
+        IOptimismPortal optimismPortalImpl;
+        IETHLockbox ethLockboxImpl;
+        IPreimageOracle preimageOracleSingleton;
+        IMIPS mipsSingleton;
+        ISystemConfig systemConfigImpl;
+        IL1CrossDomainMessenger l1CrossDomainMessengerImpl;
+        IL1ERC721Bridge l1ERC721BridgeImpl;
+        IL1StandardBridge l1StandardBridgeImpl;
+        IOptimismMintableERC20Factory optimismMintableERC20FactoryImpl;
+        IDisputeGameFactory disputeGameFactoryImpl;
+        IAnchorStateRegistry anchorStateRegistryImpl;
+        ISuperchainConfig superchainConfigImpl;
+        IProtocolVersions protocolVersionsImpl;
+    }
+
+    bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
+
+    // -------- Core Deployment Methods --------
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        // Deploy the implementations.
+        deploySuperchainConfigImpl(output_);
+        deployProtocolVersionsImpl(output_);
+        deploySystemConfigImpl(output_);
+        deployL1CrossDomainMessengerImpl(output_);
+        deployL1ERC721BridgeImpl(output_);
+        deployL1StandardBridgeImpl(output_);
+        deployOptimismMintableERC20FactoryImpl(output_);
+        deployOptimismPortalImpl(_input, output_);
+        deployETHLockboxImpl(output_);
+        deployDelayedWETHImpl(_input, output_);
+        deployPreimageOracleSingleton(_input, output_);
+        deployMipsSingleton(_input, output_);
+        deployDisputeGameFactoryImpl(output_);
+        deployAnchorStateRegistryImpl(_input, output_);
+
+        // Deploy the OP Contracts Manager with the new implementations set.
+        deployOPContractsManager(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    // -------- Deployment Steps --------
+
+    // --- OP Contracts Manager ---
+
+    function createOPCMContract(
+        Input memory _input,
+        Output memory _output,
+        IOPContractsManager.Blueprints memory _blueprints,
+        string memory _l1ContractsRelease
+    )
+        private
+        returns (IOPContractsManager opcm_)
+    {
+        IOPContractsManager.Implementations memory implementations = IOPContractsManager.Implementations({
+            superchainConfigImpl: address(_output.superchainConfigImpl),
+            protocolVersionsImpl: address(_output.protocolVersionsImpl),
+            l1ERC721BridgeImpl: address(_output.l1ERC721BridgeImpl),
+            optimismPortalImpl: address(_output.optimismPortalImpl),
+            ethLockboxImpl: address(_output.ethLockboxImpl),
+            systemConfigImpl: address(_output.systemConfigImpl),
+            optimismMintableERC20FactoryImpl: address(_output.optimismMintableERC20FactoryImpl),
+            l1CrossDomainMessengerImpl: address(_output.l1CrossDomainMessengerImpl),
+            l1StandardBridgeImpl: address(_output.l1StandardBridgeImpl),
+            disputeGameFactoryImpl: address(_output.disputeGameFactoryImpl),
+            anchorStateRegistryImpl: address(_output.anchorStateRegistryImpl),
+            delayedWETHImpl: address(_output.delayedWETHImpl),
+            mipsImpl: address(_output.mipsSingleton)
+        });
+
+        deployOPCMBPImplsContainer(_output, _blueprints, implementations);
+        deployOPCMGameTypeAdder(_output);
+        deployOPCMDeployer(_input, _output);
+        deployOPCMUpgrader(_output);
+        deployOPCMInteropMigrator(_output);
+
+        // Semgrep rule will fail because the arguments are encoded inside of a separate function.
+        opcm_ = IOPContractsManager(
+            // nosemgrep: sol-safety-deployutils-args
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager",
+                _args: encodeOPCMConstructor(_l1ContractsRelease, _input, _output),
+                _salt: _salt
+            })
+        );
+
+        vm.label(address(opcm_), "OPContractsManager");
+        _output.opcm = opcm_;
+    }
+
+    /// @notice Encodes the constructor of the OPContractsManager contract. Used to avoid stack too
+    ///         deep errors inside of the createOPCMContract function.
+    /// @param _l1ContractsRelease The release of the L1 contracts.
+    /// @param _input The deployment input parameters.
+    /// @param _output The deployment output parameters.
+    /// @return encoded_ The encoded constructor.
+    function encodeOPCMConstructor(
+        string memory _l1ContractsRelease,
+        Input memory _input,
+        Output memory _output
+    )
+        private
+        pure
+        returns (bytes memory encoded_)
+    {
+        encoded_ = DeployUtils.encodeConstructor(
+            abi.encodeCall(
+                IOPContractsManager.__constructor__,
+                (
+                    _output.opcmGameTypeAdder,
+                    _output.opcmDeployer,
+                    _output.opcmUpgrader,
+                    _output.opcmInteropMigrator,
+                    _input.superchainConfigProxy,
+                    _input.protocolVersionsProxy,
+                    _input.superchainProxyAdmin,
+                    _l1ContractsRelease,
+                    _input.upgradeController
+                )
+            )
+        );
+    }
+
+    function deployOPContractsManager(Input memory _input, Output memory _output) private {
+        string memory l1ContractsRelease = _input.l1ContractsRelease;
+
+        // First we deploy the blueprints for the singletons deployed by OPCM.
+        // forgefmt: disable-start
+        IOPContractsManager.Blueprints memory blueprints;
+        vm.startBroadcast(msg.sender);
+        address checkAddress;
+        (blueprints.addressManager, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("AddressManager"), _salt);
+        require(checkAddress == address(0), "OPCM-10");
+        (blueprints.proxy, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("Proxy"), _salt);
+        require(checkAddress == address(0), "OPCM-20");
+        (blueprints.proxyAdmin, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("ProxyAdmin"), _salt);
+        require(checkAddress == address(0), "OPCM-30");
+        (blueprints.l1ChugSplashProxy, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("L1ChugSplashProxy"), _salt);
+        require(checkAddress == address(0), "OPCM-40");
+        (blueprints.resolvedDelegateProxy, checkAddress) = DeployUtils.createDeterministicBlueprint(vm.getCode("ResolvedDelegateProxy"), _salt);
+        require(checkAddress == address(0), "OPCM-50");
+        // The max initcode/runtimecode size is 48KB/24KB.
+        // But for Blueprint, the initcode is stored as runtime code, that's why it's necessary to split into 2 parts.
+        (blueprints.permissionedDisputeGame1, blueprints.permissionedDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("PermissionedDisputeGame"), _salt);
+        (blueprints.permissionlessDisputeGame1, blueprints.permissionlessDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("FaultDisputeGame"), _salt);
+        (blueprints.superPermissionedDisputeGame1, blueprints.superPermissionedDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("SuperPermissionedDisputeGame"), _salt);
+        (blueprints.superPermissionlessDisputeGame1, blueprints.superPermissionlessDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("SuperFaultDisputeGame"), _salt);
+        // forgefmt: disable-end
+        vm.stopBroadcast();
+
+        IOPContractsManager opcm = createOPCMContract(_input, _output, blueprints, l1ContractsRelease);
+
+        vm.label(address(opcm), "OPContractsManager");
+        _output.opcm = opcm;
+    }
+
+    // --- Core Contracts ---
+
+    function deploySuperchainConfigImpl(Output memory _output) private {
+        ISuperchainConfig impl = ISuperchainConfig(
+            DeployUtils.createDeterministic({
+                _name: "SuperchainConfig",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISuperchainConfig.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "SuperchainConfigImpl");
+        _output.superchainConfigImpl = impl;
+    }
+
+    function deployProtocolVersionsImpl(Output memory _output) private {
+        IProtocolVersions impl = IProtocolVersions(
+            DeployUtils.createDeterministic({
+                _name: "ProtocolVersions",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProtocolVersions.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "ProtocolVersionsImpl");
+        _output.protocolVersionsImpl = impl;
+    }
+
+    function deploySystemConfigImpl(Output memory _output) private {
+        ISystemConfig impl = ISystemConfig(
+            DeployUtils.createDeterministic({
+                _name: "SystemConfig",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(ISystemConfig.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "SystemConfigImpl");
+        _output.systemConfigImpl = impl;
+    }
+
+    function deployL1CrossDomainMessengerImpl(Output memory _output) private {
+        IL1CrossDomainMessenger impl = IL1CrossDomainMessenger(
+            DeployUtils.createDeterministic({
+                _name: "L1CrossDomainMessenger",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1CrossDomainMessenger.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "L1CrossDomainMessengerImpl");
+        _output.l1CrossDomainMessengerImpl = impl;
+    }
+
+    function deployL1ERC721BridgeImpl(Output memory _output) private {
+        IL1ERC721Bridge impl = IL1ERC721Bridge(
+            DeployUtils.createDeterministic({
+                _name: "L1ERC721Bridge",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1ERC721Bridge.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "L1ERC721BridgeImpl");
+        _output.l1ERC721BridgeImpl = impl;
+    }
+
+    function deployL1StandardBridgeImpl(Output memory _output) private {
+        IL1StandardBridge impl = IL1StandardBridge(
+            DeployUtils.createDeterministic({
+                _name: "L1StandardBridge",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IL1StandardBridge.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "L1StandardBridgeImpl");
+        _output.l1StandardBridgeImpl = impl;
+    }
+
+    function deployOptimismMintableERC20FactoryImpl(Output memory _output) private {
+        IOptimismMintableERC20Factory impl = IOptimismMintableERC20Factory(
+            DeployUtils.createDeterministic({
+                _name: "OptimismMintableERC20Factory",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IOptimismMintableERC20Factory.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OptimismMintableERC20FactoryImpl");
+        _output.optimismMintableERC20FactoryImpl = impl;
+    }
+
+    function deployETHLockboxImpl(Output memory _output) private {
+        IETHLockbox impl = IETHLockbox(
+            DeployUtils.createDeterministic({
+                _name: "ETHLockbox",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IETHLockbox.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "ETHLockboxImpl");
+        _output.ethLockboxImpl = impl;
+    }
+
+    // --- Fault Proofs Contracts ---
+
+    // The fault proofs contracts are configured as follows:
+    // | Contract                | Proxied | Deployment                        | MCP Ready  |
+    // |-------------------------|---------|-----------------------------------|------------|
+    // | DisputeGameFactory      | Yes     | Bespoke                           | Yes        |
+    // | AnchorStateRegistry     | Yes     | Bespoke                           | Yes         |
+    // | FaultDisputeGame        | No      | Bespoke                           | No         | Not yet supported by OPCM
+    // | PermissionedDisputeGame | No      | Bespoke                           | No         |
+    // | DelayedWETH             | Yes     | Two bespoke (one per DisputeGame) | Yes *️⃣     |
+    // | PreimageOracle          | No      | Shared                            | N/A        |
+    // | MIPS                    | No      | Shared                            | N/A        |
+    // | OptimismPortal2         | Yes     | Shared                            | Yes *️⃣     |
+    //
+    // - *️⃣ These contracts have immutable values which are intended to be constant for all contracts within a
+    //   Superchain, and are therefore MCP ready for any chain using the Standard Configuration.
+    //
+    // This script only deploys the shared contracts. The bespoke contracts are deployed by
+    // `DeployOPChain.s.sol`. When the shared contracts are proxied, the contracts deployed here are
+    // "implementations", and when shared contracts are not proxied, they are "singletons". So
+    // here we deploy:
+    //
+    //   - DisputeGameFactory (implementation)
+    //   - AnchorStateRegistry (implementation)
+    //   - OptimismPortal2 (implementation)
+    //   - DelayedWETH (implementation)
+    //   - PreimageOracle (singleton)
+    //   - MIPS (singleton)
+    //
+    // For contracts which are not MCP ready neither the Proxy nor the implementation can be shared, therefore they
+    // are deployed by `DeployOpChain.s.sol`.
+    // These are:
+    // - FaultDisputeGame (not proxied)
+    // - PermissionedDisputeGame (not proxied)
+    // - DelayedWeth (proxies only)
+    // - OptimismPortal2 (proxies only)
+
+    function deployOptimismPortalImpl(Input memory _input, Output memory _output) private {
+        uint256 proofMaturityDelaySeconds = _input.proofMaturityDelaySeconds;
+        IOptimismPortal impl = IOptimismPortal(
+            DeployUtils.createDeterministic({
+                _name: "OptimismPortal2",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOptimismPortal.__constructor__, (proofMaturityDelaySeconds))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OptimismPortalImpl");
+        _output.optimismPortalImpl = impl;
+    }
+
+    function deployDelayedWETHImpl(Input memory _input, Output memory _output) private {
+        uint256 withdrawalDelaySeconds = _input.withdrawalDelaySeconds;
+        IDelayedWETH impl = IDelayedWETH(
+            DeployUtils.createDeterministic({
+                _name: "DelayedWETH",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IDelayedWETH.__constructor__, (withdrawalDelaySeconds))),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "DelayedWETHImpl");
+        _output.delayedWETHImpl = impl;
+    }
+
+    function deployPreimageOracleSingleton(Input memory _input, Output memory _output) private {
+        uint256 minProposalSizeBytes = _input.minProposalSizeBytes;
+        uint256 challengePeriodSeconds = _input.challengePeriodSeconds;
+        IPreimageOracle singleton = IPreimageOracle(
+            DeployUtils.createDeterministic({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IPreimageOracle.__constructor__, (minProposalSizeBytes, challengePeriodSeconds))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(singleton), "PreimageOracleSingleton");
+        _output.preimageOracleSingleton = singleton;
+    }
+
+    function deployMipsSingleton(Input memory _input, Output memory _output) private {
+        uint256 mipsVersion = _input.mipsVersion;
+        IPreimageOracle preimageOracle = IPreimageOracle(address(_output.preimageOracleSingleton));
+
+        // We want to ensure that the OPCM for upgrade 13 is deployed with Mips32 on production networks.
+        if (mipsVersion != 2) {
+            if (block.chainid == Chains.Mainnet || block.chainid == Chains.Sepolia) {
+                revert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
+            }
+        }
+
+        IMIPS singleton = IMIPS(
+            DeployUtils.createDeterministic({
+                _name: mipsVersion == 1 ? "MIPS" : "MIPS64",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS.__constructor__, (preimageOracle))),
+                _salt: _salt
+            })
+        );
+        vm.label(address(singleton), "MIPSSingleton");
+        _output.mipsSingleton = singleton;
+    }
+
+    function deployDisputeGameFactoryImpl(Output memory _output) private {
+        IDisputeGameFactory impl = IDisputeGameFactory(
+            DeployUtils.createDeterministic({
+                _name: "DisputeGameFactory",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IDisputeGameFactory.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "DisputeGameFactoryImpl");
+        _output.disputeGameFactoryImpl = impl;
+    }
+
+    function deployAnchorStateRegistryImpl(Input memory _input, Output memory _output) private {
+        uint256 disputeGameFinalityDelaySeconds = _input.disputeGameFinalityDelaySeconds;
+        IAnchorStateRegistry impl = IAnchorStateRegistry(
+            DeployUtils.createDeterministic({
+                _name: "AnchorStateRegistry",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IAnchorStateRegistry.__constructor__, (disputeGameFinalityDelaySeconds))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "AnchorStateRegistryImpl");
+        _output.anchorStateRegistryImpl = impl;
+    }
+
+    function deployOPCMBPImplsContainer(
+        Output memory _output,
+        IOPContractsManager.Blueprints memory _blueprints,
+        IOPContractsManager.Implementations memory _implementations
+    )
+        private
+    {
+        IOPContractsManagerContractsContainer impl = IOPContractsManagerContractsContainer(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager.sol:OPContractsManagerContractsContainer",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOPContractsManagerContractsContainer.__constructor__, (_blueprints, _implementations))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OPContractsManagerBPImplsContainerImpl");
+        _output.opcmContractsContainer = impl;
+    }
+
+    function deployOPCMGameTypeAdder(Output memory _output) private {
+        IOPContractsManagerGameTypeAdder impl = IOPContractsManagerGameTypeAdder(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager.sol:OPContractsManagerGameTypeAdder",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOPContractsManagerGameTypeAdder.__constructor__, (_output.opcmContractsContainer))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OPContractsManagerGameTypeAdderImpl");
+        _output.opcmGameTypeAdder = impl;
+    }
+
+    function deployOPCMDeployer(Input memory, Output memory _output) private {
+        IOPContractsManagerDeployer impl = IOPContractsManagerDeployer(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager.sol:OPContractsManagerDeployer",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOPContractsManagerDeployer.__constructor__, (_output.opcmContractsContainer))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OPContractsManagerDeployerImpl");
+        _output.opcmDeployer = impl;
+    }
+
+    function deployOPCMUpgrader(Output memory _output) private {
+        IOPContractsManagerUpgrader impl = IOPContractsManagerUpgrader(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager.sol:OPContractsManagerUpgrader",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOPContractsManagerUpgrader.__constructor__, (_output.opcmContractsContainer))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OPContractsManagerUpgraderImpl");
+        _output.opcmUpgrader = impl;
+    }
+
+    function deployOPCMInteropMigrator(Output memory _output) private {
+        IOPContractsManagerInteropMigrator impl = IOPContractsManagerInteropMigrator(
+            DeployUtils.createDeterministic({
+                _name: "OPContractsManager.sol:OPContractsManagerInteropMigrator",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IOPContractsManagerInteropMigrator.__constructor__, (_output.opcmContractsContainer))
+                ),
+                _salt: _salt
+            })
+        );
+        vm.label(address(impl), "OPContractsManagerInteropMigratorImpl");
+        _output.opcmInteropMigrator = impl;
+    }
+
+    function assertValidInput(Input memory _input) private pure {
+        require(_input.withdrawalDelaySeconds != 0, "DeployImplementations: withdrawalDelaySeconds not set");
+        require(_input.minProposalSizeBytes != 0, "DeployImplementations: minProposalSizeBytes not set");
+        require(_input.challengePeriodSeconds != 0, "DeployImplementations: challengePeriodSeconds not set");
+        require(
+            _input.challengePeriodSeconds <= type(uint64).max, "DeployImplementations: challengePeriodSeconds too large"
+        );
+        require(_input.proofMaturityDelaySeconds != 0, "DeployImplementations: proofMaturityDelaySeconds not set");
+        require(
+            _input.disputeGameFinalityDelaySeconds != 0,
+            "DeployImplementations: disputeGameFinalityDelaySeconds not set"
+        );
+        require(_input.mipsVersion != 0, "DeployImplementations: mipsVersion not set");
+        require(!LibString.eq(_input.l1ContractsRelease, ""), "DeployImplementations: l1ContractsRelease not set");
+        require(
+            address(_input.superchainConfigProxy) != address(0), "DeployImplementations: superchainConfigProxy not set"
+        );
+        require(
+            address(_input.protocolVersionsProxy) != address(0), "DeployImplementations: protocolVersionsProxy not set"
+        );
+        require(
+            address(_input.superchainProxyAdmin) != address(0), "DeployImplementations: superchainProxyAdmin not set"
+        );
+        require(address(_input.upgradeController) != address(0), "DeployImplementations: upgradeController not set");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) private view {
+        // With 12 addresses, we'd get a stack too deep error if we tried to do this inline as a
+        // single call to `Solarray.addresses`. So we split it into two calls.
+        address[] memory addrs1 = Solarray.addresses(
+            address(_output.opcm),
+            address(_output.optimismPortalImpl),
+            address(_output.delayedWETHImpl),
+            address(_output.preimageOracleSingleton),
+            address(_output.mipsSingleton),
+            address(_output.superchainConfigImpl),
+            address(_output.protocolVersionsImpl)
+        );
+
+        address[] memory addrs2 = Solarray.addresses(
+            address(_output.systemConfigImpl),
+            address(_output.l1CrossDomainMessengerImpl),
+            address(_output.l1ERC721BridgeImpl),
+            address(_output.l1StandardBridgeImpl),
+            address(_output.optimismMintableERC20FactoryImpl),
+            address(_output.disputeGameFactoryImpl),
+            address(_output.anchorStateRegistryImpl),
+            address(_output.ethLockboxImpl)
+        );
+
+        DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
+
+        assertValidDelayedWETHImpl(_input, _output);
+        assertValidDisputeGameFactoryImpl(_input, _output);
+        assertValidAnchorStateRegistryImpl(_input, _output);
+        assertValidL1CrossDomainMessengerImpl(_input, _output);
+        assertValidL1ERC721BridgeImpl(_input, _output);
+        assertValidL1StandardBridgeImpl(_input, _output);
+        assertValidMipsSingleton(_input, _output);
+        assertValidOpcm(_input, _output);
+        assertValidOptimismMintableERC20FactoryImpl(_input, _output);
+        assertValidOptimismPortalImpl(_input, _output);
+        assertValidETHLockboxImpl(_input, _output);
+        assertValidPreimageOracleSingleton(_input, _output);
+        assertValidSystemConfigImpl(_input, _output);
+    }
+
+    function assertValidOpcm(Input memory _input, Output memory _output) private view {
+        IOPContractsManager impl = IOPContractsManager(address(_output.opcm));
+        require(address(impl.superchainConfig()) == address(_input.superchainConfigProxy), "OPCMI-10");
+        require(address(impl.protocolVersions()) == address(_input.protocolVersionsProxy), "OPCMI-20");
+        require(impl.upgradeController() == _input.upgradeController, "OPCMI-30");
+    }
+
+    function assertValidOptimismPortalImpl(Input memory, Output memory _output) private view {
+        IOptimismPortal portal = _output.optimismPortalImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(portal), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(address(portal.anchorStateRegistry()) == address(0), "PORTAL-10");
+        require(address(portal.systemConfig()) == address(0), "PORTAL-20");
+        require(address(portal.superchainConfig()) == address(0), "PORTAL-30");
+        require(portal.l2Sender() == address(0), "PORTAL-40");
+
+        // This slot is the custom gas token _balance and this check ensures
+        // that it stays unset for forwards compatibility with custom gas token.
+        require(vm.load(address(portal), bytes32(uint256(61))) == bytes32(0), "PORTAL-50");
+
+        require(address(portal.ethLockbox()) == address(0), "PORTAL-60");
+    }
+
+    function assertValidETHLockboxImpl(Input memory, Output memory _output) private view {
+        IETHLockbox lockbox = _output.ethLockboxImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(lockbox), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(address(lockbox.superchainConfig()) == address(0), "ELB-10");
+        require(lockbox.authorizedPortals(_output.optimismPortalImpl) == false, "ELB-20");
+    }
+
+    function assertValidDelayedWETHImpl(Input memory _input, Output memory _output) private view {
+        IDelayedWETH delayedWETH = _output.delayedWETHImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(delayedWETH), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(delayedWETH.owner() == address(0), "DW-10");
+        require(delayedWETH.delay() == _input.withdrawalDelaySeconds, "DW-20");
+        require(delayedWETH.config() == ISuperchainConfig(address(0)), "DW-30");
+    }
+
+    function assertValidPreimageOracleSingleton(Input memory _input, Output memory _output) private view {
+        IPreimageOracle oracle = _output.preimageOracleSingleton;
+
+        require(oracle.minProposalSize() == _input.minProposalSizeBytes, "PO-10");
+        require(oracle.challengePeriod() == _input.challengePeriodSeconds, "PO-20");
+    }
+
+    function assertValidMipsSingleton(Input memory, Output memory _output) private view {
+        IMIPS mips = _output.mipsSingleton;
+        require(address(mips.oracle()) == address(_output.preimageOracleSingleton), "MIPS-10");
+    }
+
+    function assertValidSystemConfigImpl(Input memory, Output memory _output) private view {
+        ISystemConfig systemConfig = _output.systemConfigImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(systemConfig.owner() == address(0), "SYSCON-10");
+        require(systemConfig.overhead() == 0, "SYSCON-20");
+        require(systemConfig.scalar() == 0, "SYSCON-30");
+        require(systemConfig.basefeeScalar() == 0, "SYSCON-40");
+        require(systemConfig.blobbasefeeScalar() == 0, "SYSCON-50");
+        require(systemConfig.batcherHash() == bytes32(0), "SYSCON-60");
+        require(systemConfig.gasLimit() == 0, "SYSCON-70");
+        require(systemConfig.unsafeBlockSigner() == address(0), "SYSCON-80");
+
+        IResourceMetering.ResourceConfig memory resourceConfig = systemConfig.resourceConfig();
+        require(resourceConfig.maxResourceLimit == 0, "SYSCON-90");
+        require(resourceConfig.elasticityMultiplier == 0, "SYSCON-100");
+        require(resourceConfig.baseFeeMaxChangeDenominator == 0, "SYSCON-110");
+        require(resourceConfig.systemTxMaxGas == 0, "SYSCON-120");
+        require(resourceConfig.minimumBaseFee == 0, "SYSCON-130");
+        require(resourceConfig.maximumBaseFee == 0, "SYSCON-140");
+
+        require(systemConfig.startBlock() == type(uint256).max, "SYSCON-150");
+        require(systemConfig.batchInbox() == address(0), "SYSCON-160");
+        require(systemConfig.l1CrossDomainMessenger() == address(0), "SYSCON-170");
+        require(systemConfig.l1ERC721Bridge() == address(0), "SYSCON-180");
+        require(systemConfig.l1StandardBridge() == address(0), "SYSCON-190");
+        require(systemConfig.optimismPortal() == address(0), "SYSCON-200");
+        require(systemConfig.optimismMintableERC20Factory() == address(0), "SYSCON-210");
+    }
+
+    function assertValidL1CrossDomainMessengerImpl(Input memory, Output memory _output) private view {
+        IL1CrossDomainMessenger messenger = _output.l1CrossDomainMessengerImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(messenger), _isProxy: false, _slot: 0, _offset: 20 });
+
+        require(address(messenger.OTHER_MESSENGER()) == address(0), "L1xDM-10");
+        require(address(messenger.otherMessenger()) == address(0), "L1xDM-20");
+        require(address(messenger.PORTAL()) == address(0), "L1xDM-30");
+        require(address(messenger.portal()) == address(0), "L1xDM-40");
+        require(address(messenger.superchainConfig()) == address(0), "L1xDM-50");
+
+        bytes32 xdmSenderSlot = vm.load(address(messenger), bytes32(uint256(204)));
+        require(address(uint160(uint256(xdmSenderSlot))) == address(0), "L1xDM-60");
+    }
+
+    function assertValidL1ERC721BridgeImpl(Input memory, Output memory _output) private view {
+        IL1ERC721Bridge bridge = _output.l1ERC721BridgeImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(bridge), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(address(bridge.OTHER_BRIDGE()) == address(0), "L721B-10");
+        require(address(bridge.otherBridge()) == address(0), "L721B-20");
+        require(address(bridge.MESSENGER()) == address(0), "L721B-30");
+        require(address(bridge.messenger()) == address(0), "L721B-40");
+        require(address(bridge.superchainConfig()) == address(0), "L721B-50");
+    }
+
+    function assertValidL1StandardBridgeImpl(Input memory, Output memory _output) private view {
+        IL1StandardBridge bridge = _output.l1StandardBridgeImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(bridge), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(address(bridge.MESSENGER()) == address(0), "L1SB-10");
+        require(address(bridge.messenger()) == address(0), "L1SB-20");
+        require(address(bridge.OTHER_BRIDGE()) == address(0), "L1SB-30");
+        require(address(bridge.otherBridge()) == address(0), "L1SB-40");
+        require(address(bridge.superchainConfig()) == address(0), "L1SB-50");
+    }
+
+    function assertValidOptimismMintableERC20FactoryImpl(Input memory, Output memory _output) private view {
+        IOptimismMintableERC20Factory factory = _output.optimismMintableERC20FactoryImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(factory), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(address(factory.BRIDGE()) == address(0), "MERC20F-10");
+        require(address(factory.bridge()) == address(0), "MERC20F-20");
+    }
+
+    function assertValidDisputeGameFactoryImpl(Input memory, Output memory _output) private view {
+        IDisputeGameFactory factory = _output.disputeGameFactoryImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(factory), _isProxy: false, _slot: 0, _offset: 0 });
+
+        require(address(factory.owner()) == address(0), "DG-10");
+    }
+
+    function assertValidAnchorStateRegistryImpl(Input memory, Output memory _output) private view {
+        IAnchorStateRegistry registry = _output.anchorStateRegistryImpl;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(registry), _isProxy: false, _slot: 0, _offset: 0 });
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -39,10 +39,6 @@ contract DeployImplementations2_Test is Test {
         deployImplementations = new DeployImplementations2();
     }
 
-    function hash(bytes32 _seed, uint256 _i) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_seed, _i));
-    }
-
     function test_deployImplementation_succeeds() public {
         DeployImplementations2.Input memory input = defaultInput();
         DeployImplementations2.Output memory output = deployImplementations.run(input);

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -174,7 +174,7 @@ contract DeployImplementations2_Test is Test {
     }
 
     function test_challengePeriodSeconds_reverts_if_too_large(uint256 _challengePeriodSeconds) public {
-        vm.assume(_challengePeriodSeconds <= uint256(type(uint64).max));
+        vm.assume(_challengePeriodSeconds > uint256(type(uint64).max));
 
         DeployImplementations2.Input memory input = defaultInput();
         input.challengePeriodSeconds = _challengePeriodSeconds;

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -34,8 +34,10 @@ contract DeployImplementations2_Test is Test {
     address upgradeController = makeAddr("upgradeController");
 
     function setUp() public virtual {
+        // We'll need to store some code on these two addresses so that the deployment script checks pass
         vm.etch(address(superchainConfigProxy), hex"01");
         vm.etch(address(protocolVersionsProxy), hex"01");
+
         deployImplementations = new DeployImplementations2();
     }
 

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -162,16 +162,6 @@ contract DeployImplementations2_Test is Test {
         assertEq(address(output.mipsSingleton.oracle()), address(output.preimageOracleSingleton), "600");
     }
 
-    function testFuzz_run_largeChallengePeriodSeconds_reverts(uint256 _challengePeriodSeconds) public {
-        DeployImplementations2.Input memory input = defaultInput();
-
-        // Set the challenge period to a value that is too large
-        input.challengePeriodSeconds = bound(_challengePeriodSeconds, uint256(type(uint64).max) + 1, type(uint256).max);
-
-        vm.expectRevert("DeployImplementationsInput: challengePeriodSeconds too large");
-        deployImplementations.run(input);
-    }
-
     function test_run_deployMipsV1OnMainnetOrSepolia_reverts() public {
         DeployImplementations2.Input memory input = defaultInput();
         input.mipsVersion = 1;
@@ -186,7 +176,7 @@ contract DeployImplementations2_Test is Test {
     }
 
     function test_challengePeriodSeconds_reverts_if_too_large(uint256 _challengePeriodSeconds) public {
-        vm.assume(_challengePeriodSeconds > uint256(type(uint64).max));
+        vm.assume(_challengePeriodSeconds <= uint256(type(uint64).max));
 
         DeployImplementations2.Input memory input = defaultInput();
         input.challengePeriodSeconds = _challengePeriodSeconds;

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -10,23 +10,10 @@ import { Chains } from "scripts/libraries/Chains.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 
 // Interfaces
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
-import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
-import { IMIPS } from "interfaces/cannon/IMIPS.sol";
-import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
-import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
-import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
-import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
-import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 import { DeployImplementations2 } from "scripts/deploy/DeployImplementations2.s.sol";
 
@@ -73,7 +60,9 @@ contract DeployImplementations2_Test is Test {
         assertEq(address(output1.l1CrossDomainMessengerImpl), address(output2.l1CrossDomainMessengerImpl), "200");
         assertEq(address(output1.l1ERC721BridgeImpl), address(output2.l1ERC721BridgeImpl), "300");
         assertEq(address(output1.l1StandardBridgeImpl), address(output2.l1StandardBridgeImpl), "400");
-        assertEq(address(output1.optimismMintableERC20FactoryImpl), address(output2.optimismMintableERC20FactoryImpl), "500");
+        assertEq(
+            address(output1.optimismMintableERC20FactoryImpl), address(output2.optimismMintableERC20FactoryImpl), "500"
+        );
         assertEq(address(output1.optimismPortalImpl), address(output2.optimismPortalImpl), "600");
         assertEq(address(output1.delayedWETHImpl), address(output2.delayedWETHImpl), "700");
         assertEq(address(output1.preimageOracleSingleton), address(output2.preimageOracleSingleton), "800");

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing
+import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Chains } from "scripts/libraries/Chains.sol";
+import { LibString } from "@solady/utils/LibString.sol";
+
+// Interfaces
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { IMIPS } from "interfaces/cannon/IMIPS.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IProtocolVersions } from "interfaces/L1/IProtocolVersions.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+
+import { DeployImplementations2 } from "scripts/deploy/DeployImplementations2.s.sol";
+
+contract DeployImplementations2_Test is Test {
+    using stdStorage for StdStorage;
+
+    DeployImplementations2 deployImplementations;
+
+    // Define default inputs for testing.
+    uint256 withdrawalDelaySeconds = 100;
+    uint256 minProposalSizeBytes = 200;
+    uint256 challengePeriodSeconds = 300;
+    uint256 proofMaturityDelaySeconds = 400;
+    uint256 disputeGameFinalityDelaySeconds = 500;
+    ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfigProxy"));
+    IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersionsProxy"));
+    IProxyAdmin superchainProxyAdmin = IProxyAdmin(makeAddr("superchainProxyAdmin"));
+    address upgradeController = makeAddr("upgradeController");
+
+    function setUp() public virtual {
+        vm.etch(address(superchainConfigProxy), hex"01");
+        vm.etch(address(protocolVersionsProxy), hex"01");
+        deployImplementations = new DeployImplementations2();
+    }
+
+    function hash(bytes32 _seed, uint256 _i) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_seed, _i));
+    }
+
+    function test_deployImplementation_succeeds() public {
+        DeployImplementations2.Input memory input = defaultInput();
+        DeployImplementations2.Output memory output = deployImplementations.run(input);
+
+        assertNotEq(address(output.systemConfigImpl), address(0));
+    }
+
+    function test_reuseImplementation_succeeds() public {
+        DeployImplementations2.Input memory input = defaultInput();
+        DeployImplementations2.Output memory output1 = deployImplementations.run(input);
+        DeployImplementations2.Output memory output2 = deployImplementations.run(input);
+
+        // Assert that the addresses did not change.
+        assertEq(address(output1.systemConfigImpl), address(output2.systemConfigImpl), "100");
+        assertEq(address(output1.l1CrossDomainMessengerImpl), address(output2.l1CrossDomainMessengerImpl), "200");
+        assertEq(address(output1.l1ERC721BridgeImpl), address(output2.l1ERC721BridgeImpl), "300");
+        assertEq(address(output1.l1StandardBridgeImpl), address(output2.l1StandardBridgeImpl), "400");
+        assertEq(address(output1.optimismMintableERC20FactoryImpl), address(output2.optimismMintableERC20FactoryImpl), "500");
+        assertEq(address(output1.optimismPortalImpl), address(output2.optimismPortalImpl), "600");
+        assertEq(address(output1.delayedWETHImpl), address(output2.delayedWETHImpl), "700");
+        assertEq(address(output1.preimageOracleSingleton), address(output2.preimageOracleSingleton), "800");
+        assertEq(address(output1.mipsSingleton), address(output2.mipsSingleton), "900");
+        assertEq(address(output1.disputeGameFactoryImpl), address(output2.disputeGameFactoryImpl), "1000");
+        assertEq(address(output1.anchorStateRegistryImpl), address(output2.anchorStateRegistryImpl), "1100");
+        assertEq(address(output1.opcm), address(output2.opcm), "1200");
+        assertEq(address(output1.ethLockboxImpl), address(output2.ethLockboxImpl), "1300");
+    }
+
+    function testFuzz_run_memory_succeeds(
+        uint256 _withdrawalDelaySeconds,
+        uint256 _minProposalSizeBytes,
+        uint64 _challengePeriodSeconds,
+        uint256 _proofMaturityDelaySeconds,
+        uint256 _disputeGameFinalityDelaySeconds,
+        string memory _l1ContractsRelease,
+        address _superchainConfigImpl
+    )
+        public
+    {
+        vm.assume(_withdrawalDelaySeconds != 0);
+        vm.assume(_minProposalSizeBytes != 0);
+        vm.assume(_challengePeriodSeconds != 0);
+        vm.assume(_proofMaturityDelaySeconds != 0);
+        vm.assume(_disputeGameFinalityDelaySeconds != 0);
+        vm.assume(!LibString.eq(_l1ContractsRelease, ""));
+        vm.assume(_superchainConfigImpl != address(0));
+
+        // Must configure the ProxyAdmin contract.
+        superchainProxyAdmin = IProxyAdmin(
+            DeployUtils.create1({
+                _name: "ProxyAdmin",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (msg.sender)))
+            })
+        );
+        superchainConfigProxy = ISuperchainConfig(
+            DeployUtils.create1({
+                _name: "Proxy",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IProxy.__constructor__, (address(superchainProxyAdmin)))
+                )
+            })
+        );
+
+        ISuperchainConfig superchainConfigImpl = ISuperchainConfig(_superchainConfigImpl);
+        vm.prank(address(superchainProxyAdmin));
+        IProxy(payable(address(superchainConfigProxy))).upgradeTo(address(superchainConfigImpl));
+
+        DeployImplementations2.Input memory input = DeployImplementations2.Input(
+            _withdrawalDelaySeconds,
+            _minProposalSizeBytes,
+            uint256(_challengePeriodSeconds),
+            _proofMaturityDelaySeconds,
+            _disputeGameFinalityDelaySeconds,
+            1, // mipsVersion
+            _l1ContractsRelease,
+            superchainConfigProxy,
+            protocolVersionsProxy,
+            superchainProxyAdmin,
+            upgradeController
+        );
+
+        DeployImplementations2.Output memory output = deployImplementations.run(input);
+
+        // Basic assertions
+        assertNotEq(address(output.anchorStateRegistryImpl), address(0), "100");
+        assertNotEq(address(output.delayedWETHImpl), address(0), "200");
+        assertNotEq(address(output.disputeGameFactoryImpl), address(0), "300");
+        assertNotEq(address(output.ethLockboxImpl), address(0), "400");
+        assertNotEq(address(output.l1CrossDomainMessengerImpl), address(0), "500");
+        assertNotEq(address(output.l1ERC721BridgeImpl), address(0), "500");
+        assertNotEq(address(output.l1StandardBridgeImpl), address(0), "600");
+        assertNotEq(address(output.mipsSingleton), address(0), "700");
+        assertNotEq(address(output.opcm), address(0), "800");
+        assertNotEq(address(output.opcmContractsContainer), address(0), "900");
+        assertNotEq(address(output.opcmDeployer), address(0), "1000");
+        assertNotEq(address(output.opcmGameTypeAdder), address(0), "1100");
+
+        // Address contents assertions
+        bytes memory empty;
+
+        assertNotEq(address(output.anchorStateRegistryImpl).code, empty, "1200");
+        assertNotEq(address(output.delayedWETHImpl).code, empty, "1300");
+        assertNotEq(address(output.disputeGameFactoryImpl).code, empty, "1400");
+        assertNotEq(address(output.ethLockboxImpl).code, empty, "1500");
+        assertNotEq(address(output.l1CrossDomainMessengerImpl).code, empty, "1600");
+        assertNotEq(address(output.l1ERC721BridgeImpl).code, empty, "1700");
+        assertNotEq(address(output.l1StandardBridgeImpl).code, empty, "1800");
+        assertNotEq(address(output.mipsSingleton).code, empty, "1900");
+        assertNotEq(address(output.opcm).code, empty, "2000");
+        assertNotEq(address(output.opcmContractsContainer).code, empty, "2100");
+        assertNotEq(address(output.opcmDeployer).code, empty, "2200");
+        assertNotEq(address(output.opcmGameTypeAdder).code, empty, "2300");
+
+        // Architecture assertions.
+        assertEq(address(output.mipsSingleton.oracle()), address(output.preimageOracleSingleton), "600");
+    }
+
+    function testFuzz_run_largeChallengePeriodSeconds_reverts(uint256 _challengePeriodSeconds) public {
+        DeployImplementations2.Input memory input = defaultInput();
+
+        // Set the challenge period to a value that is too large
+        input.challengePeriodSeconds = bound(_challengePeriodSeconds, uint256(type(uint64).max) + 1, type(uint256).max);
+
+        vm.expectRevert("DeployImplementationsInput: challengePeriodSeconds too large");
+        deployImplementations.run(input);
+    }
+
+    function test_run_deployMipsV1OnMainnetOrSepolia_reverts() public {
+        DeployImplementations2.Input memory input = defaultInput();
+        input.mipsVersion = 1;
+
+        vm.chainId(Chains.Mainnet);
+        vm.expectRevert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
+        deployImplementations.run(input);
+
+        vm.chainId(Chains.Sepolia);
+        vm.expectRevert("DeployImplementations: Only Mips64 should be deployed on Mainnet or Sepolia");
+        deployImplementations.run(input);
+    }
+
+    function test_challengePeriodSeconds_reverts_if_too_large(uint256 _challengePeriodSeconds) public {
+        vm.assume(_challengePeriodSeconds > uint256(type(uint64).max));
+
+        DeployImplementations2.Input memory input = defaultInput();
+        input.challengePeriodSeconds = _challengePeriodSeconds;
+
+        vm.expectRevert("DeployImplementations: challengePeriodSeconds too large");
+        deployImplementations.run(input);
+    }
+
+    function test_run_nullInput_reverts() public {
+        DeployImplementations2.Input memory input;
+
+        input = defaultInput();
+        input.withdrawalDelaySeconds = 0;
+        vm.expectRevert("DeployImplementations: withdrawalDelaySeconds not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.minProposalSizeBytes = 0;
+        vm.expectRevert("DeployImplementations: minProposalSizeBytes not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.challengePeriodSeconds = 0;
+        vm.expectRevert("DeployImplementations: challengePeriodSeconds not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.proofMaturityDelaySeconds = 0;
+        vm.expectRevert("DeployImplementations: proofMaturityDelaySeconds not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.disputeGameFinalityDelaySeconds = 0;
+        vm.expectRevert("DeployImplementations: disputeGameFinalityDelaySeconds not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.mipsVersion = 0;
+        vm.expectRevert("DeployImplementations: mipsVersion not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.l1ContractsRelease = "";
+        vm.expectRevert("DeployImplementations: l1ContractsRelease not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.superchainConfigProxy = ISuperchainConfig(address(0));
+        vm.expectRevert("DeployImplementations: superchainConfigProxy not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.protocolVersionsProxy = IProtocolVersions(address(0));
+        vm.expectRevert("DeployImplementations: protocolVersionsProxy not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.superchainProxyAdmin = IProxyAdmin(address(0));
+        vm.expectRevert("DeployImplementations: superchainProxyAdmin not set");
+        deployImplementations.run(input);
+
+        input = defaultInput();
+        input.upgradeController = address(0);
+        vm.expectRevert("DeployImplementations: upgradeController not set");
+        deployImplementations.run(input);
+    }
+
+    function defaultInput() private view returns (DeployImplementations2.Input memory input_) {
+        input_ = DeployImplementations2.Input(
+            withdrawalDelaySeconds,
+            minProposalSizeBytes,
+            challengePeriodSeconds,
+            proofMaturityDelaySeconds,
+            disputeGameFinalityDelaySeconds,
+            1, // mipsVersion
+            "dev-release", // l1ContractsRelease
+            superchainConfigProxy,
+            protocolVersionsProxy,
+            superchainProxyAdmin,
+            upgradeController
+        );
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations2.t.sol
@@ -173,7 +173,7 @@ contract DeployImplementations2_Test is Test {
         deployImplementations.run(input);
     }
 
-    function test_challengePeriodSeconds_reverts_if_too_large(uint256 _challengePeriodSeconds) public {
+    function test_challengePeriodSeconds_valueTooLarge_reverts(uint256 _challengePeriodSeconds) public {
         vm.assume(_challengePeriodSeconds > uint256(type(uint64).max));
 
         DeployImplementations2.Input memory input = defaultInput();


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployImplementations2` has been introduced along with extended test coverage.

The existing tests have been adjusted to the new format (input & output structs instead of contracts) and several missing test cases have been added.

On top of the foundry tests, there is maybe a more telling integration/regression test that compares the old & the new deployment script. Because of this, no existing code has been touched.