### PR TITLE
op-program: Load custom configs if embed is missing

### DIFF
--- a/op-program/chainconfig/chaincfg_test.go
+++ b/op-program/chainconfig/chaincfg_test.go
@@ -19,6 +19,11 @@ func TestGetCustomRollupConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGetCustomRollupConfig_Missing(t *testing.T) {
+	_, err := rollupConfigByChainID(eth.ChainIDFromUInt64(11111), test.TestCustomChainConfigFS)
+	require.ErrorIs(t, err, ErrMissingChainConfig)
+}
+
 // TestGetCustomChainConfig tests loading the custom chain configs from test embed FS.
 func TestGetCustomChainConfig(t *testing.T) {
 	config, err := chainConfigByChainID(eth.ChainIDFromUInt64(901), test.TestCustomChainConfigFS)
@@ -27,6 +32,11 @@ func TestGetCustomChainConfig(t *testing.T) {
 
 	_, err = chainConfigByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.Error(t, err)
+}
+
+func TestGetCustomChainConfig_Missing(t *testing.T) {
+	_, err := chainConfigByChainID(eth.ChainIDFromUInt64(11111), test.TestCustomChainConfigFS)
+	require.ErrorIs(t, err, ErrMissingChainConfig)
 }
 
 func TestGetCustomDependencySetConfig(t *testing.T) {
@@ -42,6 +52,11 @@ func TestGetCustomDependencySetConfig(t *testing.T) {
 
 	_, err = dependencySetByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.Error(t, err)
+}
+
+func TestGetCustomDependencySetConfig_MissingConfig(t *testing.T) {
+	_, err := dependencySetByChainID(eth.ChainIDFromUInt64(11111), test.TestCustomChainConfigFS)
+	require.ErrorIs(t, err, ErrMissingChainConfig)
 }
 
 func TestListCustomChainIDs(t *testing.T) {

--- a/op-program/chainconfig/chaincfg_test.go
+++ b/op-program/chainconfig/chaincfg_test.go
@@ -55,7 +55,7 @@ func TestGetCustomDependencySetConfig(t *testing.T) {
 }
 
 func TestGetCustomDependencySetConfig_MissingConfig(t *testing.T) {
-	_, err := dependencySetByChainID(eth.ChainIDFromUInt64(11111), test.TestCustomChainConfigFS)
+	_, err := dependencySetByChainID(eth.ChainIDFromUInt64(11111), test.TestCustomChainConfigEmptyFS)
 	require.ErrorIs(t, err, ErrMissingChainConfig)
 }
 

--- a/op-program/chainconfig/test/test.go
+++ b/op-program/chainconfig/test/test.go
@@ -4,3 +4,6 @@ import "embed"
 
 //go:embed configs/*json
 var TestCustomChainConfigFS embed.FS
+
+//go:embed configs_empty/*json
+var TestCustomChainConfigEmptyFS embed.FS

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -47,7 +47,7 @@ func (c *OracleConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, 
 		return cfg, nil
 	}
 	cfg, err := chainconfig.RollupConfigByChainID(chainID)
-	if !c.customConfigsLoaded && err != nil {
+	if !c.customConfigsLoaded && errors.Is(err, chainconfig.ErrMissingChainConfig) {
 		c.loadCustomConfigs()
 		if cfg, ok := c.rollupConfigs[chainID]; !ok {
 			return nil, fmt.Errorf("%w: %v", ErrUnknownChainID, chainID)
@@ -66,7 +66,7 @@ func (c *OracleConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 		return cfg, nil
 	}
 	cfg, err := chainconfig.ChainConfigByChainID(chainID)
-	if !c.customConfigsLoaded && err != nil {
+	if !c.customConfigsLoaded && errors.Is(err, chainconfig.ErrMissingChainConfig) {
 		c.loadCustomConfigs()
 		if cfg, ok := c.l2ChainConfigs[chainID]; !ok {
 			return nil, fmt.Errorf("%w: %v", ErrUnknownChainID, chainID)
@@ -85,7 +85,7 @@ func (c *OracleConfigSource) DependencySet(chainID eth.ChainID) (depset.Dependen
 		return c.depset, nil
 	}
 	depSet, err := chainconfig.DependencySetByChainID(chainID)
-	if !c.customConfigsLoaded && err != nil {
+	if !c.customConfigsLoaded && errors.Is(err, chainconfig.ErrMissingChainConfig) {
 		c.loadCustomConfigs()
 		if c.depset == nil {
 			return nil, fmt.Errorf("%w: %v", ErrUnknownChainID, chainID)


### PR DESCRIPTION
This patch ensures that the interop program loads custom configs from the host oracle if and only if the config cannot be found in the superchain-registry or the embed.

This allows the invalid embedded configs to surface as errors and result in a panic, rather than being silently ignored to use the host oracle as a fallback config source.