### PR TITLE
feat: Simplify op-deployer scripts: DeployAlphabetVM [6/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/alphabet2.go
+++ b/op-deployer/pkg/deployer/opcm/alphabet2.go
@@ -1,0 +1,22 @@
+package opcm
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployAlphabetVM2Input struct {
+	AbsolutePrestate common.Hash
+	PreimageOracle   common.Address
+}
+
+type DeployAlphabetVM2Output struct {
+	AlphabetVM common.Address
+}
+
+type DeployAlphabetVMScript script.DeployScriptWithOutput[DeployAlphabetVM2Input, DeployAlphabetVM2Output]
+
+// NewDeployAlphabetVMScript loads and validates the DeployAlphabetVM2 script contract
+func NewDeployAlphabetVMScript(host *script.Host) (DeployAlphabetVMScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployAlphabetVM2Input, DeployAlphabetVM2Output](host, "DeployAlphabetVM2.s.sol", "DeployAlphabetVM2")
+}

--- a/op-deployer/pkg/deployer/opcm/alphabet2_test.go
+++ b/op-deployer/pkg/deployer/opcm/alphabet2_test.go
@@ -1,0 +1,51 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployAlphabetVMScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployAlphabetVM2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		deployAlphabetVM, err := opcm.NewDeployAlphabetVMScript(host1)
+		require.NoError(t, err)
+
+		// Now we run the deploy script
+		output, err := deployAlphabetVM.Run(opcm.DeployAlphabetVM2Input{
+			AbsolutePrestate: common.BigToHash(big.NewInt(1)),
+			PreimageOracle:   common.BigToAddress(big.NewInt(2)),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+
+		deprecatedOutput, err := opcm.DeployAlphabetVM(host2, opcm.DeployAlphabetVMInput{
+			AbsolutePrestate: common.BigToHash(big.NewInt(1)),
+			PreimageOracle:   common.BigToAddress(big.NewInt(2)),
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.AlphabetVM, output.AlphabetVM)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.AlphabetVM), host1.GetCode(output.AlphabetVM))
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployAlphabetVM2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAlphabetVM2.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
+import { Claim } from "src/dispute/lib/Types.sol";
+
+contract DeployAlphabetVM2 is Script {
+    struct Input {
+        bytes32 absolutePrestate;
+        IPreimageOracle preimageOracle;
+    }
+
+    struct Output {
+        AlphabetVM alphabetVM;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        Claim absolutePrestate = Claim.wrap(_input.absolutePrestate);
+        IPreimageOracle preimageOracle = _input.preimageOracle;
+
+        vm.broadcast(msg.sender);
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, preimageOracle);
+
+        output_.alphabetVM = alphabetVM;
+    }
+
+    function assertValidInput(Input memory _input) private pure {
+        require(_input.absolutePrestate != bytes32(0), "DeployAlphabetVM: absolutePrestate not set");
+        require(address(_input.preimageOracle) != address(0), "DeployAlphabetVM: preimageOracle not set");
+    }
+
+    function assertValidOutput(Output memory _output) private pure {
+        require(address(_output.alphabetVM) != address(0), "DeployAlphabetVM: alphabetVM not set");
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployAlphabetVM2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAlphabetVM2.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+
+
+// Interfaces
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+import { DeployAlphabetVM2 } from "scripts/deploy/DeployAlphabetVM2.s.sol";
+
+contract DeployAlphabetVM2_Test is Test {
+    DeployAlphabetVM2 deployAlphanetVM;
+
+    IPreimageOracle private preimageOracle = IPreimageOracle(makeAddr("preimageOracle"));
+    bytes32 private absolutePrestate = bytes32(uint256(1));
+
+    function setUp() public {
+        deployAlphanetVM = new DeployAlphabetVM2();
+    }
+
+    function test_run_succeeds() public {
+        DeployAlphabetVM2.Input memory input = defaultInput();
+        DeployAlphabetVM2.Output memory output = deployAlphanetVM.run(input);
+
+        assertNotEq(address(output.alphabetVM), address(0), "100");
+        assertEq(address(output.alphabetVM.oracle()), address(input.preimageOracle), "200");
+    }
+
+    function test_run_nullInput_reverts() public {
+        DeployAlphabetVM2.Input memory input;
+
+        input = defaultInput();
+        input.absolutePrestate = hex"";
+        vm.expectRevert("DeployAlphabetVM: absolutePrestate not set");
+        deployAlphanetVM.run(input);
+
+        input = defaultInput();
+        input.preimageOracle = IPreimageOracle(address(0));
+        vm.expectRevert("DeployAlphabetVM: preimageOracle not set");
+        deployAlphanetVM.run(input);
+    }
+
+    function defaultInput() private view returns (DeployAlphabetVM2.Input memory input_) {
+        input_ = DeployAlphabetVM2.Input(
+            absolutePrestate,
+            preimageOracle
+        );
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployAlphabetVM2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAlphabetVM2.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { Test } from "forge-std/Test.sol";
 
-
 // Interfaces
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 
@@ -42,9 +41,6 @@ contract DeployAlphabetVM2_Test is Test {
     }
 
     function defaultInput() private view returns (DeployAlphabetVM2.Input memory input_) {
-        input_ = DeployAlphabetVM2.Input(
-            absolutePrestate,
-            preimageOracle
-        );
+        input_ = DeployAlphabetVM2.Input(absolutePrestate, preimageOracle);
     }
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Follow the same pattern as #15153 and migrate `DeployAlphabetVM`