### PR TITLE
op-supervisor: Recreate Subscription Chan on Retry

### DIFF
--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -156,6 +156,8 @@ func (m *ManagedNode) SubscribeToNodeEvents() {
 			if prevErr != nil {
 				// This is the RPC runtime error, not the setup error we have logging for below.
 				m.log.Error("RPC subscription failed, restarting now", "err", prevErr)
+				// When the subscription fails, the channel may have been immediately closed
+				m.nodeEvents = make(chan *types.ManagedEvent, 10)
 			}
 			sub, err := m.Node.SubscribeEvents(ctx, m.nodeEvents)
 			if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/15103

When starting a new subscription, `m.nodeEvents` is reset to a fresh channel. However, if the subscription fails and needs to be retried, the subscription closes the provided channel. This lead to panic/crashes when a Node would reconnect to the Supervisor, exercising the connection retry.

This fixes the issue by always recreating the channel if the previous subscription attempt failed.

## Testing
Tested locally, based on reproduction steps from @pcw109550. I was able to Stop, Start and Restart Nodes, and watched the Supervisor lose connection and re-establish connections. This was not reasonable to test in existing unit/e2e tests because it is based on a live behavior in network connection retries, which is not easy to reproduce in testing.