### PR TITLE
fix(ci): acceptance tests on cci runners.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1739,7 +1739,6 @@ workflows:
           devnet: isthmus
           gate: isthmus
           no_output_timeout: 60m
-          resource_class: ethereum-optimism/latitude-1
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord


### PR DESCRIPTION
**Description**

Reverts the attempt to try to run ATs on self-hosted runners.
The self-hosted runners need things installed (like Kurtosis), so will try that another time.
