### PR TITLE
chore: Use new StandardValidatorV300

### DIFF
--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -26,8 +26,8 @@ var addresses = map[uint64]map[string]common.Address{
 		VersionV180: common.HexToAddress("0x0a5bf8ebb4b177b2dcc6eba933db726a2e2e2b4d"),
 		// Bootstrapped on 03/02/2025 using OP Deployer.
 		VersionV200: common.HexToAddress("0x37739a6b0a3f1e7429499a4ec4a0685439daff5c"),
-		// Bootstrapped on 04/02/2025 using OP Deployer.
-		VersionV300: common.HexToAddress("0x19f205b33f5637bfa584074ed040bc43eadc8586"),
+		// Bootstrapped on 04/03/2025 using OP Deployer.
+		VersionV300: common.HexToAddress("0x2d56022cb84ce6b961c3b4288ca36386bcd9024c"),
 	},
 }
 

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -27,7 +27,7 @@ var addresses = map[uint64]map[string]common.Address{
 		// Bootstrapped on 03/02/2025 using OP Deployer.
 		VersionV200: common.HexToAddress("0x37739a6b0a3f1e7429499a4ec4a0685439daff5c"),
 		// Bootstrapped on 04/02/2025 using OP Deployer.
-		VersionV300: common.HexToAddress("0xd0d7f75561bb7105db2d34dc39b31f23578fb75b"),
+		VersionV300: common.HexToAddress("0x19f205b33f5637bfa584074ed040bc43eadc8586"),
 	},
 }
 

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -26,8 +26,8 @@ var addresses = map[uint64]map[string]common.Address{
 		VersionV180: common.HexToAddress("0x0a5bf8ebb4b177b2dcc6eba933db726a2e2e2b4d"),
 		// Bootstrapped on 03/02/2025 using OP Deployer.
 		VersionV200: common.HexToAddress("0x37739a6b0a3f1e7429499a4ec4a0685439daff5c"),
-		// Bootstrapped on 03/10/2025 using OP Deployer.
-		VersionV300: common.HexToAddress("0x5fd6dc82a0cbc0db40d18963d812487772113216"),
+		// Bootstrapped on 04/02/2025 using OP Deployer.
+		VersionV300: common.HexToAddress("0xd0d7f75561bb7105db2d34dc39b31f23578fb75b"),
 	},
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

I deployed a new StandardValidatorV300 using op-deployer as was required once [this pr ](https://github.com/ethereum-optimism/optimism/pull/15015) merged in, and contract is [verified here](https://sepolia.etherscan.io/address/0xd0d7f75561bb7105db2d34dc39b31f23578fb75b#code)

**Tests**

No tests needed, just updating an address

**Additional context**

Needed in order for me to finish the U14 Sepolia Superchain upgrade tasks

**Metadata**

