### PR TITLE
op-e2e/system: add `TestSetCodeInTxPool` for pre and post isthmus

### DIFF
--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -3,7 +3,7 @@ optimism_package:
     - participants:
       - el_type: op-geth
         el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3"
-        el_log_level: "debug"
+        el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}
         el_extra_params: []
@@ -15,8 +15,8 @@ optimism_package:
         el_max_mem: 0
         cl_type: op-node
         cl_image: {{ localDockerImage "op-node" }}
-        cl_log_level: "debug"
-        cl_extra_env_vars: {"OP_NODE_MESSAGE_PASSER_ROOT_FROM_STATE": "true"}
+        cl_log_level: ""
+        cl_extra_env_vars: {}
         cl_extra_labels: {}
         cl_extra_params: []
         cl_tolerations: []
@@ -90,7 +90,7 @@ optimism_package:
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
       faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
-  global_log_level: "debug"
+  global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []
   persistent: false

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -3,7 +3,7 @@ optimism_package:
     - participants:
       - el_type: op-geth
         el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3"
-        el_log_level: ""
+        el_log_level: "debug"
         el_extra_env_vars: {}
         el_extra_labels: {}
         el_extra_params: []
@@ -15,8 +15,8 @@ optimism_package:
         el_max_mem: 0
         cl_type: op-node
         cl_image: {{ localDockerImage "op-node" }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
+        cl_log_level: "debug"
+        cl_extra_env_vars: {"OP_NODE_MESSAGE_PASSER_ROOT_FROM_STATE": "true"}
         cl_extra_labels: {}
         cl_extra_params: []
         cl_tolerations: []
@@ -90,7 +90,7 @@ optimism_package:
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
       faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
-  global_log_level: "info"
+  global_log_level: "debug"
   global_node_selectors: {}
   global_tolerations: []
   persistent: false

--- a/op-e2e/system/isthmus/isthmus_test.go
+++ b/op-e2e/system/isthmus/isthmus_test.go
@@ -1,0 +1,11 @@
+package isthmus
+
+import (
+	"testing"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+)
+
+func TestMain(m *testing.M) {
+	op_e2e.RunMain(m)
+}

--- a/op-e2e/system/isthmus/set_code_tx_test.go
+++ b/op-e2e/system/isthmus/set_code_tx_test.go
@@ -1,0 +1,68 @@
+package isthmus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetCodeInTxPool(t *testing.T) {
+	op_e2e.InitParallel(t)
+
+	tests := []struct {
+		isthmus bool
+	}{
+		{isthmus: true},
+		{isthmus: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("isthmus=%t", tt.isthmus), func(t *testing.T) {
+			t.Parallel()
+			cfg := e2esys.HoloceneSystemConfig(t, ptr[hexutil.Uint64](0))
+			if tt.isthmus {
+				cfg.DeployConfig.L2GenesisIsthmusTimeOffset = ptr(hexutil.Uint64(cfg.DeployConfig.L2BlockTime))
+			} else {
+				cfg.DeployConfig.L2GenesisIsthmusTimeOffset = nil
+			}
+
+			sys, err := cfg.Start(t)
+			require.NoError(t, err, "Error starting up system")
+
+			require.NoError(t, wait.ForNextBlock(context.Background(), sys.NodeClient(e2esys.RoleSeq)))
+
+			receipt, err := helpers.SendL2SetCodeTx(
+				cfg,
+				sys.NodeClient(e2esys.RoleSeq),
+				sys.Cfg.Secrets.Alice,
+				func(opts *helpers.TxOpts) {
+					opts.ToAddr = &common.Address{0xaa}
+					opts.Gas = 10_000_000
+				})
+
+			if tt.isthmus {
+				require.NoError(t, err)
+				require.NotNil(t, receipt)
+				require.Equal(t, receipt.Status, uint64(1), "SetCode tx should be successful")
+			} else {
+				require.Error(t, err, "SetCode tx should fail")
+				require.ErrorContains(t, err, "not yet in Prague")
+				require.Nil(t, receipt)
+			}
+		})
+	}
+}
+
+func ptr[T any](t T) *T { return &t }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds coverage to ensure that set code transactions can be accepted by the op-geth mempool if and only if isthmus is active. 

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**
Closes #15168 
