### PR TITLE
fix: Standard Validator Test V200

### DIFF
--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -1008,36 +1008,27 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
         vm.createSelectFork(rpcUrl);
 
         // When OP Mainnet is updated this will need to be updated to the current validator version.
-        StandardValidatorV180 mainnetValidator = new StandardValidatorV180(
-            StandardValidatorBase.ImplementationsBase({
-                systemConfigImpl: address(0xAB9d6cB7A427c0765163A7f45BB91cAfe5f2D375),
-                optimismPortalImpl: address(0xe2F826324b2faf99E513D16D266c3F80aE87832B),
-                l1CrossDomainMessengerImpl: address(0xD3494713A5cfaD3F5359379DfA074E2Ac8C6Fd65),
-                l1StandardBridgeImpl: address(0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF),
-                l1ERC721BridgeImpl: address(0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d),
-                optimismMintableERC20FactoryImpl: address(0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846),
-                disputeGameFactoryImpl: address(0xc641A33cab81C559F2bd4b21EA34C290E2440C2B),
-                mipsImpl: address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C),
-                anchorStateRegistryImpl: address(0x1B5CC028A4276597C607907F24E1AC05d3852cFC),
-                delayedWETHImpl: address(0x71e966Ae981d1ce531a7b6d23DC0f27B38409087)
-            }),
-            ISuperchainConfig(address(0x95703e0982140D16f8ebA6d158FccEde42f04a4C)),
-            address(0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A), // l1PAOMultisig
-            address(0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C), // mips
-            address(0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A), // challenger
-            604800
-        );
-
-        StandardValidatorV180.InputV180 memory input = StandardValidatorV180.InputV180({
+        StandardValidatorV200.InputV200 memory input = StandardValidatorV200.InputV200({
             proxyAdmin: IProxyAdmin(address(0x543bA4AADBAb8f9025686Bd03993043599c6fB04)),
             sysCfg: ISystemConfig(address(0x229047fed2591dbec1eF1118d64F7aF3dB9EB290)),
-            absolutePrestate: bytes32(0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568),
+            absolutePrestate: bytes32(0x039facea52b20c605c05efb0a33560a92de7074218998f75bcdf61e8989cb5d9),
             l2ChainID: 10
         });
+        // Deployed March 27, 2025:
+        // https://github.com/ethereum-optimism/superchain-ops/blob/5cc15911636897e8a2cebe7c2bc7cbb47d42ae11/src/improvements/tasks/eth/000-opcm-upgrade-v200/config.toml#L18
+        StandardValidatorV200 mainnetValidator = StandardValidatorV200(0xECAbAeaa1D58261F1579232520C5B460ca58a164);
+        mainnetValidator.validate(input, true);
 
-        // OP Mainnet has a different expected root than the default one, so we expect to see ANCHORP-40.
-        // OP Mainnet also has an incorrect delayed WETH owner, so we expect to see DWETH-30.
         string memory errors = mainnetValidator.validate(input, true);
+
+        // PDDG-DWETH-30: Permissioned dispute game's DelayedWETH owner must be l1PAOMultisig
+        // PLDG-DWETH-30: Permissionless dispute game's DelayedWETH owner must be l1PAOMultisig
+        //   DWETH-30 errors are pre-existing misconfigurations on OP Mainnet which are out of scope for this task.
+        // PDDG-ANCHORP-40: Permissioned dispute game's AnchorStateRegistry root must be
+        // 0xdead000000000000000000000000000000000000000000000000000000000000
+        // PLDG-ANCHORP-40: Permissionless dispute game's AnchorStateRegistry root must be
+        // 0xdead000000000000000000000000000000000000000000000000000000000000
+        //   ANCHORP-40 errors do not apply to chains over 1 week old.
         assertEq(errors, "PDDG-DWETH-30,PDDG-ANCHORP-40,PLDG-DWETH-30,PLDG-ANCHORP-40");
     }
 


### PR DESCRIPTION
We have a failing test called: `test_validate_opMainnet_succeeds` on develop. This PR updates the test so it doesn't fail anymore. 