### PR TITLE
feat(op-acceptance-tests): ci; display results summary and logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1183,13 +1183,34 @@ jobs:
           command: go test -v ./... || true # ignore failures; we're just compiling the tests
       # Run the actual acceptance tests with optimized settings
       - run:
-          name: Run acceptance tests
+          name: Run acceptance tests (devnet=<<parameters.devnet>>, gate=<<parameters.gate>>)
           working_directory: op-acceptance-tests
           no_output_timeout: 60m
           environment:
             GOFLAGS: "-mod=mod"
             GO111MODULE: "on"
           command: just acceptance-test "<<parameters.devnet>>" "<<parameters.gate>>"
+      - run:
+          name: Print results (summary)
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            cat "$LOG_DIR/summary.log" || true
+          when: always
+      - run:
+          name: Print results (failures)
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            cat "$LOG_DIR/failed/*.log" || true
+          when: on_fail
+      - run:
+          name: Print results (all)
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            cat "$LOG_DIR/all.log" || true
+          when: always
       # Save the module cache for future runs
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}


### PR DESCRIPTION
**Description**

Adds new steps in the op-acceptance-test workflow which show:
* summary of results
* logs of failed tests
* logs of all tests

Also, all the log artifacts should now be stored in CircleCI for future reference.

The summary of results looks like so:

```
TEST SUMMARY
============
Run ID: 795e1b86-ead5-4f29-92e5-cfdff4036b4e
Time: 2025-04-03T10:16:27+11:00
Duration: 1.25575ms

Results:
  Total:   2
  Passed:  1
  Failed:  1
  Skipped: 0
  Errors:  0

Pass Rate: 50.0%

Failed tests:
  - github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/....

Full details: see /Users/stefano/code/infra/op-acceptor/logs/testrun-795e1b86-ead5-4f29-92e5-cfdff4036b4e/all.log
```
