### PR TITLE
fix: superchain-ops integration tests

### DIFF
--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -247,9 +247,12 @@ contract Setup {
 
         optimismPortal2 = IOptimismPortal(artifacts.mustGetAddress("OptimismPortalProxy"));
 
-        // Only skip ETHLockbox assignment if we're in a fork test with non-upgraded fork
+        // Only set up the ETHLockbox if we're not using the ops repo,
+        // and either we're not in a fork test or we're explicitly using an upgraded fork.
         // TODO(#14691): Remove this check once Upgrade 15 is deployed on Mainnet.
-        if (!isForkTest() || deploy.cfg().useUpgradedFork()) {
+        if (!forkLive.useOpsRepo() && (!isForkTest() || deploy.cfg().useUpgradedFork())) {
+            console.log("isForkTest()", isForkTest());
+            console.log("deploy.cfg().useUpgradedFork()", deploy.cfg().useUpgradedFork());
             ethLockbox = IETHLockbox(artifacts.mustGetAddress("ETHLockboxProxy"));
         }
 


### PR DESCRIPTION
We need to get the superchain-ops integration test working with the monorepo again. This logic isn't accounting for the superchain-ops flow. 