### PR TITLE
feat(op-acceptance-tests): base test; nochainfork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2232,7 +2232,7 @@ workflows:
           # Acceptance Testing params
           name: kurtosis-simple
           devnet: simple
-          gate: sanitychecks
+          gate: base
 
           # CircleCI params
           no_output_timeout: 60m

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -5,22 +5,22 @@
 
 
 gates:
-  - id: sanitychecks
-    description: "Sanity checks for the acceptance tests."
+  - id: base
+    description: "Sanity/smoke acceptance tests for all networks."
     tests:
-      - name: TestFindRPCEndpoints
-        package: github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/...
+      - name: TestChainFork
+        package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base
 
   - id: holocene
     inherits:
-      - sanitychecks
+      - base
     description: "Holocene network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord/...
 
   - id: isthmus
     inherits:
-      - sanitychecks
+      - base
     description: "Isthmus network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/...
@@ -28,7 +28,7 @@ gates:
 
   - id: interop
     inherits:
-      - sanitychecks
+      - base
     description: "Interop network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/...

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -6,7 +6,7 @@ ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-ac
 
 # Default recipe - runs acceptance tests
 default:
-    @just acceptance-test simple holocene
+    @just acceptance-test simple base
 
 holocene:
     @just acceptance-test simple holocene

--- a/op-acceptance-tests/tests/base/chain_test.go
+++ b/op-acceptance-tests/tests/base/chain_test.go
@@ -1,0 +1,48 @@
+package base
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// TestChainFork checks that the chain does not fork.
+func TestChainFork(t *testing.T) {
+	chainIdx := uint64(0)
+
+	systest.SystemTest(t,
+		chainForkTestScenario(chainIdx),
+	)
+}
+
+func chainForkTestScenario(chainIdx uint64) systest.SystemTestFunc {
+	return func(t systest.T, sys system.System) {
+		const numCyclesToWait = 5
+
+		logger := testlog.Logger(t, log.LevelInfo)
+		logger.Info("Started test")
+
+		chain := sys.L2s()[chainIdx]
+
+		// Check for a chain fork
+		logger.Info("Checking for chain fork")
+		laterCheck, err := systest.CheckForChainFork(t.Context(), chain, logger)
+		require.NoError(t, err, "first chain fork check failed")
+
+		// Wait for a potential chain fork
+		logger.Info("Waiting for a potential chain fork")
+		time.Sleep(numCyclesToWait * 2 * time.Second)
+
+		// Check for a chain fork again
+		err = laterCheck()
+		require.NoError(t, err, "second chain fork check failed")
+		t.Log("Chain fork check passed")
+
+	}
+}


### PR DESCRIPTION
**Description**

* Renames the gate 'sanitychecks' to 'base'
* Introduces folder for real base checks
* Introduces a first base check: TestChainFork

**Tests**

Ran `just acceptance-test simple base` locally.
Ran CI manually (via dispatch) -- [link to workflow](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/86228/workflows/8c4a4bdb-26cb-4684-a5e8-aa4eedccd652).
