### PR TITLE
op-program: Lint client for err113

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ build-contracts:
 
 lint-go: ## Lints Go code with specific linters
 	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+	golangci-lint run -E err113 --timeout 5m -e "errors.As" -e "errors.Is" ./op-program/client/...
 .PHONY: lint-go
 
 lint-go-fix: ## Lints Go code with specific linters and fixes reported issues

--- a/op-program/chainconfig/chaincfg.go
+++ b/op-program/chainconfig/chaincfg.go
@@ -18,7 +18,10 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-var ErrMissingChainConfig = errors.New("missing chain config")
+var (
+	ErrMissingChainConfig = errors.New("missing chain config")
+	errChainNotFound      = errors.New("chain not found")
+)
 
 // OPSepoliaChainConfig loads the op-sepolia chain config. This is intended for tests that need an arbitrary, valid chain config.
 func OPSepoliaChainConfig() *params.ChainConfig {
@@ -104,7 +107,7 @@ func chainConfigByChainID(chainID eth.ChainID, customChainFS embed.FS) (*params.
 func mustLoadChainConfig(name string) *params.ChainConfig {
 	chainCfg := chaincfg.ChainByName(name)
 	if chainCfg == nil {
-		panic(fmt.Errorf("unknown chain config %q", name))
+		panic(fmt.Errorf("%w: unknown chain config %q", errChainNotFound, name))
 	}
 	cfg, err := ChainConfigByChainID(eth.ChainIDFromUInt64(chainCfg.ChainID))
 	if err != nil {
@@ -140,5 +143,5 @@ func dependencySetByChainID(chainID eth.ChainID, customChainFS embed.FS) (depset
 			return depSet, nil
 		}
 	}
-	return nil, fmt.Errorf("no dependency set config includes chain ID: %v", chainID)
+	return nil, fmt.Errorf("%w: no dependency set config includes chain ID: %v", errChainNotFound, chainID)
 }

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
+var errTooManyEvents = errors.New("way too many events queued up, something is wrong")
+
 type EndCondition interface {
 	Closing() bool
 	Result() (eth.L2BlockRef, error)
@@ -84,7 +86,7 @@ func (d *Driver) RunComplete() (eth.L2BlockRef, error) {
 			return d.end.Result()
 		}
 		if len(d.events) > 10000 { // sanity check, in case of bugs. Better than going OOM.
-			return eth.L2BlockRef{}, errors.New("way too many events queued up, something is wrong")
+			return eth.L2BlockRef{}, errTooManyEvents
 		}
 		ev := d.events[0]
 		d.events = d.events[1:]

--- a/op-program/client/driver/driver_test.go
+++ b/op-program/client/driver/driver_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
+var mockErr = errors.New("mock error")
+
 type fakeEnd struct {
 	closing bool
 	result  error
@@ -50,7 +52,6 @@ func TestDriver(t *testing.T) {
 	})
 
 	t.Run("insta error", func(t *testing.T) {
-		mockErr := errors.New("mock error")
 		d := newTestDriver(t, func(d *Driver, end *fakeEnd, ev event.Event) {
 			end.closing = true
 			end.result = mockErr
@@ -75,7 +76,6 @@ func TestDriver(t *testing.T) {
 
 	t.Run("error after a few events", func(t *testing.T) {
 		count := 0
-		mockErr := errors.New("mock error")
 		d := newTestDriver(t, func(d *Driver, end *fakeEnd, ev event.Event) {
 			if count > 3 {
 				end.closing = true

--- a/op-program/client/driver/program_test.go
+++ b/op-program/client/driver/program_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
+var (
+	errTestReset = errors.New("reset test err")
+	errTestTemp  = errors.New("temp test err")
+	errTestCrit  = errors.New("crit test err")
+)
+
 func TestProgramDeriver(t *testing.T) {
 	newProgram := func(t *testing.T, target uint64) (*ProgramDeriver, *testutils.MockEmitter) {
 		m := &testutils.MockEmitter{}
@@ -115,7 +121,7 @@ func TestProgramDeriver(t *testing.T) {
 	// on inconsistent chain data: stop with error
 	t.Run("reset event", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
-		p.OnEvent(rollup.ResetEvent{Err: errors.New("reset test err")})
+		p.OnEvent(rollup.ResetEvent{Err: errTestReset})
 		m.AssertExpectations(t)
 		require.True(t, p.closing)
 		require.Error(t, p.resultError)
@@ -123,7 +129,7 @@ func TestProgramDeriver(t *testing.T) {
 	// on L1 temporary error: stop with error
 	t.Run("L1 temporary error event", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
-		p.OnEvent(rollup.L1TemporaryErrorEvent{Err: errors.New("temp test err")})
+		p.OnEvent(rollup.L1TemporaryErrorEvent{Err: errTestTemp})
 		m.AssertExpectations(t)
 		require.True(t, p.closing)
 		require.Error(t, p.resultError)
@@ -132,7 +138,7 @@ func TestProgramDeriver(t *testing.T) {
 	t.Run("engine temp error event", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
 		m.ExpectOnce(engine.PendingSafeRequestEvent{})
-		p.OnEvent(rollup.EngineTemporaryErrorEvent{Err: errors.New("temp test err")})
+		p.OnEvent(rollup.EngineTemporaryErrorEvent{Err: errTestTemp})
 		m.AssertExpectations(t)
 		require.False(t, p.closing)
 		require.NoError(t, p.resultError)
@@ -140,7 +146,7 @@ func TestProgramDeriver(t *testing.T) {
 	// on critical error: stop
 	t.Run("critical error event", func(t *testing.T) {
 		p, m := newProgram(t, 1000)
-		p.OnEvent(rollup.ResetEvent{Err: errors.New("crit test err")})
+		p.OnEvent(rollup.ResetEvent{Err: errTestCrit})
 		m.AssertExpectations(t)
 		require.True(t, p.closing)
 		require.Error(t, p.resultError)

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -20,10 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var (
-	ErrInvalidBlockReplacement = errors.New("invalid block replacement error")
-	ErrNotFound                = errors.New("not found")
-)
+var ErrInvalidBlockReplacement = errors.New("invalid block replacement error")
 
 // ReceiptsToExecutingMessages returns the executing messages in the receipts indexed by their position in the log.
 func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
@@ -357,7 +355,7 @@ func (d *consolidateCheckDeps) DependencySet() depset.DependencySet {
 func (d *consolidateCheckDeps) CanonBlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
 	head := d.canonBlocks[chainID].GetHeaderByNumber(blockNum)
 	if head == nil {
-		return nil, fmt.Errorf("head not found for chain %v: %w", chainID, ErrNotFound)
+		return nil, fmt.Errorf("head not found for chain %v: %w", chainID, ethereum.NotFound)
 	}
 	return d.oracle.BlockByHash(head.Hash(), chainID), nil
 }

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -20,7 +20,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var ErrInvalidBlockReplacement = errors.New("invalid block replacement error")
+var (
+	ErrInvalidBlockReplacement = errors.New("invalid block replacement error")
+	ErrNotFound                = errors.New("not found")
+)
 
 // ReceiptsToExecutingMessages returns the executing messages in the receipts indexed by their position in the log.
 func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
@@ -138,7 +141,7 @@ func singleRoundConsolidation(
 		agreedOutput := l2PreimageOracle.OutputByRoot(common.Hash(chain.Output), chain.ChainID)
 		agreedOutputV0, ok := agreedOutput.(*eth.OutputV0)
 		if !ok {
-			return fmt.Errorf("unsupported L2 output version: %d", agreedOutput.Version())
+			return fmt.Errorf("%w: version: %d", l2.ErrUnsupportedL2Output, agreedOutput.Version())
 		}
 		agreedBlockHash := common.Hash(agreedOutputV0.BlockHash)
 
@@ -297,6 +300,7 @@ func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes
 		}
 		current += uint32(len(receipt.Logs))
 	}
+	//nolint:err113 // TODO(#14988): Handle non-existent logs
 	return supervisortypes.BlockSeal{}, fmt.Errorf("log not found")
 }
 
@@ -353,7 +357,7 @@ func (d *consolidateCheckDeps) DependencySet() depset.DependencySet {
 func (d *consolidateCheckDeps) CanonBlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
 	head := d.canonBlocks[chainID].GetHeaderByNumber(blockNum)
 	if head == nil {
-		return nil, fmt.Errorf("head not found for chain %v", chainID)
+		return nil, fmt.Errorf("head not found for chain %v: %w", chainID, ErrNotFound)
 	}
 	return d.oracle.BlockByHash(head.Hash(), chainID), nil
 }

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -527,7 +527,7 @@ func TestPanicIfAgreedPrestateIsAfterGameTimestamp(t *testing.T) {
 
 	// We have reached the game's timestamp so should just trace extend the agreed claim
 	expectedClaim := agreedPrestatehash
-	require.PanicsWithError(t, fmt.Sprintf("agreed prestate timestamp %v is after the game timestamp %v", agreedSuperRoot.Timestamp, agreedSuperRoot.Timestamp-1), func() {
+	require.PanicsWithValue(t, fmt.Sprintf("agreed prestate timestamp %v is after the game timestamp %v", agreedSuperRoot.Timestamp, agreedSuperRoot.Timestamp-1), func() {
 		verifyResult(t, logger, tasksStub, configSource, l2PreimageOracle, agreedPrestatehash, agreedSuperRoot.Timestamp-1, expectedClaim)
 	})
 }
@@ -627,7 +627,7 @@ func (s *staticConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, 
 			return cfg, nil
 		}
 	}
-	return nil, fmt.Errorf("no rollup config found for chain %d", chainID)
+	panic(fmt.Sprintf("no rollup config found for chain %d", chainID))
 }
 
 func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConfig, error) {
@@ -636,7 +636,7 @@ func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 			return cfg, nil
 		}
 	}
-	return nil, fmt.Errorf("no chain config found for chain %d", chainID)
+	panic(fmt.Sprintf("no chain config found for chain %d", chainID))
 }
 
 func (s *staticConfigSource) DependencySet(chainID eth.ChainID) (depset.DependencySet, error) {

--- a/op-program/client/interop/oracle.go
+++ b/op-program/client/interop/oracle.go
@@ -129,7 +129,7 @@ func (o *ConsolidateOracle) loadTransactions(txHash common.Hash) []*types.Transa
 		k := preimage.Keccak256Key(key).PreimageKey()
 		b, err := o.db.Get(k[:])
 		if err != nil {
-			panic(fmt.Errorf("missing tx trie node %s", key))
+			panic(fmt.Sprintf("missing tx trie node %s", key))
 		}
 		return b
 	})

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -126,7 +126,7 @@ func (p *PreimageOracle) Precompile(address common.Address, input []byte, requir
 	key := preimage.PrecompileKey(crypto.Keccak256Hash(hintBytes))
 	result := p.oracle.Get(key)
 	if len(result) == 0 { // must contain at least the status code
-		panic(fmt.Errorf("unexpected precompile oracle behavior, got result: %x", result))
+		panic(fmt.Sprintf("unexpected precompile oracle behavior, got result: %x", result))
 	}
 	return result[1:], result[0] == 1
 }

--- a/op-program/client/l2/canon.go
+++ b/op-program/client/l2/canon.go
@@ -41,7 +41,7 @@ func (o *CanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {
 		// guaranteed to be cached during lookup
 		hash, ok := o.hashByNum[n]
 		if !ok {
-			panic(fmt.Errorf("block %v was not indexed when earliest block number is %v", n, o.earliestIndexedBlock.Number))
+			panic(fmt.Sprintf("block %v was not indexed when earliest block number is %v", n, o.earliestIndexedBlock.Number))
 		}
 		return o.blockByHashFn(hash).Header()
 	}

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -11,6 +11,7 @@ import (
 	l2Types "github.com/ethereum-optimism/optimism/op-program/client/l2/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +19,6 @@ import (
 )
 
 var (
-	ErrNotFound              = errors.New("not found")
 	ErrInvalidHeader         = errors.New("invalid header")
 	ErrUnsupportedAPIVersion = errors.New("unsupported api version")
 	ErrUnknownLabel          = errors.New("unknown label")
@@ -49,7 +49,7 @@ func NewOracleEngine(rollupCfg *rollup.Config, logger log.Logger, backend engine
 func (o *OracleEngine) L2OutputRoot(l2ClaimBlockNum uint64) (common.Hash, eth.Bytes32, error) {
 	outBlock := o.backend.GetHeaderByNumber(l2ClaimBlockNum)
 	if outBlock == nil {
-		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("%w: failed to get L2 block at %d", ErrNotFound, l2ClaimBlockNum)
+		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("%w: failed to get L2 block at %d", ethereum.NotFound, l2ClaimBlockNum)
 	}
 	output, err := o.l2OutputAtHeader(outBlock)
 	if err != nil {
@@ -62,7 +62,7 @@ func (o *OracleEngine) L2OutputRoot(l2ClaimBlockNum uint64) (common.Hash, eth.By
 func (o *OracleEngine) L2OutputAtBlockHash(blockHash common.Hash) (*eth.OutputV0, error) {
 	header := o.backend.GetHeaderByHash(blockHash)
 	if header == nil {
-		return nil, fmt.Errorf("%w: failed to get L2 block at %s", ErrNotFound, blockHash)
+		return nil, fmt.Errorf("%w: failed to get L2 block at %s", ethereum.NotFound, blockHash)
 	}
 	return o.l2OutputAtHeader(header)
 }
@@ -155,7 +155,7 @@ func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPay
 func (o *OracleEngine) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
 	block := o.backend.GetBlockByHash(hash)
 	if block == nil {
-		return nil, ErrNotFound
+		return nil, ethereum.NotFound
 	}
 	return eth.BlockAsPayloadEnv(block, o.backend.Config())
 }
@@ -163,7 +163,7 @@ func (o *OracleEngine) PayloadByHash(ctx context.Context, hash common.Hash) (*et
 func (o *OracleEngine) PayloadByNumber(ctx context.Context, n uint64) (*eth.ExecutionPayloadEnvelope, error) {
 	hash := o.backend.GetCanonicalHash(n)
 	if hash == (common.Hash{}) {
-		return nil, ErrNotFound
+		return nil, ethereum.NotFound
 	}
 	return o.PayloadByHash(ctx, hash)
 }
@@ -181,11 +181,11 @@ func (o *OracleEngine) L2BlockRefByLabel(ctx context.Context, label eth.BlockLab
 		return eth.L2BlockRef{}, fmt.Errorf("%w: label: %v", ErrUnknownLabel, label)
 	}
 	if header == nil {
-		return eth.L2BlockRef{}, ErrNotFound
+		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 	block := o.backend.GetBlockByHash(header.Hash())
 	if block == nil {
-		return eth.L2BlockRef{}, ErrNotFound
+		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 	return derive.L2BlockToBlockRef(o.rollupCfg, block)
 }
@@ -193,7 +193,7 @@ func (o *OracleEngine) L2BlockRefByLabel(ctx context.Context, label eth.BlockLab
 func (o *OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	block := o.backend.GetBlockByHash(l2Hash)
 	if block == nil {
-		return eth.L2BlockRef{}, ErrNotFound
+		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 	return derive.L2BlockToBlockRef(o.rollupCfg, block)
 }
@@ -201,7 +201,7 @@ func (o *OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash)
 func (o *OracleEngine) L2BlockRefByNumber(ctx context.Context, n uint64) (eth.L2BlockRef, error) {
 	hash := o.backend.GetCanonicalHash(n)
 	if hash == (common.Hash{}) {
-		return eth.L2BlockRef{}, ErrNotFound
+		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 	return o.L2BlockRefByHash(ctx, hash)
 }

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -17,7 +17,12 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var ErrNotFound = errors.New("not found")
+var (
+	ErrNotFound              = errors.New("not found")
+	ErrInvalidHeader         = errors.New("invalid header")
+	ErrUnsupportedAPIVersion = errors.New("unsupported api version")
+	ErrUnknownLabel          = errors.New("unknown label")
+)
 
 type OracleEngine struct {
 	api    *engineapi.L2EngineAPI
@@ -44,7 +49,7 @@ func NewOracleEngine(rollupCfg *rollup.Config, logger log.Logger, backend engine
 func (o *OracleEngine) L2OutputRoot(l2ClaimBlockNum uint64) (common.Hash, eth.Bytes32, error) {
 	outBlock := o.backend.GetHeaderByNumber(l2ClaimBlockNum)
 	if outBlock == nil {
-		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("failed to get L2 block at %d", l2ClaimBlockNum)
+		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("%w: failed to get L2 block at %d", ErrNotFound, l2ClaimBlockNum)
 	}
 	output, err := o.l2OutputAtHeader(outBlock)
 	if err != nil {
@@ -57,7 +62,7 @@ func (o *OracleEngine) L2OutputRoot(l2ClaimBlockNum uint64) (common.Hash, eth.By
 func (o *OracleEngine) L2OutputAtBlockHash(blockHash common.Hash) (*eth.OutputV0, error) {
 	header := o.backend.GetHeaderByHash(blockHash)
 	if header == nil {
-		return nil, fmt.Errorf("failed to get L2 block at %s", blockHash)
+		return nil, fmt.Errorf("%w: failed to get L2 block at %s", ErrNotFound, blockHash)
 	}
 	return o.l2OutputAtHeader(header)
 }
@@ -69,7 +74,7 @@ func (o *OracleEngine) l2OutputAtHeader(header *types.Header) (*eth.OutputV0, er
 	// withdrawalRoot which is the storage root for the L2ToL1MessagePasser contract
 	if o.rollupCfg.IsIsthmus(header.Time) {
 		if header.WithdrawalsHash == nil {
-			return nil, fmt.Errorf("unexpected nil withdrawalsHash in isthmus header for block %v", blockHash)
+			return nil, fmt.Errorf("%w: unexpected nil withdrawalsHash in isthmus header for block %v", ErrInvalidHeader, blockHash)
 		}
 		storageRoot = *header.WithdrawalsHash
 	} else {
@@ -106,7 +111,7 @@ func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 	case eth.GetPayloadV2:
 		res, err = o.api.GetPayloadV2(ctx, payloadInfo.ID)
 	default:
-		return nil, fmt.Errorf("unsupported GetPayload version: %s", method)
+		return nil, fmt.Errorf("%w: GetPayload method: %s", ErrUnsupportedAPIVersion, method)
 	}
 	if err != nil {
 		return nil, err
@@ -130,7 +135,7 @@ func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.Forkchoi
 	case eth.FCUV1:
 		return o.api.ForkchoiceUpdatedV1(ctx, state, attr)
 	default:
-		return nil, fmt.Errorf("unsupported ForkchoiceUpdated version: %s", method)
+		return nil, fmt.Errorf("%w: ForkchoiceUpdated version: %s", ErrUnsupportedAPIVersion, method)
 	}
 }
 
@@ -143,7 +148,7 @@ func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPay
 	case eth.NewPayloadV2:
 		return o.api.NewPayloadV2(ctx, payload)
 	default:
-		return nil, fmt.Errorf("unsupported NewPayload version: %s", method)
+		return nil, fmt.Errorf("%w: NewPayload version: %s", ErrUnsupportedAPIVersion, method)
 	}
 }
 
@@ -173,7 +178,7 @@ func (o *OracleEngine) L2BlockRefByLabel(ctx context.Context, label eth.BlockLab
 	case eth.Finalized:
 		header = o.backend.CurrentFinalBlock()
 	default:
-		return eth.L2BlockRef{}, fmt.Errorf("unknown label: %v", label)
+		return eth.L2BlockRef{}, fmt.Errorf("%w: label: %v", ErrUnknownLabel, label)
 	}
 	if header == nil {
 		return eth.L2BlockRef{}, ErrNotFound

--- a/op-program/client/l2/engine_backend_test.go
+++ b/op-program/client/l2/engine_backend_test.go
@@ -167,7 +167,7 @@ func TestRejectBlockWithStateRootMismatch(t *testing.T) {
 	invalidBlock := types.NewBlockWithHeader(newBlock.Header())
 
 	_, err := chain.InsertBlockWithoutSetHead(invalidBlock, false)
-	require.ErrorContains(t, err, "block root mismatch")
+	require.ErrorIs(t, err, ErrUnexpectedBlockHash)
 }
 
 func TestGetHeaderByNumber(t *testing.T) {

--- a/op-program/client/l2/engine_test.go
+++ b/op-program/client/l2/engine_test.go
@@ -102,7 +102,7 @@ func TestL2BlockRefByLabel(t *testing.T) {
 	}
 	t.Run("UnknownLabel", func(t *testing.T) {
 		_, err := engine.L2BlockRefByLabel(ctx, "nope")
-		require.ErrorContains(t, err, "unknown label")
+		require.ErrorIs(t, err, ErrUnknownLabel)
 	})
 }
 

--- a/op-program/client/l2/engine_test.go
+++ b/op-program/client/l2/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -44,7 +45,7 @@ func TestPayloadByHash(t *testing.T) {
 		engine, _ := createOracleEngine(t, false)
 		hash := common.HexToHash("0x878899")
 		payload, err := engine.PayloadByHash(ctx, hash)
-		require.ErrorIs(t, err, ErrNotFound)
+		require.ErrorIs(t, err, ethereum.NotFound)
 		require.Nil(t, payload)
 	})
 }
@@ -65,7 +66,7 @@ func TestPayloadByNumber(t *testing.T) {
 	t.Run("NoCanonicalHash", func(t *testing.T) {
 		engine, _ := createOracleEngine(t, false)
 		payload, err := engine.PayloadByNumber(ctx, uint64(700))
-		require.ErrorIs(t, err, ErrNotFound)
+		require.ErrorIs(t, err, ethereum.NotFound)
 		require.Nil(t, payload)
 	})
 
@@ -75,7 +76,7 @@ func TestPayloadByNumber(t *testing.T) {
 		number := uint64(700)
 		stub.canonical[number] = hash
 		payload, err := engine.PayloadByNumber(ctx, number)
-		require.ErrorIs(t, err, ErrNotFound)
+		require.ErrorIs(t, err, ethereum.NotFound)
 		require.Nil(t, payload)
 	})
 }
@@ -120,7 +121,7 @@ func TestL2BlockRefByHash(t *testing.T) {
 
 	t.Run("UnknownBlock", func(t *testing.T) {
 		ref, err := engine.L2BlockRefByHash(ctx, common.HexToHash("0x878899"))
-		require.ErrorIs(t, err, ErrNotFound)
+		require.ErrorIs(t, err, ethereum.NotFound)
 		require.Equal(t, eth.L2BlockRef{}, ref)
 	})
 }
@@ -141,7 +142,7 @@ func TestSystemConfigByL2Hash(t *testing.T) {
 
 	t.Run("UnknownBlock", func(t *testing.T) {
 		ref, err := engine.SystemConfigByL2Hash(ctx, common.HexToHash("0x878899"))
-		require.ErrorIs(t, err, ErrNotFound)
+		require.ErrorIs(t, err, ethereum.NotFound)
 		require.Equal(t, eth.SystemConfig{}, ref)
 	})
 }

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -18,8 +18,10 @@ import (
 )
 
 var (
-	ErrExceedsGasLimit = errors.New("tx gas exceeds block gas limit")
-	ErrUsesTooMuchGas  = errors.New("action takes too much gas")
+	ErrExceedsGasLimit  = errors.New("tx gas exceeds block gas limit")
+	ErrUsesTooMuchGas   = errors.New("action takes too much gas")
+	errInvalidGasLimit  = errors.New("invalid gas limit")
+	errInvalidTimestamp = errors.New("invalid timestamp")
 )
 
 type BlockDataProvider interface {
@@ -69,11 +71,11 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 	header := types.CopyHeader(h) // Copy to avoid mutating the original header
 
 	if header.GasLimit > params.MaxGasLimit {
-		return nil, fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, params.MaxGasLimit)
+		return nil, fmt.Errorf("%w: have %v, max %v", errInvalidGasLimit, header.GasLimit, params.MaxGasLimit)
 	}
 	parentHeader := provider.GetHeaderByHash(header.ParentHash)
 	if header.Time <= parentHeader.Time {
-		return nil, errors.New("invalid timestamp")
+		return nil, errInvalidTimestamp
 	}
 	statedb, err := provider.StateAt(parentHeader.Root)
 	if err != nil {

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -188,6 +188,7 @@ func (ea *L2EngineAPI) startBlock(parent common.Hash, attrs *eth.PayloadAttribut
 	return nil
 }
 
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 func (ea *L2EngineAPI) endBlock() (*types.Block, error) {
 	if ea.blockProcessor == nil {
 		return nil, fmt.Errorf("no block is being built currently (id %s)", ea.payloadID)
@@ -240,9 +241,11 @@ func (ea *L2EngineAPI) config() *params.ChainConfig {
 func (ea *L2EngineAPI) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	if attr != nil {
 		if attr.Withdrawals != nil {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 			return STATUS_INVALID, engine.InvalidParams.With(errors.New("withdrawals not supported in V1"))
 		}
 		if ea.config().IsShanghai(ea.config().LondonBlock, uint64(attr.Timestamp)) {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 			return STATUS_INVALID, engine.InvalidParams.With(errors.New("forkChoiceUpdateV1 called post-shanghai"))
 		}
 	}
@@ -286,12 +289,14 @@ func (ea *L2EngineAPI) verifyPayloadAttributes(attr *eth.PayloadAttributes) erro
 	// Verify EIP-1559 params for Holocene.
 	if c.IsHolocene(t) {
 		if attr.EIP1559Params == nil {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 			return errors.New("got nil eip-1559 params while Holocene is active")
 		}
 		if err := eip1559.ValidateHolocene1559Params(attr.EIP1559Params[:]); err != nil {
 			return fmt.Errorf("invalid Holocene params: %w", err)
 		}
 	} else if attr.EIP1559Params != nil {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 		return errors.New("got Holocene params though fork not active")
 	}
 
@@ -300,9 +305,11 @@ func (ea *L2EngineAPI) verifyPayloadAttributes(attr *eth.PayloadAttributes) erro
 
 func checkAttribute(active func(*big.Int, uint64) bool, exists bool, block *big.Int, time uint64) error {
 	if active(block, time) && !exists {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 		return errors.New("fork active, missing expected attribute")
 	}
 	if !active(block, time) && exists {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 		return errors.New("fork inactive, unexpected attribute set")
 	}
 	return nil
@@ -310,6 +317,7 @@ func checkAttribute(active func(*big.Int, uint64) bool, exists bool, block *big.
 
 func (ea *L2EngineAPI) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
 	if payload.Withdrawals != nil {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("withdrawals not supported in V1"))
 	}
 
@@ -319,9 +327,11 @@ func (ea *L2EngineAPI) NewPayloadV1(ctx context.Context, payload *eth.ExecutionP
 func (ea *L2EngineAPI) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
 	if ea.config().IsShanghai(new(big.Int).SetUint64(uint64(payload.BlockNumber)), uint64(payload.Timestamp)) {
 		if payload.Withdrawals == nil {
+			//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
 		}
 	} else if payload.Withdrawals != nil {
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("non-nil withdrawals pre-shanghai"))
 	}
 
@@ -329,6 +339,8 @@ func (ea *L2EngineAPI) NewPayloadV2(ctx context.Context, payload *eth.ExecutionP
 }
 
 // Ported from: https://github.com/ethereum-optimism/op-geth/blob/c50337a60a1309a0f1dca3bf33ed1bb38c46cdd7/eth/catalyst/api.go#L486C1-L507
+//
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 func (ea *L2EngineAPI) NewPayloadV3(ctx context.Context, params *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
 	if params.ExcessBlobGas == nil {
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
@@ -365,6 +377,8 @@ func (ea *L2EngineAPI) NewPayloadV3(ctx context.Context, params *eth.ExecutionPa
 }
 
 // Ported from: https://github.com/ethereum-optimism/op-geth/blob/94bb3f660f770afd407280055e7f58c0d89a01af/eth/catalyst/api.go#L646
+//
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 func (ea *L2EngineAPI) NewPayloadV4(ctx context.Context, params *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
 	if params.Withdrawals == nil {
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
@@ -413,6 +427,7 @@ func (ea *L2EngineAPI) getPayload(_ context.Context, payloadId eth.PayloadID) (*
 	return eth.BlockAsPayloadEnv(bl, ea.config())
 }
 
+//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 func (ea *L2EngineAPI) forkchoiceUpdated(_ context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	ea.log.Trace("L2Engine API request received", "method", "ForkchoiceUpdated", "head", state.HeadBlockHash, "finalized", state.FinalizedBlockHash, "safe", state.SafeBlockHash)
 	if state.HeadBlockHash == (common.Hash{}) {
@@ -581,6 +596,7 @@ func (ea *L2EngineAPI) newPayload(_ context.Context, payload *eth.ExecutionPaylo
 
 	if block.Time() <= parent.Time() {
 		log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
+		//nolint:err113 // Do not use non-dynamic errors here to keep this function very similar to op-geth
 		return ea.invalid(errors.New("invalid timestamp"), parent.Header()), nil
 	}
 

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -127,7 +127,7 @@ func (o *FastCanonicalBlockHeaderOracle) getHistoricalBlockHash(head *types.Head
 		panic(fmt.Errorf("failed to get history block hash: %w", err))
 	}
 	if len(ret) != 32 {
-		panic(fmt.Errorf("invalid history storage result. got %d bytes, expected %d bytes", len(ret), common.HashLength))
+		panic(fmt.Sprintf("invalid history storage result. got %d bytes, expected %d bytes", len(ret), common.HashLength))
 	}
 	hash := common.Hash(ret)
 	if hash == (common.Hash{}) {
@@ -136,7 +136,7 @@ func (o *FastCanonicalBlockHeaderOracle) getHistoricalBlockHash(head *types.Head
 	}
 	header := o.blockByHashFn(hash)
 	if header == nil {
-		panic(fmt.Errorf("failed to get history block header for %v", n))
+		panic(fmt.Sprintf("failed to get history block header for %v", n))
 	}
 	return header
 }

--- a/op-program/client/mpt/trie.go
+++ b/op-program/client/mpt/trie.go
@@ -19,7 +19,7 @@ func ReadTrie(root common.Hash, getPreimage func(key common.Hash) []byte) []hexu
 	odb := &DB{db: Hooks{
 		Get: func(key []byte) []byte {
 			if len(key) != 32 {
-				panic(fmt.Errorf("expected 32 byte key query, but got %d bytes: %x", len(key), key))
+				panic(fmt.Sprintf("expected 32 byte key query, but got %d bytes: %x", len(key), key))
 			}
 			return getPreimage(*(*[32]byte)(key))
 		},
@@ -78,10 +78,10 @@ func ReadTrie(root common.Hash, getPreimage func(key common.Hash) []byte) []hexu
 	out := make([]hexutil.Bytes, len(values))
 	for i, x := range keys {
 		if x >= uint64(len(values)) {
-			panic(fmt.Errorf("bad key: %d", x))
+			panic(fmt.Sprintf("bad key: %d", x))
 		}
 		if out[x] != nil {
-			panic(fmt.Errorf("duplicate key %d", x))
+			panic(fmt.Sprintf("duplicate key %d", x))
 		}
 		out[x] = values[i]
 	}

--- a/op-program/client/mpt/trie_test.go
+++ b/op-program/client/mpt/trie_test.go
@@ -27,7 +27,7 @@ func (tc *trieCase) run(t *testing.T) {
 	results := ReadTrie(root, func(key common.Hash) []byte {
 		v, ok := byHash[key]
 		if !ok {
-			panic(fmt.Errorf("missing key %s", key))
+			panic(fmt.Sprintf("missing key %s", key))
 		}
 		return v
 	})

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+var errInvalidConfig = errors.New("invalid config")
 
 type Config struct {
 	SkipValidation bool
@@ -67,7 +70,7 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, !cfg.SkipValidation)
 	}
 	if cfg.DB == nil {
-		return errors.New("db config is required")
+		return fmt.Errorf("%w: db config is required", errInvalidConfig)
 	}
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
 	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData}

--- a/op-program/client/tasks/deposits_block.go
+++ b/op-program/client/tasks/deposits_block.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -18,6 +19,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
+
+var errBadFCUResult = errors.New("bad FCU result")
 
 // BuildDepositOnlyBlock builds a deposits-only block replacement for the specified optimistic block and returns the block hash and output root
 // for the new block.
@@ -65,7 +68,7 @@ func BuildDepositOnlyBlock(
 
 	id := result.PayloadID
 	if id == nil {
-		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("nil id in forkchoice result when expecting a valid ID")
+		return common.Hash{}, eth.Bytes32{}, fmt.Errorf("nil id in forkchoice result when expecting a valid ID: %w", errBadFCUResult)
 	}
 	payload, err := l2Source.GetPayload(context.Background(), eth.PayloadInfo{ID: *id, Timestamp: uint64(attrs.Timestamp)})
 	if err != nil {

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -18,6 +19,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
+
+var errNotFound = errors.New("not found")
 
 type L2Source interface {
 	L2OutputRoot(uint64) (common.Hash, eth.Bytes32, error)
@@ -91,7 +94,7 @@ func loadOutputRoot(l2ClaimBlockNum uint64, head eth.L2BlockRef, src L2Source) (
 func storeBlockData(derivedBlockHash common.Hash, db l2.KeyValueStore, backend engineapi.CachingEngineBackend) error {
 	block := backend.GetBlockByHash(derivedBlockHash)
 	if block == nil {
-		return fmt.Errorf("derived block %v is missing", derivedBlockHash)
+		return fmt.Errorf("%w: derived block %v is missing", errNotFound, derivedBlockHash)
 	}
 	headerRLP, err := rlp.EncodeToBytes(block.Header())
 	if err != nil {
@@ -111,7 +114,7 @@ func storeBlockData(derivedBlockHash common.Hash, db l2.KeyValueStore, backend e
 	}
 	receipts := backend.GetReceiptsByBlockHash(block.Hash())
 	if receipts == nil {
-		return fmt.Errorf("receipts for block %v are missing", block.Hash())
+		return fmt.Errorf("%w: receipts for block %v are missing", errNotFound, block.Hash())
 	}
 	opaqueReceipts, err := eth.EncodeReceipts(receipts)
 	if err != nil {

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -12,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
 	"github.com/ethereum-optimism/optimism/op-program/client/mpt"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -19,8 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
-
-var errNotFound = errors.New("not found")
 
 type L2Source interface {
 	L2OutputRoot(uint64) (common.Hash, eth.Bytes32, error)
@@ -94,7 +92,7 @@ func loadOutputRoot(l2ClaimBlockNum uint64, head eth.L2BlockRef, src L2Source) (
 func storeBlockData(derivedBlockHash common.Hash, db l2.KeyValueStore, backend engineapi.CachingEngineBackend) error {
 	block := backend.GetBlockByHash(derivedBlockHash)
 	if block == nil {
-		return fmt.Errorf("%w: derived block %v is missing", errNotFound, derivedBlockHash)
+		return fmt.Errorf("%w: derived block %v is missing", ethereum.NotFound, derivedBlockHash)
 	}
 	headerRLP, err := rlp.EncodeToBytes(block.Header())
 	if err != nil {
@@ -114,7 +112,7 @@ func storeBlockData(derivedBlockHash common.Hash, db l2.KeyValueStore, backend e
 	}
 	receipts := backend.GetReceiptsByBlockHash(block.Hash())
 	if receipts == nil {
-		return fmt.Errorf("%w: receipts for block %v are missing", errNotFound, block.Hash())
+		return fmt.Errorf("%w: receipts for block %v are missing", ethereum.NotFound, block.Hash())
 	}
 	opaqueReceipts, err := eth.EncodeReceipts(receipts)
 	if err != nil {

--- a/op-program/client/tasks/derive_test.go
+++ b/op-program/client/tasks/derive_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errBoom = errors.New("boom")
+
 func TestLoadOutputRoot(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		safeHead := eth.L2BlockRef{Number: 65}
@@ -37,15 +39,14 @@ func TestLoadOutputRoot(t *testing.T) {
 	})
 
 	t.Run("Error-OutputRoot", func(t *testing.T) {
-		expectedErr := errors.New("boom")
 		safeHead := eth.L2BlockRef{Number: 10}
 		l2 := &mockL2{
 			blockHash:     common.Hash{0x24},
 			outputRoot:    eth.Bytes32{0x11},
-			outputRootErr: expectedErr,
+			outputRootErr: errBoom,
 		}
 		_, err := loadOutputRoot(uint64(0), safeHead, l2)
-		require.ErrorIs(t, err, expectedErr)
+		require.ErrorIs(t, err, errBoom)
 	})
 }
 


### PR DESCRIPTION
Adds the [`err113`](https://github.com/Djarvur/go-err113) golang-ci linter to CI. At the moment, this linter is only used for the op-program client to minimize the change diff. The linter will be progressively expanded to the rest of the monorepo in future PRs.

### Why?

We've been bitten by critical bugs in the [interop op-program](https://github.com/ethereum-optimism/optimism/issues/14988) and the [op-supervisor](https://github.com/ethereum-optimism/optimism/pull/15149) due to the usage of dynamic errors. Such bugs would be less likely if the programmer were forced to be cognizant of the error values being used. `err113` accomplishes this by linting usage of dynamic errors such as the following common pattern:

```go
return nil,  errors.New("not found")
```

The programmer must instead create an error value and return that instead. And the error value should be clearly documented on API surfaces so that callers know have an idea on how to handle the error.