### PR TITLE
op-program: Guard reproducible-prestate against invalid embed configs

### DIFF
--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -47,8 +47,8 @@ op-program-client-mips64-interop:
 op-program-client-riscv:
 	env GO111MODULE=on GOOS=linux GOARCH=riscv64 go build -v -gcflags="all=-d=softfloat" -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client-riscv.elf ./client/cmd/main.go
 
-check-custom-chains:
-	env GO111MODULE=on go run ./host/cmd configs check-custom-chains
+check-custom-chains: op-program-host
+	./bin/op-program configs check-custom-chains
 
 reproducible-prestate: check-custom-chains
 	@docker build --output ./bin/ --progress plain -f Dockerfile.repro ../

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -47,7 +47,10 @@ op-program-client-mips64-interop:
 op-program-client-riscv:
 	env GO111MODULE=on GOOS=linux GOARCH=riscv64 go build -v -gcflags="all=-d=softfloat" -ldflags "$(PC_LDFLAGSSTRING)" -o ./bin/op-program-client-riscv.elf ./client/cmd/main.go
 
-reproducible-prestate:
+check-custom-chains:
+	env GO111MODULE=on go run ./host/cmd configs check-custom-chains
+
+reproducible-prestate: check-custom-chains
 	@docker build --output ./bin/ --progress plain -f Dockerfile.repro ../
 	@echo "Cannon Absolute prestate hash: "
 	@cat ./bin/prestate-proof.json | jq -r .pre

--- a/op-program/host/subcmds/configs_cmd.go
+++ b/op-program/host/subcmds/configs_cmd.go
@@ -151,7 +151,7 @@ func CheckCustomChains(ctx *cli.Context) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("errors checking custom chains: %v", errs)
+		return fmt.Errorf("errors checking custom chains: %w", errors.Join(errs))
 	}
 	return nil
 }

--- a/op-program/host/subcmds/configs_cmd.go
+++ b/op-program/host/subcmds/configs_cmd.go
@@ -1,6 +1,7 @@
 package subcmds
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -151,7 +152,7 @@ func CheckCustomChains(ctx *cli.Context) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("errors checking custom chains: %w", errors.Join(errs))
+		return fmt.Errorf("errors checking custom chains: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/op-program/host/subcmds/configs_cmd.go
+++ b/op-program/host/subcmds/configs_cmd.go
@@ -2,6 +2,7 @@ package subcmds
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
@@ -26,6 +27,13 @@ var ConfigsCommand = &cli.Command{
 	Usage:       "List the supported chain configurations",
 	Description: "List the supported chain configurations.",
 	Action:      ListConfigs,
+	Subcommands: []*cli.Command{
+		{
+			Name:   "check-custom-chains",
+			Usage:  "Check that all embedded custom chain configs are valid",
+			Action: CheckCustomChains,
+		},
+	},
 	Flags: []cli.Flag{
 		ConfigsChainIDFlag,
 		ConfigsNetworkFlag,
@@ -94,5 +102,56 @@ func listChain(chainID eth.ChainID) error {
 	}
 	description := cfg.Description(chaincfg.L2ChainIDToNetworkDisplayName)
 	fmt.Println(description)
+	return nil
+}
+
+func CheckCustomChains(ctx *cli.Context) error {
+	customChainIDs, err := chainconfig.CustomChainIDs()
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	interopChains := make(map[eth.ChainID]bool)
+
+	for _, chainID := range customChainIDs {
+		cfg, err := chainconfig.RollupConfigByChainID(chainID)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		_, err = chainconfig.ChainConfigByChainID(chainID)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if cfg.InteropTime != nil {
+			depset, err := chainconfig.DependencySetByChainID(chainID)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			for _, dep := range depset.Chains() {
+				interopChains[dep] = true
+			}
+		}
+		if err := listChain(chainID); err != nil {
+			return err
+		}
+	}
+
+	for chainID := range interopChains {
+		if !slices.Contains(customChainIDs, chainID) {
+			err := listChain(chainID)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("chain in depset not found in superchain-registry: %w", err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors checking custom chains: %v", errs)
+	}
 	return nil
 }


### PR DESCRIPTION
The change introduces a `check-custom-chains` subcommand to `configs` that checks that the embedded custom chain configuration looks OK. The check also ensures that all referenced chains in a dependency set are known to the program.

This check is now a requirement to build the reproducible prestate.