### PR TITLE
feat: Simplify op-deployer scripts: DeployAltDA [7/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/alt_da2.go
+++ b/op-deployer/pkg/deployer/opcm/alt_da2.go
@@ -1,0 +1,30 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployAltDA2Input struct {
+	Salt                     common.Hash
+	ProxyAdmin               common.Address
+	ChallengeContractOwner   common.Address
+	ChallengeWindow          *big.Int
+	ResolveWindow            *big.Int
+	BondSize                 *big.Int
+	ResolverRefundPercentage *big.Int
+}
+
+type DeployAltDA2Output struct {
+	DataAvailabilityChallengeProxy common.Address
+	DataAvailabilityChallengeImpl  common.Address
+}
+
+type DeployAltDA2Script script.DeployScriptWithOutput[DeployAltDA2Input, DeployAltDA2Output]
+
+// NewDeployAltDAScript loads and validates the DeployAltDA2 script contract
+func NewDeployAltDAScript(host *script.Host) (DeployAltDA2Script, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployAltDA2Input, DeployAltDA2Output](host, "DeployAltDA2.s.sol", "DeployAltDA2")
+}

--- a/op-deployer/pkg/deployer/opcm/alt_da2_test.go
+++ b/op-deployer/pkg/deployer/opcm/alt_da2_test.go
@@ -1,0 +1,65 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployAltDAScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployAltDA contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deploySuperchain, err := opcm.NewDeployAltDAScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deploySuperchain.Run(opcm.DeployAltDA2Input{
+			Salt:                     common.BigToHash(big.NewInt(1)),
+			ProxyAdmin:               common.BigToAddress(big.NewInt(2)),
+			ChallengeContractOwner:   common.BigToAddress(big.NewInt(3)),
+			ChallengeWindow:          big.NewInt(4),
+			ResolveWindow:            big.NewInt(5),
+			BondSize:                 big.NewInt(6),
+			ResolverRefundPercentage: big.NewInt(7),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		deprecatedOutput, err := opcm.DeployAltDA(host2, opcm.DeployAltDAInput{
+			Salt:                     common.BigToHash(big.NewInt(1)),
+			ProxyAdmin:               common.BigToAddress(big.NewInt(2)),
+			ChallengeContractOwner:   common.BigToAddress(big.NewInt(3)),
+			ChallengeWindow:          big.NewInt(4),
+			ResolveWindow:            big.NewInt(5),
+			BondSize:                 big.NewInt(6),
+			ResolverRefundPercentage: big.NewInt(7),
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.DataAvailabilityChallengeImpl, output.DataAvailabilityChallengeImpl)
+		require.Equal(t, deprecatedOutput.DataAvailabilityChallengeProxy, output.DataAvailabilityChallengeProxy)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.DataAvailabilityChallengeImpl), host1.GetCode(output.DataAvailabilityChallengeImpl))
+		require.Equal(t, host2.GetCode(deprecatedOutput.DataAvailabilityChallengeProxy), host1.GetCode(output.DataAvailabilityChallengeProxy))
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployAltDA2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAltDA2.s.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { IDataAvailabilityChallenge } from "interfaces/L1/IDataAvailabilityChallenge.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { Script } from "forge-std/Script.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+
+contract DeployAltDA2 is Script {
+    struct Input {
+        bytes32 salt;
+        IProxyAdmin proxyAdmin;
+        address challengeContractOwner;
+        uint256 challengeWindow;
+        uint256 resolveWindow;
+        uint256 bondSize;
+        uint256 resolverRefundPercentage;
+    }
+
+    struct Output {
+        IDataAvailabilityChallenge dataAvailabilityChallengeProxy;
+        IDataAvailabilityChallenge dataAvailabilityChallengeImpl;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deployDataAvailabilityChallengeProxy(_input, output_);
+        deployDataAvailabilityChallengeImpl(_input, output_);
+        initializeDataAvailabilityChallengeProxy(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function deployDataAvailabilityChallengeProxy(Input memory _input, Output memory _output) internal virtual {
+        bytes32 salt = _input.salt;
+        vm.broadcast(msg.sender);
+        IDataAvailabilityChallenge proxy = IDataAvailabilityChallenge(
+            DeployUtils.create2({
+                _name: "Proxy",
+                _salt: salt,
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (msg.sender)))
+            })
+        );
+        vm.label(address(proxy), "DataAvailabilityChallengeProxy");
+        _output.dataAvailabilityChallengeProxy = proxy;
+    }
+
+    function deployDataAvailabilityChallengeImpl(Input memory _input, Output memory _output) internal virtual {
+        bytes32 salt = _input.salt;
+        vm.broadcast(msg.sender);
+        IDataAvailabilityChallenge impl = IDataAvailabilityChallenge(
+            DeployUtils.create2({
+                _name: "DataAvailabilityChallenge",
+                _salt: salt,
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IDataAvailabilityChallenge.__constructor__, ()))
+            })
+        );
+        vm.label(address(impl), "DataAvailabilityChallengeImpl");
+        _output.dataAvailabilityChallengeImpl = impl;
+    }
+
+    function initializeDataAvailabilityChallengeProxy(Input memory _input, Output memory _output) internal virtual {
+        IProxy proxy = IProxy(payable(address(_output.dataAvailabilityChallengeProxy)));
+        IDataAvailabilityChallenge impl = _output.dataAvailabilityChallengeImpl;
+        IProxyAdmin proxyAdmin = IProxyAdmin(payable(address(_input.proxyAdmin)));
+
+        address contractOwner = _input.challengeContractOwner;
+        uint256 challengeWindow = _input.challengeWindow;
+        uint256 resolveWindow = _input.resolveWindow;
+        uint256 bondSize = _input.bondSize;
+        uint256 resolverRefundPercentage = _input.resolverRefundPercentage;
+
+        vm.startBroadcast(msg.sender);
+        proxy.upgradeToAndCall(
+            address(impl),
+            abi.encodeCall(
+                IDataAvailabilityChallenge.initialize,
+                (contractOwner, challengeWindow, resolveWindow, bondSize, resolverRefundPercentage)
+            )
+        );
+        proxy.changeAdmin(address(proxyAdmin));
+        vm.stopBroadcast();
+    }
+
+    function assertValidInput(Input memory _input) internal virtual {
+        require(_input.salt != bytes32(0), "DeployAltDA: salt not set");
+        require(address(_input.proxyAdmin) != address(0), "DeployAltDA: proxyAdmin not set");
+        require(_input.challengeContractOwner != address(0), "DeployAltDA: challengeContractOwner not set");
+        require(_input.challengeWindow != 0, "DeployAltDA: challengeWindow not set");
+        require(_input.resolveWindow != 0, "DeployAltDA: resolveWindow not set");
+        require(_input.bondSize != 0, "DeployAltDA: bondSize not set");
+        require(_input.resolverRefundPercentage != 0, "DeployAltDA: resolverRefundPercentage not set");
+        require(_input.resolverRefundPercentage <= 100, "DeployAltDA: resolverRefundPercentage too large");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) internal virtual {
+        address[] memory addresses = Solarray.addresses(
+            address(_output.dataAvailabilityChallengeProxy), address(_output.dataAvailabilityChallengeImpl)
+        );
+        DeployUtils.assertValidContractAddresses(addresses);
+
+        assertValidDataAvailabilityChallengeProxy(_input, _output);
+        assertValidDataAvailabilityChallengeImpl(_output);
+    }
+
+    function assertValidDataAvailabilityChallengeProxy(Input memory _input, Output memory _output) internal virtual {
+        DeployUtils.assertERC1967ImplementationSet(address(_output.dataAvailabilityChallengeProxy));
+
+        IProxy proxy = IProxy(payable(address(_output.dataAvailabilityChallengeProxy)));
+        vm.prank(address(0));
+        address admin = proxy.admin();
+        require(admin == address(_input.proxyAdmin), "DACP-10");
+
+        DeployUtils.assertInitialized({ _contractAddress: address(proxy), _isProxy: true, _slot: 0, _offset: 0 });
+
+        vm.prank(address(0));
+        address impl = proxy.implementation();
+        require(impl == address(_output.dataAvailabilityChallengeImpl), "DACP-20");
+
+        IDataAvailabilityChallenge dac = _output.dataAvailabilityChallengeProxy;
+        require(dac.owner() == _input.challengeContractOwner, "DACP-30");
+        require(dac.challengeWindow() == _input.challengeWindow, "DACP-40");
+        require(dac.resolveWindow() == _input.resolveWindow, "DACP-50");
+        require(dac.bondSize() == _input.bondSize, "DACP-60");
+        require(dac.resolverRefundPercentage() == _input.resolverRefundPercentage, "DACP-70");
+    }
+
+    function assertValidDataAvailabilityChallengeImpl(Output memory _output) internal view virtual {
+        IDataAvailabilityChallenge dac = _output.dataAvailabilityChallengeImpl;
+        DeployUtils.assertInitialized({ _contractAddress: address(dac), _isProxy: false, _slot: 0, _offset: 0 });
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployAltDA2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAltDA2.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { DeployAltDA2 } from "scripts/deploy/DeployAltDA2.s.sol";
+import { IDataAvailabilityChallenge } from "interfaces/L1/IDataAvailabilityChallenge.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+contract DeployAltDA2_Test is Test {
+    DeployAltDA2 deployAltDA;
+
+    // Define defaults
+    bytes32 salt = bytes32(uint256(1));
+    IProxyAdmin proxyAdmin;
+    address challengeContractOwner = makeAddr("challengeContractOwner");
+    uint256 challengeWindow = 100;
+    uint256 resolveWindow = 200;
+    uint256 bondSize = 1 ether;
+    uint256 resolverRefundPercentage = 10;
+
+    function setUp() public {
+        deployAltDA = new DeployAltDA2();
+
+        // Setup proxyAdmin
+        proxyAdmin = IProxyAdmin(
+            DeployUtils.create1({
+                _name: "ProxyAdmin",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (msg.sender)))
+            })
+        );
+    }
+
+    function test_run_succeeds(
+        DeployAltDA2.Input memory _input,
+        uint8 _resolverRefundPercentage // we use uint8 for a percentage value so that we don't need to reject almost
+            // every uint256
+    )
+        public
+    {
+        vm.assume(_input.resolverRefundPercentage != 0);
+        vm.assume(_resolverRefundPercentage <= 100);
+        _input.resolverRefundPercentage = resolverRefundPercentage;
+
+        vm.assume(_input.salt != bytes32(0));
+        vm.assume(address(_input.proxyAdmin) != address(0));
+        vm.assume(_input.challengeContractOwner != address(0));
+        vm.assume(_input.challengeWindow != 0);
+        vm.assume(_input.resolveWindow != 0);
+        vm.assume(_input.bondSize != 0);
+
+        // Run deployment
+        DeployAltDA2.Output memory output = deployAltDA.run(_input);
+
+        // Verify everything is set up correctly
+        assertTrue(address(output.dataAvailabilityChallengeImpl).code.length > 0, "200");
+
+        IDataAvailabilityChallenge dac = output.dataAvailabilityChallengeProxy;
+        assertTrue(address(dac).code.length > 0, "100");
+        assertEq(dac.owner(), _input.challengeContractOwner, "300");
+        assertEq(dac.challengeWindow(), _input.challengeWindow, "400");
+        assertEq(dac.resolveWindow(), _input.resolveWindow, "500");
+        assertEq(dac.bondSize(), _input.bondSize, "600");
+        assertEq(dac.resolverRefundPercentage(), _input.resolverRefundPercentage, "700");
+
+        // Make sure the proxy admin is set correctly.
+        vm.prank(address(0));
+        assertEq(IProxy(payable(address(dac))).admin(), address(_input.proxyAdmin), "800");
+    }
+
+    function test_run_resolverRefundPercentageTooLarge_reverts(uint256 _resolverRefundPercentage) public {
+        vm.assume(_resolverRefundPercentage > 100);
+
+        DeployAltDA2.Input memory input = defaultInput();
+        input.resolverRefundPercentage = _resolverRefundPercentage;
+
+        vm.expectRevert("DeployAltDA: resolverRefundPercentage too large");
+        deployAltDA.run(input);
+    }
+
+    function test_run_nullInputs_reverts() public {
+        DeployAltDA2.Input memory input;
+
+        input = defaultInput();
+        input.salt = bytes32(0);
+        vm.expectRevert("DeployAltDA: salt not set");
+        deployAltDA.run(input);
+
+        input = defaultInput();
+        input.proxyAdmin = IProxyAdmin(address(0));
+        vm.expectRevert("DeployAltDA: proxyAdmin not set");
+        deployAltDA.run(input);
+
+        input = defaultInput();
+        input.challengeContractOwner = address(0);
+        vm.expectRevert("DeployAltDA: challengeContractOwner not set");
+        deployAltDA.run(input);
+
+        input = defaultInput();
+        input.challengeWindow = 0;
+        vm.expectRevert("DeployAltDA: challengeWindow not set");
+        deployAltDA.run(input);
+
+        input = defaultInput();
+        input.resolveWindow = 0;
+        vm.expectRevert("DeployAltDA: resolveWindow not set");
+        deployAltDA.run(input);
+
+        input = defaultInput();
+        input.bondSize = 0;
+        vm.expectRevert("DeployAltDA: bondSize not set");
+        deployAltDA.run(input);
+
+        input = defaultInput();
+        input.resolverRefundPercentage = 0;
+        vm.expectRevert("DeployAltDA: resolverRefundPercentage not set");
+        deployAltDA.run(input);
+    }
+
+    function defaultInput() private view returns (DeployAltDA2.Input memory input_) {
+        input_ = DeployAltDA2.Input(
+            salt, proxyAdmin, challengeContractOwner, challengeWindow, resolveWindow, bondSize, resolverRefundPercentage
+        );
+    }
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployAltDA2` has been introduced along with extended test coverage.

The existing tests have been adjusted to the new format (input & output structs instead of contracts) and several missing test cases have been added.

On top of the foundry tests, there is maybe a more telling integration/regression test that compares the old & the new deployment script. Because of this, no existing code has been touched.