### PR TITLE
feat: Simplify op-deployer scripts: DeployAsterisc [8/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/asterisc2.go
+++ b/op-deployer/pkg/deployer/opcm/asterisc2.go
@@ -1,0 +1,21 @@
+package opcm
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployAsterisc2Input struct {
+	PreimageOracle common.Address
+}
+
+type DeployAsterisc2Output struct {
+	AsteriscSingleton common.Address
+}
+
+type DeployAsteriscScript script.DeployScriptWithOutput[DeployAsterisc2Input, DeployAsterisc2Output]
+
+// NewDeployAsteriscScript loads and validates the DeployAsterisc2 script contract
+func NewDeployAsteriscScript(host *script.Host) (DeployAsteriscScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployAsterisc2Input, DeployAsterisc2Output](host, "DeployAsterisc2.s.sol", "DeployAsterisc2")
+}

--- a/op-deployer/pkg/deployer/opcm/asterisc2_test.go
+++ b/op-deployer/pkg/deployer/opcm/asterisc2_test.go
@@ -1,0 +1,51 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployAsteriscScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployAsterisc2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deploySuperchain, err := opcm.NewDeployAsteriscScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deploySuperchain.Run(opcm.DeployAsterisc2Input{
+			PreimageOracle: common.BigToAddress(big.NewInt(1)),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		deprecatedOutput, err := opcm.DeployAsterisc(host2, opcm.DeployAsteriscInput{
+			PreimageOracle: common.BigToAddress(big.NewInt(1)),
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.AsteriscSingleton, output.AsteriscSingleton)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.AsteriscSingleton), host1.GetCode(output.AsteriscSingleton))
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployAsterisc2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAsterisc2.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Forge
+import { Script } from "forge-std/Script.sol";
+
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { IRISCV } from "interfaces/vendor/asterisc/IRISCV.sol";
+
+/// @title DeployAsterisc2
+contract DeployAsterisc2 is Script {
+    struct Input {
+        IPreimageOracle preimageOracle;
+    }
+
+    struct Output {
+        IRISCV asteriscSingleton;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deployAsteriscSingleton(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function deployAsteriscSingleton(Input memory _input, Output memory _output) internal {
+        vm.broadcast(msg.sender);
+        IRISCV singleton = IRISCV(
+            DeployUtils.create1({
+                _name: "RISCV",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IRISCV.__constructor__, (_input.preimageOracle)))
+            })
+        );
+
+        vm.label(address(singleton), "AsteriscSingleton");
+        _output.asteriscSingleton = singleton;
+    }
+
+    function assertValidInput(Input memory _input) internal pure {
+        require(address(_input.preimageOracle) != address(0), "DeployAsterisc: preimageOracle not set");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) internal view {
+        DeployUtils.assertValidContractAddress(address(_output.asteriscSingleton));
+
+        require(
+            _output.asteriscSingleton.oracle() == _input.preimageOracle,
+            "DeployAsterisc: preimageOracle does not match input"
+        );
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployAsterisc2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAsterisc2.t.sol
@@ -26,7 +26,9 @@ contract DeployAsterisc2_Test is Test {
         DeployAsterisc2.Output memory output = deployAsterisc.run(_input);
 
         DeployUtils.assertValidContractAddress(address(output.asteriscSingleton));
-        require(output.asteriscSingleton.oracle() == _input.preimageOracle, "100");
+
+        IPreimageOracle preimageOracle = output.asteriscSingleton.oracle();
+        require(preimageOracle == _input.preimageOracle, "100");
     }
 
     function test_run_nullInput_reverts() public {

--- a/packages/contracts-bedrock/test/opcm/DeployAsterisc2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAsterisc2.t.sol
@@ -26,9 +26,7 @@ contract DeployAsterisc2_Test is Test {
         DeployAsterisc2.Output memory output = deployAsterisc.run(_input);
 
         DeployUtils.assertValidContractAddress(address(output.asteriscSingleton));
-
-        IPreimageOracle preimageOracle = output.asteriscSingleton.oracle();
-        require(preimageOracle == _input.preimageOracle, "100");
+        assertEq(address(output.asteriscSingleton.oracle()), address(_input.preimageOracle), "100");
     }
 
     function test_run_nullInput_reverts() public {

--- a/packages/contracts-bedrock/test/opcm/DeployAsterisc2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAsterisc2.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+import { DeployAsterisc2 } from "scripts/deploy/DeployAsterisc2.s.sol";
+
+contract DeployAsterisc2_Test is Test {
+    DeployAsterisc2 deployAsterisc;
+
+    // Define default input variables for testing.
+    IPreimageOracle defaultPreimageOracle = IPreimageOracle(makeAddr("preimageOracle"));
+
+    function setUp() public {
+        deployAsterisc = new DeployAsterisc2();
+    }
+
+    function test_run_succeeds(DeployAsterisc2.Input memory _input) public {
+        vm.assume(address(_input.preimageOracle) != address(0));
+
+        DeployAsterisc2.Output memory output = deployAsterisc.run(_input);
+
+        DeployUtils.assertValidContractAddress(address(output.asteriscSingleton));
+        require(output.asteriscSingleton.oracle() == _input.preimageOracle, "100");
+    }
+
+    function test_run_nullInput_reverts() public {
+        DeployAsterisc2.Input memory input;
+
+        input = defaultInput();
+        input.preimageOracle = IPreimageOracle(address(0));
+        vm.expectRevert("DeployAsterisc: preimageOracle not set");
+        deployAsterisc.run(input);
+    }
+
+    function defaultInput() internal view returns (DeployAsterisc2.Input memory input_) {
+        input_ = DeployAsterisc2.Input(defaultPreimageOracle);
+    }
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployAsterisc2` has been introduced along with extended test coverage.

Thist deploy script had no tests so they have been added.

On top of the foundry tests, there is maybe a more telling integration/regression test that compares the old & the new deployment script. Because of this, no existing code has been touched.