### PR TITLE
ctb: Remove extra mips address from StandardValidator

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/validator.go
+++ b/op-deployer/pkg/deployer/bootstrap/validator.go
@@ -41,7 +41,6 @@ type ValidatorInput struct {
 	Release                          string         `json:"release"`
 	SuperchainConfig                 common.Address `json:"superchainConfig"`
 	L1PAOMultisig                    common.Address `json:"l1PAOMultisig"`
-	MIPS                             common.Address `json:"mips" evm:"mips"`
 	Challenger                       common.Address `json:"challenger"`
 	SuperchainConfigImpl             common.Address `json:"superchainConfigImpl"`
 	ProtocolVersionsImpl             common.Address `json:"protocolVersionsImpl"`

--- a/op-deployer/pkg/deployer/bootstrap/validator_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/validator_test.go
@@ -56,7 +56,6 @@ func testValidator(t *testing.T, forkRPCURL string, loc *artifacts.Locator, rele
 		Release:                          release,
 		SuperchainConfig:                 common.Address{'S'},
 		L1PAOMultisig:                    common.Address{'M'},
-		MIPS:                             common.Address{'I'},
 		Challenger:                       common.Address{'C'},
 		SuperchainConfigImpl:             common.Address{'1'},
 		ProtocolVersionsImpl:             common.Address{'2'},

--- a/packages/contracts-bedrock/interfaces/L1/IStandardValidator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IStandardValidator.sol
@@ -32,7 +32,6 @@ interface IStandardValidatorBase {
     function l1PAOMultisig() external view returns (address);
     function l1StandardBridgeImpl() external view returns (address);
     function l1StandardBridgeVersion() external pure returns (string memory);
-    function mips() external view returns (address);
     function mipsImpl() external view returns (address);
     function mipsVersion() external pure returns (string memory);
     function optimismMintableERC20FactoryImpl() external view returns (address);
@@ -66,7 +65,6 @@ interface IStandardValidatorV180 is IStandardValidatorBase {
         IStandardValidatorBase.ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     ) external;
@@ -86,7 +84,6 @@ interface IStandardValidatorV200 is IStandardValidatorBase {
         IStandardValidatorBase.ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     ) external;
@@ -106,7 +103,6 @@ interface IStandardValidatorV300 is IStandardValidatorBase {
         IStandardValidatorBase.ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     ) external;

--- a/packages/contracts-bedrock/scripts/deploy/DeployStandardValidator.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployStandardValidator.s.sol
@@ -50,9 +50,6 @@ contract DeployStandardValidatorInput is BaseDeployIO {
         } else if (_sel == this.l1PAOMultisig.selector) {
             require(_value != address(0), "DeployStandardValidator: l1PAOMultisig cannot be empty");
             _l1PAOMultisig = _value;
-        } else if (_sel == this.mips.selector) {
-            require(_value != address(0), "DeployStandardValidator: mips cannot be empty");
-            _mips = _value;
         } else if (_sel == this.challenger.selector) {
             require(_value != address(0), "DeployStandardValidator: challenger cannot be empty");
             _challenger = _value;
@@ -127,11 +124,6 @@ contract DeployStandardValidatorInput is BaseDeployIO {
     function l1PAOMultisig() public view returns (address) {
         require(_l1PAOMultisig != address(0), "DeployStandardValidator: l1PAOMultisig not set");
         return _l1PAOMultisig;
-    }
-
-    function mips() public view returns (address) {
-        require(_mips != address(0), "DeployStandardValidator: mips not set");
-        return _mips;
     }
 
     function challenger() public view returns (address) {
@@ -280,7 +272,6 @@ contract DeployStandardValidator is Script {
                         getImplementations(_si),
                         _si.superchainConfig(),
                         _si.l1PAOMultisig(),
-                        _si.mips(),
                         _si.challenger(),
                         _si.withdrawalDelaySeconds()
                     )
@@ -303,7 +294,6 @@ contract DeployStandardValidator is Script {
                         getImplementations(_si),
                         _si.superchainConfig(),
                         _si.l1PAOMultisig(),
-                        _si.mips(),
                         _si.challenger(),
                         _si.withdrawalDelaySeconds()
                     )
@@ -326,7 +316,6 @@ contract DeployStandardValidator is Script {
                         getImplementations(_si),
                         _si.superchainConfig(),
                         _si.l1PAOMultisig(),
-                        _si.mips(),
                         _si.challenger(),
                         _si.withdrawalDelaySeconds()
                     )
@@ -358,7 +347,6 @@ contract DeployStandardValidator is Script {
         IStandardValidatorV180 v180 = IStandardValidatorV180(_validator);
         require(address(v180.superchainConfig()) == address(_si.superchainConfig()), "SV180-10");
         require(v180.l1PAOMultisig() == _si.l1PAOMultisig(), "SV180-20");
-        require(v180.mips() == _si.mips(), "SV180-30");
         require(v180.challenger() == _si.challenger(), "SV180-40");
         require(v180.withdrawalDelaySeconds() == _si.withdrawalDelaySeconds(), "SV180-50");
     }
@@ -367,7 +355,6 @@ contract DeployStandardValidator is Script {
         IStandardValidatorV200 v200 = IStandardValidatorV200(_validator);
         require(address(v200.superchainConfig()) == address(_si.superchainConfig()), "SV200-10");
         require(v200.l1PAOMultisig() == _si.l1PAOMultisig(), "SV200-20");
-        require(v200.mips() == _si.mips(), "SV200-30");
         require(v200.challenger() == _si.challenger(), "SV200-40");
         require(v200.withdrawalDelaySeconds() == _si.withdrawalDelaySeconds(), "SV200-50");
     }

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorBase.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorBase.json
@@ -70,11 +70,6 @@
       },
       {
         "internalType": "address",
-        "name": "_mips",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "_challenger",
         "type": "address"
       },
@@ -267,19 +262,6 @@
       }
     ],
     "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "mips",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorV180.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorV180.json
@@ -70,11 +70,6 @@
       },
       {
         "internalType": "address",
-        "name": "_mips",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "_challenger",
         "type": "address"
       },
@@ -267,19 +262,6 @@
       }
     ],
     "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "mips",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorV200.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorV200.json
@@ -70,11 +70,6 @@
       },
       {
         "internalType": "address",
-        "name": "_mips",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "_challenger",
         "type": "address"
       },
@@ -267,19 +262,6 @@
       }
     ],
     "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "mips",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidatorV300.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidatorV300.json
@@ -70,11 +70,6 @@
       },
       {
         "internalType": "address",
-        "name": "_mips",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "_challenger",
         "type": "address"
       },
@@ -267,19 +262,6 @@
       }
     ],
     "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "mips",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorBase.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorBase.json
@@ -15,93 +15,86 @@
   },
   {
     "bytes": "20",
-    "label": "mips",
-    "offset": 0,
-    "slot": "2",
-    "type": "address"
-  },
-  {
-    "bytes": "20",
     "label": "challenger",
     "offset": 0,
-    "slot": "3",
+    "slot": "2",
     "type": "address"
   },
   {
     "bytes": "32",
     "label": "withdrawalDelaySeconds",
     "offset": 0,
-    "slot": "4",
+    "slot": "3",
     "type": "uint256"
   },
   {
     "bytes": "20",
     "label": "l1ERC721BridgeImpl",
     "offset": 0,
-    "slot": "5",
+    "slot": "4",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismPortalImpl",
     "offset": 0,
-    "slot": "6",
+    "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "systemConfigImpl",
     "offset": 0,
-    "slot": "7",
+    "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
-    "slot": "8",
+    "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
-    "slot": "9",
+    "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1StandardBridgeImpl",
     "offset": 0,
-    "slot": "10",
+    "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "disputeGameFactoryImpl",
     "offset": 0,
-    "slot": "11",
+    "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "anchorStateRegistryImpl",
     "offset": 0,
-    "slot": "12",
+    "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "delayedWETHImpl",
     "offset": 0,
-    "slot": "13",
+    "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "mipsImpl",
     "offset": 0,
-    "slot": "14",
+    "slot": "13",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV180.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV180.json
@@ -15,93 +15,86 @@
   },
   {
     "bytes": "20",
-    "label": "mips",
-    "offset": 0,
-    "slot": "2",
-    "type": "address"
-  },
-  {
-    "bytes": "20",
     "label": "challenger",
     "offset": 0,
-    "slot": "3",
+    "slot": "2",
     "type": "address"
   },
   {
     "bytes": "32",
     "label": "withdrawalDelaySeconds",
     "offset": 0,
-    "slot": "4",
+    "slot": "3",
     "type": "uint256"
   },
   {
     "bytes": "20",
     "label": "l1ERC721BridgeImpl",
     "offset": 0,
-    "slot": "5",
+    "slot": "4",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismPortalImpl",
     "offset": 0,
-    "slot": "6",
+    "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "systemConfigImpl",
     "offset": 0,
-    "slot": "7",
+    "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
-    "slot": "8",
+    "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
-    "slot": "9",
+    "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1StandardBridgeImpl",
     "offset": 0,
-    "slot": "10",
+    "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "disputeGameFactoryImpl",
     "offset": 0,
-    "slot": "11",
+    "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "anchorStateRegistryImpl",
     "offset": 0,
-    "slot": "12",
+    "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "delayedWETHImpl",
     "offset": 0,
-    "slot": "13",
+    "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "mipsImpl",
     "offset": 0,
-    "slot": "14",
+    "slot": "13",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV200.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV200.json
@@ -15,93 +15,86 @@
   },
   {
     "bytes": "20",
-    "label": "mips",
-    "offset": 0,
-    "slot": "2",
-    "type": "address"
-  },
-  {
-    "bytes": "20",
     "label": "challenger",
     "offset": 0,
-    "slot": "3",
+    "slot": "2",
     "type": "address"
   },
   {
     "bytes": "32",
     "label": "withdrawalDelaySeconds",
     "offset": 0,
-    "slot": "4",
+    "slot": "3",
     "type": "uint256"
   },
   {
     "bytes": "20",
     "label": "l1ERC721BridgeImpl",
     "offset": 0,
-    "slot": "5",
+    "slot": "4",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismPortalImpl",
     "offset": 0,
-    "slot": "6",
+    "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "systemConfigImpl",
     "offset": 0,
-    "slot": "7",
+    "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
-    "slot": "8",
+    "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
-    "slot": "9",
+    "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1StandardBridgeImpl",
     "offset": 0,
-    "slot": "10",
+    "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "disputeGameFactoryImpl",
     "offset": 0,
-    "slot": "11",
+    "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "anchorStateRegistryImpl",
     "offset": 0,
-    "slot": "12",
+    "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "delayedWETHImpl",
     "offset": 0,
-    "slot": "13",
+    "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "mipsImpl",
     "offset": 0,
-    "slot": "14",
+    "slot": "13",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV300.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/StandardValidatorV300.json
@@ -15,93 +15,86 @@
   },
   {
     "bytes": "20",
-    "label": "mips",
-    "offset": 0,
-    "slot": "2",
-    "type": "address"
-  },
-  {
-    "bytes": "20",
     "label": "challenger",
     "offset": 0,
-    "slot": "3",
+    "slot": "2",
     "type": "address"
   },
   {
     "bytes": "32",
     "label": "withdrawalDelaySeconds",
     "offset": 0,
-    "slot": "4",
+    "slot": "3",
     "type": "uint256"
   },
   {
     "bytes": "20",
     "label": "l1ERC721BridgeImpl",
     "offset": 0,
-    "slot": "5",
+    "slot": "4",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismPortalImpl",
     "offset": 0,
-    "slot": "6",
+    "slot": "5",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "systemConfigImpl",
     "offset": 0,
-    "slot": "7",
+    "slot": "6",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "optimismMintableERC20FactoryImpl",
     "offset": 0,
-    "slot": "8",
+    "slot": "7",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1CrossDomainMessengerImpl",
     "offset": 0,
-    "slot": "9",
+    "slot": "8",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "l1StandardBridgeImpl",
     "offset": 0,
-    "slot": "10",
+    "slot": "9",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "disputeGameFactoryImpl",
     "offset": 0,
-    "slot": "11",
+    "slot": "10",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "anchorStateRegistryImpl",
     "offset": 0,
-    "slot": "12",
+    "slot": "11",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "delayedWETHImpl",
     "offset": 0,
-    "slot": "13",
+    "slot": "12",
     "type": "address"
   },
   {
     "bytes": "20",
     "label": "mipsImpl",
     "offset": 0,
-    "slot": "14",
+    "slot": "13",
     "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -553,13 +553,7 @@ contract StandardValidatorV180 is StandardValidatorBase {
         address _challenger,
         uint256 _withdrawalDelaySeconds
     )
-        StandardValidatorBase(
-            _implementations,
-            _superchainConfig,
-            _l1PAOMultisig,
-            _challenger,
-            _withdrawalDelaySeconds
-        )
+        StandardValidatorBase(_implementations, _superchainConfig, _l1PAOMultisig, _challenger, _withdrawalDelaySeconds)
     { }
 
     function validate(InputV180 memory _input, bool _allowFailure) public view returns (string memory) {
@@ -590,13 +584,7 @@ contract StandardValidatorV200 is StandardValidatorBase {
         address _challenger,
         uint256 _withdrawalDelaySeconds
     )
-        StandardValidatorBase(
-            _implementations,
-            _superchainConfig,
-            _l1PAOMultisig,
-            _challenger,
-            _withdrawalDelaySeconds
-        )
+        StandardValidatorBase(_implementations, _superchainConfig, _l1PAOMultisig, _challenger, _withdrawalDelaySeconds)
     { }
 
     function validate(InputV200 memory _input, bool _allowFailure) public view returns (string memory) {
@@ -697,13 +685,7 @@ contract StandardValidatorV300 is StandardValidatorBase {
         address _challenger,
         uint256 _withdrawalDelaySeconds
     )
-        StandardValidatorBase(
-            _implementations,
-            _superchainConfig,
-            _l1PAOMultisig,
-            _challenger,
-            _withdrawalDelaySeconds
-        )
+        StandardValidatorBase(_implementations, _superchainConfig, _l1PAOMultisig, _challenger, _withdrawalDelaySeconds)
     { }
 
     function validate(InputV300 memory _input, bool _allowFailure) public view returns (string memory) {

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -27,7 +27,6 @@ import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 contract StandardValidatorBase {
     ISuperchainConfig public superchainConfig;
     address public l1PAOMultisig;
-    address public mips;
     address public challenger;
     uint256 public withdrawalDelaySeconds;
 
@@ -60,13 +59,11 @@ contract StandardValidatorBase {
         ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     ) {
         superchainConfig = _superchainConfig;
         l1PAOMultisig = _l1PAOMultisig;
-        mips = _mips;
         challenger = _challenger;
         withdrawalDelaySeconds = _withdrawalDelaySeconds;
 
@@ -407,7 +404,7 @@ contract StandardValidatorBase {
         view
         returns (string memory)
     {
-        bool validGameVM = address(_game.vm()) == address(mips);
+        bool validGameVM = address(_game.vm()) == address(mipsImpl);
 
         _errors = internalRequire(
             stringEq(_game.version(), permissionedDisputeGameVersion()), string.concat(_errorPrefix, "-20"), _errors
@@ -553,7 +550,6 @@ contract StandardValidatorV180 is StandardValidatorBase {
         ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     )
@@ -561,7 +557,6 @@ contract StandardValidatorV180 is StandardValidatorBase {
             _implementations,
             _superchainConfig,
             _l1PAOMultisig,
-            _mips,
             _challenger,
             _withdrawalDelaySeconds
         )
@@ -592,7 +587,6 @@ contract StandardValidatorV200 is StandardValidatorBase {
         ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     )
@@ -600,7 +594,6 @@ contract StandardValidatorV200 is StandardValidatorBase {
             _implementations,
             _superchainConfig,
             _l1PAOMultisig,
-            _mips,
             _challenger,
             _withdrawalDelaySeconds
         )
@@ -701,7 +694,6 @@ contract StandardValidatorV300 is StandardValidatorBase {
         ImplementationsBase memory _implementations,
         ISuperchainConfig _superchainConfig,
         address _l1PAOMultisig,
-        address _mips,
         address _challenger,
         uint256 _withdrawalDelaySeconds
     )
@@ -709,7 +701,6 @@ contract StandardValidatorV300 is StandardValidatorBase {
             _implementations,
             _superchainConfig,
             _l1PAOMultisig,
-            _mips,
             _challenger,
             _withdrawalDelaySeconds
         )

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -679,11 +679,6 @@ abstract contract StandardValidatorTest is Test {
         );
         vm.mockCall(
             address(proxyAdmin),
-            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(mips))),
-            abi.encode(validator.mipsImpl())
-        );
-        vm.mockCall(
-            address(proxyAdmin),
             abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(permissionedASR))),
             abi.encode(validator.anchorStateRegistryImpl())
         );
@@ -987,13 +982,12 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
                 l1ERC721BridgeImpl: makeAddr("l1ERC721BridgeImpl"),
                 optimismMintableERC20FactoryImpl: makeAddr("optimismMintableERC20FactoryImpl"),
                 disputeGameFactoryImpl: makeAddr("disputeGameFactoryImpl"),
-                mipsImpl: makeAddr("mipsImpl"),
+                mipsImpl: makeAddr("mips"),
                 anchorStateRegistryImpl: makeAddr("anchorStateRegistryImpl"),
                 delayedWETHImpl: makeAddr("delayedWETHImpl")
             }),
             superchainConfig,
             l1PAOMultisig,
-            mips,
             challenger,
             302400
         );
@@ -1081,13 +1075,12 @@ contract StandardValidatorV200_Test is StandardValidatorTest {
                 l1ERC721BridgeImpl: makeAddr("l1ERC721BridgeImpl"),
                 optimismMintableERC20FactoryImpl: makeAddr("optimismMintableERC20FactoryImpl"),
                 disputeGameFactoryImpl: makeAddr("disputeGameFactoryImpl"),
-                mipsImpl: makeAddr("mipsImpl"),
+                mipsImpl: makeAddr("mips"),
                 anchorStateRegistryImpl: makeAddr("anchorStateRegistryImpl"),
                 delayedWETHImpl: makeAddr("delayedWETHImpl")
             }),
             superchainConfig,
             l1PAOMultisig,
-            mips,
             challenger,
             302400
         );
@@ -1183,13 +1176,12 @@ contract StandardValidatorV300_Test is StandardValidatorTest {
                 l1ERC721BridgeImpl: makeAddr("l1ERC721BridgeImpl"),
                 optimismMintableERC20FactoryImpl: makeAddr("optimismMintableERC20FactoryImpl"),
                 disputeGameFactoryImpl: makeAddr("disputeGameFactoryImpl"),
-                mipsImpl: makeAddr("mipsImpl"),
+                mipsImpl: makeAddr("mips"),
                 anchorStateRegistryImpl: makeAddr("anchorStateRegistryImpl"),
                 delayedWETHImpl: makeAddr("delayedWETHImpl")
             }),
             superchainConfig,
             l1PAOMultisig,
-            mips,
             challenger,
             302400
         );

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -892,7 +892,6 @@ contract Specification_Test is CommonTest {
 
         _addSpec({ _name: "StandardValidator", _sel: _getSel("superchainConfig()") });
         _addSpec({ _name: "StandardValidator", _sel: _getSel("l1PAOMultisig()") });
-        _addSpec({ _name: "StandardValidator", _sel: _getSel("mips()") });
         _addSpec({ _name: "StandardValidator", _sel: _getSel("challenger()") });
         _addSpec({ _name: "StandardValidator", _sel: _getSel("l1ERC721BridgeImpl()") });
         _addSpec({ _name: "StandardValidator", _sel: _getSel("optimismPortalImpl()") });


### PR DESCRIPTION
There was both a `mips` and a `mipsImpl` address in the `StandardValidator`, which was causing confusion.

Only one was used, so I deleted `mips` and kept `mipsImpl` because it is consistent with what is [in the OPCM](https://github.com/ethereum-optimism/optimism/blob/3905129d6f203dba896328306cba521a7c4bd6b4/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L1565).