### PR TITLE
feat(op-acceptance-tests): ci; produce JUnit XML test report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1211,6 +1211,13 @@ jobs:
             LOG_DIR=$(ls -td -- logs/* | head -1)
             cat "$LOG_DIR/all.log" || true
           when: always
+      - run:
+          name: Generate JUnit XML test report for CircleCI
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            gotestsum --junitfile results/results.xml --raw-command cat $(LOG_DIR)/raw_go_events.log
+          when: always
       # Save the module cache for future runs
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}


### PR DESCRIPTION
**Description**

Producing a JUnit XML test report of the acceptance tests. This will hopefully provide us with an alternate, perhaps nicer, visualisation of the results.

If we're lucky, CircleCI will also generate some test insights for us:
https://circleci.com/docs/insights-tests
(Although I'm not sure this is supported for Go)

**Tests**

Runs fine locally.
