### PR TITLE
op-e2e: Migrate tests on game mechanics to the Super DG

### DIFF
--- a/op-e2e/e2eutils/disputegame/claim_helper.go
+++ b/op-e2e/e2eutils/disputegame/claim_helper.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -81,15 +79,7 @@ func (c *ClaimHelper) WaitForCounterClaim(ctx context.Context, ignoreClaims ...*
 
 // WaitForCountered waits until the claim is countered either by a child claim or by a step call.
 func (c *ClaimHelper) WaitForCountered(ctx context.Context) {
-	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
-	err := wait.For(timedCtx, time.Second, func() (bool, error) {
-		latestData := c.game.getClaim(ctx, c.Index)
-		return latestData.CounteredBy != common.Address{}, nil
-	})
-	if err != nil { // Avoid waiting time capturing game data when there's no error
-		c.require.NoErrorf(err, "Claim %v was not countered\n%v", c.Index, c.game.GameData(ctx))
-	}
+	c.game.WaitForCountered(ctx, c.Index)
 }
 
 func (c *ClaimHelper) RequireCorrectOutputRoot(ctx context.Context) {

--- a/op-e2e/e2eutils/disputegame/split_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/split_game_helper.go
@@ -27,17 +27,18 @@ import (
 const defaultTimeout = 20 * time.Minute
 
 type SplitGameHelper struct {
-	T                     *testing.T
-	Require               *require.Assertions
-	Client                *ethclient.Client
-	Opts                  *bind.TransactOpts
-	PrivKey               *ecdsa.PrivateKey
-	Game                  contracts.FaultDisputeGameContract
-	FactoryAddr           common.Address
-	Addr                  common.Address
-	CorrectOutputProvider types.TraceProvider
-	System                DisputeSystem
-	DescribePosition      func(pos types.Position, splitDepth types.Depth) string
+	T                       *testing.T
+	Require                 *require.Assertions
+	Client                  *ethclient.Client
+	Opts                    *bind.TransactOpts
+	PrivKey                 *ecdsa.PrivateKey
+	Game                    contracts.FaultDisputeGameContract
+	FactoryAddr             common.Address
+	Addr                    common.Address
+	CorrectOutputProvider   types.TraceProvider
+	System                  DisputeSystem
+	DescribePosition        func(pos types.Position, splitDepth types.Depth) string
+	ClaimedL2SequenceNumber func(pos types.Position) (uint64, error)
 }
 
 type moveCfg struct {
@@ -279,6 +280,18 @@ func (g *SplitGameHelper) WaitForAllClaimsCountered(ctx context.Context) {
 		})
 }
 
+func (g *SplitGameHelper) WaitForCountered(ctx context.Context, claimIdx int64) {
+	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		claim := g.getClaim(ctx, claimIdx)
+		return claim.CounteredBy != common.Address{}, nil
+	})
+	if err != nil { // Avoid waiting time capturing game data when there's no error
+		g.Require.NoErrorf(err, "Claim %v was not countered\n%v", claimIdx, g.GameData(ctx))
+	}
+}
+
 func (g *SplitGameHelper) Resolve(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
@@ -416,6 +429,25 @@ func WithoutWaitingForStep() DefendClaimOpt {
 	return func(cfg *defendClaimCfg) {
 		cfg.skipWaitingForStep = true
 	}
+}
+
+func (g *SplitGameHelper) SupportClaim(ctx context.Context, claim *ClaimHelper, performMove Mover, attemptStep Stepper) {
+	g.T.Logf("Supporting claim %v at depth %v", claim.Index, claim.Depth())
+	for !claim.IsMaxDepth(ctx) {
+		g.LogGameData(ctx)
+		// Wait for the challenger to counter
+		claim = claim.WaitForCounterClaim(ctx)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+		g.LogGameData(ctx)
+
+		// Respond with our own move
+		claim = performMove(claim)
+	}
+
+	g.LogGameData(ctx)
+	attemptStep(claim.Index)
 }
 
 // DefendClaim uses the supplied Mover to perform moves in an attempt to defend the supplied claim.
@@ -564,4 +596,53 @@ func (g *SplitGameHelper) ResolveClaim(ctx context.Context, claimIdx int64) {
 	candidate, err := g.Game.ResolveClaimTx(uint64(claimIdx))
 	g.Require.NoError(err, "Failed to create resolve claim candidate tx")
 	transactions.RequireSendTx(g.T, ctx, g.Client, candidate, g.PrivKey)
+}
+
+func (g *SplitGameHelper) DisputeLastBlock(ctx context.Context) *ClaimHelper {
+	return g.DisputeBlock(ctx, g.L2BlockNum(ctx))
+}
+
+// DisputeBlock posts claims from both the honest and dishonest actor to progress the output root part of the game
+// through to the split depth and the claims are setup such that the last block in the game range is the block
+// to execute cannon on. ie the first block the honest and dishonest actors disagree about is the l2 block of the game.
+func (g *SplitGameHelper) DisputeBlock(ctx context.Context, disputeBlockNum uint64) *ClaimHelper {
+	dishonestValue := g.GetClaimValue(ctx, 0)
+	correctRootClaim := g.correctClaimValue(ctx, types.NewPositionFromGIndex(big.NewInt(1)))
+	rootIsValid := dishonestValue == correctRootClaim
+	if rootIsValid {
+		// Ensure that the dishonest actor is actually posting invalid roots.
+		// Otherwise, the honest challenger will defend our counter and ruin everything.
+		dishonestValue = common.Hash{0xff, 0xff, 0xff}
+	}
+	pos := types.NewPositionFromGIndex(big.NewInt(1))
+	getClaimValue := func(parentClaim *ClaimHelper, claimPos types.Position) common.Hash {
+		claimBlockNum, err := g.ClaimedL2SequenceNumber(claimPos)
+		g.Require.NoError(err, "failed to calculate claim block number")
+		if claimBlockNum < disputeBlockNum {
+			// Use the correct output root for all claims prior to the dispute block number
+			// This pushes the game to dispute the last block in the range
+			return g.correctClaimValue(ctx, claimPos)
+		}
+		if rootIsValid == parentClaim.AgreesWithOutputRoot() {
+			// We are responding to a parent claim that agrees with a valid root, so we're being dishonest
+			return dishonestValue
+		} else {
+			// Otherwise we must be the honest actor so use the correct root
+			return g.correctClaimValue(ctx, claimPos)
+		}
+	}
+
+	claim := g.RootClaim(ctx)
+	for !claim.IsOutputRootLeaf(ctx) {
+		parentClaimBlockNum, err := g.ClaimedL2SequenceNumber(pos)
+		g.Require.NoError(err, "failed to calculate parent claim block number")
+		if parentClaimBlockNum >= disputeBlockNum {
+			pos = pos.Attack()
+			claim = claim.Attack(ctx, getClaimValue(claim, pos))
+		} else {
+			pos = pos.Defend()
+			claim = claim.Defend(ctx, getClaimValue(claim, pos))
+		}
+	}
+	return claim
 }

--- a/op-e2e/e2eutils/disputegame/super_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/super_game_helper.go
@@ -33,7 +33,6 @@ func NewSuperGameHelper(t *testing.T, require *require.Assertions, client *ethcl
 			CorrectOutputProvider: correctOutputProvider,
 			System:                system,
 			DescribePosition: func(pos types.Position, splitDepth types.Depth) string {
-
 				if pos.Depth() > splitDepth {
 					return ""
 				}
@@ -42,6 +41,10 @@ func NewSuperGameHelper(t *testing.T, require *require.Assertions, client *ethcl
 					return ""
 				}
 				return fmt.Sprintf("Timestamp: %v, Step: %v", timestamp, step)
+			},
+			ClaimedL2SequenceNumber: func(pos types.Position) (uint64, error) {
+				timestamp, _, err := correctOutputProvider.ComputeStep(pos)
+				return timestamp, err
 			},
 		},
 	}

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -38,7 +38,6 @@ func testCannonGame(t *testing.T, ctx context.Context, arena gameArena, game *di
 
 	// Attack the root of the cannon trace subgame
 	claim = claim.Attack(ctx, common.Hash{0x00, 0xcc})
-	lastDishonestClaim := claim
 	for !claim.IsMaxDepth(ctx) {
 		if claim.AgreesWithOutputRoot() {
 			// If the latest claim supports the output root, wait for the honest challenger to respond
@@ -47,26 +46,247 @@ func testCannonGame(t *testing.T, ctx context.Context, arena gameArena, game *di
 		} else {
 			// Otherwise we need to counter the honest claim
 			claim = claim.Defend(ctx, common.Hash{0x00, 0xdd})
-			lastDishonestClaim = claim
 			game.LogGameData(ctx)
 		}
 	}
 
-	if expectChallengerToStep := game.MaxDepth(ctx)%2 == 0; expectChallengerToStep {
-		t.Log("Waiting for challenger to step...")
-		claim.WaitForCountered(ctx)
-	} else {
-		t.Log("Calling step on challenger's claim...")
-		require.NotEqual(t, lastDishonestClaim.Position, claim.Position, "sanity checking challenger claim failed")
-		honestActor := arena.CreateHonestActor(ctx)
-		honestActor.StepFails(ctx, claim.Index, false)
-		honestActor.StepFails(ctx, claim.Index, true)
-	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
 	game.LogGameData(ctx)
 
 	arena.AdvanceTime(game.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
 	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func testCannonChallengeAllZeroClaim(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	game.LogGameData(ctx)
+
+	claim := game.DisputeLastBlock(ctx)
+	arena.CreateChallenger(ctx)
+
+	game.SupportClaim(ctx, claim, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		if parent.IsBottomGameRoot(ctx) {
+			return parent.Attack(ctx, common.Hash{})
+		}
+		return parent.Defend(ctx, common.Hash{})
+	}, verifyFinalStepper(t, ctx, arena, game))
+	game.LogGameData(ctx)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	game.LogGameData(ctx)
+}
+
+func testCannonDefendStep(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	outputRootClaim := game.DisputeLastBlock(ctx)
+	game.LogGameData(ctx)
+	arena.CreateChallenger(ctx)
+
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	maxDepth := game.MaxDepth(ctx)
+	game.SupportClaim(ctx, outputRootClaim, func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		// Post invalid claims for most steps to get down into the early part of the trace
+		if claim.Depth() < maxDepth-3 {
+			return claim.Attack(ctx, common.Hash{0xaa})
+		} else {
+			// Post our own counter but using the correct hash in low levels to force a defense step
+			return correctTrace.AttackClaim(ctx, claim)
+		}
+	}, verifyFinalStepper(t, ctx, arena, game))
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func testCannonPoisonedPostState(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	// Honest first attack at "honest" level
+	claim := correctTrace.AttackClaim(ctx, game.RootClaim(ctx))
+
+	// Honest defense at "dishonest" level
+	claim = correctTrace.DefendClaim(ctx, claim)
+
+	// Dishonest attack at "honest" level - honest move would be to ignore
+	claimToIgnore1 := claim.Attack(ctx, common.Hash{0x03, 0xaa})
+
+	// Honest attack at "dishonest" level - honest move would be to ignore
+	claimToIgnore2 := correctTrace.AttackClaim(ctx, claimToIgnore1)
+	game.LogGameData(ctx)
+
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	// Start dishonest challenger that posts correct claims
+	for {
+		game.LogGameData(ctx)
+		// Wait for the challenger to counter
+		// Note that we need to ignore claimToIgnore1 which already counters this...
+		claim = claim.WaitForCounterClaim(ctx, claimToIgnore1)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+
+		// Respond with our own move
+		if claim.IsBottomGameRoot(ctx) {
+			// Root of the cannon game must have the right VM status code (so it can't be honest).
+			// Note this occurs when there are splitDepth + 4 claims because there are multiple forks in this game.
+			claim = claim.Attack(ctx, common.Hash{0x01})
+		} else {
+			claim = correctTrace.DefendClaim(ctx, claim)
+		}
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	// Verify that the challenger didn't challenge our poisoned claims
+	claimToIgnore1.RequireOnlyCounteredBy(ctx, claimToIgnore2)
+	claimToIgnore2.RequireOnlyCounteredBy(ctx /* nothing */)
+
+	// Time travel past when the game will be resolvable.
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.LogGameData(ctx)
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+}
+
+func testDisputeRootBeyondProposedBlockValidOutputRoot(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, rootIsCorrect(t, ctx, arena, game), "This test must be run with a correct proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	claim := game.RootClaim(ctx)
+	// Attack the output root
+	claim = correctTrace.AttackClaim(ctx, claim)
+	// Wait for the challenger to respond
+	claim = claim.WaitForCounterClaim(ctx)
+	// Then defend until the split depth to force the game into the extension part of the output root bisection
+	// ie. the output root we wind up disputing is theoretically for a block after block number 1
+	for !claim.IsOutputRootLeaf(ctx) {
+		claim = correctTrace.DefendClaim(ctx, claim)
+		claim = claim.WaitForCounterClaim(ctx)
+	}
+	game.LogGameData(ctx)
+	// At this point we've reached the bottom of the output root bisection and every claim
+	// will have the same, valid, output root. We now need to post a cannon trace root that claims its invalid.
+	claim = claim.Defend(ctx, common.Hash{0x01, 0xaa})
+	// Now defend with the correct trace
+	for {
+		game.LogGameData(ctx)
+		claim = claim.WaitForCounterClaim(ctx)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
+		claim = correctTrace.DefendClaim(ctx, claim)
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	// Time travel past when the game will be resolvable.
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
+	game.LogGameData(ctx)
+}
+
+func testDisputeRootBeyondProposedBlockInvalidOutputRoot(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	claim := game.RootClaim(ctx)
+	// Wait for the honest challenger to counter the root
+	claim = claim.WaitForCounterClaim(ctx)
+	// Then defend until the split depth to force the game into the extension part of the output root bisection
+	// ie. the output root we wind up disputing is theoretically for a block after block number 1
+	// The dishonest actor challenges with the correct roots
+	for claim.IsOutputRoot(ctx) {
+		claim = correctTrace.DefendClaim(ctx, claim)
+		claim = claim.WaitForCounterClaim(ctx)
+	}
+	game.LogGameData(ctx)
+	// Now defend with the correct trace
+	for !claim.IsMaxDepth(ctx) {
+		game.LogGameData(ctx)
+		if claim.IsBottomGameRoot(ctx) {
+			claim = correctTrace.AttackClaim(ctx, claim)
+		} else {
+			claim = correctTrace.DefendClaim(ctx, claim)
+		}
+		if !claim.IsMaxDepth(ctx) {
+			// Have to attack the root of the cannon trace
+			claim = claim.WaitForCounterClaim(ctx)
+		}
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	// Time travel past when the game will be resolvable.
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	game.LogGameData(ctx)
+}
+
+func testDisputeRootChangeClaimedRoot(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, !rootIsCorrect(t, ctx, arena, game), "This test must be run with an incorrect proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	// Start the honest challenger
+	arena.CreateChallenger(ctx)
+
+	claim := game.RootClaim(ctx)
+	// Wait for the honest challenger to counter the root
+	claim = claim.WaitForCounterClaim(ctx)
+
+	// Then attack every claim until the leaf of output root bisection
+	for {
+		claim = claim.Attack(ctx, common.Hash{0xbb})
+		claim = claim.WaitForCounterClaim(ctx)
+		if claim.Depth() == game.SplitDepth(ctx)-1 {
+			// Post the correct output root as the leaf.
+			// This is for epoch 1 which is what the original root proposal was for too
+			claim = correctTrace.AttackClaim(ctx, claim)
+			// Challenger should post the first cannon trace
+			claim = claim.WaitForCounterClaim(ctx)
+			break
+		}
+	}
+
+	game.LogGameData(ctx)
+
+	// Now defend with the correct trace
+	for !claim.IsMaxDepth(ctx) {
+		game.LogGameData(ctx)
+		if claim.IsBottomGameRoot(ctx) {
+			claim = correctTrace.AttackClaim(ctx, claim)
+		} else {
+			claim = correctTrace.DefendClaim(ctx, claim)
+		}
+		if !claim.IsMaxDepth(ctx) {
+			// Have to attack the root of the cannon trace
+			claim = claim.WaitForCounterClaim(ctx)
+		}
+	}
+	verifyFinalStepExecution(t, ctx, arena, game, claim)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	game.LogGameData(ctx)
 }
 
 func rootIsCorrect(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) bool {
@@ -76,4 +296,37 @@ func rootIsCorrect(t *testing.T, ctx context.Context, arena gameArena, game *dis
 	require.NoError(t, err)
 	output := arena.GetProposalRoot(ctx, l2SequenceNumber)
 	return output == root.Value
+}
+
+func verifyFinalStepper(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) disputegame.Stepper {
+	return func(parentClaimIdx int64) {
+		validRoot := rootIsCorrect(t, ctx, arena, game)
+		maxDepth := game.MaxDepth(ctx)
+		expectChallengerToStep := validRoot == (maxDepth%2 == 1)
+		if expectChallengerToStep {
+			t.Log("Waiting for challenger to step on dishonest claim...")
+			game.WaitForCountered(ctx, parentClaimIdx)
+		} else {
+			t.Log("Calling step on challenger's claim...")
+			honestActor := arena.CreateHonestActor(ctx)
+			honestActor.StepFails(ctx, parentClaimIdx, false)
+			honestActor.StepFails(ctx, parentClaimIdx, true)
+		}
+	}
+}
+
+func verifyFinalStepExecution(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper, claim *disputegame.ClaimHelper) {
+	validRoot := rootIsCorrect(t, ctx, arena, game)
+	maxDepth := game.MaxDepth(ctx)
+	expectChallengerToStep := validRoot == (maxDepth%2 == 1)
+
+	if expectChallengerToStep {
+		t.Log("Waiting for challenger to step on dishonest claim...")
+		claim.WaitForCountered(ctx)
+	} else {
+		t.Log("Calling step on challenger's claim...")
+		honestActor := arena.CreateHonestActor(ctx)
+		honestActor.StepFails(ctx, claim.Index, false)
+		honestActor.StepFails(ctx, claim.Index, true)
+	}
 }

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -188,6 +188,9 @@ func testDisputeRootBeyondProposedBlockValidOutputRoot(t *testing.T, ctx context
 			break
 		}
 		claim = correctTrace.DefendClaim(ctx, claim)
+		if claim.IsMaxDepth(ctx) {
+			break
+		}
 	}
 	verifyFinalStepExecution(t, ctx, arena, game, claim)
 

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -34,8 +34,6 @@ func testOutputCannonGame(t *testing.T, allocType config.AllocType) {
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 4, common.Hash{0x01})
-	game.LogGameData(ctx)
-
 	arena := createOutputGameArena(t, sys, game)
 	testCannonGame(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -52,29 +50,13 @@ func testOutputCannonChallengeAllZeroClaim(t *testing.T, allocType config.AllocT
 	// The dishonest actor always posts claims with all zeros.
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, common.Hash{})
-	game.LogGameData(ctx)
-
-	claim := game.DisputeLastBlock(ctx)
-	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	game.DefendClaim(ctx, claim, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
-		if parent.IsBottomGameRoot(ctx) {
-			return parent.Attack(ctx, common.Hash{})
-		}
-		return parent.Defend(ctx, common.Hash{})
-	})
-
-	game.LogGameData(ctx)
-
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonChallengeAllZeroClaim(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestOutputCannon_PublishCannonRootClaim_Standard(t *testing.T) {
@@ -184,34 +166,13 @@ func testOutputCannonDefendStep(t *testing.T, allocType config.AllocType) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
-	require.NotNil(t, game)
-	outputRootClaim := game.DisputeLastBlock(ctx)
-	game.LogGameData(ctx)
-
-	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Mallory))
-
-	maxDepth := game.MaxDepth(ctx)
-	game.DefendClaim(ctx, outputRootClaim, func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
-		// Post invalid claims for most steps to get down into the early part of the trace
-		if claim.Depth() < maxDepth-3 {
-			return claim.Attack(ctx, common.Hash{0xaa})
-		} else {
-			// Post our own counter but using the correct hash in low levels to force a defense step
-			return correctTrace.AttackClaim(ctx, claim)
-		}
-	})
-
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonDefendStep(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestOutputCannonStepWithLargePreimage_Standard(t *testing.T) {
@@ -476,64 +437,14 @@ func testOutputCannonPoisonedPostState(t *testing.T, allocType config.AllocType)
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	// Honest first attack at "honest" level
-	claim := correctTrace.AttackClaim(ctx, game.RootClaim(ctx))
-
-	// Honest defense at "dishonest" level
-	claim = correctTrace.DefendClaim(ctx, claim)
-
-	// Dishonest attack at "honest" level - honest move would be to ignore
-	claimToIgnore1 := claim.Attack(ctx, common.Hash{0x03, 0xaa})
-
-	// Honest attack at "dishonest" level - honest move would be to ignore
-	claimToIgnore2 := correctTrace.AttackClaim(ctx, claimToIgnore1)
-	game.LogGameData(ctx)
-
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	// Start dishonest challenger that posts correct claims
-	for {
-		game.LogGameData(ctx)
-		// Wait for the challenger to counter
-		// Note that we need to ignore claimToIgnore1 which already counters this...
-		claim = claim.WaitForCounterClaim(ctx, claimToIgnore1)
-
-		// Respond with our own move
-		if claim.IsBottomGameRoot(ctx) {
-			// Root of the cannon game must have the right VM status code (so it can't be honest).
-			// Note this occurs when there are splitDepth + 4 claims because there are multiple forks in this game.
-			claim = claim.Attack(ctx, common.Hash{0x01})
-		} else {
-			claim = correctTrace.DefendClaim(ctx, claim)
-		}
-
-		// Defender moves last. If we're at max depth, then we're done
-		if claim.IsMaxDepth(ctx) {
-			break
-		}
-	}
-
-	// Wait for the challenger to call step
-	claim.WaitForCountered(ctx)
-	// Verify that the challenger didn't challenge our poisoned claims
-	claimToIgnore1.RequireOnlyCounteredBy(ctx, claimToIgnore2)
-	claimToIgnore2.RequireOnlyCounteredBy(ctx /* nothing */)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.LogGameData(ctx)
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+	arena := createOutputGameArena(t, sys, game)
+	testCannonPoisonedPostState(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot_Standard(t *testing.T) {
@@ -548,50 +459,14 @@ func testDisputeOutputRootBeyondProposedBlockValidOutputRoot(t *testing.T, alloc
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	claim := game.RootClaim(ctx)
-	// Attack the output root
-	claim = correctTrace.AttackClaim(ctx, claim)
-	// Wait for the challenger to respond
-	claim = claim.WaitForCounterClaim(ctx)
-	// Then defend until the split depth to force the game into the extension part of the output root bisection
-	// ie. the output root we wind up disputing is theoretically for a block after block number 1
-	for !claim.IsOutputRootLeaf(ctx) {
-		claim = correctTrace.DefendClaim(ctx, claim)
-		claim = claim.WaitForCounterClaim(ctx)
-	}
-	game.LogGameData(ctx)
-	// At this point we've reached the bottom of the output root bisection and every claim
-	// will have the same, valid, output root. We now need to post a cannon trace root that claims its invalid.
-	claim = claim.Defend(ctx, common.Hash{0x01, 0xaa})
-	// Now defend with the correct trace
-	for {
-		game.LogGameData(ctx)
-		claim = claim.WaitForCounterClaim(ctx)
-		if claim.IsMaxDepth(ctx) {
-			break
-		}
-		claim = correctTrace.DefendClaim(ctx, claim)
-	}
-	// Should not be able to step either attacking or defending
-	correctTrace.StepClaimFails(ctx, claim, true)
-	correctTrace.StepClaimFails(ctx, claim, false)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testDisputeRootBeyondProposedBlockValidOutputRoot(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot_Standard(t *testing.T) {
@@ -606,51 +481,14 @@ func testDisputeOutputRootBeyondProposedBlockInvalidOutputRoot(t *testing.T, all
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	claim := game.RootClaim(ctx)
-	// Wait for the honest challenger to counter the root
-	claim = claim.WaitForCounterClaim(ctx)
-	// Then defend until the split depth to force the game into the extension part of the output root bisection
-	// ie. the output root we wind up disputing is theoretically for a block after block number 1
-	// The dishonest actor challenges with the correct roots
-	for claim.IsOutputRoot(ctx) {
-		claim = correctTrace.DefendClaim(ctx, claim)
-		claim = claim.WaitForCounterClaim(ctx)
-	}
-	game.LogGameData(ctx)
-	// Now defend with the correct trace
-	for !claim.IsMaxDepth(ctx) {
-		game.LogGameData(ctx)
-		if claim.IsBottomGameRoot(ctx) {
-			claim = correctTrace.AttackClaim(ctx, claim)
-		} else {
-			claim = correctTrace.DefendClaim(ctx, claim)
-		}
-		if !claim.IsMaxDepth(ctx) {
-			// Have to attack the root of the cannon trace
-			claim = claim.WaitForCounterClaim(ctx)
-		}
-	}
-
-	// Wait for our final claim to be countered by the challenger calling step
-	claim.WaitForCountered(ctx)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testDisputeRootBeyondProposedBlockInvalidOutputRoot(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestTestDisputeOutputRoot_ChangeClaimedOutputRoot_Standard(t *testing.T) {
@@ -665,60 +503,14 @@ func testTestDisputeOutputRootChangeClaimedOutputRoot(t *testing.T, allocType co
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
 	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
-	correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
-
-	// Start the honest challenger
-	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
-
-	claim := game.RootClaim(ctx)
-	// Wait for the honest challenger to counter the root
-	claim = claim.WaitForCounterClaim(ctx)
-
-	// Then attack every claim until the leaf of output root bisection
-	for {
-		claim = claim.Attack(ctx, common.Hash{0xbb})
-		claim = claim.WaitForCounterClaim(ctx)
-		if claim.Depth() == game.SplitDepth(ctx)-1 {
-			// Post the correct output root as the leaf.
-			// This is for block 1 which is what the original output root was for too
-			claim = correctTrace.AttackClaim(ctx, claim)
-			// Challenger should post the first cannon trace
-			claim = claim.WaitForCounterClaim(ctx)
-			break
-		}
-	}
-
-	game.LogGameData(ctx)
-
-	// Now defend with the correct trace
-	for !claim.IsMaxDepth(ctx) {
-		game.LogGameData(ctx)
-		if claim.IsBottomGameRoot(ctx) {
-			claim = correctTrace.AttackClaim(ctx, claim)
-		} else {
-			claim = correctTrace.DefendClaim(ctx, claim)
-		}
-		if !claim.IsMaxDepth(ctx) {
-			// Have to attack the root of the cannon trace
-			claim = claim.WaitForCounterClaim(ctx)
-		}
-	}
-
-	// Wait for our final claim to be countered by the challenger calling step
-	claim.WaitForCountered(ctx)
-
-	// Time travel past when the game will be resolvable.
-	sys.TimeTravelClock.AdvanceTime(game.MaxClockDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-
-	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
-	game.LogGameData(ctx)
+	arena := createOutputGameArena(t, sys, game)
+	testDisputeRootChangeClaimedRoot(t, ctx, arena, &game.SplitGameHelper)
 }
 
 func TestInvalidateUnsafeProposal_Standard(t *testing.T) {

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -31,6 +31,54 @@ func TestSuperCannonGame(t *testing.T) {
 	testCannonGame(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
 }
 
+func TestSuperCannonGame_ChallengeAllZeroClaim(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testCannonChallengeAllZeroClaim(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonDefendStep(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testCannonDefendStep(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonPoisonedPostState(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testCannonPoisonedPostState(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonRootBeyondProposedBlock_ValidRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRoot(ctx)
+	testDisputeRootBeyondProposedBlockValidOutputRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonRootBeyondProposedBlock_InvalidRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testDisputeRootBeyondProposedBlockInvalidOutputRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+	testDisputeRootChangeClaimedRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
 func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()

--- a/op-e2e/faultproofs/util_interop.go
+++ b/op-e2e/faultproofs/util_interop.go
@@ -49,12 +49,12 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 	// wait for the supervisor to sync genesis
 	var lastError error
 	err = wait.For(ctx, 1*time.Minute, func() (bool, error) {
-		_, err := s2.SupervisorClient().SyncStatus(ctx)
+		status, err := s2.SupervisorClient().SyncStatus(ctx)
 		if err != nil {
 			lastError = err
 			return false, nil
 		}
-		return true, nil
+		return status.SafeTimestamp != 0, nil
 	})
 	require.NoErrorf(t, err, "failed to wait for supervisor to sync genesis: %v", lastError)
 


### PR DESCRIPTION
Part 2 of the FDG test migration to support the Super game type.

This migration focuses on game mechanics that are unchanged in the Super DG, and are agnostic to the game-type. Generic test scenarios are introduced, using the `gameArena` object, to de-dup a lot of the test setup.
The remaining game-type specific tests will be migrated in a later PR.

part of https://github.com/ethereum-optimism/optimism/issues/14974