### PR TITLE
ci: Run acceptance tests only on commits to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2230,9 +2230,12 @@ workflows:
 
   acceptance-tests:
     when:
-      or:
-        - equal: ["develop", <<pipeline.git.branch>>]
-        - equal: [true, <<pipeline.parameters.acceptance_tests_dispatch>>]
+      and:
+        - or:
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: [true, <<pipeline.parameters.acceptance_tests_dispatch>>]
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       # KURTOSIS (Simple)
       - op-acceptance-tests:


### PR DESCRIPTION
**Description**

Was previously also running on all scheduled pipelines.

