### PR TITLE
feat: Simplify op-deployer scripts: DeployAuthSystem [9/N]

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployAuthSystem2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAuthSystem2.s.sol
@@ -47,7 +47,6 @@ contract DeployAuthSystem2 is Script {
         //
         // TODO: replace with a real deployment.
         //
-
         address safe = makeAddr("safe");
         vm.etch(safe, type(Safe).runtimeCode);
         vm.store(safe, bytes32(uint256(3)), bytes32(_input.owners.length));

--- a/packages/contracts-bedrock/scripts/deploy/DeployAuthSystem2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAuthSystem2.s.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
+
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+
+contract DeployAuthSystem2 is Script {
+    struct Input {
+        uint256 threshold;
+        address[] owners;
+    }
+
+    struct Output {
+        Safe safe;
+    }
+
+    bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deploySafe(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function assertValidInput(Input memory _input) internal pure {
+        require(_input.owners.length != 0, "DeployAuthSystem: owners not set");
+        require(_input.threshold != 0, "DeployAuthSystem: threshold not set");
+        require(_input.threshold <= _input.owners.length, "DeployAuthSystem: threshold too large");
+
+        for (uint256 i = 0; i < _input.owners.length; i++) {
+            require(_input.owners[i] != address(0), "DeployAuthSystem: owner not set");
+        }
+
+        DeployUtils.assertUniqueAddresses(_input.owners);
+    }
+
+    function assertValidOutput(Input memory, Output memory _output) internal view {
+        DeployUtils.assertValidContractAddress(address(_output.safe));
+    }
+
+    function deploySafe(Input memory _input, Output memory _output) public {
+        //
+        // TODO: replace with a real deployment.
+        //
+
+        address safe = makeAddr("safe");
+        vm.etch(safe, type(Safe).runtimeCode);
+        vm.store(safe, bytes32(uint256(3)), bytes32(_input.owners.length));
+        vm.store(safe, bytes32(uint256(4)), bytes32(_input.threshold));
+
+        _output.safe = Safe(payable(safe));
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployAuthSystem2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAuthSystem2.s.sol
@@ -6,7 +6,6 @@ import { Script } from "forge-std/Script.sol";
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
-import { Solarray } from "scripts/libraries/Solarray.sol";
 
 contract DeployAuthSystem2 is Script {
     struct Input {

--- a/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
+++ b/packages/contracts-bedrock/scripts/libraries/DeployUtils.sol
@@ -330,16 +330,9 @@ library DeployUtils {
         );
     }
 
-    /// @notice Asserts that the given addresses are valid contract addresses.
+    /// @notice Asserts that the given list of addresses does not contain duplicates.
     /// @param _addrs Addresses to check.
-    function assertValidContractAddresses(address[] memory _addrs) internal view {
-        // Assert that all addresses are non-zero and have code.
-        // We use LibString to avoid the need for adding cheatcodes to this contract.
-        for (uint256 i = 0; i < _addrs.length; i++) {
-            address who = _addrs[i];
-            assertValidContractAddress(who);
-        }
-
+    function assertUniqueAddresses(address[] memory _addrs) internal pure {
         // All addresses should be unique.
         for (uint256 i = 0; i < _addrs.length; i++) {
             for (uint256 j = i + 1; j < _addrs.length; j++) {
@@ -351,6 +344,20 @@ library DeployUtils {
                 );
             }
         }
+    }
+
+    /// @notice Asserts that the given addresses are valid contract addresses.
+    /// @param _addrs Addresses to check.
+    function assertValidContractAddresses(address[] memory _addrs) internal view {
+        // Assert that all addresses are non-zero and have code.
+        // We use LibString to avoid the need for adding cheatcodes to this contract.
+        for (uint256 i = 0; i < _addrs.length; i++) {
+            address who = _addrs[i];
+            assertValidContractAddress(who);
+        }
+
+        // All addresses should be unique.
+        assertUniqueAddresses(_addrs);
     }
 
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1 (if a proxy contract) or

--- a/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
@@ -49,7 +49,19 @@ contract DeployUtils_Test is Test {
         addresses[_length] = addresses[_duplicateIndex];
 
         // Unfortunately it's not possible to use vm.expectRevert() here because the revert message is not a calldata argument
-        vm.expectRevert();
-        DeployUtils.assertUniqueAddresses(addresses);
+        // so we need to externalize the call
+        DeployUtils_Test(this).helper_assertUniqueAddresses_withDuplicateAddress_reverts(
+            string.concat("DeployUtils: check failed, duplicates at ", vm.toString(_duplicateIndex), ",", vm.toString(_length)),
+            addresses
+        );
+    }
+
+    /// @notice Helper function to test the revert message of assertUniqueAddresses with duplicate addresses.
+    /// @dev This function only exists because expectRevert only accepts a calldata argument
+    /// but string concatenation (required to create the revert message) is not possible in calldata.
+    /// @dev See testFuzz_assertUniqueAddresses_withDuplicateAddress_reverts
+    function helper_assertUniqueAddresses_withDuplicateAddress_reverts(string calldata _message, address[] calldata _addresses) external {
+        vm.expectRevert(bytes(_message));
+        DeployUtils.assertUniqueAddresses(_addresses);
     }
 }

--- a/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Forge
+import { Test } from "forge-std/Test.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+
+/// @title DeployUtils_Test
+contract DeployUtils_Test is Test {
+    function test_assertUniqueAddresses_withEmptyArray_succeeds() public pure {
+        DeployUtils.assertUniqueAddresses(new address[](0));
+    }
+
+    /// @param value The address to be tested.
+    function testFuzz_assertUniqueAddresses_withOneAddress_succeeds(address value) public pure {
+        DeployUtils.assertUniqueAddresses(Solarray.addresses(value));
+    }
+
+    /// @param _length The length of the array of addresses.
+    /// @param _seed The seed for generating the addresses.
+    function testFuzz_assertUniqueAddresses_withUniqueAddresses_succeeds(uint8 _length, bytes32 _seed) public pure {
+        vm.assume(_length != 0);
+
+        address[] memory addresses = new address[](_length);
+        for (uint256 i = 0; i < _length; i++) {
+            addresses[i] = address(uint160(uint256(keccak256(abi.encode(_seed, i)))));
+        }
+
+        DeployUtils.assertUniqueAddresses(addresses);
+    }
+
+    /// @param _length The length of the array of addresses.
+    /// @param _duplicateIndex The index of the address to be duplicated.
+    /// @param _seed The seed for generating the addresses.
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzz_assertUniqueAddresses_withDuplicateAddress_reverts(uint8 _length, uint8 _duplicateIndex, bytes32 _seed) public {
+        vm.assume(_length != 0);
+        vm.assume(_duplicateIndex < _length);
+
+        address[] memory addresses = new address[](uint16(_length) + 1);
+        for (uint256 i = 0; i < _length; i++) {
+            addresses[i] = address(uint160(uint256(keccak256(abi.encode(_seed, i)))));
+        }
+
+        // Insert a duplicate address at the end of the array
+        addresses[_length] = addresses[_duplicateIndex];
+
+        // Unfortunately it's not possible to use vm.expectRevert() here because the revert message is not a calldata argument
+        vm.expectRevert();
+        DeployUtils.assertUniqueAddresses(addresses);
+    }
+}

--- a/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
@@ -36,7 +36,13 @@ contract DeployUtils_Test is Test {
     /// @param _duplicateIndex The index of the address to be duplicated.
     /// @param _seed The seed for generating the addresses.
     /// forge-config: default.allow_internal_expect_revert = true
-    function testFuzz_assertUniqueAddresses_withDuplicateAddress_reverts(uint8 _length, uint8 _duplicateIndex, bytes32 _seed) public {
+    function testFuzz_assertUniqueAddresses_withDuplicateAddress_reverts(
+        uint8 _length,
+        uint8 _duplicateIndex,
+        bytes32 _seed
+    )
+        public
+    {
         vm.assume(_length != 0);
         vm.assume(_duplicateIndex < _length);
 
@@ -48,10 +54,13 @@ contract DeployUtils_Test is Test {
         // Insert a duplicate address at the end of the array
         addresses[_length] = addresses[_duplicateIndex];
 
-        // Unfortunately it's not possible to use vm.expectRevert() here because the revert message is not a calldata argument
+        // Unfortunately it's not possible to use vm.expectRevert() here because the revert message is not a calldata
+        // argument
         // so we need to externalize the call
         DeployUtils_Test(this).helper_assertUniqueAddresses_withDuplicateAddress_reverts(
-            string.concat("DeployUtils: check failed, duplicates at ", vm.toString(_duplicateIndex), ",", vm.toString(_length)),
+            string.concat(
+                "DeployUtils: check failed, duplicates at ", vm.toString(_duplicateIndex), ",", vm.toString(_length)
+            ),
             addresses
         );
     }
@@ -60,7 +69,12 @@ contract DeployUtils_Test is Test {
     /// @dev This function only exists because expectRevert only accepts a calldata argument
     /// but string concatenation (required to create the revert message) is not possible in calldata.
     /// @dev See testFuzz_assertUniqueAddresses_withDuplicateAddress_reverts
-    function helper_assertUniqueAddresses_withDuplicateAddress_reverts(string calldata _message, address[] calldata _addresses) external {
+    function helper_assertUniqueAddresses_withDuplicateAddress_reverts(
+        string calldata _message,
+        address[] calldata _addresses
+    )
+        external
+    {
         vm.expectRevert(bytes(_message));
         DeployUtils.assertUniqueAddresses(_addresses);
     }

--- a/packages/contracts-bedrock/test/opcm/DeployAuthSystem2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAuthSystem2.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
+import { stdToml } from "forge-std/StdToml.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+
+import { DeployAuthSystem2 } from "scripts/deploy/DeployAuthSystem2.s.sol";
+
+// contract DeployAuthSystemInput_Test is Test {
+//     DeployAuthSystemInput dasi;
+
+//     uint256 threshold = 5;
+//     address[] owners;
+
+//     function setUp() public {
+//         dasi = new DeployAuthSystemInput();
+//         address[] memory _owners = Solarray.addresses(
+//             0x1111111111111111111111111111111111111111,
+//             0x2222222222222222222222222222222222222222,
+//             0x3333333333333333333333333333333333333333,
+//             0x4444444444444444444444444444444444444444,
+//             0x5555555555555555555555555555555555555555,
+//             0x6666666666666666666666666666666666666666,
+//             0x7777777777777777777777777777777777777777
+//         );
+
+//         for (uint256 i = 0; i < _owners.length; i++) {
+//             owners.push(_owners[i]);
+//         }
+//     }
+
+//     function test_getters_whenNotSet_reverts() public {
+//         vm.expectRevert("DeployAuthSystemInput: threshold not set");
+//         dasi.threshold();
+
+//         vm.expectRevert("DeployAuthSystemInput: owners not set");
+//         dasi.owners();
+//     }
+
+//     function test_setters_ownerAlreadySet_reverts() public {
+//         dasi.set(dasi.owners.selector, owners);
+
+//         vm.expectRevert("DeployAuthSystemInput: owners already set");
+//         dasi.set(dasi.owners.selector, owners);
+//     }
+// }
+
+// contract DeployAuthSystemOutput_Test is Test {
+//     using stdToml for string;
+
+//     DeployAuthSystemOutput daso;
+
+//     function setUp() public {
+//         daso = new DeployAuthSystemOutput();
+//     }
+
+//     function test_set_succeeds() public {
+//         address safeAddr = makeAddr("safe");
+
+//         vm.etch(safeAddr, hex"01");
+
+//         daso.set(daso.safe.selector, safeAddr);
+
+//         assertEq(safeAddr, address(daso.safe()), "100");
+//     }
+
+//     function test_getter_whenNotSet_reverts() public {
+//         vm.expectRevert("DeployUtils: zero address");
+//         daso.safe();
+//     }
+
+//     function test_getter_whenAddrHasNoCode_reverts() public {
+//         address emptyAddr = makeAddr("emptyAddr");
+//         bytes memory expectedErr = bytes(string.concat("DeployUtils: no code at ", vm.toString(emptyAddr)));
+
+//         daso.set(daso.safe.selector, emptyAddr);
+//         vm.expectRevert(expectedErr);
+//         daso.safe();
+//     }
+// }
+
+contract DeployAuthSystem2_Test is Test {
+    using stdStorage for StdStorage;
+
+    DeployAuthSystem2 deployAuthSystem;
+
+    // Define default input variables for testing.
+    uint256 defaultThreshold = 5;
+    uint256 defaultOwnersLength = 7;
+    address[] defaultOwners;
+
+    function setUp() public {
+        deployAuthSystem = new DeployAuthSystem2();
+
+        for (uint256 i = 0; i < defaultOwnersLength; i++) {
+            defaultOwners.push(makeAddr(string.concat("owner", vm.toString(i))));
+        }
+    }
+
+    function hash(bytes32 _seed, uint256 _i) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_seed, _i));
+    }
+
+    function testFuzz_run_succeeds(bytes32 _seed, uint8 _numOwners, uint64 _threshold) public {
+        vm.assume(_threshold > 0);
+        vm.assume(_numOwners >= _threshold);
+
+        address[] memory owners = new address[](_numOwners);
+        for (uint8 i = 0; i < _numOwners; i++) {
+            owners[i] = address(uint160(uint256(hash(_seed, i))));
+        }
+
+        DeployAuthSystem2.Input memory input = DeployAuthSystem2.Input(_threshold, owners);
+
+        DeployAuthSystem2.Output memory output = deployAuthSystem.run(input);
+
+        assertNotEq(address(output.safe), address(0), "100");
+        assertEq(output.safe.getThreshold(), _threshold, "200");
+
+        // TODO The rest of the Safe setup is not finished atm
+    }
+
+    function test_run_nullInput_reverts() public {
+        DeployAuthSystem2.Input memory input;
+
+        input = DeployAuthSystem2.Input(0, Solarray.addresses(0x1111111111111111111111111111111111111111));
+        vm.expectRevert("DeployAuthSystem: threshold not set");
+        deployAuthSystem.run(input);
+
+        input = DeployAuthSystem2.Input(1, Solarray.addresses(address(0)));
+        vm.expectRevert("DeployAuthSystem: owner not set");
+        deployAuthSystem.run(input);
+
+        input = DeployAuthSystem2.Input(1, new address[](0));
+        vm.expectRevert("DeployAuthSystem: owners not set");
+        deployAuthSystem.run(input);
+    }
+
+    function test_run_thresholdTooLarge_reverts(uint8 _numOwners, uint64 _threshold) public {
+        vm.assume(_numOwners != 0);
+        vm.assume(_numOwners < _threshold);
+
+        address[] memory owners = new address[](_numOwners);
+
+        DeployAuthSystem2.Input memory input = DeployAuthSystem2.Input(_threshold, owners);
+        vm.expectRevert("DeployAuthSystem: threshold too large");
+        deployAuthSystem.run(input);
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployAuthSystem2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAuthSystem2.t.sol
@@ -2,83 +2,9 @@
 pragma solidity 0.8.15;
 
 import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
-import { stdToml } from "forge-std/StdToml.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 
 import { DeployAuthSystem2 } from "scripts/deploy/DeployAuthSystem2.s.sol";
-
-// contract DeployAuthSystemInput_Test is Test {
-//     DeployAuthSystemInput dasi;
-
-//     uint256 threshold = 5;
-//     address[] owners;
-
-//     function setUp() public {
-//         dasi = new DeployAuthSystemInput();
-//         address[] memory _owners = Solarray.addresses(
-//             0x1111111111111111111111111111111111111111,
-//             0x2222222222222222222222222222222222222222,
-//             0x3333333333333333333333333333333333333333,
-//             0x4444444444444444444444444444444444444444,
-//             0x5555555555555555555555555555555555555555,
-//             0x6666666666666666666666666666666666666666,
-//             0x7777777777777777777777777777777777777777
-//         );
-
-//         for (uint256 i = 0; i < _owners.length; i++) {
-//             owners.push(_owners[i]);
-//         }
-//     }
-
-//     function test_getters_whenNotSet_reverts() public {
-//         vm.expectRevert("DeployAuthSystemInput: threshold not set");
-//         dasi.threshold();
-
-//         vm.expectRevert("DeployAuthSystemInput: owners not set");
-//         dasi.owners();
-//     }
-
-//     function test_setters_ownerAlreadySet_reverts() public {
-//         dasi.set(dasi.owners.selector, owners);
-
-//         vm.expectRevert("DeployAuthSystemInput: owners already set");
-//         dasi.set(dasi.owners.selector, owners);
-//     }
-// }
-
-// contract DeployAuthSystemOutput_Test is Test {
-//     using stdToml for string;
-
-//     DeployAuthSystemOutput daso;
-
-//     function setUp() public {
-//         daso = new DeployAuthSystemOutput();
-//     }
-
-//     function test_set_succeeds() public {
-//         address safeAddr = makeAddr("safe");
-
-//         vm.etch(safeAddr, hex"01");
-
-//         daso.set(daso.safe.selector, safeAddr);
-
-//         assertEq(safeAddr, address(daso.safe()), "100");
-//     }
-
-//     function test_getter_whenNotSet_reverts() public {
-//         vm.expectRevert("DeployUtils: zero address");
-//         daso.safe();
-//     }
-
-//     function test_getter_whenAddrHasNoCode_reverts() public {
-//         address emptyAddr = makeAddr("emptyAddr");
-//         bytes memory expectedErr = bytes(string.concat("DeployUtils: no code at ", vm.toString(emptyAddr)));
-
-//         daso.set(daso.safe.selector, emptyAddr);
-//         vm.expectRevert(expectedErr);
-//         daso.safe();
-//     }
-// }
 
 contract DeployAuthSystem2_Test is Test {
     using stdStorage for StdStorage;


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployAuthSystem2` has been introduced along with extended test coverage.

The on significant thing to mention is that part of `assertValidContractAddresses` function in `DeployUtils` has been isolated as `assertUniqueAddresses`. New test suite has been added (since `DeployuUtils` didn't have one). Since [`expectRevert` no longer works with internal calls](https://github.com/foundry-rs/foundry/pull/9537), `allow_internal_expect_revert` has been enabled for the test function that checks that the code reverts.

To make things a tad bit more complex still, `expectRevert` does not play nice with `memory` variables, it only likes `calldata` - and our error message needs to be dynamically created which mean the only way to make it `calldata` again is to add an external call - that's where `helper_assertUniqueAddresses_withDuplicateAddress_reverts` comes in.

This deploy script has no go bindings so no new bindings were created (the script is just a stub it seems).