### PR TITLE
devnet-sdk: Update devstack example tests to work with kurtosis systems

### DIFF
--- a/devnet-sdk/devstack/presets/interop.go
+++ b/devnet-sdk/devstack/presets/interop.go
@@ -1,13 +1,13 @@
 package presets
 
 import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/sysgo"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/dsl"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/shim"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
-	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/sysgo"
 )
 
 type SimpleInterop struct {
@@ -18,24 +18,39 @@ type SimpleInterop struct {
 
 func NewSimpleInterop(dest *TestSetup[*SimpleInterop]) stack.Option {
 	return func(orch stack.Orchestrator) {
-		_, ok := orch.(*sysgo.Orchestrator)
-		orch.P().Require().True(ok, "only sysgo supported for now")
-
-		contracts, err := contractPaths()
-		orch.P().Require().NoError(err, "could not get contract paths")
-		var ids sysgo.DefaultInteropSystemIDs
-		opt := sysgo.DefaultInteropSystem(contracts, &ids)
-		opt(orch)
-		*dest = func(t devtest.T) *SimpleInterop {
-			system := shim.NewSystem(t)
-			orch.Hydrate(system)
-
-			sys := dsl.Hydrate(t, system)
-			return &SimpleInterop{
-				Log:        t.Logger(),
-				T:          t,
-				Supervisor: sys.Supervisor(ids.Supervisor),
-			}
+		if _, isSysGo := orch.(*sysgo.Orchestrator); isSysGo {
+			startInProcessSimpleInterop(orch)
 		}
+		*dest = func(t devtest.T) *SimpleInterop {
+			return hydrateSimpleInterop(t, orch)
+		}
+	}
+}
+
+// startInProcessSimpleInterop starts a new system that meets the simple interop criteria
+func startInProcessSimpleInterop(orch stack.Orchestrator) {
+	contracts, err := contractPaths()
+	orch.P().Require().NoError(err, "could not get contract paths")
+	var ids sysgo.DefaultInteropSystemIDs
+	opt := sysgo.DefaultInteropSystem(contracts, &ids)
+	opt(orch)
+}
+
+// hydrateSimpleInterop hydrates the test specific view of a shared system and selects the resources required for
+// a simple interop system.
+func hydrateSimpleInterop(t devtest.T, orch stack.Orchestrator) *SimpleInterop {
+	system := shim.NewSystem(t)
+	orch.Hydrate(system)
+
+	t.Require().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
+	// At this point, any supervisor is acceptable but as the DSL gets fleshed out this should be selecting supervisors
+	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
+	// since currently there's no way to tell which nodes are using which supervisor.
+	supervisorId := system.Supervisors()[0]
+	sys := dsl.Hydrate(t, system)
+	return &SimpleInterop{
+		Log:        t.Logger(),
+		T:          t,
+		Supervisor: sys.Supervisor(supervisorId),
 	}
 }

--- a/devnet-sdk/devstack/sysext/orchestrator.go
+++ b/devnet-sdk/devstack/sysext/orchestrator.go
@@ -1,10 +1,15 @@
 package sysext
 
 import (
+	"os"
+
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
 )
+
+const defaultDevnetUrl = "kt://interop-devnet"
 
 type OrchestratorOption func(*Orchestrator)
 
@@ -20,7 +25,14 @@ type Orchestrator struct {
 var _ stack.Orchestrator = (*Orchestrator)(nil)
 
 func NewOrchestrator(p devtest.P) *Orchestrator {
-	return &Orchestrator{p: p}
+	url := os.Getenv(env.EnvURLVar)
+	if url == "" {
+		p.Logger().Warn("No devnet URL specified, using default", "default", defaultDevnetUrl)
+		url = defaultDevnetUrl
+	}
+	env, err := env.LoadDevnetFromURL(url)
+	p.Require().NoError(err, "Error loading devnet environment")
+	return &Orchestrator{env: &env.Config, p: p}
 }
 
 func (o *Orchestrator) P() devtest.P {


### PR DESCRIPTION
**Description**

Updates the devstack example tests so they work against the kurtosis interop-devnet.  The system startup is now separated from location of required resources so it no longer assumes the fixed IDs used by the sys go implementation are what it needs to use.

Currently, it only exposes a single Supervisor so it doesn't really do any filtering, but as the DSL evolves to expose more things this filtering will expand to determine the most suitable endpoints to use for each component. https://github.com/ethereum-optimism/optimism/pull/15258 shows how that filtering can evolve and handle more complex requirements.

