### PR TITLE
Add two L2 chains in the same cluster to SimpleInterop

### DIFF
--- a/devnet-sdk/devstack/dsl/dsl.go
+++ b/devnet-sdk/devstack/dsl/dsl.go
@@ -50,6 +50,29 @@ func (s *System) Supervisor(id stack.SupervisorID) *Supervisor {
 	return newSupervisor(commonWithLog(s.common, s.log.New("id", id)), super)
 }
 
+func (s *System) ClusteredL2Networks(predicate func(cluster stack.Cluster) bool) []*L2Network {
+	for _, clusterID := range s.sys.Clusters() {
+		cluster := s.sys.Cluster(clusterID)
+		if !predicate(cluster) {
+			continue
+		}
+		chainIDs := cluster.DependencySet().Chains()
+		l2Networks := make([]*L2Network, len(chainIDs))
+		for i, chainID := range chainIDs {
+			l2NetworkID := s.sys.L2NetworkID(chainID)
+			l2Networks[i] = s.L2Network(l2NetworkID)
+		}
+		return l2Networks
+	}
+	s.require.Fail("No suitable cluster found")
+	return nil
+}
+
+func (s *System) L2Network(id stack.L2NetworkID) *L2Network {
+	network := s.sys.L2Network(id)
+	return newL2Network(s.common, network)
+}
+
 func Hydrate(t devtest.T, sys stack.System) *System {
 	return &System{
 		common: common{

--- a/devnet-sdk/devstack/dsl/l2_chain.go
+++ b/devnet-sdk/devstack/dsl/l2_chain.go
@@ -1,0 +1,20 @@
+package dsl
+
+import "github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+
+type L2Network struct {
+	common
+	net stack.Network
+}
+
+func newL2Network(c common, net stack.Network) *L2Network {
+	return &L2Network{
+		common: c,
+		net:    net,
+	}
+}
+
+func (n *L2Network) NewWallet() *Wallet {
+	user := n.net.Faucet().NewUser()
+	return newWallet(commonWithLog(n.common, n.common.log.New("id", user.ID(), "address", user.Address())), user)
+}

--- a/devnet-sdk/devstack/dsl/wallet.go
+++ b/devnet-sdk/devstack/dsl/wallet.go
@@ -1,0 +1,16 @@
+package dsl
+
+import "github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+
+// Wallet represents a
+type Wallet struct {
+	common
+	user stack.User
+}
+
+func newWallet(c common, user stack.User) *Wallet {
+	return &Wallet{
+		common: c,
+		user:   user,
+	}
+}

--- a/devnet-sdk/devstack/example/example_test.go
+++ b/devnet-sdk/devstack/example/example_test.go
@@ -21,3 +21,11 @@ func TestExample2(gt *testing.T) {
 
 	sys.Supervisor.VerifySyncStatus(dsl.WithAllLocalUnsafeHeadsAdvancedBy(4))
 }
+
+func TestExample3(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	t.Skip("No faucet support yet")
+	sys := SimpleInterop(t)
+
+	sys.ChainA.NewWallet()
+}

--- a/devnet-sdk/devstack/presets/interop.go
+++ b/devnet-sdk/devstack/presets/interop.go
@@ -14,6 +14,9 @@ type SimpleInterop struct {
 	Log        log.Logger
 	T          devtest.T
 	Supervisor *dsl.Supervisor
+
+	ChainA *dsl.L2Network
+	ChainB *dsl.L2Network
 }
 
 func NewSimpleInterop(dest *TestSetup[*SimpleInterop]) stack.Option {
@@ -39,16 +42,22 @@ func startInProcessSimpleInterop(orch stack.Orchestrator) {
 func hydrateSimpleInterop(t devtest.T, orch stack.Orchestrator) *SimpleInterop {
 	system := shim.NewSystem(t)
 	orch.Hydrate(system)
-
 	t.Require().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
+	
+	sys := dsl.Hydrate(t, system)
+
+	// Find L2 networks in a cluster with at least 2 chains
+	l2Networks := sys.ClusteredL2Networks(func(cluster stack.Cluster) bool {
+		return len(cluster.DependencySet().Chains()) >= 2
+	})
 	// At this point, any supervisor is acceptable but as the DSL gets fleshed out this should be selecting supervisors
 	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
 	// since currently there's no way to tell which nodes are using which supervisor.
-	supervisorId := system.Supervisors()[0]
-	sys := dsl.Hydrate(t, system)
 	return &SimpleInterop{
 		Log:        t.Logger(),
 		T:          t,
-		Supervisor: sys.Supervisor(supervisorId),
+		Supervisor: sys.Supervisor(system.Supervisors()[0]),
+		ChainA:     l2Networks[0],
+		ChainB:     l2Networks[1],
 	}
 }

--- a/devnet-sdk/devstack/stack/l2_cl.go
+++ b/devnet-sdk/devstack/stack/l2_cl.go
@@ -31,6 +31,7 @@ func SortL2CLNodeIDs(ids []L2CLNodeID) []L2CLNodeID {
 
 type RollupAPI interface {
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
+	SequencerActive(ctx context.Context) (bool, error)
 }
 
 // L2CLNode is a L2 ethereum consensus-layer node


### PR DESCRIPTION
**Description**

Starts expanding out the DSL to perform more realistic filtering/searching of the system. In this case, finding a cluster that contains at least two L2 chains.  This is roughly equivalent to the existing tests adding a precondition that there be two chains, but additionally ensures those two chains are actually in the same interop cluster.

At this stage the DSL for actually using the found network isn't thought through at all, but putting this up early to help show the direction that #15257 is going.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/15257
