### PR TITLE
OPCM checks v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,7 +736,7 @@ jobs:
   contracts-bedrock-coverage:
     circleci_ip_ranges: true
     docker:
-        - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     parameters:
       test_flags:
@@ -906,6 +906,8 @@ jobs:
           command: unused-imports-check-no-build
       - run-contracts-check:
           command: validate-spacers-no-build
+      - run-contracts-check:
+          command: opcm-upgrade-checks
 
   todo-issues:
     parameters:
@@ -1091,7 +1093,6 @@ jobs:
           name: Sanitize op-program client
           command: make sanitize-program GUEST_PROGRAM=../op-program/bin/op-program-client.elf
           working_directory: cannon
-
 
   cannon-prestate-quick:
     machine: true
@@ -1389,19 +1390,18 @@ jobs:
             goreleaser release --clean -f ./<<parameters.module>>/<<parameters.filename>>
 
   stale-check:
-      machine:
-        image: ubuntu-2204:2024.08.1
-      steps:
-        - utils/github-stale:
-            stale-issue-message: 'This issue has been automatically marked as stale and will be closed in 5 days if no updates'
-            stale-pr-message: 'This pr has been automatically marked as stale and will be closed in 5 days if no updates'
-            close-issue-message: 'This issue was closed as stale.  Please reopen if this is a mistake'
-            close-pr-message: 'This PR was closed as stale.  Please reopen if this is a mistake'
-            days-before-issue-stale: 999
-            days-before-pr-stale: 14
-            days-before-issue-close: 5
-            days-before-pr-close: 5
-
+    machine:
+      image: ubuntu-2204:2024.08.1
+    steps:
+      - utils/github-stale:
+          stale-issue-message: "This issue has been automatically marked as stale and will be closed in 5 days if no updates"
+          stale-pr-message: "This pr has been automatically marked as stale and will be closed in 5 days if no updates"
+          close-issue-message: "This issue was closed as stale.  Please reopen if this is a mistake"
+          close-pr-message: "This PR was closed as stale.  Please reopen if this is a mistake"
+          days-before-issue-stale: 999
+          days-before-pr-stale: 14
+          days-before-issue-close: 5
+          days-before-pr-close: 5
 
 workflows:
   main:

--- a/op-chain-ops/solc/types.go
+++ b/op-chain-ops/solc/types.go
@@ -179,6 +179,7 @@ type AstNode struct {
 	StateMutability  string            `json:"stateMutability,omitempty"`
 	Virtual          bool              `json:"virtual,omitempty"`
 	Visibility       string            `json:"visibility,omitempty"`
+	FunctionSelector string            `json:"functionSelector,omitempty"`
 
 	// Variable specific
 	Constant         bool                 `json:"constant,omitempty"`
@@ -194,6 +195,9 @@ type AstNode struct {
 	IsLValue        bool        `json:"isLValue,omitempty"`
 	IsPure          bool        `json:"isPure,omitempty"`
 	LValueRequested bool        `json:"lValueRequested,omitempty"`
+	ExternalCall    *AstNode    `json:"externalCall,omitempty"`
+	TryCall         bool        `json:"tryCall,omitempty"`
+	Clauses         []Clauses   `json:"clauses,omitempty"`
 
 	// Literal specific
 	HexValue string      `json:"hexValue,omitempty"`
@@ -201,11 +205,22 @@ type AstNode struct {
 	Value    interface{} `json:"value,omitempty"`
 
 	// Other fields
-	Arguments []Expression `json:"arguments,omitempty"`
-	Condition *Expression  `json:"condition,omitempty"`
-	TrueBody  *AstBlock    `json:"trueBody,omitempty"`
-	FalseBody *AstBlock    `json:"falseBody,omitempty"`
-	Operator  string       `json:"operator,omitempty"`
+	ModifierName    *Expression  `json:"modifierName,omitempty"`
+	Modifiers       []AstNode    `json:"modifiers,omitempty"`
+	Arguments       []Expression `json:"arguments,omitempty"`
+	Condition       *Expression  `json:"condition,omitempty"`
+	TrueBody        *AstNode     `json:"trueBody,omitempty"`
+	FalseBody       *AstNode     `json:"falseBody,omitempty"`
+	TrueExpression  *AstNode     `json:"trueExpression,omitempty"`
+	FalseExpression *AstNode     `json:"falseExpression,omitempty"`
+	Operator        string       `json:"operator,omitempty"`
+	Statements      *[]AstNode   `json:"statements,omitempty"`
+}
+
+type Clauses struct {
+	Block     *AstBlock `json:"block,omitempty"`
+	ErrorName string    `json:"errorName,omitempty"`
+	NodeType  string    `json:"nodeType,omitempty"`
 }
 
 type AstBaseContract struct {
@@ -259,6 +274,12 @@ type Expression struct {
 	OverloadedDeclarations []int                 `json:"overloadedDeclarations,omitempty"`
 	ReferencedDeclaration  int                   `json:"referencedDeclaration,omitempty"`
 	ArgumentTypes          []AstTypeDescriptions `json:"argumentTypes,omitempty"`
+	Value                  interface{}           `json:"value,omitempty"`
+	MemberName             string                `json:"memberName,omitempty"`
+	Kind                   string                `json:"kind,omitempty"`
+	Expression             *Expression           `json:"expression,omitempty"`
+	TrueExpression         *AstNode              `json:"trueExpression,omitempty"`
+	FalseExpression        *AstNode              `json:"falseExpression,omitempty"`
 }
 
 type ForgeArtifact struct {

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -207,6 +207,16 @@ snapshots-check: build snapshots-check-no-build
 interfaces-check-no-build:
   go run ./scripts/checks/interfaces
 
+# Checks that, if any L1 source contracts that have an upgrade method,
+# that upgrade method is called in the OPContractsManagerUpgrader.upgrade method.
+# Build the contracts first.
+opcm-upgrade-checks: clean build-dev opcm-upgrade-checks-no-build
+
+# Checks that, if any L1 source contracts that have an upgrade method,
+# that upgrade method is called in the OPContractsManagerUpgrader.upgrade method.
+opcm-upgrade-checks-no-build:
+  go run ./scripts/checks/opcm-upgrade-checks/
+
 # Checks that all interfaces are appropriately named and accurately reflect the corresponding
 # contract that they're meant to represent. We run "clean" before building because leftover
 # artifacts can cause the script to detect issues incorrectly.

--- a/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/OPCMUpgradeChecksMocks.sol
+++ b/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/OPCMUpgradeChecksMocks.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+IUpgradeable constant UPGRADE_CONTRACT = IUpgradeable(address(111));
+
+interface IUpgradeable {
+    function upgrade() external;
+}
+
+contract WithNoExternalUpgradeFunction {
+    bool constant EXPECTED_OUTPUT = false;
+
+    function aaa() external {
+        UPGRADE_CONTRACT.upgrade();
+    }
+}
+
+contract WithinTopLevelFunction {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade() external {
+        UPGRADE_CONTRACT.upgrade();
+    }
+}
+
+contract WithinBlockStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade() external {
+        {
+            UPGRADE_CONTRACT.upgrade();
+        }
+    }
+}
+
+contract WithinForLoop {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade() external {
+        for (uint256 i = 0; i < 10; i++) {
+            UPGRADE_CONTRACT.upgrade();
+        }
+    }
+}
+
+contract WithinWhileLoop {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade() external {
+        while (true) {
+            UPGRADE_CONTRACT.upgrade();
+        }
+    }
+}
+
+contract WithinDoWhileLoop {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade() external {
+        do {
+            UPGRADE_CONTRACT.upgrade();
+        } while (true);
+    }
+}
+
+contract WithinTrueBlockOfIfStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade(uint256 _a) external {
+        if (_a < 10) {
+            UPGRADE_CONTRACT.upgrade();
+        } else {
+            revert();
+        }
+    }
+}
+
+contract WithinFalseBlockOfIfStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade(uint256 _a) external {
+        if (_a < 10) {
+            revert();
+        } else {
+            UPGRADE_CONTRACT.upgrade();
+        }
+    }
+}
+
+contract WithinElseIfBlockOfIfStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade(uint256 _a) external {
+        if (_a < 10) {
+            revert();
+        } else if (_a < 20) {
+            UPGRADE_CONTRACT.upgrade();
+        } else {
+            revert();
+        }
+    }
+}
+
+contract WithinTrueBlockOfTernaryStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function mock() external { }
+
+    function upgrade(uint256 _a) external {
+        _a < 10 ? UPGRADE_CONTRACT.upgrade() : this.mock();
+    }
+}
+
+contract WithinFalseBlockOfTernaryStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function mock() external { }
+
+    function upgrade(uint256 _a) external {
+        _a < 10 ? this.mock() : UPGRADE_CONTRACT.upgrade();
+    }
+}
+
+contract WithTryStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function upgrade() external {
+        try UPGRADE_CONTRACT.upgrade() { } catch { }
+    }
+}
+
+contract WithinTryBlockOfTryCatchStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function mock() external { }
+
+    function upgrade() external {
+        try this.mock() {
+            UPGRADE_CONTRACT.upgrade();
+        } catch { }
+    }
+}
+
+contract WithinCatchBlockOfTryCatchStatement {
+    bool constant EXPECTED_OUTPUT = true;
+
+    function mock() external { }
+
+    function upgrade() external {
+        try this.mock() { }
+        catch {
+            UPGRADE_CONTRACT.upgrade();
+        }
+    }
+}

--- a/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main.go
+++ b/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/solc"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/scripts/checks/common"
+)
+
+var opcmArtifactPath = "forge-artifacts/OPContractsManager.sol/OPContractsManagerUpgrader.json"
+var opcmAst *solc.ForgeArtifact
+var opcmUpgradeFunctionSelector = "ff2dd5a1"
+
+func main() {
+	var err error
+
+	// Get OPCM's AST.
+	opcmAst, err = common.ReadForgeArtifact(opcmArtifactPath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Process.
+	if _, err := common.ProcessFilesGlob(
+		[]string{"forge-artifacts/**/*.json"},
+		[]string{"forge-artifacts/OPContractsManager.sol/*.json"},
+		processFile,
+	); err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func processFile(artifactPath string) (*common.Void, []error) {
+	// Get the artifact.
+	artifact, err := common.ReadForgeArtifact(artifactPath)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	// If the absolute path is not src/L1, return early.
+	if !strings.HasPrefix(artifact.Ast.AbsolutePath, "src/L1") {
+		return nil, nil
+	}
+
+	// Find if it contains any upgrade function and if there are no upgradeFunctions, return early.
+	if getNumberOfUpgradeFunctions(artifact) == 0 {
+		return nil, nil
+	}
+
+	// Get the AST of OPCM's upgrade function.
+	opcmUpgradeAst := getOpcmUpgradeFunctionAst(opcmAst)
+
+	// Check that there is a call to contract.upgrade.
+	contractName := strings.Split(filepath.Base(artifactPath), ".")[0]
+	typeName := "contract I" + contractName
+	if !upgradesContract(opcmUpgradeAst.Body.Statements, typeName) {
+		return nil, []error{fmt.Errorf("OPCM upgrade function does not call %v.upgrade", contractName)}
+	}
+
+	return nil, nil
+}
+
+// We want to ensure that:
+// - Top level external upgrade calls can be identified
+// - External upgrade calls within in a block i.e `{ }` can be identified
+// - External upgrade calls within a for, while, do loop can be identified
+// - External upgrade calls within the true/false block of if/else-if/else statements can be identified
+// - External upgrade calls within a try or catch path
+// - External upgrade calls within the true/false block of ternary statements can be identified
+// - Any combination of the aforementioned can be identified
+func upgradesContract(opcmUpgradeAst []solc.AstNode, typeName string) bool {
+	// Loop through all statements finding any external call to an upgrade function with a contract type of `typeName`
+	for _, node := range opcmUpgradeAst {
+		// To support nested statements or blocks.
+		if node.Statements != nil {
+			found := upgradesContract(*node.Statements, typeName)
+			if found {
+				return found
+			}
+		}
+
+		// For if / else-if / else statements
+		if node.TrueBody != nil {
+			found := upgradesContract([]solc.AstNode{*node.TrueBody}, typeName)
+			if found {
+				return found
+			}
+		}
+		if node.FalseBody != nil {
+			found := upgradesContract([]solc.AstNode{*node.FalseBody}, typeName)
+			if found {
+				return found
+			}
+		}
+
+		// For tenary statement
+		if node.Expression != nil && node.Expression.NodeType == "Conditional" {
+			if node.Expression.TrueExpression != nil {
+				found := upgradesContract([]solc.AstNode{*node.Expression.TrueExpression}, typeName)
+				if found {
+					return found
+				}
+			}
+			if node.Expression.FalseExpression != nil {
+				found := upgradesContract([]solc.AstNode{*node.Expression.FalseExpression}, typeName)
+				if found {
+					return found
+				}
+			}
+		}
+
+		// For nested tenary statement
+		if node.TrueExpression != nil {
+			found := upgradesContract([]solc.AstNode{*node.TrueExpression}, typeName)
+			if found {
+				return found
+			}
+		}
+		if node.FalseExpression != nil {
+			found := upgradesContract([]solc.AstNode{*node.FalseExpression}, typeName)
+			if found {
+				return found
+			}
+		}
+
+		// To support loops.
+		if node.Body != nil && node.Body.Statements != nil {
+			found := upgradesContract(node.Body.Statements, typeName)
+			if found {
+				return found
+			}
+		}
+
+		// To support try/catch blocks.
+		// Try part
+		if node.NodeType == "TryStatement" && node.ExternalCall != nil {
+			found := upgradesContract([]solc.AstNode{*node.ExternalCall}, typeName)
+			if found {
+				return found
+			}
+		}
+		// Catch part
+		if node.Clauses != nil {
+			for _, clause := range node.Clauses {
+				if clause.Block != nil && clause.Block.Statements != nil {
+					found := upgradesContract(clause.Block.Statements, typeName)
+					if found {
+						return found
+					}
+				}
+			}
+		}
+
+		// If not nested, check if the statement is an external call to an upgrade function with a contract type of `typeName`
+		if node.NodeType == "ExpressionStatement" {
+			if node.Expression.Expression != nil && node.Expression.Expression.Expression != nil {
+				if node.Expression.Expression.MemberName == "upgrade" && node.Expression.Expression.Expression.TypeDescriptions.TypeString == typeName {
+					return true
+				}
+			}
+		}
+
+		// To support try external calls and external calls within tenary statements.
+		if node.NodeType == "FunctionCall" {
+			// Try branch.
+			if node.Expression != nil && node.Expression.Expression != nil {
+				if node.Expression.MemberName == "upgrade" && node.Expression.Expression.TypeDescriptions.TypeString == typeName {
+					return true
+				}
+			}
+		}
+	}
+
+	// Else return false.
+	return false
+}
+
+// Get the AST of OPCM's upgrade function.
+func getOpcmUpgradeFunctionAst(opcmArtifact *solc.ForgeArtifact) *solc.AstNode {
+	opcmUpgradeAst := solc.AstNode{}
+	for _, astNode := range opcmArtifact.Ast.Nodes {
+		if astNode.NodeType == "ContractDefinition" && astNode.Name == "OPContractsManagerUpgrader" {
+			for _, node := range astNode.Nodes {
+				if node.NodeType == "FunctionDefinition" &&
+					node.Name == "upgrade" &&
+					node.Visibility == "external" &&
+					node.FunctionSelector == opcmUpgradeFunctionSelector {
+					opcmUpgradeAst = node
+					break
+				}
+			}
+		}
+	}
+
+	return &opcmUpgradeAst
+}
+
+// Get the first upgrade function from the input artifact.
+func getNumberOfUpgradeFunctions(artifact *solc.ForgeArtifact) int {
+	upgradeFunctions := []solc.AstNode{}
+	for _, astNode := range artifact.Ast.Nodes {
+		if astNode.NodeType == "ContractDefinition" {
+			for _, node := range astNode.Nodes {
+				if node.NodeType == "FunctionDefinition" &&
+					node.Name == "upgrade" &&
+					(node.Visibility == "external" || node.Visibility == "public") {
+					upgradeFunctions = append(upgradeFunctions, node)
+				}
+			}
+		}
+	}
+
+	return len(upgradeFunctions)
+}

--- a/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main.go
+++ b/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/scripts/checks/common"
 )
 
-var opcmArtifactPath = "forge-artifacts/OPContractsManager.sol/OPContractsManagerUpgrader.json"
+var opcmArtifactPath = "forge-artifacts/OPContractsManager.sol/OPContractsManager.json"
 var opcmAst *solc.ForgeArtifact
 var opcmUpgradeFunctionSelector = "ff2dd5a1"
 
@@ -27,7 +27,7 @@ func main() {
 	// Process.
 	if _, err := common.ProcessFilesGlob(
 		[]string{"forge-artifacts/**/*.json"},
-		[]string{"forge-artifacts/OPContractsManager.sol/*.json"},
+		[]string{"forge-artifacts/OPContractsManager.sol/*.json", "forge-artifacts/OPPrestateUpdater.sol/*.json"},
 		processFile,
 	); err != nil {
 		fmt.Printf("error: %v\n", err)

--- a/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main_test.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/solc"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/scripts/checks/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
+	tests := []struct {
+		name         string
+		opcmArtifact *solc.ForgeArtifact
+		expectedAst  *solc.AstNode
+	}{
+		{
+			name: "With upgrade function",
+			opcmArtifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:         "FunctionDefinition",
+									Name:             "upgrade",
+									Visibility:       "external",
+									FunctionSelector: opcmUpgradeFunctionSelector,
+									Nodes: []solc.AstNode{
+										{
+											NodeType: "UniqueNonExistentNodeType",
+										},
+									},
+								},
+							},
+							Name: "OPContractsManagerUpgrader",
+						},
+					},
+				},
+			},
+			expectedAst: &solc.AstNode{
+				NodeType:         "FunctionDefinition",
+				Name:             "upgrade",
+				Visibility:       "external",
+				FunctionSelector: opcmUpgradeFunctionSelector,
+				Nodes: []solc.AstNode{
+					{
+						NodeType: "UniqueNonExistentNodeType",
+					},
+				},
+			},
+		},
+		{
+			name: "With an upgrade function but not the right visibility",
+			opcmArtifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:         "FunctionDefinition",
+									Name:             "upgrade",
+									Visibility:       "public",
+									FunctionSelector: opcmUpgradeFunctionSelector,
+									Nodes: []solc.AstNode{
+										{
+											NodeType: "UniqueNonExistentNodeType",
+										},
+									},
+								},
+							},
+							Name: "OPContractsManagerUpgrader",
+						},
+					},
+				},
+			},
+			expectedAst: &solc.AstNode{},
+		},
+		{
+			name: "With an upgrade function but not the right function selector",
+			opcmArtifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:         "FunctionDefinition",
+									Name:             "upgrade",
+									Visibility:       "external",
+									FunctionSelector: "aabbccdd",
+									Nodes: []solc.AstNode{
+										{
+											NodeType: "UniqueNonExistentNodeType",
+										},
+									},
+								},
+							},
+							Name: "OPContractsManagerUpgrader",
+						},
+					},
+				},
+			},
+			expectedAst: &solc.AstNode{},
+		},
+		{
+			name: "With no upgrade function",
+			opcmArtifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:         "FunctionDefinition",
+									Name:             "randomFunctionName",
+									Visibility:       "external",
+									FunctionSelector: opcmUpgradeFunctionSelector,
+									Nodes: []solc.AstNode{
+										{
+											NodeType: "UniqueNonExistentNodeType",
+										},
+									},
+								},
+							},
+							Name: "OPContractsManagerUpgrader",
+						},
+					},
+				},
+			},
+			expectedAst: &solc.AstNode{},
+		},
+		{
+			name: "With no contract definition",
+			opcmArtifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{},
+				},
+			},
+			expectedAst: &solc.AstNode{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ast := getOpcmUpgradeFunctionAst(test.opcmArtifact)
+			assert.Equal(t, test.expectedAst, ast)
+		})
+	}
+}
+
+func TestGetNumberOfUpgradeFunctions(t *testing.T) {
+	tests := []struct {
+		name        string
+		artifact    *solc.ForgeArtifact
+		expectedNum int
+	}{
+		{
+			name: "With an external upgrade function",
+			artifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "external",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNum: 1,
+		},
+		{
+			name: "With a public upgrade function",
+			artifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "public",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNum: 1,
+		},
+		{
+			name: "With multiple upgrade functions",
+			artifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "external",
+								},
+							},
+						},
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "public",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNum: 2,
+		},
+		{
+			name: "With no upgrade functions",
+			artifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{},
+				},
+			},
+			expectedNum: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			num := getNumberOfUpgradeFunctions(test.artifact)
+			assert.Equal(t, test.expectedNum, num)
+		})
+	}
+}
+
+func TestUpgradesContract(t *testing.T) {
+	// To add tests for this, create a contract with one or a combination of solidity statements and an optional upgrade function call within it to a contract type of IUpgradeable.
+	// Then create a constant bool variable EXPECTED_OUTPUT and set it to true if the upgrade function call is expected to be found and false otherwise.
+	// See opcm_upgrade_checks_mocks.sol for already existing mock contracts used for testing.
+
+	artifact, err := common.ReadForgeArtifact("../../../forge-artifacts/OPCMUpgradeChecksMocks.sol/IUpgradeable.json")
+	if err != nil {
+		t.Fatalf("Failed to load artifact: %v", err)
+	}
+
+	type test struct {
+		name           string
+		upgradeAst     []solc.AstNode
+		typeName       string
+		expectedOutput bool
+	}
+
+	tests := []test{}
+
+	for _, node := range artifact.Ast.Nodes {
+		if node.NodeType == "ContractDefinition" && node.Name != "IUpgradeable" {
+			upgradeAst := solc.AstNode{}
+			expectedOutput := false
+			for _, astNode := range node.Nodes {
+				if astNode.NodeType == "FunctionDefinition" && astNode.Name == "upgrade" {
+					if upgradeAst.NodeType != "" {
+						t.Fatalf("Expected only one upgrade function")
+					}
+					upgradeAst = astNode
+				}
+
+				if astNode.NodeType == "VariableDeclaration" &&
+					astNode.Name == "EXPECTED_OUTPUT" &&
+					astNode.Mutability == "constant" {
+
+					value, ok := astNode.Value.(map[string]interface{})
+					if !ok {
+						t.Fatalf("Expected value to be a map: %v", astNode.Value)
+					}
+
+					if value["kind"] != "bool" {
+						continue
+					}
+
+					if value["value"] == "true" {
+						expectedOutput = true
+					} else if value["value"] == "false" {
+						expectedOutput = false
+					} else {
+						t.Fatalf("Expected output is not a boolean: %s", astNode.Value)
+					}
+				}
+			}
+
+			tests = append(tests, struct {
+				name           string
+				upgradeAst     []solc.AstNode
+				typeName       string
+				expectedOutput bool
+			}{node.Name, []solc.AstNode{upgradeAst}, "contract IUpgradeable", expectedOutput})
+		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := upgradesContract(test.upgradeAst, test.typeName)
+			assert.Equal(t, test.expectedOutput, output)
+		})
+	}
+}


### PR DESCRIPTION
Running OPCM upgrade checks on [op-contracts/v2.0.0-rc.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv2.0.0-rc.1)

Steps:
- `cd packages/contracts-bedrock`
- `go run ./scripts/checks/opcm-upgrade-checks`

Result
- No output, all good