### PR TITLE
op e2e: interop action test: cross pattern same timestamp

### DIFF
--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -631,6 +631,7 @@ func TestCrossPatternSameTimestamp(gt *testing.T) {
 	alice := setupUser(t, is, actors.ChainA, 0)
 	bob := setupUser(t, is, actors.ChainB, 0)
 
+	// deploy eventLogger per chain
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 	deployOptsA, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainA, 1), actors.ChainA)
 	eventLoggerAddressA := DeployEventLogger(t, deployOptsA)

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -18,39 +19,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type txSubmitter struct {
-	t       helpers.Testing
-	chain   *dsl.Chain
-	from    common.Address
-	receipt *types.Receipt
+// BlockBuilder helps txplan to be integrated with intra block building functionality.
+type BlockBuilder struct {
+	t                  helpers.Testing
+	sc                 *sources.EthClient
+	chain              *dsl.Chain
+	signer             types.Signer
+	intraBlockReceipts []*types.Receipt
+	receipts           []*types.Receipt
+	keepBlockOpen      bool
 }
 
-func (ts *txSubmitter) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+func (b *BlockBuilder) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	// we need low level interaction here
 	// do not submit transactions via RPC, instead directly interact with block builder
-	receipt, err := ts.chain.SequencerEngine.EngineApi.IncludeTx(tx, ts.from)
+	from, err := types.Sender(b.signer, tx)
+	if err != nil {
+		return err
+	}
+	intraBlockReceipt, err := b.chain.SequencerEngine.EngineApi.IncludeTx(tx, from)
 	if err == nil {
 		// be aware that this receipt is not finalized...
 		// which means its info may be incorrect, such as block hash
 		// you must call ActL2EndBlock to seal the L2 block
-		ts.receipt = receipt
+		b.intraBlockReceipts = append(b.intraBlockReceipts, intraBlockReceipt)
 	}
 	return err
 }
 
-type receiptGetter struct {
-	t             helpers.Testing
-	chain         *dsl.Chain
-	sc            *sources.EthClient
-	keepBlockOpen bool
-}
-
-func (rg *receiptGetter) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-	if !rg.keepBlockOpen {
+func (b *BlockBuilder) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	if !b.keepBlockOpen {
 		// close l2 block before fetching actual receipt
-		rg.chain.Sequencer.ActL2EndBlock(rg.t)
+		b.chain.Sequencer.ActL2EndBlock(b.t)
+		b.keepBlockOpen = false
 	}
-	return rg.sc.TransactionReceipt(ctx, txHash)
+	// retrospectively fill in all resulting receipts after sealing block
+	for _, intraBlockReceipt := range b.intraBlockReceipts {
+		receipt, _ := b.sc.TransactionReceipt(ctx, intraBlockReceipt.TxHash)
+		b.receipts = append(b.receipts, receipt)
+	}
+	receipt, err := b.sc.TransactionReceipt(ctx, txHash)
+	if err == nil {
+		b.receipts = append(b.receipts, receipt)
+	}
+	return receipt, err
 }
 
 func TestTxPlanDeployEventLogger(gt *testing.T) {
@@ -62,19 +74,8 @@ func TestTxPlanDeployEventLogger(gt *testing.T) {
 
 	aliceA := setupUser(t, is, actors.ChainA, 0)
 
-	l2sc := actors.ChainA.SequencerEngine.SourceClient(t, 10)
-
-	submitter1 := &txSubmitter{t: t, chain: actors.ChainA, from: aliceA.address}
-	// txplan options for only tx submission, not ensuring block inclusion
-	opts1 := txplan.Combine(
-		txplan.WithPrivateKey(aliceA.secret),
-		txplan.WithChainID(l2sc),
-		txplan.WithAgainstLatestBlock(l2sc),
-		txplan.WithPendingNonce(l2sc),
-		txplan.WithEstimator(l2sc, false),
-		txplan.WithTransactionSubmitter(submitter1),
-	)
-
+	nonce := uint64(0)
+	opts1, builder1 := DefaultTxOptsWithoutBlockSeal(t, aliceA, actors.ChainA, nonce)
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 
 	deployCalldata := common.FromHex(bindings.EventloggerBin)
@@ -85,40 +86,29 @@ func TestTxPlanDeployEventLogger(gt *testing.T) {
 	latestBlock, err := deployTxWithoutSeal.AgainstBlock.Eval(t.Ctx())
 	require.NoError(t, err)
 
-	getter := &receiptGetter{t: t, chain: actors.ChainA, sc: l2sc}
-	submitter2 := &txSubmitter{t: t, chain: actors.ChainA, from: aliceA.address}
-	// txplan options for tx submission and ensuring block inclusion
-	opts2 := txplan.Combine(
-		txplan.WithPrivateKey(aliceA.secret),
-		txplan.WithChainID(l2sc),
-		txplan.WithAgainstLatestBlock(l2sc),
-		// no pending nonce
-		txplan.WithEstimator(l2sc, false),
-		txplan.WithTransactionSubmitter(submitter2),
-		txplan.WithAssumedInclusion(getter),
-		txplan.WithBlockInclusionInfo(l2sc),
-	)
-	deployTx := txplan.NewPlannedTx(opts2, txplan.WithData(deployCalldata))
+	opts2, builder2 := DefaultTxOpts(t, aliceA, actors.ChainA)
 	// manually set nonce because we cannot use the pending nonce
-	nonce, err := deployTxWithoutSeal.Nonce.Get()
-	require.NoError(t, err)
-	deployTx.Nonce.Set(nonce + 1)
+	opts2 = txplan.Combine(opts2, txplan.WithStaticNonce(nonce+1))
 
-	// tx submitted and sealed in block
-	// now the tx is actually included in L2 block, as well as included the tx submitted before
+	deployTx := txplan.NewPlannedTx(opts2, txplan.WithData(deployCalldata))
+
 	receipt, err := deployTx.Included.Eval(t.Ctx())
 	require.NoError(t, err)
+	// now the tx is actually included in L2 block, as well as included the tx submitted before
+	// tx submitted and sealed in block
 
 	// all intermediate receipts / finalized receipt must contain the contractAddress field
 	// because they all deployed contract
 	require.NotNil(t, receipt.ContractAddress)
-	require.NotNil(t, submitter1.receipt.ContractAddress)
-	require.NotNil(t, submitter2.receipt.ContractAddress)
+	require.Equal(t, 1, len(builder1.intraBlockReceipts))
+	require.Equal(t, 1, len(builder2.intraBlockReceipts))
+	require.NotNil(t, builder1.intraBlockReceipts[0].ContractAddress)
+	require.NotNil(t, builder2.intraBlockReceipts[0].ContractAddress)
 
 	// different nonce so different contract address
-	require.NotEqual(t, submitter1.receipt.ContractAddress, submitter2.receipt.ContractAddress)
+	require.NotEqual(t, builder1.intraBlockReceipts[0].ContractAddress, builder2.intraBlockReceipts[0].ContractAddress)
 	// second and the finalized contract address must be equal
-	require.Equal(t, submitter2.receipt.ContractAddress, receipt.ContractAddress)
+	require.Equal(t, builder2.intraBlockReceipts[0].ContractAddress, receipt.ContractAddress)
 
 	includedBlock, err := deployTx.IncludedBlock.Eval(t.Ctx())
 	require.NoError(t, err)
@@ -127,10 +117,10 @@ func TestTxPlanDeployEventLogger(gt *testing.T) {
 	require.Equal(t, latestBlock.NumberU64()+1, includedBlock.Number)
 }
 
-func DefaultTxOpts(t helpers.Testing, user *userWithKeys, chain *dsl.Chain) txplan.Option {
+func DefaultTxOpts(t helpers.Testing, user *userWithKeys, chain *dsl.Chain) (txplan.Option, *BlockBuilder) {
 	sc := chain.SequencerEngine.SourceClient(t, 10)
-	getter := &receiptGetter{t: t, chain: chain, sc: sc}
-	submitter := &txSubmitter{t: t, chain: chain, from: user.address}
+	signer := types.LatestSignerForChainID(chain.ChainID.ToBig())
+	builder := &BlockBuilder{t: t, chain: chain, sc: sc, signer: signer}
 	// txplan options for tx submission and ensuring block inclusion
 	return txplan.Combine(
 		txplan.WithPrivateKey(user.secret),
@@ -138,16 +128,16 @@ func DefaultTxOpts(t helpers.Testing, user *userWithKeys, chain *dsl.Chain) txpl
 		txplan.WithAgainstLatestBlock(sc),
 		txplan.WithPendingNonce(sc),
 		txplan.WithEstimator(sc, false),
-		txplan.WithTransactionSubmitter(submitter),
-		txplan.WithAssumedInclusion(getter),
+		txplan.WithTransactionSubmitter(builder),
+		txplan.WithAssumedInclusion(builder),
 		txplan.WithBlockInclusionInfo(sc),
-	)
+	), builder
 }
 
-func DefaultTxOptsWithoutBlockSeal(t helpers.Testing, user *userWithKeys, chain *dsl.Chain, nonce uint64) txplan.Option {
+func DefaultTxOptsWithoutBlockSeal(t helpers.Testing, user *userWithKeys, chain *dsl.Chain, nonce uint64) (txplan.Option, *BlockBuilder) {
 	sc := chain.SequencerEngine.SourceClient(t, 10)
-	getter := &receiptGetter{t: t, chain: chain, sc: sc, keepBlockOpen: true}
-	submitter := &txSubmitter{t: t, chain: chain, from: user.address}
+	signer := types.LatestSignerForChainID(chain.ChainID.ToBig())
+	builder := &BlockBuilder{t: t, chain: chain, sc: sc, keepBlockOpen: true, signer: signer}
 	return txplan.Combine(
 		txplan.WithPrivateKey(user.secret),
 		txplan.WithChainID(sc),
@@ -155,10 +145,10 @@ func DefaultTxOptsWithoutBlockSeal(t helpers.Testing, user *userWithKeys, chain 
 		// nonce must be manually set since pending nonce may be incorrect
 		txplan.WithNonce(nonce),
 		txplan.WithEstimator(sc, false),
-		txplan.WithTransactionSubmitter(submitter),
-		txplan.WithAssumedInclusion(getter),
+		txplan.WithTransactionSubmitter(builder),
+		txplan.WithAssumedInclusion(builder),
 		txplan.WithBlockInclusionInfo(sc),
-	)
+	), builder
 }
 
 func DeployEventLogger(t helpers.Testing, opts txplan.Option) common.Address {
@@ -171,6 +161,53 @@ func DeployEventLogger(t helpers.Testing, opts txplan.Option) common.Address {
 	return eventLoggerAddress
 }
 
+func consolidateToSafe(t helpers.Testing, actors *dsl.InteropActors, startA, startB, endA, endB uint64) {
+	// Batch L2 blocks of chain A, B and submit to L1 to ensure safe head advances without a reorg.
+	// Checking cross-unsafe consolidation is sufficient for sanity check but lets add safe check as well.
+	actors.ChainA.Batcher.ActSubmitAll(t)
+	actors.ChainB.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+
+	actors.Supervisor.SignalLatestL1(t)
+
+	t.Log("awaiting L1-exhaust event")
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, actors.ChainA, endA, startA, startA, startA)
+	assertHeads(t, actors.ChainB, endB, startB, startB, startB)
+
+	t.Log("awaiting supervisor to provide L1 data")
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	assertHeads(t, actors.ChainA, endA, startA, startA, startA)
+	assertHeads(t, actors.ChainB, endB, startB, startB, startB)
+
+	t.Log("awaiting node to sync: unsafe to local0safe")
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, actors.ChainA, endA, endA, startA, startA)
+	assertHeads(t, actors.ChainB, endB, endB, startB, startB)
+
+	t.Log("expecting supervisor to sync")
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	assertHeads(t, actors.ChainA, endA, endA, startA, startA)
+	assertHeads(t, actors.ChainB, endB, endB, startB, startB)
+
+	t.Log("supervisor promotes cross-unsafe and safe")
+	actors.Supervisor.ProcessFull(t)
+
+	t.Log("awaiting nodes to sync: local-safe to safe")
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
+	assertHeads(t, actors.ChainA, endA, endA, endA, endA)
+	assertHeads(t, actors.ChainB, endB, endB, endB, endB)
+}
+
 func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))
@@ -180,8 +217,8 @@ func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	alice := setupUser(t, is, actors.ChainA, 0)
 	bob := setupUser(t, is, actors.ChainB, 0)
 
-	optsA := DefaultTxOpts(t, alice, actors.ChainA)
-	optsB := DefaultTxOpts(t, bob, actors.ChainB)
+	optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)
+	optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 
 	// chain A progressed single unsafe block
@@ -256,8 +293,8 @@ func TestBreakTimestampInvariant(gt *testing.T) {
 	alice := setupUser(t, is, actors.ChainA, 0)
 	bob := setupUser(t, is, actors.ChainB, 0)
 
-	optsA := DefaultTxOpts(t, alice, actors.ChainA)
-	optsB := DefaultTxOpts(t, bob, actors.ChainB)
+	optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)
+	optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 	// chain A progressed single unsafe block
 	eventLoggerAddress := DeployEventLogger(t, optsA)
@@ -358,8 +395,8 @@ func TestExecMsgDifferTxIndex(gt *testing.T) {
 		alice := setupUser(t, is, actors.ChainA, 0)
 		bob := setupUser(t, is, actors.ChainB, 0)
 
-		optsA := DefaultTxOpts(t, alice, actors.ChainA)
-		optsB := DefaultTxOpts(t, bob, actors.ChainB)
+		optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)
+		optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
 		actors.ChainA.Sequencer.ActL2StartBlock(t)
 		// chain A progressed single unsafe block
 		eventLoggerAddress := DeployEventLogger(t, optsA)
@@ -372,7 +409,7 @@ func TestExecMsgDifferTxIndex(gt *testing.T) {
 		txCount := 3 + rng.Intn(15)
 		initTxs := []*txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]{}
 		for range txCount {
-			opts := DefaultTxOptsWithoutBlockSeal(t, alice, actors.ChainA, nonce)
+			opts, _ := DefaultTxOptsWithoutBlockSeal(t, alice, actors.ChainA, nonce)
 
 			// Intent to initiate message(or emit event) on chain A
 			tx := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](opts)
@@ -427,49 +464,7 @@ func TestExecMsgDifferTxIndex(gt *testing.T) {
 	require.Equal(t, targetNum, chainBUnsafeHead.Number)
 	require.Equal(t, uint64(4), targetNum)
 
-	// Batch L2 blocks of chain A, B and submit to L1 to ensure safe head advances without a reorg.
-	// Checking cross-unsafe consolidation is sufficient for sanity check but lets add safe check as well.
-	actors.ChainA.Batcher.ActSubmitAll(t)
-	actors.ChainB.Batcher.ActSubmitAll(t)
-	actors.L1Miner.ActL1StartBlock(12)(t)
-	actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
-	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
-	actors.L1Miner.ActL1EndBlock(t)
-
-	actors.Supervisor.SignalLatestL1(t)
-
-	t.Log("awaiting L1-exhaust event")
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
-	assertHeads(t, actors.ChainB, 4, 0, 0, 0)
-
-	t.Log("awaiting supervisor to provide L1 data")
-	actors.ChainA.Sequencer.SyncSupervisor(t)
-	actors.ChainB.Sequencer.SyncSupervisor(t)
-	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
-	assertHeads(t, actors.ChainB, 4, 0, 0, 0)
-
-	t.Log("awaiting node to sync: unsafe to local-safe")
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	assertHeads(t, actors.ChainA, 2, 2, 0, 0)
-	assertHeads(t, actors.ChainB, 4, 4, 0, 0)
-
-	t.Log("expecting supervisor to sync")
-	actors.ChainA.Sequencer.SyncSupervisor(t)
-	actors.ChainB.Sequencer.SyncSupervisor(t)
-	assertHeads(t, actors.ChainA, 2, 2, 0, 0)
-	assertHeads(t, actors.ChainB, 4, 4, 0, 0)
-
-	t.Log("supervisor promotes cross-unsafe and safe")
-	actors.Supervisor.ProcessFull(t)
-
-	t.Log("awaiting nodes to sync: local-safe to safe")
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	assertHeads(t, actors.ChainA, 2, 2, 2, 2)
-	assertHeads(t, actors.ChainB, 4, 4, 4, 4)
+	consolidateToSafe(t, actors, 0, 0, 2, 4)
 
 	// unsafe head of chain B did not get updated
 	require.Equal(t, chainBUnsafeHead, actors.ChainB.Sequencer.SyncStatus().UnsafeL2)
@@ -491,8 +486,8 @@ func TestExpiredMessage(gt *testing.T) {
 	alice := setupUser(t, is, actors.ChainA, 0)
 	bob := setupUser(t, is, actors.ChainB, 0)
 
-	optsA := DefaultTxOpts(t, alice, actors.ChainA)
-	optsB := DefaultTxOpts(t, bob, actors.ChainB)
+	optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)
+	optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 	// chain A progressed single unsafe block
 	eventLoggerAddress := DeployEventLogger(t, optsA)
@@ -618,4 +613,135 @@ func TestExpiredMessage(gt *testing.T) {
 	require.NotEqual(t, reorgedOutBlock.Hash, replacedBlock.Hash)
 	require.Equal(t, reorgedOutBlock.Number, replacedBlock.Number)
 	require.Equal(t, expiredMsgBlockNum, replacedBlock.Number)
+}
+
+// TestCrossPatternSameTimestamp tests below scenario:
+// Transaction on B executes message from A, and vice-versa. Cross-pattern, within same timestamp:
+// Four transactions happen in same timestamp:
+// tx0: chainA: alice initiates message X
+// tx1: chainB: bob executes message X
+// tx2: chainB: bob initiates message Y
+// tx3: chainA: alice executes message Y
+func TestCrossPatternSameTimestamp(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	rng := rand.New(rand.NewSource(1234))
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+	alice := setupUser(t, is, actors.ChainA, 0)
+	bob := setupUser(t, is, actors.ChainB, 0)
+
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	deployOptsA, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainA, 1), actors.ChainA)
+	eventLoggerAddressA := DeployEventLogger(t, deployOptsA)
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+	deployOptsB, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainB, 1), actors.ChainB)
+	eventLoggerAddressB := DeployEventLogger(t, deployOptsB)
+
+	assertHeads(t, actors.ChainA, 1, 0, 0, 0)
+	assertHeads(t, actors.ChainB, 1, 0, 0, 0)
+
+	require.Equal(t, actors.ChainA.RollupCfg.Genesis.L2Time, actors.ChainB.RollupCfg.Genesis.L2Time)
+	// assume all four txs land in block number 2, same time
+	targetTime := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime*2
+	// start with nonce as 0 for both alice and bob
+	nonce := uint64(0)
+	optsA, builderA := DefaultTxOptsWithoutBlockSeal(t, alice, actors.ChainA, nonce)
+	optsB, builderB := DefaultTxOptsWithoutBlockSeal(t, bob, actors.ChainB, nonce)
+
+	// open blocks on both chains
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+
+	// Intent to initiate message X on chain A
+	tx0 := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsA)
+	tx0.Content.Set(interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10))
+
+	_, err := tx0.PlannedTx.Submitted.Eval(t.Ctx())
+	require.NoError(t, err)
+	// manually update the included info since block is not sealed yet
+	require.NotNil(t, builderA.intraBlockReceipts[0])
+	tx0.PlannedTx.Included.Set(builderA.intraBlockReceipts[0])
+	tx0.PlannedTx.IncludedBlock.Set(eth.BlockRef{Time: targetTime})
+
+	// Intent to execute message X on chain B
+	tx1 := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsB)
+	tx1.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &tx0.Result, 0))
+	tx1.Content.DependOn(&tx0.Result)
+
+	_, err = tx1.PlannedTx.Submitted.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// Intent to initiate message Y on chain B
+	// override nonce
+	optsB = txplan.Combine(optsB, txplan.WithStaticNonce(nonce+1))
+	tx2 := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsB)
+	tx2.Content.Set(interop.RandomInitTrigger(rng, eventLoggerAddressB, 4, 9))
+	_, err = tx2.PlannedTx.Submitted.Eval(t.Ctx())
+	require.NoError(t, err)
+	// manually update the included info since block is not sealed yet
+	require.NotNil(t, builderB.intraBlockReceipts[0])
+	tx2.PlannedTx.Included.Set(builderB.intraBlockReceipts[0])
+	tx2.PlannedTx.IncludedBlock.Set(eth.BlockRef{Time: targetTime})
+
+	// Intent to execute message Y on chain A
+	// override nonce
+	optsA = txplan.Combine(optsA, txplan.WithStaticNonce(nonce+1))
+	tx3 := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsA)
+	tx3.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &tx2.Result, 0))
+	tx3.Content.DependOn(&tx2.Result)
+
+	_, err = tx3.PlannedTx.Submitted.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// finally seal block
+	actors.ChainA.Sequencer.ActL2EndBlock(t)
+	actors.ChainB.Sequencer.ActL2EndBlock(t)
+	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
+	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
+
+	// store unsafe head of chain A, B to compare after consolidation
+	chainAUnsafeHead := actors.ChainA.Sequencer.SyncStatus().UnsafeL2
+	chainBUnsafeHead := actors.ChainB.Sequencer.SyncStatus().UnsafeL2
+
+	consolidateToSafe(t, actors, 0, 0, 2, 2)
+
+	// unsafe heads consolidated to safe
+	require.Equal(t, chainAUnsafeHead, actors.ChainA.Sequencer.SyncStatus().SafeL2)
+	require.Equal(t, chainBUnsafeHead, actors.ChainB.Sequencer.SyncStatus().SafeL2)
+
+	t.Log("Check that all tx included blocks and receipts can be fetched using the RPC")
+	targetBlockNum := uint64(2)
+
+	// check tx1 first instead of tx0 not to make tx0 submitted
+	receipt, err := tx1.PlannedTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, targetBlockNum, receipt.BlockNumber.Uint64())
+	block, err := tx1.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, targetTime, block.Time)
+
+	// invalidate receipt which is incorrect since it was fetched intra block
+	tx0.PlannedTx.Included.Invalidate()
+	tx0.PlannedTx.IncludedBlock.Invalidate()
+	block, err = tx0.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, targetBlockNum, block.Number)
+	require.Equal(t, targetTime, block.Time)
+
+	// check tx3 first instead of tx2 not to make tx2 submitted
+	receipt, err = tx3.PlannedTx.Included.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, targetBlockNum, receipt.BlockNumber.Uint64())
+	block, err = tx3.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, targetTime, block.Time)
+
+	// invalidate receipt which is incorrect since it was fetched intra block
+	tx2.PlannedTx.Included.Invalidate()
+	tx2.PlannedTx.IncludedBlock.Invalidate()
+	block, err = tx2.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, targetBlockNum, block.Number)
+	require.Equal(t, targetTime, block.Time)
 }

--- a/op-service/plan/node.go
+++ b/op-service/plan/node.go
@@ -215,6 +215,13 @@ func (p *Lazy[V]) invalidate() {
 	p.depInvalidate(reasonGen.Add(1))
 }
 
+// Invalidate exposes invalidation with mutex
+func (p *Lazy[V]) Invalidate() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.invalidate()
+}
+
 type Fn[V any] func(ctx context.Context) (V, error)
 
 // Fn sets what makes this Lazy lazily compute the value.

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -98,6 +98,15 @@ func WithNonce(nonce uint64) Option {
 	}
 }
 
+func WithStaticNonce(nonce uint64) Option {
+	return func(tx *PlannedTx) {
+		tx.Nonce.Set(nonce)
+		tx.Nonce.Fn(func(ctx context.Context) (uint64, error) {
+			return nonce, nil
+		})
+	}
+}
+
 func WithAccessList(al types.AccessList) Option {
 	return func(tx *PlannedTx) {
 		tx.AccessList.Set(al)
@@ -255,7 +264,6 @@ type PendingNonceAt interface {
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
 }
 
-// WithPendingNonce automatically
 func WithPendingNonce(cl PendingNonceAt) Option {
 	return func(tx *PlannedTx) {
 		tx.Nonce.DependOn(&tx.AgainstBlock, &tx.Sender)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds op-e2e interop action test using txintent. Checks that

- Transaction on B executes message from A, and vice-versa. Cross-pattern
    - [x] Within same timestamp: `TestCrossPatternSameTimestamp `

which are part of https://github.com/ethereum-optimism/optimism/issues/15092.

In addition,
- Refactors and introduces `BlockBuilder` which is for txplan to be integrated with intra block building functionality. 
- Exposes plan module's `invalidate` functionality for explicitly invalidating txplan fields.
- Adds `WithStaticNonce` helper for txplan to wipe out registered `fn` for updating nonces.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15261
