### PR TITLE
feat: Simplify op-deployer scripts: DeployDisputeGame [11/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/dispute_game2.go
+++ b/op-deployer/pkg/deployer/opcm/dispute_game2.go
@@ -1,0 +1,38 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+)
+
+type DeployDisputeGame2Input struct {
+	Release                  string
+	StandardVersionsToml     string
+	GameKind                 string
+	GameType                 *big.Int
+	AbsolutePrestate         common.Hash
+	MaxGameDepth             *big.Int
+	SplitDepth               *big.Int
+	ClockExtension           *big.Int
+	MaxClockDuration         *big.Int
+	DelayedWethProxy         common.Address
+	AnchorStateRegistryProxy common.Address
+	VmAddress                common.Address `abi:"vm"`
+	L2ChainId                *big.Int
+	Proposer                 common.Address
+	Challenger               common.Address
+}
+
+type DeployDisputeGame2Output struct {
+	DisputeGameImpl common.Address
+}
+
+type DeployDisputeGameScript script.DeployScriptWithOutput[DeployDisputeGame2Input, DeployDisputeGame2Output]
+
+// NewDeployDisputeGameScript loads and validates the DeployDisputeGame2 script contract
+func NewDeployDisputeGameScript(host *script.Host) (DeployDisputeGameScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployDisputeGame2Input, DeployDisputeGame2Output](host, "DeployDisputeGame2.s.sol", "DeployDisputeGame2")
+}

--- a/op-deployer/pkg/deployer/opcm/dispute_game2_test.go
+++ b/op-deployer/pkg/deployer/opcm/dispute_game2_test.go
@@ -1,0 +1,115 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployDisputeGameScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployDisputeGame2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// Deploy the prerequisite contracts
+		vm1Address := deployDisputeGameScriptVM(t, host1)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deploySuperchain, err := opcm.NewDeployDisputeGameScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deploySuperchain.Run(opcm.DeployDisputeGame2Input{
+			Release:                  "dev",
+			StandardVersionsToml:     "dev.toml",
+			VmAddress:                vm1Address,
+			GameKind:                 "PermissionedDisputeGame",
+			GameType:                 big.NewInt(1),
+			AbsolutePrestate:         common.Hash{'A'},
+			MaxGameDepth:             big.NewInt(int64(standard.DisputeMaxGameDepth)),
+			SplitDepth:               big.NewInt(int64(standard.DisputeSplitDepth)),
+			ClockExtension:           big.NewInt(int64(standard.DisputeClockExtension)),
+			MaxClockDuration:         big.NewInt(int64(standard.DisputeMaxClockDuration)),
+			DelayedWethProxy:         common.Address{'D'},
+			AnchorStateRegistryProxy: common.Address{'A'},
+			L2ChainId:                big.NewInt(69),
+			Proposer:                 common.Address{'P'},
+			Challenger:               common.Address{'C'},
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+
+		// Deploy the prerequisite contracts
+		vm2Address := deployDisputeGameScriptVM(t, host2)
+		require.NoError(t, err)
+
+		deprecatedOutput, err := opcm.DeployDisputeGame(host2, opcm.DeployDisputeGameInput{
+			Release:                  "dev",
+			VmAddress:                vm2Address,
+			GameKind:                 "PermissionedDisputeGame",
+			GameType:                 1,
+			AbsolutePrestate:         common.Hash{'A'},
+			MaxGameDepth:             standard.DisputeMaxGameDepth,
+			SplitDepth:               standard.DisputeSplitDepth,
+			ClockExtension:           standard.DisputeClockExtension,
+			MaxClockDuration:         standard.DisputeMaxClockDuration,
+			DelayedWethProxy:         common.Address{'D'},
+			AnchorStateRegistryProxy: common.Address{'A'},
+			L2ChainId:                common.BigToHash(big.NewInt(69)),
+			Proposer:                 common.Address{'P'},
+			Challenger:               common.Address{'C'},
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.DisputeGameImpl, output.DisputeGameImpl)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.DisputeGameImpl), host1.GetCode(output.DisputeGameImpl))
+	})
+}
+
+func deployDisputeGameScriptVM(t *testing.T, host *script.Host) common.Address {
+	preimageOracleArtifact, err := host.Artifacts().ReadArtifact("PreimageOracle.sol", "PreimageOracle")
+	require.NoError(t, err)
+
+	encodedPreimageOracleConstructor, err := preimageOracleArtifact.ABI.Pack("", big.NewInt(0), big.NewInt(0))
+	require.NoError(t, err)
+
+	preimageOracleAddress, err := host.Create(addresses.ScriptDeployer, append(preimageOracleArtifact.Bytecode.Object, encodedPreimageOracleConstructor...))
+	require.NoError(t, err)
+
+	bigStepperArtifact, err := host.Artifacts().ReadArtifact("RISCV.sol", "RISCV")
+	require.NoError(t, err)
+
+	encodedBigStepperConstructor, err := bigStepperArtifact.ABI.Pack("", preimageOracleAddress)
+	require.NoError(t, err)
+
+	bigStepperAddress, err := host.Create(addresses.ScriptDeployer, append(bigStepperArtifact.Bytecode.Object, encodedBigStepperConstructor...))
+	require.NoError(t, err)
+
+	host.Label(preimageOracleAddress, "PreimageOracle")
+	host.Label(bigStepperAddress, "BigStepper")
+
+	return bigStepperAddress
+
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame2.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame2.s.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Forge
+import { Script } from "forge-std/Script.sol";
+
+// Scripts
+import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
+import { GameType, Claim, Duration } from "src/dispute/lib/Types.sol";
+import { LibString } from "@solady/utils/LibString.sol";
+
+// Interfaces
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+
+/// @title DeployDisputeGame
+contract DeployDisputeGame2 is Script {
+    /// We need a struct for constructor args to avoid stack-too-deep errors.
+    struct Input {
+        // Common inputs.
+        string release;
+        string standardVersionsToml;
+        // Specify which game kind is being deployed here.
+        string gameKind;
+        // All inputs required to deploy FaultDisputeGame.
+        uint256 gameType;
+        bytes32 absolutePrestate;
+        uint256 maxGameDepth;
+        uint256 splitDepth;
+        uint256 clockExtension;
+        uint256 maxClockDuration;
+        IDelayedWETH delayedWethProxy;
+        IAnchorStateRegistry anchorStateRegistryProxy;
+        IBigStepper vm;
+        uint256 l2ChainId;
+        // Additional inputs required to deploy PermissionedDisputeGame.
+        address proposer;
+        address challenger;
+    }
+
+    struct Output {
+        IPermissionedDisputeGame disputeGameImpl;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deployDisputeGameImpl(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function deployDisputeGameImpl(Input memory _input, Output memory _output) internal {
+        // Shove the arguments into a struct to avoid stack-too-deep errors.
+        IFaultDisputeGame.GameConstructorParams memory args = IFaultDisputeGame.GameConstructorParams({
+            gameType: GameType.wrap(uint32(_input.gameType)),
+            absolutePrestate: Claim.wrap(_input.absolutePrestate),
+            maxGameDepth: _input.maxGameDepth,
+            splitDepth: _input.splitDepth,
+            clockExtension: Duration.wrap(uint64(_input.clockExtension)),
+            maxClockDuration: Duration.wrap(uint64(_input.maxClockDuration)),
+            vm: _input.vm,
+            weth: _input.delayedWethProxy,
+            anchorStateRegistry: _input.anchorStateRegistryProxy,
+            l2ChainId: _input.l2ChainId
+        });
+
+        // PermissionedDisputeGame is used as the type here because it is a superset of
+        // FaultDisputeGame. If the user requests to deploy a FaultDisputeGame, the user will get a
+        // FaultDisputeGame (and not a PermissionedDisputeGame).
+        IPermissionedDisputeGame impl;
+        if (LibString.eq(_input.gameKind, "FaultDisputeGame")) {
+            impl = IPermissionedDisputeGame(
+                DeployUtils.createDeterministic({
+                    _name: "FaultDisputeGame",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IFaultDisputeGame.__constructor__, (args))),
+                    _salt: DeployUtils.DEFAULT_SALT
+                })
+            );
+        } else {
+            impl = IPermissionedDisputeGame(
+                DeployUtils.createDeterministic({
+                    _name: "PermissionedDisputeGame",
+                    _args: DeployUtils.encodeConstructor(
+                        abi.encodeCall(IPermissionedDisputeGame.__constructor__, (args, _input.proposer, _input.challenger))
+                    ),
+                    _salt: DeployUtils.DEFAULT_SALT
+                })
+            );
+        }
+
+        vm.label(address(impl), string.concat(_input.gameKind, "Impl"));
+        _output.disputeGameImpl = impl;
+    }
+
+    // A release is considered a 'develop' release if it does not start with 'op-contracts'.
+    function isDevelopRelease(string memory _release) internal pure returns (bool) {
+        return !LibString.startsWith(_release, "op-contracts");
+    }
+
+    function assertValidInput(Input memory _input) internal pure {
+        require(_input.gameType <= type(uint32).max, "DeployDisputeGame: gameType must fit inside uint32");
+        require(_input.maxGameDepth != 0, "DeployDisputeGame: maxGameDepth not set");
+        require(_input.splitDepth != 0, "DeployDisputeGame: splitDepth not set");
+        require(_input.clockExtension <= type(uint64).max, "DeployDisputeGame: clockExtension must fit inside uint64");
+        require(_input.clockExtension != 0, "DeployDisputeGame: clockExtension not set");
+        require(
+            _input.maxClockDuration <= type(uint64).max, "DeployDisputeGame: maxClockDuration must fit inside uint64"
+        );
+        require(_input.maxClockDuration != 0, "DeployDisputeGame: maxClockDuration not set");
+        require(_input.l2ChainId != 0, "DeployDisputeGame: l2ChainId not set");
+        require(address(_input.delayedWethProxy) != address(0), "DeployDisputeGame: delayedWethProxy not set");
+        require(
+            address(_input.anchorStateRegistryProxy) != address(0),
+            "DeployDisputeGame: anchorStateRegistryProxy not set"
+        );
+        require(address(_input.vm) != address(0), "DeployDisputeGame: vm not set");
+        require(!LibString.eq(_input.release, ""), "DeployDisputeGame: release not set");
+        require(!LibString.eq(_input.standardVersionsToml, ""), "DeployDisputeGame: standardVersionsToml not set");
+        require(
+            LibString.eq(_input.gameKind, "FaultDisputeGame")
+                || LibString.eq(_input.gameKind, "PermissionedDisputeGame"),
+            "DeployDisputeGame: unknown game kind"
+        );
+
+        if (LibString.eq(_input.gameKind, "FaultDisputeGame")) {
+            require(_input.proposer == address(0), "DeployDisputeGame: proposer must be empty");
+            require(_input.challenger == address(0), "DeployDisputeGame: challenger must be empty");
+        } else {
+            require(_input.proposer != address(0), "DeployDisputeGame: proposer not set");
+            require(_input.challenger != address(0), "DeployDisputeGame: challenger not set");
+        }
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) internal view {
+        IPermissionedDisputeGame game = _output.disputeGameImpl;
+
+        DeployUtils.assertValidContractAddress(address(game));
+
+        require(game.gameType().raw() == uint32(_input.gameType), "DG-10");
+        require(game.maxGameDepth() == _input.maxGameDepth, "DG-20");
+        require(game.splitDepth() == _input.splitDepth, "DG-30");
+        require(game.clockExtension().raw() == uint64(_input.clockExtension), "DG-40");
+        require(game.maxClockDuration().raw() == uint64(_input.maxClockDuration), "DG-50");
+        require(game.vm() == _input.vm, "DG-60");
+        require(game.weth() == _input.delayedWethProxy, "DG-70");
+        require(game.anchorStateRegistry() == _input.anchorStateRegistryProxy, "DG-80");
+        require(game.l2ChainId() == _input.l2ChainId, "DG-90");
+
+        if (LibString.eq(_input.gameKind, "PermissionedDisputeGame")) {
+            require(game.proposer() == _input.proposer, "DG-100");
+            require(game.challenger() == _input.challenger, "DG-110");
+        }
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame2.s.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.15;
 import { Script } from "forge-std/Script.sol";
 
 // Scripts
-import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
@@ -45,7 +45,7 @@ contract DeployDisputeGame2_Test is Test {
         uint32 _gameType,
         uint32 _clockExtension,
         uint64 _maxClockDuration,
-        uint128 _splitDepth,
+        uint8 _splitDepth,
         uint8 _maxGameDepth
     )
         public

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
@@ -86,7 +86,7 @@ contract DeployDisputeGame2_Test is Test {
         uint32 _gameType,
         uint32 _clockExtension,
         uint64 _maxClockDuration,
-        uint128 _splitDepth,
+        uint8 _splitDepth,
         uint8 _maxGameDepth
     )
         public

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+// Interfaces
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+// Libraries
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { LibPosition } from "src/dispute/lib/LibPosition.sol";
+import { LibString } from "@solady/utils/LibString.sol";
+
+import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
+import { DeployDisputeGame2 } from "scripts/deploy/DeployDisputeGame2.s.sol";
+
+contract DeployDisputeGame2_Test is Test {
+    DeployDisputeGame2 deployDisputeGame;
+
+    PreimageOracle preimageOracle;
+
+    DeployDisputeGameBigStepper bigStepper;
+
+    // Define default input variables for testing.
+    IDelayedWETH defaultDelayedWethProxy = IDelayedWETH(payable(makeAddr("IDelayedWETH")));
+    IAnchorStateRegistry defaultAnchorStateRegistryProxy = IAnchorStateRegistry(makeAddr("IAnchorStateRegistry"));
+    address defaultProposer = makeAddr("Proposer");
+    address defaultChallenger = makeAddr("Challenger");
+
+    function setUp() public {
+        deployDisputeGame = new DeployDisputeGame2();
+        preimageOracle = new PreimageOracle(0, 0);
+        bigStepper = new DeployDisputeGameBigStepper(preimageOracle);
+
+        vm.label(address(deployDisputeGame), "DeployDisputeGame");
+        vm.label(address(preimageOracle), "PreimageOracle");
+        vm.label(address(bigStepper), "BigStepper");
+    }
+
+    function testFuzz_run_withFaultDisputeGame_succeeds(
+        DeployDisputeGame2.Input memory _input,
+        uint32 _gameType,
+        uint32 _clockExtension,
+        uint64 _maxClockDuration,
+        uint128 _splitDepth,
+        uint8 _maxGameDepth
+    )
+        public
+    {
+        vm.assume(_input.l2ChainId != 0);
+        vm.assume(_gameType != 0);
+        vm.assume(_clockExtension != 0);
+        vm.assume(!LibString.eq(_input.release, ""));
+        vm.assume(!LibString.eq(_input.standardVersionsToml, ""));
+        vm.assume(address(_input.anchorStateRegistryProxy) != address(0));
+        vm.assume(address(_input.delayedWethProxy) != address(0));
+
+        // These come from the constructor or FaultDisputeGame
+        vm.assume(_gameType != type(uint32).max);
+        vm.assume(_splitDepth >= 2);
+        vm.assume(uint256(_splitDepth) + 1 < _maxGameDepth);
+        vm.assume(_maxGameDepth <= LibPosition.MAX_POSITION_BITLEN - 1);
+        vm.assume(uint256(_clockExtension) * 2 <= _maxClockDuration);
+        vm.assume(uint256(_clockExtension) * 2 <= type(uint64).max);
+
+        _input.gameKind = "FaultDisputeGame";
+        _input.gameType = _gameType;
+        _input.clockExtension = _clockExtension;
+        _input.maxClockDuration = _maxClockDuration;
+        _input.maxGameDepth = _maxGameDepth;
+        _input.splitDepth = _splitDepth;
+        _input.vm = bigStepper;
+
+        // For FaultDisputeGame, these must be empty
+        _input.challenger = address(0);
+        _input.proposer = address(0);
+
+        // Run the deployment script.
+        deployDisputeGame.run(_input);
+    }
+
+    function testFuzz_run_withPermissionedDisputeGame_succeeds(
+        DeployDisputeGame2.Input memory _input,
+        uint32 _gameType,
+        uint32 _clockExtension,
+        uint64 _maxClockDuration,
+        uint128 _splitDepth,
+        uint8 _maxGameDepth
+    )
+        public
+    {
+        vm.assume(_input.l2ChainId != 0);
+        vm.assume(_gameType != 0);
+        vm.assume(_clockExtension != 0);
+        vm.assume(!LibString.eq(_input.release, ""));
+        vm.assume(!LibString.eq(_input.standardVersionsToml, ""));
+        vm.assume(address(_input.anchorStateRegistryProxy) != address(0));
+        vm.assume(address(_input.delayedWethProxy) != address(0));
+        vm.assume(_input.challenger != address(0));
+        vm.assume(_input.proposer != address(0));
+
+        // These come from the constructor or FaultDisputeGame
+        vm.assume(_gameType != type(uint32).max);
+        vm.assume(_splitDepth >= 2);
+        vm.assume(uint256(_splitDepth) + 1 < _maxGameDepth);
+        vm.assume(_maxGameDepth <= LibPosition.MAX_POSITION_BITLEN - 1);
+        vm.assume(uint256(_clockExtension) * 2 <= _maxClockDuration);
+        vm.assume(uint256(_clockExtension) * 2 <= type(uint64).max);
+
+        _input.gameKind = "PermissionedDisputeGame";
+        _input.gameType = _gameType;
+        _input.clockExtension = _clockExtension;
+        _input.maxClockDuration = _maxClockDuration;
+        _input.maxGameDepth = _maxGameDepth;
+        _input.splitDepth = _splitDepth;
+        _input.vm = bigStepper;
+
+        // Run the deployment script.
+        deployDisputeGame.run(_input);
+    }
+
+    function test_run_nullInputsWithFaultDisputeGame_reverts() public {
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultFaultDisputeGameInput();
+        input.release = "";
+        vm.expectRevert("DeployDisputeGame: release not set");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.standardVersionsToml = "";
+        vm.expectRevert("DeployDisputeGame: standardVersionsToml not set");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.l2ChainId = 0;
+        vm.expectRevert("DeployDisputeGame: l2ChainId not set");
+        deployDisputeGame.run(input);
+
+        // Test case: clockExtension not set
+        input = defaultFaultDisputeGameInput();
+        input.clockExtension = 0;
+        vm.expectRevert("DeployDisputeGame: clockExtension not set");
+        deployDisputeGame.run(input);
+
+        // Test case: maxClockDuration not set
+        input = defaultFaultDisputeGameInput();
+        input.maxClockDuration = 0;
+        vm.expectRevert("DeployDisputeGame: maxClockDuration not set");
+        deployDisputeGame.run(input);
+
+        // Test case: maxGameDepth not set
+        input = defaultFaultDisputeGameInput();
+        input.maxGameDepth = 0;
+        vm.expectRevert("DeployDisputeGame: maxGameDepth not set");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.delayedWethProxy = IDelayedWETH(payable(address(0)));
+        vm.expectRevert("DeployDisputeGame: delayedWethProxy not set");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.anchorStateRegistryProxy = IAnchorStateRegistry(payable(address(0)));
+        vm.expectRevert("DeployDisputeGame: anchorStateRegistryProxy not set");
+        deployDisputeGame.run(input);
+    }
+
+    function test_run_proposerWithFaultDisputeGame_reverts(address _proposerOrChallenger) public {
+        vm.assume(_proposerOrChallenger != address(0));
+
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultFaultDisputeGameInput();
+        input.proposer = _proposerOrChallenger;
+        vm.expectRevert("DeployDisputeGame: proposer must be empty");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.challenger = _proposerOrChallenger;
+        vm.expectRevert("DeployDisputeGame: challenger must be empty");
+        deployDisputeGame.run(input);
+    }
+
+    function test_run_nullInputsWithPermissionedDisputeGame_reverts() public {
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultPermissionedDisputeGameInput();
+        input.proposer = address(0);
+        vm.expectRevert("DeployDisputeGame: proposer not set");
+        deployDisputeGame.run(input);
+
+        input = defaultPermissionedDisputeGameInput();
+        input.challenger = address(0);
+        vm.expectRevert("DeployDisputeGame: challenger not set");
+        deployDisputeGame.run(input);
+    }
+
+    function test_run_withUnknownGameKind_reverts(string memory _gameKind) public {
+        vm.assume(!LibString.eq(_gameKind, "PermissionedDisputeGame"));
+        vm.assume(!LibString.eq(_gameKind, "FaultDisputeGame"));
+
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultPermissionedDisputeGameInput();
+        input.gameKind = _gameKind;
+        vm.expectRevert("DeployDisputeGame: unknown game kind");
+        deployDisputeGame.run(input);
+    }
+
+    function test_run_withClockExtensionTooLarge_reverts(uint256 _clockExtension) public {
+        vm.assume(_clockExtension > type(uint64).max);
+
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultPermissionedDisputeGameInput();
+        input.clockExtension = _clockExtension;
+        vm.expectRevert("DeployDisputeGame: clockExtension must fit inside uint64");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.clockExtension = _clockExtension;
+        vm.expectRevert("DeployDisputeGame: clockExtension must fit inside uint64");
+        deployDisputeGame.run(input);
+    }
+
+    function test_run_withGameTypeTooLarge_reverts(uint256 _gameType) public {
+        vm.assume(_gameType > type(uint32).max);
+
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultPermissionedDisputeGameInput();
+        input.gameType = _gameType;
+        vm.expectRevert("DeployDisputeGame: gameType must fit inside uint32");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.gameType = _gameType;
+        vm.expectRevert("DeployDisputeGame: gameType must fit inside uint32");
+        deployDisputeGame.run(input);
+    }
+
+    function test_run_withMaxClockDurationTooLarge_reverts(uint256 _maxClockDuration) public {
+        vm.assume(_maxClockDuration > type(uint64).max);
+
+        DeployDisputeGame2.Input memory input;
+
+        input = defaultPermissionedDisputeGameInput();
+        input.maxClockDuration = _maxClockDuration;
+        vm.expectRevert("DeployDisputeGame: maxClockDuration must fit inside uint64");
+        deployDisputeGame.run(input);
+
+        input = defaultFaultDisputeGameInput();
+        input.maxClockDuration = _maxClockDuration;
+        vm.expectRevert("DeployDisputeGame: maxClockDuration must fit inside uint64");
+        deployDisputeGame.run(input);
+    }
+
+    function defaultFaultDisputeGameInput() private view returns (DeployDisputeGame2.Input memory input_) {
+        input_ = DeployDisputeGame2.Input({
+            release: "op-contracts",
+            standardVersionsToml: "op-versions.toml",
+            gameKind: "FaultDisputeGame",
+            gameType: 1,
+            absolutePrestate: bytes32(uint256(1)),
+            maxGameDepth: 10,
+            splitDepth: 2,
+            clockExtension: 1,
+            maxClockDuration: 1000,
+            l2ChainId: 1,
+            delayedWethProxy: defaultDelayedWethProxy,
+            anchorStateRegistryProxy: defaultAnchorStateRegistryProxy,
+            vm: bigStepper,
+            proposer: address(0),
+            challenger: address(0)
+        });
+    }
+
+    function defaultPermissionedDisputeGameInput() private view returns (DeployDisputeGame2.Input memory input_) {
+        input_ = DeployDisputeGame2.Input({
+            release: "op-contracts",
+            standardVersionsToml: "op-versions.toml",
+            gameKind: "PermissionedDisputeGame",
+            gameType: 1,
+            absolutePrestate: bytes32(uint256(1)),
+            maxGameDepth: 10,
+            splitDepth: 2,
+            clockExtension: 1,
+            maxClockDuration: 1000,
+            l2ChainId: 1,
+            delayedWethProxy: defaultDelayedWethProxy,
+            anchorStateRegistryProxy: defaultAnchorStateRegistryProxy,
+            vm: bigStepper,
+            proposer: defaultProposer,
+            challenger: defaultChallenger
+        });
+    }
+}
+
+contract DeployDisputeGameBigStepper is IBigStepper {
+    PreimageOracle private immutable mockOracle;
+
+    constructor(PreimageOracle _oracle) {
+        mockOracle = _oracle;
+    }
+
+    function step(bytes calldata, bytes calldata, bytes32) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function oracle() external view override returns (IPreimageOracle) {
+        return IPreimageOracle(address(mockOracle));
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
@@ -10,7 +10,6 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 
 // Libraries
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame2.t.sol
@@ -59,18 +59,16 @@ contract DeployDisputeGame2_Test is Test {
 
         // These come from the constructor or FaultDisputeGame
         vm.assume(_gameType != type(uint32).max);
-        vm.assume(_splitDepth >= 2);
-        vm.assume(uint256(_splitDepth) + 1 < _maxGameDepth);
+        vm.assume(_maxClockDuration >= 2);
+        vm.assume(_maxGameDepth >= 4);
         vm.assume(_maxGameDepth <= LibPosition.MAX_POSITION_BITLEN - 1);
-        vm.assume(uint256(_clockExtension) * 2 <= _maxClockDuration);
-        vm.assume(uint256(_clockExtension) * 2 <= type(uint64).max);
 
         _input.gameKind = "FaultDisputeGame";
         _input.gameType = _gameType;
-        _input.clockExtension = _clockExtension;
+        _input.clockExtension = bound(_clockExtension, 1, _maxClockDuration / 2);
         _input.maxClockDuration = _maxClockDuration;
         _input.maxGameDepth = _maxGameDepth;
-        _input.splitDepth = _splitDepth;
+        _input.splitDepth = bound(_splitDepth, 2, _maxGameDepth - 2);
         _input.vm = bigStepper;
 
         // For FaultDisputeGame, these must be empty
@@ -103,18 +101,16 @@ contract DeployDisputeGame2_Test is Test {
 
         // These come from the constructor or FaultDisputeGame
         vm.assume(_gameType != type(uint32).max);
-        vm.assume(_splitDepth >= 2);
-        vm.assume(uint256(_splitDepth) + 1 < _maxGameDepth);
+        vm.assume(_maxClockDuration >= 2);
+        vm.assume(_maxGameDepth >= 4);
         vm.assume(_maxGameDepth <= LibPosition.MAX_POSITION_BITLEN - 1);
-        vm.assume(uint256(_clockExtension) * 2 <= _maxClockDuration);
-        vm.assume(uint256(_clockExtension) * 2 <= type(uint64).max);
 
         _input.gameKind = "PermissionedDisputeGame";
         _input.gameType = _gameType;
-        _input.clockExtension = _clockExtension;
+        _input.clockExtension = bound(_clockExtension, 1, _maxClockDuration / 2);
         _input.maxClockDuration = _maxClockDuration;
         _input.maxGameDepth = _maxGameDepth;
-        _input.splitDepth = _splitDepth;
+        _input.splitDepth = bound(_splitDepth, 2, _maxGameDepth - 2);
         _input.vm = bigStepper;
 
         // Run the deployment script.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployDisputeGame2` has been introduced along with extended test coverage.

No existing tests were present so a test suite was added.

Relates to https://github.com/ethereum-optimism/optimism/issues/14976