### PR TITLE
feat: Simplify op-deployer scripts: DeployMIPS [12/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/mips2.go
+++ b/op-deployer/pkg/deployer/opcm/mips2.go
@@ -1,0 +1,24 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployMIPS2Input struct {
+	PreimageOracle common.Address
+	MipsVersion    *big.Int
+}
+
+type DeployMIPS2Output struct {
+	MipsSingleton common.Address
+}
+
+type DeployMIPSScript script.DeployScriptWithOutput[DeployMIPS2Input, DeployMIPS2Output]
+
+// NewDeployMIPSScript loads and validates the DeployMIPS2 script contract
+func NewDeployMIPSScript(host *script.Host) (DeployMIPSScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployMIPS2Input, DeployMIPS2Output](host, "DeployMIPS2.s.sol", "DeployMIPS2")
+}

--- a/op-deployer/pkg/deployer/opcm/mips2_test.go
+++ b/op-deployer/pkg/deployer/opcm/mips2_test.go
@@ -1,0 +1,53 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployMIPSScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployMIPS2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deploySuperchain, err := opcm.NewDeployMIPSScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deploySuperchain.Run(opcm.DeployMIPS2Input{
+			PreimageOracle: common.Address{'P'},
+			MipsVersion:    big.NewInt(1),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		deprecatedOutput, err := opcm.DeployMIPS(host2, opcm.DeployMIPSInput{
+			PreimageOracle: common.Address{'P'},
+			MipsVersion:    1,
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.MipsSingleton, output.MipsSingleton)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.MipsSingleton), host1.GetCode(output.MipsSingleton))
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS2.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS2.s.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Forge
+import { Script } from "forge-std/Script.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+import { IMIPS } from "interfaces/cannon/IMIPS.sol";
+
+/// @title DeployMIPS
+contract DeployMIPS2 is Script {
+    struct Input {
+        // Specify the PreimageOracle to use
+        IPreimageOracle preimageOracle;
+        // Specify which MIPS version to use.
+        uint256 mipsVersion;
+    }
+
+    struct Output {
+        IMIPS mipsSingleton;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deployMipsSingleton(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function deployMipsSingleton(Input memory _input, Output memory _output) internal {
+        uint256 mipsVersion = _input.mipsVersion;
+        string memory contractName = mipsVersion == 1 ? "MIPS" : "MIPS64";
+
+        IMIPS singleton = IMIPS(
+            DeployUtils.createDeterministic({
+                _name: contractName,
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS.__constructor__, (_input.preimageOracle))),
+                _salt: DeployUtils.DEFAULT_SALT
+            })
+        );
+
+        vm.label(address(singleton), "MIPSSingleton");
+        _output.mipsSingleton = singleton;
+    }
+
+    function assertValidInput(Input memory _input) public pure {
+        require(address(_input.preimageOracle) != address(0), "DeployMIPS: preimageOracle not set");
+        require(_input.mipsVersion != 0, "DeployMIPS: mipsVersion not set");
+        require(_input.mipsVersion == 1 || _input.mipsVersion == 2, "DeployMIPS: unknown mips version");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) public view {
+        DeployUtils.assertValidContractAddress(address(_output.mipsSingleton));
+        require(address(_output.mipsSingleton.oracle()) == address(_input.preimageOracle), "MIPS-10");
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployMIPS2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployMIPS2.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+// Interfaces
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+import { DeployMIPS2 } from "scripts/deploy/DeployMIPS2.s.sol";
+import { MIPS } from "src/cannon/MIPS.sol";
+import { MIPS64 } from "src/cannon/MIPS64.sol";
+
+contract DeployMIPS2_Test is Test {
+    DeployMIPS2 deployMIPS;
+
+    // Define default input variables for testing.
+    IPreimageOracle defaultPreimageOracle = IPreimageOracle(makeAddr("PreimageOracle"));
+    uint256 defaultMIPSVersion = 1;
+
+    function setUp() public {
+        deployMIPS = new DeployMIPS2();
+    }
+
+    function testFuzz_run_mipsVersion1_succeeds(DeployMIPS2.Input memory _input) public {
+        vm.assume(address(_input.preimageOracle) != address(0));
+        _input.mipsVersion = 1;
+
+        // Run the deployment script.
+        DeployMIPS2.Output memory output1 = deployMIPS.run(_input);
+
+        // Make sure we deployed the correct MIPS
+        MIPS mips = new MIPS(_input.preimageOracle);
+        assertEq(address(output1.mipsSingleton).code, address(mips).code, "100");
+
+        // Run the deployment script again
+        DeployMIPS2.Output memory output2 = deployMIPS.run(_input);
+
+        // Make sure the contract did not get redeployed
+        assertEq(address(output1.mipsSingleton), address(output2.mipsSingleton), "200");
+    }
+
+    function testFuzz_run_mipsVersion2_succeeds(DeployMIPS2.Input memory _input) public {
+        vm.assume(address(_input.preimageOracle) != address(0));
+        _input.mipsVersion = 2;
+
+        // Run the deployment script.
+        DeployMIPS2.Output memory output1 = deployMIPS.run(_input);
+
+        // Make sure we deployed the correct MIPS
+        MIPS64 mips = new MIPS64(_input.preimageOracle);
+        assertEq(address(output1.mipsSingleton).code, address(mips).code, "100");
+
+        // Run the deployment script again
+        DeployMIPS2.Output memory output2 = deployMIPS.run(_input);
+
+        assertEq(address(output1.mipsSingleton), address(output2.mipsSingleton), "200");
+    }
+
+    function test_run_nullInput_reverts() public {
+        DeployMIPS2.Input memory input;
+
+        input = defaultInput();
+        input.preimageOracle = IPreimageOracle(address(0));
+        vm.expectRevert("DeployMIPS: preimageOracle not set");
+        deployMIPS.run(input);
+
+        input = defaultInput();
+        input.mipsVersion = 0;
+        vm.expectRevert("DeployMIPS: mipsVersion not set");
+        deployMIPS.run(input);
+    }
+
+    function defaultInput() internal view returns (DeployMIPS2.Input memory input_) {
+        input_ = DeployMIPS2.Input(defaultPreimageOracle, defaultMIPSVersion);
+    }
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployMIPS2` has been introduced along with extended test coverage.

No existing tests were present so a test suite was added.

Relates to https://github.com/ethereum-optimism/optimism/issues/14976