### PR TITLE
feat: Simplify op-deployer scripts: DeployPreimageOracle [13/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/perimage_oracle2.go
+++ b/op-deployer/pkg/deployer/opcm/perimage_oracle2.go
@@ -1,0 +1,24 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployPreimageOracle2Input struct {
+	MinProposalSize *big.Int
+	ChallengePeriod *big.Int
+}
+
+type DeployPreimageOracle2Output struct {
+	PreimageOracle common.Address
+}
+
+type DeployPreimageOracleScript script.DeployScriptWithOutput[DeployPreimageOracle2Input, DeployPreimageOracle2Output]
+
+// NewDeployPreimageOracleScript loads and validates the DeployPreimageOracle2 script contract
+func NewDeployPreimageOracleScript(host *script.Host) (DeployPreimageOracleScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployPreimageOracle2Input, DeployPreimageOracle2Output](host, "DeployPreimageOracle2.s.sol", "DeployPreimageOracle2")
+}

--- a/op-deployer/pkg/deployer/opcm/preimage_oracle2_test.go
+++ b/op-deployer/pkg/deployer/opcm/preimage_oracle2_test.go
@@ -1,0 +1,52 @@
+package opcm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployPreimageOracleScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployPreimageOracle2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deployPreimageOracle, err := opcm.NewDeployPreimageOracleScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deployPreimageOracle.Run(opcm.DeployPreimageOracle2Input{
+			MinProposalSize: big.NewInt(1),
+			ChallengePeriod: big.NewInt(2),
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		deprecatedOutput, err := opcm.DeployPreimageOracle(host2, opcm.DeployPreimageOracleInput{
+			MinProposalSize: big.NewInt(1),
+			ChallengePeriod: big.NewInt(2),
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.PreimageOracle, output.PreimageOracle)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.PreimageOracle), host1.GetCode(output.PreimageOracle))
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployPreimageOracle2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployPreimageOracle2.s.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+// Interfaces
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+contract DeployPreimageOracle2 is Script {
+    struct Input {
+        uint256 minProposalSize;
+        uint256 challengePeriod;
+    }
+
+    struct Output {
+        IPreimageOracle preimageOracle;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deployPreimageOracle(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function deployPreimageOracle(Input memory _input, Output memory _output) internal {
+        vm.broadcast(msg.sender);
+        IPreimageOracle preimageOracle = IPreimageOracle(
+            DeployUtils.create1({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IPreimageOracle.__constructor__, (_input.minProposalSize, _input.challengePeriod))
+                )
+            })
+        );
+
+        vm.label(address(preimageOracle), "PreimageOracle");
+        _output.preimageOracle = preimageOracle;
+    }
+
+    function assertValidInput(Input memory _input) internal pure {
+        require(_input.minProposalSize != 0, "DeployPreimageOracle: minProposalSize not set");
+        require(_input.challengePeriod != 0, "DeployPreimageOracle: challengePeriod not set");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) internal view {
+        DeployUtils.assertValidContractAddress(address(_output.preimageOracle));
+        require(_output.preimageOracle.minProposalSize() == _input.minProposalSize, "DPO-10");
+        require(_output.preimageOracle.challengePeriod() == _input.challengePeriod, "DPO-20");
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployPreimageOracle2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployPreimageOracle2.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+
+import { DeployPreimageOracle2 } from "scripts/deploy/DeployPreimageOracle2.s.sol";
+
+contract DeployPreimageOracle2_Test is Test {
+    DeployPreimageOracle2 deployPreimageOracle;
+
+    uint256 defaultMinProposalSize = 1000;
+    uint256 defaultChallengePeriod = 7 days;
+
+    function setUp() public {
+        deployPreimageOracle = new DeployPreimageOracle2();
+    }
+
+    function testFuzz_run_succeeds(DeployPreimageOracle2.Input memory _input, uint64 _challengePeriod) public {
+        vm.assume(_input.minProposalSize != 0);
+        vm.assume(_challengePeriod != 0);
+
+        _input.challengePeriod = _challengePeriod;
+
+        DeployPreimageOracle2.Output memory output = deployPreimageOracle.run(_input);
+
+        assertNotEq(address(output.preimageOracle), address(0));
+        assertEq(output.preimageOracle.minProposalSize(), _input.minProposalSize);
+        assertEq(output.preimageOracle.challengePeriod(), _input.challengePeriod);
+    }
+
+    function test_run_nullInputs_reverts() public {
+        DeployPreimageOracle2.Input memory input;
+
+        input = defaultInput();
+        input.minProposalSize = 0;
+        vm.expectRevert("DeployPreimageOracle: minProposalSize not set");
+        deployPreimageOracle.run(input);
+
+        input = defaultInput();
+        input.challengePeriod = 0;
+        vm.expectRevert("DeployPreimageOracle: challengePeriod not set");
+        deployPreimageOracle.run(input);
+    }
+
+    function defaultInput() internal view returns (DeployPreimageOracle2.Input memory input_) {
+        input_ = DeployPreimageOracle2.Input({
+            minProposalSize: defaultMinProposalSize,
+            challengePeriod: defaultChallengePeriod
+        });
+    }
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployPreimageOracle2` has been introduced along with extended test coverage.

Relates to https://github.com/ethereum-optimism/optimism/issues/14976