### PR TITLE
feat: Simplify op-deployer scripts: DeployProxy [14/N]

### DIFF
--- a/op-deployer/pkg/deployer/opcm/proxy2.go
+++ b/op-deployer/pkg/deployer/opcm/proxy2.go
@@ -1,0 +1,21 @@
+package opcm
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployProxy2Input struct {
+	Owner common.Address
+}
+
+type DeployProxy2Output struct {
+	Proxy common.Address
+}
+
+type DeployProxyScript script.DeployScriptWithOutput[DeployProxy2Input, DeployProxy2Output]
+
+// NewDeployProxyScript loads and validates the DeployProxy2 script contract
+func NewDeployProxyScript(host *script.Host) (DeployProxyScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployProxy2Input, DeployProxy2Output](host, "DeployProxy2.s.sol", "DeployProxy2")
+}

--- a/op-deployer/pkg/deployer/opcm/proxy2_test.go
+++ b/op-deployer/pkg/deployer/opcm/proxy2_test.go
@@ -1,0 +1,50 @@
+package opcm_test
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployProxyScript(t *testing.T) {
+	t.Run("should not fail with current version of DeployProxy2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deployProxy, err := opcm.NewDeployProxyScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deployProxy.Run(opcm.DeployProxy2Input{
+			Owner: common.Address{'O'},
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		deprecatedOutput, err := opcm.DeployProxy(host2, opcm.DeployProxyInput{
+			Owner: common.Address{'O'},
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.Proxy, output.Proxy)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.Proxy), host1.GetCode(output.Proxy))
+	})
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployProxy2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployProxy2.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployProxy2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployProxy2.s.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Forge
+import { Script } from "forge-std/Script.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IProxy } from "interfaces/universal/IProxy.sol";
+
+/// @title DeployProxy
+contract DeployProxy2 is Script {
+    struct Input {
+        address owner;
+    }
+
+    struct Output {
+        IProxy proxy;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        assertValidInput(_input);
+
+        deployProxySingleton(_input, output_);
+
+        assertValidOutput(_input, output_);
+    }
+
+    function deployProxySingleton(Input memory _input, Output memory _output) internal {
+        vm.broadcast(msg.sender);
+        IProxy proxy = IProxy(
+            DeployUtils.create1({
+                _name: "Proxy",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (_input.owner)))
+            })
+        );
+
+        vm.label(address(proxy), "Proxy");
+        _output.proxy = proxy;
+    }
+
+    function assertValidInput(Input memory _input) internal pure {
+        require(_input.owner != address(0), "DeployProxy: owner not set");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) internal {
+        IProxy proxy = _output.proxy;
+        DeployUtils.assertValidContractAddress(address(proxy));
+
+        vm.prank(_input.owner);
+        address proxyAdmin = proxy.admin();
+
+        require(
+            proxyAdmin == _input.owner, "DeployProxy: owner of proxy does not match the owner specified in the input"
+        );
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/DeployProxy2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployProxy2.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+import { DeployProxy2 } from "scripts/deploy/DeployProxy2.s.sol";
+
+contract DeployProxy2_Test is Test {
+    DeployProxy2 deployProxy;
+
+    // Define default input variables for testing.
+    address defaultProxyAdmin = makeAddr("ProxyAdmin");
+
+    function setUp() public {
+        deployProxy = new DeployProxy2();
+    }
+
+    function testFuzz_run_memory_succeeds(DeployProxy2.Input memory _input) public {
+        vm.assume(_input.owner != address(0));
+
+        // Run the deployment script.
+        DeployProxy2.Output memory output = deployProxy.run(_input);
+
+        // Assert inputs were properly passed through to the contract initializers.
+        vm.prank(_input.owner);
+        assertEq(address(output.proxy.admin()), _input.owner, "100");
+    }
+
+    function test_run_nullInput_reverts() public {
+        DeployProxy2.Input memory input;
+
+        input = defaultInput();
+        input.owner = address(0);
+        vm.expectRevert("DeployProxy: owner not set");
+        deployProxy.run(input);
+    }
+
+    function defaultInput() internal view returns (DeployProxy2.Input memory input_) {
+        input_ = DeployProxy2.Input({ owner: defaultProxyAdmin });
+    }
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Applying the same pattern as `DeploySuperchain2`, `DeployProxy2` has been introduced along with extended test coverage.

No existing tests were present so a test suite was added.

Relates to https://github.com/ethereum-optimism/optimism/issues/14976