### PR TITLE
op-program: Fix flaky miner test

### DIFF
--- a/op-program/client/l2/test/miner.go
+++ b/op-program/client/l2/test/miner.go
@@ -67,9 +67,6 @@ func NewMiner(t *testing.T, logger log.Logger, isthmusTime uint64) (*Miner, *cor
 	}
 	n, err := node.New(nodeCfg)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = n.Close()
-	})
 	backend, err := geth.New(n, ethCfg)
 	require.NoError(t, err)
 	chain := backend.BlockChain()


### PR DESCRIPTION
Fix some weirdness during cleanup of various op-program canonical block oracle tests. I failed to figure out why the test cleanup is problematic but this fix seems to eliminate flakes. Downside is that the tests take quite a bit longer to finish, from 1 second to 14 seconds locally.

testing:
```
go test ./op-program/client/... -count=10
```