### PR TITLE
op-node,op-service: Add Isthmus & Interrop override flags

### DIFF
--- a/op-node/service.go
+++ b/op-node/service.go
@@ -274,6 +274,14 @@ func applyOverrides(ctx *cli.Context, rollupConfig *rollup.Config) {
 		pectrablobschedule := ctx.Uint64(opflags.PectraBlobScheduleOverrideFlagName)
 		rollupConfig.PectraBlobScheduleTime = &pectrablobschedule
 	}
+	if ctx.IsSet(opflags.IsthmusOverrideFlagName) {
+		isthmus := ctx.Uint64(opflags.IsthmusOverrideFlagName)
+		rollupConfig.IsthmusTime = &isthmus
+	}
+	if ctx.IsSet(opflags.InteropOverrideFlagName) {
+		interop := ctx.Uint64(opflags.InteropOverrideFlagName)
+		rollupConfig.InteropTime = &interop
+	}
 }
 
 func NewSyncConfig(ctx *cli.Context, log log.Logger) (*sync.Config, error) {

--- a/op-service/flags/flags.go
+++ b/op-service/flags/flags.go
@@ -20,6 +20,8 @@ const (
 	GraniteOverrideFlagName            = "override.granite"
 	HoloceneOverrideFlagName           = "override.holocene"
 	PectraBlobScheduleOverrideFlagName = "override.pectrablobschedule"
+	IsthmusOverrideFlagName            = "override.isthmus"
+	InteropOverrideFlagName            = "override.interop"
 )
 
 func CLIFlags(envPrefix string, category string) []cli.Flag {
@@ -70,6 +72,20 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 			Name:     PectraBlobScheduleOverrideFlagName,
 			Usage:    "Manually specify the PectraBlobSchedule fork timestamp, overriding the bundled setting",
 			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_PECTRABLOBSCHEDULE"),
+			Hidden:   false,
+			Category: category,
+		},
+		&cli.Uint64Flag{
+			Name:     IsthmusOverrideFlagName,
+			Usage:    "Manually specify the Isthmus fork timestamp, overriding the bundled setting",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_ISTHMUS"),
+			Hidden:   false,
+			Category: category,
+		},
+		&cli.Uint64Flag{
+			Name:     InteropOverrideFlagName,
+			Usage:    "Manually specify the Interop fork timestamp, overriding the bundled setting",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_INTEROP"),
 			Hidden:   false,
 			Category: category,
 		},


### PR DESCRIPTION
**Description**

Those weren't added when the original fork references were added.
