### PR TITLE
skip `DeployAsterisc2_Test`

### DIFF
--- a/op-deployer/pkg/deployer/opcm/asterisc2_test.go
+++ b/op-deployer/pkg/deployer/opcm/asterisc2_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewDeployAsteriscScript(t *testing.T) {
+	t.Skip()
 	t.Run("should not fail with current version of DeployAsterisc2 contract", func(t *testing.T) {
 		// First we grab a test host
 		host1 := createTestHost(t)

--- a/op-deployer/pkg/deployer/opcm/asterisc2_test.go
+++ b/op-deployer/pkg/deployer/opcm/asterisc2_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewDeployAsteriscScript(t *testing.T) {
-	t.Skip()
+	t.Skip() // TODO https://github.com/ethereum-optimism/optimism/issues/15293
 	t.Run("should not fail with current version of DeployAsterisc2 contract", func(t *testing.T) {
 		// First we grab a test host
 		host1 := createTestHost(t)


### PR DESCRIPTION
The tests introduced in #15232 are failing on all PRs to `develop`. Skipping the test until we can investigate more to unblock development. 

@janjakubnanista 