### PR TITLE
contracts: Pin solidity version for flaky deploy scripts

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployAsterisc.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAsterisc.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployAsterisc2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAsterisc2.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 // Forge
 import { Script } from "forge-std/Script.sol";


### PR DESCRIPTION
The TestNewDeployAsteriscScript frequently [flakes](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/86613/workflows/e7101e71-7321-430f-ac93-b16c668df109/jobs/3422654) because OPCM cannot locate the artifacts of the `DeployAsterisc2` contract script. This occurs whenever multiple artifacts are generated to satisfy Solidity compiler version build requirements. Since OPCM attempts to use the "default" non-versioned artifact, it fails to find the correct one.

As a workaround, we can pin the Solidity compiler version to ensure that only one artifact is generated. However, in the longer term, OPCM should be fixed to handle artifacts for multiple contract versions.