### PR TITLE
feat: resend message

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -36,6 +36,9 @@ interface IL2ToL2CrossDomainMessenger {
     /// @notice Thrown when a reentrant call is detected.
     error ReentrantCall();
 
+    /// @notice Thrown when the provided message parameters do not match any hash of a previously sent message.
+    error InvalidMessage();
+
     /// @notice Emitted whenever a message is sent to a destination
     /// @param destination  Chain ID of the destination chain.
     /// @param target       Target contract or wallet address.
@@ -66,6 +69,11 @@ interface IL2ToL2CrossDomainMessenger {
     /// @return Nonce of the next message to be sent, with added message version.
     function messageNonce() external view returns (uint256);
 
+    /// @notice Mapping of message hashes to boolean sent values. Note that a message will only be present in this
+    ///         mapping if it has been sent from this chain to a destination chain.
+    /// @return Returns true if the message corresponding to the `_msgHash` was successfully sent.
+    function sentMessages(bytes32) external view returns (bool);
+
     /// @notice Retrieves the sender of the current cross domain message.
     /// @return sender_ Address of the sender of the current cross domain message.
     function crossDomainMessageSender() external view returns (address sender_);
@@ -89,6 +97,24 @@ interface IL2ToL2CrossDomainMessenger {
     /// @return msgHash_ The hash of the message being sent, which can be used for tracking whether
     ///                  the message has successfully been relayed.
     function sendMessage(uint256 _destination, address _target, bytes calldata _message) external returns (bytes32);
+
+    /// @notice Re-emits a previously sent message event for old messages that haven't been
+    ///         relayed yet, allowing offchain infrastructure to pick them up and relay them.
+    /// @dev    Emitting a message that has already been relayed will have no effect, as it is only
+    ///         relayed once on the destination chain.
+    /// @param _destination Chain ID of the destination chain.
+    /// @param _nonce Nonce of the message sent
+    /// @param _sender Address that sent the message
+    /// @param _target Target contract or wallet address.
+    /// @param _message Message payload to call target with.
+    function reEmitMessageSent(
+        uint256 _destination,
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        bytes calldata _message
+    )
+        external;
 
     /// @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
     ///         be executed via cross-chain call from the other messenger OR if the message was

--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -94,9 +94,15 @@ interface IL2ToL2CrossDomainMessenger {
     /// @param _destination Chain ID of the destination chain.
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message to trigger the target address with.
-    /// @return msgHash_ The hash of the message being sent, which can be used for tracking whether
-    ///                  the message has successfully been relayed.
-    function sendMessage(uint256 _destination, address _target, bytes calldata _message) external returns (bytes32);
+    /// @return messageHash_ The hash of the message being sent, used to track whether the message
+    ///                      has successfully been relayed.
+    function sendMessage(
+        uint256 _destination,
+        address _target,
+        bytes calldata _message
+    )
+        external
+        returns (bytes32 messageHash_);
 
     /// @notice Re-emits a previously sent message event for old messages that haven't been
     ///         relayed yet, allowing offchain infrastructure to pick them up and relay them.

--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -113,7 +113,7 @@ interface IL2ToL2CrossDomainMessenger {
     /// @param _sender Address that sent the message
     /// @param _target Target contract or wallet address.
     /// @param _message Message payload to call target with.
-    function reEmitMessageSent(
+    function resendMessage(
         uint256 _destination,
         uint256 _nonce,
         address _sender,

--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL2CrossDomainMessenger.sol
@@ -113,6 +113,7 @@ interface IL2ToL2CrossDomainMessenger {
     /// @param _sender Address that sent the message
     /// @param _target Target contract or wallet address.
     /// @param _message Message payload to call target with.
+    /// @return messageHash_ The hash of the message being re-sent.
     function resendMessage(
         uint256 _destination,
         uint256 _nonce,
@@ -120,7 +121,8 @@ interface IL2ToL2CrossDomainMessenger {
         address _target,
         bytes calldata _message
     )
-        external;
+        external
+        returns (bytes32 messageHash_);
 
     /// @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
     ///         be executed via cross-chain call from the other messenger OR if the message was

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -72,6 +72,39 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "_destination",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_target",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      }
+    ],
+    "name": "reEmitMessageSent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "components": [
           {
             "internalType": "address",
@@ -142,11 +175,30 @@
     "outputs": [
       {
         "internalType": "bytes32",
-        "name": "",
+        "name": "messageHash_",
         "type": "bytes32"
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "sentMessages",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -251,6 +303,11 @@
   {
     "inputs": [],
     "name": "IdOriginNotL2ToL2CrossDomainMessenger",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMessage",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -72,39 +72,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_destination",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_nonce",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "_sender",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_target",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "_message",
-        "type": "bytes"
-      }
-    ],
-    "name": "reEmitMessageSent",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "components": [
           {
             "internalType": "address",
@@ -151,6 +118,39 @@
       }
     ],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_destination",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_target",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      }
+    ],
+    "name": "resendMessage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/abi/L2ToL2CrossDomainMessenger.json
@@ -149,7 +149,13 @@
       }
     ],
     "name": "resendMessage",
-    "outputs": [],
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "messageHash_",
+        "type": "bytes32"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -84,8 +84,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol:L2ToL2CrossDomainMessenger": {
-    "initCodeHash": "0x7ad26c308c506ca65e080c8a33eceac48201221cd291030844021cf1cfde4871",
-    "sourceCodeHash": "0xe59eec8a64d6c42d9cc2a67aa649718cad590961f92787d62435bf8cde93f7f3"
+    "initCodeHash": "0x3531197206d6cac9b4919f74668cefadb073a04c55b98dad0340876d4652181e",
+    "sourceCodeHash": "0x7d9e819f8c4501e27f8bec5f32e332d56518e1172f443160714656094dea8fe4"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
     "initCodeHash": "0x3d8c0d7736e8767f2f797da1c20c5fe30bd7f48a4cf75f376290481ad7c0f91f",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -84,8 +84,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol:L2ToL2CrossDomainMessenger": {
-    "initCodeHash": "0xe7cd3ce077d1584ec9f7c2771bdf8afdb03fc4af35cb9060b6f12905fa14d2e7",
-    "sourceCodeHash": "0xb0c4d6fb360f19664c5f1aa8617834d8337fba3592f5cf4f316c28df891394e5"
+    "initCodeHash": "0xcf875a2073bf91cecffea3308c11f7160274c5eeabe1490065378401d6a8ff3d",
+    "sourceCodeHash": "0x4f14cd11f43a2efe041b6e8aabccddb5d6c7826362f831c584eccf2ad7c50293"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
     "initCodeHash": "0x3d8c0d7736e8767f2f797da1c20c5fe30bd7f48a4cf75f376290481ad7c0f91f",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -84,8 +84,8 @@
     "sourceCodeHash": "0xaef8ea36c5b78cd12e0e62811d51db627ccf0dfd2cc5479fb707a10ef0d42048"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol:L2ToL2CrossDomainMessenger": {
-    "initCodeHash": "0x3531197206d6cac9b4919f74668cefadb073a04c55b98dad0340876d4652181e",
-    "sourceCodeHash": "0x7d9e819f8c4501e27f8bec5f32e332d56518e1172f443160714656094dea8fe4"
+    "initCodeHash": "0xe7cd3ce077d1584ec9f7c2771bdf8afdb03fc4af35cb9060b6f12905fa14d2e7",
+    "sourceCodeHash": "0xb0c4d6fb360f19664c5f1aa8617834d8337fba3592f5cf4f316c28df891394e5"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
     "initCodeHash": "0x3d8c0d7736e8767f2f797da1c20c5fe30bd7f48a4cf75f376290481ad7c0f91f",

--- a/packages/contracts-bedrock/snapshots/storageLayout/L2ToL2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L2ToL2CrossDomainMessenger.json
@@ -12,5 +12,12 @@
     "offset": 0,
     "slot": "1",
     "type": "uint240"
+  },
+  {
+    "bytes": "32",
+    "label": "sentMessages",
+    "offset": 0,
+    "slot": "2",
+    "type": "mapping(bytes32 => bool)"
   }
 ]

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -64,8 +64,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0-beta.0
-    string public constant version = "1.1.0-beta.0";
+    /// @custom:semver 1.1.0
+    string public constant version = "1.1.0";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -128,8 +128,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param _destination Chain ID of the destination chain.
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message payload to call target with.
-    /// @return messageHash_ The hash of the message being sent, used to track whether the message has successfully been
-    /// relayed.
+    /// @return messageHash_ The hash of the message being sent, used to track whether the message
+    ///                      has successfully been relayed.
     function sendMessage(
         uint256 _destination,
         address _target,
@@ -175,7 +175,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     )
         external
     {
-        bytes32 messageHash_ = Hashing.hashL2toL2CrossDomainMessage({
+        bytes32 messageHash = Hashing.hashL2toL2CrossDomainMessage({
             _destination: _destination,
             _source: block.chainid,
             _nonce: _nonce,
@@ -184,17 +184,17 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
             _message: _message
         });
 
-        if (!sentMessages[messageHash_]) revert InvalidMessage();
+        if (!sentMessages[messageHash]) revert InvalidMessage();
 
         emit SentMessage(_destination, _target, _nonce, _sender, _message);
     }
+
     /// @notice Relays a message that was sent by the other L2ToL2CrossDomainMessenger contract. Can only be executed
     ///         via cross chain call from the other messenger OR if the message was already received once and is
     ///         currently being replayed.
     /// @param _id          Identifier of the SentMessage event to be relayed
     /// @param _sentMessage Payload of the `SentMessage` event
     /// @return returnData_ Return data from the target contract call.
-
     function relayMessage(
         Identifier calldata _id,
         bytes calldata _sentMessage

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -35,6 +35,9 @@ error MessageAlreadyRelayed();
 /// @notice Thrown when a reentrant call is detected.
 error ReentrantCall();
 
+/// @notice Thrown when the provided message parameters do not match any hash of a previously sent message.
+error InvalidMessage();
+
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000023
 /// @title L2ToL2CrossDomainMessenger
@@ -61,8 +64,8 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     uint16 public constant messageVersion = uint16(0);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.16
-    string public constant version = "1.0.0-beta.16";
+    /// @custom:semver 1.1.0-beta.0
+    string public constant version = "1.1.0-beta.0";
 
     /// @notice Mapping of message hashes to boolean receipt values. Note that a message will only be present in this
     ///         mapping if it has successfully been relayed on this chain, and can therefore not be relayed again.
@@ -72,6 +75,10 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     ///         which will insert the message version into the nonce to give you the actual nonce to be used for the
     ///         message.
     uint240 internal msgNonce;
+
+    /// @notice Mapping of message hashes to boolean sent values. Note that a message will only be present in this
+    ///         mapping if it has been sent from this chain to a destination chain.
+    mapping(bytes32 => bool) public sentMessages;
 
     /// @notice Emitted whenever a message is sent to a destination
     /// @param destination  Chain ID of the destination chain.
@@ -121,17 +128,21 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param _destination Chain ID of the destination chain.
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message payload to call target with.
-    /// @return The hash of the message being sent, used to track whether the message has successfully been relayed.
-    function sendMessage(uint256 _destination, address _target, bytes calldata _message) external returns (bytes32) {
+    /// @return messageHash_ The hash of the message being sent, used to track whether the message has successfully been
+    /// relayed.
+    function sendMessage(
+        uint256 _destination,
+        address _target,
+        bytes calldata _message
+    )
+        external
+        returns (bytes32 messageHash_)
+    {
         if (_destination == block.chainid) revert MessageDestinationSameChain();
         if (_target == Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER) revert MessageTargetL2ToL2CrossDomainMessenger();
 
         uint256 nonce = messageNonce();
-        emit SentMessage(_destination, _target, nonce, msg.sender, _message);
-
-        msgNonce++;
-
-        return Hashing.hashL2toL2CrossDomainMessage({
+        messageHash_ = Hashing.hashL2toL2CrossDomainMessage({
             _destination: _destination,
             _source: block.chainid,
             _nonce: nonce,
@@ -139,14 +150,51 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
             _target: _target,
             _message: _message
         });
+
+        sentMessages[messageHash_] = true;
+        msgNonce++;
+
+        emit SentMessage(_destination, _target, nonce, msg.sender, _message);
     }
 
+    /// @notice Re-emits a previously sent message event for old messages that haven't been
+    ///         relayed yet, allowing offchain infrastructure to pick them up and relay them.
+    /// @dev    Emitting a message that has already been relayed will have no effect, as it is only
+    ///         relayed once on the destination chain.
+    /// @param _destination Chain ID of the destination chain.
+    /// @param _nonce Nonce of the message sent
+    /// @param _sender Address that sent the message
+    /// @param _target Target contract or wallet address.
+    /// @param _message Message payload to call target with.
+    function reEmitMessageSent(
+        uint256 _destination,
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        bytes calldata _message
+    )
+        external
+    {
+        bytes32 messageHash_ = Hashing.hashL2toL2CrossDomainMessage({
+            _destination: _destination,
+            _source: block.chainid,
+            _nonce: _nonce,
+            _sender: _sender,
+            _target: _target,
+            _message: _message
+        });
+
+        if (sentMessages[messageHash_]) revert InvalidMessage();
+
+        emit SentMessage(_destination, _target, _nonce, _sender, _message);
+    }
     /// @notice Relays a message that was sent by the other L2ToL2CrossDomainMessenger contract. Can only be executed
     ///         via cross chain call from the other messenger OR if the message was already received once and is
     ///         currently being replayed.
     /// @param _id          Identifier of the SentMessage event to be relayed
     /// @param _sentMessage Payload of the `SentMessage` event
     /// @return returnData_ Return data from the target contract call.
+
     function relayMessage(
         Identifier calldata _id,
         bytes calldata _sentMessage

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -184,7 +184,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
             _message: _message
         });
 
-        if (sentMessages[messageHash_]) revert InvalidMessage();
+        if (!sentMessages[messageHash_]) revert InvalidMessage();
 
         emit SentMessage(_destination, _target, _nonce, _sender, _message);
     }

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -166,6 +166,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param _sender Address that sent the message
     /// @param _target Target contract or wallet address.
     /// @param _message Message payload to call target with.
+    /// @return messageHash_ The hash of the message being re-sent.
     function resendMessage(
         uint256 _destination,
         uint256 _nonce,
@@ -174,8 +175,9 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
         bytes calldata _message
     )
         external
+        returns (bytes32 messageHash_)
     {
-        bytes32 messageHash = Hashing.hashL2toL2CrossDomainMessage({
+        messageHash_ = Hashing.hashL2toL2CrossDomainMessage({
             _destination: _destination,
             _source: block.chainid,
             _nonce: _nonce,
@@ -184,7 +186,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
             _message: _message
         });
 
-        if (!sentMessages[messageHash]) revert InvalidMessage();
+        if (!sentMessages[messageHash_]) revert InvalidMessage();
 
         emit SentMessage(_destination, _target, _nonce, _sender, _message);
     }

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -166,7 +166,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param _sender Address that sent the message
     /// @param _target Target contract or wallet address.
     /// @param _message Message payload to call target with.
-    function reEmitMessageSent(
+    function resendMessage(
         uint256 _destination,
         uint256 _nonce,
         address _sender,

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -226,7 +226,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Look for correct emitted event
         vm.recordLogs();
 
-        // Call the sendMessage function
+        // Call the `sendMessage` function
         vm.prank(_sender);
         bytes32 msgHash = l2ToL2CrossDomainMessenger.sendMessage(_destination, _target, _message);
         assertEq(
@@ -251,7 +251,7 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(l2ToL2CrossDomainMessenger.messageNonce(), messageNonce + 1);
         assertEq(l2ToL2CrossDomainMessenger.sentMessages(msgHash), true);
 
-        // Call the reEmitMessageSent function
+        // Call the `reEmitMessageSent` function
         l2ToL2CrossDomainMessenger.reEmitMessageSent(_destination, messageNonce, _sender, _target, _message);
 
         // Check that the event was emitted with the correct parameters

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -19,7 +19,8 @@ import {
     MessageDestinationNotRelayChain,
     MessageTargetL2ToL2CrossDomainMessenger,
     MessageAlreadyRelayed,
-    ReentrantCall
+    ReentrantCall,
+    InvalidMessage
 } from "src/L2/L2ToL2CrossDomainMessenger.sol";
 
 // Interfaces
@@ -115,8 +116,9 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // data
         assertEq(logs[0].data, abi.encode(address(this), _message));
 
-        // Check that the message nonce has been incremented
+        // Check that the message nonce has been incremented and the message hash has been stored
         assertEq(l2ToL2CrossDomainMessenger.messageNonce(), messageNonce + 1);
+        assertEq(l2ToL2CrossDomainMessenger.sentMessages(msgHash), true);
     }
 
     /// @dev Tests that the `sendMessage` function reverts when sending a ETH
@@ -179,65 +181,88 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         });
     }
 
-    /// @dev Tests that the `relayMessage` function succeeds and emits the correct RelayedMessage event.
-    function testFuzz_relayMessage_succeeds(
-        uint256 _source,
+    /// @dev Tests that the `reEmitMessageSent` function reverts when the message hash does not correspond to
+    ///      any previously sent message.
+    function testFuzz_reEmitMessageSent_invalidMessage_reverts(
+        uint256 _destination,
         uint256 _nonce,
         address _sender,
         address _target,
-        bytes calldata _message,
-        uint256 _value,
-        uint64 _blockNum,
-        uint32 _logIndex,
-        uint64 _time
+        bytes calldata _message
     )
         external
     {
-        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger or the foundry VM
-        vm.assume(
-            _target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
-                && _target != foundryVMAddress
-        );
+        // Get the message hash and ensure it has not been sent yet
+        bytes32 msgHash =
+            Hashing.hashL2toL2CrossDomainMessage(_destination, block.chainid, _nonce, _sender, _target, _message);
+        vm.assume(l2ToL2CrossDomainMessenger.sentMessages(msgHash) == false);
 
-        // Ensure that the target call is payable if value is sent
-        if (_value > 0) assumePayable(_target);
+        // Expect a revert with the InvalidMessage selector
+        vm.expectRevert(InvalidMessage.selector);
 
-        // Ensure that the target is not a forge address.
-        assumeNotForgeAddress(_target);
+        // Call the reEmitMessageSent function
+        l2ToL2CrossDomainMessenger.reEmitMessageSent(_destination, _nonce, _sender, _target, _message);
+    }
 
-        // Ensure that the target contract does not revert
-        vm.mockCall({ callee: _target, msgValue: _value, data: _message, returnData: abi.encode(true) });
+    /// @dev Tests that `reEmitMessageSent` succeeds and emits the same SentMessage event as the one
+    ///      emitted by `sendMessage`.
+    function testFuzz_reEmitMessageSent_succeeds(
+        address _sender,
+        uint256 _destination,
+        address _target,
+        bytes calldata _message
+    )
+        external
+    {
+        // Ensure the destination is not the same as the source, otherwise the function will revert
+        vm.assume(_destination != block.chainid);
 
-        // Construct the SentMessage payload & identifier
-        Identifier memory id =
-            Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _blockNum, _logIndex, _time, _source);
-        bytes memory sentMessage = abi.encodePacked(
-            abi.encode(L2ToL2CrossDomainMessenger.SentMessage.selector, block.chainid, _target, _nonce), // topics
-            abi.encode(_sender, _message) // data
-        );
+        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger
+        vm.assume(_target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
 
-        // Ensure the CrossL2Inbox validates this message
-        vm.mockCall({
-            callee: Predeploys.CROSS_L2_INBOX,
-            data: abi.encodeCall(ICrossL2Inbox.validateMessage, (id, keccak256(sentMessage))),
-            returnData: ""
-        });
+        // Get the current message nonce
+        uint256 messageNonce = l2ToL2CrossDomainMessenger.messageNonce();
 
         // Look for correct emitted event
-        vm.expectEmit(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
-        emit L2ToL2CrossDomainMessenger.RelayedMessage(
-            _source, _nonce, keccak256(abi.encode(block.chainid, _source, _nonce, _sender, _target, _message))
+        vm.recordLogs();
+
+        // Call the sendMessage function
+        vm.prank(_sender);
+        bytes32 msgHash = l2ToL2CrossDomainMessenger.sendMessage(_destination, _target, _message);
+        assertEq(
+            msgHash,
+            Hashing.hashL2toL2CrossDomainMessage(_destination, block.chainid, messageNonce, _sender, _target, _message)
         );
 
-        // relay the message
-        hoax(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, _value);
-        l2ToL2CrossDomainMessenger.relayMessage{ value: _value }(id, sentMessage);
-        assertEq(
-            l2ToL2CrossDomainMessenger.successfulMessages(
-                keccak256(abi.encode(block.chainid, _source, _nonce, _sender, _target, _message))
-            ),
-            true
-        );
+        // Check that the event was emitted with the correct parameters
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+
+        // topics
+        assertEq(logs[0].topics[0], L2ToL2CrossDomainMessenger.SentMessage.selector);
+        assertEq(logs[0].topics[1], bytes32(_destination));
+        assertEq(logs[0].topics[2], bytes32(uint256(uint160(_target))));
+        assertEq(logs[0].topics[3], bytes32(messageNonce));
+
+        // data
+        assertEq(logs[0].data, abi.encode(_sender, _message));
+
+        // Check that the message nonce has been incremented and the message hash has been stored
+        assertEq(l2ToL2CrossDomainMessenger.messageNonce(), messageNonce + 1);
+        assertEq(l2ToL2CrossDomainMessenger.sentMessages(msgHash), true);
+
+        // Call the reEmitMessageSent function
+        l2ToL2CrossDomainMessenger.reEmitMessageSent(_destination, messageNonce, _sender, _target, _message);
+
+        // Check that the event was emitted with the correct parameters
+        logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+
+        // topics
+        assertEq(logs[0].topics[0], L2ToL2CrossDomainMessenger.SentMessage.selector);
+        assertEq(logs[0].topics[1], bytes32(_destination));
+        assertEq(logs[0].topics[2], bytes32(uint256(uint160(_target))));
+        assertEq(logs[0].topics[3], bytes32(messageNonce));
     }
 
     function testFuzz_relayMessage_eventPayloadNotSentMessage_reverts(

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -252,7 +252,8 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(l2ToL2CrossDomainMessenger.sentMessages(msgHash), true);
 
         // Call the `resendMessage` function
-        l2ToL2CrossDomainMessenger.resendMessage(_destination, messageNonce, _sender, _target, _message);
+        bytes32 resendMsgHash =
+            l2ToL2CrossDomainMessenger.resendMessage(_destination, messageNonce, _sender, _target, _message);
 
         // Check that the event was emitted with the correct parameters
         logs = vm.getRecordedLogs();
@@ -263,6 +264,9 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(logs[0].topics[1], bytes32(_destination));
         assertEq(logs[0].topics[2], bytes32(uint256(uint160(_target))));
         assertEq(logs[0].topics[3], bytes32(messageNonce));
+
+        // Check that the message hash returned by `sendMessage` is the same as the one returned by `resendMessage`
+        assertEq(resendMsgHash, msgHash);
     }
 
     function testFuzz_relayMessage_eventPayloadNotSentMessage_reverts(

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -181,9 +181,9 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         });
     }
 
-    /// @dev Tests that the `reEmitMessageSent` function reverts when the message hash does not correspond to
+    /// @dev Tests that the `resendMessage` function reverts when the message hash does not correspond to
     ///      any previously sent message.
-    function testFuzz_reEmitMessageSent_invalidMessage_reverts(
+    function testFuzz_resendMessage_invalidMessage_reverts(
         uint256 _destination,
         uint256 _nonce,
         address _sender,
@@ -200,13 +200,13 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         // Expect a revert with the InvalidMessage selector
         vm.expectRevert(InvalidMessage.selector);
 
-        // Call the reEmitMessageSent function
-        l2ToL2CrossDomainMessenger.reEmitMessageSent(_destination, _nonce, _sender, _target, _message);
+        // Call the resendMessage function
+        l2ToL2CrossDomainMessenger.resendMessage(_destination, _nonce, _sender, _target, _message);
     }
 
-    /// @dev Tests that `reEmitMessageSent` succeeds and emits the same SentMessage event as the one
+    /// @dev Tests that `resendMessage` succeeds and emits the same SentMessage event as the one
     ///      emitted by `sendMessage`.
-    function testFuzz_reEmitMessageSent_succeeds(
+    function testFuzz_resendMessage_succeeds(
         address _sender,
         uint256 _destination,
         address _target,
@@ -251,8 +251,8 @@ contract L2ToL2CrossDomainMessengerTest is Test {
         assertEq(l2ToL2CrossDomainMessenger.messageNonce(), messageNonce + 1);
         assertEq(l2ToL2CrossDomainMessenger.sentMessages(msgHash), true);
 
-        // Call the `reEmitMessageSent` function
-        l2ToL2CrossDomainMessenger.reEmitMessageSent(_destination, messageNonce, _sender, _target, _message);
+        // Call the `resendMessage` function
+        l2ToL2CrossDomainMessenger.resendMessage(_destination, messageNonce, _sender, _target, _message);
 
         // Check that the event was emitted with the correct parameters
         logs = vm.getRecordedLogs();


### PR DESCRIPTION
**Description**

Introducing a new `resendMessage` to re-emit the `SentMessage` event for a message that was never relayed and became very old for the supervisor to pick it up.

**Additional Context**

* Deisgn doc: https://github.com/ethereum-optimism/design-docs/pull/259
* Spec: https://github.com/ethereum-optimism/specs/pull/659

**Metadata**

Closes https://github.com/ethereum-optimism/optimism/issues/15284

Authored by @0xDiscotech 