### PR TITLE
devnet-sdk/devstack: match stack components, with fast path for IDs

### DIFF
--- a/devnet-sdk/devstack/devtest/testing.go
+++ b/devnet-sdk/devstack/devtest/testing.go
@@ -109,6 +109,7 @@ func (t *testingT) Run(name string, fn func(T)) {
 			logger: t.logger.New("subtest", name),
 			ctx:    ctx,
 		}
+		subT.req = require.New(subT)
 		fn(subT)
 	})
 }

--- a/devnet-sdk/devstack/example/example_test.go
+++ b/devnet-sdk/devstack/example/example_test.go
@@ -12,6 +12,7 @@ func TestExample1(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := SimpleInterop(t)
 
+	t.Require().NotEqual(sys.L2ChainA.ChainID(), sys.L2ChainB.ChainID(), "sanity-check we have two different chains")
 	sys.Supervisor.VerifySyncStatus(dsl.WithAllLocalUnsafeHeadsAdvancedBy(10))
 }
 

--- a/devnet-sdk/devstack/presets/interop.go
+++ b/devnet-sdk/devstack/presets/interop.go
@@ -1,6 +1,7 @@
 package presets
 
 import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
@@ -15,6 +16,9 @@ type SimpleInterop struct {
 	T            devtest.T
 	Supervisor   *dsl.Supervisor
 	ControlPlane stack.ControlPlane
+
+	L2ChainA stack.L2Network
+	L2ChainB stack.L2Network
 }
 
 func NewSimpleInterop(dest *TestSetup[*SimpleInterop]) stack.Option {
@@ -52,5 +56,7 @@ func hydrateSimpleInterop(t devtest.T, orch stack.Orchestrator) *SimpleInterop {
 		T:            t,
 		Supervisor:   sys.Supervisor(supervisorId),
 		ControlPlane: orch.ControlPlane(),
+		L2ChainA:     system.L2Network(match.L2ChainA),
+		L2ChainB:     system.L2Network(match.L2ChainB),
 	}
 }

--- a/devnet-sdk/devstack/presets/interop.go
+++ b/devnet-sdk/devstack/presets/interop.go
@@ -1,13 +1,13 @@
 package presets
 
 import (
-	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/sysgo"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/dsl"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/shim"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/sysgo"
 )
 
 type SimpleInterop struct {
@@ -45,7 +45,7 @@ func hydrateSimpleInterop(t devtest.T, orch stack.Orchestrator) *SimpleInterop {
 	// At this point, any supervisor is acceptable but as the DSL gets fleshed out this should be selecting supervisors
 	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
 	// since currently there's no way to tell which nodes are using which supervisor.
-	supervisorId := system.Supervisors()[0]
+	supervisorId := system.SupervisorIDs()[0]
 	sys := dsl.Hydrate(t, system)
 	return &SimpleInterop{
 		Log:          t.Logger(),

--- a/devnet-sdk/devstack/shim/common.go
+++ b/devnet-sdk/devstack/shim/common.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
 )
 
 // CommonConfig provides common inputs for creating a new component
@@ -28,9 +29,10 @@ func NewCommonConfig(t devtest.T) CommonConfig {
 }
 
 type commonImpl struct {
-	log log.Logger
-	t   devtest.T
-	req *require.Assertions
+	log    log.Logger
+	t      devtest.T
+	req    *require.Assertions
+	labels *locks.RWMap[string, string]
 }
 
 var _ interface {
@@ -41,9 +43,10 @@ var _ interface {
 // newCommon creates an object to hold on to common component data, safe to embed in other structs
 func newCommon(cfg CommonConfig) commonImpl {
 	return commonImpl{
-		log: cfg.T.Logger(),
-		t:   cfg.T,
-		req: cfg.T.Require(),
+		log:    cfg.T.Logger(),
+		t:      cfg.T,
+		req:    cfg.T.Require(),
+		labels: new(locks.RWMap[string, string]),
 	}
 }
 
@@ -57,4 +60,13 @@ func (c *commonImpl) Logger() log.Logger {
 
 func (c *commonImpl) require() *require.Assertions {
 	return c.req
+}
+
+func (c *commonImpl) Label(key string) string {
+	out, _ := c.labels.Get(key)
+	return out
+}
+
+func (c *commonImpl) SetLabel(key, value string) {
+	c.labels.Set(key, value)
 }

--- a/devnet-sdk/devstack/shim/l1_network.go
+++ b/devnet-sdk/devstack/shim/l1_network.go
@@ -36,9 +36,9 @@ func (p *presetL1Network) ID() stack.L1NetworkID {
 	return p.id
 }
 
-func (p *presetL1Network) L1ELNode(id stack.L1ELNodeID) stack.L1ELNode {
-	v, ok := p.els.Get(id)
-	p.require().True(ok, "l1 EL node %s must exist", id)
+func (p *presetL1Network) L1ELNode(m stack.L1ELMatcher) stack.L1ELNode {
+	v, ok := findMatch(m, p.els.Get, p.L1ELNodes)
+	p.require().True(ok, "must find L1 EL %s", m)
 	return v
 }
 
@@ -48,9 +48,9 @@ func (p *presetL1Network) AddL1ELNode(v stack.L1ELNode) {
 	p.require().True(p.els.SetIfMissing(id, v), "l1 EL node %s must not already exist", id)
 }
 
-func (p *presetL1Network) L1CLNode(id stack.L1CLNodeID) stack.L1CLNode {
-	v, ok := p.cls.Get(id)
-	p.require().True(ok, "l1 CL node %s must exist", id)
+func (p *presetL1Network) L1CLNode(m stack.L1CLMatcher) stack.L1CLNode {
+	v, ok := findMatch(m, p.cls.Get, p.L1CLNodes)
+	p.require().True(ok, "must find L1 CL %s", m)
 	return v
 }
 
@@ -60,10 +60,18 @@ func (p *presetL1Network) AddL1CLNode(v stack.L1CLNode) {
 	p.require().True(p.cls.SetIfMissing(id, v), "l1 CL node %s must not already exist", id)
 }
 
-func (p *presetL1Network) L1ELNodes() []stack.L1ELNodeID {
+func (p *presetL1Network) L1ELNodeIDs() []stack.L1ELNodeID {
 	return stack.SortL1ELNodeIDs(p.els.Keys())
 }
 
-func (p *presetL1Network) L1CLNodes() []stack.L1CLNodeID {
+func (p *presetL1Network) L1ELNodes() []stack.L1ELNode {
+	return stack.SortL1ELNodes(p.els.Values())
+}
+
+func (p *presetL1Network) L1CLNodeIDs() []stack.L1CLNodeID {
 	return stack.SortL1CLNodeIDs(p.cls.Keys())
+}
+
+func (p *presetL1Network) L1CLNodes() []stack.L1CLNode {
+	return stack.SortL1CLNodes(p.cls.Values())
 }

--- a/devnet-sdk/devstack/shim/l2_cl.go
+++ b/devnet-sdk/devstack/shim/l2_cl.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
@@ -18,9 +19,11 @@ type rpcL2CLNode struct {
 	id           stack.L2CLNodeID
 	client       client.RPC
 	rollupClient apis.RollupClient
+	els          locks.RWMap[stack.L2ELNodeID, stack.L2ELNode]
 }
 
 var _ stack.L2CLNode = (*rpcL2CLNode)(nil)
+var _ stack.LinkableL2CLNode = (*rpcL2CLNode)(nil)
 
 func NewL2CLNode(cfg L2CLNodeConfig) stack.L2CLNode {
 	cfg.Log = cfg.Log.New("chainID", cfg.ID.ChainID, "id", cfg.ID)
@@ -38,4 +41,12 @@ func (r *rpcL2CLNode) ID() stack.L2CLNodeID {
 
 func (r *rpcL2CLNode) RollupAPI() apis.RollupClient {
 	return r.rollupClient
+}
+
+func (r *rpcL2CLNode) LinkEL(el stack.L2ELNode) {
+	r.els.Set(el.ID(), el)
+}
+
+func (r *rpcL2CLNode) ELs() []stack.L2ELNode {
+	return stack.SortL2ELNodes(r.els.Values())
 }

--- a/devnet-sdk/devstack/shim/l2_network.go
+++ b/devnet-sdk/devstack/shim/l2_network.go
@@ -95,9 +95,9 @@ func (p *presetL2Network) Cluster() stack.Cluster {
 	return p.cluster
 }
 
-func (p *presetL2Network) L2Batcher(id stack.L2BatcherID) stack.L2Batcher {
-	v, ok := p.batchers.Get(id)
-	p.require().True(ok, "l2 batcher %s must exist", id)
+func (p *presetL2Network) L2Batcher(m stack.L2BatcherMatcher) stack.L2Batcher {
+	v, ok := findMatch(m, p.batchers.Get, p.L2Batchers)
+	p.require().True(ok, "must find L2 batcher %s", m)
 	return v
 }
 
@@ -107,9 +107,9 @@ func (p *presetL2Network) AddL2Batcher(v stack.L2Batcher) {
 	p.require().True(p.batchers.SetIfMissing(id, v), "l2 batcher %s must not already exist", id)
 }
 
-func (p *presetL2Network) L2Proposer(id stack.L2ProposerID) stack.L2Proposer {
-	v, ok := p.proposers.Get(id)
-	p.require().True(ok, "l2 proposer %s must exist", id)
+func (p *presetL2Network) L2Proposer(m stack.L2ProposerMatcher) stack.L2Proposer {
+	v, ok := findMatch(m, p.proposers.Get, p.L2Proposers)
+	p.require().True(ok, "must find L2 proposer %s", m)
 	return v
 }
 
@@ -119,9 +119,9 @@ func (p *presetL2Network) AddL2Proposer(v stack.L2Proposer) {
 	p.require().True(p.proposers.SetIfMissing(id, v), "l2 proposer %s must not already exist", id)
 }
 
-func (p *presetL2Network) L2Challenger(id stack.L2ChallengerID) stack.L2Challenger {
-	v, ok := p.challengers.Get(id)
-	p.require().True(ok, "l2 challenger %s must exist", id)
+func (p *presetL2Network) L2Challenger(m stack.L2ChallengerMatcher) stack.L2Challenger {
+	v, ok := findMatch(m, p.challengers.Get, p.L2Challengers)
+	p.require().True(ok, "must find L2 challenger %s", m)
 	return v
 }
 
@@ -131,9 +131,9 @@ func (p *presetL2Network) AddL2Challenger(v stack.L2Challenger) {
 	p.require().True(p.challengers.SetIfMissing(id, v), "l2 challenger %s must not already exist", id)
 }
 
-func (p *presetL2Network) L2CLNode(id stack.L2CLNodeID) stack.L2CLNode {
-	v, ok := p.cls.Get(id)
-	p.require().True(ok, "l2 CL node %s must exist", id)
+func (p *presetL2Network) L2CLNode(m stack.L2CLMatcher) stack.L2CLNode {
+	v, ok := findMatch(m, p.cls.Get, p.L2CLNodes)
+	p.require().True(ok, "must find L2 CL %s", m)
 	return v
 }
 
@@ -143,9 +143,9 @@ func (p *presetL2Network) AddL2CLNode(v stack.L2CLNode) {
 	p.require().True(p.cls.SetIfMissing(id, v), "l2 CL node %s must not already exist", id)
 }
 
-func (p *presetL2Network) L2ELNode(id stack.L2ELNodeID) stack.L2ELNode {
-	v, ok := p.els.Get(id)
-	p.require().True(ok, "l2 EL node %s must exist", id)
+func (p *presetL2Network) L2ELNode(m stack.L2ELMatcher) stack.L2ELNode {
+	v, ok := findMatch(m, p.els.Get, p.L2ELNodes)
+	p.require().True(ok, "must find L2 EL %s", m)
 	return v
 }
 
@@ -155,22 +155,42 @@ func (p *presetL2Network) AddL2ELNode(v stack.L2ELNode) {
 	p.require().True(p.els.SetIfMissing(id, v), "l2 EL node %s must not already exist", id)
 }
 
-func (p *presetL2Network) L2Batchers() []stack.L2BatcherID {
+func (p *presetL2Network) L2BatcherIDs() []stack.L2BatcherID {
 	return stack.SortL2BatcherIDs(p.batchers.Keys())
 }
 
-func (p *presetL2Network) L2Proposers() []stack.L2ProposerID {
+func (p *presetL2Network) L2Batchers() []stack.L2Batcher {
+	return stack.SortL2Batchers(p.batchers.Values())
+}
+
+func (p *presetL2Network) L2ProposerIDs() []stack.L2ProposerID {
 	return stack.SortL2ProposerIDs(p.proposers.Keys())
 }
 
-func (p *presetL2Network) L2Challengers() []stack.L2ChallengerID {
+func (p *presetL2Network) L2Proposers() []stack.L2Proposer {
+	return stack.SortL2Proposers(p.proposers.Values())
+}
+
+func (p *presetL2Network) L2ChallengerIDs() []stack.L2ChallengerID {
 	return stack.SortL2ChallengerIDs(p.challengers.Keys())
 }
 
-func (p *presetL2Network) L2CLNodes() []stack.L2CLNodeID {
+func (p *presetL2Network) L2Challengers() []stack.L2Challenger {
+	return stack.SortL2Challengers(p.challengers.Values())
+}
+
+func (p *presetL2Network) L2CLNodeIDs() []stack.L2CLNodeID {
 	return stack.SortL2CLNodeIDs(p.cls.Keys())
 }
 
-func (p *presetL2Network) L2ELNodes() []stack.L2ELNodeID {
+func (p *presetL2Network) L2CLNodes() []stack.L2CLNode {
+	return stack.SortL2CLNodes(p.cls.Values())
+}
+
+func (p *presetL2Network) L2ELNodeIDs() []stack.L2ELNodeID {
 	return stack.SortL2ELNodeIDs(p.els.Keys())
+}
+
+func (p *presetL2Network) L2ELNodes() []stack.L2ELNode {
+	return stack.SortL2ELNodes(p.els.Values())
 }

--- a/devnet-sdk/devstack/shim/matcher.go
+++ b/devnet-sdk/devstack/shim/matcher.go
@@ -1,0 +1,20 @@
+package shim
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
+
+// findMatch checks if the matcher is an ID for direct lookup. If not, then it will search the list of values for a matching element.
+// If multiple elements match, the first found is returned.
+// The values function is used to lazy-fetch values in sorted order, such that the search is deterministic.
+func findMatch[I comparable, E stack.Identifiable[I]](m stack.Matcher[I, E], getValue func(I) (E, bool), values func() []E) (out E, found bool) {
+	id, ok := m.(I)
+	if ok {
+		return getValue(id)
+	}
+	got := m.Match(values())
+	if len(got) == 0 {
+		return
+	}
+	return got[0], true
+}

--- a/devnet-sdk/devstack/shim/network.go
+++ b/devnet-sdk/devstack/shim/network.go
@@ -46,9 +46,9 @@ func (p *presetNetwork) Faucet() stack.Faucet {
 	return p.faucet
 }
 
-func (p *presetNetwork) User(id stack.UserID) stack.User {
-	v, ok := p.users.Get(id)
-	p.require().True(ok, "user %s must exist", id)
+func (p *presetNetwork) User(m stack.UserMatcher) stack.User {
+	v, ok := findMatch(m, p.users.Get, p.Users)
+	p.require().True(ok, "must find user %s", m)
 	return v
 }
 
@@ -56,6 +56,10 @@ func (p *presetNetwork) AddUser(v stack.User) {
 	p.require().True(p.users.SetIfMissing(v.ID(), v), "user %s must not already exist", v.ID())
 }
 
-func (p *presetNetwork) Users() []stack.UserID {
+func (p *presetNetwork) Users() []stack.User {
+	return stack.SortUsers(p.users.Values())
+}
+
+func (p *presetNetwork) UserIDs() []stack.UserID {
 	return stack.SortUserIDs(p.users.Keys())
 }

--- a/devnet-sdk/devstack/shim/system.go
+++ b/devnet-sdk/devstack/shim/system.go
@@ -19,15 +19,10 @@ type presetSystem struct {
 	superchains locks.RWMap[stack.SuperchainID, stack.Superchain]
 	clusters    locks.RWMap[stack.ClusterID, stack.Cluster]
 
-	// tracks L1 networks by name
+	// tracks L1 networks by L1NetworkID (a typed eth.ChainID)
 	l1Networks locks.RWMap[stack.L1NetworkID, stack.L1Network]
-	// tracks L2 networks by name
+	// tracks L2 networks by L2NetworkID (a typed eth.ChainID)
 	l2Networks locks.RWMap[stack.L2NetworkID, stack.L2Network]
-
-	// tracks IDs of L1 networks by eth.ChainID
-	l1ChainIDs locks.RWMap[eth.ChainID, stack.L1NetworkID]
-	// tracks IDs of L2 networks by eth.ChainID
-	l2ChainIDs locks.RWMap[eth.ChainID, stack.L2NetworkID]
 
 	// tracks all networks, and ensures there are no networks with the same eth.ChainID
 	networks locks.RWMap[eth.ChainID, stack.Network]
@@ -44,9 +39,9 @@ func NewSystem(t devtest.T) stack.ExtensibleSystem {
 	}
 }
 
-func (p *presetSystem) Superchain(id stack.SuperchainID) stack.Superchain {
-	v, ok := p.superchains.Get(id)
-	p.require().True(ok, "superchain %s must exist", id)
+func (p *presetSystem) Superchain(m stack.SuperchainMatcher) stack.Superchain {
+	v, ok := findMatch(m, p.superchains.Get, p.Superchains)
+	p.require().True(ok, "must find superchain %s", m)
 	return v
 }
 
@@ -54,9 +49,9 @@ func (p *presetSystem) AddSuperchain(v stack.Superchain) {
 	p.require().True(p.superchains.SetIfMissing(v.ID(), v), "superchain %s must not already exist", v.ID())
 }
 
-func (p *presetSystem) Cluster(id stack.ClusterID) stack.Cluster {
-	v, ok := p.clusters.Get(id)
-	p.require().True(ok, "cluster %s must exist", id)
+func (p *presetSystem) Cluster(m stack.ClusterMatcher) stack.Cluster {
+	v, ok := findMatch(m, p.clusters.Get, p.Clusters)
+	p.require().True(ok, "must find cluster %s", m)
 	return v
 }
 
@@ -64,47 +59,33 @@ func (p *presetSystem) AddCluster(v stack.Cluster) {
 	p.require().True(p.clusters.SetIfMissing(v.ID(), v), "cluster %s must not already exist", v.ID())
 }
 
-func (p *presetSystem) L1Network(id stack.L1NetworkID) stack.L1Network {
-	v, ok := p.l1Networks.Get(id)
-	p.require().True(ok, "l1 chain %s must exist", id)
+func (p *presetSystem) L1Network(m stack.L1NetworkMatcher) stack.L1Network {
+	v, ok := findMatch(m, p.l1Networks.Get, p.L1Networks)
+	p.require().True(ok, "must find l1 network %s", m)
 	return v
 }
 
 func (p *presetSystem) AddL1Network(v stack.L1Network) {
 	id := v.ID()
 	p.require().True(p.networks.SetIfMissing(id.ChainID(), v), "chain with id %s must not already exist", id.ChainID())
-	p.require().True(p.l1ChainIDs.SetIfMissing(id.ChainID(), id), "l1 chain id %s mapping must not already exist", id)
-	p.require().True(p.l1Networks.SetIfMissing(id, v), "l1 chain %s must not already exist", id)
+	p.require().True(p.l1Networks.SetIfMissing(id, v), "L1 chain %s must not already exist", id)
 }
 
-func (p *presetSystem) L2Network(id stack.L2NetworkID) stack.L2Network {
-	v, ok := p.l2Networks.Get(id)
-	p.require().True(ok, "l2 chain %s must exist", id)
+func (p *presetSystem) L2Network(m stack.L2NetworkMatcher) stack.L2Network {
+	v, ok := findMatch(m, p.l2Networks.Get, p.L2Networks)
+	p.require().True(ok, "must find l2 network %s", m)
 	return v
 }
 
 func (p *presetSystem) AddL2Network(v stack.L2Network) {
 	id := v.ID()
 	p.require().True(p.networks.SetIfMissing(id.ChainID(), v), "chain with id %s must not already exist", id.ChainID())
-	p.require().True(p.l2ChainIDs.SetIfMissing(id.ChainID(), id), "l2 chain id %s mapping must not already exist", id)
-	p.require().True(p.l2Networks.SetIfMissing(id, v), "l2 chain %s must not already exist", id)
+	p.require().True(p.l2Networks.SetIfMissing(id, v), "L2 chain %s must not already exist", id)
 }
 
-func (p *presetSystem) L1NetworkID(id eth.ChainID) stack.L1NetworkID {
-	v, ok := p.l1ChainIDs.Get(id)
-	p.require().True(ok, "l1 chain id %s mapping must exist", id)
-	return v
-}
-
-func (p *presetSystem) L2NetworkID(id eth.ChainID) stack.L2NetworkID {
-	v, ok := p.l2ChainIDs.Get(id)
-	p.require().True(ok, "l2 chain id %s mapping must exist", id)
-	return v
-}
-
-func (p *presetSystem) Supervisor(id stack.SupervisorID) stack.Supervisor {
-	v, ok := p.supervisors.Get(id)
-	p.require().True(ok, "supervisor %s must exist", id)
+func (p *presetSystem) Supervisor(m stack.SupervisorMatcher) stack.Supervisor {
+	v, ok := findMatch(m, p.supervisors.Get, p.Supervisors)
+	p.require().True(ok, "must find supervisor %s", m)
 	return v
 }
 
@@ -112,22 +93,42 @@ func (p *presetSystem) AddSupervisor(v stack.Supervisor) {
 	p.require().True(p.supervisors.SetIfMissing(v.ID(), v), "supervisor %s must not already exist", v.ID())
 }
 
-func (p *presetSystem) Superchains() []stack.SuperchainID {
+func (p *presetSystem) SuperchainIDs() []stack.SuperchainID {
 	return stack.SortSuperchainIDs(p.superchains.Keys())
 }
 
-func (p *presetSystem) Clusters() []stack.ClusterID {
+func (p *presetSystem) Superchains() []stack.Superchain {
+	return stack.SortSuperchains(p.superchains.Values())
+}
+
+func (p *presetSystem) ClusterIDs() []stack.ClusterID {
 	return stack.SortClusterIDs(p.clusters.Keys())
 }
 
-func (p *presetSystem) L1Networks() []stack.L1NetworkID {
+func (p *presetSystem) Clusters() []stack.Cluster {
+	return stack.SortClusters(p.clusters.Values())
+}
+
+func (p *presetSystem) L1NetworkIDs() []stack.L1NetworkID {
 	return stack.SortL1NetworkIDs(p.l1Networks.Keys())
 }
 
-func (p *presetSystem) L2Networks() []stack.L2NetworkID {
+func (p *presetSystem) L1Networks() []stack.L1Network {
+	return stack.SortL1Networks(p.l1Networks.Values())
+}
+
+func (p *presetSystem) L2NetworkIDs() []stack.L2NetworkID {
 	return stack.SortL2NetworkIDs(p.l2Networks.Keys())
 }
 
-func (p *presetSystem) Supervisors() []stack.SupervisorID {
+func (p *presetSystem) L2Networks() []stack.L2Network {
+	return stack.SortL2Networks(p.l2Networks.Values())
+}
+
+func (p *presetSystem) SupervisorIDs() []stack.SupervisorID {
 	return stack.SortSupervisorIDs(p.supervisors.Keys())
+}
+
+func (p *presetSystem) Supervisors() []stack.Supervisor {
+	return stack.SortSupervisors(p.supervisors.Values())
 }

--- a/devnet-sdk/devstack/stack/cluster.go
+++ b/devnet-sdk/devstack/stack/cluster.go
@@ -25,6 +25,16 @@ func SortClusterIDs(ids []ClusterID) []ClusterID {
 	return copyAndSortCmp(ids)
 }
 
+func SortClusters(elems []Cluster) []Cluster {
+	return copyAndSort(elems, lessElemOrdered[ClusterID, Cluster])
+}
+
+var _ ClusterMatcher = ClusterID("")
+
+func (id ClusterID) Match(elems []Cluster) []Cluster {
+	return findByID(id, elems)
+}
+
 // Cluster represents a set of chains that interop with each other.
 // This may include L1 chains (although potentially not two-way interop due to consensus-layer limitations).
 type Cluster interface {

--- a/devnet-sdk/devstack/stack/common.go
+++ b/devnet-sdk/devstack/stack/common.go
@@ -9,4 +9,12 @@ import (
 type Common interface {
 	T() devtest.T
 	Logger() log.Logger
+
+	// Label retrieves a label by key.
+	// If the label does not exist, it returns an empty string.
+	Label(key string) string
+
+	// SetLabel sets a label by key.
+	// Note that labels added by tests are not visible to other tests against the same backend.
+	SetLabel(key, value string)
 }

--- a/devnet-sdk/devstack/stack/faucet.go
+++ b/devnet-sdk/devstack/stack/faucet.go
@@ -23,6 +23,18 @@ func SortFaucetIDs(ids []FaucetID) []FaucetID {
 	})
 }
 
+func SortFaucets(elems []Faucet) []Faucet {
+	return copyAndSort(elems, func(a, b Faucet) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ FaucetMatcher = FaucetID{}
+
+func (id FaucetID) Match(elems []Faucet) []Faucet {
+	return findByID(id, elems)
+}
+
 type Faucet interface {
 	Common
 	ID() FaucetID

--- a/devnet-sdk/devstack/stack/id.go
+++ b/devnet-sdk/devstack/stack/id.go
@@ -166,6 +166,10 @@ func lessIDOnlyChainID(a, b idOnlyChainID) bool {
 	return a.ChainID().Cmp(b.ChainID()) < 0
 }
 
+func lessElemOrdered[I cmp.Ordered, E Identifiable[I]](a, b E) bool {
+	return a.ID() < b.ID()
+}
+
 // copyAndSortCmp is a helper function to copy and sort a slice of elements that are already natively comparable.
 func copyAndSortCmp[V ~[]E, E cmp.Ordered](vs V) V {
 	out := slices.Clone(vs)

--- a/devnet-sdk/devstack/stack/l1_cl.go
+++ b/devnet-sdk/devstack/stack/l1_cl.go
@@ -27,6 +27,18 @@ func SortL1CLNodeIDs(ids []L1CLNodeID) []L1CLNodeID {
 	})
 }
 
+func SortL1CLNodes(elems []L1CLNode) []L1CLNode {
+	return copyAndSort(elems, func(a, b L1CLNode) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L1CLMatcher = L1CLNodeID{}
+
+func (id L1CLNodeID) Match(elems []L1CLNode) []L1CLNode {
+	return findByID(id, elems)
+}
+
 // L1CLNode is a L1 ethereum consensus-layer node, aka Beacon node.
 // This node may not be a full beacon node, and instead run a mock L1 consensus node.
 type L1CLNode interface {

--- a/devnet-sdk/devstack/stack/l1_el.go
+++ b/devnet-sdk/devstack/stack/l1_el.go
@@ -23,6 +23,18 @@ func SortL1ELNodeIDs(ids []L1ELNodeID) []L1ELNodeID {
 	})
 }
 
+func SortL1ELNodes(elems []L1ELNode) []L1ELNode {
+	return copyAndSort(elems, func(a, b L1ELNode) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L1ELMatcher = L1ELNodeID{}
+
+func (id L1ELNodeID) Match(elems []L1ELNode) []L1ELNode {
+	return findByID(id, elems)
+}
+
 // L1ELNode is a L1 ethereum execution-layer node
 type L1ELNode interface {
 	ID() L1ELNodeID

--- a/devnet-sdk/devstack/stack/l1_network.go
+++ b/devnet-sdk/devstack/stack/l1_network.go
@@ -29,16 +29,31 @@ func SortL1NetworkIDs(ids []L1NetworkID) []L1NetworkID {
 	})
 }
 
+func SortL1Networks(elems []L1Network) []L1Network {
+	return copyAndSort(elems, func(a, b L1Network) bool {
+		return lessIDOnlyChainID(idOnlyChainID(a.ID()), idOnlyChainID(b.ID()))
+	})
+}
+
+var _ L1NetworkMatcher = L1NetworkID{}
+
+func (id L1NetworkID) Match(elems []L1Network) []L1Network {
+	return findByID(id, elems)
+}
+
 // L1Network represents a L1 chain, a collection of configuration and node resources.
 type L1Network interface {
 	Network
 	ID() L1NetworkID
 
-	L1ELNode(id L1ELNodeID) L1ELNode
-	L1CLNode(id L1CLNodeID) L1CLNode
+	L1ELNode(m L1ELMatcher) L1ELNode
+	L1CLNode(m L1CLMatcher) L1CLNode
 
-	L1ELNodes() []L1ELNodeID
-	L1CLNodes() []L1CLNodeID
+	L1ELNodeIDs() []L1ELNodeID
+	L1CLNodeIDs() []L1CLNodeID
+
+	L1ELNodes() []L1ELNode
+	L1CLNodes() []L1CLNode
 }
 
 type ExtensibleL1Network interface {

--- a/devnet-sdk/devstack/stack/l2_batcher.go
+++ b/devnet-sdk/devstack/stack/l2_batcher.go
@@ -23,6 +23,18 @@ func SortL2BatcherIDs(ids []L2BatcherID) []L2BatcherID {
 	})
 }
 
+func SortL2Batchers(elems []L2Batcher) []L2Batcher {
+	return copyAndSort(elems, func(a, b L2Batcher) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L2BatcherMatcher = L2BatcherID{}
+
+func (id L2BatcherID) Match(elems []L2Batcher) []L2Batcher {
+	return findByID(id, elems)
+}
+
 // L2Batcher represents an L2 batch-submission service, posting L2 data of an L2 to L1.
 type L2Batcher interface {
 	Common

--- a/devnet-sdk/devstack/stack/l2_challenger.go
+++ b/devnet-sdk/devstack/stack/l2_challenger.go
@@ -23,6 +23,18 @@ func SortL2ChallengerIDs(ids []L2ChallengerID) []L2ChallengerID {
 	})
 }
 
+func SortL2Challengers(elems []L2Challenger) []L2Challenger {
+	return copyAndSort(elems, func(a, b L2Challenger) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L2ChallengerMatcher = L2ChallengerID{}
+
+func (id L2ChallengerID) Match(elems []L2Challenger) []L2Challenger {
+	return findByID(id, elems)
+}
+
 type L2Challenger interface {
 	Common
 	ID() L2ChallengerID

--- a/devnet-sdk/devstack/stack/l2_cl.go
+++ b/devnet-sdk/devstack/stack/l2_cl.go
@@ -27,10 +27,31 @@ func SortL2CLNodeIDs(ids []L2CLNodeID) []L2CLNodeID {
 	})
 }
 
+func SortL2CLNodes(elems []L2CLNode) []L2CLNode {
+	return copyAndSort(elems, func(a, b L2CLNode) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L2CLMatcher = L2CLNodeID{}
+
+func (id L2CLNodeID) Match(elems []L2CLNode) []L2CLNode {
+	return findByID(id, elems)
+}
+
 // L2CLNode is a L2 ethereum consensus-layer node
 type L2CLNode interface {
 	Common
 	ID() L2CLNodeID
 
 	RollupAPI() apis.RollupClient
+
+	// ELs returns the engine(s) that this L2CLNode is connected to.
+	// This may be empty, if the L2CL is not connected to any.
+	ELs() []L2ELNode
+}
+
+type LinkableL2CLNode interface {
+	// Links the nodes. Does not make any backend changes, just registers the EL as connected to this CL.
+	LinkEL(el L2ELNode)
 }

--- a/devnet-sdk/devstack/stack/l2_el.go
+++ b/devnet-sdk/devstack/stack/l2_el.go
@@ -23,6 +23,18 @@ func SortL2ELNodeIDs(ids []L2ELNodeID) []L2ELNodeID {
 	})
 }
 
+func SortL2ELNodes(elems []L2ELNode) []L2ELNode {
+	return copyAndSort(elems, func(a, b L2ELNode) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L2ELMatcher = L2ELNodeID{}
+
+func (id L2ELNodeID) Match(elems []L2ELNode) []L2ELNode {
+	return findByID(id, elems)
+}
+
 // L2ELNode is a L2 ethereum execution-layer node
 type L2ELNode interface {
 	ID() L2ELNodeID

--- a/devnet-sdk/devstack/stack/l2_network.go
+++ b/devnet-sdk/devstack/stack/l2_network.go
@@ -37,6 +37,18 @@ func SortL2NetworkIDs(ids []L2NetworkID) []L2NetworkID {
 	})
 }
 
+func SortL2Networks(elems []L2Network) []L2Network {
+	return copyAndSort(elems, func(a, b L2Network) bool {
+		return lessIDOnlyChainID(idOnlyChainID(a.ID()), idOnlyChainID(b.ID()))
+	})
+}
+
+var _ L2NetworkMatcher = L2NetworkID{}
+
+func (id L2NetworkID) Match(elems []L2Network) []L2Network {
+	return findByID(id, elems)
+}
+
 type L2Deployment interface {
 	SystemConfigProxyAddr() common.Address
 	DisputeGameFactoryProxyAddr() common.Address
@@ -61,17 +73,23 @@ type L2Network interface {
 	L1() L1Network
 	Cluster() Cluster
 
-	L2Batcher(id L2BatcherID) L2Batcher
-	L2Proposer(id L2ProposerID) L2Proposer
-	L2Challenger(id L2ChallengerID) L2Challenger
-	L2CLNode(id L2CLNodeID) L2CLNode
-	L2ELNode(id L2ELNodeID) L2ELNode
+	L2Batcher(m L2BatcherMatcher) L2Batcher
+	L2Proposer(m L2ProposerMatcher) L2Proposer
+	L2Challenger(m L2ChallengerMatcher) L2Challenger
+	L2CLNode(m L2CLMatcher) L2CLNode
+	L2ELNode(m L2ELMatcher) L2ELNode
 
-	L2Batchers() []L2BatcherID
-	L2Proposers() []L2ProposerID
-	L2Challengers() []L2ChallengerID
-	L2CLNodes() []L2CLNodeID
-	L2ELNodes() []L2ELNodeID
+	L2BatcherIDs() []L2BatcherID
+	L2ProposerIDs() []L2ProposerID
+	L2ChallengerIDs() []L2ChallengerID
+	L2CLNodeIDs() []L2CLNodeID
+	L2ELNodeIDs() []L2ELNodeID
+
+	L2Batchers() []L2Batcher
+	L2Proposers() []L2Proposer
+	L2Challengers() []L2Challenger
+	L2CLNodes() []L2CLNode
+	L2ELNodes() []L2ELNode
 }
 
 // ExtensibleL2Network is an optional extension interface for L2Network,

--- a/devnet-sdk/devstack/stack/l2_proposer.go
+++ b/devnet-sdk/devstack/stack/l2_proposer.go
@@ -23,6 +23,18 @@ func SortL2ProposerIDs(ids []L2ProposerID) []L2ProposerID {
 	})
 }
 
+func SortL2Proposers(elems []L2Proposer) []L2Proposer {
+	return copyAndSort(elems, func(a, b L2Proposer) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ L2ProposerMatcher = L2ProposerID{}
+
+func (id L2ProposerID) Match(elems []L2Proposer) []L2Proposer {
+	return findByID(id, elems)
+}
+
 // L2Proposer is a L2 output proposer, posting claims of L2 state to L1.
 type L2Proposer interface {
 	Common

--- a/devnet-sdk/devstack/stack/match/core.go
+++ b/devnet-sdk/devstack/stack/match/core.go
@@ -1,0 +1,42 @@
+package match
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
+
+// MatchFn implements stack.Matcher, checking all elements at once.
+type MatchFn[I comparable, E stack.Identifiable[I]] func(elems []E) []E
+
+func (m MatchFn[I, E]) Match(elems []E) []E {
+	return m(elems)
+}
+
+func (m MatchFn[I, E]) String() string {
+	var id I
+	var x E
+	return fmt.Sprintf("MatchFn[%T, %T]", id, x)
+}
+
+var _ stack.Matcher[stack.L2NetworkID, stack.L2Network] = MatchFn[stack.L2NetworkID, stack.L2Network](nil)
+
+// MatchElemFn implements stack.Matcher, checking one element at a time.
+type MatchElemFn[I comparable, E stack.Identifiable[I]] func(elem E) bool
+
+func (m MatchElemFn[I, E]) Match(elems []E) (out []E) {
+	for _, elem := range elems {
+		if m(elem) {
+			out = append(out, elem)
+		}
+	}
+	return out
+}
+
+func (m MatchElemFn[I, E]) String() string {
+	var id I
+	var x E
+	return fmt.Sprintf("MatchElemFn[%T, %T]", id, x)
+}
+
+var _ stack.Matcher[stack.L2NetworkID, stack.L2Network] = MatchElemFn[stack.L2NetworkID, stack.L2Network](nil)

--- a/devnet-sdk/devstack/stack/match/doc.go
+++ b/devnet-sdk/devstack/stack/match/doc.go
@@ -1,0 +1,16 @@
+/*
+Package match provides matching presets and utils for selecting devstack components.
+
+Matchers can be composed, e.g.:
+- `And(OpGeth, WithLabel("name", "alice"))` to select the op-geth node named "alice".
+- `Or(OpGeth, OpReth)` to select an op-geth or op-reth node.
+- `Not(OpGeth)` to select anything but an op-geth node.
+
+Custom matchers can also be implemented:
+- MatchFn can filter a list of elements down to just the matched elements
+- MatchElemFn can filter by checking each individual element
+
+For convenience, aliases for common matchers are also provided,
+e.g. for matching "chain A", or matching the first L2 EL node.
+*/
+package match

--- a/devnet-sdk/devstack/stack/match/engine.go
+++ b/devnet-sdk/devstack/stack/match/engine.go
@@ -1,0 +1,14 @@
+package match
+
+import "github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+
+func WithEngine(engine stack.L2ELNodeID) stack.Matcher[stack.L2CLNodeID, stack.L2CLNode] {
+	return MatchElemFn[stack.L2CLNodeID, stack.L2CLNode](func(elem stack.L2CLNode) bool {
+		for _, el := range elem.ELs() {
+			if el.ID() == engine {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/devnet-sdk/devstack/stack/match/first.go
+++ b/devnet-sdk/devstack/stack/match/first.go
@@ -1,0 +1,21 @@
+package match
+
+import "github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+
+var FirstL2EL = First[stack.L2ELNodeID, stack.L2ELNode]()
+var FirstL2CL = First[stack.L2CLNodeID, stack.L2CLNode]()
+var FirstL2Batcher = First[stack.L2BatcherID, stack.L2Batcher]()
+var FirstL2Proposer = First[stack.L2ProposerID, stack.L2Proposer]()
+var FirstL2Challenger = First[stack.L2ChallengerID, stack.L2Challenger]()
+
+var FirstSupervisor = First[stack.SupervisorID, stack.Supervisor]()
+
+var FirstL1EL = First[stack.L1ELNodeID, stack.L1ELNode]()
+var FirstL1CL = First[stack.L1CLNodeID, stack.L1CLNode]()
+
+var FirstL1Network = First[stack.L1NetworkID, stack.L1Network]()
+var FirstL2Network = First[stack.L2NetworkID, stack.L2Network]()
+var FirstSuperchain = First[stack.SuperchainID, stack.Superchain]()
+var FirstCluster = First[stack.ClusterID, stack.Cluster]()
+
+var FirstUser = First[stack.UserID, stack.User]()

--- a/devnet-sdk/devstack/stack/match/interop.go
+++ b/devnet-sdk/devstack/stack/match/interop.go
@@ -1,0 +1,9 @@
+package match
+
+import "github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+
+// L2ChainA is an alias for the first L2 network.
+var L2ChainA = First[stack.L2NetworkID, stack.L2Network]()
+
+// L2ChainB is an alias for the second L2 network.
+var L2ChainB = Second[stack.L2NetworkID, stack.L2Network]()

--- a/devnet-sdk/devstack/stack/match/labels.go
+++ b/devnet-sdk/devstack/stack/match/labels.go
@@ -1,0 +1,33 @@
+package match
+
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
+
+func WithLabel[I comparable, E interface {
+	stack.Identifiable[I]
+	Label(key string) string
+}](key, value string) stack.Matcher[I, E] {
+	return MatchElemFn[I, E](func(elem E) bool {
+		return elem.Label(key) == value
+	})
+}
+
+const (
+	LabelVendor = "vendor"
+)
+
+type L2ELVendor string
+
+const (
+	OpReth L2ELVendor = "op-reth"
+	OpGeth L2ELVendor = "op-geth"
+)
+
+func (v L2ELVendor) Match(elems []stack.L2ELNode) []stack.L2ELNode {
+	return WithLabel[stack.L2ELNodeID, stack.L2ELNode](LabelVendor, string(v)).Match(elems)
+}
+
+func (v L2ELVendor) String() string {
+	return string(v)
+}

--- a/devnet-sdk/devstack/stack/match/util.go
+++ b/devnet-sdk/devstack/stack/match/util.go
@@ -1,7 +1,8 @@
 package match
 
 import (
-	"math/rand"
+	"fmt"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
 )
@@ -14,95 +15,151 @@ func Second[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
 	return ByIndex[I, E](1)
 }
 
+type byIndexMatcher[I comparable, E stack.Identifiable[I]] struct {
+	index int
+}
+
+func (ma byIndexMatcher[I, E]) Match(elems []E) []E {
+	if ma.index < 0 {
+		return nil
+	}
+	if ma.index >= len(elems) {
+		return nil
+	}
+	return elems[ma.index : ma.index+1]
+}
+
+func (ma byIndexMatcher[I, E]) String() string {
+	return fmt.Sprintf("ByIndex(%d)", ma.index)
+}
+
 // ByIndex matches element i (zero-indexed).
 func ByIndex[I comparable, E stack.Identifiable[I]](index int) stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		if index < 0 {
-			return nil
-		}
-		if index >= len(elems) {
-			return nil
-		}
-		return elems[index : index+1]
-	})
+	return byIndexMatcher[I, E]{index: index}
+}
+
+type lastMatcher[I comparable, E stack.Identifiable[I]] struct{}
+
+func (ma lastMatcher[I, E]) Match(elems []E) []E {
+	if len(elems) == 0 {
+		return nil
+	}
+	return elems[len(elems)-1:]
+}
+
+func (ma lastMatcher[I, E]) String() string {
+	return "Last"
 }
 
 // Last matches the last element.
 func Last[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		if len(elems) == 0 {
-			return nil
-		}
-		return elems[len(elems)-1:]
-	})
+	return lastMatcher[I, E]{}
 }
 
-// Random matches a singular random element.
-func Random[I comparable, E stack.Identifiable[I]](rng *rand.Rand) stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		if len(elems) == 0 {
-			return nil
-		}
-		i := rng.Intn(len(elems))
-		return elems[i : i+1]
-	})
+type onlyMatcher[I comparable, E stack.Identifiable[I]] struct{}
+
+func (ma onlyMatcher[I, E]) Match(elems []E) []E {
+	if len(elems) != 1 {
+		return nil
+	}
+	return elems
+}
+
+func (ma onlyMatcher[I, E]) String() string {
+	return "Only"
 }
 
 // Only matches the only value. If there are none, or more than one, then no value is matched.
 func Only[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		if len(elems) != 1 {
-			return nil
-		}
-		return elems
-	})
+	return onlyMatcher[I, E]{}
 }
 
-// Combine combines all the matchers, by running them all, narrowing down the set with each application.
+type andMatcher[I comparable, E stack.Identifiable[I]] struct {
+	inner []stack.Matcher[I, E]
+}
+
+func (ma andMatcher[I, E]) Match(elems []E) []E {
+	for _, matcher := range ma.inner {
+		elems = matcher.Match(elems)
+	}
+	return elems
+}
+
+func (ma andMatcher[I, E]) String() string {
+	return fmt.Sprintf("And(%s)", joinStr(ma.inner))
+}
+
+// And combines all the matchers, by running them all, narrowing down the set with each application.
 // If none are provided, all inputs are matched.
-func Combine[I comparable, E stack.Identifiable[I]](matchers ...stack.Matcher[I, E]) stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		for _, matcher := range matchers {
-			elems = matcher.Match(elems)
+func And[I comparable, E stack.Identifiable[I]](matchers ...stack.Matcher[I, E]) stack.Matcher[I, E] {
+	return andMatcher[I, E]{inner: matchers}
+}
+
+type orMatcher[I comparable, E stack.Identifiable[I]] struct {
+	inner []stack.Matcher[I, E]
+}
+
+func (ma orMatcher[I, E]) Match(elems []E) []E {
+	seen := make(map[I]struct{})
+	for _, matcher := range ma.inner {
+		for _, elem := range matcher.Match(elems) {
+			seen[elem.ID()] = struct{}{}
 		}
-		return elems
-	})
+	}
+	// preserve sort order and duplicates by iterating the original list
+	out := make([]E, 0, len(seen))
+	for _, elem := range elems {
+		if _, ok := seen[elem.ID()]; ok {
+			out = append(out, elem)
+		}
+	}
+	return out
+}
+
+func (ma orMatcher[I, E]) String() string {
+	return fmt.Sprintf("Or(%s)", joinStr(ma.inner))
+}
+
+func joinStr[V fmt.Stringer](elems []V) string {
+	var out strings.Builder
+	for i, e := range elems {
+		out.WriteString(e.String())
+		if i < len(elems)-1 {
+			out.WriteString(", ")
+		}
+	}
+	return out.String()
 }
 
 // Or returns each of the inputs that have a match with any of the matchers.
 // All inputs are applied to all matchers, even if matched previously.
 func Or[I comparable, E stack.Identifiable[I]](matchers ...stack.Matcher[I, E]) stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		seen := make(map[I]struct{})
-		for _, matcher := range matchers {
-			for _, elem := range matcher.Match(elems) {
-				seen[elem.ID()] = struct{}{}
-			}
+	return orMatcher[I, E]{inner: matchers}
+}
+
+type notMatcher[I comparable, E stack.Identifiable[I]] struct {
+	inner stack.Matcher[I, E]
+}
+
+func (ma notMatcher[I, E]) Match(elems []E) []E {
+	matched := make(map[I]struct{})
+	for _, elem := range ma.inner.Match(elems) {
+		matched[elem.ID()] = struct{}{}
+	}
+	out := make([]E, 0, len(elems))
+	for _, elem := range elems {
+		if _, ok := matched[elem.ID()]; !ok {
+			out = append(out, elem)
 		}
-		// preserve sort order and duplicates by iterating the original list
-		out := make([]E, 0, len(seen))
-		for _, elem := range elems {
-			if _, ok := seen[elem.ID()]; ok {
-				out = append(out, elem)
-			}
-		}
-		return out
-	})
+	}
+	return out
+}
+
+func (ma notMatcher[I, E]) String() string {
+	return fmt.Sprintf("Not(%s)", ma.inner)
 }
 
 // Not matches the elements that do not match the given matcher.
 func Not[I comparable, E stack.Identifiable[I]](matcher stack.Matcher[I, E]) stack.Matcher[I, E] {
-	return MatchFn[I, E](func(elems []E) []E {
-		matched := make(map[I]struct{})
-		for _, elem := range matcher.Match(elems) {
-			matched[elem.ID()] = struct{}{}
-		}
-		out := make([]E, 0, len(elems))
-		for _, elem := range elems {
-			if _, ok := matched[elem.ID()]; !ok {
-				out = append(out, elem)
-			}
-		}
-		return out
-	})
+	return notMatcher[I, E]{inner: matcher}
 }

--- a/devnet-sdk/devstack/stack/match/util.go
+++ b/devnet-sdk/devstack/stack/match/util.go
@@ -1,0 +1,108 @@
+package match
+
+import (
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
+
+func First[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
+	return ByIndex[I, E](0)
+}
+
+func Second[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
+	return ByIndex[I, E](1)
+}
+
+// ByIndex matches element i (zero-indexed).
+func ByIndex[I comparable, E stack.Identifiable[I]](index int) stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		if index < 0 {
+			return nil
+		}
+		if index >= len(elems) {
+			return nil
+		}
+		return elems[index : index+1]
+	})
+}
+
+// Last matches the last element.
+func Last[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		if len(elems) == 0 {
+			return nil
+		}
+		return elems[len(elems)-1:]
+	})
+}
+
+// Random matches a singular random element.
+func Random[I comparable, E stack.Identifiable[I]](rng *rand.Rand) stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		if len(elems) == 0 {
+			return nil
+		}
+		i := rng.Intn(len(elems))
+		return elems[i : i+1]
+	})
+}
+
+// Only matches the only value. If there are none, or more than one, then no value is matched.
+func Only[I comparable, E stack.Identifiable[I]]() stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		if len(elems) != 1 {
+			return nil
+		}
+		return elems
+	})
+}
+
+// Combine combines all the matchers, by running them all, narrowing down the set with each application.
+// If none are provided, all inputs are matched.
+func Combine[I comparable, E stack.Identifiable[I]](matchers ...stack.Matcher[I, E]) stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		for _, matcher := range matchers {
+			elems = matcher.Match(elems)
+		}
+		return elems
+	})
+}
+
+// Or returns each of the inputs that have a match with any of the matchers.
+// All inputs are applied to all matchers, even if matched previously.
+func Or[I comparable, E stack.Identifiable[I]](matchers ...stack.Matcher[I, E]) stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		seen := make(map[I]struct{})
+		for _, matcher := range matchers {
+			for _, elem := range matcher.Match(elems) {
+				seen[elem.ID()] = struct{}{}
+			}
+		}
+		// preserve sort order and duplicates by iterating the original list
+		out := make([]E, 0, len(seen))
+		for _, elem := range elems {
+			if _, ok := seen[elem.ID()]; ok {
+				out = append(out, elem)
+			}
+		}
+		return out
+	})
+}
+
+// Not matches the elements that do not match the given matcher.
+func Not[I comparable, E stack.Identifiable[I]](matcher stack.Matcher[I, E]) stack.Matcher[I, E] {
+	return MatchFn[I, E](func(elems []E) []E {
+		matched := make(map[I]struct{})
+		for _, elem := range matcher.Match(elems) {
+			matched[elem.ID()] = struct{}{}
+		}
+		out := make([]E, 0, len(elems))
+		for _, elem := range elems {
+			if _, ok := matched[elem.ID()]; !ok {
+				out = append(out, elem)
+			}
+		}
+		return out
+	})
+}

--- a/devnet-sdk/devstack/stack/match/util_test.go
+++ b/devnet-sdk/devstack/stack/match/util_test.go
@@ -1,7 +1,6 @@
 package match
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,11 +25,10 @@ func TestUtils(t *testing.T) {
 	b := &testObject{id: "b"}
 	c := &testObject{id: "c"}
 	d := &testObject{id: "d"}
-	all := []*testObject{a, b, c, d}
 
 	t.Run("first", func(t *testing.T) {
 		m := First[testID, *testObject]()
-		t.Log(m.String())
+		require.Equal(t, m.String(), "ByIndex(0)")
 		require.Equal(t, []*testObject{a}, m.Match([]*testObject{a, b, c, d}))
 		require.Equal(t, []*testObject{b}, m.Match([]*testObject{b, a, c, d}))
 		require.Equal(t, []*testObject{b}, m.Match([]*testObject{b, b, b}))
@@ -38,21 +36,9 @@ func TestUtils(t *testing.T) {
 	})
 	t.Run("last", func(t *testing.T) {
 		m := Last[testID, *testObject]()
-		t.Log(m.String())
+		require.Equal(t, m.String(), "Last")
 		require.Equal(t, []*testObject{d}, m.Match([]*testObject{a, b, c, d}))
 		require.Equal(t, []*testObject{c}, m.Match([]*testObject{b, a, c}))
-	})
-	t.Run("random", func(t *testing.T) {
-		rng := rand.New(rand.NewSource(123))
-		i0 := rng.Intn(4)
-		i1 := rng.Intn(4)
-		rng.Seed(123) // reset
-		m := Random[testID, *testObject](rng)
-		t.Log(m.String())
-		expected0 := all[i0]
-		expected1 := all[i1]
-		require.Equal(t, []*testObject{expected0}, m.Match([]*testObject{a, b, c, d}))
-		require.Equal(t, []*testObject{expected1}, m.Match([]*testObject{a, b, c, d}))
 	})
 	t.Run("only", func(t *testing.T) {
 		m := Only[testID, *testObject]()
@@ -62,13 +48,13 @@ func TestUtils(t *testing.T) {
 		require.Equal(t, []*testObject{c}, m.Match([]*testObject{c}))
 		require.Equal(t, []*testObject(nil), m.Match([]*testObject{}))
 	})
-	t.Run("combine", func(t *testing.T) {
-		m := Combine(First[testID, *testObject](), Second[testID, *testObject]())
-		t.Log(m.String())
+	t.Run("and", func(t *testing.T) {
+		m := And(First[testID, *testObject](), Second[testID, *testObject]())
+		require.Equal(t, m.String(), "And(ByIndex(0), ByIndex(1))")
 		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, b, c, d}))
 		// narrowed down to single element with First
 		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, a}))
-		m2 := Combine(Second[testID, *testObject](), First[testID, *testObject]())
+		m2 := And(Second[testID, *testObject](), First[testID, *testObject]())
 		// Narrowed down to b, then select b as first
 		require.Equal(t, []*testObject{b}, m2.Match([]*testObject{a, b}))
 	})
@@ -79,7 +65,7 @@ func TestUtils(t *testing.T) {
 	})
 	t.Run("not", func(t *testing.T) {
 		m := Not(Or(First[testID, *testObject](), Second[testID, *testObject]()))
-		t.Log(m.String())
+		require.Equal(t, m.String(), "Not(Or(ByIndex(0), ByIndex(1)))")
 		require.Equal(t, []*testObject{c, d}, m.Match([]*testObject{a, b, c, d}))
 		require.Equal(t, []*testObject{}, m.Match([]*testObject{}))
 		m2 := Not(Last[testID, *testObject]())
@@ -88,7 +74,7 @@ func TestUtils(t *testing.T) {
 	})
 	t.Run("by-index", func(t *testing.T) {
 		m := ByIndex[testID, *testObject](2)
-		t.Log(m.String())
+		require.Equal(t, m.String(), "ByIndex(2)")
 		require.Equal(t, []*testObject{c}, m.Match([]*testObject{a, b, c, d}))
 		require.Equal(t, []*testObject{c}, m.Match([]*testObject{a, b, c}))
 		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, b}))

--- a/devnet-sdk/devstack/stack/match/util_test.go
+++ b/devnet-sdk/devstack/stack/match/util_test.go
@@ -1,0 +1,100 @@
+package match
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
+
+type testID string
+
+type testObject struct {
+	id testID
+}
+
+func (t *testObject) ID() testID {
+	return t.id
+}
+
+var _ stack.Identifiable[testID] = (*testObject)(nil)
+
+func TestUtils(t *testing.T) {
+	a := &testObject{id: "a"}
+	b := &testObject{id: "b"}
+	c := &testObject{id: "c"}
+	d := &testObject{id: "d"}
+	all := []*testObject{a, b, c, d}
+
+	t.Run("first", func(t *testing.T) {
+		m := First[testID, *testObject]()
+		t.Log(m.String())
+		require.Equal(t, []*testObject{a}, m.Match([]*testObject{a, b, c, d}))
+		require.Equal(t, []*testObject{b}, m.Match([]*testObject{b, a, c, d}))
+		require.Equal(t, []*testObject{b}, m.Match([]*testObject{b, b, b}))
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{}))
+	})
+	t.Run("last", func(t *testing.T) {
+		m := Last[testID, *testObject]()
+		t.Log(m.String())
+		require.Equal(t, []*testObject{d}, m.Match([]*testObject{a, b, c, d}))
+		require.Equal(t, []*testObject{c}, m.Match([]*testObject{b, a, c}))
+	})
+	t.Run("random", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(123))
+		i0 := rng.Intn(4)
+		i1 := rng.Intn(4)
+		rng.Seed(123) // reset
+		m := Random[testID, *testObject](rng)
+		t.Log(m.String())
+		expected0 := all[i0]
+		expected1 := all[i1]
+		require.Equal(t, []*testObject{expected0}, m.Match([]*testObject{a, b, c, d}))
+		require.Equal(t, []*testObject{expected1}, m.Match([]*testObject{a, b, c, d}))
+	})
+	t.Run("only", func(t *testing.T) {
+		m := Only[testID, *testObject]()
+		t.Log(m.String())
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, b, c, d}))
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, b}))
+		require.Equal(t, []*testObject{c}, m.Match([]*testObject{c}))
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{}))
+	})
+	t.Run("combine", func(t *testing.T) {
+		m := Combine(First[testID, *testObject](), Second[testID, *testObject]())
+		t.Log(m.String())
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, b, c, d}))
+		// narrowed down to single element with First
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, a}))
+		m2 := Combine(Second[testID, *testObject](), First[testID, *testObject]())
+		// Narrowed down to b, then select b as first
+		require.Equal(t, []*testObject{b}, m2.Match([]*testObject{a, b}))
+	})
+	t.Run("or", func(t *testing.T) {
+		m := Or(First[testID, *testObject](), Second[testID, *testObject]())
+		t.Log(m.String())
+		require.Equal(t, []*testObject{a, b}, m.Match([]*testObject{a, b, c, d}))
+	})
+	t.Run("not", func(t *testing.T) {
+		m := Not(Or(First[testID, *testObject](), Second[testID, *testObject]()))
+		t.Log(m.String())
+		require.Equal(t, []*testObject{c, d}, m.Match([]*testObject{a, b, c, d}))
+		require.Equal(t, []*testObject{}, m.Match([]*testObject{}))
+		m2 := Not(Last[testID, *testObject]())
+		t.Log(m.String())
+		require.Equal(t, []*testObject{a, b, c}, m2.Match([]*testObject{a, b, c, d}))
+	})
+	t.Run("by-index", func(t *testing.T) {
+		m := ByIndex[testID, *testObject](2)
+		t.Log(m.String())
+		require.Equal(t, []*testObject{c}, m.Match([]*testObject{a, b, c, d}))
+		require.Equal(t, []*testObject{c}, m.Match([]*testObject{a, b, c}))
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a, b}))
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{a}))
+		require.Equal(t, []*testObject(nil), m.Match([]*testObject{}))
+		m2 := ByIndex[testID, *testObject](-1)
+		require.Equal(t, []*testObject(nil), m2.Match([]*testObject{a, b}))
+	})
+}

--- a/devnet-sdk/devstack/stack/matcher.go
+++ b/devnet-sdk/devstack/stack/matcher.go
@@ -1,0 +1,58 @@
+package stack
+
+type Identifiable[I comparable] interface {
+	ID() I
+}
+
+// Matcher is abstracts what can be used as getter-method argument.
+// All ID types implement this interface, and lookup functions check
+// if the argument is an ID before searching for a match.
+// This enables lookups such as getting a component by labels,
+// by its state, by its relation to other components, etc.
+type Matcher[I comparable, E Identifiable[I]] interface {
+	// Match finds the elements that pass the matcher.
+	// If no element passes, it returns an empty slice.
+	// Callers should guarantee a stable order of ids, to ensure a deterministic match.
+	Match(elems []E) []E
+
+	// String must describe the matcher for debugging purposes.
+	// This does not get used for matching.
+	String() string
+}
+
+func findByID[I comparable, E Identifiable[I]](id I, elems []E) []E {
+	for i, elem := range elems {
+		if elem.ID() == id {
+			return elems[i : i+1]
+		}
+	}
+	return nil
+}
+
+type ClusterMatcher = Matcher[ClusterID, Cluster]
+
+type L1CLMatcher = Matcher[L1CLNodeID, L1CLNode]
+
+type L1ELMatcher = Matcher[L1ELNodeID, L1ELNode]
+
+type L1NetworkMatcher = Matcher[L1NetworkID, L1Network]
+
+type L2NetworkMatcher = Matcher[L2NetworkID, L2Network]
+
+type SuperchainMatcher = Matcher[SuperchainID, Superchain]
+
+type L2BatcherMatcher = Matcher[L2BatcherID, L2Batcher]
+
+type L2ChallengerMatcher = Matcher[L2ChallengerID, L2Challenger]
+
+type L2ProposerMatcher = Matcher[L2ProposerID, L2Proposer]
+
+type L2CLMatcher = Matcher[L2CLNodeID, L2CLNode]
+
+type SupervisorMatcher = Matcher[SupervisorID, Supervisor]
+
+type L2ELMatcher = Matcher[L2ELNodeID, L2ELNode]
+
+type UserMatcher = Matcher[UserID, User]
+
+type FaucetMatcher = Matcher[FaucetID, Faucet]

--- a/devnet-sdk/devstack/stack/matcher.go
+++ b/devnet-sdk/devstack/stack/matcher.go
@@ -4,7 +4,7 @@ type Identifiable[I comparable] interface {
 	ID() I
 }
 
-// Matcher is abstracts what can be used as getter-method argument.
+// Matcher abstracts what can be used as getter-method argument.
 // All ID types implement this interface, and lookup functions check
 // if the argument is an ID before searching for a match.
 // This enables lookups such as getting a component by labels,

--- a/devnet-sdk/devstack/stack/network.go
+++ b/devnet-sdk/devstack/stack/network.go
@@ -18,8 +18,9 @@ type Network interface {
 
 	Faucet() Faucet
 
-	User(id UserID) User
-	Users() []UserID
+	User(m UserMatcher) User
+	Users() []User
+	UserIDs() []UserID
 }
 
 type ExtensibleNetwork interface {

--- a/devnet-sdk/devstack/stack/superchain.go
+++ b/devnet-sdk/devstack/stack/superchain.go
@@ -28,6 +28,16 @@ func SortSuperchainIDs(ids []SuperchainID) []SuperchainID {
 	return copyAndSortCmp(ids)
 }
 
+func SortSuperchains(elems []Superchain) []Superchain {
+	return copyAndSort(elems, lessElemOrdered[SuperchainID, Superchain])
+}
+
+var _ SuperchainMatcher = SuperchainID("")
+
+func (id SuperchainID) Match(elems []Superchain) []Superchain {
+	return findByID(id, elems)
+}
+
 // Superchain is a collection of L2 chains with common rules and shared configuration on L1
 type Superchain interface {
 	Common

--- a/devnet-sdk/devstack/stack/supervisor.go
+++ b/devnet-sdk/devstack/stack/supervisor.go
@@ -25,6 +25,16 @@ func SortSupervisorIDs(ids []SupervisorID) []SupervisorID {
 	return copyAndSortCmp(ids)
 }
 
+func SortSupervisors(elems []Supervisor) []Supervisor {
+	return copyAndSort(elems, lessElemOrdered[SupervisorID, Supervisor])
+}
+
+var _ SupervisorMatcher = SupervisorID("")
+
+func (id SupervisorID) Match(elems []Supervisor) []Supervisor {
+	return findByID(id, elems)
+}
+
 // Supervisor is an interop service, used to cross-verify messages between chains.
 type Supervisor interface {
 	Common

--- a/devnet-sdk/devstack/stack/system.go
+++ b/devnet-sdk/devstack/stack/system.go
@@ -1,30 +1,27 @@
 package stack
 
-import (
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-)
-
 // System represents a collection of L1 and L2 chains, any superchains or clusters, and any peripherals.
 type System interface {
 	Common
 
-	Superchain(id SuperchainID) Superchain
-	Cluster(id ClusterID) Cluster
-	L1Network(id L1NetworkID) L1Network
-	L2Network(id L2NetworkID) L2Network
+	Superchain(m SuperchainMatcher) Superchain
+	Cluster(m ClusterMatcher) Cluster
+	L1Network(m L1NetworkMatcher) L1Network
+	L2Network(m L2NetworkMatcher) L2Network
 
-	Superchains() []SuperchainID
-	Clusters() []ClusterID
-	L1Networks() []L1NetworkID
-	L2Networks() []L2NetworkID
+	Supervisor(m SupervisorMatcher) Supervisor
 
-	// L1NetworkID looks up the L1NetworkID (system name) by eth ChainID
-	L1NetworkID(id eth.ChainID) L1NetworkID
-	// L2NetworkID looks up the L2NetworkID (system name) by eth ChainID
-	L2NetworkID(id eth.ChainID) L2NetworkID
+	SuperchainIDs() []SuperchainID
+	ClusterIDs() []ClusterID
+	L1NetworkIDs() []L1NetworkID
+	L2NetworkIDs() []L2NetworkID
+	SupervisorIDs() []SupervisorID
 
-	Supervisor(id SupervisorID) Supervisor
-	Supervisors() []SupervisorID
+	Superchains() []Superchain
+	Clusters() []Cluster
+	L1Networks() []L1Network
+	L2Networks() []L2Network
+	Supervisors() []Supervisor
 }
 
 // ExtensibleSystem is an extension-interface to add new components to the system.

--- a/devnet-sdk/devstack/stack/user.go
+++ b/devnet-sdk/devstack/stack/user.go
@@ -30,6 +30,18 @@ func SortUserIDs(ids []UserID) []UserID {
 	})
 }
 
+func SortUsers(elems []User) []User {
+	return copyAndSort(elems, func(a, b User) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ UserMatcher = UserID{}
+
+func (id UserID) Match(elems []User) []User {
+	return findByID(id, elems)
+}
+
 // User represents a single user-key, specific to a single chain,
 // with a default connection to interact with the execution-layer of said chain.
 type User interface {

--- a/devnet-sdk/devstack/sysext/l1.go
+++ b/devnet-sdk/devstack/sysext/l1.go
@@ -3,6 +3,7 @@ package sysext
 import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/shim"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -57,7 +58,7 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 			CommonConfig: commonConfig,
 			ID:           stack.UserID{Key: name, ChainID: l1ID},
 			Priv:         priv,
-			EL:           l1.L1ELNode(l1.L1ELNodes()[0]),
+			EL:           l1.L1ELNode(match.FirstL1EL),
 		}))
 	}
 

--- a/devnet-sdk/devstack/sysgo/l1_nodes.go
+++ b/devnet-sdk/devstack/sysgo/l1_nodes.go
@@ -32,8 +32,7 @@ func (n *L1ELNode) hydrate(system stack.ExtensibleSystem) {
 			ChainID:      n.id.ChainID,
 		},
 	})
-	l1ID := system.L1NetworkID(n.id.ChainID)
-	l1Net := system.L1Network(l1ID)
+	l1Net := system.L1Network(stack.L1NetworkID(n.id.ChainID))
 	l1Net.(stack.ExtensibleL1Network).AddL1ELNode(frontend)
 }
 
@@ -50,8 +49,7 @@ func (n *L1CLNode) hydrate(system stack.ExtensibleSystem) {
 		ID:           n.id,
 		Client:       beaconCl,
 	})
-	l1ID := system.L1NetworkID(n.id.ChainID)
-	l1Net := system.L1Network(l1ID)
+	l1Net := system.L1Network(stack.L1NetworkID(n.id.ChainID))
 	l1Net.(stack.ExtensibleL1Network).AddL1CLNode(frontend)
 }
 

--- a/devnet-sdk/devstack/sysgo/l2_batcher.go
+++ b/devnet-sdk/devstack/sysgo/l2_batcher.go
@@ -39,8 +39,7 @@ func (b *L2Batcher) hydrate(system stack.ExtensibleSystem) {
 		ID:           b.id,
 		Client:       rpcCl,
 	})
-	l2ID := system.L2NetworkID(b.id.ChainID)
-	l2Net := system.L2Network(l2ID)
+	l2Net := system.L2Network(stack.L2NetworkID(b.id.ChainID))
 	l2Net.(stack.ExtensibleL2Network).AddL2Batcher(bFrontend)
 }
 

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -32,8 +32,8 @@ type L2CLNode struct {
 	interopRPC string
 	cfg        *node.Config
 	p          devtest.P
-
-	logger log.Logger
+	logger     log.Logger
+	el         stack.L2ELNodeID
 }
 
 var _ stack.Lifecycle = (*L2CLNode)(nil)
@@ -49,9 +49,9 @@ func (n *L2CLNode) hydrate(system stack.ExtensibleSystem) {
 		ID:           n.id,
 		Client:       rpcCl,
 	})
-	l2ID := system.L2NetworkID(n.id.ChainID)
-	l2Net := system.L2Network(l2ID)
+	l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID))
 	l2Net.(stack.ExtensibleL2Network).AddL2CLNode(sysL2CL)
+	sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
 }
 
 func (n *L2CLNode) rememberPort() {
@@ -194,6 +194,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			cfg:    nodeCfg,
 			logger: logger,
 			p:      o.P(),
+			el:     l2ELID,
 		}
 		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), "must not already exist")
 		l2CLNode.Start()

--- a/devnet-sdk/devstack/sysgo/l2_el.go
+++ b/devnet-sdk/devstack/sysgo/l2_el.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/shim"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 )
@@ -30,8 +31,8 @@ func (n *L2ELNode) hydrate(system stack.ExtensibleSystem) {
 		},
 		ID: n.id,
 	})
-	l2ID := system.L2NetworkID(n.id.ChainID)
-	l2Net := system.L2Network(l2ID)
+	sysL2EL.SetLabel(match.LabelVendor, string(match.OpGeth))
+	l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID))
 	l2Net.(stack.ExtensibleL2Network).AddL2ELNode(sysL2EL)
 }
 

--- a/devnet-sdk/devstack/sysgo/l2_network.go
+++ b/devnet-sdk/devstack/sysgo/l2_network.go
@@ -20,8 +20,7 @@ type L2Network struct {
 }
 
 func (c *L2Network) hydrate(system stack.ExtensibleSystem) {
-	l1NetId := system.L1NetworkID(c.l1ChainID)
-	l1Net := system.L1Network(l1NetId)
+	l1Net := system.L1Network(stack.L1NetworkID(c.l1ChainID))
 	sysL2Net := shim.NewL2Network(shim.L2NetworkConfig{
 		NetworkConfig: shim.NetworkConfig{
 			CommonConfig: shim.NewCommonConfig(system.T()),

--- a/devnet-sdk/devstack/sysgo/l2_proposer.go
+++ b/devnet-sdk/devstack/sysgo/l2_proposer.go
@@ -37,8 +37,7 @@ func (p *L2Proposer) hydrate(system stack.ExtensibleSystem) {
 		ID:           p.id,
 		Client:       rpcCl,
 	})
-	l2ID := system.L2NetworkID(p.id.ChainID)
-	l2Net := system.L2Network(l2ID)
+	l2Net := system.L2Network(stack.L2NetworkID(p.id.ChainID))
 	l2Net.(stack.ExtensibleL2Network).AddL2Proposer(bFrontend)
 }
 

--- a/devnet-sdk/devstack/sysgo/system_test.go
+++ b/devnet-sdk/devstack/sysgo/system_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/shim"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -56,26 +55,70 @@ func TestSystem(gt *testing.T) {
 func testSystem(ids DefaultInteropSystemIDs, system stack.System) {
 	t := system.T()
 	logger := t.Logger()
-	seqA := system.L2Network(ids.L2A).L2CLNode(ids.L2ACL)
-	seqB := system.L2Network(ids.L2B).L2CLNode(ids.L2BCL)
-	blocks := uint64(10)
-	// wait for this many blocks, with some margin for delays
-	for i := uint64(0); i < blocks*2+10; i++ {
-		time.Sleep(time.Second * 2)
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		statusA, err := seqA.RollupAPI().SyncStatus(ctx)
-		require.NoError(t, err)
-		statusB, err := seqB.RollupAPI().SyncStatus(ctx)
-		require.NoError(t, err)
-		cancel()
-		logger.Info("chain A", "tip", statusA.UnsafeL2)
-		logger.Info("chain B", "tip", statusB.UnsafeL2)
+	t.Run("test matchers", func(t devtest.T) {
+		require := t.Require()
+		require.Equal(ids.L1, system.L1Network(match.FirstL1Network).ID())
+		require.Equal(ids.L1EL, system.L1Network(match.FirstL1Network).L1ELNode(match.FirstL1EL).ID())
+		require.Equal(ids.L1CL, system.L1Network(match.FirstL1Network).L1CLNode(match.FirstL1CL).ID())
+		require.Equal(ids.L2A, system.L2Network(match.L2ChainA).ID())
+		require.Equal(ids.L2A, system.L2Network(match.FirstL2Network).ID())
+		require.Equal(ids.L2B, system.L2Network(match.L2ChainB).ID())
+		require.Equal(ids.Cluster, system.Cluster(match.FirstCluster).ID())
+		require.Equal(ids.Superchain, system.Superchain(match.FirstSuperchain).ID())
+		require.Equal(ids.Supervisor, system.Supervisor(match.FirstSupervisor).ID())
+		l2A := system.L2Network(match.L2ChainA)
+		require.Equal(ids.L2ACL, l2A.L2CLNode(match.FirstL2CL).ID())
+		require.Equal(ids.L2AEL, l2A.L2ELNode(match.FirstL2EL).ID())
+		require.Equal(ids.L2ABatcher, l2A.L2Batcher(match.FirstL2Batcher).ID())
+		require.Equal(ids.L2AProposer, l2A.L2Proposer(match.FirstL2Proposer).ID())
+	})
 
-		if statusA.UnsafeL2.Number > blocks && statusB.UnsafeL2.Number > blocks {
-			return
+	t.Run("test labeling", func(t devtest.T) {
+		require := t.Require()
+		netB := system.L2Network(match.L2ChainB)
+		require.Equal("", netB.Label("nickname"))
+		netB.SetLabel("nickname", "Network B")
+		require.Equal("Network B", netB.Label("nickname"))
+		v := system.L2Network(match.WithLabel[stack.L2NetworkID, stack.L2Network](
+			"nickname", "Network B"))
+		require.Equal(ids.L2B, v.ID())
+	})
+
+	t.Run("op-geth match", func(t devtest.T) {
+		elNode := system.L2Network(match.L2ChainA).L2ELNode(match.OpGeth)
+		t.Require().Equal(string(match.OpGeth), elNode.Label(match.LabelVendor))
+	})
+
+	t.Run("find CL", func(t devtest.T) {
+		elNode := system.L2Network(match.L2ChainA).L2ELNode(match.FirstL2EL)
+		clNode := system.L2Network(match.L2ChainA).L2CLNode(match.WithEngine(elNode.ID()))
+		t.Require().Contains(clNode.ELs(), elNode)
+	})
+
+	t.Run("sync", func(t devtest.T) {
+		require := t.Require()
+		seqA := system.L2Network(ids.L2A).L2CLNode(ids.L2ACL)
+		seqB := system.L2Network(ids.L2B).L2CLNode(ids.L2BCL)
+		blocks := uint64(5)
+		// wait for this many blocks, with some margin for delays
+		for i := uint64(0); i < blocks*2+10; i++ {
+			time.Sleep(time.Second * 2)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			statusA, err := seqA.RollupAPI().SyncStatus(ctx)
+			require.NoError(err)
+			statusB, err := seqB.RollupAPI().SyncStatus(ctx)
+			require.NoError(err)
+			cancel()
+			logger.Info("chain A", "tip", statusA.UnsafeL2)
+			logger.Info("chain B", "tip", statusB.UnsafeL2)
+
+			if statusA.UnsafeL2.Number > blocks && statusB.UnsafeL2.Number > blocks {
+				return
+			}
 		}
-	}
-	t.Errorf("Expected to reach block %d on both chains", blocks)
-	t.FailNow()
+		t.Errorf("Expected to reach block %d on both chains", blocks)
+		t.FailNow()
+	})
 }


### PR DESCRIPTION
**Description**

This allows any package to define new key types, that match elements of a system collection.

This also cleans up the getters. Everything can be listed by keys (IDs) and values (components) now.
And the chainID lookups are removed, since the L1NetworkID and L2NetworkID are just typed chainIDs since the deployer integration PR.

All identifiers are by default matchers, and don't require a linear search.

This allows matchers to be programmed, for lookups like:
- `cl := l2Net.L2CLNode(match.FirstL2CL)`
- `el := l2Net.L2ELNode(match.WithEngine(cl.ID()))`
- `el := l2Net.L2ELNode(match.OpReth)`
- `chainA := system.L2Network(match.L2ChainA)`
- etc.

This also adds labels to each stack component, so matchers can build on top of those labels. E.g. to select vendors etc.

And there are also a few generic util-matchers, to compose matchers:, `And`, `Or`, `Random`, `First`, `ByIndex`, `Last`, `Only`, etc.

This PR also includes a fix for sub-tests to have a non-nil `require` instance.

**Tests**

- Unit-tested the matcher utils
- Covered the common matcher aliases and label usage in the sysgo test

**Additional context**

This helps with the test-setup part, where parts of a hydrated system need to be selected for the returned DSL bundle struct.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15271
