### PR TITLE
op-supervisor: query benchmark

### DIFF
--- a/op-e2e/interop/interop_benchmark_test.go
+++ b/op-e2e/interop/interop_benchmark_test.go
@@ -1,0 +1,211 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+// setupAndRun is a helper function that sets up a SuperSystem
+// which contains two L2 Chains, and two users on each chain.
+func setup(t testing.TB, config SuperSystemConfig) SuperSystem {
+	recipe := interopgen.InteropDevRecipe{
+		L1ChainID:        900100,
+		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
+		GenesisTimestamp: uint64(time.Now().Unix() + 3), // start chain 3 seconds from now
+	}
+	worldResources := WorldResourcePaths{
+		FoundryArtifacts: "../../packages/contracts-bedrock/forge-artifacts",
+		SourceMap:        "../../packages/contracts-bedrock",
+	}
+
+	// create a super system from the recipe
+	// and get the L2 IDs for use in the test
+	s2 := NewSuperSystem(t, &recipe, worldResources, config)
+
+	// create two users on all L2 chains
+	s2.AddUser("Alice")
+	s2.AddUser("Bob")
+	s2.AddUser("Charlie")
+	s2.AddUser("Dennis")
+	s2.AddUser("Eve")
+	s2.AddUser("Frank")
+
+	return s2
+}
+
+func BenchmarkCheckMessages(b *testing.B) {
+	// Skip this benchmark
+	b.Skip("Run benchmarks on demand only")
+
+	// Set up the SuperSystem once before the benchmark loop
+	s2 := setup(b, SuperSystemConfig{})
+
+	// Set up chains with Emitter Contracts
+	chains := s2.L2IDs()
+	chainA := chains[0]
+	chainB := chains[1]
+	clientA := s2.L2GethClient(chainA, "sequencer")
+	clientB := s2.L2GethClient(chainB, "sequencer")
+	// Deploy emitter to chain A
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	EmitterA := s2.DeployEmitterContract(ctx, chainA, "Alice")
+
+	// Deploy emitter to chain B
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	EmitterB := s2.DeployEmitterContract(ctx, chainB, "Alice")
+
+	// Set up chains with lots of initiating messages
+	numEmits := 100
+	// emit logs on both chains in parallel
+	var emitParallel sync.WaitGroup
+	emitOn := func(chainID string, address string) {
+		for i := 0; i < numEmits; i++ {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			payload := fmt.Sprintf("%s-%d", address, i)
+			s2.EmitData(ctx, chainID, "sequencer", address, payload)
+			cancel()
+		}
+		emitParallel.Done()
+	}
+	// 6 users on chain A, 6 users on chain B
+	// all will submit 100 messages
+	emitParallel.Add(6 * 2)
+	go emitOn(chainA, "Alice")
+	go emitOn(chainB, "Alice")
+	go emitOn(chainA, "Bob")
+	go emitOn(chainB, "Bob")
+	go emitOn(chainA, "Charlie")
+	go emitOn(chainB, "Charlie")
+	go emitOn(chainA, "Dennis")
+	go emitOn(chainB, "Dennis")
+	go emitOn(chainA, "Eve")
+	go emitOn(chainB, "Eve")
+	go emitOn(chainA, "Frank")
+	go emitOn(chainB, "Frank")
+	emitParallel.Wait()
+
+	// Get every possible log from both chains, as potential queries
+	// check that the logs are emitted on chain A
+	qA := ethereum.FilterQuery{
+		Addresses: []common.Address{EmitterA},
+	}
+	logsA, err := clientA.FilterLogs(context.Background(), qA)
+	require.NoError(b, err)
+	require.Len(b, logsA, numEmits*6)
+
+	// check that the logs are emitted on chain B
+	qB := ethereum.FilterQuery{
+		Addresses: []common.Address{EmitterB},
+	}
+	logsB, err := clientB.FilterLogs(context.Background(), qB)
+	require.NoError(b, err)
+	require.Len(b, logsB, numEmits*6)
+
+	// helper function to turn a log into an access-list object
+	logToAccessListHashes := func(chainID string, log gethTypes.Log) []common.Hash {
+		client := s2.L2GethClient(chainID, "sequencer")
+		// construct the expected hash of the log's payload
+		// (topics concatenated with data)
+		msgPayload := make([]byte, 0)
+		for _, topic := range log.Topics {
+			msgPayload = append(msgPayload, topic.Bytes()...)
+		}
+		msgPayload = append(msgPayload, log.Data...)
+		msgHash := crypto.Keccak256Hash(msgPayload)
+
+		// get block for the log (for timestamp)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		block, err := client.BlockByHash(ctx, log.BlockHash)
+		require.NoError(b, err)
+
+		args := types.ChecksumArgs{
+			BlockNumber: log.BlockNumber,
+			Timestamp:   block.Time(),
+			LogIndex:    uint32(log.Index),
+			ChainID:     eth.ChainIDFromBig(s2.ChainID(chainID)),
+			LogHash:     types.PayloadHashToLogHash(msgHash, log.Address),
+		}
+		accessList := types.EncodeAccessList([]types.Access{args.Access()})
+		return accessList
+	}
+	// get all access lists from both chains
+	allAccessLists := make([][]common.Hash, 0)
+	for _, log := range logsA {
+		allAccessLists = append(allAccessLists, logToAccessListHashes(chainA, log))
+	}
+	for _, log := range logsB {
+		allAccessLists = append(allAccessLists, logToAccessListHashes(chainB, log))
+	}
+
+	super := s2.SupervisorClient()
+
+	executingDescriptor := types.ExecutingDescriptor{Timestamp: uint64(time.Now().Unix() + 1000)}
+	// Run the actual benchmark as a sub-benchmark
+	b.Run("CheckAccessList", func(b *testing.B) {
+		// Reset the timer before the benchmark loop to exclude setup time
+		b.ResetTimer()
+
+		// Run the benchmark loop
+		for i := 0; i < b.N; i++ {
+			// select a random access list
+			randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
+			super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+		}
+	})
+
+	// Run a benchmark with 10 parallel CheckAccessList calls
+	b.Run("CheckAccessListParallel10", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var wg sync.WaitGroup
+			wg.Add(10)
+
+			for j := 0; j < 10; j++ {
+				go func() {
+					defer wg.Done()
+					randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
+					super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+				}()
+			}
+
+			wg.Wait()
+		}
+	})
+
+	// Run a benchmark with 100 parallel CheckAccessList calls
+	b.Run("CheckAccessListParallel100", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var wg sync.WaitGroup
+			wg.Add(100)
+
+			for j := 0; j < 100; j++ {
+				go func() {
+					defer wg.Done()
+					randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
+					super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+				}()
+			}
+
+			wg.Wait()
+		}
+	})
+}

--- a/op-e2e/interop/interop_benchmark_test.go
+++ b/op-e2e/interop/interop_benchmark_test.go
@@ -165,7 +165,8 @@ func BenchmarkCheckMessages(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			// select a random access list
 			randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
-			super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+			err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+			require.NoError(b, err)
 		}
 	})
 
@@ -181,7 +182,8 @@ func BenchmarkCheckMessages(b *testing.B) {
 				go func() {
 					defer wg.Done()
 					randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
-					super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+					err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+					require.NoError(b, err)
 				}()
 			}
 
@@ -201,7 +203,8 @@ func BenchmarkCheckMessages(b *testing.B) {
 				go func() {
 					defer wg.Done()
 					randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
-					super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+					err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+					require.NoError(b, err)
 				}()
 			}
 

--- a/op-e2e/interop/interop_benchmark_test.go
+++ b/op-e2e/interop/interop_benchmark_test.go
@@ -154,61 +154,31 @@ func BenchmarkCheckMessages(b *testing.B) {
 	}
 
 	super := s2.SupervisorClient()
-
 	executingDescriptor := types.ExecutingDescriptor{Timestamp: uint64(time.Now().Unix() + 1000)}
-	// Run the actual benchmark as a sub-benchmark
-	b.Run("CheckAccessList", func(b *testing.B) {
-		// Reset the timer before the benchmark loop to exclude setup time
-		b.ResetTimer()
 
-		// Run the benchmark loop
-		for i := 0; i < b.N; i++ {
-			// select a random access list
-			randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
-			err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
-			require.NoError(b, err)
-		}
-	})
+	runParallel := func(b *testing.B, num int) {
+		b.Run(fmt.Sprintf("CheckAccessListParallel%d", num), func(b *testing.B) {
+			b.ResetTimer()
 
-	// Run a benchmark with 10 parallel CheckAccessList calls
-	b.Run("CheckAccessListParallel10", func(b *testing.B) {
-		b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var wg sync.WaitGroup
+				wg.Add(num)
 
-		for i := 0; i < b.N; i++ {
-			var wg sync.WaitGroup
-			wg.Add(10)
+				for j := 0; j < num; j++ {
+					go func() {
+						defer wg.Done()
+						randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
+						err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
+						require.NoError(b, err)
+					}()
+				}
 
-			for j := 0; j < 10; j++ {
-				go func() {
-					defer wg.Done()
-					randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
-					err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
-					require.NoError(b, err)
-				}()
+				wg.Wait()
 			}
+		})
+	}
 
-			wg.Wait()
-		}
-	})
-
-	// Run a benchmark with 100 parallel CheckAccessList calls
-	b.Run("CheckAccessListParallel100", func(b *testing.B) {
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			var wg sync.WaitGroup
-			wg.Add(100)
-
-			for j := 0; j < 100; j++ {
-				go func() {
-					defer wg.Done()
-					randomAccessList := allAccessLists[rand.Intn(len(allAccessLists))]
-					err := super.CheckAccessList(context.Background(), randomAccessList, types.CrossUnsafe, executingDescriptor)
-					require.NoError(b, err)
-				}()
-			}
-
-			wg.Wait()
-		}
-	})
+	runParallel(b, 1)
+	runParallel(b, 10)
+	runParallel(b, 100)
 }

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -32,7 +32,7 @@ import (
 
 // setupAndRun is a helper function that sets up a SuperSystem
 // which contains two L2 Chains, and two users on each chain.
-func setupAndRun(t *testing.T, config SuperSystemConfig, fn func(*testing.T, SuperSystem)) {
+func setupAndRun(t testing.TB, config SuperSystemConfig, fn func(testing.TB, SuperSystem)) {
 	recipe := interopgen.InteropDevRecipe{
 		L1ChainID:        900100,
 		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
@@ -61,7 +61,7 @@ func setupAndRun(t *testing.T, config SuperSystemConfig, fn func(*testing.T, Sup
 // and only Chain A is affected.
 func TestInterop_IsolatedChains(t *testing.T) {
 	t.Parallel()
-	test := func(t *testing.T, s2 SuperSystem) {
+	test := func(t testing.TB, s2 SuperSystem) {
 		ids := s2.L2IDs()
 		chainA := ids[0]
 		chainB := ids[1]
@@ -117,7 +117,7 @@ func TestInterop_IsolatedChains(t *testing.T) {
 // It waits for the finalized block to advance past the genesis block.
 func TestInterop_SupervisorFinality(t *testing.T) {
 	t.Parallel()
-	test := func(t *testing.T, s2 SuperSystem) {
+	test := func(t testing.TB, s2 SuperSystem) {
 		supervisor := s2.SupervisorClient()
 		require.Eventually(t, func() bool {
 			final, err := supervisor.FinalizedL1(context.Background())
@@ -140,7 +140,7 @@ func TestInterop_SupervisorFinality(t *testing.T) {
 // A contract is deployed on each chain, and logs are emitted repeatedly.
 func TestInterop_EmitLogs(t *testing.T) {
 	t.Parallel()
-	test := func(t *testing.T, s2 SuperSystem) {
+	test := func(t testing.TB, s2 SuperSystem) {
 		ids := s2.L2IDs()
 		chainA := ids[0]
 		chainB := ids[1]
@@ -256,7 +256,7 @@ func TestInteropBlockBuilding(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelInfo)
 	oplog.SetGlobalLogHandler(logger.Handler())
 
-	test := func(t *testing.T, s2 SuperSystem) {
+	test := func(t testing.TB, s2 SuperSystem) {
 		ids := s2.L2IDs()
 		chainA := ids[0]
 		chainB := ids[1]
@@ -368,7 +368,7 @@ func TestInteropBlockBuilding(t *testing.T) {
 
 func TestMultiNode(t *testing.T) {
 	t.Parallel()
-	test := func(t *testing.T, s2 SuperSystem) {
+	test := func(t testing.TB, s2 SuperSystem) {
 		supervisor := s2.SupervisorClient()
 		require.Eventually(t, func() bool {
 			final, err := supervisor.FinalizedL1(context.Background())
@@ -416,7 +416,7 @@ func TestMultiNode(t *testing.T) {
 
 func TestProposals(t *testing.T) {
 	t.Parallel()
-	test := func(t *testing.T, s2 SuperSystem) {
+	test := func(t testing.TB, s2 SuperSystem) {
 		logger := testlog.Logger(t, log.LvlInfo)
 		ids := s2.L2IDs()
 		chainA := ids[0]

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -111,7 +111,7 @@ type SuperSystemConfig struct {
 }
 
 // NewSuperSystem creates a new SuperSystem from a recipe. It creates an interopE2ESystem.
-func NewSuperSystem(t *testing.T, recipe *interopgen.InteropDevRecipe, w WorldResourcePaths, config SuperSystemConfig) SuperSystem {
+func NewSuperSystem(t testing.TB, recipe *interopgen.InteropDevRecipe, w WorldResourcePaths, config SuperSystemConfig) SuperSystem {
 	s2 := &interopE2ESystem{recipe: recipe, config: &config}
 	s2.prepare(t, w)
 	return s2
@@ -122,7 +122,7 @@ func NewSuperSystem(t *testing.T, recipe *interopgen.InteropDevRecipe, w WorldRe
 // the functionality is broken down into smaller functions so that
 // the system can be prepared iteratively if desired
 type interopE2ESystem struct {
-	t               *testing.T
+	t               testing.TB
 	recipe          *interopgen.InteropDevRecipe
 	logger          log.Logger
 	timeTravelClock *clock.AdvancingClock
@@ -334,7 +334,7 @@ func (s *interopE2ESystem) SupervisorClient() *sources.SupervisorClient {
 // prepare sets up the system for testing
 // components are built iteratively, so that they can be reused or modified
 // their creation can't be safely skipped or reordered at this time
-func (s *interopE2ESystem) prepare(t *testing.T, w WorldResourcePaths) {
+func (s *interopE2ESystem) prepare(t testing.TB, w WorldResourcePaths) {
 	s.t = t
 	s.logger = testlog.Logger(s.t, log.LevelDebug)
 	s.hdWallet = s.prepareHDWallet()
@@ -586,7 +586,7 @@ func (s *interopE2ESystem) DependencySet() *depset.StaticConfigDependencySet {
 	return stDepSet
 }
 
-func mustDial(t *testing.T, logger log.Logger) func(v string) *rpc.Client {
+func mustDial(t testing.TB, logger log.Logger) func(v string) *rpc.Client {
 	return func(v string) *rpc.Client {
 		cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
 		require.NoError(t, err, "failed to dial")

--- a/op-e2e/system/helpers/tx_helper.go
+++ b/op-e2e/system/helpers/tx_helper.go
@@ -91,7 +91,7 @@ func defaultDepositTxOpts(opts *bind.TransactOpts) *DepositTxOpts {
 // The supplied privKey is used to specify the account to send from and the transaction is sent to the supplied l2Client
 // Transaction options and expected status can be configured in the applyTxOpts function by modifying the supplied TxOpts
 // Will verify that the transaction is included with the expected status on l2Client and any clients added to TxOpts.VerifyClients
-func SendL2TxWithID(t *testing.T, chainID *big.Int, l2Client *ethclient.Client, privKey *ecdsa.PrivateKey, applyTxOpts TxOptsFn) *types.Receipt {
+func SendL2TxWithID(t testing.TB, chainID *big.Int, l2Client *ethclient.Client, privKey *ecdsa.PrivateKey, applyTxOpts TxOptsFn) *types.Receipt {
 	opts := defaultTxOpts()
 	applyTxOpts(opts)
 	tx := types.MustSignNewTx(privKey, types.LatestSignerForChainID(chainID), &types.DynamicFeeTx{
@@ -122,7 +122,7 @@ func SendL2TxWithID(t *testing.T, chainID *big.Int, l2Client *ethclient.Client, 
 	return receipt
 }
 
-func SendL2Tx(t *testing.T, cfg e2esys.SystemConfig, l2Client *ethclient.Client, privKey *ecdsa.PrivateKey, applyTxOpts TxOptsFn) *types.Receipt {
+func SendL2Tx(t testing.TB, cfg e2esys.SystemConfig, l2Client *ethclient.Client, privKey *ecdsa.PrivateKey, applyTxOpts TxOptsFn) *types.Receipt {
 	return SendL2TxWithID(t, cfg.L2ChainIDBig(), l2Client, privKey, applyTxOpts)
 }
 


### PR DESCRIPTION
Check Access List Benchmarking!

This test creates 6 users on 2 chains, and then has all 12 total users submit 100 `EmitMessage` contract interactions.
Once that setup is done, the three benchmarks run, which make randomized queries against the supervisor.

The three sub-benchmarks are levels of parallel requests:
- 1 call at a time
- 10 calls at a time
- 100 calls at a time

```
BenchmarkCheckMessages/CheckAccessList-12                   2948            411590 ns/op          289822 B/op       1076 allocs/op
BenchmarkCheckMessages/CheckAccessListParallel10-12                  346           3095544 ns/op         2957943 B/op      11112 allocs/op
BenchmarkCheckMessages/CheckAccessListParallel100-12                  44          30240143 ns/op        30400986 B/op     113907 allocs/op
```

These results demonstrate that the Supervisor is stable against parallel requests. I *did* find that the benchmark time went up as I added more transactions. This makes sense, as the database is binary-searched, meaning that as the database grows, this should level off to Log(N). The test takes much longer to run when a larger setup is used, and already takes quite a while.

This test is also skipped by default so that CI doesn't run it. This test should be used for performance testing of the Supervisor, which is not a PR/CI activity.

#### Note
- Also changes all of SuperSystem to use a `testing.TB` for compatability
