### PR TITLE
chore(op-acceptance-tests): change notifier for build fails.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1237,7 +1237,7 @@ jobs:
       # Notification step
       - notify-failures-on-develop:
           channel: "C03N11M0BBN"  # #notify-ci-failures
-          mentions: "@protocol-devx-pod"
+          mentions: "@stefano" # temporarily just mention Stefano until the acceptance tests are stable (was: @protocol-devx-pod)
 
   sanitize-op-program:
     docker:


### PR DESCRIPTION
**Description**

Temporarily directs all the acceptance test fail notifications to just me, until we get them more stable.
This is to prevent spamming the greater group.
