### PR TITLE
fix(kt-devnet): fix broken ethereum-package

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -3,6 +3,6 @@ description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
   github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@1cf76907eaa437ee9fcf902167714fece027962a
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This picks up the ethereum-package fix from https://github.com/ethpandaops/ethereum-package/pull/957

Long story short: ethereum-package depends on moving-label python
images, and the default one appears to have regressed.

Going forward we'll need a good way to pin those images for
reproducibility.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Manually deployed simple-devnet and isthmus-devnet (used in acceptance tests)

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
