### PR TITLE
op-e2e: Migrate the remaining Super DG tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2113,7 +2113,7 @@ workflows:
           notify: true
           mentions: "@proofs-team"
           no_output_timeout: 60m
-          test_timeout: 59m
+          test_timeout: 75m
           resource_class: ethereum-optimism/latitude-fps-1
           environment_overrides: |
             export OP_E2E_CANNON_ENABLED="true"

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -411,7 +411,7 @@ func (h *FactoryHelper) WaitForSuperTimestamp(l2Timestamp uint64, cfg *GameCfg) 
 						break
 					}
 				}
-				if !localUnsafeAtTimestamp {
+				if localUnsafeAtTimestamp {
 					return
 				}
 			} else {
@@ -421,7 +421,7 @@ func (h *FactoryHelper) WaitForSuperTimestamp(l2Timestamp uint64, cfg *GameCfg) 
 			}
 			// log every 30 seconds
 			if time.Since(lastLog) > 30*time.Second {
-				h.T.Logf("Waiting for super timestamp %v. Latest safe timestamp: %v", l2Timestamp, status.SafeTimestamp)
+				h.T.Logf("Waiting for super timestamp %v. Latest safe: %v", l2Timestamp, status.SafeTimestamp)
 				lastLog = time.Now()
 			}
 		case <-ctx.Done():

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -230,12 +230,24 @@ func (h *FactoryHelper) StartSuperCannonGameWithCorrectRoot(ctx context.Context,
 	return h.startSuperCannonGameOfType(ctx, l2Timestamp, common.Hash(output.SuperRoot), superCannonGameType, opts...)
 }
 
+func (h *FactoryHelper) StartSuperCannonGameWithCorrectRootAtTimestamp(ctx context.Context, l2Timestamp uint64, opts ...GameOpt) *SuperCannonGameHelper {
+	cfg := NewGameCfg(opts...)
+	h.WaitForSuperTimestamp(l2Timestamp, cfg)
+	output, err := h.System.SupervisorClient().SuperRootAtTimestamp(ctx, hexutil.Uint64(l2Timestamp))
+	h.Require.NoErrorf(err, "Failed to get output at timestamp %v", l2Timestamp)
+	return h.startSuperCannonGameOfType(ctx, l2Timestamp, common.Hash(output.SuperRoot), superCannonGameType, opts...)
+}
+
 func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, rootClaim common.Hash, opts ...GameOpt) *SuperCannonGameHelper {
 	// Can't create a game at L1 genesis!
 	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1))
 	b, err := h.Client.BlockByNumber(ctx, nil)
 	require.NoError(h.T, err)
 	return h.startSuperCannonGameOfType(ctx, b.Time(), rootClaim, superCannonGameType, opts...)
+}
+
+func (h *FactoryHelper) StartSuperCannonGameAtTimestamp(ctx context.Context, timestamp uint64, rootClaim common.Hash, opts ...GameOpt) *SuperCannonGameHelper {
+	return h.startSuperCannonGameOfType(ctx, timestamp, rootClaim, superCannonGameType, opts...)
 }
 
 func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestamp uint64, rootClaim common.Hash, gameType uint32, opts ...GameOpt) *SuperCannonGameHelper {
@@ -251,7 +263,7 @@ func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestam
 	tx, err := transactions.PadGasEstimate(h.Opts, 2, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return h.Factory.Create(opts, gameType, rootClaim, extraData)
 	})
-	h.Require.NoError(err, "create fault dispute game")
+	h.Require.NoErrorf(err, "create fault dispute game at timestamp %v. extraData: %x", timestamp, extraData)
 	rcpt, err := wait.ForReceiptOK(ctx, h.Client, tx.Hash())
 	h.Require.NoError(err, "wait for create fault dispute game receipt to be OK")
 	h.Require.Len(rcpt.Logs, 2, "should have emitted a single DisputeGameCreated event")
@@ -378,7 +390,7 @@ func (h *FactoryHelper) WaitForSuperTimestamp(l2Timestamp uint64, cfg *GameCfg) 
 	}
 
 	client := h.System.SupervisorClient()
-	absoluteTimeout := 3 * time.Minute
+	absoluteTimeout := 5 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), absoluteTimeout)
 	defer cancel()
 
@@ -409,7 +421,7 @@ func (h *FactoryHelper) WaitForSuperTimestamp(l2Timestamp uint64, cfg *GameCfg) 
 			}
 			// log every 30 seconds
 			if time.Since(lastLog) > 30*time.Second {
-				h.T.Logf("Waiting for super timestamp %v", l2Timestamp)
+				h.T.Logf("Waiting for super timestamp %v. Latest safe timestamp: %v", l2Timestamp, status.SafeTimestamp)
 				lastLog = time.Now()
 			}
 		case <-ctx.Done():

--- a/op-e2e/e2eutils/disputegame/split_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/split_game_helper.go
@@ -431,6 +431,9 @@ func WithoutWaitingForStep() DefendClaimOpt {
 	}
 }
 
+// SupportClaim uses the supplied Mover to perform moves in an attempt to support the supplied claim.
+// It is assumed that the specified claim is valid and that an honest op-challenger is already running.
+// When the game has reached the maximum depth it uses the specified stepper to counter the leaf claim.
 func (g *SplitGameHelper) SupportClaim(ctx context.Context, claim *ClaimHelper, performMove Mover, attemptStep Stepper) {
 	g.T.Logf("Supporting claim %v at depth %v", claim.Index, claim.Depth())
 	for !claim.IsMaxDepth(ctx) {

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -292,6 +292,86 @@ func testDisputeRootChangeClaimedRoot(t *testing.T, ctx context.Context, arena g
 	game.LogGameData(ctx)
 }
 
+func testCannonProposalValid_AttackWithCorrectTrace(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, rootIsCorrect(t, ctx, arena, game), "This test must be run with a correct proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	performStep := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
+		// Attack step should fail
+		correctTrace.StepFails(ctx, parentClaimIdx, true)
+		// Defending should fail too
+		correctTrace.StepFails(ctx, parentClaimIdx, false)
+	}
+	performMove := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		// Attack everything but oddly using the correct hash.
+		// Except the root of the cannon game must have an invalid VM status code.
+		if claim.IsOutputRootLeaf(ctx) {
+			return claim.Attack(ctx, common.Hash{0x01})
+		}
+		return correctTrace.AttackClaim(ctx, claim)
+	}
+
+	arena.CreateChallenger(ctx)
+
+	rootAttack := performMove(ctx, correctTrace, game.RootClaim(ctx))
+	game.SupportClaim(ctx,
+		rootAttack,
+		func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+			return performMove(ctx, correctTrace, claim)
+		},
+		func(parentClaimIdx int64) {
+			performStep(ctx, correctTrace, parentClaimIdx)
+		},
+	)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
+}
+
+func testCannonProposalValid_DefendWithCorrectTrace(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) {
+	require.True(t, rootIsCorrect(t, ctx, arena, game), "This test must be run with a correct proposal root")
+	correctTrace := arena.CreateHonestActor(ctx)
+
+	performStep := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
+		// Attack step should fail
+		correctTrace.StepFails(ctx, parentClaimIdx, true)
+		// Defending should fail too
+		correctTrace.StepFails(ctx, parentClaimIdx, false)
+	}
+	performMove := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		// Can only attack the root claim or the first cannon claim
+		if claim.IsRootClaim() {
+			return correctTrace.AttackClaim(ctx, claim)
+		}
+		// The root of the cannon game must have an invalid VM status code
+		// Attacking ensure we're running the cannon trace between two different blocks
+		// instead of being in the trace extension of the output root bisection
+		if claim.IsOutputRootLeaf(ctx) {
+			return claim.Attack(ctx, common.Hash{0x01})
+		}
+		// Otherwise, defend everything using the correct hash.
+		return correctTrace.DefendClaim(ctx, claim)
+	}
+
+	arena.CreateChallenger(ctx)
+
+	rootAttack := performMove(ctx, correctTrace, game.RootClaim(ctx))
+	game.SupportClaim(ctx,
+		rootAttack,
+		func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+			return performMove(ctx, correctTrace, claim)
+		},
+		func(parentClaimIdx int64) {
+			performStep(ctx, correctTrace, parentClaimIdx)
+		},
+	)
+
+	arena.AdvanceTime(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, arena.L1Client()))
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
+}
+
 func rootIsCorrect(t *testing.T, ctx context.Context, arena gameArena, game *disputegame.SplitGameHelper) bool {
 	root, err := game.Game.GetClaim(ctx, 0)
 	require.NoError(t, err)

--- a/op-e2e/faultproofs/dispute_tests.go
+++ b/op-e2e/faultproofs/dispute_tests.go
@@ -296,12 +296,6 @@ func testCannonProposalValid_AttackWithCorrectTrace(t *testing.T, ctx context.Co
 	require.True(t, rootIsCorrect(t, ctx, arena, game), "This test must be run with a correct proposal root")
 	correctTrace := arena.CreateHonestActor(ctx)
 
-	performStep := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
-		// Attack step should fail
-		correctTrace.StepFails(ctx, parentClaimIdx, true)
-		// Defending should fail too
-		correctTrace.StepFails(ctx, parentClaimIdx, false)
-	}
 	performMove := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 		// Attack everything but oddly using the correct hash.
 		// Except the root of the cannon game must have an invalid VM status code.
@@ -319,9 +313,7 @@ func testCannonProposalValid_AttackWithCorrectTrace(t *testing.T, ctx context.Co
 		func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 			return performMove(ctx, correctTrace, claim)
 		},
-		func(parentClaimIdx int64) {
-			performStep(ctx, correctTrace, parentClaimIdx)
-		},
+		verifyFinalStepper(t, ctx, arena, game),
 	)
 
 	arena.AdvanceTime(game.MaxClockDuration(ctx))
@@ -333,12 +325,6 @@ func testCannonProposalValid_DefendWithCorrectTrace(t *testing.T, ctx context.Co
 	require.True(t, rootIsCorrect(t, ctx, arena, game), "This test must be run with a correct proposal root")
 	correctTrace := arena.CreateHonestActor(ctx)
 
-	performStep := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
-		// Attack step should fail
-		correctTrace.StepFails(ctx, parentClaimIdx, true)
-		// Defending should fail too
-		correctTrace.StepFails(ctx, parentClaimIdx, false)
-	}
 	performMove := func(ctx context.Context, correctTrace *disputegame.OutputHonestHelper, claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 		// Can only attack the root claim or the first cannon claim
 		if claim.IsRootClaim() {
@@ -362,9 +348,7 @@ func testCannonProposalValid_DefendWithCorrectTrace(t *testing.T, ctx context.Co
 		func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
 			return performMove(ctx, correctTrace, claim)
 		},
-		func(parentClaimIdx int64) {
-			performStep(ctx, correctTrace, parentClaimIdx)
-		},
+		verifyFinalStepper(t, ctx, arena, game),
 	)
 
 	arena.AdvanceTime(game.MaxClockDuration(ctx))

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-e2e/interop"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -248,10 +250,12 @@ func TestSuperCannonStepWithPreimage(t *testing.T) {
 		// So we don't waste time resolving the game - that's tested elsewhere.
 	}
 
-	// TODO(#15311): Add blob preimage test case
-	preimageConditions := []string{"keccak", "sha256"}
+	preimageConditions := []string{"keccak", "sha256", "blob"}
 	for _, preimageType := range preimageConditions {
 		preimageType := preimageType
+		if preimageType == "blob" || preimageType == "sha256" {
+			t.Skip("TODO(#15311): Add blob preimage test case. sha256 is also used for blobs")
+		}
 		t.Run("non-existing preimage-"+preimageType, func(t *testing.T) {
 			testPreimageStep(t, utils.FirstPreimageLoadOfType(preimageType), false)
 		})
@@ -311,6 +315,7 @@ func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
 }
 
 func TestSuperInvalidateUnsafeProposal(t *testing.T) {
+	t.Skip("TODO(#15321): Challenger does not respond to unsafe proposals")
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	tests := []struct {
@@ -342,10 +347,33 @@ func TestSuperInvalidateUnsafeProposal(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
-			timestamp := uint64(1)
 			sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+
+			client := sys.SupervisorClient()
+			status, err := client.SyncStatus(ctx)
+			require.NoError(t, err, "Failed to get sync status")
+			// Ensure that the superchain has progressed a bit past the genesis timestamp
+			disputeGameFactory.WaitForSuperTimestamp(status.SafeTimestamp+4, &disputegame.GameCfg{})
+			// halt the safe chain
+			for _, id := range sys.L2IDs() {
+				require.NoError(t, sys.Batcher(id).Stop(ctx))
+			}
+
+			status, err = client.SyncStatus(ctx)
+			require.NoError(t, err, "Failed to get sync status")
+
+			// Wait for any client to advance its unsafe head past the safe chain. We know this head will remain unsafe since the batc
+			l2Client := sys.L2GethClient(sys.L2IDs()[0], "sequencer")
+			wait.ForNextBlock(ctx, l2Client)
+			head, err := l2Client.BlockByNumber(ctx, nil)
+			require.NoError(t, err, "Failed to get head block")
+			unsafeTimestamp := head.Time()
+
 			// Root claim is _dishonest_ because the required data is not available on L1
-			game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, timestamp, disputegame.WithUnsafeProposal())
+			unsafeSuper := createSuperRoot(t, ctx, sys, unsafeTimestamp)
+			unsafeRoot := eth.SuperRoot(unsafeSuper)
+			game := disputeGameFactory.StartSuperCannonGameAtTimestamp(ctx, unsafeTimestamp, common.Hash(unsafeRoot), disputegame.WithFutureProposal())
+
 			correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
 				c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
 			})
@@ -660,4 +688,29 @@ func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {
 	sys.AdvanceL1Time(game.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
 	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
+}
+
+func createSuperRoot(t *testing.T, ctx context.Context, sys interop.SuperSystem, timestamp uint64) *eth.SuperV1 {
+	chains := make(map[eth.ChainID]eth.Bytes32)
+	for _, id := range sys.L2IDs() {
+		rollupCfg := sys.RollupConfig(id)
+		blockNum, err := rollupCfg.TargetBlockNumber(timestamp)
+		t.Logf("Target block number for timestamp %v (%v): %v", timestamp, rollupCfg.L2ChainID, blockNum)
+		require.NoError(t, err)
+
+		client := sys.L2RollupClient(id, "sequencer")
+		output, err := client.OutputAtBlock(ctx, blockNum)
+		require.NoError(t, err)
+		chains[eth.ChainIDFromBig(rollupCfg.L2ChainID)] = output.OutputRoot
+	}
+
+	var output eth.SuperV1
+	for _, chainID := range sys.DependencySet().Chains() {
+		output.Chains = append(output.Chains, eth.ChainIDAndOutput{
+			ChainID: chainID,
+			Output:  chains[chainID],
+		})
+	}
+	output.Timestamp = timestamp
+	return &output
 }

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -2,15 +2,25 @@ package faultproofs
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/batcher"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,12 +49,233 @@ func TestSuperCannonGame_ChallengeAllZeroClaim(t *testing.T) {
 	testCannonChallengeAllZeroClaim(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
 }
 
+func TestSuperCannonPublishCannonRootClaim(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+
+	tests := []struct {
+		disputeL2SequenceNumberOffset uint64
+	}{
+		{2},
+		{3},
+		{4},
+		{5},
+		{6},
+	}
+	vmStatusCh := make(chan byte, len(tests))
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("Dispute_%v", test.disputeL2SequenceNumberOffset), func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+			ctx := context.Background()
+
+			sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+			b, err := sys.L1GethClient().BlockByNumber(ctx, nil)
+			require.NoError(t, err)
+			disputeL2SequenceNumber := b.Time() + test.disputeL2SequenceNumberOffset
+
+			game := disputeGameFactory.StartSuperCannonGameAtTimestamp(ctx, disputeL2SequenceNumber, common.Hash{0x01})
+			game.DisputeLastBlock(ctx)
+			game.LogGameData(ctx)
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+			splitDepth := game.SplitDepth(ctx)
+			t.Logf("Waiting for claim at depth %v (split depth %v)", splitDepth+1, splitDepth)
+			game.WaitForClaimAtDepth(ctx, splitDepth+1)
+
+			claims, err := game.Game.GetAllClaims(ctx, rpcblock.Latest)
+			require.NoError(t, err)
+			var bottomRootClaim types.Claim
+			for _, claim := range claims {
+				if claim.Depth() == splitDepth+1 {
+					require.True(t, bottomRootClaim == types.Claim{}, "Found multiple bottom root claims")
+					bottomRootClaim = claim
+				}
+			}
+			require.True(t, bottomRootClaim != types.Claim{}, "Failed to find bottom root claim")
+			t.Logf("Bottom root claim: %v", bottomRootClaim.Value)
+			vmStatusCh <- bottomRootClaim.Value[0]
+		})
+	}
+
+	// Cleanup ensures that the subtests run to completion before asserting the VM statuses
+	t.Cleanup(func() {
+		close(vmStatusCh)
+		vmStatuses := make(map[byte]bool)
+		for status := range vmStatusCh {
+			vmStatuses[status] = true
+		}
+		require.Greater(t, len(vmStatuses), 1,
+			"Invalid test setup. Expected at least 2 different VM statuses, got %v instead. Ensure that the disputeL2SequenceNumberOffsets are set correctly.",
+			vmStatuses)
+	})
+}
+
+func TestSuperCannonDisputeGame(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	tests := []struct {
+		name             string
+		defendClaimDepth types.Depth
+	}{
+		{"StepFirst", 0},
+		{"StepMiddle", 28},
+		{"StepInExtension", 1},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+
+			ctx := context.Background()
+			sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+			game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01, 0xaa})
+			game.LogGameData(ctx)
+
+			disputeClaim := game.DisputeLastBlock(ctx)
+			splitDepth := game.SplitDepth(ctx)
+
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+			game.SupportClaim(
+				ctx,
+				disputeClaim,
+				func(claim *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+					if claim.Depth()+1 == splitDepth+test.defendClaimDepth {
+						return claim.Defend(ctx, common.Hash{byte(claim.Depth())})
+					} else {
+						return claim.Attack(ctx, common.Hash{byte(claim.Depth())})
+					}
+				},
+				func(parentIdx int64) {
+					t.Log("Calling step on challenger's claim...")
+					honestActor := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+						c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+					})
+					honestActor.StepFails(ctx, parentIdx, false)
+					honestActor.StepFails(ctx, parentIdx, true)
+				},
+			)
+
+			sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+
+			game.LogGameData(ctx)
+			game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+		})
+	}
+}
+
 func TestSuperCannonDefendStep(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
 	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
 	testCannonDefendStep(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonStepWithLargePreimage(t *testing.T) {
+	t.Skip("Skipping large preimage test due to cross-safe stall in the supervisor")
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+
+	for _, id := range sys.L2IDs() {
+		require.NoError(t, sys.Batcher(id).Stop(ctx))
+	}
+	// Manually send a tx from the correct batcher key to the batcher input with very large (invalid) data
+	// This forces op-program to load a large preimage.
+	for _, id := range sys.L2IDs() {
+		batcherKey := sys.L2OperatorKey(id, devkeys.BatcherRole)
+		batcherHelper := batcher.NewHelper(t, &batcherKey, sys.RollupConfig(id), sys.L1GethClient())
+		t.Logf("Sending large invalid batch from batcher %v", id)
+		batcherHelper.SendLargeInvalidBatch(ctx)
+	}
+	for _, id := range sys.L2IDs() {
+		require.NoError(t, sys.Batcher(id).Start(ctx))
+	}
+
+	L1Head, err := sys.L1GethClient().BlockByNumber(ctx, nil)
+	require.NoError(t, err)
+	t.Logf("L1 head %d (%x) timestamp: %v", L1Head.NumberU64(), L1Head.Hash(), L1Head.Time())
+	l2Timestamp := L1Head.Time()
+	disputeGameFactory.WaitForSuperTimestamp(l2Timestamp, &disputegame.GameCfg{})
+
+	// Dispute any block - it will have to read the L1 batches to see if the block is reached
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, l2Timestamp)
+	topGameLeaf := game.DisputeBlock(ctx, l2Timestamp)
+	game.LogGameData(ctx)
+
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+	topGameLeaf = topGameLeaf.Attack(ctx, common.Hash{0x01})
+
+	game.LogGameData(ctx)
+	// Now the honest challenger is positioned as the defender of the execution game. We then dispute it by inducing a large preimage load.
+	sender := crypto.PubkeyToAddress(aliceKey(t).PublicKey)
+	preimageLoadCheck := game.CreateStepLargePreimageLoadCheck(ctx, sender)
+	game.ChallengeToPreimageLoad(ctx, topGameLeaf, aliceKey(t), utils.PreimageLargerThan(preimage.MinPreimageSize), preimageLoadCheck, false)
+	// The above method already verified the image was uploaded and step called successfully
+	// So we don't waste time resolving the game - that's tested elsewhere.
+}
+
+func TestSuperCannonStepWithPreimage(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	testPreimageStep := func(t *testing.T, preimageType utils.PreimageOpt, preloadPreimage bool) {
+		op_e2e.InitParallel(t, op_e2e.UsesCannon)
+
+		ctx := context.Background()
+		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+
+		status, err := sys.SupervisorClient().SyncStatus(ctx)
+		require.NoError(t, err)
+		l2Timestamp := status.SafeTimestamp
+
+		game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, l2Timestamp)
+		topGameLeaf := game.DisputeLastBlock(ctx)
+		game.LogGameData(ctx)
+
+		game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+		// This attack creates a bottom game such that we will be making the last move at the bottom. (see game depth parameters for the super DG)
+		// This presents an opportunity for the challenger to step on our dishonest claim at the bottom.
+		// This assumes the execution game depth is even. But if it is odd, then this test should be set up more like the FDG counter part.
+		topGameLeaf = topGameLeaf.Attack(ctx, common.Hash{0x01})
+
+		// Now the honest challenger is positioned as the defender of the execution game. We then move to challenge it to induce a preimage load
+		preimageLoadCheck := game.CreateStepPreimageLoadCheck(ctx)
+		game.ChallengeToPreimageLoad(ctx, topGameLeaf, aliceKey(t), preimageType, preimageLoadCheck, preloadPreimage)
+		// The above method already verified the image was uploaded and step called successfully
+		// So we don't waste time resolving the game - that's tested elsewhere.
+	}
+
+	// TODO(#15311): Add blob preimage test case
+	preimageConditions := []string{"keccak", "sha256"}
+	for _, preimageType := range preimageConditions {
+		preimageType := preimageType
+		t.Run("non-existing preimage-"+preimageType, func(t *testing.T) {
+			testPreimageStep(t, utils.FirstPreimageLoadOfType(preimageType), false)
+		})
+	}
+	// Only test pre-existing images with one type to save runtime
+	t.Run("preimage already exists", func(t *testing.T) {
+		testPreimageStep(t, utils.FirstKeccakPreimageLoad(), true)
+	})
+}
+
+func TestSuperCannonProposalValid_AttackWithCorrectTrace(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRoot(ctx)
+	testCannonProposalValid_AttackWithCorrectTrace(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperCannonProposalValid_DefendWithCorrectTrace(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRoot(ctx)
+	testCannonProposalValid_DefendWithCorrectTrace(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
 }
 
 func TestSuperCannonPoisonedPostState(t *testing.T) {
@@ -77,6 +308,323 @@ func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
 	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
 	game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
 	testDisputeRootChangeClaimedRoot(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+}
+
+func TestSuperInvalidateUnsafeProposal(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		strategy func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper
+	}{
+		{
+			name: "Attack",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.AttackClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Defend",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.DefendClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Counter",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.CounterClaim(ctx, parent)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+
+			timestamp := uint64(1)
+			sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+			// Root claim is _dishonest_ because the required data is not available on L1
+			game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, timestamp, disputegame.WithUnsafeProposal())
+			correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+				c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+			})
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+			game.SupportClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				if parent.IsBottomGameRoot(ctx) {
+					return correctTrace.AttackClaim(ctx, parent)
+				}
+				return test.strategy(correctTrace, parent)
+			},
+				func(parentIdx int64) {
+					t.Log("Calling step on challenger's claim...")
+					correctTrace.StepFails(ctx, parentIdx, false)
+					correctTrace.StepFails(ctx, parentIdx, true)
+				},
+			)
+
+			// Time travel past when the game will be resolvable.
+			sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+
+			game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+			game.LogGameData(ctx)
+		})
+	}
+}
+
+func TestSuperInvalidateProposalForFutureBlock(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		strategy func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper
+	}{
+		{
+			name: "Attack",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.AttackClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Defend",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.DefendClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Counter",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.CounterClaim(ctx, parent)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+			sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+			// Root claim is _dishonest_ because the required data is not available on L1
+			farFutureTimestamp := time.Now().Add(time.Second * 10_000_000).Unix()
+			game := disputeGameFactory.StartSuperCannonGameAtTimestamp(ctx, uint64(farFutureTimestamp), common.Hash{0x01}, disputegame.WithFutureProposal())
+			correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+				c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+			})
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+			game.SupportClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				if parent.IsBottomGameRoot(ctx) {
+					return correctTrace.AttackClaim(ctx, parent)
+				}
+				return test.strategy(correctTrace, parent)
+			},
+				func(parentIdx int64) {
+					t.Log("Calling step on challenger's claim...")
+					correctTrace.StepFails(ctx, parentIdx, false)
+					correctTrace.StepFails(ctx, parentIdx, true)
+				},
+			)
+
+			// Time travel past when the game will be resolvable.
+			sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+
+			game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+			game.LogGameData(ctx)
+		})
+	}
+}
+
+func TestSuperInvalidateCorrectProposalFutureBlock(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		strategy func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper
+	}{
+		{
+			name: "Attack",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.AttackClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Defend",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.DefendClaim(ctx, parent)
+			},
+		},
+		{
+			name: "Counter",
+			strategy: func(correctTrace *disputegame.OutputHonestHelper, parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				return correctTrace.CounterClaim(ctx, parent)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
+			sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+			client := sys.SupervisorClient()
+
+			status, err := client.SyncStatus(ctx)
+			require.NoError(t, err, "Failed to get sync status")
+			superRoot, err := client.SuperRootAtTimestamp(ctx, hexutil.Uint64(status.SafeTimestamp))
+			require.NoError(t, err, "Failed to get super root at safe timestamp")
+
+			// Stop the batcher so the safe head doesn't advance
+			for _, id := range sys.L2IDs() {
+				require.NoError(t, sys.Batcher(id).Stop(ctx))
+			}
+
+			// Create a dispute game with a proposal that is valid at `superRoot.Timestamp`, but that claims to correspond to timestamp
+			// `superRoot.Timestamp + 100000`. This is dishonest, because the superchain hasn't reached this timestamp yet.
+			game := disputeGameFactory.StartSuperCannonGameAtTimestamp(ctx, superRoot.Timestamp+100_000, common.Hash(superRoot.SuperRoot), disputegame.WithFutureProposal())
+
+			game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+			correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+				c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+			})
+
+			game.SupportClaim(ctx, game.RootClaim(ctx), func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+				if parent.IsBottomGameRoot(ctx) {
+					return correctTrace.AttackClaim(ctx, parent)
+				}
+				return test.strategy(correctTrace, parent)
+			},
+				func(parentIdx int64) {
+					t.Log("Calling step on challenger's claim...")
+					correctTrace.StepFails(ctx, parentIdx, false)
+					correctTrace.StepFails(ctx, parentIdx, true)
+				},
+			)
+			game.LogGameData(ctx)
+
+			// Time travel past when the game will be resolvable.
+			sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+
+			game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
+			game.LogGameData(ctx)
+		})
+	}
+}
+
+func TestSuperCannonHonestSafeTraceExtensionValidRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	client := sys.SupervisorClient()
+	// Wait for there to be there are safe L2 blocks past the claimed safe timestamp that have data available on L1 within
+	// the commitment stored in the dispute game.
+	status, err := client.SyncStatus(ctx)
+	require.NoError(t, err, "Failed to get sync status")
+	safeTimestamp := status.SafeTimestamp
+
+	disputeGameFactory.WaitForSuperTimestamp(safeTimestamp, new(disputegame.GameCfg))
+
+	game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, safeTimestamp-1)
+	require.NotNil(t, game)
+
+	// Create a correct trace actor with an honest trace extending to L2 block #5
+	// Notably, L2 block #5 is a valid block within the safe chain, and the data required to reproduce it
+	// will be committed to within the L1 head of the dispute game.
+	correctTracePlus1 := game.CreateHonestActor(ctx,
+		disputegame.WithPrivKey(malloryKey(t)),
+		disputegame.WithClaimedL2BlockNumber(safeTimestamp),
+		func(c *disputegame.HonestActorConfig) {
+			c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+		},
+	)
+
+	// Start the honest challenger. They will defend the root claim.
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+	root := game.RootClaim(ctx)
+	// Have to disagree with the root claim - we're trying to invalidate a valid output root
+	firstAttack := root.Attack(ctx, common.Hash{0xdd})
+	game.SupportClaim(ctx, firstAttack, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		return correctTracePlus1.CounterClaim(ctx, parent)
+	}, func(parentClaimIdx int64) {
+		t.Logf("Waiting for bottom claim %v to be countered", parentClaimIdx)
+		claim, err := game.Game.GetClaim(ctx, uint64(parentClaimIdx))
+		require.NoError(t, err)
+		require.Equal(t, game.MaxDepth(ctx), claim.Position.Depth())
+		game.WaitForCountered(ctx, parentClaimIdx)
+	})
+	game.LogGameData(ctx)
+
+	// Time travel past when the game will be resolvable.
+	sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusDefenderWon)
+}
+
+func TestSuperCannonHonestSafeTraceExtensionInvalidRoot(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
+	ctx := context.Background()
+
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(config.AllocTypeMTCannon))
+	client := sys.SupervisorClient()
+	// Wait for there to be there are safe L2 blocks past the claimed safe timestamp that have data available on L1 within
+	// the commitment stored in the dispute game.
+	status, err := client.SyncStatus(ctx)
+	require.NoError(t, err, "Failed to get sync status")
+	safeTimestamp := status.SafeTimestamp
+
+	disputeGameFactory.WaitForSuperTimestamp(safeTimestamp, new(disputegame.GameCfg))
+
+	game := disputeGameFactory.StartSuperCannonGameAtTimestamp(ctx, safeTimestamp-1, common.Hash{0xCA, 0xFE})
+	require.NotNil(t, game)
+
+	// Create a correct trace actor with an honest trace extending to safeTimestamp
+	correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+		c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+	})
+
+	// Create a correct trace actor with an honest trace extending to L2 block #5
+	// Notably, L2 block #5 is a valid block within the safe chain, and the data required to reproduce it
+	// will be committed to within the L1 head of the dispute game.
+	correctTracePlus1 := game.CreateHonestActor(ctx,
+		disputegame.WithPrivKey(malloryKey(t)),
+		disputegame.WithClaimedL2BlockNumber(safeTimestamp),
+		func(c *disputegame.HonestActorConfig) {
+			c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+		},
+	)
+
+	// Start the honest challenger. They will defend the root claim.
+	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+
+	claim := game.RootClaim(ctx)
+	game.SupportClaim(ctx, claim, func(parent *disputegame.ClaimHelper) *disputegame.ClaimHelper {
+		// Have to disagree with the root claim - we're trying to invalidate a valid output root
+		if parent.IsRootClaim() {
+			return parent.Attack(ctx, common.Hash{0xdd})
+		}
+		return correctTracePlus1.CounterClaim(ctx, parent)
+	}, func(parentClaimIdx int64) {
+		correctTrace.StepFails(ctx, parentClaimIdx, true)
+		correctTrace.StepFails(ctx, parentClaimIdx, false)
+		correctTracePlus1.StepFails(ctx, parentClaimIdx, true)
+		correctTracePlus1.StepFails(ctx, parentClaimIdx, false)
+	})
+	game.LogGameData(ctx)
+
+	// Time travel past when the game will be resolvable.
+	sys.AdvanceL1Time(game.MaxClockDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, sys.L1GethClient()))
+
+	game.WaitForGameStatus(ctx, gameTypes.GameStatusChallengerWon)
 }
 
 func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -364,7 +364,7 @@ func TestSuperInvalidateUnsafeProposal(t *testing.T) {
 
 			// Wait for any client to advance its unsafe head past the safe chain. We know this head will remain unsafe since the batc
 			l2Client := sys.L2GethClient(sys.L2IDs()[0], "sequencer")
-			wait.ForNextBlock(ctx, l2Client)
+			require.NoError(t, wait.ForNextBlock(ctx, l2Client))
 			head, err := l2Client.BlockByNumber(ctx, nil)
 			require.NoError(t, err, "Failed to get head block")
 			unsafeTimestamp := head.Time()


### PR DESCRIPTION
The remaining FDG e2e tests are migrated to the Super DG. This migration was mostly done by duplicating a lot of similar tests from the FDG tests. While it's possible to make these tests more generic to the DG type, as was done in previous PRs via the `gameArena`, doing so at the moment is more trouble than it's worth. So for simplicity I've directly ported the tests. In the future, we should aim to have a more common set of test implementations.

fixes https://github.com/ethereum-optimism/optimism/issues/14974
