### PR TITLE
Pin block number for operator fee NAT test expectation calculation

### DIFF
--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -201,11 +201,14 @@ func operatorFeeTestProcedure(t systest.T, sys system.System, l1FundingWallet sy
 
 	// Update operator fee parameters
 	logger.Info("Updating operator fee parameters",
-		"constant", tc.OperatorFeeConstant,
-		"scalar", tc.OperatorFeeScalar)
+		"operator_fee_constant", tc.OperatorFeeConstant,
+		"operator_fee_scalar", tc.OperatorFeeScalar,
+		"l1_base_fee_scalar", tc.L1BaseFeeScalar,
+		"l1_blob_base_fee_scalar", tc.L1BlobBaseFeeScalar,
+	)
 	err, reset := EnsureFeeParams(systemConfig, systemConfigProxyAddr, l2L1BlockContract, l1RollupOwnerWallet, tc)
 	require.NoError(t, err)
-	logger.Info("Fee parameters updated")
+	logger.Info("Ensure fee parameters updated")
 	defer func() {
 		logger.Info("Resetting fee parameters")
 		err := reset()
@@ -221,7 +224,6 @@ func operatorFeeTestProcedure(t systest.T, sys system.System, l1FundingWallet sy
 	logger.Debug("Initial balances", "balances", startBalances)
 
 	// Send the test transaction
-	logger.Info("Current base fee", "fee", l2PreTestHeader.BaseFee)
 	tx, receipt, err := SendValueTx(l2TestWallet1, l2TestWallet2.Address(), big.NewInt(1000))
 	require.NoError(t, err, "failed to send test transaction where it should succeed")
 


### PR DESCRIPTION
## Issue
CI tests for operator fees were failing due to timing inconsistencies:
- [Failing CI job](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/86781/workflows/842e21e1-5cff-4ae4-a87f-352d1d0acdc8/jobs/3428774)
- [Error logs](https://gist.github.com/sigma/c19554a9e827e8b0201881259a61a952)

The test failure showed:
```
L1FeeVault: expected 3038741235, got 3038758613 (diff: 17378)
WalletBalance: expected 999967164910135246, got 999967164910117868 (diff: -17378)
```

## Root Cause
Fee expectation calculations were using the latest block (nil blockNumber parameter) when calculating fees. If the node is slow to sync after transaction submission, the calculations might use different blocks between expectation calculation and verification.

## Solution
This PR pins the exact block number when calculating fee expectations by:
1. Adding blockNumber parameter to fee calculation functions
2. Creating a stateGetterAdapterFactory to produce adapters with specific block numbers
3. Ensuring all state queries for fee calculations use the same block reference

This ensures consistent fee calculations regardless of node sync speed.