### PR TITLE
op-e2e: e2eutils: fakebeacon fix superfluous header

### DIFF
--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -140,8 +140,6 @@ func (f *FakeBeacon) Start(addr string) error {
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			f.log.Error("version handler err", "err", err)
-		} else {
-			w.WriteHeader(http.StatusOK)
 		}
 	})
 	f.beaconSrv = &http.Server{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

From https://pkg.go.dev/net/http (checked go1.22),

```
	// If WriteHeader is not called explicitly, the first call to Write
	// will trigger an implicit WriteHeader(http.StatusOK).
	// Thus explicit calls to WriteHeader are mainly used to
	// send error codes or 1xx informational responses.
```

The original code did not, resulting in warnings like below:
```
INFO [04-10|18:23:50.135] http: superfluous response.WriteHeader call from github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon.(*FakeBeacon).Start.func4 (blobs.go:144)
```