### PR TITLE
op-batcher: Fix incorrect CLI flag name in log

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -168,7 +168,7 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 		l.wg.Add(1)
 		go l.throttlingLoop(l.wg, pendingBytesUpdated) // ranges over pendingBytesUpdated channel
 	} else {
-		l.Log.Warn("Throttling loop is DISABLED due to 0 throttle-interval. This should not be disabled in prod.")
+		l.Log.Warn("Throttling loop is DISABLED due to 0 throttle-threshold. This should not be disabled in prod.")
 	}
 
 	l.wg.Add(3)


### PR DESCRIPTION
**Description**

This PR fixes a mismatch between the CLI flag name shown in logs and the actual parameter name.
The logs currently refer to `throttle-interval`, but the correct CLI flag bound to the corresponding variable is `throttle-threshold`.

https://github.com/ethereum-optimism/optimism/blob/f4264b98709e96ed6b69726be2f3c78dd4979a43/op-batcher/flags/flags.go#L159-L164

