### PR TITLE
op-supervisor: error syncStatus when status tracker not ready

### DIFF
--- a/op-supervisor/supervisor/backend/status/status_test.go
+++ b/op-supervisor/supervisor/backend/status/status_test.go
@@ -13,10 +13,8 @@ import (
 func TestInitialSyncStatus(t *testing.T) {
 	chains := []eth.ChainID{eth.ChainIDFromUInt64(1), eth.ChainIDFromUInt64(2)}
 	tracker := NewStatusTracker(chains)
-	status, err := tracker.SyncStatus()
-	require.NoError(t, err)
-	require.Zero(t, status.MinSyncedL1)
-	require.Len(t, status.Chains, 2)
+	_, err := tracker.SyncStatus()
+	require.Error(t, ErrStatusTrackerNotReady, err)
 }
 
 func TestUpdateMinSyncedL1(t *testing.T) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

When op-supervisor restarts there is a timespan where all node's sync status is not fetched yet. At this time, when we call `supervisor_syncStatus` all the contents are zero. 

Error immediately until at least single node sync status is not empty.

**Tests**

Unit tests patched. If no node status is available, error!

**Additional context**

Drawback of this design is, even if some node sync status is not empty, its minSyncedL1 value may be still nil.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15104

