### PR TITLE
op-proposer: edge case when L1 view not updated

### DIFF
--- a/op-proposer/proposer/source/source_supervisor.go
+++ b/op-proposer/proposer/source/source_supervisor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+var ErrNilL1View = errors.New("every supervisor node L1 block view is nil")
+
 type SupervisorClient interface {
 	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
@@ -67,6 +69,10 @@ func (s *SupervisorProposalSource) SyncStatus(ctx context.Context) (SyncStatus, 
 			continue
 		}
 		if earliestResponse.MinSyncedL1 == (eth.L1BlockRef{}) || result.status.MinSyncedL1.Number < earliestResponse.MinSyncedL1.Number {
+			if result.status.MinSyncedL1 == (eth.L1BlockRef{}) {
+				errs = append(errs, ErrNilL1View)
+				continue
+			}
 			earliestResponse = result.status
 		}
 	}

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -75,6 +75,7 @@ func (su *StatusTracker) SyncStatus() (eth.SupervisorSyncStatus, error) {
 	for chainID, nodeStatus := range su.statuses {
 		// if the min synced L1 is not set, or the node's current L1 is lower than the min synced L1, set it
 		if supervisorStatus.MinSyncedL1 == (eth.L1BlockRef{}) || supervisorStatus.MinSyncedL1.Number > nodeStatus.CurrentL1.Number {
+			// even after this update, MinSyncedL1 may still be empty when CurrentL1 was never updated
 			supervisorStatus.MinSyncedL1 = nodeStatus.CurrentL1
 		}
 		// if the height is equal, we need to compare the hash


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Current interop op-proposer consumes multiple supervisor endpoints, queries the supervisors via supervisor_syncStatus and gather block views of each nodes connected by supervisor.

supervisor_syncStatus non-error response may include empty `MinSyncedL1` (`status.MinSyncedL1 == (eth.L1BlockRef{})`) and this is not properly error handled, resulting in error messages like

```
    driver.go:448:              [33mWARN [0m[04-10|22:57:23.942] Error getting proposal                   [33mid[0m=L2Proposer-main-902 [33merr[0m="could not fetch current block number: getting sync status: no available sync status sources: %!w(<nil>)"
```

Before this patch,

https://github.com/ethereum-optimism/optimism/blob/0bbfcb8494d5568d91980041c1e3e25b17ec59cb/op-proposer/proposer/source/source_supervisor.go#L79-L81 

wrapped no errors since no error was thrown in the edge case of
- supervisor responded syncStatus API with no error...
- but its `MinSyncedL1 `(L1View) is empty.

**Tests**

Unit tests added.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15341
