### PR TITLE
feat(kt-devnet): make use of reverse proxy

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -2,6 +2,7 @@ package descriptors
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -12,6 +13,8 @@ type PortInfo struct {
 	Scheme      string `json:"scheme,omitempty"`
 	Port        int    `json:"port,omitempty"`
 	PrivatePort int    `json:"private_port,omitempty"`
+
+	ReverseProxyHeader http.Header `json:"reverse_proxy_header,omitempty"`
 }
 
 // EndpointMap is a map of service names to their endpoints.
@@ -63,9 +66,12 @@ type WalletMap map[string]Wallet
 
 // DevnetEnvironment exposes the relevant information to interact with a devnet.
 type DevnetEnvironment struct {
-	Name string     `json:"name"`
-	L1   *Chain     `json:"l1"`
-	L2   []*L2Chain `json:"l2"`
+	Name string `json:"name"`
+
+	ReverseProxyURL string `json:"reverse_proxy_url,omitempty"`
+
+	L1 *Chain     `json:"l1"`
+	L2 []*L2Chain `json:"l2"`
 
 	Features []string        `json:"features,omitempty"`
 	DepSet   json.RawMessage `json:"dep_set,omitempty"`

--- a/devnet-sdk/devstack/sysext/helpers.go
+++ b/devnet-sdk/devstack/sysext/helpers.go
@@ -3,9 +3,11 @@ package sysext
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"net/http"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
@@ -23,31 +25,90 @@ const (
 	FeatureInterop = "interop"
 )
 
-func (orch *Orchestrator) rpcClient(t devtest.T, endpoint string) client.RPC {
+func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, protocol string) client.RPC {
+	t.Helper()
+
+	endpoint, header, err := orch.findProtocolService(service, protocol)
+	t.Require().NoError(err)
+
 	opts := []client.RPCOption{}
 	if !orch.useEagerRPCClients {
 		opts = append(opts, client.WithLazyDial())
 	}
+
+	if orch.env.ReverseProxyURL != "" && !orch.useDirectCnx {
+		opts = append(
+			opts,
+			client.WithGethRPCOptions(
+				rpc.WithHeaders(header),
+				// we need both Header["Host"] and req.Host to be set
+				rpc.WithHTTPClient(&http.Client{
+					Transport: hostAwareRoundTripper(header),
+				}),
+			),
+		)
+	}
+
 	cl, err := client.NewRPC(t.Ctx(), t.Logger(), endpoint, opts...)
 	t.Require().NoError(err)
 	t.Cleanup(cl.Close)
 	return cl
 }
 
-func (orch *Orchestrator) findProtocolService(service *descriptors.Service, protocol string) (string, error) {
+func (orch *Orchestrator) httpClient(t devtest.T, service *descriptors.Service, protocol string) *client.BasicHTTPClient {
+	t.Helper()
+
+	endpoint, header, err := orch.findProtocolService(service, protocol)
+	t.Require().NoError(err)
+
+	opts := []client.BasicHTTPClientOption{}
+
+	if orch.env.ReverseProxyURL != "" && !orch.useDirectCnx {
+		opts = append(
+			opts,
+			client.WithHeader(header),
+			client.WithTransport(hostAwareRoundTripper(header)),
+		)
+	}
+
+	return client.NewBasicHTTPClient(endpoint, t.Logger(), opts...)
+}
+
+func (orch *Orchestrator) findProtocolService(service *descriptors.Service, protocol string) (string, http.Header, error) {
 	for proto, endpoint := range service.Endpoints {
 		if proto == protocol {
+			if orch.env.ReverseProxyURL != "" && !orch.useDirectCnx {
+				return orch.env.ReverseProxyURL, endpoint.ReverseProxyHeader, nil
+			}
+
 			port := endpoint.Port
 			if orch.usePrivatePorts {
 				port = endpoint.PrivatePort
 			}
-			return fmt.Sprintf("http://%s:%d", endpoint.Host, port), nil
+			return fmt.Sprintf("http://%s:%d", endpoint.Host, port), nil, nil
 		}
 	}
-	return "", fmt.Errorf("protocol %s not found", protocol)
+	return "", nil, fmt.Errorf("protocol %s not found", protocol)
 }
 
 func decodePrivateKey(key string) (*ecdsa.PrivateKey, error) {
 	b := common.FromHex(key)
 	return crypto.ToECDSA(b)
+}
+
+type hostSettingRoundTripper struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (h *hostSettingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Host = h.host
+	return h.rt.RoundTrip(req)
+}
+
+func hostAwareRoundTripper(header http.Header) http.RoundTripper {
+	return &hostSettingRoundTripper{
+		host: header.Get("Host"),
+		rt:   http.DefaultTransport,
+	}
 }

--- a/devnet-sdk/devstack/sysext/l2.go
+++ b/devnet-sdk/devstack/sysext/l2.go
@@ -74,9 +74,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 
 	elService, ok := node.Services[ELServiceName]
 	require.True(ok, "need L2 EL service for chain", l2ID)
-	elRPC, err := o.findProtocolService(&elService, RPCProtocol)
-	require.NoError(err)
-	elClient := o.rpcClient(l2Net.T(), elRPC)
+	elClient := o.rpcClient(l2Net.T(), &elService, RPCProtocol)
 	l2Net.AddL2ELNode(shim.NewL2ELNode(shim.L2ELNodeConfig{
 		ELNodeConfig: shim.ELNodeConfig{
 			CommonConfig: shim.NewCommonConfig(l2Net.T()),
@@ -93,9 +91,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 	require.True(ok, "need L2 CL service for chain", l2ID)
 
 	// it's an RPC, but 'http' in kurtosis descriptor
-	clRPC, err := o.findProtocolService(&clService, HTTPProtocol)
-	require.NoError(err)
-	clClient := o.rpcClient(l2Net.T(), clRPC)
+	clClient := o.rpcClient(l2Net.T(), &clService, HTTPProtocol)
 	l2Net.AddL2CLNode(shim.NewL2CLNode(shim.L2CLNodeConfig{
 		ID: stack.L2CLNodeID{
 			Key:     clService.Name,
@@ -117,16 +113,13 @@ func (o *Orchestrator) hydrateBatcherMaybe(net *descriptors.L2Chain, l2Net stack
 		return
 	}
 
-	batcherRPC, err := o.findProtocolService(&batcherService, HTTPProtocol)
-	require.NoError(err)
-
 	l2Net.AddL2Batcher(shim.NewL2Batcher(shim.L2BatcherConfig{
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),
 		ID: stack.L2BatcherID{
 			Key:     batcherService.Name,
 			ChainID: l2ID.ChainID(),
 		},
-		Client: o.rpcClient(l2Net.T(), batcherRPC),
+		Client: o.rpcClient(l2Net.T(), &batcherService, HTTPProtocol),
 	}))
 }
 
@@ -141,17 +134,13 @@ func (o *Orchestrator) hydrateProposerMaybe(net *descriptors.L2Chain, l2Net stac
 		return
 	}
 
-	// it's an RPC, but 'http' in kurtosis descriptor
-	proposerRPC, err := o.findProtocolService(&proposerService, HTTPProtocol)
-	require.NoError(err)
-
 	l2Net.AddL2Proposer(shim.NewL2Proposer(shim.L2ProposerConfig{
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),
 		ID: stack.L2ProposerID{
 			Key:     proposerService.Name,
 			ChainID: l2ID.ChainID(),
 		},
-		Client: o.rpcClient(l2Net.T(), proposerRPC),
+		Client: o.rpcClient(l2Net.T(), &proposerService, HTTPProtocol),
 	}))
 }
 

--- a/devnet-sdk/devstack/sysext/orchestrator.go
+++ b/devnet-sdk/devstack/sysext/orchestrator.go
@@ -22,6 +22,7 @@ type Orchestrator struct {
 	useEagerRPCClients bool
 
 	controlPlane *ControlPlane
+	useDirectCnx bool
 }
 
 var _ stack.Orchestrator = (*Orchestrator)(nil)
@@ -38,7 +39,9 @@ func NewOrchestrator(p devtest.P) *Orchestrator {
 	}
 	env, err := env.LoadDevnetFromURL(url)
 	p.Require().NoError(err, "Error loading devnet environment")
-	return &Orchestrator{env: &env.Config, p: p}
+	orch := &Orchestrator{env: &env.Config, p: p}
+
+	return orch
 }
 
 func (o *Orchestrator) P() devtest.P {
@@ -79,5 +82,11 @@ func WithPrivatePorts() OrchestratorOption {
 func WithEagerRPCClients() OrchestratorOption {
 	return func(orchestrator *Orchestrator) {
 		orchestrator.useEagerRPCClients = true
+	}
+}
+
+func WithDirectConnections() OrchestratorOption {
+	return func(orchestrator *Orchestrator) {
+		orchestrator.useDirectCnx = true
 	}
 }

--- a/devnet-sdk/devstack/sysext/system.go
+++ b/devnet-sdk/devstack/sysext/system.go
@@ -42,8 +42,6 @@ func (o *Orchestrator) hydrateSupervisorMaybe(sys stack.ExtensibleSystem) {
 		return
 	}
 
-	require := sys.T().Require()
-
 	// hack, supervisor is part of the first L2
 	supervisorService, ok := o.env.L2[0].Services["supervisor"]
 	if !ok {
@@ -53,12 +51,9 @@ func (o *Orchestrator) hydrateSupervisorMaybe(sys stack.ExtensibleSystem) {
 
 	// ideally we should check supervisor is consistent across all L2s
 	// but that's what Kurtosis does.
-	supervisorRPC, err := o.findProtocolService(&supervisorService, RPCProtocol)
-	require.NoError(err)
-	supervisorClient := o.rpcClient(sys.T(), supervisorRPC)
 	sys.AddSupervisor(shim.NewSupervisor(shim.SupervisorConfig{
 		CommonConfig: shim.NewCommonConfig(sys.T()),
 		ID:           stack.SupervisorID(supervisorService.Name),
-		Client:       supervisorClient,
+		Client:       o.rpcClient(sys.T(), &supervisorService, RPCProtocol),
 	}))
 }

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -20,6 +20,9 @@ import (
 const (
 	DefaultPackageName = "github.com/ethpandaops/optimism-package"
 	DefaultEnclave     = "devnet"
+
+	// static URL for kurtosis reverse proxy
+	defaultKurtosisReverseProxyURL = "http://127.0.0.1:9730"
 )
 
 // KurtosisEnvironment represents the output of a Kurtosis deployment
@@ -182,6 +185,8 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 
 	env := &KurtosisEnvironment{
 		DevnetEnvironment: descriptors.DevnetEnvironment{
+			ReverseProxyURL: defaultKurtosisReverseProxyURL,
+
 			L2:       make([]*descriptors.L2Chain, 0, len(s.Chains)),
 			Features: s.Features,
 			DepSet:   depsetData,

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -314,6 +314,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 			jwt: testJWTs,
 			want: &KurtosisEnvironment{
 				DevnetEnvironment: descriptors.DevnetEnvironment{
+					ReverseProxyURL: defaultKurtosisReverseProxyURL,
 					L1: &descriptors.Chain{
 						ID:       "1234",
 						Name:     "Ethereum",
@@ -393,6 +394,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 			jwt: testJWTs,
 			want: &KurtosisEnvironment{
 				DevnetEnvironment: descriptors.DevnetEnvironment{
+					ReverseProxyURL: defaultKurtosisReverseProxyURL,
 					L1: &descriptors.Chain{
 						ID:       "1234",
 						Name:     "Ethereum",
@@ -452,6 +454,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 			jwt: testJWTs,
 			want: &KurtosisEnvironment{
 				DevnetEnvironment: descriptors.DevnetEnvironment{
+					ReverseProxyURL: defaultKurtosisReverseProxyURL,
 					L1: &descriptors.Chain{
 						ID:       "1234",
 						Name:     "Ethereum",

--- a/op-service/client/http.go
+++ b/op-service/client/http.go
@@ -59,6 +59,12 @@ func WithHeader(h http.Header) BasicHTTPClientOption {
 	})
 }
 
+func WithTransport(t http.RoundTripper) BasicHTTPClientOption {
+	return BasicHTTPClientOptionFn(func(c *BasicHTTPClient) {
+		c.client.Transport = t
+	})
+}
+
 var ErrNoEndpoint = errors.New("no endpoint is configured")
 
 func (cl *BasicHTTPClient) Get(ctx context.Context, p string, query url.Values, headers http.Header) (*http.Response, error) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This change does a few things:

Add (optional) reverse proxy information into the devnet descriptor.
This is meant to allow service access through that reverse proxy.

Then in the case of kurtosis we make use of the builtin global
reverse-proxy, that routes services through traefik Host annotations.

Finally, the devstack backend is adjusted to make use of the
reverse-proxy information if provided (and not opted out of) 

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
manually tested with devstack/example/... against the syskt backend.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Part of #15270
