### PR TITLE
feat(kt-devnet): add basic control surface

### DIFF
--- a/devnet-sdk/controller/kt/kt.go
+++ b/devnet-sdk/controller/kt/kt.go
@@ -1,0 +1,52 @@
+package kt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/controller/surface"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/run"
+)
+
+type KurtosisControllerSurface struct {
+	runner *run.KurtosisRunner
+}
+
+func NewKurtosisControllerSurface(enclave string) (*KurtosisControllerSurface, error) {
+	runner, err := run.NewKurtosisRunner(run.WithKurtosisRunnerEnclave(enclave))
+	if err != nil {
+		return nil, err
+	}
+	return &KurtosisControllerSurface{
+		runner: runner,
+	}, nil
+}
+
+func (s *KurtosisControllerSurface) StartService(ctx context.Context, serviceName string) error {
+	script := fmt.Sprintf(`
+def run(plan):
+	plan.start_service(name="%s")
+`, serviceName)
+	// start_service is not idempotent, and doesn't return a typed error,
+	// so we need to check the error message
+	if err := s.runner.RunScript(ctx, script); err != nil {
+		msg := err.Error()
+		if strings.Contains(strings.ToLower(msg), "is already in use by container") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *KurtosisControllerSurface) StopService(ctx context.Context, serviceName string) error {
+	script := fmt.Sprintf(`
+def run(plan):
+	plan.stop_service(name="%s")
+`, serviceName)
+	// stop_service is idempotent
+	return s.runner.RunScript(ctx, script)
+}
+
+var _ surface.ServiceLifecycleSurface = (*KurtosisControllerSurface)(nil)

--- a/devnet-sdk/controller/kt/kt_test.go
+++ b/devnet-sdk/controller/kt/kt_test.go
@@ -1,0 +1,99 @@
+package kt
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/fake"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/run"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKurtosisControllerSurface(t *testing.T) {
+	ctx := context.Background()
+	testErr := errors.New("test error")
+
+	tests := []struct {
+		name        string
+		serviceName string
+		operation   string // "start" or "stop"
+		runErr      error
+		wantErr     bool
+	}{
+		{
+			name:        "successful service start",
+			serviceName: "test-service",
+			operation:   "start",
+			runErr:      nil,
+			wantErr:     false,
+		},
+		{
+			name:        "service already running",
+			serviceName: "test-service",
+			operation:   "start",
+			runErr:      errors.New("is already in use by container"),
+			wantErr:     false,
+		},
+		{
+			name:        "error starting service",
+			serviceName: "test-service",
+			operation:   "start",
+			runErr:      testErr,
+			wantErr:     true,
+		},
+		{
+			name:        "successful service stop",
+			serviceName: "test-service",
+			operation:   "stop",
+			runErr:      nil,
+			wantErr:     false,
+		},
+		{
+			name:        "error stopping service",
+			serviceName: "test-service",
+			operation:   "stop",
+			runErr:      testErr,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake Kurtosis context that will return our test error
+			fakeCtx := &fake.KurtosisContext{
+				EnclaveCtx: &fake.EnclaveContext{
+					RunErr: tt.runErr,
+				},
+			}
+
+			// Create a KurtosisRunner with our fake context
+			runner, err := run.NewKurtosisRunner(
+				run.WithKurtosisRunnerEnclave("test-enclave"),
+				run.WithKurtosisRunnerKurtosisContext(fakeCtx),
+			)
+			require.NoError(t, err)
+
+			// Create the controller surface
+			surface := &KurtosisControllerSurface{
+				runner: runner,
+			}
+
+			switch tt.operation {
+			case "start":
+				err = surface.StartService(ctx, tt.serviceName)
+			case "stop":
+				err = surface.StopService(ctx, tt.serviceName)
+			default:
+				t.Fatalf("unknown operation: %s", tt.operation)
+			}
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/devnet-sdk/controller/surface/surface.go
+++ b/devnet-sdk/controller/surface/surface.go
@@ -1,0 +1,11 @@
+package surface
+
+import "context"
+
+type ControlSurface interface {
+}
+
+type ServiceLifecycleSurface interface {
+	StartService(context.Context, string) error
+	StopService(context.Context, string) error
+}

--- a/devnet-sdk/shell/cmd/ctrl/main.go
+++ b/devnet-sdk/shell/cmd/ctrl/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/controller/surface"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
+	"github.com/urfave/cli/v2"
+)
+
+func run(ctx *cli.Context) error {
+	devnetURL := ctx.String("devnet")
+	action := ctx.String("action")
+	service := ctx.String("service")
+
+	devnetEnv, err := env.LoadDevnetFromURL(devnetURL)
+	if err != nil {
+		return err
+	}
+
+	ctrl, err := devnetEnv.Control()
+	if err != nil {
+		return err
+	}
+
+	lc, ok := ctrl.(surface.ServiceLifecycleSurface)
+	if !ok {
+		return fmt.Errorf("control surface does not support lifecycle management")
+	}
+
+	switch action {
+	case "start":
+		return lc.StartService(ctx.Context, service)
+	case "stop":
+		return lc.StopService(ctx.Context, service)
+	default:
+		return fmt.Errorf("invalid action: %s", action)
+	}
+}
+
+func main() {
+	app := &cli.App{
+		Name:  "ctrl",
+		Usage: "Control devnet services",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "devnet",
+				Usage:    "URL to devnet JSON file",
+				EnvVars:  []string{env.EnvURLVar},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "action",
+				Usage:    "Action to perform (start or stop)",
+				Required: true,
+				Value:    "",
+				Action: func(ctx *cli.Context, v string) error {
+					if v != "start" && v != "stop" {
+						return fmt.Errorf("action must be either 'start' or 'stop'")
+					}
+					return nil
+				},
+			},
+			&cli.StringFlag{
+				Name:     "service",
+				Usage:    "Service to perform action on",
+				Required: true,
+			},
+		},
+		Action: run,
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/kurtosis-devnet/pkg/kurtosis/api/fake/fake.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/fake/fake.go
@@ -50,6 +50,10 @@ func (f *EnclaveContext) RunStarlarkPackage(ctx context.Context, pkg string, par
 	return ch, "", nil
 }
 
+func (f *EnclaveContext) RunStarlarkScript(ctx context.Context, script string, params *starlark_run_config.StarlarkRunConfig) error {
+	return f.RunErr
+}
+
 // StarlarkResponse implements interfaces.StarlarkResponse for testing
 type StarlarkResponse struct {
 	Err          interfaces.StarlarkError

--- a/kurtosis-devnet/pkg/kurtosis/api/interfaces/iface.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/interfaces/iface.go
@@ -49,6 +49,7 @@ type StarlarkResponse interface {
 
 type EnclaveContext interface {
 	RunStarlarkPackage(context.Context, string, *starlark_run_config.StarlarkRunConfig) (<-chan StarlarkResponse, string, error)
+	RunStarlarkScript(context.Context, string, *starlark_run_config.StarlarkRunConfig) error
 }
 
 type KurtosisContextInterface interface {

--- a/kurtosis-devnet/pkg/kurtosis/api/run/kurtosis_run.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/run/kurtosis_run.go
@@ -90,7 +90,7 @@ func (r *KurtosisRunner) Run(ctx context.Context, packageName string, args io.Re
 	}
 
 	// Set up run config with args if provided
-	var serializedParams string
+	serializedParams := "{}"
 	if args != nil {
 		argsBytes, err := io.ReadAll(args)
 		if err != nil {
@@ -127,5 +127,21 @@ func (r *KurtosisRunner) Run(ctx context.Context, packageName string, args io.Re
 	}
 
 	return nil
+}
 
+func (r *KurtosisRunner) RunScript(ctx context.Context, script string) error {
+	if r.dryRun {
+		fmt.Printf("Dry run mode enabled, would run following script in enclave %s\n%s\n",
+			r.enclave, script)
+		return nil
+	}
+
+	enclaveCtx, err := r.kurtosisCtx.GetEnclave(ctx, r.enclave)
+	if err != nil {
+		return fmt.Errorf("failed to get enclave: %w", err)
+	}
+
+	return enclaveCtx.RunStarlarkScript(ctx, script, &starlark_run_config.StarlarkRunConfig{
+		SerializedParams: "{}",
+	})
 }

--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
@@ -93,6 +93,12 @@ func (w *EnclaveContextWrapper) RunStarlarkPackage(ctx context.Context, pkg stri
 	return wrappedStream, "", nil
 }
 
+func (w *EnclaveContextWrapper) RunStarlarkScript(ctx context.Context, script string, serializedParams *starlark_run_config.StarlarkRunConfig) error {
+	// TODO: we should probably collect some data from the result and extend the error.
+	_, err := w.EnclaveContext.RunStarlarkScriptBlocking(ctx, script, serializedParams)
+	return err
+}
+
 func (w *starlarkRunResponseLineWrapper) GetError() interfaces.StarlarkError {
 	if err := w.StarlarkRunResponseLine.GetError(); err != nil {
 		return &starlarkErrorWrapper{err}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This change adds the basic ability to start/stop services through
devnet-sdk, if provided by the underlying backend.

These lifecycle operations are idempotent.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- part of #15270
