### PR TITLE
op-service,devstack: cleanup apis pkg usage

### DIFF
--- a/devnet-sdk/devstack/shim/l2_cl.go
+++ b/devnet-sdk/devstack/shim/l2_cl.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
@@ -16,7 +17,7 @@ type rpcL2CLNode struct {
 	commonImpl
 	id           stack.L2CLNodeID
 	client       client.RPC
-	rollupClient stack.RollupAPI
+	rollupClient apis.RollupClient
 }
 
 var _ stack.L2CLNode = (*rpcL2CLNode)(nil)
@@ -35,6 +36,6 @@ func (r *rpcL2CLNode) ID() stack.L2CLNodeID {
 	return r.id
 }
 
-func (r *rpcL2CLNode) RollupAPI() stack.RollupAPI {
+func (r *rpcL2CLNode) RollupAPI() apis.RollupClient {
 	return r.rollupClient
 }

--- a/devnet-sdk/devstack/stack/l2_cl.go
+++ b/devnet-sdk/devstack/stack/l2_cl.go
@@ -1,9 +1,7 @@
 package stack
 
 import (
-	"context"
-
-	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 )
 
 // L2CLNodeID identifies a L2CLNode by name and chainID, is type-safe, and can be value-copied and used as map key.
@@ -29,14 +27,10 @@ func SortL2CLNodeIDs(ids []L2CLNodeID) []L2CLNodeID {
 	})
 }
 
-type RollupAPI interface {
-	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
-}
-
 // L2CLNode is a L2 ethereum consensus-layer node
 type L2CLNode interface {
 	Common
 	ID() L2CLNodeID
 
-	RollupAPI() RollupAPI
+	RollupAPI() apis.RollupClient
 }

--- a/op-service/apis/doc.go
+++ b/op-service/apis/doc.go
@@ -1,7 +1,5 @@
-package apis
-
 /*
-Apis is a package that provides Go interfaces for most RPC / HTTP APIs used in the OP-Stack.
+Package apis provides Go interfaces for most RPC / HTTP APIs used in the OP-Stack.
 
 Every interface name ending with "Client" represents a client-binding:
 this provides typing and methods exclusive to the client-side.
@@ -25,3 +23,4 @@ always prefer to consume the smaller fitting interface, to increase compatibilit
 Extension-interfaces, as popularized in the Golang FS design, may also be used on clients,
 to expand scope only when necessary, and maintain simple defaults.
 */
+package apis

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -17,7 +17,7 @@ type RollupClient struct {
 	rpc client.RPC
 }
 
-var _ apis.RollupNodeClient = (*RollupClient)(nil)
+var _ apis.RollupClient = (*RollupClient)(nil)
 
 func NewRollupClient(rpc client.RPC) *RollupClient {
 	return &RollupClient{rpc}
@@ -85,6 +85,10 @@ func (r *RollupClient) ConductorEnabled(ctx context.Context) (bool, error) {
 
 func (r *RollupClient) SetLogLevel(ctx context.Context, lvl slog.Level) error {
 	return r.rpc.CallContext(ctx, nil, "admin_setLogLevel", lvl.String())
+}
+
+func (r *RollupClient) SetRecoverMode(ctx context.Context, mode bool) error {
+	return r.rpc.CallContext(ctx, nil, "admin_setRecoverMode", mode)
 }
 
 func (r *RollupClient) Close() {


### PR DESCRIPTION
**Description**

Quick PR to cleanup some small apis related things:
- make rollup-client implement the full rollup-client interface (= combined node + admin client interfaces)
- use rollup-client interface in devstack
- Fix apis package go doc declaration

