### PR TITLE
go: Prepare Isthmus Mainnet release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.3-rc.1
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.4-rc.1
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101503.3-rc.1 h1:3nr+L/fSURVBA5XlJhiQ8fWHcv+u9JJCtsevar2v6vs=
-github.com/ethereum-optimism/op-geth v1.101503.3-rc.1/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
+github.com/ethereum-optimism/op-geth v1.101503.4-rc.1 h1:ddcoFOmABL7bwz6b0pllSE4Org9iFTwMN6r1G6NRy3w=
+github.com/ethereum-optimism/op-geth v1.101503.4-rc.1/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/op-node/chaincfg/chains_test.go
+++ b/op-node/chaincfg/chains_test.go
@@ -76,6 +76,7 @@ var mainnetCfg = rollup.Config{
 	FjordTime:               u64Ptr(1720627201),
 	GraniteTime:             u64Ptr(1726070401),
 	HoloceneTime:            u64Ptr(1736445601),
+	IsthmusTime:             u64Ptr(1746806401),
 	ProtocolVersionsAddress: common.HexToAddress("0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935"),
 	ChainOpConfig:           defaultOpConfig,
 }


### PR DESCRIPTION
By updating op-geth to v1.101503.4-rc.1, which pulls in superchain-registry@4791054602a56a72705ac7ecd601433c9c955791

Towards https://github.com/ethereum-optimism/release-management/issues/178