### PR TITLE
op-node: report unsafe payloads queue status

### DIFF
--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -107,6 +107,8 @@ func (eq *CLSync) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 	eq.log.Debug("CL sync received forkchoice update",
 		"unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
 
+	eq.reportUnsafePayloadsQueueStatus(x)
+
 	for {
 		pop, abort := eq.fromQueue(x)
 		if abort {
@@ -124,6 +126,33 @@ func (eq *CLSync) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 	// We don't pop from the queue. If there is a temporary error then we can retry.
 	// Upon next forkchoice update or invalid-payload event we can remove it from the queue.
 	eq.emitter.Emit(engine.ProcessUnsafePayloadEvent{Envelope: firstEnvelope})
+}
+
+// reportUnsafePayloadsQueueStatus emits log event about unsafe payload queue status.
+func (eq *CLSync) reportUnsafePayloadsQueueStatus(x engine.ForkchoiceUpdateEvent) {
+	minBlockQueued := eq.unsafePayloads.Peek()
+	maxBlockQueued := eq.unsafePayloads.Max()
+	len := uint64(eq.unsafePayloads.Len())
+
+	if minBlockQueued == nil || maxBlockQueued == nil {
+		return
+	}
+
+	missingBlocks := func() uint64 {
+		latest := uint64(maxBlockQueued.ExecutionPayload.BlockNumber)
+
+		if latest == x.UnsafeL2Head.Number || len < 2 {
+			return 0
+		}
+
+		return latest - x.UnsafeL2Head.Number - len - 1
+	}
+
+	eq.log.Info("CL sync unsafe payloads queue status",
+		"unsafe", x.UnsafeL2Head.Number,
+		"min", uint64(minBlockQueued.ExecutionPayload.BlockNumber), "max", uint64(maxBlockQueued.ExecutionPayload.BlockNumber), "len", len,
+		"missing", missingBlocks(),
+	)
 }
 
 // fromQueue determines what to do with the tip of the payloads-queue, given the forkchoice pre-state.

--- a/op-node/rollup/clsync/payloads_queue.go
+++ b/op-node/rollup/clsync/payloads_queue.go
@@ -1,9 +1,11 @@
 package clsync
 
 import (
+	"cmp"
 	"container/heap"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -143,6 +145,20 @@ func (upq *PayloadsQueue) Peek() *eth.ExecutionPayloadEnvelope {
 	// peek into the priority queue, the first element is the highest priority (lowest block number).
 	// This does not apply to other elements, those are structured like a heap.
 	return upq.pq[0].envelope
+}
+
+// Max retrieves the payload with the highest block number from the queue, or nil if the queue is empty.
+func (upq *PayloadsQueue) Max() *eth.ExecutionPayloadEnvelope {
+	if len(upq.pq) == 0 {
+		return nil
+	}
+
+	payload := slices.MaxFunc(upq.pq,
+		func(a, b payloadAndSize) int {
+			return cmp.Compare(uint64(a.envelope.ExecutionPayload.BlockNumber), uint64(b.envelope.ExecutionPayload.BlockNumber))
+		})
+
+	return payload.envelope
 }
 
 // Pop removes the payload with the lowest block number from the queue in O(log(N)),

--- a/op-node/rollup/clsync/payloads_queue_test.go
+++ b/op-node/rollup/clsync/payloads_queue_test.go
@@ -87,6 +87,7 @@ func TestPayloadsQueue(t *testing.T) {
 	require.Equal(t, 0, pq.Len())
 	require.Nil(t, pq.Peek())
 	require.Nil(t, pq.Pop())
+	require.Nil(t, pq.Max())
 
 	a := envelope(&eth.ExecutionPayload{BlockNumber: 3, BlockHash: common.Hash{3}})
 	b := envelope(&eth.ExecutionPayload{BlockNumber: 4, BlockHash: common.Hash{4}})
@@ -98,6 +99,7 @@ func TestPayloadsQueue(t *testing.T) {
 	require.NoError(t, pq.Push(b))
 	require.Equal(t, pq.Len(), 1)
 	require.Equal(t, pq.Peek(), b)
+	require.Equal(t, pq.Max(), b)
 
 	require.Error(t, pq.Push(nil), "cannot add nil payloads")
 
@@ -105,16 +107,19 @@ func TestPayloadsQueue(t *testing.T) {
 	require.Equal(t, pq.Len(), 2)
 	require.Equal(t, pq.MemSize(), 2*payloadMemFixedCost)
 	require.Equal(t, pq.Peek(), b, "expecting b to still be the lowest number payload")
+	require.Equal(t, pq.Max(), c)
 
 	require.NoError(t, pq.Push(a))
 	require.Equal(t, pq.Len(), 3)
 	require.Equal(t, pq.MemSize(), 3*payloadMemFixedCost)
 	require.Equal(t, pq.Peek(), a, "expecting a to be new lowest number")
+	require.Equal(t, pq.Max(), c)
 
 	require.Equal(t, pq.Pop(), a)
 	require.Equal(t, pq.Len(), 2, "expecting to pop the lowest")
 
 	require.Equal(t, pq.Peek(), b, "expecting b to be lowest, compared to c")
+	require.Equal(t, pq.Max(), c)
 
 	require.Equal(t, pq.Pop(), b)
 	require.Equal(t, pq.Len(), 1)
@@ -129,12 +134,15 @@ func TestPayloadsQueue(t *testing.T) {
 	require.NoError(t, pq.Push(b))
 	require.Equal(t, pq.Len(), 1, "expecting b")
 	require.Equal(t, pq.Peek(), b)
+	require.Equal(t, pq.Max(), b)
 	require.NoError(t, pq.Push(c))
 	require.Equal(t, pq.Len(), 2, "expecting b, c")
 	require.Equal(t, pq.Peek(), b)
+	require.Equal(t, pq.Max(), c)
 	require.NoError(t, pq.Push(a))
 	require.Equal(t, pq.Len(), 3, "expecting a, b, c")
 	require.Equal(t, pq.Peek(), a)
+	require.Equal(t, pq.Max(), c)
 
 	// No duplicates allowed
 	require.Error(t, pq.Push(bDup))
@@ -144,5 +152,6 @@ func TestPayloadsQueue(t *testing.T) {
 	require.NoError(t, pq.Push(d))
 	require.Equal(t, pq.Len(), 3)
 	require.Equal(t, pq.Peek(), b, "expecting b, c, d")
+	require.Equal(t, pq.Max(), d)
 	require.NotContainsf(t, pq.pq[:], a, "a should be dropped after 3 items already exist under max size constraint")
 }


### PR DESCRIPTION


<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The unsafe payloads queue status may deliver a value when you notice that clsync is stuck and unsafel2head is not progressing. Think of it as additional context. We have experienced it a few times at @conduitxyz. Unfortunately, we cannot reproduce it yet, and it happens very rarely.

**Tests**

Test for `Max()` to verify if it returns the highest block number from the unsafe payload queue.
