### PR TITLE
op-program: Use cannon release for reprod builds

### DIFF
--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -14,8 +14,13 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 COPY . /app
 
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0 AS cannon-released
+
 # we need a separate stage for src so we can build a service provides prestates for unnanounced chains
 FROM src AS builder
+
+COPY --from=cannon-released /usr/local/bin/cannon /app/cannon/bin/cannon-released
+
 # We avoid copying the full .git dir into the build for just some metadata.
 # Instead, specify:
 # --build-arg GIT_COMMIT=$(git rev-parse HEAD)

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 COPY . /app
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.4.0 AS cannon-released
+FROM --platform=$BUILDPLATFORM ghcr.io/ethereum-optimism/optimism/cannon:v1.4.0 AS cannon-released
 
 # we need a separate stage for src so we can build a service provides prestates for unnanounced chains
 FROM src AS builder

--- a/op-program/repro.justfile
+++ b/op-program/repro.justfile
@@ -7,19 +7,6 @@ OP_PROGRAM_VERSION := "v0.0.0"
 GOOS := ""
 GOARCH := ""
 
-# Build the cannon binary
-cannon:
-    #!/bin/bash
-    # in devnet scenario, the cannon binary is already built.
-    [ -x /app/cannon/bin/cannon ] && exit 0
-    cd ../cannon
-    make cannon \
-        GOOS={{GOOS}} \
-        GOARCH={{GOARCH}} \
-        GITCOMMIT={{GIT_COMMIT}} \
-        GITDATE={{GIT_DATE}} \
-        VERSION={{CANNON_VERSION}}
-
 # Build the op-program-client elf binaries
 op-program-client-mips:
     #!/bin/bash
@@ -33,9 +20,9 @@ op-program-client-mips:
         VERSION={{OP_PROGRAM_VERSION}}
 
 # Run the op-program-client elf binary directly through cannon's load-elf subcommand.
-client TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: cannon op-program-client-mips
+client TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: op-program-client-mips
     #!/bin/bash
-    /app/cannon/bin/cannon load-elf \
+    /app/cannon/bin/cannon-released load-elf \
         --type {{TYPE}} \
         --path /app/op-program/bin/op-program-client{{CLIENT_SUFFIX}}.elf \
         --out /app/op-program/bin/prestate{{PRESTATE_SUFFIX}}.bin.gz \
@@ -44,7 +31,7 @@ client TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: cannon op-program-client-mips
 # Generate the prestate proof containing the absolute pre-state hash.
 prestate TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: (client TYPE CLIENT_SUFFIX PRESTATE_SUFFIX)
     #!/bin/bash
-    /app/cannon/bin/cannon run \
+    /app/cannon/bin/cannon-released run \
         --proof-at '=0' \
         --stop-at '=1' \
         --input /app/op-program/bin/prestate{{PRESTATE_SUFFIX}}.bin.gz \


### PR DESCRIPTION
Introducing new cannon state versions breaks the reproducible-prestate build. This is because the locally-built multicannon program is not aware of older state versions. We need to be able to continue cannon development without breaking the reproducible-prestate workflow.

To fix this, the reproducible-prestate build is updated to use a cannon release that supports all state versions. The `cannon/v1.4.0` docker image is used for this purpose. This makes local development a bit inconvenient as users have to login to GCP in order to build the prestates.