### PR TITLE
op-program: Cache executing messages in logs

### DIFF
--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -42,11 +42,6 @@ func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtyp
 	return execMsgs, curr, nil
 }
 
-type execMessageCacheKey struct {
-	blockHash common.Hash
-	chainID   eth.ChainID
-}
-
 type execMessageCacheEntry struct {
 	execMsgs map[uint32]*supervisortypes.ExecutingMessage
 	logCount uint32
@@ -57,7 +52,7 @@ type consolidateState struct {
 	replacedChains map[eth.ChainID]bool
 
 	// execMessageCache is used to memoize iteration of logs in blocks to speed up executing message retrieval
-	execMessageCache map[execMessageCacheKey]execMessageCacheEntry
+	execMessageCache map[common.Hash]execMessageCacheEntry
 }
 
 func newConsolidateState(transitionState *types.TransitionState) *consolidateState {
@@ -68,7 +63,7 @@ func newConsolidateState(transitionState *types.TransitionState) *consolidateSta
 			Step:            transitionState.Step,
 		},
 		replacedChains:   make(map[eth.ChainID]bool),
-		execMessageCache: make(map[execMessageCacheKey]execMessageCacheEntry),
+		execMessageCache: make(map[common.Hash]execMessageCacheEntry),
 	}
 	// We will be updating the transition state as blocks are replaced, so make a copy
 	copy(s.PendingProgress, transitionState.PendingProgress)
@@ -85,16 +80,16 @@ func (s *consolidateState) setReplaced(transitionStateIndex int, chainID eth.Cha
 	s.replacedChains[chainID] = true
 }
 
-func (s *consolidateState) getCachedExecMsgs(blockHash common.Hash, chainID eth.ChainID) (map[uint32]*supervisortypes.ExecutingMessage, uint32, bool) {
-	entry, ok := s.execMessageCache[execMessageCacheKey{blockHash: blockHash, chainID: chainID}]
+func (s *consolidateState) getCachedExecMsgs(blockHash common.Hash) (map[uint32]*supervisortypes.ExecutingMessage, uint32, bool) {
+	entry, ok := s.execMessageCache[blockHash]
 	if !ok {
 		return nil, 0, false
 	}
 	return entry.execMsgs, entry.logCount, true
 }
 
-func (s *consolidateState) setCachedExecMsgs(blockHash common.Hash, chainID eth.ChainID, execMsgs map[uint32]*supervisortypes.ExecutingMessage, logCount uint32) {
-	s.execMessageCache[execMessageCacheKey{blockHash: blockHash, chainID: chainID}] = execMessageCacheEntry{
+func (s *consolidateState) setCachedExecMsgs(blockHash common.Hash, execMsgs map[uint32]*supervisortypes.ExecutingMessage, logCount uint32) {
+	s.execMessageCache[blockHash] = execMessageCacheEntry{
 		execMsgs: execMsgs,
 		logCount: logCount,
 	}
@@ -378,7 +373,7 @@ func (d *consolidateCheckDeps) OpenBlock(
 		Hash:   block.Hash(),
 		Number: block.NumberU64(),
 	}
-	if execMsgs, logCount, ok := d.consolidateState.getCachedExecMsgs(block.Hash(), chainID); ok {
+	if execMsgs, logCount, ok := d.consolidateState.getCachedExecMsgs(block.Hash()); ok {
 		return ref, logCount, execMsgs, nil
 	}
 
@@ -387,7 +382,7 @@ func (d *consolidateCheckDeps) OpenBlock(
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, err
 	}
-	d.consolidateState.setCachedExecMsgs(block.Hash(), chainID, execMsgs, logCount)
+	d.consolidateState.setCachedExecMsgs(block.Hash(), execMsgs, logCount)
 	return ref, logCount, execMsgs, nil
 }
 

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -42,9 +42,37 @@ func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtyp
 	return execMsgs, curr, nil
 }
 
+type execMessageCacheKey struct {
+	blockHash common.Hash
+	chainID   eth.ChainID
+}
+
+type execMessageCacheEntry struct {
+	execMsgs map[uint32]*supervisortypes.ExecutingMessage
+	logCount uint32
+}
+
 type consolidateState struct {
 	*types.TransitionState
 	replacedChains map[eth.ChainID]bool
+
+	// execMessageCache is used to memoize iteration of logs in blocks to speed up executing message retrieval
+	execMessageCache map[execMessageCacheKey]execMessageCacheEntry
+}
+
+func newConsolidateState(transitionState *types.TransitionState) *consolidateState {
+	s := &consolidateState{
+		TransitionState: &types.TransitionState{
+			PendingProgress: make([]types.OptimisticBlock, len(transitionState.PendingProgress)),
+			SuperRoot:       transitionState.SuperRoot,
+			Step:            transitionState.Step,
+		},
+		replacedChains:   make(map[eth.ChainID]bool),
+		execMessageCache: make(map[execMessageCacheKey]execMessageCacheEntry),
+	}
+	// We will be updating the transition state as blocks are replaced, so make a copy
+	copy(s.PendingProgress, transitionState.PendingProgress)
+	return s
 }
 
 func (s *consolidateState) isReplaced(chainID eth.ChainID) bool {
@@ -57,6 +85,21 @@ func (s *consolidateState) setReplaced(transitionStateIndex int, chainID eth.Cha
 	s.replacedChains[chainID] = true
 }
 
+func (s *consolidateState) getCachedExecMsgs(blockHash common.Hash, chainID eth.ChainID) (map[uint32]*supervisortypes.ExecutingMessage, uint32, bool) {
+	entry, ok := s.execMessageCache[execMessageCacheKey{blockHash: blockHash, chainID: chainID}]
+	if !ok {
+		return nil, 0, false
+	}
+	return entry.execMsgs, entry.logCount, true
+}
+
+func (s *consolidateState) setCachedExecMsgs(blockHash common.Hash, chainID eth.ChainID, execMsgs map[uint32]*supervisortypes.ExecutingMessage, logCount uint32) {
+	s.execMessageCache[execMessageCacheKey{blockHash: blockHash, chainID: chainID}] = execMessageCacheEntry{
+		execMsgs: execMsgs,
+		logCount: logCount,
+	}
+}
+
 func RunConsolidation(
 	logger log.Logger,
 	bootInfo *boot.BootInfoInterop,
@@ -66,16 +109,7 @@ func RunConsolidation(
 	superRoot *eth.SuperV1,
 	tasks taskExecutor,
 ) (eth.Bytes32, error) {
-	consolidateState := consolidateState{
-		TransitionState: &types.TransitionState{
-			PendingProgress: make([]types.OptimisticBlock, len(transitionState.PendingProgress)),
-			SuperRoot:       transitionState.SuperRoot,
-			Step:            transitionState.Step,
-		},
-		replacedChains: make(map[eth.ChainID]bool),
-	}
-	// We will be updating the transition state as blocks are replaced, so make a copy
-	copy(consolidateState.PendingProgress, transitionState.PendingProgress)
+	consolidateState := newConsolidateState(transitionState)
 	// Use a reference to the transition state so the consolidate oracle has a recent view.
 	// The TransitionStateByRoot method isn't expected to be used during consolidation,
 	// but we pass the state for safety in case this changes in the future.
@@ -84,7 +118,7 @@ func RunConsolidation(
 	// Keep consolidating until there are no more invalid blocks to replace
 loop:
 	for {
-		err := singleRoundConsolidation(logger, bootInfo, l1PreimageOracle, consolidateOracle, &consolidateState, superRoot, tasks)
+		err := singleRoundConsolidation(logger, bootInfo, l1PreimageOracle, consolidateOracle, consolidateState, superRoot, tasks)
 		switch {
 		case err == nil:
 			break loop
@@ -123,7 +157,7 @@ func singleRoundConsolidation(
 	if err != nil {
 		return fmt.Errorf("failed to get dependency set: %w", err)
 	}
-	deps, err := newConsolidateCheckDeps(depset, bootInfo, consolidateState.TransitionState, superRoot.Chains, l2PreimageOracle)
+	deps, err := newConsolidateCheckDeps(depset, bootInfo, consolidateState.TransitionState, superRoot.Chains, l2PreimageOracle, consolidateState)
 	if err != nil {
 		return fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
@@ -231,6 +265,8 @@ type consolidateCheckDeps struct {
 	oracle      l2.Oracle
 	depset      depset.DependencySet
 	canonBlocks map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle
+
+	consolidateState *consolidateState
 }
 
 func newConsolidateCheckDeps(
@@ -239,6 +275,7 @@ func newConsolidateCheckDeps(
 	transitionState *types.TransitionState,
 	chains []eth.ChainIDAndOutput,
 	oracle l2.Oracle,
+	consolidateState *consolidateState,
 ) (*consolidateCheckDeps, error) {
 	// TODO(#14415): handle case where dep set changes in a given timestamp
 	canonBlocks := make(map[eth.ChainID]*l2.FastCanonicalBlockHeaderOracle)
@@ -259,9 +296,10 @@ func newConsolidateCheckDeps(
 	}
 
 	return &consolidateCheckDeps{
-		oracle:      oracle,
-		depset:      depset,
-		canonBlocks: canonBlocks,
+		oracle:           oracle,
+		depset:           depset,
+		canonBlocks:      canonBlocks,
+		consolidateState: consolidateState,
 	}, nil
 }
 
@@ -340,11 +378,16 @@ func (d *consolidateCheckDeps) OpenBlock(
 		Hash:   block.Hash(),
 		Number: block.NumberU64(),
 	}
+	if execMsgs, logCount, ok := d.consolidateState.getCachedExecMsgs(block.Hash(), chainID); ok {
+		return ref, logCount, execMsgs, nil
+	}
+
 	_, receipts := d.oracle.ReceiptsByBlockHash(block.Hash(), chainID)
 	execMsgs, logCount, err = ReceiptsToExecutingMessages(d.depset, receipts)
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, err
 	}
+	d.consolidateState.setCachedExecMsgs(block.Hash(), chainID, execMsgs, logCount)
 	return ref, logCount, execMsgs, nil
 }
 

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -344,9 +344,6 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.name != "ReplaceBothChains-CascadingReorg" {
-				t.Skip()
-			}
 			runConsolidationTestCase(t, tt.testCase)
 		})
 	}


### PR DESCRIPTION
During consolidation, cache the result of `ReceiptsToExecutingMessages` to reduce execution cost of the fault proof in the worst case.

For each consolidation round, at most N-1 chains have to be rechecked for invalid messages, where N is the number of chains checked in the previous round. This isn't great when iterating blocks for logs as the number of logs visited can blow up pretty quick. While this isn't a real concern for a initial 2-sized interop set, it gets worse quickly as the interop set grows.

fixes https://github.com/ethereum-optimism/optimism/issues/14975