### PR TITLE
Rename SuperchainWETH constant to SuperchainETHBridge

### DIFF
--- a/devnet-sdk/contracts/constants/constants.go
+++ b/devnet-sdk/contracts/constants/constants.go
@@ -26,7 +26,7 @@ var (
 	EAS                           types.Address = common.HexToAddress("0x4200000000000000000000000000000000000021")
 	CrossL2Inbox                  types.Address = common.HexToAddress("0x4200000000000000000000000000000000000022")
 	L2ToL2CrossDomainMessenger    types.Address = common.HexToAddress("0x4200000000000000000000000000000000000023")
-	SuperchainWETH                types.Address = common.HexToAddress("0x4200000000000000000000000000000000000024")
+	SuperchainETHBridge           types.Address = common.HexToAddress("0x4200000000000000000000000000000000000024")
 	ETHLiquidity                  types.Address = common.HexToAddress("0x4200000000000000000000000000000000000025")
 	SuperchainTokenBridge         types.Address = common.HexToAddress("0x4200000000000000000000000000000000000028")
 	GovernanceToken               types.Address = common.HexToAddress("0x4200000000000000000000000000000000000042")

--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -31,7 +31,7 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		funds := sdktypes.NewBalance(big.NewInt(0.5 * constants.ETH))
 		user := walletGetter(ctx)
 
-		scw0Addr := constants. SuperchainETHBridge
+		scw0Addr := constants.SuperchainETHBridge
 		scw0, err := chain.Nodes()[0].ContractsRegistry().SuperchainWETH(scw0Addr)
 		require.NoError(t, err)
 		logger.Info("using SuperchainWETH", "contract", scw0Addr)

--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -31,7 +31,7 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		funds := sdktypes.NewBalance(big.NewInt(0.5 * constants.ETH))
 		user := walletGetter(ctx)
 
-		scw0Addr := constants.SuperchainWETH
+		scw0Addr := common.HexToAddress("0x4200000000000000000000000000000000000024")
 		scw0, err := chain.Nodes()[0].ContractsRegistry().SuperchainWETH(scw0Addr)
 		require.NoError(t, err)
 		logger.Info("using SuperchainWETH", "contract", scw0Addr)

--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -31,20 +31,20 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		funds := sdktypes.NewBalance(big.NewInt(0.5 * constants.ETH))
 		user := walletGetter(ctx)
 
-		scw0Addr := constants.SuperchainETHBridge
-		scw0, err := chain.Nodes()[0].ContractsRegistry().SuperchainWETH(scw0Addr)
+		bridgeAddr := constants.SuperchainETHBridge
+		bridge, err := chain.Nodes()[0].ContractsRegistry().SuperchainWETH(bridgeAddr)
 		require.NoError(t, err)
-		logger.Info("using SuperchainWETH", "contract", scw0Addr)
+		logger.Info("using SuperchainWETH", "contract", bridgeAddr)
 
-		initialBalance, err := scw0.BalanceOf(user.Address()).Call(ctx)
+		initialBalance, err := bridge.BalanceOf(user.Address()).Call(ctx)
 		require.NoError(t, err)
 		logger = logger.With("user", user.Address())
 		logger.Info("initial balance retrieved", "balance", initialBalance)
 
 		logger.Info("sending ETH to contract", "amount", funds)
-		require.NoError(t, user.SendETH(scw0Addr, funds).Send(ctx).Wait())
+		require.NoError(t, user.SendETH(bridgeAddr, funds).Send(ctx).Wait())
 
-		balance, err := scw0.BalanceOf(user.Address()).Call(ctx)
+		balance, err := bridge.BalanceOf(user.Address()).Call(ctx)
 		require.NoError(t, err)
 		logger.Info("final balance retrieved", "balance", balance)
 

--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -31,7 +31,7 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		funds := sdktypes.NewBalance(big.NewInt(0.5 * constants.ETH))
 		user := walletGetter(ctx)
 
-		scw0Addr := common.HexToAddress("0x4200000000000000000000000000000000000024")
+		scw0Addr := constants. SuperchainETHBridge
 		scw0, err := chain.Nodes()[0].ContractsRegistry().SuperchainWETH(scw0Addr)
 		require.NoError(t, err)
 		logger.Info("using SuperchainWETH", "contract", scw0Addr)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**



This PR updates the constants.go file to rename the `SuperchainWETH` constant to `SuperchainETHBridge` for better clarity and consistency with the actual functionality. The address value remains unchanged.
