### PR TITLE
Bitwise expression simplification

### DIFF
--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -468,8 +468,8 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 
 func SignExtend(dat Word, idx Word) Word {
 	isSigned := (dat>>(idx-1))&1 != 0
-	signed := ((Word(1) << (arch.WordSize - idx)) - 1) << idx
 	mask := (Word(1) << idx) - 1
+	signed := ^mask
 	if isSigned {
 		return dat&mask | signed
 	} else {

--- a/cannon/mipsevm/exec/mips_instructions32_test.go
+++ b/cannon/mipsevm/exec/mips_instructions32_test.go
@@ -138,6 +138,10 @@ func TestSignExtend_32bit(t *testing.T) {
 		{name: "idx 8, unsigned, nonzero upper bits", data: 0xFFFF_FF75, index: 8, expected: 0x0000_0075},
 		{name: "idx 16, signed, nonzero upper bits", data: 0x1234_A123, index: 16, expected: 0xFFFF_A123},
 		{name: "idx 16, unsigned, nonzero upper bits", data: 0x1234_7123, index: 16, expected: 0x0000_7123},
+
+		// Test cases to specifically verify ~mask implementation
+		{name: "~mask test idx 8", data: 0xFF, index: 8, expected: 0xFFFFFFFF},
+		{name: "~mask test idx 16", data: 0x8000, index: 16, expected: 0xFFFF8000},
 	}
 
 	for _, c := range cases {

--- a/packages/contracts-bedrock/src/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS.sol
@@ -47,8 +47,8 @@ contract MIPS is ISemver {
     }
 
     /// @notice The semantic version of the MIPS contract.
-    /// @custom:semver 1.3.0
-    string public constant version = "1.3.0";
+    /// @custom:semver 1.3.1
+    string public constant version = "1.3.1";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS2.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS2.sol
@@ -61,8 +61,8 @@ contract MIPS2 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS2 contract.
-    /// @custom:semver 1.0.0-beta.29
-    string public constant version = "1.0.0-beta.29";
+    /// @custom:semver 1.0.0-beta.30
+    string public constant version = "1.0.0-beta.30";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -63,8 +63,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -595,8 +595,8 @@ library MIPS64Instructions {
     function signExtend(uint64 _dat, uint64 _idx) internal pure returns (uint64 out_) {
         unchecked {
             bool isSigned = (_dat >> (_idx - 1)) & 1 != 0;
-            uint256 signed = ((1 << (arch.WORD_SIZE - _idx)) - 1) << _idx;
             uint256 mask = (1 << _idx) - 1;
+            uint256 signed = ~mask;
             return uint64(_dat & mask | (isSigned ? signed : 0));
         }
     }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
@@ -445,8 +445,8 @@ library MIPSInstructions {
     function signExtend(uint32 _dat, uint32 _idx) internal pure returns (uint32 out_) {
         unchecked {
             bool isSigned = (_dat >> (_idx - 1)) & 1 != 0;
-            uint256 signed = ((1 << (32 - _idx)) - 1) << _idx;
             uint256 mask = (1 << _idx) - 1;
+            uint256 signed = ~mask;
             return uint32(_dat & mask | (isSigned ? signed : 0));
         }
     }


### PR DESCRIPTION
Fixed bitwise expression in signExtend function as described in issue #13445. Replaced complex expression with equivalent ~mask for better readability and gas efficiency.