### PR TITLE
op-service/eth: ETH type

### DIFF
--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -124,34 +124,6 @@ func (e ETH) ToBig() *big.Int {
 	return (*uint256.Int)(&e).ToBig()
 }
 
-// SetFromUint64 sets from an uint64, in wei.
-// The upper 192 bits are zeroed.
-func (e *ETH) SetFromUint64(v uint64) {
-	(*uint256.Int)(e).SetUint64(v)
-}
-
-// SetFromBig sets from a *big.Int,
-// and returns true if the value does not fit and overflows the uint256 max size.
-func (e *ETH) SetFromBig(v *big.Int) (overflow bool) {
-	if v == nil {
-		panic("cannot set to nil big.Int")
-	}
-	return (*uint256.Int)(e).SetFromBig(v)
-}
-
-// SetFromUint256 sets from a *uint256.Int
-func (e *ETH) SetFromUint256(v *uint256.Int) {
-	if v == nil {
-		panic("cannot set to nil uint256.Int")
-	}
-	*e = ETH(*v)
-}
-
-// Set sets to the given ETH value
-func (e *ETH) Set(v ETH) {
-	*e = v
-}
-
 // Add adds v and returns the result. No value is mutated.
 // Add panics if the computation overflows uint256.
 func (e ETH) Add(v ETH) (out ETH) {
@@ -252,21 +224,33 @@ func (e ETH) MarshalText() ([]byte, error) {
 }
 
 // WeiBig turns the given big.Int amount of wei into ETH-typed wei.
-// This panics if the amount does not fit in 256 bits.
+// This panics if the amount does not fit in 256 bits, or if it is negative.
 func WeiBig(wei *big.Int) (out ETH) {
-	out.SetFromBig(wei)
+	if wei == nil {
+		panic("nil *big.Int input to ETH constructor")
+	}
+	if wei.Sign() < 0 {
+		panic("negative amounts are not supported")
+	}
+	overflow := (*uint256.Int)(&out).SetFromBig(wei)
+	if overflow {
+		panic("*big.Int input does not fit in uint256")
+	}
 	return
 }
 
 // WeiU256 turns the given uint256.Int amount of wei into ETH-typed wei.
 func WeiU256(wei *uint256.Int) (out ETH) {
-	out.SetFromUint256(wei)
-	return
+	if wei == nil {
+		panic("nil *uint256.Int input to ETH constructor")
+	}
+	return ETH(*wei)
 }
 
 // WeiU64 turns the given uint64 amount of wei into ETH-typed wei.
+// The upper 192 bits are zeroed.
 func WeiU64(wei uint64) (out ETH) {
-	out.SetFromUint64(wei)
+	(*uint256.Int)(&out).SetUint64(wei)
 	return
 }
 

--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
+
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/params"
@@ -26,4 +29,261 @@ func GweiToWei(gwei float64) (*big.Int, error) {
 	}
 
 	return wei, nil
+}
+
+var (
+	MaxU256Wei    = ETH(uint256.Int{0: ^uint64(0), 1: ^uint64(0), 2: ^uint64(0), 3: ^uint64(0)})
+	MaxU128Wei    = ETH(uint256.Int{0: ^uint64(0), 1: ^uint64(0), 2: 0, 3: 0})
+	MaxU64Wei     = ETH(uint256.Int{0: ^uint64(0), 1: 0, 2: 0, 3: 0})
+	BillionEther  = Ether(1000_000_000)
+	MillionEther  = Ether(1000_000)
+	ThousandEther = Ether(1000)
+	OneEther      = Ether(1)
+	OneGWei       = GWei(1)
+	OneWei        = WeiU64(1)
+	ZeroWei       = WeiU64(0)
+)
+
+// some internal helper constant values
+var (
+	weiPerGWei = uint256.NewInt(params.GWei)
+	weiPerEth  = uint256.NewInt(params.Ether)
+)
+
+// ETH is a typed ETH (test-)currency integer, expressed in number of wei.
+// Most methods and usages prefer a flat value presentation, instead of pointer.
+// And return the new value, instead of mutating in-place.
+// This type is not optimized for speed,
+// but is instead designed for readability and to remove mutability foot-guns.
+type ETH uint256.Int
+
+// String prints the amount of ETH, with thousands comma-separators, and unit.
+// If the amount is perfectly divisible by 1 ether, the amount is printed in ethers.
+// If the amount is perfectly divisible by 1 gwei, the amount is printed in gwei.
+// If not neatly divisible, the amount is printed in wei.
+// This String function is optimized for readability, without precision loss,
+// to not hide any precision data during debugging.
+func (e ETH) String() string {
+	vWei := (*uint256.Int)(&e)
+	if vWei.Sign() == 0 {
+		return "0 wei"
+	}
+	var vGWei uint256.Int
+	var remainder uint256.Int
+	vGWei.DivMod(vWei, weiPerGWei, &remainder)
+	if remainder.Sign() == 0 {
+		// an exact number of gwei
+		var vEth uint256.Int
+		vEth.DivMod(vWei, weiPerEth, &remainder)
+		if remainder.Sign() == 0 {
+			// an exact number of eth
+			return vEth.PrettyDec(',') + " ether"
+		}
+		return vGWei.PrettyDec(',') + " gwei"
+	}
+	return vWei.PrettyDec(',') + " wei"
+}
+
+// Decimal returns the amount, in wei, in decimal form.
+func (e ETH) Decimal() string {
+	return (*uint256.Int)(&e).String()
+}
+
+// Hex returns the amount, in wei, in hexadecimal form with 0x prefix.
+func (e ETH) Hex() string {
+	return (*uint256.Int)(&e).Hex()
+}
+
+// Format implements fmt.Formatter
+func (e ETH) Format(s fmt.State, ch rune) {
+	(*uint256.Int)(&e).Format(s, ch)
+}
+
+// WeiFloat returns the amount as floating point number, in wei (approximate).
+// Warning: precision loss. This may not present the exact number of wei.
+func (e ETH) WeiFloat() float64 {
+	vWei := (*uint256.Int)(&e)
+	return vWei.Float64()
+}
+
+// EtherString returns the amount, string-ified, forced in ether units (excl. unit suffix)
+func (e ETH) EtherString() string {
+	var ethers uint256.Int
+	var remainder uint256.Int
+	ethers.DivMod((*uint256.Int)(&e), OneEther.ToU256(), &remainder)
+	if remainder.Sign() == 0 {
+		return ethers.Dec()
+	}
+	// No trailing zeroes
+	suffix := strings.TrimRight(fmt.Sprintf("%018d", &remainder), "0")
+	return ethers.Dec() + "." + suffix
+}
+
+// ToBig converts to *big.Int, in wei.
+func (e ETH) ToBig() *big.Int {
+	return (*uint256.Int)(&e).ToBig()
+}
+
+// SetFromUint64 sets from an uint64, in wei.
+// The upper 192 bits are zeroed.
+func (e *ETH) SetFromUint64(v uint64) {
+	(*uint256.Int)(e).SetUint64(v)
+}
+
+// SetFromBig sets from a *big.Int,
+// and returns true if the value does not fit and overflows the uint256 max size.
+func (e *ETH) SetFromBig(v *big.Int) (overflow bool) {
+	if v == nil {
+		panic("cannot set to nil big.Int")
+	}
+	return (*uint256.Int)(e).SetFromBig(v)
+}
+
+// SetFromUint256 sets from a *uint256.Int
+func (e *ETH) SetFromUint256(v *uint256.Int) {
+	if v == nil {
+		panic("cannot set to nil uint256.Int")
+	}
+	*e = ETH(*v)
+}
+
+// Set sets to the given ETH value
+func (e *ETH) Set(v ETH) {
+	*e = v
+}
+
+// Add adds v and returns the result. No value is mutated.
+// Add panics if the computation overflows uint256.
+func (e ETH) Add(v ETH) (out ETH) {
+	var overflow bool
+	out, overflow = e.AddOverflow(v)
+	if overflow {
+		panic(fmt.Errorf("add overflow: %s + %s != %s", e, v, out))
+	}
+	return
+}
+
+// AddOverflow adds v and returns the result. No value is mutated.
+// This also returns a boolean indicating if the computation overflowed.
+func (e ETH) AddOverflow(v ETH) (out ETH, overflow bool) {
+	_, overflow = (*uint256.Int)(&out).AddOverflow((*uint256.Int)(&e), (*uint256.Int)(&v))
+	return
+}
+
+// Sub subtracts v and returns the result. No value is mutated.
+// Sub panics if the computation underflows.
+func (e ETH) Sub(v ETH) (out ETH) {
+	var underflow bool
+	out, underflow = e.SubUnderflow(v)
+	if underflow {
+		panic(fmt.Errorf("sub underflow: %s - %s != %s", e, v, out))
+	}
+	return
+}
+
+// SubUnderflow subtracts v and returns the result. No value is mutated.
+// This also returns a boolean indicating if the computation underflowed.
+func (e ETH) SubUnderflow(v ETH) (out ETH, underflow bool) {
+	_, underflow = (*uint256.Int)(&out).SubOverflow((*uint256.Int)(&e), (*uint256.Int)(&v))
+	return
+}
+
+// Mul multiplies by the given uint64 scalar, and returns the result. No value is mutated.
+// Mul panics if the given computation overflows uin256.
+func (e ETH) Mul(scalar uint64) (out ETH) {
+	var overflow bool
+	out, overflow = e.MulOverflow(scalar)
+	if overflow {
+		panic(fmt.Errorf("overflow on ETH mul: %s * %d != %s", e, scalar, out))
+	}
+	return
+}
+
+// MulOverflow multiplies by the given scalar, and returns the result. No value is mutated.
+// This also returns a boolean indicating if the result overflowed.
+func (e ETH) MulOverflow(scalar uint64) (out ETH, overflow bool) {
+	_, overflow = (*uint256.Int)(&out).MulOverflow((*uint256.Int)(&e), uint256.NewInt(scalar))
+	return
+}
+
+// Div returns the quotient self/denominator.
+// Div performs integer division and always rounds down.
+// No value is mutated.
+// If denominator == 0, this returns 0.
+func (e ETH) Div(denominator uint64) (out ETH) {
+	(*uint256.Int)(&out).Div((*uint256.Int)(&e), uint256.NewInt(denominator))
+	return
+}
+
+// Lt returns if this is less than the given ETH value.
+func (e ETH) Lt(v ETH) bool {
+	return (*uint256.Int)(&e).Lt((*uint256.Int)(&v))
+}
+
+// Gt returns if this is greater than the given ETH value.
+func (e ETH) Gt(v ETH) bool {
+	return (*uint256.Int)(&e).Gt((*uint256.Int)(&v))
+}
+
+// IsZero returns if this equals 0.
+func (e ETH) IsZero() bool {
+	return (*uint256.Int)(&e).IsZero()
+}
+
+// ToU256 converts to *uint256.Int, in wei.
+// This returns a clone, not the underlying uint256.Int type.
+func (e ETH) ToU256() *uint256.Int {
+	return (*uint256.Int)(&e).Clone()
+}
+
+// Bytes32 converts to [32]byte, as big-endian uint256, in wei.
+func (e ETH) Bytes32() [32]byte {
+	return (*uint256.Int)(&e).Bytes32()
+}
+
+// UnmarshalText supports hexadecimal (0x prefix) and decimal.
+func (e *ETH) UnmarshalText(data []byte) error {
+	return (*uint256.Int)(e).UnmarshalText(data)
+}
+
+// MarshalText marshals as decimal number, without comma separators or unit
+func (e ETH) MarshalText() ([]byte, error) {
+	return (*uint256.Int)(&e).MarshalText()
+}
+
+// WeiBig turns the given big.Int amount of wei into ETH-typed wei.
+// This panics if the amount does not fit in 256 bits.
+func WeiBig(wei *big.Int) (out ETH) {
+	out.SetFromBig(wei)
+	return
+}
+
+// WeiU256 turns the given uint256.Int amount of wei into ETH-typed wei.
+func WeiU256(wei *uint256.Int) (out ETH) {
+	out.SetFromUint256(wei)
+	return
+}
+
+// WeiU64 turns the given uint64 amount of wei into ETH-typed wei.
+func WeiU64(wei uint64) (out ETH) {
+	out.SetFromUint64(wei)
+	return
+}
+
+// GWei turns the given amount of GWei into ETH-typed wei.
+// I.e. this multiplies the amount by 1e9 to denominate into wei.
+func GWei(gwei uint64) (out ETH) {
+	var x uint256.Int
+	x.SetUint64(gwei)
+	x.Mul(&x, weiPerGWei)
+	return ETH(x)
+}
+
+// Ether turns the given amount of ether into ETH-typed wei.
+// I.e. this multiplies the amount by 1e18 to denominate into wei.
+func Ether(ether uint64) ETH {
+	var x uint256.Int
+	x.SetUint64(ether)
+	x.Mul(&x, weiPerEth)
+	return ETH(x)
 }

--- a/op-service/eth/ether_test.go
+++ b/op-service/eth/ether_test.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/stretchr/testify/require"
 )
@@ -68,4 +70,182 @@ func TestGweiToWei(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEther(t *testing.T) {
+	t.Run("constants", func(t *testing.T) {
+		require.EqualValues(t, OneGWei, OneWei.Mul(1e9))
+		require.EqualValues(t, OneEther, OneGWei.Mul(1e9))
+		require.EqualValues(t, ThousandEther, OneEther.Mul(1e3))
+		require.EqualValues(t, MillionEther, ThousandEther.Mul(1e3))
+		require.EqualValues(t, BillionEther, MillionEther.Mul(1e3))
+		require.EqualValues(t, big.NewInt(1), OneWei.ToBig(), "sanity check not mutated value")
+	})
+
+	t.Run("constant string", func(t *testing.T) {
+		require.Equal(t, "0 wei", ZeroWei.String())
+		require.Equal(t, "1 wei", OneWei.String())
+		require.Equal(t, "1 gwei", OneGWei.String())
+		require.Equal(t, "1 ether", OneEther.String())
+		require.Equal(t, "1,000 ether", ThousandEther.String())
+		require.Equal(t, "1,000,000 ether", MillionEther.String())
+		require.Equal(t, "1,000,000,000 ether", BillionEther.String())
+	})
+
+	t.Run("constant float", func(t *testing.T) {
+		require.Equal(t, float64(0), ZeroWei.WeiFloat())
+		require.Equal(t, float64(1), OneWei.WeiFloat())
+		require.Equal(t, float64(1e9), OneGWei.WeiFloat())
+	})
+
+	t.Run("ether string force", func(t *testing.T) {
+		require.Equal(t, "0.000000000000000001", OneWei.EtherString())
+		require.Equal(t, "0.000000001", OneGWei.EtherString())
+		require.Equal(t, "1", OneEther.EtherString())
+		require.Equal(t, "1000", ThousandEther.EtherString())
+		require.Equal(t, "1.000000001", OneEther.Add(OneGWei).EtherString())
+		require.Equal(t, "100.000000001", Ether(100).Add(OneGWei).EtherString())
+	})
+
+	t.Run("other string", func(t *testing.T) {
+		require.Equal(t, "1,234,567 wei", WeiU64(1_234_567).String())
+		require.Equal(t, "1,234,567 gwei", GWei(1_234_567).String())
+		require.Equal(t, "1,234,567 ether", Ether(1_234_567).String())
+		require.Equal(t, "0 wei", WeiU64(0).String())
+		require.Equal(t, "0 wei", GWei(0).String())
+		require.Equal(t, "0 wei", Ether(0).String())
+	})
+
+	t.Run("big strings", func(t *testing.T) {
+		require.Equal(t, "1,234,567 wei", WeiU64(1_234_567).String())
+		require.Equal(t, "18,446,744,073,709,551,615 wei", MaxU64Wei.String())
+		require.Equal(t, "0xffffffffffffffff", MaxU64Wei.Hex())
+		require.Equal(t, "340,282,366,920,938,463,463,374,607,431,768,211,455 wei", MaxU128Wei.String())
+		require.Equal(t, "0xffffffffffffffffffffffffffffffff", MaxU128Wei.Hex())
+		require.Equal(t, "115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457,584,007,913,129,639,935 wei", MaxU256Wei.String())
+		require.Equal(t, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", MaxU256Wei.Hex())
+		require.Equal(t, "115792089237316195423570985008687907853269984665640564039457584007913129639935", MaxU256Wei.Decimal())
+	})
+
+	t.Run("add", func(t *testing.T) {
+		require.Equal(t, Ether(4), OneEther.Add(Ether(3)))
+		require.Equal(t, "3,000,000,000,000,000,001 wei", OneWei.Add(Ether(3)).String())
+
+		_, overflowed := MaxU256Wei.AddOverflow(OneWei)
+		require.True(t, overflowed)
+		require.Panics(t, func() {
+			MaxU256Wei.Add(OneWei)
+		}, "expect overflow panic")
+	})
+
+	t.Run("sub", func(t *testing.T) {
+		require.Equal(t, "2,999,999,999,999,999,999 wei", Ether(3).Sub(OneWei).String())
+
+		_, underflowed := ZeroWei.SubUnderflow(OneWei)
+		require.True(t, underflowed)
+		require.Panics(t, func() {
+			ZeroWei.Sub(OneWei)
+		}, "expect underflow panic")
+	})
+
+	t.Run("mul", func(t *testing.T) {
+		require.Equal(t, Ether(3000), ThousandEther.Mul(3))
+		require.Equal(t, ZeroWei, ThousandEther.Mul(0))
+		require.Equal(t, ZeroWei, ZeroWei.Mul(1))
+		require.Equal(t, ZeroWei, OneWei.Mul(0))
+		require.Equal(t, OneWei, OneWei.Mul(1))
+		_, overflowed := MaxU256Wei.MulOverflow(2)
+		require.True(t, overflowed)
+		require.Panics(t, func() {
+			MaxU256Wei.Mul(2)
+		})
+		tmp, overflowed := MaxU256Wei.Div(2).MulOverflow(2)
+		require.False(t, overflowed)
+		require.Equal(t, MaxU256Wei.Sub(OneWei), tmp, "last bit was effectively shifted out and back in as 0")
+		var v uint256.Int
+		v.Lsh(uint256.NewInt(1), 256-2)
+		a := WeiU256(&v)
+		a.Mul(2)
+		require.Panics(t, func() {
+			a.Mul(4)
+		})
+		_, overflowed = a.MulOverflow(4)
+		require.True(t, overflowed)
+	})
+
+	t.Run("div", func(t *testing.T) {
+		require.Equal(t, ZeroWei, ZeroWei.Div(1))
+		require.Equal(t, ZeroWei, ZeroWei.Div(0))
+		require.Equal(t, ZeroWei, OneWei.Div(0))
+		require.Equal(t, ZeroWei, ThousandEther.Div(0))
+		require.Equal(t, OneWei, OneWei.Div(1))
+		require.Equal(t, WeiU64(2), WeiU64(4).Div(2))
+		require.Equal(t, ThousandEther, MillionEther.Div(1000))
+		require.Equal(t, OneGWei, OneEther.Div(1e9))
+		require.Equal(t, OneWei, OneGWei.Div(1e9))
+		require.Equal(t, WeiU64(16), WeiU64(16*4+3).Div(4), "must round down")
+		require.Equal(t, MaxU256Wei, MaxU256Wei.Div(1))
+		require.Equal(t, MaxU128Wei, MaxU256Wei.Div(1<<63).Div(1<<63).Div(1<<2))
+	})
+
+	t.Run("set", func(t *testing.T) {
+		var x ETH
+		x.Set(OneEther)
+		require.Equal(t, x, OneEther)
+		x.Set(Ether(2))
+		require.Equal(t, x, Ether(2))
+	})
+
+	t.Run("lt", func(t *testing.T) {
+		require.True(t, WeiU64(123).Lt(WeiU64(124)))
+		require.False(t, WeiU64(124).Lt(WeiU64(124)))
+		require.False(t, WeiU64(125).Lt(WeiU64(124)))
+	})
+
+	t.Run("gt", func(t *testing.T) {
+		require.False(t, WeiU64(123).Gt(WeiU64(124)))
+		require.False(t, WeiU64(124).Gt(WeiU64(124)))
+		require.True(t, WeiU64(125).Gt(WeiU64(124)))
+	})
+
+	t.Run("isZero", func(t *testing.T) {
+		require.True(t, ZeroWei.IsZero())
+		require.False(t, OneWei.IsZero())
+		require.False(t, OneEther.IsZero())
+		mostlyZero := [32]byte{0: 1}
+		require.False(t, WeiU256(new(uint256.Int).SetBytes(mostlyZero[:])).IsZero())
+		require.False(t, MaxU256Wei.IsZero())
+	})
+
+	t.Run("convert", func(t *testing.T) {
+		require.EqualValues(t, uint256.NewInt(123).String(), WeiU64(123).ToU256().String())
+		require.EqualValues(t, big.NewInt(123).String(), WeiU64(123).ToBig().String())
+		require.EqualValues(t, [32]byte{31: 123}, WeiU64(123).Bytes32())
+
+		require.Panics(t, func() {
+			WeiBig(nil)
+		})
+		require.Panics(t, func() {
+			WeiU256(nil)
+		})
+		require.Equal(t, MaxU256Wei, WeiBig(MaxU256Wei.ToBig()))
+		require.Equal(t, MaxU256Wei, WeiU256(MaxU256Wei.ToU256()))
+		v := uint256.Int{0: 0xc0ff_ee12, 1: 0xabcd_1234, 2: 0xef56_7801, 3: 0x1234_5657}
+		require.Equal(t, v.String(), WeiU256(&v).ToU256().String())
+		require.Equal(t, v.ToBig().String(), WeiU256(&v).ToBig().String())
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		var x ETH
+		require.NoError(t, x.UnmarshalText([]byte("1234")))
+		require.Equal(t, "1,234 wei", x.String())
+		require.NoError(t, x.UnmarshalText([]byte("0xdeadbeef")))
+		require.Equal(t, "0xdeadbeef", x.Hex())
+	})
+
+	t.Run("marshal", func(t *testing.T) {
+		data, err := OneEther.MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, "1000000000000000000", string(data))
+	})
 }

--- a/op-service/eth/ether_test.go
+++ b/op-service/eth/ether_test.go
@@ -189,11 +189,11 @@ func TestEther(t *testing.T) {
 	})
 
 	t.Run("set", func(t *testing.T) {
-		var x ETH
-		x.Set(OneEther)
+		x := OneEther
 		require.Equal(t, x, OneEther)
-		x.Set(Ether(2))
+		x = Ether(2)
 		require.Equal(t, x, Ether(2))
+		require.Equal(t, Ether(1), OneEther, "no mutation of original")
 	})
 
 	t.Run("lt", func(t *testing.T) {
@@ -233,6 +233,17 @@ func TestEther(t *testing.T) {
 		v := uint256.Int{0: 0xc0ff_ee12, 1: 0xabcd_1234, 2: 0xef56_7801, 3: 0x1234_5657}
 		require.Equal(t, v.String(), WeiU256(&v).ToU256().String())
 		require.Equal(t, v.ToBig().String(), WeiU256(&v).ToBig().String())
+		// check overflow
+		require.Panics(t, func() {
+			WeiBig(new(big.Int).Lsh(big.NewInt(1), 256))
+		})
+		require.Panics(t, func() {
+			WeiBig(new(big.Int).Lsh(big.NewInt(123), 300))
+		})
+		// check negative
+		require.Panics(t, func() {
+			WeiBig(big.NewInt(-1))
+		})
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Typed ETH, to make tests, tx related code, utils more readable and safe.

Methods are included for the common eth units: `eth.Ether(123)`, `eth.GWei(123)`, `eth.Wei(123)`

The implementation prefers by-value operations:
- so we have no more hard to read/manage method-receiver mutations.
- so we can easily chain together multiple operations
- so composed formulas become easier to read, without side-effects on input numbers.

At 32 bytes, the as--value operations and local copies are cheap enough, and if it stays on the stack instead of escaping to the heap, even better so.

This will help remove the `*big.Int` and `*uint256.Int` usage everywhere.

**Tests**

All new utils/methods have unit-test coverage.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
