### PR TITLE
op e2e: interop action test: cross pattern same tx

### DIFF
--- a/op-acceptance-tests/tests/interop/interop_test_helpers.go
+++ b/op-acceptance-tests/tests/interop/interop_test_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/testlib/validators"
 	sdktypes "github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -115,6 +116,22 @@ func RandomInitTrigger(rng *rand.Rand, eventLoggerAddress common.Address, cnt, l
 		Topics:     topics,
 		OpaqueData: data,
 	}
+}
+
+// ExecTriggerFromInitTrigger returns corresponding execTrigger with necessary information
+func ExecTriggerFromInitTrigger(init *txintent.InitTrigger, logIndex uint, targetNum, targetTime uint64, chainID eth.ChainID) *txintent.ExecTrigger {
+	topics := []common.Hash{}
+	for _, topic := range init.Topics {
+		topics = append(topics, topic)
+	}
+	log := &types.Log{Address: init.Emitter, Topics: topics,
+		Data: init.OpaqueData, BlockNumber: targetNum, Index: logIndex}
+	logs := []*types.Log{log}
+	rec := &types.Receipt{Logs: logs}
+	includedIn := eth.BlockRef{Time: targetTime}
+	outputX := &txintent.InteropOutput{}
+	outputX.FromReceipt(context.TODO(), rec, includedIn, chainID)
+	return &txintent.ExecTrigger{Executor: constants.CrossL2Inbox, Msg: outputX.Entries[0]}
 }
 
 func SetupDefaultInteropSystemTest(l2ChainNums int) ([]validators.WalletGetter, []systest.PreconditionValidator) {

--- a/op-acceptance-tests/tests/interop/interop_test_helpers.go
+++ b/op-acceptance-tests/tests/interop/interop_test_helpers.go
@@ -119,7 +119,7 @@ func RandomInitTrigger(rng *rand.Rand, eventLoggerAddress common.Address, cnt, l
 }
 
 // ExecTriggerFromInitTrigger returns corresponding execTrigger with necessary information
-func ExecTriggerFromInitTrigger(init *txintent.InitTrigger, logIndex uint, targetNum, targetTime uint64, chainID eth.ChainID) *txintent.ExecTrigger {
+func ExecTriggerFromInitTrigger(init *txintent.InitTrigger, logIndex uint, targetNum, targetTime uint64, chainID eth.ChainID) (*txintent.ExecTrigger, error) {
 	topics := []common.Hash{}
 	for _, topic := range init.Topics {
 		topics = append(topics, topic)
@@ -129,9 +129,15 @@ func ExecTriggerFromInitTrigger(init *txintent.InitTrigger, logIndex uint, targe
 	logs := []*types.Log{log}
 	rec := &types.Receipt{Logs: logs}
 	includedIn := eth.BlockRef{Time: targetTime}
-	outputX := &txintent.InteropOutput{}
-	outputX.FromReceipt(context.TODO(), rec, includedIn, chainID)
-	return &txintent.ExecTrigger{Executor: constants.CrossL2Inbox, Msg: outputX.Entries[0]}
+	output := &txintent.InteropOutput{}
+	err := output.FromReceipt(context.TODO(), rec, includedIn, chainID)
+	if err != nil {
+		return nil, err
+	}
+	if x := len(output.Entries); x <= int(logIndex) {
+		return nil, fmt.Errorf("invalid index: %d, only have %d events", logIndex, x)
+	}
+	return &txintent.ExecTrigger{Executor: constants.CrossL2Inbox, Msg: output.Entries[logIndex]}, nil
 }
 
 func SetupDefaultInteropSystemTest(l2ChainNums int) ([]validators.WalletGetter, []systest.PreconditionValidator) {

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -786,9 +786,11 @@ func TestCrossPatternSameTx(gt *testing.T) {
 	// speculatively build exec messages by knowing necessary info to build Message
 	initX := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
 	logIndexX, logIndexY := uint(0), uint(0)
-	execX := interop.ExecTriggerFromInitTrigger(initX, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+	execX, err := interop.ExecTriggerFromInitTrigger(initX, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+	require.NoError(t, err)
 	initY := interop.RandomInitTrigger(rng, eventLoggerAddressB, 4, 7)
-	execY := interop.ExecTriggerFromInitTrigger(initY, logIndexY, targetNum, targetTime, actors.ChainB.ChainID)
+	execY, err := interop.ExecTriggerFromInitTrigger(initY, logIndexY, targetNum, targetTime, actors.ChainB.ChainID)
+	require.NoError(t, err)
 
 	callsA := []txintent.Call{initX, execY}
 	callsB := []txintent.Call{initY, execX}

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -185,7 +185,7 @@ func consolidateToSafe(t helpers.Testing, actors *dsl.InteropActors, startA, sta
 	assertHeads(t, actors.ChainA, endA, startA, startA, startA)
 	assertHeads(t, actors.ChainB, endB, startB, startB, startB)
 
-	t.Log("awaiting node to sync: unsafe to local0safe")
+	t.Log("awaiting node to sync: unsafe to local-safe")
 	actors.ChainA.Sequencer.ActL2PipelineFull(t)
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	assertHeads(t, actors.ChainA, endA, endA, startA, startA)
@@ -699,7 +699,7 @@ func TestCrossPatternSameTimestamp(gt *testing.T) {
 	actors.ChainA.Sequencer.ActL2EndBlock(t)
 	actors.ChainB.Sequencer.ActL2EndBlock(t)
 	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
-	assertHeads(t, actors.ChainA, 2, 0, 0, 0)
+	assertHeads(t, actors.ChainB, 2, 0, 0, 0)
 
 	// store unsafe head of chain A, B to compare after consolidation
 	chainAUnsafeHead := actors.ChainA.Sequencer.SyncStatus().UnsafeL2

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -751,7 +751,7 @@ func TestCrossPatternSameTimestamp(gt *testing.T) {
 // Transaction on B executes message from A, and vice-versa. Cross-pattern, within same tx: inter-dependent but non-cyclic txs.
 // Two transactions happen in same timestamp:
 // txA: chain A: alice initiates message X and executes message Y
-// txB: chain B: bob initiates message Y and excecutes message X
+// txB: chain B: bob initiates message Y and executes message X
 func TestCrossPatternSameTx(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -746,3 +746,95 @@ func TestCrossPatternSameTimestamp(gt *testing.T) {
 	require.Equal(t, targetBlockNum, block.Number)
 	require.Equal(t, targetTime, block.Time)
 }
+
+// TestCrossPatternSameTx tests below scenario:
+// Transaction on B executes message from A, and vice-versa. Cross-pattern, within same tx: inter-dependent but non-cyclic txs.
+// Two transactions happen in same timestamp:
+// txA: chain A: alice initiates message X and executes message Y
+// txB: chain B: bob initiates message Y and excecutes message X
+func TestCrossPatternSameTx(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	rng := rand.New(rand.NewSource(1234))
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+	alice := setupUser(t, is, actors.ChainA, 0)
+	bob := setupUser(t, is, actors.ChainB, 0)
+
+	// deploy eventLogger per chain
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	deployOptsA, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainA, 1), actors.ChainA)
+	eventLoggerAddressA := DeployEventLogger(t, deployOptsA)
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+	deployOptsB, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainB, 1), actors.ChainB)
+	eventLoggerAddressB := DeployEventLogger(t, deployOptsB)
+
+	assertHeads(t, actors.ChainA, 1, 0, 0, 0)
+	assertHeads(t, actors.ChainB, 1, 0, 0, 0)
+
+	require.Equal(t, actors.ChainA.RollupCfg.Genesis.L2Time, actors.ChainB.RollupCfg.Genesis.L2Time)
+	// assume all two txs land in block number 2, same time
+	targetTime := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime*2
+	targetNum := uint64(2)
+	optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)
+	optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
+
+	// open blocks on both chains
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+
+	// speculatively build exec messages by knowing necessary info to build Message
+	initX := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
+	logIndexX, logIndexY := uint(0), uint(0)
+	execX := interop.ExecTriggerFromInitTrigger(initX, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+	initY := interop.RandomInitTrigger(rng, eventLoggerAddressB, 4, 7)
+	execY := interop.ExecTriggerFromInitTrigger(initY, logIndexY, targetNum, targetTime, actors.ChainB.ChainID)
+
+	callsA := []txintent.Call{initX, execY}
+	callsB := []txintent.Call{initY, execX}
+
+	// Intent to initiate message X and execute message Y at chain A
+	txA := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](optsA)
+	txA.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: callsA})
+	// Intent to initiate message Y and execute message X at chain B
+	txB := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](optsB)
+	txB.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: callsB})
+
+	includedA, err := txA.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+	includedB, err := txB.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// Make sure two txs both sealed in block at expected time
+	require.Equal(t, includedA.Time, targetTime)
+	require.Equal(t, includedA.Number, targetNum)
+	require.Equal(t, includedB.Time, targetTime)
+	require.Equal(t, includedB.Number, targetNum)
+
+	assertHeads(t, actors.ChainA, targetNum, 0, 0, 0)
+	assertHeads(t, actors.ChainB, targetNum, 0, 0, 0)
+
+	// confirm speculatively built exec message X by rebuilding after txA inclusion
+	_, err = txA.Result.Eval(t.Ctx())
+	require.NoError(t, err)
+	multiTriggerA, err := txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txA.Result, []int{int(logIndexX)})(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, multiTriggerA.Calls[logIndexX], execX)
+
+	// confirm speculatively built exec message Y by rebuilding after txB inclusion
+	_, err = txB.Result.Eval(t.Ctx())
+	require.NoError(t, err)
+	multiTriggerB, err := txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &txB.Result, []int{int(logIndexY)})(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, multiTriggerB.Calls[logIndexY], execY)
+
+	// store unsafe head of chain A, B to compare after consolidation
+	chainAUnsafeHead := actors.ChainA.Sequencer.SyncStatus().UnsafeL2
+	chainBUnsafeHead := actors.ChainB.Sequencer.SyncStatus().UnsafeL2
+
+	consolidateToSafe(t, actors, 0, 0, targetNum, targetNum)
+
+	// unsafe heads consolidated to safe
+	require.Equal(t, chainAUnsafeHead, actors.ChainA.Sequencer.SyncStatus().SafeL2)
+	require.Equal(t, chainBUnsafeHead, actors.ChainB.Sequencer.SyncStatus().SafeL2)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds op-e2e interop action test using txintent. Checks that

- Transaction on B executes message from A, and vice-versa. Cross-pattern
    - [x] Within same tx: inter-dependent but non-cyclic txs. `TestCrossPatternSameTx `

which are part of https://github.com/ethereum-optimism/optimism/issues/15092.

To make executing messages before initiating messages are sealed inside a block, I added `ExecTriggerFromInitTrigger` method which takes block inclusion info to speculatively make executing message tx. Used multicall to pack initiating message and executing message per chain.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15388