### PR TITLE
chore(devnet-sdk): make devnet descriptor easiliy mutable

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -18,7 +18,7 @@ type PortInfo struct {
 }
 
 // EndpointMap is a map of service names to their endpoints.
-type EndpointMap map[string]PortInfo
+type EndpointMap map[string]*PortInfo
 
 // Service represents a chain service (e.g. batcher, proposer, challenger)
 type Service struct {
@@ -27,7 +27,7 @@ type Service struct {
 }
 
 // ServiceMap is a map of service names to services.
-type ServiceMap map[string]Service
+type ServiceMap map[string]*Service
 
 // Node represents a node for a chain
 type Node struct {
@@ -50,7 +50,7 @@ type Chain struct {
 }
 
 type L2Chain struct {
-	Chain
+	*Chain
 	L1Addresses AddressMap `json:"l1_addresses,omitempty"`
 	L1Wallets   WalletMap  `json:"l1_wallets,omitempty"`
 }
@@ -62,7 +62,7 @@ type Wallet struct {
 }
 
 // WalletMap is a map of wallet names to wallets.
-type WalletMap map[string]Wallet
+type WalletMap map[string]*Wallet
 
 // DevnetEnvironment exposes the relevant information to interact with a devnet.
 type DevnetEnvironment struct {

--- a/devnet-sdk/devstack/sysext/l1.go
+++ b/devnet-sdk/devstack/sysext/l1.go
@@ -29,7 +29,7 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 		l1.AddL1ELNode(shim.NewL1ELNode(shim.L1ELNodeConfig{
 			ELNodeConfig: shim.ELNodeConfig{
 				CommonConfig: commonConfig,
-				Client:       o.rpcClient(system.T(), &elService, RPCProtocol),
+				Client:       o.rpcClient(system.T(), elService, RPCProtocol),
 				ChainID:      l1ID,
 			},
 			ID: stack.L1ELNodeID{
@@ -47,7 +47,7 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 				ChainID: l1ID,
 			},
 			CommonConfig: commonConfig,
-			Client:       o.httpClient(system.T(), &clService, HTTPProtocol),
+			Client:       o.httpClient(system.T(), clService, HTTPProtocol),
 		}))
 	}
 

--- a/devnet-sdk/devstack/sysext/l2.go
+++ b/devnet-sdk/devstack/sysext/l2.go
@@ -76,7 +76,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 
 	elService, ok := node.Services[ELServiceName]
 	require.True(ok, "need L2 EL service for chain", l2ID)
-	elClient := o.rpcClient(l2Net.T(), &elService, RPCProtocol)
+	elClient := o.rpcClient(l2Net.T(), elService, RPCProtocol)
 	l2EL := shim.NewL2ELNode(shim.L2ELNodeConfig{
 		ELNodeConfig: shim.ELNodeConfig{
 			CommonConfig: shim.NewCommonConfig(l2Net.T()),
@@ -100,7 +100,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 	require.True(ok, "need L2 CL service for chain", l2ID)
 
 	// it's an RPC, but 'http' in kurtosis descriptor
-	clClient := o.rpcClient(l2Net.T(), &clService, HTTPProtocol)
+	clClient := o.rpcClient(l2Net.T(), clService, HTTPProtocol)
 	l2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
 		ID: stack.L2CLNodeID{
 			Key:     clService.Name,
@@ -130,7 +130,7 @@ func (o *Orchestrator) hydrateBatcherMaybe(net *descriptors.L2Chain, l2Net stack
 			Key:     batcherService.Name,
 			ChainID: l2ID.ChainID(),
 		},
-		Client: o.rpcClient(l2Net.T(), &batcherService, HTTPProtocol),
+		Client: o.rpcClient(l2Net.T(), batcherService, HTTPProtocol),
 	}))
 }
 
@@ -151,7 +151,7 @@ func (o *Orchestrator) hydrateProposerMaybe(net *descriptors.L2Chain, l2Net stac
 			Key:     proposerService.Name,
 			ChainID: l2ID.ChainID(),
 		},
-		Client: o.rpcClient(l2Net.T(), &proposerService, HTTPProtocol),
+		Client: o.rpcClient(l2Net.T(), proposerService, HTTPProtocol),
 	}))
 }
 

--- a/devnet-sdk/devstack/sysext/system.go
+++ b/devnet-sdk/devstack/sysext/system.go
@@ -54,6 +54,6 @@ func (o *Orchestrator) hydrateSupervisorMaybe(sys stack.ExtensibleSystem) {
 	sys.AddSupervisor(shim.NewSupervisor(shim.SupervisorConfig{
 		CommonConfig: shim.NewCommonConfig(sys.T()),
 		ID:           stack.SupervisorID(supervisorService.Name),
-		Client:       o.rpcClient(sys.T(), &supervisorService, RPCProtocol),
+		Client:       o.rpcClient(sys.T(), supervisorService, RPCProtocol),
 	}))
 }

--- a/devnet-sdk/shell/env/devnet.go
+++ b/devnet-sdk/shell/env/devnet.go
@@ -100,7 +100,7 @@ func (d *DevnetEnv) GetChain(chainName string) (*ChainConfig, error) {
 	} else {
 		for _, l2Chain := range d.Config.L2 {
 			if l2Chain.Name == chainName {
-				chain = &l2Chain.Chain
+				chain = l2Chain.Chain
 				break
 			}
 		}

--- a/devnet-sdk/shell/env/env_test.go
+++ b/devnet-sdk/shell/env/env_test.go
@@ -116,7 +116,7 @@ func TestGetChain(t *testing.T) {
 			},
 			L2: []*descriptors.L2Chain{
 				{
-					Chain: descriptors.Chain{
+					Chain: &descriptors.Chain{
 						Name: "op",
 						Nodes: []descriptors.Node{
 							{
@@ -141,7 +141,7 @@ func TestGetChain(t *testing.T) {
 						"deployer": common.HexToAddress("0x2345678901234567890123456789012345678901"),
 					},
 					L1Wallets: descriptors.WalletMap{
-						"deployer": descriptors.Wallet{
+						"deployer": &descriptors.Wallet{
 							Address:    common.HexToAddress("0x2345678901234567890123456789012345678901"),
 							PrivateKey: "0x2345678901234567890123456789012345678901",
 						},

--- a/devnet-sdk/system/chain.go
+++ b/devnet-sdk/system/chain.go
@@ -218,7 +218,7 @@ func newChain(chainID string, wallets WalletMap, chainConfig *params.ChainConfig
 func newL2ChainFromDescriptor(d *descriptors.L2Chain) (*l2Chain, error) {
 	// TODO: handle incorrect descriptors better. We could panic here.
 
-	nodes := newNodesFromDescriptor(&d.Chain)
+	nodes := newNodesFromDescriptor(d.Chain)
 	c := newL2Chain(d.ID, nil, nil, d.Config, AddressMap(d.L1Addresses), AddressMap(d.Addresses), nodes) // Create chain first
 
 	l2Wallets, err := newWalletMapFromDescriptorWalletMap(d.Wallets, c)

--- a/devnet-sdk/system/chain_test.go
+++ b/devnet-sdk/system/chain_test.go
@@ -50,9 +50,9 @@ func TestChainFromDescriptor(t *testing.T) {
 		Nodes: []descriptors.Node{
 			{
 				Services: descriptors.ServiceMap{
-					"el": descriptors.Service{
+					"el": &descriptors.Service{
 						Endpoints: descriptors.EndpointMap{
-							"rpc": descriptors.PortInfo{
+							"rpc": &descriptors.PortInfo{
 								Host: "localhost",
 								Port: 8545,
 							},
@@ -62,7 +62,7 @@ func TestChainFromDescriptor(t *testing.T) {
 			},
 		},
 		Wallets: descriptors.WalletMap{
-			"user1": descriptors.Wallet{
+			"user1": &descriptors.Wallet{
 				PrivateKey: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 				Address:    common.HexToAddress("0x1234567890123456789012345678901234567890"),
 			},
@@ -85,14 +85,14 @@ func TestChainFromDescriptor(t *testing.T) {
 
 func TestL2ChainFromDescriptor(t *testing.T) {
 	descriptor := &descriptors.L2Chain{
-		Chain: descriptors.Chain{
+		Chain: &descriptors.Chain{
 			ID: "1",
 			Nodes: []descriptors.Node{
 				{
 					Services: descriptors.ServiceMap{
-						"el": descriptors.Service{
+						"el": &descriptors.Service{
 							Endpoints: descriptors.EndpointMap{
-								"rpc": descriptors.PortInfo{
+								"rpc": &descriptors.PortInfo{
 									Host: "localhost",
 									Port: 8545,
 								},
@@ -102,7 +102,7 @@ func TestL2ChainFromDescriptor(t *testing.T) {
 				},
 			},
 			Wallets: descriptors.WalletMap{
-				"user1": descriptors.Wallet{
+				"user1": &descriptors.Wallet{
 					PrivateKey: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 					Address:    common.HexToAddress("0x1234567890123456789012345678901234567890"),
 				},
@@ -115,7 +115,7 @@ func TestL2ChainFromDescriptor(t *testing.T) {
 			"user1": common.HexToAddress("0x1234567890123456789012345678901234567890"),
 		},
 		L1Wallets: descriptors.WalletMap{
-			"user1": descriptors.Wallet{
+			"user1": &descriptors.Wallet{
 				PrivateKey: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 				Address:    common.HexToAddress("0x1234567890123456789012345678901234567890"),
 			},

--- a/devnet-sdk/system/system_test.go
+++ b/devnet-sdk/system/system_test.go
@@ -22,11 +22,11 @@ func TestNewSystemFromEnv(t *testing.T) {
 		L1: &descriptors.Chain{
 			ID: "1",
 			Nodes: []descriptors.Node{{
-				Services: map[string]descriptors.Service{
+				Services: map[string]*descriptors.Service{
 					"el": {
 						Name: "geth",
 						Endpoints: descriptors.EndpointMap{
-							"rpc": descriptors.PortInfo{
+							"rpc": &descriptors.PortInfo{
 								Host: "localhost",
 								Port: 8545,
 							},
@@ -35,7 +35,7 @@ func TestNewSystemFromEnv(t *testing.T) {
 				},
 			}},
 			Wallets: descriptors.WalletMap{
-				"default": descriptors.Wallet{
+				"default": &descriptors.Wallet{
 					Address:    common.HexToAddress("0x123"),
 					PrivateKey: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 				},
@@ -46,14 +46,14 @@ func TestNewSystemFromEnv(t *testing.T) {
 		},
 		L2: []*descriptors.L2Chain{
 			{
-				Chain: descriptors.Chain{
+				Chain: &descriptors.Chain{
 					ID: "2",
 					Nodes: []descriptors.Node{{
-						Services: map[string]descriptors.Service{
+						Services: map[string]*descriptors.Service{
 							"el": {
 								Name: "geth",
 								Endpoints: descriptors.EndpointMap{
-									"rpc": descriptors.PortInfo{
+									"rpc": &descriptors.PortInfo{
 										Host: "localhost",
 										Port: 8546,
 									},
@@ -62,7 +62,7 @@ func TestNewSystemFromEnv(t *testing.T) {
 						},
 					}},
 					Wallets: descriptors.WalletMap{
-						"default": descriptors.Wallet{
+						"default": &descriptors.Wallet{
 							Address:    common.HexToAddress("0x123"),
 							PrivateKey: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 						},
@@ -75,7 +75,7 @@ func TestNewSystemFromEnv(t *testing.T) {
 					"defaultl1": common.HexToAddress("0x123"),
 				},
 				L1Wallets: descriptors.WalletMap{
-					"default": descriptors.Wallet{
+					"default": &descriptors.Wallet{
 						Address:    common.HexToAddress("0x123"),
 						PrivateKey: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 					},
@@ -96,11 +96,11 @@ func TestNewSystemFromEnv(t *testing.T) {
 
 func TestSystemFromDevnet(t *testing.T) {
 	testNode := descriptors.Node{
-		Services: map[string]descriptors.Service{
+		Services: map[string]*descriptors.Service{
 			"el": {
 				Name: "geth",
 				Endpoints: descriptors.EndpointMap{
-					"rpc": descriptors.PortInfo{
+					"rpc": &descriptors.PortInfo{
 						Host: "localhost",
 						Port: 8545,
 					},
@@ -109,7 +109,7 @@ func TestSystemFromDevnet(t *testing.T) {
 		},
 	}
 
-	testWallet := descriptors.Wallet{
+	testWallet := &descriptors.Wallet{
 		Address:    common.HexToAddress("0x123"),
 		PrivateKey: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 	}
@@ -135,7 +135,7 @@ func TestSystemFromDevnet(t *testing.T) {
 				},
 				L2: []*descriptors.L2Chain{
 					{
-						Chain: descriptors.Chain{
+						Chain: &descriptors.Chain{
 							ID:    "2",
 							Nodes: []descriptors.Node{testNode},
 							Wallets: descriptors.WalletMap{
@@ -169,11 +169,22 @@ func TestSystemFromDevnet(t *testing.T) {
 				},
 				L2: []*descriptors.L2Chain{
 					{
-						Chain: descriptors.Chain{
+						Chain: &descriptors.Chain{
 							ID:    "2",
 							Nodes: []descriptors.Node{testNode},
 							Wallets: descriptors.WalletMap{
 								"default": testWallet,
+							},
+							Services: descriptors.ServiceMap{
+								"supervisor": &descriptors.Service{
+									Name: "supervisor",
+									Endpoints: descriptors.EndpointMap{
+										"rpc": &descriptors.PortInfo{
+											Host: "localhost",
+											Port: 8545,
+										},
+									},
+								},
 							},
 						},
 						L1Addresses: descriptors.AddressMap{

--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -117,7 +117,7 @@ func (f *ServiceFinder) findRPCEndpoints(matchService func(string) (string, int,
 					for portName, portInfo := range ports {
 						endpoints[portName] = portInfo
 					}
-					nodes[num-1].Services[serviceIdentifier] = descriptors.Service{
+					nodes[num-1].Services[serviceIdentifier] = &descriptors.Service{
 						Name:      serviceName,
 						Endpoints: endpoints,
 					}
@@ -129,7 +129,7 @@ func (f *ServiceFinder) findRPCEndpoints(matchService func(string) (string, int,
 				for portName, portInfo := range ports {
 					endpoints[portName] = portInfo
 				}
-				serviceMap[serviceIdentifier] = descriptors.Service{
+				serviceMap[serviceIdentifier] = &descriptors.Service{
 					Name:      serviceName,
 					Endpoints: endpoints,
 				}

--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -66,7 +66,7 @@ func TestFindRPCEndpoints(t *testing.T) {
 			wantNodes: []descriptors.Node{
 				{
 					Services: descriptors.ServiceMap{
-						"cl": descriptors.Service{
+						"cl": &descriptors.Service{
 							Name: "cl-1-lighthouse-geth",
 							Endpoints: descriptors.EndpointMap{
 								"metrics":       {Port: 52691},
@@ -75,7 +75,7 @@ func TestFindRPCEndpoints(t *testing.T) {
 								"http":          {Port: 52693},
 							},
 						},
-						"el": descriptors.Service{
+						"el": &descriptors.Service{
 							Name: "el-1-geth-lighthouse",
 							Endpoints: descriptors.EndpointMap{
 								"metrics":       {Port: 52643},
@@ -100,7 +100,7 @@ func TestFindRPCEndpoints(t *testing.T) {
 			wantNodes: []descriptors.Node{
 				{
 					Services: descriptors.ServiceMap{
-						"cl": descriptors.Service{
+						"cl": &descriptors.Service{
 							Name: "op-cl-1-op-node-op-geth-op-kurtosis",
 							Endpoints: descriptors.EndpointMap{
 								"udp-discovery": {Port: 50990},
@@ -108,7 +108,7 @@ func TestFindRPCEndpoints(t *testing.T) {
 								"tcp-discovery": {Port: 53504},
 							},
 						},
-						"el": descriptors.Service{
+						"el": &descriptors.Service{
 							Name: "op-el-1-op-geth-op-node-op-kurtosis",
 							Endpoints: descriptors.EndpointMap{
 								"udp-discovery": {Port: 53233},
@@ -123,7 +123,7 @@ func TestFindRPCEndpoints(t *testing.T) {
 				},
 			},
 			wantServices: descriptors.ServiceMap{
-				"batcher": descriptors.Service{
+				"batcher": &descriptors.Service{
 					Name: "op-batcher-op-kurtosis",
 					Endpoints: descriptors.EndpointMap{
 						"http": {Port: 53572},
@@ -143,7 +143,7 @@ func TestFindRPCEndpoints(t *testing.T) {
 			},
 			wantNodes: nil,
 			wantServices: descriptors.ServiceMap{
-				"batcher": descriptors.Service{
+				"batcher": &descriptors.Service{
 					Name: "op-batcher-custom-host",
 					Endpoints: descriptors.EndpointMap{
 						"http": {Host: "custom.host", Port: 8080},

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -147,7 +147,7 @@ func NewKurtosisDeployer(opts ...KurtosisDeployerOptions) (*KurtosisDeployer, er
 func (d *KurtosisDeployer) getWallets(wallets deployer.WalletList) descriptors.WalletMap {
 	walletMap := make(descriptors.WalletMap)
 	for _, wallet := range wallets {
-		walletMap[wallet.Name] = descriptors.Wallet{
+		walletMap[wallet.Name] = &descriptors.Wallet{
 			Address:    types.Address(wallet.Address),
 			PrivateKey: wallet.PrivateKey,
 		}
@@ -222,7 +222,7 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 		nodes, services := finder.FindL2Services(chainSpec.Name)
 
 		chain := &descriptors.L2Chain{
-			Chain: descriptors.Chain{
+			Chain: &descriptors.Chain{
 				Name:     chainSpec.Name,
 				ID:       chainSpec.NetworkID,
 				Services: services,

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -264,7 +264,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 	// Create test services map with the expected structure
 	testServices := make(inspect.ServiceMap)
 	testServices["el-1-geth-lighthouse"] = inspect.PortMap{
-		"rpc": descriptors.PortInfo{Port: 52645},
+		"rpc": &descriptors.PortInfo{Port: 52645},
 	}
 
 	testWallet := &deployer.Wallet{
@@ -281,10 +281,10 @@ func TestGetEnvironmentInfo(t *testing.T) {
 
 	// Create expected L1 services
 	l1Services := make(descriptors.ServiceMap)
-	l1Services["el"] = descriptors.Service{
+	l1Services["el"] = &descriptors.Service{
 		Name: "el-1-geth-lighthouse",
 		Endpoints: descriptors.EndpointMap{
-			"rpc": descriptors.PortInfo{Port: 52645},
+			"rpc": &descriptors.PortInfo{Port: 52645},
 		},
 	}
 
@@ -337,7 +337,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					},
 					L2: []*descriptors.L2Chain{
 						{
-							Chain: descriptors.Chain{
+							Chain: &descriptors.Chain{
 								Name:     "op-kurtosis",
 								ID:       "1234",
 								Services: make(descriptors.ServiceMap),
@@ -417,7 +417,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					},
 					L2: []*descriptors.L2Chain{
 						{
-							Chain: descriptors.Chain{
+							Chain: &descriptors.Chain{
 								Name:     "op-kurtosis",
 								ID:       "1234",
 								Services: make(descriptors.ServiceMap),
@@ -477,7 +477,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					},
 					L2: []*descriptors.L2Chain{
 						{
-							Chain: descriptors.Chain{
+							Chain: &descriptors.Chain{
 								Name:     "op-kurtosis",
 								ID:       "1234",
 								Services: make(descriptors.ServiceMap),

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
 )
 
-type PortMap map[string]descriptors.PortInfo
+type PortMap map[string]*descriptors.PortInfo
 
 type ServiceMap map[string]PortMap
 
@@ -70,7 +70,7 @@ func (e *Inspector) ExtractData(ctx context.Context) (*InspectData, error) {
 		portMap := make(PortMap)
 
 		for port, portSpec := range svcCtx.GetPublicPorts() {
-			portMap[port] = descriptors.PortInfo{
+			portMap[port] = &descriptors.PortInfo{
 				Host: svcCtx.GetMaybePublicIPAddress(),
 				Port: int(portSpec.GetNumber()),
 			}


### PR DESCRIPTION
**Description**

This change doesn't introduce function changes.
It does make it easier to mutate parts of the descriptor in-place though.

The rationale being that with the development of mutation operations,
available at the test level, it is no longer practical to treat the
descriptor as immutable. In particular, we need to be able to easily
update information pertaining to the various services that are part of
the devnet.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- part of #15270 