### PR TITLE
chore(kt-devnet): move inspect to using correct wrapper

### DIFF
--- a/kurtosis-devnet/pkg/build/contracts_test.go
+++ b/kurtosis-devnet/pkg/build/contracts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/enclave"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/starlark_run_config"
 	"github.com/spf13/afero"
@@ -114,6 +115,22 @@ func (e *testEnclaveContext) RunStarlarkPackage(ctx context.Context, pkg string,
 
 func (e *testEnclaveContext) RunStarlarkScript(ctx context.Context, script string, config *starlark_run_config.StarlarkRunConfig) error {
 	return nil
+}
+
+func (e *testEnclaveContext) GetEnclaveUuid() enclaves.EnclaveUUID {
+	return enclaves.EnclaveUUID("test-enclave-uuid")
+}
+
+func (e *testEnclaveContext) GetServices() (map[services.ServiceName]services.ServiceUUID, error) {
+	return nil, nil
+}
+
+func (e *testEnclaveContext) GetService(serviceIdentifier string) (interfaces.ServiceContext, error) {
+	return nil, nil
+}
+
+func (e *testEnclaveContext) GetAllFilesArtifactNamesAndUuids(ctx context.Context) ([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, error) {
+	return nil, nil
 }
 
 type testKurtosisContext struct{}

--- a/kurtosis-devnet/pkg/kurtosis/api/interfaces/iface.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/interfaces/iface.go
@@ -3,6 +3,9 @@ package interfaces
 import (
 	"context"
 
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/starlark_run_config"
 )
 
@@ -47,7 +50,21 @@ type StarlarkResponse interface {
 	GetInstructionResult() InstructionResult
 }
 
+type ServiceContext interface {
+	GetServiceUUID() services.ServiceUUID
+	GetMaybePublicIPAddress() string
+	GetPublicPorts() map[string]*services.PortSpec
+	GetPrivatePorts() map[string]*services.PortSpec
+}
+
 type EnclaveContext interface {
+	GetEnclaveUuid() enclaves.EnclaveUUID
+
+	GetService(serviceIdentifier string) (ServiceContext, error)
+	GetServices() (map[services.ServiceName]services.ServiceUUID, error)
+
+	GetAllFilesArtifactNamesAndUuids(ctx context.Context) ([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, error)
+
 	RunStarlarkPackage(context.Context, string, *starlark_run_config.StarlarkRunConfig) (<-chan StarlarkResponse, string, error)
 	RunStarlarkScript(context.Context, string, *starlark_run_config.StarlarkRunConfig) error
 }

--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/starlark_run_config"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
 )
@@ -19,6 +20,10 @@ type KurtosisContextWrapper struct {
 
 type EnclaveContextWrapper struct {
 	*enclaves.EnclaveContext
+}
+
+type ServiceContextWrapper struct {
+	*services.ServiceContext
 }
 
 type starlarkRunResponseLineWrapper struct {
@@ -67,6 +72,14 @@ func (w KurtosisContextWrapper) GetEnclave(ctx context.Context, name string) (in
 		return nil, err
 	}
 	return &EnclaveContextWrapper{enclaveCtx}, nil
+}
+
+func (w *EnclaveContextWrapper) GetService(serviceIdentifier string) (interfaces.ServiceContext, error) {
+	svcCtx, err := w.EnclaveContext.GetServiceContext(serviceIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceContextWrapper{svcCtx}, nil
 }
 
 func (w *EnclaveContextWrapper) RunStarlarkPackage(ctx context.Context, pkg string, serializedParams *starlark_run_config.StarlarkRunConfig) (<-chan interfaces.StarlarkResponse, string, error) {

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
-	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/wrappers"
 )
 
 type PortMap map[string]descriptors.PortInfo
@@ -28,12 +28,12 @@ func NewInspector(enclaveID string) *Inspector {
 }
 
 func (e *Inspector) ExtractData(ctx context.Context) (*InspectData, error) {
-	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	kurtosisCtx, err := wrappers.GetDefaultKurtosisContext()
 	if err != nil {
 		return nil, err
 	}
 
-	enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctx, e.enclaveID)
+	enclaveCtx, err := kurtosisCtx.GetEnclave(ctx, e.enclaveID)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (e *Inspector) ExtractData(ctx context.Context) (*InspectData, error) {
 
 	for svc := range services {
 		svc := string(svc)
-		svcCtx, err := enclaveCtx.GetServiceContext(svc)
+		svcCtx, err := enclaveCtx.GetService(svc)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Description**

Functionally there's no change.
But now tests can enforce *not* talking to a live kurtosis engine, which is cleaner.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

`just kurtosis-devnet/test` is exercising this code (and ensures a local kurtosis is not inadvertently used), and will be added to CI eventually.

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
