### PR TITLE
cannon: Feature toggle eventfd2 support

### DIFF
--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -16,7 +17,7 @@ import (
 )
 
 func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta *program.Metadata) mipsevm.FPVM {
-	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta, mipsevm.FeatureToggles{})
+	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta, allFeaturesEnabled())
 }
 
 func TestInstrumentedState_OpenMips(t *testing.T) {
@@ -53,7 +54,7 @@ func TestInstrumentedState_UtilsCheck(t *testing.T) {
 			oracle := testutil.StaticOracle(t, []byte{})
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
+			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, allFeaturesEnabled())
 
 			for i := 0; i < 1_000_000; i++ {
 				if us.GetState().GetExited() {
@@ -186,7 +187,7 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 			oracle := testutil.StaticOracle(t, []byte{})
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
+			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, allFeaturesEnabled())
 
 			for i := 0; i < test.steps; i++ {
 				if us.GetState().GetExited() {
@@ -231,7 +232,7 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 			state, meta := testutil.LoadELFProgram(t, testutil.ProgramPath("alloc"), CreateInitialState, false)
 			oracle := testutil.AllocOracle(t, test.numAllocs, test.allocSize)
 
-			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
+			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta, allFeaturesEnabled())
 			require.NoError(t, us.InitDebug())
 			// emulation shouldn't take more than 20 B steps
 			for i := 0; i < 20_000_000_000; i++ {
@@ -251,4 +252,16 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 			require.Less(t, memUsage, test.maxMemoryUsageCheck, "memory allocation is too large")
 		})
 	}
+}
+
+// allFeaturesEnabled returns a FeatureToggles with all toggles enabled.
+// We can't use versions.FeaturesForVersion to test the specific toggles for each version because it creates a
+// dependency loop, so we just cover the everything enabled case as that should be the upcoming version.
+func allFeaturesEnabled() mipsevm.FeatureToggles {
+	toggles := mipsevm.FeatureToggles{}
+	tRef := reflect.ValueOf(toggles)
+	for i := 0; i < tRef.NumField(); i++ {
+		tRef.Field(i).Set(reflect.ValueOf(true))
+	}
+	return toggles
 }

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -253,35 +253,45 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			state := multithreaded.CreateEmptyState()
-			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
-			state.GetRegistersRef()[4] = c.flags       // Set first argument
-			curStep := state.Step
-
-			var err error
-			var stepWitness *mipsevm.StepWitness
-			goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, mipsevm.FeatureToggles{})
-			if !c.valid {
-				// The VM should exit
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-				require.Equal(t, curStep+1, state.GetStep())
-				require.Equal(t, true, goVm.GetState().GetExited())
-				require.Equal(t, uint8(mipsevm.VMStatusPanic), goVm.GetState().GetExitCode())
-				require.Equal(t, 1, state.ThreadCount())
-			} else {
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-				require.Equal(t, curStep+1, state.GetStep())
-				require.Equal(t, false, goVm.GetState().GetExited())
-				require.Equal(t, uint8(0), goVm.GetState().GetExitCode())
-				require.Equal(t, 2, state.ThreadCount())
+		c := c
+		for _, version := range versions.StateVersionTypes {
+			version := version
+			if arch.IsMips32 && !versions.IsSupportedMultiThreaded(version) {
+				continue
 			}
+			if !arch.IsMips32 && !versions.IsSupportedMultiThreaded64(version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%v-%v", version.String(), c.name), func(t *testing.T) {
+				state := multithreaded.CreateEmptyState()
+				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+				state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
+				state.GetRegistersRef()[4] = c.flags       // Set first argument
+				curStep := state.Step
 
-			testutil.ValidateEVM(t, stepWitness, curStep, goVm, multithreaded.GetStateHashFn(), contracts)
-		})
+				var err error
+				var stepWitness *mipsevm.StepWitness
+				goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, versions.FeaturesForVersion(version))
+				if !c.valid {
+					// The VM should exit
+					stepWitness, err = goVm.Step(true)
+					require.NoError(t, err)
+					require.Equal(t, curStep+1, state.GetStep())
+					require.Equal(t, true, goVm.GetState().GetExited())
+					require.Equal(t, uint8(mipsevm.VMStatusPanic), goVm.GetState().GetExitCode())
+					require.Equal(t, 1, state.ThreadCount())
+				} else {
+					stepWitness, err = goVm.Step(true)
+					require.NoError(t, err)
+					require.Equal(t, curStep+1, state.GetStep())
+					require.Equal(t, false, goVm.GetState().GetExited())
+					require.Equal(t, uint8(0), goVm.GetState().GetExitCode())
+					require.Equal(t, 2, state.ThreadCount())
+				}
+
+				testutil.ValidateEVM(t, stepWitness, curStep, goVm, multithreaded.GetStateHashFn(), contracts)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**Description**

Sets up feature toggling for eventfd2 support so that we can support both the current production STF and the new one supporting eventfd2.  The solidity implementation hasn't been updated yet.

Also since all the examples are now built with go1.23 tests are failing for versions other than the new multithreaded. Either need to go back to compiling them for 1.22 or only run those tests on the new version.

Builds on https://github.com/ethereum-optimism/optimism/pull/14692/