### PR TITLE
cannon: Support feature toggles

### DIFF
--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -58,7 +58,7 @@ type FPVMState interface {
 	EncodeWitness() (witness []byte, hash common.Hash)
 
 	// CreateVM creates a FPVM that can operate on this state.
-	CreateVM(logger log.Logger, po PreimageOracle, stdOut, stdErr io.Writer, meta Metadata) FPVM
+	CreateVM(logger log.Logger, po PreimageOracle, stdOut, stdErr io.Writer, meta Metadata, features FeatureToggles) FPVM
 }
 
 type SymbolMatcher func(addr arch.Word) bool
@@ -66,6 +66,14 @@ type SymbolMatcher func(addr arch.Word) bool
 type Metadata interface {
 	LookupSymbol(addr arch.Word) string
 	CreateSymbolMatcher(name string) SymbolMatcher
+}
+
+// FeatureToggles defines the set of features which are enabled only on some of the supported state versions.
+// This allows supporting multiple state versions concurrently without needing to create completely separate
+// FPVM implementations and duplicate a lot of code.
+// Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
+// version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
+type FeatureToggles struct {
 }
 
 type FPVM interface {

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,6 +74,7 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
+	SupportSysEventFd2 bool
 }
 
 type FPVM interface {

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,7 +74,6 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
-	SupportSysEventFd2 bool
 }
 
 type FPVM interface {

--- a/cannon/mipsevm/multithreaded/instrumented.go
+++ b/cannon/mipsevm/multithreaded/instrumented.go
@@ -24,11 +24,12 @@ type InstrumentedState struct {
 
 	preimageOracle *exec.TrackingPreimageOracleReader
 	meta           mipsevm.Metadata
+	features       mipsevm.FeatureToggles
 }
 
 var _ mipsevm.FPVM = (*InstrumentedState)(nil)
 
-func NewInstrumentedState(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta mipsevm.Metadata) *InstrumentedState {
+func NewInstrumentedState(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta mipsevm.Metadata, features mipsevm.FeatureToggles) *InstrumentedState {
 	return &InstrumentedState{
 		state:          state,
 		log:            log,
@@ -39,6 +40,7 @@ func NewInstrumentedState(state *State, po mipsevm.PreimageOracle, stdOut, stdEr
 		statsTracker:   NoopStatsTracker(),
 		preimageOracle: exec.NewTrackingPreimageOracleReader(po),
 		meta:           meta,
+		features:       features,
 	}
 }
 

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta *program.Metadata) mipsevm.FPVM {
-	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta)
+	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta, mipsevm.FeatureToggles{})
 }
 
 func TestInstrumentedState_OpenMips(t *testing.T) {
@@ -53,7 +53,7 @@ func TestInstrumentedState_UtilsCheck(t *testing.T) {
 			oracle := testutil.StaticOracle(t, []byte{})
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta)
+			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
 
 			for i := 0; i < 1_000_000; i++ {
 				if us.GetState().GetExited() {
@@ -186,7 +186,7 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 			oracle := testutil.StaticOracle(t, []byte{})
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta)
+			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
 
 			for i := 0; i < test.steps; i++ {
 				if us.GetState().GetExited() {
@@ -231,7 +231,7 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 			state, meta := testutil.LoadELFProgram(t, testutil.ProgramPath("alloc"), CreateInitialState, false)
 			oracle := testutil.AllocOracle(t, test.numAllocs, test.allocSize)
 
-			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta)
+			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
 			require.NoError(t, us.InitDebug())
 			// emulation shouldn't take more than 20 B steps
 			for i := 0; i < 20_000_000_000; i++ {

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -16,7 +17,7 @@ import (
 )
 
 func vmFactory(state *State, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, meta *program.Metadata) mipsevm.FPVM {
-	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta, mipsevm.FeatureToggles{})
+	return NewInstrumentedState(state, po, stdOut, stdErr, log, meta, allFeaturesEnabled())
 }
 
 func TestInstrumentedState_OpenMips(t *testing.T) {
@@ -53,7 +54,7 @@ func TestInstrumentedState_UtilsCheck(t *testing.T) {
 			oracle := testutil.StaticOracle(t, []byte{})
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
+			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, allFeaturesEnabled())
 
 			for i := 0; i < 1_000_000; i++ {
 				if us.GetState().GetExited() {
@@ -186,7 +187,7 @@ func TestInstrumentedState_MultithreadedProgram(t *testing.T) {
 			oracle := testutil.StaticOracle(t, []byte{})
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
+			us := NewInstrumentedState(state, oracle, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta, allFeaturesEnabled())
 
 			for i := 0; i < test.steps; i++ {
 				if us.GetState().GetExited() {
@@ -231,7 +232,7 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 			state, meta := testutil.LoadELFProgram(t, testutil.ProgramPath("alloc"), CreateInitialState, false)
 			oracle := testutil.AllocOracle(t, test.numAllocs, test.allocSize)
 
-			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta, mipsevm.FeatureToggles{})
+			us := NewInstrumentedState(state, oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), meta, allFeaturesEnabled())
 			require.NoError(t, us.InitDebug())
 			// emulation shouldn't take more than 20 B steps
 			for i := 0; i < 20_000_000_000; i++ {
@@ -251,4 +252,16 @@ func TestInstrumentedState_Alloc(t *testing.T) {
 			require.Less(t, memUsage, test.maxMemoryUsageCheck, "memory allocation is too large")
 		})
 	}
+}
+
+// allFeaturesEnabled returns a FeatureToggles with all toggles enabled.
+// We can't use versions.FeaturesForVersion to test the specific toggles for each version because it creates a
+// dependency loop, so we just cover the everything enabled case as that should be the upcoming version.
+func allFeaturesEnabled() mipsevm.FeatureToggles {
+	toggles := mipsevm.FeatureToggles{}
+	tRef := reflect.ValueOf(toggles)
+	for i := 0; i < tRef.NumField(); i++ {
+		tRef.Field(i).Set(reflect.ValueOf(true))
+	}
+	return toggles
 }

--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -103,9 +103,9 @@ func CreateInitialState(pc, heapStart Word) *State {
 	return state
 }
 
-func (s *State) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata) mipsevm.FPVM {
+func (s *State) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata, features mipsevm.FeatureToggles) mipsevm.FPVM {
 	logger.Info("Using cannon multithreaded VM", "is32", arch.IsMips32)
-	return NewInstrumentedState(s, po, stdOut, stdErr, logger, meta)
+	return NewInstrumentedState(s, po, stdOut, stdErr, logger, meta, features)
 }
 
 func (s *State) GetCurrentThread() *ThreadState {

--- a/cannon/mipsevm/program/testutil/mocks.go
+++ b/cannon/mipsevm/program/testutil/mocks.go
@@ -125,6 +125,6 @@ func (m MockFPVMState) EncodeWitness() (witness []byte, hash common.Hash) {
 	panic("not implemented")
 }
 
-func (m MockFPVMState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata) mipsevm.FPVM {
+func (m MockFPVMState) CreateVM(_ log.Logger, _ mipsevm.PreimageOracle, _, _ io.Writer, _ mipsevm.Metadata, _ mipsevm.FeatureToggles) mipsevm.FPVM {
 	panic("not implemented")
 }

--- a/cannon/mipsevm/singlethreaded/state.go
+++ b/cannon/mipsevm/singlethreaded/state.go
@@ -70,7 +70,7 @@ func CreateInitialState(pc, heapStart Word) *State {
 	return state
 }
 
-func (s *State) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata) mipsevm.FPVM {
+func (s *State) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata, _ mipsevm.FeatureToggles) mipsevm.FPVM {
 	return NewInstrumentedState(s, po, stdOut, stdErr, meta)
 }
 

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/stretchr/testify/require"
 
@@ -27,21 +28,13 @@ func TestEVM_OpenMIPS(t *testing.T) {
 	require.NoError(t, err)
 
 	cases := GetMipsVersionTestCases(t)
-	skippedTests := map[string][]string{
-		"multi-threaded":  {"clone.bin"},
-		"single-threaded": {},
-	}
 
 	for _, c := range cases {
-		skipped, exists := skippedTests[c.Name]
-		require.True(t, exists)
 		for _, f := range testFiles {
 			testName := fmt.Sprintf("%v (%v)", f.Name(), c.Name)
 			t.Run(testName, func(t *testing.T) {
-				for _, skipped := range skipped {
-					if f.Name() == skipped {
-						t.Skipf("Skipping explicitly excluded open_mips testcase: %v", f.Name())
-					}
+				if !versions.IsSupportedSingleThreaded(c.Version) && f.Name() == "clone.bin" {
+					t.Skipf("%v only supported for singlethreaded VMs", f.Name())
 				}
 
 				oracle := testutil.SelectOracleFixture(t, f.Name())

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -1095,7 +1096,22 @@ func TestEVM_SchedQuantumThreshold(t *testing.T) {
 }
 
 func setup(t require.TestingT, randomSeed int, preimageOracle mipsevm.PreimageOracle, opts ...testutil.StateOption) (mipsevm.FPVM, *multithreaded.State, *testutil.ContractMetadata) {
-	v := GetMultiThreadedTestCase(t)
+	// Find the most recent supported multithreaded version
+	for i := len(versions.StateVersionTypes) - 1; i >= 0; i-- {
+		version := versions.StateVersionTypes[i]
+		if arch.IsMips32 && versions.IsSupportedMultiThreaded(version) {
+			return setupWithVersion(t, version, randomSeed, preimageOracle, opts...)
+		}
+		if !arch.IsMips32 && versions.IsSupportedMultiThreaded64(version) {
+			return setupWithVersion(t, version, randomSeed, preimageOracle, opts...)
+		}
+	}
+	require.Fail(t, "no supported version available")
+	return nil, nil, nil
+}
+
+func setupWithVersion(t require.TestingT, version versions.StateVersion, randomSeed int, preimageOracle mipsevm.PreimageOracle, opts ...testutil.StateOption) (mipsevm.FPVM, *multithreaded.State, *testutil.ContractMetadata) {
+	v := GetMultiThreadedTestCase(t, version)
 	allOpts := append([]testutil.StateOption{testutil.WithRandomization(int64(randomSeed))}, opts...)
 	vm := v.VMFactory(preimageOracle, os.Stdout, os.Stderr, testutil.CreateLogger(), allOpts...)
 	state := mttestutil.GetMtState(t, vm)

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -261,7 +261,7 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 
 			var err error
 			var stepWitness *mipsevm.StepWitness
-			goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil)
+			goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, mipsevm.FeatureToggles{})
 			if !c.valid {
 				// The VM should exit
 				stepWitness, err = goVm.Step(true)

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -948,7 +948,7 @@ var NoopSyscalls = map[string]uint32{
 
 func TestEVM_NoopSyscall32(t *testing.T) {
 	testutil.Cannon32OnlyTest(t, "These tests are fully covered for 64-bits in TestEVM_NoopSyscall64")
-	testNoopSyscall(t, NoopSyscalls)
+	testNoopSyscall(t, GetMultiThreadedTestCase(t, versions.VersionMultiThreaded), NoopSyscalls)
 }
 
 func TestEVM_UnsupportedSyscall32(t *testing.T) {
@@ -966,7 +966,7 @@ func TestEVM_UnsupportedSyscall32(t *testing.T) {
 		unsupportedSyscalls = append(unsupportedSyscalls, candidate)
 	}
 
-	testUnsupportedSyscall(t, unsupportedSyscalls)
+	testUnsupportedSyscall(t, GetMultiThreadedTestCase(t, versions.VersionMultiThreaded), unsupportedSyscalls)
 }
 
 func TestEVM_EmptyThreadStacks(t *testing.T) {
@@ -1096,26 +1096,15 @@ func TestEVM_SchedQuantumThreshold(t *testing.T) {
 }
 
 func setup(t require.TestingT, randomSeed int, preimageOracle mipsevm.PreimageOracle, opts ...testutil.StateOption) (mipsevm.FPVM, *multithreaded.State, *testutil.ContractMetadata) {
-	// Find the most recent supported multithreaded version
-	for i := len(versions.StateVersionTypes) - 1; i >= 0; i-- {
-		version := versions.StateVersionTypes[i]
-		if arch.IsMips32 && versions.IsSupportedMultiThreaded(version) {
-			return setupWithVersion(t, version, randomSeed, preimageOracle, opts...)
-		}
-		if !arch.IsMips32 && versions.IsSupportedMultiThreaded64(version) {
-			return setupWithVersion(t, version, randomSeed, preimageOracle, opts...)
-		}
-	}
-	require.Fail(t, "no supported version available")
-	return nil, nil, nil
+	cases := GetMultiThreadedTestCases(t)
+	require.NotZero(t, len(cases), "must have at least one supported multithreaded test case")
+	// Use the most recent supported version
+	return setupWithTestCase(t, cases[len(cases)-1], randomSeed, preimageOracle, opts...)
 }
 
-func setupWithVersion(t require.TestingT, version versions.StateVersion, randomSeed int, preimageOracle mipsevm.PreimageOracle, opts ...testutil.StateOption) (mipsevm.FPVM, *multithreaded.State, *testutil.ContractMetadata) {
-	v := GetMultiThreadedTestCase(t, version)
+func setupWithTestCase(t require.TestingT, v VersionedVMTestCase, randomSeed int, preimageOracle mipsevm.PreimageOracle, opts ...testutil.StateOption) (mipsevm.FPVM, *multithreaded.State, *testutil.ContractMetadata) {
 	allOpts := append([]testutil.StateOption{testutil.WithRandomization(int64(randomSeed))}, opts...)
 	vm := v.VMFactory(preimageOracle, os.Stdout, os.Stderr, testutil.CreateLogger(), allOpts...)
 	state := mttestutil.GetMtState(t, vm)
-
 	return vm, state, v.Contracts
-
 }

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -253,35 +253,45 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			state := multithreaded.CreateEmptyState()
-			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
-			state.GetRegistersRef()[4] = c.flags       // Set first argument
-			curStep := state.Step
-
-			var err error
-			var stepWitness *mipsevm.StepWitness
-			goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, mipsevm.FeatureToggles{})
-			if !c.valid {
-				// The VM should exit
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-				require.Equal(t, curStep+1, state.GetStep())
-				require.Equal(t, true, goVm.GetState().GetExited())
-				require.Equal(t, uint8(mipsevm.VMStatusPanic), goVm.GetState().GetExitCode())
-				require.Equal(t, 1, state.ThreadCount())
-			} else {
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-				require.Equal(t, curStep+1, state.GetStep())
-				require.Equal(t, false, goVm.GetState().GetExited())
-				require.Equal(t, uint8(0), goVm.GetState().GetExitCode())
-				require.Equal(t, 2, state.ThreadCount())
+		c := c
+		for _, version := range versions.StateVersionTypes {
+			version := version
+			if arch.IsMips32 && !versions.IsSupportedMultiThreaded(version) {
+				continue
 			}
+			if !arch.IsMips32 && !versions.IsSupportedMultiThreaded64(version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%v-%v", version.String(), c.name), func(t *testing.T) {
+				state := multithreaded.CreateEmptyState()
+				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+				state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
+				state.GetRegistersRef()[4] = c.flags       // Set first argument
+				curStep := state.Step
 
-			testutil.ValidateEVM(t, stepWitness, curStep, goVm, multithreaded.GetStateHashFn(), contracts)
-		})
+				var err error
+				var stepWitness *mipsevm.StepWitness
+				goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, versions.FeaturesForVersion(version))
+				if !c.valid {
+					// The VM should exit
+					stepWitness, err = goVm.Step(true)
+					require.NoError(t, err)
+					require.Equal(t, curStep+1, state.GetStep())
+					require.Equal(t, true, goVm.GetState().GetExited())
+					require.Equal(t, uint8(mipsevm.VMStatusPanic), goVm.GetState().GetExitCode())
+					require.Equal(t, 1, state.ThreadCount())
+				} else {
+					stepWitness, err = goVm.Step(true)
+					require.NoError(t, err)
+					require.Equal(t, curStep+1, state.GetStep())
+					require.Equal(t, false, goVm.GetState().GetExited())
+					require.Equal(t, uint8(0), goVm.GetState().GetExitCode())
+					require.Equal(t, 2, state.ThreadCount())
+				}
+
+				testutil.ValidateEVM(t, stepWitness, curStep, goVm, multithreaded.GetStateHashFn(), contracts)
+			})
+		}
 	}
 }
 

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -254,15 +254,9 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		for _, version := range versions.StateVersionTypes {
+		for _, version := range GetMultiThreadedTestCases(t) {
 			version := version
-			if arch.IsMips32 && !versions.IsSupportedMultiThreaded(version) {
-				continue
-			}
-			if !arch.IsMips32 && !versions.IsSupportedMultiThreaded64(version) {
-				continue
-			}
-			t.Run(fmt.Sprintf("%v-%v", version.String(), c.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%v-%v", version.Name, c.name), func(t *testing.T) {
 				state := multithreaded.CreateEmptyState()
 				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 				state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
@@ -271,7 +265,7 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 
 				var err error
 				var stepWitness *mipsevm.StepWitness
-				goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, versions.FeaturesForVersion(version))
+				goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, versions.FeaturesForVersion(version.Version))
 				if !c.valid {
 					// The VM should exit
 					stepWitness, err = goVm.Step(true)

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -17,8 +17,8 @@ import (
 func FuzzStateSyscallCloneMT(f *testing.F) {
 	versions := GetMultiThreadedTestCases(f)
 	require.NotZero(f, len(versions), "must have at least one multithreaded version supported")
-	f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64) {
-		v := versions[len(versions)-1]
+	f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64, version int) {
+		v := versions[version%len(versions)]
 		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
 		state := mttestutil.GetMtState(t, goVm)
 		// Update existing threads to avoid collision with nextThreadId

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -15,54 +15,55 @@ import (
 )
 
 func FuzzStateSyscallCloneMT(f *testing.F) {
-	v := GetMultiThreadedTestCase(f)
-	f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64) {
-		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
-		state := mttestutil.GetMtState(t, goVm)
-		// Update existing threads to avoid collision with nextThreadId
-		if mttestutil.FindThread(state, nextThreadId) != nil {
-			for i, t := range mttestutil.GetAllThreads(state) {
-				t.ThreadId = nextThreadId - Word(i+1)
+	for _, v := range GetMultiThreadedTestCases(f) {
+		f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64) {
+			goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
+			state := mttestutil.GetMtState(t, goVm)
+			// Update existing threads to avoid collision with nextThreadId
+			if mttestutil.FindThread(state, nextThreadId) != nil {
+				for i, t := range mttestutil.GetAllThreads(state) {
+					t.ThreadId = nextThreadId - Word(i+1)
+				}
 			}
-		}
 
-		// Setup
-		state.NextThreadId = nextThreadId
-		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-		state.GetRegistersRef()[2] = arch.SysClone
-		state.GetRegistersRef()[4] = exec.ValidCloneFlags
-		state.GetRegistersRef()[5] = stackPtr
-		step := state.GetStep()
+			// Setup
+			state.NextThreadId = nextThreadId
+			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+			state.GetRegistersRef()[2] = arch.SysClone
+			state.GetRegistersRef()[4] = exec.ValidCloneFlags
+			state.GetRegistersRef()[5] = stackPtr
+			step := state.GetStep()
 
-		// Set up expectations
-		expected := mttestutil.NewExpectedMTState(state)
-		expected.Step += 1
-		// Set original thread expectations
-		expected.PrestateActiveThread().PC = state.GetCpu().NextPC
-		expected.PrestateActiveThread().NextPC = state.GetCpu().NextPC + 4
-		expected.PrestateActiveThread().Registers[2] = nextThreadId
-		expected.PrestateActiveThread().Registers[7] = 0
-		// Set expectations for new, cloned thread
-		expected.ActiveThreadId = nextThreadId
-		epxectedNewThread := expected.ExpectNewThread()
-		epxectedNewThread.PC = state.GetCpu().NextPC
-		epxectedNewThread.NextPC = state.GetCpu().NextPC + 4
-		epxectedNewThread.Registers[register.RegSyscallNum] = 0
-		epxectedNewThread.Registers[register.RegSyscallErrno] = 0
-		epxectedNewThread.Registers[register.RegSP] = stackPtr
-		expected.NextThreadId = nextThreadId + 1
-		expected.StepsSinceLastContextSwitch = 0
-		if state.TraverseRight {
-			expected.RightStackSize += 1
-		} else {
-			expected.LeftStackSize += 1
-		}
+			// Set up expectations
+			expected := mttestutil.NewExpectedMTState(state)
+			expected.Step += 1
+			// Set original thread expectations
+			expected.PrestateActiveThread().PC = state.GetCpu().NextPC
+			expected.PrestateActiveThread().NextPC = state.GetCpu().NextPC + 4
+			expected.PrestateActiveThread().Registers[2] = nextThreadId
+			expected.PrestateActiveThread().Registers[7] = 0
+			// Set expectations for new, cloned thread
+			expected.ActiveThreadId = nextThreadId
+			epxectedNewThread := expected.ExpectNewThread()
+			epxectedNewThread.PC = state.GetCpu().NextPC
+			epxectedNewThread.NextPC = state.GetCpu().NextPC + 4
+			epxectedNewThread.Registers[register.RegSyscallNum] = 0
+			epxectedNewThread.Registers[register.RegSyscallErrno] = 0
+			epxectedNewThread.Registers[register.RegSP] = stackPtr
+			expected.NextThreadId = nextThreadId + 1
+			expected.StepsSinceLastContextSwitch = 0
+			if state.TraverseRight {
+				expected.RightStackSize += 1
+			} else {
+				expected.LeftStackSize += 1
+			}
 
-		stepWitness, err := goVm.Step(true)
-		require.NoError(t, err)
-		require.False(t, stepWitness.HasPreimage())
+			stepWitness, err := goVm.Step(true)
+			require.NoError(t, err)
+			require.False(t, stepWitness.HasPreimage())
 
-		expected.Validate(t, state)
-		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
-	})
+			expected.Validate(t, state)
+			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
+		})
+	}
 }

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -15,55 +15,56 @@ import (
 )
 
 func FuzzStateSyscallCloneMT(f *testing.F) {
-	for _, v := range GetMultiThreadedTestCases(f) {
-		f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64) {
-			goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
-			state := mttestutil.GetMtState(t, goVm)
-			// Update existing threads to avoid collision with nextThreadId
-			if mttestutil.FindThread(state, nextThreadId) != nil {
-				for i, t := range mttestutil.GetAllThreads(state) {
-					t.ThreadId = nextThreadId - Word(i+1)
-				}
+	versions := GetMultiThreadedTestCases(f)
+	require.NotZero(f, len(versions), "must have at least one multithreaded version supported")
+	f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64) {
+		v := versions[len(versions)-1]
+		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(seed))
+		state := mttestutil.GetMtState(t, goVm)
+		// Update existing threads to avoid collision with nextThreadId
+		if mttestutil.FindThread(state, nextThreadId) != nil {
+			for i, t := range mttestutil.GetAllThreads(state) {
+				t.ThreadId = nextThreadId - Word(i+1)
 			}
+		}
 
-			// Setup
-			state.NextThreadId = nextThreadId
-			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = arch.SysClone
-			state.GetRegistersRef()[4] = exec.ValidCloneFlags
-			state.GetRegistersRef()[5] = stackPtr
-			step := state.GetStep()
+		// Setup
+		state.NextThreadId = nextThreadId
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysClone
+		state.GetRegistersRef()[4] = exec.ValidCloneFlags
+		state.GetRegistersRef()[5] = stackPtr
+		step := state.GetStep()
 
-			// Set up expectations
-			expected := mttestutil.NewExpectedMTState(state)
-			expected.Step += 1
-			// Set original thread expectations
-			expected.PrestateActiveThread().PC = state.GetCpu().NextPC
-			expected.PrestateActiveThread().NextPC = state.GetCpu().NextPC + 4
-			expected.PrestateActiveThread().Registers[2] = nextThreadId
-			expected.PrestateActiveThread().Registers[7] = 0
-			// Set expectations for new, cloned thread
-			expected.ActiveThreadId = nextThreadId
-			epxectedNewThread := expected.ExpectNewThread()
-			epxectedNewThread.PC = state.GetCpu().NextPC
-			epxectedNewThread.NextPC = state.GetCpu().NextPC + 4
-			epxectedNewThread.Registers[register.RegSyscallNum] = 0
-			epxectedNewThread.Registers[register.RegSyscallErrno] = 0
-			epxectedNewThread.Registers[register.RegSP] = stackPtr
-			expected.NextThreadId = nextThreadId + 1
-			expected.StepsSinceLastContextSwitch = 0
-			if state.TraverseRight {
-				expected.RightStackSize += 1
-			} else {
-				expected.LeftStackSize += 1
-			}
+		// Set up expectations
+		expected := mttestutil.NewExpectedMTState(state)
+		expected.Step += 1
+		// Set original thread expectations
+		expected.PrestateActiveThread().PC = state.GetCpu().NextPC
+		expected.PrestateActiveThread().NextPC = state.GetCpu().NextPC + 4
+		expected.PrestateActiveThread().Registers[2] = nextThreadId
+		expected.PrestateActiveThread().Registers[7] = 0
+		// Set expectations for new, cloned thread
+		expected.ActiveThreadId = nextThreadId
+		epxectedNewThread := expected.ExpectNewThread()
+		epxectedNewThread.PC = state.GetCpu().NextPC
+		epxectedNewThread.NextPC = state.GetCpu().NextPC + 4
+		epxectedNewThread.Registers[register.RegSyscallNum] = 0
+		epxectedNewThread.Registers[register.RegSyscallErrno] = 0
+		epxectedNewThread.Registers[register.RegSP] = stackPtr
+		expected.NextThreadId = nextThreadId + 1
+		expected.StepsSinceLastContextSwitch = 0
+		if state.TraverseRight {
+			expected.RightStackSize += 1
+		} else {
+			expected.LeftStackSize += 1
+		}
 
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-			require.False(t, stepWitness.HasPreimage())
+		stepWitness, err := goVm.Step(true)
+		require.NoError(t, err)
+		require.False(t, stepWitness.HasPreimage())
 
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
-		})
-	}
+		expected.Validate(t, state)
+		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
+	})
 }

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"io"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -26,13 +27,13 @@ func singleThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer
 	return singlethreaded.NewInstrumentedState(state, po, stdOut, stdErr, nil)
 }
 
-func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM {
+func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, features mipsevm.FeatureToggles, opts ...testutil.StateOption) mipsevm.FPVM {
 	state := multithreaded.CreateEmptyState()
 	mutator := mttestutil.NewStateMutatorMultiThreaded(state)
 	for _, opt := range opts {
 		opt(mutator)
 	}
-	return multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, nil, mipsevm.FeatureToggles{})
+	return multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, nil, features)
 }
 
 type ElfVMFactory func(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM
@@ -44,9 +45,9 @@ func singleThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.Pre
 	return fpvm
 }
 
-func multiThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
+func multiThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, features mipsevm.FeatureToggles) mipsevm.FPVM {
 	state, meta := testutil.LoadELFProgram(t, elfFile, multithreaded.CreateInitialState, false)
-	fpvm := multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, meta, mipsevm.FeatureToggles{})
+	fpvm := multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, meta, features)
 	require.NoError(t, fpvm.InitDebug())
 	return fpvm
 }
@@ -105,29 +106,41 @@ func GetSingleThreadedTestCase(t require.TestingT) VersionedVMTestCase {
 	}
 }
 
-func GetMultiThreadedTestCase(t require.TestingT) VersionedVMTestCase {
+func GetMultiThreadedTestCase(t require.TestingT, version versions.StateVersion) VersionedVMTestCase {
+	features := versions.FeaturesForVersion(version)
 	return VersionedVMTestCase{
-		Name:           "multi-threaded",
-		Contracts:      testutil.TestContractsSetup(t, testutil.MipsMultithreaded),
-		StateHashFn:    multithreaded.GetStateHashFn(),
-		VMFactory:      multiThreadedVmFactory,
-		ElfVMFactory:   multiThreadElfVmFactory,
+		Name:        version.String(),
+		Contracts:   testutil.TestContractsSetup(t, testutil.MipsMultithreaded),
+		StateHashFn: multithreaded.GetStateHashFn(),
+		VMFactory: func(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger, opts ...testutil.StateOption) mipsevm.FPVM {
+			return multiThreadedVmFactory(po, stdOut, stdErr, log, features, opts...)
+		},
+		ElfVMFactory: func(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
+			return multiThreadElfVmFactory(t, elfFile, po, stdOut, stdErr, log, features)
+		},
 		ProofGenerator: multiThreadedProofGenerator,
 	}
 }
 
-func GetMipsVersionTestCases(t require.TestingT) []VersionedVMTestCase {
-	if arch.IsMips32 {
-		return []VersionedVMTestCase{
-			GetSingleThreadedTestCase(t),
-			GetMultiThreadedTestCase(t),
+func GetMultiThreadedTestCases(t require.TestingT) []VersionedVMTestCase {
+	var cases []VersionedVMTestCase
+	for _, version := range versions.StateVersionTypes {
+		if arch.IsMips32 && versions.IsSupportedMultiThreaded(version) {
+			cases = append(cases, GetMultiThreadedTestCase(t, version))
 		}
-	} else {
-		// 64-bit only supports MTCannon
-		return []VersionedVMTestCase{
-			GetMultiThreadedTestCase(t),
+		if !arch.IsMips32 && versions.IsSupportedMultiThreaded64(version) {
+			cases = append(cases, GetMultiThreadedTestCase(t, version))
 		}
 	}
+	return cases
+}
+
+func GetMipsVersionTestCases(t require.TestingT) []VersionedVMTestCase {
+	cases := GetMultiThreadedTestCases(t)
+	if arch.IsMips32 {
+		cases = append(cases, GetSingleThreadedTestCase(t))
+	}
+	return cases
 }
 
 type threadProofTestcase struct {

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -93,6 +93,7 @@ type VersionedVMTestCase struct {
 	VMFactory      VMFactory
 	ElfVMFactory   ElfVMFactory
 	ProofGenerator ProofGenerator
+	Version        versions.StateVersion
 }
 
 func GetSingleThreadedTestCase(t require.TestingT) VersionedVMTestCase {
@@ -103,6 +104,7 @@ func GetSingleThreadedTestCase(t require.TestingT) VersionedVMTestCase {
 		VMFactory:      singleThreadedVmFactory,
 		ElfVMFactory:   singleThreadElfVmFactory,
 		ProofGenerator: singleThreadedProofGenerator,
+		Version:        versions.VersionSingleThreaded2,
 	}
 }
 
@@ -119,6 +121,7 @@ func GetMultiThreadedTestCase(t require.TestingT, version versions.StateVersion)
 			return multiThreadElfVmFactory(t, elfFile, po, stdOut, stdErr, log, features)
 		},
 		ProofGenerator: multiThreadedProofGenerator,
+		Version:        version,
 	}
 }
 

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -32,7 +32,7 @@ func multiThreadedVmFactory(po mipsevm.PreimageOracle, stdOut, stdErr io.Writer,
 	for _, opt := range opts {
 		opt(mutator)
 	}
-	return multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, nil)
+	return multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, nil, mipsevm.FeatureToggles{})
 }
 
 type ElfVMFactory func(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM
@@ -46,7 +46,7 @@ func singleThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.Pre
 
 func multiThreadElfVmFactory(t require.TestingT, elfFile string, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, log log.Logger) mipsevm.FPVM {
 	state, meta := testutil.LoadELFProgram(t, elfFile, multithreaded.CreateInitialState, false)
-	fpvm := multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, meta)
+	fpvm := multithreaded.NewInstrumentedState(state, po, stdOut, stdErr, log, meta, mipsevm.FeatureToggles{})
 	require.NoError(t, fpvm.InitDebug())
 	return fpvm
 }

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -426,11 +426,11 @@ func testMTSysReadPreimage(t *testing.T, preimageValue []byte, cases []testMTSys
 	}
 }
 
-func testNoopSyscall(t *testing.T, syscalls map[string]uint32) {
+func testNoopSyscall(t *testing.T, version VersionedVMTestCase, syscalls map[string]uint32) {
 	for noopName, noopVal := range syscalls {
-		t.Run(noopName, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v-%v", version.Name, noopName), func(t *testing.T) {
 			t.Parallel()
-			goVm, state, contracts := setup(t, int(noopVal), nil)
+			goVm, state, contracts := setupWithTestCase(t, version, int(noopVal), nil)
 
 			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = Word(noopVal) // Set syscall number
@@ -453,14 +453,14 @@ func testNoopSyscall(t *testing.T, syscalls map[string]uint32) {
 	}
 }
 
-func testUnsupportedSyscall(t *testing.T, unsupportedSyscalls []uint32) {
+func testUnsupportedSyscall(t *testing.T, version VersionedVMTestCase, unsupportedSyscalls []uint32) {
 	for i, syscallNum := range unsupportedSyscalls {
-		testName := fmt.Sprintf("Unsupported syscallNum %v", syscallNum)
+		testName := fmt.Sprintf("%v Unsupported syscallNum %v", version.Name, syscallNum)
 		i := i
 		syscallNum := syscallNum
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			goVm, state, contracts := setup(t, i*3434, nil)
+			goVm, state, contracts := setupWithTestCase(t, version, i*3434, nil)
 			// Setup basic getThreadId syscall instruction
 			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 			state.GetRegistersRef()[2] = Word(syscallNum)

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -170,39 +170,40 @@ func testLoadStore(t *testing.T, cases []loadStoreTestCase) {
 	baseReg := uint32(9)
 	rtReg := uint32(8)
 
-	v := GetMultiThreadedTestCase(t)
-	for i, tt := range cases {
-		testName := fmt.Sprintf("%v %v", v.Name, tt.name)
-		t.Run(testName, func(t *testing.T) {
-			addr := tt.base + Word(tt.imm)
-			effAddr := arch.AddressMask & addr
+	for _, v := range GetMultiThreadedTestCases(t) {
+		for i, tt := range cases {
+			testName := fmt.Sprintf("%v %v", v.Name, tt.name)
+			t.Run(testName, func(t *testing.T) {
+				addr := tt.base + Word(tt.imm)
+				effAddr := arch.AddressMask & addr
 
-			goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithPCAndNextPC(0))
-			state := goVm.GetState()
+				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)), testutil.WithPCAndNextPC(0))
+				state := goVm.GetState()
 
-			insn := tt.opcode<<26 | baseReg<<21 | rtReg<<16 | uint32(tt.imm)
-			state.GetRegistersRef()[rtReg] = tt.rt
-			state.GetRegistersRef()[baseReg] = tt.base
+				insn := tt.opcode<<26 | baseReg<<21 | rtReg<<16 | uint32(tt.imm)
+				state.GetRegistersRef()[rtReg] = tt.rt
+				state.GetRegistersRef()[baseReg] = tt.base
 
-			testutil.StoreInstruction(state.GetMemory(), 0, insn)
-			state.GetMemory().SetWord(effAddr, tt.memVal)
-			step := state.GetStep()
+				testutil.StoreInstruction(state.GetMemory(), 0, insn)
+				state.GetMemory().SetWord(effAddr, tt.memVal)
+				step := state.GetStep()
 
-			// Setup expectations
-			expected := testutil.NewExpectedState(state)
-			expected.ExpectStep()
-			if tt.expectMemVal != 0 {
-				expected.ExpectMemoryWriteWord(effAddr, tt.expectMemVal)
-			} else {
-				expected.Registers[rtReg] = tt.expectRes
-			}
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
+				// Setup expectations
+				expected := testutil.NewExpectedState(state)
+				expected.ExpectStep()
+				if tt.expectMemVal != 0 {
+					expected.ExpectMemoryWriteWord(effAddr, tt.expectMemVal)
+				} else {
+					expected.Registers[rtReg] = tt.expectRes
+				}
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
 
-			// Check expectations
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-		})
+				// Check expectations
+				expected.Validate(t, state)
+				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
+			})
+		}
 	}
 }
 

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/ethereum-optimism/optimism/op-service/serialize"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
@@ -64,6 +65,12 @@ func NewFromState(state mipsevm.FPVMState) (*VersionedState, error) {
 type VersionedState struct {
 	Version StateVersion
 	mipsevm.FPVMState
+}
+
+func (s *VersionedState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata) mipsevm.FPVM {
+	features := mipsevm.FeatureToggles{}
+	// Set any required feature toggles based on the state version here.
+	return s.FPVMState.CreateVM(logger, po, stdOut, stdErr, meta, features)
 }
 
 func (s *VersionedState) Serialize(w io.Writer) error {

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -68,12 +68,17 @@ type VersionedState struct {
 }
 
 func (s *VersionedState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata) mipsevm.FPVM {
+	features := FeaturesForVersion(s.Version)
+	return s.FPVMState.CreateVM(logger, po, stdOut, stdErr, meta, features)
+}
+
+func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
-	if s.Version >= VersionMultiThreaded64_v4 {
+	if version >= VersionMultiThreaded64_v4 {
 		features.SupportSysEventFd2 = true
 	}
-	return s.FPVMState.CreateVM(logger, po, stdOut, stdErr, meta, features)
+	return features
 }
 
 func (s *VersionedState) Serialize(w io.Writer) error {

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -28,30 +28,30 @@ func LoadStateFromFile(path string) (*VersionedState, error) {
 		if err != nil {
 			return nil, err
 		}
-		return NewFromState(state)
+		return NewFromState(VersionSingleThreaded, state)
 	}
 	return serialize.LoadSerializedBinary[VersionedState](path)
 }
 
-func NewFromState(state mipsevm.FPVMState) (*VersionedState, error) {
+func NewFromState(vers StateVersion, state mipsevm.FPVMState) (*VersionedState, error) {
 	switch state := state.(type) {
 	case *singlethreaded.State:
 		if !arch.IsMips32 {
 			return nil, ErrUnsupportedMipsArch
 		}
 		return &VersionedState{
-			Version:   GetCurrentSingleThreaded(),
+			Version:   vers,
 			FPVMState: state,
 		}, nil
 	case *multithreaded.State:
 		if arch.IsMips32 {
 			return &VersionedState{
-				Version:   GetCurrentMultiThreaded(),
+				Version:   vers,
 				FPVMState: state,
 			}, nil
 		} else {
 			return &VersionedState{
-				Version:   GetCurrentMultiThreaded64(),
+				Version:   vers,
 				FPVMState: state,
 			}, nil
 		}
@@ -70,6 +70,9 @@ type VersionedState struct {
 func (s *VersionedState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, stdOut, stdErr io.Writer, meta mipsevm.Metadata) mipsevm.FPVM {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
+	if s.Version >= VersionMultiThreaded64_v4 {
+		features.SupportSysEventFd2 = true
+	}
 	return s.FPVMState.CreateVM(logger, po, stdOut, stdErr, meta, features)
 }
 
@@ -87,8 +90,7 @@ func (s *VersionedState) Deserialize(in io.Reader) error {
 		return err
 	}
 
-	switch s.Version {
-	case GetCurrentSingleThreaded():
+	if IsSupportedSingleThreaded(s.Version) {
 		if !arch.IsMips32 {
 			return ErrUnsupportedMipsArch
 		}
@@ -98,7 +100,7 @@ func (s *VersionedState) Deserialize(in io.Reader) error {
 		}
 		s.FPVMState = state
 		return nil
-	case GetCurrentMultiThreaded():
+	} else if IsSupportedMultiThreaded(s.Version) {
 		if !arch.IsMips32 {
 			return ErrUnsupportedMipsArch
 		}
@@ -108,7 +110,7 @@ func (s *VersionedState) Deserialize(in io.Reader) error {
 		}
 		s.FPVMState = state
 		return nil
-	case GetCurrentMultiThreaded64():
+	} else if IsSupportedMultiThreaded64(s.Version) {
 		if arch.IsMips32 {
 			return ErrUnsupportedMipsArch
 		}
@@ -118,7 +120,7 @@ func (s *VersionedState) Deserialize(in io.Reader) error {
 		}
 		s.FPVMState = state
 		return nil
-	default:
+	} else {
 		return fmt.Errorf("%w: %d", ErrUnknownVersion, s.Version)
 	}
 }

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -10,25 +10,21 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
-	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/ethereum-optimism/optimism/op-service/serialize"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
 	ErrUnknownVersion      = errors.New("unknown version")
+	ErrUnsupportedVersion  = errors.New("unsupported version")
 	ErrJsonNotSupported    = errors.New("json not supported")
 	ErrUnsupportedMipsArch = errors.New("mips architecture is not supported")
 )
 
 func LoadStateFromFile(path string) (*VersionedState, error) {
 	if !serialize.IsBinaryFile(path) {
-		// Always use singlethreaded for JSON states
-		state, err := jsonutil.LoadJSON[singlethreaded.State](path)
-		if err != nil {
-			return nil, err
-		}
-		return NewFromState(VersionSingleThreaded, state)
+		// JSON states are always singlethreaded v1 which is no longer supported
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedVersion, VersionSingleThreaded)
 	}
 	return serialize.LoadSerializedBinary[VersionedState](path)
 }
@@ -36,6 +32,9 @@ func LoadStateFromFile(path string) (*VersionedState, error) {
 func NewFromState(vers StateVersion, state mipsevm.FPVMState) (*VersionedState, error) {
 	switch state := state.(type) {
 	case *singlethreaded.State:
+		if !IsSupportedSingleThreaded(vers) {
+			return nil, fmt.Errorf("%w: %v", ErrUnsupportedVersion, vers)
+		}
 		if !arch.IsMips32 {
 			return nil, ErrUnsupportedMipsArch
 		}
@@ -45,11 +44,17 @@ func NewFromState(vers StateVersion, state mipsevm.FPVMState) (*VersionedState, 
 		}, nil
 	case *multithreaded.State:
 		if arch.IsMips32 {
+			if !IsSupportedMultiThreaded(vers) {
+				return nil, fmt.Errorf("%w: %v", ErrUnsupportedVersion, vers)
+			}
 			return &VersionedState{
 				Version:   vers,
 				FPVMState: state,
 			}, nil
 		} else {
+			if !IsSupportedMultiThreaded64(vers) {
+				return nil, fmt.Errorf("%w: %v", ErrUnsupportedVersion, vers)
+			}
 			return &VersionedState{
 				Version:   vers,
 				FPVMState: state,

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -75,9 +75,6 @@ func (s *VersionedState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, 
 func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
-	if version >= VersionMultiThreaded64_v4 {
-		features.SupportSysEventFd2 = true
-	}
 	return features
 }
 

--- a/cannon/mipsevm/versions/state64_test.go
+++ b/cannon/mipsevm/versions/state64_test.go
@@ -15,37 +15,56 @@ import (
 )
 
 func TestNewFromState(t *testing.T) {
-	t.Run("multithreaded64-latestVersion", func(t *testing.T) {
-		actual, err := NewFromState(multithreaded.CreateEmptyState())
-		require.NoError(t, err)
-		require.IsType(t, &multithreaded.State{}, actual.FPVMState)
-		require.Equal(t, GetCurrentMultiThreaded64(), actual.Version)
-	})
+	for _, version := range StateVersionTypes {
+		if !IsSupportedMultiThreaded64(version) {
+			continue
+		}
+		t.Run(version.String(), func(t *testing.T) {
+			actual, err := NewFromState(version, multithreaded.CreateEmptyState())
+			require.NoError(t, err)
+			require.IsType(t, &multithreaded.State{}, actual.FPVMState)
+			require.Equal(t, version, actual.Version)
+		})
+	}
 }
 
 func TestLoadStateFromFile(t *testing.T) {
-	t.Run("Multithreaded64_latestVersion_FromBinary", func(t *testing.T) {
-		expected, err := NewFromState(multithreaded.CreateEmptyState())
-		require.NoError(t, err)
+	for _, version := range StateVersionTypes {
+		if !IsSupportedMultiThreaded64(version) {
+			continue
+		}
+		t.Run(version.String(), func(t *testing.T) {
+			expected, err := NewFromState(version, multithreaded.CreateEmptyState())
+			require.NoError(t, err)
 
-		path := writeToFile(t, "state.bin.gz", expected)
-		actual, err := LoadStateFromFile(path)
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
-	})
+			path := writeToFile(t, "state.bin.gz", expected)
+			actual, err := LoadStateFromFile(path)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
+type versionAndStateCreator struct {
+	version     StateVersion
+	createState func() mipsevm.FPVMState
 }
 
 func TestVersionsOtherThanZeroDoNotSupportJSON(t *testing.T) {
-	tests := []struct {
+	var tests []struct {
 		version     StateVersion
 		createState func() mipsevm.FPVMState
-	}{
-		{GetCurrentMultiThreaded64(), func() mipsevm.FPVMState { return multithreaded.CreateEmptyState() }},
+	}
+	for _, version := range StateVersionTypes {
+		if !IsSupportedMultiThreaded64(version) {
+			continue
+		}
+		tests = append(tests, versionAndStateCreator{version: version, createState: func() mipsevm.FPVMState { return multithreaded.CreateEmptyState() }})
 	}
 	for _, test := range tests {
 		test := test
 		t.Run(test.version.String(), func(t *testing.T) {
-			state, err := NewFromState(test.createState())
+			state, err := NewFromState(test.version, test.createState())
 			require.NoError(t, err)
 
 			dir := t.TempDir()

--- a/cannon/mipsevm/versions/state64_test.go
+++ b/cannon/mipsevm/versions/state64_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -17,14 +18,22 @@ import (
 func TestNewFromState(t *testing.T) {
 	for _, version := range StateVersionTypes {
 		if !IsSupportedMultiThreaded64(version) {
-			continue
+			t.Run(version.String()+"-unsupported", func(t *testing.T) {
+				_, err := NewFromState(version, multithreaded.CreateEmptyState())
+				require.ErrorIs(t, err, ErrUnsupportedVersion)
+			})
+		} else {
+			t.Run(version.String(), func(t *testing.T) {
+				actual, err := NewFromState(version, multithreaded.CreateEmptyState())
+				require.NoError(t, err)
+				require.IsType(t, &multithreaded.State{}, actual.FPVMState)
+				require.Equal(t, version, actual.Version)
+			})
+			t.Run(version.String()+"-st-unsupported", func(t *testing.T) {
+				_, err := NewFromState(version, singlethreaded.CreateEmptyState())
+				require.ErrorIs(t, err, ErrUnsupportedVersion)
+			})
 		}
-		t.Run(version.String(), func(t *testing.T) {
-			actual, err := NewFromState(version, multithreaded.CreateEmptyState())
-			require.NoError(t, err)
-			require.IsType(t, &multithreaded.State{}, actual.FPVMState)
-			require.Equal(t, version, actual.Version)
-		})
 	}
 }
 

--- a/cannon/mipsevm/versions/state_test.go
+++ b/cannon/mipsevm/versions/state_test.go
@@ -15,56 +15,59 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/serialize"
 )
 
-func TestNewFromState(t *testing.T) {
-	t.Run("singlethreaded-latestVersion", func(t *testing.T) {
-		actual, err := NewFromState(singlethreaded.CreateEmptyState())
-		require.NoError(t, err)
-		require.IsType(t, &singlethreaded.State{}, actual.FPVMState)
-		require.Equal(t, GetCurrentSingleThreaded(), actual.Version)
-	})
+func TestLoadStateFromFile(t *testing.T) {
+	for _, version := range StateVersionTypes {
+		if IsSupportedSingleThreaded(version) {
+			t.Run(version.String(), func(t *testing.T) {
+				expected, err := NewFromState(version, singlethreaded.CreateEmptyState())
+				require.NoError(t, err)
 
-	t.Run("multithreaded-latestVersion", func(t *testing.T) {
-		actual, err := NewFromState(multithreaded.CreateEmptyState())
-		require.NoError(t, err)
-		require.IsType(t, &multithreaded.State{}, actual.FPVMState)
-		require.Equal(t, GetCurrentMultiThreaded(), actual.Version)
-	})
+				path := writeToFile(t, "state.bin.gz", expected)
+				actual, err := LoadStateFromFile(path)
+				require.NoError(t, err)
+				require.Equal(t, expected, actual)
+			})
+		}
+		if IsSupportedMultiThreaded(version) {
+			t.Run(version.String(), func(t *testing.T) {
+				expected, err := NewFromState(version, multithreaded.CreateEmptyState())
+				require.NoError(t, err)
+
+				path := writeToFile(t, "state.bin.gz", expected)
+				actual, err := LoadStateFromFile(path)
+				require.NoError(t, err)
+				require.Equal(t, expected, actual)
+			})
+		}
+	}
 }
 
-func TestLoadStateFromFile(t *testing.T) {
-	t.Run("SinglethreadedFromBinary", func(t *testing.T) {
-		expected, err := NewFromState(singlethreaded.CreateEmptyState())
-		require.NoError(t, err)
-
-		path := writeToFile(t, "state.bin.gz", expected)
-		actual, err := LoadStateFromFile(path)
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
-	})
-
-	t.Run("MultithreadedFromBinary", func(t *testing.T) {
-		expected, err := NewFromState(multithreaded.CreateEmptyState())
-		require.NoError(t, err)
-
-		path := writeToFile(t, "state.bin.gz", expected)
-		actual, err := LoadStateFromFile(path)
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
-	})
+type versionAndStateCreator struct {
+	version     StateVersion
+	createState func() mipsevm.FPVMState
 }
 
 func TestVersionsOtherThanZeroDoNotSupportJSON(t *testing.T) {
-	tests := []struct {
+	var tests []struct {
 		version     StateVersion
 		createState func() mipsevm.FPVMState
-	}{
-		{GetCurrentSingleThreaded(), func() mipsevm.FPVMState { return singlethreaded.CreateEmptyState() }},
-		{GetCurrentMultiThreaded(), func() mipsevm.FPVMState { return multithreaded.CreateEmptyState() }},
+	}
+	for _, version := range StateVersionTypes {
+		if !IsSupportedSingleThreaded(version) {
+			continue
+		}
+		tests = append(tests, versionAndStateCreator{version: version, createState: func() mipsevm.FPVMState { return singlethreaded.CreateEmptyState() }})
+	}
+	for _, version := range StateVersionTypes {
+		if !IsSupportedMultiThreaded(version) {
+			continue
+		}
+		tests = append(tests, versionAndStateCreator{version: version, createState: func() mipsevm.FPVMState { return multithreaded.CreateEmptyState() }})
 	}
 	for _, test := range tests {
 		test := test
 		t.Run(test.version.String(), func(t *testing.T) {
-			state, err := NewFromState(test.createState())
+			state, err := NewFromState(test.version, test.createState())
 			require.NoError(t, err)
 
 			dir := t.TempDir()

--- a/cannon/mipsevm/versions/state_test.go
+++ b/cannon/mipsevm/versions/state_test.go
@@ -4,7 +4,9 @@
 package versions
 
 import (
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +16,39 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/singlethreaded"
 	"github.com/ethereum-optimism/optimism/op-service/serialize"
 )
+
+func TestNewFromState(t *testing.T) {
+	for _, version := range StateVersionTypes {
+		if IsSupportedSingleThreaded(version) {
+			t.Run(version.String(), func(t *testing.T) {
+				actual, err := NewFromState(version, singlethreaded.CreateEmptyState())
+				require.NoError(t, err)
+				require.IsType(t, &singlethreaded.State{}, actual.FPVMState)
+				require.Equal(t, version, actual.Version)
+			})
+			t.Run(version.String()+"-mt-unsupported", func(t *testing.T) {
+				_, err := NewFromState(version, multithreaded.CreateEmptyState())
+				require.ErrorIs(t, err, ErrUnsupportedVersion)
+			})
+		} else if IsSupportedMultiThreaded(version) {
+			t.Run(version.String(), func(t *testing.T) {
+				actual, err := NewFromState(version, multithreaded.CreateEmptyState())
+				require.NoError(t, err)
+				require.IsType(t, &multithreaded.State{}, actual.FPVMState)
+				require.Equal(t, version, actual.Version)
+			})
+			t.Run(version.String()+"-st-unsupported", func(t *testing.T) {
+				_, err := NewFromState(version, singlethreaded.CreateEmptyState())
+				require.ErrorIs(t, err, ErrUnsupportedVersion)
+			})
+		} else {
+			t.Run(version.String()+"-unsupported", func(t *testing.T) {
+				_, err := NewFromState(version, multithreaded.CreateEmptyState())
+				require.ErrorIs(t, err, ErrUnsupportedVersion)
+			})
+		}
+	}
+}
 
 func TestLoadStateFromFile(t *testing.T) {
 	for _, version := range StateVersionTypes {
@@ -40,6 +75,18 @@ func TestLoadStateFromFile(t *testing.T) {
 			})
 		}
 	}
+
+	t.Run("JSONUnsupported", func(t *testing.T) {
+		filename := strconv.Itoa(int(VersionSingleThreaded)) + ".json"
+		dir := t.TempDir()
+		path := filepath.Join(dir, filename)
+		in, err := historicStates.ReadFile(filepath.Join(statesPath, filename))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, in, 0o644))
+
+		_, err = LoadStateFromFile(path)
+		require.ErrorIs(t, err, ErrUnsupportedVersion)
+	})
 }
 
 type versionAndStateCreator struct {

--- a/cannon/mipsevm/versions/version.go
+++ b/cannon/mipsevm/versions/version.go
@@ -89,17 +89,17 @@ func GetStateVersionStrings() []string {
 	return vers
 }
 
-// GetCurrentMultiThreaded64 returns the 64-bit multithreaded VM version that is currently supported
-func GetCurrentMultiThreaded64() StateVersion {
-	return VersionMultiThreaded64_v3
+// IsSupportedMultiThreaded64 returns true if the state version is a 64-bit multithreaded VM that is currently supported
+func IsSupportedMultiThreaded64(ver StateVersion) bool {
+	return ver == VersionMultiThreaded64_v3
 }
 
-// GetCurrentMultiThreaded returns the 32-bit multithreaded VM version that is currently supported
-func GetCurrentMultiThreaded() StateVersion {
-	return VersionMultiThreaded_v2
+// IsSupportedMultiThreaded returns true if the state version is a 32-bit multithreaded VM that is currently supported
+func IsSupportedMultiThreaded(ver StateVersion) bool {
+	return ver == VersionMultiThreaded_v2
 }
 
-// GetCurrentSingleThreaded returns the 32-bit single-threaded VM version that is currently supported
-func GetCurrentSingleThreaded() StateVersion {
-	return VersionSingleThreaded2
+// IsSupportedSingleThreaded returns true if the state version is a 32-bit single-threaded VM that is currently supported
+func IsSupportedSingleThreaded(ver StateVersion) bool {
+	return ver == VersionSingleThreaded2
 }


### PR DESCRIPTION
**Description**

Introduces support for feature toggling cannon STF based on the state version.  Only implements the go side of this currently and there are no features using toggles currently (https://github.com/ethereum-optimism/optimism/pull/15408/ shows how this would be used).

This also fully embraces the idea of their being more than one supported version (which is already true but currently there's only one supported version per "type").

**Tests**

Updated most tests to run over all supported versions rather than just the latest.

