### PR TITLE
op e2e: interop action test: cycle in self at single tx

### DIFF
--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -208,6 +208,89 @@ func consolidateToSafe(t helpers.Testing, actors *dsl.InteropActors, startA, sta
 	assertHeads(t, actors.ChainB, endB, endB, endB, endB)
 }
 
+// reorgOutUnsafeAndConsolidateToSafe assume that chainY is reorged, but chainX is not.
+// chainY is expected to experience cross-unsafe invalidation and reorging unsafe blocks.
+// Consolidate with steps: unsafe -> cross-unsafe -> local-safe -> safe
+func reorgOutUnsafeAndConsolidateToSafe(t helpers.Testing, actors *dsl.InteropActors, chainX, chainY *dsl.Chain, startX, startY, endX, endY, unsafeHeadNumAfterReorg uint64) {
+	require.GreaterOrEqual(t, endY, unsafeHeadNumAfterReorg)
+	// Check to make batcher happy
+	require.Positive(t, endY-startY)
+	require.Positive(t, endX-startX)
+
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+
+	assertHeads(t, chainX, endX, startX, endX, startX)
+	assertHeads(t, chainY, endY, startY, unsafeHeadNumAfterReorg, startY)
+
+	// check chain Y and and supervisor view of chain Y is consistent
+	reorgedOutBlock := chainY.Sequencer.SyncStatus().UnsafeL2
+	require.Equal(t, unsafeHeadNumAfterReorg+1, reorgedOutBlock.Number)
+	localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), chainY.ChainID)
+	require.NoError(t, err)
+	require.Equal(t, reorgedOutBlock.ID(), localUnsafe)
+
+	// now try to advance safe heads
+	chainX.Batcher.ActSubmitAll(t)
+	chainY.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(chainX.BatcherAddr)(t)
+	actors.L1Miner.ActL1IncludeTx(chainY.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+
+	actors.Supervisor.SignalLatestL1(t)
+
+	t.Log("awaiting L1-exhaust event")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, chainX, endX, startX, endX, startX)
+	assertHeads(t, chainY, endY, startY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("awaiting supervisor to provide L1 data")
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	assertHeads(t, chainX, endX, startX, endX, startX)
+	assertHeads(t, chainY, endY, startY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("awaiting node to sync: unsafe to local-safe")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, chainX, endX, endX, endX, startX)
+	assertHeads(t, chainY, endY, endY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("expecting supervisor to sync")
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	assertHeads(t, chainX, endX, endX, endX, startX)
+	assertHeads(t, chainY, endY, endY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("supervisor promotes cross-unsafe and safe")
+	actors.Supervisor.ProcessFull(t)
+
+	// check supervisor head, expect it to be rewound
+	localUnsafe, err = actors.Supervisor.LocalUnsafe(t.Ctx(), chainY.ChainID)
+	require.NoError(t, err)
+	require.Equal(t, unsafeHeadNumAfterReorg, localUnsafe.Number, "unsafe chain needs to be rewound")
+
+	t.Log("awaiting nodes to sync: local-safe to safe")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+
+	assertHeads(t, chainX, endX, endX, endX, endX)
+	assertHeads(t, chainY, endY, endY, endY, endY)
+
+	// Make sure the replaced block has different blockhash
+	replacedBlock := chainY.Sequencer.SyncStatus().LocalSafeL2
+	require.NotEqual(t, reorgedOutBlock.Hash, replacedBlock.Hash)
+	require.Equal(t, reorgedOutBlock.Number, replacedBlock.Number)
+	require.Equal(t, unsafeHeadNumAfterReorg+1, replacedBlock.Number)
+}
+
 func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))
@@ -540,79 +623,7 @@ func TestExpiredMessage(gt *testing.T) {
 	// BUT we intentionally break the message expiry invariant
 	require.Greater(t, includedB.Time, includedA.Time+expiryTime)
 
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	actors.ChainA.Sequencer.SyncSupervisor(t)
-	actors.ChainB.Sequencer.SyncSupervisor(t)
-	actors.Supervisor.ProcessFull(t)
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-
-	assertHeads(t, actors.ChainA, 2, 0, 2, 0)
-	// cross unsafe did not advance for chain B
-	assertHeads(t, actors.ChainB, expiredMsgBlockNum, 0, expiredMsgBlockNum-1, 0)
-
-	// check chain B and and supervisor view of chain B is consistent
-	reorgedOutBlock := actors.ChainB.Sequencer.SyncStatus().UnsafeL2
-	require.Equal(t, expiredMsgBlockNum, reorgedOutBlock.Number)
-	localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
-
-	require.NoError(t, err)
-	require.Equal(t, reorgedOutBlock.ID(), localUnsafe)
-
-	// now try to advance safe heads
-	actors.ChainA.Batcher.ActSubmitAll(t)
-	actors.ChainB.Batcher.ActSubmitAll(t)
-	actors.L1Miner.ActL1StartBlock(12)(t)
-	actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
-	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
-	actors.L1Miner.ActL1EndBlock(t)
-
-	actors.Supervisor.SignalLatestL1(t)
-
-	t.Log("awaiting L1-exhaust event")
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	assertHeads(t, actors.ChainA, 2, 0, 2, 0)
-	assertHeads(t, actors.ChainB, expiredMsgBlockNum, 0, expiredMsgBlockNum-1, 0)
-
-	t.Log("awaiting supervisor to provide L1 data")
-	actors.ChainA.Sequencer.SyncSupervisor(t)
-	actors.ChainB.Sequencer.SyncSupervisor(t)
-	assertHeads(t, actors.ChainA, 2, 0, 2, 0)
-	assertHeads(t, actors.ChainB, expiredMsgBlockNum, 0, expiredMsgBlockNum-1, 0)
-
-	t.Log("awaiting node to sync: unsafe to local-safe")
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	assertHeads(t, actors.ChainA, 2, 2, 2, 0)
-	assertHeads(t, actors.ChainB, expiredMsgBlockNum, expiredMsgBlockNum, expiredMsgBlockNum-1, 0)
-
-	t.Log("expecting supervisor to sync")
-	actors.ChainA.Sequencer.SyncSupervisor(t)
-	actors.ChainB.Sequencer.SyncSupervisor(t)
-	assertHeads(t, actors.ChainA, 2, 2, 2, 0)
-	assertHeads(t, actors.ChainB, expiredMsgBlockNum, expiredMsgBlockNum, expiredMsgBlockNum-1, 0)
-
-	t.Log("supervisor promotes cross-unsafe and safe")
-	actors.Supervisor.ProcessFull(t)
-
-	// check supervisor head, expect it to be rewound
-	localUnsafe, err = actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
-	require.NoError(t, err)
-	require.Equal(t, expiredMsgBlockNum-1, localUnsafe.Number, "unsafe chain needs to be rewound")
-
-	t.Log("awaiting nodes to sync: local-safe to safe")
-	actors.ChainA.Sequencer.ActL2PipelineFull(t)
-	actors.ChainB.Sequencer.ActL2PipelineFull(t)
-	assertHeads(t, actors.ChainA, 2, 2, 2, 2)
-	assertHeads(t, actors.ChainB, expiredMsgBlockNum, expiredMsgBlockNum, expiredMsgBlockNum, expiredMsgBlockNum)
-
-	// Make sure the replaced block has different blockhash
-	replacedBlock := actors.ChainB.Sequencer.SyncStatus().LocalSafeL2
-	require.NotEqual(t, reorgedOutBlock.Hash, replacedBlock.Hash)
-	require.Equal(t, reorgedOutBlock.Number, replacedBlock.Number)
-	require.Equal(t, expiredMsgBlockNum, replacedBlock.Number)
+	reorgOutUnsafeAndConsolidateToSafe(t, actors, actors.ChainA, actors.ChainB, 0, 0, 2, expiredMsgBlockNum, expiredMsgBlockNum-1)
 }
 
 // TestCrossPatternSameTimestamp tests below scenario:

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -868,7 +868,7 @@ func TestCycleInTx(gt *testing.T) {
 
 	assertHeads(t, actors.ChainA, 1, 0, 0, 0)
 
-	// assume all two txs land in block number 2, same time
+	// assume tx which multicalls exec message and init message land in block number 2
 	targetTime := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime*2
 	targetNum := uint64(2)
 	optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -851,3 +851,54 @@ func TestCrossPatternSameTx(gt *testing.T) {
 	require.Equal(t, chainAUnsafeHead, actors.ChainA.Sequencer.SyncStatus().SafeL2)
 	require.Equal(t, chainBUnsafeHead, actors.ChainB.Sequencer.SyncStatus().SafeL2)
 }
+
+// TestCycleInTx tests below scenario:
+// Transaction executes message, then initiates it: cycle with self
+func TestCycleInTx(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	rng := rand.New(rand.NewSource(1234))
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+	alice := setupUser(t, is, actors.ChainA, 0)
+
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	deployOptsA, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainA, 1), actors.ChainA)
+	eventLoggerAddressA := DeployEventLogger(t, deployOptsA)
+
+	assertHeads(t, actors.ChainA, 1, 0, 0, 0)
+
+	// assume all two txs land in block number 2, same time
+	targetTime := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime*2
+	targetNum := uint64(2)
+	optsA, _ := DefaultTxOpts(t, alice, actors.ChainA)
+
+	// open blocks
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+
+	// speculatively build exec message by knowing necessary info to build Message
+	init := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
+	logIndexX := uint(0)
+	exec, err := interop.ExecTriggerFromInitTrigger(init, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+	require.NoError(t, err)
+
+	// tx includes cycle with self
+	calls := []txintent.Call{exec, init}
+
+	// Intent to execute message X and initiate message X at chain A
+	tx := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](optsA)
+	tx.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: calls})
+
+	included, err := tx.PlannedTx.IncludedBlock.Eval(t.Ctx())
+	require.NoError(t, err)
+
+	// Make sure tx in block sealed at expected time
+	require.Equal(t, included.Time, targetTime)
+	require.Equal(t, included.Number, targetNum)
+
+	// Make batcher happy by advancing at least a single block
+	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
+
+	unsafeHeadNumAfterReorg := targetNum - 1
+	reorgOutUnsafeAndConsolidateToSafe(t, actors, actors.ChainB, actors.ChainA, 0, 0, 1, targetNum, unsafeHeadNumAfterReorg)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Do not merge till the base PR : https://github.com/ethereum-optimism/optimism/pull/15389 is merged to develop

This PR adds op-e2e interop action test using txintent. Checks that
- [x] Transaction executes message, then initiates it: cycle with self.

which are part of https://github.com/ethereum-optimism/optimism/issues/15092.

This PR builds on top of https://github.com/ethereum-optimism/optimism/pull/15389, which uses `ExecTriggerFromInitTrigger`. Also, refactors out the consolidation checker logic and adds `reorgOutUnsafeAndConsolidateToSafe` method; which promotes blocks following `unsafe -> cross-unsafe -> local-safe -> safe` pattern.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15391