### PR TITLE
Revert "op-node/p2p: ensure all topics are added to the topic scoring map"

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -82,20 +82,15 @@ func blocksTopicV4(cfg *rollup.Config) string {
 	return fmt.Sprintf("/optimism/%s/3/blocks", cfg.L2ChainID.String())
 }
 
-func allBlocksTopics(cfg *rollup.Config) []string {
-	return []string{
-		blocksTopicV1(cfg),
-		blocksTopicV2(cfg),
-		blocksTopicV3(cfg),
-		blocksTopicV4(cfg),
-		// add more topics here in the future, if any.
-	}
-}
-
 // BuildSubscriptionFilter builds a simple subscription filter,
 // to help protect against peers spamming useless subscriptions.
 func BuildSubscriptionFilter(cfg *rollup.Config) pubsub.SubscriptionFilter {
-	return pubsub.NewAllowlistSubscriptionFilter(allBlocksTopics(cfg)...)
+	return pubsub.NewAllowlistSubscriptionFilter(
+		blocksTopicV1(cfg),
+		blocksTopicV2(cfg),
+		blocksTopicV3(cfg),
+		blocksTopicV4(cfg), // add more topics here in the future, if any.
+	)
 }
 
 var msgBufPool = sync.Pool{New: func() any {

--- a/op-node/p2p/peer_params.go
+++ b/op-node/p2p/peer_params.go
@@ -43,34 +43,28 @@ func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
 	tenEpochs := 10 * epoch
 	oneHundredEpochs := 100 * epoch
 	invalidDecayPeriod := 50 * epoch
-
-	defaultTopicScoreParams := pubsub.TopicScoreParams{
-		TopicWeight:                     0.8,
-		TimeInMeshWeight:                MaxInMeshScore / inMeshCap(slot),
-		TimeInMeshQuantum:               slot,
-		TimeInMeshCap:                   inMeshCap(slot),
-		FirstMessageDeliveriesWeight:    1,
-		FirstMessageDeliveriesDecay:     ScoreDecay(20*epoch, slot),
-		FirstMessageDeliveriesCap:       23,
-		MeshMessageDeliveriesWeight:     MeshWeight,
-		MeshMessageDeliveriesDecay:      ScoreDecay(DecayEpoch*epoch, slot),
-		MeshMessageDeliveriesCap:        float64(uint64(epoch/slot) * uint64(DecayEpoch)),
-		MeshMessageDeliveriesThreshold:  float64(uint64(epoch/slot) * uint64(DecayEpoch) / 10),
-		MeshMessageDeliveriesWindow:     2 * time.Second,
-		MeshMessageDeliveriesActivation: 4 * epoch,
-		MeshFailurePenaltyWeight:        MeshWeight,
-		MeshFailurePenaltyDecay:         ScoreDecay(DecayEpoch*epoch, slot),
-		InvalidMessageDeliveriesWeight:  -140.4475,
-		InvalidMessageDeliveriesDecay:   ScoreDecay(invalidDecayPeriod, slot),
-	}
-
-	topics := make(map[string]*pubsub.TopicScoreParams)
-	for _, topic := range allBlocksTopics(cfg) {
-		topics[topic] = &defaultTopicScoreParams
-	}
-
 	return pubsub.PeerScoreParams{
-		Topics:        topics,
+		Topics: map[string]*pubsub.TopicScoreParams{
+			blocksTopicV1(cfg): {
+				TopicWeight:                     0.8,
+				TimeInMeshWeight:                MaxInMeshScore / inMeshCap(slot),
+				TimeInMeshQuantum:               slot,
+				TimeInMeshCap:                   inMeshCap(slot),
+				FirstMessageDeliveriesWeight:    1,
+				FirstMessageDeliveriesDecay:     ScoreDecay(20*epoch, slot),
+				FirstMessageDeliveriesCap:       23,
+				MeshMessageDeliveriesWeight:     MeshWeight,
+				MeshMessageDeliveriesDecay:      ScoreDecay(DecayEpoch*epoch, slot),
+				MeshMessageDeliveriesCap:        float64(uint64(epoch/slot) * uint64(DecayEpoch)),
+				MeshMessageDeliveriesThreshold:  float64(uint64(epoch/slot) * uint64(DecayEpoch) / 10),
+				MeshMessageDeliveriesWindow:     2 * time.Second,
+				MeshMessageDeliveriesActivation: 4 * epoch,
+				MeshFailurePenaltyWeight:        MeshWeight,
+				MeshFailurePenaltyDecay:         ScoreDecay(DecayEpoch*epoch, slot),
+				InvalidMessageDeliveriesWeight:  -140.4475,
+				InvalidMessageDeliveriesDecay:   ScoreDecay(invalidDecayPeriod, slot),
+			},
+		},
 		TopicScoreCap: 34,
 		AppSpecificScore: func(p peer.ID) float64 {
 			return 0

--- a/op-node/p2p/peer_params_test.go
+++ b/op-node/p2p/peer_params_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/suite"
 )
@@ -66,7 +65,11 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 	scoringParams, err := GetScoringParams("light", cfg)
 	peerParams := scoringParams.PeerScoring
 	testSuite.NoError(err)
-	requireAllTopicsPresent(testSuite, peerParams, cfg)
+	// Topics should contain options for block topic
+	testSuite.Len(peerParams.Topics, 1)
+	topicParams, ok := peerParams.Topics[blocksTopicV1(cfg)]
+	testSuite.True(ok, "should have block topic params")
+	testSuite.NotZero(topicParams.TimeInMeshQuantum)
 	testSuite.Equal(peerParams.TopicScoreCap, float64(34))
 	testSuite.Equal(peerParams.AppSpecificWeight, float64(1))
 	testSuite.Equal(peerParams.IPColocationFactorWeight, float64(-35))
@@ -91,15 +94,6 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 	testSuite.Positive(appParams.RejectedPayloadDecay)
 	testSuite.Equal(DecayToZero, appParams.DecayToZero)
 	testSuite.Equal(slot, appParams.DecayInterval)
-}
-
-// requireAllTopicsPresent checks that all block topics are present in the peer params.
-func requireAllTopicsPresent(testSuite *PeerParamsTestSuite, peerParams pubsub.PeerScoreParams, cfg *rollup.Config) {
-	for _, topic := range allBlocksTopics(cfg) {
-		topicParams, ok := peerParams.Topics[topic]
-		testSuite.True(ok, "should have block topic params, topic: %s", topic)
-		testSuite.NotZero(topicParams.TimeInMeshQuantum, "should have nonzero TimeInMeshQuantum")
-	}
 }
 
 // TestParamsZeroBlockTime validates peer score params use default slot for 0 block time.


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#15314

It causes serious peering issues in its current form. Need to investigate a proper fix first.