### PR TITLE
op-chain-ops/check-prestate: add diff-check.zsh post-processing script

### DIFF
--- a/op-chain-ops/cmd/check-prestate/README.md
+++ b/op-chain-ops/cmd/check-prestate/README.md
@@ -1,0 +1,30 @@
+# check-prestate
+
+The `check-prestate` tool can be used to generate a status report for an absolute prestate hash.
+It outputs JSON to stdout that contains useful information like its op-program version tag and commit of the monorepo,
+its type (cannon32/64), and the underlying op-geth and superchain-registry commits.
+It then also checks for each specified chain if the included chain configuration has changed
+compared to the latest changes in the superchain-registry.
+
+## Usage
+
+The script internally clones op-geth and runs its `sync-superchain.sh` script,
+so `git`, `jq`, `dasel`, and `zipinfo` need to be installed on your system.
+
+Given an absolute prestate hash and a list of chains (with their canonical network names), the tool can be run like the following:
+```sh
+HASH=0x03ee2917da962ec266b091f4b62121dc9682bb0db534633707325339f99ee405
+CHAINS=op-sepolia,ink-sepolia,base-sepolia,unichain-sepolia,soneium-minato-sepolia,op-mainnet,ink-mainnet,base-mainnet,unichain-mainnet,soneium-mainnet
+go run . --prestate-hash $HASH --chains $CHAINS | tee check.json | pbcopy
+```
+This will write the output JSON report to file `check.json` and also copy it to your clipboard (on MacOS).
+
+However, if there are diffs in the chain configurations, the different chain configs will be printed out, in full,
+for each chain in the `"outdated-chains"` array, at JSON paths `diff.prestate` and `diff.latest`.
+This makes it hard to tell the actual differences.
+The included script `diff-check.zsh` can be used for post-processing to only show what actually changed.
+It can be used like this:
+```sh
+./diff-check.zsh < check.json | pbcopy
+```
+after you have written the output of `check-prestate` to `check.json`.

--- a/op-chain-ops/cmd/check-prestate/diff-check.zsh
+++ b/op-chain-ops/cmd/check-prestate/diff-check.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-cat - | jq -r '."outdated-chains"[] | .name + "\n" + .diff.message + "\n" + (.diff.prestate | tostring) + "\n" + (.diff.latest | tostring)' | while read -r name; do
+cat - | jq -r '."outdated-chains" | sort_by(.name)[] | .name + "\n" + .diff.message + "\n" + (.diff.prestate | tostring) + "\n" + (.diff.latest | tostring)' | while read -r name; do
     read -r message
     read -r prestate
     read -r latest

--- a/op-chain-ops/cmd/check-prestate/diff-check.zsh
+++ b/op-chain-ops/cmd/check-prestate/diff-check.zsh
@@ -7,5 +7,5 @@ cat - | jq -r '."outdated-chains" | sort_by(.name)[] | .name + "\n" + .diff.mess
 
     echo "\n=== $name ===\n$message\n"
 
-    diff -u --label=prestate --label=latest <(echo "$prestate" | jq) <(echo "$latest" | jq)
+    diff -u --label="$name-prestate" --label="$name-latest" <(echo "$prestate" | jq) <(echo "$latest" | jq)
 done

--- a/op-chain-ops/cmd/check-prestate/diff-check.zsh
+++ b/op-chain-ops/cmd/check-prestate/diff-check.zsh
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh
+
+cat - | jq -r '."outdated-chains"[] | .name + "\n" + .diff.message + "\n" + (.diff.prestate | tostring) + "\n" + (.diff.latest | tostring)' | while read -r name; do
+    read -r message
+    read -r prestate
+    read -r latest
+
+    echo "\n=== $name ===\n$message\n"
+
+    diff -u --label=prestate --label=latest <(echo "$prestate" | jq) <(echo "$latest" | jq)
+done


### PR DESCRIPTION
**Description**

Adds a post-processing script `diff-check.zsh` for `check-prestate` and a `README.md`. The output of the script looks like
```diff
=== soneium-mainnet ===
Chain config mismatch

--- prestate
+++ latest
@@ -21,7 +21,7 @@
     "FjordTime": 0,
     "GraniteTime": 0,
     "HoloceneTime": 1738573200,
-    "IsthmusTime": null,
+    "IsthmusTime": 1746806401,
     "JovianTime": null,
     "PectraBlobScheduleTime": null
   },
```
see also the new README.