### PR TITLE
op-supervisor: Lint package for dynamic errors

### DIFF
--- a/op-supervisor/cmd/main_test.go
+++ b/op-supervisor/cmd/main_test.go
@@ -64,7 +64,7 @@ func TestL2ConsensusNodes(t *testing.T) {
 
 func TestDatadir(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag datadir is required", addRequiredArgsExcept("--datadir"))
+		verifyArgsInvalid(t, "required flag is missing: datadir", addRequiredArgsExcept("--datadir"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -17,6 +17,8 @@ import (
 
 const EnvVarPrefix = "OP_SUPERVISOR"
 
+var ErrRequiredFlagMissing = fmt.Errorf("required flag is missing")
+
 func prefixEnvVars(name string) []string {
 	return opservice.PrefixEnvVar(EnvVarPrefix, name)
 }
@@ -100,7 +102,7 @@ var Flags []cli.Flag
 func CheckRequired(ctx *cli.Context) error {
 	for _, f := range requiredFlags {
 		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
+			return fmt.Errorf("%w: %s", ErrRequiredFlagMissing, f.Names()[0])
 		}
 	}
 	return nil

--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -17,7 +17,6 @@ var (
 	ErrExecMsgUnknownChain    = fmt.Errorf("%w: executing message references unknown chain", types.ErrConflict)
 
 	errInconsistentBlockSeal = errors.New("inconsistent block seal")
-	errOpenBlock             = errors.New("failed to open block")
 )
 
 // CycleCheckDeps is an interface for checking cyclical dependencies between logs.

--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -1,6 +1,7 @@
 package cross
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,9 @@ var (
 	ErrCycle                  = fmt.Errorf("%w: cycle detected", types.ErrConflict)
 	ErrExecMsgHasInvalidIndex = fmt.Errorf("%w: executing message has invalid log index", types.ErrConflict)
 	ErrExecMsgUnknownChain    = fmt.Errorf("%w: executing message references unknown chain", types.ErrConflict)
+
+	errInconsistentBlockSeal = errors.New("inconsistent block seal")
+	errOpenBlock             = errors.New("failed to open block")
 )
 
 // CycleCheckDeps is an interface for checking cyclical dependencies between logs.
@@ -101,7 +105,7 @@ func gatherLogs(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 		}
 
 		if !blockSealMatchesRef(hazardBlock, bl) {
-			return nil, nil, fmt.Errorf("tried to open block %s of chain %s, but got different block %s than expected, use a reorg lock for consistency", hazardBlock, hazardChainID, bl)
+			return nil, nil, fmt.Errorf("tried to open block %s of chain %s, but got different block %s than expected, use a reorg lock for consistency: %w", hazardBlock, hazardChainID, bl, errInconsistentBlockSeal)
 		}
 
 		// Validate executing message indices

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -137,7 +137,7 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 		// Get the block and ensure it's allowed to execute messages.
 		opened, _, execMsgs, err := deps.OpenBlock(destChainID, candidate.Number)
 		if err != nil {
-			return fmt.Errorf("%w: %w", errOpenBlock, err)
+			return fmt.Errorf("failed to open block: %w", err)
 		}
 		if opened.ID() != candidate.ID() {
 			return fmt.Errorf("unsafe L2 DB has %s, but candidate cross-safe was %s: %w", opened, candidate, types.ErrConflict)

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+var (
+	errHazardSetNilDeps = errors.New("hazard dependencies cannot be nil")
+)
+
 type HazardDeps interface {
 	Contains(chain eth.ChainID, query types.ContainsQuery) (types.BlockSeal, error)
 	DependencySet() depset.DependencySet
@@ -26,7 +30,7 @@ type HazardSet struct {
 // NewHazardSet creates a new HazardSet with the given dependencies and initial block
 func NewHazardSet(deps HazardDeps, logger log.Logger, chainID eth.ChainID, block types.BlockSeal) (*HazardSet, error) {
 	if deps == nil {
-		return nil, fmt.Errorf("hazard dependencies cannot be nil")
+		return nil, errHazardSetNilDeps
 	}
 	h := &HazardSet{
 		entries: make(map[types.ChainIndex]types.BlockSeal),
@@ -64,7 +68,7 @@ func (h *HazardSet) checkChainCanExecute(depSet depset.DependencySet, chainID et
 
 // checkChainCanInitiate verifies that a chain can initiate messages at a given timestamp.
 // The chain must be able to initiate at the timestamp of the message we're referencing.
-func (h *HazardSet) checkChainCanInitiate(depSet depset.DependencySet, initChainID eth.ChainID, candidate types.BlockSeal, msg *types.ExecutingMessage) error {
+func (h *HazardSet) checkChainCanInitiate(depSet depset.DependencySet, initChainID eth.ChainID, msg *types.ExecutingMessage) error {
 	if ok, err := depSet.CanInitiateAt(initChainID, msg.Timestamp); err != nil {
 		return fmt.Errorf("cannot check message initiation of msg %s (chain %s): %w", msg, initChainID, err)
 	} else if !ok {
@@ -97,7 +101,7 @@ func (h *HazardSet) checkMessageWithCurrentTimestamp(msg *types.ExecutingMessage
 	existing, ok := h.entries[msg.Chain]
 	if ok {
 		if existing.ID() != includedIn.ID() {
-			return true, fmt.Errorf("found dependency on %s (chain %d), but already depend on %s", includedIn, initChainID, existing)
+			return true, fmt.Errorf("found dependency on %s (chain %d), but already depend on %s: %w", includedIn, initChainID, existing, types.ErrConflict)
 		}
 	}
 	return ok, nil
@@ -133,7 +137,7 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 		// Get the block and ensure it's allowed to execute messages.
 		opened, _, execMsgs, err := deps.OpenBlock(destChainID, candidate.Number)
 		if err != nil {
-			return fmt.Errorf("failed to open block: %w", err)
+			return fmt.Errorf("%w: %w", errOpenBlock, err)
 		}
 		if opened.ID() != candidate.ID() {
 			return fmt.Errorf("unsafe L2 DB has %s, but candidate cross-safe was %s: %w", opened, candidate, types.ErrConflict)
@@ -153,7 +157,7 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 				}
 				return err
 			}
-			if err := h.checkChainCanInitiate(depSet, srcChainID, candidate, msg); err != nil {
+			if err := h.checkChainCanInitiate(depSet, srcChainID, msg); err != nil {
 				return err
 			}
 			// performance: short-circuit inclusion checks if the message has expired

--- a/op-supervisor/supervisor/backend/cross/hazard_set_test.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set_test.go
@@ -63,7 +63,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1),
 				makeBlock(1, 100, 2),
 			},
-			expectErr: fmt.Errorf("already depend on"),
+			expectErr: types.ErrConflict,
 		},
 		{
 			name: "Hazards Across Multiple Chains",

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+var errRewindFailed = errors.New("rewind failed")
+
 type LogStorage interface {
 	io.Closer
 
@@ -219,7 +221,7 @@ func (db *ChainsDB) ResumeFromLastSealedBlock() error {
 		}
 		db.logger.Info("Resuming, starting from last sealed block", "head", head)
 		if err := logStore.Rewind(head); err != nil {
-			result = fmt.Errorf("failed to rewind chain %s to sealed block %d", chain, head)
+			result = fmt.Errorf("%w: failed to rewind chain %s to sealed block %d", errRewindFailed, chain, head)
 			return false
 		}
 		return true

--- a/op-supervisor/supervisor/backend/db/fromda/entry.go
+++ b/op-supervisor/supervisor/backend/db/fromda/entry.go
@@ -109,7 +109,7 @@ func (d *LinkEntry) encode() Entry {
 		out[0] = uint8(SourceV0)
 	}
 	if d.revision&(1<<63) != 0 {
-		panic(fmt.Errorf("cannot encode invalid revision value: %b", d.revision))
+		panic(fmt.Sprintf("cannot encode invalid revision value: %b", d.revision))
 	}
 	offset := 4
 	binary.BigEndian.PutUint64(out[offset:offset+8], d.source.Number)

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+var errInvalidateMismatch = fmt.Errorf("cannot invalidate mismatching block")
+
 func (db *DB) AddDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
@@ -319,7 +321,7 @@ func (db *DB) addLink(source eth.BlockRef, derived eth.BlockRef, invalidated com
 			if _, v, err := db.derivedNumToLastSource(derived.Number, last.revision); err != nil {
 				return fmt.Errorf("failed to check if older invalidated derived block was known: %w", err)
 			} else if v.derived.Hash != invalidated {
-				return fmt.Errorf("cannot invalidate mismatching block: expected %s but invalidating %s", link.derived, invalidated)
+				return fmt.Errorf("expected %s but invalidating %s: %w", link.derived, invalidated, errInvalidateMismatch)
 			}
 		} else {
 			return fmt.Errorf("derived block %s is older than current derived block %s: %w",

--- a/op-supervisor/supervisor/backend/db/logs/entries.go
+++ b/op-supervisor/supervisor/backend/db/logs/entries.go
@@ -2,12 +2,15 @@ package logs
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
+
+var errLogIndexTooLarge = errors.New("log index is too large")
 
 // searchCheckpoint is both a checkpoint for searching, as well as a checkpoint for sealing blocks.
 type searchCheckpoint struct {
@@ -116,7 +119,7 @@ type executingLink struct {
 
 func newExecutingLink(msg types.ExecutingMessage) (executingLink, error) {
 	if msg.LogIdx > 1<<24 {
-		return executingLink{}, fmt.Errorf("log idx is too large (%v)", msg.LogIdx)
+		return executingLink{}, fmt.Errorf("%w: %v", errLogIndexTooLarge, msg.LogIdx)
 	}
 	return executingLink{
 		chain:     uint32(msg.Chain),

--- a/op-supervisor/supervisor/backend/db/sync/client.go
+++ b/op-supervisor/supervisor/backend/db/sync/client.go
@@ -28,8 +28,7 @@ var (
 var (
 	errRootNotDir           = errors.New("root path is not a directory")
 	errUnknownFileAlias     = errors.New("unknown file alias")
-	errHeadRequest          = errors.New("HEAD request failed")
-	errGetRequest           = errors.New("GET request failed")
+	errHTTPRequestFailed    = errors.New("http request failed")
 	errDatabaseCopy         = errors.New("database copy failed")
 	errMissingContentLength = errors.New("missing Content-Length header")
 )
@@ -53,7 +52,7 @@ func NewClient(config Config, serverURL string) (*Client, error) {
 		return nil, fmt.Errorf("cannot access root directory: %w", err)
 	}
 	if !rootInfo.IsDir() {
-		return nil, fmt.Errorf("root path is not a directory: %w", errRootNotDir)
+		return nil, errRootNotDir
 	}
 
 	// Create the HTTP client
@@ -132,7 +131,7 @@ func (c *Client) attemptSync(ctx context.Context, chainID eth.ChainID, database 
 		return fmt.Errorf("HEAD request body failed to close: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: status %d", errHeadRequest, resp.StatusCode)
+		return fmt.Errorf("HEAD %w: status %d", errHTTPRequestFailed, resp.StatusCode)
 	}
 	totalSize, err := parseContentLength(resp.Header)
 	if err != nil {
@@ -159,7 +158,7 @@ func (c *Client) attemptSync(ctx context.Context, chainID eth.ChainID, database 
 		}
 	}()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-		return fmt.Errorf("%w: status %d", errGetRequest, resp.StatusCode)
+		return fmt.Errorf("GET %w: status %d", errHTTPRequestFailed, resp.StatusCode)
 	}
 
 	// Open the output file in the appropriate mode
@@ -196,7 +195,7 @@ func (c *Client) buildURLPath(chainID eth.ChainID, database Database) string {
 func parseContentLength(h http.Header) (int64, error) {
 	v := h.Get("Content-Length")
 	if v == "" {
-		return 0, fmt.Errorf("%w", errMissingContentLength)
+		return 0, errMissingContentLength
 	}
 	return strconv.ParseInt(v, 10, 64)
 }

--- a/op-supervisor/supervisor/backend/db/sync/client.go
+++ b/op-supervisor/supervisor/backend/db/sync/client.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,6 +25,15 @@ var (
 	}
 )
 
+var (
+	errRootNotDir           = errors.New("root path is not a directory")
+	errUnknownFileAlias     = errors.New("unknown file alias")
+	errHeadRequest          = errors.New("HEAD request failed")
+	errGetRequest           = errors.New("GET request failed")
+	errDatabaseCopy         = errors.New("database copy failed")
+	errMissingContentLength = errors.New("missing Content-Length header")
+)
+
 // Client handles downloading files from a sync server.
 type Client struct {
 	config     Config
@@ -43,7 +53,7 @@ func NewClient(config Config, serverURL string) (*Client, error) {
 		return nil, fmt.Errorf("cannot access root directory: %w", err)
 	}
 	if !rootInfo.IsDir() {
-		return nil, fmt.Errorf("root path is not a directory: %s", root)
+		return nil, fmt.Errorf("root path is not a directory: %w", errRootNotDir)
 	}
 
 	// Create the HTTP client
@@ -74,7 +84,7 @@ func (c *Client) SyncDatabase(ctx context.Context, chainID eth.ChainID, database
 	// Validate file alias
 	filePath, exists := Databases[database]
 	if !exists {
-		return fmt.Errorf("unknown file alias: %s", database)
+		return fmt.Errorf("%w: %s", errUnknownFileAlias, database)
 	}
 
 	// Ensure the chain directory exists
@@ -122,7 +132,7 @@ func (c *Client) attemptSync(ctx context.Context, chainID eth.ChainID, database 
 		return fmt.Errorf("HEAD request body failed to close: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HEAD request failed with status %d", resp.StatusCode)
+		return fmt.Errorf("%w: status %d", errHeadRequest, resp.StatusCode)
 	}
 	totalSize, err := parseContentLength(resp.Header)
 	if err != nil {
@@ -149,7 +159,7 @@ func (c *Client) attemptSync(ctx context.Context, chainID eth.ChainID, database 
 		}
 	}()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-		return fmt.Errorf("GET request failed with status %d", resp.StatusCode)
+		return fmt.Errorf("%w: status %d", errGetRequest, resp.StatusCode)
 	}
 
 	// Open the output file in the appropriate mode
@@ -171,7 +181,7 @@ func (c *Client) attemptSync(ctx context.Context, chainID eth.ChainID, database 
 	// Copy the data to disk
 	_, err = io.Copy(f, resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to copy data: %s", database)
+		return fmt.Errorf("%w: %s", errDatabaseCopy, database)
 	}
 
 	return nil
@@ -186,7 +196,7 @@ func (c *Client) buildURLPath(chainID eth.ChainID, database Database) string {
 func parseContentLength(h http.Header) (int64, error) {
 	v := h.Get("Content-Length")
 	if v == "" {
-		return 0, fmt.Errorf("missing Content-Length header")
+		return 0, fmt.Errorf("%w", errMissingContentLength)
 	}
 	return strconv.ParseInt(v, 10, 64)
 }

--- a/op-supervisor/supervisor/backend/db/sync/server.go
+++ b/op-supervisor/supervisor/backend/db/sync/server.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -8,6 +9,11 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var (
+	errInvalidRootDirectory = errors.New("invalid root directory")
+	errInvalidPath          = errors.New("invalid path")
 )
 
 // Server handles sync requests
@@ -30,7 +36,7 @@ func NewServer(config Config, chains []eth.ChainID) (*Server, error) {
 		return nil, fmt.Errorf("cannot access root directory: %w", err)
 	}
 	if !rootInfo.IsDir() {
-		return nil, fmt.Errorf("root path is not a directory: %s", root)
+		return nil, fmt.Errorf("root path is not a directory: %s. %w", root, errInvalidRootDirectory)
 	}
 
 	// Build map of valid chains for efficient lookup
@@ -54,7 +60,7 @@ func parsePath(path string) (eth.ChainID, string, error) {
 	// Trim leading and trailing slashes and split into segments
 	segments := strings.Split(strings.Trim(path, "/"), "/")
 	if len(segments) < 2 {
-		return chainID, fileAlias, fmt.Errorf("invalid path: %s", path)
+		return chainID, fileAlias, fmt.Errorf("%w: %s", errInvalidPath, path)
 	}
 	chainIDStr := segments[len(segments)-2]
 	fileAlias = segments[len(segments)-1]

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -3,6 +3,7 @@ package depset
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -11,6 +12,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
+
+var errDuplicateChainIndex = errors.New("duplicate chain index")
 
 type StaticConfigDependency struct {
 	// ChainIndex is the unique short identifier of this chain.
@@ -89,7 +92,7 @@ func (ds *StaticConfigDependencySet) hydrate() error {
 	ds.chainIDs = make([]eth.ChainID, 0, len(ds.dependencies))
 	for id, dep := range ds.dependencies {
 		if existing, ok := ds.indexToID[dep.ChainIndex]; ok {
-			return fmt.Errorf("chain %s cannot have the same index (%d) as chain %s", id, dep.ChainIndex, existing)
+			return fmt.Errorf("%w: chain %s cannot have the same index (%d) as chain %s", errDuplicateChainIndex, id, dep.ChainIndex, existing)
 		}
 		ds.indexToID[dep.ChainIndex] = id
 		ds.chainIDs = append(ds.chainIDs, id)

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -17,6 +17,8 @@ import (
 
 const reqTimeout = time.Second * 10
 
+var errNoL1Source = errors.New("no L1 source configured")
+
 type L1Source interface {
 	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
 	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
@@ -123,7 +125,7 @@ func (p *L1Accessor) PullFinalized() error {
 	p.clientMu.RLock()
 	defer p.clientMu.RUnlock()
 	if p.client == nil {
-		return errors.New("no L1 source configured")
+		return errNoL1Source
 	}
 
 	ctx, cancel := context.WithTimeout(p.sysCtx, reqTimeout)
@@ -141,7 +143,7 @@ func (p *L1Accessor) PullLatest() error {
 	defer p.clientMu.RUnlock()
 
 	if p.client == nil {
-		return errors.New("no L1 source configured")
+		return errNoL1Source
 	}
 
 	ctx, cancel := context.WithTimeout(p.sysCtx, reqTimeout)
@@ -186,7 +188,7 @@ func (p *L1Accessor) L1BlockRefByNumber(ctx context.Context, number uint64) (eth
 	p.clientMu.RLock()
 	defer p.clientMu.RUnlock()
 	if p.client == nil {
-		return eth.L1BlockRef{}, errors.New("no L1 source available")
+		return eth.L1BlockRef{}, errNoL1Source
 	}
 	// block access to requests more recent than the confirmation depth
 	if number > p.tip.Number-p.confDepth {

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"errors"
 	"io"
 	"sync/atomic"
 
@@ -27,14 +26,14 @@ func NewMockBackend() *MockBackend {
 
 func (m *MockBackend) Start(ctx context.Context) error {
 	if !m.started.CompareAndSwap(false, true) {
-		return errors.New("already started")
+		return errAlreadyStarted
 	}
 	return nil
 }
 
 func (m *MockBackend) Stop(ctx context.Context) error {
 	if !m.started.CompareAndSwap(true, false) {
-		return errors.New("already stopped")
+		return errAlreadyStopped
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-var ErrStatusTrackerNotReady = fmt.Errorf("supervisor status tracker not ready")
+var (
+	ErrStatusTrackerNotReady = errors.New("supervisor status tracker not ready")
+	ErrMinSyncedL1Mismatch   = errors.New("min synced L1 mismatch")
+)
 
 type StatusTracker struct {
 	statuses map[eth.ChainID]*NodeSyncStatus
@@ -102,7 +106,7 @@ func (su *StatusTracker) SyncStatus() (eth.SupervisorSyncStatus, error) {
 		if supervisorStatus.MinSyncedL1.Number == nodeStatus.CurrentL1.Number &&
 			supervisorStatus.MinSyncedL1.Hash != nodeStatus.CurrentL1.Hash {
 			// if the hashes are not equal, return an empty status
-			return eth.SupervisorSyncStatus{}, fmt.Errorf("min synced L1 hash mismatch: %v != %v", supervisorStatus.MinSyncedL1.Hash, nodeStatus.CurrentL1.Hash)
+			return eth.SupervisorSyncStatus{}, fmt.Errorf("%w: %v != %v", ErrMinSyncedL1Mismatch, supervisorStatus.MinSyncedL1.Hash, nodeStatus.CurrentL1.Hash)
 		}
 		// if the node's current L1 is higher than the min synced L1, we can skip it,
 		// because we already know a different node isn't synced to it yet

--- a/op-supervisor/supervisor/service.go
+++ b/op-supervisor/supervisor/service.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
 )
 
+var errInvalidMetricer = errors.New("invalid metricer")
+
 type Backend interface {
 	frontend.Backend
 }
@@ -134,7 +136,7 @@ func (su *SupervisorService) initMetricsServer(cfg *config.Config) error {
 	}
 	m, ok := su.metrics.(opmetrics.RegistryMetricer)
 	if !ok {
-		return fmt.Errorf("metrics were enabled, but metricer %T does not expose registry for metrics-server", su.metrics)
+		return fmt.Errorf("metrics were enabled, but metricer %T does not expose registry for metrics-server: %w", su.metrics, errInvalidMetricer)
 	}
 	su.log.Debug("Starting metrics server", "addr", cfg.MetricsConfig.ListenAddr, "port", cfg.MetricsConfig.ListenPort)
 	metricsSrv, err := opmetrics.StartServer(m.Registry(), cfg.MetricsConfig.ListenAddr, cfg.MetricsConfig.ListenPort)


### PR DESCRIPTION
Follow up on https://github.com/ethereum-optimism/optimism/pull/15192 to lint the op-supervisor package for dynamic errors. 

The tests in the op-supervisor package are not sanitized in this PR so that reviewers can easily observe that this change does not alter behavior. The tests will be taken care of in another PR, and once that's done op-supervisor will be checked for err113 in CI.