### PR TITLE
op-batcher: Record error when increaseGasPrice sign fails

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -885,7 +885,7 @@ func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transa
 	signedTx, err := m.cfg.Signer(ctx, m.cfg.From, newTx)
 	if err != nil {
 		m.l.Warn("failed to sign new transaction", "err", err, "tx", tx.Hash())
-		return tx, nil
+		return nil, err
 	}
 	return signedTx, nil
 }


### PR DESCRIPTION
**Description**

Previously, the error would be suppressed which meant that the batcher could get into a state where it would no longer increase the gas price of the transaction.

The tests properly fail if the fix is commented out.
