### PR TITLE
interop: op-supervisor <> op-node reconnection

### DIFF
--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -39,6 +39,10 @@ func TestL2CLResync(gt *testing.T) {
 
 	control := orch.ControlPlane()
 
+	blockTime := system.L2Network(ids.L2A).RollupConfig().BlockTime
+	require.Equal(t, blockTime, system.L2Network(ids.L2B).RollupConfig().BlockTime)
+
+	waitTime := time.Duration(blockTime+1) * time.Second
 	{
 		logger := system.T().Logger()
 
@@ -58,55 +62,57 @@ func TestL2CLResync(gt *testing.T) {
 		}
 
 		logger.Info("wait until passing genesis")
-		for range 5 {
-			query()
-			time.Sleep(time.Millisecond * 2500)
-		}
-
-		logger.Info("check unsafe chains are advancing")
-		prevBlockA, prevBlockB := query()
-		time.Sleep(time.Millisecond * 2500)
-		for range 5 {
+		var prevBlockA, prevBlockB eth.BlockRef
+		require.Eventually(t, func() bool {
 			blockA, blockB := query()
-			require.Greater(t, blockA.Number, prevBlockA.Number)
-			require.Greater(t, blockB.Number, prevBlockB.Number)
 			prevBlockA, prevBlockB = blockA, blockB
-			time.Sleep(time.Millisecond * 2500)
-		}
+			return blockA.Number > 0 && blockB.Number > 0
+		}, 16*time.Second, waitTime)
 
-		logger.Info("stop CL nodes")
+		time.Sleep(waitTime)
+		logger.Info("check unsafe chains are advancing")
+		require.Never(t, func() bool {
+			blockA, blockB := query()
+			advanced := prevBlockA.Number < blockA.Number && prevBlockB.Number < blockB.Number
+			prevBlockA, prevBlockB = blockA, blockB
+			return !advanced
+		}, 10*time.Second, waitTime)
+
+		logger.Info("stop L2CL nodes")
 		control.L2CLNodeState(ids.L2ACL, stack.Stop)
 		control.L2CLNodeState(ids.L2BCL, stack.Stop)
 
-		logger.Info("make sure ELs does not advance")
-		pausedBlockA, pausedBlockB := query()
-		for range 5 {
+		logger.Info("make sure L2ELs does not advance")
+		require.Eventually(t, func() bool {
 			blockA, blockB := query()
-			require.Equal(t, pausedBlockA.Hash, blockA.Hash)
-			require.Equal(t, pausedBlockB.Hash, blockB.Hash)
-			time.Sleep(time.Millisecond * 2500)
-		}
+			isStatic := prevBlockA.Hash == blockA.Hash && prevBlockB.Hash == blockB.Hash
+			prevBlockA, prevBlockB = blockA, blockB
+			return isStatic
+		}, 10*time.Second, waitTime)
 
-		logger.Info("restart CL nodes")
+		logger.Info("restart L2CL nodes")
 		control.L2CLNodeState(ids.L2ACL, stack.Start)
 		control.L2CLNodeState(ids.L2BCL, stack.Start)
 
-		// supervisor will attempt to reconnect with L2CLs at this point because L2CL ws endpoint is recovered
-		logger.Info("wait until L2CLs heat up again")
-		for range 5 {
-			query()
-			time.Sleep(time.Millisecond * 2500)
-		}
-
-		logger.Info("check unsafe chains are advancing again")
-		prevBlockA, prevBlockB = pausedBlockA, pausedBlockB
-		for range 5 {
+		// L2CL may advance a few blocks without supervisor connection, but eventually it will stop without the connection
+		// we must check that unsafe head is advancing due to reconnection
+		logger.Info("boot up L2CL nodes")
+		require.Eventually(t, func() bool {
 			blockA, blockB := query()
-			require.Greater(t, blockA.Number, prevBlockA.Number)
-			require.Greater(t, blockB.Number, prevBlockB.Number)
+			advanced := prevBlockA.Number < blockA.Number && prevBlockB.Number < blockB.Number
 			prevBlockA, prevBlockB = blockA, blockB
-			time.Sleep(time.Millisecond * 2500)
-		}
-		// supervisor is successfully connected with managed L2CLs
+			return advanced
+		}, 15*time.Second, waitTime)
+
+		// supervisor will attempt to reconnect with L2CLs at this point because L2CL ws endpoint is recovered
+		logger.Info("check unsafe chains are advancing again")
+		require.Never(t, func() bool {
+			blockA, blockB := query()
+			advanced := prevBlockA.Number < blockA.Number && prevBlockB.Number < blockB.Number
+			prevBlockA, prevBlockB = blockA, blockB
+			return !advanced
+		}, 15*time.Second, waitTime)
+
+		// supervisor successfully connected with managed L2CLs
 	}
 }

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -1,0 +1,111 @@
+package sysgo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/shim"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// TestL2CLResync checks that unsafe head advances after restarting L2CL
+func TestL2CLResync(gt *testing.T) {
+	var ids DefaultInteropSystemIDs
+	opt := DefaultInteropSystem(&ids)
+
+	logger := testlog.Logger(gt, log.LevelInfo)
+
+	p := devtest.NewP(logger, func() {
+		gt.Helper()
+		gt.FailNow()
+	})
+	gt.Cleanup(p.Close)
+
+	orch := NewOrchestrator(p)
+	opt(orch)
+
+	t := devtest.SerialT(gt)
+	system := shim.NewSystem(t)
+	orch.Hydrate(system)
+
+	control := orch.ControlPlane()
+
+	{
+		logger := system.T().Logger()
+
+		elA := system.L2Network(ids.L2A).L2ELNode(ids.L2AEL)
+		elB := system.L2Network(ids.L2B).L2ELNode(ids.L2BEL)
+
+		query := func() (eth.BlockRef, eth.BlockRef) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			blockA, err := elA.EthClient().BlockRefByLabel(ctx, "latest")
+			require.NoError(t, err)
+			blockB, err := elB.EthClient().BlockRefByLabel(ctx, "latest")
+			require.NoError(t, err)
+			cancel()
+			logger.Info("chain A", "blockNum", blockA.Number, "tip", blockA)
+			logger.Info("chain B", "blockNum", blockB.Number, "tip", blockB)
+			return blockA, blockB
+		}
+
+		logger.Info("wait until passing genesis")
+		for range 5 {
+			query()
+			time.Sleep(time.Millisecond * 2500)
+		}
+
+		logger.Info("check unsafe chains are advancing")
+		prevBlockA, prevBlockB := query()
+		time.Sleep(time.Millisecond * 2500)
+		for range 5 {
+			blockA, blockB := query()
+			require.Greater(t, blockA.Number, prevBlockA.Number)
+			require.Greater(t, blockB.Number, prevBlockB.Number)
+			prevBlockA, prevBlockB = blockA, blockB
+			time.Sleep(time.Millisecond * 2500)
+		}
+
+		logger.Info("stop CL nodes")
+		control.L2CLNodeState(ids.L2ACL, stack.Stop)
+		control.L2CLNodeState(ids.L2BCL, stack.Stop)
+
+		logger.Info("make sure ELs does not advance")
+		pausedBlockA, pausedBlockB := query()
+		for range 5 {
+			blockA, blockB := query()
+			require.Equal(t, pausedBlockA.Hash, blockA.Hash)
+			require.Equal(t, pausedBlockB.Hash, blockB.Hash)
+			time.Sleep(time.Millisecond * 2500)
+		}
+
+		logger.Info("restart CL nodes")
+		control.L2CLNodeState(ids.L2ACL, stack.Start)
+		control.L2CLNodeState(ids.L2BCL, stack.Start)
+
+		// supervisor will attempt to reconnect with L2CLs at this point because L2CL ws endpoint is recovered
+		logger.Info("wait until L2CLs heat up again")
+		for range 5 {
+			query()
+			time.Sleep(time.Millisecond * 2500)
+		}
+
+		logger.Info("check unsafe chains are advancing again")
+		prevBlockA, prevBlockB = pausedBlockA, pausedBlockB
+		for range 5 {
+			blockA, blockB := query()
+			require.Greater(t, blockA.Number, prevBlockA.Number)
+			require.Greater(t, blockB.Number, prevBlockB.Number)
+			prevBlockA, prevBlockB = blockA, blockB
+			time.Sleep(time.Millisecond * 2500)
+		}
+		// supervisor is successfully connected with managed L2CLs
+	}
+}

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-// TestL2CLResync checks that unsafe head advances after restarting L2CL
+// TestL2CLResync checks that unsafe head advances after restarting L2CL.
+// Resync is only possible when supervisor and L2CL reconnects.
 func TestL2CLResync(gt *testing.T) {
 	var ids DefaultInteropSystemIDs
 	opt := DefaultInteropSystem(&ids)

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -98,6 +98,10 @@ func (m *mockSyncControl) String() string {
 	return "mock"
 }
 
+func (m *mockSyncControl) ReconnectRPC(ctx context.Context) error {
+	return nil
+}
+
 var _ SyncControl = (*mockSyncControl)(nil)
 
 type mockBackend struct {

--- a/op-supervisor/supervisor/backend/syncnode/dial.go
+++ b/op-supervisor/supervisor/backend/syncnode/dial.go
@@ -35,8 +35,6 @@ func (r *RPCDialSetup) Setup(ctx context.Context, logger log.Logger, m opmetrics
 	if err != nil {
 		return nil, err
 	}
-	return &RPCSyncNode{
-		name: fmt.Sprintf("RPCSyncSource(%s)", r.Endpoint),
-		cl:   rpcCl,
-	}, nil
+	name := fmt.Sprintf("RPCSyncSource(%s)", r.Endpoint)
+	return NewRPCSyncNode(name, rpcCl, opts, logger, r), nil
 }

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -49,6 +49,8 @@ type SyncControl interface {
 	ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error
 	AnchorPoint(ctx context.Context) (types.DerivedBlockRefPair, error)
 
+	ReconnectRPC(ctx context.Context) error
+
 	fmt.Stringer
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds reconnection logic between op-supervisor and op-node

When op-node shuts down, supervisor detects closed `nodeEvent` channel, and stops the ManagedNode busy loop consuming events:
https://github.com/ethereum-optimism/optimism/blob/273fd6abd4a92824e05f3daa9322b0c8add9e843/op-supervisor/supervisor/backend/syncnode/node.go#L197-L216

Even if the `nodeEvent` channel is reinitialized at:
https://github.com/ethereum-optimism/optimism/blob/273fd6abd4a92824e05f3daa9322b0c8add9e843/op-supervisor/supervisor/backend/syncnode/node.go#L149-L161

the event consuming loop already exited.

Diff of this PR:
- Supervisor ManagedNode loop does not exit when `nodeEvent` channel is closed. Instead it sleeps for some time quantum and loops again to check the `nodeEvent` channel is open again.
- When websocket closure is detected, it attempts to reconnect with the op-node with its known auth info and endpoint.

Supervisor will now reconnect and make the op-node happy and re-sync(advancing unsafe head).

**Tests**

Added `TestL2CLResync` sysgo test which restarts L2 CL and checks it resyncs.

Example testlogs(discard the XXX)
```
    sync_test.go:65:            INFO [04-17|19:11:24.638] wait until passing genesis               XXX=XXX
    sync_test.go:60:            INFO [04-17|19:11:27.644] chain A                                  XXX=XXX blockNum=0 tip=1371d7..d59b9c:0
    sync_test.go:61:            INFO [04-17|19:11:27.645] chain B                                  XXX=XXX blockNum=0 tip=f6a2bf..0df97f:0
    sync_test.go:60:            INFO [04-17|19:11:30.639] chain A                                  XXX=XXX blockNum=3 tip=aa0ca2..04e08d:3
    sync_test.go:61:            INFO [04-17|19:11:30.639] chain B                                  XXX=XXX blockNum=3 tip=eb1e1e..d9d1e0:3
    sync_test.go:74:            INFO [04-17|19:11:33.639] check unsafe chains are advancing        XXX=XXX
    sync_test.go:60:            INFO [04-17|19:11:36.640] chain A                                  XXX=XXX blockNum=6 tip=c3597e..7c1597:6
    sync_test.go:61:            INFO [04-17|19:11:36.640] chain B                                  XXX=XXX blockNum=6 tip=d534ca..58c45e:6
    sync_test.go:60:            INFO [04-17|19:11:39.641] chain A                                  XXX=XXX blockNum=7 tip=5ab9c8..86da2b:7
    sync_test.go:61:            INFO [04-17|19:11:39.641] chain B                                  XXX=XXX blockNum=7 tip=6b039d..f2b802:7
    sync_test.go:60:            INFO [04-17|19:11:42.641] chain A                                  XXX=XXX blockNum=9 tip=558841..246877:9
    sync_test.go:61:            INFO [04-17|19:11:42.641] chain B                                  XXX=XXX blockNum=9 tip=53312a..a46a65:9
    sync_test.go:82:            INFO [04-17|19:11:43.640] stop L2CL nodes                          XXX=XXX
    sync_test.go:86:            INFO [04-17|19:11:43.642] make sure L2ELs does not advance         XXX=XXX
    sync_test.go:60:            INFO [04-17|19:11:46.644] chain A                                  XXX=XXX blockNum=9 tip=558841..246877:9
    sync_test.go:61:            INFO [04-17|19:11:46.645] chain B                                  XXX=XXX blockNum=9 tip=53312a..a46a65:9
    sync_test.go:94:            INFO [04-17|19:11:46.645] restart L2CL nodes                       XXX=XXX
    sync_test.go:100:           INFO [04-17|19:11:46.708] boot up L2CL nodes                       XXX=XXX
    sync_test.go:60:            INFO [04-17|19:11:49.710] chain A                                  XXX=XXX blockNum=12 tip=089910..ce0ad9:12
    sync_test.go:61:            INFO [04-17|19:11:49.710] chain B                                  XXX=XXX blockNum=12 tip=6f171c..6c27ec:12
    sync_test.go:109:           INFO [04-17|19:11:49.710] check unsafe chains are advancing again  XXX=XXX
    sync_test.go:60:            INFO [04-17|19:11:52.712] chain A                                  XXX=XXX blockNum=14 tip=c3c8fe..7339ab:14
    sync_test.go:61:            INFO [04-17|19:11:52.712] chain B                                  XXX=XXX blockNum=14 tip=96cf2e..b768d4:14
    sync_test.go:60:            INFO [04-17|19:11:55.711] chain A                                  XXX=XXX blockNum=15 tip=082967..b26aa6:15
    sync_test.go:61:            INFO [04-17|19:11:55.711] chain B                                  XXX=XXX blockNum=15 tip=6211ad..7689bd:15
    sync_test.go:60:            INFO [04-17|19:11:58.712] chain A                                  XXX=XXX blockNum=17 tip=b2d5aa..467707:17
    sync_test.go:61:            INFO [04-17|19:11:58.712] chain B                                  XXX=XXX blockNum=17 tip=be8109..be84ea:17
    sync_test.go:60:            INFO [04-17|19:12:01.712] chain A                                  XXX=XXX blockNum=18 tip=5e5699..0519d9:18
    sync_test.go:61:            INFO [04-17|19:12:01.712] chain B                                  XXX=XXX blockNum=18 tip=eac32d..df0b3d:18
```

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15427
