### PR TITLE
fix(devnet-sdk): keep devnet descriptor updated

### DIFF
--- a/devnet-sdk/controller/kt/kt.go
+++ b/devnet-sdk/controller/kt/kt.go
@@ -4,26 +4,62 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/controller/surface"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/run"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/wrappers"
 )
 
 type KurtosisControllerSurface struct {
-	runner *run.KurtosisRunner
+	env         *descriptors.DevnetEnvironment
+	kurtosisCtx interfaces.KurtosisContextInterface
+	runner      *run.KurtosisRunner
+	devnetfs    *fs.DevnetFS
+
+	// control operations are disruptive, let's make sure we don't run them
+	// concurrently so that test logic has a fighting chance of being correct.
+	mtx sync.Mutex
 }
 
-func NewKurtosisControllerSurface(enclave string) (*KurtosisControllerSurface, error) {
-	runner, err := run.NewKurtosisRunner(run.WithKurtosisRunnerEnclave(enclave))
+func NewKurtosisControllerSurface(env *descriptors.DevnetEnvironment) (*KurtosisControllerSurface, error) {
+	enclave := env.Name
+
+	kurtosisCtx, err := wrappers.GetDefaultKurtosisContext()
 	if err != nil {
 		return nil, err
 	}
+
+	runner, err := run.NewKurtosisRunner(
+		run.WithKurtosisRunnerEnclave(enclave),
+		run.WithKurtosisRunnerKurtosisContext(kurtosisCtx),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	enclaveFS, err := fs.NewEnclaveFS(context.TODO(), enclave)
+	if err != nil {
+		return nil, err
+	}
+	// Create a new DevnetFS instance using the enclaveFS
+	devnetfs := fs.NewDevnetFS(enclaveFS)
+
 	return &KurtosisControllerSurface{
-		runner: runner,
+		env:         env,
+		kurtosisCtx: kurtosisCtx,
+		runner:      runner,
+		devnetfs:    devnetfs,
 	}, nil
 }
 
 func (s *KurtosisControllerSurface) StartService(ctx context.Context, serviceName string) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
 	script := fmt.Sprintf(`
 def run(plan):
 	plan.start_service(name="%s")
@@ -33,20 +69,41 @@ def run(plan):
 	if err := s.runner.RunScript(ctx, script); err != nil {
 		msg := err.Error()
 		if strings.Contains(strings.ToLower(msg), "is already in use by container") {
+			// we know we don't need to update the env, as the service was already running
 			return nil
 		}
 		return err
 	}
-	return nil
+	return s.updateDevnetEnvironmentForService(ctx, serviceName, true)
 }
 
 func (s *KurtosisControllerSurface) StopService(ctx context.Context, serviceName string) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
 	script := fmt.Sprintf(`
 def run(plan):
 	plan.stop_service(name="%s")
 `, serviceName)
-	// stop_service is idempotent
-	return s.runner.RunScript(ctx, script)
+	// stop_service is idempotent, so errors here are real
+	if err := s.runner.RunScript(ctx, script); err != nil {
+		return err
+	}
+	// conversely, we don't know if the service was running or not, so we need to update the env
+	return s.updateDevnetEnvironmentForService(ctx, serviceName, false)
+}
+
+func (s *KurtosisControllerSurface) updateDevnetEnvironmentForService(ctx context.Context, serviceName string, on bool) error {
+	//
+	refreshed, err := s.updateDevnetEnvironmentService(ctx, serviceName, on)
+	if err != nil {
+		return err
+	}
+	if !refreshed {
+		return nil
+	}
+
+	return s.devnetfs.UploadDevnetDescriptor(ctx, s.env)
 }
 
 var _ surface.ServiceLifecycleSurface = (*KurtosisControllerSurface)(nil)

--- a/devnet-sdk/controller/kt/mutate_env.go
+++ b/devnet-sdk/controller/kt/mutate_env.go
@@ -1,0 +1,101 @@
+package kt
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
+)
+
+// a hack because some L2 services are duplicated across chains
+type redundantService []*descriptors.Service
+
+func (s redundantService) getEndpoints() descriptors.EndpointMap {
+	if len(s) == 0 {
+		return nil
+	}
+
+	return s[0].Endpoints
+}
+
+func (s redundantService) setEndpoints(endpoints descriptors.EndpointMap) {
+	for _, svc := range s {
+		svc.Endpoints = endpoints
+	}
+}
+
+func (s redundantService) refreshEndpoints(serviceCtx interfaces.ServiceContext) {
+	endpoints := s.getEndpoints()
+
+	publicPorts := serviceCtx.GetPublicPorts()
+	privatePorts := serviceCtx.GetPrivatePorts()
+
+	for name, info := range publicPorts {
+		endpoints[name].Port = int(info.GetNumber())
+	}
+	for name, info := range privatePorts {
+		endpoints[name].PrivatePort = int(info.GetNumber())
+	}
+
+	s.setEndpoints(endpoints)
+}
+
+func findSvcInEnv(env *descriptors.DevnetEnvironment, serviceName string) redundantService {
+	if svc := findSvcInChain(env.L1, serviceName); svc != nil {
+		return redundantService{svc}
+	}
+
+	var services redundantService = nil
+	for _, l2 := range env.L2 {
+		if svc := findSvcInChain(l2.Chain, serviceName); svc != nil {
+			services = append(services, svc)
+		}
+	}
+	return services
+}
+
+func findSvcInChain(chain *descriptors.Chain, serviceName string) *descriptors.Service {
+	for _, svc := range chain.Services {
+		if svc.Name == serviceName {
+			return svc
+		}
+	}
+
+	for _, node := range chain.Nodes {
+		for _, svc := range node.Services {
+			if svc.Name == serviceName {
+				return svc
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *KurtosisControllerSurface) updateDevnetEnvironmentService(ctx context.Context, serviceName string, on bool) (bool, error) {
+	svc := findSvcInEnv(s.env, serviceName)
+	if svc == nil {
+		// service is not part of the env, so we don't need to do anything
+		return false, nil
+	}
+
+	// get the enclave
+	enclaveCtx, err := s.kurtosisCtx.GetEnclave(ctx, s.env.Name)
+	if err != nil {
+		return false, err
+	}
+
+	serviceCtx, err := enclaveCtx.GetService(serviceName)
+	if err != nil {
+		return false, err
+	}
+
+	if on {
+		fmt.Println("on")
+		svc.refreshEndpoints(serviceCtx)
+	}
+	// otherwise the service is down anyway, it doesn't matter if it has outdated endpoints
+	return on, nil
+}

--- a/devnet-sdk/controller/kt/mutate_env_test.go
+++ b/devnet-sdk/controller/kt/mutate_env_test.go
@@ -1,0 +1,150 @@
+package kt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedundantServiceRefreshEndpoints(t *testing.T) {
+	// Create a test service with some initial endpoints
+	svc1 := &descriptors.Service{
+		Name: "test-service",
+		Endpoints: descriptors.EndpointMap{
+			"http": {
+				Port:        0,
+				PrivatePort: 0,
+			},
+			"ws": {
+				Port:        0,
+				PrivatePort: 0,
+			},
+		},
+	}
+	svc2 := &descriptors.Service{
+		Name: "test-service",
+		Endpoints: descriptors.EndpointMap{
+			"http": {
+				Port:        0,
+				PrivatePort: 0,
+			},
+			"ws": {
+				Port:        0,
+				PrivatePort: 0,
+			},
+		},
+	}
+
+	// Create a redundant service with both services
+	redundant := redundantService{svc1, svc2}
+
+	// Create a test service context with new port numbers
+	testCtx := &testServiceContext{
+		publicPorts: map[string]interfaces.PortSpec{
+			"http": &testPortSpec{number: 8080},
+			"ws":   &testPortSpec{number: 8081},
+		},
+		privatePorts: map[string]interfaces.PortSpec{
+			"http": &testPortSpec{number: 8082},
+			"ws":   &testPortSpec{number: 8083},
+		},
+	}
+
+	// Call refreshEndpoints
+	redundant.refreshEndpoints(testCtx)
+
+	// Verify that both services have been updated with the new port numbers
+	for _, svc := range redundant {
+		require.Equal(t, 8080, svc.Endpoints["http"].Port)
+		require.Equal(t, 8081, svc.Endpoints["ws"].Port)
+		require.Equal(t, 8082, svc.Endpoints["http"].PrivatePort)
+		require.Equal(t, 8083, svc.Endpoints["ws"].PrivatePort)
+	}
+}
+
+func TestRedundantServiceEmpty(t *testing.T) {
+	// Test behavior with empty redundant service
+	redundant := redundantService{}
+	testCtx := &testServiceContext{
+		publicPorts:  map[string]interfaces.PortSpec{},
+		privatePorts: map[string]interfaces.PortSpec{},
+	}
+
+	// This should not panic
+	redundant.refreshEndpoints(testCtx)
+}
+
+func TestUpdateDevnetEnvironmentService(t *testing.T) {
+	// Create a test environment with a service
+	env := &descriptors.DevnetEnvironment{
+		Name: "test-env",
+		L1: &descriptors.Chain{
+			Services: descriptors.ServiceMap{
+				"test-service": &descriptors.Service{
+					Name: "test-service",
+					Endpoints: descriptors.EndpointMap{
+						"http": {
+							Port:        0,
+							PrivatePort: 0,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create a test service context with new port numbers
+	testSvcCtx := &testServiceContext{
+		publicPorts: map[string]interfaces.PortSpec{
+			"http": &testPortSpec{number: 8080},
+		},
+		privatePorts: map[string]interfaces.PortSpec{
+			"http": &testPortSpec{number: 8082},
+		},
+	}
+
+	// Create a mock enclave context with our service
+	mockEnclave := &mockEnclaveContext{
+		services: map[services.ServiceName]interfaces.ServiceContext{
+			"test-service": testSvcCtx,
+		},
+	}
+
+	// Create a mock kurtosis context with our enclave
+	mockKurtosisCtx := &mockKurtosisContext{
+		enclaves: map[string]interfaces.EnclaveContext{
+			"test-env": mockEnclave,
+		},
+	}
+
+	// Create the controller surface
+	controller := &KurtosisControllerSurface{
+		kurtosisCtx: mockKurtosisCtx,
+		env:         env,
+	}
+
+	// Create the mock DevnetFS
+	mockDevnetFS, err := newMockDevnetFS(env)
+	require.NoError(t, err)
+	controller.devnetfs = mockDevnetFS
+
+	// Test updating the service (turning it on)
+	updated, err := controller.updateDevnetEnvironmentService(context.Background(), "test-service", true)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	// Verify that the service's endpoints were updated
+	svc := findSvcInEnv(env, "test-service")
+	require.NotNil(t, svc)
+	require.Equal(t, 8080, svc[0].Endpoints["http"].Port)
+	require.Equal(t, 8082, svc[0].Endpoints["http"].PrivatePort)
+
+	// Test updating a non-existent service
+	updated, err = controller.updateDevnetEnvironmentService(context.Background(), "non-existent-service", true)
+	require.NoError(t, err)
+	require.False(t, updated)
+}

--- a/devnet-sdk/controller/kt/test_helpers.go
+++ b/devnet-sdk/controller/kt/test_helpers.go
@@ -1,0 +1,129 @@
+package kt
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/starlark_run_config"
+	"github.com/spf13/afero"
+)
+
+// testPortSpec implements interfaces.PortSpec
+type testPortSpec struct {
+	number uint16
+}
+
+func (m *testPortSpec) GetNumber() uint16 {
+	return m.number
+}
+
+// testServiceContext implements interfaces.ServiceContext
+type testServiceContext struct {
+	publicPorts  map[string]interfaces.PortSpec
+	privatePorts map[string]interfaces.PortSpec
+}
+
+func (m *testServiceContext) GetServiceUUID() services.ServiceUUID {
+	return "mock-service-uuid"
+}
+
+func (m *testServiceContext) GetMaybePublicIPAddress() string {
+	return "127.0.0.1"
+}
+
+func (m *testServiceContext) GetPublicPorts() map[string]interfaces.PortSpec {
+	return m.publicPorts
+}
+
+func (m *testServiceContext) GetPrivatePorts() map[string]interfaces.PortSpec {
+	return m.privatePorts
+}
+
+// mockEnclaveFS implements fs.EnclaveContextIface for testing
+type mockEnclaveFS struct {
+	env *descriptors.DevnetEnvironment
+}
+
+func (m *mockEnclaveFS) GetAllFilesArtifactNamesAndUuids(ctx context.Context) ([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, error) {
+	return nil, nil
+}
+
+func (m *mockEnclaveFS) DownloadFilesArtifact(ctx context.Context, name string) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockEnclaveFS) UploadFiles(pathToUpload string, artifactName string) (services.FilesArtifactUUID, services.FileArtifactName, error) {
+	return "", "", nil
+}
+
+// newMockDevnetFS creates a new mock DevnetFS for testing
+func newMockDevnetFS(env *descriptors.DevnetEnvironment) (*fs.DevnetFS, error) {
+	mockEnclaveFS := &mockEnclaveFS{env: env}
+	enclaveFS, err := fs.NewEnclaveFS(context.Background(), "test-enclave",
+		fs.WithEnclaveCtx(mockEnclaveFS),
+		fs.WithFs(afero.NewMemMapFs()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return fs.NewDevnetFS(enclaveFS), nil
+}
+
+type mockEnclaveContext struct {
+	services map[services.ServiceName]interfaces.ServiceContext
+}
+
+func (m *mockEnclaveContext) GetEnclaveUuid() enclaves.EnclaveUUID {
+	return "mock-enclave-uuid"
+}
+
+func (m *mockEnclaveContext) GetService(serviceIdentifier string) (interfaces.ServiceContext, error) {
+	if svc, ok := m.services[services.ServiceName(serviceIdentifier)]; ok {
+		return svc, nil
+	}
+	return nil, nil
+}
+
+func (m *mockEnclaveContext) GetServices() (map[services.ServiceName]services.ServiceUUID, error) {
+	result := make(map[services.ServiceName]services.ServiceUUID)
+	for name, svc := range m.services {
+		result[name] = svc.GetServiceUUID()
+	}
+	return result, nil
+}
+
+func (m *mockEnclaveContext) GetAllFilesArtifactNamesAndUuids(ctx context.Context) ([]*kurtosis_core_rpc_api_bindings.FilesArtifactNameAndUuid, error) {
+	return nil, nil
+}
+
+func (m *mockEnclaveContext) RunStarlarkPackage(ctx context.Context, pkg string, serializedParams *starlark_run_config.StarlarkRunConfig) (<-chan interfaces.StarlarkResponse, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockEnclaveContext) RunStarlarkScript(ctx context.Context, script string, serializedParams *starlark_run_config.StarlarkRunConfig) error {
+	return nil
+}
+
+// mockKurtosisContext implements interfaces.KurtosisContextInterface
+type mockKurtosisContext struct {
+	enclaves map[string]interfaces.EnclaveContext
+}
+
+func (m *mockKurtosisContext) CreateEnclave(ctx context.Context, name string) (interfaces.EnclaveContext, error) {
+	if enclave, ok := m.enclaves[name]; ok {
+		return enclave, nil
+	}
+	return nil, nil
+}
+
+func (m *mockKurtosisContext) GetEnclave(ctx context.Context, name string) (interfaces.EnclaveContext, error) {
+	if enclave, ok := m.enclaves[name]; ok {
+		return enclave, nil
+	}
+	return nil, nil
+}

--- a/devnet-sdk/shell/env/devnet.go
+++ b/devnet-sdk/shell/env/devnet.go
@@ -13,7 +13,7 @@ import (
 )
 
 type surfaceGetter func() (surface.ControlSurface, error)
-type controllerFactory func(string) surfaceGetter
+type controllerFactory func(*descriptors.DevnetEnvironment) surfaceGetter
 
 type DevnetEnv struct {
 	Env *descriptors.DevnetEnvironment
@@ -30,9 +30,9 @@ type schemeBackend struct {
 	ctrlFactory controllerFactory
 }
 
-func getKurtosisController(enclave string) surfaceGetter {
+func getKurtosisController(env *descriptors.DevnetEnvironment) surfaceGetter {
 	return func() (surface.ControlSurface, error) {
-		return kt.NewKurtosisControllerSurface(enclave)
+		return kt.NewKurtosisControllerSurface(env)
 	}
 }
 
@@ -80,7 +80,7 @@ func LoadDevnetFromURL(devnetURL string) (*DevnetEnv, error) {
 	// we're safe here as fetchDevnetData above ensures the scheme is supported
 	ctrlFactory := schemeToBackend[parsedURL.Scheme].ctrlFactory
 	if ctrlFactory != nil {
-		ctrl = ctrlFactory(parsedURL.Host)
+		ctrl = ctrlFactory(env)
 	}
 
 	return &DevnetEnv{

--- a/kurtosis-devnet/pkg/kurtosis/api/interfaces/iface.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/interfaces/iface.go
@@ -50,11 +50,15 @@ type StarlarkResponse interface {
 	GetInstructionResult() InstructionResult
 }
 
+type PortSpec interface {
+	GetNumber() uint16
+}
+
 type ServiceContext interface {
 	GetServiceUUID() services.ServiceUUID
 	GetMaybePublicIPAddress() string
-	GetPublicPorts() map[string]*services.PortSpec
-	GetPrivatePorts() map[string]*services.PortSpec
+	GetPublicPorts() map[string]PortSpec
+	GetPrivatePorts() map[string]PortSpec
 }
 
 type EnclaveContext interface {

--- a/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/wrappers/wrappers.go
@@ -26,6 +26,23 @@ type ServiceContextWrapper struct {
 	*services.ServiceContext
 }
 
+// mostly a no-op, to force the values to be typed as interfaces
+func convertPortSpecMap(ports map[string]*services.PortSpec) map[string]interfaces.PortSpec {
+	wrappedPorts := make(map[string]interfaces.PortSpec)
+	for name, port := range ports {
+		wrappedPorts[name] = port
+	}
+	return wrappedPorts
+}
+
+func (w *ServiceContextWrapper) GetPublicPorts() map[string]interfaces.PortSpec {
+	return convertPortSpecMap(w.ServiceContext.GetPublicPorts())
+}
+
+func (w *ServiceContextWrapper) GetPrivatePorts() map[string]interfaces.PortSpec {
+	return convertPortSpecMap(w.ServiceContext.GetPrivatePorts())
+}
+
 type starlarkRunResponseLineWrapper struct {
 	*kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Make sure that after service lifecycle operations the devnet
descriptor stored in Kurtosis enclave still reflects the reality of
the deployment.

This enables tests to be somewhat destructive, yet leave the devnet in
a usable state for the next test.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
manual validation that stopping/restarting services indeed  refreshes the descriptor stored in the enclave


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Fixes #15270
