### PR TITLE
docs: fixed typo

### DIFF
--- a/op-deployer/book/src/user-guide/verify.md
+++ b/op-deployer/book/src/user-guide/verify.md
@@ -81,6 +81,6 @@ INFO [03-05|15:57:07.971] final results                            numVerified=4
 
 ## Known Limitations
 
-- Does not currently work for contracts in the `opchain` bundle (deployed via `op-deployer apply`) that have constructor args. Those constructors args cannot be extracted from the deployment `tx.Data()` since `OPContractsManager.deploy()` uses factory pattern with CREATE2 to deploy those contracts.
+- Does not currently work for contracts in the `opchain` bundle (deployed via `op-deployer apply`) that have constructor args. Those constructor args cannot be extracted from the deployment `tx.Data()` since `OPContractsManager.deploy()` uses factory pattern with CREATE2 to deploy those contracts.
 
 - Currently only supports etherscan block explorers. Blockscout support is planned but not yet implemented.


### PR DESCRIPTION
**Description**  
corrected a typo where "constructors args" was used instead of "constructor args."

**Tests**  
no tests were required for this update, as it’s a documentation fix.

**Additional context**  
this was a minor typo that didn’t impact functionality but needed to be addressed for clarity.