### PR TITLE
fix(opcm): add check to updatePrestate for OnlyDelegateCall

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x44797707aea8c63dec049a02d69ea056662a06e5cf320028ab8b388634bf1c67"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x2e51d63c8fa99efc38dd70c07f1b13ff727b7cd5e055aac51f0e3b80bbad9d61",
-    "sourceCodeHash": "0x6e228dcfb910b44b06ced59e075a450e829ccbe173992099d825fa87264f0397"
+    "initCodeHash": "0x79ce06922146af2018e46e287076eef59286a5aa8776556c62f3aac536b01b8c",
+    "sourceCodeHash": "0x28c9ef682d58416e5c4379e2677b6b57f797a9c8dfd4482ba9bb386de46f2a55"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xbc7db7b1016025228d99a40db1760290b333bb90563dff5514fd253fd91019ba",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1747,6 +1747,8 @@ contract OPContractsManager is ISemver {
     /// @notice Updates the prestate hash for a new game type while keeping all other parameters the same
     /// @param _prestateUpdateInputs The new prestate hash to use
     function updatePrestate(OpChainConfig[] memory _prestateUpdateInputs) public {
+        if (address(this) == address(thisOPCM)) revert OnlyDelegatecall();
+
         bytes memory data = abi.encodeWithSelector(
             OPContractsManagerGameTypeAdder.updatePrestate.selector, _prestateUpdateInputs, superchainConfig
         );

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1595,9 +1595,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 1.13.0
+    /// @custom:semver 1.14.0
     function version() public pure virtual returns (string memory) {
-        return "1.13.0";
+        return "1.14.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1320,6 +1320,16 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
         fdg.weth().balanceOf(address(0));
     }
 
+    function test_updatePrestate_notDelegateCall_reverts() public {
+        IOPContractsManager.OpChainConfig[] memory inputs = new IOPContractsManager.OpChainConfig[](1);
+        inputs[0] = IOPContractsManager.OpChainConfig(
+            chainDeployOutput1.systemConfigProxy, chainDeployOutput1.opChainProxyAdmin, Claim.wrap(bytes32(hex"ABBA"))
+        );
+
+        vm.expectRevert(IOPContractsManager.OnlyDelegatecall.selector);
+        opcm.updatePrestate(inputs);
+    }
+
     function test_updatePrestate_whenPDGPrestateIsZero_reverts() public {
         IOPContractsManager.OpChainConfig[] memory inputs = new IOPContractsManager.OpChainConfig[](1);
         inputs[0] = IOPContractsManager.OpChainConfig({


### PR DESCRIPTION
**Description**

Updated the OPContractsManager updatePrestate function to check if the context of the call frame is a delegatecall to OPCM

**Tests**

Added a test to verify that when the function is not called via a delegatecall, the call reverts

**Additional context**

tbd
