### PR TITLE
update mainnet SVV300

### DIFF
--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -18,8 +18,8 @@ var addresses = map[uint64]map[string]common.Address{
 		VersionV180: common.HexToAddress("0x37fb5b21750d0e08a992350574bd1c24f4bcedf9"),
 		// Bootstrapped on 03/07/2025 using OP Deployer.
 		VersionV200: common.HexToAddress("0x12a9e38628e5a5b24d18b1956ed68a24fe4e3dc0"),
-		// Bootstrapped on 03/10/2025 using OP Deployer.
-		VersionV300: common.HexToAddress("0x1b8f0e76bb49b60dffbe3b847e25d6429ebff3e6"),
+		// Bootstrapped on 03/16/2025 using OP Deployer.
+		VersionV300: common.HexToAddress("0xf989Df70FB46c581ba6157Ab335c0833bA60e1f0"),
 	},
 	11155111: {
 		// Bootstrapped on 03/02/2025 using OP Deployer.

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -18,7 +18,7 @@ var addresses = map[uint64]map[string]common.Address{
 		VersionV180: common.HexToAddress("0x37fb5b21750d0e08a992350574bd1c24f4bcedf9"),
 		// Bootstrapped on 03/07/2025 using OP Deployer.
 		VersionV200: common.HexToAddress("0x12a9e38628e5a5b24d18b1956ed68a24fe4e3dc0"),
-		// Bootstrapped on 03/16/2025 using OP Deployer.
+		// Bootstrapped on 04/16/2025 using OP Deployer.
 		VersionV300: common.HexToAddress("0xf989Df70FB46c581ba6157Ab335c0833bA60e1f0"),
 	},
 	11155111: {


### PR DESCRIPTION
Newly deployed validator. 

Config used was: 

```
{
  "release": "v3.0.0",
  "superchainConfig": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
  "protocolVersions": "0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935",
  "l1PAOMultisig": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
  "challenger": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
  "superchainConfigImpl": "0x4da82a327773965b8d4D85Fa3dB8249b387458E7",
  "protocolVersionsImpl": "0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C",
  "l1ERC721BridgeImpl": "0x7ae1d3bd877a4c5ca257404ce26be93a02c98013",
  "optimismPortalImpl": "0xb443da3e07052204a02d630a8933dac05a0d6fb4",
  "systemConfigImpl": "0x340f923e5c7cbb2171146f64169ec9d5a9ffe647",
  "optimismMintableERC20FactoryImpl": "0x5493f4677A186f64805fe7317D6993ba4863988F",
  "l1CrossDomainMessengerImpl": "0x5d5a095665886119693f0b41d8dfee78da033e8b",
  "l1StandardBridgeImpl": "0x0b09ba359a106c9ea3b181cbc5f394570c7d2a7a",
  "disputeGameFactoryImpl": "0x4bbA758F006Ef09402eF31724203F316ab74e4a0",
  "delayedWETHImpl": "0x5e40b9231b86984b5150507046e354dbfbed3d9e",
  "mipsImpl": "0xF027F4A985560fb13324e943edf55ad6F1d15Dc1",
  "anchorStateRegistryImpl": "0x7b465370bb7a333f99edd19599eb7fb1c2d3f8d2",
  "withdrawalDelaySeconds": 302400
}
```