### PR TITLE
feat(op-acceptance-tests): fail fast when devnet doesn't spin up

### DIFF
--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -34,12 +34,10 @@ acceptance-test devnet="simple" gate="holocene":
             exit 0
         fi
 
-        # Run the appropriate devnet from the kurtosis-devnet directory if needed.
-        # Note: For now, due to a known bug, we ignore failures here
-        #       because if the devnet is already running then this command will fail.
-        just {{KURTOSIS_DIR}}/{{ devnet }}-devnet || true
+        # Run the appropriate devnet
+        just {{KURTOSIS_DIR}}/{{ devnet }}-devnet
 
-        # Print which binary is being used (for debugging)
+        # Print which binary is being used
         BINARY_PATH=$(mise which op-acceptor)
         echo "Using mise-managed binary: $BINARY_PATH"
 
@@ -62,8 +60,7 @@ acceptance-test-docker devnet="simple" gate="holocene":
     echo -e "DEVNET: {{devnet}}, GATE: {{gate}}\n"
 
     # First run the appropriate devnet from the kurtosis-devnet directory if needed.
-    # We ignore failures here because if the devnet is already running then this command will fail.
-    just {{KURTOSIS_DIR}}/{{ devnet }}-devnet || true
+    just {{KURTOSIS_DIR}}/{{ devnet }}-devnet
 
     # Print which image is being used (for debugging)
     echo "Using acceptor image: {{ACCEPTOR_IMAGE}}"


### PR DESCRIPTION
**Description**

Fail fast and exit early if the devnet fails to spin up.
This was previously not done as a workaround to an ephemeral issue whereby if you double-started a devnet (eg. when running locally) it'd throw an error. But this issue should now be resolved, so this workaround shouldn't be needed.
