### PR TITLE
add rule to ensure vm.env* only lives in Config.sol, implement the changes required

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -350,3 +350,12 @@ rules:
         - packages/contracts-bedrock/src/safe/LivenessModule.sol
         - packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
         - packages/contracts-bedrock/src/universal/ReinitializableBase.sol
+
+  - id: sol-style-vm-env-only-in-config-sol
+    languages: [solidity]
+    severity: ERROR
+    message: vm.env* should only be used in Config.sol
+    pattern-regex: vm.env
+    paths:
+      exclude:
+        - packages/contracts-bedrock/scripts/libraries/Config.sol

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -132,9 +132,9 @@ contract L2Genesis is Deployer {
             OutputMode.NONE,
             Config.fork(),
             L1Dependencies({
-                l1CrossDomainMessengerProxy: payable(vm.envAddress("L2GENESIS_L1CrossDomainMessengerProxy")),
-                l1StandardBridgeProxy: payable(vm.envAddress("L2GENESIS_L1StandardBridgeProxy")),
-                l1ERC721BridgeProxy: payable(vm.envAddress("L2GENESIS_L1ERC721BridgeProxy"))
+                l1CrossDomainMessengerProxy: Config.l2Genesis_L1CrossDomainMessengerProxy(),
+                l1StandardBridgeProxy: Config.l2Genesis_L1StandardBridgeProxy(),
+                l1ERC721BridgeProxy: Config.l2Genesis_L1ERC721BridgeProxy()
             })
         );
     }

--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -175,4 +175,63 @@ library Config {
             revert(string.concat("Config: unknown fork: ", forkStr));
         }
     }
+
+    /// @notice Returns the address of the L1CrossDomainMessengerProxy to use for the L2 genesis usage.
+    function l2Genesis_L1CrossDomainMessengerProxy() internal view returns (address payable) {
+        return payable(vm.envAddress("L2GENESIS_L1CrossDomainMessengerProxy"));
+    }
+
+    /// @notice Returns the address of the L1StandardBridgeProxy to use for the L2 genesis usage.
+    function l2Genesis_L1StandardBridgeProxy() internal view returns (address payable) {
+        return payable(vm.envAddress("L2GENESIS_L1StandardBridgeProxy"));
+    }
+
+    /// @notice Returns the address of the L1ERC721BridgeProxy to use for the L2 genesis usage.
+    function l2Genesis_L1ERC721BridgeProxy() internal view returns (address payable) {
+        return payable(vm.envAddress("L2GENESIS_L1ERC721BridgeProxy"));
+    }
+
+    /// @notice Returns the string identifier of the OP chain use for forking.
+    ///         If not set, "op" is returned.
+    function forkOpChain() internal view returns (string memory) {
+        return vm.envOr("FORK_OP_CHAIN", string("op"));
+    }
+
+    /// @notice Returns the string identifier of the base chain to use for forking.
+    ///         if not set, "mainnet" is returned.
+    function forkBaseChain() internal view returns (string memory) {
+        return vm.envOr("FORK_BASE_CHAIN", string("mainnet"));
+    }
+
+    /// @notice Returns the RPC URL of the mainnet.
+    ///         If not set, an empty string is returned.
+    function mainnetRpcUrl() internal view returns (string memory) {
+        return vm.envOr("MAINNET_RPC_URL", string(""));
+    }
+
+    /// @notice Returns the RPC URL to use for forking.
+    function forkRpcUrl() internal view returns (string memory) {
+        return vm.envString("FORK_RPC_URL");
+    }
+
+    /// @notice Returns the block number to use for forking.
+    function forkBlockNumber() internal view returns (uint256) {
+        return vm.envUint("FORK_BLOCK_NUMBER");
+    }
+
+    /// @notice Returns the profile to use for the foundry commands.
+    ///         If not set, "default" is returned.
+    function foundryProfile() internal view returns (string memory) {
+        return vm.envOr("FOUNDRY_PROFILE", string("default"));
+    }
+
+    /// @notice Returns the path to the superchain ops allocs.
+    function superchainOpsAllocsPath() internal view returns (string memory) {
+        return vm.envOr("SUPERCHAIN_OPS_ALLOCS_PATH", string(""));
+    }
+
+    /// @notice Returns true if the fork is a test fork.
+    function forkTest() internal view returns (bool) {
+        return vm.envOr("FORK_TEST", false);
+    }
 }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -12,7 +12,7 @@ import { DelegateCaller } from "test/mocks/Callers.sol";
 import { DeployOPChainInput } from "scripts/deploy/DeployOPChain.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
-
+import { Config } from "scripts/libraries/Config.sol";
 // Libraries
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Blueprint } from "src/libraries/Blueprint.sol";
@@ -253,7 +253,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
     address upgrader;
     IOPContractsManager.OpChainConfig[] opChainConfigs;
     Claim absolutePrestate;
-    string public opChain = vm.envOr("FORK_OP_CHAIN", string("op"));
+    string public opChain = Config.forkOpChain();
 
     function setUp() public virtual override {
         super.disableUpgradedFork();

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.15;
 // Testing
 import { Test } from "forge-std/Test.sol";
 
+// Scripts
+import { Config } from "scripts/libraries/Config.sol";
+
 // Target contract
 import {
     StandardValidatorBase,
@@ -994,7 +997,7 @@ contract StandardValidatorV180_Test is StandardValidatorTest {
     }
 
     function test_validate_opMainnet_succeeds() public {
-        string memory rpcUrl = vm.envOr(string("MAINNET_RPC_URL"), string(""));
+        string memory rpcUrl = Config.mainnetRpcUrl();
         if (bytes(rpcUrl).length == 0) {
             return;
         }

--- a/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
@@ -7,6 +7,7 @@ import { VmSafe } from "forge-std/Vm.sol";
 
 // Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";
@@ -108,10 +109,7 @@ contract L1ChugSplashProxy_Test is Test {
         // Because forge coverage always runs with the optimizer disabled,
         // if forge coverage is run before testing this with forge test or forge snapshot, forge clean should be
         // run first so that it recompiles the contracts using the foundry.toml optimizer settings.
-        if (
-            vm.isContext(VmSafe.ForgeContext.Coverage)
-                || LibString.eq(vm.envOr("FOUNDRY_PROFILE", string("default")), "lite")
-        ) {
+        if (vm.isContext(VmSafe.ForgeContext.Coverage) || LibString.eq(Config.foundryProfile(), "lite")) {
             gasLimit = 95_000;
         } else if (vm.isContext(VmSafe.ForgeContext.Test) || vm.isContext(VmSafe.ForgeContext.Snapshot)) {
             gasLimit = 65_000;

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Scripts
+import { Config } from "scripts/libraries/Config.sol";
+
 // Forge
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";
@@ -134,10 +137,7 @@ contract SafeCall_Test is Test {
             // Because forge coverage always runs with the optimizer disabled,
             // if forge coverage is run before testing this with forge test or forge snapshot, forge clean should be
             // run first so that it recompiles the contracts using the foundry.toml optimizer settings.
-            if (
-                vm.isContext(VmSafe.ForgeContext.Coverage)
-                    || LibString.eq(vm.envOr("FOUNDRY_PROFILE", string("default")), "lite")
-            ) {
+            if (vm.isContext(VmSafe.ForgeContext.Coverage) || LibString.eq(Config.foundryProfile(), "lite")) {
                 // 66_290 is the exact amount of gas required to make the safe call
                 // successfully with the optimizer disabled (ran via forge coverage)
                 expected = 66_290;
@@ -177,10 +177,7 @@ contract SafeCall_Test is Test {
             // Because forge coverage always runs with the optimizer disabled,
             // if forge coverage is run before testing this with forge test or forge snapshot, forge clean should be
             // run first so that it recompiles the contracts using the foundry.toml optimizer settings.
-            if (
-                vm.isContext(VmSafe.ForgeContext.Coverage)
-                    || LibString.eq(vm.envOr("FOUNDRY_PROFILE", string("default")), "lite")
-            ) {
+            if (vm.isContext(VmSafe.ForgeContext.Coverage) || LibString.eq(Config.foundryProfile(), "lite")) {
                 // 15_278_989 is the exact amount of gas required to make the safe call
                 // successfully with the optimizer disabled (ran via forge coverage)
                 expected = 15_278_989;

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -10,6 +10,7 @@ import { DelegateCaller } from "test/mocks/Callers.sol";
 // Scripts
 import { Deployer } from "scripts/deploy/Deployer.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
+import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { GameTypes, Claim } from "src/dispute/lib/Types.sol";
@@ -48,13 +49,13 @@ contract ForkLive is Deployer {
     /// @notice Returns the base chain name to use for forking
     /// @return The base chain name as a string
     function baseChain() internal view returns (string memory) {
-        return vm.envOr("FORK_BASE_CHAIN", string("mainnet"));
+        return Config.forkBaseChain();
     }
 
     /// @notice Returns the OP chain name to use for forking
     /// @return The OP chain name as a string
     function opChain() internal view returns (string memory) {
-        return vm.envOr("FORK_OP_CHAIN", string("op"));
+        return Config.forkOpChain();
     }
 
     /// @dev This function sets up the system to test it as follows:
@@ -64,7 +65,7 @@ contract ForkLive is Deployer {
     ///      4. If the environment variable wasn't set, deploy the updated OPCM and implementations of the contracts.
     ///      5. Upgrade the system using the OPCM.upgrade() function if useUpgradedFork is true.
     function run() public {
-        string memory superchainOpsAllocsPath = vm.envOr("SUPERCHAIN_OPS_ALLOCS_PATH", string(""));
+        string memory superchainOpsAllocsPath = Config.superchainOpsAllocsPath();
 
         useOpsRepo = bytes(superchainOpsAllocsPath).length > 0;
         if (useOpsRepo) {

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -13,6 +13,7 @@ import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
 import { OutputMode, Fork, ForkUtils } from "scripts/libraries/Config.sol";
 import { Artifacts } from "scripts/Artifacts.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
@@ -139,12 +140,12 @@ contract Setup {
 
     /// @notice Indicates whether a test is running against a forked production network.
     function isForkTest() public view returns (bool) {
-        return vm.envOr("FORK_TEST", false);
+        return Config.forkTest();
     }
 
     /// @notice Indicates whether a test is running against a forked network that is OP.
     function isOpFork() public view returns (bool) {
-        string memory opChain = vm.envOr("FORK_OP_CHAIN", string("op"));
+        string memory opChain = Config.forkOpChain();
         return keccak256(bytes(opChain)) == keccak256(bytes("op"));
     }
 
@@ -159,7 +160,7 @@ contract Setup {
         console.log("Setup: L1 setup start!");
 
         if (isForkTest()) {
-            vm.createSelectFork(vm.envString("FORK_RPC_URL"), vm.envUint("FORK_BLOCK_NUMBER"));
+            vm.createSelectFork(Config.forkRpcUrl(), Config.forkBlockNumber());
             console.log("Setup: fork selected!");
             require(
                 block.chainid == Chains.Sepolia || block.chainid == Chains.Mainnet,


### PR DESCRIPTION
Implements the 6th semgrep issue from https://github.com/ethereum-optimism/client-pod/issues/846 i.e `All vm.env* must be in Config.sol (from https://github.com/ethereum-optimism/optimism/pull/9475#discussion_r1502711324)`
