### PR TITLE
add semgrep rule to assert no usage of testFail

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -350,3 +350,12 @@ rules:
         - packages/contracts-bedrock/src/safe/LivenessModule.sol
         - packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
         - packages/contracts-bedrock/src/universal/ReinitializableBase.sol
+
+  - id: sol-style-no-testFail-usage
+    languages: [solidity]
+    severity: ERROR
+    message: testFail should not be used
+    pattern-regex: function\s+testFail\w*\s*\(
+    paths:
+      include:
+        - packages/contracts-bedrock/test

--- a/.semgrep/tests/sol-rules.sol-style-no-testFail-usage.sol
+++ b/.semgrep/tests/sol-rules.sol-style-no-testFail-usage.sol
@@ -1,0 +1,13 @@
+contract SemgrepTest__sol_style_no_testFail_usage {
+    // ruleid: sol-style-no-testFail-usage
+    function testFail() public {}
+
+    // ruleid: sol-style-no-testFail-usage
+    function testFail2() public {}
+
+    // ok: sol-style-no-testFail-usage
+    function testPass() public {}
+
+    // ok: sol-style-no-testFail-usage
+    function testPass2() public {}
+}


### PR DESCRIPTION
Implements the 4th semgrep issue from https://github.com/ethereum-optimism/client-pod/issues/846 i.e `No function testFail* tests (same as prior bullet)`