### PR TITLE
add semgrep rule to ensure no usage of vm.ffi or vm.tryFfi outside the process library

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -350,3 +350,16 @@ rules:
         - packages/contracts-bedrock/src/safe/LivenessModule.sol
         - packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
         - packages/contracts-bedrock/src/universal/ReinitializableBase.sol
+
+  - id: sol-style-use-process-run
+    languages: [solidity]
+    severity: ERROR
+    message: Use Process.run instead of vm.ffi or vm.tryFfi
+    pattern-either:
+      - pattern: |
+          vm.ffi(...);
+      - pattern: |
+          vm.tryFfi(...);
+    paths:
+      exclude:
+        - packages/contracts-bedrock/scripts/libraries/Process.sol


### PR DESCRIPTION
Implements the 9th semgrep issue from https://github.com/ethereum-optimism/client-pod/issues/846 i.e `Use Process.run() (see https://github.com/ethereum-optimism/optimism/pull/10677 instead of vm.ffi)`
