### PR TITLE
op-batcher: refactor: Replace `io.EOF` with custom `ErrNoTxData` error for clarity in `TxData` path

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -17,6 +17,7 @@ import (
 )
 
 var ErrReorg = errors.New("block does not extend existing chain")
+var ErrNoTxData = errors.New("no tx data available to submit")
 
 type ChannelOutFactory func(cfg ChannelConfig, rollupCfg *rollup.Config) (derive.ChannelOut, error)
 
@@ -203,7 +204,7 @@ func (s *channelManager) handleChannelInvalidated(c *channel) {
 func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 	if channel == nil || !channel.HasTxData() {
 		s.log.Trace("no next tx data")
-		return txData{}, io.EOF // TODO: not enough data error instead
+		return txData{}, ErrNoTxData
 	}
 	tx := channel.NextTxData()
 

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -104,7 +104,7 @@ func ChannelManagerReturnsErrReorgWhenDrained(t *testing.T, batchType uint) {
 	_, err := m.TxData(eth.BlockID{}, false)
 	require.NoError(t, err)
 	_, err = m.TxData(eth.BlockID{}, false)
-	require.ErrorIs(t, err, io.EOF)
+	require.ErrorIs(t, err, ErrNoTxData)
 
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
 }
@@ -213,7 +213,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 
 	// ensure channel is drained
 	_, err = m.TxData(eth.BlockID{}, false)
-	require.ErrorIs(err, io.EOF)
+	require.ErrorIs(err, ErrNoTxData)
 
 	// requeue frame
 	m.TxFailed(txdata0.ID())
@@ -362,7 +362,7 @@ func TestChannelManager_TxData(t *testing.T) {
 
 			// Call TxData a first time to trigger blocks->channels pipeline
 			_, err := m.TxData(eth.BlockID{}, false)
-			require.ErrorIs(t, err, io.EOF)
+			require.ErrorIs(t, err, ErrNoTxData)
 
 			// The test requires us to have something in the channel queue
 			// at this point, but not yet ready to send and not full
@@ -384,7 +384,7 @@ func TestChannelManager_TxData(t *testing.T) {
 				if err == nil && data.Len() > 0 {
 					break
 				}
-				if !errors.Is(err, io.EOF) {
+				if !errors.Is(err, ErrNoTxData) {
 					require.NoError(t, err)
 				}
 			}

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -2,7 +2,6 @@ package batcher
 
 import (
 	"errors"
-	"io"
 	"math/big"
 	"math/rand"
 	"testing"

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -91,7 +91,7 @@ func TestChannelManager_NextTxData(t *testing.T) {
 
 	// Nil pending channel should return EOF
 	returnedTxData, err := m.nextTxData(nil)
-	require.ErrorIs(t, err, io.EOF)
+	require.ErrorIs(t, err, ErrNoTxData)
 	require.Equal(t, txData{}, returnedTxData)
 
 	// Set the pending channel
@@ -101,7 +101,7 @@ func TestChannelManager_NextTxData(t *testing.T) {
 	channel := m.currentChannel
 	require.NotNil(t, channel)
 	returnedTxData, err = m.nextTxData(channel)
-	require.ErrorIs(t, err, io.EOF)
+	require.ErrorIs(t, err, ErrNoTxData)
 	require.Equal(t, txData{}, returnedTxData)
 
 	// Manually push a frame into the pending channel

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -2,7 +2,6 @@ package batcher
 
 import (
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/compressor"


### PR DESCRIPTION
This PR introduces a small but meaningful improvement to error handling within the `op-batcher` module. Specifically, it replaces instances where `io.EOF` was used to indicate absence of transaction data (`TxData`) with a more explicit sentinel error `ErrNoTxData`.

### Key changes:
- Introduced `var ErrNoTxData = errors.New("no tx data available to submit")` in `channel_manager.go`
- Updated `nextTxData()` to return `ErrNoTxData` instead of `io.EOF`
- Adjusted unit tests to expect `ErrNoTxData` instead of `io.EOF` for better semantic accuracy and readability
