### PR TITLE
test(sysext): add support for control plane

### DIFF
--- a/devnet-sdk/controller/kt/mutate_env.go
+++ b/devnet-sdk/controller/kt/mutate_env.go
@@ -2,10 +2,8 @@ package kt
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
-
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/interfaces"
 )
 
@@ -93,7 +91,6 @@ func (s *KurtosisControllerSurface) updateDevnetEnvironmentService(ctx context.C
 	}
 
 	if on {
-		fmt.Println("on")
 		svc.refreshEndpoints(serviceCtx)
 	}
 	// otherwise the service is down anyway, it doesn't matter if it has outdated endpoints

--- a/devnet-sdk/devstack/sysext/control_plane.go
+++ b/devnet-sdk/devstack/sysext/control_plane.go
@@ -1,16 +1,37 @@
 package sysext
 
-import "github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+import (
+	"github.com/ethereum-optimism/optimism/devnet-sdk/controller/surface"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
 
 type ControlPlane struct {
+	o *Orchestrator
+}
+
+func (c *ControlPlane) setLifecycleState(svcID string, mode stack.ControlAction) {
+	ctx := c.o.P().Ctx()
+	require := c.o.P().Require()
+
+	ctl, err := c.o.env.Control()
+	require.NoError(err, "Error getting control plane")
+	lc, ok := ctl.(surface.ServiceLifecycleSurface)
+	require.True(ok, "Control plane does not support service lifecycle management")
+
+	switch mode {
+	case stack.Start:
+		require.NoError(lc.StartService(ctx, svcID), "Error starting service")
+	case stack.Stop:
+		require.NoError(lc.StopService(ctx, svcID), "Error stopping service")
+	}
 }
 
 func (c *ControlPlane) SupervisorState(id stack.SupervisorID, mode stack.ControlAction) {
-	panic("not implemented: plug in kurtosis wrapper")
+	c.setLifecycleState(string(id), mode)
 }
 
 func (c *ControlPlane) L2CLNodeState(id stack.L2CLNodeID, mode stack.ControlAction) {
-	panic("not implemented: plug in kurtosis wrapper")
+	c.setLifecycleState(id.Key, mode)
 }
 
 var _ stack.ControlPlane = (*ControlPlane)(nil)

--- a/devnet-sdk/devstack/sysext/helpers.go
+++ b/devnet-sdk/devstack/sysext/helpers.go
@@ -33,7 +33,7 @@ func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, p
 		opts = append(opts, client.WithLazyDial())
 	}
 
-	if orch.env.ReverseProxyURL != "" && !orch.useDirectCnx {
+	if orch.env.Env.ReverseProxyURL != "" && !orch.useDirectCnx {
 		opts = append(
 			opts,
 			client.WithGethRPCOptions(
@@ -60,7 +60,7 @@ func (orch *Orchestrator) httpClient(t devtest.T, service *descriptors.Service, 
 
 	opts := []client.BasicHTTPClientOption{}
 
-	if orch.env.ReverseProxyURL != "" && !orch.useDirectCnx {
+	if orch.env.Env.ReverseProxyURL != "" && !orch.useDirectCnx {
 		opts = append(
 			opts,
 			client.WithHeader(header),
@@ -74,8 +74,8 @@ func (orch *Orchestrator) httpClient(t devtest.T, service *descriptors.Service, 
 func (orch *Orchestrator) findProtocolService(service *descriptors.Service, protocol string) (string, http.Header, error) {
 	for proto, endpoint := range service.Endpoints {
 		if proto == protocol {
-			if orch.env.ReverseProxyURL != "" && !orch.useDirectCnx {
-				return orch.env.ReverseProxyURL, endpoint.ReverseProxyHeader, nil
+			if orch.env.Env.ReverseProxyURL != "" && !orch.useDirectCnx {
+				return orch.env.Env.ReverseProxyURL, endpoint.ReverseProxyHeader, nil
 			}
 
 			port := endpoint.Port

--- a/devnet-sdk/devstack/sysext/l1.go
+++ b/devnet-sdk/devstack/sysext/l1.go
@@ -12,16 +12,16 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 	env := o.env
 
 	commonConfig := shim.NewCommonConfig(system.T())
-	l1ID := eth.ChainIDFromBig(env.L1.Config.ChainID)
+	l1ID := eth.ChainIDFromBig(env.Env.L1.Config.ChainID)
 	l1 := shim.NewL1Network(shim.L1NetworkConfig{
 		NetworkConfig: shim.NetworkConfig{
 			CommonConfig: commonConfig,
-			ChainConfig:  env.L1.Config,
+			ChainConfig:  env.Env.L1.Config,
 		},
 		ID: stack.L1NetworkID(l1ID),
 	})
 
-	for idx, node := range env.L1.Nodes {
+	for idx, node := range env.Env.L1.Nodes {
 		elService, ok := node.Services[ELServiceName]
 		require.True(ok, "need L1 EL service %d", idx)
 

--- a/devnet-sdk/devstack/sysext/l2.go
+++ b/devnet-sdk/devstack/sysext/l2.go
@@ -23,7 +23,7 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 	env := o.env
 	l2ID := getL2ID(net)
 
-	l1 := system.L1Network(stack.L1NetworkID(eth.ChainIDFromBig(env.L1.Config.ChainID)))
+	l1 := system.L1Network(stack.L1NetworkID(eth.ChainIDFromBig(env.Env.L1.Config.ChainID)))
 
 	cfg := shim.L2NetworkConfig{
 		NetworkConfig: shim.NetworkConfig{
@@ -38,11 +38,11 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 		},
 		Deployment: newL2AddressBook(system.T(), net.L1Addresses),
 		Keys:       o.defineSystemKeys(system.T()),
-		Superchain: system.Superchain(stack.SuperchainID(env.Name)),
+		Superchain: system.Superchain(stack.SuperchainID(env.Env.Name)),
 		L1:         l1,
 	}
 	if o.isInterop() {
-		cfg.Cluster = system.Cluster(stack.ClusterID(env.Name))
+		cfg.Cluster = system.Cluster(stack.ClusterID(env.Env.Name))
 	}
 
 	l2 := shim.NewL2Network(cfg)

--- a/devnet-sdk/devstack/sysext/system.go
+++ b/devnet-sdk/devstack/sysext/system.go
@@ -12,8 +12,8 @@ func (o *Orchestrator) hydrateSuperchain(sys stack.ExtensibleSystem) {
 	env := o.env
 	sys.AddSuperchain(shim.NewSuperchain(shim.SuperchainConfig{
 		CommonConfig: shim.NewCommonConfig(sys.T()),
-		ID:           stack.SuperchainID(env.Name),
-		Deployment:   newL1AddressBook(sys.T(), env.L1.Addresses),
+		ID:           stack.SuperchainID(env.Env.Name),
+		Deployment:   newL1AddressBook(sys.T(), env.Env.L1.Addresses),
 	}))
 }
 
@@ -27,11 +27,11 @@ func (o *Orchestrator) hydrateClusterMaybe(sys stack.ExtensibleSystem) {
 	env := o.env
 
 	var depSet depset.StaticConfigDependencySet
-	require.NoError(json.Unmarshal(o.env.DepSet, &depSet))
+	require.NoError(json.Unmarshal(o.env.Env.DepSet, &depSet))
 
 	sys.AddCluster(shim.NewCluster(shim.ClusterConfig{
 		CommonConfig:  shim.NewCommonConfig(sys.T()),
-		ID:            stack.ClusterID(env.Name),
+		ID:            stack.ClusterID(env.Env.Name),
 		DependencySet: &depSet,
 	}))
 }
@@ -43,7 +43,7 @@ func (o *Orchestrator) hydrateSupervisorMaybe(sys stack.ExtensibleSystem) {
 	}
 
 	// hack, supervisor is part of the first L2
-	supervisorService, ok := o.env.L2[0].Services["supervisor"]
+	supervisorService, ok := o.env.Env.L2[0].Services["supervisor"]
 	if !ok {
 		sys.T().Logger().Warn("Missing supervisor service")
 		return


### PR DESCRIPTION
**Description**

This implements the control plane interface for the sysext side of devstack.
Note that only kurtosis devnets provide a corresponding implementations for now.

For convenience, the orchestrator now embeds a DevnetEnv, which is the
enriched wrapper around descriptors.DevnetEnvironment (data-only
object)

**Tests**

Validated using a slightly adjusted version of
devnet-sdk/devstack/sysgo/control_plane_test.go but that's a temporary
measure. A real test against the devstack interfaces will be required.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- fixes #15270 
