### PR TITLE
devnet-sdk: devstack: sysgo: support op-node p2p

### DIFF
--- a/devnet-sdk/devstack/shim/l2_cl.go
+++ b/devnet-sdk/devstack/shim/l2_cl.go
@@ -19,6 +19,7 @@ type rpcL2CLNode struct {
 	id           stack.L2CLNodeID
 	client       client.RPC
 	rollupClient apis.RollupClient
+	p2pClient    apis.P2PClient
 	els          locks.RWMap[stack.L2ELNodeID, stack.L2ELNode]
 }
 
@@ -32,6 +33,7 @@ func NewL2CLNode(cfg L2CLNodeConfig) stack.L2CLNode {
 		id:           cfg.ID,
 		client:       cfg.Client,
 		rollupClient: sources.NewRollupClient(cfg.Client),
+		p2pClient:    sources.NewP2PClient(cfg.Client),
 	}
 }
 
@@ -41,6 +43,10 @@ func (r *rpcL2CLNode) ID() stack.L2CLNodeID {
 
 func (r *rpcL2CLNode) RollupAPI() apis.RollupClient {
 	return r.rollupClient
+}
+
+func (r *rpcL2CLNode) P2PAPI() apis.P2PClient {
+	return r.p2pClient
 }
 
 func (r *rpcL2CLNode) LinkEL(el stack.L2ELNode) {

--- a/devnet-sdk/devstack/stack/l2_cl.go
+++ b/devnet-sdk/devstack/stack/l2_cl.go
@@ -45,6 +45,7 @@ type L2CLNode interface {
 	ID() L2CLNodeID
 
 	RollupAPI() apis.RollupClient
+	P2PAPI() apis.P2PClient
 
 	// ELs returns the engine(s) that this L2CLNode is connected to.
 	// This may be empty, if the L2CL is not connected to any.

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -268,8 +269,8 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		p2pClient1, p2pClient2 := getP2PClient(l2CL1), getP2PClient(l2CL2)
 
 		// get peer info per L2CL
-		getPeerInfo := func(p2pClient *sources.P2PClient) *p2p.PeerInfo {
-			peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*p2p.PeerInfo, error) {
+		getPeerInfo := func(p2pClient *sources.P2PClient) *apis.PeerInfo {
+			peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerInfo, error) {
 				return p2pClient.Self(ctx)
 			})
 			require.NoError(err, "failed to get peer info")
@@ -290,15 +291,15 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		connectPeer(p2pClient2, peer1MultiAddress)
 
 		// sanity check that peers are registered
-		getPeers := func(p2pClient *sources.P2PClient) *p2p.PeerDump {
-			peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*p2p.PeerDump, error) {
+		getPeers := func(p2pClient *sources.P2PClient) *apis.PeerDump {
+			peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerDump, error) {
 				return p2pClient.Peers(ctx, true)
 			})
 			require.NoError(err, "failed to get peers")
 			return peerDump
 		}
 		peerDump1, peerDump2 := getPeers(p2pClient1), getPeers(p2pClient2)
-		check := func(peerDump *p2p.PeerDump, peerInfo *p2p.PeerInfo) {
+		check := func(peerDump *apis.PeerDump, peerInfo *apis.PeerInfo) {
 			multiAddress := peerInfo.PeerID.String()
 			_, ok := peerDump.Peers[multiAddress]
 			require.True(ok, "peer register invalid")

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -2,6 +2,8 @@ package sysgo
 
 import (
 	"context"
+	"encoding/hex"
+	"flag"
 	"sync"
 	"time"
 
@@ -11,16 +13,20 @@ import (
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
+	opNodeFlags "github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
-	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
 )
 
 type L2CLNode struct {
@@ -81,9 +87,11 @@ func (n *L2CLNode) Start() {
 	n.logger.Info("Started op-node")
 	n.opNode = opNode
 
+	// store endpoints to reuse when restart
 	n.userRPC = opNode.UserRPC().RPC()
 	interopRPC, _ := opNode.InteropRPC()
 	n.interopRPC = interopRPC
+	// for p2p endpoints / node keys, they are already persistent, stored at p2p configs
 
 	n.rememberPort()
 }
@@ -123,11 +131,46 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 
 		jwtPath, jwtSecret := orch.writeDefaultJWT()
 
-		var p2pSigner *p2p.PreparedSigner
-		if isSequencer {
-			p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID.ToBig()))
-			require.NoError(err, "need p2p key for sequencer")
-			p2pSigner = &p2p.PreparedSigner{Signer: opsigner.NewLocalSigner(p2pKey)}
+		logger := o.P().Logger().New("service", "op-node", "id", l2CLID)
+
+		var p2pSignerSetup p2p.SignerSetup
+		var p2pConfig *p2p.Config
+		// code block for P2P setup
+		{
+			// make a dummy flagset since p2p config initialization helpers only input cli context
+			fs := flag.NewFlagSet("", flag.ContinueOnError)
+			// use default flags
+			for _, f := range opNodeFlags.P2PFlags(opNodeFlags.EnvVarPrefix) {
+				require.NoError(f.Apply(fs))
+			}
+			// mandatory P2P flags
+			require.NoError(fs.Set(opNodeFlags.AdvertiseIPName, "127.0.0.1"))
+			require.NoError(fs.Set(opNodeFlags.AdvertiseTCPPortName, "0"))
+			require.NoError(fs.Set(opNodeFlags.AdvertiseUDPPortName, "0"))
+			require.NoError(fs.Set(opNodeFlags.ListenIPName, "127.0.0.1"))
+			require.NoError(fs.Set(opNodeFlags.ListenTCPPortName, "0"))
+			require.NoError(fs.Set(opNodeFlags.ListenUDPPortName, "0"))
+			// avoid resource unavailable error by using memorydb
+			require.NoError(fs.Set(opNodeFlags.DiscoveryPathName, "memory"))
+			require.NoError(fs.Set(opNodeFlags.PeerstorePathName, "memory"))
+			// For peer ID
+			networkPrivKey, err := crypto.GenerateKey()
+			require.NoError(err)
+			networkPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(networkPrivKey))
+			_ = fs.Set(opNodeFlags.P2PPrivRawName, networkPrivKeyHex)
+
+			cliCtx := cli.NewContext(&cli.App{}, fs, nil)
+			if isSequencer {
+				p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID.ToBig()))
+				require.NoError(err, "need p2p key for sequencer")
+				p2pKeyHex := hex.EncodeToString(crypto.FromECDSA(p2pKey))
+				require.NoError(fs.Set(opNodeFlags.SequencerP2PKeyName, p2pKeyHex))
+				p2pSignerSetup, err = p2pcli.LoadSignerSetup(cliCtx, logger)
+				require.NoError(err, "failed to load p2p signer")
+				logger.Info("Sequencer key acquired")
+			}
+			p2pConfig, err = p2pcli.NewConfig(cliCtx, l2Net.rollupCfg)
+			require.NoError(err, "failed to load p2p config")
 		}
 
 		nodeCfg := &node.Config{
@@ -152,7 +195,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 				SequencerEnabled: isSequencer,
 			},
 			Rollup:    *l2Net.rollupCfg,
-			P2PSigner: p2pSigner,
+			P2PSigner: p2pSignerSetup, // nil when not sequencer
 			RPC: node.RPCConfig{
 				ListenAddr: "127.0.0.1",
 				// When L2CL starts, store its RPC port here
@@ -167,7 +210,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 				RPCPort:          0,
 				RPCJwtSecretPath: jwtPath,
 			},
-			P2P:                         nil, // disabled P2P setup for now
+			P2P:                         p2pConfig,
 			L1EpochPollInterval:         time.Second * 2,
 			RuntimeConfigReloadInterval: 0,
 			Tracer:                      nil,
@@ -188,7 +231,6 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			AltDA:                           altda.CLIConfig{},
 			IgnoreMissingPectraBlobSchedule: false,
 		}
-		logger := o.P().Logger().New("service", "op-node", "id", l2CLID)
 		l2CLNode := &L2CLNode{
 			id:     l2CLID,
 			cfg:    nodeCfg,
@@ -199,5 +241,69 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), "must not already exist")
 		l2CLNode.Start()
 		orch.p.Cleanup(l2CLNode.Stop)
+	}
+}
+
+// WithL2CLP2PConnection P2P connects two L2CLs
+func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
+	return func(o stack.Orchestrator) {
+		orch := o.(*Orchestrator)
+		require := o.P().Require()
+
+		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
+		require.True(ok, "looking for L2 CL node 1 to connect p2p")
+		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
+		require.True(ok, "looking for L2 CL node 2 to connect p2p")
+
+		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
+
+		ctx := o.P().Ctx()
+
+		// initialize p2p clients per L2CL
+		getP2PClient := func(l2CLNode *L2CLNode) *sources.P2PClient {
+			rpcClient, err := client.NewRPC(ctx, o.P().Logger(), l2CLNode.userRPC, client.WithLazyDial())
+			require.NoError(err, "failed to initialize rpc client for p2p client")
+			return sources.NewP2PClient(rpcClient)
+		}
+		p2pClient1, p2pClient2 := getP2PClient(l2CL1), getP2PClient(l2CL2)
+
+		// get peer info per L2CL
+		getPeerInfo := func(p2pClient *sources.P2PClient) *p2p.PeerInfo {
+			peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*p2p.PeerInfo, error) {
+				return p2pClient.Self(ctx)
+			})
+			require.NoError(err, "failed to get peer info")
+			return peerInfo
+		}
+		peerInfo1, peerInfo2 := getPeerInfo(p2pClient1), getPeerInfo(p2pClient2)
+		require.True(len(peerInfo1.Addresses) > 0 && len(peerInfo2.Addresses) > 0, "malformed peer info")
+		peer1MultiAddress, peer2MultiAddress := peerInfo1.Addresses[0], peerInfo2.Addresses[0]
+
+		// bidirectional p2p connection
+		connectPeer := func(p2pClient *sources.P2PClient, multiAddress string) {
+			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
+				return p2pClient.ConnectPeer(ctx, multiAddress)
+			})
+			require.NoError(err, "failed to connect peer")
+		}
+		connectPeer(p2pClient1, peer2MultiAddress)
+		connectPeer(p2pClient2, peer1MultiAddress)
+
+		// sanity check that peers are registered
+		getPeers := func(p2pClient *sources.P2PClient) *p2p.PeerDump {
+			peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*p2p.PeerDump, error) {
+				return p2pClient.Peers(ctx, true)
+			})
+			require.NoError(err, "failed to get peers")
+			return peerDump
+		}
+		peerDump1, peerDump2 := getPeers(p2pClient1), getPeers(p2pClient2)
+		check := func(peerDump *p2p.PeerDump, peerInfo *p2p.PeerInfo) {
+			multiAddress := peerInfo.PeerID.String()
+			_, ok := peerDump.Peers[multiAddress]
+			require.True(ok, "peer register invalid")
+		}
+		check(peerDump1, peerInfo2)
+		check(peerDump2, peerInfo1)
 	}
 }

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -201,7 +201,7 @@ func TestL2CLSyncP2P(gt *testing.T) {
 		time.Sleep(waitTime)
 		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL)(orch)
 
-		targetBlockNum2 := uint64(20)
+		targetBlockNum2 := uint64(30)
 		require.Greater(t, targetBlockNum2, targetBlockNum1)
 		logger.Info("wait until reaching target block", "blockNum", targetBlockNum2)
 		require.Eventually(t, func() bool {

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -207,7 +207,7 @@ func TestL2CLSyncP2P(gt *testing.T) {
 		require.Eventually(t, func() bool {
 			blockA, blockA2 := queryLatest()
 			return blockA.Number >= targetBlockNum2 && blockA2.Number >= targetBlockNum2
-		}, 30*time.Second, waitTime)
+		}, 60*time.Second, waitTime)
 
 		logger.Info("check sequencer and verifier holds identical chain until target block", "blockNum", targetBlockNum2)
 		for blockNum := range targetBlockNum2 + 1 {

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -116,3 +116,106 @@ func TestL2CLResync(gt *testing.T) {
 		// supervisor successfully connected with managed L2CLs
 	}
 }
+
+// TestL2CLSyncP2P checks that unsafe head is propagated from sequencer to verifier.
+// Tests started/restarted L2CL advances unsafe head via P2P connection.
+func TestL2CLSyncP2P(gt *testing.T) {
+	var ids DefaultRedundancyInteropSystemIDs
+	opt := DefaultRedundancyInteropSystem(&ids)
+
+	logger := testlog.Logger(gt, log.LevelInfo)
+
+	p := devtest.NewP(logger, func() {
+		gt.Helper()
+		gt.FailNow()
+	})
+	gt.Cleanup(p.Close)
+
+	orch := NewOrchestrator(p)
+
+	opt(orch)
+
+	t := devtest.SerialT(gt)
+	system := shim.NewSystem(t)
+	orch.Hydrate(system)
+
+	control := orch.controlPlane
+
+	blockTime := system.L2Network(ids.L2A).RollupConfig().BlockTime
+
+	waitTime := time.Duration(blockTime+1) * time.Second
+	{
+		logger := system.T().Logger()
+
+		elA := system.L2Network(ids.L2A).L2ELNode(ids.L2AEL)
+		elA2 := system.L2Network(ids.L2A).L2ELNode(ids.L2A2EL)
+
+		queryLatest := func() (eth.BlockRef, eth.BlockRef) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			blockA, err := elA.EthClient().BlockRefByLabel(ctx, "latest")
+			require.NoError(t, err)
+			blockA2, err := elA2.EthClient().BlockRefByLabel(ctx, "latest")
+			require.NoError(t, err)
+			cancel()
+			logger.Info("chain A", "blockNum", blockA.Number, "tip", blockA)
+			logger.Info("chain A2", "blockNum", blockA2.Number, "tip", blockA2)
+			return blockA, blockA2
+		}
+
+		queryBlock := func(blockNum uint64) (eth.BlockRef, eth.BlockRef) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			blockA, err := elA.EthClient().BlockRefByNumber(ctx, blockNum)
+			require.NoError(t, err)
+			blockA2, err := elA2.EthClient().BlockRefByNumber(ctx, blockNum)
+			require.NoError(t, err)
+			cancel()
+			logger.Info("chain A", "blockNum", blockA.Number, "tip", blockA)
+			logger.Info("chain A2", "blockNum", blockA2.Number, "tip", blockA2)
+			return blockA, blockA2
+		}
+
+		targetBlockNum1 := uint64(10)
+		logger.Info("wait until reaching target block", "blockNum", targetBlockNum1)
+		require.Eventually(t, func() bool {
+			blockA, blockA2 := queryLatest()
+			return blockA.Number >= targetBlockNum1 && blockA2.Number >= targetBlockNum1
+		}, 30*time.Second, waitTime)
+
+		logger.Info("stop verifier")
+		control.L2CLNodeState(ids.L2A2CL, stack.Stop)
+
+		logger.Info("make sure verifier does not advance")
+		var prevBlockA2 eth.BlockRef
+		require.Eventually(t, func() bool {
+			_, blockA2 := queryLatest()
+			isStatic := prevBlockA2.Hash == blockA2.Hash
+			prevBlockA2 = blockA2
+			return isStatic
+		}, 10*time.Second, waitTime)
+
+		logger.Info("restart verifier")
+		control.L2CLNodeState(ids.L2A2CL, stack.Start)
+
+		logger.Info("explicit reconnection of L2CL P2P between sequencer and verifier")
+		// wait until restarted L2CL can receive p2p API request
+		time.Sleep(waitTime)
+		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL)(orch)
+
+		targetBlockNum2 := uint64(20)
+		require.Greater(t, targetBlockNum2, targetBlockNum1)
+		logger.Info("wait until reaching target block", "blockNum", targetBlockNum2)
+		require.Eventually(t, func() bool {
+			blockA, blockA2 := queryLatest()
+			return blockA.Number >= targetBlockNum2 && blockA2.Number >= targetBlockNum2
+		}, 30*time.Second, waitTime)
+
+		logger.Info("check sequencer and verifier holds identical chain until target block", "blockNum", targetBlockNum2)
+		for blockNum := range targetBlockNum2 + 1 {
+			blockA, blockA2 := queryBlock(blockNum)
+			require.Equal(t, blockA.Hash, blockA2.Hash)
+			require.Equal(t, blockNum, blockA.Number)
+			require.Equal(t, blockNum, blockA2.Number)
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-conductor/health"
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	conductorrpc "github.com/ethereum-optimism/optimism/op-conductor/rpc"
-	opp2p "github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	opclient "github.com/ethereum-optimism/optimism/op-service/client"
@@ -208,12 +207,7 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 		return errors.Wrap(err, "failed to create node rpc client")
 	}
 	node := sources.NewRollupClient(nc)
-
-	pc, err := rpc.DialContext(ctx, c.cfg.NodeRPC)
-	if err != nil {
-		return errors.Wrap(err, "failed to create p2p rpc client")
-	}
-	p2p := opp2p.NewClient(pc)
+	p2p := sources.NewP2PClient(nc)
 
 	c.hmon = health.NewSequencerHealthMonitor(
 		c.log,

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 )
 
@@ -35,7 +35,7 @@ type HealthMonitor interface {
 // interval is the interval between health checks measured in seconds.
 // safeInterval is the interval between safe head progress measured in seconds.
 // minPeerCount is the minimum number of peers required for the sequencer to be healthy.
-func NewSequencerHealthMonitor(log log.Logger, metrics metrics.Metricer, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p p2p.API) HealthMonitor {
+func NewSequencerHealthMonitor(log log.Logger, metrics metrics.Metricer, interval, unsafeInterval, safeInterval, minPeerCount uint64, safeEnabled bool, rollupCfg *rollup.Config, node dial.RollupClientInterface, p2p apis.P2PClient) HealthMonitor {
 	return &SequencerHealthMonitor{
 		log:            log,
 		metrics:        metrics,
@@ -72,7 +72,7 @@ type SequencerHealthMonitor struct {
 	timeProviderFn func() uint64
 
 	node dial.RollupClientInterface
-	p2p  p2p.API
+	p2p  apis.P2PClient
 }
 
 var _ HealthMonitor = (*SequencerHealthMonitor)(nil)

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	p2pMocks "github.com/ethereum-optimism/optimism/op-node/p2p/mocks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -51,7 +51,7 @@ func (s *HealthMonitorTestSuite) SetupMonitor(
 	tp := &timeProvider{now: now}
 	if mockP2P == nil {
 		mockP2P = &p2pMocks.API{}
-		ps1 := &p2p.PeerStats{
+		ps1 := &apis.PeerStats{
 			Connected: healthyPeerCount,
 		}
 		mockP2P.EXPECT().PeerStats(mock.Anything).Return(ps1, nil)
@@ -85,7 +85,7 @@ func (s *HealthMonitorTestSuite) TestUnhealthyLowPeerCount() {
 	rc.ExpectSyncStatus(ss1, nil)
 
 	pc := &p2pMocks.API{}
-	ps1 := &p2p.PeerStats{
+	ps1 := &apis.PeerStats{
 		Connected: unhealthyPeerCount,
 	}
 	pc.EXPECT().PeerStats(mock.Anything).Return(ps1, nil).Times(1)

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
@@ -135,11 +134,7 @@ func TestP2PFull(t *testing.T) {
 			})
 		}})
 
-	backend := NewP2PAPIBackend(nodeA, logA)
-	srv := rpc.NewServer()
-	require.NoError(t, srv.RegisterName("opp2p", backend))
-	client := rpc.DialInProc(srv)
-	p2pClientA := NewClient(client)
+	p2pClientA := NewP2PAPIBackend(nodeA, logA)
 
 	// Set up B to connect statically
 	confB.StaticPeers, err = peer.AddrInfoToP2pAddrs(&peer.AddrInfo{ID: hostA.ID(), Addrs: hostA.Addrs()})

--- a/op-node/p2p/mocks/API.go
+++ b/op-node/p2p/mocks/API.go
@@ -10,7 +10,7 @@ import (
 
 	net "net"
 
-	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
+	p2p "github.com/ethereum-optimism/optimism/op-service/apis"
 
 	peer "github.com/libp2p/go-libp2p/core/peer"
 )

--- a/op-node/p2p/rpc_api.go
+++ b/op-node/p2p/rpc_api.go
@@ -1,63 +1,14 @@
 package p2p
 
 import (
-	"context"
-	"net"
-	"time"
-
-	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/peer"
-
-	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
-type PeerInfo struct {
-	PeerID          peer.ID  `json:"peerID"`
-	NodeID          enode.ID `json:"nodeID"`
-	UserAgent       string   `json:"userAgent"`
-	ProtocolVersion string   `json:"protocolVersion"`
-	ENR             string   `json:"ENR"`       // might not always be known, e.g. if the peer connected us instead of us discovering them
-	Addresses       []string `json:"addresses"` // multi-addresses. may be mix of LAN / docker / external IPs. All of them are communicated.
-	Protocols       []string `json:"protocols"` // negotiated protocols list
-	// GossipScore float64
-	// PeerScore float64
-	Connectedness network.Connectedness `json:"connectedness"` // "NotConnected", "Connected", "CanConnect" (gracefully disconnected), or "CannotConnect" (tried but failed)
-	Direction     network.Direction     `json:"direction"`     // "Unknown", "Inbound" (if the peer contacted us), "Outbound" (if we connected to them)
-	Protected     bool                  `json:"protected"`     // Protected peers do not get
-	ChainID       uint64                `json:"chainID"`       // some peers might try to connect, but we figure out they are on a different chain later. This may be 0 if the peer is not an optimism node at all.
-	Latency       time.Duration         `json:"latency"`
+// backwards compatibility
+var NamespaceRPC = sources.NamespaceRPC
 
-	GossipBlocks bool `json:"gossipBlocks"` // if the peer is in our gossip topic
-
-	PeerScores store.PeerScores `json:"scores"`
-}
-
-type PeerDump struct {
-	TotalConnected uint                 `json:"totalConnected"`
-	Peers          map[string]*PeerInfo `json:"peers"`
-	BannedPeers    []peer.ID            `json:"bannedPeers"`
-	BannedIPS      []net.IP             `json:"bannedIPS"`
-	BannedSubnets  []*net.IPNet         `json:"bannedSubnets"`
-}
-
-//go:generate mockery --name API --output mocks/ --with-expecter=true
-type API interface {
-	Self(ctx context.Context) (*PeerInfo, error)
-	Peers(ctx context.Context, connected bool) (*PeerDump, error)
-	PeerStats(ctx context.Context) (*PeerStats, error)
-	DiscoveryTable(ctx context.Context) ([]*enode.Node, error)
-	BlockPeer(ctx context.Context, p peer.ID) error
-	UnblockPeer(ctx context.Context, p peer.ID) error
-	ListBlockedPeers(ctx context.Context) ([]peer.ID, error)
-	BlockAddr(ctx context.Context, ip net.IP) error
-	UnblockAddr(ctx context.Context, ip net.IP) error
-	ListBlockedAddrs(ctx context.Context) ([]net.IP, error)
-	BlockSubnet(ctx context.Context, ipnet *net.IPNet) error
-	UnblockSubnet(ctx context.Context, ipnet *net.IPNet) error
-	ListBlockedSubnets(ctx context.Context) ([]*net.IPNet, error)
-	ProtectPeer(ctx context.Context, p peer.ID) error
-	UnprotectPeer(ctx context.Context, p peer.ID) error
-	ConnectPeer(ctx context.Context, addr string) error
-	DisconnectPeer(ctx context.Context, id peer.ID) error
-}
+type API = apis.P2PClient
+type PeerInfo = apis.PeerInfo
+type PeerDump = apis.PeerDump
+type PeerStats = apis.PeerStats

--- a/op-node/p2p/rpc_api.go
+++ b/op-node/p2p/rpc_api.go
@@ -6,7 +6,7 @@ import (
 )
 
 // backwards compatibility
-var NamespaceRPC = sources.NamespaceRPC
+var NamespaceRPC = sources.P2PNamespaceRPC
 
 type API = apis.P2PClient
 type PeerInfo = apis.PeerInfo

--- a/op-node/p2p/rpc_client.go
+++ b/op-node/p2p/rpc_client.go
@@ -10,6 +10,7 @@ type Client struct {
 	c sources.P2PClient
 }
 
+// Legacy for supporting backwards compatibility
 func NewClient(c *rpc.Client) *Client {
 	return &Client{c: *sources.NewP2PClient(client.NewBaseRPCClient(c))}
 }

--- a/op-node/p2p/rpc_client.go
+++ b/op-node/p2p/rpc_client.go
@@ -1,109 +1,15 @@
 package p2p
 
 import (
-	"context"
-	"net"
-
-	"github.com/libp2p/go-libp2p/core/peer"
-
-	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-var NamespaceRPC = "opp2p"
-
 type Client struct {
-	c *rpc.Client
+	c sources.P2PClient
 }
-
-var _ API = (*Client)(nil)
 
 func NewClient(c *rpc.Client) *Client {
-	return &Client{c: c}
-}
-
-func prefixRPC(method string) string {
-	return NamespaceRPC + "_" + method
-}
-
-func (c *Client) Self(ctx context.Context) (*PeerInfo, error) {
-	var out *PeerInfo
-	err := c.c.CallContext(ctx, &out, prefixRPC("self"))
-	return out, err
-}
-
-func (c *Client) Peers(ctx context.Context, connected bool) (*PeerDump, error) {
-	var out *PeerDump
-	err := c.c.CallContext(ctx, &out, prefixRPC("peers"), connected)
-	return out, err
-}
-
-func (c *Client) PeerStats(ctx context.Context) (*PeerStats, error) {
-	var out *PeerStats
-	err := c.c.CallContext(ctx, &out, prefixRPC("peerStats"))
-	return out, err
-}
-
-func (c *Client) DiscoveryTable(ctx context.Context) ([]*enode.Node, error) {
-	var out []*enode.Node
-	err := c.c.CallContext(ctx, &out, prefixRPC("discoveryTable"))
-	return out, err
-}
-
-func (c *Client) BlockPeer(ctx context.Context, p peer.ID) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("blockPeer"), p)
-}
-
-func (c *Client) UnblockPeer(ctx context.Context, p peer.ID) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("unblockPeer"), p)
-}
-
-func (c *Client) ListBlockedPeers(ctx context.Context) ([]peer.ID, error) {
-	var out []peer.ID
-	err := c.c.CallContext(ctx, &out, prefixRPC("listBlockedPeers"))
-	return out, err
-}
-
-func (c *Client) BlockAddr(ctx context.Context, ip net.IP) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("blockAddr"), ip)
-}
-
-func (c *Client) UnblockAddr(ctx context.Context, ip net.IP) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("unblockAddr"), ip)
-}
-
-func (c *Client) ListBlockedAddrs(ctx context.Context) ([]net.IP, error) {
-	var out []net.IP
-	err := c.c.CallContext(ctx, &out, prefixRPC("listBlockedAddrs"))
-	return out, err
-}
-
-func (c *Client) BlockSubnet(ctx context.Context, ipnet *net.IPNet) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("blockSubnet"), ipnet)
-}
-
-func (c *Client) UnblockSubnet(ctx context.Context, ipnet *net.IPNet) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("unblockSubnet"), ipnet)
-}
-
-func (c *Client) ListBlockedSubnets(ctx context.Context) ([]*net.IPNet, error) {
-	var out []*net.IPNet
-	err := c.c.CallContext(ctx, &out, prefixRPC("listBlockedSubnets"))
-	return out, err
-}
-
-func (c *Client) ProtectPeer(ctx context.Context, p peer.ID) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("protectPeer"), p)
-}
-
-func (c *Client) UnprotectPeer(ctx context.Context, p peer.ID) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("unprotectPeer"), p)
-}
-
-func (c *Client) ConnectPeer(ctx context.Context, addr string) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("connectPeer"), addr)
-}
-
-func (c *Client) DisconnectPeer(ctx context.Context, id peer.ID) error {
-	return c.c.CallContext(ctx, nil, prefixRPC("disconnectPeer"), id)
+	return &Client{c: *sources.NewP2PClient(client.NewBaseRPCClient(c))}
 }

--- a/op-service/apis/p2p.go
+++ b/op-service/apis/p2p.go
@@ -1,0 +1,72 @@
+package apis
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type P2PClient interface {
+	Self(ctx context.Context) (*PeerInfo, error)
+	Peers(ctx context.Context, connected bool) (*PeerDump, error)
+	PeerStats(ctx context.Context) (*PeerStats, error)
+	DiscoveryTable(ctx context.Context) ([]*enode.Node, error)
+	BlockPeer(ctx context.Context, p peer.ID) error
+	UnblockPeer(ctx context.Context, p peer.ID) error
+	ListBlockedPeers(ctx context.Context) ([]peer.ID, error)
+	BlockAddr(ctx context.Context, ip net.IP) error
+	UnblockAddr(ctx context.Context, ip net.IP) error
+	ListBlockedAddrs(ctx context.Context) ([]net.IP, error)
+	BlockSubnet(ctx context.Context, ipnet *net.IPNet) error
+	UnblockSubnet(ctx context.Context, ipnet *net.IPNet) error
+	ListBlockedSubnets(ctx context.Context) ([]*net.IPNet, error)
+	ProtectPeer(ctx context.Context, p peer.ID) error
+	UnprotectPeer(ctx context.Context, p peer.ID) error
+	ConnectPeer(ctx context.Context, addr string) error
+	DisconnectPeer(ctx context.Context, id peer.ID) error
+}
+
+type PeerDump struct {
+	TotalConnected uint                 `json:"totalConnected"`
+	Peers          map[string]*PeerInfo `json:"peers"`
+	BannedPeers    []peer.ID            `json:"bannedPeers"`
+	BannedIPS      []net.IP             `json:"bannedIPS"`
+	BannedSubnets  []*net.IPNet         `json:"bannedSubnets"`
+}
+
+type PeerInfo struct {
+	PeerID          peer.ID  `json:"peerID"`
+	NodeID          enode.ID `json:"nodeID"`
+	UserAgent       string   `json:"userAgent"`
+	ProtocolVersion string   `json:"protocolVersion"`
+	ENR             string   `json:"ENR"`       // might not always be known, e.g. if the peer connected us instead of us discovering them
+	Addresses       []string `json:"addresses"` // multi-addresses. may be mix of LAN / docker / external IPs. All of them are communicated.
+	Protocols       []string `json:"protocols"` // negotiated protocols list
+	// GossipScore float64
+	// PeerScore float64
+	Connectedness network.Connectedness `json:"connectedness"` // "NotConnected", "Connected", "CanConnect" (gracefully disconnected), or "CannotConnect" (tried but failed)
+	Direction     network.Direction     `json:"direction"`     // "Unknown", "Inbound" (if the peer contacted us), "Outbound" (if we connected to them)
+	Protected     bool                  `json:"protected"`     // Protected peers do not get
+	ChainID       uint64                `json:"chainID"`       // some peers might try to connect, but we figure out they are on a different chain later. This may be 0 if the peer is not an optimism node at all.
+	Latency       time.Duration         `json:"latency"`
+
+	GossipBlocks bool `json:"gossipBlocks"` // if the peer is in our gossip topic
+
+	PeerScores store.PeerScores `json:"scores"`
+}
+
+type PeerStats struct {
+	Connected     uint `json:"connected"`
+	Table         uint `json:"table"`
+	BlocksTopic   uint `json:"blocksTopic"`
+	BlocksTopicV2 uint `json:"blocksTopicV2"`
+	BlocksTopicV3 uint `json:"blocksTopicV3"`
+	BlocksTopicV4 uint `json:"blocksTopicV4"`
+	Banned        uint `json:"banned"`
+	Known         uint `json:"known"`
+}

--- a/op-service/sources/p2p_client.go
+++ b/op-service/sources/p2p_client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -16,7 +16,7 @@ type P2PClient struct {
 
 var NamespaceRPC = "opp2p"
 
-var _ p2p.API = (*P2PClient)(nil)
+var _ apis.P2PClient = (*P2PClient)(nil)
 
 func prefixRPC(method string) string {
 	return NamespaceRPC + "_" + method
@@ -28,20 +28,20 @@ func NewP2PClient(client client.RPC) *P2PClient {
 	}
 }
 
-func (pc *P2PClient) Self(ctx context.Context) (*p2p.PeerInfo, error) {
-	output := &p2p.PeerInfo{}
+func (pc *P2PClient) Self(ctx context.Context) (*apis.PeerInfo, error) {
+	output := &apis.PeerInfo{}
 	err := pc.client.CallContext(ctx, output, prefixRPC("self"))
 	return output, err
 }
 
-func (pc *P2PClient) Peers(ctx context.Context, connected bool) (*p2p.PeerDump, error) {
-	output := &p2p.PeerDump{}
+func (pc *P2PClient) Peers(ctx context.Context, connected bool) (*apis.PeerDump, error) {
+	output := &apis.PeerDump{}
 	err := pc.client.CallContext(ctx, &output, prefixRPC("peers"), connected)
 	return output, err
 }
 
-func (pc *P2PClient) PeerStats(ctx context.Context) (*p2p.PeerStats, error) {
-	output := &p2p.PeerStats{}
+func (pc *P2PClient) PeerStats(ctx context.Context) (*apis.PeerStats, error) {
+	output := &apis.PeerStats{}
 	err := pc.client.CallContext(ctx, output, prefixRPC("peerStats"))
 	return output, err
 }

--- a/op-service/sources/p2p_client.go
+++ b/op-service/sources/p2p_client.go
@@ -14,12 +14,12 @@ type P2PClient struct {
 	client client.RPC
 }
 
-var NamespaceRPC = "opp2p"
+var P2PNamespaceRPC = "opp2p"
 
 var _ apis.P2PClient = (*P2PClient)(nil)
 
-func prefixRPC(method string) string {
-	return NamespaceRPC + "_" + method
+func prefixP2PRPC(method string) string {
+	return P2PNamespaceRPC + "_" + method
 }
 
 func NewP2PClient(client client.RPC) *P2PClient {
@@ -30,82 +30,82 @@ func NewP2PClient(client client.RPC) *P2PClient {
 
 func (pc *P2PClient) Self(ctx context.Context) (*apis.PeerInfo, error) {
 	output := &apis.PeerInfo{}
-	err := pc.client.CallContext(ctx, output, prefixRPC("self"))
+	err := pc.client.CallContext(ctx, output, prefixP2PRPC("self"))
 	return output, err
 }
 
 func (pc *P2PClient) Peers(ctx context.Context, connected bool) (*apis.PeerDump, error) {
 	output := &apis.PeerDump{}
-	err := pc.client.CallContext(ctx, &output, prefixRPC("peers"), connected)
+	err := pc.client.CallContext(ctx, &output, prefixP2PRPC("peers"), connected)
 	return output, err
 }
 
 func (pc *P2PClient) PeerStats(ctx context.Context) (*apis.PeerStats, error) {
 	output := &apis.PeerStats{}
-	err := pc.client.CallContext(ctx, output, prefixRPC("peerStats"))
+	err := pc.client.CallContext(ctx, output, prefixP2PRPC("peerStats"))
 	return output, err
 }
 
 func (pc *P2PClient) DiscoveryTable(ctx context.Context) ([]*enode.Node, error) {
 	output := []*enode.Node{}
-	err := pc.client.CallContext(ctx, &output, prefixRPC("discoveryTable"))
+	err := pc.client.CallContext(ctx, &output, prefixP2PRPC("discoveryTable"))
 	return output, err
 }
 
 func (pc *P2PClient) BlockPeer(ctx context.Context, p peer.ID) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("blockPeer"), p)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("blockPeer"), p)
 }
 
 func (pc *P2PClient) UnblockPeer(ctx context.Context, p peer.ID) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("unblockPeer"), p)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("unblockPeer"), p)
 }
 
 func (pc *P2PClient) ListBlockedPeers(ctx context.Context) ([]peer.ID, error) {
 	output := []peer.ID{}
-	err := pc.client.CallContext(ctx, &output, prefixRPC("listBlockedPeers"))
+	err := pc.client.CallContext(ctx, &output, prefixP2PRPC("listBlockedPeers"))
 	return output, err
 }
 
 func (pc *P2PClient) BlockAddr(ctx context.Context, ip net.IP) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("blockAddr"), ip)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("blockAddr"), ip)
 }
 
 func (pc *P2PClient) UnblockAddr(ctx context.Context, ip net.IP) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("unblockAddr"), ip)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("unblockAddr"), ip)
 }
 
 func (pc *P2PClient) ListBlockedAddrs(ctx context.Context) ([]net.IP, error) {
 	output := []net.IP{}
-	err := pc.client.CallContext(ctx, &output, prefixRPC("listBlockedAddrs"))
+	err := pc.client.CallContext(ctx, &output, prefixP2PRPC("listBlockedAddrs"))
 	return output, err
 }
 
 func (pc *P2PClient) BlockSubnet(ctx context.Context, ipnet *net.IPNet) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("blockSubnet"), ipnet)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("blockSubnet"), ipnet)
 }
 
 func (pc *P2PClient) UnblockSubnet(ctx context.Context, ipnet *net.IPNet) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("unblockSubnet"), ipnet)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("unblockSubnet"), ipnet)
 }
 
 func (pc *P2PClient) ListBlockedSubnets(ctx context.Context) ([]*net.IPNet, error) {
 	output := []*net.IPNet{}
-	err := pc.client.CallContext(ctx, &output, prefixRPC("listBlockedSubnets"))
+	err := pc.client.CallContext(ctx, &output, prefixP2PRPC("listBlockedSubnets"))
 	return output, err
 }
 
 func (pc *P2PClient) ProtectPeer(ctx context.Context, p peer.ID) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("protectPeer"), p)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("protectPeer"), p)
 }
 
 func (pc *P2PClient) UnprotectPeer(ctx context.Context, p peer.ID) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("unprotectPeer"), p)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("unprotectPeer"), p)
 }
 
 func (pc *P2PClient) ConnectPeer(ctx context.Context, addr string) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("connectPeer"), addr)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("connectPeer"), addr)
 }
 
 func (pc *P2PClient) DisconnectPeer(ctx context.Context, id peer.ID) error {
-	return pc.client.CallContext(ctx, nil, prefixRPC("disconnectPeer"), id)
+	return pc.client.CallContext(ctx, nil, prefixP2PRPC("disconnectPeer"), id)
 }

--- a/op-service/sources/p2p_client.go
+++ b/op-service/sources/p2p_client.go
@@ -1,0 +1,111 @@
+package sources
+
+import (
+	"context"
+	"net"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type P2PClient struct {
+	client client.RPC
+}
+
+var NamespaceRPC = "opp2p"
+
+var _ p2p.API = (*P2PClient)(nil)
+
+func prefixRPC(method string) string {
+	return NamespaceRPC + "_" + method
+}
+
+func NewP2PClient(client client.RPC) *P2PClient {
+	return &P2PClient{
+		client: client,
+	}
+}
+
+func (pc *P2PClient) Self(ctx context.Context) (*p2p.PeerInfo, error) {
+	output := &p2p.PeerInfo{}
+	err := pc.client.CallContext(ctx, output, prefixRPC("self"))
+	return output, err
+}
+
+func (pc *P2PClient) Peers(ctx context.Context, connected bool) (*p2p.PeerDump, error) {
+	output := &p2p.PeerDump{}
+	err := pc.client.CallContext(ctx, &output, prefixRPC("peers"), connected)
+	return output, err
+}
+
+func (pc *P2PClient) PeerStats(ctx context.Context) (*p2p.PeerStats, error) {
+	output := &p2p.PeerStats{}
+	err := pc.client.CallContext(ctx, output, prefixRPC("peerStats"))
+	return output, err
+}
+
+func (pc *P2PClient) DiscoveryTable(ctx context.Context) ([]*enode.Node, error) {
+	output := []*enode.Node{}
+	err := pc.client.CallContext(ctx, &output, prefixRPC("discoveryTable"))
+	return output, err
+}
+
+func (pc *P2PClient) BlockPeer(ctx context.Context, p peer.ID) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("blockPeer"), p)
+}
+
+func (pc *P2PClient) UnblockPeer(ctx context.Context, p peer.ID) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("unblockPeer"), p)
+}
+
+func (pc *P2PClient) ListBlockedPeers(ctx context.Context) ([]peer.ID, error) {
+	output := []peer.ID{}
+	err := pc.client.CallContext(ctx, &output, prefixRPC("listBlockedPeers"))
+	return output, err
+}
+
+func (pc *P2PClient) BlockAddr(ctx context.Context, ip net.IP) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("blockAddr"), ip)
+}
+
+func (pc *P2PClient) UnblockAddr(ctx context.Context, ip net.IP) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("unblockAddr"), ip)
+}
+
+func (pc *P2PClient) ListBlockedAddrs(ctx context.Context) ([]net.IP, error) {
+	output := []net.IP{}
+	err := pc.client.CallContext(ctx, &output, prefixRPC("listBlockedAddrs"))
+	return output, err
+}
+
+func (pc *P2PClient) BlockSubnet(ctx context.Context, ipnet *net.IPNet) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("blockSubnet"), ipnet)
+}
+
+func (pc *P2PClient) UnblockSubnet(ctx context.Context, ipnet *net.IPNet) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("unblockSubnet"), ipnet)
+}
+
+func (pc *P2PClient) ListBlockedSubnets(ctx context.Context) ([]*net.IPNet, error) {
+	output := []*net.IPNet{}
+	err := pc.client.CallContext(ctx, &output, prefixRPC("listBlockedSubnets"))
+	return output, err
+}
+
+func (pc *P2PClient) ProtectPeer(ctx context.Context, p peer.ID) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("protectPeer"), p)
+}
+
+func (pc *P2PClient) UnprotectPeer(ctx context.Context, p peer.ID) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("unprotectPeer"), p)
+}
+
+func (pc *P2PClient) ConnectPeer(ctx context.Context, addr string) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("connectPeer"), addr)
+}
+
+func (pc *P2PClient) DisconnectPeer(ctx context.Context, id peer.ID) error {
+	return pc.client.CallContext(ctx, nil, prefixRPC("disconnectPeer"), id)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Enables p2p connection between L2CLs, assuming that each L2CL implements `opp2p` namespace.
Additionally added a RPC client wrapper for P2P node at op-service, to invoke them at devstack sysgo.

**Tests**

I added a `DefaultRedundancyInteropSystem` which adds additional L2 CL-EL pairs to test P2P connections, as well as unsafe head sync between them.

Added tests at `TestL2CLSyncP2P`, which 
- checks p2p connected sequencer and verifier advance unsafe heads just in time.
- make verifier stop, restart, explicitly connect p2p, and check that it catches unsafe heads up again.

**Additional context**

This unblocks interop sync testing: https://github.com/ethereum-optimism/optimism/issues/15325. In order to sync test, we need a redundancy for L2CL, and p2p connection is need to make both L2CLs sync.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15448

