### PR TITLE
test: add multiple access lists test

### DIFF
--- a/op-e2e/e2eutils/interop/contracts/src/ICrossL2Inbox.sol
+++ b/op-e2e/e2eutils/interop/contracts/src/ICrossL2Inbox.sol
@@ -11,7 +11,6 @@ struct Identifier {
 }
 
 interface ICrossL2Inbox {
-    error NoExecutingDeposits();
     error NotInAccessList();
     error BlockNumberTooHigh();
     error TimestampTooHigh();

--- a/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
@@ -12,7 +12,6 @@ struct Identifier {
 }
 
 interface ICrossL2Inbox {
-    error NoExecutingDeposits();
     error NotInAccessList();
     error BlockNumberTooHigh();
     error TimestampTooHigh();

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -166,11 +166,6 @@
   },
   {
     "inputs": [],
-    "name": "NoExecutingDeposits",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "NotInAccessList",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0x508610081cade08f935e2a66f31cc193874bc0e2971a65db4a7842f1a428b1d0"
   },
   "src/L2/CrossL2Inbox.sol:CrossL2Inbox": {
-    "initCodeHash": "0x0be496404eb141292d302686c0df7aec62547b4fb645789de4dd5c7d0756bb8e",
-    "sourceCodeHash": "0xa7d5540afd6bc0712d907ad675bd1621c2a2afee8febd0d04f5f168c38e94f17"
+    "initCodeHash": "0x56f868e561c4abe539043f98b16aad9305479e68fd03ece2233249b0c73a24ea",
+    "sourceCodeHash": "0x7c6d362a69a480a06a079542a7fd2ce48cb1dd80d6b9043fba60218569371349"
   },
   "src/L2/ETHLiquidity.sol:ETHLiquidity": {
     "initCodeHash": "0x0ada742cc59d927979b0e56dba10f3816a542e46cc6481c9e811fd6660c121a8",

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -29,9 +29,6 @@ struct Identifier {
 ///      in the tx's access list. Nodes pre-check message validity before execution. The checksum
 ///      combines the message's `Identifier` and `msgHash` with type-3 bit masking.
 contract CrossL2Inbox is ISemver {
-    /// @notice Thrown when trying to execute a cross chain message on a deposit transaction.
-    error NoExecutingDeposits();
-
     /// @notice Thrown when trying to validate a cross chain message with a checksum
     ///         that is invalid or was not provided in the transaction's access list to set the slot
     ///         as warm.
@@ -50,8 +47,8 @@ contract CrossL2Inbox is ISemver {
     error LogIndexTooHigh();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1
-    string public constant version = "1.0.1";
+    /// @custom:semver 1.0.2
+    string public constant version = "1.0.2";
 
     /// @notice The mask for the most significant bits of the checksum.
     /// @dev    Used to set the most significant byte to zero.

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -174,9 +174,7 @@ contract CrossL2InboxTest is CommonTest {
         _id.timestamp = bound(_id.timestamp, 0, type(uint64).max);
 
         // Try and retry the message without any access list
-        vm.expectCall(
-            address(crossL2Inbox), abi.encodeWithSelector(ICrossL2Inbox.validateMessage.selector, _id, _messageHash), 2
-        );
+        vm.expectCall(address(crossL2Inbox), abi.encodeCall(ICrossL2Inbox.validateMessage, (_id, _messageHash)), 2);
         validateMessageRelayer.validateAndRetry(_id, _messageHash);
     }
 

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
+import { Test } from "forge-std/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 
@@ -13,9 +14,15 @@ import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
 contract CrossL2InboxTest is CommonTest {
     event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
 
+    ValidateMessageRelayer public validateMessageRelayer;
+
+    mapping(bytes32 => bool) public relayedMessages;
+    mapping(bytes32 => bool) public warmedSlots;
+
     function setUp() public override {
         useInteropOverride = true;
         super.setUp();
+        validateMessageRelayer = new ValidateMessageRelayer(address(crossL2Inbox));
     }
 
     /// Test that `validateMessage` reverts when the slot is not warm.
@@ -35,19 +42,22 @@ contract CrossL2InboxTest is CommonTest {
 
     /// Test that `validateMessage` succeeds when the slot for the message checksum is warm.
     /// forge-config: default.isolate = true
-    function testFuzz_validateMessage_succeeds(Identifier memory _id, bytes32 _messageHash) external {
+    function testFuzz_validateMessage_succeeds(
+        Identifier memory _id,
+        bytes32 _messageHash
+    )
+        public
+        returns (bytes32 slot_)
+    {
         // Bound values types to ensure they are not too large
         _id.blockNumber = bound(_id.blockNumber, 0, type(uint64).max);
         _id.logIndex = bound(_id.logIndex, 0, type(uint32).max);
         _id.timestamp = bound(_id.timestamp, 0, type(uint64).max);
 
-        // cool the contract's slots
-        vm.cool(address(crossL2Inbox));
-
         // Prepare the access list to be sent with the next call
-        bytes32 slot = crossL2Inbox.calculateChecksum(_id, _messageHash);
+        slot_ = crossL2Inbox.calculateChecksum(_id, _messageHash);
         bytes32[] memory slots = new bytes32[](1);
-        slots[0] = slot;
+        slots[0] = slot_;
         VmSafe.AccessListItem[] memory accessList = new VmSafe.AccessListItem[](1);
         accessList[0] = VmSafe.AccessListItem({ target: address(crossL2Inbox), storageKeys: slots });
 
@@ -58,6 +68,151 @@ contract CrossL2InboxTest is CommonTest {
         // Validate the message
         vm.accessList(accessList);
         crossL2Inbox.validateMessage(_id, _messageHash);
+    }
+
+    /// Test that multiple calls to`validateMessage` with different access lists don't collide and succeeds.
+    /// @dev This tests that the way we encode and hash the checksum slot is unique enough to avoid collisions.
+    /// forge-config: default.isolate = true
+    function testFuzz_validateMessage_multipleAccessLists_succeeds(
+        Identifier[20] memory _ids,
+        bytes32[20] calldata _messageHash
+    )
+        external
+    {
+        // Send batches of calls with different access lists and check they never collide and always succeed
+        for (uint256 i; i < _ids.length; i++) {
+            // Make sure we're not re-validating the same message
+            bytes32 msgToValidate = keccak256(abi.encode(_ids[i], _messageHash[i]));
+            vm.assume(relayedMessages[msgToValidate] == false);
+            relayedMessages[msgToValidate] = true;
+
+            // Call validateMessage and get the slot
+            bytes32 slot_ = testFuzz_validateMessage_succeeds(_ids[i], _messageHash[i]);
+            // Check that the slot doesn't match a previously warmed slot
+            assertEq(warmedSlots[slot_], false);
+            // Mark the slot as warmed
+            warmedSlots[slot_] = true;
+
+            // Remove the access list
+            vm.noAccessList();
+        }
+    }
+
+    /// Test that an invalid tx calling `validateMessage` doesn't warm the slot for the next one.
+    /// forge-config: default.isolate = true
+    function test_validateMessage_revertDoesntWarm_reverts(
+        Identifier memory _idOne,
+        Identifier memory _idTwo,
+        bytes32 _messageHashOne,
+        bytes32 _messageHashTwo
+    )
+        external
+    {
+        // Bound values types to ensure they are not too large
+        _idOne.blockNumber = bound(_idOne.blockNumber, 0, type(uint64).max);
+        _idOne.logIndex = bound(_idOne.logIndex, 0, type(uint32).max);
+        _idOne.timestamp = bound(_idOne.timestamp, 0, type(uint64).max);
+        _idTwo.blockNumber = bound(_idTwo.blockNumber, 0, type(uint64).max);
+        _idTwo.logIndex = bound(_idTwo.logIndex, 0, type(uint32).max);
+        _idTwo.timestamp = bound(_idTwo.timestamp, 0, type(uint64).max);
+
+        // Make sure the first message is valid
+        bytes32 slotTwo = crossL2Inbox.calculateChecksum(_idTwo, _messageHashTwo);
+        bytes32[] memory slots = new bytes32[](1);
+        slots[0] = slotTwo;
+        VmSafe.AccessListItem[] memory accessList = new VmSafe.AccessListItem[](1);
+        accessList[0] = VmSafe.AccessListItem({ target: address(crossL2Inbox), storageKeys: slots });
+
+        // Expect a revert on the tx1 warming the slot two
+        vm.expectRevert(ICrossL2Inbox.NotInAccessList.selector);
+        vm.accessList(accessList);
+        crossL2Inbox.validateMessage(_idOne, _messageHashOne);
+
+        // Send the tx2 but without any access list and check that it reverts since the slot should not be warmed
+        vm.expectRevert(ICrossL2Inbox.NotInAccessList.selector);
+        crossL2Inbox.validateMessage(_idTwo, _messageHashTwo);
+    }
+
+    /// Test that a valid tx calling `validateMessage` doesn't warm the slot for the next one.
+    /// forge-config: default.isolate = true
+    function test_validateMessage_validDoesntWarm_reverts(Identifier memory _id, bytes32 _messageHash) external {
+        // Bound values types to ensure they are not too large
+        _id.blockNumber = bound(_id.blockNumber, 0, type(uint64).max);
+        _id.logIndex = bound(_id.logIndex, 0, type(uint32).max);
+        _id.timestamp = bound(_id.timestamp, 0, type(uint64).max);
+
+        // Make sure the first message is valid
+        bytes32 slotOne = crossL2Inbox.calculateChecksum(_id, _messageHash);
+        bytes32[] memory slots = new bytes32[](1);
+        slots[0] = slotOne;
+        VmSafe.AccessListItem[] memory accessList = new VmSafe.AccessListItem[](1);
+        accessList[0] = VmSafe.AccessListItem({ target: address(crossL2Inbox), storageKeys: slots });
+
+        // Expect `ExecutingMessage` event to be emitted
+        vm.expectEmit(address(crossL2Inbox));
+        emit ExecutingMessage(_messageHash, _id);
+
+        // Validate the message
+        vm.accessList(accessList);
+        crossL2Inbox.validateMessage(_id, _messageHash);
+
+        // Send the same msg but without any access list and check that it reverts since the slot should not be warmed
+        vm.expectRevert(ICrossL2Inbox.NotInAccessList.selector);
+        crossL2Inbox.validateMessage(_id, _messageHash);
+    }
+
+    /// Test that an invalid message without access list does not succeed warm the slot and fails the second time
+    function test_validateMessage_sameMsgWithoutAccessListTwice_reverts(
+        Identifier memory _id,
+        bytes32 _messageHash
+    )
+        public
+    {
+        // Make sure the Identifier is valid
+        _id.blockNumber = bound(_id.blockNumber, 0, type(uint64).max);
+        _id.logIndex = bound(_id.logIndex, 0, type(uint32).max);
+        _id.timestamp = bound(_id.timestamp, 0, type(uint64).max);
+
+        // Try and retry the message without any access list
+        vm.expectCall(
+            address(crossL2Inbox), abi.encodeWithSelector(ICrossL2Inbox.validateMessage.selector, _id, _messageHash), 2
+        );
+        validateMessageRelayer.validateAndRetry(_id, _messageHash);
+    }
+
+    /// Test that multiple calls to `validateMessage` with multiple storage keys succeeds on the same tx succeeds.
+    /// forge-config: default.isolate = true
+    function test_validateMessage_multipleStorageKeys_succeeds(
+        Identifier[20] memory _ids,
+        bytes32[20] memory _messageHashes
+    )
+        public
+    {
+        bytes32[] memory slots = new bytes32[](_ids.length);
+        for (uint256 i; i < _ids.length; i++) {
+            // Make sure the Identifier is valid
+            _ids[i].blockNumber = bound(_ids[i].blockNumber, 0, type(uint64).max);
+            _ids[i].logIndex = bound(_ids[i].logIndex, 0, type(uint32).max);
+            _ids[i].timestamp = bound(_ids[i].timestamp, 0, type(uint64).max);
+
+            // Calculate the checksum for the message and add it to the storage keys
+            bytes32 slot = crossL2Inbox.calculateChecksum(_ids[i], _messageHashes[i]);
+            slots[i] = slot;
+        }
+
+        // Prepare the access list to be sent with the next txs
+        VmSafe.AccessListItem[] memory accessList = new VmSafe.AccessListItem[](1);
+        accessList[0] = VmSafe.AccessListItem({ target: address(crossL2Inbox), storageKeys: slots });
+
+        // Expect `ExecutingMessage` events to be emitted
+        for (uint256 i; i < _ids.length; i++) {
+            vm.expectEmit(address(crossL2Inbox));
+            emit ExecutingMessage(_messageHashes[i], _ids[i]);
+        }
+
+        // Validate the message
+        vm.accessList(accessList);
+        validateMessageRelayer.validateMessages(_ids, _messageHashes);
     }
 
     /// Test that calculate checcksum reverts when the block number is greater than 2^64.
@@ -122,5 +277,33 @@ contract CrossL2InboxTest is CommonTest {
 
         // Expect it to match
         assertEq(checksum, expectedChecksum);
+    }
+}
+
+/// @dev For test contract used to validate multiple messages in a single tx.
+contract ValidateMessageRelayer is Test {
+    ICrossL2Inbox public immutable CROSS_L2_INBOX;
+
+    constructor(address _crossL2Inbox) {
+        CROSS_L2_INBOX = ICrossL2Inbox(_crossL2Inbox);
+    }
+
+    /// @notice Validates a message and retries it after it reverts.
+    function validateAndRetry(Identifier memory _id, bytes32 _messageHash) external {
+        try CROSS_L2_INBOX.validateMessage(_id, _messageHash) {
+            // It should always revert
+            assertFalse(true);
+        } catch {
+            // It should revert with NotInAccessList when called a second time without any access list
+            vm.expectRevert(ICrossL2Inbox.NotInAccessList.selector);
+            CROSS_L2_INBOX.validateMessage(_id, _messageHash);
+        }
+    }
+
+    /// @notice Validates multiple messages in a single tx.
+    function validateMessages(Identifier[20] memory _ids, bytes32[20] memory _messageHashes) external {
+        for (uint256 i; i < _ids.length; i++) {
+            CROSS_L2_INBOX.validateMessage(_ids[i], _messageHashes[i]);
+        }
     }
 }


### PR DESCRIPTION
**Description**

Add `CrossL2Inbox`'s multiple access list tests to complete FMA actions items.

**Additional context**

Interop access list FMA: https://github.com/ethereum-optimism/design-docs/pull/252

Authored by @0xDiscotech 