### PR TITLE
feat: initial implementation of the SuperRootMigrator

### DIFF
--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { RLPReader } from "../libraries/rlp/RLPReader.sol";
+import { Hashing } from "../libraries/Hashing.sol";
 import { IDisputeGameFactory } from "../../interfaces/dispute/IDisputeGameFactory.sol";
 import { IDisputeGame, GameStatus } from "../../interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "../../interfaces/dispute/IAnchorStateRegistry.sol";
@@ -113,7 +114,7 @@ contract SuperRootMigrator {
             }
 
             bytes32 outputRoot = game.rootClaim().raw();
-            if (hashOutputRootProof(_outputs[i]) != outputRoot) {
+            if (Hashing.hashOutputRootProof(_outputs[i]) != outputRoot) {
                 revert InvalidOutput();
             }
             if (keccak256(_headerRLP[i]) != _outputs[i].latestBlockhash) {
@@ -151,20 +152,5 @@ contract SuperRootMigrator {
         // Or just put this method on AnchorStateRegistry and it can update itself.
 
         return (superBytes, superRoot);
-    }
-
-    /// @notice Hashes the various elements of an output root proof into an output root hash which
-    ///         can be used to check if the proof is valid.
-    /// @param _outputRootProof Output root proof which should hash to an output root.
-    /// @return Hashed output root proof.
-    function hashOutputRootProof(Types.OutputRootProof memory _outputRootProof) internal pure returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                _outputRootProof.version,
-                _outputRootProof.stateRoot,
-                _outputRootProof.messagePasserStorageRoot,
-                _outputRootProof.latestBlockhash
-            )
-        );
     }
 }

--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { RLPReader } from "../libraries/rlp/RLPReader.sol";
 import { IDisputeGameFactory } from "../../interfaces/dispute/IDisputeGameFactory.sol";
 import { IDisputeGame, GameStatus } from "../../interfaces/dispute/IDisputeGame.sol";
+import { IAnchorStateRegistry } from "../../interfaces/dispute/IAnchorStateRegistry.sol";
 import { Claim, LibClaim } from "../dispute/lib/LibUDT.sol";
 import { Types } from "../libraries/Types.sol";
 
@@ -20,6 +21,8 @@ contract SuperRootMigrator {
     error InvalidGameProxy();
     error LengthMismatch();
     error ChainIDsNotAscending();
+    error BlacklistedGame();
+    error MissingAnchorStateRegistry();
 
     /// @notice The index of the block number in the RLP-encoded block header.
     uint256 internal constant HEADER_TIMESTAMP_INDEX = 11;
@@ -27,9 +30,16 @@ contract SuperRootMigrator {
 
     IDisputeGameFactory[] public gameFactories;
     uint256[] public chainIDs;
+    mapping(uint256 => IAnchorStateRegistry) public anchorStateRegistries;
 
-    constructor(IDisputeGameFactory[] memory _gameFactories, uint256[] memory _chainIDs) {
-        if (_gameFactories.length != _chainIDs.length) revert LengthMismatch();
+    constructor(
+        IDisputeGameFactory[] memory _gameFactories,
+        IAnchorStateRegistry[] memory _anchorStateRegistries,
+        uint256[] memory _chainIDs
+    ) {
+        if (_gameFactories.length != _chainIDs.length || _gameFactories.length != _anchorStateRegistries.length) {
+            revert LengthMismatch();
+        }
 
         // Verify that chainIDs are in ascending order per doc
         for (uint256 i = 1; i < _chainIDs.length; i++) {
@@ -40,6 +50,9 @@ contract SuperRootMigrator {
 
         gameFactories = _gameFactories;
         chainIDs = _chainIDs;
+        for (uint256 i = 0; i < _chainIDs.length; i++) {
+            anchorStateRegistries[_chainIDs[i]] = _anchorStateRegistries[i];
+        }
     }
 
     function chainsLen() external view returns (uint256) {
@@ -63,9 +76,16 @@ contract SuperRootMigrator {
         bytes memory chainData;
         for (uint256 i = 0; i < chainCount; i++) {
             (,, IDisputeGame game) = gameFactories[i].gameAtIndex(_gameIdxs[i]);
-            /// TODO: check blacklist?
             if (address(game) == address(0)) {
                 revert InvalidGameProxy();
+            }
+            // Fetch the ASR for the specific chain
+            IAnchorStateRegistry asr = anchorStateRegistries[chainIDs[i]];
+            if (address(asr) == address(0)) {
+                revert MissingAnchorStateRegistry();
+            }
+            if (asr.isGameBlacklisted(game)) {
+                revert BlacklistedGame();
             }
             if (!game.wasRespectedGameTypeWhenCreated()) {
                 revert InvalidGameType();

--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -68,8 +68,10 @@ contract SuperRootMigrator {
         view
         returns (bytes memory super_, bytes32 superRoot_)
     {
-        /// TODO: Requirements on gameIdx length based on # of factories
         uint256 chainCount = gameFactories.length;
+        if (_gameIdxs.length != chainCount) {
+            revert LengthMismatch();
+        }
         /// TODO: should this be in the loop based on the game? implies that this contract can only migrate factories
         /// with games at the same timestamp?
         uint256 expectedTimestamp = 0;

--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -18,16 +18,16 @@ contract SuperRootMigrator {
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
-    error InvalidOutput();
-    error InvalidHeaderRLP();
-    error InvalidGameStatus();
-    error TimestampMismatch();
-    error InvalidGameType();
-    error InvalidGameProxy();
-    error LengthMismatch();
-    error ChainIDsNotAscending();
-    error BlacklistedGame();
-    error MissingAnchorStateRegistry();
+    error SuperRootMigrator_InvalidOutput();
+    error SuperRootMigrator_InvalidHeaderRLP();
+    error SuperRootMigrator_InvalidGameStatus();
+    error SuperRootMigrator_TimestampMismatch();
+    error SuperRootMigrator_InvalidGameType();
+    error SuperRootMigrator_InvalidGameProxy();
+    error SuperRootMigrator_LengthMismatch();
+    error SuperRootMigrator_ChainIDsNotAscending();
+    error SuperRootMigrator_BlacklistedGame();
+    error SuperRootMigrator_MissingAnchorStateRegistry();
 
     /*//////////////////////////////////////////////////////////////
                                CONSTANTS
@@ -51,13 +51,13 @@ contract SuperRootMigrator {
         uint256[] memory _chainIDs
     ) {
         if (_gameFactories.length != _chainIDs.length || _gameFactories.length != _anchorStateRegistries.length) {
-            revert LengthMismatch();
+            revert SuperRootMigrator_LengthMismatch();
         }
 
         // Verify that chainIDs are in ascending order per doc
         for (uint256 i = 1; i < _chainIDs.length; i++) {
             if (_chainIDs[i] <= _chainIDs[i - 1]) {
-                revert ChainIDsNotAscending();
+                revert SuperRootMigrator_ChainIDsNotAscending();
             }
         }
 
@@ -87,7 +87,7 @@ contract SuperRootMigrator {
     {
         uint256 chainCount = gameFactories.length;
         if (_gameIdxs.length != chainCount) {
-            revert LengthMismatch();
+            revert SuperRootMigrator_LengthMismatch();
         }
         /// TODO: should this be in the loop based on the game? implies that this contract can only migrate factories
         /// with games at the same timestamp?
@@ -96,29 +96,29 @@ contract SuperRootMigrator {
         for (uint256 i = 0; i < chainCount; i++) {
             (,, IDisputeGame game) = gameFactories[i].gameAtIndex(_gameIdxs[i]);
             if (address(game) == address(0)) {
-                revert InvalidGameProxy();
+                revert SuperRootMigrator_InvalidGameProxy();
             }
             // Fetch the ASR for the specific chain
             IAnchorStateRegistry asr = anchorStateRegistries[chainIDs[i]];
             if (address(asr) == address(0)) {
-                revert MissingAnchorStateRegistry();
+                revert SuperRootMigrator_MissingAnchorStateRegistry();
             }
             if (asr.isGameBlacklisted(game)) {
-                revert BlacklistedGame();
+                revert SuperRootMigrator_BlacklistedGame();
             }
             if (!game.wasRespectedGameTypeWhenCreated()) {
-                revert InvalidGameType();
+                revert SuperRootMigrator_InvalidGameType();
             }
             if (game.status() != GameStatus.DEFENDER_WINS) {
-                revert InvalidGameStatus();
+                revert SuperRootMigrator_InvalidGameStatus();
             }
 
             bytes32 outputRoot = game.rootClaim().raw();
             if (Hashing.hashOutputRootProof(_outputs[i]) != outputRoot) {
-                revert InvalidOutput();
+                revert SuperRootMigrator_InvalidOutput();
             }
             if (keccak256(_headerRLP[i]) != _outputs[i].latestBlockhash) {
-                revert InvalidHeaderRLP();
+                revert SuperRootMigrator_InvalidHeaderRLP();
             }
 
             // Decode the header RLP to find the number of the block. In the consensus encoding, the timestamp
@@ -128,7 +128,7 @@ contract SuperRootMigrator {
 
             // Sanity check the block number string length.
             if (rawTimestamp.length > 32) {
-                revert InvalidHeaderRLP();
+                revert SuperRootMigrator_InvalidHeaderRLP();
             }
 
             // Convert the raw, left-aligned timestamp to a uint256 by aligning it as a big-endian
@@ -141,7 +141,7 @@ contract SuperRootMigrator {
                 blockTimestamp := shr(shl(0x03, sub(0x20, mload(rawTimestamp))), mload(add(rawTimestamp, 0x20)))
             }
             if (i != 0 && blockTimestamp != expectedTimestamp) {
-                revert TimestampMismatch();
+                revert SuperRootMigrator_TimestampMismatch();
             }
             chainData = abi.encodePacked(chainData, chainIDs[i], outputRoot);
         }

--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { RLPReader } from "../libraries/rlp/RLPReader.sol";
+import { IDisputeGameFactory } from "../../interfaces/dispute/IDisputeGameFactory.sol";
+import { IDisputeGame, GameStatus } from "../../interfaces/dispute/IDisputeGame.sol";
+import { Claim, LibClaim } from "../dispute/lib/LibUDT.sol";
+import { Types } from "../libraries/Types.sol";
+
+contract SuperRootMigrator {
+    using LibClaim for Claim;
+    using RLPReader for RLPReader.RLPItem;
+    using RLPReader for bytes;
+
+    error InvalidOutput();
+    error InvalidHeaderRLP();
+    error InvalidGameStatus();
+    error TimestampMismatch();
+    error InvalidGameType();
+    error InvalidGameProxy();
+    error LengthMismatch();
+    error ChainIDsNotAscending();
+
+    /// @notice The index of the block number in the RLP-encoded block header.
+    uint256 internal constant HEADER_TIMESTAMP_INDEX = 11;
+    uint8 internal constant SUPER_VERSION = uint8(1);
+
+    IDisputeGameFactory[] public gameFactories;
+    uint256[] public chainIDs;
+
+    constructor(IDisputeGameFactory[] memory _gameFactories, uint256[] memory _chainIDs) {
+        if (_gameFactories.length != _chainIDs.length) revert LengthMismatch();
+
+        // Verify that chainIDs are in ascending order per doc
+        for (uint256 i = 1; i < _chainIDs.length; i++) {
+            if (_chainIDs[i] <= _chainIDs[i - 1]) {
+                revert ChainIDsNotAscending();
+            }
+        }
+
+        gameFactories = _gameFactories;
+        chainIDs = _chainIDs;
+    }
+
+    function chainsLen() external view returns (uint256) {
+        return gameFactories.length;
+    }
+
+    function migrate(
+        uint256[] calldata _gameIdxs,
+        Types.OutputRootProof[] calldata _outputs,
+        bytes[] calldata _headerRLP
+    )
+        external
+        view
+        returns (bytes memory super_, bytes32 superRoot_)
+    {
+        /// TODO: Requirements on gameIdx length based on # of factories
+        uint256 chainCount = gameFactories.length;
+        /// TODO: should this be in the loop based on the game? implies that this contract can only migrate factories
+        /// with games at the same timestamp?
+        uint256 expectedTimestamp = 0;
+        bytes memory chainData;
+        for (uint256 i = 0; i < chainCount; i++) {
+            (,, IDisputeGame game) = gameFactories[i].gameAtIndex(_gameIdxs[i]);
+            /// TODO: check blacklist?
+            if (address(game) == address(0)) {
+                revert InvalidGameProxy();
+            }
+            if (!game.wasRespectedGameTypeWhenCreated()) {
+                revert InvalidGameType();
+            }
+            if (game.status() != GameStatus.DEFENDER_WINS) {
+                revert InvalidGameStatus();
+            }
+
+            bytes32 outputRoot = game.rootClaim().raw();
+            if (hashOutputRootProof(_outputs[i]) != outputRoot) {
+                revert InvalidOutput();
+            }
+            if (keccak256(_headerRLP[i]) != _outputs[i].latestBlockhash) {
+                revert InvalidHeaderRLP();
+            }
+
+            // Decode the header RLP to find the number of the block. In the consensus encoding, the timestamp
+            // is the 12th element in the list that represents the block header.
+            RLPReader.RLPItem[] memory headerContents = _headerRLP[i].toRLPItem().readList();
+            bytes memory rawTimestamp = headerContents[HEADER_TIMESTAMP_INDEX].readBytes();
+
+            // Sanity check the block number string length.
+            if (rawTimestamp.length > 32) {
+                revert InvalidHeaderRLP();
+            }
+
+            // Convert the raw, left-aligned timestamp to a uint256 by aligning it as a big-endian
+            // number in the low-order bytes of a 32-byte word.
+            //
+            // SAFETY: The length of `rawTimestamp` is checked above to ensure it is at most 32 bytes.
+            /// TODO: simplify this without assembly with casting OOO
+            uint256 blockTimestamp;
+            assembly {
+                blockTimestamp := shr(shl(0x03, sub(0x20, mload(rawTimestamp))), mload(add(rawTimestamp, 0x20)))
+            }
+            if (i != 0 && blockTimestamp != expectedTimestamp) {
+                revert TimestampMismatch();
+            }
+            chainData = abi.encodePacked(chainData, chainIDs[i], outputRoot);
+        }
+        bytes memory superBytes = abi.encodePacked(SUPER_VERSION, uint64(expectedTimestamp), chainData);
+
+        bytes32 superRoot = keccak256(superBytes);
+        // TODO: call AnchorStateRegistry.updateAnchorState(expectedTimestamp, superRoot);
+        // Or just put this method on AnchorStateRegistry and it can update itself.
+
+        return (superBytes, superRoot);
+    }
+
+    /// @notice Hashes the various elements of an output root proof into an output root hash which
+    ///         can be used to check if the proof is valid.
+    /// @param _outputRootProof Output root proof which should hash to an output root.
+    /// @return Hashed output root proof.
+    function hashOutputRootProof(Types.OutputRootProof memory _outputRootProof) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _outputRootProof.version,
+                _outputRootProof.stateRoot,
+                _outputRootProof.messagePasserStorageRoot,
+                _outputRootProof.latestBlockhash
+            )
+        );
+    }
+}

--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -13,6 +13,10 @@ contract SuperRootMigrator {
     using RLPReader for RLPReader.RLPItem;
     using RLPReader for bytes;
 
+    /*//////////////////////////////////////////////////////////////
+                                 ERRORS
+    //////////////////////////////////////////////////////////////*/
+
     error InvalidOutput();
     error InvalidHeaderRLP();
     error InvalidGameStatus();
@@ -24,9 +28,17 @@ contract SuperRootMigrator {
     error BlacklistedGame();
     error MissingAnchorStateRegistry();
 
+    /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
     /// @notice The index of the block number in the RLP-encoded block header.
     uint256 internal constant HEADER_TIMESTAMP_INDEX = 11;
     uint8 internal constant SUPER_VERSION = uint8(1);
+
+    /*//////////////////////////////////////////////////////////////
+                                 STATE
+    //////////////////////////////////////////////////////////////*/
 
     IDisputeGameFactory[] public gameFactories;
     uint256[] public chainIDs;
@@ -54,6 +66,10 @@ contract SuperRootMigrator {
             anchorStateRegistries[_chainIDs[i]] = _anchorStateRegistries[i];
         }
     }
+
+    /*//////////////////////////////////////////////////////////////
+                           EXTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
 
     function chainsLen() external view returns (uint256) {
         return gameFactories.length;

--- a/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/SuperRootMigrator.sol
@@ -89,9 +89,7 @@ contract SuperRootMigrator {
         if (_gameIdxs.length != chainCount) {
             revert SuperRootMigrator_LengthMismatch();
         }
-        /// TODO: should this be in the loop based on the game? implies that this contract can only migrate factories
-        /// with games at the same timestamp?
-        uint256 expectedTimestamp = 0;
+        uint256 expectedTimestamp;
         bytes memory chainData;
         for (uint256 i = 0; i < chainCount; i++) {
             (,, IDisputeGame game) = gameFactories[i].gameAtIndex(_gameIdxs[i]);
@@ -140,9 +138,14 @@ contract SuperRootMigrator {
             assembly {
                 blockTimestamp := shr(shl(0x03, sub(0x20, mload(rawTimestamp))), mload(add(rawTimestamp, 0x20)))
             }
-            if (i != 0 && blockTimestamp != expectedTimestamp) {
+
+            // Set the expected timestamp on the first iteration, compare on subsequent iterations.
+            if (i == 0) {
+                expectedTimestamp = blockTimestamp;
+            } else if (blockTimestamp != expectedTimestamp) {
                 revert SuperRootMigrator_TimestampMismatch();
             }
+
             chainData = abi.encodePacked(chainData, chainIDs[i], outputRoot);
         }
         bytes memory superBytes = abi.encodePacked(SUPER_VERSION, uint64(expectedTimestamp), chainData);

--- a/packages/contracts-bedrock/test/L1/SuperRootMigrator.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperRootMigrator.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { CommonTest } from "test/setup/CommonTest.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+import { IDisputeGameFactory } from "../../interfaces/dispute/IDisputeGameFactory.sol";
+import { IAnchorStateRegistry } from "../../interfaces/dispute/IAnchorStateRegistry.sol";
+import { AnchorStateRegistry } from "../../src/dispute/AnchorStateRegistry.sol";
+import { SuperRootMigrator } from "../../src/L1/SuperRootMigrator.sol";
+
+contract SuperRootMigrator_TestBase is CommonTest {
+    SuperRootMigrator internal superRootMigrator;
+
+    IDisputeGameFactory[] internal gameFactories;
+    IAnchorStateRegistry[] internal anchorStateRegistries;
+    uint256[] internal chainIDs;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        gameFactories = new IDisputeGameFactory[](1);
+        gameFactories[0] = disputeGameFactory; // From CommonTest
+
+        anchorStateRegistries = new IAnchorStateRegistry[](1);
+        anchorStateRegistries[0] = anchorStateRegistry; // From CommonTest
+
+        chainIDs = new uint256[](1);
+        chainIDs[0] = block.chainid; // TODO: validate
+
+        superRootMigrator = new SuperRootMigrator(gameFactories, anchorStateRegistries, chainIDs);
+
+        vm.label(address(superRootMigrator), "SuperRootMigrator");
+        vm.label(address(gameFactories[0]), "DisputeGameFactory (Chain 1)");
+        vm.label(address(anchorStateRegistries[0]), "AnchorStateRegistry (Chain 1)");
+    }
+}
+
+contract SuperRootMigrator_Setup_Test is SuperRootMigrator_TestBase {
+    function test_setUp_succeeds() external view {
+        assertEq(superRootMigrator.chainIDs(0), chainIDs[0], "ChainID mismatch");
+        assertEq(
+            address(superRootMigrator.anchorStateRegistries(chainIDs[0])),
+            address(anchorStateRegistries[0]),
+            "AnchorStateRegistry mismatch"
+        );
+        assertEq(superRootMigrator.chainsLen(), 1, "Incorrect chains length");
+    }
+}

--- a/packages/contracts-bedrock/test/L1/SuperRootMigrator.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperRootMigrator.t.sol
@@ -44,6 +44,11 @@ contract SuperRootMigrator_Setup_Test is SuperRootMigrator_TestBase {
             address(anchorStateRegistries[0]),
             "AnchorStateRegistry mismatch"
         );
+        assertEq(
+            address(superRootMigrator.gameFactories(0)),
+            address(gameFactories[0]),
+            "GameFactory mismatch"
+        );
         assertEq(superRootMigrator.chainsLen(), 1, "Incorrect chains length");
     }
 }

--- a/packages/contracts-bedrock/test/L1/SuperRootMigrator.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperRootMigrator.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 import { IDisputeGameFactory } from "../../interfaces/dispute/IDisputeGameFactory.sol";
 import { IAnchorStateRegistry } from "../../interfaces/dispute/IAnchorStateRegistry.sol";
@@ -44,11 +43,7 @@ contract SuperRootMigrator_Setup_Test is SuperRootMigrator_TestBase {
             address(anchorStateRegistries[0]),
             "AnchorStateRegistry mismatch"
         );
-        assertEq(
-            address(superRootMigrator.gameFactories(0)),
-            address(gameFactories[0]),
-            "GameFactory mismatch"
-        );
+        assertEq(address(superRootMigrator.gameFactories(0)), address(gameFactories[0]), "GameFactory mismatch");
         assertEq(superRootMigrator.chainsLen(), 1, "Incorrect chains length");
     }
 }


### PR DESCRIPTION
**Description**

Implement a contract to convert OutputRoots to SuperRoots in a trustless manner from finalized dispute games for l2 chains

**Tests**

tbd

**Additional context**

tbd

**Metadata**

The first part of this parent issue https://github.com/ethereum-optimism/optimism/issues/15299

Scope: for this PR is the initial implementation of this sub issue https://github.com/ethereum-optimism/optimism/issues/15440
