### PR TITLE
devstack: devtest.T.Gate and match.Assume

### DIFF
--- a/devnet-sdk/devstack/devtest/gate.go
+++ b/devnet-sdk/devstack/devtest/gate.go
@@ -1,0 +1,27 @@
+package devtest
+
+import "github.com/stretchr/testify/require"
+
+// gateAdapter implements the require.TestingT interface by using skips instead of errors.
+// This is used to program test-gate conditions easily.
+// The underlying test-interface may remap the test-skip to a test-error,
+// if skips are not expected / allowed.
+type gateAdapter struct {
+	inner interface {
+		Helper()
+		Skipf(format string, args ...any)
+		SkipNow()
+	}
+}
+
+var _ require.TestingT = (*gateAdapter)(nil)
+
+func (g *gateAdapter) Errorf(format string, args ...interface{}) {
+	g.inner.Helper()
+	g.inner.Skipf(format, args...)
+}
+
+func (g *gateAdapter) FailNow() {
+	g.inner.Helper()
+	g.inner.SkipNow()
+}

--- a/devnet-sdk/devstack/stack/match/gate.go
+++ b/devnet-sdk/devstack/stack/match/gate.go
@@ -1,0 +1,31 @@
+package match
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
+)
+
+type assume[I comparable, E stack.Identifiable[I]] struct {
+	t     devtest.T
+	inner stack.Matcher[I, E]
+}
+
+func (a *assume[I, E]) Match(elems []E) []E {
+	elems = a.inner.Match(elems)
+	a.t.Gate().NotEmpty(elems, "must match something to continue, but matched nothing with %s", a.inner)
+	return elems
+}
+
+func (a *assume[I, E]) String() string {
+	return fmt.Sprintf("Assume(%s)", a.inner)
+}
+
+// Assume skips the test if no elements were matched with the inner matcher
+func Assume[I comparable, E stack.Identifiable[I]](t devtest.T, inner stack.Matcher[I, E]) stack.Matcher[I, E] {
+	return &assume[I, E]{
+		t:     t,
+		inner: inner,
+	}
+}

--- a/devnet-sdk/devstack/stack/match/gate_test.go
+++ b/devnet-sdk/devstack/stack/match/gate_test.go
@@ -1,0 +1,48 @@
+package match
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
+)
+
+type gateTesting struct {
+	log func(format string, args ...interface{})
+	hit bool
+}
+
+func (g *gateTesting) Errorf(format string, args ...interface{}) {
+	g.log(format, args...)
+}
+
+func (g *gateTesting) FailNow() {
+	g.hit = true
+	panic("gate hit")
+}
+
+type fakeTesting struct {
+	devtest.T // embedded but nil, to inherit interface
+	g         *gateTesting
+}
+
+func (f *fakeTesting) Gate() *require.Assertions {
+	return require.New(f.g)
+}
+
+func TestAssume(t *testing.T) {
+	a := &testObject{id: "a"}
+	b := &testObject{id: "b"}
+	fT := &fakeTesting{T: nil, g: &gateTesting{log: t.Logf}}
+
+	m := Assume(fT, First[testID, *testObject]())
+	require.Equal(t, m.String(), "Assume(ByIndex(0))")
+	require.Equal(t, []*testObject{a}, m.Match([]*testObject{a}))
+	require.Equal(t, []*testObject{a}, m.Match([]*testObject{a, b}))
+	require.False(t, fT.g.hit, "no skipping if we got a match")
+	require.PanicsWithValue(t, "gate hit", func() {
+		m.Match([]*testObject{})
+	})
+	require.True(t, fT.g.hit, "skip if we have no match")
+}


### PR DESCRIPTION
**Description**

This makes it much easier to program test gates and filter down the system and skip if the system components are not available.

Test gates can be programmed in-place, like require-checks now.

Any matcher can now be wrapped with `match.SkipIfNone(t, <inner>)`, and it will skip the test if no match is found.

**Tests**

Covered the `SkipIfNone` util, and the Gate is used in the `SkipIfNone` and example test preset setup.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
