### PR TITLE
ctb,op-deployer: Remove deployconfig from l2genesis

### DIFF
--- a/op-deployer/pkg/deployer/opcm/alphabet2_test.go
+++ b/op-deployer/pkg/deployer/opcm/alphabet2_test.go
@@ -1,10 +1,9 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -14,11 +13,11 @@ func TestNewDeployAlphabetVMScript(t *testing.T) {
 		// First we grab a test host
 		host1 := createTestHost(t)
 
-		deployAlphabetVM, err := opcm.NewDeployAlphabetVMScript(host1)
+		deployAlphabetVM, err := NewDeployAlphabetVMScript(host1)
 		require.NoError(t, err)
 
 		// Now we run the deploy script
-		output, err := deployAlphabetVM.Run(opcm.DeployAlphabetVM2Input{
+		output, err := deployAlphabetVM.Run(DeployAlphabetVM2Input{
 			AbsolutePrestate: common.BigToHash(big.NewInt(1)),
 			PreimageOracle:   common.BigToAddress(big.NewInt(2)),
 		})
@@ -33,7 +32,7 @@ func TestNewDeployAlphabetVMScript(t *testing.T) {
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
 
-		deprecatedOutput, err := opcm.DeployAlphabetVM(host2, opcm.DeployAlphabetVMInput{
+		deprecatedOutput, err := DeployAlphabetVM(host2, DeployAlphabetVMInput{
 			AbsolutePrestate: common.BigToHash(big.NewInt(1)),
 			PreimageOracle:   common.BigToAddress(big.NewInt(2)),
 		})

--- a/op-deployer/pkg/deployer/opcm/alt_da2_test.go
+++ b/op-deployer/pkg/deployer/opcm/alt_da2_test.go
@@ -1,10 +1,9 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +16,11 @@ func TestNewDeployAltDAScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deploySuperchain, err := opcm.NewDeployAltDAScript(host1)
+		deploySuperchain, err := NewDeployAltDAScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deploySuperchain.Run(opcm.DeployAltDA2Input{
+		output, err := deploySuperchain.Run(DeployAltDA2Input{
 			Salt:                     common.BigToHash(big.NewInt(1)),
 			ProxyAdmin:               common.BigToAddress(big.NewInt(2)),
 			ChallengeContractOwner:   common.BigToAddress(big.NewInt(3)),
@@ -40,7 +39,7 @@ func TestNewDeployAltDAScript(t *testing.T) {
 		// We run it on a fresh host so that the deployer nonces are the same
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
-		deprecatedOutput, err := opcm.DeployAltDA(host2, opcm.DeployAltDAInput{
+		deprecatedOutput, err := DeployAltDA(host2, DeployAltDAInput{
 			Salt:                     common.BigToHash(big.NewInt(1)),
 			ProxyAdmin:               common.BigToAddress(big.NewInt(2)),
 			ChallengeContractOwner:   common.BigToAddress(big.NewInt(3)),

--- a/op-deployer/pkg/deployer/opcm/asterisc2_test.go
+++ b/op-deployer/pkg/deployer/opcm/asterisc2_test.go
@@ -1,10 +1,9 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +16,11 @@ func TestNewDeployAsteriscScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deploySuperchain, err := opcm.NewDeployAsteriscScript(host1)
+		deploySuperchain, err := NewDeployAsteriscScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deploySuperchain.Run(opcm.DeployAsterisc2Input{
+		output, err := deploySuperchain.Run(DeployAsterisc2Input{
 			PreimageOracle: common.BigToAddress(big.NewInt(1)),
 		})
 
@@ -34,7 +33,7 @@ func TestNewDeployAsteriscScript(t *testing.T) {
 		// We run it on a fresh host so that the deployer nonces are the same
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
-		deprecatedOutput, err := opcm.DeployAsterisc(host2, opcm.DeployAsteriscInput{
+		deprecatedOutput, err := DeployAsterisc(host2, DeployAsteriscInput{
 			PreimageOracle: common.BigToAddress(big.NewInt(1)),
 		})
 

--- a/op-deployer/pkg/deployer/opcm/bootstrap_test.go
+++ b/op-deployer/pkg/deployer/opcm/bootstrap_test.go
@@ -1,4 +1,4 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"

--- a/op-deployer/pkg/deployer/opcm/dispute_game2_test.go
+++ b/op-deployer/pkg/deployer/opcm/dispute_game2_test.go
@@ -1,4 +1,4 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -23,11 +22,11 @@ func TestNewDeployDisputeGameScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deploySuperchain, err := opcm.NewDeployDisputeGameScript(host1)
+		deploySuperchain, err := NewDeployDisputeGameScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deploySuperchain.Run(opcm.DeployDisputeGame2Input{
+		output, err := deploySuperchain.Run(DeployDisputeGame2Input{
 			Release:                  "dev",
 			StandardVersionsToml:     "dev.toml",
 			VmAddress:                vm1Address,
@@ -59,7 +58,7 @@ func TestNewDeployDisputeGameScript(t *testing.T) {
 		vm2Address := deployDisputeGameScriptVM(t, host2)
 		require.NoError(t, err)
 
-		deprecatedOutput, err := opcm.DeployDisputeGame(host2, opcm.DeployDisputeGameInput{
+		deprecatedOutput, err := DeployDisputeGame(host2, DeployDisputeGameInput{
 			Release:                  "dev",
 			VmAddress:                vm2Address,
 			GameKind:                 "PermissionedDisputeGame",

--- a/op-deployer/pkg/deployer/opcm/implementations2_test.go
+++ b/op-deployer/pkg/deployer/opcm/implementations2_test.go
@@ -1,4 +1,4 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -52,11 +51,11 @@ func TestNewDeployImplementationsScript(t *testing.T) {
 		// We'll need some contracts already deployed for this to work
 		proxyAdminAddress, proxyAddress, protocolVersionsAddress := deployDependencies(host1)
 
-		deployImplementations, err := opcm.NewDeployImplementationsScript(host1)
+		deployImplementations, err := NewDeployImplementationsScript(host1)
 		require.NoError(t, err)
 
 		// Now we run the deploy script
-		output, err := deployImplementations.Run(opcm.DeployImplementations2Input{
+		output, err := deployImplementations.Run(DeployImplementations2Input{
 			WithdrawalDelaySeconds:          big.NewInt(1),
 			MinProposalSizeBytes:            big.NewInt(2),
 			ChallengePeriodSeconds:          big.NewInt(3),
@@ -84,7 +83,7 @@ func TestNewDeployImplementationsScript(t *testing.T) {
 		// We'll need some contracts already deployed for this to work
 		proxyAdminAddress, proxyAddress, protocolVersionsAddress = deployDependencies(host2)
 
-		deprecatedOutput, err := opcm.DeployImplementations(host2, opcm.DeployImplementationsInput{
+		deprecatedOutput, err := DeployImplementations(host2, DeployImplementationsInput{
 			WithdrawalDelaySeconds:          big.NewInt(1),
 			MinProposalSizeBytes:            big.NewInt(2),
 			ChallengePeriodSeconds:          big.NewInt(3),

--- a/op-deployer/pkg/deployer/opcm/l2genesis2.go
+++ b/op-deployer/pkg/deployer/opcm/l2genesis2.go
@@ -1,0 +1,37 @@
+package opcm
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type L2Genesis2Input struct {
+	L1ChainID                                *big.Int
+	L2ChainID                                *big.Int
+	L1CrossDomainMessengerProxy              common.Address
+	L1StandardBridgeProxy                    common.Address
+	L1ERC721BridgeProxy                      common.Address
+	L2ProxyAdminOwner                        common.Address
+	SequencerFeeVaultRecipient               common.Address
+	SequencerFeeVaultMinimumWithdrawalAmount *big.Int
+	SequencerFeeVaultWithdrawalNetwork       *big.Int
+	BaseFeeVaultRecipient                    common.Address
+	BaseFeeVaultMinimumWithdrawalAmount      *big.Int
+	BaseFeeVaultWithdrawalNetwork            *big.Int
+	L1FeeVaultRecipient                      common.Address
+	L1FeeVaultMinimumWithdrawalAmount        *big.Int
+	L1FeeVaultWithdrawalNetwork              *big.Int
+	GovernanceTokenOwner                     common.Address
+	Fork                                     *big.Int
+	UseInterop                               bool
+	EnableGovernance                         bool
+	FundDevAccounts                          bool
+}
+
+type L2Genesis2Script script.DeployScriptWithoutOutput[L2Genesis2Input]
+
+func NewL2Genesis2Script(host *script.Host) (L2Genesis2Script, error) {
+	return script.NewDeployScriptWithoutOutputFromFile[L2Genesis2Input](host, "L2Genesis2.s.sol", "L2Genesis")
+}

--- a/op-deployer/pkg/deployer/opcm/l2genesis2_test.go
+++ b/op-deployer/pkg/deployer/opcm/l2genesis2_test.go
@@ -2,13 +2,14 @@ package opcm
 
 import (
 	"encoding/json"
+	"math/big"
+	"testing"
+
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
 )
 
 func TestL2Genesis2Differential(t *testing.T) {
@@ -45,7 +46,7 @@ func TestL2Genesis2Differential(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			initCfg := genesis.L2InitializationConfig{
 				DevDeployConfig: genesis.DevDeployConfig{FundDevAccounts: true},
 				OwnershipDeployConfig: genesis.OwnershipDeployConfig{

--- a/op-deployer/pkg/deployer/opcm/l2genesis2_test.go
+++ b/op-deployer/pkg/deployer/opcm/l2genesis2_test.go
@@ -1,0 +1,135 @@
+package opcm
+
+import (
+	"encoding/json"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+)
+
+func TestL2Genesis2Differential(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutator func(*genesis.L2InitializationConfig, *L2Genesis2Input)
+	}{
+		{
+			name:    "no changes",
+			mutator: func(initCfg *genesis.L2InitializationConfig, input *L2Genesis2Input) {},
+		},
+		{
+			"interop",
+			func(initCfg *genesis.L2InitializationConfig, input *L2Genesis2Input) {
+				initCfg.UseInterop = true
+				input.UseInterop = true
+			},
+		},
+		{
+			"no dev account",
+			func(initCfg *genesis.L2InitializationConfig, input *L2Genesis2Input) {
+				initCfg.DevDeployConfig.FundDevAccounts = false
+				input.FundDevAccounts = false
+			},
+		},
+		{
+			"no governance",
+			func(initCfg *genesis.L2InitializationConfig, input *L2Genesis2Input) {
+				initCfg.GovernanceDeployConfig.EnableGovernance = false
+				input.EnableGovernance = false
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			initCfg := genesis.L2InitializationConfig{
+				DevDeployConfig: genesis.DevDeployConfig{FundDevAccounts: true},
+				OwnershipDeployConfig: genesis.OwnershipDeployConfig{
+					ProxyAdminOwner:  common.Address{'O'},
+					FinalSystemOwner: common.Address{'F'},
+				},
+				GovernanceDeployConfig: genesis.GovernanceDeployConfig{
+					EnableGovernance:      true,
+					GovernanceTokenSymbol: "OP",
+					GovernanceTokenName:   "Optimism",
+					GovernanceTokenOwner:  common.HexToAddress("0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAdDEad"),
+				},
+				L2CoreDeployConfig: genesis.L2CoreDeployConfig{
+					L1ChainID: 999,
+					L2ChainID: 1000,
+				},
+				L2VaultsDeployConfig: genesis.L2VaultsDeployConfig{
+					BaseFeeVaultRecipient:                    common.Address{'B'},
+					L1FeeVaultRecipient:                      common.Address{'L'},
+					SequencerFeeVaultRecipient:               common.Address{'S'},
+					BaseFeeVaultMinimumWithdrawalAmount:      (*hexutil.Big)(big.NewInt(1)),
+					L1FeeVaultMinimumWithdrawalAmount:        (*hexutil.Big)(big.NewInt(1)),
+					SequencerFeeVaultMinimumWithdrawalAmount: (*hexutil.Big)(big.NewInt(1)),
+					BaseFeeVaultWithdrawalNetwork:            genesis.WithdrawalNetwork("local"),
+					L1FeeVaultWithdrawalNetwork:              genesis.WithdrawalNetwork("local"),
+					SequencerFeeVaultWithdrawalNetwork:       genesis.WithdrawalNetwork("local"),
+				},
+			}
+			initCfg.UpgradeScheduleDeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
+
+			l1Deps := L1Deployments{
+				L1CrossDomainMessengerProxy: common.Address{'M'},
+				L1StandardBridgeProxy:       common.Address{'B'},
+				L1ERC721BridgeProxy:         common.Address{'E'},
+			}
+
+			newInput := L2Genesis2Input{
+				L1ChainID:                                new(big.Int).SetUint64(initCfg.L1ChainID),
+				L2ChainID:                                new(big.Int).SetUint64(initCfg.L2ChainID),
+				L1CrossDomainMessengerProxy:              l1Deps.L1CrossDomainMessengerProxy,
+				L1StandardBridgeProxy:                    l1Deps.L1StandardBridgeProxy,
+				L1ERC721BridgeProxy:                      l1Deps.L1ERC721BridgeProxy,
+				L2ProxyAdminOwner:                        initCfg.OwnershipDeployConfig.ProxyAdminOwner,
+				SequencerFeeVaultRecipient:               initCfg.L2VaultsDeployConfig.SequencerFeeVaultRecipient,
+				SequencerFeeVaultMinimumWithdrawalAmount: (*big.Int)(initCfg.L2VaultsDeployConfig.SequencerFeeVaultMinimumWithdrawalAmount),
+				SequencerFeeVaultWithdrawalNetwork:       big.NewInt(int64(initCfg.L2VaultsDeployConfig.SequencerFeeVaultWithdrawalNetwork.ToUint8())),
+				BaseFeeVaultRecipient:                    initCfg.L2VaultsDeployConfig.BaseFeeVaultRecipient,
+				BaseFeeVaultMinimumWithdrawalAmount:      (*big.Int)(initCfg.L2VaultsDeployConfig.BaseFeeVaultMinimumWithdrawalAmount),
+				BaseFeeVaultWithdrawalNetwork:            big.NewInt(int64(initCfg.L2VaultsDeployConfig.BaseFeeVaultWithdrawalNetwork.ToUint8())),
+				L1FeeVaultRecipient:                      initCfg.L2VaultsDeployConfig.L1FeeVaultRecipient,
+				L1FeeVaultMinimumWithdrawalAmount:        (*big.Int)(initCfg.L2VaultsDeployConfig.L1FeeVaultMinimumWithdrawalAmount),
+				L1FeeVaultWithdrawalNetwork:              big.NewInt(int64(initCfg.L2VaultsDeployConfig.L1FeeVaultWithdrawalNetwork.ToUint8())),
+				GovernanceTokenOwner:                     initCfg.GovernanceDeployConfig.GovernanceTokenOwner,
+				Fork:                                     big.NewInt(6), // corresponds to isthmus
+				UseInterop:                               false,
+				EnableGovernance:                         true,
+				FundDevAccounts:                          true,
+			}
+
+			tt.mutator(&initCfg, &newInput)
+
+			hostOld := createTestHost(t)
+			require.NoError(t, L2Genesis(hostOld, &L2GenesisInput{
+				L1Deployments: l1Deps,
+				L2Config:      initCfg,
+			}))
+
+			hostNew := createTestHost(t)
+			script, err := NewL2Genesis2Script(hostNew)
+			require.NoError(t, err)
+
+			require.NoError(t, script.Run(newInput))
+
+			dumpOld, err := hostOld.StateDump()
+			require.NoError(t, err)
+			dumpNew, err := hostNew.StateDump()
+			require.NoError(t, err)
+
+			dumpOldJSON, err := json.MarshalIndent(dumpOld, "", "  ")
+			require.NoError(t, err)
+			dumpNewJSON, err := json.MarshalIndent(dumpNew, "", "  ")
+			require.NoError(t, err)
+
+			require.JSONEq(t, string(dumpOldJSON), string(dumpNewJSON))
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/opcm/mips2_test.go
+++ b/op-deployer/pkg/deployer/opcm/mips2_test.go
@@ -1,10 +1,9 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +16,11 @@ func TestNewDeployMIPSScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deploySuperchain, err := opcm.NewDeployMIPSScript(host1)
+		deploySuperchain, err := NewDeployMIPSScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deploySuperchain.Run(opcm.DeployMIPS2Input{
+		output, err := deploySuperchain.Run(DeployMIPS2Input{
 			PreimageOracle: common.Address{'P'},
 			MipsVersion:    big.NewInt(1),
 		})
@@ -35,7 +34,7 @@ func TestNewDeployMIPSScript(t *testing.T) {
 		// We run it on a fresh host so that the deployer nonces are the same
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
-		deprecatedOutput, err := opcm.DeployMIPS(host2, opcm.DeployMIPSInput{
+		deprecatedOutput, err := DeployMIPS(host2, DeployMIPSInput{
 			PreimageOracle: common.Address{'P'},
 			MipsVersion:    1,
 		})

--- a/op-deployer/pkg/deployer/opcm/preimage_oracle2_test.go
+++ b/op-deployer/pkg/deployer/opcm/preimage_oracle2_test.go
@@ -1,10 +1,9 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,11 +15,11 @@ func TestNewDeployPreimageOracleScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deployPreimageOracle, err := opcm.NewDeployPreimageOracleScript(host1)
+		deployPreimageOracle, err := NewDeployPreimageOracleScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deployPreimageOracle.Run(opcm.DeployPreimageOracle2Input{
+		output, err := deployPreimageOracle.Run(DeployPreimageOracle2Input{
 			MinProposalSize: big.NewInt(1),
 			ChallengePeriod: big.NewInt(2),
 		})
@@ -34,7 +33,7 @@ func TestNewDeployPreimageOracleScript(t *testing.T) {
 		// We run it on a fresh host so that the deployer nonces are the same
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
-		deprecatedOutput, err := opcm.DeployPreimageOracle(host2, opcm.DeployPreimageOracleInput{
+		deprecatedOutput, err := DeployPreimageOracle(host2, DeployPreimageOracleInput{
 			MinProposalSize: big.NewInt(1),
 			ChallengePeriod: big.NewInt(2),
 		})

--- a/op-deployer/pkg/deployer/opcm/proxy2_test.go
+++ b/op-deployer/pkg/deployer/opcm/proxy2_test.go
@@ -1,9 +1,8 @@
-package opcm_test
+package opcm
 
 import (
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -16,11 +15,11 @@ func TestNewDeployProxyScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deployProxy, err := opcm.NewDeployProxyScript(host1)
+		deployProxy, err := NewDeployProxyScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deployProxy.Run(opcm.DeployProxy2Input{
+		output, err := deployProxy.Run(DeployProxy2Input{
 			Owner: common.Address{'O'},
 		})
 
@@ -33,7 +32,7 @@ func TestNewDeployProxyScript(t *testing.T) {
 		// We run it on a fresh host so that the deployer nonces are the same
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
-		deprecatedOutput, err := opcm.DeployProxy(host2, opcm.DeployProxyInput{
+		deprecatedOutput, err := DeployProxy(host2, DeployProxyInput{
 			Owner: common.Address{'O'},
 		})
 

--- a/op-deployer/pkg/deployer/opcm/scripts_test.go
+++ b/op-deployer/pkg/deployer/opcm/scripts_test.go
@@ -1,9 +1,8 @@
-package opcm_test
+package opcm
 
 import (
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +14,7 @@ func TestNewScripts(t *testing.T) {
 		// Then we load the scripts
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		scripts, err := opcm.NewScripts(host)
+		scripts, err := NewScripts(host)
 		require.NoError(t, err)
 
 		// And we just make sure we have all the scripts loaded

--- a/op-deployer/pkg/deployer/opcm/superchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain2_test.go
@@ -1,10 +1,9 @@
-package opcm_test
+package opcm
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -18,11 +17,11 @@ func TestNewDeploySuperchainScript(t *testing.T) {
 		// Then we load the script
 		//
 		// This would raise an error if the Go types didn't match the ABI
-		deploySuperchain, err := opcm.NewDeploySuperchainScript(host1)
+		deploySuperchain, err := NewDeploySuperchainScript(host1)
 		require.NoError(t, err)
 
 		// Then we deploy
-		output, err := deploySuperchain.Run(opcm.DeploySuperchain2Input{
+		output, err := deploySuperchain.Run(DeploySuperchain2Input{
 			Guardian:                   common.BigToAddress(big.NewInt(1)),
 			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
 			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
@@ -40,7 +39,7 @@ func TestNewDeploySuperchainScript(t *testing.T) {
 		// We run it on a fresh host so that the deployer nonces are the same
 		// which in turn means we should get identical output
 		host2 := createTestHost(t)
-		deprecatedOutput, err := opcm.DeploySuperchain(host2, opcm.DeploySuperchainInput{
+		deprecatedOutput, err := DeploySuperchain(host2, DeploySuperchainInput{
 			Guardian:                   common.BigToAddress(big.NewInt(1)),
 			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
 			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -154,13 +154,13 @@ contract L2Genesis is Script {
             return;
         }
 
-        if (!shouldApplyFork(_fork, Fork.JOVIAN)) {
+        if (forkEquals(_fork, Fork.JOVIAN)) {
             return;
         }
     }
 
-    function shouldApplyFork(Fork _latest, Fork _current) internal pure returns (bool) {
-        return _latest != _current;
+    function forkEquals(Fork _latest, Fork _current) internal pure returns (bool) {
+        return _latest == _current;
     }
 
     /// @notice Give all of the precompiles 1 wei

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+
+// Scripts
+import { Script } from "forge-std/Script.sol";
+import { Deployer } from "scripts/deploy/Deployer.sol";
+import { Config, OutputMode, OutputModeUtils, Fork, ForkUtils, LATEST_FORK } from "scripts/libraries/Config.sol";
+import { Process } from "scripts/libraries/Process.sol";
+import { SetPreinstalls } from "scripts/SetPreinstalls.s.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Preinstalls } from "src/libraries/Preinstalls.sol";
+import { Types } from "src/libraries/Types.sol";
+
+// Interfaces
+import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
+import { IBaseFeeVault } from "interfaces/L2/IBaseFeeVault.sol";
+import { IL1FeeVault } from "interfaces/L2/IL1FeeVault.sol";
+import { IOperatorFeeVault } from "interfaces/L2/IOperatorFeeVault.sol";
+import { IOptimismMintableERC721Factory } from "interfaces/L2/IOptimismMintableERC721Factory.sol";
+import { IGovernanceToken } from "interfaces/governance/IGovernanceToken.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+import { IL2StandardBridge } from "interfaces/L2/IL2StandardBridge.sol";
+import { IL2ERC721Bridge } from "interfaces/L2/IL2ERC721Bridge.sol";
+import { IStandardBridge } from "interfaces/universal/IStandardBridge.sol";
+import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
+import { IL2CrossDomainMessenger } from "interfaces/L2/IL2CrossDomainMessenger.sol";
+import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
+import { IL1Block } from "interfaces/L2/IL1Block.sol";
+
+/// @title L2Genesis
+/// @notice Generates the genesis state for the L2 network.
+///         The following safety invariants are used when setting state:
+///         1. `vm.getDeployedBytecode` can only be used with `vm.etch` when there are no side
+///         effects in the constructor and no immutables in the bytecode.
+///         2. A contract must be deployed using the `new` syntax if there are immutables in the code.
+///         Any other side effects from the init code besides setting the immutables must be cleaned up afterwards.
+contract L2Genesis is Script {
+    struct Input {
+        uint256 l1ChainID;
+        uint256 l2ChainID;
+        address payable l1CrossDomainMessengerProxy;
+        address payable l1StandardBridgeProxy;
+        address payable l1ERC721BridgeProxy;
+        address l2ProxyAdminOwner;
+        address sequencerFeeVaultRecipient;
+        uint256 sequencerFeeVaultMinimumWithdrawalAmount;
+        uint256 sequencerFeeVaultWithdrawalNetwork;
+        address baseFeeVaultRecipient;
+        uint256 baseFeeVaultMinimumWithdrawalAmount;
+        uint256 baseFeeVaultWithdrawalNetwork;
+        address l1FeeVaultRecipient;
+        uint256 l1FeeVaultMinimumWithdrawalAmount;
+        uint256 l1FeeVaultWithdrawalNetwork;
+        address governanceTokenOwner;
+        uint256 fork;
+        bool useInterop;
+        bool enableGovernance;
+        bool fundDevAccounts;
+    }
+
+    using ForkUtils for Fork;
+    using OutputModeUtils for OutputMode;
+
+    uint256 public constant PRECOMPILE_COUNT = 256;
+
+    uint80 internal constant DEV_ACCOUNT_FUND_AMT = 10_000 ether;
+
+    /// @notice Default Anvil dev accounts. Only funded if `cfg.fundDevAccounts == true`.
+    /// Also known as "test test test test test test test test test test test junk" mnemonic accounts,
+    /// on path "m/44'/60'/0'/0/i" (where i is the account index).
+    address[30] internal devAccounts = [
+        0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, // 0
+        0x70997970C51812dc3A010C7d01b50e0d17dc79C8, // 1
+        0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC, // 2
+        0x90F79bf6EB2c4f870365E785982E1f101E93b906, // 3
+        0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65, // 4
+        0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc, // 5
+        0x976EA74026E726554dB657fA54763abd0C3a0aa9, // 6
+        0x14dC79964da2C08b23698B3D3cc7Ca32193d9955, // 7
+        0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f, // 8
+        0xa0Ee7A142d267C1f36714E4a8F75612F20a79720, // 9
+        0xBcd4042DE499D14e55001CcbB24a551F3b954096, // 10
+        0x71bE63f3384f5fb98995898A86B02Fb2426c5788, // 11
+        0xFABB0ac9d68B0B445fB7357272Ff202C5651694a, // 12
+        0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec, // 13
+        0xdF3e18d64BC6A983f673Ab319CCaE4f1a57C7097, // 14
+        0xcd3B766CCDd6AE721141F452C550Ca635964ce71, // 15
+        0x2546BcD3c84621e976D8185a91A922aE77ECEc30, // 16
+        0xbDA5747bFD65F08deb54cb465eB87D40e51B197E, // 17
+        0xdD2FD4581271e230360230F9337D5c0430Bf44C0, // 18
+        0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199, // 19
+        0x09DB0a93B389bEF724429898f539AEB7ac2Dd55f, // 20
+        0x02484cb50AAC86Eae85610D6f4Bf026f30f6627D, // 21
+        0x08135Da0A343E492FA2d4282F2AE34c6c5CC1BbE, // 22
+        0x5E661B79FE2D3F6cE70F5AAC07d8Cd9abb2743F1, // 23
+        0x61097BA76cD906d2ba4FD106E757f7Eb455fc295, // 24
+        0xDf37F81dAAD2b0327A0A50003740e1C935C70913, // 25
+        0x553BC17A05702530097c3677091C5BB47a3a7931, // 26
+        0x87BdCE72c06C21cd96219BD8521bDF1F42C78b5e, // 27
+        0x40Fc963A729c542424cD800349a7E4Ecc4896624, // 28
+        0x9DCCe783B6464611f38631e6C851bf441907c710 // 29
+    ];
+
+    /// @notice Alias for `runWithStateDump` so that no `--sig` needs to be specified.
+    function run(Input memory _input) public {
+        address deployer = makeAddr("deployer");
+        vm.startPrank(deployer);
+        vm.chainId(_input.l2ChainID);
+
+        dealEthToPrecompiles();
+        setPredeployProxies(_input);
+        setPredeployImplementations(_input);
+        setPreinstalls();
+        if (_input.fundDevAccounts) {
+            fundDevAccounts();
+        }
+        vm.stopPrank();
+        vm.deal(deployer, 0);
+        vm.resetNonce(deployer);
+
+        Fork _fork = Fork(_input.fork);
+
+        if (!shouldApplyFork(_fork, Fork.DELTA)) {
+            return;
+        }
+
+        activateEcotone();
+
+        if (!shouldApplyFork(_fork, Fork.ECOTONE)) {
+            return;
+        }
+
+        activateFjord();
+
+        if (!shouldApplyFork(_fork, Fork.FJORD)) {
+            return;
+        }
+
+        if (!shouldApplyFork(_fork, Fork.GRANITE)) {
+            return;
+        }
+
+        if (!shouldApplyFork(_fork, Fork.HOLOCENE)) {
+            return;
+        }
+
+        activateIsthmus();
+
+        if (!shouldApplyFork(_fork, Fork.ISTHMUS)) {
+            return;
+        }
+
+        if (!shouldApplyFork(_fork, Fork.JOVIAN)) {
+            return;
+        }
+    }
+
+    function shouldApplyFork(Fork _latest, Fork _current) internal pure returns (bool) {
+        return _latest != _current;
+    }
+
+    /// @notice Give all of the precompiles 1 wei
+    function dealEthToPrecompiles() internal {
+        for (uint256 i; i < PRECOMPILE_COUNT; i++) {
+            vm.deal(address(uint160(i)), 1);
+        }
+    }
+
+    /// @notice Set up the accounts that correspond to the predeploys.
+    ///         The Proxy bytecode should be set. All proxied predeploys should have
+    ///         the 1967 admin slot set to the ProxyAdmin predeploy. All defined predeploys
+    ///         should have their implementations set.
+    ///         Warning: the predeploy accounts have contract code, but 0 nonce value, contrary
+    ///         to the expected nonce of 1 per EIP-161. This is because the legacy go genesis
+    //          script didn't set the nonce and we didn't want to change that behavior when
+    ///         migrating genesis generation to Solidity.
+    function setPredeployProxies(Input memory _input) public {
+        bytes memory code = vm.getDeployedCode("Proxy.sol:Proxy");
+        uint160 prefix = uint160(0x420) << 148;
+
+        for (uint256 i = 0; i < Predeploys.PREDEPLOY_COUNT; i++) {
+            address addr = address(prefix | uint160(i));
+            if (Predeploys.notProxied(addr)) {
+                continue;
+            }
+
+            vm.etch(addr, code);
+            EIP1967Helper.setAdmin(addr, Predeploys.PROXY_ADMIN);
+
+            if (Predeploys.isSupportedPredeploy(addr, _input.useInterop)) {
+                address implementation = Predeploys.predeployToCodeNamespace(addr);
+                EIP1967Helper.setImplementation(addr, implementation);
+            }
+        }
+    }
+
+    /// @notice Sets all the implementations for the predeploy proxies. For contracts without proxies,
+    ///      sets the deployed bytecode at their expected predeploy address.
+    ///      LEGACY_ERC20_ETH and L1_MESSAGE_SENDER are deprecated and are not set.
+    function setPredeployImplementations(Input memory _input) internal {
+        setLegacyMessagePasser(); // 0
+        // 01: legacy, not used in OP-Stack
+        setDeployerWhitelist(); // 2
+        // 3,4,5: legacy, not used in OP-Stack.
+        setWETH(); // 6: WETH (not behind a proxy)
+        setL2CrossDomainMessenger(_input.l1CrossDomainMessengerProxy); // 7
+        // 8,9,A,B,C,D,E: legacy, not used in OP-Stack.
+        setGasPriceOracle(); // f
+        setL2StandardBridge(_input.l1StandardBridgeProxy); // 10
+        setSequencerFeeVault(_input); // 11
+        setOptimismMintableERC20Factory(); // 12
+        setL1BlockNumber(); // 13
+        setL2ERC721Bridge(_input.l1ERC721BridgeProxy); // 14
+        setL1Block(); // 15
+        setL2ToL1MessagePasser(); // 16
+        setOptimismMintableERC721Factory(_input); // 17
+        setProxyAdmin(_input); // 18
+        setBaseFeeVault(_input); // 19
+        setL1FeeVault(_input); // 1A
+        setOperatorFeeVault(); // 1B
+        // 1C,1D,1E,1F: not used.
+        setSchemaRegistry(); // 20
+        setEAS(); // 21
+        setGovernanceToken(_input); // 42: OP (not behind a proxy)
+        if (_input.useInterop) {
+            setCrossL2Inbox(); // 22
+            setL2ToL2CrossDomainMessenger(); // 23
+            setSuperchainWETH(); // 24
+            setETHLiquidity(); // 25
+            setSuperchainTokenBridge(); // 28
+        }
+    }
+
+    function setProxyAdmin(Input memory _input) public {
+        // Note the ProxyAdmin implementation itself is behind a proxy that owns itself.
+        address impl = _setImplementationCode(Predeploys.PROXY_ADMIN);
+
+        bytes32 _ownerSlot = bytes32(0);
+
+        // there is no initialize() function, so we just set the storage manually.
+        vm.store(Predeploys.PROXY_ADMIN, _ownerSlot, bytes32(uint256(uint160(_input.l2ProxyAdminOwner))));
+        // update the proxy to not be uninitialized (although not standard initialize pattern)
+        vm.store(impl, _ownerSlot, bytes32(uint256(uint160(_input.l2ProxyAdminOwner))));
+    }
+
+    function setL2ToL1MessagePasser() public {
+        _setImplementationCode(Predeploys.L2_TO_L1_MESSAGE_PASSER);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setL2CrossDomainMessenger(address payable _l1CrossDomainMessengerProxy) public {
+        address impl = _setImplementationCode(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
+
+        IL2CrossDomainMessenger(impl).initialize({ _l1CrossDomainMessenger: ICrossDomainMessenger(address(0)) });
+
+        IL2CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER).initialize({
+            _l1CrossDomainMessenger: ICrossDomainMessenger(_l1CrossDomainMessengerProxy)
+        });
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setL2StandardBridge(address payable _l1StandardBridgeProxy) public {
+        address impl = _setImplementationCode(Predeploys.L2_STANDARD_BRIDGE);
+
+        IL2StandardBridge(payable(impl)).initialize({ _otherBridge: IStandardBridge(payable(address(0))) });
+
+        IL2StandardBridge(payable(Predeploys.L2_STANDARD_BRIDGE)).initialize({
+            _otherBridge: IStandardBridge(_l1StandardBridgeProxy)
+        });
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setL2ERC721Bridge(address payable _l1ERC721BridgeProxy) public {
+        address impl = _setImplementationCode(Predeploys.L2_ERC721_BRIDGE);
+
+        IL2ERC721Bridge(impl).initialize({ _l1ERC721Bridge: payable(address(0)) });
+
+        IL2ERC721Bridge(Predeploys.L2_ERC721_BRIDGE).initialize({ _l1ERC721Bridge: payable(_l1ERC721BridgeProxy) });
+    }
+
+    /// @notice This predeploy is following the safety invariant #2,
+    function setSequencerFeeVault(Input memory _input) public {
+        ISequencerFeeVault vault = ISequencerFeeVault(
+            DeployUtils.create1({
+                _name: "SequencerFeeVault",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        ISequencerFeeVault.__constructor__,
+                        (
+                            _input.sequencerFeeVaultRecipient,
+                            _input.sequencerFeeVaultMinimumWithdrawalAmount,
+                            Types.WithdrawalNetwork(_input.sequencerFeeVaultWithdrawalNetwork)
+                        )
+                    )
+                )
+            })
+        );
+
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.SEQUENCER_FEE_WALLET);
+        vm.etch(impl, address(vault).code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(vault), "");
+        vm.resetNonce(address(vault));
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setOptimismMintableERC20Factory() public {
+        address impl = _setImplementationCode(Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY);
+
+        IOptimismMintableERC20Factory(impl).initialize({ _bridge: address(0) });
+
+        IOptimismMintableERC20Factory(Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY).initialize({
+            _bridge: Predeploys.L2_STANDARD_BRIDGE
+        });
+    }
+
+    /// @notice This predeploy is following the safety invariant #2,
+    function setOptimismMintableERC721Factory(Input memory _input) public {
+        IOptimismMintableERC721Factory factory = IOptimismMintableERC721Factory(
+            DeployUtils.create1({
+                _name: "OptimismMintableERC721Factory",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IOptimismMintableERC721Factory.__constructor__, (Predeploys.L2_ERC721_BRIDGE, _input.l1ChainID)
+                    )
+                )
+            })
+        );
+
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY);
+        vm.etch(impl, address(factory).code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(factory), "");
+        vm.resetNonce(address(factory));
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setL1Block() public {
+        // Note: L1 block attributes are set to 0.
+        // Before the first user-tx the state is overwritten with actual L1 attributes.
+        _setImplementationCode(Predeploys.L1_BLOCK_ATTRIBUTES);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setGasPriceOracle() public {
+        _setImplementationCode(Predeploys.GAS_PRICE_ORACLE);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setDeployerWhitelist() public {
+        _setImplementationCode(Predeploys.DEPLOYER_WHITELIST);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract is NOT proxied and the state that is set
+    ///         in the constructor is set manually.
+    function setWETH() public {
+        vm.etch(Predeploys.WETH, vm.getDeployedCode("WETH.sol:WETH"));
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setL1BlockNumber() public {
+        _setImplementationCode(Predeploys.L1_BLOCK_NUMBER);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setLegacyMessagePasser() public {
+        _setImplementationCode(Predeploys.LEGACY_MESSAGE_PASSER);
+    }
+
+    /// @notice This predeploy is following the safety invariant #2.
+    function setBaseFeeVault(Input memory _input) public {
+        IBaseFeeVault vault = IBaseFeeVault(
+            DeployUtils.create1({
+                _name: "BaseFeeVault",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IBaseFeeVault.__constructor__,
+                        (
+                            _input.baseFeeVaultRecipient,
+                            _input.baseFeeVaultMinimumWithdrawalAmount,
+                            Types.WithdrawalNetwork(_input.baseFeeVaultWithdrawalNetwork)
+                        )
+                    )
+                )
+            })
+        );
+
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.BASE_FEE_VAULT);
+        vm.etch(impl, address(vault).code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(vault), "");
+        vm.resetNonce(address(vault));
+    }
+
+    /// @notice This predeploy is following the safety invariant #2.
+    function setL1FeeVault(Input memory _input) public {
+        IL1FeeVault vault = IL1FeeVault(
+            DeployUtils.create1({
+                _name: "L1FeeVault",
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IL1FeeVault.__constructor__,
+                        (
+                            _input.l1FeeVaultRecipient,
+                            _input.l1FeeVaultMinimumWithdrawalAmount,
+                            Types.WithdrawalNetwork(_input.l1FeeVaultWithdrawalNetwork)
+                        )
+                    )
+                )
+            })
+        );
+
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.L1_FEE_VAULT);
+        vm.etch(impl, address(vault).code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(vault), "");
+        vm.resetNonce(address(vault));
+    }
+
+    /// @notice This predeploy is following the safety invariant #2.
+    function setOperatorFeeVault() public {
+        IOperatorFeeVault vault = IOperatorFeeVault(
+            DeployUtils.create1({
+                _name: "OperatorFeeVault",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IOperatorFeeVault.__constructor__, ()))
+            })
+        );
+
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.OPERATOR_FEE_VAULT);
+        vm.etch(impl, address(vault).code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(vault), "");
+        vm.resetNonce(address(vault));
+    }
+
+    /// @notice This predeploy is following the safety invariant #2.
+    function setGovernanceToken(Input memory _input) public {
+        if (!_input.enableGovernance) {
+            return;
+        }
+
+        IGovernanceToken token = IGovernanceToken(
+            DeployUtils.create1({
+                _name: "GovernanceToken",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IGovernanceToken.__constructor__, ()))
+            })
+        );
+        vm.etch(Predeploys.GOVERNANCE_TOKEN, address(token).code);
+
+        bytes32 _nameSlot = hex"0000000000000000000000000000000000000000000000000000000000000003";
+        bytes32 _symbolSlot = hex"0000000000000000000000000000000000000000000000000000000000000004";
+        bytes32 _ownerSlot = hex"000000000000000000000000000000000000000000000000000000000000000a";
+
+        vm.store(Predeploys.GOVERNANCE_TOKEN, _nameSlot, vm.load(address(token), _nameSlot));
+        vm.store(Predeploys.GOVERNANCE_TOKEN, _symbolSlot, vm.load(address(token), _symbolSlot));
+        vm.store(Predeploys.GOVERNANCE_TOKEN, _ownerSlot, bytes32(uint256(uint160(_input.governanceTokenOwner))));
+
+        /// Reset so its not included state dump
+        vm.etch(address(token), "");
+        vm.resetNonce(address(token));
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    function setSchemaRegistry() public {
+        _setImplementationCode(Predeploys.SCHEMA_REGISTRY);
+    }
+
+    /// @notice This predeploy is following the safety invariant #2,
+    ///         It uses low level create to deploy the contract due to the code
+    ///         having immutables and being a different compiler version.
+    function setEAS() public {
+        string memory cname = Predeploys.getName(Predeploys.EAS);
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.EAS);
+        bytes memory code = vm.getCode(string.concat(cname, ".sol:", cname));
+
+        address eas;
+        assembly {
+            eas := create(0, add(code, 0x20), mload(code))
+        }
+
+        vm.etch(impl, eas.code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(eas), "");
+        vm.resetNonce(address(eas));
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setCrossL2Inbox() internal {
+        _setImplementationCode(Predeploys.CROSS_L2_INBOX);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setL2ToL2CrossDomainMessenger() internal {
+        _setImplementationCode(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setETHLiquidity() internal {
+        _setImplementationCode(Predeploys.ETH_LIQUIDITY);
+        vm.deal(Predeploys.ETH_LIQUIDITY, type(uint248).max);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setSuperchainWETH() internal {
+        _setImplementationCode(Predeploys.SUPERCHAIN_WETH);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setOptimismSuperchainERC20Factory() internal {
+        _setImplementationCode(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setOptimismSuperchainERC20Beacon() internal {
+        address superchainERC20Impl = Predeploys.OPTIMISM_SUPERCHAIN_ERC20;
+        vm.etch(superchainERC20Impl, vm.getDeployedCode("OptimismSuperchainERC20.sol:OptimismSuperchainERC20"));
+
+        _setImplementationCode(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setSuperchainTokenBridge() internal {
+        _setImplementationCode(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
+    }
+
+    /// @notice Sets all the preinstalls.
+    function setPreinstalls() public {
+        address tmpSetPreinstalls = address(uint160(uint256(keccak256("SetPreinstalls"))));
+        vm.etch(tmpSetPreinstalls, vm.getDeployedCode("SetPreinstalls.s.sol:SetPreinstalls"));
+        SetPreinstalls(tmpSetPreinstalls).setPreinstalls();
+        vm.etch(tmpSetPreinstalls, "");
+    }
+
+    /// @notice Activate Ecotone network upgrade.
+    function activateEcotone() public {
+        require(Preinstalls.BeaconBlockRoots.code.length > 0, "L2Genesis: must have beacon-block-roots contract");
+        vm.prank(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
+        IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setEcotone();
+    }
+
+    function activateFjord() public {
+        vm.prank(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
+        IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setFjord();
+    }
+
+    function activateIsthmus() public {
+        vm.prank(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
+        IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setIsthmus();
+    }
+
+    /// @notice Sets the bytecode in state
+    function _setImplementationCode(address _addr) internal returns (address) {
+        string memory cname = Predeploys.getName(_addr);
+        address impl = Predeploys.predeployToCodeNamespace(_addr);
+        vm.etch(impl, vm.getDeployedCode(string.concat(cname, ".sol:", cname)));
+        return impl;
+    }
+
+    /// @notice Funds the default dev accounts with ether
+    function fundDevAccounts() internal {
+        for (uint256 i; i < devAccounts.length; i++) {
+            vm.deal(devAccounts[i], DEV_ACCOUNT_FUND_AMT);
+        }
+    }
+}

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -518,6 +518,27 @@ contract L2Genesis is Script {
 
     /// @notice This predeploy is following the safety invariant #1.
     ///         This contract has no initializer.
+    function setSuperchainETHBridge() internal {
+        _setImplementationCode(Predeploys.SUPERCHAIN_ETH_BRIDGE);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setOptimismSuperchainERC20Factory() internal {
+        _setImplementationCode(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
+    function setOptimismSuperchainERC20Beacon() internal {
+        address superchainERC20Impl = Predeploys.OPTIMISM_SUPERCHAIN_ERC20;
+        vm.etch(superchainERC20Impl, vm.getDeployedCode("OptimismSuperchainERC20.sol:OptimismSuperchainERC20"));
+
+        _setImplementationCode(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON);
+    }
+
+    /// @notice This predeploy is following the safety invariant #1.
+    ///         This contract has no initializer.
     function setSuperchainTokenBridge() internal {
         _setImplementationCode(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
     }

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -124,33 +124,33 @@ contract L2Genesis is Script {
 
         Fork _fork = Fork(_input.fork);
 
-        if (!shouldApplyFork(_fork, Fork.DELTA)) {
+        if (forkEquals(_fork, Fork.DELTA)) {
             return;
         }
 
         activateEcotone();
 
-        if (!shouldApplyFork(_fork, Fork.ECOTONE)) {
+        if (forkEquals(_fork, Fork.ECOTONE)) {
             return;
         }
 
         activateFjord();
 
-        if (!shouldApplyFork(_fork, Fork.FJORD)) {
+        if (forkEquals(_fork, Fork.FJORD)) {
             return;
         }
 
-        if (!shouldApplyFork(_fork, Fork.GRANITE)) {
+        if (forkEquals(_fork, Fork.GRANITE)) {
             return;
         }
 
-        if (!shouldApplyFork(_fork, Fork.HOLOCENE)) {
+        if (forkEquals(_fork, Fork.HOLOCENE)) {
             return;
         }
 
         activateIsthmus();
 
-        if (!shouldApplyFork(_fork, Fork.ISTHMUS)) {
+        if (forkEquals(_fork, Fork.ISTHMUS)) {
             return;
         }
 

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -231,7 +231,7 @@ contract L2Genesis is Script {
         if (_input.useInterop) {
             setCrossL2Inbox(); // 22
             setL2ToL2CrossDomainMessenger(); // 23
-            setSuperchainWETH(); // 24
+            setSuperchainETHBridge(); // 24
             setETHLiquidity(); // 25
             setSuperchainTokenBridge(); // 28
         }
@@ -514,27 +514,6 @@ contract L2Genesis is Script {
     function setETHLiquidity() internal {
         _setImplementationCode(Predeploys.ETH_LIQUIDITY);
         vm.deal(Predeploys.ETH_LIQUIDITY, type(uint248).max);
-    }
-
-    /// @notice This predeploy is following the safety invariant #1.
-    ///         This contract has no initializer.
-    function setSuperchainWETH() internal {
-        _setImplementationCode(Predeploys.SUPERCHAIN_WETH);
-    }
-
-    /// @notice This predeploy is following the safety invariant #1.
-    ///         This contract has no initializer.
-    function setOptimismSuperchainERC20Factory() internal {
-        _setImplementationCode(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
-    }
-
-    /// @notice This predeploy is following the safety invariant #1.
-    ///         This contract has no initializer.
-    function setOptimismSuperchainERC20Beacon() internal {
-        address superchainERC20Impl = Predeploys.OPTIMISM_SUPERCHAIN_ERC20;
-        vm.etch(superchainERC20Impl, vm.getDeployedCode("OptimismSuperchainERC20.sol:OptimismSuperchainERC20"));
-
-        _setImplementationCode(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON);
     }
 
     /// @notice This predeploy is following the safety invariant #1.

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -65,7 +65,7 @@ contract L2Genesis is Script {
     using ForkUtils for Fork;
     using OutputModeUtils for OutputMode;
 
-    uint256 public constant PRECOMPILE_COUNT = 256;
+    uint256 internal constant PRECOMPILE_COUNT = 256;
 
     uint80 internal constant DEV_ACCOUNT_FUND_AMT = 10_000 ether;
 
@@ -178,7 +178,7 @@ contract L2Genesis is Script {
     ///         to the expected nonce of 1 per EIP-161. This is because the legacy go genesis
     //          script didn't set the nonce and we didn't want to change that behavior when
     ///         migrating genesis generation to Solidity.
-    function setPredeployProxies(Input memory _input) public {
+    function setPredeployProxies(Input memory _input) internal {
         bytes memory code = vm.getDeployedCode("Proxy.sol:Proxy");
         uint160 prefix = uint160(0x420) << 148;
 
@@ -235,7 +235,7 @@ contract L2Genesis is Script {
         }
     }
 
-    function setProxyAdmin(Input memory _input) public {
+    function setProxyAdmin(Input memory _input) internal {
         // Note the ProxyAdmin implementation itself is behind a proxy that owns itself.
         address impl = _setImplementationCode(Predeploys.PROXY_ADMIN);
 
@@ -247,12 +247,12 @@ contract L2Genesis is Script {
         vm.store(impl, _ownerSlot, bytes32(uint256(uint160(_input.l2ProxyAdminOwner))));
     }
 
-    function setL2ToL1MessagePasser() public {
+    function setL2ToL1MessagePasser() internal {
         _setImplementationCode(Predeploys.L2_TO_L1_MESSAGE_PASSER);
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setL2CrossDomainMessenger(address payable _l1CrossDomainMessengerProxy) public {
+    function setL2CrossDomainMessenger(address payable _l1CrossDomainMessengerProxy) internal {
         address impl = _setImplementationCode(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
 
         IL2CrossDomainMessenger(impl).initialize({ _l1CrossDomainMessenger: ICrossDomainMessenger(address(0)) });
@@ -263,7 +263,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setL2StandardBridge(address payable _l1StandardBridgeProxy) public {
+    function setL2StandardBridge(address payable _l1StandardBridgeProxy) internal {
         address impl = _setImplementationCode(Predeploys.L2_STANDARD_BRIDGE);
 
         IL2StandardBridge(payable(impl)).initialize({ _otherBridge: IStandardBridge(payable(address(0))) });
@@ -274,7 +274,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setL2ERC721Bridge(address payable _l1ERC721BridgeProxy) public {
+    function setL2ERC721Bridge(address payable _l1ERC721BridgeProxy) internal {
         address impl = _setImplementationCode(Predeploys.L2_ERC721_BRIDGE);
 
         IL2ERC721Bridge(impl).initialize({ _l1ERC721Bridge: payable(address(0)) });
@@ -283,7 +283,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #2,
-    function setSequencerFeeVault(Input memory _input) public {
+    function setSequencerFeeVault(Input memory _input) internal {
         ISequencerFeeVault vault = ISequencerFeeVault(
             DeployUtils.create1({
                 _name: "SequencerFeeVault",
@@ -309,7 +309,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setOptimismMintableERC20Factory() public {
+    function setOptimismMintableERC20Factory() internal {
         address impl = _setImplementationCode(Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY);
 
         IOptimismMintableERC20Factory(impl).initialize({ _bridge: address(0) });
@@ -320,7 +320,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #2,
-    function setOptimismMintableERC721Factory(Input memory _input) public {
+    function setOptimismMintableERC721Factory(Input memory _input) internal {
         IOptimismMintableERC721Factory factory = IOptimismMintableERC721Factory(
             DeployUtils.create1({
                 _name: "OptimismMintableERC721Factory",
@@ -341,41 +341,41 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setL1Block() public {
+    function setL1Block() internal {
         // Note: L1 block attributes are set to 0.
         // Before the first user-tx the state is overwritten with actual L1 attributes.
         _setImplementationCode(Predeploys.L1_BLOCK_ATTRIBUTES);
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setGasPriceOracle() public {
+    function setGasPriceOracle() internal {
         _setImplementationCode(Predeploys.GAS_PRICE_ORACLE);
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setDeployerWhitelist() public {
+    function setDeployerWhitelist() internal {
         _setImplementationCode(Predeploys.DEPLOYER_WHITELIST);
     }
 
     /// @notice This predeploy is following the safety invariant #1.
     ///         This contract is NOT proxied and the state that is set
     ///         in the constructor is set manually.
-    function setWETH() public {
+    function setWETH() internal {
         vm.etch(Predeploys.WETH, vm.getDeployedCode("WETH.sol:WETH"));
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setL1BlockNumber() public {
+    function setL1BlockNumber() internal {
         _setImplementationCode(Predeploys.L1_BLOCK_NUMBER);
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setLegacyMessagePasser() public {
+    function setLegacyMessagePasser() internal {
         _setImplementationCode(Predeploys.LEGACY_MESSAGE_PASSER);
     }
 
     /// @notice This predeploy is following the safety invariant #2.
-    function setBaseFeeVault(Input memory _input) public {
+    function setBaseFeeVault(Input memory _input) internal {
         IBaseFeeVault vault = IBaseFeeVault(
             DeployUtils.create1({
                 _name: "BaseFeeVault",
@@ -401,7 +401,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #2.
-    function setL1FeeVault(Input memory _input) public {
+    function setL1FeeVault(Input memory _input) internal {
         IL1FeeVault vault = IL1FeeVault(
             DeployUtils.create1({
                 _name: "L1FeeVault",
@@ -427,7 +427,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #2.
-    function setOperatorFeeVault() public {
+    function setOperatorFeeVault() internal {
         IOperatorFeeVault vault = IOperatorFeeVault(
             DeployUtils.create1({
                 _name: "OperatorFeeVault",
@@ -444,7 +444,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #2.
-    function setGovernanceToken(Input memory _input) public {
+    function setGovernanceToken(Input memory _input) internal {
         if (!_input.enableGovernance) {
             return;
         }
@@ -471,14 +471,14 @@ contract L2Genesis is Script {
     }
 
     /// @notice This predeploy is following the safety invariant #1.
-    function setSchemaRegistry() public {
+    function setSchemaRegistry() internal {
         _setImplementationCode(Predeploys.SCHEMA_REGISTRY);
     }
 
     /// @notice This predeploy is following the safety invariant #2,
     ///         It uses low level create to deploy the contract due to the code
     ///         having immutables and being a different compiler version.
-    function setEAS() public {
+    function setEAS() internal {
         string memory cname = Predeploys.getName(Predeploys.EAS);
         address impl = Predeploys.predeployToCodeNamespace(Predeploys.EAS);
         bytes memory code = vm.getCode(string.concat(cname, ".sol:", cname));
@@ -542,7 +542,7 @@ contract L2Genesis is Script {
     }
 
     /// @notice Sets all the preinstalls.
-    function setPreinstalls() public {
+    function setPreinstalls() internal {
         address tmpSetPreinstalls = address(uint160(uint256(keccak256("SetPreinstalls"))));
         vm.etch(tmpSetPreinstalls, vm.getDeployedCode("SetPreinstalls.s.sol:SetPreinstalls"));
         SetPreinstalls(tmpSetPreinstalls).setPreinstalls();
@@ -550,18 +550,18 @@ contract L2Genesis is Script {
     }
 
     /// @notice Activate Ecotone network upgrade.
-    function activateEcotone() public {
+    function activateEcotone() internal {
         require(Preinstalls.BeaconBlockRoots.code.length > 0, "L2Genesis: must have beacon-block-roots contract");
         vm.prank(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setEcotone();
     }
 
-    function activateFjord() public {
+    function activateFjord() internal {
         vm.prank(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setFjord();
     }
 
-    function activateIsthmus() public {
+    function activateIsthmus() internal {
         vm.prank(IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).DEPOSITOR_ACCOUNT());
         IGasPriceOracle(Predeploys.GAS_PRICE_ORACLE).setIsthmus();
     }

--- a/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis2.s.sol
@@ -6,9 +6,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { Script } from "forge-std/Script.sol";
-import { Deployer } from "scripts/deploy/Deployer.sol";
-import { Config, OutputMode, OutputModeUtils, Fork, ForkUtils, LATEST_FORK } from "scripts/libraries/Config.sol";
-import { Process } from "scripts/libraries/Process.sol";
+import { OutputMode, OutputModeUtils, Fork, ForkUtils } from "scripts/libraries/Config.sol";
 import { SetPreinstalls } from "scripts/SetPreinstalls.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -10,7 +10,7 @@ import { Deploy } from "scripts/deploy/Deploy.s.sol";
 import { ForkLive } from "test/setup/ForkLive.s.sol";
 import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
 import { L2Genesis } from "scripts/L2Genesis2.s.sol";
-import { OutputMode, Fork, ForkUtils } from "scripts/libraries/Config.sol";
+import { Fork, ForkUtils } from "scripts/libraries/Config.sol";
 import { Artifacts } from "scripts/Artifacts.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Config } from "scripts/libraries/Config.sol";
@@ -183,7 +183,7 @@ contract Setup {
         }
 
         console.log("Setup: L2 setup start!");
-        vm.etch(address(l2Genesis), vm.getDeployedCode("L2Genesis.s.sol:L2Genesis"));
+        vm.etch(address(l2Genesis), vm.getDeployedCode("L2Genesis2.s.sol:L2Genesis"));
         vm.allowCheatcodes(address(l2Genesis));
         console.log("Setup: L2 setup done!");
     }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -9,7 +9,7 @@ import { Vm, VmSafe } from "forge-std/Vm.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
 import { ForkLive } from "test/setup/ForkLive.s.sol";
 import { Fork, LATEST_FORK } from "scripts/libraries/Config.sol";
-import { L2Genesis, L1Dependencies } from "scripts/L2Genesis.s.sol";
+import { L2Genesis } from "scripts/L2Genesis2.s.sol";
 import { OutputMode, Fork, ForkUtils } from "scripts/libraries/Config.sol";
 import { Artifacts } from "scripts/Artifacts.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
@@ -185,7 +185,6 @@ contract Setup {
         console.log("Setup: L2 setup start!");
         vm.etch(address(l2Genesis), vm.getDeployedCode("L2Genesis.s.sol:L2Genesis"));
         vm.allowCheatcodes(address(l2Genesis));
-        l2Genesis.setUp();
         console.log("Setup: L2 setup done!");
     }
 
@@ -289,13 +288,28 @@ contract Setup {
         }
 
         console.log("Setup: creating L2 genesis with fork %s", l2Fork.toString());
-        l2Genesis.runWithOptions(
-            OutputMode.NONE,
-            l2Fork,
-            L1Dependencies({
+        l2Genesis.run(
+            L2Genesis.Input({
+                l1ChainID: deploy.cfg().l1ChainID(),
+                l2ChainID: deploy.cfg().l2ChainID(),
                 l1CrossDomainMessengerProxy: payable(address(l1CrossDomainMessenger)),
                 l1StandardBridgeProxy: payable(address(l1StandardBridge)),
-                l1ERC721BridgeProxy: payable(address(l1ERC721Bridge))
+                l1ERC721BridgeProxy: payable(address(l1ERC721Bridge)),
+                l2ProxyAdminOwner: deploy.cfg().proxyAdminOwner(),
+                sequencerFeeVaultRecipient: deploy.cfg().sequencerFeeVaultRecipient(),
+                sequencerFeeVaultMinimumWithdrawalAmount: deploy.cfg().sequencerFeeVaultMinimumWithdrawalAmount(),
+                sequencerFeeVaultWithdrawalNetwork: deploy.cfg().sequencerFeeVaultWithdrawalNetwork(),
+                baseFeeVaultRecipient: deploy.cfg().baseFeeVaultRecipient(),
+                baseFeeVaultMinimumWithdrawalAmount: deploy.cfg().baseFeeVaultMinimumWithdrawalAmount(),
+                baseFeeVaultWithdrawalNetwork: deploy.cfg().baseFeeVaultWithdrawalNetwork(),
+                l1FeeVaultRecipient: deploy.cfg().l1FeeVaultRecipient(),
+                l1FeeVaultMinimumWithdrawalAmount: deploy.cfg().l1FeeVaultMinimumWithdrawalAmount(),
+                l1FeeVaultWithdrawalNetwork: deploy.cfg().l1FeeVaultWithdrawalNetwork(),
+                governanceTokenOwner: deploy.cfg().governanceTokenOwner(),
+                fork: uint256(l2Fork),
+                useInterop: deploy.cfg().useInterop(),
+                enableGovernance: deploy.cfg().enableGovernance(),
+                fundDevAccounts: deploy.cfg().fundDevAccounts()
             })
         );
 


### PR DESCRIPTION
First PR in a series that updates the `L2Genesis` script to use structs for input rather than the `DeployConfig` contract or environment variables. To prove equivalency between the new and old `L2Genesis` scripts, this PR adds a new `L2Genesis2` script and leaves the old one in place. The unit tests then run both scripts on the same input, and assert that the output is the same. The old script will be removed after this PR is merged. Contract tests have been updated to point at the new script to demonstrate that it works.