### PR TITLE
op-deployer: handle `IntentType` in `NewIntent`

### DIFF
--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -83,7 +83,6 @@ func Init(cfg InitConfig) error {
 	if err != nil {
 		return err
 	}
-	intent.ConfigType = cfg.IntentType
 
 	st := &state.State{
 		Version: 1,

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -273,20 +273,25 @@ func (c *Intent) checkL2Prod() error {
 	return err
 }
 
-func NewIntent(configType IntentType, l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error) {
+func NewIntent(configType IntentType, l1ChainId uint64, l2ChainIds []common.Hash) (intent Intent, err error) {
 	switch configType {
 	case IntentTypeCustom:
-		return NewIntentCustom(l1ChainId, l2ChainIds)
+		intent, err = NewIntentCustom(l1ChainId, l2ChainIds)
 
 	case IntentTypeStandard:
-		return NewIntentStandard(l1ChainId, l2ChainIds)
+		intent, err = NewIntentStandard(l1ChainId, l2ChainIds)
 
 	case IntentTypeStandardOverrides:
-		return NewIntentStandardOverrides(l1ChainId, l2ChainIds)
+		intent, err = NewIntentStandardOverrides(l1ChainId, l2ChainIds)
 
 	default:
 		return Intent{}, fmt.Errorf("intent type not supported: %s (valid types: %s, %s, %s)", configType, IntentTypeStandard, IntentTypeCustom, IntentTypeStandardOverrides)
 	}
+	if err != nil {
+		return
+	}
+	intent.ConfigType = configType
+	return
 }
 
 // Sets all Intent fields to their zero value with the expectation that the


### PR DESCRIPTION
Currently the code is like this:

```golang
intent, err := state.NewIntent(cfg.IntentType, cfg.L1ChainID, cfg.L2ChainIDs)
if err != nil {
    return err
}
intent.ConfigType = cfg.IntentType
```

This PR moves the assignment for `ConfigType` into `NewIntent` so that the code is more self-contained.