### PR TITLE
Update testing documentation referencing SuperchainWETH

### DIFF
--- a/devnet-sdk/book/src/testing.md
+++ b/devnet-sdk/book/src/testing.md
@@ -85,8 +85,8 @@ func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) syst
         user := walletGetter(ctx)
         
         // Access contract registry
-        bridgeAddr := constants.SuperchainETHBridge
-        weth, err := chain.ContractsRegistry().SuperchainETHBridge(bridgeAddr)
+        wethAddr := constants.WETH
+        weth, err := chain.ContractsRegistry().WETH(bridgeAddr)
         require.NoError(t, err)
         
         // Test logic using pure interfaces

--- a/devnet-sdk/book/src/testing.md
+++ b/devnet-sdk/book/src/testing.md
@@ -85,8 +85,8 @@ func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) syst
         user := walletGetter(ctx)
         
         // Access contract registry
-        wethAddr := constants.SuperchainWETH
-        weth, err := chain.ContractsRegistry().SuperchainWETH(wethAddr)
+        wethAddr := constants.SuperchainETHBridge
+        weth, err := chain.ContractsRegistry().SuperchainETHBridge(wethAddr)
         require.NoError(t, err)
         
         // Test logic using pure interfaces

--- a/devnet-sdk/book/src/testing.md
+++ b/devnet-sdk/book/src/testing.md
@@ -86,7 +86,7 @@ func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) syst
         
         // Access contract registry
         wethAddr := constants.WETH
-        weth, err := chain.ContractsRegistry().WETH(bridgeAddr)
+        weth, err := chain.ContractsRegistry().WETH(wethAddr)
         require.NoError(t, err)
         
         // Test logic using pure interfaces
@@ -94,7 +94,7 @@ func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) syst
         initialBalance, err := weth.BalanceOf(user.Address()).Call(ctx)
         require.NoError(t, err)
         
-        require.NoError(t, user.SendETH(bridgeAddr, funds).Send(ctx).Wait())
+        require.NoError(t, user.SendETH(wethAddr, funds).Send(ctx).Wait())
         
         finalBalance, err := weth.BalanceOf(user.Address()).Call(ctx)
         require.NoError(t, err)

--- a/devnet-sdk/book/src/testing.md
+++ b/devnet-sdk/book/src/testing.md
@@ -85,8 +85,8 @@ func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) syst
         user := walletGetter(ctx)
         
         // Access contract registry
-        wethAddr := constants.SuperchainETHBridge
-        weth, err := chain.ContractsRegistry().SuperchainETHBridge(wethAddr)
+        bridgeAddr := constants.SuperchainETHBridge
+        weth, err := chain.ContractsRegistry().SuperchainETHBridge(bridgeAddr)
         require.NoError(t, err)
         
         // Test logic using pure interfaces
@@ -94,7 +94,7 @@ func wrapETHScenario(chainIdx uint64, walletGetter validators.WalletGetter) syst
         initialBalance, err := weth.BalanceOf(user.Address()).Call(ctx)
         require.NoError(t, err)
         
-        require.NoError(t, user.SendETH(wethAddr, funds).Send(ctx).Wait())
+        require.NoError(t, user.SendETH(bridgeAddr, funds).Send(ctx).Wait())
         
         finalBalance, err := weth.BalanceOf(user.Address()).Call(ctx)
         require.NoError(t, err)


### PR DESCRIPTION


**Description:**
This PR updates the testing documentation to reflect the API changes where SuperchainWETH has been replaced with SuperchainETHBridge. The change ensures that the code examples in the documentation match the current implementation of the contracts registry.

