### PR TITLE
op-service: parse JSON number into ETH type

### DIFF
--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -218,6 +218,13 @@ func (e *ETH) UnmarshalText(data []byte) error {
 	return (*uint256.Int)(e).UnmarshalText(data)
 }
 
+// UnmarshalJSON implements json.Unmarshaler. UnmarshalJSON accepts either
+// - Quoted string: either hexadecimal OR decimal
+// - Not quoted string: only decimal
+func (e *ETH) UnmarshalJSON(data []byte) error {
+	return (*uint256.Int)(e).UnmarshalJSON(data)
+}
+
 // MarshalText marshals as decimal number, without comma separators or unit
 func (e ETH) MarshalText() ([]byte, error) {
 	return (*uint256.Int)(&e).MarshalText()


### PR DESCRIPTION
**Description**

This makes cast work when the `ETH` type is used as JSON RPC parameter, and when the user does not add quotes explicitly.

**Tests**

Added more test cases for JSON unmarshal case.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
