### PR TITLE
op-node/p2p: ensure consistency between marshalling and publishing BlockVersions

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -561,8 +561,7 @@ func (p *publisher) PublishSignedL2Payload(ctx context.Context, signedEnvelope *
 	}
 
 	data := buf.Bytes()
-	timestamp := uint64(signedEnvelope.Envelope.ExecutionPayload.Timestamp)
-	return p.publishRawSignedPayload(ctx, timestamp, data)
+	return p.publishRawSignedPayload(ctx, signedEnvelope.Envelope.ExecutionPayload.InferVersion(), data)
 }
 
 func (p *publisher) SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, signer Signer) error {
@@ -593,21 +592,22 @@ func (p *publisher) SignAndPublishL2Payload(ctx context.Context, envelope *eth.E
 		return fmt.Errorf("failed to sign execution payload with signer: %w", err)
 	}
 	copy(data[:65], sig[:])
-	return p.publishRawSignedPayload(ctx, uint64(envelope.ExecutionPayload.Timestamp), data)
+	return p.publishRawSignedPayload(ctx, envelope.ExecutionPayload.InferVersion(), data)
 }
 
-func (p *publisher) publishRawSignedPayload(ctx context.Context, timestamp uint64, data []byte) error {
+func (p *publisher) publishRawSignedPayload(ctx context.Context, version eth.BlockVersion, data []byte) error {
 	// compress the full message
 	// This also copies the data, freeing up the original buffer to go back into the pool
 	out := snappy.Encode(nil, data)
 
-	if p.cfg.IsIsthmus(timestamp) {
+	switch version {
+	case eth.BlockV4:
 		return p.blocksV4.topic.Publish(ctx, out)
-	} else if p.cfg.IsEcotone(timestamp) {
+	case eth.BlockV3:
 		return p.blocksV3.topic.Publish(ctx, out)
-	} else if p.cfg.IsCanyon(timestamp) {
+	case eth.BlockV2:
 		return p.blocksV2.topic.Publish(ctx, out)
-	} else {
+	default:
 		return p.blocksV1.topic.Publish(ctx, out)
 	}
 }

--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -97,7 +97,7 @@ func executionPayloadFixedPart(version BlockVersion) uint32 {
 	}
 }
 
-func (payload *ExecutionPayload) inferVersion() BlockVersion {
+func (payload *ExecutionPayload) InferVersion() BlockVersion {
 	if payload.WithdrawalsRoot != nil && *payload.WithdrawalsRoot != types.EmptyWithdrawalsHash {
 		return BlockV4
 	} else if payload.ExcessBlobGas != nil && payload.BlobGasUsed != nil {
@@ -110,7 +110,7 @@ func (payload *ExecutionPayload) inferVersion() BlockVersion {
 }
 
 func (payload *ExecutionPayload) SizeSSZ() (full uint32) {
-	return executionPayloadFixedPart(payload.inferVersion()) + uint32(len(payload.ExtraData)) + payload.transactionSize() + payload.withdrawalSize()
+	return executionPayloadFixedPart(payload.InferVersion()) + uint32(len(payload.ExtraData)) + payload.transactionSize() + payload.withdrawalSize()
 }
 
 func (payload *ExecutionPayload) withdrawalSize() uint32 {
@@ -150,7 +150,7 @@ func unmarshalBytes32LE(in []byte, z *Uint256Quantity) {
 
 // MarshalSSZ encodes the ExecutionPayload as SSZ type
 func (payload *ExecutionPayload) MarshalSSZ(w io.Writer) (n int, err error) {
-	fixedSize := executionPayloadFixedPart(payload.inferVersion())
+	fixedSize := executionPayloadFixedPart(payload.InferVersion())
 	transactionSize := payload.transactionSize()
 
 	// Cast to uint32 to enable 32-bit MIPS support where math.MaxUint32-executionPayloadFixedPart is too big for int
@@ -211,7 +211,7 @@ func (payload *ExecutionPayload) MarshalSSZ(w io.Writer) (n int, err error) {
 		offset += 4
 	}
 
-	payloadVersion := payload.inferVersion()
+	payloadVersion := payload.InferVersion()
 	if payloadVersion.HasBlobProperties() {
 		if payload.BlobGasUsed == nil || payload.ExcessBlobGas == nil {
 			return 0, errors.New("cannot encode ecotone payload without dencun header attributes")
@@ -224,7 +224,7 @@ func (payload *ExecutionPayload) MarshalSSZ(w io.Writer) (n int, err error) {
 
 	if payloadVersion.HasWithdrawalsRoot() {
 		if payload.WithdrawalsRoot == nil {
-			return 0, errors.New("cannot encode Isthmus payload without withdrawals root")
+			return 0, fmt.Errorf("cannot encode payload version %d without withdrawals root", payloadVersion)
 		}
 		copy(buf[offset:offset+32], (*payload.WithdrawalsRoot)[:])
 		offset += 32

--- a/op-service/eth/ssz_test.go
+++ b/op-service/eth/ssz_test.go
@@ -622,3 +622,26 @@ func TestFailsWrongVersionWithWithdrawalRoot(t *testing.T) {
 	err = payload.UnmarshalSSZ(BlockV3, uint32(len(data)), bytes.NewReader(data))
 	require.ErrorContains(t, err, ErrBadExtraDataOffset.Error())
 }
+
+func TestInferVersion(t *testing.T) {
+	zero := uint64(0)
+	payload := &ExecutionPayloadEnvelope{
+		ExecutionPayload: &ExecutionPayload{
+			WithdrawalsRoot: &types.EmptyWithdrawalsHash, // Should be V3 even if an Isthmus block
+			BlobGasUsed:     (*Uint64Quantity)(&zero),
+			ExcessBlobGas:   (*Uint64Quantity)(&zero),
+		},
+	}
+	inferredVersion := payload.ExecutionPayload.InferVersion()
+	assert.Equal(t, BlockV3, inferredVersion)
+
+	payload = &ExecutionPayloadEnvelope{
+		ExecutionPayload: &ExecutionPayload{
+			WithdrawalsRoot: &common.MaxHash,
+			BlobGasUsed:     (*Uint64Quantity)(&zero),
+			ExcessBlobGas:   (*Uint64Quantity)(&zero),
+		},
+	}
+	inferredVersion = payload.ExecutionPayload.InferVersion()
+	assert.Equal(t, BlockV4, inferredVersion)
+}


### PR DESCRIPTION
Closes #15458

TODO 

- [x] regression test
- [x] accompanying specs change (if the withdrawals root is empty, keep using BlockV3 even if Isthmus, and clarify that the withdrawals root will actually never be empty even at genesis because of the implementation and owner storage fields being set. ) https://github.com/ethereum-optimism/specs/pull/676
