### PR TITLE
op-acceptance-tests: interop: fix wrappedeth smoke test

### DIFF
--- a/devnet-sdk/contracts/registry/client/client.go
+++ b/devnet-sdk/contracts/registry/client/client.go
@@ -18,12 +18,14 @@ type ClientRegistry struct {
 
 var _ interfaces.ContractsRegistry = (*ClientRegistry)(nil)
 
-func (r *ClientRegistry) SuperchainWETH(address types.Address) (interfaces.SuperchainWETH, error) {
+func (r *ClientRegistry) WETH(address types.Address) (interfaces.WETH, error) {
+	// SuperchainWETH was removed and replaced with SuperchainETHBridge
+	// NewSuperchainWETH can be still used for fetching WETH balance
 	binding, err := bindings.NewSuperchainWETH(address, r.Client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SuperchainWETH binding: %w", err)
+		return nil, fmt.Errorf("failed to create WETH binding: %w", err)
 	}
-	return &superchainWETHBinding{
+	return &WETHBinding{
 		contractAddress: address,
 		client:          r.Client,
 		binding:         binding,

--- a/devnet-sdk/contracts/registry/client/weth.go
+++ b/devnet-sdk/contracts/registry/client/weth.go
@@ -9,27 +9,27 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-type superchainWETHBinding struct {
+type WETHBinding struct {
 	contractAddress types.Address
 	client          *ethclient.Client
 	binding         *bindings.SuperchainWETH
 }
 
-var _ interfaces.SuperchainWETH = (*superchainWETHBinding)(nil)
+var _ interfaces.WETH = (*WETHBinding)(nil)
 
-func (b *superchainWETHBinding) BalanceOf(addr types.Address) types.ReadInvocation[types.Balance] {
-	return &superchainWETHBalanceOfImpl{
+func (b *WETHBinding) BalanceOf(addr types.Address) types.ReadInvocation[types.Balance] {
+	return &WETHBalanceOfImpl{
 		contract: b,
 		addr:     addr,
 	}
 }
 
-type superchainWETHBalanceOfImpl struct {
-	contract *superchainWETHBinding
+type WETHBalanceOfImpl struct {
+	contract *WETHBinding
 	addr     types.Address
 }
 
-func (i *superchainWETHBalanceOfImpl) Call(ctx context.Context) (types.Balance, error) {
+func (i *WETHBalanceOfImpl) Call(ctx context.Context) (types.Balance, error) {
 	balance, err := i.contract.binding.BalanceOf(nil, i.addr)
 	if err != nil {
 		return types.Balance{}, err

--- a/devnet-sdk/contracts/registry/empty/empty.go
+++ b/devnet-sdk/contracts/registry/empty/empty.go
@@ -10,9 +10,9 @@ type EmptyRegistry struct{}
 
 var _ interfaces.ContractsRegistry = (*EmptyRegistry)(nil)
 
-func (r *EmptyRegistry) SuperchainWETH(address types.Address) (interfaces.SuperchainWETH, error) {
+func (r *EmptyRegistry) WETH(address types.Address) (interfaces.WETH, error) {
 	return nil, &interfaces.ErrContractNotFound{
-		ContractType: "SuperchainWETH",
+		ContractType: "WETH",
 		Address:      address,
 	}
 }

--- a/devnet-sdk/interfaces/registry.go
+++ b/devnet-sdk/interfaces/registry.go
@@ -19,12 +19,12 @@ func (e *ErrContractNotFound) Error() string {
 
 // ContractsRegistry provides access to all supported contract instances
 type ContractsRegistry interface {
-	SuperchainWETH(address types.Address) (SuperchainWETH, error)
+	WETH(address types.Address) (WETH, error)
 	L2ToL2CrossDomainMessenger(address types.Address) (L2ToL2CrossDomainMessenger, error)
 }
 
-// SuperchainWETH represents the interface for interacting with the SuperchainWETH contract
-type SuperchainWETH interface {
+// WETH represents the interface for interacting with the WETH contract
+type WETH interface {
 	BalanceOf(user types.Address) types.ReadInvocation[types.Balance]
 }
 

--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -28,23 +28,21 @@ func smokeTestScenario(chainIdx uint64, walletGetter validators.WalletGetter) sy
 		logger = logger.With("chain", chain.ID())
 		logger.Info("starting test")
 
-		funds := sdktypes.NewBalance(big.NewInt(0.5 * constants.ETH))
+		funds := sdktypes.NewBalance(big.NewInt(1 * constants.ETH))
 		user := walletGetter(ctx)
 
-		bridgeAddr := constants.SuperchainETHBridge
-		bridge, err := chain.Nodes()[0].ContractsRegistry().SuperchainWETH(bridgeAddr)
+		wethAddr := constants.WETH
+		weth, err := chain.Nodes()[0].ContractsRegistry().WETH(wethAddr)
 		require.NoError(t, err)
-		logger.Info("using SuperchainWETH", "contract", bridgeAddr)
-
-		initialBalance, err := bridge.BalanceOf(user.Address()).Call(ctx)
+		initialBalance, err := weth.BalanceOf(user.Address()).Call(ctx)
 		require.NoError(t, err)
 		logger = logger.With("user", user.Address())
 		logger.Info("initial balance retrieved", "balance", initialBalance)
 
 		logger.Info("sending ETH to contract", "amount", funds)
-		require.NoError(t, user.SendETH(bridgeAddr, funds).Send(ctx).Wait())
+		require.NoError(t, user.SendETH(wethAddr, funds).Send(ctx).Wait())
 
-		balance, err := bridge.BalanceOf(user.Address()).Call(ctx)
+		balance, err := weth.BalanceOf(user.Address()).Call(ctx)
 		require.NoError(t, err)
 		logger.Info("final balance retrieved", "balance", balance)
 

--- a/op-acceptance-tests/tests/interop/mocks_test.go
+++ b/op-acceptance-tests/tests/interop/mocks_test.go
@@ -114,12 +114,12 @@ type mockContractsRegistry struct {
 	empty.EmptyRegistry
 }
 
-// mockSuperchainWETH implements a minimal SuperchainWETH interface for testing
-type mockSuperchainWETH struct {
+// mockWETH implements a minimal WETH interface for testing
+type mockWETH struct {
 	addr types.Address
 }
 
-func (m *mockSuperchainWETH) BalanceOf(account types.Address) types.ReadInvocation[types.Balance] {
+func (m *mockWETH) BalanceOf(account types.Address) types.ReadInvocation[types.Balance] {
 	return &mockReadInvocation{balance: types.NewBalance(big.NewInt(0))}
 }
 
@@ -132,8 +132,8 @@ func (m *mockReadInvocation) Call(ctx context.Context) (types.Balance, error) {
 	return m.balance, nil
 }
 
-func (r *mockContractsRegistry) SuperchainWETH(address types.Address) (interfaces.SuperchainWETH, error) {
-	return &mockSuperchainWETH{addr: address}, nil
+func (r *mockContractsRegistry) WETH(address types.Address) (interfaces.WETH, error) {
+	return &mockWETH{addr: address}, nil
 }
 
 // mockFailingChain implements system.Chain with a failing SendETH


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

SuperchainWETH contract is converted to SuperchainETHBridge at https://github.com/ethereum-optimism/design-docs/pull/217. This PR fixes the smoke tests to check using the WETH contract.

**Tests**

`TestSystemWrapETH` was failing before this PR. Tested against local interop devnet and it passes.

**Additional context**

superchainWETH binding was manually generated, and it still enables binding with weth contract interaction. Instead of re-creating the WETH binding, I decided to reuse the existing binding. In the intermediate term, this test will be migrated to devstack, so we eventually need to rehandle the abi.

**Metadata**

Attempting to enable interop NAT test in CI.