### PR TITLE
op-acceptance-tests: enable interop NAT tests at CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2321,7 +2321,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
-            # KURTOSIS (Isthmus)
+        # KURTOSIS (Interop)
       - op-acceptance-tests:
           # Acceptance Testing params
           name: kurtosis-interop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2321,7 +2321,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
-        # KURTOSIS (Interop)
+      # KURTOSIS (Interop)
       - op-acceptance-tests:
           # Acceptance Testing params
           name: kurtosis-interop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2321,6 +2321,18 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
+            # KURTOSIS (Isthmus)
+      - op-acceptance-tests:
+          # Acceptance Testing params
+          name: kurtosis-interop
+          devnet: interop
+          gate: interop
+
+          # CircleCI params
+          no_output_timeout: 60m
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
   close-issue-workflow:
     when:
       and:

--- a/op-acceptance-tests/tests/interop/interop_txplan_test.go
+++ b/op-acceptance-tests/tests/interop/interop_txplan_test.go
@@ -539,33 +539,74 @@ func randomDirectedGraph(
 	}
 }
 
-func TestInteropTxTest(t *testing.T) {
+func TestInteropInitAndExecMsg(t *testing.T) {
 	l2ChainNums := 2
 	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		initAndExecMsg(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
 
-	tests := []struct {
-		name     string
-		testFunc systest.InteropSystemTestFunc
-	}{
-		// success case
-		{"initAndExecMsg", initAndExecMsg(l2ChainNums, walletGetters)},
-		{"initAndExecMultipleMsg", initAndExecMultipleMsg(l2ChainNums, walletGetters)},
-		{"execSameMsgTwice", execSameMsgTwice(l2ChainNums, walletGetters)},
-		{"randomDirectedGraph", randomDirectedGraph(l2ChainNums, walletGetters)},
-		{"execMsgDifferentTopicCount", execMsgDifferentTopicCount(l2ChainNums, walletGetters)},
-		{"execMsgOpagueData", execMsgOpagueData(l2ChainNums, walletGetters)},
-		{"execMsgDifferEventIndexInSingleTx", execMsgDifferEventIndexInSingleTx(l2ChainNums, walletGetters)},
-		// failure case
-		{"executeMessageInvalidAttributes", executeMessageInvalidAttributes(l2ChainNums, walletGetters)},
-	}
+func TestInteropInitAndExecMultipleMsg(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		initAndExecMultipleMsg(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
 
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			systest.InteropSystemTest(t,
-				test.testFunc,
-				totalValidators...,
-			)
-		})
-	}
+func TestInteropExecSameMsgTwice(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		execSameMsgTwice(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
+
+func TestInteropRandomDirectedGraph(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		randomDirectedGraph(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
+
+func TestInteropExecMsgDifferentTopicCount(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		execMsgDifferentTopicCount(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
+
+func TestInteropExecMsgOpagueData(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		execMsgOpagueData(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
+
+func TestInteropExecMsgDifferEventIndexInSingleTx(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		execMsgDifferEventIndexInSingleTx(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
+}
+
+func TestInteropExecuteMessageInvalidAttributes(t *testing.T) {
+	l2ChainNums := 2
+	walletGetters, totalValidators := SetupDefaultInteropSystemTest(l2ChainNums)
+	systest.InteropSystemTest(t,
+		executeMessageInvalidAttributes(l2ChainNums, walletGetters),
+		totalValidators...,
+	)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Enable interop NAT tests at CI. 
Also splits out existing interop txplan tests to separate test, to make op-acceptor report the test results in a fine grained manner.

Depends on https://github.com/ethereum-optimism/optimism/pull/15503. Develop branch acceptance test CI will fail if we merge this PR before the dep PR.

**Tests**

All NAT interop tests are passing using the op-acceptor. Relevant logs:
```
 Acceptance Testing Results (6m23s)                                                                                                     
 TYPE   ID                                                                           DURATION  TESTS  PASSED  FAILED  SKIPPED  STATUS   
 Gate   interop                                                                         6m23s      -      17       0        0  ✓ pass   
 Test   ├── github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop     6m19s      1       1       0        0  ✓ pass   
            ├── TestMessagePassing                                                         7s      1       1       0        0  ✓ pass   
            ├── TestInteropInitAndExecMsg                                                 14s      1       1       0        0  ✓ pass   
            ├── TestInteropInitAndExecMultipleMsg                                         15s      1       1       0        0  ✓ pass   
            ├── TestInteropExecSameMsgTwice                                               15s      1       1       0        0  ✓ pass   
            ├── TestSystemWrapETH                                                          4s      1       1       0        0  ✓ pass   
            ├── TestInteropSystemNoop                                                      0s      1       1       0        0  ✓ pass   
            ├── TestInteropSystemSupervisor                                                0s      1       1       0        0  ✓ pass   
            ├── TestSmokeTestFailure                                                       0s      1       1       0        0  ✓ pass   
            ├── TestInteropExecMsgDifferentTopicCount                                     15s      1       1       0        0  ✓ pass   
            ├── TestInteropExecMsgDifferEventIndexInSingleTx                              14s      1       1       0        0  ✓ pass   
            ├── TestInteropRandomDirectedGraph                                          1m22s      1       1       0        0  ✓ pass   
            ├── TestInteropExecMsgOpagueData                                              14s      1       1       0        0  ✓ pass   
            └── TestInteropExecuteMessageInvalidAttributes                              2m43s      1       1       0        0  ✓ pass   
 Test   └── TestChainFork                                                                  4s      1       1       0        0  ✓ pass   
            ├── TestChainFork/Chain_0                                                      1s      1       1       0        0  ✓ pass   
            └── TestChainFork/Chain_1                                                      1s      1       1       0        0  ✓ pass   
 TOTAL                                                                               6M23S     17         17       0        0  ✓ PASS   
```


