### PR TITLE
fix(kt-devnet): handle new format for node names

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -295,6 +295,12 @@ func TestServiceTag(t *testing.T) {
 			wantTag:   "multi-part-name",
 			wantIndex: 1,
 		},
+		{
+			name:      "service with multiple numbers",
+			input:     "node-42-1",
+			wantTag:   "node",
+			wantIndex: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description**

With https://github.com/ethpandaops/optimism-package/pull/227 the
format for el/cl nodes has changed slightly. Adjust the parsing logic
accordingly.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
