### PR TITLE
op-chain-ops: create single source of truth for L1 contract/role names

### DIFF
--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -25,16 +25,16 @@ type ImplementationsContracts struct {
 	OpcmDeployerImpl                 common.Address
 	OpcmUpgraderImpl                 common.Address
 	OpcmInteropMigratorImpl          common.Address
-	DelayedWETHImpl                  common.Address
+	DelayedWethImpl                  common.Address
 	OptimismPortalImpl               common.Address
-	ETHLockboxImpl                   common.Address
+	EthLockboxImpl                   common.Address
 	PreimageOracleImpl               common.Address
 	MipsImpl                         common.Address
 	SystemConfigImpl                 common.Address
 	L1CrossDomainMessengerImpl       common.Address
-	L1ERC721BridgeImpl               common.Address
+	L1Erc721BridgeImpl               common.Address
 	L1StandardBridgeImpl             common.Address
-	OptimismMintableERC20FactoryImpl common.Address
+	OptimismMintableErc20FactoryImpl common.Address
 	DisputeGameFactoryImpl           common.Address
 	AnchorStateRegistryImpl          common.Address
 }
@@ -50,9 +50,9 @@ type OpChainContracts struct {
 type OpChainCoreContracts struct {
 	OpChainProxyAdminImpl             common.Address
 	AddressManagerImpl                common.Address
-	L1ERC721BridgeProxy               common.Address
+	L1Erc721BridgeProxy               common.Address
 	SystemConfigProxy                 common.Address
-	OptimismMintableERC20FactoryProxy common.Address
+	OptimismMintableErc20FactoryProxy common.Address
 	L1StandardBridgeProxy             common.Address
 	L1CrossDomainMessengerProxy       common.Address
 }
@@ -60,13 +60,13 @@ type OpChainCoreContracts struct {
 // DeployOPChain.s.sol output
 type OpChainFaultProofsContracts struct {
 	OptimismPortalProxy                common.Address
-	ETHLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
+	EthLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
 	DisputeGameFactoryProxy            common.Address
 	AnchorStateRegistryProxy           common.Address
 	FaultDisputeGameImpl               common.Address
 	PermissionedDisputeGameImpl        common.Address
-	DelayedWETHPermissionedGameProxy   common.Address
-	DelayedWETHPermissionlessGameProxy common.Address
+	DelayedWethPermissionedGameProxy   common.Address
+	DelayedWethPermissionlessGameProxy common.Address
 }
 
 // DeployAltDA.s.sol output

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -40,14 +40,14 @@ type ImplementationsContracts struct {
 }
 
 type OpChainContracts struct {
-	Base        *OpChainBaseContracts
+	Core        *OpChainCoreContracts
 	FaultProofs *OpChainFaultProofsContracts
 	AltDA       *OpChainAltDAContracts
 	Legacy      *OpChainLegacyContracts
 }
 
 // DeployOPChain.s.sol output
-type OpChainBaseContracts struct {
+type OpChainCoreContracts struct {
 	OpChainProxyAdminImpl             common.Address
 	AddressManagerImpl                common.Address
 	L1ERC721BridgeProxy               common.Address

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -8,9 +8,9 @@ import "github.com/ethereum/go-ethereum/common"
 //   - all contract field names are suffixed with "Impl" or "Proxy" to indicate the type of contract
 
 type L1Contracts struct {
-	Superchain      *SuperchainContracts
-	Implementations *ImplementationsContracts
-	OpChain         *OpChainContracts
+	SuperchainContracts
+	ImplementationsContracts
+	OpChainContracts
 }
 
 // SuperchainContracts struct contains all the superchain-level contracts

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -69,6 +69,7 @@ type OpChainCoreContracts struct {
 	OptimismMintableErc20FactoryProxy common.Address
 	L1StandardBridgeProxy             common.Address
 	L1CrossDomainMessengerProxy       common.Address
+	EthLockboxProxy                   common.Address
 }
 
 type OpChainFaultProofsContracts struct {
@@ -78,7 +79,6 @@ type OpChainFaultProofsContracts struct {
 	PermissionedDisputeGameImpl        common.Address
 	DelayedWethPermissionedGameProxy   common.Address
 	DelayedWethPermissionlessGameProxy common.Address
-	EthLockboxProxy                    common.Address
 }
 
 type OpChainAltDAContracts struct {

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -78,7 +78,7 @@ type OpChainFaultProofsContracts struct {
 	PermissionedDisputeGameImpl        common.Address
 	DelayedWethPermissionedGameProxy   common.Address
 	DelayedWethPermissionlessGameProxy common.Address
-	EthLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
+	EthLockboxProxy                    common.Address
 }
 
 type OpChainAltDAContracts struct {

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -8,7 +8,6 @@ type L1Contracts struct {
 	OpChain         *OpChainContracts
 }
 
-// DeploySuperchain.s.sol output
 type SuperchainContracts struct {
 	SuperchainProxyAdminImpl common.Address
 	SuperchainConfigProxy    common.Address
@@ -17,7 +16,6 @@ type SuperchainContracts struct {
 	ProtocolVersionsImpl     common.Address
 }
 
-// DeployImplementations.s.sol output
 type ImplementationsContracts struct {
 	OpcmImpl                         common.Address
 	OpcmContractsContainerImpl       common.Address
@@ -40,15 +38,15 @@ type ImplementationsContracts struct {
 }
 
 type OpChainContracts struct {
-	Core        *OpChainCoreContracts
-	FaultProofs *OpChainFaultProofsContracts
-	AltDA       *OpChainAltDAContracts
-	Legacy      *OpChainLegacyContracts
+	OpChainCoreContracts
+	OpChainFaultProofsContracts
+	OpChainAltDAContracts
+	OpChainLegacyContracts
 }
 
-// DeployOPChain.s.sol output
 type OpChainCoreContracts struct {
 	OpChainProxyAdminImpl             common.Address
+	OptimismPortalProxy               common.Address
 	AddressManagerImpl                common.Address
 	L1Erc721BridgeProxy               common.Address
 	SystemConfigProxy                 common.Address
@@ -57,19 +55,16 @@ type OpChainCoreContracts struct {
 	L1CrossDomainMessengerProxy       common.Address
 }
 
-// DeployOPChain.s.sol output
 type OpChainFaultProofsContracts struct {
-	OptimismPortalProxy                common.Address
-	EthLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
 	DisputeGameFactoryProxy            common.Address
 	AnchorStateRegistryProxy           common.Address
 	FaultDisputeGameImpl               common.Address
 	PermissionedDisputeGameImpl        common.Address
 	DelayedWethPermissionedGameProxy   common.Address
 	DelayedWethPermissionlessGameProxy common.Address
+	EthLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
 }
 
-// DeployAltDA.s.sol output
 type OpChainAltDAContracts struct {
 	AltDAChallengeProxy common.Address
 	AltDAChallengeImpl  common.Address

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -2,12 +2,19 @@ package addresses
 
 import "github.com/ethereum/go-ethereum/common"
 
+// This file contains the standard structs and contract names for all L1 contracts involved in an OpChain
+//   - structs are namespaced by deployment contract bundle (Superchain, Implementations and OpChain), then
+//     by feature set (e.g. FaultProofs has its own set of contracts nested within the OpChainContracts struct)
+//   - all contract field names are suffixed with "Impl" or "Proxy" to indicate the type of contract
+
 type L1Contracts struct {
 	Superchain      *SuperchainContracts
 	Implementations *ImplementationsContracts
 	OpChain         *OpChainContracts
 }
 
+// SuperchainContracts struct contains all the superchain-level contracts
+//   - these contracts are shared by all OpChains that are members of the same superchain
 type SuperchainContracts struct {
 	SuperchainProxyAdminImpl common.Address
 	SuperchainConfigProxy    common.Address
@@ -16,6 +23,9 @@ type SuperchainContracts struct {
 	ProtocolVersionsImpl     common.Address
 }
 
+// ImplementationsContracts struct contains all the implementation contracts for a superchain
+//   - these contracts are shared by all OpChains that are members of the same superchain
+//   - these contracts are not upgradable, but can be replaced by new contract releases/deployments
 type ImplementationsContracts struct {
 	OpcmImpl                         common.Address
 	OpcmContractsContainerImpl       common.Address
@@ -37,6 +47,11 @@ type ImplementationsContracts struct {
 	AnchorStateRegistryImpl          common.Address
 }
 
+// OpChainContracts struct contains all the contracts for a specific L2 OpChain
+//   - these contracts are not shared by any other OpChains
+//   - these contracts are mostly proxies, which point to ImplementationContracts
+//   - feature sets are represented by nested structs, which are inlined so that individual contracts
+//     can be accessed directly on the OpChainContracts struct (i.e. no leaky abstraction)
 type OpChainContracts struct {
 	OpChainCoreContracts
 	OpChainFaultProofsContracts
@@ -44,6 +59,7 @@ type OpChainContracts struct {
 	OpChainLegacyContracts
 }
 
+// OpChainCoreContracts struct contains contracts that all L2s need, regardless of feature set
 type OpChainCoreContracts struct {
 	OpChainProxyAdminImpl             common.Address
 	OptimismPortalProxy               common.Address

--- a/op-chain-ops/addresses/contracts.go
+++ b/op-chain-ops/addresses/contracts.go
@@ -1,0 +1,80 @@
+package addresses
+
+import "github.com/ethereum/go-ethereum/common"
+
+type L1Contracts struct {
+	Superchain      *SuperchainContracts
+	Implementations *ImplementationsContracts
+	OpChain         *OpChainContracts
+}
+
+// DeploySuperchain.s.sol output
+type SuperchainContracts struct {
+	SuperchainProxyAdminImpl common.Address
+	SuperchainConfigProxy    common.Address
+	SuperchainConfigImpl     common.Address
+	ProtocolVersionsProxy    common.Address
+	ProtocolVersionsImpl     common.Address
+}
+
+// DeployImplementations.s.sol output
+type ImplementationsContracts struct {
+	OpcmImpl                         common.Address
+	OpcmContractsContainerImpl       common.Address
+	OpcmGameTypeAdderImpl            common.Address
+	OpcmDeployerImpl                 common.Address
+	OpcmUpgraderImpl                 common.Address
+	OpcmInteropMigratorImpl          common.Address
+	DelayedWETHImpl                  common.Address
+	OptimismPortalImpl               common.Address
+	ETHLockboxImpl                   common.Address
+	PreimageOracleImpl               common.Address
+	MipsImpl                         common.Address
+	SystemConfigImpl                 common.Address
+	L1CrossDomainMessengerImpl       common.Address
+	L1ERC721BridgeImpl               common.Address
+	L1StandardBridgeImpl             common.Address
+	OptimismMintableERC20FactoryImpl common.Address
+	DisputeGameFactoryImpl           common.Address
+	AnchorStateRegistryImpl          common.Address
+}
+
+type OpChainContracts struct {
+	Base        *OpChainBaseContracts
+	FaultProofs *OpChainFaultProofsContracts
+	AltDA       *OpChainAltDAContracts
+	Legacy      *OpChainLegacyContracts
+}
+
+// DeployOPChain.s.sol output
+type OpChainBaseContracts struct {
+	OpChainProxyAdminImpl             common.Address
+	AddressManagerImpl                common.Address
+	L1ERC721BridgeProxy               common.Address
+	SystemConfigProxy                 common.Address
+	OptimismMintableERC20FactoryProxy common.Address
+	L1StandardBridgeProxy             common.Address
+	L1CrossDomainMessengerProxy       common.Address
+}
+
+// DeployOPChain.s.sol output
+type OpChainFaultProofsContracts struct {
+	OptimismPortalProxy                common.Address
+	ETHLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
+	DisputeGameFactoryProxy            common.Address
+	AnchorStateRegistryProxy           common.Address
+	FaultDisputeGameImpl               common.Address
+	PermissionedDisputeGameImpl        common.Address
+	DelayedWETHPermissionedGameProxy   common.Address
+	DelayedWETHPermissionlessGameProxy common.Address
+}
+
+// DeployAltDA.s.sol output
+type OpChainAltDAContracts struct {
+	AltDAChallengeProxy common.Address
+	AltDAChallengeImpl  common.Address
+}
+
+type OpChainLegacyContracts struct {
+	L2OutputOracleProxy common.Address
+}

--- a/op-chain-ops/addresses/roles.go
+++ b/op-chain-ops/addresses/roles.go
@@ -1,0 +1,30 @@
+package addresses
+
+import "github.com/ethereum/go-ethereum/common"
+
+type L1Roles struct {
+	Superchain *SuperchainRoles
+	OpChain    *OpChainRoles
+}
+
+type SuperchainRoles struct {
+	SuperchainProxyAdminOwner common.Address
+}
+
+type OpChainRoles struct {
+	Base        *OpChainBaseRoles
+	FaultProofs *OpChainFaultProofsRoles
+}
+
+type OpChainBaseRoles struct {
+	SystemConfigOwner      common.Address
+	OpChainProxyAdminOwner common.Address
+	Guardian               common.Address
+	Proposer               common.Address
+	UnsafeBlockSigner      common.Address
+	BatchSubmitter         common.Address
+}
+
+type OpChainFaultProofsRoles struct {
+	Challenger common.Address
+}

--- a/op-chain-ops/addresses/roles.go
+++ b/op-chain-ops/addresses/roles.go
@@ -20,11 +20,11 @@ type OpChainCoreRoles struct {
 	SystemConfigOwner      common.Address
 	OpChainProxyAdminOwner common.Address
 	Guardian               common.Address
-	Proposer               common.Address
 	UnsafeBlockSigner      common.Address
 	BatchSubmitter         common.Address
 }
 
 type OpChainFaultProofsRoles struct {
+	Proposer   common.Address
 	Challenger common.Address
 }

--- a/op-chain-ops/addresses/roles.go
+++ b/op-chain-ops/addresses/roles.go
@@ -12,11 +12,11 @@ type SuperchainRoles struct {
 }
 
 type OpChainRoles struct {
-	Base        *OpChainBaseRoles
+	Core        *OpChainCoreRoles
 	FaultProofs *OpChainFaultProofsRoles
 }
 
-type OpChainBaseRoles struct {
+type OpChainCoreRoles struct {
 	SystemConfigOwner      common.Address
 	OpChainProxyAdminOwner common.Address
 	Guardian               common.Address

--- a/op-chain-ops/addresses/roles.go
+++ b/op-chain-ops/addresses/roles.go
@@ -3,8 +3,8 @@ package addresses
 import "github.com/ethereum/go-ethereum/common"
 
 type L1Roles struct {
-	Superchain *SuperchainRoles
-	OpChain    *OpChainRoles
+	SuperchainRoles
+	OpChainRoles
 }
 
 type SuperchainRoles struct {
@@ -12,8 +12,8 @@ type SuperchainRoles struct {
 }
 
 type OpChainRoles struct {
-	Core        *OpChainCoreRoles
-	FaultProofs *OpChainFaultProofsRoles
+	OpChainCoreRoles
+	OpChainFaultProofsRoles
 }
 
 type OpChainCoreRoles struct {


### PR DESCRIPTION
# Overview
We currently have redundant go structs sprinkled across the monorepo that represent the same sets of contracts. We should remove these redundancies to improve compatibility across different go packages. See [this notion doc](https://www.notion.so/oplabs/redundant-address-structs-1c3f153ee16280e1af1afe2bda94f752) for notes on the redundancies.

This pr introduces a new set of go structs to define the L1 contracts and roles. The idea is to use those structs (which live in a new `op-chain-ops/addresses` package) as the standard, single-source of truth across all other go code in the op stack. 

# Details
The new standard structs are namespaced by deployment contract bundle (`superchain`, `implementations` and `opchain`), then by feature set (e.g. `FaultProofs` has its own set of contracts nested within the `OpChainContracts` struct). The feature sets are inlined within the `OpChainContracts` struct so that you can read/write to the contract fields directly without having to specify the nested feature set (i.e. no leaky abstraction)

All contract field names are suffixed with either `Impl` or `Proxy` to indicate which type of contract they are. Contracts that were previously suffixed with `Singleton` are now suffixed with `Impl` so that they don't have to have awareness about whether there is any proxy contract deployed on top (i.e. they are future-proof to adding a proxy).

# Follow-up Work
The plan is to remove redundant structs one-by-one, each with their own pr, until all packages are using the new standard structs.

# Related Issues
* https://github.com/ethereum-optimism/optimism/issues/14977