### PR TITLE
Add fund() to ETHLiquidity contract for setup

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/IETHLiquidity.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IETHLiquidity.sol
@@ -3,12 +3,15 @@ pragma solidity ^0.8.0;
 
 interface IETHLiquidity {
     error Unauthorized();
+    error InvalidAmount();
 
     event LiquidityBurned(address indexed caller, uint256 value);
     event LiquidityMinted(address indexed caller, uint256 value);
+    event LiquidityFunded(address indexed funder, uint256 amount);
 
     function burn() external payable;
     function mint(uint256 _amount) external;
+    function fund() external payable;
     function version() external view returns (string memory);
 
     function __constructor__() external;

--- a/packages/contracts-bedrock/snapshots/abi/ETHLiquidity.json
+++ b/packages/contracts-bedrock/snapshots/abi/ETHLiquidity.json
@@ -7,6 +7,13 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "fund",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -57,6 +64,25 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "funder",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "LiquidityFunded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "caller",
         "type": "address"
       },
@@ -69,6 +95,11 @@
     ],
     "name": "LiquidityMinted",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAmount",
+    "type": "error"
   },
   {
     "inputs": [],

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -48,8 +48,8 @@
     "sourceCodeHash": "0xa7d5540afd6bc0712d907ad675bd1621c2a2afee8febd0d04f5f168c38e94f17"
   },
   "src/L2/ETHLiquidity.sol:ETHLiquidity": {
-    "initCodeHash": "0x0ada742cc59d927979b0e56dba10f3816a542e46cc6481c9e811fd6660c121a8",
-    "sourceCodeHash": "0xab297d42ef5dda4cd4e15a6b2268a1b1211aa4ce27ede9fa8bc41d33da781570"
+    "initCodeHash": "0xd4a8b5b95e29bdad905637c4007af161b28224f350f54508e66299f56cffcef0",
+    "sourceCodeHash": "0x6d137fef431d75a8bf818444915fc39c8b1d93434a9af9971d96fb3170bc72b7"
   },
   "src/L2/GasPriceOracle.sol:GasPriceOracle": {
     "initCodeHash": "0x38ef70b2783dd45ad807afcf57972c7df4abaaeb5d16d17cdb451b9e931a9cbb",

--- a/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
+++ b/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
@@ -11,6 +11,9 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
+// Errors
+import { InvalidAmount } from "src/libraries/errors/CommonErrors.sol";
+
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000025
 /// @title ETHLiquidity
@@ -24,9 +27,12 @@ contract ETHLiquidity is ISemver {
     /// @notice Emitted when an address mints ETH liquidity.
     event LiquidityMinted(address indexed caller, uint256 value);
 
+    /// @notice Event to emit when funds are received
+    event LiquidityFunded(address indexed funder, uint256 amount);
+
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1
-    string public constant version = "1.0.1";
+    /// @custom:semver 1.1.0
+    string public constant version = "1.1.0";
 
     /// @notice Allows an address to lock ETH liquidity into this contract.
     function burn() external payable {
@@ -40,5 +46,12 @@ contract ETHLiquidity is ISemver {
         if (msg.sender != Predeploys.SUPERCHAIN_ETH_BRIDGE) revert Unauthorized();
         new SafeSend{ value: _amount }(payable(msg.sender));
         emit LiquidityMinted(msg.sender, _amount);
+    }
+
+    /// @notice Fund the contract by sending ETH
+    /// @dev The function is payable to accept ETH
+    function fund() external payable {
+        if (msg.value == 0) revert InvalidAmount();
+        emit LiquidityFunded(msg.sender, msg.value);
     }
 }

--- a/packages/contracts-bedrock/src/libraries/errors/CommonErrors.sol
+++ b/packages/contracts-bedrock/src/libraries/errors/CommonErrors.sol
@@ -9,3 +9,6 @@ error TransferFailed();
 
 /// @notice Thrown when attempting to perform an operation and the account is the zero address.
 error ZeroAddress();
+
+/// @notice Error for when an invalid amount is provided.
+error InvalidAmount();


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This adds `function fund() external payable` to the `ETHLiquidity` predeploy so it can be funded with unbacked L2 ETH upon fork upgrade.

**Tests**

Tests have been added to cover the new functionality testing that the function does not break invariants and errors if no funds are sent.
