### PR TITLE
fix(kt-devnet): adjust to possible multiple depsets

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -64,6 +64,8 @@ type Wallet struct {
 // WalletMap is a map of wallet names to wallets.
 type WalletMap map[string]*Wallet
 
+type DepSet = json.RawMessage
+
 // DevnetEnvironment exposes the relevant information to interact with a devnet.
 type DevnetEnvironment struct {
 	Name string `json:"name"`
@@ -73,6 +75,6 @@ type DevnetEnvironment struct {
 	L1 *Chain     `json:"l1"`
 	L2 []*L2Chain `json:"l2"`
 
-	Features []string        `json:"features,omitempty"`
-	DepSet   json.RawMessage `json:"dep_set,omitempty"`
+	Features []string `json:"features,omitempty"`
+	DepSets  []DepSet `json:"dep_sets,omitempty"`
 }

--- a/devnet-sdk/devstack/sysext/system.go
+++ b/devnet-sdk/devstack/sysext/system.go
@@ -26,14 +26,18 @@ func (o *Orchestrator) hydrateClusterMaybe(sys stack.ExtensibleSystem) {
 	require := sys.T().Require()
 	env := o.env
 
-	var depSet depset.StaticConfigDependencySet
-	require.NoError(json.Unmarshal(o.env.Env.DepSet, &depSet))
+	depsets := o.env.Env.DepSets
 
-	sys.AddCluster(shim.NewCluster(shim.ClusterConfig{
-		CommonConfig:  shim.NewCommonConfig(sys.T()),
-		ID:            stack.ClusterID(env.Env.Name),
-		DependencySet: &depSet,
-	}))
+	for _, d := range depsets {
+		var depSet depset.StaticConfigDependencySet
+		require.NoError(json.Unmarshal(d, &depSet))
+
+		sys.AddCluster(shim.NewCluster(shim.ClusterConfig{
+			CommonConfig:  shim.NewCommonConfig(sys.T()),
+			ID:            stack.ClusterID(env.Env.Name),
+			DependencySet: &depSet,
+		}))
+	}
 }
 
 func (o *Orchestrator) hydrateSupervisorMaybe(sys stack.ExtensibleSystem) {

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -18,25 +18,11 @@
 optimism_package:
   interop:
     enabled: true
+    sets:
+      - name: "interop-set"
+        participants: "*"
     supervisor_params:
       image: {{ $local_images.op_supervisor }}
-      dependency_set: |
-        {
-          "dependencies": {
-            "2151908": {
-              "chainIndex": "2151908",
-              "activationTime": 0,
-              "historyMinTime": 0
-            },
-            "2151909": {
-              "chainIndex": "2151909",
-              "activationTime": 0,
-              "historyMinTime": 0
-            }
-          }
-        }
-      extra_params:
-      - {{ $flags.log_level }}
   chains:
     - participants:
       - el_type: op-geth

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@1cf76907eaa437ee9fcf902167714fece027962a
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@07fcbfb17fdf00f048242c938471849bba128bf0
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173

--- a/kurtosis-devnet/pkg/kurtosis/adapters.go
+++ b/kurtosis-devnet/pkg/kurtosis/adapters.go
@@ -2,9 +2,9 @@ package kurtosis
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/deployer"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/depset"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect"
@@ -47,7 +47,7 @@ var _ interfaces.JWTExtractor = (*enclaveJWTAdapter)(nil)
 
 type enclaveDepsetAdapter struct{}
 
-func (a *enclaveDepsetAdapter) ExtractData(ctx context.Context, enclave string) (json.RawMessage, error) {
+func (a *enclaveDepsetAdapter) ExtractData(ctx context.Context, enclave string) ([]descriptors.DepSet, error) {
 	return depset.NewExtractor(enclave).ExtractData(ctx)
 }
 

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -3,7 +3,6 @@ package kurtosis
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -175,9 +174,9 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 	}
 
 	// Get dependency set
-	var depsetData json.RawMessage
+	var depsets []descriptors.DepSet
 	if s.Features.Contains(spec.FeatureInterop) {
-		depsetData, err = d.depsetExtractor.ExtractData(ctx, d.enclave)
+		depsets, err = d.depsetExtractor.ExtractData(ctx, d.enclave)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract dependency set: %w", err)
 		}
@@ -190,7 +189,7 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 
 			L2:       make([]*descriptors.L2Chain, 0, len(s.Chains)),
 			Features: s.Features,
-			DepSet:   depsetData,
+			DepSets:  depsets,
 		},
 	}
 

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -2,7 +2,6 @@ package kurtosis
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -119,11 +118,11 @@ func (f *fakeJWTExtractor) ExtractData(ctx context.Context, enclave string) (*jw
 }
 
 type fakeDepsetExtractor struct {
-	data json.RawMessage
+	data []descriptors.DepSet
 	err  error
 }
 
-func (f *fakeDepsetExtractor) ExtractData(ctx context.Context, enclave string) (json.RawMessage, error) {
+func (f *fakeDepsetExtractor) ExtractData(ctx context.Context, enclave string) ([]descriptors.DepSet, error) {
 	return f.data, f.err
 }
 
@@ -346,7 +345,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 							},
 						},
 					},
-					DepSet: nil,
+					DepSets: nil,
 				},
 			},
 		},
@@ -428,7 +427,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 						},
 					},
 					Features: spec.FeatureList{spec.FeatureInterop},
-					DepSet:   json.RawMessage(`{}`),
+					DepSets:  []descriptors.DepSet{descriptors.DepSet(`{}`)},
 				},
 			},
 		},
@@ -489,7 +488,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 						},
 					},
 					Features: spec.FeatureList{},
-					DepSet:   nil,
+					DepSets:  nil,
 				},
 			},
 		},
@@ -503,9 +502,9 @@ func TestGetEnvironmentInfo(t *testing.T) {
 			}
 
 			// Create depset data based on whether interop is enabled
-			var depsetData json.RawMessage
+			var depsets []descriptors.DepSet
 			if tt.spec != nil && tt.spec.Features.Contains(spec.FeatureInterop) {
-				depsetData = json.RawMessage(`{}`)
+				depsets = []descriptors.DepSet{descriptors.DepSet(`{}`)}
 			}
 
 			deployer, err := NewKurtosisDeployer(
@@ -523,7 +522,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					err:  tt.err,
 				}),
 				WithKurtosisDepsetExtractor(&fakeDepsetExtractor{
-					data: depsetData,
+					data: depsets,
 					err:  tt.err,
 				}),
 			)

--- a/kurtosis-devnet/pkg/kurtosis/sources/interfaces/interfaces.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/interfaces/interfaces.go
@@ -2,9 +2,9 @@ package interfaces
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/deployer"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/jwt"
@@ -28,5 +28,5 @@ type JWTExtractor interface {
 }
 
 type DepsetExtractor interface {
-	ExtractData(context.Context, string) (json.RawMessage, error)
+	ExtractData(context.Context, string) ([]descriptors.DepSet, error)
 }


### PR DESCRIPTION
**Description**

The previous approach of associating a single dependency set to a
devnet doesn't work anymore, as we're aiming to work with multiple
interop sets, multiple supervisors, and so on.

We're also importing the corresponding optimism-package
version, and adjusting the interop devnet definition


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

deployed simple, isthmus and interop devnets
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
