### PR TITLE
kt-devnet: add op-faucet support

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -5,6 +5,7 @@
   "op_proposer" (localDockerImage "op-proposer")
   "op_deployer" (localDockerImage "op-deployer")
   "op_supervisor" (localDockerImage "op-supervisor")
+  "op_faucet" (localDockerImage "op-faucet")
 -}}
 {{- $urls := dict
   "prestate" (localPrestate.URL)
@@ -16,6 +17,9 @@
 -}}
 ---
 optimism_package:
+  faucet:
+    enabled: true
+    image: {{ $local_images.op_faucet }}
   interop:
     enabled: true
     supervisor_params:

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -43,6 +43,7 @@ op-program-image TAG='op-program:devnet': (_docker_build_stack TAG "op-program-t
 op-proposer-image TAG='op-proposer:devnet': (_docker_build_stack TAG "op-proposer-target")
 op-supervisor-image TAG='op-supervisor:devnet': (_docker_build_stack TAG "op-supervisor-target")
 op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target")
+op-faucet-image TAG='op-faucet:devnet': (_docker_build_stack TAG "op-faucet-target")
 
 op-program-builder-image TAG='op-program-builder:devnet': _prerequisites
     just op-program-svc/op-program-svc {{TAG}}

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -145,6 +145,12 @@ ARG OP_DRIPPER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd op-dripper && make op-dripper  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_DRIPPER_VERSION"
 
+FROM --platform=$BUILDPLATFORM builder AS op-faucet-builder
+ARG OP_FAUCET_VERSION=v0.0.0
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
+  GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_FAUCET_VERSION" \
+  op-faucet/op-faucet
+
 FROM $TARGET_BASE_IMAGE AS cannon-target
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 COPY --from=cannon-builder /app/cannon/multicannon/embeds/* /usr/local/bin/
@@ -214,3 +220,7 @@ CMD ["op-deployer"]
 FROM $TARGET_BASE_IMAGE AS op-dripper-target
 COPY --from=op-dripper-builder /app/op-dripper/bin/op-dripper /usr/local/bin/
 CMD ["op-dripper"]
+
+FROM $TARGET_BASE_IMAGE AS op-faucet-target
+COPY --from=op-faucet-builder /app/op-faucet/bin/op-faucet /usr/local/bin/
+CMD ["op-faucet"]

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -20,6 +20,7 @@
 !/op-supervisor
 !/op-wheel
 !/op-alt-da
+!/op-faucet
 !/go.mod
 !/go.sum
 !/justfiles


### PR DESCRIPTION
**Description**

This allows building op-faucet from local repo (only option for now,
until a proper release is cut), with a working example in the interop
devnet.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Requires https://github.com/ethpandaops/optimism-package/pull/228
- Fixes #15486 
