### PR TITLE
fix: rollup-boost conductor flags

### DIFF
--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -168,6 +168,8 @@ var optionalFlags = []cli.Flag{
 	RaftTrailingLogs,
 	RaftHeartbeatTimeout,
 	RaftLeaderLeaseTimeout,
+	RollupBoostEnabled,
+	RollupBoostHealthcheckTimeout,
 }
 
 func init() {


### PR DESCRIPTION
Fixes CLI Flags not being initialized on the conductor service
