### PR TITLE
feat: Simplify op-deployer scripts: Collect all new scripts under a struct [16/N] 

### DIFF
--- a/op-deployer/pkg/deployer/opcm/scripts.go
+++ b/op-deployer/pkg/deployer/opcm/scripts.go
@@ -1,0 +1,81 @@
+package opcm
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+)
+
+// Scripts contains all the deployment scripts for ease of passing them around
+type Scripts struct {
+	DeployAlphabetVM      DeployAlphabetVMScript
+	DeployAltDA           DeployAltDA2Script
+	DeployAsterisc        DeployAsteriscScript
+	DeployDisputeGame     DeployDisputeGameScript
+	DeployImplementations DeployImplementations2Script
+	DeployMIPS            DeployMIPSScript
+	DeployPreimageOracle  DeployPreimageOracleScript
+	DeployProxy           DeployProxyScript
+	DeploySuperchain      DeploySuperchainScript
+}
+
+// NewScripts collects all the deployment scripts, raising exceptions if any of them
+// are not found or if the Go types don't match the ABI
+func NewScripts(host *script.Host) (*Scripts, error) {
+	deployImplementations, err := NewDeployImplementationsScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployImplementations script: %w", err)
+	}
+
+	deploySuperchain, err := NewDeploySuperchainScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeploySuperchain script: %w", err)
+	}
+
+	deployAlphabetVM, err := NewDeployAlphabetVMScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployAlphabetVM script: %w", err)
+	}
+
+	deployAltDA, err := NewDeployAltDAScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployAltDA script: %w", err)
+	}
+
+	deployAsterisc, err := NewDeployAsteriscScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployAsterisc script: %w", err)
+	}
+
+	deployDisputeGame, err := NewDeployDisputeGameScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployDisputeGame script: %w", err)
+	}
+
+	deployMIPSScript, err := NewDeployMIPSScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployMIPSScript script: %w", err)
+	}
+
+	deployPreimageOracle, err := NewDeployPreimageOracleScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployPreimageOracle script: %w", err)
+	}
+
+	deployProxy, err := NewDeployProxyScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployProxy script: %w", err)
+	}
+
+	return &Scripts{
+		DeployAlphabetVM:      deployAlphabetVM,
+		DeployAltDA:           deployAltDA,
+		DeployAsterisc:        deployAsterisc,
+		DeployDisputeGame:     deployDisputeGame,
+		DeployMIPS:            deployMIPSScript,
+		DeployPreimageOracle:  deployPreimageOracle,
+		DeployProxy:           deployProxy,
+		DeployImplementations: deployImplementations,
+		DeploySuperchain:      deploySuperchain,
+	}, nil
+}

--- a/op-deployer/pkg/deployer/opcm/scripts_test.go
+++ b/op-deployer/pkg/deployer/opcm/scripts_test.go
@@ -1,0 +1,32 @@
+package opcm_test
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewScripts(t *testing.T) {
+	t.Run("should not fail with current versions of script contracts", func(t *testing.T) {
+		// First we grab a test host
+		host := createTestHost(t)
+
+		// Then we load the scripts
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		scripts, err := opcm.NewScripts(host)
+		require.NoError(t, err)
+
+		// And we just make sure we have all the scripts loaded
+		require.NotNil(t, scripts.DeployImplementations)
+		require.NotNil(t, scripts.DeploySuperchain)
+		require.NotNil(t, scripts.DeployAlphabetVM)
+		require.NotNil(t, scripts.DeployAltDA)
+		require.NotNil(t, scripts.DeployAsterisc)
+		require.NotNil(t, scripts.DeployDisputeGame)
+		require.NotNil(t, scripts.DeployMIPS)
+		require.NotNil(t, scripts.DeployPreimageOracle)
+		require.NotNil(t, scripts.DeployProxy)
+	})
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

To unblock the next step in `op-deployer` script migration while wrapping up the rest of the deployment scripts, we introduce a small quality-of-life functionality that loads all opcm scripts in one go and wraps them in a struct.

This allows us to pass this struct around instead of passing individual scripts.