### PR TITLE
op-e2e: Fix panics in logging

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -253,8 +252,6 @@ func TestInterop_EmitLogs(t *testing.T) {
 
 func TestInteropBlockBuilding(t *testing.T) {
 	t.Parallel()
-	logger := testlog.Logger(t, log.LevelInfo)
-	oplog.SetGlobalLogHandler(logger.Handler())
 
 	test := func(t *testing.T, s2 SuperSystem) {
 		ids := s2.L2IDs()


### PR DESCRIPTION
**Description**

Ensures that the buffer used to write logs is thread safe since there are a few ways it can wind up "escaping" the test logger we create and not being protected by its mutex.  We've been getting a number of weird panic's in CI which I think is because of this:
```
panic: runtime error: slice bounds out of range [4229:4096]

goroutine 24201615 [running]:
bufio.(*Writer).Write(0xc0026ec0c0, {0xc004d38000?, 0x4c029e0?, 0x252a3a9?})
	/data/mise-data/installs/go/1.22.7/src/bufio/bufio.go:681 +0x1b5
github.com/ethereum/go-ethereum/log.(*TerminalHandler).Handle(_, {_, _}, {{0xc1fa1df1828f460a, 0x2762c0baa26, 0x4c029e0}, {0x252a3a9, 0x16}, 0x0, 0xcb1936, ...})
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/log/handler.go:80 +0x118
github.com/ethereum/go-ethereum/log.(*logger).Write(0xc004d8a020, 0x0, {0x252a3a9, 0x16}, {0xc5ec00fb00, 0x8, 0x8})
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/log/logger.go:173 +0x2a6
github.com/ethereum/go-ethereum/log.Info({0x252a3a9?, 0xc00ea5cb37?}, {0xc5ec00fb00?, 0xfead566a07d81485?, 0x236cfa0?})
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/log/root.go:68 +0x10a
github.com/ethereum/go-ethereum/core.(*BlockChain).SetCanonical(0xc1b0b56c08, 0xc66a9298c0)
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/core/blockchain.go:2410 +0xab6
github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).forkchoiceUpdated(0xc26fdb5040, {{0x19, 0x75, 0x54, 0x66, 0xe4, 0x11, 0x16, 0xb2, 0xe8, ...}, ...}, ...)
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/eth/catalyst/api.go:384 +0x192c
github.com/ethereum/go-ethereum/eth/catalyst.(*ConsensusAPI).ForkchoiceUpdatedV3(0x50e0fa77251c6597?, {{0x19, 0x75, 0x54, 0x66, 0xe4, 0x11, 0x16, 0xb2, 0xe8, ...}, ...}, ...)
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/eth/catalyst/api.go:252 +0x3fa
github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth.(*fakePoS).Start.func1(0xc3ac6e8ae0)
	/var/opt/circleci/data/workdir/op-e2e/e2eutils/geth/fakepos.go:194 +0x13ba
github.com/ethereum/go-ethereum/event.NewSubscription.func1()
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/event/subscription.go:53 +0x5f
created by github.com/ethereum/go-ethereum/event.NewSubscription in goroutine 3472221
	/home/circleci/go/pkg/mod/github.com/ethereum-optimism/op-geth@v1.101503.4-rc.1/event/subscription.go:51 +0xd2

```

Also removes a `SetRootLogger` call from one of the e2e tests which is just a really bad idea.
