### PR TITLE
kurtosis-devnet: add rotatory welcome message with feature announcements

### DIFF
--- a/kurtosis-devnet/README.md
+++ b/kurtosis-devnet/README.md
@@ -1,7 +1,5 @@
 # Getting Started
 
-Welcome to the Kurtosis Devnet! This tool helps you quickly spin up local development networks for testing and development purposes. Whether you're working on simple test networks or complex interoperability scenarios, this devnet environment has you covered.
-
 Running a Kurtosis Devnet has the following prerequisites:
 - Kurtosis must be installed. This is automatically handled by `mise`, same as with other dev tools in this repository
 - Docker Desktop must be installed and running
@@ -154,43 +152,12 @@ In particular, cleaning up a devnet can be achieved using
 
 ## Troubleshooting
 
-### Autofix mode
-
-Autofix mode helps recover from failed devnet deployments by automatically 
-cleaning up the environment. It has two modes:
-
-1. **Normal Mode** (`AUTOFIX=true`)
-   - Sets up the correct shell and updates dependencies
-   - Cleans up dangling networks and stopped devnets
-   - Preserves other running enclaves
-   - Good for fixing minor deployment issues
-
-2. **Nuke Mode** (`AUTOFIX=nuke`)
-   - Sets up the correct shell and updates dependencies
-   - Completely resets the Kurtosis environment
-   - Removes all networks and containers
-   - Use when you need a fresh start
-
-Usage:
-```bash
-# For normal cleanup
-AUTOFIX=true just interop-devnet
-
-# For complete reset
-AUTOFIX=nuke just interop-devnet
-```
-
-Note: Nuke mode will stop all running enclaves, so use it carefully.
-
-### Older kurtosis versions
-
 In some cases, a newer kurtosis client might not be able to handle an
 older kurtosis engine. This typically happens if the kurtosis
 command-line managed by mise gets updated while some enclaves are
 already running.
 
-To help recover, you can either run with `AUTOFIX=nuke` or kill the 
-old engine with:
+To help recover, you can kill the old engine with:
 
 ```shell
 docker rm -f $(docker ps -aqf "name=kurtosis-*")
@@ -201,3 +168,31 @@ Potentially you'll also need to cleanup dangling docker networks:
 ```shell
 docker network rm -f $(docker network ls -qf "name=kt-*")
 ```
+
+## Welcome Messages
+
+Kurtosis Devnet displays a random welcome message at startup, which provides tips and information about new features.
+
+### Customizing Welcome Messages
+
+You can customize the welcome messages by editing the `welcome_messages.txt` file in the kurtosis-devnet directory.
+Each line in this file will be treated as a separate message.
+
+### Disabling Welcome Messages
+
+There are several ways to disable the welcome messages:
+
+1. Use the `NO_WELCOME` parameter when running a devnet:
+   ```
+   just simple-devnet yes
+   ```
+
+2. Create a `.disable-welcome` file in the kurtosis-devnet directory:
+   ```
+   touch .disable-welcome
+   ```
+
+3. Set the environment variable `KURTOSIS_DEVNET_DISABLE_WELCOME`:
+   ```
+   export KURTOSIS_DEVNET_DISABLE_WELCOME=1
+   ```

--- a/kurtosis-devnet/cmd/main.go
+++ b/kurtosis-devnet/cmd/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/deploy"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/welcome"
 	"github.com/urfave/cli/v2"
 )
 
@@ -21,6 +22,7 @@ type config struct {
 	dryRun          bool
 	baseDir         string
 	kurtosisBinary  string
+	disableWelcome  bool
 }
 
 func newConfig(c *cli.Context) (*config, error) {
@@ -32,6 +34,7 @@ func newConfig(c *cli.Context) (*config, error) {
 		environment:     c.String("environment"),
 		dryRun:          c.Bool("dry-run"),
 		kurtosisBinary:  c.String("kurtosis-binary"),
+		disableWelcome:  c.Bool("disable-welcome"),
 	}
 
 	// Validate required flags
@@ -63,12 +66,34 @@ func writeEnvironment(path string, env *kurtosis.KurtosisEnvironment) error {
 	return nil
 }
 
-func mainAction(c *cli.Context) error {
+func displayWelcomeMessage(basePath string, disableWelcome bool) {
+	// Skip if welcome messages are disabled via flag
+	if disableWelcome {
+		return
+	}
 
+	// Try to get and display welcome message
+	msg, err := welcome.GetWelcomeMessage(basePath)
+	if err != nil {
+		// Just log the error, but don't fail the whole process
+		log.Printf("Warning: could not display welcome message: %v", err)
+		return
+	}
+
+	// If message is not empty, print it
+	if msg != "" {
+		fmt.Println(msg)
+	}
+}
+
+func mainAction(c *cli.Context) error {
 	cfg, err := newConfig(c)
 	if err != nil {
 		return fmt.Errorf("error parsing config: %w", err)
 	}
+
+	// Display welcome message
+	displayWelcomeMessage(cfg.baseDir, cfg.disableWelcome)
 
 	deployer := deploy.NewDeployer(
 		deploy.WithKurtosisPackage(cfg.kurtosisPackage),
@@ -121,6 +146,10 @@ func getFlags() []cli.Flag {
 			Name:  "kurtosis-binary",
 			Usage: "Path to kurtosis binary (optional)",
 			Value: "kurtosis",
+		},
+		&cli.BoolFlag{
+			Name:  "disable-welcome",
+			Usage: "Disable welcome message (optional)",
 		},
 	}
 }

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -1,17 +1,43 @@
-import '../justfiles/prerequisites.just'
+set shell := ["/bin/bash", "-c"]
 
 KURTOSIS_PACKAGE := "./optimism-package-trampoline/"
 
-test: _prerequisites
+test:
     go test --tags=testonly ./...
 
 _kurtosis-run PACKAGE_NAME ARG_FILE ENCLAVE:
 	kurtosis run {{PACKAGE_NAME}} --args-file {{ARG_FILE}} --enclave {{ENCLAVE}} --show-enclave-inspect=false --image-download=missing
 
+# Internal recipes for kurtosis-devnet.
+# This builds the forge contracts and bundles them into a tarball,
+# which is uploaded to the kurtosis enclave as a file artifact.
+# We need to ensure that the tarball is reproducible (always has the same content)
+# because kurtosis uses the md5 hash of the tarball to determine if it needs to be re-uploaded:
+# https://github.com/kurtosis-tech/kurtosis/blob/bf315c6993d5e70a47265f1f41f0f7273fdd904b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go#L206
+# BSD tar on macOS doesn't support the --mtime flag, so we need to use GNU tar if we're on macOS.
+# See https://unix.stackexchange.com/questions/438329/tar-produces-different-files-each-time
+# Couldn't find gnu tar on mise so we're recommending it to be installed via brew.
+_contracts-build BUNDLE='contracts-bundle.tar.gz':
+    #!/usr/bin/env bash
+    just ../packages/contracts-bedrock/forge-build
+    if tar --version | grep -q GNU; then
+      # Linux
+      GZIP=-n tar --mtime='1970-01-01 00:00:00' \
+        -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
+    else
+      # macOS
+      if ! command -v gtar &> /dev/null; then
+        echo "GNU tar not found. Please install with: brew install gnu-tar"
+        exit 1
+      fi
+      GZIP=-n gtar --mtime='1970-01-01 00:00:00' \
+        -czf {{BUNDLE}} -C ../packages/contracts-bedrock artifacts forge-artifacts cache
+    fi
+
 _prestate-build PATH='.':
     docker buildx build --output {{PATH}} --progress plain -f ../op-program/Dockerfile.repro ../
 
-_docker_build TAG TARGET CONTEXT DOCKERFILE *ARGS: _prerequisites
+_docker_build TAG TARGET CONTEXT DOCKERFILE *ARGS:
     #!/usr/bin/env bash
     # --load is needed to ensure the image ends up in the local registry
     # --provenance=false is needed to make the build idempotent
@@ -31,10 +57,10 @@ _docker_build_stack TAG TARGET *ARGS: (_docker_build TAG TARGET "../" "ops/docke
 cannon-image TAG='cannon:devnet': (_docker_build_stack TAG "cannon-target")
 da-server-image TAG='da-server:devnet': (_docker_build_stack TAG "da-server-target")
 op-batcher-image TAG='op-batcher:devnet': (_docker_build_stack TAG "op-batcher-target")
-# TODO: this is a temporary hack to get the kona + asterisc version right.
+# TODO: this is a temporary hack to get the kona version right.
 # Ideally the Dockerfile should be self-sufficient (right now we depend on
 # docker-bake.hcl to do the right thing).
-op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=0.1.0-beta.15" "--build-arg" "ASTERISC_VERSION=v1.2.0")
+op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=kona-client-v0.1.0-beta.6")
 op-conductor-image TAG='op-conductor:devnet': (_docker_build_stack TAG "op-conductor-target")
 op-deployer-image TAG='op-deployer:devnet': (_docker_build_stack TAG "op-deployer-target")
 op-dispute-mon-image TAG='op-dispute-mon:devnet': (_docker_build_stack TAG "op-dispute-mon-target")
@@ -44,12 +70,12 @@ op-proposer-image TAG='op-proposer:devnet': (_docker_build_stack TAG "op-propose
 op-supervisor-image TAG='op-supervisor:devnet': (_docker_build_stack TAG "op-supervisor-target")
 op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target")
 
-op-program-builder-image TAG='op-program-builder:devnet': _prerequisites
+op-program-builder-image TAG='op-program-builder:devnet':
     just op-program-svc/op-program-svc {{TAG}}
 
 
 # Devnet template recipe
-devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE: _prerequisites
+devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE NO_WELCOME="":
     #!/usr/bin/env bash
     export DEVNET_NAME={{NAME}}
     if [ -z "{{NAME}}" ]; then
@@ -65,9 +91,10 @@ devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE: _prerequisit
         -template "{{TEMPLATE_FILE}}" \
         -data "{{DATA_FILE}}" \
         -enclave "$ENCL_NAME" \
+        {{ if NO_WELCOME != "" { "-disable-welcome" } else { "" } }} \
     && cat "tests/$ENCL_NAME.json"
 
-devnet-test DEVNET *TEST: _prerequisites
+devnet-test DEVNET *TEST:
     #!/usr/bin/env bash
     export TESTS=({{TEST}})
     # we need a timestamp in there to force kurtosis to not cache the test solely based on its name!
@@ -79,22 +106,22 @@ devnet-test DEVNET *TEST: _prerequisites
 # Devnet recipes
 
 # Simple devnet
-simple-devnet: (devnet "simple.yaml")
+simple-devnet NO_WELCOME="": (devnet "simple.yaml" "" "" KURTOSIS_PACKAGE NO_WELCOME)
 
 # Interop devnet
-interop-devnet: (devnet "interop.yaml")
+interop-devnet NO_WELCOME="": (devnet "interop.yaml" "" "" KURTOSIS_PACKAGE NO_WELCOME)
 interop-devnet-test: (devnet-test "interop-devnet" "interop-smoke-test.sh")
 
 # User devnet
-user-devnet DATA_FILE:
-    {{just_executable()}} devnet "user.yaml" {{DATA_FILE}} {{file_stem(DATA_FILE)}}
+user-devnet DATA_FILE NO_WELCOME="":
+    {{just_executable()}} devnet "user.yaml" {{DATA_FILE}} {{file_stem(DATA_FILE)}} {{KURTOSIS_PACKAGE}} {{NO_WELCOME}}
 
 # Pectra devnet
-pectra-devnet: (devnet "pectra.yaml")
+pectra-devnet NO_WELCOME="": (devnet "pectra.yaml" "" "" KURTOSIS_PACKAGE NO_WELCOME)
 
 # Isthmus devnet
-isthmus-devnet: (devnet "isthmus.yaml")
+isthmus-devnet NO_WELCOME="": (devnet "isthmus.yaml" "" "" KURTOSIS_PACKAGE NO_WELCOME)
 
 # subshells
-enter-devnet DEVNET CHAIN='Ethereum' NODE_INDEX='0': _prerequisites
-    go run ../devnet-sdk/shell/cmd/enter/main.go --devnet kt://{{DEVNET}} --chain {{CHAIN}} --node-index {{NODE_INDEX}}
+enter-devnet DEVNET CHAIN='Ethereum' NODE_INDEX='0':
+    exec go run ../devnet-sdk/shell/cmd/enter/main.go --devnet kt://{{DEVNET}} --chain {{CHAIN}} --node-index {{NODE_INDEX}}

--- a/kurtosis-devnet/pkg/welcome/welcome.go
+++ b/kurtosis-devnet/pkg/welcome/welcome.go
@@ -1,0 +1,122 @@
+package welcome
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DisableEnvVar is the environment variable to disable welcome messages
+	DisableEnvVar = "KURTOSIS_DEVNET_DISABLE_WELCOME"
+
+	// DisableFlagFile is a file that can be created to disable welcome messages
+	DisableFlagFile = ".disable-welcome"
+
+	// DefaultWelcomeFile is the default file containing welcome messages
+	DefaultWelcomeFile = "welcome_messages.txt"
+)
+
+var defaultMessages = []string{
+	"Welcome to Kurtosis Devnet! Run 'just devnet-test DEVNET_NAME test-name.sh' to run tests against your devnet.",
+	"New feature: You can customize network configs using template files. Check the README for more details.",
+	"Tip: Use 'kurtosis enclave inspect DEVNET_NAME' to see details about your running devnet.",
+	"Did you know? You can run multiple devnets simultaneously with different configurations.",
+	"Need help? Check out the README.md file in the kurtosis-devnet directory for troubleshooting.",
+}
+
+// GetWelcomeMessage returns a random welcome message
+func GetWelcomeMessage(basePath string) (string, error) {
+	// Check if welcome messages are disabled
+	if isDisabled() {
+		return "", nil
+	}
+
+	messages, err := loadMessages(basePath)
+	if err != nil {
+		return "", err
+	}
+
+	if len(messages) == 0 {
+		return "", nil
+	}
+
+	// Seed random with current time
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Pick a random message
+	message := messages[r.Intn(len(messages))]
+
+	return formatMessage(message), nil
+}
+
+// isDisabled checks if welcome messages are disabled
+func isDisabled() bool {
+	// Check environment variable
+	if os.Getenv(DisableEnvVar) != "" {
+		return true
+	}
+
+	// Check for disable flag file in current directory
+	if _, err := os.Stat(DisableFlagFile); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// loadMessages loads welcome messages from file or uses defaults
+func loadMessages(basePath string) ([]string, error) {
+	welcomeFilePath := filepath.Join(basePath, DefaultWelcomeFile)
+
+	data, err := os.ReadFile(welcomeFilePath)
+	if err != nil {
+		// If file doesn't exist, use default messages
+		if os.IsNotExist(err) {
+			return defaultMessages, nil
+		}
+		return nil, fmt.Errorf("error reading welcome messages file: %w", err)
+	}
+
+	messages := strings.Split(string(data), "\n")
+
+	// Filter out empty lines
+	var filteredMessages []string
+	for _, msg := range messages {
+		msg = strings.TrimSpace(msg)
+		if msg != "" {
+			filteredMessages = append(filteredMessages, msg)
+		}
+	}
+
+	if len(filteredMessages) == 0 {
+		return defaultMessages, nil
+	}
+
+	return filteredMessages, nil
+}
+
+// formatMessage formats a welcome message with fancy borders
+func formatMessage(message string) string {
+	// Create a box around the message
+	width := len(message) + 4
+
+	var sb strings.Builder
+	sb.WriteString("\n\033[1;36m") // Cyan, bold
+
+	// Top border
+	sb.WriteString("+" + strings.Repeat("-", width-2) + "+\n")
+
+	// Message with side borders
+	sb.WriteString("| " + message + " |\n")
+
+	// Bottom border
+	sb.WriteString("+" + strings.Repeat("-", width-2) + "+")
+
+	sb.WriteString("\033[0m\n") // Reset color
+
+	return sb.String()
+}

--- a/kurtosis-devnet/pkg/welcome/welcome_messages.txt
+++ b/kurtosis-devnet/pkg/welcome/welcome_messages.txt
@@ -1,0 +1,10 @@
+Welcome to Kurtosis Devnet! The easiest way to run a local Optimism development environment.
+NEW FEATURE: All chains now support separate fileserver artifact archives for improved isolation.
+TIP: You can use 'just enter-devnet DEVNET_NAME CHAIN_NAME' to get a shell inside a devnet container.
+Did you know? Kurtosis Devnet supports multiple L2 chains with different configurations in the same environment.
+NEW FEATURE: Support for Isthmus upgrade is now available - try 'just isthmus-devnet'.
+TIP: Check out 'kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go' to see all available configuration options.
+TROUBLESHOOTING: If you encounter issues, try stopping the kurtosis engine with 'kurtosis engine stop' and try again.
+NEW FEATURE: The op-program service now supports multiple execution modes for testing fault proofs.
+TIP: Use 'kurtosis enclave ls' to see all running devnets on your system.
+Did you know? You can customize your devnet by creating a user yaml file and running 'just user-devnet YOUR_FILE.json'.

--- a/kurtosis-devnet/pkg/welcome/welcome_test.go
+++ b/kurtosis-devnet/pkg/welcome/welcome_test.go
@@ -1,0 +1,128 @@
+package welcome
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetWelcomeMessage(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "welcome-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Test case 1: No welcome file, should return a default message
+	msg, err := GetWelcomeMessage(tempDir)
+	if err != nil {
+		t.Errorf("GetWelcomeMessage returned error: %v", err)
+	}
+	if msg == "" {
+		t.Error("Expected a non-empty default message")
+	}
+
+	// Test case 2: Create a custom welcome file
+	testMessage := "This is a test welcome message"
+	welcomeFile := filepath.Join(tempDir, DefaultWelcomeFile)
+	err = os.WriteFile(welcomeFile, []byte(testMessage), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test welcome file: %v", err)
+	}
+
+	msg, err = GetWelcomeMessage(tempDir)
+	if err != nil {
+		t.Errorf("GetWelcomeMessage returned error: %v", err)
+	}
+	if !strings.Contains(msg, testMessage) {
+		t.Errorf("Message does not contain the expected content. Got: %s", msg)
+	}
+
+	// Test case 3: Disable welcome with environment variable
+	os.Setenv(DisableEnvVar, "1")
+	defer os.Unsetenv(DisableEnvVar)
+
+	msg, err = GetWelcomeMessage(tempDir)
+	if err != nil {
+		t.Errorf("GetWelcomeMessage returned error: %v", err)
+	}
+	if msg != "" {
+		t.Errorf("Expected empty message when disabled by env var, got: %s", msg)
+	}
+
+	// Test case 4: Disable welcome with flag file
+	os.Unsetenv(DisableEnvVar)
+	disableFile := filepath.Join(".", DisableFlagFile)
+	_, err = os.Create(disableFile)
+	if err != nil {
+		t.Fatalf("Failed to create disable flag file: %v", err)
+	}
+	defer os.Remove(disableFile)
+
+	msg, err = GetWelcomeMessage(tempDir)
+	if err != nil {
+		t.Errorf("GetWelcomeMessage returned error: %v", err)
+	}
+	if msg != "" {
+		t.Errorf("Expected empty message when disabled by flag file, got: %s", msg)
+	}
+}
+
+func TestLoadMessages(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "welcome-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Test case 1: No welcome file, should use default messages
+	messages, err := loadMessages(tempDir)
+	if err != nil {
+		t.Errorf("loadMessages returned error: %v", err)
+	}
+	if len(messages) != len(defaultMessages) {
+		t.Errorf("Expected %d default messages, got %d", len(defaultMessages), len(messages))
+	}
+
+	// Test case 2: Empty welcome file, should use default messages
+	welcomeFile := filepath.Join(tempDir, DefaultWelcomeFile)
+	err = os.WriteFile(welcomeFile, []byte(""), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test welcome file: %v", err)
+	}
+
+	messages, err = loadMessages(tempDir)
+	if err != nil {
+		t.Errorf("loadMessages returned error: %v", err)
+	}
+	if len(messages) != len(defaultMessages) {
+		t.Errorf("Expected %d default messages for empty file, got %d", len(defaultMessages), len(messages))
+	}
+
+	// Test case 3: Custom welcome file with multiple messages
+	customMessages := []string{
+		"Message 1",
+		"Message 2",
+		"Message 3",
+	}
+	err = os.WriteFile(welcomeFile, []byte(strings.Join(customMessages, "\n")), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test welcome file: %v", err)
+	}
+
+	messages, err = loadMessages(tempDir)
+	if err != nil {
+		t.Errorf("loadMessages returned error: %v", err)
+	}
+	if len(messages) != len(customMessages) {
+		t.Errorf("Expected %d custom messages, got %d", len(customMessages), len(messages))
+	}
+	for i, msg := range customMessages {
+		if messages[i] != msg {
+			t.Errorf("Message %d doesn't match expected value. Expected: %s, Got: %s", i, msg, messages[i])
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a rotatory welcome message feature to kurtosis-devnet that displays tips and announcements about new features. The welcome message is randomly selected from a list of messages stored in `welcome_messages.txt` and is displayed in a colored box at the beginning of each devnet run. Users can customize the messages by editing this text file or add their own announcements for team members. The feature can be disabled in three ways: by passing a `NO_WELCOME` parameter to any devnet command, by creating a `.disable-welcome` file, or by setting the `KURTOSIS_DEVNET_DISABLE_WELCOME` environment variable. The implementation is non-intrusive and gracefully handles errors without affecting the devnet deployment process. This enhancement improves discoverability of new features in kurtosis-devnet and provides a channel for communicating important information to users without requiring them to read documentation. Testing is included to ensure both the message display and disabling mechanisms work correctly.
resolves #15511 