### PR TITLE
op e2e: interop action test: cycle across chains at same timestamp

### DIFF
--- a/op-acceptance-tests/tests/interop/interop_test_helpers.go
+++ b/op-acceptance-tests/tests/interop/interop_test_helpers.go
@@ -110,6 +110,9 @@ func RandomTopicAndData(rng *rand.Rand, cnt, len int) ([][32]byte, []byte) {
 }
 
 func RandomInitTrigger(rng *rand.Rand, eventLoggerAddress common.Address, cnt, len int) *txintent.InitTrigger {
+	if cnt >= 5 {
+		panic(fmt.Sprintf("log holds at most 4 topics, got %d", cnt))
+	}
 	topics, data := RandomTopicAndData(rng, cnt, len)
 	return &txintent.InitTrigger{
 		Emitter:    eventLoggerAddress,

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -1097,3 +1097,82 @@ func TestCycleInBlock(gt *testing.T) {
 	unsafeHeadNumAfterReorg := targetNum - 1
 	reorgOutUnsafeAndConsolidateToSafe(t, actors, actors.ChainB, actors.ChainA, 0, 0, 1, targetNum, unsafeHeadNumAfterReorg)
 }
+
+// TestCycleAcrossChainsSameTimestamp tests below scenario:
+// Transaction B0 exec chain A1, A0 exec B1: cycle across chains: within same timestamp
+// Four transactions happen in same timestamp:
+// tx0: chainA: alice executes message X
+// tx1: chainB: bob executes message Y
+// tx2: chainB: bob initiates message X
+// tx3: chainA: alice initiates message Y
+// cycle: tx0 depends on tx3 (init exec relation) && tx3 depends on tx0 (tx order)
+// cycle: tx1 depends on tx2 (init exec relation) && tx2 depends on tx1 (tx order)
+func TestCycleAcrossChainsSameTimestamp(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	rng := rand.New(rand.NewSource(1234))
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	actors.PrepareChainState(t)
+	alice := setupUser(t, is, actors.ChainA, 0)
+	bob := setupUser(t, is, actors.ChainB, 0)
+
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	deployOptsA, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainA, 1), actors.ChainA)
+	eventLoggerAddressA := DeployEventLogger(t, deployOptsA)
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+	deployOptsB, _ := DefaultTxOpts(t, setupUser(t, is, actors.ChainB, 1), actors.ChainB)
+	eventLoggerAddressB := DeployEventLogger(t, deployOptsB)
+
+	assertHeads(t, actors.ChainA, 1, 0, 0, 0)
+	assertHeads(t, actors.ChainB, 1, 0, 0, 0)
+
+	targetTime := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime*2
+	targetNum := uint64(2)
+
+	// open blocks on both chains
+	actors.ChainA.Sequencer.ActL2StartBlock(t)
+	actors.ChainB.Sequencer.ActL2StartBlock(t)
+
+	// speculatively build exec message by knowing necessary info to build Message
+	logIndexX, logIndexY := uint(0), uint(0)
+	initX := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
+	execX, err := interop.ExecTriggerFromInitTrigger(initX, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+	require.NoError(t, err)
+	initY := interop.RandomInitTrigger(rng, eventLoggerAddressB, 7, 15)
+	execY, err := interop.ExecTriggerFromInitTrigger(initY, logIndexY, targetNum, targetTime, actors.ChainB.ChainID)
+	require.NoError(t, err)
+
+	intents := []*txintent.IntentTx[txintent.Call, *txintent.InteropOutput]{}
+
+	nonceA, nonceB := uint64(0), uint64(0)
+	// tx0: Intent to execute message X at chain A
+	submitIntent(t, execX, &nonceA, alice, actors.ChainA, &intents)
+	// tx1: Intent to execute message Y at chain B
+	submitIntent(t, execY, &nonceB, bob, actors.ChainB, &intents)
+	// tx2: Intent to initiate message X at chain B
+	submitIntent(t, initX, &nonceB, bob, actors.ChainB, &intents)
+	// tx3: Intent to initiate message Y at chain A
+	submitIntent(t, initY, &nonceA, alice, actors.ChainA, &intents)
+	require.Equal(t, uint64(2), nonceA)
+	require.Equal(t, uint64(2), nonceB)
+
+	actors.ChainA.Sequencer.ActL2EndBlock(t)
+	actors.ChainB.Sequencer.ActL2EndBlock(t)
+
+	// Make sure tx in block sealed at expected time
+	includedBlocks := []eth.BlockRef{}
+	for _, intent := range intents {
+		included, err := intent.PlannedTx.IncludedBlock.Eval(t.Ctx())
+		require.NoError(t, err)
+		require.Equal(t, included.Time, targetTime)
+		require.Equal(t, included.Number, targetNum)
+		includedBlocks = append(includedBlocks, included)
+	}
+	// tx0 and tx3 land in same block at chain A
+	require.Equal(t, includedBlocks[0], includedBlocks[3])
+	// tx1 and tx2 land in same block at chain B
+	require.Equal(t, includedBlocks[1], includedBlocks[2])
+
+	unsafeHeadNumAfterReorg := targetNum - 1
+	reorgOutUnsafeAndConsolidateToSafeBothChain(t, actors, actors.ChainA, actors.ChainB, 0, 0, targetNum, targetNum, unsafeHeadNumAfterReorg)
+}

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -1006,6 +1006,9 @@ func TestCycleInTx(gt *testing.T) {
 	reorgOutUnsafeAndConsolidateToSafe(t, actors, actors.ChainB, actors.ChainA, 0, 0, 1, targetNum, unsafeHeadNumAfterReorg)
 }
 
+// submitIntent method submits txintent to a chain.
+// Useful when building blocks with transactions, without block sealing.
+// It receives nonce because chain does not hold updated pending nonce yet because block sealing was not done.
 var submitIntent = func(
 	t helpers.StatefulTesting,
 	trigger txintent.Call,

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -1054,7 +1054,7 @@ func TestCycleInBlock(gt *testing.T) {
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 
 	nonce := uint64(0)
-	txCount := 2 + rng.Intn(20)
+	txCount := uint64(2 + rng.Intn(20))
 
 	// speculatively build exec message by knowing necessary info to build Message
 	init := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -1008,7 +1008,8 @@ func TestCycleInTx(gt *testing.T) {
 
 // submitIntent method submits txintent to a chain.
 // Useful when building blocks with transactions, without block sealing.
-// It receives nonce because chain does not hold updated pending nonce yet because block sealing was not done.
+// It receives nonce because chain does not hold updated pending nonce yet because the method assumes
+// block sealing is not done yet.
 var submitIntent = func(
 	t helpers.StatefulTesting,
 	trigger txintent.Call,

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -912,6 +912,23 @@ func TestCycleInTx(gt *testing.T) {
 	reorgOutUnsafeAndConsolidateToSafe(t, actors, actors.ChainB, actors.ChainA, 0, 0, 1, targetNum, unsafeHeadNumAfterReorg)
 }
 
+var submitIntent = func(
+	t helpers.StatefulTesting,
+	trigger txintent.Call,
+	nonce *uint64,
+	user *userWithKeys,
+	chain *dsl.Chain,
+	intents *[]*txintent.IntentTx[txintent.Call, *txintent.InteropOutput],
+) {
+	opts, _ := DefaultTxOptsWithoutBlockSeal(t, user, chain, *nonce)
+	intent := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](opts)
+	intent.Content.Set(trigger)
+	_, err := intent.PlannedTx.Submitted.Eval(t.Ctx())
+	require.NoError(t, err)
+	*intents = append(*intents, intent)
+	*nonce += 1
+}
+
 // TestCycleInBlock tests below scenario:
 // Transaction executes message, then initiates it: cycle in block
 // To elaborate, single block contains txs in below order:
@@ -949,30 +966,18 @@ func TestCycleInBlock(gt *testing.T) {
 	require.NoError(t, err)
 
 	intents := []*txintent.IntentTx[txintent.Call, *txintent.InteropOutput]{}
-	submitIntent := func(trigger txintent.Call, nonce uint64) {
-		opts, _ := DefaultTxOptsWithoutBlockSeal(t, alice, actors.ChainA, nonce)
-		intent := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](opts)
-		intent.Content.Set(trigger)
-		_, err := intent.PlannedTx.Submitted.Eval(t.Ctx())
-		require.NoError(t, err)
-		intents = append(intents, intent)
-	}
+
 	// include exec message X tx first in block
-	{
-		submitIntent(exec, nonce)
-		nonce += 1
-	}
+	submitIntent(t, exec, &nonce, alice, actors.ChainA, &intents)
 	// include dummy txs in block
 	for range txCount - 2 {
 		randomInitTrigger := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
-		submitIntent(randomInitTrigger, nonce)
-		nonce += 1
+		submitIntent(t, randomInitTrigger, &nonce, alice, actors.ChainA, &intents)
 	}
 	// include init message X last in block
-	{
-		submitIntent(init, nonce)
-		// no need to increment nonce since this is the last tx
-	}
+	submitIntent(t, init, &nonce, alice, actors.ChainA, &intents)
+	require.Equal(t, txCount, nonce)
+
 	actors.ChainA.Sequencer.ActL2EndBlock(t)
 
 	// Make sure tx in block sealed at expected time

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -361,12 +361,20 @@ func reorgOutUnsafeAndConsolidateToSafeBothChain(t helpers.Testing, actors *dsl.
 	t.Log("supervisor promotes cross-unsafe and safe")
 	actors.Supervisor.ProcessFull(t)
 
-	// check supervisor head, expect it to be rewound
-	for _, chain := range l2chains {
-		localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), chain.ChainID)
-		require.NoError(t, err)
-		require.Equal(t, unsafeHeadNumAfterReorg, localUnsafe.Number, "unsafe chain needs to be rewound")
-	}
+	t.Log("awaiting nodes to sync: local-safe to safe")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, chainX, endX, endX, endX, endX)
+	assertHeads(t, chainY, endY, endY, unsafeHeadNumAfterReorg, unsafeHeadNumAfterReorg)
+
+	t.Log("expecting supervisor to sync")
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	assertHeads(t, chainX, endX, endX, endX, endX)
+	assertHeads(t, chainY, endY, endY, unsafeHeadNumAfterReorg, unsafeHeadNumAfterReorg)
+
+	t.Log("supervisor promotes cross-unsafe and safe")
+	actors.Supervisor.ProcessFull(t)
 
 	t.Log("awaiting nodes to sync: local-safe to safe")
 	chainX.Sequencer.ActL2PipelineFull(t)
@@ -1109,8 +1117,11 @@ func TestCycleInBlock(gt *testing.T) {
 // tx1: chainB: bob executes message Y
 // tx2: chainB: bob initiates message X
 // tx3: chainA: alice initiates message Y
-// cycle: tx0 depends on tx3 (init exec relation) && tx3 depends on tx0 (tx order)
-// cycle: tx1 depends on tx2 (init exec relation) && tx2 depends on tx1 (tx order)
+// tx0 depends on tx2 (init exec relation)
+// tx3 depends on tx0 (tx order)
+// tx1 depends on tx3 (init exec relation)
+// tx2 depends on tx1 (tx order)
+// cycle: tx0 -> tx3 -> tx1 -> tx2 -> tx0
 func TestCycleAcrossChainsSameTimestamp(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))
@@ -1138,12 +1149,13 @@ func TestCycleAcrossChainsSameTimestamp(gt *testing.T) {
 	actors.ChainB.Sequencer.ActL2StartBlock(t)
 
 	// speculatively build exec message by knowing necessary info to build Message
-	logIndexX, logIndexY := uint(0), uint(0)
-	initX := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
-	execX, err := interop.ExecTriggerFromInitTrigger(initX, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+	// log index of init messages are 1, not 0 because exec message will firstly executed, emitting a single log
+	logIndexX, logIndexY := uint(1), uint(1)
+	initX := interop.RandomInitTrigger(rng, eventLoggerAddressB, 3, 10)
+	execX, err := interop.ExecTriggerFromInitTrigger(initX, logIndexX, targetNum, targetTime, actors.ChainB.ChainID)
 	require.NoError(t, err)
-	initY := interop.RandomInitTrigger(rng, eventLoggerAddressB, 7, 15)
-	execY, err := interop.ExecTriggerFromInitTrigger(initY, logIndexY, targetNum, targetTime, actors.ChainB.ChainID)
+	initY := interop.RandomInitTrigger(rng, eventLoggerAddressA, 2, 15)
+	execY, err := interop.ExecTriggerFromInitTrigger(initY, logIndexY, targetNum, targetTime, actors.ChainA.ChainID)
 	require.NoError(t, err)
 
 	intents := []*txintent.IntentTx[txintent.Call, *txintent.InteropOutput]{}
@@ -1176,6 +1188,22 @@ func TestCycleAcrossChainsSameTimestamp(gt *testing.T) {
 	require.Equal(t, includedBlocks[0], includedBlocks[3])
 	// tx1 and tx2 land in same block at chain B
 	require.Equal(t, includedBlocks[1], includedBlocks[2])
+
+	// confirm speculatively built exec message by rebuilding after tx inclusion
+	tx2 := intents[2]
+	_, err = tx2.Result.Eval(t.Ctx())
+	require.NoError(t, err)
+	// log index is 0 because tx emitted a single log
+	execX2, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &tx2.Result, 0)(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, execX2, execX)
+	tx3 := intents[3]
+	_, err = tx3.Result.Eval(t.Ctx())
+	require.NoError(t, err)
+	// log index is 0 because tx emitted a single log
+	execY2, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &tx3.Result, 0)(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, execY2, execY)
 
 	unsafeHeadNumAfterReorg := targetNum - 1
 	reorgOutUnsafeAndConsolidateToSafeBothChain(t, actors, actors.ChainA, actors.ChainB, 0, 0, targetNum, targetNum, unsafeHeadNumAfterReorg)

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -297,8 +297,8 @@ func reorgOutUnsafeAndConsolidateToSafe(t helpers.Testing, actors *dsl.InteropAc
 func reorgOutUnsafeAndConsolidateToSafeBothChain(t helpers.Testing, actors *dsl.InteropActors, chainX, chainY *dsl.Chain, startX, startY, endX, endY, unsafeHeadNumAfterReorg uint64) {
 	require.GreaterOrEqual(t, endY, unsafeHeadNumAfterReorg)
 	// Check to make batcher happy
-	require.Positive(t, endY-startY)
-	require.Positive(t, endX-startX)
+	require.Less(t, startX, endX)
+	require.Less(t, startY, endY)
 
 	chainX.Sequencer.ActL2PipelineFull(t)
 	chainY.Sequencer.ActL2PipelineFull(t)

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -291,6 +291,100 @@ func reorgOutUnsafeAndConsolidateToSafe(t helpers.Testing, actors *dsl.InteropAc
 	require.Equal(t, unsafeHeadNumAfterReorg+1, replacedBlock.Number)
 }
 
+// reorgOutUnsafeAndConsolidateToSafeBothChain assumes both chainX and chainY are reorged.
+// chain{X|Y} both expected to experience cross-unsafe invalidation and reorging unsafe blocks.
+// Consolidate with steps: unsafe -> cross-unsafe -> local-safe -> safe
+func reorgOutUnsafeAndConsolidateToSafeBothChain(t helpers.Testing, actors *dsl.InteropActors, chainX, chainY *dsl.Chain, startX, startY, endX, endY, unsafeHeadNumAfterReorg uint64) {
+	require.GreaterOrEqual(t, endY, unsafeHeadNumAfterReorg)
+	// Check to make batcher happy
+	require.Positive(t, endY-startY)
+	require.Positive(t, endX-startX)
+
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+
+	assertHeads(t, chainX, endX, startX, unsafeHeadNumAfterReorg, startX)
+	assertHeads(t, chainY, endY, startY, unsafeHeadNumAfterReorg, startY)
+
+	l2chains := []*dsl.Chain{chainX, chainY}
+
+	// check chains and supervisor views are consistent
+	reorgedOutBlocks := []eth.L2BlockRef{}
+	for _, chain := range l2chains {
+		reorgedOutBlock := chain.Sequencer.SyncStatus().UnsafeL2
+		require.Equal(t, unsafeHeadNumAfterReorg+1, reorgedOutBlock.Number)
+		localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), chain.ChainID)
+		require.NoError(t, err)
+		require.Equal(t, reorgedOutBlock.ID(), localUnsafe)
+		reorgedOutBlocks = append(reorgedOutBlocks, reorgedOutBlock)
+	}
+
+	// now try to advance safe heads
+	chainX.Batcher.ActSubmitAll(t)
+	chainY.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(chainX.BatcherAddr)(t)
+	actors.L1Miner.ActL1IncludeTx(chainY.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+
+	actors.Supervisor.SignalLatestL1(t)
+
+	t.Log("awaiting L1-exhaust event")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, chainX, endX, startX, unsafeHeadNumAfterReorg, startX)
+	assertHeads(t, chainY, endY, startY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("awaiting supervisor to provide L1 data")
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	assertHeads(t, chainX, endX, startX, unsafeHeadNumAfterReorg, startX)
+	assertHeads(t, chainY, endY, startY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("awaiting node to sync: unsafe to local-safe")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+	assertHeads(t, chainX, endX, endX, unsafeHeadNumAfterReorg, startX)
+	assertHeads(t, chainY, endY, endY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("expecting supervisor to sync")
+	chainX.Sequencer.SyncSupervisor(t)
+	chainY.Sequencer.SyncSupervisor(t)
+	assertHeads(t, chainX, endX, endX, unsafeHeadNumAfterReorg, startX)
+	assertHeads(t, chainY, endY, endY, unsafeHeadNumAfterReorg, startY)
+
+	t.Log("supervisor promotes cross-unsafe and safe")
+	actors.Supervisor.ProcessFull(t)
+
+	// check supervisor head, expect it to be rewound
+	for _, chain := range l2chains {
+		localUnsafe, err := actors.Supervisor.LocalUnsafe(t.Ctx(), chain.ChainID)
+		require.NoError(t, err)
+		require.Equal(t, unsafeHeadNumAfterReorg, localUnsafe.Number, "unsafe chain needs to be rewound")
+	}
+
+	t.Log("awaiting nodes to sync: local-safe to safe")
+	chainX.Sequencer.ActL2PipelineFull(t)
+	chainY.Sequencer.ActL2PipelineFull(t)
+
+	assertHeads(t, chainX, endX, endX, endX, endX)
+	assertHeads(t, chainY, endY, endY, endY, endY)
+
+	// Make sure the replaced blocks have different blockhash
+	for idx, chain := range l2chains {
+		reorgedOutBlock := reorgedOutBlocks[idx]
+		replacedBlock := chain.Sequencer.SyncStatus().LocalSafeL2
+		require.NotEqual(t, reorgedOutBlock.Hash, replacedBlock.Hash)
+		require.Equal(t, reorgedOutBlock.Number, replacedBlock.Number)
+		require.Equal(t, unsafeHeadNumAfterReorg+1, replacedBlock.Number)
+	}
+}
+
 func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	rng := rand.New(rand.NewSource(1234))


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Depends on https://github.com/ethereum-optimism/optimism/pull/15569

This PR adds op-e2e interop action test using txintent. Checks that
- Transaction B0 exec chain A1, A0 exec B1: cycle across chains.
    - [x] Within same timestamp (requires coordinated building, naive test may thus flake, needs to be accounted for): `TestCycleAcrossChainsSameTimestamp`

which are part of https://github.com/ethereum-optimism/optimism/issues/15092.

Also adds `reorgOutUnsafeAndConsolidateToSafeBothChain` helper since this test checks that both interoping chains unsafe reorges.

Refactor out `submitIntent` method for unsealed blocks to include transaction intents.

Ensure random init trigger does not create invalid log messages by panicking when topic count in single log is larger than 4(4 is max by `LOG4` opcode).

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15493
