### PR TITLE
fix(kt-devnet): support multiple depsets per devnet

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -75,6 +75,6 @@ type DevnetEnvironment struct {
 	L1 *Chain     `json:"l1"`
 	L2 []*L2Chain `json:"l2"`
 
-	Features []string `json:"features,omitempty"`
-	DepSets  []DepSet `json:"dep_sets,omitempty"`
+	Features []string          `json:"features,omitempty"`
+	DepSets  map[string]DepSet `json:"dep_sets,omitempty"`
 }

--- a/kurtosis-devnet/pkg/kurtosis/adapters.go
+++ b/kurtosis-devnet/pkg/kurtosis/adapters.go
@@ -47,7 +47,7 @@ var _ interfaces.JWTExtractor = (*enclaveJWTAdapter)(nil)
 
 type enclaveDepsetAdapter struct{}
 
-func (a *enclaveDepsetAdapter) ExtractData(ctx context.Context, enclave string) ([]descriptors.DepSet, error) {
+func (a *enclaveDepsetAdapter) ExtractData(ctx context.Context, enclave string) (map[string]descriptors.DepSet, error) {
 	return depset.NewExtractor(enclave).ExtractData(ctx)
 }
 

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -118,11 +118,11 @@ func (f *fakeJWTExtractor) ExtractData(ctx context.Context, enclave string) (*jw
 }
 
 type fakeDepsetExtractor struct {
-	data []descriptors.DepSet
+	data map[string]descriptors.DepSet
 	err  error
 }
 
-func (f *fakeDepsetExtractor) ExtractData(ctx context.Context, enclave string) ([]descriptors.DepSet, error) {
+func (f *fakeDepsetExtractor) ExtractData(ctx context.Context, enclave string) (map[string]descriptors.DepSet, error) {
 	return f.data, f.err
 }
 
@@ -427,7 +427,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 						},
 					},
 					Features: spec.FeatureList{spec.FeatureInterop},
-					DepSets:  []descriptors.DepSet{descriptors.DepSet(`{}`)},
+					DepSets:  map[string]descriptors.DepSet{"test-dep-set": descriptors.DepSet(`{}`)},
 				},
 			},
 		},
@@ -502,9 +502,9 @@ func TestGetEnvironmentInfo(t *testing.T) {
 			}
 
 			// Create depset data based on whether interop is enabled
-			var depsets []descriptors.DepSet
+			var depsets map[string]descriptors.DepSet
 			if tt.spec != nil && tt.spec.Features.Contains(spec.FeatureInterop) {
-				depsets = []descriptors.DepSet{descriptors.DepSet(`{}`)}
+				depsets = map[string]descriptors.DepSet{"test-dep-set": descriptors.DepSet(`{}`)}
 			}
 
 			deployer, err := NewKurtosisDeployer(

--- a/kurtosis-devnet/pkg/kurtosis/sources/interfaces/interfaces.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/interfaces/interfaces.go
@@ -28,5 +28,5 @@ type JWTExtractor interface {
 }
 
 type DepsetExtractor interface {
-	ExtractData(context.Context, string) ([]descriptors.DepSet, error)
+	ExtractData(context.Context, string) (map[string]descriptors.DepSet, error)
 }


### PR DESCRIPTION
**Description**

We now need to support multiple dependency sets within the same devnet.

This change adds room for it, and adjust naming conventions parsing to
accomodate the fact that kurtosis names supervisor instances with the
interop depset.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
