### PR TITLE
feat: Collect authoriship metrics for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1685,6 +1685,18 @@ jobs:
             MESSAGE: << parameters.message >>
             LABEL_NAME: << parameters.label_name >>
 
+  devnet-metrics-collect-authorship:
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    steps:
+      - utils/checkout-with-mise
+      - run:
+          name: Collect devnet metrics for op-acceptance-tests
+          command: ./devnet-sdk/scripts/metrics-collect-authorship.sh op-acceptance-tests/tests > .metrics--authorship--op-acceptance-tests
+      - store_artifacts:
+          path: .metrics--authorship--op-acceptance-tests
+          destination: metrics--authorship--op-acceptance-tests
+
 workflows:
   main:
     when:
@@ -2336,3 +2348,16 @@ workflows:
                 This issue will be closed now."
          context:
           - circleci-repo-optimism
+
+  devnet-metrics-collect:
+    when:
+      and:
+        # FIXME change to develop after testing
+        - equal: ["jan/metrics--authors", <<pipeline.git.branch>>]
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+
+    jobs:
+      - devnet-metrics-collect-authorship:
+          context:
+            - circleci-repo-readonly-authenticated-github-token

--- a/devnet-sdk/scripts/metrics-collect-authorship.sh
+++ b/devnet-sdk/scripts/metrics-collect-authorship.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIRECTORY=$1
+if [ -z "$DIRECTORY" ]; then
+  echo "Usage: $0 <directory>"
+  exit 1
+fi
+
+# - We list all the tracked files in the specified directory
+# - We blame the files (using porcelain for easy consumption)
+# - We take the author emails out of the blame output
+# - We replace the <brackets around the emails>
+# - We sort the emails and remove duplicates
+git ls-files -z "$DIRECTORY" \
+    | xargs -0n1 git --no-pager blame --porcelain \
+    | sed -n -e '/^author-mail /s/^author-mail //p' \
+    | sed -e 's/[<>]//g' \
+    | sort | uniq


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Stub of authorship metrics collection for devnet SDK tests. At the moment, the script produces a newline-delimited list of developers (their emails) that contributed to `op-acceptance-tests/tests` directory and uploads it as an artifact.

This artifact can then be ingested into a downstream analytics pipeline. Down the line the artifact storing should be replaced with a better data pool.