### PR TITLE
op-node/p2p: expand PeerScores metrics and p2p store to be multi-topic

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -245,7 +245,7 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "peer_scores",
 			Help:      "Histogram of currently connected peer scores",
 			Buckets:   []float64{-100, -40, -20, -10, -5, -2, -1, -0.5, -0.05, 0, 0.05, 0.5, 1, 2, 5, 10, 20, 40},
-		}, []string{"type"}),
+		}, []string{"type", "topic"}),
 		StreamCount: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Subsystem: "p2p",
@@ -403,17 +403,21 @@ func NewMetrics(procName string) *Metrics {
 // Accepts a slice of peer scores in any order.
 func (m *Metrics) SetPeerScores(allScores []store.PeerScores) {
 	for _, scores := range allScores {
-		m.PeerScores.WithLabelValues("total").Observe(scores.Gossip.Total)
-		m.PeerScores.WithLabelValues("ipColocation").Observe(scores.Gossip.IPColocationFactor)
-		m.PeerScores.WithLabelValues("behavioralPenalty").Observe(scores.Gossip.BehavioralPenalty)
-		m.PeerScores.WithLabelValues("blocksFirstMessage").Observe(scores.Gossip.Blocks.FirstMessageDeliveries)
-		m.PeerScores.WithLabelValues("blocksTimeInMesh").Observe(scores.Gossip.Blocks.TimeInMesh)
-		m.PeerScores.WithLabelValues("blocksMessageDeliveries").Observe(scores.Gossip.Blocks.MeshMessageDeliveries)
-		m.PeerScores.WithLabelValues("blocksInvalidMessageDeliveries").Observe(scores.Gossip.Blocks.InvalidMessageDeliveries)
+		m.PeerScores.WithLabelValues("total", "global").Observe(scores.Gossip.Total)
+		m.PeerScores.WithLabelValues("ipColocation", "global").Observe(scores.Gossip.IPColocationFactor)
+		m.PeerScores.WithLabelValues("behavioralPenalty", "global").Observe(scores.Gossip.BehavioralPenalty)
 
-		m.PeerScores.WithLabelValues("reqRespValidResponses").Observe(scores.ReqResp.ValidResponses)
-		m.PeerScores.WithLabelValues("reqRespErrorResponses").Observe(scores.ReqResp.ErrorResponses)
-		m.PeerScores.WithLabelValues("reqRespRejectedPayloads").Observe(scores.ReqResp.RejectedPayloads)
+		m.PeerScores.WithLabelValues("reqRespValidResponses", "global").Observe(scores.ReqResp.ValidResponses)
+		m.PeerScores.WithLabelValues("reqRespErrorResponses", "global").Observe(scores.ReqResp.ErrorResponses)
+		m.PeerScores.WithLabelValues("reqRespRejectedPayloads", "global").Observe(scores.ReqResp.RejectedPayloads)
+
+		for topic, scores := range scores.Gossip.Blocks {
+			m.PeerScores.WithLabelValues("blocksFirstMessage", topic).Observe(scores.FirstMessageDeliveries)
+			m.PeerScores.WithLabelValues("blocksTimeInMesh", topic).Observe(scores.TimeInMesh)
+			m.PeerScores.WithLabelValues("blocksMessageDeliveries", topic).Observe(scores.MeshMessageDeliveries)
+			m.PeerScores.WithLabelValues("blocksInvalidMessageDeliveries", topic).Observe(scores.InvalidMessageDeliveries)
+		}
+
 	}
 }
 

--- a/op-node/p2p/peer_scorer.go
+++ b/op-node/p2p/peer_scorer.go
@@ -61,22 +61,23 @@ func NewScorer(cfg *rollup.Config, peerStore Peerstore, metricer ScoreMetrics, a
 // The returned [pubsub.ExtendedPeerScoreInspectFn] is called with a mapping of peer IDs to peer score snapshots.
 // The incoming peer score snapshots only contain gossip-score components.
 func (s *scorer) SnapshotHook() pubsub.ExtendedPeerScoreInspectFn {
-	blocksTopicName := blocksTopicV1(s.cfg)
 	return func(m map[peer.ID]*pubsub.PeerScoreSnapshot) {
 		allScores := make([]store.PeerScores, 0, len(m))
 		// Now set the new scores.
 		for id, snap := range m {
 			diff := store.GossipScores{
 				Total:              snap.Score,
-				Blocks:             store.TopicScores{},
+				Blocks:             make(map[string]store.TopicScores),
 				IPColocationFactor: snap.IPColocationFactor,
 				BehavioralPenalty:  snap.BehaviourPenalty,
 			}
-			if topSnap, ok := snap.Topics[blocksTopicName]; ok {
-				diff.Blocks.TimeInMesh = float64(topSnap.TimeInMesh) / float64(time.Second)
-				diff.Blocks.MeshMessageDeliveries = topSnap.MeshMessageDeliveries
-				diff.Blocks.FirstMessageDeliveries = topSnap.FirstMessageDeliveries
-				diff.Blocks.InvalidMessageDeliveries = topSnap.InvalidMessageDeliveries
+			for topic, topSnap := range snap.Topics {
+				diff.Blocks[topic] = store.TopicScores{
+					TimeInMesh:               float64(topSnap.TimeInMesh) / float64(time.Second),
+					MeshMessageDeliveries:    topSnap.MeshMessageDeliveries,
+					FirstMessageDeliveries:   topSnap.FirstMessageDeliveries,
+					InvalidMessageDeliveries: topSnap.InvalidMessageDeliveries,
+				}
 			}
 			if peerScores, err := s.peerStore.SetScore(id, &diff); err != nil {
 				s.log.Warn("Unable to update peer gossip score", "err", err)

--- a/op-node/p2p/peer_scorer_test.go
+++ b/op-node/p2p/peer_scorer_test.go
@@ -49,9 +49,10 @@ func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 	)
 	inspectFn := scorer.SnapshotHook()
 
+	emptyBlocks := make(map[string]store.TopicScores)
 	scores := store.PeerScores{Gossip: store.GossipScores{Total: 3}}
 	// Expect updating the peer store
-	testSuite.mockStore.On("SetScore", peer.ID("peer1"), &store.GossipScores{Total: float64(-100)}).Return(scores, nil).Once()
+	testSuite.mockStore.On("SetScore", peer.ID("peer1"), &store.GossipScores{Total: float64(-100), Blocks: emptyBlocks}).Return(scores, nil).Once()
 
 	// The metricer should then be called with the peer score band map
 	testSuite.mockMetricer.On("SetPeerScores", []store.PeerScores{scores}).Return(nil).Once()
@@ -65,7 +66,7 @@ func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 	inspectFn(snapshotMap)
 
 	// Expect updating the peer store
-	testSuite.mockStore.On("SetScore", peer.ID("peer1"), &store.GossipScores{Total: 0}).Return(scores, nil).Once()
+	testSuite.mockStore.On("SetScore", peer.ID("peer1"), &store.GossipScores{Total: 0, Blocks: emptyBlocks}).Return(scores, nil).Once()
 
 	// The metricer should then be called with the peer score band map
 	testSuite.mockMetricer.On("SetPeerScores", []store.PeerScores{scores}).Return(nil).Once()

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -18,10 +18,10 @@ type TopicScores struct {
 }
 
 type GossipScores struct {
-	Total              float64     `json:"total"`
-	Blocks             TopicScores `json:"blocks"` // fully zeroed if the peer has not been in the mesh on the topic
-	IPColocationFactor float64     `json:"IPColocationFactor"`
-	BehavioralPenalty  float64     `json:"behavioralPenalty"`
+	Total              float64                `json:"total"`
+	Blocks             map[string]TopicScores `json:"blocks"` // fully zeroed if the peer has not been in the mesh on the topic
+	IPColocationFactor float64                `json:"IPColocationFactor"`
+	BehavioralPenalty  float64                `json:"behavioralPenalty"`
 }
 
 func (g GossipScores) Apply(rec *scoreRecord) {

--- a/op-node/p2p/store/scorebook_test.go
+++ b/op-node/p2p/store/scorebook_test.go
@@ -174,7 +174,7 @@ func TestPrune(t *testing.T) {
 	hasScoreRecorded := func(id peer.ID) bool {
 		scores, err := book.GetPeerScores(id)
 		require.NoError(t, err)
-		return scores != PeerScores{}
+		return scores.Gossip.Total != 0
 	}
 
 	firstStore := clock.Now()
@@ -228,7 +228,7 @@ func TestPruneMultipleBatches(t *testing.T) {
 	hasScoreRecorded := func(id peer.ID) bool {
 		scores, err := book.GetPeerScores(id)
 		require.NoError(t, err)
-		return scores != PeerScores{}
+		return scores.Gossip.Total != 0
 	}
 
 	// Set scores for more peers than the max batch size

--- a/op-node/p2p/store/serialize_test.go
+++ b/op-node/p2p/store/serialize_test.go
@@ -31,16 +31,18 @@ func TestParseHistoricSerializationsV0(t *testing.T) {
 		expected scoreRecord
 	}{
 		{
-			data: `{"peerScores":{"gossip":{"total":1234.52382,"blocks":{"timeInMesh":1234,"firstMessageDeliveries":12,"meshMessageDeliveries":34,"invalidMessageDeliveries":56},"IPColocationFactor":12.34,"behavioralPenalty":56.78},"reqRespSync":123456},"lastUpdate":1923841}`,
+			data: `{"peerScores":{"gossip":{"total":1234.52382,"blocks":{"topic":{"timeInMesh":1234,"firstMessageDeliveries":12,"meshMessageDeliveries":34,"invalidMessageDeliveries":56}},"IPColocationFactor":12.34,"behavioralPenalty":56.78},"reqRespSync":123456},"lastUpdate":1923841}`,
 			expected: scoreRecord{
 				PeerScores: PeerScores{
 					Gossip: GossipScores{
 						Total: 1234.52382,
-						Blocks: TopicScores{
-							TimeInMesh:               1234,
-							FirstMessageDeliveries:   12,
-							MeshMessageDeliveries:    34,
-							InvalidMessageDeliveries: 56,
+						Blocks: map[string]TopicScores{
+							"topic": {
+								TimeInMesh:               1234,
+								FirstMessageDeliveries:   12,
+								MeshMessageDeliveries:    34,
+								InvalidMessageDeliveries: 56,
+							},
 						},
 						IPColocationFactor: 12.34,
 						BehavioralPenalty:  56.78,
@@ -51,16 +53,18 @@ func TestParseHistoricSerializationsV0(t *testing.T) {
 			},
 		},
 		{
-			data: `{"peerScores":{"gossip":{"total":1234.52382,"blocks":{"timeInMesh":1234,"firstMessageDeliveries":12,"meshMessageDeliveries":34,"invalidMessageDeliveries":56},"IPColocationFactor":12.34,"behavioralPenalty":56.78},"reqResp":{"validResponses":99,"errorResponses":88,"rejectedPayloads":77}},"lastUpdate":1923841}`,
+			data: `{"peerScores":{"gossip":{"total":1234.52382,"blocks":{"topic":{"timeInMesh":1234,"firstMessageDeliveries":12,"meshMessageDeliveries":34,"invalidMessageDeliveries":56}},"IPColocationFactor":12.34,"behavioralPenalty":56.78},"reqResp":{"validResponses":99,"errorResponses":88,"rejectedPayloads":77}},"lastUpdate":1923841}`,
 			expected: scoreRecord{
 				PeerScores: PeerScores{
 					Gossip: GossipScores{
 						Total: 1234.52382,
-						Blocks: TopicScores{
-							TimeInMesh:               1234,
-							FirstMessageDeliveries:   12,
-							MeshMessageDeliveries:    34,
-							InvalidMessageDeliveries: 56,
+						Blocks: map[string]TopicScores{
+							"topic": {
+								TimeInMesh:               1234,
+								FirstMessageDeliveries:   12,
+								MeshMessageDeliveries:    34,
+								InvalidMessageDeliveries: 56,
+							},
 						},
 						IPColocationFactor: 12.34,
 						BehavioralPenalty:  56.78,


### PR DESCRIPTION
Related to #15297.

This allows some metrics to be filtered by topic -- e.g. we can plot the "time in mesh" separately for each topic (until now, we could only see the metric for `blocksTopicV1` which is very old.

