### PR TITLE
fix comment of preimage oracle key of blob element

### DIFF
--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -343,7 +343,7 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 		}
 
 		// Put all of the blob's field elements into the kv store. There should be 4096. The preimage oracle key for
-		// each field element is the keccak256 hash of `abi.encodePacked(sidecar.KZGCommitment, uint256(i))`
+		// each field element is the keccak256 hash of `abi.encodePacked(sidecar.KZGCommitment, RootsOfUnity[i])`
 		blobKey := make([]byte, 80)
 		copy(blobKey[:48], sidecar.KZGCommitment[:])
 		for i := 0; i < params.BlobTxFieldElementsPerBlob; i++ {


### PR DESCRIPTION
This PR makes the comment consistent with the code after [this](https://github.com/ethereum-optimism/optimism/pull/15354) PR.