### PR TITLE
op-{program,supervisor}: Short-circuit inclusion check of expired msgs

### DIFF
--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -151,7 +151,7 @@ func singleRoundConsolidation(
 	if err != nil {
 		return fmt.Errorf("failed to get dependency set: %w", err)
 	}
-	deps, err := newConsolidateCheckDeps(depset, bootInfo, consolidateState.TransitionState, superRoot.Chains, l2PreimageOracle, consolidateState)
+	deps, err := newConsolidateCheckDeps(depset, bootInfo.Configs, consolidateState.TransitionState, superRoot.Chains, l2PreimageOracle, consolidateState)
 	if err != nil {
 		return fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
@@ -265,7 +265,7 @@ type consolidateCheckDeps struct {
 
 func newConsolidateCheckDeps(
 	depset depset.DependencySet,
-	bootInfo *boot.BootInfoInterop,
+	configSource boot.ConfigSource,
 	transitionState *types.TransitionState,
 	chains []eth.ChainIDAndOutput,
 	oracle l2.Oracle,
@@ -281,7 +281,7 @@ func newConsolidateCheckDeps(
 		blockByHash := func(hash common.Hash) *ethtypes.Block {
 			return oracle.BlockByHash(hash, chain.ChainID)
 		}
-		l2ChainConfig, err := bootInfo.Configs.ChainConfig(chain.ChainID)
+		l2ChainConfig, err := configSource.ChainConfig(chain.ChainID)
 		if err != nil {
 			return nil, fmt.Errorf("no chain config available for chain ID %v: %w", chain.ChainID, err)
 		}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -460,6 +460,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 			return opened, 0, execs, nil
 		}
 		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
+			require.Fail(t, "unexpected checkFn call. expected short-circuit for expired message")
 			return types.BlockSeal{}, errors.New("unexpected checkFn call. expected short-circuit")
 		}
 		// when OpenBlock and CandidateCrossSafe return different blocks,

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -459,6 +459,9 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 0, execs, nil
 		}
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
+			return types.BlockSeal{}, errors.New("unexpected checkFn call. expected short-circuit")
+		}
 		// when OpenBlock and CandidateCrossSafe return different blocks,
 		// an ErrConflict is returned
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)


### PR DESCRIPTION
This patch reduces the processing cost of expired messages in the supervisor by skipping database reads for expired messages.

More critically, it fixes a DoS vector in the Fault Proof by ensuring that the linear search for canonical blocks is bounded by the expiry window. Otherwise, it could be possible for an attacker to induce a fault proof that is too expensive to generate in a FPVM.

fixes https://github.com/ethereum-optimism/optimism/issues/15169