### PR TITLE
op-supervisor: add dependencySet API

### DIFF
--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -31,5 +32,6 @@ type SupervisorQueryAPI interface {
 	FinalizedL1(ctx context.Context) (eth.BlockRef, error)
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
 	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
+	DependencySet(ctx context.Context) (depset.DependencySet, error)
 	AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error)
 }

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -116,6 +117,12 @@ func (cl *SupervisorClient) AllSafeDerivedAt(ctx context.Context, derivedFrom et
 
 func (cl *SupervisorClient) SyncStatus(ctx context.Context) (result eth.SupervisorSyncStatus, err error) {
 	err = cl.client.CallContext(ctx, &result, "supervisor_syncStatus")
+	return result, err
+}
+
+func (cl *SupervisorClient) DependencySet(ctx context.Context) (depset.DependencySet, error) {
+	var result *depset.StaticConfigDependencySet
+	err := cl.client.CallContext(ctx, &result, "supervisor_dependencySet")
 	return result, err
 }
 

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -421,13 +421,6 @@ func (su *SupervisorBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret
 	return err
 }
 
-// Internal methods, for processors
-// ----------------------------
-
-func (su *SupervisorBackend) DependencySet() depset.DependencySet {
-	return su.depSet
-}
-
 // Query methods
 // ----------------------------
 
@@ -726,6 +719,10 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 
 func (su *SupervisorBackend) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
 	return su.statusTracker.SyncStatus()
+}
+
+func (su *SupervisorBackend) DependencySet(ctx context.Context) (depset.DependencySet, error) {
+	return su.depSet, nil
 }
 
 // PullLatestL1 makes the supervisor aware of the latest L1 block. Exposed for testing purposes.

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -173,6 +173,16 @@ type mockDependencySet struct {
 	messageExpiryWindow uint64
 }
 
+func (m mockDependencySet) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("unsupported")
+}
+
+func (m mockDependencySet) UnmarshalJSON(bytes []byte) error {
+	return errors.New("unsupported")
+}
+
+var _ depset.DependencySet = (*mockDependencySet)(nil)
+
 func (m mockDependencySet) CanExecuteAt(chain eth.ChainID, timestamp uint64) (bool, error) {
 	if m.canExecuteAtfn != nil {
 		return m.canExecuteAtfn()

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -2,6 +2,7 @@ package depset
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -41,6 +42,9 @@ type DependencySet interface {
 
 	ChainIndexFromID
 	ChainIDFromIndex
+
+	json.Marshaler
+	json.Unmarshaler
 }
 
 type ChainIndexFromID interface {

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/frontend"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type MockBackend struct {
@@ -78,6 +80,10 @@ func (m *MockBackend) SuperRootAtTimestamp(ctx context.Context, timestamp hexuti
 
 func (m *MockBackend) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
 	return eth.SupervisorSyncStatus{}, nil
+}
+
+func (m *MockBackend) DependencySet(ctx context.Context) (depset.DependencySet, error) {
+	return nil, errors.New("not supported")
 }
 
 func (m *MockBackend) Close() error {

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -63,6 +64,10 @@ func (q *QueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.Bl
 
 func (q *QueryFrontend) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
 	return q.Supervisor.SyncStatus(ctx)
+}
+
+func (q *QueryFrontend) DependencySet(ctx context.Context) (depset.DependencySet, error) {
+	return q.Supervisor.DependencySet(ctx)
 }
 
 type AdminFrontend struct {


### PR DESCRIPTION
**Description**

Make the dependency set config available in the op-supervisor API.

Work in progress: adding specs for this RPC method.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15048
