### PR TITLE
chore(op-node): Remove dead deposit source

### DIFF
--- a/op-node/rollup/derive/deposit_source.go
+++ b/op-node/rollup/derive/deposit_source.go
@@ -12,12 +12,14 @@ type UserDepositSource struct {
 	LogIndex    uint64
 }
 
+// NOTE: Source domain `3` is deprecated and unused in the protocol. In an early version of the interop feature,
+// it was used to signify the source domain of "deposit context window" transactions. This has since been removed
+// in favor of access-list based checks in the `CrossL2Inbox` predeploy.
 const (
-	UserDepositSourceDomain       = 0
-	L1InfoDepositSourceDomain     = 1
-	UpgradeDepositSourceDomain    = 2
-	AfterForceIncludeSourceDomain = 3
-	InvalidatedBlockSourceDomain  = 4
+	UserDepositSourceDomain      = 0
+	L1InfoDepositSourceDomain    = 1
+	UpgradeDepositSourceDomain   = 2
+	InvalidatedBlockSourceDomain = 4
 )
 
 func (dep *UserDepositSource) SourceHash() common.Hash {
@@ -63,24 +65,6 @@ func (dep *UpgradeDepositSource) SourceHash() common.Hash {
 	var domainInput [32 * 2]byte
 	binary.BigEndian.PutUint64(domainInput[32-8:32], UpgradeDepositSourceDomain)
 	copy(domainInput[32:], intentHash[:])
-	return crypto.Keccak256Hash(domainInput[:])
-}
-
-// AfterForceIncludeSource identifies the DepositsComplete post-user-deposits deposit-transaction.
-type AfterForceIncludeSource struct {
-	L1BlockHash common.Hash
-	SeqNumber   uint64 // without this the Deposit tx would have the same tx hash for every time the L1 info repeats.
-}
-
-func (dep *AfterForceIncludeSource) SourceHash() common.Hash {
-	var input [32 * 2]byte
-	copy(input[:32], dep.L1BlockHash[:])
-	binary.BigEndian.PutUint64(input[32*2-8:], dep.SeqNumber)
-	depositIDHash := crypto.Keccak256Hash(input[:])
-
-	var domainInput [32 * 2]byte
-	binary.BigEndian.PutUint64(domainInput[32-8:32], AfterForceIncludeSourceDomain)
-	copy(domainInput[32:], depositIDHash[:])
 	return crypto.Keccak256Hash(domainInput[:])
 }
 

--- a/op-node/rollup/derive/deposit_source_test.go
+++ b/op-node/rollup/derive/deposit_source_test.go
@@ -51,21 +51,6 @@ func TestL1InfoDepositSource(t *testing.T) {
 	assert.Equal(t, expected, actual.Hex())
 }
 
-// TestAfterForceIncludeSourceHash
-// cast keccak $(cast concat-hex 0x0000000000000000000000000000000000000000000000000000000000000003 $(cast keccak $(cast concat-hex 0xc00e5d67c2755389aded7d8b151cbd5bcdf7ed275ad5e028b664880fc7581c77 0x0000000000000000000000000000000000000000000000000000000000000004)))
-// # 0x0d165c391384b29c29f655e3f32315755b8c1e4c1147d1824d1243420dda5ec3
-func TestAfterForceIncludeSource(t *testing.T) {
-	source := AfterForceIncludeSource{
-		L1BlockHash: common.HexToHash("0xc00e5d67c2755389aded7d8b151cbd5bcdf7ed275ad5e028b664880fc7581c77"),
-		SeqNumber:   4,
-	}
-
-	actual := source.SourceHash()
-	expected := "0x0d165c391384b29c29f655e3f32315755b8c1e4c1147d1824d1243420dda5ec3"
-
-	assert.Equal(t, expected, actual.Hex())
-}
-
 // TestInvalidatedBlockSource
 // cast keccak $(cast concat-hex 0x0000000000000000000000000000000000000000000000000000000000000004 0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8)
 // # 0x4a62bcfa03cf778234ae28fa39c9e0748f11099997b19fef9bb3fffc154fe456


### PR DESCRIPTION
## Overview

Removes the dead `AfterForceInclude` deposit source. Retained a comment in the source domain constant declarations for context on why `3` is unused.