### PR TITLE
interop: supervisor: fix cycle detection logic

### DIFF
--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -173,15 +173,6 @@ func buildGraph(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 				return nil, ErrExecMsgUnknownChain
 			}
 
-			// Check if we care about the init message
-			initChainMsgs, ok := execMsgs[m.Chain]
-			if !ok {
-				continue
-			}
-			if _, ok := initChainMsgs[m.LogIdx]; !ok {
-				continue
-			}
-
 			// Check if the init message exists
 			if logCount, ok := logCounts[m.Chain]; !ok || m.LogIdx >= logCount {
 				return nil, fmt.Errorf("%w: initiating message log index out of bounds", types.ErrConflict)

--- a/op-supervisor/supervisor/backend/cross/cycle_test.go
+++ b/op-supervisor/supervisor/backend/cross/cycle_test.go
@@ -353,45 +353,6 @@ func TestHazardCycleChecksNoCycle(t *testing.T) {
 			},
 			msg: "expected no cycle found first log is exec",
 		},
-		{
-			name: "cycle through older timestamp",
-			chainBlocks: map[string]chainBlockDef{
-				"1": {
-					logCount: 2,
-					messages: map[uint32]*types.ExecutingMessage{
-						0: execMsg("2", 0),
-						1: execMsgWithTimestamp("2", 1, 101),
-					},
-				},
-				"2": {
-					logCount: 2,
-					messages: map[uint32]*types.ExecutingMessage{
-						0: execMsg("1", 1),
-					},
-				},
-			},
-			msg: "expected no cycle detection error for cycle through messages with different timestamps",
-		},
-		// This should be caught by earlier validations, but included for completeness.
-		{
-			name: "cycle through younger timestamp",
-			chainBlocks: map[string]chainBlockDef{
-				"1": {
-					logCount: 2,
-					messages: map[uint32]*types.ExecutingMessage{
-						0: execMsg("2", 0),
-						1: execMsgWithTimestamp("2", 1, 99),
-					},
-				},
-				"2": {
-					logCount: 2,
-					messages: map[uint32]*types.ExecutingMessage{
-						0: execMsg("1", 1),
-					},
-				},
-			},
-			msg: "expected no cycle detection error for cycle through messages with different timestamps",
-		},
 	}
 	runHazardCycleChecksTestCaseGroup(t, "NoCycle", tests)
 }
@@ -527,6 +488,51 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			},
 			msg: "expected cycle detection error for cycle through executing messages",
 		},
+		{
+			name: "cycle through single chain, exec message prior to init and adjacent",
+			chainBlocks: map[string]chainBlockDef{
+				"1": {
+					logCount: 2,
+					messages: map[uint32]*types.ExecutingMessage{
+						0: execMsg("1", 1),
+					},
+				},
+			},
+			expectErr: ErrCycle,
+			msg:       "expected cycle detection error",
+		},
+		{
+			name: "cycle through single chain, exec message prior to init and not adjacent",
+			chainBlocks: map[string]chainBlockDef{
+				"1": {
+					logCount: 3,
+					messages: map[uint32]*types.ExecutingMessage{
+						0: execMsg("1", 2),
+					},
+				},
+			},
+			expectErr: ErrCycle,
+			msg:       "expected cycle detection error",
+		},
+		{
+			name: "3-cycle across chains",
+			chainBlocks: map[string]chainBlockDef{
+				"1": {
+					logCount: 2,
+					messages: map[uint32]*types.ExecutingMessage{
+						0: execMsg("2", 0),
+					},
+				},
+				"2": {
+					logCount: 2,
+					messages: map[uint32]*types.ExecutingMessage{
+						0: execMsg("1", 1),
+					},
+				},
+			},
+			expectErr: ErrCycle,
+			msg:       "expected cycle detection error",
+		},
 	}
 	runHazardCycleChecksTestCaseGroup(t, "Cycle", tests)
 }
@@ -571,7 +577,6 @@ func TestHazardCycleChecksLargeGraphCycle(t *testing.T) {
 	chainBlocks := make(map[string]chainBlockDef)
 	for i := 1; i <= largeGraphChains; i++ {
 		msgs := make(map[uint32]*types.ExecutingMessage)
-
 		// Create a chain of dependencies across chains
 		if i > 1 {
 			for j := uint32(0); j < largeGraphLogsPerChain; j++ {

--- a/op-supervisor/supervisor/backend/cross/cycle_test.go
+++ b/op-supervisor/supervisor/backend/cross/cycle_test.go
@@ -372,9 +372,12 @@ func TestHazardCycleChecksNoCycle(t *testing.T) {
 }
 
 func TestHazardCycleChecksCycle(t *testing.T) {
+	// Comment cycle notation: `executing message -> corresponding initiating message`
+	// The index of the log itself is used as name of the message.
+	// For different chains, "A" or "B", etc. may be prefixed, to identify the chain with the corresponding chain index. (A=0, B=1, etc.)
 	tests := []hazardCycleChecksTestCase{
 		{
-			// 0->1->2->0
+			// 0->2->1->0  - executing message pointing to the future, cycle completed by regular log ordering
 			name: "3-cycle in single chain",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -388,8 +391,8 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
-			// 0->1->2->0
-			// 0->2->0
+			// 0->2->0   - both the executing messages
+			// 0->2->1->0  - first executing message combined with regular log-ordering dependencies
 			name: "3-cycle in single chain, 2-cycle in single chain with first log",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -434,8 +437,8 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
-			// 1->3->1
-			// 1->2->3->1
+			// 1->3->1  - two executing messages
+			// 1->3->2->1  - one executing message and regular log ordering
 			name: "2,3-cycle in single chain, not first, not adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -470,9 +473,10 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error for cycle through executing messages",
 		},
 		{
-			// 1->2->1
-			// 2->3->2
-			// 1->3->2->1
+			// 1->2->1  - 1 executes the next log, forming a small cycle
+			// 2->3->2  - 2 executes the next log, forming a small cycle
+			// 3->1->2->3  - (3->1) is a valid executing message, but part of a larger cycle where 2 and 1 depend on the next future log.
+			// 3->2->1->2->3  - we have the regular order of logs, and then multiple logs pointing to the future logs, making an even larger cycle.
 			name: "2,2,3-cycle in single chain",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -488,8 +492,8 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error for 3-node cycle",
 		},
 		{
-			// 1->2->3->4->5->1
-			// 1->2->5->1
+			// 1->5->4->3->2->1  - executing message, and multiple regular log ordering steps
+			// 1->5->2->1 - two executing messages and single regular log ordering dependency
 			name: "cycle through adjacency dependency",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -544,7 +548,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
-			// 0->1->2->0
+			// 0->2->1->0
 			name: "cycle through single chain, exec message prior to init and not adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -558,7 +562,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
-			// A1->B0->A0->A1
+			// A0->B0->A1->A0  - A may not depend on a log of B that depends on the future of A
 			name: "3-cycle across chains",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {

--- a/op-supervisor/supervisor/backend/cross/cycle_test.go
+++ b/op-supervisor/supervisor/backend/cross/cycle_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+const testDefaultTimestamp = 100
+
 type testDepSet struct {
 	mapping map[types.ChainIndex]eth.ChainID
 }
@@ -101,7 +103,7 @@ func runHazardCycleChecksTestCase(t *testing.T, tc hazardCycleChecksTestCase) {
 		depSet.mapping[index] = eth.ChainIDFromUInt64(uint64(index))
 	}
 	// Run the test
-	err := HazardCycleChecks(depSet, deps, 100, NewHazardSetFromEntries(hazards))
+	err := HazardCycleChecks(depSet, deps, testDefaultTimestamp, NewHazardSetFromEntries(hazards))
 
 	// No error expected
 	if tc.expectErr == nil {
@@ -127,7 +129,7 @@ func chainIndex(s string) types.ChainIndex {
 }
 
 func execMsg(chain string, logIdx uint32) *types.ExecutingMessage {
-	return execMsgWithTimestamp(chain, logIdx, 100)
+	return execMsgWithTimestamp(chain, logIdx, testDefaultTimestamp)
 }
 
 func execMsgWithTimestamp(chain string, logIdx uint32, timestamp uint64) *types.ExecutingMessage {
@@ -353,6 +355,18 @@ func TestHazardCycleChecksNoCycle(t *testing.T) {
 			},
 			msg: "expected no cycle found first log is exec",
 		},
+		{
+			name: "no cycle using different timestamp",
+			chainBlocks: map[string]chainBlockDef{
+				"1": {
+					logCount: 2,
+					messages: map[uint32]*types.ExecutingMessage{
+						0: execMsgWithTimestamp("1", 1, testDefaultTimestamp+1),
+					},
+				},
+			},
+			msg: "expected no cycle for different timestamp",
+		},
 	}
 	runHazardCycleChecksTestCaseGroup(t, "NoCycle", tests)
 }
@@ -360,7 +374,23 @@ func TestHazardCycleChecksNoCycle(t *testing.T) {
 func TestHazardCycleChecksCycle(t *testing.T) {
 	tests := []hazardCycleChecksTestCase{
 		{
-			name: "2-cycle in single chain with first log",
+			// 0->1->2->0
+			name: "3-cycle in single chain",
+			chainBlocks: map[string]chainBlockDef{
+				"1": {
+					logCount: 3,
+					messages: map[uint32]*types.ExecutingMessage{
+						0: execMsg("1", 2),
+					},
+				},
+			},
+			expectErr: ErrCycle,
+			msg:       "expected cycle detection error",
+		},
+		{
+			// 0->1->2->0
+			// 0->2->0
+			name: "3-cycle in single chain, 2-cycle in single chain with first log",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
 					logCount: 3,
@@ -374,6 +404,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
+			// 0->1->0
 			name: "2-cycle in single chain with first log, adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -388,6 +419,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
+			// 1->2->1
 			name: "2-cycle in single chain, not first, adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -402,7 +434,9 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
-			name: "2-cycle in single chain, not first, not adjacent",
+			// 1->3->1
+			// 1->2->3->1
+			name: "2,3-cycle in single chain, not first, not adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
 					logCount: 4,
@@ -416,6 +450,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
+			// A1->B0->A1
 			name: "2-cycle across chains",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -435,7 +470,10 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error for cycle through executing messages",
 		},
 		{
-			name: "3-cycle in single chain",
+			// 1->2->1
+			// 2->3->2
+			// 1->3->2->1
+			name: "2,2,3-cycle in single chain",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
 					logCount: 4,
@@ -450,6 +488,8 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error for 3-node cycle",
 		},
 		{
+			// 1->2->3->4->5->1
+			// 1->2->5->1
 			name: "cycle through adjacency dependency",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -464,6 +504,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error for when cycle goes through adjacency dependency",
 		},
 		{
+			// A1->B1->A1
 			name: "2-cycle across chains with 3 hazard chains",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -489,6 +530,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg: "expected cycle detection error for cycle through executing messages",
 		},
 		{
+			// 0->1->0
 			name: "cycle through single chain, exec message prior to init and adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -502,6 +544,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
+			// 0->1->2->0
 			name: "cycle through single chain, exec message prior to init and not adjacent",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {
@@ -515,6 +558,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 			msg:       "expected cycle detection error",
 		},
 		{
+			// A1->B0->A0->A1
 			name: "3-cycle across chains",
 			chainBlocks: map[string]chainBlockDef{
 				"1": {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Message dependency check is crucial and they are checked via cycle detection. Supervisor constructs a directed graph, which edges are message dependencies and nodes are message.

Every logs in block can be a message, and each adjacent logs have dependencies. So if a single block has 3 logs A0, A1, A2, there are two edges, and entire dependency graph be A0->A1->A2.

In interop, there are special messages called executing messages, and they depend on single log, or we call them initiating message. So if a single block from chain A contains logs, and its 3rd log is A2, and chain B attempts to execute message B3 at 4th log in its block for A2, the graph edge be A2->B3.

Supervisor gathers logs, group them in same timestamp, construct directed graph, and checks cycles. Supervisor must mark blocks which contain cyclic dependency as invalid, and spread that information to everyone.

The original graph building algorithm contained below code segment:
```go
			// Check if we care about the init message
			initChainMsgs, ok := execMsgs[m.Chain]
			if !ok {
				continue
			}
			if _, ok := initChainMsgs[m.LogIdx]; !ok {
				continue
			}
```
and made the final graph not to include some edges, resulting in wrong graph resulting in invalid cycle detection. This PR attempts to remove upper logic to construct a correct graph.

**Tests**

Unit tests added. `cycle through younger|older timestamp` test cases were not considered as cycle detection, but they contained cycle. Removed these tests. 

Added comments for explicit cycles.
 
**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15567

