### PR TITLE
op-{supervisor|e2e}: reorg when cycle detection + fix action test single chain cycle test

### DIFF
--- a/op-acceptance-tests/tests/interop/interop_test_helpers.go
+++ b/op-acceptance-tests/tests/interop/interop_test_helpers.go
@@ -126,7 +126,12 @@ func ExecTriggerFromInitTrigger(init *txintent.InitTrigger, logIndex uint, targe
 	}
 	log := &types.Log{Address: init.Emitter, Topics: topics,
 		Data: init.OpaqueData, BlockNumber: targetNum, Index: logIndex}
-	logs := []*types.Log{log}
+	logs := make([]*types.Log, logIndex+1)
+	for i := range logs {
+		// dummy logs to fit in log index
+		logs[i] = &types.Log{}
+	}
+	logs[logIndex] = log
 	rec := &types.Receipt{Logs: logs}
 	includedIn := eth.BlockRef{Time: targetTime}
 	output := &txintent.InteropOutput{}

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -878,7 +878,7 @@ func TestCycleInTx(gt *testing.T) {
 
 	// speculatively build exec message by knowing necessary info to build Message
 	init := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
-	// log index of init message is 1, not 0 because exec message will firstly executed, emiting a single log
+	// log index of init message is 1, not 0 because exec message will firstly executed, emitting a single log
 	logIndexX := uint(1)
 	exec, err := interop.ExecTriggerFromInitTrigger(init, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
 

--- a/op-e2e/actions/interop/interop_txplan_test.go
+++ b/op-e2e/actions/interop/interop_txplan_test.go
@@ -878,8 +878,10 @@ func TestCycleInTx(gt *testing.T) {
 
 	// speculatively build exec message by knowing necessary info to build Message
 	init := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
-	logIndexX := uint(0)
+	// log index of init message is 1, not 0 because exec message will firstly executed, emiting a single log
+	logIndexX := uint(1)
 	exec, err := interop.ExecTriggerFromInitTrigger(init, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
+
 	require.NoError(t, err)
 
 	// tx includes cycle with self
@@ -895,6 +897,13 @@ func TestCycleInTx(gt *testing.T) {
 	// Make sure tx in block sealed at expected time
 	require.Equal(t, included.Time, targetTime)
 	require.Equal(t, included.Number, targetNum)
+
+	// confirm speculatively built exec message by rebuilding after tx inclusion
+	_, err = tx.Result.Eval(t.Ctx())
+	require.NoError(t, err)
+	exec2, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &tx.Result, int(logIndexX))(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, exec2, exec)
 
 	// Make batcher happy by advancing at least a single block
 	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
@@ -930,10 +939,12 @@ func TestCycleInBlock(gt *testing.T) {
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 
 	nonce := uint64(0)
+	txCount := 2 + rng.Intn(20)
 
 	// speculatively build exec message by knowing necessary info to build Message
 	init := interop.RandomInitTrigger(rng, eventLoggerAddressA, 3, 10)
-	logIndexX := uint(0)
+	// log index of init message is txCount - 1, not 0 because each tx before init message X emits a single log
+	logIndexX := uint(txCount - 1)
 	exec, err := interop.ExecTriggerFromInitTrigger(init, logIndexX, targetNum, targetTime, actors.ChainA.ChainID)
 	require.NoError(t, err)
 
@@ -946,7 +957,6 @@ func TestCycleInBlock(gt *testing.T) {
 		require.NoError(t, err)
 		intents = append(intents, intent)
 	}
-	txCount := 2 + rng.Intn(15)
 	// include exec message X tx first in block
 	{
 		submitIntent(exec, nonce)
@@ -972,6 +982,15 @@ func TestCycleInBlock(gt *testing.T) {
 		require.Equal(t, included.Time, targetTime)
 		require.Equal(t, included.Number, targetNum)
 	}
+
+	// confirm speculatively built exec message by rebuilding after tx inclusion
+	tx := intents[txCount-1]
+	_, err = tx.Result.Eval(t.Ctx())
+	require.NoError(t, err)
+	// log index is 0 because tx emitted a single log
+	exec2, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &tx.Result, 0)(t.Ctx())
+	require.NoError(t, err)
+	require.Equal(t, exec2, exec)
 
 	// Make batcher happy by advancing at least a single block
 	actors.ChainB.Sequencer.ActL2EmptyBlock(t)

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -228,11 +228,7 @@ func singleRoundConsolidation(
 }
 
 func isInvalidMessageError(err error) bool {
-	// TODO(#14011): Create an error category for InvalidExecutingMessage errors in the cross package for easier maintenance.
-	return errors.Is(err, supervisortypes.ErrConflict) ||
-		errors.Is(err, cross.ErrExecMsgHasInvalidIndex) ||
-		errors.Is(err, cross.ErrExecMsgUnknownChain) ||
-		errors.Is(err, cross.ErrCycle) || errors.Is(err, supervisortypes.ErrUnknownChain)
+	return errors.Is(err, supervisortypes.ErrConflict) || errors.Is(err, supervisortypes.ErrUnknownChain)
 }
 
 type ConsolidateCheckDeps interface {

--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -1,7 +1,6 @@
 package cross
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -10,10 +9,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+// These error must be considered as ErrConflict to trigger a reorg.
 var (
-	ErrCycle                  = errors.New("cycle detected")
-	ErrExecMsgHasInvalidIndex = errors.New("executing message has invalid log index")
-	ErrExecMsgUnknownChain    = errors.New("executing message references unknown chain")
+	ErrCycle                  = fmt.Errorf("%w: cycle detected", types.ErrConflict)
+	ErrExecMsgHasInvalidIndex = fmt.Errorf("%w: executing message has invalid log index", types.ErrConflict)
+	ErrExecMsgUnknownChain    = fmt.Errorf("%w: executing message references unknown chain", types.ErrConflict)
 )
 
 // CycleCheckDeps is an interface for checking cyclical dependencies between logs.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Depends on https://github.com/ethereum-optimism/optimism/pull/15568

op-e2e action tests for single chain cycle test was wrongly implemented. The chains reorged because the executing messages pointed to wrong index, not because of cycle.

This PR fixes the `ExecTriggerFromInitTrigger` method to generate correct executing messages for creating a cycle.

**Tests**

Fixes `TestCycleInTx`, `TestCycleInBlock` to use correct log index for executing message. Also checks that speculatively generated executing messages before transaction execution for emitting initiating messages are correct, comparing after the initiating message tx inclusion.

**Additional context**

Cycle errors were not considered as `ErrConflict`, and did not trigger reorgs. Wrap them and consider them as `ErrConflict` to trigger reorg.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15391
- Fixes https://github.com/ethereum-optimism/optimism/issues/15410
- Fixes https://github.com/ethereum-optimism/optimism/issues/14011
