### PR TITLE
op-test-sequencer: update TODO

### DIFF
--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
@@ -65,7 +65,7 @@ func (s *Sequencer) Open(ctx context.Context) error {
 	}
 
 	opts := &seqtypes.BuildOpts{
-		Parent:   common.Hash{}, // TODO(#14124): update sequencer to chain blocks together
+		Parent:   common.Hash{}, // TODO(#15572): update sequencer to chain blocks together
 		L1Origin: nil,
 	}
 


### PR DESCRIPTION

**Description**

Fixes TODO comment to point to new github issue that tracks the actual thing. The previous issue was too wide, and captured the base functionality that was merged already in https://github.com/ethereum-optimism/optimism/pull/14604
