### PR TITLE
op-node: fix reset-confirmed metadata

### DIFF
--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -443,7 +443,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 		d.emitter.Emit(TryUpdateEngineEvent{})
 
 		v := EngineResetConfirmedEvent{
-			LocalUnsafe: d.ec.LocalSafeL2Head(),
+			LocalUnsafe: d.ec.UnsafeL2Head(),
 			CrossUnsafe: d.ec.CrossUnsafeL2Head(),
 			LocalSafe:   d.ec.LocalSafeL2Head(),
 			CrossSafe:   d.ec.SafeL2Head(),


### PR DESCRIPTION
**Description**

There are no usages of this field besides logging, and so no affect on the outcome, but it was set wrong nevertheless.
