### PR TITLE
fix: more generic ast search for upgrade checks

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main_test.go
@@ -10,12 +10,13 @@ import (
 
 func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 	tests := []struct {
-		name         string
-		opcmArtifact *solc.ForgeArtifact
-		expectedAst  *solc.AstNode
+		name          string
+		opcmArtifact  *solc.ForgeArtifact
+		expectedAst   *solc.AstNode
+		expectedError string
 	}{
 		{
-			name: "With upgrade function",
+			name: "With one external upgrade function",
 			opcmArtifact: &solc.ForgeArtifact{
 				Ast: solc.Ast{
 					Nodes: []solc.AstNode{
@@ -23,10 +24,9 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 							NodeType: "ContractDefinition",
 							Nodes: []solc.AstNode{
 								{
-									NodeType:         "FunctionDefinition",
-									Name:             "upgrade",
-									Visibility:       "external",
-									FunctionSelector: OPCM_UPGRADE_FUNCTION_SELECTOR,
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "external",
 									Nodes: []solc.AstNode{
 										{
 											NodeType: "UniqueNonExistentNodeType",
@@ -40,19 +40,19 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 				},
 			},
 			expectedAst: &solc.AstNode{
-				NodeType:         "FunctionDefinition",
-				Name:             "upgrade",
-				Visibility:       "external",
-				FunctionSelector: OPCM_UPGRADE_FUNCTION_SELECTOR,
+				NodeType:   "FunctionDefinition",
+				Name:       "upgrade",
+				Visibility: "external",
 				Nodes: []solc.AstNode{
 					{
 						NodeType: "UniqueNonExistentNodeType",
 					},
 				},
 			},
+			expectedError: "",
 		},
 		{
-			name: "With an upgrade function but not the right visibility",
+			name: "With an upgrade function but public visibility",
 			opcmArtifact: &solc.ForgeArtifact{
 				Ast: solc.Ast{
 					Nodes: []solc.AstNode{
@@ -60,15 +60,9 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 							NodeType: "ContractDefinition",
 							Nodes: []solc.AstNode{
 								{
-									NodeType:         "FunctionDefinition",
-									Name:             "upgrade",
-									Visibility:       "public",
-									FunctionSelector: OPCM_UPGRADE_FUNCTION_SELECTOR,
-									Nodes: []solc.AstNode{
-										{
-											NodeType: "UniqueNonExistentNodeType",
-										},
-									},
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "public",
 								},
 							},
 							Name: "OPContractsManagerUpgrader",
@@ -76,10 +70,11 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 					},
 				},
 			},
-			expectedAst: &solc.AstNode{},
+			expectedAst:   nil,
+			expectedError: "no external upgrade function found in OPContractsManagerUpgrader",
 		},
 		{
-			name: "With an upgrade function but not the right function selector",
+			name: "With an upgrade function and irrelevant function selector",
 			opcmArtifact: &solc.ForgeArtifact{
 				Ast: solc.Ast{
 					Nodes: []solc.AstNode{
@@ -103,7 +98,45 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 					},
 				},
 			},
-			expectedAst: &solc.AstNode{},
+			expectedAst: &solc.AstNode{
+				NodeType:         "FunctionDefinition",
+				Name:             "upgrade",
+				Visibility:       "external",
+				FunctionSelector: "aabbccdd",
+				Nodes: []solc.AstNode{
+					{
+						NodeType: "UniqueNonExistentNodeType",
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "With multiple external upgrade functions",
+			opcmArtifact: &solc.ForgeArtifact{
+				Ast: solc.Ast{
+					Nodes: []solc.AstNode{
+						{
+							NodeType: "ContractDefinition",
+							Nodes: []solc.AstNode{
+								{
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "external",
+								},
+								{
+									NodeType:   "FunctionDefinition",
+									Name:       "upgrade",
+									Visibility: "external",
+								},
+							},
+							Name: "OPContractsManagerUpgrader",
+						},
+					},
+				},
+			},
+			expectedAst:   nil,
+			expectedError: "multiple external upgrade functions found in OPContractsManagerUpgrader, expected 1",
 		},
 		{
 			name: "With no upgrade function",
@@ -114,15 +147,9 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 							NodeType: "ContractDefinition",
 							Nodes: []solc.AstNode{
 								{
-									NodeType:         "FunctionDefinition",
-									Name:             "randomFunctionName",
-									Visibility:       "external",
-									FunctionSelector: OPCM_UPGRADE_FUNCTION_SELECTOR,
-									Nodes: []solc.AstNode{
-										{
-											NodeType: "UniqueNonExistentNodeType",
-										},
-									},
+									NodeType:   "FunctionDefinition",
+									Name:       "randomFunctionName",
+									Visibility: "external",
 								},
 							},
 							Name: "OPContractsManagerUpgrader",
@@ -130,7 +157,8 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 					},
 				},
 			},
-			expectedAst: &solc.AstNode{},
+			expectedAst:   nil,
+			expectedError: "no external upgrade function found in OPContractsManagerUpgrader",
 		},
 		{
 			name: "With no contract definition",
@@ -139,14 +167,25 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 					Nodes: []solc.AstNode{},
 				},
 			},
-			expectedAst: &solc.AstNode{},
+			expectedAst:   nil,
+			expectedError: "no external upgrade function found in OPContractsManagerUpgrader",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ast := getOpcmUpgradeFunctionAst(test.opcmArtifact)
-			assert.Equal(t, test.expectedAst, ast)
+			ast, err := getOpcmUpgradeFunctionAst(test.opcmArtifact)
+
+			if test.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedAst, ast)
+			} else {
+				assert.Error(t, err)
+				assert.Nil(t, ast)
+				if err != nil {
+					assert.Equal(t, test.expectedError, err.Error())
+				}
+			}
 		})
 	}
 }

--- a/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/opcm-upgrade-checks/main_test.go
@@ -150,6 +150,11 @@ func TestGetOpcmUpgradeFunctionAst(t *testing.T) {
 									NodeType:   "FunctionDefinition",
 									Name:       "randomFunctionName",
 									Visibility: "external",
+									Nodes: []solc.AstNode{
+										{
+											NodeType: "UniqueNonExistentNodeType",
+										},
+									},
 								},
 							},
 							Name: "OPContractsManagerUpgrader",


### PR DESCRIPTION
Fixes the AST search for the upgrade function to be generic and robust against changes in the function signature of the upgrade function.

