### PR TITLE
Update kurtosis config to use mt64

### DIFF
--- a/kurtosis-devnet/book/src/local_artifacts.md
+++ b/kurtosis-devnet/book/src/local_artifacts.md
@@ -38,7 +38,7 @@ In the `simple.yaml` configuration, you'll notice several custom template functi
 # Example usage in simple.yaml
 image: {{ localDockerImage "op-node" }}
 l1_artifacts_locator: {{ localContractArtifacts "l1" }}
-faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
 ```
 
 These template functions map to specific builders in the Go codebase that handle artifact construction.
@@ -78,7 +78,7 @@ The prestate builder manages the generation of fault proof prestates:
 
 ```yaml
 # Usage in YAML:
-faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
 ```
 
 This builder:
@@ -108,7 +108,7 @@ optimism_package:
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
 ```
 
 This integration system ensures that your devnet can seamlessly use locally built components while maintaining reproducibility and ease of configuration.

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -89,7 +89,7 @@ optimism_package:
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []
@@ -110,4 +110,3 @@ ethereum_package:
           "nonce": "1"
         }
       }
-

--- a/kurtosis-devnet/op-program-svc/README.md
+++ b/kurtosis-devnet/op-program-svc/README.md
@@ -35,7 +35,6 @@ $ curl -X POST -H "Content-Type: multipart/form-data" \
 ```
 $ curl -q http://localhost:8080/info.json
 {
-  "prestate": "0x03f4b7435fec731578c72635d8e8180f7b48703073d038fc7f8c494eeed1ce19",
   "prestate_interop": "0x034731331d519c93fc0562643e0728c43f8e45a0af1160ad4c57c4e5141d2bbb",
   "prestate_mt64": "0x0325bb0ca8521b468bb8234d8ba54b1b74db60e2b5bc75d0077a0fe2098b6b45"
 }

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -60,7 +60,7 @@ optimism_package:
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []
@@ -88,4 +88,3 @@ ethereum_package:
           "nonce": "1"
         }
       }
-

--- a/kurtosis-devnet/pkg/deploy/prestate.go
+++ b/kurtosis-devnet/pkg/deploy/prestate.go
@@ -46,7 +46,6 @@ func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
 
 	if h.dryRun {
 		// In dry run, populate with placeholder keys to avoid template errors during first pass
-		info.Hashes["prestate"] = "dry_run_placeholder"
 		info.Hashes["prestate_mt64"] = "dry_run_placeholder"
 		info.Hashes["prestate_interop"] = "dry_run_placeholder"
 		h.info = info
@@ -55,7 +54,6 @@ func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
 
 	// Map of known file prefixes to their keys
 	fileToKey := map[string]string{
-		"prestate-proof.json":         "prestate",
 		"prestate-proof-mt64.json":    "prestate_mt64",
 		"prestate-proof-interop.json": "prestate_interop",
 	}

--- a/kurtosis-devnet/pkg/deploy/template.go
+++ b/kurtosis-devnet/pkg/deploy/template.go
@@ -154,7 +154,6 @@ func (f *Templater) localPrestateOption(buildWg *sync.WaitGroup) tmpl.TemplateCo
 			return &PrestateInfo{
 				URL: f.urlBuilder(prestatePath...),
 				Hashes: map[string]string{
-					"prestate":         "dry_run_placeholder",
 					"prestate_mt64":    "dry_run_placeholder",
 					"prestate_interop": "dry_run_placeholder",
 				},

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -69,7 +69,7 @@ imageA1: {{ localDockerImage "project-a" }}
 imageB: {{ localDockerImage "project-b" }}
 imageA2: {{ localDockerImage "project-a" }}
 contracts: {{ localContractArtifacts "l1" }}
-prestateHash: {{ (localPrestate).Hashes.prestate }}`
+prestateHash: {{ (localPrestate).Hashes.prestate_mt64 }}`
 
 	templatePath := filepath.Join(tmpDir, "template.yaml")
 	err = os.WriteFile(templatePath, []byte(templateContent), 0644)
@@ -182,7 +182,6 @@ func TestLocalPrestateOption(t *testing.T) {
 	// In dry run mode, we should get a placeholder prestate with the correct URL
 	expectedURL := "http://localhost:8080/proofs/op-program/cannon"
 	assert.Equal(t, expectedURL, prestate.URL)
-	assert.Equal(t, "dry_run_placeholder", prestate.Hashes["prestate"])
 	assert.Equal(t, "dry_run_placeholder", prestate.Hashes["prestate_mt64"])
 	assert.Equal(t, "dry_run_placeholder", prestate.Hashes["prestate_interop"])
 

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -60,7 +60,7 @@ optimism_package:
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []

--- a/kurtosis-devnet/templates/devnet.yaml
+++ b/kurtosis-devnet/templates/devnet.yaml
@@ -26,7 +26,7 @@ optimism_package:
     l2_artifacts_locator: {{ dig "overrides" "urls" "l2_artifacts" (localContractArtifacts "l2") $context }}
 {{ if $interop }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ dig "overrides" "deployer" "prestate" (localPrestate.Hashes.prestate) $context }}
+      faultGameAbsolutePrestate: {{ dig "overrides" "deployer" "prestate" (localPrestate.Hashes.prestate_mt64) $context }}
 {{ end }}
   global_log_level: "info"
   global_node_selectors: {}


### PR DESCRIPTION
**Description**

Updates the prestate in kurtosis to use cannon mt64. The 32-bit variant has been removed.