### PR TITLE
Replace prestate_interop with prestate_mt64 in fault game absolute prestate

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -168,7 +168,7 @@ optimism_package:
     l1_artifacts_locator: {{ $urls.l1_artifacts }}
     l2_artifacts_locator: {{ $urls.l2_artifacts }}
     global_deploy_overrides:
-      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_interop }}
+      faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate_mt64 }}
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []


### PR DESCRIPTION
This PR updates the fault game absolute prestate configuration in interop.yaml to use prestate_mt64 instead of prestate_interop. This change aligns with updated prestate hash requirements for the fault game implementation.

Changes:
- Modified kurtosis-devnet/interop.yaml to update faultGameAbsolutePrestate from using localPrestate.Hashes.prestate_interop to localPrestate.Hashes.prestate_mt64