### PR TITLE
fix: correct interface definitions for `_isOptimismMintableERC20` token validation

### DIFF
--- a/packages/contracts-bedrock/interfaces/legacy/ILegacyMintableERC20.sol
+++ b/packages/contracts-bedrock/interfaces/legacy/ILegacyMintableERC20.sol
@@ -11,6 +11,8 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 interface ILegacyMintableERC20 is IERC165 {
     function l1Token() external view returns (address);
 
+    function l2Bridge() external view returns (address);
+
     function mint(address _to, uint256 _amount) external;
 
     function burn(address _from, uint256 _amount) external;

--- a/packages/contracts-bedrock/interfaces/universal/IOptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/interfaces/universal/IOptimismMintableERC20.sol
@@ -10,7 +10,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 interface IOptimismMintableERC20 is IERC165 {
     function remoteToken() external view returns (address);
 
-    function bridge() external returns (address);
+    function bridge() external view returns (address);
 
     function mint(address _to, uint256 _amount) external;
 

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -389,8 +389,11 @@ abstract contract StandardBridge is Initializable {
     /// @param _token Address of the token to check.
     /// @return True if the token is an OptimismMintableERC20.
     function _isOptimismMintableERC20(address _token) internal view returns (bool) {
-        return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
-            || ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
+        return
+            (ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId) &&
+              address(this) == ILegacyMintableERC20(_token).l2Bridge()) ||
+            (ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId) &&
+              address(this) == IOptimismMintableERC20(_token).bridge());
     }
 
     /// @notice Checks if the "other token" is the correct pair token for the OptimismMintableERC20.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Found and fixed an issue where StandardBridge couldn't properly validate tokens due to interface inconsistencies.

Changes:
- Added `view` modifier to the `bridge()` function in IOptimismMintableERC20 interface
- Added `l2Bridge()` function to the ILegacyMintableERC20 interface

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

This fixes the token validation in the `_isOptimismMintableERC20` function which prevents potential security problems with accepting invalid tokens.

**Metadata**

- Fixes #15108 