### PR TITLE
fix(kt-devnet): parse old op-supervisor setup

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -112,6 +112,11 @@ func (f *ServiceFinder) FindL2Services(s ChainSpec) ([]descriptors.Node, descrip
 		// supervisor is special: itcovers multiple networks, so we need to
 		// identify the depset this chain belongs to
 		if strings.HasPrefix(serviceName, "op-supervisor") {
+			// temporary backward-compatible hack for single op-supervisor instance
+			if serviceName == "op-supervisor" {
+				return "supervisor", 0, true
+			}
+
 			for dsName, ds := range s.DepSets {
 				suffix := "-" + dsName
 				if !strings.HasSuffix(serviceName, suffix) {


### PR DESCRIPTION
**Description**

Since we reverted op-supervisor changes in
https://github.com/ethpandaops/optimism-package/pull/234 the old
parsing logic needs to be emulated.

This is a temporary measure, and will be reverted as soon as we roll
forward a new version of the op-supervisor deployment strategy.

 <!-- A clear and concise
description of the features you're adding in this pull request. -->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
