### PR TITLE
interop: sync test: op-supervisor ahead of op-node, unsafe chain unknown

### DIFF
--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"flag"
+	"fmt"
 	"sync"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/urfave/cli/v2"
 )
 
@@ -158,7 +160,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			networkPrivKey, err := crypto.GenerateKey()
 			require.NoError(err)
 			networkPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(networkPrivKey))
-			_ = fs.Set(opNodeFlags.P2PPrivRawName, networkPrivKeyHex)
+			require.NoError(fs.Set(opNodeFlags.P2PPrivRawName, networkPrivKeyHex))
 
 			cliCtx := cli.NewContext(&cli.App{}, fs, nil)
 			if isSequencer {
@@ -245,6 +247,14 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 	}
 }
 
+func GetP2PClient(ctx context.Context, logger log.Logger, l2CLNode *L2CLNode) (*sources.P2PClient, error) {
+	rpcClient, err := client.NewRPC(ctx, logger, l2CLNode.userRPC, client.WithLazyDial())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize rpc client for p2p client: %w", err)
+	}
+	return sources.NewP2PClient(rpcClient), nil
+}
+
 // WithL2CLP2PConnection P2P connects two L2CLs
 func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 	return func(o stack.Orchestrator) {
@@ -259,14 +269,13 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
 		ctx := o.P().Ctx()
+		logger := o.P().Logger()
 
 		// initialize p2p clients per L2CL
-		getP2PClient := func(l2CLNode *L2CLNode) *sources.P2PClient {
-			rpcClient, err := client.NewRPC(ctx, o.P().Logger(), l2CLNode.userRPC, client.WithLazyDial())
-			require.NoError(err, "failed to initialize rpc client for p2p client")
-			return sources.NewP2PClient(rpcClient)
-		}
-		p2pClient1, p2pClient2 := getP2PClient(l2CL1), getP2PClient(l2CL2)
+		p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
+		require.NoError(err)
+		p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)
+		require.NoError(err)
 
 		// get peer info per L2CL
 		getPeerInfo := func(p2pClient *sources.P2PClient) *apis.PeerInfo {
@@ -287,6 +296,7 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 			})
 			require.NoError(err, "failed to connect peer")
 		}
+
 		connectPeer(p2pClient1, peer2MultiAddress)
 		connectPeer(p2pClient2, peer1MultiAddress)
 
@@ -303,6 +313,67 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 			multiAddress := peerInfo.PeerID.String()
 			_, ok := peerDump.Peers[multiAddress]
 			require.True(ok, "peer register invalid")
+		}
+		check(peerDump1, peerInfo2)
+		check(peerDump2, peerInfo1)
+	}
+}
+
+func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
+	return func(o stack.Orchestrator) {
+		orch := o.(*Orchestrator)
+		require := o.P().Require()
+
+		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
+		require.True(ok, "looking for L2 CL node 1 to connect p2p")
+		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
+		require.True(ok, "looking for L2 CL node 2 to connect p2p")
+
+		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
+
+		ctx := o.P().Ctx()
+		logger := o.P().Logger()
+
+		// initialize p2p clients per L2CL
+		p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
+		require.NoError(err)
+		p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)
+		require.NoError(err)
+
+		// get peer info per L2CL
+		getPeerInfo := func(p2pClient *sources.P2PClient) *apis.PeerInfo {
+			peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerInfo, error) {
+				return p2pClient.Self(ctx)
+			})
+			require.NoError(err, "failed to get peer info")
+			return peerInfo
+		}
+		peerInfo1, peerInfo2 := getPeerInfo(p2pClient1), getPeerInfo(p2pClient2)
+
+		// disconnect bidirectional p2p connection
+		disconnectPeer := func(p2pClient *sources.P2PClient, id peer.ID) {
+			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
+				return p2pClient.DisconnectPeer(ctx, id)
+			})
+			require.NoError(err, "failed to disconnect peer")
+		}
+
+		disconnectPeer(p2pClient1, peerInfo2.PeerID)
+		disconnectPeer(p2pClient2, peerInfo1.PeerID)
+
+		// sanity check that peers are registered
+		getPeers := func(p2pClient *sources.P2PClient) *apis.PeerDump {
+			peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerDump, error) {
+				return p2pClient.Peers(ctx, true)
+			})
+			require.NoError(err, "failed to get peers")
+			return peerDump
+		}
+		peerDump1, peerDump2 := getPeers(p2pClient1), getPeers(p2pClient2)
+		check := func(peerDump *apis.PeerDump, peerInfo *apis.PeerInfo) {
+			multiAddress := peerInfo.PeerID.String()
+			_, ok := peerDump.Peers[multiAddress]
+			require.False(ok, "peer deregister invalid")
 		}
 		check(peerDump1, peerInfo2)
 		check(peerDump2, peerInfo1)

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -283,10 +283,10 @@ type p2pClientsAndPeers struct {
 	peerInfo2 *apis.PeerInfo
 }
 
-func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *require.Assertions, l2cl1, l2cl2 *L2CLNode) *p2pClientsAndPeers {
-	p2pClient1, err := GetP2PClient(ctx, logger, l2cl1)
+func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *require.Assertions, l2CL1, l2CL2 *L2CLNode) *p2pClientsAndPeers {
+	p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
 	require.NoError(err)
-	p2pClient2, err := GetP2PClient(ctx, logger, l2cl2)
+	p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)
 	require.NoError(err)
 
 	peerInfo1, err := GetPeerInfo(ctx, p2pClient1)
@@ -310,16 +310,16 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		orch := o.(*Orchestrator)
 		require := o.P().Require()
 
-		l2cl1, ok := orch.l2CLs.Get(l2CL1ID)
+		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
 		require.True(ok, "looking for L2 CL node 1 to connect p2p")
-		l2cl2, ok := orch.l2CLs.Get(l2CL2ID)
+		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
 		require.True(ok, "looking for L2 CL node 2 to connect p2p")
-		require.Equal(l2cl1.cfg.Rollup.L2ChainID, l2cl2.cfg.Rollup.L2ChainID, "must be same l2 chain")
+		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
 		ctx := o.P().Ctx()
 		logger := o.P().Logger()
 
-		p := getP2PClientsAndPeers(ctx, logger, require, l2cl1, l2cl2)
+		p := getP2PClientsAndPeers(ctx, logger, require, l2CL1, l2CL2)
 
 		connectPeer := func(p2pClient *sources.P2PClient, multiAddress string) {
 			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
@@ -353,16 +353,16 @@ func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		orch := o.(*Orchestrator)
 		require := o.P().Require()
 
-		l2cl1, ok := orch.l2CLs.Get(l2CL1ID)
+		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
 		require.True(ok, "looking for L2 CL node 1 to disconnect p2p")
-		l2cl2, ok := orch.l2CLs.Get(l2CL2ID)
+		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
 		require.True(ok, "looking for L2 CL node 2 to disconnect p2p")
-		require.Equal(l2cl1.cfg.Rollup.L2ChainID, l2cl2.cfg.Rollup.L2ChainID, "must be same l2 chain")
+		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
 		ctx := o.P().Ctx()
 		logger := o.P().Logger()
 
-		p := getP2PClientsAndPeers(ctx, logger, require, l2cl1, l2cl2)
+		p := getP2PClientsAndPeers(ctx, logger, require, l2CL1, l2CL2)
 
 		disconnectPeer := func(p2pClient *sources.P2PClient, id peer.ID) {
 			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
 
@@ -255,41 +256,71 @@ func GetP2PClient(ctx context.Context, logger log.Logger, l2CLNode *L2CLNode) (*
 	return sources.NewP2PClient(rpcClient), nil
 }
 
-// WithL2CLP2PConnection P2P connects two L2CLs
+func GetPeerInfo(ctx context.Context, p2pClient *sources.P2PClient) (*apis.PeerInfo, error) {
+	peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerInfo, error) {
+		return p2pClient.Self(ctx)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get peer info: %w", err)
+	}
+	return peerInfo, nil
+}
+
+func GetPeers(ctx context.Context, p2pClient *sources.P2PClient) (*apis.PeerDump, error) {
+	peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerDump, error) {
+		return p2pClient.Peers(ctx, true)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get peers: %w", err)
+	}
+	return peerDump, nil
+}
+
+type p2pClientsAndPeers struct {
+	client1   *sources.P2PClient
+	client2   *sources.P2PClient
+	peerInfo1 *apis.PeerInfo
+	peerInfo2 *apis.PeerInfo
+}
+
+func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *require.Assertions, l2cl1, l2cl2 *L2CLNode) *p2pClientsAndPeers {
+	p2pClient1, err := GetP2PClient(ctx, logger, l2cl1)
+	require.NoError(err)
+	p2pClient2, err := GetP2PClient(ctx, logger, l2cl2)
+	require.NoError(err)
+
+	peerInfo1, err := GetPeerInfo(ctx, p2pClient1)
+	require.NoError(err)
+	peerInfo2, err := GetPeerInfo(ctx, p2pClient2)
+	require.NoError(err)
+
+	require.True(len(peerInfo1.Addresses) > 0 && len(peerInfo2.Addresses) > 0, "malformed peer info")
+
+	return &p2pClientsAndPeers{
+		client1:   p2pClient1,
+		client2:   p2pClient2,
+		peerInfo1: peerInfo1,
+		peerInfo2: peerInfo2,
+	}
+}
+
+// WithL2CLP2PConnection disconnects P2P between two L2CLs
 func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 	return func(o stack.Orchestrator) {
 		orch := o.(*Orchestrator)
 		require := o.P().Require()
 
-		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
+		l2cl1, ok := orch.l2CLs.Get(l2CL1ID)
 		require.True(ok, "looking for L2 CL node 1 to connect p2p")
-		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
+		l2cl2, ok := orch.l2CLs.Get(l2CL2ID)
 		require.True(ok, "looking for L2 CL node 2 to connect p2p")
-
-		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
+		require.Equal(l2cl1.cfg.Rollup.L2ChainID, l2cl2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
 		ctx := o.P().Ctx()
 		logger := o.P().Logger()
 
-		// initialize p2p clients per L2CL
-		p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
-		require.NoError(err)
-		p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)
-		require.NoError(err)
+		p := getP2PClientsAndPeers(ctx, logger, require, l2cl1, l2cl2)
 
-		// get peer info per L2CL
-		getPeerInfo := func(p2pClient *sources.P2PClient) *apis.PeerInfo {
-			peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerInfo, error) {
-				return p2pClient.Self(ctx)
-			})
-			require.NoError(err, "failed to get peer info")
-			return peerInfo
-		}
-		peerInfo1, peerInfo2 := getPeerInfo(p2pClient1), getPeerInfo(p2pClient2)
-		require.True(len(peerInfo1.Addresses) > 0 && len(peerInfo2.Addresses) > 0, "malformed peer info")
-		peer1MultiAddress, peer2MultiAddress := peerInfo1.Addresses[0], peerInfo2.Addresses[0]
-
-		// bidirectional p2p connection
 		connectPeer := func(p2pClient *sources.P2PClient, multiAddress string) {
 			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
 				return p2pClient.ConnectPeer(ctx, multiAddress)
@@ -297,60 +328,42 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 			require.NoError(err, "failed to connect peer")
 		}
 
-		connectPeer(p2pClient1, peer2MultiAddress)
-		connectPeer(p2pClient2, peer1MultiAddress)
+		connectPeer(p.client1, p.peerInfo2.Addresses[0])
+		connectPeer(p.client2, p.peerInfo1.Addresses[0])
 
-		// sanity check that peers are registered
-		getPeers := func(p2pClient *sources.P2PClient) *apis.PeerDump {
-			peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerDump, error) {
-				return p2pClient.Peers(ctx, true)
-			})
-			require.NoError(err, "failed to get peers")
-			return peerDump
-		}
-		peerDump1, peerDump2 := getPeers(p2pClient1), getPeers(p2pClient2)
 		check := func(peerDump *apis.PeerDump, peerInfo *apis.PeerInfo) {
 			multiAddress := peerInfo.PeerID.String()
 			_, ok := peerDump.Peers[multiAddress]
 			require.True(ok, "peer register invalid")
 		}
-		check(peerDump1, peerInfo2)
-		check(peerDump2, peerInfo1)
+
+		peerDump1, err := GetPeers(ctx, p.client1)
+		require.NoError(err)
+		peerDump2, err := GetPeers(ctx, p.client2)
+		require.NoError(err)
+
+		check(peerDump1, p.peerInfo2)
+		check(peerDump2, p.peerInfo1)
 	}
 }
 
+// DisconnectL2CLP2P disconnects P2P between two L2CLs
 func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 	return func(o stack.Orchestrator) {
 		orch := o.(*Orchestrator)
 		require := o.P().Require()
 
-		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
-		require.True(ok, "looking for L2 CL node 1 to connect p2p")
-		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
-		require.True(ok, "looking for L2 CL node 2 to connect p2p")
-
-		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
+		l2cl1, ok := orch.l2CLs.Get(l2CL1ID)
+		require.True(ok, "looking for L2 CL node 1 to disconnect p2p")
+		l2cl2, ok := orch.l2CLs.Get(l2CL2ID)
+		require.True(ok, "looking for L2 CL node 2 to disconnect p2p")
+		require.Equal(l2cl1.cfg.Rollup.L2ChainID, l2cl2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
 		ctx := o.P().Ctx()
 		logger := o.P().Logger()
 
-		// initialize p2p clients per L2CL
-		p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
-		require.NoError(err)
-		p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)
-		require.NoError(err)
+		p := getP2PClientsAndPeers(ctx, logger, require, l2cl1, l2cl2)
 
-		// get peer info per L2CL
-		getPeerInfo := func(p2pClient *sources.P2PClient) *apis.PeerInfo {
-			peerInfo, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerInfo, error) {
-				return p2pClient.Self(ctx)
-			})
-			require.NoError(err, "failed to get peer info")
-			return peerInfo
-		}
-		peerInfo1, peerInfo2 := getPeerInfo(p2pClient1), getPeerInfo(p2pClient2)
-
-		// disconnect bidirectional p2p connection
 		disconnectPeer := func(p2pClient *sources.P2PClient, id peer.ID) {
 			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
 				return p2pClient.DisconnectPeer(ctx, id)
@@ -358,24 +371,21 @@ func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 			require.NoError(err, "failed to disconnect peer")
 		}
 
-		disconnectPeer(p2pClient1, peerInfo2.PeerID)
-		disconnectPeer(p2pClient2, peerInfo1.PeerID)
+		disconnectPeer(p.client1, p.peerInfo2.PeerID)
+		disconnectPeer(p.client2, p.peerInfo1.PeerID)
 
-		// sanity check that peers are registered
-		getPeers := func(p2pClient *sources.P2PClient) *apis.PeerDump {
-			peerDump, err := retry.Do(ctx, 3, retry.Exponential(), func() (*apis.PeerDump, error) {
-				return p2pClient.Peers(ctx, true)
-			})
-			require.NoError(err, "failed to get peers")
-			return peerDump
-		}
-		peerDump1, peerDump2 := getPeers(p2pClient1), getPeers(p2pClient2)
 		check := func(peerDump *apis.PeerDump, peerInfo *apis.PeerInfo) {
 			multiAddress := peerInfo.PeerID.String()
 			_, ok := peerDump.Peers[multiAddress]
 			require.False(ok, "peer deregister invalid")
 		}
-		check(peerDump1, peerInfo2)
-		check(peerDump2, peerInfo1)
+
+		peerDump1, err := GetPeers(ctx, p.client1)
+		require.NoError(err)
+		peerDump2, err := GetPeers(ctx, p.client2)
+		require.NoError(err)
+
+		check(peerDump1, p.peerInfo2)
+		check(peerDump2, p.peerInfo1)
 	}
 }

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -304,7 +304,7 @@ func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *requ
 	}
 }
 
-// WithL2CLP2PConnection disconnects P2P between two L2CLs
+// WithL2CLP2PConnection connects P2P between two L2CLs
 func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 	return func(o stack.Orchestrator) {
 		orch := o.(*Orchestrator)

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -219,3 +219,126 @@ func TestL2CLSyncP2P(gt *testing.T) {
 		}
 	}
 }
+
+// TestUnsafeChainUnknownToL2CL tests the below scenario:
+// supervisor unsafe ahead of L2CL unsafe, aka L2CL processes new blocks first.
+// To create this out-of-sync scenario, we follow the steps below:
+// 1. Make sequencer (L2CL), verifier (L2CL), and supervisor sync for a few blocks.
+// - Sequencer and verifier are connected via P2P, which makes their unsafe heads in sync.
+// - Both L2CLs are in managed mode, digesting L1 blocks from the supervisor and reporting unsafe and safe blocks back to the supervisor.
+// 2. Disconnect the P2P connection between the sequencer and verifier.
+// - The verifier will not receive unsafe heads via P2P, and can only update unsafe heads matching with safe heads by reading L1 batches.
+// - The verifier safe head will lag behind or match the sequencer and supervisor because all three components share the same L1 view.
+// - The verifier unsafe head will lag and always be out of sync compared to the sequencer and supervisor.
+// - The supervisor unsafe head is ahead of the verifier unsafe head, which means there are unsafe blocks unknown to the verifier.
+// 3. Reconnect the P2P connection between the sequencer and verifier.
+// - The sequencer will broadcast all unknown unsafe blocks to the verifier.
+// - The verifier will quickly catch up with the sequencer unsafe head as well as the supervisor.
+// - The verifier will process previously unknown unsafe blocks and advance its unsafe head.
+func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
+	var ids DefaultRedundancyInteropSystemIDs
+	opt := DefaultRedundancyInteropSystem(&ids)
+
+	logger := testlog.Logger(gt, log.LevelInfo)
+
+	p := devtest.NewP(logger, func() {
+		gt.Helper()
+		gt.FailNow()
+	})
+	gt.Cleanup(p.Close)
+
+	orch := NewOrchestrator(p)
+	opt(orch)
+
+	t := devtest.SerialT(gt)
+	system := shim.NewSystem(t)
+	orch.Hydrate(system)
+
+	blockTime := system.L2Network(ids.L2A).RollupConfig().BlockTime
+
+	waitTime := time.Duration(blockTime+1) * time.Second
+	{
+		logger := system.T().Logger()
+
+		elA := system.L2Network(ids.L2A).L2ELNode(ids.L2AEL)
+		elA2 := system.L2Network(ids.L2A).L2ELNode(ids.L2A2EL)
+		clA := system.L2Network(ids.L2A).L2CLNode(ids.L2ACL)
+		clA2 := system.L2Network(ids.L2A).L2CLNode(ids.L2A2CL)
+		supervisor := system.Supervisor(ids.Supervisor)
+
+		queryEL := func(label eth.BlockLabel) (eth.BlockRef, eth.BlockRef) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			blockA, err := elA.EthClient().BlockRefByLabel(ctx, label)
+			require.NoError(t, err)
+			blockA2, err := elA2.EthClient().BlockRefByLabel(ctx, label)
+			require.NoError(t, err)
+			cancel()
+			logger.Info("chain A", "blockNum", blockA.Number, "block", blockA)
+			logger.Info("chain A2", "blockNum", blockA2.Number, "block", blockA2)
+			return blockA, blockA2
+		}
+
+		queryCL := func() (*eth.SyncStatus, *eth.SyncStatus) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			syncA, err := clA.RollupAPI().SyncStatus(ctx)
+			require.NoError(t, err)
+			syncA2, err := clA2.RollupAPI().SyncStatus(ctx)
+			require.NoError(t, err)
+			cancel()
+			logger.Info("chain A", "sync", syncA)
+			logger.Info("chain A2", "sync", syncA2)
+			return syncA, syncA2
+		}
+
+		querySupervisor := func(chainID eth.ChainID) eth.BlockID {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			view, err := supervisor.QueryAPI().LocalUnsafe(ctx, chainID)
+			require.NoError(t, err)
+			cancel()
+			return view
+		}
+
+		targetBlockNum1 := uint64(10)
+		logger.Info("wait until reaching target block", "blockNum", targetBlockNum1)
+		require.Eventually(t, func() bool {
+			blockA, blockA2 := queryEL(eth.Unsafe)
+			return blockA.Number >= targetBlockNum1 && blockA2.Number >= targetBlockNum1
+		}, 30*time.Second, waitTime)
+
+		logger.Info("disconnect p2p between L2CLs")
+		DisconnectL2CLP2P(ids.L2ACL, ids.L2A2CL)(orch)
+
+		// verifier lost its P2P connection with sequencer, and will advance its unsafe head by reading L1 but not by P2P
+		_, prevblockA2 := queryEL(eth.Unsafe)
+		targetBlockNum2 := prevblockA2.Number + 5
+		logger.Info("make sure verifier advances safe head by reading L1", "blockNum", targetBlockNum2)
+		require.Eventually(t, func() bool {
+			_, syncA2 := queryCL()
+			// unsafe head and safe head both advanced from last observed unsafe head
+			return syncA2.SafeL2.Number == syncA2.UnsafeL2.Number && syncA2.SafeL2.Number > targetBlockNum2
+		}, 60*time.Second, waitTime)
+
+		logger.Info("verifier heads will lag compared from sequencer heads and supervisor view")
+		require.Never(t, func() bool {
+			syncA, syncA2 := queryCL()
+			chainAView := querySupervisor(elA2.ChainID())
+			// unsafe head will always lagged
+			check := syncA.UnsafeL2.Number > syncA2.UnsafeL2.Number
+			// safe head may be matched or lagged
+			check = check && syncA.SafeL2.Number >= syncA2.SafeL2.Number
+			// unsafe head may be matched or lagged compared to supervisor unsafe head view for chain A
+			check = check && chainAView.Number >= syncA2.UnsafeL2.Number
+			logger.Info("unsafe head sync status", "sequencer", syncA.UnsafeL2.Number, "supervisor", chainAView.Number, "verifier", syncA2.UnsafeL2.Number)
+			return !check
+		}, 15*time.Second, waitTime)
+
+		logger.Info("explicit reconnection of L2CL P2P between sequencer and verifier")
+		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL)(orch)
+
+		logger.Info("verifier catchs up sequencer unsafe chain with was unknown for verifier")
+		require.Eventually(t, func() bool {
+			blockA, blockA2 := queryEL(eth.Unsafe)
+			return blockA.Number == blockA2.Number && blockA.Hash == blockA2.Hash
+		}, 10*time.Second, waitTime)
+	}
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds test which tests below supervisor<>L2CL out of sync scenario:

```go
// TestUnsafeChainUnknownToL2CL tests the below scenario:
// supervisor unsafe ahead of L2CL unsafe, aka L2CL processes new blocks first.
// To create this out-of-sync scenario, we follow the steps below:
// 1. Make sequencer (L2CL), verifier (L2CL), and supervisor sync for a few blocks.
// - Sequencer and verifier are connected via P2P, which makes their unsafe heads in sync.
// - Both L2CLs are in managed mode, digesting L1 blocks from the supervisor and reporting unsafe and safe blocks back to the supervisor.
// 2. Disconnect the P2P connection between the sequencer and verifier.
// - The verifier will not receive unsafe heads via P2P, and can only update unsafe heads matching with safe heads by reading L1 batches.
// - The verifier safe head will lag behind or match the sequencer and supervisor because all three components share the same L1 view.
// - The verifier unsafe head will lag and always be out of sync compared to the sequencer and supervisor.
// - The supervisor unsafe head is ahead of the verifier unsafe head, which means there are unsafe blocks unknown to the verifier.
// 3. Reconnect the P2P connection between the sequencer and verifier.
// - The sequencer will broadcast all unknown unsafe blocks to the verifier.
// - The verifier will quickly catch up with the sequencer unsafe head as well as the supervisor.
// - The verifier will process previously unknown unsafe blocks and advance its unsafe head.
```

To do this, P2P disconnection logic was added to the current sysgo stack.

Note that the current sync tests lives in sysgo, but will be removed to parent directory or op-acceptance-tests/ dir for targeting both sysgo and sysext backends. Sysgo is a start.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15097