### PR TITLE
superchainerc20: floating pragma version

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -117,7 +117,7 @@
   },
   "src/L2/SuperchainERC20.sol:SuperchainERC20": {
     "initCodeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-    "sourceCodeHash": "0xe94cae4cd7ffba312ae909ff354e29c8cc6bec52d2d1933ab98425f35bc39f51"
+    "sourceCodeHash": "0x76eb2c7617e9b0b8dcd6b88470797cc946798a9ac067e3f195fff971fcabdbf5"
   },
   "src/L2/SuperchainETHBridge.sol:SuperchainETHBridge": {
     "initCodeHash": "0xa43665ad0f2b4f092ff04b12e38f24aa8d2cb34ae7a06fc037970743547bdf98",

--- a/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 // Contracts
 import { ERC20 } from "@solady-v0.0.245/tokens/ERC20.sol";
@@ -21,9 +21,9 @@ import { IERC7802, IERC165 } from "interfaces/L2/IERC7802.sol";
 ///         interacting with this contract.
 abstract contract SuperchainERC20 is ERC20, IERC7802, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1
+    /// @custom:semver 1.0.2
     function version() external view virtual returns (string memory) {
-        return "1.0.1";
+        return "1.0.2";
     }
 
     /// @notice Allows the SuperchainTokenBridge to mint tokens.


### PR DESCRIPTION
Updates the SuperchainERC20 contract to use a floating pragma: ^0.8.25