### PR TITLE
chore: Bump `kona` version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "REPOSITORY" {
 }
 
 variable "KONA_VERSION" {
-  default = "0.1.0-beta.15"
+  default = "0.1.0-beta.18"
 }
 
 variable "ASTERISC_VERSION" {

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -34,7 +34,7 @@ op-batcher-image TAG='op-batcher:devnet': (_docker_build_stack TAG "op-batcher-t
 # TODO: this is a temporary hack to get the kona + asterisc version right.
 # Ideally the Dockerfile should be self-sufficient (right now we depend on
 # docker-bake.hcl to do the right thing).
-op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=0.1.0-beta.15" "--build-arg" "ASTERISC_VERSION=v1.2.0")
+op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=0.1.0-beta.18" "--build-arg" "ASTERISC_VERSION=v1.2.0")
 op-conductor-image TAG='op-conductor:devnet': (_docker_build_stack TAG "op-conductor-target")
 op-deployer-image TAG='op-deployer:devnet': (_docker_build_stack TAG "op-deployer-target")
 op-dispute-mon-image TAG='op-dispute-mon:devnet': (_docker_build_stack TAG "op-dispute-mon-target")

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -186,7 +186,7 @@ ENV OP_CHALLENGER_CANNON_SERVER=/usr/local/bin/op-program
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 ENV OP_CHALLENGER_CANNON_BIN=/usr/local/bin/cannon
 # Copy in kona and asterisc
-COPY --from=kona /kona-host /usr/local/bin/
+COPY --from=kona /usr/local/bin/kona-host /usr/local/bin/
 ENV OP_CHALLENGER_ASTERISC_KONA_SERVER=/usr/local/bin/kona-host
 COPY --from=asterisc /usr/local/bin/asterisc /usr/local/bin/
 ENV OP_CHALLENGER_ASTERISC_BIN=/usr/local/bin/asterisc


### PR DESCRIPTION
## Overview

Bumps the version of kona to `v0.1.0-beta.18`, to be included in the next release of `op-challenger.