### PR TITLE
Make `WithL2ELNode` configurable with mempool filter and interop flags

### DIFF
--- a/devnet-sdk/devstack/sysgo/l2_el.go
+++ b/devnet-sdk/devstack/sysgo/l2_el.go
@@ -36,7 +36,7 @@ func (n *L2ELNode) hydrate(system stack.ExtensibleSystem) {
 	l2Net.(stack.ExtensibleL2Network).AddL2ELNode(sysL2EL)
 }
 
-func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID) stack.Option {
+func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID, enableMempoolFilter bool, enableInterop bool) stack.Option {
 	return func(o stack.Orchestrator) {
 		orch := o.(*Orchestrator)
 		require := o.P().Require()
@@ -46,7 +46,7 @@ func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID) stack.O
 
 		jwtPath, _ := orch.writeDefaultJWT()
 
-		useInterop := l2Net.genesis.Config.InteropTime != nil
+		useInterop := enableInterop
 
 		supervisorRPC := ""
 		if useInterop {
@@ -60,7 +60,7 @@ func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID) stack.O
 		l2Geth, err := geth.InitL2(id.String(), l2Net.genesis, jwtPath,
 			func(ethCfg *ethconfig.Config, nodeCfg *gn.Config) error {
 				ethCfg.InteropMessageRPC = supervisorRPC
-				ethCfg.InteropMempoolFiltering = true // TODO option
+				ethCfg.InteropMempoolFiltering = enableMempoolFilter
 				return nil
 			})
 		require.NoError(err)

--- a/devnet-sdk/devstack/sysgo/system.go
+++ b/devnet-sdk/devstack/sysgo/system.go
@@ -79,8 +79,8 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option {
 
 	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
 
-	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
-	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
+	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor, true, true))
+	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor, true, true))
 
 	opt.Add(WithL2CLNode(ids.L2ACL, true, ids.L1CL, ids.L1EL, ids.L2AEL))
 	opt.Add(WithL2CLNode(ids.L2BCL, true, ids.L1CL, ids.L1EL, ids.L2BEL))
@@ -128,7 +128,7 @@ func DefaultRedundancyInteropSystem(dest *DefaultRedundancyInteropSystemIDs) sta
 	var parentIds DefaultInteropSystemIDs
 	opt := DefaultInteropSystem(&parentIds)
 
-	opt.Add(WithL2ELNode(ids.L2A2EL, &ids.Supervisor))
+	opt.Add(WithL2ELNode(ids.L2A2EL, &ids.Supervisor, true, true))
 	opt.Add(WithL2CLNode(ids.L2A2CL, false, ids.L1CL, ids.L1EL, ids.L2A2EL))
 
 	// verifier must be also managed or it cannot advance


### PR DESCRIPTION
### Description

This PR refactors the `WithL2ELNode` function to make it more flexible by adding two explicit parameters:

- `enableMempoolFilter` (previously hardcoded `true`)
- `enableInterop` (previously inferred from `genesis.Config.InteropTime`)

This makes the behavior of L2 EL nodes more transparent and configurable, while maintaining existing defaults through updated usage in `DefaultInteropSystem` and `DefaultRedundancyInteropSystem`.

No functional logic is changed — only hardcoded behavior is moved to parameters.

---

### Tests

No tests were changed, as the behavior of the system remains the same. Existing tests (`TestSystem`) confirm correct node wiring, sync progress, and matchers, and all still pass.

---

### Additional context

This change simplifies future test and system configuration. It removes reliance on implicit conditions (e.g. presence of `InteropTime`), which improves clarity and testability of orchestration code.

---

### Metadata

- Ref: TODO add issue if relevant, or remove this section
