### PR TITLE
op-deployer: Support custom OPCM

### DIFF
--- a/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
+++ b/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
@@ -1,0 +1,30 @@
+package opcm
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ReadSuperchainDeploymentInput struct {
+	OPCMAddress common.Address `abi:"opcmAddress"`
+}
+
+type ReadSuperchainDeploymentOutput struct {
+	ProtocolVersionsImpl  common.Address
+	ProtocolVersionsProxy common.Address
+	SuperchainConfigImpl  common.Address
+	SuperchainConfigProxy common.Address
+	SuperchainProxyAdmin  common.Address
+
+	Guardian                   common.Address
+	ProtocolVersionsOwner      common.Address
+	SuperchainProxyAdminOwner  common.Address
+	RecommendedProtocolVersion [32]byte
+	RequiredProtocolVersion    [32]byte
+}
+
+type ReadSuperchainDeploymentScript script.DeployScriptWithOutput[ReadSuperchainDeploymentInput, ReadSuperchainDeploymentOutput]
+
+func NewReadSuperchainDeploymentScript(host *script.Host) (ReadSuperchainDeploymentScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[ReadSuperchainDeploymentInput, ReadSuperchainDeploymentOutput](host, "ReadSuperchainDeployment.s.sol", "ReadSuperchainDeployment")
+}

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -57,7 +57,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			SuperchainConfigProxy:           st.SuperchainDeployment.SuperchainConfigProxyAddress,
 			ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxyAddress,
 			SuperchainProxyAdmin:            st.SuperchainDeployment.ProxyAdminAddress,
-			UpgradeController:               intent.SuperchainRoles.ProxyAdminOwner,
+			UpgradeController:               st.SuperchainRoles.ProxyAdminOwner,
 			UseInterop:                      intent.UseInterop,
 		},
 	)

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 
@@ -25,8 +25,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return err
 	}
 
-	opcmAddress, opcmAddrErr := standard.ManagerImplementationAddrFor(intent.L1ChainID, intent.L1ContractsLocator.Tag)
-	hasPredeployedOPCM := opcmAddrErr == nil
+	hasPredeployedOPCM := intent.OPCMAddress != nil
 	isL1Tag := intent.L1ContractsLocator.IsTag()
 	isL2Tag := intent.L2ContractsLocator.IsTag()
 
@@ -38,38 +37,23 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return fmt.Errorf("unsupported L2 version: %s", intent.L2ContractsLocator.Tag)
 	}
 
-	isStandardIntent := intent.ConfigType == state.IntentTypeStandard ||
-		intent.ConfigType == state.IntentTypeStandardOverrides
-	if isL1Tag && hasPredeployedOPCM && isStandardIntent {
+	if isL1Tag && hasPredeployedOPCM {
 		if intent.SuperchainConfigProxy != nil {
-			return fmt.Errorf("cannot set superchain config proxy for standard intent")
+			return fmt.Errorf("cannot set superchain config proxy for predeployed OPCM")
 		}
 
-		stdRoles, err := state.GetStandardSuperchainRoles(intent.L1ChainID)
+		if intent.SuperchainRoles != nil {
+			return fmt.Errorf("cannot set superchain roles for predeployed OPCM")
+		}
+
+		superDeployment, superRoles, err := PopulateSuperchainState(env.L1ScriptHost, *intent.OPCMAddress)
 		if err != nil {
-			return fmt.Errorf("error getting superchain roles: %w", err)
+			return fmt.Errorf("error populating superchain state: %w", err)
 		}
-
-		if *intent.SuperchainRoles == *stdRoles {
-			superCfg, err := standard.SuperchainFor(intent.L1ChainID)
-			if err != nil {
-				return fmt.Errorf("error getting superchain config: %w", err)
-			}
-
-			proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(intent.L1ChainID)
-			if err != nil {
-				return fmt.Errorf("error getting superchain proxy admin address: %w", err)
-			}
-
-			st.SuperchainDeployment = &state.SuperchainDeployment{
-				ProxyAdminAddress:            proxyAdmin,
-				ProtocolVersionsProxyAddress: superCfg.ProtocolVersionsAddr,
-				SuperchainConfigProxyAddress: superCfg.SuperchainConfigAddr,
-			}
-
-			st.ImplementationsDeployment = &state.ImplementationsDeployment{
-				OpcmAddress: opcmAddress,
-			}
+		st.SuperchainDeployment = superDeployment
+		st.SuperchainRoles = superRoles
+		st.ImplementationsDeployment = &state.ImplementationsDeployment{
+			OpcmAddress: *intent.OPCMAddress,
 		}
 	}
 
@@ -146,4 +130,32 @@ func InitGenesisStrategy(env *Env, intent *state.Intent, st *state.State) error 
 
 func immutableErr(field string, was, is any) error {
 	return fmt.Errorf("%s is immutable: was %v, is %v", field, was, is)
+}
+
+func PopulateSuperchainState(host *script.Host, opcmAddr common.Address) (*state.SuperchainDeployment, *state.SuperchainRoles, error) {
+	readScript, err := opcm.NewReadSuperchainDeploymentScript(host)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error generating read superchain deployment script: %w", err)
+	}
+
+	out, err := readScript.Run(opcm.ReadSuperchainDeploymentInput{
+		OPCMAddress: opcmAddr,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading superchain deployment: %w", err)
+	}
+
+	deployment := &state.SuperchainDeployment{
+		ProxyAdminAddress:            out.SuperchainProxyAdmin,
+		SuperchainConfigProxyAddress: out.SuperchainConfigProxy,
+		SuperchainConfigImplAddress:  out.SuperchainConfigImpl,
+		ProtocolVersionsProxyAddress: out.ProtocolVersionsProxy,
+		ProtocolVersionsImplAddress:  out.ProtocolVersionsImpl,
+	}
+	roles := &state.SuperchainRoles{
+		Guardian:              out.Guardian,
+		ProtocolVersionsOwner: out.ProtocolVersionsOwner,
+		ProxyAdminOwner:       out.SuperchainProxyAdminOwner,
+	}
+	return deployment, roles, nil
 }

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -2,16 +2,17 @@ package pipeline
 
 import (
 	"context"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 	"log/slog"
 	"math/big"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -2,7 +2,13 @@ package pipeline
 
 import (
 	"context"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"log/slog"
+	"math/big"
 	"os"
 	"testing"
 	"time"
@@ -18,6 +24,8 @@ import (
 )
 
 func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
+	t.Parallel()
+
 	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
 	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
 
@@ -31,8 +39,9 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	client, err := ethclient.Dial(retryProxy.Endpoint())
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
 	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
 
 	l1ChainID := uint64(11155111)
 	t.Run("untagged L1 locator", func(t *testing.T) {
@@ -60,7 +69,21 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 
 	t.Run("tagged L1 locator with standard intent types and standard roles", func(t *testing.T) {
 		runTest := func(configType state.IntentType) {
+			_, afacts := testutil.LocalArtifacts(t)
+			host, err := env.DefaultForkedScriptHost(
+				ctx,
+				broadcaster.NoopBroadcaster(),
+				testlog.Logger(t, log.LevelInfo),
+				common.Address{'D'},
+				afacts,
+				rpcClient,
+			)
+			require.NoError(t, err)
+
 			stdSuperchainRoles, err := state.GetStandardSuperchainRoles(l1ChainID)
+			require.NoError(t, err)
+
+			opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainID, artifacts.DefaultL1ContractsLocator.Tag)
 			require.NoError(t, err)
 
 			intent := &state.Intent{
@@ -68,7 +91,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 				L1ChainID:          l1ChainID,
 				L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
 				L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-				SuperchainRoles:    stdSuperchainRoles,
+				OPCMAddress:        &opcmAddr,
 			}
 			st := &state.State{
 				Version: 1,
@@ -76,8 +99,9 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			require.NoError(t, InitLiveStrategy(
 				ctx,
 				&Env{
-					L1Client: client,
-					Logger:   lgr,
+					L1Client:     client,
+					Logger:       lgr,
+					L1ScriptHost: host,
 				},
 				intent,
 				st,
@@ -88,20 +112,22 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			require.NoError(t, err)
 			proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(l1ChainID)
 			require.NoError(t, err)
-			opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainID, intent.L1ContractsLocator.Tag)
-			require.NoError(t, err)
 
 			expDeployment := &state.SuperchainDeployment{
 				ProxyAdminAddress:            proxyAdmin,
 				ProtocolVersionsProxyAddress: superCfg.ProtocolVersionsAddr,
+				ProtocolVersionsImplAddress:  common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 				SuperchainConfigProxyAddress: superCfg.SuperchainConfigAddr,
+				SuperchainConfigImplAddress:  common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM
 			require.NotNil(t, st.SuperchainDeployment)
 			require.NotNil(t, st.ImplementationsDeployment)
+			require.NotNil(t, st.SuperchainRoles)
 			require.Equal(t, *expDeployment, *st.SuperchainDeployment)
 			require.Equal(t, opcmAddr, st.ImplementationsDeployment.OpcmAddress)
+			require.Equal(t, *stdSuperchainRoles, *st.SuperchainRoles)
 		}
 
 		runTest(state.IntentTypeStandard)
@@ -168,4 +194,58 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 		require.Nil(t, st.SuperchainDeployment)
 		require.Nil(t, st.ImplementationsDeployment)
 	})
+}
+
+// TestPopulateSuperchainState validates that the ReadSuperchainDeployment script successfully returns data about the
+// given Superchain. For testing purposes, we use a forked script host that points to a pinned block on Sepolia. Pinning
+// the block lets us use constant values in the test without worrying about changes on chain. We use values from the SR
+// whenever possible, however some (like the Superchain PAO) are not included in the SR and are therefore hardcoded.
+func TestPopulateSuperchainState(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	host, err := env.ForkedScriptHost(
+		broadcaster.NoopBroadcaster(),
+		testlog.Logger(t, log.LevelInfo),
+		common.Address{'D'},
+		afacts,
+		rpcClient,
+		// corresponds to the latest block on sepolia as of 04/30/2025. used to prevent config drift on sepolia
+		// from failing this test
+		big.NewInt(8227159),
+	)
+	require.NoError(t, err)
+
+	l1Versions, err := standard.L1VersionsFor(11155111)
+	require.NoError(t, err)
+	superchain, err := standard.SuperchainFor(11155111)
+	require.NoError(t, err)
+	opcmAddr := l1Versions["op-contracts/v2.0.0-rc.1"].OPContractsManager.Address
+	dep, roles, err := PopulateSuperchainState(host, common.Address(*opcmAddr))
+	require.NoError(t, err)
+	require.Equal(t, state.SuperchainDeployment{
+		ProxyAdminAddress:            common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"),
+		SuperchainConfigProxyAddress: superchain.SuperchainConfigAddr,
+		SuperchainConfigImplAddress:  common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
+		ProtocolVersionsProxyAddress: superchain.ProtocolVersionsAddr,
+		ProtocolVersionsImplAddress:  common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
+	}, *dep)
+	require.Equal(t, state.SuperchainRoles{
+		ProxyAdminOwner:       common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2"),
+		ProtocolVersionsOwner: common.HexToAddress("0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"),
+		Guardian:              common.HexToAddress("0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"),
+	}, *roles)
 }

--- a/op-deployer/pkg/deployer/pipeline/superchain.go
+++ b/op-deployer/pkg/deployer/pipeline/superchain.go
@@ -41,6 +41,7 @@ func DeploySuperchain(env *Env, intent *state.Intent, st *state.State) error {
 		ProtocolVersionsProxyAddress: dso.ProtocolVersionsProxy,
 		ProtocolVersionsImplAddress:  dso.ProtocolVersionsImpl,
 	}
+	st.SuperchainRoles = intent.SuperchainRoles
 
 	return nil
 }

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -69,6 +69,14 @@ func TestValidateStandardValues(t *testing.T) {
 			},
 			ErrNonStandardValue,
 		},
+		{
+			"OPCMAddress",
+			func(intent *Intent) {
+				addr := common.HexToAddress("0x9999")
+				intent.OPCMAddress = &addr
+			},
+			ErrNonStandardValue,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -43,6 +43,9 @@ type State struct {
 	// can be looked up on chain.
 	SuperchainDeployment *SuperchainDeployment `json:"superchainDeployment"`
 
+	// SuperchainRoles contains the addresses of the Superchain roles.
+	SuperchainRoles *SuperchainRoles `json:"superchainRoles"`
+
 	// ImplementationsDeployment contains the addresses of the common implementation
 	// contracts required for the Superchain to function.
 	ImplementationsDeployment *ImplementationsDeployment `json:"implementationsDeployment"`

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+
+contract ReadSuperchainDeployment is Script {
+    struct Input {
+        IOPContractsManager opcmAddress;
+    }
+
+    struct Output {
+        IProtocolVersions protocolVersionsImpl;
+        IProtocolVersions protocolVersionsProxy;
+        ISuperchainConfig superchainConfigImpl;
+        ISuperchainConfig superchainConfigProxy;
+        IProxyAdmin superchainProxyAdmin;
+        address guardian;
+        address protocolVersionsOwner;
+        address superchainProxyAdminOwner;
+        bytes32 recommendedProtocolVersion;
+        bytes32 requiredProtocolVersion;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        require(address(_input.opcmAddress) != address(0), "ReadSuperchainDeployment: opcmAddress not set");
+
+        IOPContractsManager opcm = IOPContractsManager(_input.opcmAddress);
+
+        output_.protocolVersionsProxy = IProtocolVersions(opcm.protocolVersions());
+        output_.superchainConfigProxy = ISuperchainConfig(opcm.superchainConfig());
+        output_.superchainProxyAdmin = IProxyAdmin(opcm.superchainProxyAdmin());
+
+        IProxy protocolVersionsProxy = IProxy(payable(address(output_.protocolVersionsProxy)));
+        IProxy superchainConfigProxy = IProxy(payable(address(output_.superchainConfigProxy)));
+
+        vm.startPrank(address(0));
+        output_.protocolVersionsImpl = IProtocolVersions(address(protocolVersionsProxy.implementation()));
+        output_.superchainConfigImpl = ISuperchainConfig(address(superchainConfigProxy.implementation()));
+        output_.protocolVersionsImpl = IProtocolVersions(protocolVersionsProxy.implementation());
+        output_.superchainConfigImpl = ISuperchainConfig(superchainConfigProxy.implementation());
+        vm.stopPrank();
+
+        output_.guardian = output_.superchainConfigProxy.guardian();
+        output_.protocolVersionsOwner = output_.protocolVersionsProxy.owner();
+        output_.superchainProxyAdminOwner = output_.superchainProxyAdmin.owner();
+        output_.recommendedProtocolVersion =
+            bytes32(ProtocolVersion.unwrap(output_.protocolVersionsProxy.recommended()));
+        output_.requiredProtocolVersion = bytes32(ProtocolVersion.unwrap(output_.protocolVersionsProxy.required()));
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -7,9 +7,6 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
-import { Solarray } from "scripts/libraries/Solarray.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 
 contract ReadSuperchainDeployment is Script {


### PR DESCRIPTION
This update lets `op-deployer` handle custom OPCM deployments. To make this work, the OPCM is now a required field in the intent. Running `init` with a config type of `standard` will pre-populate the correct OPCM.