### PR TITLE
op-e2e: Add action test for consolidation step prior to interop being active

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -308,7 +308,7 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) err
 		L1FeeVaultWithdrawalNetwork:              big.NewInt(int64(cfg.L1FeeVaultWithdrawalNetwork.ToUint8())),
 		GovernanceTokenOwner:                     cfg.GovernanceTokenOwner,
 		Fork:                                     big.NewInt(cfg.SolidityForkNumber(1)),
-		UseInterop:                               true,
+		UseInterop:                               cfg.UseInterop,
 		EnableGovernance:                         cfg.EnableGovernance,
 		FundDevAccounts:                          cfg.FundDevAccounts,
 	}); err != nil {

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -262,7 +262,8 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 				L2GenesisJovianTimeOffset:   nil,
 				L1CancunTimeOffset:          new(hexutil.Uint64),
 				L1PragueTimeOffset:          new(hexutil.Uint64),
-				UseInterop:                  true,
+				// Don't deploy interop L2 contracts if interop hard fork isn't active at genesis
+				UseInterop: r.InteropOffset == 0,
 			},
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
 				L1ChainID:                 l1ChainID,

--- a/op-e2e/actions/interop/dsl/inbox.go
+++ b/op-e2e/actions/interop/dsl/inbox.go
@@ -30,6 +30,7 @@ func NewInboxContract(t helpers.Testing) *InboxContract {
 type ExecuteOpts struct {
 	Identifier *inbox.Identifier
 	Payload    *[]byte
+	GasLimit   uint64
 }
 
 func WithIdentifier(ident inbox.Identifier) func(opts *ExecuteOpts) {
@@ -41,6 +42,12 @@ func WithIdentifier(ident inbox.Identifier) func(opts *ExecuteOpts) {
 func WithPayload(payload []byte) func(opts *ExecuteOpts) {
 	return func(opts *ExecuteOpts) {
 		opts.Payload = &payload
+	}
+}
+
+func WithFixedGasLimit() func(opts *ExecuteOpts) {
+	return func(opts *ExecuteOpts) {
+		opts.GasLimit = 1_000_000 // Overly large to ensure the tx doesn't OOG.
 	}
 }
 
@@ -87,6 +94,7 @@ func (i *InboxContract) Execute(user *DSLUser, initTx *GeneratedTransaction, arg
 			payload = initTx.MessagePayload()
 		}
 		txOpts, from := user.TransactOpts(chain.ChainID.ToBig())
+		txOpts.GasLimit = opts.GasLimit
 		contract, err := inbox.NewInbox(predeploys.CrossL2InboxAddr, chain.SequencerEngine.EthClient())
 		require.NoError(i.t, err)
 		id := stypes.Identifier{

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -140,6 +140,18 @@ func SetInteropOffsetForAllL2s(offset uint64) setupOption {
 	}
 }
 
+func SetInteropForkScheduledButInactive() setupOption {
+	return func(recipe *interopgen.InteropDevRecipe) {
+		// Update in place to avoid making a copy and losing the change.
+		// Set to a year in the future. Far enough tests won't hit it
+		// but not so far it will overflow when added to current time.
+		val := uint64(365 * 24 * 60 * 60)
+		for key := range recipe.L2s {
+			recipe.L2s[key].InteropOffset = val
+		}
+	}
+}
+
 // SetupInterop creates an InteropSetup to instantiate actors on, with 2 L2 chains.
 func SetupInterop(t helpers.Testing, opts ...setupOption) *InteropSetup {
 	recipe := interopgen.InteropDevRecipe{

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -176,8 +176,18 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	system := dsl.NewInteropDSL(t, dsl.SetInteropForkScheduledButInactive())
 
-	system.AddL2Block(system.Actors.ChainA)
-	system.AddL2Block(system.Actors.ChainB)
+	actors := system.Actors
+	endTimestamp := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime
+	startTimestamp := endTimestamp - 1
+	require.False(t, actors.ChainA.RollupCfg.IsInterop(endTimestamp), "Interop should not be active")
+
+	alice := system.CreateUser()
+	emitter := system.DeployEmitterContracts()
+
+	system.AddL2Block(system.Actors.ChainA, dsl.WithL2BlockTransactions(emitter.EmitMessage(alice, "hello")))
+	initMsg := emitter.LastEmittedMessage()
+	system.AddL2Block(system.Actors.ChainB, dsl.WithL2BlockTransactions(system.InboxContract.Execute(alice, initMsg, dsl.WithPayload([]byte("wrong")))))
+	system.InboxContract.LastTransaction().CheckIncluded()
 
 	// Submit batch data for each chain in separate L1 blocks so tests can have one chain safe and one unsafe
 	system.SubmitBatchData(func(opts *dsl.SubmitBatchDataOpts) {
@@ -186,12 +196,9 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 	system.SubmitBatchData(func(opts *dsl.SubmitBatchDataOpts) {
 		opts.SetChains(system.Actors.ChainB)
 	})
-
-	actors := system.Actors
-
-	endTimestamp := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime
-	startTimestamp := endTimestamp - 1
-	require.False(t, actors.ChainA.RollupCfg.IsInterop(endTimestamp), "Interop should not be active")
+	// Check that the supervisor didn't re-org out this transaction.
+	// Interop isn't active yet so the extra derivation rules to validate executing messages must not be active.
+	system.InboxContract.LastTransaction().CheckIncluded()
 
 	start := system.Outputs.SuperRoot(startTimestamp)
 	end := system.Outputs.SuperRoot(endTimestamp)
@@ -222,6 +229,8 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 			disputedClaim:      step1Expected,
 			disputedTraceIndex: 0,
 			expectValid:        true,
+			startTimestamp:     startTimestamp,
+			proposalTimestamp:  endTimestamp,
 		},
 		{
 			name:               "SecondChainOptimisticBlock",
@@ -229,6 +238,8 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 			disputedClaim:      step2Expected,
 			disputedTraceIndex: 1,
 			expectValid:        true,
+			startTimestamp:     startTimestamp,
+			proposalTimestamp:  endTimestamp,
 		},
 		{
 			name:               "FirstPaddingStep",
@@ -236,6 +247,8 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 			disputedClaim:      firstPaddingStep,
 			disputedTraceIndex: 2,
 			expectValid:        true,
+			startTimestamp:     startTimestamp,
+			proposalTimestamp:  endTimestamp,
 		},
 		{
 			name:               "Consolidate",
@@ -243,6 +256,8 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 			disputedClaim:      end.Marshal(),
 			disputedTraceIndex: consolidateStep,
 			expectValid:        true,
+			startTimestamp:     startTimestamp,
+			proposalTimestamp:  endTimestamp,
 		},
 	}
 

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -172,6 +172,83 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 	runFppAndChallengerTests(gt, system, tests)
 }
 
+func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	system := dsl.NewInteropDSL(t, dsl.SetInteropForkScheduledButInactive())
+
+	system.AddL2Block(system.Actors.ChainA)
+	system.AddL2Block(system.Actors.ChainB)
+
+	// Submit batch data for each chain in separate L1 blocks so tests can have one chain safe and one unsafe
+	system.SubmitBatchData(func(opts *dsl.SubmitBatchDataOpts) {
+		opts.SetChains(system.Actors.ChainA)
+	})
+	system.SubmitBatchData(func(opts *dsl.SubmitBatchDataOpts) {
+		opts.SetChains(system.Actors.ChainB)
+	})
+
+	actors := system.Actors
+
+	endTimestamp := actors.ChainA.RollupCfg.Genesis.L2Time + actors.ChainA.RollupCfg.BlockTime
+	startTimestamp := endTimestamp - 1
+	require.False(t, actors.ChainA.RollupCfg.IsInterop(endTimestamp), "Interop should not be active")
+
+	start := system.Outputs.SuperRoot(startTimestamp)
+	end := system.Outputs.SuperRoot(endTimestamp)
+
+	step1Expected := system.Outputs.TransitionState(startTimestamp, 1,
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainA, endTimestamp),
+	).Marshal()
+
+	step2Expected := system.Outputs.TransitionState(startTimestamp, 2,
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainA, endTimestamp),
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainB, endTimestamp),
+	).Marshal()
+
+	firstPaddingStep := system.Outputs.TransitionState(startTimestamp, 3,
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainA, endTimestamp),
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainB, endTimestamp),
+	).Marshal()
+
+	lastPaddingStep := system.Outputs.TransitionState(startTimestamp, consolidateStep,
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainA, endTimestamp),
+		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainB, endTimestamp),
+	).Marshal()
+
+	tests := []*transitionTest{
+		{
+			name:               "FirstChainOptimisticBlock",
+			agreedClaim:        start.Marshal(),
+			disputedClaim:      step1Expected,
+			disputedTraceIndex: 0,
+			expectValid:        true,
+		},
+		{
+			name:               "SecondChainOptimisticBlock",
+			agreedClaim:        step1Expected,
+			disputedClaim:      step2Expected,
+			disputedTraceIndex: 1,
+			expectValid:        true,
+		},
+		{
+			name:               "FirstPaddingStep",
+			agreedClaim:        step2Expected,
+			disputedClaim:      firstPaddingStep,
+			disputedTraceIndex: 2,
+			expectValid:        true,
+		},
+		{
+			name:               "Consolidate",
+			agreedClaim:        lastPaddingStep,
+			disputedClaim:      end.Marshal(),
+			disputedTraceIndex: consolidateStep,
+			expectValid:        true,
+		},
+	}
+
+	runFppAndChallengerTests(gt, system, tests)
+}
+
 func TestInteropFaultProofs(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	system := dsl.NewInteropDSL(t)

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -186,8 +186,12 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 
 	system.AddL2Block(system.Actors.ChainA, dsl.WithL2BlockTransactions(emitter.EmitMessage(alice, "hello")))
 	initMsg := emitter.LastEmittedMessage()
-	system.AddL2Block(system.Actors.ChainB, dsl.WithL2BlockTransactions(system.InboxContract.Execute(alice, initMsg, dsl.WithPayload([]byte("wrong")))))
-	system.InboxContract.LastTransaction().CheckIncluded()
+	system.AddL2Block(system.Actors.ChainB,
+		dsl.WithL2BlockTransactions(system.InboxContract.Execute(alice, initMsg,
+			dsl.WithPayload([]byte("wrong")),
+			// CrossL2Inbox contract isn't deployed so the tx will revert. Need to avoid using eth_estimateGas
+			dsl.WithFixedGasLimit())))
+	system.InboxContract.LastTransaction().CheckIncluded(dsl.WithRevertExpected())
 
 	// Submit batch data for each chain in separate L1 blocks so tests can have one chain safe and one unsafe
 	system.SubmitBatchData(func(opts *dsl.SubmitBatchDataOpts) {
@@ -198,7 +202,7 @@ func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 	})
 	// Check that the supervisor didn't re-org out this transaction.
 	// Interop isn't active yet so the extra derivation rules to validate executing messages must not be active.
-	system.InboxContract.LastTransaction().CheckIncluded()
+	system.InboxContract.LastTransaction().CheckIncluded(dsl.WithRevertExpected())
 
 	start := system.Outputs.SuperRoot(startTimestamp)
 	end := system.Outputs.SuperRoot(endTimestamp)


### PR DESCRIPTION
**Description**

Mostly checks the supervisor can return super roots prior to interop. The action test deployment is fixed to not include the interop contracts in L2 genesis unless interop is enabled from genesis.  The test sends a message to the CrossL2Inbox which reverts because the proxy is uninitialised (because we didn't deploy the contract yet). The test then confirms the transaction isn't re-orged out (with revert status) and that op-program matches the op-supervisor behaviour.

**Metadata**

part of #15625 
