### PR TITLE
op-deployer: support MIPS64 contract verification

### DIFF
--- a/op-deployer/pkg/deployer/verify/artifacts.go
+++ b/op-deployer/pkg/deployer/verify/artifacts.go
@@ -21,7 +21,7 @@ type contractArtifact struct {
 
 // Map state.json struct fields to forge artifact paths
 var contractNameExceptions = map[string]string{
-	"OptimismPortalImpl":          "OptimismPortal2.sol/OptimismPortal2.json",
+	"OptimismPortal":              "OptimismPortal2.sol/OptimismPortal2.json",
 	"L1StandardBridgeProxy":       "L1ChugSplashProxy.sol/L1ChugSplashProxy.json",
 	"L1CrossDomainMessengerProxy": "ResolvedDelegateProxy.sol/ResolvedDelegateProxy.json",
 	"Opcm":                        "OPContractsManager.sol/OPContractsManager.json",
@@ -30,10 +30,13 @@ var contractNameExceptions = map[string]string{
 	"OpcmDeployer":                "OPContractsManager.sol/OPContractsManagerDeployer.json",
 	"OpcmUpgrader":                "OPContractsManager.sol/OPContractsManagerUpgrader.json",
 	"OpcmInteropMigrator":         "OPContractsManager.sol/OPContractsManagerInteropMigrator.json",
+	"Mips":                        "MIPS64.sol/MIPS64.json",
 }
 
 func getArtifactPath(name string) string {
 	lookupName := strings.TrimSuffix(name, "Address")
+	lookupName = strings.TrimSuffix(lookupName, "Impl")
+	lookupName = strings.TrimSuffix(lookupName, "Singleton")
 	lookupName = strings.ToUpper(string(lookupName[0])) + lookupName[1:]
 
 	if artifactPath, exists := contractNameExceptions[lookupName]; exists {
@@ -41,8 +44,6 @@ func getArtifactPath(name string) string {
 	}
 
 	lookupName = strings.TrimSuffix(lookupName, "Proxy")
-	lookupName = strings.TrimSuffix(lookupName, "Impl")
-	lookupName = strings.TrimSuffix(lookupName, "Singleton")
 
 	// If it was a proxy and not a special case, return "Proxy"
 	if strings.HasSuffix(name, "ProxyAddress") {

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -37,9 +37,11 @@ type EtherscanClient struct {
 func getAPIEndpoint(l1ChainID uint64) (string, error) {
 	switch l1ChainID {
 	case 1:
-		return "https://api.etherscan.io/api", nil // mainnet
+		return "https://api.etherscan.io/api", nil // eth-mainnet
 	case 11155111:
-		return "https://api-sepolia.etherscan.io/api", nil // sepolia
+		return "https://api-sepolia.etherscan.io/api", nil // eth-sepolia
+	case 84532:
+		return "https://api-sepolia.basescan.org/api", nil // base-sepolia
 	default:
 		return "", fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -35,6 +35,7 @@ func NewVerifier(apiKey string, l1ChainID uint64, artifactsFS foundry.StatDirFs,
 	if err != nil {
 		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}
+	l.Info("found etherscan url", "url", etherscanUrl)
 
 	etherscan := NewEtherscanClient(apiKey, etherscanUrl, rate.NewLimiter(rate.Limit(3), 2))
 


### PR DESCRIPTION
The default MIPS contract that gets deployed is now `MIPS64` so we need to point to that forge-artifact during contract verification. The name of the contract in our go structs is still `mips` or `mipsSingleton` so this pr adds an exception that maps `Mips` --> `MIPS64.sol/MIPS64.json`