### PR TITLE
refactor(test): improve ProtocolVersions test structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -9,7 +9,9 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 
-contract ProtocolVersions_Init is CommonTest {
+/// @title ProtocolVersions Test Init
+/// @notice Test initialization for ProtocolVersions tests.
+contract ProtocolVersions_TestInit is CommonTest {
     event ConfigUpdate(uint256 indexed version, IProtocolVersions.UpdateType indexed updateType, bytes data);
 
     ProtocolVersion required;
@@ -22,8 +24,10 @@ contract ProtocolVersions_Init is CommonTest {
     }
 }
 
-contract ProtocolVersions_Initialize_Test is ProtocolVersions_Init {
-    /// @dev Tests that initialization sets the correct values.
+/// @title ProtocolVersions_Initialize_Test
+/// @notice Test contract for ProtocolVersions `initialize` function.
+contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
+    /// @notice Tests that initialization sets the correct values.
     function test_initialize_values_succeeds() external {
         skipIfForkTest(
             "ProtocolVersions_Initialize_Test: cannot test initialization on forked network against hardhat config"
@@ -40,7 +44,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_Init {
         assertEq(protocolVersionsImpl.owner(), address(0));
     }
 
-    /// @dev Ensures that the events are emitted during initialization.
+    /// @notice Ensures that the events are emitted during initialization.
     function test_initialize_events_succeeds() external {
         IProtocolVersions protocolVersionsImpl = IProtocolVersions(artifacts.mustGetAddress("ProtocolVersionsImpl"));
 
@@ -68,22 +72,10 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_Init {
     }
 }
 
-contract ProtocolVersions_Setters_TestFail is ProtocolVersions_Init {
-    /// @dev Tests that `setRequired` reverts if the caller is not the owner.
-    function test_setRequired_notOwner_reverts() external {
-        vm.expectRevert("Ownable: caller is not the owner");
-        protocolVersions.setRequired(ProtocolVersion.wrap(0));
-    }
-
-    /// @dev Tests that `setRecommended` reverts if the caller is not the owner.
-    function test_setRecommended_notOwner_reverts() external {
-        vm.expectRevert("Ownable: caller is not the owner");
-        protocolVersions.setRecommended(ProtocolVersion.wrap(0));
-    }
-}
-
-contract ProtocolVersions_Setters_Test is ProtocolVersions_Init {
-    /// @dev Tests that `setRequired` updates the required protocol version successfully.
+/// @title ProtocolVersions_SetRequired_Test
+/// @notice Test contract for ProtocolVersions `setRequired` function.
+contract ProtocolVersions_SetRequired_Test is ProtocolVersions_TestInit {
+    /// @notice Tests that `setRequired` updates the required protocol version successfully.
     function testFuzz_setRequired_succeeds(uint256 _version) external {
         vm.expectEmit(true, true, true, true);
         emit ConfigUpdate(0, IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(_version));
@@ -93,7 +85,17 @@ contract ProtocolVersions_Setters_Test is ProtocolVersions_Init {
         assertEq(ProtocolVersion.unwrap(protocolVersions.required()), _version);
     }
 
-    /// @dev Tests that `setRecommended` updates the recommended protocol version successfully.
+    /// @notice Tests that `setRequired` reverts if the caller is not the owner.
+    function test_setRequired_notOwner_reverts() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+        protocolVersions.setRequired(ProtocolVersion.wrap(0));
+    }
+}
+
+/// @title ProtocolVersions_SetRecommended_Test
+/// @notice Test contract for ProtocolVersions `setRecommended` function.
+contract ProtocolVersions_SetRecommended_Test is ProtocolVersions_TestInit {
+    /// @notice Tests that `setRecommended` updates the recommended protocol version successfully.
     function testFuzz_setRecommended_succeeds(uint256 _version) external {
         vm.expectEmit(true, true, true, true);
         emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(_version));
@@ -101,5 +103,11 @@ contract ProtocolVersions_Setters_Test is ProtocolVersions_Init {
         vm.prank(protocolVersions.owner());
         protocolVersions.setRecommended(ProtocolVersion.wrap(_version));
         assertEq(ProtocolVersion.unwrap(protocolVersions.recommended()), _version);
+    }
+
+    /// @notice Tests that `setRecommended` reverts if the caller is not the owner.
+    function test_setRecommended_notOwner_reverts() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+        protocolVersions.setRecommended(ProtocolVersion.wrap(0));
     }
 }


### PR DESCRIPTION
- consolidate test initialization into a single ProtocolVersions_TestInit contract
- organize individual test functions into separate contracts inheriting from TestInit
- add @title and @notice tags to all test contracts
- convert @dev to @notice tags where appropriate
- ensure comment lines stay within 100 character limit