### PR TITLE
proofs: Add variable shadowing to test util

### DIFF
--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -183,6 +183,8 @@ func RunTestsAcrossVmTypes[T any](t *testing.T, testCases []T, test VMTestCase[T
 
 	for _, testCase := range testCases {
 		for _, allocType := range options.allocTypes {
+			testCase := testCase
+			allocType := allocType
 			testName := options.testNameModifier(string(allocType), testCase)
 			t.Run(testName, func(t *testing.T) {
 				op_e2e.InitParallel(t, op_e2e.UsesCannon)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fix test utility introduced in https://github.com/ethereum-optimism/optimism/pull/14692.  

Add proper variable shadowing in `RunTestsAcrossVmTypes` to ensure each subtest runs independently with the correct data. Without this variable shadowing, all subtests capture references to the same loop iterator variables, which are being mutated during iteration.

**Metadata**

Relates to https://github.com/ethereum-optimism/optimism/issues/13447
