### PR TITLE
op-conductor: proxy `miner_setMaxDASize` even when not the leader

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -647,7 +647,6 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 		updateChans[i] = make(chan struct{}, 1)
 		innerWg.Add(1)
 		go l.singleEndpointThrottler(&innerWg, updateChans[i], endpoint)
-		l.Log.Info("Started throttling loop for endpoint", "endpoint", endpoint)
 	}
 
 	for pb := range pendingBytesUpdated {

--- a/op-conductor/rpc/excecution_miner_proxy.go
+++ b/op-conductor/rpc/excecution_miner_proxy.go
@@ -29,9 +29,6 @@ func NewExecutionMinerProxyBackend(log log.Logger, con conductor, client *ethcli
 
 func (api *ExecutionMinerProxyBackend) SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) bool {
 	var result bool
-	if !api.con.Leader(ctx) {
-		return false
-	}
 	err := api.client.Client().Call(&result, "miner_setMaxDASize", maxTxSize, maxBlockSize)
 	if err != nil {
 		return false


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Also removes a redundant log from the batcher.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

We recently changed the batcher to throttle all sequencer endpoints that it is configured with. So we want those throttling messages to get through the op-conductor proxy. 

<!--
Add any other context about the problem you're solving.
-->

**Metadata**
- Fixes #15653 
