### PR TITLE
op-supervisor: Return NotFound for missing cross-safe data

### DIFF
--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -323,7 +323,6 @@ func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
 }
 
 func TestSuperInvalidateUnsafeProposal(t *testing.T) {
-	t.Skip("TODO(#15321): Challenger does not respond to unsafe proposals")
 	ctx := context.Background()
 	type TestCase struct {
 		name     string

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -713,7 +713,11 @@ func (su *SupervisorBackend) SuperRootAtTimestamp(ctx context.Context, timestamp
 		}
 		source, err := su.chainDBs.CrossDerivedToSource(chainID, ref.ID())
 		if err != nil {
-			return eth.SuperRootResponse{}, err
+			// Transform error to ethereum.NotFound at RPC boundary so that the challenger can detect this case
+			if errors.Is(err, types.ErrFuture) {
+				err = errors.Join(err, ethereum.NotFound)
+			}
+			return eth.SuperRootResponse{}, fmt.Errorf("cross-derived-to-source failed for chain %s: %w", chainID, err)
 		}
 		if crossSafeSource.Number == 0 || crossSafeSource.Number < source.Number {
 			crossSafeSource = source.ID()


### PR DESCRIPTION
This ensures that `ethereum.NotFound` error percolates through the supervisor RPC so that it's observed by the op-challenger. When no super root exists at timestamp, we use `ethereum.NotFound` to indicate this, and this is used by the op-challenger to dispute using the `InvalidTransition` super root.


## Context on op-challenger disputes

[This](https://github.com/ethereum-optimism/optimism/issues/15321) explains the rationale. But to further illustrate the point, consider the stalled batcher case:

```
L1:         0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6
L2(safe):   0 -> 1 -> 2 -> 3 -> X -> X -> 4
L2(unsafe): 0 -> 1 -> 2 -> 3 -> 4 -> 5 -> ...
```
where `X` represents missing super roots at that L1 head. In this scenario, the safe chain stalls for 2 L1 blocks. That is there are 2 blocks on L1 that don't contain any batches. The batcher comes back online at `L1(5)` and the safe chain progresses.

Let's say someone proposes the latest super root at `L1(4)`. Even though this super root eventually becomes cross-safe, it's merely cross-unsafe at the time of the proposal. Thus, this super root must be invalid. The op-challenger will then query `supervisor_superRootAtiTimestamp` at `L1(4).timestamp` and it gets back an `ethereum.NotFound` error. Which confirms the invalidity of the super root, triggering an `InvalidTransition` response.

fixes https://github.com/ethereum-optimism/optimism/issues/15321