### PR TITLE
op-supervisor: failed RPC subscription is a warn not an error log

### DIFF
--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -156,7 +156,7 @@ func (m *ManagedNode) SubscribeToNodeEvents() {
 		func(ctx context.Context, prevErr error) (gethevent.Subscription, error) {
 			if prevErr != nil {
 				// This is the RPC runtime error, not the setup error we have logging for below.
-				m.log.Error("RPC subscription failed, restarting now", "err", prevErr)
+				m.log.Warn("RPC subscription failed, retrying", "err", prevErr)
 				var closeErr *websocket.CloseError
 				if errors.As(prevErr, &closeErr) {
 					m.log.Warn("RPC websocket connection closed")


### PR DESCRIPTION
Because there is a path to recovery, IMO this should only be a warning. 

Also, prefer "retrying" to "restarting" which could be misconstrued as e.g. restarting the process.