### PR TITLE
fix(kt-devnet): move to more recent cannon

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -85,13 +85,6 @@ optimism_package:
         image: {{ $local_images.op_batcher }}
         extra_params:
         - {{ $flags.log_level }}
-      challenger_params:
-        image: {{ $local_images.op_challenger }}
-        cannon_prestate_path: ""
-        cannon_prestates_url: {{ $urls.prestate }}
-        cannon_trace_types: ["cannon", "permissioned", "super-cannon"]
-        extra_params:
-        - {{ $flags.log_level }}
       proposer_params:
         image: {{ $local_images.op_proposer }}
         extra_params:
@@ -145,13 +138,6 @@ optimism_package:
         image: {{ $local_images.op_batcher }}
         extra_params:
         - {{ $flags.log_level }}
-      challenger_params:
-        image: {{ $local_images.op_challenger }}
-        cannon_prestate_path: ""
-        cannon_prestates_url: {{ $urls.prestate }}
-        cannon_trace_types: ["cannon", "permissioned", "super-cannon"]
-        extra_params:
-        - {{ $flags.log_level }}
       proposer_params:
         image: {{ $local_images.op_proposer }}
         extra_params:
@@ -163,6 +149,15 @@ optimism_package:
         builder_host: ""
         builder_port: ""
       additional_services: []
+  challengers:
+    challenger:
+      enabled: true
+      image: {{ $local_images.op_challenger }}
+      participants: "*"
+      cannon_prestates_url: {{ localPrestate.URL }}
+      cannon_trace_types: ["super-cannon", "super-permissioned"]
+      extra_params:
+      - {{ $flags.log_level }}
   op_contract_deployer_params:
     image: {{ $local_images.op_deployer }}
     l1_artifacts_locator: {{ $urls.l1_artifacts }}

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -69,11 +69,6 @@ optimism_package:
       batcher_params:
         image: {{ localDockerImage "op-batcher" }}
         extra_params: []
-      challenger_params:
-        image: {{ localDockerImage "op-challenger" }}
-        cannon_prestate_path: ""
-        cannon_prestates_url: {{ localPrestate.URL }}
-        extra_params: []
       proposer_params:
         image: {{ localDockerImage "op-proposer" }}
         extra_params: []
@@ -84,6 +79,13 @@ optimism_package:
         builder_host: ""
         builder_port: ""
       additional_services: []
+  challengers:
+    challenger:
+      enabled: true
+      image: {{ localDockerImage "op-challenger" }}
+      participants: "*"
+      cannon_prestates_url: {{ localPrestate.URL }}
+      cannon_trace_types: ["cannon", "permissioned"]
   op_contract_deployer_params:
     image: {{ localDockerImage "op-deployer" }}
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@7b49f9876c9e343b9112feec50bade9691825ccd
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@c124cb9877000e286e6e9d21e12ce0b3cdaae632
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -40,11 +40,6 @@ optimism_package:
       batcher_params:
         image: {{ localDockerImage "op-batcher" }}
         extra_params: []
-      challenger_params:
-        image: {{ localDockerImage "op-challenger" }}
-        cannon_prestate_path: ""
-        cannon_prestates_url: "http://fileserver/proofs/op-program/cannon"
-        extra_params: []
       proposer_params:
         image: {{ localDockerImage "op-proposer" }}
         extra_params: []
@@ -55,6 +50,13 @@ optimism_package:
         builder_host: ""
         builder_port: ""
       additional_services: []
+  challengers:
+    challenger:
+      enabled: true
+      image: {{ localDockerImage "op-challenger" }}
+      participants: "*"
+      cannon_prestates_url: {{ localPrestate.URL }}
+      cannon_trace_types: ["cannon", "permissioned"]
   op_contract_deployer_params:
     image: {{ localDockerImage "op-deployer" }}
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}

--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -141,6 +141,12 @@ func (f *ServiceFinder) FindL2Services(s ChainSpec) ([]descriptors.Node, descrip
 			return "", 0, false
 		}
 
+		// challenger is special too, and right now there's no way to identify which L2s it covers
+		// TODO: fix this horror, right now we're forced to assume there's only one.
+		if strings.HasPrefix(serviceName, "op-challenger") {
+			return "challenger", 0, true
+		}
+
 		// Some services don't have a network suffix, as they span multiple chains
 		if strings.HasPrefix(serviceName, f.l2ServicePrefix) {
 			tag, idx := f.serviceTag(strings.TrimPrefix(serviceName, f.l2ServicePrefix))

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -40,11 +40,6 @@ optimism_package:
       batcher_params:
         image: {{ localDockerImage "op-batcher" }}
         extra_params: []
-      challenger_params:
-        image: {{ localDockerImage "op-challenger" }}
-        cannon_prestate_path: ""
-        cannon_prestates_url: "http://fileserver/proofs/op-program/cannon"
-        extra_params: []
       proposer_params:
         image: {{ localDockerImage "op-proposer" }}
         extra_params: []
@@ -55,6 +50,13 @@ optimism_package:
         builder_host: ""
         builder_port: ""
       additional_services: []
+  challengers:
+    challenger:
+      enabled: true
+      image: {{ localDockerImage "op-challenger" }}
+      participants: "*"
+      cannon_prestates_url: {{ localPrestate.URL }}
+      cannon_trace_types: ["cannon", "permissioned"]
   op_contract_deployer_params:
     image: {{ localDockerImage "op-deployer" }}
     l1_artifacts_locator: {{ localContractArtifacts "l1" }}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
The goal of this change is to move to modern cannon for devnet deployments.

This entails:
- bumping optimism-package to a version that supports it by default
- catching up with devnet definition changes introduced at the challenger level
- adding a temporary hack for challenger detection, as there's no way to identify which chains it covers right now

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
