### PR TITLE
feat: have opcm migrate function clear old dispute game implementations

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0xc1c4ef5d0e5e310d496b183307f0d5bf4bcae7adf94d774ec450b243f05e15a1"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x5472e5d8838ad3d9da8bbe6b9d02830c1865323e174f65aab5acf736763e01e7",
-    "sourceCodeHash": "0xc4dc0501dd606e63819a6711c30ceee14ac8c3eb27df3b2bf9ee656d99aae949"
+    "initCodeHash": "0x72ef12360f4e4675abed6da10ca40042ef23ef50efcf934e0d76ddcb18afa617",
+    "sourceCodeHash": "0xc0c8adad457fbca1879157bea5f5645a9a96ba83da8426c83e9510318a2bc584"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x1173bf0b771bb515aacd5857fb29fb147f2b7ba04f81d3703906c9450e00c00d",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
     "initCodeHash": "0x5472e5d8838ad3d9da8bbe6b9d02830c1865323e174f65aab5acf736763e01e7",
-    "sourceCodeHash": "0x846e691812feb9c3752675663750ad5f141fd59f5f9726ba764d0dbbab756dfc"
+    "sourceCodeHash": "0xc4dc0501dd606e63819a6711c30ceee14ac8c3eb27df3b2bf9ee656d99aae949"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x1173bf0b771bb515aacd5857fb29fb147f2b7ba04f81d3703906c9450e00c00d",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1697,9 +1697,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 2.0.2
+    /// @custom:semver 2.1.0
     function version() public pure virtual returns (string memory) {
-        return "2.0.2";
+        return "2.1.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1451,6 +1451,15 @@ contract OPContractsManagerInteropMigrator is OPContractsManagerBase {
             // Migrate the existing ETHLockbox to the new ETHLockbox.
             existingLockbox.migrateLiquidity(newEthLockbox);
 
+            // Before migrating the portal, clear out any implementations that might exist in the
+            // old DisputeGameFactory proxy. We clear out all 4 potential game types to be safe.
+            IDisputeGameFactory oldDisputeGameFactory =
+                IDisputeGameFactory(payable(address(portals[i].disputeGameFactory())));
+            oldDisputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(0)));
+            oldDisputeGameFactory.setImplementation(GameTypes.SUPER_CANNON, IDisputeGame(address(0)));
+            oldDisputeGameFactory.setImplementation(GameTypes.PERMISSIONED_CANNON, IDisputeGame(address(0)));
+            oldDisputeGameFactory.setImplementation(GameTypes.SUPER_PERMISSIONED_CANNON, IDisputeGame(address(0)));
+
             // Migrate the portal to the new ETHLockbox and AnchorStateRegistry.
             portals[i].migrateToSuperRoots(newEthLockbox, newAnchorStateRegistry);
         }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the OPCM.migrate function so that it clears out any existing game implementations in the `DisputeGameFactory`. Note that this implementation will clear out all four known game types regardless of what actually exists, this makes the function simpler and also makes sure that it'll work if the migrate function is used to bring a third chain into the interop set.