### PR TITLE
supervisor and testing: interop: reorg-testing: reorg a chain with invalid exec msg

### DIFF
--- a/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
@@ -47,23 +47,16 @@ func TestInteropHappyTx(gt *testing.T) {
 		pk, err := crypto.GenerateKey()
 		require.NoError(t, err)
 		alice = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
-		sys.FaucetA.Fund(alice.Address(), eth.ThousandEther)
+		sys.FaucetA.Fund(alice.Address(), eth.OneEther)
 
 		// bob is on chain B
 		pk, err = crypto.GenerateKey()
 		require.NoError(t, err)
 		bob = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELB)
-		sys.FaucetB.Fund(bob.Address(), eth.ThousandEther)
-
-		// cathrine is on chain A
-		pk, err = crypto.GenerateKey()
-		require.NoError(t, err)
-		cathrine = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
-		sys.FaucetA.Fund(cathrine.Address(), eth.ThousandEther)
+		sys.FaucetB.Fund(bob.Address(), eth.OneEther)
 
 		l.Info("alice", "address", alice.Address())
 		l.Info("bob", "address", bob.Address())
-		l.Info("cathrine", "address", cathrine.Address())
 	}
 
 	sys.L1Network.WaitForBlock()

--- a/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
@@ -40,8 +40,8 @@ func TestInteropHappyTx(gt *testing.T) {
 	sys := SimpleInterop(t)
 	l := sys.Log
 
-	// three EOAs for triggering the init and exec interop txs, as well as a simple transfer tx
-	var alice, bob, cathrine *dsl.EOA
+	// two EOAs for triggering the init and exec interop txs
+	var alice, bob *dsl.EOA
 	{
 		// alice is on chain A
 		pk, err := crypto.GenerateKey()

--- a/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
@@ -1,0 +1,176 @@
+package happy
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+var SimpleInterop presets.TestSetup[*presets.SimpleInterop]
+
+// TestMain creates the test-setups against the shared backend
+func TestMain(m *testing.M) {
+	// Other setups may be added here, hydrated from the same orchestrator
+	presets.DoMain(m, presets.NewSimpleInterop(&SimpleInterop))
+}
+
+// TestInteropHappyTx is testing that a valid init message, followed by a valid exec message are correctly
+// included in two L2 chains and that the cross-safe ref for both of them progresses as expected beyond
+// the block number where the messages were included
+func TestInteropHappyTx(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	ctx := t.Ctx()
+
+	sys := SimpleInterop(t)
+	l := sys.Log
+
+	// three EOAs for triggering the init and exec interop txs, as well as a simple transfer tx
+	var alice, bob, cathrine *dsl.EOA
+	{
+		// alice is on chain A
+		pk, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		alice = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
+		sys.FaucetA.Fund(alice.Address(), eth.ThousandEther)
+
+		// bob is on chain B
+		pk, err = crypto.GenerateKey()
+		require.NoError(t, err)
+		bob = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELB)
+		sys.FaucetB.Fund(bob.Address(), eth.ThousandEther)
+
+		// cathrine is on chain A
+		pk, err = crypto.GenerateKey()
+		require.NoError(t, err)
+		cathrine = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
+		sys.FaucetA.Fund(cathrine.Address(), eth.ThousandEther)
+
+		l.Info("alice", "address", alice.Address())
+		l.Info("bob", "address", bob.Address())
+		l.Info("cathrine", "address", cathrine.Address())
+	}
+
+	sys.L1Network.WaitForBlock()
+	sys.L2ChainA.WaitForBlock()
+
+	// deploy event logger on chain A
+	var eventLoggerAddress common.Address
+	{
+		tx := txplan.NewPlannedTx(txplan.Combine(
+			alice.Plan(),
+			txplan.WithData(common.FromHex(bindings.EventloggerBin)),
+		))
+		res, err := tx.Included.Eval(ctx)
+		require.NoError(t, err)
+
+		eventLoggerAddress = res.ContractAddress
+		l.Info("deployed EventLogger", "chainID", tx.ChainID.Value(), "address", eventLoggerAddress)
+	}
+
+	sys.L1Network.WaitForBlock()
+
+	var initTrigger *txintent.InitTrigger
+	// prepare init trigger (i.e. what logs to emit on chain A)
+	{
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		nTopics := 3
+		lenData := 10
+		initTrigger = interop.RandomInitTrigger(rng, eventLoggerAddress, nTopics, lenData)
+
+		l.Info("created init trigger", "address", eventLoggerAddress, "topics", nTopics, "lenData", lenData)
+	}
+
+	// wait for chain B to catch up to chain A if necessary
+	sys.L2ChainB.CatchUpTo(sys.L2ChainA)
+
+	var initTx *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]
+	var initReceipt *types.Receipt
+	// prepare and include initiating message on chain A
+	{
+		initTx = txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](alice.Plan())
+		initTx.Content.Set(initTrigger)
+		var err error
+		initReceipt, err = initTx.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+
+		l.Info("initiating message included", "chain", sys.L2ChainA.ChainID(), "block_number", initReceipt.BlockNumber, "block_hash", initReceipt.BlockHash, "now", time.Now().Unix())
+	}
+
+	// at least one block between the init tx on chain A and the exec tx on chain B
+	sys.L2ChainB.WaitForBlock()
+
+	var execTx *txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput]
+	var execReceipt *types.Receipt
+	// prepare and include executing message on chain B
+	{
+		execTx = txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](bob.Plan())
+		execTx.Content.DependOn(&initTx.Result)
+		// single event in tx so index is 0. ExecuteIndexed returns a lambda to transform InteropOutput to a new ExecTrigger
+		execTx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initTx.Result, 0))
+		var err error
+		execReceipt, err = execTx.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(execReceipt.Logs))
+
+		l.Info("executing message included", "chain", sys.L2ChainB.ChainID(), "block_number", execReceipt.BlockNumber, "block_hash", execReceipt.BlockHash, "now", time.Now().Unix())
+	}
+
+	crossSafeMinimumBlock_A := initReceipt.BlockNumber.Uint64() + 1
+	crossSafeMinimumBlock_B := execReceipt.BlockNumber.Uint64() + 1
+
+	// confirm that the cross-safe minimum block has been reached
+	err := wait.For(ctx, 5*time.Second, func() (bool, error) {
+		safeL2Head_supervisor_A := sys.Supervisor.SafeBlockID(sys.L2ChainA.ChainID()).Hash
+		safeL2Head_supervisor_B := sys.Supervisor.SafeBlockID(sys.L2ChainB.ChainID()).Hash
+		safeL2Head_sequencer_A := sys.L2CLNodeA.SafeL2BlockRef()
+		safeL2Head_sequencer_B := sys.L2CLNodeB.SafeL2BlockRef()
+
+		if safeL2Head_sequencer_A.Number < crossSafeMinimumBlock_A {
+			l.Info("Safe ref number is still behind", "block_a", crossSafeMinimumBlock_A, "safe", safeL2Head_sequencer_A.Number)
+			return false, nil
+		}
+
+		if safeL2Head_sequencer_B.Number < crossSafeMinimumBlock_B {
+			l.Info("Safe ref number is still behind", "block_b", crossSafeMinimumBlock_B, "safe", safeL2Head_sequencer_B.Number)
+			return false, nil
+		}
+
+		l.Info("Safe ref the same across supervisor and sequencers",
+			"supervisor_A", safeL2Head_supervisor_A,
+			"supervisor_B", safeL2Head_supervisor_B)
+
+		return true, nil
+	})
+	require.NoError(t, err, "Expected to get same safe ref on both supervisor and sequencer eventually")
+
+	// confirm that the init msg block and exec msg block are not reorged
+	{
+		latestBlock_A, err := sys.L2ELA.Escape().EthClient().BlockRefByNumber(ctx, initReceipt.BlockNumber.Uint64())
+		require.NoError(t, err)
+		require.Equal(t, latestBlock_A.Hash, initReceipt.BlockHash)
+
+		latestBlock_B, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, execReceipt.BlockNumber.Uint64())
+		require.NoError(t, err)
+		require.Equal(t, latestBlock_B.Hash, execReceipt.BlockHash)
+	}
+
+	sys.L2ChainA.PrintChain()
+	sys.L2ChainB.PrintChain()
+	spew.Dump(sys.Supervisor.FetchSyncStatus())
+}

--- a/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/happy/interop_happy_tx_test.go
@@ -22,12 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var SimpleInterop presets.TestSetup[*presets.SimpleInterop]
-
 // TestMain creates the test-setups against the shared backend
 func TestMain(m *testing.M) {
 	// Other setups may be added here, hydrated from the same orchestrator
-	presets.DoMain(m, presets.NewSimpleInterop(&SimpleInterop))
+	presets.DoMain(m, presets.WithSimpleInterop())
 }
 
 // TestInteropHappyTx is testing that a valid init message, followed by a valid exec message are correctly
@@ -37,7 +35,7 @@ func TestInteropHappyTx(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	ctx := t.Ctx()
 
-	sys := SimpleInterop(t)
+	sys := presets.NewSimpleInterop(t)
 	l := sys.Log
 
 	// two EOAs for triggering the init and exec interop txs
@@ -131,8 +129,8 @@ func TestInteropHappyTx(gt *testing.T) {
 	err := wait.For(ctx, 5*time.Second, func() (bool, error) {
 		safeL2Head_supervisor_A := sys.Supervisor.SafeBlockID(sys.L2ChainA.ChainID()).Hash
 		safeL2Head_supervisor_B := sys.Supervisor.SafeBlockID(sys.L2ChainB.ChainID()).Hash
-		safeL2Head_sequencer_A := sys.L2CLNodeA.SafeL2BlockRef()
-		safeL2Head_sequencer_B := sys.L2CLNodeB.SafeL2BlockRef()
+		safeL2Head_sequencer_A := sys.L2CLA.SafeL2BlockRef()
+		safeL2Head_sequencer_B := sys.L2CLB.SafeL2BlockRef()
 
 		if safeL2Head_sequencer_A.Number < crossSafeMinimumBlock_A {
 			l.Info("Safe ref number is still behind", "block_a", crossSafeMinimumBlock_A, "safe", safeL2Head_sequencer_A.Number)

--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -42,19 +42,19 @@ func TestReorgInitExecMsg(gt *testing.T) {
 		pk, err := crypto.GenerateKey()
 		require.NoError(t, err)
 		alice = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
-		sys.FaucetA.Fund(alice.Address(), eth.ThousandEther)
+		sys.FaucetA.Fund(alice.Address(), eth.OneEther)
 
 		// bob is on chain B
 		pk, err = crypto.GenerateKey()
 		require.NoError(t, err)
 		bob = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELB)
-		sys.FaucetB.Fund(bob.Address(), eth.ThousandEther)
+		sys.FaucetB.Fund(bob.Address(), eth.OneEther)
 
 		// cathrine is on chain A
 		pk, err = crypto.GenerateKey()
 		require.NoError(t, err)
 		cathrine = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
-		sys.FaucetA.Fund(cathrine.Address(), eth.ThousandEther)
+		sys.FaucetA.Fund(cathrine.Address(), eth.OneEther)
 
 		l.Info("alice", "address", alice.Address())
 		l.Info("bob", "address", bob.Address())
@@ -200,7 +200,7 @@ func TestReorgInitExecMsg(gt *testing.T) {
 
 		// include simple transfer tx in opened block
 		{
-			to := cathrine.PlanTransfer(alice.Address(), eth.OneEther)
+			to := cathrine.PlanTransfer(alice.Address(), eth.OneGWei)
 			opt := txplan.Combine(to)
 			ptx := txplan.NewPlannedTx(opt)
 			signed_tx, err := ptx.Signed.Eval(ctx)

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -65,19 +65,19 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 		pk, err := crypto.GenerateKey()
 		require.NoError(t, err)
 		alice = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
-		sys.FaucetA.Fund(alice.Address(), eth.ThousandEther)
+		sys.FaucetA.Fund(alice.Address(), eth.OneEther)
 
 		// bob is on chain B
 		pk, err = crypto.GenerateKey()
 		require.NoError(t, err)
 		bob = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELB)
-		sys.FaucetB.Fund(bob.Address(), eth.ThousandEther)
+		sys.FaucetB.Fund(bob.Address(), eth.OneEther)
 
 		// cathrine is on chain A
 		pk, err = crypto.GenerateKey()
 		require.NoError(t, err)
 		cathrine = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
-		sys.FaucetA.Fund(cathrine.Address(), eth.ThousandEther)
+		sys.FaucetA.Fund(cathrine.Address(), eth.OneEther)
 
 		l.Info("alice", "address", alice.Address())
 		l.Info("bob", "address", bob.Address())
@@ -237,7 +237,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 
 		// include simple transfer tx in opened block
 		{
-			to := cathrine.PlanTransfer(alice.Address(), eth.OneEther)
+			to := cathrine.PlanTransfer(alice.Address(), eth.OneGWei)
 			opt := txplan.Combine(to)
 			ptx := txplan.NewPlannedTx(opt)
 			signed_tx, err := ptx.Signed.Eval(ctx)

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -1,0 +1,330 @@
+package reorgs
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReorgInvalidExecMsgs tests that the supervisor reorgs the chain when an invalid exec msg is included
+// Each subtest runs a test with  a different invalid message, by modifying the message in the txModifierFn
+func TestReorgInvalidExecMsgs(gt *testing.T) {
+	gt.Run("invalid log index", func(gt *testing.T) {
+		testReorgInvalidExecMsg(gt, func(msg *suptypes.Message) {
+			msg.Identifier.LogIndex = 1024
+		})
+	})
+
+	gt.Run("invalid block number", func(gt *testing.T) {
+		testReorgInvalidExecMsg(gt, func(msg *suptypes.Message) {
+			msg.Identifier.BlockNumber = msg.Identifier.BlockNumber - 1
+		})
+	})
+
+	gt.Run("invalid chain id", func(gt *testing.T) {
+		testReorgInvalidExecMsg(gt, func(msg *suptypes.Message) {
+			msg.Identifier.ChainID = eth.ChainIDFromUInt64(1024)
+		})
+	})
+}
+
+func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Message)) {
+	t := devtest.SerialT(gt)
+	ctx := t.Ctx()
+
+	sys := SimpleInterop(t)
+	l := sys.Log
+
+	ia := sys.Sequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
+
+	// three EOAs for triggering the init and exec interop txs, as well as a simple transfer tx
+	var alice, bob, cathrine *dsl.EOA
+	{
+		// alice is on chain A
+		pk, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		alice = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
+		sys.FaucetA.Fund(alice.Address(), eth.ThousandEther)
+
+		// bob is on chain B
+		pk, err = crypto.GenerateKey()
+		require.NoError(t, err)
+		bob = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELB)
+		sys.FaucetB.Fund(bob.Address(), eth.ThousandEther)
+
+		// cathrine is on chain A
+		pk, err = crypto.GenerateKey()
+		require.NoError(t, err)
+		cathrine = dsl.NewEOA(dsl.NewKey(t, pk), sys.L2ELA)
+		sys.FaucetA.Fund(cathrine.Address(), eth.ThousandEther)
+
+		l.Info("alice", "address", alice.Address())
+		l.Info("bob", "address", bob.Address())
+		l.Info("cathrine", "address", cathrine.Address())
+	}
+
+	sys.L1Network.WaitForBlock()
+	sys.L2ChainA.WaitForBlock()
+
+	// stop batcher on chain A
+	{
+		err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
+			err := sys.L2BatcherA.Escape().ActivityAPI().StopBatcher(ctx)
+			if err != nil && strings.Contains(err.Error(), "batcher is not running") {
+				return nil
+			}
+			return err
+		})
+		require.NoError(t, err, "Expected to be able to call StopBatcher API on chain A, but got error")
+	}
+
+	// deploy event logger on chain B
+	var eventLoggerAddress common.Address
+	{
+		tx := txplan.NewPlannedTx(txplan.Combine(
+			bob.Plan(),
+			txplan.WithData(common.FromHex(bindings.EventloggerBin)),
+		))
+		res, err := tx.Included.Eval(ctx)
+		require.NoError(t, err)
+
+		eventLoggerAddress = res.ContractAddress
+		l.Info("deployed EventLogger", "chainID", tx.ChainID.Value(), "address", eventLoggerAddress)
+	}
+
+	sys.L1Network.WaitForBlock()
+
+	var initTrigger *txintent.InitTrigger
+	// prepare init trigger (i.e. what logs to emit on chain A)
+	{
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		nTopics := 3
+		lenData := 10
+		initTrigger = interop.RandomInitTrigger(rng, eventLoggerAddress, nTopics, lenData)
+
+		l.Info("created init trigger", "address", eventLoggerAddress, "topics", nTopics, "lenData", lenData)
+	}
+
+	// wait for chain B to catch up to chain A if necessary
+	sys.L2ChainB.CatchUpTo(sys.L2ChainA)
+
+	var initTx *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]
+	var initReceipt *types.Receipt
+	// prepare and include initiating message on chain B
+	{
+		initTx = txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](bob.Plan())
+		initTx.Content.Set(initTrigger)
+		var err error
+		initReceipt, err = initTx.PlannedTx.Included.Eval(ctx)
+		require.NoError(t, err)
+
+		l.Info("initiating message included in chain B", "chain", sys.L2ChainB.ChainID(), "block_number", initReceipt.BlockNumber, "block_hash", initReceipt.BlockHash, "now", time.Now().Unix())
+	}
+
+	// at least one block between the init tx on chain B and the exec tx on chain A
+	sys.L2ChainA.WaitForBlock()
+
+	var latestUnsafe_A common.Hash
+	// stop sequencer on chain A so that we later force include an invalid exec msg
+	{
+		var err error
+		latestUnsafe_A, err = sys.L2CLNodeA.Escape().RollupAPI().StopSequencer(ctx)
+		require.NoError(t, err, "expected to be able to call StopSequencer API, but got error")
+		// wait for the sequencer to become inactive
+		var active bool
+		err = wait.For(ctx, 1*time.Second, func() (bool, error) {
+			active, err = sys.L2CLNodeA.Escape().RollupAPI().SequencerActive(ctx)
+			return !active, err
+		})
+		require.NoError(t, err, "expected to be able to call SequencerActive API, and wait for inactive state for sequencer, but got error")
+
+		l.Info("rollup node sequencer status", "active", active, "unsafeHead", latestUnsafe_A)
+	}
+
+	var execTx *txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput]
+	var execSignedTx *types.Transaction
+	var execTxEncoded []byte
+	// prepare and include invalid executing message on chain B via the op-test-sequencer (no other way to force-include an invalid message)
+	{
+		execTx = txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](alice.Plan())
+		execTx.Content.DependOn(&initTx.Result)
+		// single event in tx so index is 0.
+		index := 0
+		// lambda to transform InteropOutput to a new broken ExecTrigger
+		execTx.Content.Fn(func(ctx context.Context) (*txintent.ExecTrigger, error) {
+			events := initTx.Result.Value()
+			if x := len(events.Entries); x <= index {
+				return nil, fmt.Errorf("invalid index: %d, only have %d events", index, x)
+			}
+			msg := events.Entries[index]
+			// modify the message in order to make it invalid
+			txModifierFn(&msg)
+			return &txintent.ExecTrigger{
+				Executor: constants.CrossL2Inbox,
+				Msg:      msg,
+			}, nil
+		})
+
+		var err error
+		execSignedTx, err = execTx.PlannedTx.Signed.Eval(ctx)
+		require.NoError(t, err)
+
+		l.Info("executing message signed", "to", execSignedTx.To(), "nonce", execSignedTx.Nonce(), "data", len(execSignedTx.Data()))
+
+		execTxEncoded, err = execSignedTx.MarshalBinary()
+		require.NoError(t, err, "Expected to be able to marshal a signed transaction on op-test-sequencer, but got error")
+	}
+
+	// sequence a new block with an invalid executing msg on chain A
+	{
+		l.Info("Building chain A with op-test-sequencer, and include invalid exec msg", "chain", sys.L2ChainA.ChainID(), "unsafeHead", latestUnsafe_A)
+
+		err := ia.New(ctx, seqtypes.BuildOpts{
+			Parent:   latestUnsafe_A,
+			L1Origin: nil,
+		})
+		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
+
+		// include invalid executing msg in opened block
+		err = ia.IncludeTx(ctx, execTxEncoded)
+		require.NoError(t, err, "Expected to be able to include a signed transaction on op-test-sequencer, but got error")
+
+		err = ia.Next(ctx)
+		require.NoError(t, err, "Expected to be able to call Next() after New() on op-test-sequencer, but got error")
+	}
+
+	// record divergence block numbers and original refs for future validation checks
+	var divergenceBlockNumber_A uint64
+	var originalHash_A common.Hash
+
+	// sequence a second block with op-test-sequencer
+	{
+		currentUnsafeRef := sys.L2ChainA.UnsafeHeadRef()
+
+		l.Info("Unsafe head after invalid exec msg has been included in chain A", "chain", sys.L2ChainA.ChainID(), "unsafeHead", currentUnsafeRef, "parent", currentUnsafeRef.ParentID())
+
+		divergenceBlockNumber_A = currentUnsafeRef.Number
+		originalHash_A = currentUnsafeRef.Hash
+
+		l.Info("Continue building chain A with another block with op-test-sequencer", "chain", sys.L2ChainA.ChainID(), "unsafeHead", currentUnsafeRef, "parent", currentUnsafeRef.ParentID())
+		err := ia.New(ctx, seqtypes.BuildOpts{
+			Parent:   currentUnsafeRef.Hash,
+			L1Origin: nil,
+		})
+		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
+		time.Sleep(2 * time.Second)
+
+		// include simple transfer tx in opened block
+		{
+			to := cathrine.PlanTransfer(alice.Address(), eth.OneEther)
+			opt := txplan.Combine(to)
+			ptx := txplan.NewPlannedTx(opt)
+			signed_tx, err := ptx.Signed.Eval(ctx)
+			require.NoError(t, err, "Expected to be able to evaluate a planned transaction on op-test-sequencer, but got error")
+			txdata, err := signed_tx.MarshalBinary()
+			require.NoError(t, err, "Expected to be able to marshal a signed transaction on op-test-sequencer, but got error")
+
+			err = ia.IncludeTx(ctx, txdata)
+			require.NoError(t, err, "Expected to be able to include a signed transaction on op-test-sequencer, but got error")
+		}
+
+		err = ia.Next(ctx)
+		require.NoError(t, err, "Expected to be able to call Next() after New() on op-test-sequencer, but got error")
+		time.Sleep(2 * time.Second)
+	}
+
+	// continue sequencing with op-node
+	{
+		newUnsafeHeadRef := sys.L2ChainA.UnsafeHeadRef()
+		l.Info("Continue sequencing with consensus node (op-node)", "unsafeHead", newUnsafeHeadRef)
+
+		err := sys.L2CLNodeA.Escape().RollupAPI().StartSequencer(ctx, newUnsafeHeadRef.Hash)
+		require.NoError(t, err, "Expected to be able to start sequencer on rollup node")
+
+		// wait for the sequencer to become active
+		var active bool
+		err = wait.For(ctx, 1*time.Second, func() (bool, error) {
+			active, err = sys.L2CLNodeA.Escape().RollupAPI().SequencerActive(ctx)
+			return active, err
+		})
+		require.NoError(t, err, "Expected to be able to call SequencerActive API, and wait for an active state for sequencer, but got error")
+
+		l.Info("Rollup node sequencer", "active", active)
+	}
+
+	// start batchers on chain A
+	{
+		err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
+			return sys.L2BatcherA.Escape().ActivityAPI().StartBatcher(ctx)
+		})
+		require.NoError(t, err, "Expected to be able to call StartBatcher API on chain A, but got error")
+	}
+
+	// wait for reorg on chain A
+	require.Eventually(t, func() bool {
+		reorgedRef_A, err := sys.L2ELA.Escape().EthClient().BlockRefByNumber(ctx, divergenceBlockNumber_A)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") { // reorg is happening wait a bit longer
+				l.Info("Supervisor still hasn't reorged chain A", "error", err)
+				return false
+			}
+			require.NoError(t, err, "Expected to be able to call BlockRefByNumber API, but got error")
+		}
+
+		if originalHash_A.Cmp(reorgedRef_A.Hash) == 0 { // want not equal
+			l.Info("Supervisor still hasn't reorged chain A", "ref", reorgedRef_A)
+			return false
+		}
+
+		l.Info("Reorged chain A on divergence block number (prior the reorg)", "number", divergenceBlockNumber_A, "head", originalHash_A)
+		l.Info("Reorged chain A on divergence block number (after the reorg)", "number", divergenceBlockNumber_A, "head", reorgedRef_A.Hash, "parent", reorgedRef_A.ParentID().Hash)
+		return true
+	}, 180*time.Second, 10*time.Second, "No reorg happened on chain A. Should have been triggered by the supervisor.")
+
+	err := wait.For(ctx, 5*time.Second, func() (bool, error) {
+		safeL2Head_supervisor_A := sys.Supervisor.SafeBlockID(sys.L2ChainA.ChainID()).Hash
+		safeL2Head_sequencer_A := sys.L2CLNodeA.SafeL2BlockRef()
+
+		if safeL2Head_sequencer_A.Number < divergenceBlockNumber_A {
+			l.Info("Safe ref number is still behind divergence block A number", "divergence", divergenceBlockNumber_A, "safe", safeL2Head_sequencer_A.Number)
+			return false, nil
+		}
+
+		if safeL2Head_sequencer_A.Hash.Cmp(safeL2Head_supervisor_A) != 0 {
+			l.Info("Safe ref still not the same on supervisor and sequencer A", "supervisor", safeL2Head_supervisor_A, "sequencer", safeL2Head_sequencer_A.Hash)
+			return false, nil
+		}
+
+		l.Info("Safe ref the same across supervisor and sequencers",
+			"supervisor_A", safeL2Head_supervisor_A,
+			"sequencer_A", safeL2Head_sequencer_A.Hash)
+
+		return true, nil
+	})
+	require.NoError(t, err, "Expected to get same safe ref on both supervisor and sequencer eventually")
+
+	sys.L2ChainA.PrintChain()
+	sys.L2ChainB.PrintChain()
+	spew.Dump(sys.Supervisor.FetchSyncStatus())
+}

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -53,7 +54,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 	t := devtest.SerialT(gt)
 	ctx := t.Ctx()
 
-	sys := SimpleInterop(t)
+	sys := presets.NewSimpleInterop(t)
 	l := sys.Log
 
 	ia := sys.Sequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
@@ -149,12 +150,12 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 	// stop sequencer on chain A so that we later force include an invalid exec msg
 	{
 		var err error
-		latestUnsafe_A, err = sys.L2CLNodeA.Escape().RollupAPI().StopSequencer(ctx)
+		latestUnsafe_A, err = sys.L2CLA.Escape().RollupAPI().StopSequencer(ctx)
 		require.NoError(t, err, "expected to be able to call StopSequencer API, but got error")
 		// wait for the sequencer to become inactive
 		var active bool
 		err = wait.For(ctx, 1*time.Second, func() (bool, error) {
-			active, err = sys.L2CLNodeA.Escape().RollupAPI().SequencerActive(ctx)
+			active, err = sys.L2CLA.Escape().RollupAPI().SequencerActive(ctx)
 			return !active, err
 		})
 		require.NoError(t, err, "expected to be able to call SequencerActive API, and wait for inactive state for sequencer, but got error")
@@ -259,13 +260,13 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 		newUnsafeHeadRef := sys.L2ChainA.UnsafeHeadRef()
 		l.Info("Continue sequencing with consensus node (op-node)", "unsafeHead", newUnsafeHeadRef)
 
-		err := sys.L2CLNodeA.Escape().RollupAPI().StartSequencer(ctx, newUnsafeHeadRef.Hash)
+		err := sys.L2CLA.Escape().RollupAPI().StartSequencer(ctx, newUnsafeHeadRef.Hash)
 		require.NoError(t, err, "Expected to be able to start sequencer on rollup node")
 
 		// wait for the sequencer to become active
 		var active bool
 		err = wait.For(ctx, 1*time.Second, func() (bool, error) {
-			active, err = sys.L2CLNodeA.Escape().RollupAPI().SequencerActive(ctx)
+			active, err = sys.L2CLA.Escape().RollupAPI().SequencerActive(ctx)
 			return active, err
 		})
 		require.NoError(t, err, "Expected to be able to call SequencerActive API, and wait for an active state for sequencer, but got error")
@@ -304,7 +305,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 
 	err := wait.For(ctx, 5*time.Second, func() (bool, error) {
 		safeL2Head_supervisor_A := sys.Supervisor.SafeBlockID(sys.L2ChainA.ChainID()).Hash
-		safeL2Head_sequencer_A := sys.L2CLNodeA.SafeL2BlockRef()
+		safeL2Head_sequencer_A := sys.L2CLA.SafeL2BlockRef()
 
 		if safeL2Head_sequencer_A.Number < divergenceBlockNumber_A {
 			l.Info("Safe ref number is still behind divergence block A number", "divergence", divergenceBlockNumber_A, "safe", safeL2Head_sequencer_A.Number)

--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -38,7 +38,7 @@ func TestReorgUnsafeHead(gt *testing.T) {
 	}
 
 	// two EOAs for a sample transfer tx used later in a conflicting block
-	alice := sys.FunderA.NewFundedEOA(eth.ThousandEther)
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
 	bob := sys.Wallet.NewEOA(sys.L2ELA)
 
 	sys.L1Network.WaitForBlock()
@@ -90,7 +90,7 @@ func TestReorgUnsafeHead(gt *testing.T) {
 
 			// include simple transfer tx in opened block
 			{
-				to := alice.PlanTransfer(bob.Address(), eth.OneEther)
+				to := alice.PlanTransfer(bob.Address(), eth.OneGWei)
 				opt := txplan.Combine(to)
 				ptx := txplan.NewPlannedTx(opt)
 				signed_tx, err := ptx.Signed.Eval(ctx)

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -122,7 +122,7 @@ func (c *CrossSafeWorker) OnEvent(ev event.Event) bool {
 			if errors.Is(err, types.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)
 			} else {
-				c.logger.Warn("Failed to process work", "worker", "cross-safe", "err", err)
+				c.logger.Warn("Failed to process work", "err", err)
 			}
 		}
 	default:
@@ -134,7 +134,7 @@ func (c *CrossSafeWorker) OnEvent(ev event.Event) bool {
 var _ event.Deriver = (*CrossUnsafeWorker)(nil)
 
 func NewCrossSafeWorker(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps) *CrossSafeWorker {
-	logger = logger.New("chain", chainID)
+	logger = logger.New("chain", chainID, "worker", "cross-safe")
 	return &CrossSafeWorker{
 		logger:  logger,
 		chainID: chainID,

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -122,7 +122,7 @@ func (c *CrossSafeWorker) OnEvent(ev event.Event) bool {
 			if errors.Is(err, types.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)
 			} else {
-				c.logger.Warn("Failed to process work", "err", err)
+				c.logger.Warn("Failed to process work", "worker", "cross-safe", "err", err)
 			}
 		}
 	default:

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -80,7 +80,7 @@ func (c *CrossUnsafeWorker) OnEvent(ev event.Event) bool {
 			if errors.Is(err, types.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)
 			} else {
-				c.logger.Warn("Failed to process work", "worker", "cross-unsafe", "err", err)
+				c.logger.Warn("Failed to process work", "err", err)
 			}
 		}
 	default:
@@ -92,7 +92,7 @@ func (c *CrossUnsafeWorker) OnEvent(ev event.Event) bool {
 var _ event.Deriver = (*CrossUnsafeWorker)(nil)
 
 func NewCrossUnsafeWorker(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps) *CrossUnsafeWorker {
-	logger = logger.New("chain", chainID)
+	logger = logger.New("chain", chainID, "worker", "cross-unsafe")
 	return &CrossUnsafeWorker{
 		logger:  logger,
 		chainID: chainID,

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -80,7 +80,7 @@ func (c *CrossUnsafeWorker) OnEvent(ev event.Event) bool {
 			if errors.Is(err, types.ErrFuture) {
 				c.logger.Debug("Worker awaits additional blocks", "err", err)
 			} else {
-				c.logger.Warn("Failed to process work", "err", err)
+				c.logger.Warn("Failed to process work", "worker", "cross-unsafe", "err", err)
 			}
 		}
 	default:

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -16,6 +16,13 @@ import (
 )
 
 var errDuplicateChainIndex = errors.New("duplicate chain index")
+var errUsingReservedChainIndex = errors.New("using reserved chain index")
+
+// NotFoundChainIndex is a reserved chain index signifying that a network is not in the dependency set.
+// We are persisting these invalid, but not malformed, executing messages in our internal database, and
+// we need a mapping between all ChainIDs <> ChainIndexs. However ChainID is 32 bytes, and ChainIndex
+// is 4 bytes, so we need a reserved chain index for unknown chains.
+var NotFoundChainIndex = types.ChainIndex(3735928559) // 0xDEADBEEF
 
 type StaticConfigDependency struct {
 	// ChainIndex is the unique short identifier of this chain.
@@ -154,6 +161,9 @@ func (ds *StaticConfigDependencySet) hydrate() error {
 	ds.indexToID = make(map[types.ChainIndex]eth.ChainID)
 	ds.chainIDs = make([]eth.ChainID, 0, len(ds.dependencies))
 	for id, dep := range ds.dependencies {
+		if dep.ChainIndex == NotFoundChainIndex {
+			return fmt.Errorf("%w: chain %s cannot have the reserved chain index for NotFound chains: %d", errUsingReservedChainIndex, id, NotFoundChainIndex)
+		}
 		if existing, ok := ds.indexToID[dep.ChainIndex]; ok {
 			return fmt.Errorf("%w: chain %s cannot have the same index (%d) as chain %s", errDuplicateChainIndex, id, dep.ChainIndex, existing)
 		}
@@ -210,6 +220,9 @@ func (ds *StaticConfigDependencySet) ChainIndexFromID(id eth.ChainID) (types.Cha
 func (ds *StaticConfigDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
 	id, ok := ds.indexToID[index]
 	if !ok {
+		if index == NotFoundChainIndex {
+			return eth.ChainID{}, fmt.Errorf("provided index is reserved for unknown chains, so it cannot be translated to chain ID: %w", types.ErrUnknownChain)
+		}
 		return eth.ChainID{}, fmt.Errorf("failed to translate chain index %s to chain ID: %w", index, types.ErrUnknownChain)
 	}
 	return id, nil

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -22,7 +22,7 @@ var errUsingReservedChainIndex = errors.New("using reserved chain index")
 // We are persisting these invalid, but not malformed, executing messages in our internal database, and
 // we need a mapping between all ChainIDs <> ChainIndexs. However ChainID is 32 bytes, and ChainIndex
 // is 4 bytes, so we need a reserved chain index for unknown chains.
-var NotFoundChainIndex = types.ChainIndex(3735928559) // 0xDEADBEEF
+const NotFoundChainIndex = types.ChainIndex(0xFFFF_FFFF)
 
 type StaticConfigDependency struct {
 	// ChainIndex is the unique short identifier of this chain.
@@ -220,8 +220,8 @@ func (ds *StaticConfigDependencySet) ChainIndexFromID(id eth.ChainID) (types.Cha
 func (ds *StaticConfigDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
 	id, ok := ds.indexToID[index]
 	if !ok {
-		if index == NotFoundChainIndex {
-			return eth.ChainID{}, fmt.Errorf("provided index is reserved for unknown chains, so it cannot be translated to chain ID: %w", types.ErrUnknownChain)
+		if index.IsTopBitSet() {
+			return eth.ChainID{}, fmt.Errorf("provided index has its top bit set, and this subset is reserved for internal use: %w", types.ErrUnknownChain)
 		}
 		return eth.ChainID{}, fmt.Errorf("failed to translate chain index %s to chain ID: %w", index, types.ErrUnknownChain)
 	}

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -161,8 +161,8 @@ func (ds *StaticConfigDependencySet) hydrate() error {
 	ds.indexToID = make(map[types.ChainIndex]eth.ChainID)
 	ds.chainIDs = make([]eth.ChainID, 0, len(ds.dependencies))
 	for id, dep := range ds.dependencies {
-		if dep.ChainIndex == NotFoundChainIndex {
-			return fmt.Errorf("%w: chain %s cannot have the reserved chain index for NotFound chains: %d", errUsingReservedChainIndex, id, NotFoundChainIndex)
+		if dep.ChainIndex.IsTopBitSet() {
+			return fmt.Errorf("%w: chain %s cannot have the top bit set, and this subset is reserved for internal use: %d", errUsingReservedChainIndex, id, dep.ChainIndex)
 		}
 		if existing, ok := ds.indexToID[dep.ChainIndex]; ok {
 			return fmt.Errorf("%w: chain %s cannot have the same index (%d) as chain %s", errDuplicateChainIndex, id, dep.ChainIndex, existing)

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -291,7 +291,7 @@ func (s *ChainProcessor) process(ctx context.Context, next eth.BlockRef, receipt
 			// If no logs were written successfully then the rewind wouldn't have done anything anyway.
 			s.log.Error("Failed to rewind after error processing block", "block", next, "parent", next.ParentID(), "err", err)
 		} else {
-			s.log.Debug("Successfully rewinded database to the previous block", "block", next, "parent", next.ParentID())
+			s.log.Debug("Successfully rewound database to the previous block", "block", next, "parent", next.ParentID())
 		}
 		return err
 	}

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -289,7 +289,9 @@ func (s *ChainProcessor) process(ctx context.Context, next eth.BlockRef, receipt
 		if err := s.rewinder.Rewind(s.chain, next.ParentID()); err != nil {
 			// If any logs were written, our next attempt to write will fail and we'll retry this rewind.
 			// If no logs were written successfully then the rewind wouldn't have done anything anyway.
-			s.log.Error("Failed to rewind after error processing block", "block", next, "err", err)
+			s.log.Error("Failed to rewind after error processing block", "block", next, "parent", next.ParentID(), "err", err)
+		} else {
+			s.log.Debug("Successfully rewinded database to the previous block", "block", next, "parent", next.ParentID())
 		}
 		return err
 	}

--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -1,6 +1,7 @@
 package processors
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -31,8 +32,12 @@ func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) 
 
 	var chainIndex types.ChainIndex
 	index, err := depSet.ChainIndexFromID(eth.ChainID(msg.Identifier.ChainID))
-	if err != nil { // not found
-		chainIndex = depset.NotFoundChainIndex
+	if err != nil {
+		if errors.Is(err, types.ErrUnknownChain) {
+			chainIndex = depset.NotFoundChainIndex
+		} else {
+			return nil, fmt.Errorf("failed to translate chain ID %s to chain index: %w", msg.Identifier.ChainID, err)
+		}
 	} else {
 		chainIndex = index
 	}

--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -28,12 +28,16 @@ func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) 
 		return nil, fmt.Errorf("invalid executing message: %w", err)
 	}
 	logHash := types.PayloadHashToLogHash(msg.PayloadHash, msg.Identifier.Origin)
+
+	var chainIndex types.ChainIndex
 	index, err := depSet.ChainIndexFromID(eth.ChainID(msg.Identifier.ChainID))
-	if err != nil {
-		return nil, err
+	if err != nil { // not found
+		chainIndex = depset.NotFoundChainIndex
+	} else {
+		chainIndex = index
 	}
 	return &types.ExecutingMessage{
-		Chain:     index,
+		Chain:     chainIndex,
 		BlockNum:  msg.Identifier.BlockNumber,
 		LogIdx:    msg.Identifier.LogIndex,
 		Timestamp: msg.Identifier.Timestamp,

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -47,6 +47,11 @@ func (ci *ChainIndex) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// IsTopBitSet returns true if the top bit is set. Used to check for reserved values, such as NotFoundChainIndex.
+func (ci ChainIndex) IsTopBitSet() bool {
+	return ci&(1<<31) != 0
+}
+
 type Revision uint64
 
 // RevisionAny is used as indicator to ignore the revision during lookups.


### PR DESCRIPTION
**Description**

This PR is adding 3 changes - reorg tests, happy interop init/exec msg test and modification to `DecodeExecutingMessageLog` behavior.

**1. Reorg test**

Adding tests for the reorg functionality of the supervisor when it detects an invalid exec msg:
1. We make an unsafe block that includes an invalid exec msg on chain A (the identifier of the exec msg points to unknown chain)
2. We wait for the supervisor to trigger a reorg on the executing side (chain A), without change to the initiating side (chain B).

This implies the sequencer is malicious. To cover this scenario, we use the `op-test-sequencer` to force in the bad tx.

**2. Modification to DecodeExecutingMessageLog behavior**

`DepSet` now includes a reserved ChainIndex for an unknown chain. We make sure that no chain is using that index when hydrating/initialising the set from config.

Conversion of `ChainID` to `ChainIndex` within `DecodeExecutingMessageLog` remains, during parsing of `ExecutingMessage (EM)` but if we see an unknown chain, we convert `ChainID` to the reserved chain index for unknown chain, essentially losing the value within our internal database. Later that `EM` is discarded the same way we discard other `EMs` for other validation errors.

This way the supervisor correctly triggers a reorg of the chain, and issues a similar error as other validation problems (such as `invalid block number`, or `invalid log index`, etc.)

**3. Happy-path interop init/exec msg test**

Confirming the changes in behavior in point 2. are not affecting correctly formatted `EMs`

**Metadata**

Fixes: https://github.com/ethereum-optimism/optimism/issues/15500