### PR TITLE
op-e2e: Supersystem proposer to create super games

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -437,6 +437,12 @@ func TestProposals(t *testing.T) {
 			t.Logf("Current game count: %v", count)
 			return count > 0
 		}, 5*time.Minute, time.Second)
+
+		head, err := ethClient.BlockByNumber(context.Background(), nil)
+		require.NoError(t, err)
+		game, err := factory.GetGame(context.Background(), 0, head.Hash())
+		require.NoError(t, err)
+		require.Equal(t, uint32(4) /* super permissionless */, game.GameType)
 	}
 	setupAndRun(t, SuperSystemConfig{}, test)
 }

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -232,9 +232,9 @@ func (s *interopE2ESystem) newProposerForL2(
 	proposerCLIConfig := &l2os.CLIConfig{
 		L1EthRpc:          s.l1.UserRPC().RPC(),
 		SupervisorRpcs:    []string{s.Supervisor().RPC()},
-		DGFAddress:        s.worldDeployment.L2s[id].DisputeGameFactoryProxy.Hex(),
+		DGFAddress:        s.worldDeployment.Interop.DisputeGameFactory.Hex(),
 		ProposalInterval:  6 * time.Second,
-		DisputeGameType:   1, // Permissioned game type is the only one currently deployed
+		DisputeGameType:   4, // Super Permissionless game type is the only one currently deployed
 		PollInterval:      500 * time.Millisecond,
 		TxMgrConfig:       setuputils.NewTxMgrConfig(s.L1().UserRPC(), &key),
 		AllowNonFinalized: true,


### PR DESCRIPTION
Fixes the SuperSystem op-proposer to propose super roots, rather than output roots.