### PR TITLE
op-node: `pectra_blob_schedule_time` is printed twice in `LogDescription`

### DIFF
--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -87,7 +87,7 @@ func RollupNodeMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.
 	}
 	cfg.Cancel = closeApp
 
-	// Only pretty-print the banner if it is a terminal log. Other log it as key-value pairs.
+	// Only pretty-print the banner if it is a terminal log. Otherwise log it as key-value pairs.
 	if logCfg.Format == "terminal" {
 		log.Info("rollup config:\n" + cfg.Rollup.Description(chaincfg.L2ChainIDToNetworkDisplayName))
 	} else {

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -751,10 +751,6 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 	if c.AltDAConfig != nil {
 		ctx = append(ctx, "alt_da", *c.AltDAConfig)
 	}
-	if c.PectraBlobScheduleTime != nil {
-		// only print in config if set at all
-		ctx = append(ctx, "pectra_blob_schedule_time", fmtForkTimeOrUnset(c.PectraBlobScheduleTime))
-	}
 	log.Info("Rollup Config", ctx...)
 }
 


### PR DESCRIPTION
`Config.PectraBlobScheduleTime` is already handled in `Config.forEachFork`, so no need to do it again in `Config.LogDescription`.