### PR TITLE
op-supervisor: improve sync logic

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -605,8 +605,8 @@ func (su *SupervisorBackend) CrossUnsafe(ctx context.Context, chainID eth.ChainI
 	return v.ID(), nil
 }
 
-func (su *SupervisorBackend) SafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (eth.BlockID, error) {
-	v, err := su.chainDBs.SafeDerivedAt(chainID, source)
+func (su *SupervisorBackend) LocalSafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (eth.BlockID, error) {
+	v, err := su.chainDBs.LocalSafeDerivedAt(chainID, source)
 	if err != nil {
 		return eth.BlockID{}, err
 	}
@@ -626,7 +626,7 @@ func (su *SupervisorBackend) AllSafeDerivedAt(ctx context.Context, source eth.Bl
 	chains := su.depSet.Chains()
 	ret := map[eth.ChainID]eth.BlockID{}
 	for _, chainID := range chains {
-		derived, err := su.SafeDerivedAt(ctx, chainID, source)
+		derived, err := su.LocalSafeDerivedAt(ctx, chainID, source)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get last derived block for chain %v: %w", chainID, err)
 		}
@@ -649,6 +649,10 @@ func (su *SupervisorBackend) FinalizedL1(ctx context.Context) (eth.BlockRef, err
 		return eth.BlockRef{}, fmt.Errorf("finality of L1 is not initialized: %w", ethereum.NotFound)
 	}
 	return v, nil
+}
+
+func (su *SupervisorBackend) AnchorPoint(ctx context.Context, chainID eth.ChainID) (types.DerivedBlockSealPair, error) {
+	return su.chainDBs.AnchorPoint(chainID)
 }
 
 func (su *SupervisorBackend) IsLocalUnsafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -137,7 +137,7 @@ func (db *ChainsDB) IsFinalized(chainID eth.ChainID, block eth.BlockID) error {
 	return fmt.Errorf("cross-safe source block is not finalized: %w", types.ErrFuture)
 }
 
-func (db *ChainsDB) SafeDerivedAt(chainID eth.ChainID, source eth.BlockID) (types.BlockSeal, error) {
+func (db *ChainsDB) LocalSafeDerivedAt(chainID eth.ChainID, source eth.BlockID) (types.BlockSeal, error) {
 	lDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		return types.BlockSeal{}, types.ErrUnknownChain
@@ -645,4 +645,13 @@ func (db *ChainsDB) SafeLocalUnsafe(chainID eth.ChainID) (types.BlockSeal, error
 	})
 
 	return result, err
+}
+
+// AnchorPoint returns the first cross-safe block as anchor-point for interop.
+func (db *ChainsDB) AnchorPoint(chainID eth.ChainID) (types.DerivedBlockSealPair, error) {
+	xdb, ok := db.crossDBs.Get(chainID)
+	if !ok {
+		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
+	}
+	return xdb.First()
 }

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -92,7 +92,7 @@ func TestEventResponse(t *testing.T) {
 
 func TestPrepareReset(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(1)
-	logger := testlog.Logger(t, log.LvlInfo)
+	logger := testlog.Logger(t, log.LvlDebug)
 	syncCtrl := &mockSyncControl{}
 	backend := &mockBackend{}
 
@@ -112,7 +112,7 @@ func TestPrepareReset(t *testing.T) {
 
 	// mock: control whether the blocks appear valid or not
 	var pivot uint64
-	backend.isLocalUnsafeFn = func(ctx context.Context, chainID eth.ChainID, id eth.BlockID) error {
+	backend.isLocalSafeFn = func(ctx context.Context, chainID eth.ChainID, id eth.BlockID) error {
 		if id.Number > uint64(pivot) {
 			return types.ErrConflict
 		}


### PR DESCRIPTION
**Description**

This fixes a bunch of bad sync situations that we identified while discussing RC Alpha:
- When searching for a sync starting point, use the anchor-point as the start, not literally block-0, to be upgrade-compatible
- When resetting-if-inconsistent, do not go back to the latest seen block, always prefer the local-safe chain if it is further along.
- When bisecting, bisect against the connected node against the local-safe DB, since the logs data may be stale, and is of lesser importance. Only if there's no local-safe data use the unsafe-blocks as reference.

And rename `SafeDerivedAt` while we stumbled on it, to clarify it returns local-safe data.

**Tests**

All existing sync tests pass.
Next week we may add a sequencer-window-expiry test, but I think we should expedite these fixes for RC Beta trial run 0 on Monday.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
