### PR TITLE
feat(devnet): add kurtosis PR verification checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1678,6 +1678,196 @@ jobs:
             MESSAGE: << parameters.message >>
             LABEL_NAME: << parameters.label_name >>
 
+  workflow-completed:
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    steps:
+      - run:
+          name: Workflow Completed
+          command: echo "Workflow completed successfully!"
+
+  kurtosis-pr-sanity-check:
+    docker:
+      - image: cimg/go:1.21
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Install Kurtosis
+          command: |
+            echo "Installing Kurtosis CLI..."
+            curl -sSL https://get.kurtosis.com/install.sh | bash
+            echo 'export PATH="$HOME/.kurtosis/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            kurtosis version
+      - run:
+          name: Start Kurtosis Engine
+          command: |
+            kurtosis engine start
+            kurtosis engine status
+      - run:
+          name: Build Required Docker Images
+          working_directory: kurtosis-devnet
+          command: |
+            # Install just
+            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
+            export PATH="$HOME/.local/bin:$PATH"
+
+            # Build the minimal set of Docker images required for the check
+            just op-node-image
+            just op-batcher-image
+            just op-proposer-image
+      - run:
+          name: Run Kurtosis Simple Deployment Check
+          working_directory: kurtosis-devnet
+          command: |
+            export PATH="$HOME/.local/bin:$PATH"
+
+            # Attempt to deploy the simple devnet (most lightweight option)
+            just simple-devnet
+
+            # Verify the devnet is running properly
+            ENCLAVE_NAME="simple-devnet"
+            if kurtosis enclave inspect $ENCLAVE_NAME | grep -q "RUNNING"; then
+              echo "✅ Kurtosis devnet deployed successfully!"
+              DEPLOYMENT_SUCCESS=true
+            else
+              echo "❌ Kurtosis devnet deployment failed!"
+              kurtosis enclave inspect $ENCLAVE_NAME || true
+              exit 1
+            fi
+      - run:
+          name: Clean Up Resources
+          command: |
+            kurtosis clean -a || true
+          when: always
+      - discord-notification-failures-on-develop:
+          message: "⚠️ **Kurtosis PR Sanity Check Failed**: ${CIRCLE_PROJECT_REPONAME} PR ${CIRCLE_PULL_REQUEST##*/}\nPlease ensure your changes don't break the kurtosis devnet deployments."
+          when: on_fail
+
+  kurtosis-merge-queue-check:
+    docker:
+      - image: cimg/go:1.21
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Install Kurtosis
+          command: |
+            echo "Installing Kurtosis CLI..."
+            curl -sSL https://get.kurtosis.com/install.sh | bash
+            echo 'export PATH="$HOME/.kurtosis/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            kurtosis version
+      - run:
+          name: Start Kurtosis Engine
+          command: |
+            kurtosis engine start
+            kurtosis engine status
+      - run:
+          name: Build Required Docker Images
+          working_directory: kurtosis-devnet
+          command: |
+            # Install just
+            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
+            export PATH="$HOME/.local/bin:$PATH"
+
+            # Build the minimal set of Docker images required for the check
+            just op-node-image
+            just op-batcher-image
+            just op-proposer-image
+      - run:
+          name: Check for Existing Persistent Devnet
+          command: |
+            export PATH="$HOME/.local/bin:$PATH"
+
+            # Check if the persistent-devnet already exists
+            if kurtosis enclave ls | grep -q "persistent-devnet"; then
+              echo "Persistent devnet already exists, will attempt to update it"
+              PERSISTENT_EXISTS=true
+            else
+              echo "No persistent devnet found, will create a new one"
+              PERSISTENT_EXISTS=false
+            fi
+
+            # Store the state in an environment variable for the next step
+            echo "export PERSISTENT_EXISTS=${PERSISTENT_EXISTS}" >> $BASH_ENV
+      - run:
+          name: Deploy or Update Persistent Devnet
+          working_directory: kurtosis-devnet
+          command: |
+            export PATH="$HOME/.local/bin:$PATH"
+
+            if [ "$PERSISTENT_EXISTS" = "true" ]; then
+              # Try to update the existing devnet
+              echo "Attempting to update the persistent devnet..."
+
+              # Stop any running tests
+              kurtosis enclave stop persistent-devnet || true
+
+              # Restart the enclave with new code
+              kurtosis enclave start persistent-devnet || true
+
+              # Run the simple devnet with the same name to update it
+              just devnet "simple.yaml" "" "persistent"
+            else
+              # Deploy a new devnet
+              echo "Creating new persistent devnet..."
+              just devnet "simple.yaml" "" "persistent"
+            fi
+
+            # Verify the devnet is running properly
+            ENCLAVE_NAME="persistent-devnet"
+            if kurtosis enclave inspect $ENCLAVE_NAME | grep -q "RUNNING"; then
+              echo "✅ Persistent kurtosis devnet deployed/updated successfully!"
+              DEPLOYMENT_SUCCESS=true
+            else
+              echo "❌ Persistent kurtosis devnet deployment/update failed!"
+              kurtosis enclave inspect $ENCLAVE_NAME || true
+              exit 1
+            fi
+      - discord-notification-failures-on-develop:
+          message: "⚠️ **Kurtosis Merge Queue Check Failed**: ${CIRCLE_PROJECT_REPONAME} branch ${CIRCLE_BRANCH}\nPlease ensure your changes don't break the kurtosis devnet deployments."
+          when: on_fail
+
+  # Kurtosis PR Check Workflow
+  kurtosis-pr-check:
+    # Run on all PRs except those targeting main or develop
+    when:
+      and:
+        - not:
+            equal: [ "develop", << pipeline.git.branch >> ]
+        - not:
+            equal: [ "main", << pipeline.git.branch >> ]
+        - or:
+            - matches:
+                pattern: "^pull/\\d+$"
+                value: << pipeline.git.branch >>
+            - matches:
+                pattern: "^pull/\\d+/head$"
+                value: << pipeline.git.branch >>
+    jobs:
+      - kurtosis-pr-sanity-check:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+
+  # Kurtosis Merge Queue Check
+  kurtosis-merge-queue-check:
+    # Run only in the merge queue
+    when:
+      and:
+        - or:
+            - equal: [ "merge-queue", << pipeline.git.branch >> ]
+            - matches:
+                pattern: "^merge-queue/.*$"
+                value: << pipeline.git.branch >>
+    jobs:
+      - kurtosis-merge-queue-check:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+
 workflows:
   main:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1686,48 +1686,83 @@ jobs:
           name: Workflow Completed
           command: echo "Workflow completed successfully!"
 
-  kurtosis-pr-sanity-check:
+  # Kurtosis verification check - consolidated job that can be used for both PR checks and merge queue
+  kurtosis-verification-check:
+    parameters:
+      is_persistent:
+        description: Whether to use a persistent devnet (for merge queue) or one-time devnet (for PRs)
+        type: boolean
+        default: false
+      enclave_name:
+        description: Name of the kurtosis enclave
+        type: string
+        default: "simple-devnet"
+      failure_message:
+        description: Message to display on failure
+        type: string
+        default: "Kurtosis verification check failed"
     docker:
       - image: cimg/go:1.21
     resource_class: medium
     steps:
-      - checkout
-      - run:
-          name: Install Kurtosis
-          command: |
-            echo "Installing Kurtosis CLI..."
-            curl -sSL https://get.kurtosis.com/install.sh | bash
-            echo 'export PATH="$HOME/.kurtosis/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
-            kurtosis version
+      - utils/checkout-with-mise
       - run:
           name: Start Kurtosis Engine
           command: |
             kurtosis engine start
             kurtosis engine status
+      - when:
+          condition: << parameters.is_persistent >>
+          steps:
+            - run:
+                name: Check for Existing Persistent Devnet
+                command: |
+                  # Check if the persistent-devnet already exists
+                  if kurtosis enclave ls | grep -q "<< parameters.enclave_name >>"; then
+                    echo "Persistent devnet already exists, will attempt to update it"
+                    PERSISTENT_EXISTS=true
+                  else
+                    echo "No persistent devnet found, will create a new one"
+                    PERSISTENT_EXISTS=false
+                  fi
+
+                  # Store the state in an environment variable for the next step
+                  echo "export PERSISTENT_EXISTS=${PERSISTENT_EXISTS}" >> $BASH_ENV
+            - run:
+                name: Deploy or Update Persistent Devnet
+                working_directory: kurtosis-devnet
+                command: |
+                  if [ "$PERSISTENT_EXISTS" = "true" ]; then
+                    # Try to update the existing devnet
+                    echo "Attempting to update the persistent devnet..."
+
+                    # Stop any running tests
+                    kurtosis enclave stop << parameters.enclave_name >> || true
+
+                    # Restart the enclave with new code
+                    kurtosis enclave start << parameters.enclave_name >> || true
+
+                    # Run the simple devnet with the same name to update it
+                    just devnet "simple.yaml" "" "<< parameters.enclave_name >>"
+                  else
+                    # Deploy a new devnet
+                    echo "Creating new persistent devnet..."
+                    just devnet "simple.yaml" "" "<< parameters.enclave_name >>"
+                  fi
+      - unless:
+          condition: << parameters.is_persistent >>
+          steps:
+            - run:
+                name: Run Kurtosis Simple Deployment Check
+                working_directory: kurtosis-devnet
+                command: |
+                  # Attempt to deploy the simple devnet (most lightweight option)
+                  just simple-devnet
       - run:
-          name: Build Required Docker Images
-          working_directory: kurtosis-devnet
+          name: Verify Devnet Status
           command: |
-            # Install just
-            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
-            export PATH="$HOME/.local/bin:$PATH"
-
-            # Build the minimal set of Docker images required for the check
-            just op-node-image
-            just op-batcher-image
-            just op-proposer-image
-      - run:
-          name: Run Kurtosis Simple Deployment Check
-          working_directory: kurtosis-devnet
-          command: |
-            export PATH="$HOME/.local/bin:$PATH"
-
-            # Attempt to deploy the simple devnet (most lightweight option)
-            just simple-devnet
-
             # Verify the devnet is running properly
-            ENCLAVE_NAME="simple-devnet"
+            ENCLAVE_NAME="<< parameters.enclave_name >>"
             if kurtosis enclave inspect $ENCLAVE_NAME | grep -q "RUNNING"; then
               echo "✅ Kurtosis devnet deployed successfully!"
               DEPLOYMENT_SUCCESS=true
@@ -1739,413 +1774,35 @@ jobs:
       - run:
           name: Clean Up Resources
           command: |
-            kurtosis clean -a || true
+            if [ "<< parameters.is_persistent >>" = "false" ]; then
+              # Only clean up resources for non-persistent devnets
+              kurtosis clean -a || true
+            fi
           when: always
       - discord-notification-failures-on-develop:
-          message: "⚠️ **Kurtosis PR Sanity Check Failed**: ${CIRCLE_PROJECT_REPONAME} PR ${CIRCLE_PULL_REQUEST##*/}\nPlease ensure your changes don't break the kurtosis devnet deployments."
+          message: "<< parameters.failure_message >>"
           when: on_fail
+
+  # Keep the old job definitions to maintain backward compatibility
+  kurtosis-pr-sanity-check:
+    docker:
+      - image: cimg/go:1.21
+    resource_class: medium
+    steps:
+      - kurtosis-verification-check:
+          is_persistent: false
+          enclave_name: "simple-devnet"
+          failure_message: "⚠️ **Kurtosis PR Sanity Check Failed**: ${CIRCLE_PROJECT_REPONAME} PR ${CIRCLE_PULL_REQUEST##*/}\nPlease ensure your changes don't break the kurtosis devnet deployments."
 
   kurtosis-merge-queue-check:
     docker:
       - image: cimg/go:1.21
     resource_class: medium
     steps:
-      - checkout
-      - run:
-          name: Install Kurtosis
-          command: |
-            echo "Installing Kurtosis CLI..."
-            curl -sSL https://get.kurtosis.com/install.sh | bash
-            echo 'export PATH="$HOME/.kurtosis/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
-            kurtosis version
-      - run:
-          name: Start Kurtosis Engine
-          command: |
-            kurtosis engine start
-            kurtosis engine status
-      - run:
-          name: Build Required Docker Images
-          working_directory: kurtosis-devnet
-          command: |
-            # Install just
-            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
-            export PATH="$HOME/.local/bin:$PATH"
-
-            # Build the minimal set of Docker images required for the check
-            just op-node-image
-            just op-batcher-image
-            just op-proposer-image
-      - run:
-          name: Check for Existing Persistent Devnet
-          command: |
-            export PATH="$HOME/.local/bin:$PATH"
-
-            # Check if the persistent-devnet already exists
-            if kurtosis enclave ls | grep -q "persistent-devnet"; then
-              echo "Persistent devnet already exists, will attempt to update it"
-              PERSISTENT_EXISTS=true
-            else
-              echo "No persistent devnet found, will create a new one"
-              PERSISTENT_EXISTS=false
-            fi
-
-            # Store the state in an environment variable for the next step
-            echo "export PERSISTENT_EXISTS=${PERSISTENT_EXISTS}" >> $BASH_ENV
-      - run:
-          name: Deploy or Update Persistent Devnet
-          working_directory: kurtosis-devnet
-          command: |
-            export PATH="$HOME/.local/bin:$PATH"
-
-            if [ "$PERSISTENT_EXISTS" = "true" ]; then
-              # Try to update the existing devnet
-              echo "Attempting to update the persistent devnet..."
-
-              # Stop any running tests
-              kurtosis enclave stop persistent-devnet || true
-
-              # Restart the enclave with new code
-              kurtosis enclave start persistent-devnet || true
-
-              # Run the simple devnet with the same name to update it
-              just devnet "simple.yaml" "" "persistent"
-            else
-              # Deploy a new devnet
-              echo "Creating new persistent devnet..."
-              just devnet "simple.yaml" "" "persistent"
-            fi
-
-            # Verify the devnet is running properly
-            ENCLAVE_NAME="persistent-devnet"
-            if kurtosis enclave inspect $ENCLAVE_NAME | grep -q "RUNNING"; then
-              echo "✅ Persistent kurtosis devnet deployed/updated successfully!"
-              DEPLOYMENT_SUCCESS=true
-            else
-              echo "❌ Persistent kurtosis devnet deployment/update failed!"
-              kurtosis enclave inspect $ENCLAVE_NAME || true
-              exit 1
-            fi
-      - discord-notification-failures-on-develop:
-          message: "⚠️ **Kurtosis Merge Queue Check Failed**: ${CIRCLE_PROJECT_REPONAME} branch ${CIRCLE_BRANCH}\nPlease ensure your changes don't break the kurtosis devnet deployments."
-          when: on_fail
-
-  # Kurtosis PR Check Workflow
-  kurtosis-pr-check:
-    # Run on all PRs except those targeting main or develop
-    when:
-      and:
-        - not:
-            equal: [ "develop", << pipeline.git.branch >> ]
-        - not:
-            equal: [ "main", << pipeline.git.branch >> ]
-        - or:
-            - matches:
-                pattern: "^pull/\\d+$"
-                value: << pipeline.git.branch >>
-            - matches:
-                pattern: "^pull/\\d+/head$"
-                value: << pipeline.git.branch >>
-    jobs:
-      - kurtosis-pr-sanity-check:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-
-  # Kurtosis Merge Queue Check
-  kurtosis-merge-queue-check:
-    # Run only in the merge queue
-    when:
-      and:
-        - or:
-            - equal: [ "merge-queue", << pipeline.git.branch >> ]
-            - matches:
-                pattern: "^merge-queue/.*$"
-                value: << pipeline.git.branch >>
-    jobs:
-      - kurtosis-merge-queue-check:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-
-workflows:
-  main:
-    when:
-      or:
-        - equal: ["webhook",<< pipeline.trigger_source >>]
-        - and:
-          - equal: [true, <<pipeline.parameters.main_dispatch>>]
-          - equal: ["api",<< pipeline.trigger_source >>]
-          - equal: [<< pipeline.parameters.github-event-type >>, "__not_set__"] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
-    jobs:
-      - contracts-bedrock-build:
-          name: contracts-bedrock-build
-          # Build with just core + script contracts.
-          build_args: --deny-warnings --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - check-kontrol-build:
-          requires:
-            - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests:
-          # Test everything except PreimageOracle.t.sol since it's slow.
-          name: contracts-bedrock-tests
-          test_list: find test -name "*.t.sol" -not -name "PreimageOracle.t.sol"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests:
-          # PreimageOracle test is slow, run it separately to unblock CI.
-          name: contracts-bedrock-tests-preimage-oracle
-          test_list: find test -name "PreimageOracle.t.sol"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests:
-          # Heavily fuzz any fuzz tests within added or modified test files.
-          name: contracts-bedrock-tests-heavy-fuzz-modified
-          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
-          test_timeout: 1h
-          test_profile: ciheavy
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-coverage:
-          # Generate coverage reports.
-          name: contracts-bedrock-coverage
-          test_timeout: 1h
-          test_profile: cicoverage
-          # need this requires to ensure that all FFI JSONs exist
-          requires:
-            - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade
-          fork_op_chain: op
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade base-mainnet
-          fork_op_chain: base
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade ink-mainnet
-          fork_op_chain: ink
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade unichain-mainnet
-          fork_op_chain: unichain
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-checks:
-          requires:
-            - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - contracts-bedrock-frozen-code:
-          requires:
-            - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - diff-fetcher-forge-artifacts:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - diff-asterisc-bytecode:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - semgrep-scan:
-          name: semgrep-scan-local
-          scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - semgrep-scan:
-          name: semgrep-test
-          scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - go-lint:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - fuzz-golang:
-          name: fuzz-golang-<<matrix.package_name>>
-          on_changes: <<matrix.package_name>>
-          matrix:
-            parameters:
-              package_name:
-                - op-challenger
-                - op-node
-                - op-service
-                - op-chain-ops
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - fuzz-golang:
-          name: cannon-fuzz
-          package_name: cannon
-          on_changes: cannon,packages/contracts-bedrock/src/cannon
-          uses_artifacts: true
-          requires: ["contracts-bedrock-build"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - fuzz-golang:
-          name: op-e2e-fuzz
-          package_name: op-e2e
-          on_changes: op-e2e,packages/contracts-bedrock/src
-          uses_artifacts: true
-          requires: ["contracts-bedrock-build"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - go-tests:
-          environment_overrides: |
-            export PARALLEL=24
-          packages: |
-            op-alt-da
-            op-batcher
-            op-chain-ops
-            op-node
-            op-proposer
-            op-challenger
-            op-faucet
-            op-dispute-mon
-            op-conductor
-            op-program
-            op-service
-            op-supervisor
-            op-deployer
-            op-fetcher
-            op-validator
-            op-e2e/system
-            op-e2e/e2eutils
-            op-e2e/opgeth
-            op-e2e/interop
-            op-e2e/actions
-            op-e2e/faultproofs
-            packages/contracts-bedrock/scripts/checks
-            packages/contracts-bedrock/scripts/verify
-            op-dripper
-            devnet-sdk
-            op-acceptance-tests
-            kurtosis-devnet
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - analyze-op-program-client:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - op-program-compat:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - bedrock-go-tests:
-          requires:
-            - go-lint
-            - cannon-go-lint-and-test
-            - check-generated-mocks-op-node
-            - check-generated-mocks-op-service
-            - op-program-compat
-            # Not needed for the devnet but we want to make sure they build successfully
-            - cannon-docker-build
-            - op-dispute-mon-docker-build
-            - op-program-docker-build
-            - op-supervisor-docker-build
-            - go-tests
-            - sanitize-op-program
-          context:
-            - circleci-repo-readonly-authenticated-github-tokens
-            - discord
-      - docker-build:
-          name: <<matrix.docker_name>>-docker-build
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          save_image_tag: <<pipeline.git.revision>>
-          matrix:
-            parameters:
-              docker_name:
-                - op-node
-                - op-batcher
-                - op-program
-                - op-proposer
-                - op-challenger
-                - op-dispute-mon
-                - op-conductor
-                - da-server
-                - op-supervisor
-                - cannon
-                - op-dripper
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - cannon-prestate-quick:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - sanitize-op-program:
-          requires:
-            - cannon-prestate-quick
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - check-generated-mocks-op-node:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - check-generated-mocks-op-service:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - cannon-go-lint-and-test:
-          requires:
-            - contracts-bedrock-build
-          skip_slow_tests: true
-          notify: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - todo-issues:
-          name: todo-issues-check
-          check_closed: false
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-      - shellcheck/check:
-          name: shell-check
-          # We don't need the `exclude` key as the orb detects the `.shellcheckrc`
-          dir: .
-          ignore-dirs: ./packages/contracts-bedrock/lib
-          context:
-            - circleci-repo-readonly-authenticated-github-token
+      - kurtosis-verification-check:
+          is_persistent: true
+          enclave_name: "persistent-devnet"
+          failure_message: "⚠️ **Kurtosis Merge Queue Check Failed**: ${CIRCLE_PROJECT_REPONAME} branch ${CIRCLE_BRANCH}\nPlease ensure your changes don't break the kurtosis devnet deployments."
 
   go-release-deployer:
     jobs:
@@ -2517,3 +2174,45 @@ workflows:
                 This issue will be closed now."
          context:
           - circleci-repo-optimism
+
+# Define kurtosis workflow definitions
+workflows:
+  # Kurtosis PR Check Workflow
+  kurtosis-pr-check:
+    # Run on all PRs except those targeting main or develop
+    when:
+      and:
+        - not:
+            equal: [ "develop", << pipeline.git.branch >> ]
+        - not:
+            equal: [ "main", << pipeline.git.branch >> ]
+        - or:
+            - matches:
+                pattern: "^pull/\\d+$"
+                value: << pipeline.git.branch >>
+            - matches:
+                pattern: "^pull/\\d+/head$"
+                value: << pipeline.git.branch >>
+    jobs:
+      - kurtosis-pr-sanity-check:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+
+  # Kurtosis Merge Queue Check
+  kurtosis-merge-queue-check:
+    # Run only in the merge queue
+    when:
+      and:
+        - or:
+            - equal: [ "merge-queue", << pipeline.git.branch >> ]
+            - matches:
+                pattern: "^merge-queue/.*$"
+                value: << pipeline.git.branch >>
+    jobs:
+      - kurtosis-merge-queue-check:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+
+  go-release-deployer:

--- a/.circleci/kurtosis-pr-check.yml
+++ b/.circleci/kurtosis-pr-check.yml
@@ -1,0 +1,74 @@
+version: 2.1
+
+orbs:
+  go: circleci/go@1.8.0
+  slack: circleci/slack@5.1.1
+
+# Define the kurtosis PR check job
+jobs:
+  kurtosis-pr-sanity-check:
+    docker:
+      - image: cimg/go:1.21
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Install Kurtosis
+          command: |
+            echo "Installing Kurtosis CLI..."
+            curl -sSL https://get.kurtosis.com/install.sh | bash
+            echo 'export PATH="$HOME/.kurtosis/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            kurtosis version
+      - run:
+          name: Start Kurtosis Engine
+          command: |
+            kurtosis engine start
+            kurtosis engine status
+      - run:
+          name: Build Required Docker Images
+          working_directory: kurtosis-devnet
+          command: |
+            # Install just
+            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
+            export PATH="$HOME/.local/bin:$PATH"
+
+            # Build the minimal set of Docker images required for the check
+            just op-node-image
+            just op-batcher-image
+            just op-proposer-image
+      - run:
+          name: Run Kurtosis Simple Deployment Check
+          working_directory: kurtosis-devnet
+          command: |
+            export PATH="$HOME/.local/bin:$PATH"
+
+            # Attempt to deploy the simple devnet (most lightweight option)
+            just simple-devnet
+
+            # Verify the devnet is running properly
+            ENCLAVE_NAME="simple-devnet"
+            if kurtosis enclave inspect $ENCLAVE_NAME | grep -q "RUNNING"; then
+              echo "✅ Kurtosis devnet deployed successfully!"
+              DEPLOYMENT_SUCCESS=true
+            else
+              echo "❌ Kurtosis devnet deployment failed!"
+              kurtosis enclave inspect $ENCLAVE_NAME || true
+              exit 1
+            fi
+      - run:
+          name: Clean Up Resources
+          command: |
+            kurtosis clean -a || true
+          when: always
+
+# Define the workflow for PR checks
+workflows:
+  kurtosis-pr-check:
+    jobs:
+      - kurtosis-pr-sanity-check:
+          filters:
+            branches:
+              ignore:
+                - main
+                - develop

--- a/.circleci/kurtosis-pr-check.yml
+++ b/.circleci/kurtosis-pr-check.yml
@@ -11,39 +11,18 @@ jobs:
       - image: cimg/go:1.21
     resource_class: medium
     steps:
-      - checkout
-      - run:
-          name: Install Kurtosis
-          command: |
-            echo "Installing Kurtosis CLI..."
-            curl -sSL https://get.kurtosis.com/install.sh | bash
-            echo 'export PATH="$HOME/.kurtosis/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
-            kurtosis version
+      - utils/checkout-with-mise
       - run:
           name: Start Kurtosis Engine
           command: |
             kurtosis engine start
             kurtosis engine status
       - run:
-          name: Build Required Docker Images
-          working_directory: kurtosis-devnet
-          command: |
-            # Install just
-            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
-            export PATH="$HOME/.local/bin:$PATH"
-
-            # Build the minimal set of Docker images required for the check
-            just op-node-image
-            just op-batcher-image
-            just op-proposer-image
-      - run:
           name: Run Kurtosis Simple Deployment Check
           working_directory: kurtosis-devnet
           command: |
-            export PATH="$HOME/.local/bin:$PATH"
-
             # Attempt to deploy the simple devnet (most lightweight option)
+            # just simple-devnet will build the necessary dependencies automatically
             just simple-devnet
 
             # Verify the devnet is running properly

--- a/kurtosis-devnet/README.md
+++ b/kurtosis-devnet/README.md
@@ -156,7 +156,7 @@ In particular, cleaning up a devnet can be achieved using
 
 ### Autofix mode
 
-Autofix mode helps recover from failed devnet deployments by automatically 
+Autofix mode helps recover from failed devnet deployments by automatically
 cleaning up the environment. It has two modes:
 
 1. **Normal Mode** (`AUTOFIX=true`)
@@ -189,7 +189,7 @@ older kurtosis engine. This typically happens if the kurtosis
 command-line managed by mise gets updated while some enclaves are
 already running.
 
-To help recover, you can either run with `AUTOFIX=nuke` or kill the 
+To help recover, you can either run with `AUTOFIX=nuke` or kill the
 old engine with:
 
 ```shell
@@ -201,3 +201,9 @@ Potentially you'll also need to cleanup dangling docker networks:
 ```shell
 docker network rm -f $(docker network ls -qf "name=kt-*")
 ```
+
+## PR Checks
+
+To ensure stability and prevent inadvertent breakage of the kurtosis deployments, we've implemented PR checks that automatically verify each PR can successfully deploy a kurtosis devnet.
+
+For more information, see the [PR Checks Documentation](docs/pr-checks.md).

--- a/kurtosis-devnet/docs/pr-checks.md
+++ b/kurtosis-devnet/docs/pr-checks.md
@@ -1,0 +1,48 @@
+# Kurtosis DevNet PR Checks
+
+This document explains the PR check mechanisms implemented for the Kurtosis DevNet to ensure changes don't inadvertently break the deployment process.
+
+## Overview
+
+There are two types of checks:
+
+1. **PR Sanity Check** - A lightweight check that runs on all PRs to verify that the kurtosis devnet can be deployed successfully.
+2. **Merge Queue Check** - A more efficient check that runs only in the merge queue, using a persistent devnet that's updated rather than recreated.
+
+## PR Sanity Check
+
+The PR sanity check is a relatively lightweight workflow that:
+
+1. Builds the minimal set of Docker images required for a simple devnet
+2. Deploys a simple devnet configuration
+3. Verifies that the devnet is running properly
+
+This check runs on all PRs and serves as a quick validation that the PR doesn't break the basic functionality of the devnet.
+
+## Merge Queue Check
+
+The merge queue check is more efficient and is designed to run in the GitHub merge queue. It:
+
+1. Checks for an existing persistent devnet
+2. If one exists, it updates it with the new code
+3. If one doesn't exist, it creates a new one
+4. Verifies that the devnet is running properly
+
+The merge queue workflow enforces the fact that no concurrency would disrupt the in-place update assumptions, making it an ideal place for this more efficient check.
+
+## Benefits
+
+These checks help to:
+
+1. Catch inadvertent breakage of kurtosis deployments early in the development process
+2. Provide clear feedback to developers about the impact of their changes
+3. Minimize the risk of issues being merged into the main branches
+
+## Troubleshooting
+
+If a PR check fails, you should:
+
+1. Check the CircleCI logs for detailed information
+2. Look for specific error messages related to the kurtosis deployment
+3. Test the deployment locally using the same configuration
+4. Reach out to the DevNet team for assistance if needed


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Implemented two types of kurtosis deployment verification checks to prevent inadvertent breakage of devnet deployments:
- A lightweight PR sanity check that runs on all PRs to verify successful devnet deployment
- An efficient merge queue check using a persistent devnet that's updated rather than recreated
Both checks are integrated into the CircleCI workflow to run automatically at different stages of the PR lifecycle.

**Tests**

The checks themselves serve as tests by verifying that:
- The kurtosis devnet can be deployed successfully
- The minimal set of required Docker images can be built
- The kurtosis engine functions correctly

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes #15672
