### PR TITLE
op-supervisor: close l1accessor subscribers when closed

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -408,6 +408,9 @@ func (su *SupervisorBackend) Stop(ctx context.Context) error {
 	su.sysCancel()
 	defer su.eventSys.Stop()
 
+	su.l1Accessor.UnsubscribeFinalityHandler()
+	su.l1Accessor.UnsubscribeLatestHandler()
+
 	su.chainProcessors.Clear()
 
 	su.syncNodesController.Close()

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -81,12 +81,12 @@ func (p *L1Accessor) AttachClient(client L1Source, subscribe bool) {
 
 	// if we have a finality subscription, unsubscribe from it
 	if p.finalitySub != nil {
-		p.finalitySub.Unsubscribe()
+		p.UnsubscribeFinalityHandler()
 	}
 
 	// if we have a latest subscription, unsubscribe from it
 	if p.latestSub != nil {
-		p.latestSub.Unsubscribe()
+		p.UnsubscribeLatestHandler()
 	}
 
 	p.client = client
@@ -107,6 +107,10 @@ func (p *L1Accessor) SubscribeFinalityHandler() {
 		reqTimeout)
 }
 
+func (p *L1Accessor) UnsubscribeFinalityHandler() {
+	p.finalitySub.Unsubscribe()
+}
+
 func (p *L1Accessor) SubscribeLatestHandler() {
 	p.latestSub = eth.PollBlockChanges(
 		p.log,
@@ -115,6 +119,10 @@ func (p *L1Accessor) SubscribeLatestHandler() {
 		eth.Unsafe,
 		3*time.Second,
 		reqTimeout)
+}
+
+func (p *L1Accessor) UnsubscribeLatestHandler() {
+	p.latestSub.Unsubscribe()
 }
 
 func (p *L1Accessor) SetConfDepth(depth uint64) {

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -80,14 +80,10 @@ func (p *L1Accessor) AttachClient(client L1Source, subscribe bool) {
 	defer p.clientMu.Unlock()
 
 	// if we have a finality subscription, unsubscribe from it
-	if p.finalitySub != nil {
-		p.UnsubscribeFinalityHandler()
-	}
+	p.UnsubscribeFinalityHandler()
 
 	// if we have a latest subscription, unsubscribe from it
-	if p.latestSub != nil {
-		p.UnsubscribeLatestHandler()
-	}
+	p.UnsubscribeLatestHandler()
 
 	p.client = client
 
@@ -108,7 +104,9 @@ func (p *L1Accessor) SubscribeFinalityHandler() {
 }
 
 func (p *L1Accessor) UnsubscribeFinalityHandler() {
-	p.finalitySub.Unsubscribe()
+	if p.finalitySub != nil {
+		p.finalitySub.Unsubscribe()
+	}
 }
 
 func (p *L1Accessor) SubscribeLatestHandler() {
@@ -122,7 +120,9 @@ func (p *L1Accessor) SubscribeLatestHandler() {
 }
 
 func (p *L1Accessor) UnsubscribeLatestHandler() {
-	p.latestSub.Unsubscribe()
+	if p.latestSub != nil {
+		p.latestSub.Unsubscribe()
+	}
 }
 
 func (p *L1Accessor) SetConfDepth(depth uint64) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

When supervisor shutdown, it does not close l1accessor subscribers, causing resource leak. Normally this is not a big problem since the entire supervisor processor will shut down. This was found while experimenting in devnet-sdk/devstack/sysgo's in memory test stack. Although the supervisor was stopped(or halted), the subscibers were still alive causing resource leak.