### PR TITLE
op-program: Fix reproducible prestate build

### DIFF
--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -49,6 +49,10 @@ COPY --from=builder /app/op-program/bin/op-program-client64.elf .
 COPY --from=builder /app/op-program/bin/meta-mt64.json .
 COPY --from=builder /app/op-program/bin/prestate-mt64.bin.gz .
 COPY --from=builder /app/op-program/bin/prestate-proof-mt64.json .
+# Cannon64 Next VM files
+COPY --from=builder /app/op-program/bin/meta-mt64Next.json .
+COPY --from=builder /app/op-program/bin/prestate-mt64Next.bin.gz .
+COPY --from=builder /app/op-program/bin/prestate-proof-mt64Next.json .
 # Interop files
 COPY --from=builder /app/op-program/bin/meta-interop.json .
 COPY --from=builder /app/op-program/bin/prestate-interop.bin.gz .

--- a/op-program/Dockerfile.repro.dockerignore
+++ b/op-program/Dockerfile.repro.dockerignore
@@ -10,6 +10,7 @@
 !op-program/
 !op-service/
 !op-supervisor/
+!op-test-sequencer
 
 **/bin
 **/testdata


### PR DESCRIPTION
Fix the build broken by https://github.com/ethereum-optimism/optimism/pull/15338 with the addition of a new unaccounted go package.