### PR TITLE
Simplify SV version tests

### DIFF
--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -1000,17 +1000,17 @@ contract StandardValidatorTest is CommonTest {
 
     function test_versions_succeeds() public {
         // Assert that each version function returns the expected string value.
-        assertEq(validator.systemConfigVersion(), "2.5.0");
-        assertEq(validator.optimismPortalVersion(), "3.14.0");
-        assertEq(validator.l1CrossDomainMessengerVersion(), "2.6.0");
-        assertEq(validator.l1ERC721BridgeVersion(), "2.4.0");
-        assertEq(validator.l1StandardBridgeVersion(), "2.3.0");
-        assertEq(validator.mipsVersion(), "1.0.0");
-        assertEq(validator.optimismMintableERC20FactoryVersion(), "1.10.1");
-        assertEq(validator.disputeGameFactoryVersion(), "1.0.1");
-        assertEq(validator.anchorStateRegistryVersion(), "2.2.2");
-        assertEq(validator.delayedWETHVersion(), "1.3.0");
-        assertEq(validator.permissionedDisputeGameVersion(), "1.4.1");
-        assertEq(validator.preimageOracleVersion(), "1.1.4");
+        assertTrue(bytes(validator.systemConfigVersion()).length > 0);
+        assertTrue(bytes(validator.optimismPortalVersion()).length > 0);
+        assertTrue(bytes(validator.l1CrossDomainMessengerVersion()).length > 0);
+        assertTrue(bytes(validator.l1ERC721BridgeVersion()).length > 0);
+        assertTrue(bytes(validator.l1StandardBridgeVersion()).length > 0);
+        assertTrue(bytes(validator.mipsVersion()).length > 0);
+        assertTrue(bytes(validator.optimismMintableERC20FactoryVersion()).length > 0);
+        assertTrue(bytes(validator.disputeGameFactoryVersion()).length > 0);
+        assertTrue(bytes(validator.anchorStateRegistryVersion()).length > 0);
+        assertTrue(bytes(validator.delayedWETHVersion()).length > 0);
+        assertTrue(bytes(validator.permissionedDisputeGameVersion()).length > 0);
+        assertTrue(bytes(validator.preimageOracleVersion()).length > 0);
     }
 }


### PR DESCRIPTION
Simplifies the StandardValidator version testing to only ensure that a string is returned.
This is consistent with testing elsewhere, and reduced overhead for bumping a version.