### PR TITLE
op-service: Handle truncated super root when decoding

### DIFF
--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -295,7 +295,7 @@ func newConsolidateCheckDeps(
 
 func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes.ContainsQuery) (includedIn supervisortypes.BlockSeal, err error) {
 	// We can assume the oracle has the block the executing message is in
-	block, err := d.CanonBlockByNumber(d.oracle, query.BlockNum, chain)
+	block, err := d.CanonBlockByNumber(query.BlockNum, chain)
 	if err != nil {
 		return supervisortypes.BlockSeal{}, err
 	}
@@ -345,7 +345,7 @@ func (d *consolidateCheckDeps) IsLocalUnsafe(chainID eth.ChainID, block eth.Bloc
 }
 
 func (d *consolidateCheckDeps) FindBlockID(chainID eth.ChainID, num uint64) (blockID eth.BlockID, err error) {
-	block, err := d.CanonBlockByNumber(d.oracle, num, chainID)
+	block, err := d.CanonBlockByNumber(num, chainID)
 	if err != nil {
 		return eth.BlockID{}, err
 	}
@@ -359,7 +359,7 @@ func (d *consolidateCheckDeps) OpenBlock(
 	chainID eth.ChainID,
 	blockNum uint64,
 ) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*supervisortypes.ExecutingMessage, err error) {
-	block, err := d.CanonBlockByNumber(d.oracle, blockNum, chainID)
+	block, err := d.CanonBlockByNumber(blockNum, chainID)
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, err
 	}
@@ -384,7 +384,7 @@ func (d *consolidateCheckDeps) DependencySet() depset.DependencySet {
 	return d.depset
 }
 
-func (d *consolidateCheckDeps) CanonBlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
+func (d *consolidateCheckDeps) CanonBlockByNumber(blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {
 	head := d.canonBlocks[chainID].GetHeaderByNumber(blockNum)
 	if head == nil {
 		return nil, fmt.Errorf("head not found for chain %v: %w", chainID, supervisortypes.ErrConflict)

--- a/op-service/eth/super_root.go
+++ b/op-service/eth/super_root.go
@@ -21,7 +21,7 @@ var (
 const (
 	// SuperRootVersionV1MinLen is the minimum length of a V1 super root prior to hashing
 	// Must contain a 1 byte version, uint64 timestamp and at least one chain's output root hash
-	SuperRootVersionV1MinLen = 1 + 8 + 32
+	SuperRootVersionV1MinLen = 1 + 8 + 64
 )
 
 type Super interface {
@@ -96,7 +96,7 @@ func unmarshalSuperRootV1(data []byte) (*SuperV1, error) {
 		return nil, ErrInvalidSuperRoot
 	}
 	// Must contain complete chain output roots
-	if (len(data)-9)%32 != 0 {
+	if (len(data)-9)%64 != 0 {
 		return nil, ErrInvalidSuperRoot
 	}
 	var output SuperV1

--- a/op-service/eth/super_root_test.go
+++ b/op-service/eth/super_root_test.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"bytes"
 	"encoding/binary"
 	"testing"
 
@@ -46,6 +47,13 @@ func TestSuperRootV1Codec(t *testing.T) {
 	t.Run("PartialChainSuperRoot", func(t *testing.T) {
 		input := binary.BigEndian.AppendUint64([]byte{SuperRootVersionV1}, 134058)
 		input = append(input, 0x01, 0x02, 0x03)
+		_, err := UnmarshalSuperRoot(input)
+		require.ErrorIs(t, err, ErrInvalidSuperRoot)
+	})
+
+	t.Run("TruncatedChainOutput", func(t *testing.T) {
+		input := binary.BigEndian.AppendUint64([]byte{SuperRootVersionV1}, 134058)
+		input = append(input, bytes.Repeat([]byte{0x01}, 65)...)
 		_, err := UnmarshalSuperRoot(input)
 		require.ErrorIs(t, err, ErrInvalidSuperRoot)
 	})


### PR DESCRIPTION
And cleanup some unused identifiers in the op-program.

fixes https://github.com/ethereum-optimism/optimism/issues/15170