### PR TITLE
ci: Make colon options in todo format

### DIFF
--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -59,7 +59,7 @@ for arg in "$@"; do
 done
 
 # Use ripgrep to search for the pattern in all files within the repo
-todos=$(rg -o --with-filename -i -n -g '!ops/scripts/todo-checker.sh' -g '!packages/contracts-bedrock/lib' 'TODO\(([^)]+)\): [^,;]*')
+todos=$(rg -o --with-filename -i -n -g '!ops/scripts/todo-checker.sh' -g '!packages/contracts-bedrock/lib' 'TODO\(([^)]+)\):? [^,;]*')
 
 # Check each TODO comment in the repo
 IFS=$'\n' # Set Internal Field Separator to newline for iteration
@@ -69,7 +69,7 @@ for todo in $todos; do
     LINE_NUM=$(echo "$todo" | awk -F':' '{print $2}')
     ISSUE_REFERENCE=$(echo "$todo" | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
 
-    # Parse the format of the TODO comment. There are 3 supported formats:
+    # Parse the format of the TODO comment. There are 3 supported formats (the colon is optional in all of them):
     # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/monorepo")
     # * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
     # * TODO(org/repo#<issue_number>): <description>


### PR DESCRIPTION
**Description**

The todo checker was missing some todos because they didn't have a colon after `TODO(#xxx)`. Now it picks them up.

Will need to merge after https://github.com/ethereum-optimism/optimism/pull/15706
