### PR TITLE
op-service: Fix length checks when parsing super roots

### DIFF
--- a/op-program/client/interop/types/roots.go
+++ b/op-program/client/interop/types/roots.go
@@ -51,7 +51,7 @@ func UnmarshalTransitionState(data []byte) (*TransitionState, error) {
 	}
 	switch data[0] {
 	case IntermediateTransitionVersion:
-		return unmarshalTransitionSate(data)
+		return unmarshalTransitionState(data)
 	case eth.SuperRootVersionV1:
 		return &TransitionState{SuperRoot: data}, nil
 	default:
@@ -59,7 +59,7 @@ func UnmarshalTransitionState(data []byte) (*TransitionState, error) {
 	}
 }
 
-func unmarshalTransitionSate(data []byte) (*TransitionState, error) {
+func unmarshalTransitionState(data []byte) (*TransitionState, error) {
 	if len(data) == 0 {
 		return nil, eth.ErrInvalidSuperRoot
 	}

--- a/op-service/eth/super_root.go
+++ b/op-service/eth/super_root.go
@@ -19,9 +19,10 @@ var (
 )
 
 const (
+	chainIDAndOutputLen = 64
 	// SuperRootVersionV1MinLen is the minimum length of a V1 super root prior to hashing
 	// Must contain a 1 byte version, uint64 timestamp and at least one chain's output root hash
-	SuperRootVersionV1MinLen = 1 + 8 + 32
+	SuperRootVersionV1MinLen = 1 + 8 + chainIDAndOutputLen
 )
 
 type Super interface {
@@ -40,7 +41,7 @@ type ChainIDAndOutput struct {
 }
 
 func (c *ChainIDAndOutput) Marshal() []byte {
-	d := make([]byte, 64)
+	d := make([]byte, chainIDAndOutputLen)
 	chainID := c.ChainID.Bytes32()
 	copy(d[0:32], chainID[:])
 	copy(d[32:], c.Output[:])
@@ -67,7 +68,7 @@ func (o *SuperV1) Version() byte {
 }
 
 func (o *SuperV1) Marshal() []byte {
-	buf := make([]byte, 0, 9+len(o.Chains)*64)
+	buf := make([]byte, 0, 9+len(o.Chains)*chainIDAndOutputLen)
 	version := o.Version()
 	buf = append(buf, version)
 	buf = binary.BigEndian.AppendUint64(buf, o.Timestamp)
@@ -96,7 +97,7 @@ func unmarshalSuperRootV1(data []byte) (*SuperV1, error) {
 		return nil, ErrInvalidSuperRoot
 	}
 	// Must contain complete chain output roots
-	if (len(data)-9)%32 != 0 {
+	if (len(data)-9)%chainIDAndOutputLen != 0 {
 		return nil, ErrInvalidSuperRoot
 	}
 	var output SuperV1


### PR DESCRIPTION
**Description**

Update the length checks when parsing super roots to account for each chain now adding 64 bytes (chain ID and output root instead of just output root).

**Tests**

Updated unit tests.


**Metadata**

fixes #15170 
fixes #15221 
fixes #15216 because it was trivial.