### PR TITLE
op-program: Optimisations recommended by audit

### DIFF
--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -155,7 +155,6 @@ func singleRoundConsolidation(
 	if err != nil {
 		return fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
-	invalidChains := make(map[eth.ChainID]*ethtypes.Block)
 
 	for i, chain := range superRoot.Chains {
 		// Do not check chains that have been replaced with a deposits-only block.
@@ -187,23 +186,13 @@ func singleRoundConsolidation(
 			if !isInvalidMessageError(err) {
 				return err
 			}
-			invalidChains[chain.ChainID] = optimisticBlock
-		}
-	}
-
-	if len(invalidChains) == 0 {
-		return nil
-	}
-
-	for i, chain := range superRoot.Chains {
-		if optimisticBlock, ok := invalidChains[chain.ChainID]; ok {
-			chainAgreedPrestate := superRoot.Chains[i]
+			// Invalid executing message found. Replace with a deposit only block
 			replacementBlockHash, outputRoot, err := buildDepositOnlyBlock(
 				logger,
 				bootInfo,
 				l1PreimageOracle,
 				l2PreimageOracle,
-				chainAgreedPrestate,
+				chain,
 				tasks,
 				optimisticBlock,
 				// Update the preimage oracle database with the replaced block data
@@ -218,13 +207,16 @@ func singleRoundConsolidation(
 				"replacedBlock", eth.ToBlockID(optimisticBlock),
 				"replacementBlockHash", replacementBlockHash,
 				"outputRoot", outputRoot,
-				"replacedOutputRoot", superRoot.Chains[i].Output,
+				"replacedOutputRoot", chain.Output,
 			)
 			superRoot.Chains[i].Output = outputRoot
 			consolidateState.setReplaced(i, chain.ChainID, outputRoot, replacementBlockHash)
+			// Indicate that there was an invalid block so we have to re-check all chains.
+			// The re-check wil pick up invalid messages in any chains we haven't gotten to yet so don't waste time now.
+			return ErrInvalidBlockReplacement
 		}
 	}
-	return ErrInvalidBlockReplacement
+	return nil
 }
 
 func isInvalidMessageError(err error) bool {

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -234,9 +234,6 @@ func checkHazards(logger log.Logger, deps ConsolidateCheckDeps, candidate superv
 	if err != nil {
 		return err
 	}
-	if err := cross.HazardUnsafeFrontierChecks(deps, hazards); err != nil {
-		return err
-	}
 	if err := cross.HazardCycleChecks(deps.DependencySet(), deps, candidate.Timestamp, hazards); err != nil {
 		return err
 	}

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -299,6 +299,9 @@ func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes
 	if err != nil {
 		return supervisortypes.BlockSeal{}, err
 	}
+	if block.Time() != query.Timestamp {
+		return supervisortypes.BlockSeal{}, fmt.Errorf("block timestamp mismatch: %d != %d: %w", block.Time(), query.Timestamp, supervisortypes.ErrConflict)
+	}
 	_, receipts := d.oracle.ReceiptsByBlockHash(block.Hash(), chain)
 	var current uint32
 	for _, receipt := range receipts {
@@ -313,8 +316,6 @@ func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes
 				}.Checksum()
 				if checksum != query.Checksum {
 					return supervisortypes.BlockSeal{}, fmt.Errorf("checksum mismatch: %s != %s: %w", checksum, query.Checksum, supervisortypes.ErrConflict)
-				} else if block.Time() != query.Timestamp {
-					return supervisortypes.BlockSeal{}, fmt.Errorf("block timestamp mismatch: %d != %d: %w", block.Time(), query.Timestamp, supervisortypes.ErrConflict)
 				} else {
 					return supervisortypes.BlockSeal{
 						Hash:      block.Hash(),


### PR DESCRIPTION
**Description**

*  Check block timestamp before retrieving receipts
* Stop checking chains once a replacement block is inserted
* Skip HazardUnsafeFrontierChecks as those checks will always pass by definition in the fault proof program as the parent of any available block must be at or before the agreed block and is thus cross-finalised.

**Tests**

No functional change.

**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/15212
fixes https://github.com/ethereum-optimism/optimism/issues/15203
fixes https://github.com/ethereum-optimism/optimism/issues/15211