### PR TITLE
op-deployer: Fix override application in l2genesis

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 
 	op_service "github.com/ethereum-optimism/optimism/op-service"
@@ -19,6 +22,18 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 )
+
+type l2GenesisOverrides struct {
+	FundDevAccounts                          bool                      `json:"fundDevAccounts"`
+	BaseFeeVaultMinimumWithdrawalAmount      *hexutil.Big              `json:"baseFeeVaultMinimumWithdrawalAmount"`
+	L1FeeVaultMinimumWithdrawalAmount        *hexutil.Big              `json:"l1FeeVaultMinimumWithdrawalAmount"`
+	SequencerFeeVaultMinimumWithdrawalAmount *hexutil.Big              `json:"sequencerFeeVaultMinimumWithdrawalAmount"`
+	BaseFeeVaultWithdrawalNetwork            genesis.WithdrawalNetwork `json:"baseFeeVaultWithdrawalNetwork"`
+	L1FeeVaultWithdrawalNetwork              genesis.WithdrawalNetwork `json:"l1FeeVaultWithdrawalNetwork"`
+	SequencerFeeVaultWithdrawalNetwork       genesis.WithdrawalNetwork `json:"sequencerFeeVaultWithdrawalNetwork"`
+	EnableGovernance                         bool                      `json:"enableGovernance"`
+	GovernanceTokenOwner                     common.Address            `json:"governanceTokenOwner"`
+}
 
 func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, st *state.State, chainID common.Hash) error {
 	lgr := pEnv.Logger.New("stage", "generate-l2-genesis")
@@ -55,27 +70,9 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		return fmt.Errorf("failed to create L2Genesis script: %w", err)
 	}
 
-	schedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
-	if intent.UseInterop {
-		if schedule.L2GenesisIsthmusTimeOffset == nil {
-			return fmt.Errorf("expecting isthmus fork to be enabled for interop deployments")
-		}
-		schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
-		schedule.UseInterop = true
-	}
-
-	if len(intent.GlobalDeployOverrides) > 0 {
-		schedule, err = jsonutil.MergeJSON(schedule, intent.GlobalDeployOverrides)
-		if err != nil {
-			return fmt.Errorf("failed to merge global deploy overrides: %w", err)
-		}
-	}
-
-	if len(thisIntent.DeployOverrides) > 0 {
-		schedule, err = jsonutil.MergeJSON(schedule, thisIntent.DeployOverrides)
-		if err != nil {
-			return fmt.Errorf("failed to merge L2 deploy overrides: %w", err)
-		}
+	overrides, schedule, err := calculateL2GenesisOverrides(intent, thisIntent)
+	if err != nil {
+		return fmt.Errorf("failed to calculate L2 genesis overrides: %w", err)
 	}
 
 	if err := script.Run(opcm.L2GenesisInput{
@@ -85,20 +82,20 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		L1StandardBridgeProxy:                    thisChainState.L1StandardBridgeProxy,
 		L1ERC721BridgeProxy:                      thisChainState.L1Erc721BridgeProxy,
 		OpChainProxyAdminOwner:                   thisIntent.Roles.L2ProxyAdminOwner,
-		BaseFeeVaultWithdrawalNetwork:            common.Big1,
-		L1FeeVaultWithdrawalNetwork:              common.Big1,
-		SequencerFeeVaultWithdrawalNetwork:       common.Big1,
-		SequencerFeeVaultMinimumWithdrawalAmount: standard.VaultMinWithdrawalAmount.ToInt(),
-		BaseFeeVaultMinimumWithdrawalAmount:      standard.VaultMinWithdrawalAmount.ToInt(),
-		L1FeeVaultMinimumWithdrawalAmount:        standard.VaultMinWithdrawalAmount.ToInt(),
+		BaseFeeVaultWithdrawalNetwork:            wdNetworkToBig(overrides.BaseFeeVaultWithdrawalNetwork),
+		L1FeeVaultWithdrawalNetwork:              wdNetworkToBig(overrides.L1FeeVaultWithdrawalNetwork),
+		SequencerFeeVaultWithdrawalNetwork:       wdNetworkToBig(overrides.SequencerFeeVaultWithdrawalNetwork),
+		SequencerFeeVaultMinimumWithdrawalAmount: overrides.SequencerFeeVaultMinimumWithdrawalAmount.ToInt(),
+		BaseFeeVaultMinimumWithdrawalAmount:      overrides.BaseFeeVaultMinimumWithdrawalAmount.ToInt(),
+		L1FeeVaultMinimumWithdrawalAmount:        overrides.L1FeeVaultMinimumWithdrawalAmount.ToInt(),
 		BaseFeeVaultRecipient:                    thisIntent.BaseFeeVaultRecipient,
 		L1FeeVaultRecipient:                      thisIntent.L1FeeVaultRecipient,
 		SequencerFeeVaultRecipient:               thisIntent.SequencerFeeVaultRecipient,
-		GovernanceTokenOwner:                     govTokenOwner(intent, thisIntent),
+		GovernanceTokenOwner:                     overrides.GovernanceTokenOwner,
 		Fork:                                     big.NewInt(schedule.SolidityForkNumber(1)),
 		UseInterop:                               intent.UseInterop,
-		EnableGovernance:                         isGovEnabled(intent, thisIntent),
-		FundDevAccounts:                          intent.FundDevAccounts,
+		EnableGovernance:                         overrides.EnableGovernance,
+		FundDevAccounts:                          overrides.FundDevAccounts,
 	}); err != nil {
 		return fmt.Errorf("failed to call L2Genesis script: %w", err)
 	}
@@ -117,60 +114,62 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 	return nil
 }
 
+func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIntent) (l2GenesisOverrides, *genesis.UpgradeScheduleDeployConfig, error) {
+	schedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
+	if intent.UseInterop {
+		if schedule.L2GenesisIsthmusTimeOffset == nil {
+			return l2GenesisOverrides{}, nil, fmt.Errorf("expecting isthmus fork to be enabled for interop deployments")
+		}
+		schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
+		schedule.UseInterop = true
+	}
+
+	overrides := defaultOverrides()
+	var err error
+	if len(intent.GlobalDeployOverrides) > 0 {
+		schedule, err = jsonutil.MergeJSON(schedule, intent.GlobalDeployOverrides)
+		if err != nil {
+			return l2GenesisOverrides{}, nil, fmt.Errorf("failed to merge global deploy overrides: %w", err)
+		}
+		overrides, err = jsonutil.MergeJSON(overrides, intent.GlobalDeployOverrides)
+		if err != nil {
+			return l2GenesisOverrides{}, nil, fmt.Errorf("failed to merge global deploy overrides: %w", err)
+		}
+	}
+
+	if len(thisIntent.DeployOverrides) > 0 {
+		schedule, err = jsonutil.MergeJSON(schedule, thisIntent.DeployOverrides)
+		if err != nil {
+			return l2GenesisOverrides{}, nil, fmt.Errorf("failed to merge L2 deploy overrides: %w", err)
+		}
+		overrides, err = jsonutil.MergeJSON(overrides, thisIntent.DeployOverrides)
+		if err != nil {
+			return l2GenesisOverrides{}, nil, fmt.Errorf("failed to merge global deploy overrides: %w", err)
+		}
+	}
+
+	return overrides, schedule, nil
+}
+
 func shouldGenerateL2Genesis(thisChainState *state.ChainState) bool {
 	return thisChainState.Allocs == nil
 }
 
-func govTokenOwner(intent *state.Intent, chainIntent *state.ChainIntent) common.Address {
-	if !isGovEnabled(intent, chainIntent) {
-		return standard.GovernanceTokenOwner
-	}
-
-	globalOverride := intent.GlobalDeployOverrides["governanceTokenOwner"]
-	chainOverride := chainIntent.DeployOverrides["governanceTokenOwner"]
-
-	var globalOverrideAddr, chainOverrideStr string
-	var ok bool
-
-	if chainOverride != nil {
-		chainOverrideStr, ok = chainOverride.(string)
-		if !ok || !common.IsHexAddress(chainOverrideStr) {
-			return standard.GovernanceTokenOwner
-		}
-		return common.HexToAddress(chainOverrideStr)
-	}
-
-	if globalOverride != nil {
-		globalOverrideAddr, ok = globalOverride.(string)
-		if !ok || !common.IsHexAddress(globalOverrideAddr) {
-			return standard.GovernanceTokenOwner
-		}
-		return common.HexToAddress(globalOverrideAddr)
-	}
-
-	return standard.GovernanceTokenOwner
+func wdNetworkToBig(wd genesis.WithdrawalNetwork) *big.Int {
+	n := wd.ToUint8()
+	return big.NewInt(int64(n))
 }
 
-func isGovEnabled(intent *state.Intent, chainIntent *state.ChainIntent) bool {
-	globalOverride := intent.GlobalDeployOverrides["enableGovernance"]
-	chainOverride := chainIntent.DeployOverrides["enableGovernance"]
-
-	var globalEnabled, chainEnabled, ok bool
-	if chainOverride != nil {
-		chainEnabled, ok = chainOverride.(bool)
-		if !ok {
-			chainEnabled = false
-		}
-		return chainEnabled
+func defaultOverrides() l2GenesisOverrides {
+	return l2GenesisOverrides{
+		FundDevAccounts:                          false,
+		BaseFeeVaultMinimumWithdrawalAmount:      standard.VaultMinWithdrawalAmount,
+		L1FeeVaultMinimumWithdrawalAmount:        standard.VaultMinWithdrawalAmount,
+		SequencerFeeVaultMinimumWithdrawalAmount: standard.VaultMinWithdrawalAmount,
+		BaseFeeVaultWithdrawalNetwork:            "local",
+		L1FeeVaultWithdrawalNetwork:              "local",
+		SequencerFeeVaultWithdrawalNetwork:       "local",
+		EnableGovernance:                         false,
+		GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
 	}
-
-	if globalOverride != nil {
-		globalEnabled, ok = globalOverride.(bool)
-		if !ok {
-			globalEnabled = false
-		}
-		return globalEnabled
-	}
-
-	return false
 }

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -125,6 +125,9 @@ func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIn
 	}
 
 	overrides := defaultOverrides()
+	// Special case for FundDevAccounts since it's both an intent value and an override.
+	overrides.FundDevAccounts = intent.FundDevAccounts
+
 	var err error
 	if len(intent.GlobalDeployOverrides) > 0 {
 		schedule, err = jsonutil.MergeJSON(schedule, intent.GlobalDeployOverrides)

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -1,0 +1,144 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateL2GenesisOverrides(t *testing.T) {
+	testCases := []struct {
+		name              string
+		intent            *state.Intent
+		chainIntent       *state.ChainIntent
+		expectError       bool
+		expectedOverrides l2GenesisOverrides
+		expectedSchedule  func() *genesis.UpgradeScheduleDeployConfig
+	}{
+		{
+			name: "basic",
+			intent: &state.Intent{
+				L1ContractsLocator: &artifacts.Locator{},
+			},
+			chainIntent:       &state.ChainIntent{},
+			expectError:       false,
+			expectedOverrides: defaultOverrides(),
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				return standard.DefaultHardforkScheduleForTag("")
+			},
+		},
+		{
+			name: "with overrides",
+			intent: &state.Intent{
+				L1ContractsLocator: &artifacts.Locator{},
+				GlobalDeployOverrides: map[string]any{
+					"fundDevAccounts":                          true,
+					"baseFeeVaultMinimumWithdrawalAmount":      "0x1234",
+					"l1FeeVaultMinimumWithdrawalAmount":        "0x2345",
+					"sequencerFeeVaultMinimumWithdrawalAmount": "0x3456",
+					"baseFeeVaultWithdrawalNetwork":            "remote",
+					"l1FeeVaultWithdrawalNetwork":              "remote",
+					"sequencerFeeVaultWithdrawalNetwork":       "remote",
+					"enableGovernance":                         true,
+					"governanceTokenOwner":                     "0x1111111111111111111111111111111111111111",
+					"l2GenesisInteropTimeOffset":               "0x1234",
+				},
+			},
+			chainIntent: &state.ChainIntent{},
+			expectError: false,
+			expectedOverrides: l2GenesisOverrides{
+				FundDevAccounts:                          true,
+				BaseFeeVaultMinimumWithdrawalAmount:      (*hexutil.Big)(hexutil.MustDecodeBig("0x1234")),
+				L1FeeVaultMinimumWithdrawalAmount:        (*hexutil.Big)(hexutil.MustDecodeBig("0x2345")),
+				SequencerFeeVaultMinimumWithdrawalAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x3456")),
+				BaseFeeVaultWithdrawalNetwork:            "remote",
+				L1FeeVaultWithdrawalNetwork:              "remote",
+				SequencerFeeVaultWithdrawalNetwork:       "remote",
+				EnableGovernance:                         true,
+				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			},
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				sched := standard.DefaultHardforkScheduleForTag("")
+				sched.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0x1234)
+				return sched
+			},
+		},
+		{
+			name: "with chain-specific overrides",
+			intent: &state.Intent{
+				L1ContractsLocator: &artifacts.Locator{},
+				GlobalDeployOverrides: map[string]any{
+					"fundDevAccounts": false,
+				},
+			},
+			chainIntent: &state.ChainIntent{
+				DeployOverrides: map[string]any{
+					"fundDevAccounts":                          true,
+					"baseFeeVaultMinimumWithdrawalAmount":      "0x1234",
+					"l1FeeVaultMinimumWithdrawalAmount":        "0x2345",
+					"sequencerFeeVaultMinimumWithdrawalAmount": "0x3456",
+					"baseFeeVaultWithdrawalNetwork":            "remote",
+					"l1FeeVaultWithdrawalNetwork":              "remote",
+					"sequencerFeeVaultWithdrawalNetwork":       "remote",
+					"enableGovernance":                         true,
+					"governanceTokenOwner":                     "0x1111111111111111111111111111111111111111",
+					"l2GenesisInteropTimeOffset":               "0x1234",
+				},
+			},
+			expectError: false,
+			expectedOverrides: l2GenesisOverrides{
+				FundDevAccounts:                          true,
+				BaseFeeVaultMinimumWithdrawalAmount:      (*hexutil.Big)(hexutil.MustDecodeBig("0x1234")),
+				L1FeeVaultMinimumWithdrawalAmount:        (*hexutil.Big)(hexutil.MustDecodeBig("0x2345")),
+				SequencerFeeVaultMinimumWithdrawalAmount: (*hexutil.Big)(hexutil.MustDecodeBig("0x3456")),
+				BaseFeeVaultWithdrawalNetwork:            "remote",
+				L1FeeVaultWithdrawalNetwork:              "remote",
+				SequencerFeeVaultWithdrawalNetwork:       "remote",
+				EnableGovernance:                         true,
+				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			},
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				sched := standard.DefaultHardforkScheduleForTag("")
+				sched.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0x1234)
+				return sched
+			},
+		},
+		{
+			name: "interop mode",
+			intent: &state.Intent{
+				L1ContractsLocator: &artifacts.Locator{},
+				UseInterop:         true,
+			},
+			chainIntent:       &state.ChainIntent{},
+			expectError:       false,
+			expectedOverrides: defaultOverrides(),
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				schedule := standard.DefaultHardforkScheduleForTag("")
+				schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
+				schedule.UseInterop = true
+				return schedule
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			overrides, schedule, err := calculateL2GenesisOverrides(tc.intent, tc.chainIntent)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedOverrides, overrides)
+				require.Equal(t, tc.expectedSchedule(), schedule)
+			}
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -36,6 +36,29 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			},
 		},
 		{
+			name: "special case for fund dev accounts in intent",
+			intent: &state.Intent{
+				L1ContractsLocator: &artifacts.Locator{},
+				FundDevAccounts:    true,
+			},
+			chainIntent: &state.ChainIntent{},
+			expectError: false,
+			expectedOverrides: l2GenesisOverrides{
+				FundDevAccounts:                          true,
+				BaseFeeVaultMinimumWithdrawalAmount:      standard.VaultMinWithdrawalAmount,
+				L1FeeVaultMinimumWithdrawalAmount:        standard.VaultMinWithdrawalAmount,
+				SequencerFeeVaultMinimumWithdrawalAmount: standard.VaultMinWithdrawalAmount,
+				BaseFeeVaultWithdrawalNetwork:            "local",
+				L1FeeVaultWithdrawalNetwork:              "local",
+				SequencerFeeVaultWithdrawalNetwork:       "local",
+				EnableGovernance:                         false,
+				GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
+			},
+			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
+				return standard.DefaultHardforkScheduleForTag("")
+			},
+		},
+		{
 			name: "with overrides",
 			intent: &state.Intent{
 				L1ContractsLocator: &artifacts.Locator{},


### PR DESCRIPTION
Overrides were not being properly applied in l2genesis:

- `fundDevAccounts` can be specified both as a top-level flag as well as an overrides. The latter is used by Kurtosis, and was broken in the l2genesis refactor.
- Chain-specific overrides were not being applied at all.
- Certain overrides were unimplemented (e.g., custom fee withdrawal networks). This has now been implemented.
