### PR TITLE
op-deployer: Fix intent validation with pre-deployed OPCM

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -39,7 +39,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return fmt.Errorf("unsupported L2 version: %s", intent.L2ContractsLocator.Tag)
 	}
 
-	if isL1Tag && hasPredeployedOPCM {
+	if hasPredeployedOPCM {
 		if intent.SuperchainConfigProxy != nil {
 			return fmt.Errorf("cannot set superchain config proxy for predeployed OPCM")
 		}

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -85,7 +85,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			stdSuperchainRoles, err := state.GetStandardSuperchainRoles(l1ChainID)
 			require.NoError(t, err)
 
-			opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainID, artifacts.DefaultL1ContractsLocator.Tag)
+			opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, artifacts.DefaultL1ContractsLocator.Tag)
 			require.NoError(t, err)
 
 			intent := &state.Intent{

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -140,7 +140,7 @@ func SuperchainFor(chainID uint64) (superchain.Superchain, error) {
 	}
 }
 
-func ManagerImplementationAddrFor(chainID uint64, tag string) (common.Address, error) {
+func OPCMImplAddressFor(chainID uint64, tag string) (common.Address, error) {
 	versionsData, err := L1VersionsFor(chainID)
 	if err != nil {
 		return common.Address{}, fmt.Errorf("unsupported chainID: %d", chainID)

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -138,7 +138,7 @@ func TestManagerImplementationAddrFor(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			addr, err := ManagerImplementationAddrFor(tc.chainID, tc.tag)
+			addr, err := OPCMImplAddressFor(tc.chainID, tc.tag)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -90,6 +90,7 @@ var ErrChainRoleZeroAddress = fmt.Errorf("ChainRole is set to zero address")
 var ErrFeeVaultZeroAddress = fmt.Errorf("chain has a fee vault set to zero address")
 var ErrNonStandardValue = fmt.Errorf("chain contains non-standard config value")
 var ErrEip1559ZeroValue = fmt.Errorf("eip1559 param is set to zero value")
+var ErrIncompatibleValue = fmt.Errorf("chain contains incompatible config value")
 
 func (c *ChainIntent) Check() error {
 	if c.ID == emptyHash {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -140,7 +140,7 @@ func (c *Intent) validateStandardValues() error {
 		return ErrIncompatibleValue
 	}
 
-	standardOPCM, err := standard.ManagerImplementationAddrFor(c.L1ChainID, c.L1ContractsLocator.Tag)
+	standardOPCM, err := standard.OPCMImplAddressFor(c.L1ChainID, c.L1ContractsLocator.Tag)
 	if err != nil {
 		return fmt.Errorf("error getting OPCM address: %w", err)
 	}
@@ -254,7 +254,7 @@ func (c *Intent) checkL1Prod() error {
 		return fmt.Errorf("tag '%s' not found in standard versions", c.L1ContractsLocator.Tag)
 	}
 
-	opcmAddr, err := standard.ManagerImplementationAddrFor(c.L1ChainID, c.L1ContractsLocator.Tag)
+	opcmAddr, err := standard.OPCMImplAddressFor(c.L1ChainID, c.L1ContractsLocator.Tag)
 	if err != nil {
 		return fmt.Errorf("error getting OPCM address: %w", err)
 	}
@@ -311,9 +311,9 @@ func NewIntentCustom(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error)
 }
 
 func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error) {
-	opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainId, artifacts.DefaultL1ContractsLocator.Tag)
+	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainId, artifacts.DefaultL1ContractsLocator.Tag)
 	if err != nil {
-		return Intent{}, fmt.Errorf("error getting OPCM address: %w", err)
+		return Intent{}, fmt.Errorf("error getting OPCM impl address: %w", err)
 	}
 
 	intent := Intent{

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -89,16 +89,23 @@ func (c *Intent) validateCustomConfig() error {
 		(c.L1ContractsLocator.Tag == "" && c.L1ContractsLocator.URL == &url.URL{}) {
 		return ErrL1ContractsLocatorUndefined
 	}
+
 	if c.L2ContractsLocator == nil ||
 		(c.L2ContractsLocator.Tag == "" && c.L2ContractsLocator.URL == &url.URL{}) {
 		return ErrL2ContractsLocatorUndefined
 	}
 
-	if c.SuperchainRoles == nil {
-		return errors.New("SuperchainRoles is set to nil")
-	}
-	if err := c.SuperchainRoles.CheckNoZeroAddresses(); err != nil {
-		return err
+	if c.OPCMAddress == nil {
+		if c.SuperchainRoles == nil {
+			return fmt.Errorf("%w: must set superchain roles if OPCM address is nil", ErrIncompatibleValue)
+		}
+		if err := c.SuperchainRoles.CheckNoZeroAddresses(); err != nil {
+			return err
+		}
+	} else {
+		if c.SuperchainRoles != nil {
+			return fmt.Errorf("%w: must not set superchain roles if OPCM address is set", ErrIncompatibleValue)
+		}
 	}
 
 	if len(c.Chains) == 0 {
@@ -126,15 +133,19 @@ func (c *Intent) validateStandardValues() error {
 	}
 
 	if c.SuperchainConfigProxy != nil {
-		return ErrNonStandardValue
+		return ErrIncompatibleValue
 	}
 
-	standardSuperchainRoles, err := GetStandardSuperchainRoles(c.L1ChainID)
-	if err != nil {
-		return fmt.Errorf("error getting standard superchain roles: %w", err)
+	if c.SuperchainRoles != nil {
+		return ErrIncompatibleValue
 	}
-	if c.SuperchainRoles == nil || *c.SuperchainRoles != *standardSuperchainRoles {
-		return fmt.Errorf("SuperchainRoles does not match standard value")
+
+	standardOPCM, err := standard.ManagerImplementationAddrFor(c.L1ChainID, c.L1ContractsLocator.Tag)
+	if err != nil {
+		return fmt.Errorf("error getting OPCM address: %w", err)
+	}
+	if c.OPCMAddress == nil || *c.OPCMAddress != standardOPCM {
+		return fmt.Errorf("%w: opcmAddress=%s", ErrNonStandardValue, standardOPCM)
 	}
 
 	for _, chain := range c.Chains {
@@ -300,18 +311,18 @@ func NewIntentCustom(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error)
 }
 
 func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error) {
+	opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainId, artifacts.DefaultL1ContractsLocator.Tag)
+	if err != nil {
+		return Intent{}, fmt.Errorf("error getting OPCM address: %w", err)
+	}
+
 	intent := Intent{
 		ConfigType:         IntentTypeStandard,
 		L1ChainID:          l1ChainId,
 		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
 		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
+		OPCMAddress:        &opcmAddr,
 	}
-
-	superchainRoles, err := GetStandardSuperchainRoles(l1ChainId)
-	if err != nil {
-		return Intent{}, fmt.Errorf("error getting standard superchain roles: %w", err)
-	}
-	intent.SuperchainRoles = superchainRoles
 
 	challenger, err := standard.ChallengerAddressFor(l1ChainId)
 	if err != nil {
@@ -325,12 +336,6 @@ func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, erro
 	if err != nil {
 		return Intent{}, fmt.Errorf("error getting OpChainProxyAdminOwner: %w", err)
 	}
-
-	opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainId, intent.L1ContractsLocator.Tag)
-	if err != nil {
-		return Intent{}, fmt.Errorf("error getting OPCM address: %w", err)
-	}
-	intent.OPCMAddress = &opcmAddr
 
 	for _, l2ChainID := range l2ChainIds {
 		intent.Chains = append(intent.Chains, &ChainIntent{


### PR DESCRIPTION
Previously, users were always required to provide the `SuperchainRoles` in their intent. Now that the intent supports providing an OPCM address, this is no longer necessary since we can look those values up on chain. The lookup was implemented in #15623, however users still had to provide `SuperchainRoles` in their intent to avoid validation errors.

The new logic is as follows:

- `standard` intents **must** specify the correct, standard OPCM address for the specified L1 and contracts version. Anything else is an error.
- All other intent types must **either** specify `SuperchainRoles`, or an OPCM address. Specifying both or neither will result in an error.
- The deployment pipeline will always pull `SuperchainRoles` data from the chain if the OPCM address is specified. Previously, it would only do this if the OPCM address was specified _and_ the L1 locator was a tag.
