### PR TITLE
op-e2e: make `NewL2FaultProofEnv` more defensive

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -68,6 +69,8 @@ func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eut
 			dp.DeployConfig.ActivateForkAtGenesis(rollup.Holocene)
 		case Isthmus:
 			dp.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
+		default:
+			panic(fmt.Sprintf("unhandled HF:%v", testCfg.Hardfork))
 		}
 
 		for _, override := range deployConfigOverrides {

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"fmt"
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -70,7 +69,7 @@ func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eut
 		case Isthmus:
 			dp.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
 		default:
-			panic(fmt.Sprintf("unhandled HF:%v", testCfg.Hardfork))
+			t.Fatalf("unhandled HF:%v", testCfg.Hardfork)
 		}
 
 		for _, override := range deployConfigOverrides {


### PR DESCRIPTION
This PR makes `NewL2FaultProofEnv` panic if HF is not explicitly handled so that when new HFs are added without changing `NewL2FaultProofEnv`, it fails out loud.