### PR TITLE
fix game types var used for tests

### DIFF
--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -998,7 +998,7 @@ contract StandardValidatorTest is CommonTest {
         assertEq("", validate(true));
     }
 
-    function test_versions_succeeds() public {
+    function test_versions_succeeds() public view {
         // Assert that each version function returns the expected string value.
         assertTrue(bytes(validator.systemConfigVersion()).length > 0);
         assertTrue(bytes(validator.optimismPortalVersion()).length > 0);

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -31,7 +31,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
 contract FaultDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameTypes.CANNON;
+    GameType internal immutable GAME_TYPE = GameTypes.CANNON;
 
     /// @dev The initial bond for the game.
     uint256 internal initBond;

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -31,7 +31,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
 contract FaultDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameType.wrap(0);
+    GameType internal constant GAME_TYPE = GameTypes.CANNON;
 
     /// @dev The initial bond for the game.
     uint256 internal initBond;

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -20,7 +20,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 
 contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
+    GameType internal immutable GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
     /// @dev Mock proposer key
     address internal constant PROPOSER = address(0xfacade9);
     /// @dev Mock challenger key

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -20,7 +20,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 
 contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameType.wrap(1);
+    GameType internal constant GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
     /// @dev Mock proposer key
     address internal constant PROPOSER = address(0xfacade9);
     /// @dev Mock challenger key

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -32,7 +32,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
 contract SuperFaultDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameType.wrap(4);
+    GameType internal constant GAME_TYPE = GameTypes.SUPER_FAULT_CANNON;
 
     /// @dev The implementation of the game.
     ISuperFaultDisputeGame internal gameImpl;

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -32,7 +32,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
 contract SuperFaultDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameTypes.SUPER_FAULT_CANNON;
+    GameType internal immutable GAME_TYPE = GameTypes.SUPER_CANNON;
 
     /// @dev The implementation of the game.
     ISuperFaultDisputeGame internal gameImpl;

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -20,7 +20,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 
 contract SuperPermissionedDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameTypes.SUPER_PERMISSIONED_CANNON;
+    GameType internal immutable GAME_TYPE = GameTypes.SUPER_PERMISSIONED_CANNON;
     /// @dev Mock proposer key
     address internal constant PROPOSER = address(0xfacade9);
     /// @dev Mock challenger key

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -20,7 +20,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 
 contract SuperPermissionedDisputeGame_Init is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
-    GameType internal constant GAME_TYPE = GameType.wrap(1);
+    GameType internal constant GAME_TYPE = GameTypes.SUPER_PERMISSIONED_CANNON;
     /// @dev Mock proposer key
     address internal constant PROPOSER = address(0xfacade9);
     /// @dev Mock challenger key


### PR DESCRIPTION
fix game types var used for tests

Major change is that of the super permissioned test game type variable which uses game type 1 instead of 5. Using the named type (incl for others) makes it easier to read and less error prone