### PR TITLE
op-node: disable per-topic peer scoring entirely

### DIFF
--- a/op-node/p2p/peer_params.go
+++ b/op-node/p2p/peer_params.go
@@ -42,29 +42,13 @@ func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
 	epoch := 6 * slot
 	tenEpochs := 10 * epoch
 	oneHundredEpochs := 100 * epoch
-	invalidDecayPeriod := 50 * epoch
 	return pubsub.PeerScoreParams{
-		Topics: map[string]*pubsub.TopicScoreParams{
-			blocksTopicV1(cfg): {
-				TopicWeight:                     0.8,
-				TimeInMeshWeight:                MaxInMeshScore / inMeshCap(slot),
-				TimeInMeshQuantum:               slot,
-				TimeInMeshCap:                   inMeshCap(slot),
-				FirstMessageDeliveriesWeight:    1,
-				FirstMessageDeliveriesDecay:     ScoreDecay(20*epoch, slot),
-				FirstMessageDeliveriesCap:       23,
-				MeshMessageDeliveriesWeight:     MeshWeight,
-				MeshMessageDeliveriesDecay:      ScoreDecay(DecayEpoch*epoch, slot),
-				MeshMessageDeliveriesCap:        float64(uint64(epoch/slot) * uint64(DecayEpoch)),
-				MeshMessageDeliveriesThreshold:  float64(uint64(epoch/slot) * uint64(DecayEpoch) / 10),
-				MeshMessageDeliveriesWindow:     2 * time.Second,
-				MeshMessageDeliveriesActivation: 4 * epoch,
-				MeshFailurePenaltyWeight:        MeshWeight,
-				MeshFailurePenaltyDecay:         ScoreDecay(DecayEpoch*epoch, slot),
-				InvalidMessageDeliveriesWeight:  -140.4475,
-				InvalidMessageDeliveriesDecay:   ScoreDecay(invalidDecayPeriod, slot),
-			},
-		},
+		// We inentionally do not use any per-topic scoring,
+		// since it is expected for the netowrk to migrate
+		// from older topics to newer ones over time and we don't
+		// want to penalize peers for not participating in the old topics.
+		// Therefore the Topics map is nil:
+		Topics:        nil,
 		TopicScoreCap: 34,
 		AppSpecificScore: func(p peer.ID) float64 {
 			return 0

--- a/op-node/p2p/peer_params.go
+++ b/op-node/p2p/peer_params.go
@@ -48,8 +48,7 @@ func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
 		// from older topics to newer ones over time and we don't
 		// want to penalize peers for not participating in the old topics.
 		// Therefore the Topics map is nil:
-		Topics:        nil,
-		TopicScoreCap: 34,
+		Topics: nil,
 		AppSpecificScore: func(p peer.ID) float64 {
 			return 0
 		},

--- a/op-node/p2p/peer_params.go
+++ b/op-node/p2p/peer_params.go
@@ -44,7 +44,7 @@ func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
 	oneHundredEpochs := 100 * epoch
 	return pubsub.PeerScoreParams{
 		// We inentionally do not use any per-topic scoring,
-		// since it is expected for the netowrk to migrate
+		// since it is expected for the network to migrate
 		// from older topics to newer ones over time and we don't
 		// want to penalize peers for not participating in the old topics.
 		// Therefore the Topics map is nil:
@@ -64,11 +64,6 @@ func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
 		DecayToZero:                 DecayToZero,
 		RetainScore:                 oneHundredEpochs,
 	}
-}
-
-// the cap for `inMesh` time scoring.
-func inMeshCap(slot time.Duration) float64 {
-	return float64((3600 * time.Second) / slot)
 }
 
 func GetScoringParams(name string, cfg *rollup.Config) (*ScoringParams, error) {

--- a/op-node/p2p/peer_params_test.go
+++ b/op-node/p2p/peer_params_test.go
@@ -68,9 +68,8 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 	// Topics should not contain options for any block topic
 	testSuite.Len(peerParams.Topics, 0)
 	_, ok := peerParams.Topics[blocksTopicV1(cfg)]
-	testSuite.False(ok, "should have block topic params")
+	testSuite.False(ok, "should not have block topic params")
 
-	testSuite.Equal(peerParams.TopicScoreCap, float64(34))
 	testSuite.Equal(peerParams.AppSpecificWeight, float64(1))
 	testSuite.Equal(peerParams.IPColocationFactorWeight, float64(-35))
 	testSuite.Equal(peerParams.IPColocationFactorThreshold, 10)

--- a/op-node/p2p/peer_params_test.go
+++ b/op-node/p2p/peer_params_test.go
@@ -65,11 +65,11 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 	scoringParams, err := GetScoringParams("light", cfg)
 	peerParams := scoringParams.PeerScoring
 	testSuite.NoError(err)
-	// Topics should contain options for block topic
-	testSuite.Len(peerParams.Topics, 1)
-	topicParams, ok := peerParams.Topics[blocksTopicV1(cfg)]
-	testSuite.True(ok, "should have block topic params")
-	testSuite.NotZero(topicParams.TimeInMeshQuantum)
+	// Topics should not contain options for any block topic
+	testSuite.Len(peerParams.Topics, 0)
+	_, ok := peerParams.Topics[blocksTopicV1(cfg)]
+	testSuite.False(ok, "should have block topic params")
+
 	testSuite.Equal(peerParams.TopicScoreCap, float64(34))
 	testSuite.Equal(peerParams.AppSpecificWeight, float64(1))
 	testSuite.Equal(peerParams.IPColocationFactorWeight, float64(-35))


### PR DESCRIPTION
Closes [ #15314 ](https://github.com/ethereum-optimism/optimism/issues/15297)

Confirmed that unsafe head progresses on all nodes when running `just interop-devnet` from kurtosis-devnet directory. 

I'm hopeful that this may _improve_ peering behavior on op-node, because we won't be negatively scoring peers for failing to publish on an old topic. 