### PR TITLE
devstack: split options into lifecycle stages, make interop customizable

### DIFF
--- a/devnet-sdk/devstack/devtest/helpers.go
+++ b/devnet-sdk/devstack/devtest/helpers.go
@@ -1,0 +1,20 @@
+package devtest
+
+import (
+	"fmt"
+)
+
+// RunParallel runs the test-function, for each of the given elements, in parallel.
+// This awaits the result of all sub-tests to complete,
+// by grouping everything into a regular sub-test.
+func RunParallel[V any](t T, elems []V, fn func(t T, v V)) {
+	t.Run("group", func(t T) {
+		for _, elem := range elems {
+			elem := elem
+			t.Run(fmt.Sprintf("%v", elem), func(t T) {
+				t.Parallel()
+				fn(t, elem)
+			})
+		}
+	})
+}

--- a/devnet-sdk/devstack/devtest/testing.go
+++ b/devnet-sdk/devstack/devtest/testing.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -51,6 +52,12 @@ type T interface {
 
 	// Gate provides everything that Require does, but skips instead of fails the test upon error.
 	Gate() *require.Assertions
+
+	// Deadline reports the time at which the test binary will have
+	// exceeded the timeout specified by the -timeout flag.
+	//
+	// The ok result is false if the -timeout flag indicates “no timeout” (0).
+	Deadline() (deadline time.Time, ok bool)
 
 	// This distinguishes the interface from other testing interfaces,
 	// such as the one used at package-level for shared system construction.
@@ -195,6 +202,14 @@ func (t *testingT) SkipNow() {
 
 func (t *testingT) Gate() *require.Assertions {
 	return t.gate
+}
+
+// Deadline reports the time at which the test binary will have
+// exceeded the timeout specified by the -timeout flag.
+//
+// The ok result is false if the -timeout flag indicates “no timeout” (0).
+func (t *testingT) Deadline() (deadline time.Time, ok bool) {
+	return t.t.Deadline()
 }
 
 func (t *testingT) _TestOnly() {

--- a/devnet-sdk/devstack/dsl/l2_network.go
+++ b/devnet-sdk/devstack/dsl/l2_network.go
@@ -103,14 +103,13 @@ func (n *L2Network) UnsafeHeadRef() eth.BlockRef {
 	return unsafeHeadRef
 }
 
-// LatestPreActivation finds the latest block before fork activation
-func (n *L2Network) LatestPreActivation(t devtest.T, forkTimestamp *uint64) eth.BlockRef {
+// LatestBlockBeforeTimestamp finds the latest block before fork activation
+func (n *L2Network) LatestBlockBeforeTimestamp(t devtest.T, timestamp uint64) eth.BlockRef {
 	require := t.Require()
 
-	t.Gate().NotNil(forkTimestamp, "Must have fork configured")
-	t.Gate().Greater(*forkTimestamp, uint64(0), "Must not start fork at genesis")
+	t.Gate().Greater(timestamp, uint64(0), "Must not start fork at genesis")
 
-	activationBlockNum, err := n.Escape().RollupConfig().TargetBlockNumber(*forkTimestamp)
+	blockNum, err := n.Escape().RollupConfig().TargetBlockNumber(timestamp)
 	require.NoError(err)
 
 	el := n.Escape().L2ELNode(match.FirstL2EL)
@@ -119,14 +118,14 @@ func (n *L2Network) LatestPreActivation(t devtest.T, forkTimestamp *uint64) eth.
 
 	t.Logger().Info("Preparing",
 		"head", head, "head_time", head.Time,
-		"activationNum", activationBlockNum, "activationTime", *forkTimestamp)
+		"target_num", blockNum, "target_time", timestamp)
 
-	if head.Number < activationBlockNum {
-		t.Logger().Info("No activation yet, checking head block instead")
+	if head.Number < blockNum {
+		t.Logger().Info("No block with given timestamp yet, checking head block instead")
 		return head
 	} else {
-		t.Logger().Info("Reached activation block already, proceeding with last block before activation")
-		v, err := el.EthClient().BlockRefByNumber(t.Ctx(), activationBlockNum-1)
+		t.Logger().Info("Reached block already, proceeding with last block before timestamp")
+		v, err := el.EthClient().BlockRefByNumber(t.Ctx(), blockNum-1)
 		require.NoError(err)
 		return v
 	}

--- a/devnet-sdk/devstack/dsl/l2_network.go
+++ b/devnet-sdk/devstack/dsl/l2_network.go
@@ -137,7 +137,7 @@ func (n *L2Network) AwaitActivation(t devtest.T, forkTimestamp *uint64) eth.Bloc
 	require := t.Require()
 
 	t.Gate().NotNil(forkTimestamp, "Must have fork configured")
-	t.Gate().Greater(*forkTimestamp, uint64(0), "Must not start frok at genesis")
+	t.Gate().Greater(*forkTimestamp, uint64(0), "Must not start fork at genesis")
 
 	upgradeTime := time.Unix(int64(*forkTimestamp), 0)
 

--- a/devnet-sdk/devstack/dsl/l2_network.go
+++ b/devnet-sdk/devstack/dsl/l2_network.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
@@ -100,4 +101,72 @@ func (n *L2Network) UnsafeHeadRef() eth.BlockRef {
 	n.require.NoError(err, "Expected to get block ref by hash")
 
 	return unsafeHeadRef
+}
+
+// LatestPreActivation finds the latest block before fork activation
+func (n *L2Network) LatestPreActivation(t devtest.T, forkTimestamp *uint64) eth.BlockRef {
+	require := t.Require()
+
+	t.Gate().NotNil(forkTimestamp, "Must have fork configured")
+	t.Gate().Greater(*forkTimestamp, uint64(0), "Must not start fork at genesis")
+
+	activationBlockNum, err := n.Escape().RollupConfig().TargetBlockNumber(*forkTimestamp)
+	require.NoError(err)
+
+	el := n.Escape().L2ELNode(match.FirstL2EL)
+	head, err := el.EthClient().BlockRefByLabel(t.Ctx(), eth.Unsafe)
+	require.NoError(err)
+
+	t.Logger().Info("Preparing",
+		"head", head, "head_time", head.Time,
+		"activationNum", activationBlockNum, "activationTime", *forkTimestamp)
+
+	if head.Number < activationBlockNum {
+		t.Logger().Info("No activation yet, checking head block instead")
+		return head
+	} else {
+		t.Logger().Info("Reached activation block already, proceeding with last block before activation")
+		v, err := el.EthClient().BlockRefByNumber(t.Ctx(), activationBlockNum-1)
+		require.NoError(err)
+		return v
+	}
+}
+
+// AwaitActivation awaits the fork activation time, and returns the activation block
+func (n *L2Network) AwaitActivation(t devtest.T, forkTimestamp *uint64) eth.BlockRef {
+	require := t.Require()
+
+	t.Gate().NotNil(forkTimestamp, "Must have fork configured")
+	t.Gate().Greater(*forkTimestamp, uint64(0), "Must not start frok at genesis")
+
+	upgradeTime := time.Unix(int64(*forkTimestamp), 0)
+
+	if deadline, hasDeadline := t.Deadline(); hasDeadline {
+		t.Gate().True(upgradeTime.Before(deadline), "test must not time out before upgrade happens")
+	}
+
+	activationBlockNum, err := n.Escape().RollupConfig().TargetBlockNumber(*forkTimestamp)
+	require.NoError(err)
+
+	now := time.Now()
+	fromNow := upgradeTime.Sub(now)
+	if fromNow > 0 {
+		t.Logger().Info("Awaiting upgrade", "fromNow", fromNow,
+			"upgradeTime", upgradeTime,
+			"timestamp", *forkTimestamp,
+			"activationBlock", activationBlockNum)
+
+		select {
+		case <-time.After(fromNow):
+		case <-t.Ctx().Done():
+			t.Require().FailNow("failed to await fork within test time")
+		}
+	}
+
+	el := n.Escape().L2ELNode(match.FirstL2EL)
+	activationBlock, err := el.EthClient().BlockRefByNumber(t.Ctx(), activationBlockNum)
+	require.NoError(err)
+
+	t.Logger().Info("Activation block", "block", activationBlock)
+	return activationBlock
 }

--- a/devnet-sdk/devstack/presets/orchestrator.go
+++ b/devnet-sdk/devstack/presets/orchestrator.go
@@ -38,6 +38,7 @@ func DoMain(m *testing.M, opts ...stack.CommonOption) {
 		}()
 		defer func() {
 			if x := recover(); x != nil {
+				debug.PrintStack()
 				_, _ = fmt.Fprintf(os.Stderr, "Panic during test Main: %v\n", x)
 				_, _ = fmt.Fprintf(os.Stderr, "Stacktrace from panic: \n"+string(debug.Stack()))
 

--- a/devnet-sdk/devstack/presets/orchestrator.go
+++ b/devnet-sdk/devstack/presets/orchestrator.go
@@ -27,7 +27,7 @@ var lockedOrchestrator locks.RWValue[stack.Orchestrator]
 // DoMain runs M with the pre- and post-processing of tests,
 // to setup the default global orchestrator and global logger.
 // This will os.Exit(code) and not return.
-func DoMain(m *testing.M, opts ...stack.Option) {
+func DoMain(m *testing.M, opts ...stack.CommonOption) {
 	// nest the function, so we can defer-recover and defer-cleanup, before os.Exit
 	code := func() (errCode int) {
 		failed := new(atomic.Bool)
@@ -75,7 +75,7 @@ func DoMain(m *testing.M, opts ...stack.Option) {
 		// TODO(#15139): set log-level filter, reduce noise
 		//log.SetDefault(t.Log.New("logger", "global"))
 
-		initOrchestrator(p, opts...)
+		initOrchestrator(p, stack.Combine(opts...))
 
 		errCode = m.Run()
 		return
@@ -84,7 +84,7 @@ func DoMain(m *testing.M, opts ...stack.Option) {
 	os.Exit(code)
 }
 
-func initOrchestrator(p devtest.P, opts ...stack.Option) {
+func initOrchestrator(p devtest.P, opt stack.CommonOption) {
 	lockedOrchestrator.Lock()
 	defer lockedOrchestrator.Unlock()
 	if lockedOrchestrator.Value != nil {
@@ -103,9 +103,7 @@ func initOrchestrator(p devtest.P, opts ...stack.Option) {
 	default:
 		p.Logger().Crit("Unknown devstack backend", "kind", kind)
 	}
-	for _, opt := range opts {
-		opt(lockedOrchestrator.Value)
-	}
+	stack.ApplyOptionLifecycle(opt, lockedOrchestrator.Value)
 }
 
 // Orchestrator returns the globally configured orchestrator.

--- a/devnet-sdk/devstack/stack/orchestrator.go
+++ b/devnet-sdk/devstack/stack/orchestrator.go
@@ -194,21 +194,29 @@ func MakeCommon[O Orchestrator](opt Option[O]) CommonOption {
 		BeforeDeployFn: func(orch Orchestrator) {
 			if o, ok := orch.(O); ok {
 				opt.BeforeDeploy(o)
+			} else {
+				orch.P().Logger().Debug("BeforeDeploy option does not apply to this orchestrator type")
 			}
 		},
 		DeployFn: func(orch Orchestrator) {
 			if o, ok := orch.(O); ok {
 				opt.Deploy(o)
+			} else {
+				orch.P().Logger().Debug("Deploy option does not apply to this orchestrator type")
 			}
 		},
 		AfterDeployFn: func(orch Orchestrator) {
 			if o, ok := orch.(O); ok {
 				opt.AfterDeploy(o)
+			} else {
+				orch.P().Logger().Debug("AfterDeploy option does not apply to this orchestrator type")
 			}
 		},
 		FinallyFn: func(orch Orchestrator, hook SystemHook) {
 			if o, ok := orch.(O); ok {
 				opt.Finally(o, hook)
+			} else {
+				orch.P().Logger().Debug("Finally option does not apply to this orchestrator type")
 			}
 		},
 		PostHydrateFn: func(sys System) {

--- a/devnet-sdk/devstack/stack/orchestrator.go
+++ b/devnet-sdk/devstack/stack/orchestrator.go
@@ -45,17 +45,174 @@ type Orchestrator interface {
 // step 3: maybe try different things, if none work, test-skip
 // }
 
-// Option is used to define a function that inspects and/or changes a System.
-type Option func(orch Orchestrator)
+type SystemHook interface {
+	// PostHydrate runs after a system is hydrated, to run any checks
+	PostHydrate(sys System)
+}
+
+// ApplyOptionLifecycle applies all option lifecycle stages to the given orchestrator
+func ApplyOptionLifecycle[O Orchestrator](opt Option[O], orch O) {
+	opt.BeforeDeploy(orch)
+	opt.Deploy(orch)
+	opt.AfterDeploy(orch)
+	opt.Finally(orch, opt)
+}
+
+// Option is used to define a change that inspects and/or changes a System during the lifecycle.
+type Option[O Orchestrator] interface {
+	// BeforeDeploy runs before any chain is created/deployed
+	BeforeDeploy(orch O)
+	// Deploy runs the deployment
+	Deploy(orch O)
+	// AfterDeploy runs after chains are created/deployed
+	AfterDeploy(orch O)
+	// Finally runs at the very end.
+	// A system hook is available, to validate any produced systems
+	Finally(orch O, hook SystemHook)
+	// SystemHook is embedded: Options may expose system hooks
+	SystemHook
+}
+
+type CommonOption = Option[Orchestrator]
+
+// CombinedOption is a list of options.
+// For each option lifecycle stage, all options are applied, left to right.
+type CombinedOption[O Orchestrator] []Option[O]
+
+var _ CommonOption = (CombinedOption[Orchestrator])(nil)
+
+// Combine is a method to define a CombinedOption, more readable than a slice definition.
+func Combine[O Orchestrator](opts ...Option[O]) CombinedOption[O] {
+	return CombinedOption[O](opts)
+}
 
 // Add changes the option into a new Option that that first applies the receiver, and then the other options.
 // This is a convenience for bundling options together.
-func (fn *Option) Add(other ...Option) {
-	inner := *fn
-	*fn = func(orch Orchestrator) {
-		inner(orch)
-		for _, oFn := range other {
-			oFn(orch)
-		}
+func (c *CombinedOption[O]) Add(other ...Option[O]) {
+	*c = append(*c, other...)
+}
+
+func (c CombinedOption[O]) BeforeDeploy(orch O) {
+	for _, opt := range c {
+		opt.BeforeDeploy(orch)
+	}
+}
+
+func (c CombinedOption[O]) Deploy(orch O) {
+	for _, opt := range c {
+		opt.Deploy(orch)
+	}
+}
+
+func (c CombinedOption[O]) AfterDeploy(orch O) {
+	for _, opt := range c {
+		opt.AfterDeploy(orch)
+	}
+}
+
+func (c CombinedOption[O]) Finally(orch O, hook SystemHook) {
+	for _, opt := range c {
+		opt.Finally(orch, hook)
+	}
+}
+
+func (c CombinedOption[O]) PostHydrate(sys System) {
+	for _, opt := range c {
+		opt.PostHydrate(sys)
+	}
+}
+
+// FnOption defines an option with more flexible function instances per option lifecycle stage.
+// Each nil attribute is simply a no-op when not set.
+type FnOption[O Orchestrator] struct {
+	BeforeDeployFn func(orch O)
+	DeployFn       func(orch O)
+	AfterDeployFn  func(orch O)
+	FinallyFn      func(orch O, hook SystemHook)
+	PostHydrateFn  func(sys System)
+}
+
+var _ CommonOption = (*FnOption[Orchestrator])(nil)
+
+func (f FnOption[O]) BeforeDeploy(orch O) {
+	if f.BeforeDeployFn != nil {
+		f.BeforeDeployFn(orch)
+	}
+}
+
+func (f FnOption[O]) Deploy(orch O) {
+	if f.DeployFn != nil {
+		f.DeployFn(orch)
+	}
+}
+
+func (f FnOption[O]) AfterDeploy(orch O) {
+	if f.AfterDeployFn != nil {
+		f.AfterDeployFn(orch)
+	}
+}
+
+func (f FnOption[O]) Finally(orch O, hook SystemHook) {
+	if f.FinallyFn != nil {
+		f.FinallyFn(orch, hook)
+	}
+}
+
+func (f FnOption[O]) PostHydrate(sys System) {
+	if f.PostHydrateFn != nil {
+		f.PostHydrateFn(sys)
+	}
+}
+
+func BeforeDeploy[O Orchestrator](fn func(orch O)) Option[O] {
+	return FnOption[O]{BeforeDeployFn: fn}
+}
+
+func Deploy[O Orchestrator](fn func(orch O)) Option[O] {
+	return FnOption[O]{DeployFn: fn}
+}
+
+func AfterDeploy[O Orchestrator](fn func(orch O)) Option[O] {
+	return FnOption[O]{AfterDeployFn: fn}
+}
+
+func Finally[O Orchestrator](fn func(orch O, hook SystemHook)) Option[O] {
+	return FnOption[O]{FinallyFn: fn}
+}
+
+func PostHydrate[O Orchestrator](fn func(sys System)) Option[O] {
+	return FnOption[O]{PostHydrateFn: fn}
+}
+
+// MakeCommon makes the type-specific option a common option.
+// If the result runs with a different orchestrator type than expected
+// the actual typed option will not run.
+// This can be used to mix in customizations.
+// Later common options should verify the orchestrator has the properties it needs to have.
+func MakeCommon[O Orchestrator](opt Option[O]) CommonOption {
+	return FnOption[Orchestrator]{
+		BeforeDeployFn: func(orch Orchestrator) {
+			if o, ok := orch.(O); ok {
+				opt.BeforeDeploy(o)
+			}
+		},
+		DeployFn: func(orch Orchestrator) {
+			if o, ok := orch.(O); ok {
+				opt.Deploy(o)
+			}
+		},
+		AfterDeployFn: func(orch Orchestrator) {
+			if o, ok := orch.(O); ok {
+				opt.AfterDeploy(o)
+			}
+		},
+		FinallyFn: func(orch Orchestrator, hook SystemHook) {
+			if o, ok := orch.(O); ok {
+				opt.Finally(o, hook)
+			}
+		},
+		PostHydrateFn: func(sys System) {
+			opt.PostHydrate(sys)
+		},
 	}
 }

--- a/devnet-sdk/devstack/sysgo/control_plane_test.go
+++ b/devnet-sdk/devstack/sysgo/control_plane_test.go
@@ -32,7 +32,7 @@ func TestControlPlane(gt *testing.T) {
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p)
-	opt(orch)
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	control := orch.ControlPlane()
 

--- a/devnet-sdk/devstack/sysgo/deployer.go
+++ b/devnet-sdk/devstack/sysgo/deployer.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -113,13 +114,16 @@ type worldBuilder struct {
 
 	builder intentbuilder.Builder
 
-	output                  *state.State
-	outL1Genesis            *core.Genesis
-	l2Chains                []eth.ChainID
-	outL2Genesis            map[eth.ChainID]*core.Genesis
-	outL2RollupCfg          map[eth.ChainID]*rollup.Config
-	outL2Deployment         map[eth.ChainID]*L2Deployment
-	outDepset               *depset.StaticConfigDependencySet
+	output          *state.State
+	outL1Genesis    *core.Genesis
+	l2Chains        []eth.ChainID
+	outL2Genesis    map[eth.ChainID]*core.Genesis
+	outL2RollupCfg  map[eth.ChainID]*rollup.Config
+	outL2Deployment map[eth.ChainID]*L2Deployment
+
+	// outDepset is nil if none of the chains has a scheduled interop activation time
+	outDepset *depset.StaticConfigDependencySet
+
 	outSuperchainDeployment *SuperchainDeployment
 }
 
@@ -216,20 +220,25 @@ func (wb *worldBuilder) buildL2Genesis() {
 }
 
 func (wb *worldBuilder) buildDepSet() {
-	if wb.output.InteropDepSet == nil {
-		return
-	}
+	// Note: deployer has a dep set of itself, but it only supports the at-genesis case
+	// So we work around it, and build our own here for now.
+
 	// Deployer uses a different type than the dependency-set itself, so we have to convert
 	depSetContents := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for _, ch := range wb.output.Chains {
+	for chainIndex, ch := range wb.output.Chains {
 		id := eth.ChainIDFromBytes32(ch.ID)
-		deployerDep, ok := wb.output.InteropDepSet.Dependencies[id.String()]
-		wb.require.True(ok, "expecting deployer to use stringified chain IDs")
-		depSetContents[id] = &depset.StaticConfigDependency{
-			ChainIndex:     supervisortypes.ChainIndex(deployerDep.ChainIndex),
-			ActivationTime: deployerDep.ActivationTime,
-			HistoryMinTime: deployerDep.HistoryMinTime,
+		interopTime := wb.outL2Genesis[id].Config.InteropTime
+		if interopTime == nil {
+			continue
 		}
+		depSetContents[id] = &depset.StaticConfigDependency{
+			ChainIndex:     supervisortypes.ChainIndex(chainIndex),
+			ActivationTime: *interopTime,
+			HistoryMinTime: *interopTime,
+		}
+	}
+	if len(depSetContents) == 0 {
+		return // no dependency set output if no chain had interop active
 	}
 	staticDepSet, err := depset.NewStaticConfigDependencySet(depSetContents)
 	wb.require.NoError(err)
@@ -264,9 +273,24 @@ func (wb *worldBuilder) Build() {
 	intent, err := wb.builder.Build()
 	wb.require.NoError(err)
 
-	if len(intent.Chains) > 1 { // multiple L2s implies interop
-		intent.UseInterop = true
+	inDepSetAtGenesis := false
+	for _, ch := range intent.Chains {
+		v, ok := ch.DeployOverrides["l2GenesisInteropTimeOffset"]
+		if !ok {
+			continue
+		}
+		offset, ok := v.(*hexutil.Uint64)
+		if !ok {
+			continue
+		}
+		if *offset == 0 {
+			inDepSetAtGenesis = true
+		}
 	}
+	wb.logger.Info("Dependency set setting", "atGenesis", inDepSetAtGenesis)
+
+	// If any chains are activating interop at genesis, then set useInterop to true
+	intent.UseInterop = inDepSetAtGenesis
 
 	pipelineOpts := deployer.ApplyPipelineOpts{
 		DeploymentTarget:   deployer.DeploymentTargetGenesis,

--- a/devnet-sdk/devstack/sysgo/deployer.go
+++ b/devnet-sdk/devstack/sysgo/deployer.go
@@ -31,62 +31,76 @@ const funderMnemonicIndex = 10_000
 
 type DeployerOption func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder)
 
-func WithDeployer(opts ...DeployerOption) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
-		require := o.P().Require()
-
-		wb := &worldBuilder{
-			p:       o.P(),
-			logger:  o.P().Logger(),
-			require: o.P().Require(),
-			keys:    orch.keys,
-			builder: intentbuilder.New(),
-		}
+func WithDeployerOptions(opts ...DeployerOption) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Require().NotNil(o.wb, "must have a world builder")
 		for _, opt := range opts {
-			opt(o.P(), orch.keys, wb.builder)
+			opt(o.P(), o.keys, o.wb.builder)
 		}
-		wb.Build()
+	})
+}
 
-		l1ID := stack.L1NetworkID(eth.ChainIDFromUInt64(wb.output.AppliedIntent.L1ChainID))
-		superchainID := stack.SuperchainID("main")
-		clusterID := stack.ClusterID("main")
-
-		l1Net := &L1Network{
-			id:        l1ID,
-			genesis:   wb.outL1Genesis,
-			blockTime: 6,
-		}
-		orch.l1Nets.Set(l1ID.ChainID(), l1Net)
-
-		orch.superchains.Set(superchainID, &Superchain{
-			id:         superchainID,
-			deployment: wb.outSuperchainDeployment,
-		})
-		orch.clusters.Set(clusterID, &Cluster{
-			id:     clusterID,
-			depset: wb.outDepset,
-		})
-
-		for _, chainID := range wb.l2Chains {
-			l2Genesis, ok := wb.outL2Genesis[chainID]
-			require.True(ok, "L2 genesis must exist")
-			l2RollupCfg, ok := wb.outL2RollupCfg[chainID]
-			require.True(ok, "L2 rollup config must exist")
-			l2Dep, ok := wb.outL2Deployment[chainID]
-			require.True(ok, "L2 deployment must exist")
-
-			l2ID := stack.L2NetworkID(chainID)
-			l2Net := &L2Network{
-				id:         l2ID,
-				l1ChainID:  l1ID.ChainID(),
-				genesis:    l2Genesis,
-				rollupCfg:  l2RollupCfg,
-				deployment: l2Dep,
-				keys:       orch.keys,
+func WithDeployer() stack.Option[*Orchestrator] {
+	return stack.FnOption[*Orchestrator]{
+		BeforeDeployFn: func(o *Orchestrator) {
+			o.P().Require().Nil(o.wb, "must not already have a world builder")
+			o.wb = &worldBuilder{
+				p:       o.P(),
+				logger:  o.P().Logger(),
+				require: o.P().Require(),
+				keys:    o.keys,
+				builder: intentbuilder.New(),
 			}
-			orch.l2Nets.Set(l2ID.ChainID(), l2Net)
-		}
+		},
+		DeployFn: func(o *Orchestrator) {
+			o.P().Require().NotNil(o.wb, "must have a world builder")
+			o.wb.Build()
+		},
+		AfterDeployFn: func(o *Orchestrator) {
+			wb := o.wb
+			require := o.P().Require()
+			require.NotNil(o.wb, "must have a world builder")
+
+			l1ID := stack.L1NetworkID(eth.ChainIDFromUInt64(wb.output.AppliedIntent.L1ChainID))
+			superchainID := stack.SuperchainID("main")
+			clusterID := stack.ClusterID("main")
+
+			l1Net := &L1Network{
+				id:        l1ID,
+				genesis:   wb.outL1Genesis,
+				blockTime: 6,
+			}
+			o.l1Nets.Set(l1ID.ChainID(), l1Net)
+
+			o.superchains.Set(superchainID, &Superchain{
+				id:         superchainID,
+				deployment: wb.outSuperchainDeployment,
+			})
+			o.clusters.Set(clusterID, &Cluster{
+				id:     clusterID,
+				depset: wb.outDepset,
+			})
+
+			for _, chainID := range wb.l2Chains {
+				l2Genesis, ok := wb.outL2Genesis[chainID]
+				require.True(ok, "L2 genesis must exist")
+				l2RollupCfg, ok := wb.outL2RollupCfg[chainID]
+				require.True(ok, "L2 rollup config must exist")
+				l2Dep, ok := wb.outL2Deployment[chainID]
+				require.True(ok, "L2 deployment must exist")
+
+				l2ID := stack.L2NetworkID(chainID)
+				l2Net := &L2Network{
+					id:         l2ID,
+					l1ChainID:  l1ID.ChainID(),
+					genesis:    l2Genesis,
+					rollupCfg:  l2RollupCfg,
+					deployment: l2Dep,
+					keys:       o.keys,
+				}
+				o.l2Nets.Set(l2ID.ChainID(), l2Net)
+			}
+		},
 	}
 }
 

--- a/devnet-sdk/devstack/sysgo/deployer.go
+++ b/devnet-sdk/devstack/sysgo/deployer.go
@@ -1,7 +1,6 @@
 package sysgo
 
 import (
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 

--- a/devnet-sdk/devstack/sysgo/deployer.go
+++ b/devnet-sdk/devstack/sysgo/deployer.go
@@ -194,6 +194,15 @@ func WithPrefundedL2(chainID eth.ChainID) DeployerOption {
 	}
 }
 
+// WithInteropAtGenesis activates interop at genesis for all known L2s
+func WithInteropAtGenesis() DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithForkAtOffset(rollup.Interop, new(uint64))
+		}
+	}
+}
+
 func (wb *worldBuilder) buildL1Genesis() {
 	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
 	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")

--- a/devnet-sdk/devstack/sysgo/interopgen.go
+++ b/devnet-sdk/devstack/sysgo/interopgen.go
@@ -82,11 +82,10 @@ func (c *Cluster) hydrate(system stack.ExtensibleSystem) {
 
 // WithInteropGen is a system option that will create a L1 chain, superchain, cluster and L2 chains.
 func WithInteropGen(l1ID stack.L1NetworkID, superchainID stack.SuperchainID,
-	clusterID stack.ClusterID, l2IDs []stack.L2NetworkID, res ContractPaths) stack.Option {
+	clusterID stack.ClusterID, l2IDs []stack.L2NetworkID, res ContractPaths) stack.Option[*Orchestrator] {
 
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
-		require := o.P().Require()
+	return stack.Deploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
 
 		require.True(l1ID.ChainID().ToBig().IsInt64(), "interop gen uses small chain IDs")
 		genesisTime := uint64(time.Now().Add(time.Second * 2).Unix())
@@ -110,7 +109,7 @@ func WithInteropGen(l1ID stack.L1NetworkID, superchainID stack.SuperchainID,
 		require.NoError(err)
 
 		// create a logger for the world configuration
-		logger := o.P().Logger().New("role", "world")
+		logger := orch.P().Logger().New("role", "world")
 		require.NoError(worldCfg.Check(logger))
 
 		// create the foundry artifacts and source map
@@ -175,5 +174,5 @@ func WithInteropGen(l1ID stack.L1NetworkID, superchainID stack.SuperchainID,
 			}
 			orch.l2Nets.Set(l2ID.ChainID(), l2Net)
 		}
-	}
+	})
 }

--- a/devnet-sdk/devstack/sysgo/keys.go
+++ b/devnet-sdk/devstack/sysgo/keys.go
@@ -5,12 +5,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 )
 
-func WithMnemonicKeys(mnemonic string) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
-		require := o.P().Require()
+func WithMnemonicKeys(mnemonic string) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
 		hd, err := devkeys.NewMnemonicDevKeys(mnemonic)
 		require.NoError(err)
 		orch.keys = hd
-	}
+	})
 }

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -116,10 +116,9 @@ func (n *L2CLNode) Stop() {
 	n.opNode = nil
 }
 
-func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
-		require := o.P().Require()
+func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
 
 		l2Net, ok := orch.l2Nets.Get(l2CLID.ChainID)
 		require.True(ok, "l2 network required")
@@ -135,7 +134,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 
 		jwtPath, jwtSecret := orch.writeDefaultJWT()
 
-		logger := o.P().Logger().New("service", "op-node", "id", l2CLID)
+		logger := orch.P().Logger().New("service", "op-node", "id", l2CLID)
 
 		var p2pSignerSetup p2p.SignerSetup
 		var p2pConfig *p2p.Config
@@ -240,13 +239,13 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			id:     l2CLID,
 			cfg:    nodeCfg,
 			logger: logger,
-			p:      o.P(),
+			p:      orch.P(),
 			el:     l2ELID,
 		}
 		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), "must not already exist")
 		l2CLNode.Start()
 		orch.p.Cleanup(l2CLNode.Stop)
-	}
+	})
 }
 
 func GetP2PClient(ctx context.Context, logger log.Logger, l2CLNode *L2CLNode) (*sources.P2PClient, error) {
@@ -306,10 +305,9 @@ func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *requ
 }
 
 // WithL2CLP2PConnection connects P2P between two L2CLs
-func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
-		require := o.P().Require()
+func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
 
 		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
 		require.True(ok, "looking for L2 CL node 1 to connect p2p")
@@ -317,8 +315,8 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		require.True(ok, "looking for L2 CL node 2 to connect p2p")
 		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
-		ctx := o.P().Ctx()
-		logger := o.P().Logger()
+		ctx := orch.P().Ctx()
+		logger := orch.P().Logger()
 
 		p := getP2PClientsAndPeers(ctx, logger, require, l2CL1, l2CL2)
 
@@ -345,14 +343,13 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 
 		check(peerDump1, p.peerInfo2)
 		check(peerDump2, p.peerInfo1)
-	}
+	})
 }
 
 // DisconnectL2CLP2P disconnects P2P between two L2CLs
-func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
-		require := o.P().Require()
+func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
 
 		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
 		require.True(ok, "looking for L2 CL node 1 to disconnect p2p")
@@ -360,8 +357,8 @@ func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 		require.True(ok, "looking for L2 CL node 2 to disconnect p2p")
 		require.Equal(l2CL1.cfg.Rollup.L2ChainID, l2CL2.cfg.Rollup.L2ChainID, "must be same l2 chain")
 
-		ctx := o.P().Ctx()
-		logger := o.P().Logger()
+		ctx := orch.P().Ctx()
+		logger := orch.P().Logger()
 
 		p := getP2PClientsAndPeers(ctx, logger, require, l2CL1, l2CL2)
 
@@ -388,5 +385,5 @@ func DisconnectL2CLP2P(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option {
 
 		check(peerDump1, p.peerInfo2)
 		check(peerDump2, p.peerInfo1)
-	}
+	})
 }

--- a/devnet-sdk/devstack/sysgo/l2_cl.go
+++ b/devnet-sdk/devstack/sysgo/l2_cl.go
@@ -161,6 +161,8 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			require.NoError(err)
 			networkPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(networkPrivKey))
 			require.NoError(fs.Set(opNodeFlags.P2PPrivRawName, networkPrivKeyHex))
+			// Explicitly set to empty; do not default to resolving DNS of external bootnodes
+			require.NoError(fs.Set(opNodeFlags.BootnodesName, ""))
 
 			cliCtx := cli.NewContext(&cli.App{}, fs, nil)
 			if isSequencer {
@@ -321,7 +323,7 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option[*Orch
 		p := getP2PClientsAndPeers(ctx, logger, require, l2CL1, l2CL2)
 
 		connectPeer := func(p2pClient *sources.P2PClient, multiAddress string) {
-			err := retry.Do0(ctx, 3, retry.Exponential(), func() error {
+			err := retry.Do0(ctx, 6, retry.Exponential(), func() error {
 				return p2pClient.ConnectPeer(ctx, multiAddress)
 			})
 			require.NoError(err, "failed to connect peer")

--- a/devnet-sdk/devstack/sysgo/orchestrator.go
+++ b/devnet-sdk/devstack/sysgo/orchestrator.go
@@ -21,6 +21,8 @@ type Orchestrator struct {
 
 	keys devkeys.Keys
 
+	wb *worldBuilder
+
 	// nil if no time travel is supported
 	timeTravelClock *clock.AdvancingClock
 

--- a/devnet-sdk/devstack/sysgo/sequencer.go
+++ b/devnet-sdk/devstack/sysgo/sequencer.go
@@ -69,12 +69,11 @@ func (s *Sequencer) hydrate(sys stack.ExtensibleSystem) {
 	}))
 }
 
-func WithSequencer(sequencerID stack.SequencerID, l2CLID stack.L2CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
+func WithSequencer(sequencerID stack.SequencerID, l2CLID stack.L2CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
 		require := orch.P().Require()
 
-		logger := o.P().Logger().New("service", "op-test-sequencer", "id", sequencerID)
+		logger := orch.P().Logger().New("service", "op-test-sequencer", "id", sequencerID)
 
 		l1EL, ok := orch.l1ELs.Get(l1ELID)
 		require.True(ok, "l1 EL node required")
@@ -214,5 +213,5 @@ func WithSequencer(sequencerID stack.SequencerID, l2CLID stack.L2CLNodeID, l1ELI
 		}
 		logger.Info("Sequencer User RPC", "http_endpoint", sequencerNode.userRPC)
 		orch.sequencers.Set(sequencerID, sequencerNode)
-	}
+	})
 }

--- a/devnet-sdk/devstack/sysgo/supervisor.go
+++ b/devnet-sdk/devstack/sysgo/supervisor.go
@@ -92,9 +92,8 @@ func (s *Supervisor) Stop() {
 	s.service = nil
 }
 
-func WithSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID, l1ELID stack.L1ELNodeID) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
+func WithSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID, l1ELID stack.L1ELNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
 		require := orch.P().Require()
 
 		l1EL, ok := orch.l1ELs.Get(l1ELID)
@@ -139,19 +138,18 @@ func WithSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID, 
 			id:      supervisorID,
 			userRPC: "", // set on start
 			cfg:     cfg,
-			p:       o.P(),
+			p:       orch.P(),
 			logger:  plog,
 			service: nil, // set on start
 		}
 		orch.supervisors.Set(supervisorID, supervisorNode)
 		supervisorNode.Start()
 		orch.p.Cleanup(supervisorNode.Stop)
-	}
+	})
 }
 
-func WithManagedBySupervisor(l2CLID stack.L2CLNodeID, supervisorID stack.SupervisorID) stack.Option {
-	return func(o stack.Orchestrator) {
-		orch := o.(*Orchestrator)
+func WithManagedBySupervisor(l2CLID stack.L2CLNodeID, supervisorID stack.SupervisorID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
 		require := orch.P().Require()
 
 		l2CL, ok := orch.l2CLs.Get(l2CLID)
@@ -161,14 +159,14 @@ func WithManagedBySupervisor(l2CLID stack.L2CLNodeID, supervisorID stack.Supervi
 		s, ok := orch.supervisors.Get(supervisorID)
 		require.True(ok, "looking for supervisor")
 
-		ctx := o.P().Ctx()
-		rpcClient, err := client.NewRPC(ctx, o.P().Logger(), s.userRPC, client.WithLazyDial())
-		o.P().Require().NoError(err)
+		ctx := orch.P().Ctx()
+		rpcClient, err := client.NewRPC(ctx, orch.P().Logger(), s.userRPC, client.WithLazyDial())
+		orch.P().Require().NoError(err)
 		supClient := sources.NewSupervisorClient(rpcClient)
 
 		err = retry.Do0(ctx, 10, retry.Exponential(), func() error {
 			return supClient.AddL2RPC(ctx, interopEndpoint, secret)
 		})
 		require.NoError(err, "must connect CL node %s to supervisor %s", l2CLID, supervisorID)
-	}
+	})
 }

--- a/devnet-sdk/devstack/sysgo/supervisor.go
+++ b/devnet-sdk/devstack/sysgo/supervisor.go
@@ -102,6 +102,7 @@ func WithSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID, 
 		cluster, ok := orch.clusters.Get(clusterID)
 		require.True(ok, "need cluster to determine dependency set")
 
+		require.NotNil(cluster.depset, "need a dependency set")
 		cfg := &supervisorConfig.Config{
 			MetricsConfig: metrics.CLIConfig{
 				Enabled: false,

--- a/devnet-sdk/devstack/sysgo/sync_test.go
+++ b/devnet-sdk/devstack/sysgo/sync_test.go
@@ -31,7 +31,7 @@ func TestL2CLResync(gt *testing.T) {
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p)
-	opt(orch)
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	t := devtest.SerialT(gt)
 	system := shim.NewSystem(t)
@@ -132,8 +132,7 @@ func TestL2CLSyncP2P(gt *testing.T) {
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p)
-
-	opt(orch)
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	t := devtest.SerialT(gt)
 	system := shim.NewSystem(t)
@@ -199,7 +198,8 @@ func TestL2CLSyncP2P(gt *testing.T) {
 		logger.Info("explicit reconnection of L2CL P2P between sequencer and verifier")
 		// wait until restarted L2CL can receive p2p API request
 		time.Sleep(waitTime)
-		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL)(orch)
+
+		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL).AfterDeploy(orch)
 
 		targetBlockNum2 := uint64(30)
 		require.Greater(t, targetBlockNum2, targetBlockNum1)
@@ -248,7 +248,7 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p)
-	opt(orch)
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	t := devtest.SerialT(gt)
 	system := shim.NewSystem(t)
@@ -306,7 +306,7 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 		}, 30*time.Second, waitTime)
 
 		logger.Info("disconnect p2p between L2CLs")
-		DisconnectL2CLP2P(ids.L2ACL, ids.L2A2CL)(orch)
+		DisconnectL2CLP2P(ids.L2ACL, ids.L2A2CL).AfterDeploy(orch)
 
 		// verifier lost its P2P connection with sequencer, and will advance its unsafe head by reading L1 but not by P2P
 		_, prevblockA2 := queryEL(eth.Unsafe)
@@ -333,7 +333,7 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 		}, 15*time.Second, waitTime)
 
 		logger.Info("explicit reconnection of L2CL P2P between sequencer and verifier")
-		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL)(orch)
+		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL).AfterDeploy(orch)
 
 		logger.Info("verifier catchs up sequencer unsafe chain with was unknown for verifier")
 		require.Eventually(t, func() bool {

--- a/devnet-sdk/devstack/sysgo/system.go
+++ b/devnet-sdk/devstack/sysgo/system.go
@@ -56,23 +56,25 @@ func NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultInteropSy
 	return ids
 }
 
-func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option {
+func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2AID := eth.ChainIDFromUInt64(901)
 	l2BID := eth.ChainIDFromUInt64(902)
 	ids := NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID)
 
-	opt := stack.Option(func(o stack.Orchestrator) {
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
 		o.P().Logger().Info("Setting up")
-	})
+	}))
 
 	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
 
-	opt.Add(WithDeployer(
-		WithLocalContractSources(),
-		WithCommons(ids.L1.ChainID()),
-		WithPrefundedL2(ids.L2A.ChainID()),
-		WithPrefundedL2(ids.L2B.ChainID())))
+	opt.Add(WithDeployer(),
+		WithDeployerOptions(
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L2A.ChainID()),
+			WithPrefundedL2(ids.L2B.ChainID())))
 
 	//opt.Add(WithInteropGen(ids.L1, ids.Superchain, ids.Cluster,
 	//	[]stack.L2NetworkID{ids.L2A, ids.L2B}, contractPaths))
@@ -104,9 +106,9 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option {
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
-	opt.Add(func(orch stack.Orchestrator) {
+	opt.Add(stack.Finally(func(orch *Orchestrator, hook stack.SystemHook) {
 		*dest = ids
-	})
+	}))
 
 	return opt
 }
@@ -118,7 +120,7 @@ type DefaultRedundancyInteropSystemIDs struct {
 	L2A2EL stack.L2ELNodeID
 }
 
-func DefaultRedundancyInteropSystem(dest *DefaultRedundancyInteropSystemIDs) stack.Option {
+func DefaultRedundancyInteropSystem(dest *DefaultRedundancyInteropSystemIDs) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2AID := eth.ChainIDFromUInt64(901)
 	l2BID := eth.ChainIDFromUInt64(902)
@@ -130,7 +132,8 @@ func DefaultRedundancyInteropSystem(dest *DefaultRedundancyInteropSystemIDs) sta
 
 	// start with default interop system
 	var parentIds DefaultInteropSystemIDs
-	opt := DefaultInteropSystem(&parentIds)
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(DefaultInteropSystem(&parentIds))
 
 	opt.Add(WithL2ELNode(ids.L2A2EL, &ids.Supervisor))
 	opt.Add(WithL2CLNode(ids.L2A2CL, false, ids.L1CL, ids.L1EL, ids.L2A2EL))
@@ -143,9 +146,9 @@ func DefaultRedundancyInteropSystem(dest *DefaultRedundancyInteropSystemIDs) sta
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
-	opt.Add(func(orch stack.Orchestrator) {
+	opt.Add(stack.Finally(func(orch *Orchestrator, hook stack.SystemHook) {
 		*dest = ids
-	})
+	}))
 
 	return opt
 }

--- a/devnet-sdk/devstack/sysgo/system.go
+++ b/devnet-sdk/devstack/sysgo/system.go
@@ -74,7 +74,10 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 			WithLocalContractSources(),
 			WithCommons(ids.L1.ChainID()),
 			WithPrefundedL2(ids.L2A.ChainID()),
-			WithPrefundedL2(ids.L2B.ChainID())))
+			WithPrefundedL2(ids.L2B.ChainID()),
+			WithInteropAtGenesis(), // this can be overridden by later options
+		),
+	)
 
 	//opt.Add(WithInteropGen(ids.L1, ids.Superchain, ids.Cluster,
 	//	[]stack.L2NetworkID{ids.L2A, ids.L2B}, contractPaths))

--- a/devnet-sdk/devstack/sysgo/system_test.go
+++ b/devnet-sdk/devstack/sysgo/system_test.go
@@ -27,7 +27,7 @@ func TestSystem(gt *testing.T) {
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p)
-	opt(orch)
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	// Run two tests in parallel: see if we can share the same orchestrator
 	// between two test scopes, with two different hydrated system frontends.

--- a/op-acceptance-tests/tests/interop/upgrade/main_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/main_test.go
@@ -1,0 +1,16 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/presets"
+)
+
+var SimpleInterop presets.TestSetup[*presets.SimpleInterop]
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.NewSimpleInterop(&SimpleInterop),
+		presets.WithSuggestedInteropActivationOffset(30),
+		presets.WithInteropNotAtGenesis())
+}

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -1,0 +1,32 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/dsl"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+)
+
+func TestPostInbox(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := SimpleInterop(t)
+	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
+		require := t.Require()
+		activationBlock := net.AwaitActivation(t, net.Escape().ChainConfig().InteropTime)
+
+		el := net.Escape().L2ELNode(match.FirstL2EL)
+		implAddrBytes, err := el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
+			genesis.ImplementationSlot, activationBlock.Hash.String())
+		require.NoError(err)
+		implAddr := common.BytesToAddress(implAddrBytes[:])
+		require.NotEqual(common.Address{}, implAddr)
+		code, err := el.EthClient().CodeAtHash(t.Ctx(), implAddr, activationBlock.Hash)
+		require.NoError(err)
+		require.NotEmpty(code)
+	})
+}

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -20,7 +20,9 @@ func TestPreNoInbox(gt *testing.T) {
 	t.Logger().Info("Starting")
 
 	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
-		pre := net.LatestPreActivation(t, net.Escape().ChainConfig().InteropTime)
+		interopTime := net.Escape().ChainConfig().InteropTime
+		t.Require().NotNil(interopTime)
+		pre := net.LatestBlockBeforeTimestamp(t, *interopTime)
 		el := net.Escape().L2ELNode(match.FirstL2EL)
 		codeAddr := common.HexToAddress("0xC0D3C0d3C0D3C0d3c0d3c0D3c0D3C0d3C0D30022")
 		implCode, err := el.EthClient().CodeAtHash(t.Ctx(), codeAddr, pre.Hash)

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -1,0 +1,37 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/devtest"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/dsl"
+	"github.com/ethereum-optimism/optimism/devnet-sdk/devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+)
+
+func TestPreNoInbox(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := SimpleInterop(t)
+	require := t.Require()
+
+	t.Logger().Info("Starting")
+
+	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
+		pre := net.LatestPreActivation(t, net.Escape().ChainConfig().InteropTime)
+		el := net.Escape().L2ELNode(match.FirstL2EL)
+		codeAddr := common.HexToAddress("0xC0D3C0d3C0D3C0d3c0d3c0D3c0D3C0d3C0D30022")
+		implCode, err := el.EthClient().CodeAtHash(t.Ctx(), codeAddr, pre.Hash)
+		require.NoError(err)
+		// TODO this is not empty yet
+		require.Len(implCode, 0, "needs to be empty")
+		implAddrBytes, err := el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
+			genesis.ImplementationSlot, pre.Hash.String())
+		require.NoError(err)
+		// TODO: this still points to 0xC0D3C0d3C0D3C0d3c0d3c0D3c0D3C0d3C0D30022
+		require.Equal(common.Address{}, common.BytesToAddress(implAddrBytes[:]))
+	})
+	t.Logger().Info("Done")
+}

--- a/op-e2e/e2eutils/intentbuilder/builder_test.go
+++ b/op-e2e/e2eutils/intentbuilder/builder_test.go
@@ -159,14 +159,14 @@ func TestBuilder(t *testing.T) {
 				OperatorFeeConstant:      200,
 				DeployOverrides: map[string]any{
 					"l2BlockTime":                 uint64(2),
-					"l2GenesisRegolithTimeOffset": 0,
-					"l2GenesisCanyonTimeOffset":   0,
-					"l2GenesisDeltaTimeOffset":    0,
-					"l2GenesisEcotoneTimeOffset":  0,
-					"l2GenesisFjordTimeOffset":    0,
-					"l2GenesisGraniteTimeOffset":  0,
-					"l2GenesisHoloceneTimeOffset": 0,
-					"l2GenesisIsthmusTimeOffset":  isthmusOffset,
+					"l2GenesisRegolithTimeOffset": hexutil.Uint64(0),
+					"l2GenesisCanyonTimeOffset":   hexutil.Uint64(0),
+					"l2GenesisDeltaTimeOffset":    hexutil.Uint64(0),
+					"l2GenesisEcotoneTimeOffset":  hexutil.Uint64(0),
+					"l2GenesisFjordTimeOffset":    hexutil.Uint64(0),
+					"l2GenesisGraniteTimeOffset":  hexutil.Uint64(0),
+					"l2GenesisHoloceneTimeOffset": hexutil.Uint64(0),
+					"l2GenesisIsthmusTimeOffset":  hexutil.Uint64(isthmusOffset),
 				},
 				L2DevGenesisParams: &state.L2DevGenesisParams{
 					Prefund: map[common.Address]*hexutil.U256{

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -116,6 +116,10 @@ type EthBalance interface {
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 }
 
+type EthCode interface {
+	CodeAtHash(ctx context.Context, account common.Address, blockHash common.Hash) ([]byte, error)
+}
+
 type EthClient interface {
 	ChainID
 	EthBlockInfo
@@ -129,6 +133,7 @@ type EthClient interface {
 	TransactionSender
 	EthNonce
 	EthBalance
+	EthCode
 }
 
 type EthExtendedClient interface {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -569,3 +569,10 @@ func (s *EthClient) BalanceAt(ctx context.Context, account common.Address, block
 	err := s.client.CallContext(ctx, &result, "eth_getBalance", account, toBlockNumArg(blockNumber))
 	return (*big.Int)(&result), err
 }
+
+// CodeAtHash returns the contract code of the given account.
+func (s *EthClient) CodeAtHash(ctx context.Context, account common.Address, blockHash common.Hash) ([]byte, error) {
+	var result hexutil.Bytes
+	err := s.client.CallContext(ctx, &result, "eth_getCode", account, blockHash)
+	return result, err
+}


### PR DESCRIPTION
**Description**

This PR:
- Introduces lifecycles to the devstack setup option pattern, so we can make things run at different times. This allows for easier deployment customization.
- Add `Deadline()` to devtest, so we can tell in helper funcs if the test is going to run out of time before it reaches the desired time, e.g. when waiting for an upgrade
- Add `LatestPreActivation` to L2 network DSL to get a pre-activation block
- Add `AwaitActivation` to L2 network DSL to wait and get the activation block
- Add `devtest.RunParallel` helper to easily run a sub-test for multiple things, e.g. multiple L2s
- Update `sysgo` to use the typed options and lifecycle stages
- Refactor `NewSimpleInterop` to use the option type changes
- Add preset option for suggesting a fork offset `WithSuggestedInteropActivationOffset`
- Add preset option to check for non-zero interop fork time `WithInteropNotAtGenesis`

**Tests**

- Add upgrade test package with:
  - a `TestMain` that configures a non-zero interop upgrade
  - a `TestPreNoInbox` to test that before activation the cross-L2-inbox predeploy is not there, as needed for safety pre-interop
  - a `TestPostInbox` to test what happens after activation to the cross-L2-inbox predeploy

Work in progress to add additional and better pre/post upgrade checks. We may want to merge something like this as-is, and then split out the further upgrade tests into new PRs

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
