### PR TITLE
fix(op-proposer): clarify poll-interval CLI flag documentation

### DIFF
--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -46,7 +46,7 @@ var (
 	}
 	PollIntervalFlag = &cli.DurationFlag{
 		Name:    "poll-interval",
-		Usage:   "How frequently to poll L2 for new blocks (legacy L2OO)",
+		Usage:   "How frequently to check if a new proposal needs to be submitted",
 		Value:   12 * time.Second,
 		EnvVars: prefixEnvVars("POLL_INTERVAL"),
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updates the documentation for the poll-interval CLI flag to accurately reflect its purpose. The flag sets the frequency of checking if a new proposal needs to be submitted, not polling for L2 blocks as previously described. Removed confusing reference to legacy L2OO.

**Tests**

No tests added as this is a documentation-only change.

**Additional context**

The flag controls how often the proposer checks whether it should create a new proposal based on the configured proposal interval

**Metadata**

- Fixes #15715
