### PR TITLE
upgrade-16: Bump StandardValidator mipsVersion

### DIFF
--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -108,7 +108,7 @@ contract StandardValidator {
     }
 
     function mipsVersion() public pure returns (string memory) {
-        return "1.0.0";
+        return "1.3.0";
     }
 
     function optimismMintableERC20FactoryVersion() public pure returns (string memory) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Bump StandardValidator mipsVersion to `1.3.0`.
