### PR TITLE
op-program: Fix regeneration of optimistic blocks when they have been pruned

### DIFF
--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -8,11 +8,15 @@ import (
 	"reflect"
 	"testing"
 
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	fpHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
+	sync2 "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
@@ -20,7 +24,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1391,13 +1397,57 @@ func WithInteropEnabled(t helpers.StatefulTesting, actors *dsl.InteropActors, de
 		f.DependencySet = depSet
 
 		for _, chain := range []*dsl.Chain{actors.ChainA, actors.ChainB} {
+			verifier, canonicalOnlyEngine := createVerifierWithOnlyCanonicalBlocks(t, actors.L1Miner, chain)
 			f.L2Sources = append(f.L2Sources, &fpHelpers.FaultProofProgramL2Source{
-				Node:        chain.Sequencer.L2Verifier,
-				Engine:      chain.SequencerEngine,
+				Node:        verifier,
+				Engine:      canonicalOnlyEngine,
 				ChainConfig: chain.L2Genesis.Config,
 			})
 		}
 	}
+}
+
+func createVerifierWithOnlyCanonicalBlocks(t helpers.StatefulTesting, l1Miner *helpers.L1Miner, chain *dsl.Chain) (*helpers.L2Verifier, *helpers.L2Engine) {
+	jwtPath := e2eutils.WriteDefaultJWT(t)
+	canonicalOnlyEngine := helpers.NewL2Engine(t, testlog.Logger(t, log.LvlInfo).New("role", "canonicalOnlyEngine"), chain.L2Genesis, jwtPath)
+	head := chain.Sequencer.L2Unsafe()
+	for i := uint64(1); i <= head.Number; i++ {
+		block, err := chain.SequencerEngine.EthClient().BlockByNumber(t.Ctx(), new(big.Int).SetUint64(i))
+		require.NoErrorf(t, err, "failed to get block by number %v", i)
+		envelope, err := eth.BlockAsPayloadEnv(block, chain.L2Genesis.Config)
+		require.NoErrorf(t, err, "could not convert block %v to payload envelope")
+		result, err := canonicalOnlyEngine.EngineApi.NewPayloadV4(t.Ctx(), envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{})
+		require.NoErrorf(t, err, "could not import payload for block %v", i)
+		require.Equal(t, eth.ExecutionValid, result.Status)
+	}
+	fcuResult, err := canonicalOnlyEngine.EngineApi.ForkchoiceUpdatedV3(t.Ctx(), &eth.ForkchoiceState{
+		HeadBlockHash:      head.Hash,
+		SafeBlockHash:      head.Hash,
+		FinalizedBlockHash: head.Hash,
+	}, nil)
+	require.NoErrorf(t, err, "could not update fork choice for block %v", head.Hash)
+	require.Equal(t, eth.ExecutionValid, fcuResult.PayloadStatus.Status)
+
+	// Verify chain matches exactly
+	for i := uint64(0); i <= head.Number; i++ {
+		blockNum := new(big.Int).SetUint64(i)
+		expected, err := chain.SequencerEngine.EthClient().BlockByNumber(t.Ctx(), blockNum)
+		require.NoErrorf(t, err, "failed to get original block by number %v", i)
+		actual, err := canonicalOnlyEngine.EthClient().BlockByNumber(t.Ctx(), blockNum)
+		require.NoErrorf(t, err, "failed to get canonical-only block by number %v", i)
+		require.Equalf(t, expected.Hash(), actual.Hash(), "block %v does not match", i)
+	}
+
+	verifier := helpers.NewL2Verifier(t,
+		testlog.Logger(t, log.LvlInfo).New("role", "canonicalOnlyVerifier"),
+		l1Miner.L1Client(t, chain.RollupCfg),
+		l1Miner.BlobSource(),
+		altda.Disabled,
+		canonicalOnlyEngine.EngineClient(t, chain.RollupCfg),
+		chain.RollupCfg,
+		&sync2.Config{},
+		safedb.Disabled)
+	return verifier, canonicalOnlyEngine
 }
 
 func assertTime(t helpers.Testing, chain *dsl.Chain, unsafe, crossUnsafe, localSafe, safe uint64) {

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -1407,6 +1407,8 @@ func WithInteropEnabled(t helpers.StatefulTesting, actors *dsl.InteropActors, de
 	}
 }
 
+// createVerifierWithOnlyCanonicalBlocks creates a new L2Verifier and associated L2Engine that only has the canonical
+// blocks from chain in its database. Non-canonical blocks, their world state, receipts and other data are not available
 func createVerifierWithOnlyCanonicalBlocks(t helpers.StatefulTesting, l1Miner *helpers.L1Miner, chain *dsl.Chain) (*helpers.L2Verifier, *helpers.L2Engine) {
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 	canonicalOnlyEngine := helpers.NewL2Engine(t, testlog.Logger(t, log.LvlInfo).New("role", "canonicalOnlyEngine"), chain.L2Genesis, jwtPath)

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -164,18 +164,7 @@ func singleRoundConsolidation(
 			continue
 		}
 
-		agreedOutput := l2PreimageOracle.OutputByRoot(common.Hash(chain.Output), chain.ChainID)
-		agreedOutputV0, ok := agreedOutput.(*eth.OutputV0)
-		if !ok {
-			return fmt.Errorf("%w: version: %d", l2.ErrUnsupportedL2Output, agreedOutput.Version())
-		}
-		agreedBlockHash := common.Hash(agreedOutputV0.BlockHash)
-
 		progress := consolidateState.PendingProgress[i]
-		// It's possible that the optimistic block is not canonical.
-		// So we use the blockDataByHash hint to trigger a block rebuild to ensure that the block data, including receipts, are available.
-		_ = l2PreimageOracle.BlockDataByHash(agreedBlockHash, progress.BlockHash, chain.ChainID)
-
 		optimisticBlock, _ := l2PreimageOracle.ReceiptsByBlockHash(progress.BlockHash, chain.ChainID)
 
 		candidate := supervisortypes.BlockSeal{
@@ -273,7 +262,10 @@ func newConsolidateCheckDeps(
 		progress := transitionState.PendingProgress[i]
 		// This is the optimistic head. It's OK if it's replaced by a deposits-only block.
 		// Because by then the replacement block won't be used for hazard checks.
-		head := oracle.BlockByHash(progress.BlockHash, chain.ChainID)
+		head, err := fetchOptimisticBlock(oracle, progress.BlockHash, chain)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch optimistic block for chain %v: %w", chain.ChainID, err)
+		}
 		blockByHash := func(hash common.Hash) *ethtypes.Block {
 			return oracle.BlockByHash(hash, chain.ChainID)
 		}
@@ -291,6 +283,15 @@ func newConsolidateCheckDeps(
 		canonBlocks:      canonBlocks,
 		consolidateState: consolidateState,
 	}, nil
+}
+
+func fetchOptimisticBlock(oracle l2.Oracle, blockHash common.Hash, chain eth.ChainIDAndOutput) (*ethtypes.Block, error) {
+	agreedOutput := oracle.OutputByRoot(common.Hash(chain.Output), chain.ChainID)
+	agreedOutputV0, ok := agreedOutput.(*eth.OutputV0)
+	if !ok {
+		return nil, fmt.Errorf("%w: version: %d", l2.ErrUnsupportedL2Output, agreedOutput.Version())
+	}
+	return oracle.BlockDataByHash(agreedOutputV0.BlockHash, blockHash, chain.ChainID), nil
 }
 
 func (d *consolidateCheckDeps) Contains(chain eth.ChainID, query supervisortypes.ContainsQuery) (includedIn supervisortypes.BlockSeal, err error) {

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -474,10 +474,6 @@ func runConsolidationTestCase(t *testing.T, testCase consolidationTestCase) {
 
 	l2PreimageOracle.Outputs[common.Hash(agreedSuperRoot.Chains[0].Output)] = createOutput(block1A.Hash())
 	l2PreimageOracle.Outputs[common.Hash(agreedSuperRoot.Chains[1].Output)] = createOutput(block1B.Hash())
-	l2PreimageOracle.BlockData = map[common.Hash]*gethTypes.Block{
-		block2A.Hash(): block2A,
-		block2B.Hash(): block2B,
-	}
 	l2PreimageOracle.Blocks[block1A.Hash()] = block1A
 	l2PreimageOracle.Blocks[block2A.Hash()] = block2A
 	l2PreimageOracle.Blocks[block2B.Hash()] = block2B
@@ -503,7 +499,6 @@ func runConsolidationTestCase(t *testing.T, testCase consolidationTestCase) {
 			finalRoots[chainIndexToReplace] = depositsOnlyOutputRoot
 			// stub the preimages in the replacement block
 			l2PreimageOracle.Blocks[depositsOnlyBlock.Hash()] = depositsOnlyBlock
-			l2PreimageOracle.BlockData[depositsOnlyBlock.Hash()] = depositsOnlyBlock
 			l2PreimageOracle.Outputs[common.Hash(depositsOnlyOutputRoot)] = depositsOnlyOutput
 			l2PreimageOracle.Receipts[depositsOnlyBlock.Hash()] = depositsOnlyBlockReceipts
 		}
@@ -645,6 +640,9 @@ func TestHazardSet_ExpiredMessageShortCircuitsInclusionCheck(t *testing.T) {
 		l2PreimageOracle.Blocks[block2B.Hash()] = block2B
 		l2PreimageOracle.Receipts[block2A.Hash()] = block2AReceipts
 		l2PreimageOracle.Receipts[block2B.Hash()] = block2BReceipts
+		for _, chain := range agreedSuperRoot.Chains {
+			l2PreimageOracle.Outputs[common.Hash(chain.Output)] = &eth.OutputV0{}
+		}
 
 		consolidateState := newConsolidateState(transitionState)
 		consolidateDeps, err := newConsolidateCheckDeps(configSource.depset, configSource, transitionState, agreedSuperRoot.Chains, l2PreimageOracle, consolidateState)

--- a/op-program/client/l2/test/stub_oracle.go
+++ b/op-program/client/l2/test/stub_oracle.go
@@ -23,7 +23,6 @@ type stateOracle interface {
 type StubBlockOracle struct {
 	t                *testing.T
 	Blocks           map[common.Hash]*gethTypes.Block
-	BlockData        map[common.Hash]*gethTypes.Block
 	Receipts         map[common.Hash]gethTypes.Receipts
 	Outputs          map[common.Hash]eth.Output
 	TransitionStates map[common.Hash]*interopTypes.TransitionState
@@ -35,7 +34,6 @@ func NewStubOracle(t *testing.T) (*StubBlockOracle, *StubStateOracle) {
 	blockOracle := StubBlockOracle{
 		t:                t,
 		Blocks:           make(map[common.Hash]*gethTypes.Block),
-		BlockData:        make(map[common.Hash]*gethTypes.Block),
 		Outputs:          make(map[common.Hash]eth.Output),
 		TransitionStates: make(map[common.Hash]*interopTypes.TransitionState),
 		Receipts:         make(map[common.Hash]gethTypes.Receipts),
@@ -89,7 +87,7 @@ func (o StubBlockOracle) Hinter() l2Types.OracleHinter {
 }
 
 func (o StubBlockOracle) BlockDataByHash(agreedBlockHash, blockHash common.Hash, chainID eth.ChainID) *gethTypes.Block {
-	block, ok := o.BlockData[blockHash]
+	block, ok := o.Blocks[blockHash]
 	if !ok {
 		o.t.Fatalf("requested unknown block %s", blockHash)
 	}

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -34,5 +34,9 @@ func RunPreInteropProgram(
 	if err != nil {
 		return err
 	}
+	if opts.SkipValidation {
+		logger.Info("Validation skipped", "blockHash", result.BlockHash, "outputRoot", result.OutputRoot)
+		return nil
+	}
 	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
 }

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -34,6 +34,9 @@ type DerivationOptions struct {
 	// StoreBlockData controls whether block data, including intermediate trie nodes from transactions and receipts
 	// of the derived block should be stored in the l2.KeyValueStore.
 	StoreBlockData bool
+
+	// SkipValidation controls whether the claim is validated after the block is derived.
+	SkipValidation bool
 }
 
 // RunDerivation executes the L2 state transition, given a minimal interface to retrieve data.

--- a/op-program/compatibility-test/baseline-cannon-multithreaded-64.json
+++ b/op-program/compatibility-test/baseline-cannon-multithreaded-64.json
@@ -27776,5 +27776,4270 @@
     "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
     "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
     "hash": "fe35df5511505818ce1133621afa9876c42fe27577b33044678438013b218eb2"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1417513,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateHead",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1406184,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1403182,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1411634,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1402732,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 2290456,
+                      "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2289785,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2331365,
+                          "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2705734,
+                            "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 3824213,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3818947,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3818537,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3822486,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3822316,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3826431,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3826138,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826711,
+                                            "function": "main.main",
+                                            "absPath": "/tmp/temp_assembly_output"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "0d5200c4f1aca6d140a4f5181a212989b7ba0de4e47f2c263f222bfb10b578e6"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1417513,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateHead",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1406184,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1403182,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1411634,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1402732,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 2290456,
+                      "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2289785,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2331365,
+                          "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2705734,
+                            "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 3825033,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3825267,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "57f0bd4aa42c5ac255ad37ca18916d2d98738d893feb4e225598e9242be5d8d0"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1414670,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1414106,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1403182,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1411634,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1402732,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 2290456,
+                      "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2289785,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2331365,
+                          "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2705734,
+                            "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 3825033,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3825267,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "5e58af1e4da717319b5cff1c1d518b1c9232dc4074160d35b532fac695b890f4"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1414670,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1414106,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1403182,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1411634,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1402732,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 2290456,
+                      "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2289785,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2331365,
+                          "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2705734,
+                            "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 3824213,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3818947,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3818537,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3822486,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3822316,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3826431,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3826138,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826711,
+                                            "function": "main.main",
+                                            "absPath": "/tmp/temp_assembly_output"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "839b6468bd8c92a97c1a840ec04495d1d42a8733d66e3c1a630e55c5a64c8bc5"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1411542,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421405,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418820,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1403182,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1411634,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1402732,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2290456,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2289785,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2331365,
+                            "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2705734,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3825033,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825267,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3824213,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818947,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818537,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822486,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822316,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826431,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826138,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826711,
+                                                  "function": "main.main",
+                                                  "absPath": "/tmp/temp_assembly_output"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "8dec9eb244f128fc341f1db9cd6bf178d5715ac121c27abc1a9060481488f03a"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1411542,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421405,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418820,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1414106,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825033,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825267,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "afc91439bdf7126a81cfbef6e4d68d33e6f3a0080e79c39bec37c227aecb998c"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 297106,
+      "function": "syscall.Fsync",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 336221,
+        "function": "internal/poll.(*FD).Fsync",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 353231,
+          "function": "os.(*File).Sync",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 1411542,
+            "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421405,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418820,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1414106,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential Incompatible Syscall Detected: 5072",
+    "severity": "CRITICAL",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "b9154b9c9341c7a08d92c1e7d7349b321c6b2753c12f790ae13da8f13e54b1cc"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 300196,
+      "function": "syscall.fstat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 294338,
+        "function": "syscall.Fstat",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 343216,
+          "function": "internal/poll.(*FD).Fstat",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 357200,
+            "function": "os.(*File).Stat",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421405,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418151,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825033,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825267,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5005",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "1867e7a930fdf1d2bf8ec927d970981e71a315f5a36f886194dd1d15ad33728f"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 300196,
+      "function": "syscall.fstat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 294338,
+        "function": "syscall.Fstat",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 343216,
+          "function": "internal/poll.(*FD).Fstat",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 357200,
+            "function": "os.(*File).Stat",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421405,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418151,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5005",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "2980f0bda450812b72ff061e7683758c238f54961c90f9a479bb83fc91b1af0c"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419412,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesAfter",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1417513,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateHead",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1406184,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1403182,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1411634,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1402732,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2290456,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2289785,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2331365,
+                                  "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2705734,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3825033,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3825267,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3824213,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3818947,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3818537,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3822486,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3822316,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826431,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826138,
+                                                      "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                      "absPath": "/tmp/temp_assembly_output",
+                                                      "callStack": {
+                                                        "file": "temp_assembly_output",
+                                                        "line": 3826711,
+                                                        "function": "main.main",
+                                                        "absPath": "/tmp/temp_assembly_output"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "2bae9d08793c3e5167bcf6bda1a9052e9927053a4bb8c87f0ae3318dc136daf1"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419496,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesBefore",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1414670,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1414106,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1403182,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1411634,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1402732,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2290456,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2289785,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2331365,
+                                  "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2705734,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3825033,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3825267,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3824213,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3818947,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3818537,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3822486,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3822316,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826431,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826138,
+                                                      "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                      "absPath": "/tmp/temp_assembly_output",
+                                                      "callStack": {
+                                                        "file": "temp_assembly_output",
+                                                        "line": 3826711,
+                                                        "function": "main.main",
+                                                        "absPath": "/tmp/temp_assembly_output"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "2dbea9e83c66e6e1259675975b080118e69266858500b39a07f2432cc92f6ad2"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 296167,
+      "function": "syscall.openat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 352914,
+        "function": "os.open",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354132,
+          "function": "os.openFileNolog",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 352147,
+            "function": "os.OpenFile",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1414106,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1403182,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1411634,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1402732,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 2290456,
+                      "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2289785,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2331365,
+                          "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2705734,
+                            "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 3825033,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3825267,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5247",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "306f4ac96f1a30e7e071286dec0d8c841570abaa5179e1af46f7ef739a04baff"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419412,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesAfter",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1417397,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).preopen",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1414670,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1414106,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1403182,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1411634,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 1402732,
+                              "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2290456,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2289785,
+                                  "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2331365,
+                                    "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 2705734,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3824213,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818947,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3818537,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822486,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3822316,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826431,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826138,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826711,
+                                                      "function": "main.main",
+                                                      "absPath": "/tmp/temp_assembly_output"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "34416e32eead7c82eb8b7432506229190bfafaee61052014555be86e03687b78"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1421405,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1418820,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825033,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825267,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "517f19dbb2fd0eb9274c76dec6d1bc5f87bca9bdd707def2792ab59b05bbfd96"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 300196,
+      "function": "syscall.fstat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 294338,
+        "function": "syscall.Fstat",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 343216,
+          "function": "internal/poll.(*FD).Fstat",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 357200,
+            "function": "os.(*File).Stat",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421046,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).sizeNolock",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418151,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5005",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "650733d109a11252d2fd65283dd46294d1b74df421858277df8445d152e652b5"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418151,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825033,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825267,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "6591613bae28aa3923e1cad3c6a48a16f45b2a6e1dc5672b9083ccd57efe5978"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1421405,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1418151,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1406184,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1403182,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1411634,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1402732,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2290456,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2289785,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2331365,
+                                "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2705734,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825033,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3825267,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3824213,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818947,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3818537,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822486,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3822316,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826431,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826138,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826711,
+                                                      "function": "main.main",
+                                                      "absPath": "/tmp/temp_assembly_output"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "68d17da87b6b41b995dd0d53e450e5b6c3889fe905432319e00031e62d6ce1ac"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 300196,
+      "function": "syscall.fstat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 294338,
+        "function": "syscall.Fstat",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 343216,
+          "function": "internal/poll.(*FD).Fstat",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 357200,
+            "function": "os.(*File).Stat",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421046,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).sizeNolock",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1417513,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateHead",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825033,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825267,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5005",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "86c0218558e6731a4e6767a80ec389790c1c5d07df4d12f1e91a63979fa35f3e"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1421405,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1418820,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1414106,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1403182,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1411634,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1402732,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2290456,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2289785,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2331365,
+                                "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2705734,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3824213,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818947,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818537,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822486,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822316,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826431,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826138,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826711,
+                                                  "function": "main.main",
+                                                  "absPath": "/tmp/temp_assembly_output"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "938267f96d5e6bdc026eea3594f07c91bcf4fbef11f037b5a489d7f0ab385a1c"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 296167,
+      "function": "syscall.openat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 352914,
+        "function": "os.open",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354132,
+          "function": "os.openFileNolog",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 352147,
+            "function": "os.OpenFile",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1414106,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1403182,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1411634,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1402732,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 2290456,
+                      "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 2289785,
+                        "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2331365,
+                          "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2705734,
+                            "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 3824213,
+                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 3818947,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3818537,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3822486,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3822316,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3826431,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3826138,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826711,
+                                            "function": "main.main",
+                                            "absPath": "/tmp/temp_assembly_output"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5247",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "95ad609311f457afe9d15e84f37a76977d19a211801c8004d76f6c3b8860f819"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1421405,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1418151,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1406184,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1403182,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1411634,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1402732,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2290456,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2289785,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2331365,
+                                "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2705734,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3824213,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818947,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818537,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822486,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822316,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826431,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826138,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826711,
+                                                  "function": "main.main",
+                                                  "absPath": "/tmp/temp_assembly_output"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "a9ae2d415750950a83b403f8d9faeb792c6da8de4e68ab80ec3346ac9b9ec06a"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1421405,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1418820,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1414106,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1403182,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1411634,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1402732,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2290456,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2289785,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2331365,
+                                "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2705734,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825033,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3825267,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3824213,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818947,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3818537,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822486,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3822316,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826431,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826138,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826711,
+                                                      "function": "main.main",
+                                                      "absPath": "/tmp/temp_assembly_output"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "b54b1cdac0dce3c02378c79e2fd5ea2c99b53648f9c7918b52383f2b5ad4dc20"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 298492,
+      "function": "syscall.Seek",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 344774,
+        "function": "internal/poll.(*FD).Seek",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354463,
+          "function": "os.(*File).seek",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 351851,
+            "function": "os.(*File).Seek",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1411542,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTableMeta).write",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1421405,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).doSync",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1418820,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).Close",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5008",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "bd7035f1a7daeb997eaebc11230534372ab38e47e67facbae9a3403c7e0dc312"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419412,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesAfter",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1417513,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateHead",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1406184,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1403182,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1411634,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1402732,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2290456,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2289785,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2331365,
+                                  "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2705734,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "c8fe571ed4b950c219b12bf1f27f9568dfdcbe2fe50a02ebc9d7311a50085132"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419496,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesBefore",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1414670,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1414106,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1403182,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1411634,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1402732,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2290456,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2289785,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2331365,
+                                  "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2705734,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "ca5eb8d02839fc6421f82b5dd8a84d54c0402e336072d824bf6cb52ff75711d6"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 300196,
+      "function": "syscall.fstat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 294338,
+        "function": "syscall.Fstat",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 343216,
+          "function": "internal/poll.(*FD).Fstat",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 357200,
+            "function": "os.(*File).Stat",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421046,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).sizeNolock",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418151,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3825033,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3825267,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3824213,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3818947,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3818537,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3822486,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3822316,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826431,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3826138,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826711,
+                                                    "function": "main.main",
+                                                    "absPath": "/tmp/temp_assembly_output"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5005",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "cfbc210c473ebdf8707a38e6b9bbaddf03d302206833b98113d4976220bca27b"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 296167,
+      "function": "syscall.openat",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 352914,
+        "function": "os.open",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 354132,
+          "function": "os.openFileNolog",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 352147,
+            "function": "os.OpenFile",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 1421529,
+              "function": "github.com/ethereum/go-ethereum/core/rawdb.copyFrom",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 1418151,
+                "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).truncateTail",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1406184,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*Freezer).repair",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1403182,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1411634,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1402732,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 2290456,
+                          "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 2289785,
+                            "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2331365,
+                              "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2705734,
+                                "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 3824213,
+                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 3818947,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3818537,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3822486,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3822316,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3826431,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3826138,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3826711,
+                                                "function": "main.main",
+                                                "absPath": "/tmp/temp_assembly_output"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5247",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "dd664e3f9bc63d2eded5d561f0942a9443423426671c6202ef5c3a14749931c7"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419412,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesAfter",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1417397,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).preopen",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1414670,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1414106,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1403182,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1411634,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 1402732,
+                              "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2290456,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2289785,
+                                  "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2331365,
+                                    "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 2705734,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3825033,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3825267,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3824213,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3818947,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3818537,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3822486,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3822316,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826431,
+                                                      "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                      "absPath": "/tmp/temp_assembly_output",
+                                                      "callStack": {
+                                                        "file": "temp_assembly_output",
+                                                        "line": 3826138,
+                                                        "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                        "absPath": "/tmp/temp_assembly_output",
+                                                        "callStack": {
+                                                          "file": "temp_assembly_output",
+                                                          "line": 3826711,
+                                                          "function": "main.main",
+                                                          "absPath": "/tmp/temp_assembly_output"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "e27376671547a7e1ae532bfbdc9c3d278ce76bf263f0d6f5bdca2ddcb3e64a08"
+  },
+  {
+    "callStack": {
+      "file": "temp_assembly_output",
+      "line": 82264,
+      "function": "runtime.netpollclose",
+      "absPath": "/tmp/temp_assembly_output",
+      "callStack": {
+        "file": "temp_assembly_output",
+        "line": 165099,
+        "function": "internal/poll.runtime_pollClose",
+        "absPath": "/tmp/temp_assembly_output",
+        "callStack": {
+          "file": "temp_assembly_output",
+          "line": 338237,
+          "function": "internal/poll.(*FD).destroy",
+          "absPath": "/tmp/temp_assembly_output",
+          "callStack": {
+            "file": "temp_assembly_output",
+            "line": 336710,
+            "function": "internal/poll.(*FD).decref",
+            "absPath": "/tmp/temp_assembly_output",
+            "callStack": {
+              "file": "temp_assembly_output",
+              "line": 338289,
+              "function": "internal/poll.(*FD).Close",
+              "absPath": "/tmp/temp_assembly_output",
+              "callStack": {
+                "file": "temp_assembly_output",
+                "line": 354292,
+                "function": "os.(*file).close",
+                "absPath": "/tmp/temp_assembly_output",
+                "callStack": {
+                  "file": "temp_assembly_output",
+                  "line": 1419412,
+                  "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).releaseFilesAfter",
+                  "absPath": "/tmp/temp_assembly_output",
+                  "callStack": {
+                    "file": "temp_assembly_output",
+                    "line": 1414670,
+                    "function": "github.com/ethereum/go-ethereum/core/rawdb.(*freezerTable).repair",
+                    "absPath": "/tmp/temp_assembly_output",
+                    "callStack": {
+                      "file": "temp_assembly_output",
+                      "line": 1414106,
+                      "function": "github.com/ethereum/go-ethereum/core/rawdb.newTable",
+                      "absPath": "/tmp/temp_assembly_output",
+                      "callStack": {
+                        "file": "temp_assembly_output",
+                        "line": 1403182,
+                        "function": "github.com/ethereum/go-ethereum/core/rawdb.NewFreezer",
+                        "absPath": "/tmp/temp_assembly_output",
+                        "callStack": {
+                          "file": "temp_assembly_output",
+                          "line": 1411634,
+                          "function": "github.com/ethereum/go-ethereum/core/rawdb.newResettableFreezer",
+                          "absPath": "/tmp/temp_assembly_output",
+                          "callStack": {
+                            "file": "temp_assembly_output",
+                            "line": 1402732,
+                            "function": "github.com/ethereum/go-ethereum/core/rawdb.NewStateFreezer",
+                            "absPath": "/tmp/temp_assembly_output",
+                            "callStack": {
+                              "file": "temp_assembly_output",
+                              "line": 2290456,
+                              "function": "github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).repairHistory",
+                              "absPath": "/tmp/temp_assembly_output",
+                              "callStack": {
+                                "file": "temp_assembly_output",
+                                "line": 2289785,
+                                "function": "github.com/ethereum/go-ethereum/triedb/pathdb.New",
+                                "absPath": "/tmp/temp_assembly_output",
+                                "callStack": {
+                                  "file": "temp_assembly_output",
+                                  "line": 2331365,
+                                  "function": "github.com/ethereum/go-ethereum/triedb.NewDatabase",
+                                  "absPath": "/tmp/temp_assembly_output",
+                                  "callStack": {
+                                    "file": "temp_assembly_output",
+                                    "line": 2705734,
+                                    "function": "github.com/ethereum-optimism/optimism/op-program/client/mpt.ReadTrie",
+                                    "absPath": "/tmp/temp_assembly_output",
+                                    "callStack": {
+                                      "file": "temp_assembly_output",
+                                      "line": 3825033,
+                                      "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).loadTransactions",
+                                      "absPath": "/tmp/temp_assembly_output",
+                                      "callStack": {
+                                        "file": "temp_assembly_output",
+                                        "line": 3825267,
+                                        "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).consolidatedBlockByHash",
+                                        "absPath": "/tmp/temp_assembly_output",
+                                        "callStack": {
+                                          "file": "temp_assembly_output",
+                                          "line": 3824213,
+                                          "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.(*ConsolidateOracle).ReceiptsByBlockHash",
+                                          "absPath": "/tmp/temp_assembly_output",
+                                          "callStack": {
+                                            "file": "temp_assembly_output",
+                                            "line": 3818947,
+                                            "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.singleRoundConsolidation",
+                                            "absPath": "/tmp/temp_assembly_output",
+                                            "callStack": {
+                                              "file": "temp_assembly_output",
+                                              "line": 3818537,
+                                              "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.RunConsolidation",
+                                              "absPath": "/tmp/temp_assembly_output",
+                                              "callStack": {
+                                                "file": "temp_assembly_output",
+                                                "line": 3822486,
+                                                "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.stateTransition",
+                                                "absPath": "/tmp/temp_assembly_output",
+                                                "callStack": {
+                                                  "file": "temp_assembly_output",
+                                                  "line": 3822316,
+                                                  "function": "github.com/ethereum-optimism/optimism/op-program/client/interop.runInteropProgram",
+                                                  "absPath": "/tmp/temp_assembly_output",
+                                                  "callStack": {
+                                                    "file": "temp_assembly_output",
+                                                    "line": 3826431,
+                                                    "function": "github.com/ethereum-optimism/optimism/op-program/client.RunProgram",
+                                                    "absPath": "/tmp/temp_assembly_output",
+                                                    "callStack": {
+                                                      "file": "temp_assembly_output",
+                                                      "line": 3826138,
+                                                      "function": "github.com/ethereum-optimism/optimism/op-program/client.Main",
+                                                      "absPath": "/tmp/temp_assembly_output",
+                                                      "callStack": {
+                                                        "file": "temp_assembly_output",
+                                                        "line": 3826711,
+                                                        "function": "main.main",
+                                                        "absPath": "/tmp/temp_assembly_output"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "message": "Potential NOOP Syscall Detected: 5208",
+    "severity": "WARNING",
+    "impact": "This syscall is present in the program, but its execution depends on the actual runtime behavior. \n             If the execution path does not reach this syscall, it may not affect execution.",
+    "reference": "https://github.com/ChainSafe/vm-compat?tab=readme-ov-file#how-it-works",
+    "hash": "ee019853c1c8cd393e91ae684a879ab4e80224ef34f34fecda7a42b8ee738ffb"
   }
 ]

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -25,10 +25,11 @@ type Prefetcher interface {
 }
 type PrefetcherCreator func(ctx context.Context, logger log.Logger, kv kvstore.KV, cfg *config.Config) (Prefetcher, error)
 type programCfg struct {
-	prefetcher     PrefetcherCreator
-	skipValidation bool
-	db             l2.KeyValueStore
-	storeBlockData bool
+	prefetcher       PrefetcherCreator
+	skipValidation   bool
+	db               l2.KeyValueStore
+	storeBlockData   bool
+	forceHintChainID bool
 }
 
 type ProgramOpt func(c *programCfg)
@@ -60,6 +61,13 @@ func WithDB(db l2.KeyValueStore) ProgramOpt {
 func WithStoreBlockData(store bool) ProgramOpt {
 	return func(c *programCfg) {
 		c.storeBlockData = store
+	}
+}
+
+// WithForceHintChainID controls whether hints are forced to include the chain ID even if interop is disabled.
+func WithForceHintChainID(force bool) ProgramOpt {
+	return func(c *programCfg) {
+		c.forceHintChainID = force
 	}
 }
 
@@ -141,6 +149,7 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		clientCfg.InteropEnabled = cfg.InteropEnabled
 		clientCfg.DB = programConfig.db
 		clientCfg.StoreBlockData = programConfig.storeBlockData
+		clientCfg.ForceHintChainID = programConfig.forceHintChainID
 		return cl.RunProgram(logger, pClientRW, hClientRW, clientCfg)
 	}
 }

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -114,6 +114,7 @@ func (p *programExecutor) RunProgram(
 	ctx context.Context,
 	prefetcher hostcommon.Prefetcher,
 	blockNum uint64,
+	output eth.Output,
 	chainID eth.ChainID,
 	db l2.KeyValueStore,
 ) error {
@@ -121,6 +122,12 @@ func (p *programExecutor) RunProgram(
 	newCfg.ExecCmd = "" // ensure we run the program in the same process
 	newCfg.L2ClaimBlockNumber = blockNum
 	newCfg.InteropEnabled = false
+	newCfg.L2OutputRoot = common.Hash(eth.OutputRoot(output))
+	outputV0, ok := output.(*eth.OutputV0)
+	if !ok {
+		return fmt.Errorf("unsupported output root type: %T", output)
+	}
+	newCfg.L2Head = outputV0.BlockHash
 	// Leave the newCfg.L2ChainID as is. It may be set to the customChainID for testing.
 	// newCfg.L2ChainConfigs and newCfg.Rollups will be reconfigured to the specified chainID for the program execution.
 
@@ -162,6 +169,7 @@ func (p *programExecutor) RunProgram(
 		hostcommon.WithSkipValidation(true),
 		hostcommon.WithDB(db),
 		hostcommon.WithStoreBlockData(true),
+		hostcommon.WithForceHintChainID(true), // Our prefetcher expects chain IDs but pre-interop does not specify them
 	)
 }
 

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -169,7 +169,8 @@ func (p *programExecutor) RunProgram(
 		hostcommon.WithSkipValidation(true),
 		hostcommon.WithDB(db),
 		hostcommon.WithStoreBlockData(true),
-		hostcommon.WithForceHintChainID(true), // Our prefetcher expects chain IDs but pre-interop does not specify them
+		// Our prefetcher expects chain IDs but pre-interop does not normally include them in hint data
+		hostcommon.WithForceHintChainID(true),
 	)
 }
 

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -641,6 +641,12 @@ func TestFetchL2BlockData(t *testing.T) {
 		}
 		if !isCanonical {
 			l2Client.ExpectInfoAndTxsByHash(block.Hash(), eth.BlockToInfo(block), block.Transactions(), nil)
+			output := &eth.OutputV0{
+				BlockHash:                block.Hash(),
+				StateRoot:                eth.Bytes32(block.Root()),
+				MessagePasserStorageRoot: eth.Bytes32{},
+			}
+			l2Client.ExpectOutputByRoot(block.Hash(), output, nil)
 		}
 
 		defer l2Client.MockDebugClient.AssertExpectations(t)
@@ -1033,7 +1039,7 @@ type mockExecutor struct {
 }
 
 func (m *mockExecutor) RunProgram(
-	ctx context.Context, prefetcher hostcommon.Prefetcher, blockNumber uint64, chainID eth.ChainID, db l2.KeyValueStore) error {
+	_ context.Context, _ hostcommon.Prefetcher, blockNumber uint64, _ eth.Output, chainID eth.ChainID, _ l2.KeyValueStore) error {
 	m.invoked = true
 	m.blockNumber = blockNumber
 	m.chainID = chainID


### PR DESCRIPTION
**Description**

Fixes op-program so that it can correctly regenerate optimistic blocks that were replaced and are no longer available from the source node.  This had been broken due to some refactoring causing the client to request the optimistic block by hash prior to sending the magic hint that triggers regeneration and some changes in how chain ID is added to hints which caused the regeneration to fail.

**Tests**

Updated action tests to create a verifier node to run FPP against that only contains canonical blocks so replaced optimistic blocks are not available without regeneration.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Closes #14014 because it no longer makes sense to change the API.  The `BlockDataByHash` method is actually exactly what we need in the first place that we request the optimistic block.  The `ReceiptsByBlockHash` method is then used elsewhere so makes sense to be separate.
