### PR TITLE
op-challenger/op-dispute-mon: Load dispute game factory from multiple network args

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -190,8 +190,8 @@ func TestGameFactoryAddress(t *testing.T) {
 		verifyArgsInvalid(t, "flag game-factory-address or network is required", addRequiredArgsExcept(types.TraceTypeAlphabet, "--game-factory-address"))
 	})
 
-	t.Run("RequiredWhenMultipleNetworksSupplied", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag game-factory-address required when multiple networks specified", addRequiredArgsExcept(types.TraceTypeAlphabet, "--game-factory-address", "--network", "op-sepolia,op-mainnet"))
+	t.Run("RequiredWhenMultipleNetworksSuppliedWithDifferentFactories", func(t *testing.T) {
+		verifyArgsInvalid(t, "specified networks use different dispute game factories, flag game-factory-address required", addRequiredArgsExcept(types.TraceTypeAlphabet, "--game-factory-address", "--network", "op-sepolia,op-mainnet"))
 	})
 
 	t.Run("Valid", func(t *testing.T) {

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -452,16 +452,12 @@ func parseTraceTypes(ctx *cli.Context) ([]types.TraceType, error) {
 	return traceTypes, nil
 }
 
-type chainAddressesSource func(network string) (superchain.AddressesConfig, error)
+type ChainAddressesSource func(network string) (superchain.AddressesConfig, error)
 
-var superchainAddressSource chainAddressesSource = func(network string) (superchain.AddressesConfig, error) {
+var superchainAddressSource ChainAddressesSource = func(network string) (superchain.AddressesConfig, error) {
 	chainCfg := chaincfg.ChainByName(network)
 	if chainCfg == nil {
-		var opts []string
-		for _, cfg := range superchain.Chains {
-			opts = append(opts, cfg.Name+"-"+cfg.Network)
-		}
-		return superchain.AddressesConfig{}, fmt.Errorf("unknown chain: %v (Valid options: %v)", network, strings.Join(opts, ", "))
+		return superchain.AddressesConfig{}, fmt.Errorf("unknown chain: %v (Valid options: %v)", network, strings.Join(chaincfg.AvailableNetworks(), ", "))
 	}
 	return chainCfg.Addresses, nil
 }
@@ -479,10 +475,10 @@ func FactoryAddress(ctx *cli.Context) (common.Address, error) {
 	if len(networks) == 0 {
 		return common.Address{}, fmt.Errorf("flag %v or %v is required", FactoryAddressFlag.Name, flags.NetworkFlagName)
 	}
-	return factoryAddressForNetworks(networks, superchainAddressSource)
+	return FactoryAddressForNetworks(networks, superchainAddressSource)
 }
 
-func factoryAddressForNetworks(networks []string, addressSource chainAddressesSource) (common.Address, error) {
+func FactoryAddressForNetworks(networks []string, addressSource ChainAddressesSource) (common.Address, error) {
 	var factoryAddress common.Address
 	for _, network := range networks {
 		addrs, err := addressSource(network)

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -452,6 +452,20 @@ func parseTraceTypes(ctx *cli.Context) ([]types.TraceType, error) {
 	return traceTypes, nil
 }
 
+type chainAddressesSource func(network string) (superchain.AddressesConfig, error)
+
+var superchainAddressSource chainAddressesSource = func(network string) (superchain.AddressesConfig, error) {
+	chainCfg := chaincfg.ChainByName(network)
+	if chainCfg == nil {
+		var opts []string
+		for _, cfg := range superchain.Chains {
+			opts = append(opts, cfg.Name+"-"+cfg.Network)
+		}
+		return superchain.AddressesConfig{}, fmt.Errorf("unknown chain: %v (Valid options: %v)", network, strings.Join(opts, ", "))
+	}
+	return chainCfg.Addresses, nil
+}
+
 func FactoryAddress(ctx *cli.Context) (common.Address, error) {
 	// Use FactoryAddressFlag in preference to Network. Allows overriding the default dispute game factory.
 	if ctx.IsSet(FactoryAddressFlag.Name) {
@@ -462,27 +476,30 @@ func FactoryAddress(ctx *cli.Context) (common.Address, error) {
 		return gameFactoryAddress, nil
 	}
 	networks := ctx.StringSlice(flags.NetworkFlagName)
-	if len(networks) > 1 {
-		return common.Address{}, fmt.Errorf("flag %v required when multiple networks specified", FactoryAddressFlag.Name)
-	}
 	if len(networks) == 0 {
 		return common.Address{}, fmt.Errorf("flag %v or %v is required", FactoryAddressFlag.Name, flags.NetworkFlagName)
 	}
+	return factoryAddressForNetworks(networks, superchainAddressSource)
+}
 
-	network := networks[0]
-	chainCfg := chaincfg.ChainByName(network)
-	if chainCfg == nil {
-		var opts []string
-		for _, cfg := range superchain.Chains {
-			opts = append(opts, cfg.Name+"-"+cfg.Network)
+func factoryAddressForNetworks(networks []string, addressSource chainAddressesSource) (common.Address, error) {
+	var factoryAddress common.Address
+	for _, network := range networks {
+		addrs, err := addressSource(network)
+		if err != nil {
+			return common.Address{}, err
 		}
-		return common.Address{}, fmt.Errorf("unknown chain: %v (Valid options: %v)", network, strings.Join(opts, ", "))
+		if addrs.DisputeGameFactoryProxy == nil {
+			return common.Address{}, fmt.Errorf("dispute factory proxy not available for chain %v", network)
+		}
+		addr := *addrs.DisputeGameFactoryProxy
+		if factoryAddress == (common.Address{}) {
+			factoryAddress = addr
+		} else if factoryAddress != addr {
+			return common.Address{}, fmt.Errorf("specified networks use different dispute game factories, flag %v required", FactoryAddressFlag.Name)
+		}
 	}
-	addrs := chainCfg.Addresses
-	if addrs.DisputeGameFactoryProxy == nil {
-		return common.Address{}, fmt.Errorf("dispute factory proxy not available for chain %v", network)
-	}
-	return *addrs.DisputeGameFactoryProxy, nil
+	return factoryAddress, nil
 }
 
 // NewConfigFromCLI parses the Config from the provided flags or environment variables.

--- a/op-challenger/flags/flags_test.go
+++ b/op-challenger/flags/flags_test.go
@@ -8,6 +8,8 @@ import (
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/superchain"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
@@ -89,4 +91,33 @@ func TestEnvVarFormat(t *testing.T) {
 			require.Equal(t, expectedEnvVar, envFlags[0])
 		})
 	}
+}
+
+func TestMultipleNetworksMustShareDisputeGameFactory(t *testing.T) {
+	addrs := map[string]superchain.AddressesConfig{
+		"a1": {DisputeGameFactoryProxy: &common.Address{0xAA}},
+		"a2": {DisputeGameFactoryProxy: &common.Address{0xAA}},
+		"b1": {DisputeGameFactoryProxy: &common.Address{0xBB}},
+	}
+	source := func(network string) (superchain.AddressesConfig, error) {
+		return addrs[network], nil
+	}
+
+	t.Run("SameAddress", func(t *testing.T) {
+		actual, err := factoryAddressForNetworks([]string{"a1", "a2"}, source)
+		require.NoError(t, err)
+		require.Equal(t, actual, common.Address{0xAA})
+	})
+
+	t.Run("DifferentAddresses", func(t *testing.T) {
+		actual, err := factoryAddressForNetworks([]string{"a1", "a2", "b1"}, source)
+		require.ErrorContains(t, err, "different dispute game factories")
+		require.Equal(t, actual, common.Address{})
+	})
+
+	t.Run("SingleNetwork", func(t *testing.T) {
+		actual, err := factoryAddressForNetworks([]string{"b1"}, source)
+		require.NoError(t, err)
+		require.Equal(t, actual, common.Address{0xBB})
+	})
 }

--- a/op-challenger/flags/flags_test.go
+++ b/op-challenger/flags/flags_test.go
@@ -104,19 +104,19 @@ func TestMultipleNetworksMustShareDisputeGameFactory(t *testing.T) {
 	}
 
 	t.Run("SameAddress", func(t *testing.T) {
-		actual, err := factoryAddressForNetworks([]string{"a1", "a2"}, source)
+		actual, err := FactoryAddressForNetworks([]string{"a1", "a2"}, source)
 		require.NoError(t, err)
 		require.Equal(t, actual, common.Address{0xAA})
 	})
 
 	t.Run("DifferentAddresses", func(t *testing.T) {
-		actual, err := factoryAddressForNetworks([]string{"a1", "a2", "b1"}, source)
+		actual, err := FactoryAddressForNetworks([]string{"a1", "a2", "b1"}, source)
 		require.ErrorContains(t, err, "different dispute game factories")
 		require.Equal(t, actual, common.Address{})
 	})
 
 	t.Run("SingleNetwork", func(t *testing.T) {
-		actual, err := factoryAddressForNetworks([]string{"b1"}, source)
+		actual, err := FactoryAddressForNetworks([]string{"b1"}, source)
 		require.NoError(t, err)
 		require.Equal(t, actual, common.Address{0xBB})
 	})


### PR DESCRIPTION
**Description**

Updates op-challenger and op-dispute-mon to support loading the `DisputeGameFactoryProxy` address from superchain-registry when specifying multiple network names. They validate that all named networks do share the same `DisputeGameFactoryProxy` and fails to start with an error if not.

Previously challenger required use of the `--game-factory-address` arg if multiple networks were specified (but could load the rollup and genesis config via the network names). And dispute-mon only supported a single arg for `--network`.

Loading the factory address from the superchain-registry is simpler and less error prone and by specifying all networks instead of just one, the program will automatically verify that they do actually share a dispute game factory reducing the risk that a factory would be left unmonitored by accident.

**Tests**

Updated CLI tests.

**Metadata**

https://github.com/ethereum-optimism/optimism/issues/13907 - may be all that's required if superchain-registry continues to record the factory address per chain which seems likely at this stage.