### PR TITLE
supervisor: Trigger Indexing on Local Safe Update

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -189,6 +189,10 @@ func (su *SupervisorBackend) OnEvent(ev event.Event) bool {
 			ChainID: x.ChainID,
 		})
 	case superevents.LocalSafeUpdateEvent:
+		su.emitter.Emit(superevents.ChainProcessEvent{
+			ChainID: x.ChainID,
+			Target:  x.NewLocalSafe.Derived.Number,
+		})
 		su.emitter.Emit(superevents.UpdateCrossSafeRequestEvent{
 			ChainID: x.ChainID,
 		})

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -113,6 +113,10 @@ func (s *ChainProcessor) OnEvent(ev event.Event) bool {
 }
 
 func (s *ChainProcessor) onRequest(target uint64) {
+	if target < s.nextNum() {
+		s.log.Debug("Indexing for target block already done", "target", target, "next", s.nextNum())
+		return
+	}
 	processed, err := s.rangeUpdate(target)
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {


### PR DESCRIPTION
If ever the Managed Node is only receiving L2 blocks via Derivation (like if the P2P is broken, or if the Sequencing Window has Lapsed), the Supervisor still needs to be prompted to index all log events.

This trigger will happen in response to the L1:L2 link being recorded in the Derivation database, and will happen prior to Cross Safe updating.