### PR TITLE
op-e2e: remove dead code in operator_fee_test.go

### DIFF
--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -234,9 +234,6 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 			env.Batcher.ActL2BatchBuffer(t)
 
 			aliceInitialBalance, l1FeeVaultInitialBalance, baseFeeVaultInitialBalance, sequencerFeeVaultInitialBalance, operatorFeeVaultInitialBalance = getCurrentBalances()
-			if testCfg.Custom != NotEnoughFundsInBatchMissingOpFee {
-				require.Equal(t, operatorFeeVaultInitialBalance.Sign(), 0)
-			}
 
 			// Craft a transaction from Alice -> Bob
 			env.Alice.L2.ActResetTxOpts(t)


### PR DESCRIPTION
This code is under the case `testCfg.Custom == NotEnoughFundsInBatchMissingOpFee`, so `testCfg.Custom != NotEnoughFundsInBatchMissingOpFee` is always false.