### PR TITLE
chore: bump foundry version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -30,9 +30,9 @@ just = "1.37.0"
 # GitHub release, so we need to use the aliasing trick to get mise to not error
 # The git ref here should be on the `stable` branch.
 # Updated to use the specific nightly build
-forge = "nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd"
-cast = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
-anvil = "nightly-654c8f01721e43dbc8a53c7a3b022548cb82b2f9"
+forge = "1.1.0"
+cast = "1.1.0"
+anvil = "1.1.0"
 
 # Other dependencies
 codecov-uploader = "0.8.0"


### PR DESCRIPTION
**Description**

Updates the mise.toml tool versions for the foundry suite of tools

forge
anvil
cast

to the latest stable version

**Tests**

Updated the tools using mise and ran the contracts-bedrock package
 tests to verify functionality

**Additional context**

There is a feature in this release of foundry that drastically decrease the compile time for our repo. On my machine is ~7-8 minutes to less than 1

**Metadata**

[foundry v1.1.1](https://github.com/foundry-rs/foundry/releases/tag/v1.1.0)
