### PR TITLE
op-e2e: simplify HF management in `NewL2FaultProofEnv`

### DIFF
--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -45,32 +44,11 @@ func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eut
 	log, logs := testlog.CaptureLogger(t, log.LevelDebug)
 
 	dp := NewDeployParams(t, tp, func(dp *e2eutils.DeployParams) {
-		genesisBlock := hexutil.Uint64(0)
-
-		// Enable cancun always
-		dp.DeployConfig.L1CancunTimeOffset = &genesisBlock
-
 		// Enable L2 feature.
-		switch testCfg.Hardfork {
-		case Regolith:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Regolith)
-		case Canyon:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Canyon)
-		case Delta:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Delta)
-		case Ecotone:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Ecotone)
-		case Fjord:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Fjord)
-		case Granite:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Granite)
-		case Holocene:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Holocene)
-		case Isthmus:
-			dp.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
-		default:
-			t.Fatalf("unhandled HF:%v", testCfg.Hardfork)
+		if testCfg.Hardfork == nil {
+			t.Fatalf("HF not set")
 		}
+		dp.DeployConfig.ActivateForkAtGenesis(rollup.ForkName(testCfg.Hardfork.Name))
 
 		for _, override := range deployConfigOverrides {
 			override(dp.DeployConfig)

--- a/op-e2e/actions/proofs/helpers/matrix.go
+++ b/op-e2e/actions/proofs/helpers/matrix.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -116,14 +117,14 @@ type ForkMatrix = []*Hardfork
 
 // Hardfork definitions
 var (
-	Regolith = &Hardfork{Name: "Regolith", Precedence: 1}
-	Canyon   = &Hardfork{Name: "Canyon", Precedence: 2}
-	Delta    = &Hardfork{Name: "Delta", Precedence: 3}
-	Ecotone  = &Hardfork{Name: "Ecotone", Precedence: 4}
-	Fjord    = &Hardfork{Name: "Fjord", Precedence: 5}
-	Granite  = &Hardfork{Name: "Granite", Precedence: 6}
-	Holocene = &Hardfork{Name: "Holocene", Precedence: 7}
-	Isthmus  = &Hardfork{Name: "Isthmus", Precedence: 8}
+	Regolith = &Hardfork{Name: string(rollup.Regolith), Precedence: 1}
+	Canyon   = &Hardfork{Name: string(rollup.Canyon), Precedence: 2}
+	Delta    = &Hardfork{Name: string(rollup.Delta), Precedence: 3}
+	Ecotone  = &Hardfork{Name: string(rollup.Ecotone), Precedence: 4}
+	Fjord    = &Hardfork{Name: string(rollup.Fjord), Precedence: 5}
+	Granite  = &Hardfork{Name: string(rollup.Granite), Precedence: 6}
+	Holocene = &Hardfork{Name: string(rollup.Holocene), Precedence: 7}
+	Isthmus  = &Hardfork{Name: string(rollup.Isthmus), Precedence: 8}
 )
 
 var (


### PR DESCRIPTION
`L1CancunTimeOffset` is enabled by default in [`ApplyDeployConfigForks`](https://github.com/ethereum-optimism/optimism/blob/31c94eec2c07e2a8f6f9511cde9dd1b2fb645ead/op-e2e/e2eutils/setup.go#L276)(called in `MakeDeployParams`), so there's no need to re-enable it in `NewL2FaultProofEnv`.

Besides, this PR eliminates the need for the switch case of HF by re-using `rollup.ForkName` as `Hardfork.Name`.