### PR TITLE
op-conductor: ensure a transparent proxy for miner_setMaxDASize

### DIFF
--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// createHTTPHandler creates a mock HTTP handler for testing, it accepts a callback which
-// is invoked when the expected request is received.
+// createHTTPHandler creates a mock HTTP handler for testing. If alwaysFails is true,
+// the handler will return a JSON-RPC MethodNotFound error response for any vaild request.
 func createHTTPHandler(t *testing.T, alwaysFails bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {

--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -20,7 +20,7 @@ import (
 
 // createHTTPHandler creates a mock HTTP handler for testing, it accepts a callback which
 // is invoked when the expected request is received.
-func createHTTPHandler(t *testing.T, cb func(), alwaysFails bool) http.HandlerFunc {
+func createHTTPHandler(t *testing.T, alwaysFails bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
 			var req struct {
@@ -32,17 +32,31 @@ func createHTTPHandler(t *testing.T, cb func(), alwaysFails bool) http.HandlerFu
 			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
 
 				if alwaysFails {
-					// TODO return a 200 but use a JSON RPC error response
-					http.Error(w, "Method Not Found", http.StatusInternalServerError)
-					if cb != nil {
-						cb()
+					w.Header().Set("Content-Type", "application/json")
+					errorResp := struct {
+						JSONRPC string      `json:"jsonrpc"`
+						ID      interface{} `json:"id"`
+						Error   struct {
+							Code    int    `json:"code"`
+							Message string `json:"message"`
+						} `json:"error"`
+					}{
+						JSONRPC: "2.0",
+						ID:      req.ID,
+						Error: struct {
+							Code    int    `json:"code"`
+							Message string `json:"message"`
+						}{
+							Code:    -32601, // Method not found error code
+							Message: "Method not found",
+						},
+					}
+					if err := json.NewEncoder(w).Encode(errorResp); err != nil {
+						t.Logf("Error writing response: %v", err)
 					}
 					return
 				}
 				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
-					if cb != nil {
-						cb()
-					}
 					w.Header().Set("Content-Type", "application/json")
 					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
 					if err != nil {
@@ -56,6 +70,8 @@ func createHTTPHandler(t *testing.T, cb func(), alwaysFails bool) http.HandlerFu
 	}
 }
 
+// TestSetMaxDASize tests the SetMaxDASize method of the ExecutionMinerProxyBackend
+// It ensures that the proxy is transparently proxying the call to the execution engine
 func TestSetMaxDASize(t *testing.T) {
 	t.Run("compliant sequencer", func(t *testing.T) {
 		testSetMaxDASize(t, true)
@@ -67,7 +83,7 @@ func TestSetMaxDASize(t *testing.T) {
 
 func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
 	ctx := context.Background()
-	sequencer := httptest.NewServer(createHTTPHandler(t, nil, !compliantSequencer))
+	sequencer := httptest.NewServer(createHTTPHandler(t, !compliantSequencer))
 	defer sequencer.Close()
 
 	config := mockConfig(t)
@@ -114,7 +130,7 @@ func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
 		t.Log("Proxied a successful miner_setMaxDASize call")
 	} else {
 		require.Error(t, err)
-		require.EqualError(t, err, "Simulated failure")
+		require.Contains(t, err.Error(), "Method not found")
 		t.Log("Proxied a failed miner_setMaxDASize call")
 	}
 }

--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -2,11 +2,8 @@ package conductor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	clientmocks "github.com/ethereum-optimism/optimism/op-conductor/client/mocks"
@@ -14,61 +11,10 @@ import (
 	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/mockrpc"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
-
-// createHTTPHandler creates a mock HTTP handler for testing. If alwaysFails is true,
-// the handler will return a JSON-RPC MethodNotFound error response for any vaild request.
-func createHTTPHandler(t *testing.T, alwaysFails bool) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" {
-			var req struct {
-				JSONRPC string        `json:"jsonrpc"`
-				Method  string        `json:"method"`
-				Params  []interface{} `json:"params"`
-				ID      interface{}   `json:"id"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
-
-				if alwaysFails {
-					w.Header().Set("Content-Type", "application/json")
-					errorResp := struct {
-						JSONRPC string      `json:"jsonrpc"`
-						ID      interface{} `json:"id"`
-						Error   struct {
-							Code    int    `json:"code"`
-							Message string `json:"message"`
-						} `json:"error"`
-					}{
-						JSONRPC: "2.0",
-						ID:      req.ID,
-						Error: struct {
-							Code    int    `json:"code"`
-							Message string `json:"message"`
-						}{
-							Code:    -32601, // Method not found error code
-							Message: "Method not found",
-						},
-					}
-					if err := json.NewEncoder(w).Encode(errorResp); err != nil {
-						t.Logf("Error writing response: %v", err)
-					}
-					return
-				}
-				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
-					w.Header().Set("Content-Type", "application/json")
-					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
-					if err != nil {
-						t.Logf("Error writing response: %v", err)
-					}
-					return
-				}
-			}
-		}
-		http.Error(w, "Unexpected request", http.StatusBadRequest)
-	}
-}
 
 // TestSetMaxDASize tests the SetMaxDASize method of the ExecutionMinerProxyBackend
 // It ensures that the proxy is transparently proxying the call to the execution engine
@@ -83,12 +29,17 @@ func TestSetMaxDASize(t *testing.T) {
 
 func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
 	ctx := context.Background()
-	sequencer := httptest.NewServer(createHTTPHandler(t, !compliantSequencer))
-	defer sequencer.Close()
+	var expectationsFile string
+	if compliantSequencer {
+		expectationsFile = "testdata/compliant-sequencer.json"
+	} else {
+		expectationsFile = "testdata/non-compliant-sequencer.json"
+	}
+	sequencer := mockrpc.NewMockRPC(t, testlog.Logger(t, slog.LevelDebug), mockrpc.WithExpectationsFile(t, expectationsFile))
 
 	config := mockConfig(t)
-	config.ExecutionRPC = sequencer.URL
-	config.NodeRPC = sequencer.URL // this won't be used but needs to be set to get the conductor to init properly
+	config.ExecutionRPC = sequencer.Endpoint()
+	config.NodeRPC = sequencer.Endpoint() // this won't be used but needs to be set to get the conductor to init properly
 	config.RPCEnableProxy = true
 	config.RPC.ListenAddr = "localhost"
 	config.RPC.ListenPort = 0 // Let the system pick a random port, which we will inspect later

--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -20,14 +20,17 @@ import (
 // It ensures that the proxy is transparently proxying the call to the execution engine
 func TestSetMaxDASize(t *testing.T) {
 	t.Run("compliant sequencer", func(t *testing.T) {
-		testSetMaxDASize(t, true)
+		testSetMaxDASize(t, true, false)
 	})
 	t.Run("non-compliant sequencer", func(t *testing.T) {
-		testSetMaxDASize(t, false)
+		testSetMaxDASize(t, false, false)
+	})
+	t.Run("sequencer down", func(t *testing.T) {
+		testSetMaxDASize(t, true, true)
 	})
 }
 
-func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
+func testSetMaxDASize(t *testing.T, compliantSequencer bool, sequencerDown bool) {
 	ctx := context.Background()
 	var expectationsFile string
 	if compliantSequencer {
@@ -35,29 +38,32 @@ func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
 	} else {
 		expectationsFile = "testdata/non-compliant-sequencer.json"
 	}
+
 	sequencer := mockrpc.NewMockRPC(t, testlog.Logger(t, slog.LevelDebug), mockrpc.WithExpectationsFile(t, expectationsFile))
+	endpoint := sequencer.Endpoint()
 
 	config := mockConfig(t)
-	config.ExecutionRPC = sequencer.Endpoint()
-	config.NodeRPC = sequencer.Endpoint() // this won't be used but needs to be set to get the conductor to init properly
+	config.ExecutionRPC = endpoint
+	config.NodeRPC = endpoint // this won't be used but needs to be set to get the conductor to init properly
 	config.RPCEnableProxy = true
 	config.RPC.ListenAddr = "localhost"
 	config.RPC.ListenPort = 0 // Let the system pick a random port, which we will inspect later
 
+	logger, logs := testlog.CaptureLogger(t, slog.LevelDebug)
+
 	conductor, err := NewOpConductor(
 		ctx,
 		&config,
-		testlog.Logger(t, slog.LevelDebug),
+		logger,
 		&metrics.NoopMetricsImpl{},
 		"test-version",
 		&clientmocks.SequencerControl{}, // not used in this test
 		&consensusmocks.Consensus{},     // not used in this test
 		&healthmocks.HealthMonitor{},    // not used in this test
 	)
-
 	require.NoError(t, err)
 
-	// Start the the RPC server part of the conductor
+	// Start the RPC server part of the conductor
 	err = conductor.rpcServer.Start()
 	require.NoError(t, err)
 	defer func() { _ = conductor.rpcServer.Stop() }()
@@ -72,16 +78,32 @@ func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
 	require.NoError(t, err)
 	defer rpcClient.Close()
 
+	if sequencerDown {
+		require.NoError(t, sequencer.Close())
+	}
+
 	var result bool
 	err = rpcClient.CallContext(ctx, &result, "miner_setMaxDASize", "0x1", "0x2")
+
+	if sequencerDown {
+		require.Error(t, err)
+		expectedLog := "proxy miner_setMaxDASize call failed"
+		r := logs.FindLog(testlog.NewMessageContainsFilter(expectedLog))
+		require.NotNil(t, r, "could not find log message containing '%s'", expectedLog)
+		return
+	}
 
 	if compliantSequencer {
 		require.NoError(t, err)
 		require.True(t, result)
-		t.Log("Proxied a successful miner_setMaxDASize call")
+		expectedLog := "successfully proxied miner_setMaxDASize call"
+		r := logs.FindLog(testlog.NewMessageContainsFilter(expectedLog))
+		require.NotNil(t, r, "could not find log message containing '%s'", expectedLog)
 	} else {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Method not found")
-		t.Log("Proxied a failed miner_setMaxDASize call")
+		expectedLog := "proxy miner_setMaxDASize call returned an RPC error"
+		r := logs.FindLog(testlog.NewMessageContainsFilter(expectedLog))
+		require.NotNil(t, r, "could not find log message containing '%s'", expectedLog)
 	}
 }

--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -109,7 +109,7 @@ func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
 	// Start the the RPC server part of the conductor
 	err = conductor.rpcServer.Start()
 	require.NoError(t, err)
-	defer conductor.rpcServer.Stop()
+	defer func() { _ = conductor.rpcServer.Stop() }()
 
 	port, err := conductor.rpcServer.Port()
 	require.NoError(t, err)

--- a/op-conductor/conductor/execution_miner_proxy_test.go
+++ b/op-conductor/conductor/execution_miner_proxy_test.go
@@ -1,0 +1,120 @@
+package conductor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	clientmocks "github.com/ethereum-optimism/optimism/op-conductor/client/mocks"
+	consensusmocks "github.com/ethereum-optimism/optimism/op-conductor/consensus/mocks"
+	healthmocks "github.com/ethereum-optimism/optimism/op-conductor/health/mocks"
+	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+// createHTTPHandler creates a mock HTTP handler for testing, it accepts a callback which
+// is invoked when the expected request is received.
+func createHTTPHandler(t *testing.T, cb func(), alwaysFails bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			var req struct {
+				JSONRPC string        `json:"jsonrpc"`
+				Method  string        `json:"method"`
+				Params  []interface{} `json:"params"`
+				ID      interface{}   `json:"id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+
+				if alwaysFails {
+					// TODO return a 200 but use a JSON RPC error response
+					http.Error(w, "Method Not Found", http.StatusInternalServerError)
+					if cb != nil {
+						cb()
+					}
+					return
+				}
+				if req.Method == "miner_setMaxDASize" && len(req.Params) == 2 {
+					if cb != nil {
+						cb()
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, err := w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":true}`))
+					if err != nil {
+						t.Logf("Error writing response: %v", err)
+					}
+					return
+				}
+			}
+		}
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}
+}
+
+func TestSetMaxDASize(t *testing.T) {
+	t.Run("compliant sequencer", func(t *testing.T) {
+		testSetMaxDASize(t, true)
+	})
+	t.Run("non-compliant sequencer", func(t *testing.T) {
+		testSetMaxDASize(t, false)
+	})
+}
+
+func testSetMaxDASize(t *testing.T, compliantSequencer bool) {
+	ctx := context.Background()
+	sequencer := httptest.NewServer(createHTTPHandler(t, nil, !compliantSequencer))
+	defer sequencer.Close()
+
+	config := mockConfig(t)
+	config.ExecutionRPC = sequencer.URL
+	config.NodeRPC = sequencer.URL // this won't be used but needs to be set to get the conductor to init properly
+	config.RPCEnableProxy = true
+	config.RPC.ListenAddr = "localhost"
+	config.RPC.ListenPort = 0 // Let the system pick a random port, which we will inspect later
+
+	conductor, err := NewOpConductor(
+		ctx,
+		&config,
+		testlog.Logger(t, slog.LevelDebug),
+		&metrics.NoopMetricsImpl{},
+		"test-version",
+		&clientmocks.SequencerControl{}, // not used in this test
+		&consensusmocks.Consensus{},     // not used in this test
+		&healthmocks.HealthMonitor{},    // not used in this test
+	)
+
+	require.NoError(t, err)
+
+	// Start the the RPC server part of the conductor
+	err = conductor.rpcServer.Start()
+	require.NoError(t, err)
+	defer conductor.rpcServer.Stop()
+
+	port, err := conductor.rpcServer.Port()
+	require.NoError(t, err)
+	t.Log("RPC server listening on port:", port)
+
+	url := fmt.Sprintf("http://localhost:%d", port)
+
+	rpcClient, err := rpc.Dial(url)
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	var result bool
+	err = rpcClient.CallContext(ctx, &result, "miner_setMaxDASize", "0x1", "0x2")
+
+	if compliantSequencer {
+		require.NoError(t, err)
+		require.True(t, result)
+		t.Log("Proxied a successful miner_setMaxDASize call")
+	} else {
+		require.Error(t, err)
+		require.EqualError(t, err, "Simulated failure")
+		t.Log("Proxied a failed miner_setMaxDASize call")
+	}
+}

--- a/op-conductor/conductor/testdata/compliant-sequencer.json
+++ b/op-conductor/conductor/testdata/compliant-sequencer.json
@@ -1,0 +1,10 @@
+[
+  {
+    "method": "miner_setMaxDASize",
+    "params": [
+      "0x1",
+      "0x2"
+    ],
+    "result": true
+  }
+]

--- a/op-conductor/conductor/testdata/non-compliant-sequencer.json
+++ b/op-conductor/conductor/testdata/non-compliant-sequencer.json
@@ -1,0 +1,11 @@
+[
+  {
+    "method": "miner_setMaxDASize",
+    "params": [
+      "0x1",
+      "0x2"
+    ],
+    "err": "Method not found",
+    "errCode": -32601
+  }
+]

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -71,7 +71,7 @@ type ExecutionProxyAPI interface {
 // ExecutionMinerProxyAPI defines the methods proxied to the execution 'miner_' rpc backend
 // This should include all methods that are called by op-batcher or op-proposer
 type ExecutionMinerProxyAPI interface {
-	SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) bool
+	SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) (bool, error)
 }
 
 // NodeProxyAPI defines the methods proxied to the node 'optimism_' rpc backend

--- a/op-conductor/rpc/excecution_miner_proxy.go
+++ b/op-conductor/rpc/excecution_miner_proxy.go
@@ -27,12 +27,20 @@ func NewExecutionMinerProxyBackend(log log.Logger, con conductor, client *ethcli
 	}
 }
 
-func (api *ExecutionMinerProxyBackend) SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) bool {
+func (api *ExecutionMinerProxyBackend) SetMaxDASize(ctx context.Context, maxTxSize hexutil.Big, maxBlockSize hexutil.Big) (bool, error) {
 	var result bool
 	err := api.client.Client().Call(&result, "miner_setMaxDASize", maxTxSize, maxBlockSize)
 	if err != nil {
-		api.log.Warn("proxy miner_setMaxDASize call failed", "err", err)
-		return false
+		api.log.Debug("proxy miner_setMaxDASize call failed",
+			"err", err,
+			"maxTxSize", maxTxSize,
+			"maxBlockSize", maxBlockSize,
+			"method", "miner_setMaxDASize")
+		return false, err
 	}
-	return result
+	api.log.Debug("successfully proxied miner_setMaxDASize call",
+		"maxTxSize", maxTxSize,
+		"maxBlockSize", maxBlockSize,
+		"result", result)
+	return result, nil
 }

--- a/op-conductor/rpc/excecution_miner_proxy.go
+++ b/op-conductor/rpc/excecution_miner_proxy.go
@@ -2,10 +2,12 @@ package rpc
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var ExecutionMinerRPCNamespace = "miner"
@@ -31,11 +33,21 @@ func (api *ExecutionMinerProxyBackend) SetMaxDASize(ctx context.Context, maxTxSi
 	var result bool
 	err := api.client.Client().Call(&result, "miner_setMaxDASize", maxTxSize, maxBlockSize)
 	if err != nil {
-		api.log.Debug("proxy miner_setMaxDASize call failed",
-			"err", err,
-			"maxTxSize", maxTxSize,
-			"maxBlockSize", maxBlockSize,
-			"method", "miner_setMaxDASize")
+		var rpcErr rpc.Error
+		switch {
+		case errors.As(err, &rpcErr):
+			api.log.Debug("proxy miner_setMaxDASize call returned an RPC error",
+				"err", err,
+				"maxTxSize", maxTxSize,
+				"maxBlockSize", maxBlockSize,
+				"method", "miner_setMaxDASize")
+		default:
+			api.log.Warn("proxy miner_setMaxDASize call failed",
+				"err", err,
+				"maxTxSize", maxTxSize,
+				"maxBlockSize", maxBlockSize,
+				"method", "miner_setMaxDASize")
+		}
 		return false, err
 	}
 	api.log.Debug("successfully proxied miner_setMaxDASize call",

--- a/op-service/testutils/mockrpc/mockrpc.go
+++ b/op-service/testutils/mockrpc/mockrpc.go
@@ -73,6 +73,8 @@ type MockRPC struct {
 
 	lis net.Listener
 	err error
+
+	srv *http.Server
 }
 
 type Option func(*MockRPC)
@@ -113,6 +115,8 @@ func NewMockRPC(t *testing.T, lgr log.Logger, opts ...Option) *MockRPC {
 	srv := &http.Server{
 		Handler: m,
 	}
+
+	m.srv = srv
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -226,6 +230,10 @@ func (m *MockRPC) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+func (m *MockRPC) Close() error {
+	return m.srv.Shutdown(context.Background())
 }
 
 func (m *MockRPC) Endpoint() string {


### PR DESCRIPTION
Previously we were translating an error from the origin server into a "false" boolean return value. This messes up the error handling in downstream software like the batcher.

Adds an integration test to ensure correct behaviour.

Use debug logging for rpc errors (part of normal proxy behavior). Keep a warn log for other issues such as connection issues.