### PR TITLE
fix(telemetry): improve setup

### DIFF
--- a/devnet-sdk/telemetry/init.go
+++ b/devnet-sdk/telemetry/init.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	serviceNameEnvVar    = "OTEL_SERVICE_NAME"
-	serviceVersionEnvVar = "OTEL_SERVICE_VERSION"
-)
+	serviceNameEnvVar     = "OTEL_SERVICE_NAME"
+	serviceVersionEnvVar  = "OTEL_SERVICE_VERSION"
+	tracesEndpointEnvVar  = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	metricsEndpointEnvVar = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
 
-var (
-	serviceName    = envOrDefault(serviceNameEnvVar, "devstack")
-	serviceVersion = envOrDefault(serviceVersionEnvVar, "0.0.0")
+	defaultServiceName    = "devstack"
+	defaultServiceVersion = "0.0.0"
 )
 
 func envOrDefault(key, def string) string {
@@ -25,17 +25,23 @@ func envOrDefault(key, def string) string {
 }
 
 func SetupOpenTelemetry(ctx context.Context, opts ...otelconfig.Option) (context.Context, func(), error) {
-	// do not use localhost:4317 by default, we want telemetry to be opt-in and
-	// explicit.
-	if os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") == "" {
-		return ctx, func() {}, nil
+	defaultOpts := []otelconfig.Option{
+		otelconfig.WithServiceName(envOrDefault(serviceNameEnvVar, defaultServiceName)),
+		otelconfig.WithServiceVersion(envOrDefault(serviceVersionEnvVar, defaultServiceVersion)),
+		otelconfig.WithPropagators(defaultPropagators),
 	}
 
-	opts = append([]otelconfig.Option{
-		otelconfig.WithServiceName(serviceName),
-		otelconfig.WithServiceVersion(serviceVersion),
-		otelconfig.WithPropagators(defaultPropagators),
-	}, opts...)
+	// do not use localhost:4317 by default, we want telemetry to be opt-in and
+	// explicit.
+	// The caller is still able to override this by passing in their own opts.
+	if os.Getenv(tracesEndpointEnvVar) == "" {
+		defaultOpts = append(defaultOpts, otelconfig.WithTracesEnabled(false))
+	}
+	if os.Getenv(metricsEndpointEnvVar) == "" {
+		defaultOpts = append(defaultOpts, otelconfig.WithMetricsEnabled(false))
+	}
+
+	opts = append(defaultOpts, opts...)
 	otelShutdown, err := otelconfig.ConfigureOpenTelemetry(opts...)
 	if err != nil {
 		return ctx, nil, err


### PR DESCRIPTION
**Description**

We can be a little bit more precise in our telemetry enablement code:
- disable traces and metrics defaults independently
- keep the ability for the caller to override these choices

In effect it only deactivates pointing to the local exporter by default,
and does not longer disable opentelemetry altogether.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
