### PR TITLE
feat(kurtosis-devnet): add telemetry support for provisioning

### DIFF
--- a/kurtosis-devnet/pkg/build/contracts.go
+++ b/kurtosis-devnet/pkg/build/contracts.go
@@ -16,6 +16,7 @@ import (
 	ktfs "github.com/ethereum-optimism/optimism/devnet-sdk/kt/fs"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/enclave"
 	"github.com/spf13/afero"
+	"go.opentelemetry.io/otel"
 )
 
 // ContractBuilder handles building smart contracts using just commands
@@ -107,7 +108,10 @@ func NewContractBuilder(opts ...ContractBuilderOptions) *ContractBuilder {
 }
 
 // Build executes the contract build command
-func (b *ContractBuilder) Build(_ string) (string, error) {
+func (b *ContractBuilder) Build(ctx context.Context, _ string) (string, error) {
+	_, span := otel.Tracer("contract-builder").Start(ctx, "build contracts")
+	defer span.End()
+
 	// since we ignore layer for now, we can skip the build if the file already
 	// exists: it'll be the same file!
 	if url, ok := b.builtContracts[""]; ok {

--- a/kurtosis-devnet/pkg/build/contracts_test.go
+++ b/kurtosis-devnet/pkg/build/contracts_test.go
@@ -244,7 +244,7 @@ func TestContractBuilder_Build(t *testing.T) {
 			builder.enclaveManager = enclaveManager
 
 			// Execute build
-			output, err := builder.Build("")
+			output, err := builder.Build(context.Background(), "")
 
 			// Verify results
 			if tt.expectError {

--- a/kurtosis-devnet/pkg/build/docker_test.go
+++ b/kurtosis-devnet/pkg/build/docker_test.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -39,7 +40,7 @@ func TestDockerBuilder_Build_Success(t *testing.T) {
 	)
 
 	// Execute build
-	resultTag, err := builder.Build(projectName, initialTag)
+	resultTag, err := builder.Build(context.Background(), projectName, initialTag)
 
 	// Verify results
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestDockerBuilder_Build_CommandFailure(t *testing.T) {
 	)
 
 	// Try to build a project
-	result, err := builder.Build("test-project", "test-tag")
+	result, err := builder.Build(context.Background(), "test-project", "test-tag")
 
 	// Verify the result
 	require.NoError(t, err)
@@ -89,7 +90,7 @@ func TestDockerBuilder_Build_ConcurrencyLimit(t *testing.T) {
 			defer wg.Done()
 			projectName := fmt.Sprintf("concurrent-project-%d", idx)
 			initialTag := fmt.Sprintf("%s:enclave1", projectName)
-			_, err := builder.Build(projectName, initialTag)
+			_, err := builder.Build(context.Background(), projectName, initialTag)
 			assert.NoError(t, err, "Build %d failed", idx)
 		}(i)
 	}
@@ -123,7 +124,7 @@ func TestDockerBuilder_Build_DryRun(t *testing.T) {
 	)
 
 	// Execute build
-	resultTag, err := builder.Build(projectName, initialTag)
+	resultTag, err := builder.Build(context.Background(), projectName, initialTag)
 
 	// Verify results
 	require.NoError(t, err)
@@ -161,7 +162,7 @@ func TestDockerBuilder_Build_DuplicateCalls(t *testing.T) {
 	for i := 0; i < numCalls; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			results[idx], errors[idx] = builder.Build(projectName, initialTag)
+			results[idx], errors[idx] = builder.Build(context.Background(), projectName, initialTag)
 		}(i)
 	}
 

--- a/kurtosis-devnet/pkg/build/prestate.go
+++ b/kurtosis-devnet/pkg/build/prestate.go
@@ -2,10 +2,13 @@ package build
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os/exec"
 	"text/template"
+
+	"go.opentelemetry.io/otel"
 )
 
 // PrestateBuilder handles building prestates using just commands
@@ -69,7 +72,10 @@ type prestateTemplateData struct {
 }
 
 // Build executes the prestate build command
-func (b *PrestateBuilder) Build(path string) error {
+func (b *PrestateBuilder) Build(ctx context.Context, path string) error {
+	_, span := otel.Tracer("prestate-builder").Start(ctx, "build prestate")
+	defer span.End()
+
 	if _, ok := b.builtPrestates[path]; ok {
 		return nil
 	}

--- a/kurtosis-devnet/pkg/deploy/fileserver.go
+++ b/kurtosis-devnet/pkg/deploy/fileserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/util"
 	"github.com/spf13/afero"
+	"go.opentelemetry.io/otel"
 )
 
 const FILESERVER_PACKAGE = "fileserver"
@@ -34,6 +35,9 @@ func (f *FileServer) URL(path ...string) string {
 }
 
 func (f *FileServer) Deploy(ctx context.Context, sourceDir string, stateCh <-chan *fileserverState) (retErr error) {
+	ctx, span := otel.Tracer("fileserver").Start(ctx, "deploy fileserver")
+	defer span.End()
+
 	if f.fs == nil {
 		f.fs = afero.NewOsFs()
 	}

--- a/kurtosis-devnet/pkg/deploy/prestate.go
+++ b/kurtosis-devnet/pkg/deploy/prestate.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,7 +26,7 @@ type localPrestateHolder struct {
 	urlBuilder func(path ...string) string
 }
 
-func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
+func (h *localPrestateHolder) GetPrestateInfo(ctx context.Context) (*PrestateInfo, error) {
 	if h.info != nil {
 		return h.info, nil
 	}
@@ -59,7 +60,7 @@ func (h *localPrestateHolder) GetPrestateInfo() (*PrestateInfo, error) {
 	}
 
 	// Build all prestate files directly in the target directory
-	if err := h.builder.Build(buildDir); err != nil {
+	if err := h.builder.Build(ctx, buildDir); err != nil {
 		return nil, fmt.Errorf("failed to build prestates: %w", err)
 	}
 

--- a/kurtosis-devnet/pkg/deploy/prestate_test.go
+++ b/kurtosis-devnet/pkg/deploy/prestate_test.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +57,7 @@ _prestate-build target:
 
 			buildWg := &sync.WaitGroup{}
 			// Create template context with just the prestate function
-			tmplCtx := tmpl.NewTemplateContext(templater.localPrestateOption(buildWg))
+			tmplCtx := tmpl.NewTemplateContext(templater.localPrestateOption(context.Background(), buildWg))
 
 			// Test template with multiple calls to localPrestate
 			template := `first:

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +49,7 @@ artifacts: {{localContractArtifacts "l1"}}`
 		},
 	}
 
-	buf, err := templater.Render()
+	buf, err := templater.Render(context.Background())
 	require.NoError(t, err)
 
 	// Verify template rendering
@@ -103,7 +104,7 @@ prestateHash: {{ (localPrestate).Hashes.prestate_mt64 }}`
 		},
 	}
 
-	buf, err := templater.Render()
+	buf, err := templater.Render(context.Background())
 	require.NoError(t, err)
 
 	// --- Assertions ---
@@ -164,7 +165,7 @@ func TestLocalPrestateOption(t *testing.T) {
 	buildWg := &sync.WaitGroup{}
 
 	// Get the localPrestate option
-	option := templater.localPrestateOption(buildWg)
+	option := templater.localPrestateOption(context.Background(), buildWg)
 
 	// Create a template context with the option
 	ctx := tmpl.NewTemplateContext(option)
@@ -221,7 +222,7 @@ func TestLocalContractArtifactsOption(t *testing.T) {
 	}
 	buildWg := &sync.WaitGroup{}
 	// Get the localContractArtifacts option
-	option := templater.localContractArtifactsOption(buildWg)
+	option := templater.localContractArtifactsOption(context.Background(), buildWg)
 
 	// Create a template context with the option
 	ctx := tmpl.NewTemplateContext(option)

--- a/kurtosis-devnet/pkg/kurtosis/api/run/handlers_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/api/run/handlers_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestHandleProgress(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	tests := []struct {
 		name     string
 		response interfaces.StarlarkResponse
@@ -33,7 +34,7 @@ func TestHandleProgress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handled, err := handleProgress(ctx, tt.response)
+			handled, err := d.handleProgress(ctx, tt.response)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, handled)
 		})
@@ -42,6 +43,7 @@ func TestHandleProgress(t *testing.T) {
 
 func TestHandleInstruction(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	tests := []struct {
 		name     string
 		response interfaces.StarlarkResponse
@@ -63,7 +65,7 @@ func TestHandleInstruction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handled, err := handleInstruction(ctx, tt.response)
+			handled, err := d.handleInstruction(ctx, tt.response)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, handled)
 		})
@@ -72,6 +74,7 @@ func TestHandleInstruction(t *testing.T) {
 
 func TestHandleWarning(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	tests := []struct {
 		name     string
 		response interfaces.StarlarkResponse
@@ -93,7 +96,7 @@ func TestHandleWarning(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handled, err := handleWarning(ctx, tt.response)
+			handled, err := d.handleWarning(ctx, tt.response)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, handled)
 		})
@@ -102,6 +105,7 @@ func TestHandleWarning(t *testing.T) {
 
 func TestHandleInfo(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	tests := []struct {
 		name     string
 		response interfaces.StarlarkResponse
@@ -123,7 +127,7 @@ func TestHandleInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handled, err := handleInfo(ctx, tt.response)
+			handled, err := d.handleInfo(ctx, tt.response)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, handled)
 		})
@@ -132,6 +136,7 @@ func TestHandleInfo(t *testing.T) {
 
 func TestHandleResult(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	tests := []struct {
 		name     string
 		response interfaces.StarlarkResponse
@@ -162,7 +167,7 @@ func TestHandleResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handled, err := handleResult(ctx, tt.response)
+			handled, err := d.handleResult(ctx, tt.response)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, handled)
 		})
@@ -171,6 +176,7 @@ func TestHandleResult(t *testing.T) {
 
 func TestHandleError(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	testErr := fmt.Errorf("test error")
 	tests := []struct {
 		name      string
@@ -211,7 +217,7 @@ func TestHandleError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handled, err := handleError(ctx, tt.response)
+			handled, err := d.handleError(ctx, tt.response)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {
@@ -224,6 +230,7 @@ func TestHandleError(t *testing.T) {
 
 func TestFirstMatchHandler(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	testErr := fmt.Errorf("test error")
 	tests := []struct {
 		name      string
@@ -235,8 +242,8 @@ func TestFirstMatchHandler(t *testing.T) {
 		{
 			name: "first handler matches",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleInfo),
-				MessageHandlerFunc(handleWarning),
+				MessageHandlerFunc(d.handleInfo),
+				MessageHandlerFunc(d.handleWarning),
 			},
 			response: &fake.StarlarkResponse{
 				Info: "test info",
@@ -246,8 +253,8 @@ func TestFirstMatchHandler(t *testing.T) {
 		{
 			name: "second handler matches",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleInfo),
-				MessageHandlerFunc(handleWarning),
+				MessageHandlerFunc(d.handleInfo),
+				MessageHandlerFunc(d.handleWarning),
 			},
 			response: &fake.StarlarkResponse{
 				Warning: "test warning",
@@ -257,8 +264,8 @@ func TestFirstMatchHandler(t *testing.T) {
 		{
 			name: "no handlers match",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleInfo),
-				MessageHandlerFunc(handleWarning),
+				MessageHandlerFunc(d.handleInfo),
+				MessageHandlerFunc(d.handleWarning),
 			},
 			response: &fake.StarlarkResponse{
 				Result: "test result", HasResult: true,
@@ -268,7 +275,7 @@ func TestFirstMatchHandler(t *testing.T) {
 		{
 			name: "handler returns error",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleError),
+				MessageHandlerFunc(d.handleError),
 			},
 			response: &fake.StarlarkResponse{
 				Err: &fake.StarlarkError{InterpretationErr: testErr},
@@ -294,6 +301,7 @@ func TestFirstMatchHandler(t *testing.T) {
 
 func TestAllHandlers(t *testing.T) {
 	ctx := context.Background()
+	d := newDefaultHandler()
 	testErr := fmt.Errorf("test error")
 	tests := []struct {
 		name      string
@@ -318,8 +326,8 @@ func TestAllHandlers(t *testing.T) {
 		{
 			name: "some handlers match",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleInfo),
-				MessageHandlerFunc(handleWarning),
+				MessageHandlerFunc(d.handleInfo),
+				MessageHandlerFunc(d.handleWarning),
 			},
 			response: &fake.StarlarkResponse{
 				Info: "test info",
@@ -329,8 +337,8 @@ func TestAllHandlers(t *testing.T) {
 		{
 			name: "no handlers match",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleInfo),
-				MessageHandlerFunc(handleWarning),
+				MessageHandlerFunc(d.handleInfo),
+				MessageHandlerFunc(d.handleWarning),
 			},
 			response: &fake.StarlarkResponse{
 				Result: "test result", HasResult: true,
@@ -340,8 +348,8 @@ func TestAllHandlers(t *testing.T) {
 		{
 			name: "handler returns error",
 			handlers: []MessageHandler{
-				MessageHandlerFunc(handleInfo),
-				MessageHandlerFunc(handleError),
+				MessageHandlerFunc(d.handleInfo),
+				MessageHandlerFunc(d.handleError),
 			},
 			response: &fake.StarlarkResponse{
 				Err: &fake.StarlarkError{InterpretationErr: testErr},


### PR DESCRIPTION
**Description**

Add tracing information to the most relevant parts of devnet
provisioning:
- pre-requisite builds (docker images, contracts, ...)
- kurtosis execution

For the most part it involves passing the context around a bit more.
The kurtosis "integration" is hacked around the logs handler though,
which is a bit dodgy, especially around span management. It'd be better
to have native kurtosis support, but in the meantime it gets the job
done.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
