### PR TITLE
op-node: move MeteredL1Fetcher

### DIFF
--- a/op-node/metrics/metered/metered_l1fetcher_test.go
+++ b/op-node/metrics/metered/metered_l1fetcher_test.go
@@ -1,4 +1,4 @@
-package driver
+package metered
 
 import (
 	"context"
@@ -6,12 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 func TestDurationRecorded(t *testing.T) {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	"github.com/ethereum-optimism/optimism/op-node/metrics/metered"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/attributes"
@@ -53,7 +54,7 @@ type Metrics interface {
 	RecordL1ReorgDepth(d uint64)
 
 	engine.Metrics
-	L1FetcherMetrics
+	metered.L1FetcherMetrics
 	event.Metrics
 	sequencing.Metrics
 }
@@ -185,7 +186,7 @@ func NewDriver(
 	l1Tracker := status.NewL1Tracker(l1)
 	sys.Register("l1-blocks", l1Tracker, opts)
 
-	l1 = NewMeteredL1Fetcher(l1Tracker, metrics)
+	l1 = metered.NewMeteredL1Fetcher(l1Tracker, metrics)
 	verifConfDepth := confdepth.NewConfDepth(driverCfg.VerifierConfDepth, statusTracker.L1Head, l1)
 
 	ec := engine.NewEngineController(l2, log, metrics, cfg, syncCfg,


### PR DESCRIPTION
**Description**

The op-node driver package is about to significantly change, and the MeteredL1Fetcher is unrelated, so I am moving it out of the package.

**Tests**

No functionality changes

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
