### PR TITLE
op-deployer: create DeployOPChain2.s.sol

### DIFF
--- a/op-deployer/pkg/deployer/opcm/opchain2.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2.go
@@ -35,10 +35,6 @@ type DeployOPChainInput2 struct {
 	OperatorFeeConstant uint64
 }
 
-func (input *DeployOPChainInput2) InputSet() bool {
-	return true
-}
-
 func (input *DeployOPChainInput2) StartingAnchorRoot() []byte {
 	return PermissionedGameStartingAnchorRoot
 }
@@ -60,10 +56,6 @@ type DeployOPChainOutput2 struct {
 	PermissionedDisputeGame            common.Address
 	DelayedWETHPermissionedGameProxy   common.Address
 	DelayedWETHPermissionlessGameProxy common.Address
-}
-
-func (output *DeployOPChainOutput2) CheckOutput(input common.Address) error {
-	return nil
 }
 
 type DeployOPChainScript2 script.DeployScriptWithOutput[DeployOPChainInput2, DeployOPChainOutput2]

--- a/op-deployer/pkg/deployer/opcm/opchain2.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2.go
@@ -1,0 +1,101 @@
+package opcm
+
+import (
+	_ "embed"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DeployOPChainInput2 struct {
+	OpChainProxyAdminOwner common.Address
+	SystemConfigOwner      common.Address
+	Batcher                common.Address
+	UnsafeBlockSigner      common.Address
+	Proposer               common.Address
+	Challenger             common.Address
+
+	BasefeeScalar     uint32
+	BlobBaseFeeScalar uint32
+	L2ChainId         *big.Int
+	Opcm              common.Address
+	SaltMixer         string
+	GasLimit          uint64
+
+	DisputeGameType              uint32
+	DisputeAbsolutePrestate      common.Hash
+	DisputeMaxGameDepth          uint64
+	DisputeSplitDepth            uint64
+	DisputeClockExtension        uint64
+	DisputeMaxClockDuration      uint64
+	AllowCustomDisputeParameters bool
+
+	OperatorFeeScalar   uint32
+	OperatorFeeConstant uint64
+}
+
+func (input *DeployOPChainInput2) InputSet() bool {
+	return true
+}
+
+func (input *DeployOPChainInput2) StartingAnchorRoot() []byte {
+	return PermissionedGameStartingAnchorRoot
+}
+
+type DeployOPChainOutput2 struct {
+	OpChainProxyAdmin                 common.Address
+	AddressManager                    common.Address
+	L1ERC721BridgeProxy               common.Address
+	SystemConfigProxy                 common.Address
+	OptimismMintableERC20FactoryProxy common.Address
+	L1StandardBridgeProxy             common.Address
+	L1CrossDomainMessengerProxy       common.Address
+	// Fault proof contracts below.
+	OptimismPortalProxy                common.Address
+	ETHLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
+	DisputeGameFactoryProxy            common.Address
+	AnchorStateRegistryProxy           common.Address
+	FaultDisputeGame                   common.Address
+	PermissionedDisputeGame            common.Address
+	DelayedWETHPermissionedGameProxy   common.Address
+	DelayedWETHPermissionlessGameProxy common.Address
+}
+
+func (output *DeployOPChainOutput2) CheckOutput(input common.Address) error {
+	return nil
+}
+
+type DeployOPChainScript2 script.DeployScriptWithOutput[DeployOPChainInput2, DeployOPChainOutput2]
+
+// NewDeployOPChainScript loads and validates the DeployOPChain2 script contract
+func NewDeployOPChainScript(host *script.Host) (DeployOPChainScript2, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployOPChainInput2, DeployOPChainOutput2](host, "DeployOPChain2.s.sol", "DeployOPChain2")
+}
+
+type ReadImplementationAddressesInput2 struct {
+	DeployOPChainOutput2
+	Opcm    common.Address
+	Release string
+}
+
+type ReadImplementationAddressesOutput2 struct {
+	DelayedWETH                  common.Address
+	OptimismPortal               common.Address
+	ETHLockbox                   common.Address `evm:"ethLockbox"`
+	SystemConfig                 common.Address
+	L1CrossDomainMessenger       common.Address
+	L1ERC721Bridge               common.Address
+	L1StandardBridge             common.Address
+	OptimismMintableERC20Factory common.Address
+	DisputeGameFactory           common.Address
+	MipsSingleton                common.Address
+	PreimageOracleSingleton      common.Address
+}
+
+type ReadImplementationAddressesScript2 script.DeployScriptWithOutput[ReadImplementationAddressesInput2, ReadImplementationAddressesOutput2]
+
+// NewReadImplementationAddressesScript loads and validates the ReadImplementationAddresses2 script contract
+func NewReadImplementationAddressesScript(host *script.Host) (ReadImplementationAddressesScript2, error) {
+	return script.NewDeployScriptWithOutputFromFile[ReadImplementationAddressesInput2, ReadImplementationAddressesOutput2](host, "ReadImplementationAddresses2.s.sol", "ReadImplementationAddresses2")
+}

--- a/op-deployer/pkg/deployer/opcm/opchain2.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2.go
@@ -49,7 +49,7 @@ type DeployOPChainOutput2 struct {
 	L1CrossDomainMessengerProxy       common.Address
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address
-	EthLockboxProxy                    common.Address
+	ETHLockboxProxy                    common.Address `abi:"ethLockboxProxy"`
 	DisputeGameFactoryProxy            common.Address
 	AnchorStateRegistryProxy           common.Address
 	FaultDisputeGame                   common.Address

--- a/op-deployer/pkg/deployer/opcm/opchain2.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2.go
@@ -25,8 +25,8 @@ type DeployOPChainInput2 struct {
 
 	DisputeGameType              uint32
 	DisputeAbsolutePrestate      common.Hash
-	DisputeMaxGameDepth          uint64
-	DisputeSplitDepth            uint64
+	DisputeMaxGameDepth          *big.Int
+	DisputeSplitDepth            *big.Int
 	DisputeClockExtension        uint64
 	DisputeMaxClockDuration      uint64
 	AllowCustomDisputeParameters bool
@@ -53,7 +53,7 @@ type DeployOPChainOutput2 struct {
 	L1CrossDomainMessengerProxy       common.Address
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address
-	ETHLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
+	EthLockboxProxy                    common.Address
 	DisputeGameFactoryProxy            common.Address
 	AnchorStateRegistryProxy           common.Address
 	FaultDisputeGame                   common.Address

--- a/op-deployer/pkg/deployer/opcm/opchain2.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2.go
@@ -72,30 +72,3 @@ type DeployOPChainScript2 script.DeployScriptWithOutput[DeployOPChainInput2, Dep
 func NewDeployOPChainScript(host *script.Host) (DeployOPChainScript2, error) {
 	return script.NewDeployScriptWithOutputFromFile[DeployOPChainInput2, DeployOPChainOutput2](host, "DeployOPChain2.s.sol", "DeployOPChain2")
 }
-
-type ReadImplementationAddressesInput2 struct {
-	DeployOPChainOutput2
-	Opcm    common.Address
-	Release string
-}
-
-type ReadImplementationAddressesOutput2 struct {
-	DelayedWETH                  common.Address
-	OptimismPortal               common.Address
-	ETHLockbox                   common.Address `evm:"ethLockbox"`
-	SystemConfig                 common.Address
-	L1CrossDomainMessenger       common.Address
-	L1ERC721Bridge               common.Address
-	L1StandardBridge             common.Address
-	OptimismMintableERC20Factory common.Address
-	DisputeGameFactory           common.Address
-	MipsSingleton                common.Address
-	PreimageOracleSingleton      common.Address
-}
-
-type ReadImplementationAddressesScript2 script.DeployScriptWithOutput[ReadImplementationAddressesInput2, ReadImplementationAddressesOutput2]
-
-// NewReadImplementationAddressesScript loads and validates the ReadImplementationAddresses2 script contract
-func NewReadImplementationAddressesScript(host *script.Host) (ReadImplementationAddressesScript2, error) {
-	return script.NewDeployScriptWithOutputFromFile[ReadImplementationAddressesInput2, ReadImplementationAddressesOutput2](host, "ReadImplementationAddresses2.s.sol", "ReadImplementationAddresses2")
-}

--- a/op-deployer/pkg/deployer/opcm/opchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2_test.go
@@ -1,6 +1,7 @@
 package opcm
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -132,21 +133,11 @@ func TestNewDeployOPChainScript(t *testing.T) {
 		require.NotNil(t, deprecatedOutput)
 
 		// Now make sure the addresses are the same
-		require.Equal(t, deprecatedOutput.OpChainProxyAdmin, output.OpChainProxyAdmin)
-		require.Equal(t, deprecatedOutput.AddressManager, output.AddressManager)
-		require.Equal(t, deprecatedOutput.L1ERC721BridgeProxy, output.L1ERC721BridgeProxy)
-		require.Equal(t, deprecatedOutput.SystemConfigProxy, output.SystemConfigProxy)
-		require.Equal(t, deprecatedOutput.OptimismMintableERC20FactoryProxy, output.OptimismMintableERC20FactoryProxy)
-		require.Equal(t, deprecatedOutput.L1StandardBridgeProxy, output.L1StandardBridgeProxy)
-		require.Equal(t, deprecatedOutput.L1CrossDomainMessengerProxy, output.L1CrossDomainMessengerProxy)
-		require.Equal(t, deprecatedOutput.OptimismPortalProxy, output.OptimismPortalProxy)
-		require.Equal(t, deprecatedOutput.ETHLockboxProxy, output.EthLockboxProxy)
-		require.Equal(t, deprecatedOutput.DisputeGameFactoryProxy, output.DisputeGameFactoryProxy)
-		require.Equal(t, deprecatedOutput.AnchorStateRegistryProxy, output.AnchorStateRegistryProxy)
-		require.Equal(t, deprecatedOutput.FaultDisputeGame, output.FaultDisputeGame)
-		require.Equal(t, deprecatedOutput.PermissionedDisputeGame, output.PermissionedDisputeGame)
-		require.Equal(t, deprecatedOutput.DelayedWETHPermissionedGameProxy, output.DelayedWETHPermissionedGameProxy)
-		require.Equal(t, deprecatedOutput.DelayedWETHPermissionlessGameProxy, output.DelayedWETHPermissionlessGameProxy)
+		deprecatedJSON, err := json.Marshal(deprecatedOutput)
+		require.NoError(t, err)
+		outputJSON, err := json.Marshal(output)
+		require.NoError(t, err)
+		require.JSONEq(t, string(deprecatedJSON), string(outputJSON))
 
 		// And just to be super sure we also compare the code deployed to the addresses
 		require.Equal(t, host2.GetCode(deprecatedOutput.OpChainProxyAdmin), host1.GetCode(output.OpChainProxyAdmin))
@@ -157,7 +148,7 @@ func TestNewDeployOPChainScript(t *testing.T) {
 		require.Equal(t, host2.GetCode(deprecatedOutput.L1StandardBridgeProxy), host1.GetCode(output.L1StandardBridgeProxy))
 		require.Equal(t, host2.GetCode(deprecatedOutput.L1CrossDomainMessengerProxy), host1.GetCode(output.L1CrossDomainMessengerProxy))
 		require.Equal(t, host2.GetCode(deprecatedOutput.OptimismPortalProxy), host1.GetCode(output.OptimismPortalProxy))
-		require.Equal(t, host2.GetCode(deprecatedOutput.ETHLockboxProxy), host1.GetCode(output.EthLockboxProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.ETHLockboxProxy), host1.GetCode(output.ETHLockboxProxy))
 		require.Equal(t, host2.GetCode(deprecatedOutput.DisputeGameFactoryProxy), host1.GetCode(output.DisputeGameFactoryProxy))
 		require.Equal(t, host2.GetCode(deprecatedOutput.AnchorStateRegistryProxy), host1.GetCode(output.AnchorStateRegistryProxy))
 		require.Equal(t, host2.GetCode(deprecatedOutput.FaultDisputeGame), host1.GetCode(output.FaultDisputeGame))

--- a/op-deployer/pkg/deployer/opcm/opchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2_test.go
@@ -1,0 +1,186 @@
+package opcm
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeployOPChainScript(t *testing.T) {
+	deployDependencies := func(host *script.Host) common.Address {
+		proxyAdminArtifact, err := host.Artifacts().ReadArtifact("ProxyAdmin.sol", "ProxyAdmin")
+		require.NoError(t, err)
+
+		encodedProxyAdmin, err := proxyAdminArtifact.ABI.Pack("", addresses.ScriptDeployer)
+		require.NoError(t, err)
+
+		proxyAdminAddress, err := host.Create(addresses.ScriptDeployer, append(proxyAdminArtifact.Bytecode.Object, encodedProxyAdmin...))
+		require.NoError(t, err)
+
+		// Then we get a proxy deployed
+		proxyArtifact, err := host.Artifacts().ReadArtifact("Proxy.sol", "Proxy")
+		require.NoError(t, err)
+
+		encodedProxy, err := proxyArtifact.ABI.Pack("", proxyAdminAddress)
+		require.NoError(t, err)
+
+		proxyAddress, err := host.Create(addresses.ScriptDeployer, append(proxyArtifact.Bytecode.Object, encodedProxy...))
+		require.NoError(t, err)
+
+		// Then we get ProtocolVersions deployed
+		protocolVersionsArtifact, err := host.Artifacts().ReadArtifact("ProtocolVersions.sol", "ProtocolVersions")
+		require.NoError(t, err)
+
+		encodedProtocolVersions, err := protocolVersionsArtifact.ABI.Pack("")
+		require.NoError(t, err)
+
+		protocolVersionsAddress, err := host.Create(addresses.ScriptDeployer, append(protocolVersionsArtifact.Bytecode.Object, encodedProtocolVersions...))
+		require.NoError(t, err)
+
+		deployImplementations, err := NewDeployImplementationsScript(host)
+		require.NoError(t, err)
+
+		mipsVersion := int64(standard.MIPSVersion)
+		implementationsOutput, err := deployImplementations.Run(DeployImplementations2Input{
+			WithdrawalDelaySeconds:          big.NewInt(1),
+			MinProposalSizeBytes:            big.NewInt(2),
+			ChallengePeriodSeconds:          big.NewInt(3),
+			ProofMaturityDelaySeconds:       big.NewInt(4),
+			DisputeGameFinalityDelaySeconds: big.NewInt(5),
+			MipsVersion:                     big.NewInt(mipsVersion),
+			L1ContractsRelease:              "dev-release",
+			SuperchainConfigProxy:           proxyAddress,
+			ProtocolVersionsProxy:           protocolVersionsAddress,
+			SuperchainProxyAdmin:            proxyAdminAddress,
+			UpgradeController:               common.BigToAddress(big.NewInt(13)),
+		})
+
+		fmt.Printf("implementationsOutput: %+v\n", implementationsOutput)
+		require.NoError(t, err)
+		return implementationsOutput.Opcm
+	}
+	t.Run("should not fail with current version of DeployOPChain2 contract", func(t *testing.T) {
+		// First we grab a test host
+		host1 := createTestHost(t)
+
+		// We'll need some contracts already deployed for this to work
+		opcmImpl := deployDependencies(host1)
+
+		// Then we load the script
+		//
+		// This would raise an error if the Go types didn't match the ABI
+		deployOPChain, err := NewDeployOPChainScript(host1)
+		require.NoError(t, err)
+
+		// Then we deploy
+		output, err := deployOPChain.Run(DeployOPChainInput2{
+			OpChainProxyAdminOwner: common.HexToAddress("0x123"),
+			SystemConfigOwner:      common.HexToAddress("0x456"),
+			Batcher:                common.HexToAddress("0x789"),
+			UnsafeBlockSigner:      common.HexToAddress("0xabc"),
+			Proposer:               common.HexToAddress("0xdef"),
+			Challenger:             common.HexToAddress("0xfed"),
+
+			BasefeeScalar:     100,
+			BlobBaseFeeScalar: 100,
+			L2ChainId:         big.NewInt(1105),
+			Opcm:              opcmImpl,
+			SaltMixer:         "0x456",
+			GasLimit:          30000000,
+
+			DisputeGameType:              1,
+			DisputeAbsolutePrestate:      common.HexToHash("0x123"),
+			DisputeMaxGameDepth:          big.NewInt(100),
+			DisputeSplitDepth:            big.NewInt(100),
+			DisputeClockExtension:        100,
+			DisputeMaxClockDuration:      100,
+			AllowCustomDisputeParameters: true,
+
+			OperatorFeeScalar:   100,
+			OperatorFeeConstant: 100,
+		})
+
+		// And do some simple asserts
+		require.NoError(t, err)
+		require.NotNil(t, output)
+
+		// Now we run the old deployer
+		//
+		// We run it on a fresh host so that the deployer nonces are the same
+		// which in turn means we should get identical output
+		host2 := createTestHost(t)
+		// We'll need some contracts already deployed for this to work
+		opcmImpl2 := deployDependencies(host2)
+
+		deprecatedOutput, err := DeployOPChain(host2, DeployOPChainInput{
+			OpChainProxyAdminOwner: common.HexToAddress("0x123"),
+			SystemConfigOwner:      common.HexToAddress("0x456"),
+			Batcher:                common.HexToAddress("0x789"),
+			UnsafeBlockSigner:      common.HexToAddress("0xabc"),
+			Proposer:               common.HexToAddress("0xdef"),
+			Challenger:             common.HexToAddress("0xfed"),
+
+			BasefeeScalar:     100,
+			BlobBaseFeeScalar: 100,
+			L2ChainId:         big.NewInt(1105),
+			Opcm:              opcmImpl2,
+			SaltMixer:         "0x456",
+			GasLimit:          30000000,
+
+			DisputeGameType:              1,
+			DisputeAbsolutePrestate:      common.HexToHash("0x123"),
+			DisputeMaxGameDepth:          100,
+			DisputeSplitDepth:            100,
+			DisputeClockExtension:        100,
+			DisputeMaxClockDuration:      100,
+			AllowCustomDisputeParameters: true,
+
+			OperatorFeeScalar:   100,
+			OperatorFeeConstant: 100,
+		})
+
+		// Make sure it succeeded
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedOutput)
+
+		// Now make sure the addresses are the same
+		require.Equal(t, deprecatedOutput.OpChainProxyAdmin, output.OpChainProxyAdmin)
+		require.Equal(t, deprecatedOutput.AddressManager, output.AddressManager)
+		require.Equal(t, deprecatedOutput.L1ERC721BridgeProxy, output.L1ERC721BridgeProxy)
+		require.Equal(t, deprecatedOutput.SystemConfigProxy, output.SystemConfigProxy)
+		require.Equal(t, deprecatedOutput.OptimismMintableERC20FactoryProxy, output.OptimismMintableERC20FactoryProxy)
+		require.Equal(t, deprecatedOutput.L1StandardBridgeProxy, output.L1StandardBridgeProxy)
+		require.Equal(t, deprecatedOutput.L1CrossDomainMessengerProxy, output.L1CrossDomainMessengerProxy)
+		require.Equal(t, deprecatedOutput.OptimismPortalProxy, output.OptimismPortalProxy)
+		require.Equal(t, deprecatedOutput.ETHLockboxProxy, output.EthLockboxProxy)
+		require.Equal(t, deprecatedOutput.DisputeGameFactoryProxy, output.DisputeGameFactoryProxy)
+		require.Equal(t, deprecatedOutput.AnchorStateRegistryProxy, output.AnchorStateRegistryProxy)
+		require.Equal(t, deprecatedOutput.FaultDisputeGame, output.FaultDisputeGame)
+		require.Equal(t, deprecatedOutput.PermissionedDisputeGame, output.PermissionedDisputeGame)
+		require.Equal(t, deprecatedOutput.DelayedWETHPermissionedGameProxy, output.DelayedWETHPermissionedGameProxy)
+		require.Equal(t, deprecatedOutput.DelayedWETHPermissionlessGameProxy, output.DelayedWETHPermissionlessGameProxy)
+
+		// And just to be super sure we also compare the code deployed to the addresses
+		require.Equal(t, host2.GetCode(deprecatedOutput.OpChainProxyAdmin), host1.GetCode(output.OpChainProxyAdmin))
+		require.Equal(t, host2.GetCode(deprecatedOutput.AddressManager), host1.GetCode(output.AddressManager))
+		require.Equal(t, host2.GetCode(deprecatedOutput.L1ERC721BridgeProxy), host1.GetCode(output.L1ERC721BridgeProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.SystemConfigProxy), host1.GetCode(output.SystemConfigProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OptimismMintableERC20FactoryProxy), host1.GetCode(output.OptimismMintableERC20FactoryProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.L1StandardBridgeProxy), host1.GetCode(output.L1StandardBridgeProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.L1CrossDomainMessengerProxy), host1.GetCode(output.L1CrossDomainMessengerProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.OptimismPortalProxy), host1.GetCode(output.OptimismPortalProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.ETHLockboxProxy), host1.GetCode(output.EthLockboxProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.DisputeGameFactoryProxy), host1.GetCode(output.DisputeGameFactoryProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.AnchorStateRegistryProxy), host1.GetCode(output.AnchorStateRegistryProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.FaultDisputeGame), host1.GetCode(output.FaultDisputeGame))
+		require.Equal(t, host2.GetCode(deprecatedOutput.PermissionedDisputeGame), host1.GetCode(output.PermissionedDisputeGame))
+		require.Equal(t, host2.GetCode(deprecatedOutput.DelayedWETHPermissionedGameProxy), host1.GetCode(output.DelayedWETHPermissionedGameProxy))
+		require.Equal(t, host2.GetCode(deprecatedOutput.DelayedWETHPermissionlessGameProxy), host1.GetCode(output.DelayedWETHPermissionlessGameProxy))
+	})
+}

--- a/op-deployer/pkg/deployer/opcm/opchain2_test.go
+++ b/op-deployer/pkg/deployer/opcm/opchain2_test.go
@@ -1,47 +1,31 @@
 package opcm
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
-	"github.com/ethereum-optimism/optimism/op-chain-ops/script/addresses"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewDeployOPChainScript(t *testing.T) {
 	deployDependencies := func(host *script.Host) common.Address {
-		proxyAdminArtifact, err := host.Artifacts().ReadArtifact("ProxyAdmin.sol", "ProxyAdmin")
+		deploySuperchain, err := NewDeploySuperchainScript(host)
 		require.NoError(t, err)
 
-		encodedProxyAdmin, err := proxyAdminArtifact.ABI.Pack("", addresses.ScriptDeployer)
+		superchainOutput, err := deploySuperchain.Run(DeploySuperchain2Input{
+			Guardian:                   common.BigToAddress(big.NewInt(1)),
+			ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
+			SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
+			Paused:                     true,
+			RecommendedProtocolVersion: params.ProtocolVersion{1},
+			RequiredProtocolVersion:    params.ProtocolVersion{2},
+		})
 		require.NoError(t, err)
-
-		proxyAdminAddress, err := host.Create(addresses.ScriptDeployer, append(proxyAdminArtifact.Bytecode.Object, encodedProxyAdmin...))
-		require.NoError(t, err)
-
-		// Then we get a proxy deployed
-		proxyArtifact, err := host.Artifacts().ReadArtifact("Proxy.sol", "Proxy")
-		require.NoError(t, err)
-
-		encodedProxy, err := proxyArtifact.ABI.Pack("", proxyAdminAddress)
-		require.NoError(t, err)
-
-		proxyAddress, err := host.Create(addresses.ScriptDeployer, append(proxyArtifact.Bytecode.Object, encodedProxy...))
-		require.NoError(t, err)
-
-		// Then we get ProtocolVersions deployed
-		protocolVersionsArtifact, err := host.Artifacts().ReadArtifact("ProtocolVersions.sol", "ProtocolVersions")
-		require.NoError(t, err)
-
-		encodedProtocolVersions, err := protocolVersionsArtifact.ABI.Pack("")
-		require.NoError(t, err)
-
-		protocolVersionsAddress, err := host.Create(addresses.ScriptDeployer, append(protocolVersionsArtifact.Bytecode.Object, encodedProtocolVersions...))
-		require.NoError(t, err)
+		require.NotNil(t, superchainOutput)
 
 		deployImplementations, err := NewDeployImplementationsScript(host)
 		require.NoError(t, err)
@@ -55,25 +39,23 @@ func TestNewDeployOPChainScript(t *testing.T) {
 			DisputeGameFinalityDelaySeconds: big.NewInt(5),
 			MipsVersion:                     big.NewInt(mipsVersion),
 			L1ContractsRelease:              "dev-release",
-			SuperchainConfigProxy:           proxyAddress,
-			ProtocolVersionsProxy:           protocolVersionsAddress,
-			SuperchainProxyAdmin:            proxyAdminAddress,
+			SuperchainConfigProxy:           superchainOutput.SuperchainConfigProxy,
+			ProtocolVersionsProxy:           superchainOutput.ProtocolVersionsProxy,
+			SuperchainProxyAdmin:            superchainOutput.SuperchainProxyAdmin,
 			UpgradeController:               common.BigToAddress(big.NewInt(13)),
 		})
-
-		fmt.Printf("implementationsOutput: %+v\n", implementationsOutput)
 		require.NoError(t, err)
+		require.NotNil(t, implementationsOutput)
+
 		return implementationsOutput.Opcm
 	}
 	t.Run("should not fail with current version of DeployOPChain2 contract", func(t *testing.T) {
 		// First we grab a test host
 		host1 := createTestHost(t)
 
-		// We'll need some contracts already deployed for this to work
+		// We need Superchain and Implementations contracts deployed for this to work
 		opcmImpl := deployDependencies(host1)
 
-		// Then we load the script
-		//
 		// This would raise an error if the Go types didn't match the ABI
 		deployOPChain, err := NewDeployOPChainScript(host1)
 		require.NoError(t, err)
@@ -88,22 +70,22 @@ func TestNewDeployOPChainScript(t *testing.T) {
 			Challenger:             common.HexToAddress("0xfed"),
 
 			BasefeeScalar:     100,
-			BlobBaseFeeScalar: 100,
-			L2ChainId:         big.NewInt(1105),
+			BlobBaseFeeScalar: 200,
+			L2ChainId:         big.NewInt(300),
 			Opcm:              opcmImpl,
-			SaltMixer:         "0x456",
-			GasLimit:          30000000,
+			SaltMixer:         "defaultSaltMixer",
+			GasLimit:          60_000_000,
 
 			DisputeGameType:              1,
-			DisputeAbsolutePrestate:      common.HexToHash("0x123"),
-			DisputeMaxGameDepth:          big.NewInt(100),
-			DisputeSplitDepth:            big.NewInt(100),
-			DisputeClockExtension:        100,
-			DisputeMaxClockDuration:      100,
-			AllowCustomDisputeParameters: true,
+			DisputeAbsolutePrestate:      common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+			DisputeMaxGameDepth:          big.NewInt(73),
+			DisputeSplitDepth:            big.NewInt(30),
+			DisputeClockExtension:        uint64(3 * 60 * 60),
+			DisputeMaxClockDuration:      uint64(3.5 * 24 * 60 * 60),
+			AllowCustomDisputeParameters: false,
 
-			OperatorFeeScalar:   100,
-			OperatorFeeConstant: 100,
+			OperatorFeeScalar:   0,
+			OperatorFeeConstant: 0,
 		})
 
 		// And do some simple asserts
@@ -127,22 +109,22 @@ func TestNewDeployOPChainScript(t *testing.T) {
 			Challenger:             common.HexToAddress("0xfed"),
 
 			BasefeeScalar:     100,
-			BlobBaseFeeScalar: 100,
-			L2ChainId:         big.NewInt(1105),
+			BlobBaseFeeScalar: 200,
+			L2ChainId:         big.NewInt(300),
 			Opcm:              opcmImpl2,
-			SaltMixer:         "0x456",
-			GasLimit:          30000000,
+			SaltMixer:         "defaultSaltMixer",
+			GasLimit:          60_000_000,
 
 			DisputeGameType:              1,
-			DisputeAbsolutePrestate:      common.HexToHash("0x123"),
-			DisputeMaxGameDepth:          100,
-			DisputeSplitDepth:            100,
-			DisputeClockExtension:        100,
-			DisputeMaxClockDuration:      100,
-			AllowCustomDisputeParameters: true,
+			DisputeAbsolutePrestate:      common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+			DisputeMaxGameDepth:          uint64(73),
+			DisputeSplitDepth:            uint64(30),
+			DisputeClockExtension:        uint64(3 * 60 * 60),
+			DisputeMaxClockDuration:      uint64(3.5 * 24 * 60 * 60),
+			AllowCustomDisputeParameters: false,
 
-			OperatorFeeScalar:   100,
-			OperatorFeeConstant: 100,
+			OperatorFeeScalar:   0,
+			OperatorFeeConstant: 0,
 		})
 
 		// Make sure it succeeded

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
@@ -4,11 +4,8 @@ pragma solidity 0.8.15;
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";
 
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
-import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { Solarray } from "scripts/libraries/Solarray.sol";
+import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
+import { LibString } from "@solady/utils/LibString.sol";
+
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Constants } from "src/libraries/Constants.sol";
+import { Constants as ScriptConstants } from "scripts/libraries/Constants.sol";
+
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
+import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { Claim, Duration, GameType, GameTypes, Hash } from "src/dispute/lib/Types.sol";
+
+import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+
+contract DeployOPChain is Script {
+    struct Input {
+        address opChainProxyAdminOwner;
+        address systemConfigOwner;
+        address batcher;
+        address unsafeBlockSigner;
+        address proposer;
+        address challenger;
+
+        // TODO Add fault proofs inputs in a future PR.
+        uint32 basefeeScalar;
+        uint32 blobBaseFeeScalar;
+        uint256 l2ChainId;
+        IOPContractsManager opcm;
+        string saltMixer;
+        uint64 gasLimit;
+
+        // Configurable dispute game inputs
+        GameType disputeGameType;
+        Claim disputeAbsolutePrestate;
+        uint256 disputeMaxGameDepth;
+        uint256 disputeSplitDepth;
+        Duration disputeClockExtension;
+        Duration disputeMaxClockDuration;
+        bool allowCustomDisputeParameters;
+
+        uint32 operatorFeeScalar;
+        uint64 operatorFeeConstant;
+    }
+
+    struct Output {
+        IProxyAdmin opChainProxyAdmin;
+        IAddressManager addressManager;
+        IL1ERC721Bridge l1ERC721BridgeProxy;
+        ISystemConfig systemConfigProxy;
+        IOptimismMintableERC20Factory optimismMintableERC20FactoryProxy;
+        IL1StandardBridge l1StandardBridgeProxy;
+        IL1CrossDomainMessenger l1CrossDomainMessengerProxy;
+        IOptimismPortal optimismPortalProxy;
+        IETHLockbox ethLockboxProxy;
+        IDisputeGameFactory disputeGameFactoryProxy;
+        IAnchorStateRegistry anchorStateRegistryProxy;
+        IFaultDisputeGame faultDisputeGame;
+        IPermissionedDisputeGame permissionedDisputeGame;
+        IDelayedWETH delayedWETHPermissionedGameProxy;
+        IDelayedWETH delayedWETHPermissionlessGameProxy;
+    }
+
+    function run(Input memory _input) public returns (Output memory output_) {
+        bytes memory startingAnchorRoot = abi.encode(ScriptConstants.DEFAULT_OUTPUT_ROOT());
+
+        assertValidInput(_input);
+
+        IOPContractsManager opcm = _input.opcm;
+
+        IOPContractsManager.Roles memory roles = IOPContractsManager.Roles({
+            opChainProxyAdminOwner: _input.opChainProxyAdminOwner,
+            systemConfigOwner: _input.systemConfigOwner,
+            batcher: _input.batcher,
+            unsafeBlockSigner: _input.unsafeBlockSigner,
+            proposer: _input.proposer,
+            challenger: _input.challenger
+        });
+        IOPContractsManager.DeployInput memory deployInput = IOPContractsManager.DeployInput({
+            roles: roles,
+            basefeeScalar: _input.basefeeScalar,
+            blobBasefeeScalar: _input.blobBaseFeeScalar,
+            l2ChainId: _input.l2ChainId,
+            startingAnchorRoot: startingAnchorRoot,
+            saltMixer: _input.saltMixer,
+            gasLimit: _input.gasLimit,
+            disputeGameType: _input.disputeGameType,
+            disputeAbsolutePrestate: _input.disputeAbsolutePrestate,
+            disputeMaxGameDepth: _input.disputeMaxGameDepth,
+            disputeSplitDepth: _input.disputeSplitDepth,
+            disputeClockExtension: _input.disputeClockExtension,
+            disputeMaxClockDuration: _input.disputeMaxClockDuration
+        });
+
+        vm.broadcast(msg.sender);
+        IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
+
+        output_ = Output({
+            opChainProxyAdmin: deployOutput.opChainProxyAdmin,
+            addressManager: deployOutput.addressManager,
+            l1ERC721BridgeProxy: deployOutput.l1ERC721BridgeProxy,
+            systemConfigProxy: deployOutput.systemConfigProxy,
+            optimismMintableERC20FactoryProxy: deployOutput.optimismMintableERC20FactoryProxy,
+            l1StandardBridgeProxy: deployOutput.l1StandardBridgeProxy,
+            l1CrossDomainMessengerProxy: deployOutput.l1CrossDomainMessengerProxy,
+            optimismPortalProxy: deployOutput.optimismPortalProxy,
+            ethLockboxProxy: deployOutput.ethLockboxProxy,
+            disputeGameFactoryProxy: deployOutput.disputeGameFactoryProxy,
+            anchorStateRegistryProxy: deployOutput.anchorStateRegistryProxy,
+            faultDisputeGame: deployOutput.faultDisputeGame,
+            permissionedDisputeGame: deployOutput.permissionedDisputeGame,
+            delayedWETHPermissionedGameProxy: deployOutput.delayedWETHPermissionedGameProxy,
+            delayedWETHPermissionlessGameProxy: deployOutput.delayedWETHPermissionlessGameProxy
+        });
+
+        vm.label(address(output_.opChainProxyAdmin), "opChainProxyAdmin");
+        vm.label(address(output_.addressManager), "addressManager");
+        vm.label(address(output_.l1ERC721BridgeProxy), "l1ERC721BridgeProxy");
+        vm.label(address(output_.systemConfigProxy), "systemConfigProxy");
+        vm.label(address(output_.optimismMintableERC20FactoryProxy), "optimismMintableERC20FactoryProxy");
+        vm.label(address(output_.l1StandardBridgeProxy), "l1StandardBridgeProxy");
+        vm.label(address(output_.l1CrossDomainMessengerProxy), "l1CrossDomainMessengerProxy");
+        vm.label(address(output_.optimismPortalProxy), "optimismPortalProxy");
+        vm.label(address(output_.ethLockboxProxy), "ethLockboxProxy");
+        vm.label(address(output_.disputeGameFactoryProxy), "disputeGameFactoryProxy");
+        vm.label(address(output_.anchorStateRegistryProxy), "anchorStateRegistryProxy");
+        // vm.label(address(output_.faultDisputeGame), "faultDisputeGame");
+        vm.label(address(output_.permissionedDisputeGame), "permissionedDisputeGame");
+        vm.label(address(output_.delayedWETHPermissionedGameProxy), "delayedWETHPermissionedGameProxy");
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // vm.label(address(output_.delayedWETHPermissionlessGameProxy), "delayedWETHPermissionlessGameProxy");
+
+        assertValidOutput(_input, output_);
+    }
+
+    function assertValidInput(Input memory _input) private pure {
+        require(_input.opChainProxyAdminOwner != address(0), "DeployOPChain: opChainProxyAdminOwner not set");
+        require(_input.systemConfigOwner != address(0), "DeployOPChain: systemConfigOwner not set");
+        require(_input.batcher != address(0), "DeployOPChain: batcher not set");
+        require(_input.unsafeBlockSigner != address(0), "DeployOPChain: unsafeBlockSigner not set");
+        require(_input.proposer != address(0), "DeployOPChain: proposer not set");
+        require(_input.challenger != address(0), "DeployOPChain: challenger not set");
+        require(_input.basefeeScalar != 0, "DeployOPChain: basefeeScalar not set");
+        require(_input.blobBaseFeeScalar != 0, "DeployOPChain: blobBaseFeeScalar not set");
+        require(_input.l2ChainId != 0, "DeployOPChain: l2ChainId not set");
+        require(address(_input.opcm) != address(0), "DeployOPChain: opcm not set");
+        require(!LibString.eq(_input.saltMixer, ""), "DeployOPChain: saltMixer not set");
+        require(_input.gasLimit != 0, "DeployOPChain: gasLimit not set");
+
+        require(_input.disputeMaxGameDepth != 0, "DeployOPChain: disputeMaxGameDepth not set");
+        require(_input.disputeSplitDepth != 0, "DeployOPChain: disputeSplitDepth not set");
+        require(Duration.unwrap(_input.disputeClockExtension) != 0, "DeployOPChain: disputeClockExtension not set");
+        require(Duration.unwrap(_input.disputeMaxClockDuration) != 0, "DeployOPChain: disputeMaxClockDuration not set");
+
+        require(_input.operatorFeeScalar != 0, "DeployOPChain: operatorFeeScalar not set");
+        require(_input.operatorFeeConstant != 0, "DeployOPChain: operatorFeeConstant not set");
+    }
+
+    function assertValidOutput(Input memory _input, Output memory _output) public {
+        // With 16 addresses, we'd get a stack too deep error if we tried to do this inline as a
+        // single call to `Solarray.addresses`. So we split it into two calls.
+        address[] memory addrs1 = Solarray.addresses(
+            address(_output.opChainProxyAdmin),
+            address(_output.addressManager),
+            address(_output.l1ERC721BridgeProxy),
+            address(_output.systemConfigProxy),
+            address(_output.optimismMintableERC20FactoryProxy),
+            address(_output.l1StandardBridgeProxy),
+            address(_output.l1CrossDomainMessengerProxy)
+        );
+        address[] memory addrs2 = Solarray.addresses(
+            address(_output.optimismPortalProxy),
+            address(_output.disputeGameFactoryProxy),
+            address(_output.anchorStateRegistryProxy),
+            address(_output.permissionedDisputeGame),
+            //address(_output.faultDisputeGame),
+            address(_output.delayedWETHPermissionedGameProxy),
+            address(_output.ethLockboxProxy)
+        );
+        // TODO: Eventually switch from Permissioned to Permissionless. Add this address back in.
+        // address(_delayedWETHPermissionlessGameProxy)
+
+        DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
+        assertValidDeploy(_input, _output);
+    }
+
+    // -------- Deployment Assertions --------
+    function assertValidDeploy(Input memory _input, Output memory _output) internal {
+        assertValidAnchorStateRegistryProxy(_input, _output);
+        assertValidDelayedWETH(_input, _output);
+        assertValidDisputeGameFactory(_input, _output);
+        assertValidL1CrossDomainMessenger(_output);
+        assertValidL1ERC721Bridge(_output);
+        assertValidL1StandardBridge(_output);
+        assertValidOptimismMintableERC20Factory(_output);
+        assertValidOptimismPortal(_input, _output);
+        assertValidETHLockbox(_input, _output);
+        assertValidPermissionedDisputeGame(_input, _output);
+        assertValidSystemConfig(_input, _output);
+        assertValidAddressManager(_input, _output);
+        assertValidOPChainProxyAdmin(_input, _output);
+    }
+
+    function assertValidPermissionedDisputeGame(Input memory _input, Output memory _output) internal {
+        IPermissionedDisputeGame game = _output.permissionedDisputeGame;
+
+        require(GameType.unwrap(game.gameType()) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON), "DPG-10");
+
+        if (_input.allowCustomDisputeParameters) {
+            return;
+        }
+
+        // This hex string is the absolutePrestate of the latest op-program release, see where the
+        // `EXPECTED_PRESTATE_HASH` is defined in `config.yml`.
+        require(
+            Claim.unwrap(game.absolutePrestate())
+                == bytes32(hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+            "DPG-20"
+        );
+
+        IOPContractsManager opcm = _input.opcm;
+        address mipsImpl = opcm.implementations().mipsImpl;
+        require(game.vm() == IBigStepper(mipsImpl), "DPG-30");
+
+        require(address(game.weth()) == address(_output.delayedWETHPermissionedGameProxy), "DPG-40");
+        require(address(game.anchorStateRegistry()) == address(_output.anchorStateRegistryProxy), "DPG-50");
+        require(game.l2ChainId() == _input.l2ChainId, "DPG-60");
+        require(game.l2BlockNumber() == 0, "DPG-70");
+        require(Duration.unwrap(game.clockExtension()) == 10800, "DPG-80");
+        require(Duration.unwrap(game.maxClockDuration()) == 302400, "DPG-110");
+        require(game.splitDepth() == 30, "DPG-90");
+        require(game.maxGameDepth() == 73, "DPG-100");
+    }
+
+    function assertValidAnchorStateRegistryProxy(Input memory _input, Output memory _output) internal {
+        // First we check the proxy as itself.
+        IProxy proxy = IProxy(payable(address(_output.anchorStateRegistryProxy)));
+        vm.prank(address(0));
+        address admin = proxy.admin();
+        require(admin == address(_output.opChainProxyAdmin), "ANCHORP-10");
+
+        // Then we check the proxy as ASR.
+        DeployUtils.assertInitialized({
+            _contractAddress: address(_output.anchorStateRegistryProxy),
+            _isProxy: true,
+            _slot: 0,
+            _offset: 0
+        });
+
+        require(
+            address(_output.anchorStateRegistryProxy.disputeGameFactory()) == address(_output.disputeGameFactoryProxy),
+            "ANCHORP-30"
+        );
+
+        (Hash actualRoot,) = _output.anchorStateRegistryProxy.anchors(GameTypes.PERMISSIONED_CANNON);
+        bytes32 expectedRoot = 0xdead000000000000000000000000000000000000000000000000000000000000;
+        require(Hash.unwrap(actualRoot) == expectedRoot, "ANCHORP-40");
+    }
+
+    function assertValidSystemConfig(Input memory _input, Output memory _output) internal {
+        ISystemConfig systemConfig = _output.systemConfigProxy;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });
+
+        require(systemConfig.owner() == _input.systemConfigOwner, "SYSCON-10");
+        require(systemConfig.basefeeScalar() == _input.basefeeScalar, "SYSCON-20");
+        require(systemConfig.blobbasefeeScalar() == _input.blobBaseFeeScalar, "SYSCON-30");
+        require(systemConfig.batcherHash() == bytes32(uint256(uint160(_input.batcher))), "SYSCON-40");
+        require(systemConfig.gasLimit() == uint64(60_000_000), "SYSCON-50");
+        require(systemConfig.unsafeBlockSigner() == _input.unsafeBlockSigner, "SYSCON-60");
+        require(systemConfig.scalar() >> 248 == 1, "SYSCON-70");
+
+        IResourceMetering.ResourceConfig memory rConfig = Constants.DEFAULT_RESOURCE_CONFIG();
+        IResourceMetering.ResourceConfig memory outputConfig = systemConfig.resourceConfig();
+        require(outputConfig.maxResourceLimit == rConfig.maxResourceLimit, "SYSCON-80");
+        require(outputConfig.elasticityMultiplier == rConfig.elasticityMultiplier, "SYSCON-90");
+        require(outputConfig.baseFeeMaxChangeDenominator == rConfig.baseFeeMaxChangeDenominator, "SYSCON-100");
+        require(outputConfig.systemTxMaxGas == rConfig.systemTxMaxGas, "SYSCON-110");
+        require(outputConfig.minimumBaseFee == rConfig.minimumBaseFee, "SYSCON-120");
+        require(outputConfig.maximumBaseFee == rConfig.maximumBaseFee, "SYSCON-130");
+
+        require(systemConfig.startBlock() == block.number, "SYSCON-140");
+        require(systemConfig.batchInbox() == _input.opcm.chainIdToBatchInboxAddress(_input.l2ChainId), "SYSCON-150");
+
+        require(systemConfig.l1CrossDomainMessenger() == address(_output.l1CrossDomainMessengerProxy), "SYSCON-160");
+        require(systemConfig.l1ERC721Bridge() == address(_output.l1ERC721BridgeProxy), "SYSCON-170");
+        require(systemConfig.l1StandardBridge() == address(_output.l1StandardBridgeProxy), "SYSCON-180");
+        require(systemConfig.optimismPortal() == address(_output.optimismPortalProxy), "SYSCON-190");
+        require(
+            systemConfig.optimismMintableERC20Factory() == address(_output.optimismMintableERC20FactoryProxy),
+            "SYSCON-200"
+        );
+    }
+
+    function assertValidL1CrossDomainMessenger(Output memory _output) internal {
+        IL1CrossDomainMessenger messenger = _output.l1CrossDomainMessengerProxy;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(messenger), _isProxy: true, _slot: 0, _offset: 20 });
+
+        require(address(messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L1xDM-10");
+        require(address(messenger.otherMessenger()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L1xDM-20");
+
+        require(address(messenger.PORTAL()) == address(_output.optimismPortalProxy), "L1xDM-30");
+        require(address(messenger.portal()) == address(_output.optimismPortalProxy), "L1xDM-40");
+        require(address(messenger.systemConfig()) == address(_output.systemConfigProxy), "L1xDM-50");
+
+        bytes32 xdmSenderSlot = vm.load(address(messenger), bytes32(uint256(204)));
+        require(address(uint160(uint256(xdmSenderSlot))) == Constants.DEFAULT_L2_SENDER, "L1xDM-60");
+    }
+
+    function assertValidL1StandardBridge(Output memory _output) internal {
+        IL1StandardBridge bridge = _output.l1StandardBridgeProxy;
+        IL1CrossDomainMessenger messenger = _output.l1CrossDomainMessengerProxy;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(bridge), _isProxy: true, _slot: 0, _offset: 0 });
+
+        require(address(bridge.MESSENGER()) == address(messenger), "L1SB-10");
+        require(address(bridge.messenger()) == address(messenger), "L1SB-20");
+        require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_STANDARD_BRIDGE, "L1SB-30");
+        require(address(bridge.otherBridge()) == Predeploys.L2_STANDARD_BRIDGE, "L1SB-40");
+        require(address(bridge.systemConfig()) == address(_output.systemConfigProxy), "L1SB-50");
+    }
+
+    function assertValidOptimismMintableERC20Factory(Output memory _output) internal {
+        IOptimismMintableERC20Factory factory = _output.optimismMintableERC20FactoryProxy;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(factory), _isProxy: true, _slot: 0, _offset: 0 });
+
+        require(factory.BRIDGE() == address(_output.l1StandardBridgeProxy), "MERC20F-10");
+        require(factory.bridge() == address(_output.l1StandardBridgeProxy), "MERC20F-20");
+    }
+
+    function assertValidL1ERC721Bridge(Output memory _output) internal {
+        IL1ERC721Bridge bridge = _output.l1ERC721BridgeProxy;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(bridge), _isProxy: true, _slot: 0, _offset: 0 });
+
+        require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE, "L721B-10");
+        require(address(bridge.otherBridge()) == Predeploys.L2_ERC721_BRIDGE, "L721B-20");
+
+        require(address(bridge.MESSENGER()) == address(_output.l1CrossDomainMessengerProxy), "L721B-30");
+        require(address(bridge.messenger()) == address(_output.l1CrossDomainMessengerProxy), "L721B-40");
+        require(address(bridge.systemConfig()) == address(_output.systemConfigProxy), "L721B-50");
+    }
+
+    function assertValidOptimismPortal(Input memory _input, Output memory _output) internal {
+        IOptimismPortal portal = _output.optimismPortalProxy;
+        ISuperchainConfig superchainConfig = ISuperchainConfig(address(_input.opcm.superchainConfig()));
+
+        require(address(portal.anchorStateRegistry()) == address(_output.anchorStateRegistryProxy), "PORTAL-10");
+        require(address(portal.disputeGameFactory()) == address(_output.disputeGameFactoryProxy), "PORTAL-20");
+        require(address(portal.systemConfig()) == address(_output.systemConfigProxy), "PORTAL-30");
+        require(address(portal.superchainConfig()) == address(superchainConfig), "PORTAL-40");
+        require(portal.guardian() == superchainConfig.guardian(), "PORTAL-50");
+        require(portal.paused() == portal.systemConfig().paused(), "PORTAL-60");
+        require(portal.l2Sender() == Constants.DEFAULT_L2_SENDER, "PORTAL-70");
+
+        // This slot is the custom gas token _balance and this check ensures
+        // that it stays unset for forwards compatibility with custom gas token.
+        require(vm.load(address(portal), bytes32(uint256(61))) == bytes32(0), "PORTAL-80");
+
+        // Check once the portal is updated to use the new lockbox.
+        require(address(portal.ethLockbox()) == address(_output.ethLockboxProxy), "PORTAL-90");
+        require(portal.proxyAdminOwner() == _input.opChainProxyAdminOwner, "PORTAL-100");
+    }
+
+    function assertValidETHLockbox(Input memory _input, Output memory _output) internal {
+        IETHLockbox lockbox = _output.ethLockboxProxy();
+
+        require(address(lockbox.systemConfig()) == address(_output.systemConfigProxy), "ETHLOCKBOX-10");
+        require(lockbox.authorizedPortals(_output.optimismPortalProxy), "ETHLOCKBOX-20");
+        require(lockbox.proxyAdminOwner() == _input.opChainProxyAdminOwner, "ETHLOCKBOX-30");
+    }
+
+    function assertValidDisputeGameFactory(Input memory _input, Output memory _output) internal {
+        IDisputeGameFactory factory = _output.disputeGameFactoryProxy;
+
+        DeployUtils.assertInitialized({ _contractAddress: address(factory), _isProxy: true, _slot: 0, _offset: 0 });
+
+        require(
+            address(factory.gameImpls(GameTypes.PERMISSIONED_CANNON)) == address(_output.permissionedDisputeGame),
+            "DF-10"
+        );
+        require(factory.owner() == _input.opChainProxyAdminOwner, "DF-20");
+    }
+
+    function assertValidDelayedWETH(Input memory _input, Output memory _output) internal {
+        IDelayedWETH permissioned = _output.delayedWETHPermissionedGameProxy;
+
+        require(permissioned.proxyAdminOwner() == _input.opChainProxyAdminOwner, "DWETH-10");
+
+        IProxy proxy = IProxy(payable(address(permissioned)));
+        vm.prank(address(0));
+        address admin = proxy.admin();
+        require(admin == address(_output.opChainProxyAdmin), "DWETH-20");
+    }
+
+    function assertValidAddressManager(Input memory _input, Output memory _output) internal view {
+        require(_output.addressManager.owner() == _input.opChainProxyAdminOwner, "AM-10");
+    }
+
+    function assertValidOPChainProxyAdmin(Input memory _input, Output memory _output) internal {
+        IProxyAdmin admin = _output.opChainProxyAdmin;
+        require(admin.owner() == _input.opChainProxyAdminOwner, "OPCPA-10");
+        require(
+            admin.getProxyImplementation(address(_output.l1CrossDomainMessengerProxy))
+                == DeployUtils.assertResolvedDelegateProxyImplementationSet(
+                    "OVM_L1CrossDomainMessenger", _output.addressManager
+                ),
+            "OPCPA-20"
+        );
+        require(address(admin.addressManager) == address(_output.addressManager), "OPCPA-30");
+        require(
+            admin.getProxyImplementation(address(_output.l1StandardBridgeProxy))
+                == DeployUtils.assertL1ChugSplashImplementationSet(address(_output.l1StandardBridgeProxy)),
+            "OPCPA-40"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.l1ERC721BridgeProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.l1ERC721BridgeProxy)),
+            "OPCPA-50"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.optimismPortalProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.optimismPortalProxy)),
+            "OPCPA-60"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.systemConfigProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.systemConfigProxy)),
+            "OPCPA-70"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.optimismMintableERC20FactoryProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.optimismMintableERC20FactoryProxy)),
+            "OPCPA-80"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.disputeGameFactoryProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.disputeGameFactoryProxy)),
+            "OPCPA-90"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.delayedWETHPermissionedGameProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.delayedWETHPermissionedGameProxy)),
+            "OPCPA-100"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.anchorStateRegistryProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.anchorStateRegistryProxy)),
+            "OPCPA-110"
+        );
+        require(
+            admin.getProxyImplementation(address(_output.ethLockboxProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_output.ethLockboxProxy)),
+            "OPCPA-120"
+        );
+    }
+
+    // -------- Utilities --------
+
+    function etchIOContracts() public returns (Input memory input_, Output memory output_) {
+        (input_, output_) = getIOContracts();
+        vm.etch(address(input_), type(Input).runtimeCode);
+        vm.etch(address(output_), type(Output).runtimeCode);
+    }
+
+    function getIOContracts() public view returns (Input memory input_, Output memory output_) {
+        input_ = Input(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainInput"));
+        output_ = Output(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainOutput"));
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
+import { console2 as console } from "forge-std/console2.sol";
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
@@ -36,7 +37,7 @@ import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
-contract DeployOPChain is Script {
+contract DeployOPChain2 is Script {
     struct Input {
         address opChainProxyAdminOwner;
         address systemConfigOwner;
@@ -44,7 +45,6 @@ contract DeployOPChain is Script {
         address unsafeBlockSigner;
         address proposer;
         address challenger;
-
         // TODO Add fault proofs inputs in a future PR.
         uint32 basefeeScalar;
         uint32 blobBaseFeeScalar;
@@ -52,7 +52,6 @@ contract DeployOPChain is Script {
         IOPContractsManager opcm;
         string saltMixer;
         uint64 gasLimit;
-
         // Configurable dispute game inputs
         GameType disputeGameType;
         Claim disputeAbsolutePrestate;
@@ -61,7 +60,6 @@ contract DeployOPChain is Script {
         Duration disputeClockExtension;
         Duration disputeMaxClockDuration;
         bool allowCustomDisputeParameters;
-
         uint32 operatorFeeScalar;
         uint64 operatorFeeConstant;
     }
@@ -85,9 +83,11 @@ contract DeployOPChain is Script {
     }
 
     function run(Input memory _input) public returns (Output memory output_) {
+        console.log("DeployOPChain2.run initiated");
         bytes memory startingAnchorRoot = abi.encode(ScriptConstants.DEFAULT_OUTPUT_ROOT());
 
         assertValidInput(_input);
+        console.log("Confirmed valid input");
 
         IOPContractsManager opcm = _input.opcm;
 
@@ -117,6 +117,7 @@ contract DeployOPChain is Script {
 
         vm.broadcast(msg.sender);
         IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
+        console.log("opcm.deploy complete");
 
         output_ = Output({
             opChainProxyAdmin: deployOutput.opChainProxyAdmin,
@@ -179,7 +180,7 @@ contract DeployOPChain is Script {
         require(_input.operatorFeeConstant != 0, "DeployOPChain: operatorFeeConstant not set");
     }
 
-    function assertValidOutput(Input memory _input, Output memory _output) public {
+    function assertValidOutput(Input memory _input, Output memory _output) private {
         // With 16 addresses, we'd get a stack too deep error if we tried to do this inline as a
         // single call to `Solarray.addresses`. So we split it into two calls.
         address[] memory addrs1 = Solarray.addresses(
@@ -208,8 +209,8 @@ contract DeployOPChain is Script {
     }
 
     // -------- Deployment Assertions --------
-    function assertValidDeploy(Input memory _input, Output memory _output) internal {
-        assertValidAnchorStateRegistryProxy(_input, _output);
+    function assertValidDeploy(Input memory _input, Output memory _output) private {
+        assertValidAnchorStateRegistryProxy(_output);
         assertValidDelayedWETH(_input, _output);
         assertValidDisputeGameFactory(_input, _output);
         assertValidL1CrossDomainMessenger(_output);
@@ -224,7 +225,7 @@ contract DeployOPChain is Script {
         assertValidOPChainProxyAdmin(_input, _output);
     }
 
-    function assertValidPermissionedDisputeGame(Input memory _input, Output memory _output) internal {
+    function assertValidPermissionedDisputeGame(Input memory _input, Output memory _output) private view {
         IPermissionedDisputeGame game = _output.permissionedDisputeGame;
 
         require(GameType.unwrap(game.gameType()) == GameType.unwrap(GameTypes.PERMISSIONED_CANNON), "DPG-10");
@@ -255,7 +256,7 @@ contract DeployOPChain is Script {
         require(game.maxGameDepth() == 73, "DPG-100");
     }
 
-    function assertValidAnchorStateRegistryProxy(Input memory _input, Output memory _output) internal {
+    function assertValidAnchorStateRegistryProxy(Output memory _output) private {
         // First we check the proxy as itself.
         IProxy proxy = IProxy(payable(address(_output.anchorStateRegistryProxy)));
         vm.prank(address(0));
@@ -280,7 +281,7 @@ contract DeployOPChain is Script {
         require(Hash.unwrap(actualRoot) == expectedRoot, "ANCHORP-40");
     }
 
-    function assertValidSystemConfig(Input memory _input, Output memory _output) internal {
+    function assertValidSystemConfig(Input memory _input, Output memory _output) private view {
         ISystemConfig systemConfig = _output.systemConfigProxy;
 
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });
@@ -315,7 +316,7 @@ contract DeployOPChain is Script {
         );
     }
 
-    function assertValidL1CrossDomainMessenger(Output memory _output) internal {
+    function assertValidL1CrossDomainMessenger(Output memory _output) private view {
         IL1CrossDomainMessenger messenger = _output.l1CrossDomainMessengerProxy;
 
         DeployUtils.assertInitialized({ _contractAddress: address(messenger), _isProxy: true, _slot: 0, _offset: 20 });
@@ -331,7 +332,7 @@ contract DeployOPChain is Script {
         require(address(uint160(uint256(xdmSenderSlot))) == Constants.DEFAULT_L2_SENDER, "L1xDM-60");
     }
 
-    function assertValidL1StandardBridge(Output memory _output) internal {
+    function assertValidL1StandardBridge(Output memory _output) private view {
         IL1StandardBridge bridge = _output.l1StandardBridgeProxy;
         IL1CrossDomainMessenger messenger = _output.l1CrossDomainMessengerProxy;
 
@@ -344,7 +345,7 @@ contract DeployOPChain is Script {
         require(address(bridge.systemConfig()) == address(_output.systemConfigProxy), "L1SB-50");
     }
 
-    function assertValidOptimismMintableERC20Factory(Output memory _output) internal {
+    function assertValidOptimismMintableERC20Factory(Output memory _output) private view {
         IOptimismMintableERC20Factory factory = _output.optimismMintableERC20FactoryProxy;
 
         DeployUtils.assertInitialized({ _contractAddress: address(factory), _isProxy: true, _slot: 0, _offset: 0 });
@@ -353,7 +354,7 @@ contract DeployOPChain is Script {
         require(factory.bridge() == address(_output.l1StandardBridgeProxy), "MERC20F-20");
     }
 
-    function assertValidL1ERC721Bridge(Output memory _output) internal {
+    function assertValidL1ERC721Bridge(Output memory _output) private view {
         IL1ERC721Bridge bridge = _output.l1ERC721BridgeProxy;
 
         DeployUtils.assertInitialized({ _contractAddress: address(bridge), _isProxy: true, _slot: 0, _offset: 0 });
@@ -366,7 +367,7 @@ contract DeployOPChain is Script {
         require(address(bridge.systemConfig()) == address(_output.systemConfigProxy), "L721B-50");
     }
 
-    function assertValidOptimismPortal(Input memory _input, Output memory _output) internal {
+    function assertValidOptimismPortal(Input memory _input, Output memory _output) private view {
         IOptimismPortal portal = _output.optimismPortalProxy;
         ISuperchainConfig superchainConfig = ISuperchainConfig(address(_input.opcm.superchainConfig()));
 
@@ -387,15 +388,15 @@ contract DeployOPChain is Script {
         require(portal.proxyAdminOwner() == _input.opChainProxyAdminOwner, "PORTAL-100");
     }
 
-    function assertValidETHLockbox(Input memory _input, Output memory _output) internal {
-        IETHLockbox lockbox = _output.ethLockboxProxy();
+    function assertValidETHLockbox(Input memory _input, Output memory _output) private view {
+        IETHLockbox lockbox = _output.ethLockboxProxy;
 
         require(address(lockbox.systemConfig()) == address(_output.systemConfigProxy), "ETHLOCKBOX-10");
         require(lockbox.authorizedPortals(_output.optimismPortalProxy), "ETHLOCKBOX-20");
         require(lockbox.proxyAdminOwner() == _input.opChainProxyAdminOwner, "ETHLOCKBOX-30");
     }
 
-    function assertValidDisputeGameFactory(Input memory _input, Output memory _output) internal {
+    function assertValidDisputeGameFactory(Input memory _input, Output memory _output) private view {
         IDisputeGameFactory factory = _output.disputeGameFactoryProxy;
 
         DeployUtils.assertInitialized({ _contractAddress: address(factory), _isProxy: true, _slot: 0, _offset: 0 });
@@ -407,7 +408,7 @@ contract DeployOPChain is Script {
         require(factory.owner() == _input.opChainProxyAdminOwner, "DF-20");
     }
 
-    function assertValidDelayedWETH(Input memory _input, Output memory _output) internal {
+    function assertValidDelayedWETH(Input memory _input, Output memory _output) private {
         IDelayedWETH permissioned = _output.delayedWETHPermissionedGameProxy;
 
         require(permissioned.proxyAdminOwner() == _input.opChainProxyAdminOwner, "DWETH-10");
@@ -418,11 +419,11 @@ contract DeployOPChain is Script {
         require(admin == address(_output.opChainProxyAdmin), "DWETH-20");
     }
 
-    function assertValidAddressManager(Input memory _input, Output memory _output) internal view {
+    function assertValidAddressManager(Input memory _input, Output memory _output) private view {
         require(_output.addressManager.owner() == _input.opChainProxyAdminOwner, "AM-10");
     }
 
-    function assertValidOPChainProxyAdmin(Input memory _input, Output memory _output) internal {
+    function assertValidOPChainProxyAdmin(Input memory _input, Output memory _output) private {
         IProxyAdmin admin = _output.opChainProxyAdmin;
         require(admin.owner() == _input.opChainProxyAdminOwner, "OPCPA-10");
         require(
@@ -432,7 +433,7 @@ contract DeployOPChain is Script {
                 ),
             "OPCPA-20"
         );
-        require(address(admin.addressManager) == address(_output.addressManager), "OPCPA-30");
+        require(address(admin.addressManager()) == address(_output.addressManager), "OPCPA-30");
         require(
             admin.getProxyImplementation(address(_output.l1StandardBridgeProxy))
                 == DeployUtils.assertL1ChugSplashImplementationSet(address(_output.l1StandardBridgeProxy)),
@@ -478,18 +479,5 @@ contract DeployOPChain is Script {
                 == DeployUtils.assertERC1967ImplementationSet(address(_output.ethLockboxProxy)),
             "OPCPA-120"
         );
-    }
-
-    // -------- Utilities --------
-
-    function etchIOContracts() public returns (Input memory input_, Output memory output_) {
-        (input_, output_) = getIOContracts();
-        vm.etch(address(input_), type(Input).runtimeCode);
-        vm.etch(address(output_), type(Output).runtimeCode);
-    }
-
-    function getIOContracts() public view returns (Input memory input_, Output memory output_) {
-        input_ = Input(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainInput"));
-        output_ = Output(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainOutput"));
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain2.s.sol
@@ -175,9 +175,6 @@ contract DeployOPChain2 is Script {
         require(_input.disputeSplitDepth != 0, "DeployOPChain: disputeSplitDepth not set");
         require(Duration.unwrap(_input.disputeClockExtension) != 0, "DeployOPChain: disputeClockExtension not set");
         require(Duration.unwrap(_input.disputeMaxClockDuration) != 0, "DeployOPChain: disputeMaxClockDuration not set");
-
-        require(_input.operatorFeeScalar != 0, "DeployOPChain: operatorFeeScalar not set");
-        require(_input.operatorFeeConstant != 0, "DeployOPChain: operatorFeeConstant not set");
     }
 
     function assertValidOutput(Input memory _input, Output memory _output) private {
@@ -221,7 +218,7 @@ contract DeployOPChain2 is Script {
         assertValidETHLockbox(_input, _output);
         assertValidPermissionedDisputeGame(_input, _output);
         assertValidSystemConfig(_input, _output);
-        assertValidAddressManager(_input, _output);
+        assertValidAddressManager(_output);
         assertValidOPChainProxyAdmin(_input, _output);
     }
 
@@ -419,8 +416,8 @@ contract DeployOPChain2 is Script {
         require(admin == address(_output.opChainProxyAdmin), "DWETH-20");
     }
 
-    function assertValidAddressManager(Input memory _input, Output memory _output) private view {
-        require(_output.addressManager.owner() == _input.opChainProxyAdminOwner, "AM-10");
+    function assertValidAddressManager(Output memory _output) private view {
+        require(_output.addressManager.owner() == address(_output.opChainProxyAdmin), "AM-10");
     }
 
     function assertValidOPChainProxyAdmin(Input memory _input, Output memory _output) private {


### PR DESCRIPTION
This pr creates DeployOPChain2.s.sol, which lives alongside DeployOPChain.s.sol. There is a go test suite in op-deployer that invokes this new script and proves equivalent output between the two versions of that solidity script. A future pr will swap usage from the legacy DeployOPChain.s.sol to the new DeployOPChain2.s.sol, at which point we can remove the legacy version.