### PR TITLE
op-supervisor: include chain id at logs in resuming from sealed block

### DIFF
--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -219,7 +219,7 @@ func (db *ChainsDB) ResumeFromLastSealedBlock() error {
 			db.logger.Info("Resuming, but found no DB contents", "chain", chain)
 			return true
 		}
-		db.logger.Info("Resuming, starting from last sealed block", "head", head)
+		db.logger.Info("Resuming, starting from last sealed block", "chain", chain, "head", head)
 		if err := logStore.Rewind(head); err != nil {
 			result = fmt.Errorf("%w: failed to rewind chain %s to sealed block %d", errRewindFailed, chain, head)
 			return false


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Better to log chain id as well.