### PR TITLE
cannon: Noop mprotect syscall

### DIFF
--- a/cannon/mipsevm/arch/arch64.go
+++ b/cannon/mipsevm/arch/arch64.go
@@ -50,6 +50,7 @@ const (
 	UndefinedSysNr = ^Word(0)
 
 	SysMunmap        = 5011
+	SysMprotect      = 5010
 	SysGetAffinity   = 5196
 	SysMadvise       = 5027
 	SysRtSigprocmask = 5014

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -76,6 +76,7 @@ type Metadata interface {
 type FeatureToggles struct {
 	SupportNoopSysEventFd2 bool
 	SupportDclzDclo        bool
+	SupportNoopMprotect    bool
 }
 
 type FPVM interface {

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -159,6 +159,10 @@ func (m *InstrumentedState) handleSyscall() error {
 		v0 = 0
 		v1 = 0
 	case arch.SysMunmap:
+	case arch.SysMprotect:
+		if !m.features.SupportNoopMprotect {
+			m.handleUnrecognizedSyscall(syscallNum)
+		}
 	case arch.SysGetAffinity:
 	case arch.SysMadvise:
 	case arch.SysRtSigprocmask:

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -442,6 +442,7 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 
 var NoopSyscalls64 = map[string]uint32{
 	"SysMunmap":        5011,
+	"SysMprotect":      5010,
 	"SysGetAffinity":   5196,
 	"SysMadvise":       5027,
 	"SysRtSigprocmask": 5014,
@@ -483,6 +484,9 @@ func getNoopSyscalls64(vmVersion versions.StateVersion) map[string]uint32 {
 	features := versions.FeaturesForVersion(vmVersion)
 	if !features.SupportNoopSysEventFd2 {
 		delete(noOpCalls, "SysEventFd2")
+	}
+	if !features.SupportNoopMprotect {
+		delete(noOpCalls, "SysMprotect")
 	}
 	return noOpCalls
 }

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -64,6 +64,7 @@ func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	if version >= VersionMultiThreaded64_v4 {
 		features.SupportNoopSysEventFd2 = true
 		features.SupportDclzDclo = true
+		features.SupportNoopMprotect = true
 	}
 	return features
 }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -132,8 +132,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x10aad63177f6592bcd3d42d7ebd7d784c01e518f5189b8a543fc096ab9be69a0",
-    "sourceCodeHash": "0x4ca87ab2c6c2356c329587f5b69fac3ddc2fc76e389e81faea1a616a3d841403"
+    "initCodeHash": "0xbee6f8ce0cae8ed7eb42ac9a84b82e05e06e75b2d9aa9ba3913fb6bc2e5ed76e",
+    "sourceCodeHash": "0x26fd2eadc502d54b541fc654e0971491cd05aca4d4a550f2e2e7173d0d693859"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.3.0
-    string public constant version = "1.3.0";
+    /// @custom:semver 1.3.1
+    string public constant version = "1.3.1";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -562,6 +562,10 @@ contract MIPS64 is ISemver {
                 v1 = 0;
             } else if (syscall_no == sys.SYS_MUNMAP) {
                 // ignored
+            } else if (syscall_no == sys.SYS_MPROTECT) {
+                if (!st.featuresForVersion(STATE_VERSION).supportNoopMprotect) {
+                    revert("MIPS64: unimplemented syscall");
+                }
             } else if (syscall_no == sys.SYS_GETAFFINITY) {
                 // ignored
             } else if (syscall_no == sys.SYS_MADVISE) {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -15,6 +15,7 @@ library MIPS64State {
     struct Features {
         bool supportNoopSysEventFd2;
         bool supportDclzDclo;
+        bool supportNoopMprotect;
     }
 
     function assertExitedIsValid(uint32 _exited) internal pure {
@@ -27,6 +28,7 @@ library MIPS64State {
         if (_version >= 7) {
             features_.supportNoopSysEventFd2 = true;
             features_.supportDclzDclo = true;
+            features_.supportNoopMprotect = true;
         }
     }
 }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -52,6 +52,7 @@ library MIPS64Syscalls {
     uint64 internal constant PAGE_SIZE = 4096;
 
     uint32 internal constant SYS_MMAP = 5009;
+    uint32 internal constant SYS_MPROTECT = 5010;
     uint32 internal constant SYS_BRK = 5012;
     uint32 internal constant SYS_CLONE = 5055;
     uint32 internal constant SYS_EXIT_GROUP = 5205;


### PR DESCRIPTION
No-ops the `mprotect(2)` syscall for go1.23 compatibility. The go1.23 runtime may use mprotect in certain situations. A no-op approach is sufficient for two reasons:
- memory protection is explicitly not a supported feature of the VM. Cannon expects userspace to track its page mappings and not access protected pages. 
- the mmap page bump allocator ensures that protected pages will never be yielded back to userspace in the future.


Closes https://github.com/ethereum-optimism/optimism/issues/13447