### PR TITLE
op-node: consume L1 signals and p2p blocks as events

### DIFF
--- a/op-devstack/sysgo/sync_test.go
+++ b/op-devstack/sysgo/sync_test.go
@@ -214,7 +214,7 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 		require.Eventually(t, func() bool {
 			_, syncA2 := queryCL()
 			// unsafe head and safe head both advanced from last observed unsafe head
-			return syncA2.SafeL2.Number == syncA2.UnsafeL2.Number && syncA2.SafeL2.Number > targetBlockNum2
+			return syncA2.UnsafeL2.Number > targetBlockNum2 && syncA2.SafeL2.Number > targetBlockNum2
 		}, 60*time.Second, waitTime)
 
 		logger.Info("verifier heads will lag compared from sequencer heads and supervisor view")

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -94,6 +94,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 
 // ActL2StartBlock starts building of a new L2 block on top of the head
 func (s *L2Sequencer) ActL2StartBlock(t Testing) {
+	require.NoError(t, s.drainer.Drain()) // can't build when other work is still blocking
 	if !s.L2PipelineIdle {
 		t.InvalidAction("cannot start L2 build when derivation is not idle")
 		return

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -178,7 +178,6 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		L2:             eng,
 		Log:            log,
 		Ctx:            ctx,
-		Drain:          executor.Drain,
 		ManagedMode:    managedMode,
 	}, opts)
 

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -330,6 +330,18 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, originalOutput.OutputRoot, eth.OutputRoot(out))
 
+	// supervisor should have the new chain indexed now
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+	localUnsafe, err = actors.Supervisor.LocalUnsafe(t.Ctx(), actors.ChainB.ChainID)
+	require.NoError(t, err)
+	require.Equal(t, crossSafe.Derived, localUnsafe)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainB.Sequencer.SyncStatus()
+	t.Logf("FOOOO unsafe L2: %s", status.UnsafeL2)
+	require.Equal(t, status.LocalSafeL2, status.UnsafeL2, "block follows on replacement block, derived to deconflict from previous empty block on L1")
+	require.Equal(t, crossSafe.Derived, status.UnsafeL2.ParentID(), "builds on the new post-replacement chain")
+
 	// Now check if we can continue to build L2 blocks on top of the new chain.
 	// Build a new L2 block
 	actors.ChainB.Sequencer.ActL2StartBlock(t)
@@ -340,14 +352,22 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	actors.L1Miner.ActL1StartBlock(12)(t)
 	actors.L1Miner.ActL1IncludeTx(actors.ChainB.BatcherAddr)(t)
 	actors.L1Miner.ActL1EndBlock(t)
-	// Sync the sequencer / supervisor, so the indexing, local-safe, cross-safe changes all propagate.
+
+	// Takes a while to become local safe
+	actors.Supervisor.SignalLatestL1(t)
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	actors.ChainB.Sequencer.SyncSupervisor(t)
-	actors.Supervisor.SignalLatestL1(t)
 	actors.Supervisor.ProcessFull(t)
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	status = actors.ChainB.Sequencer.SyncStatus()
-	require.Equal(t, uint64(2), status.SafeL2.Number)
+	require.Equal(t, uint64(3), status.LocalSafeL2.Number)
+
+	// And now cross-safe
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+	status = actors.ChainB.Sequencer.SyncStatus()
+	require.Equal(t, uint64(3), status.SafeL2.Number)
 }
 
 func TestInteropCrossSafeDependencyDelay(gt *testing.T) {

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -338,7 +338,6 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	require.Equal(t, crossSafe.Derived, localUnsafe)
 	actors.ChainB.Sequencer.ActL2PipelineFull(t)
 	status = actors.ChainB.Sequencer.SyncStatus()
-	t.Logf("FOOOO unsafe L2: %s", status.UnsafeL2)
 	require.Equal(t, status.LocalSafeL2, status.UnsafeL2, "block follows on replacement block, derived to deconflict from previous empty block on L1")
 	require.Equal(t, crossSafe.Derived, status.UnsafeL2.ParentID(), "builds on the new post-replacement chain")
 

--- a/op-node/node/comms.go
+++ b/op-node/node/comms.go
@@ -34,7 +34,7 @@ type TracerDeriver struct {
 }
 
 var _ event.Deriver = (*TracerDeriver)(nil)
-var _ event.Unattach = (*TracerDeriver)(nil)
+var _ event.Unattacher = (*TracerDeriver)(nil)
 
 func NewTracerDeriver(tracer Tracer) *TracerDeriver {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/op-node/node/comms.go
+++ b/op-node/node/comms.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -15,13 +18,47 @@ type Tracer interface {
 	OnPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope)
 }
 
-type noOpTracer struct{}
-
-func (n noOpTracer) OnNewL1Head(ctx context.Context, sig eth.L1BlockRef) {}
-
-func (n noOpTracer) OnUnsafeL2Payload(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) {
+type TracePublishBlockEvent struct {
+	Envelope *eth.ExecutionPayloadEnvelope
 }
 
-func (n noOpTracer) OnPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) {}
+func (ev TracePublishBlockEvent) String() string {
+	return "trace-publish-event"
+}
 
-var _ Tracer = (*noOpTracer)(nil)
+// TracerDeriver hooks a Tracer up to the event system as deriver
+type TracerDeriver struct {
+	tracer Tracer
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+var _ event.Deriver = (*TracerDeriver)(nil)
+var _ event.Unattach = (*TracerDeriver)(nil)
+
+func NewTracerDeriver(tracer Tracer) *TracerDeriver {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &TracerDeriver{
+		tracer: tracer,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (t *TracerDeriver) OnEvent(ev event.Event) bool {
+	switch x := ev.(type) {
+	case status.L1UnsafeEvent:
+		t.tracer.OnNewL1Head(t.ctx, x.L1Unsafe)
+	case p2p.ReceivedBlockEvent:
+		t.tracer.OnUnsafeL2Payload(t.ctx, x.From, x.Envelope)
+	case TracePublishBlockEvent:
+		t.tracer.OnPublishL2Payload(t.ctx, x.Envelope)
+	default:
+		return false
+	}
+	return true
+}
+
+func (t *TracerDeriver) Unattach() {
+	t.cancel()
+}

--- a/op-node/node/comms_test.go
+++ b/op-node/node/comms_test.go
@@ -1,0 +1,62 @@
+package node
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+type testTracer struct {
+	got string
+}
+
+func (t *testTracer) OnNewL1Head(ctx context.Context, sig eth.L1BlockRef) {
+	t.got += "L1Head: " + sig.ID().String() + "\n"
+}
+
+func (t *testTracer) OnUnsafeL2Payload(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) {
+	t.got += "P2P in: from: " + string(from) + " id: " + payload.ID().String() + "\n"
+}
+
+func (t *testTracer) OnPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) {
+	t.got += "P2P out: " + payload.ID().String() + "\n"
+}
+
+var _ Tracer = (*testTracer)(nil)
+
+// TestTracer tests that the tracer traces each thing as expected
+func TestTracer(t *testing.T) {
+	tr := &testTracer{}
+	d := NewTracerDeriver(tr)
+	rng := rand.New(rand.NewSource(123))
+
+	l1Head := testutils.RandomBlockRef(rng)
+	d.OnEvent(status.L1UnsafeEvent{L1Unsafe: l1Head})
+	require.Equal(t, "L1Head: "+l1Head.ID().String()+"\n", tr.got)
+	tr.got = ""
+
+	id := testutils.RandomBlockID(rng)
+	block := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockHash: id.Hash, BlockNumber: eth.Uint64Quantity(id.Number)}}
+
+	d.OnEvent(p2p.ReceivedBlockEvent{From: "foo", Envelope: block})
+	require.Equal(t, "P2P in: from: foo id: "+id.String()+"\n", tr.got)
+	tr.got = ""
+
+	d.OnEvent(TracePublishBlockEvent{Envelope: block})
+	require.Equal(t, "P2P out: "+id.String()+"\n", tr.got)
+	tr.got = ""
+
+	require.Nil(t, d.ctx.Err())
+	d.Unattach()
+	require.NotNil(t, d.ctx.Err())
+}

--- a/op-node/node/comms_test.go
+++ b/op-node/node/comms_test.go
@@ -56,7 +56,7 @@ func TestTracer(t *testing.T) {
 	require.Equal(t, "P2P out: "+id.String()+"\n", tr.got)
 	tr.got = ""
 
-	require.Nil(t, d.ctx.Err())
+	require.NoError(t, d.ctx.Err())
 	d.Unattach()
-	require.NotNil(t, d.ctx.Err())
+	require.Error(t, d.ctx.Err())
 }

--- a/op-node/p2p/event.go
+++ b/op-node/p2p/event.go
@@ -1,0 +1,52 @@
+package p2p
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type ReceivedBlockEvent struct {
+	From     peer.ID
+	Envelope *eth.ExecutionPayloadEnvelope
+}
+
+func (ev ReceivedBlockEvent) String() string {
+	return "received-block-event"
+}
+
+type BlockReceiverMetrics interface {
+	RecordReceivedUnsafePayload(payload *eth.ExecutionPayloadEnvelope)
+}
+
+// BlockReceiver can be plugged into the P2P gossip stack,
+// to receive payloads as ReceivedBlockEvent events.
+type BlockReceiver struct {
+	log     log.Logger
+	emitter event.Emitter
+	metrics BlockReceiverMetrics
+}
+
+var _ GossipIn = (*BlockReceiver)(nil)
+
+func NewBlockReceiver(log log.Logger, em event.Emitter, metrics BlockReceiverMetrics) *BlockReceiver {
+	return &BlockReceiver{
+		log:     log,
+		emitter: em,
+		metrics: metrics,
+	}
+}
+
+func (g *BlockReceiver) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+	g.log.Debug("Received signed execution payload from p2p",
+		"id", msg.ExecutionPayload.ID(),
+		"peer", from, "txs", len(msg.ExecutionPayload.Transactions))
+	g.metrics.RecordReceivedUnsafePayload(msg)
+	g.emitter.Emit(ReceivedBlockEvent{From: from, Envelope: msg})
+	return nil
+}

--- a/op-node/p2p/filter.go
+++ b/op-node/p2p/filter.go
@@ -1,0 +1,28 @@
+package p2p
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// FilterSelf implements GossipIn and filters blocks published by ourselves.
+type FilterSelf struct {
+	self  peer.ID
+	inner GossipIn
+}
+
+var _ GossipIn = (*FilterSelf)(nil)
+
+func NewFilterSelf(self peer.ID, inner GossipIn) *FilterSelf {
+	return &FilterSelf{self: self, inner: inner}
+}
+
+func (f *FilterSelf) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+	if f.self == from {
+		return nil // ignore blocks that we published ourselves
+	}
+	return f.inner.OnUnsafeL2Payload(ctx, from, msg)
+}

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -110,6 +110,9 @@ func (n *NodeP2P) init(
 		return fmt.Errorf("failed to start p2p host: %w", err)
 	}
 
+	// Don't ingest blocks that we publish ourselves
+	gossipIn = NewFilterSelf(n.host.ID(), gossipIn)
+
 	// Enable extra features, if any. During testing we don't setup the most advanced host all the time.
 	if extra, ok := n.host.(ExtraHostFeatures); ok {
 		n.gater = extra.ConnectionGater()

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	gosync "sync"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/clsync"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -33,7 +33,7 @@ type Driver struct {
 	sched *StepSchedulingDeriver
 
 	emitter event.Emitter
-	drain   func() error
+	drain   Drain
 
 	// Requests to block the event loop for synchronous execution to avoid reading an inconsistent state
 	stateReq chan chan struct{}
@@ -46,22 +46,8 @@ type Driver struct {
 	// May not be modified after starting the Driver.
 	driverConfig *Config
 
-	// L1 Signals:
-	//
-	// Not all L1 blocks, or all changes, have to be signalled:
-	// the derivation process traverses the chain and handles reorgs as necessary,
-	// the driver just needs to be aware of the *latest* signals enough so to not
-	// lag behind actionable data.
-	l1HeadSig      chan eth.L1BlockRef
-	l1SafeSig      chan eth.L1BlockRef
-	l1FinalizedSig chan eth.L1BlockRef
-
 	// Interface to signal the L2 block range to sync.
 	altSync AltSync
-
-	// L2 Signals:
-
-	unsafeL2Payloads chan *eth.ExecutionPayloadEnvelope
 
 	sequencer sequencing.SequencerIface
 
@@ -103,46 +89,6 @@ func (s *Driver) Close() error {
 	s.wg.Wait()
 	s.sequencer.Close()
 	return nil
-}
-
-// OnL1Head signals the driver that the L1 chain changed the "unsafe" block,
-// also known as head of the chain, or "latest".
-func (s *Driver) OnL1Head(ctx context.Context, unsafe eth.L1BlockRef) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case s.l1HeadSig <- unsafe:
-		return nil
-	}
-}
-
-// OnL1Safe signals the driver that the L1 chain changed the "safe",
-// also known as the justified checkpoint (as seen on L1 beacon-chain).
-func (s *Driver) OnL1Safe(ctx context.Context, safe eth.L1BlockRef) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case s.l1SafeSig <- safe:
-		return nil
-	}
-}
-
-func (s *Driver) OnL1Finalized(ctx context.Context, finalized eth.L1BlockRef) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case s.l1FinalizedSig <- finalized:
-		return nil
-	}
-}
-
-func (s *Driver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case s.unsafeL2Payloads <- envelope:
-		return nil
-	}
 }
 
 // the eventLoop responds to L1 changes and internal timers to produce L2 blocks.
@@ -204,17 +150,6 @@ func (s *Driver) eventLoop() {
 			return
 		}
 
-		if s.drain != nil {
-			// While event-processing is synchronous we have to drain
-			// (i.e. process all queued-up events) before creating any new events.
-			if err := s.drain(); err != nil {
-				if s.driverCtx.Err() != nil {
-					return
-				}
-				s.log.Error("unexpected error from event-draining", "err", err)
-			}
-		}
-
 		planSequencerAction()
 
 		// If the engine is not ready, or if the L2 head is actively changing, then reset the alt-sync:
@@ -235,36 +170,6 @@ func (s *Driver) eventLoop() {
 			if err != nil {
 				s.log.Warn("failed to check for unsafe L2 blocks to sync", "err", err)
 			}
-		case envelope := <-s.unsafeL2Payloads:
-			// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
-			if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
-				s.log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
-				s.Emitter.Emit(clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
-				s.metrics.RecordReceivedUnsafePayload(envelope)
-				reqStep()
-			} else if s.SyncCfg.SyncMode == sync.ELSync {
-				ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
-				if err != nil {
-					s.log.Info("Failed to turn execution payload into a block ref", "id", envelope.ExecutionPayload.ID(), "err", err)
-					continue
-				}
-				if ref.Number <= s.Engine.UnsafeL2Head().Number {
-					continue
-				}
-				s.log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
-				if err := s.Engine.InsertUnsafePayload(s.driverCtx, envelope, ref); err != nil {
-					s.log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
-				}
-			}
-		case newL1Head := <-s.l1HeadSig:
-			s.Emitter.Emit(status.L1UnsafeEvent{L1Unsafe: newL1Head})
-			reqStep() // a new L1 head may mean we have the data to not get an EOF again.
-		case newL1Safe := <-s.l1SafeSig:
-			s.Emitter.Emit(status.L1SafeEvent{L1Safe: newL1Safe})
-			// no step, justified L1 information does not do anything for L2 derivation or status
-		case newL1Finalized := <-s.l1FinalizedSig:
-			s.emitter.Emit(finality.FinalizeL1Event{FinalizedL1: newL1Finalized})
-			reqStep() // we may be able to mark more L2 data as finalized now
 		case <-s.sched.NextDelayedStep():
 			s.emitter.Emit(StepAttemptEvent{})
 		case <-s.sched.NextStep():
@@ -276,6 +181,15 @@ func (s *Driver) eventLoop() {
 			s.Derivation.Reset()
 			s.metrics.RecordPipelineReset()
 			close(respCh)
+		case <-s.drain.Await():
+			if err := s.drain.Drain(); err != nil {
+				if s.driverCtx.Err() != nil {
+					return
+				} else {
+					s.log.Error("unexpected error from event-draining", "err", err)
+					s.Emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unexpected error: %w", err)})
+				}
+			}
 		case <-s.driverCtx.Done():
 			return
 		}
@@ -309,8 +223,6 @@ type SyncDeriver struct {
 
 	Ctx context.Context
 
-	Drain func() error
-
 	// When in interop, and managed by an op-supervisor,
 	// the node performs a reset based on the instructions of the op-supervisor.
 	ManagedMode bool
@@ -322,6 +234,34 @@ func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
 
 func (s *SyncDeriver) OnEvent(ev event.Event) bool {
 	switch x := ev.(type) {
+	case status.L1UnsafeEvent:
+		// a new L1 head may mean we have the data to not get an EOF again.
+		s.Emitter.Emit(StepReqEvent{})
+	case finality.FinalizeL1Event:
+		// On "safe" L1 blocks: no step, justified L1 information does not do anything for L2 derivation or status.
+		// On "finalized" L1 blocks: we may be able to mark more L2 data as finalized now.
+		s.Emitter.Emit(StepReqEvent{})
+	case p2p.ReceivedBlockEvent:
+		envelope := x.Envelope
+		// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
+		if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
+			s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
+			s.Emitter.Emit(clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
+			s.Emitter.Emit(StepReqEvent{})
+		} else if s.SyncCfg.SyncMode == sync.ELSync {
+			ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
+			if err != nil {
+				s.Log.Info("Failed to turn execution payload into a block ref", "id", envelope.ExecutionPayload.ID(), "err", err)
+				break
+			}
+			if ref.Number <= s.Engine.UnsafeL2Head().Number {
+				break
+			}
+			s.Log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
+			if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref); err != nil {
+				s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
+			}
+		}
 	case StepEvent:
 		s.SyncStep()
 	case rollup.ResetEvent:
@@ -412,32 +352,9 @@ func (s *SyncDeriver) onResetEvent(x rollup.ResetEvent) {
 func (s *SyncDeriver) SyncStep() {
 	s.Log.Debug("Sync process step")
 
-	drain := func() (ok bool) {
-		if err := s.Drain(); err != nil {
-			if errors.Is(err, context.Canceled) {
-				return false
-			} else {
-				s.Emitter.Emit(rollup.CriticalErrorEvent{
-					Err: fmt.Errorf("unexpected error on SyncStep event Drain: %w", err)})
-				return false
-			}
-		}
-		return true
-	}
-
-	if !drain() {
-		return
-	}
-
 	s.Emitter.Emit(engine.TryBackupUnsafeReorgEvent{})
-	if !drain() {
-		return
-	}
 
 	s.Emitter.Emit(engine.TryUpdateEngineEvent{})
-	if !drain() {
-		return
-	}
 
 	if s.Engine.IsEngineSyncing() {
 		// The pipeline cannot move forwards if doing EL sync.
@@ -480,6 +397,14 @@ func (s *Driver) ResetDerivationPipeline(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func (s *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	s.emitter.Emit(p2p.ReceivedBlockEvent{
+		From:     "",
+		Envelope: payload,
+	})
+	return nil
 }
 
 func (s *Driver) StartSequencer(ctx context.Context, blockHash common.Hash) error {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -242,26 +242,7 @@ func (s *SyncDeriver) OnEvent(ev event.Event) bool {
 		// On "finalized" L1 blocks: we may be able to mark more L2 data as finalized now.
 		s.Emitter.Emit(StepReqEvent{})
 	case p2p.ReceivedBlockEvent:
-		envelope := x.Envelope
-		// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
-		if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
-			s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
-			s.Emitter.Emit(clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
-			s.Emitter.Emit(StepReqEvent{})
-		} else if s.SyncCfg.SyncMode == sync.ELSync {
-			ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
-			if err != nil {
-				s.Log.Info("Failed to turn execution payload into a block ref", "id", envelope.ExecutionPayload.ID(), "err", err)
-				break
-			}
-			if ref.Number <= s.Engine.UnsafeL2Head().Number {
-				break
-			}
-			s.Log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
-			if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref); err != nil {
-				s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
-			}
-		}
+		s.onIncomingP2PBlock(x.Envelope)
 	case StepEvent:
 		s.SyncStep()
 	case rollup.ResetEvent:
@@ -292,6 +273,28 @@ func (s *SyncDeriver) OnEvent(ev event.Event) bool {
 		return false
 	}
 	return true
+}
+
+func (s *SyncDeriver) onIncomingP2PBlock(envelope *eth.ExecutionPayloadEnvelope) {
+	// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
+	if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
+		s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
+		s.Emitter.Emit(clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
+		s.Emitter.Emit(StepReqEvent{})
+	} else if s.SyncCfg.SyncMode == sync.ELSync {
+		ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
+		if err != nil {
+			s.Log.Info("Failed to turn execution payload into a block ref", "id", envelope.ExecutionPayload.ID(), "err", err)
+			return
+		}
+		if ref.Number <= s.Engine.UnsafeL2Head().Number {
+			return
+		}
+		s.Log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
+		if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref); err != nil {
+			s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
+		}
+	}
 }
 
 func (s *SyncDeriver) onSafeDerivedBlock(x engine.SafeDerivedEvent) {

--- a/op-node/rollup/event/executor_global.go
+++ b/op-node/rollup/event/executor_global.go
@@ -209,7 +209,10 @@ func (gs *GlobalSyncExec) DrainUntil(fn func(ev Event) bool, excl bool) error {
 			ev = AnnotatedEvent{}
 			stopExcl = true
 		} else {
-			gs.events.Pop()
+			popped := gs.events.Pop()
+			if ev != popped {
+				panic("expected popped event to match")
+			}
 		}
 		if stop {
 			stopIncl = true

--- a/op-node/rollup/event/system.go
+++ b/op-node/rollup/event/system.go
@@ -16,9 +16,11 @@ type Registry interface {
 	// deriver may be nil, not all registrants have to process events.
 	// A non-nil deriver may implement AttachEmitter to automatically attach the Emitter to it,
 	// before the deriver itself becomes executable.
+	// A non-nil deriver may implement Unattach to close resources upon being unregistered.
 	Register(name string, deriver Deriver, opts ...RegisterOption) Emitter
 	// Unregister removes a named emitter,
 	// also removing it from the set of events-receiving derivers (if registered with non-nil deriver).
+	// If the originally attached Deriver implements Unattach it will be notified.
 	Unregister(name string) (old Emitter)
 }
 
@@ -36,6 +38,11 @@ type System interface {
 
 type AttachEmitter interface {
 	AttachEmitter(em Emitter)
+}
+
+// Unattach is called when a deriver/emitter is unregistered from the system.
+type Unattach interface {
+	Unattach()
 }
 
 type AnnotatedEvent struct {
@@ -189,6 +196,9 @@ func (s *Sys) unregister(name string) (previous Emitter) {
 		r.leaveExecutor()
 	}
 	delete(s.regs, name)
+	if cl, ok := r.deriv.(Unattach); ok {
+		cl.Unattach()
+	}
 	return r
 }
 

--- a/op-node/rollup/event/system.go
+++ b/op-node/rollup/event/system.go
@@ -16,11 +16,11 @@ type Registry interface {
 	// deriver may be nil, not all registrants have to process events.
 	// A non-nil deriver may implement AttachEmitter to automatically attach the Emitter to it,
 	// before the deriver itself becomes executable.
-	// A non-nil deriver may implement Unattach to close resources upon being unregistered.
+	// A non-nil deriver may implement Unattacher to close resources upon being unregistered.
 	Register(name string, deriver Deriver, opts ...RegisterOption) Emitter
 	// Unregister removes a named emitter,
 	// also removing it from the set of events-receiving derivers (if registered with non-nil deriver).
-	// If the originally attached Deriver implements Unattach it will be notified.
+	// If the originally attached Deriver implements Unattacher it will be notified.
 	Unregister(name string) (old Emitter)
 }
 
@@ -40,8 +40,8 @@ type AttachEmitter interface {
 	AttachEmitter(em Emitter)
 }
 
-// Unattach is called when a deriver/emitter is unregistered from the system.
-type Unattach interface {
+// Unattacher is called when a deriver/emitter is unregistered from the system.
+type Unattacher interface {
 	Unattach()
 }
 
@@ -196,7 +196,7 @@ func (s *Sys) unregister(name string) (previous Emitter) {
 		r.leaveExecutor()
 	}
 	delete(s.regs, name)
-	if cl, ok := r.deriv.(Unattach); ok {
+	if cl, ok := r.deriv.(Unattacher); ok {
 		cl.Unattach()
 	}
 	return r


### PR DESCRIPTION
**Description**

~~Based on top of https://github.com/ethereum-optimism/optimism/pull/15828~~

Previously we would take external inputs (L1 signals, p2p blocks), put them on a channel, and then read from the channel to put it onto the event-system.

This PR:
- makes the L1 subscriptions (latest, safe, finalized) emit corresponding events
- makes the incoming gossip emit an event with the payload
- makes the op-node tracer just listen to events, rather than having to remember to hook callbacks in all kinds of places
- moves the previous processing of channel data to instead process from corresponding events
- moves some metrics to the places where the inputs are first received, rather than the processing functions, to simplify the processing side

In practice this didn't do much, since the event processing of these events is short (it's queuing up information or mutating some constant-size data) so there's no need to synchronize these with the main processing.

**Tests**

- Added tests for tracer deriver
- Existing e2e tests cover how the external inputs are processed

**Additional context**

By reducing the Driver channels / public interface, we get closer to making the legacy driver just a predictable event processor, allowing us to move the scheduling out of it, to unify with the interop syncing driver.

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15858
