### PR TITLE
Fix Devnet Metrics Collect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2329,4 +2329,4 @@ workflows:
       - devnet-metrics-collect-authorship:
           context:
             - circleci-repo-readonly-authenticated-github-token
-            - oplabs-oplabs-network-data-bucket
+            - oplabs-tools-data-public-metrics-bucket

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1701,10 +1701,8 @@ jobs:
       - run:
           name: Store artifact in Bucket
           command: |
-            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics--authorship--op-acceptance-tests
-      # - store_artifacts:
-      #     path: .metrics--authorship--op-e2e
-      #     destination: metrics--authorship--op-e2e
+            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics
+            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics-$CIRCLE_SHA1
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ parameters:
   github-event-base64:
     type: string
     default: "__not_set__"
+  devnet-metrics-collect:
+    type: boolean
+    default: false
 
 orbs:
   go: circleci/go@1.8.0
@@ -2309,12 +2312,11 @@ workflows:
 
   devnet-metrics-collect:
     when:
-      and:
-        # FIXME change to develop after testing
-        - equal: ["jan/metrics--authors", <<pipeline.git.branch>>]
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-
+      or:
+        - equal: [<< pipeline.trigger_source >>, "webhook"]
+        - and:
+          - equal: [true, << pipeline.parameters.devnet-metrics-collect >>]
+          - equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
       - devnet-metrics-collect-authorship:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1701,7 +1701,7 @@ jobs:
       - run:
           name: Store artifact in Bucket
           command: |
-            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-sink/metrics-authorship/metrics--authorship--op-acceptance-tests
+            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics--authorship--op-acceptance-tests
       # - store_artifacts:
       #     path: .metrics--authorship--op-e2e
       #     destination: metrics--authorship--op-e2e
@@ -2329,3 +2329,4 @@ workflows:
       - devnet-metrics-collect-authorship:
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - oplabs-oplabs-network-data-bucket

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1694,9 +1694,17 @@ jobs:
       - run:
           name: Collect devnet metrics for op-acceptance-tests
           command: ./devnet-sdk/scripts/metrics-collect-authorship.sh op-acceptance-tests/tests > .metrics--authorship--op-acceptance-tests
-      - store_artifacts:
-          path: .metrics--authorship--op-acceptance-tests
-          destination: metrics--authorship--op-acceptance-tests
+      - gcp-cli/install
+      - gcp-oidc-authenticate:
+          gcp_cred_config_file_path: /tmp/gcp_cred_config.json
+          oidc_token_file_path: /tmp/oidc_token.json
+      - run:
+          name: Store artifact in Bucket
+          command: |
+            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-sink/metrics-authorship/metrics--authorship--op-acceptance-tests
+      # - store_artifacts:
+      #     path: .metrics--authorship--op-e2e
+      #     destination: metrics--authorship--op-e2e
 
 workflows:
   main:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request introduces updates to the `.circleci/config.yml` file to enhance the handling of DevNet metrics collection and artifact storage. Key changes include the addition of a new parameter for metrics collection, a switch from storing artifacts locally to uploading them to a Google Cloud Storage bucket, and adjustments to the workflow triggers for better flexibility.

### Enhancements to DevNet metrics collection:

* **New parameter for metrics collection**: Added a `devnet-metrics-collect` boolean parameter to enable or disable metrics collection during pipeline execution.

* **Artifact storage in Google Cloud Storage**: Replaced the local artifact storage step with commands to upload metrics to a public Google Cloud Storage bucket (`gs://oplabs-tools-data-public-metrics`). This includes storing the metrics with both a static and SHA-based filename for traceability.

### Workflow trigger adjustments:

* **Updated `devnet-metrics-collect` workflow conditions**: Replaced the previous branch-based and trigger-source-based conditions with a more flexible setup. Metrics collection can now be triggered via webhook or API, with the latter requiring the `devnet-metrics-collect` parameter to be true.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
