### PR TITLE
go: Update op-geth to v1.101510.0, based on geth v1.15.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -293,7 +293,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101507.0-synctest.4
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101510.0-synctest.1
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101507.0-synctest.4 h1:hIzKJ4Q1DLfGY5U785U431kXeCunb609cfgJOunwzyY=
-github.com/ethereum-optimism/op-geth v1.101507.0-synctest.4/go.mod h1:gsNKIWhHa7Q3DlgHFNxffXxD0Prw5Y2pFJBYdZXGQzI=
+github.com/ethereum-optimism/op-geth v1.101510.0-synctest.1 h1:uCgxKRBXrJK2o3S9mk3W8+A3xt1kCp9vS+egqhwtbbU=
+github.com/ethereum-optimism/op-geth v1.101510.0-synctest.1/go.mod h1:gsNKIWhHa7Q3DlgHFNxffXxD0Prw5Y2pFJBYdZXGQzI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -165,9 +165,13 @@ func (b *BlockProcessor) Assemble() (*types.Block, types.Receipts, error) {
 		_requests := [][]byte{}
 		// EIP-6110 - no-op because we just ignore all deposit requests, so no need to parse logs
 		// EIP-7002
-		core.ProcessWithdrawalQueue(&_requests, b.evm)
+		if err := core.ProcessWithdrawalQueue(&_requests, b.evm); err != nil {
+			return nil, nil, err
+		}
 		// EIP-7251
-		core.ProcessConsolidationQueue(&_requests, b.evm)
+		if err := core.ProcessConsolidationQueue(&_requests, b.evm); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	block, err := b.dataProvider.Engine().FinalizeAndAssemble(b.dataProvider, b.header, b.state, &body, b.receipts)


### PR DESCRIPTION
**Description**

Updates op-geth dependency to include upstream geth v1.15.10 changes from https://github.com/ethereum-optimism/op-geth/pull/593.

Stacked on top of https://github.com/ethereum-optimism/optimism/pull/15587

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
