### PR TITLE
ci: cover op-devstack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1863,6 +1863,7 @@ workflows:
             devnet-sdk
             op-acceptance-tests
             kurtosis-devnet
+            op-devstack
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Run op-devstack tests on ci.