### PR TITLE
op-supervisor: migrate remaining geth interop type functionality

### DIFF
--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
@@ -21,10 +20,10 @@ func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) 
 	if len(l.Topics) != 2 { // topics: event-id and payload-hash
 		return nil, nil
 	}
-	if l.Topics[0] != interoptypes.ExecutingMessageEventTopic {
+	if l.Topics[0] != types.ExecutingMessageEventTopic {
 		return nil, nil
 	}
-	var msg interoptypes.Message
+	var msg types.Message
 	if err := msg.DecodeEvent(l.Topics, l.Data); err != nil {
 		return nil, fmt.Errorf("invalid executing message: %w", err)
 	}

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -45,6 +46,162 @@ func FuzzRoundtripIdentifierJSONMarshal(f *testing.F) {
 		require.Equal(t, id.Timestamp, dec.Timestamp)
 		require.Equal(t, id.ChainID, dec.ChainID)
 	})
+}
+
+func FuzzMessage_DecodeEvent(f *testing.F) {
+	f.Fuzz(func(t *testing.T, validEvTopic bool, numTopics uint8, data []byte) {
+		if len(data) < 32 {
+			return
+		}
+		if len(data) > 100_000 {
+			return
+		}
+		if validEvTopic { // valid even signature topic implies a topic to be there
+			numTopics += 1
+		}
+		if numTopics > 4 { // There can be no more than 4 topics per log event
+			return
+		}
+		if int(numTopics)*32 > len(data) {
+			return
+		}
+		var topics []common.Hash
+		if validEvTopic {
+			topics = append(topics, ExecutingMessageEventTopic)
+		}
+		for i := 0; i < int(numTopics); i++ {
+			var topic common.Hash
+			copy(topic[:], data[:])
+			data = data[32:]
+		}
+		require.NotPanics(t, func() {
+			var m Message
+			_ = m.DecodeEvent(topics, data)
+		})
+	})
+}
+
+func TestInteropMessageFormatEdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		log           *ethTypes.Log
+		expectedError string
+	}{
+		{
+			name: "Empty Topics",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics:  []common.Hash{},
+				Data:    make([]byte, 32*5),
+			},
+			expectedError: "unexpected number of event topics: 0",
+		},
+		{
+			name: "Wrong Event Topic",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash([]byte("wrong topic")),
+					common.BytesToHash([]byte("payloadHash")),
+				},
+				Data: make([]byte, 32*5),
+			},
+			expectedError: "unexpected event topic",
+		},
+		{
+			name: "Missing PayloadHash Topic",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash(ExecutingMessageEventTopic[:]),
+				},
+				Data: make([]byte, 32*5),
+			},
+			expectedError: "unexpected number of event topics: 1",
+		},
+		{
+			name: "Too Many Topics",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash(ExecutingMessageEventTopic[:]),
+					common.BytesToHash([]byte("payloadHash")),
+					common.BytesToHash([]byte("extra")),
+				},
+				Data: make([]byte, 32*5),
+			},
+			expectedError: "unexpected number of event topics: 3",
+		},
+		{
+			name: "Data Too Short",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash(ExecutingMessageEventTopic[:]),
+					common.BytesToHash([]byte("payloadHash")),
+				},
+				Data: make([]byte, 32*4), // One word too short
+			},
+			expectedError: "unexpected identifier data length: 128",
+		},
+		{
+			name: "Data Too Long",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash(ExecutingMessageEventTopic[:]),
+					common.BytesToHash([]byte("payloadHash")),
+				},
+				Data: make([]byte, 32*6), // One word too long
+			},
+			expectedError: "unexpected identifier data length: 192",
+		},
+		{
+			name: "Invalid Address Padding",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash(ExecutingMessageEventTopic[:]),
+					common.BytesToHash([]byte("payloadHash")),
+				},
+				Data: func() []byte {
+					data := make([]byte, 32*5)
+					data[0] = 1 // Add non-zero byte in address padding
+					return data
+				}(),
+			},
+			expectedError: "invalid address padding",
+		},
+		{
+			name: "Invalid Block Number Padding",
+			log: &ethTypes.Log{
+				Address: params.InteropCrossL2InboxAddress,
+				Topics: []common.Hash{
+					common.BytesToHash(ExecutingMessageEventTopic[:]),
+					common.BytesToHash([]byte("payloadHash")),
+				},
+				Data: func() []byte {
+					data := make([]byte, 32*5)
+					data[32+23] = 1 // Add non-zero byte in block number padding
+					return data
+				}(),
+			},
+			expectedError: "invalid block number padding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var msg Message
+			err := msg.DecodeEvent(tt.log.Topics, tt.log.Data)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestChainIndex(t *testing.T) {


### PR DESCRIPTION
**Description**

We are removing the event decoding from op-geth, since it is not used by op-geth.
But it is still used by the monorepo, so I moved it here.

The other `ExecutingMessagesFromLogs` from geth is not moved, as neither repo uses it anymore.

Corresponding geth PR: <TODO>

**Tests**

Included the testing in the move of the code.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15337

