### PR TITLE
feat(op-acceptance-tests): add telemetry-friendly runner

### DIFF
--- a/op-acceptance-tests/cmd/main.go
+++ b/op-acceptance-tests/cmd/main.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/telemetry"
+	"github.com/honeycombio/otel-config-go/otelconfig"
+	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// Default values
+	defaultDevnet   = "simple"
+	defaultGate     = "holocene"
+	defaultAcceptor = "op-acceptor"
+)
+
+var (
+	// Command line flags
+	devnetFlag = &cli.StringFlag{
+		Name:    "devnet",
+		Usage:   "The devnet to run",
+		Value:   defaultDevnet,
+		EnvVars: []string{"DEVNET"},
+	}
+	gateFlag = &cli.StringFlag{
+		Name:    "gate",
+		Usage:   "The gate to use",
+		Value:   defaultGate,
+		EnvVars: []string{"GATE"},
+	}
+	testDirFlag = &cli.StringFlag{
+		Name:     "testdir",
+		Usage:    "Path to the test directory",
+		Required: true,
+		EnvVars:  []string{"TEST_DIR"},
+	}
+	validatorsFlag = &cli.StringFlag{
+		Name:     "validators",
+		Usage:    "Path to the validators YAML file",
+		Required: true,
+		EnvVars:  []string{"VALIDATORS"},
+	}
+	logLevelFlag = &cli.StringFlag{
+		Name:    "log.level",
+		Usage:   "Log level for op-acceptor",
+		Value:   "debug",
+		EnvVars: []string{"LOG_LEVEL"},
+	}
+	kurtosisDirFlag = &cli.StringFlag{
+		Name:     "kurtosis-dir",
+		Usage:    "Path to the kurtosis-devnet directory",
+		Required: true,
+		EnvVars:  []string{"KURTOSIS_DIR"},
+	}
+	acceptorFlag = &cli.StringFlag{
+		Name:    "acceptor",
+		Usage:   "Path to the op-acceptor binary",
+		Value:   defaultAcceptor,
+		EnvVars: []string{"ACCEPTOR"},
+	}
+)
+
+func main() {
+	app := &cli.App{
+		Name:  "op-acceptance-test",
+		Usage: "Run Optimism acceptance tests",
+		Flags: []cli.Flag{
+			devnetFlag,
+			gateFlag,
+			testDirFlag,
+			validatorsFlag,
+			logLevelFlag,
+			kurtosisDirFlag,
+			acceptorFlag,
+		},
+		Action: runAcceptanceTest,
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runAcceptanceTest(c *cli.Context) error {
+	// Get command line arguments
+	devnet := c.String(devnetFlag.Name)
+	gate := c.String(gateFlag.Name)
+	testDir := c.String(testDirFlag.Name)
+	validators := c.String(validatorsFlag.Name)
+	logLevel := c.String(logLevelFlag.Name)
+	kurtosisDir := c.String(kurtosisDirFlag.Name)
+	acceptor := c.String(acceptorFlag.Name)
+
+	// Get the absolute path of the test directory
+	absTestDir, err := filepath.Abs(testDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path of test directory: %w", err)
+	}
+
+	// Get the absolute path of the validators file
+	absValidators, err := filepath.Abs(validators)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path of validators file: %w", err)
+	}
+
+	// Get the absolute path of the kurtosis directory
+	absKurtosisDir, err := filepath.Abs(kurtosisDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path of kurtosis directory: %w", err)
+	}
+
+	ctx := c.Context
+	ctx, shutdown, err := telemetry.SetupOpenTelemetry(
+		ctx,
+		otelconfig.WithServiceName("op-acceptance-tests"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to setup OpenTelemetry: %w", err)
+	}
+	defer shutdown()
+
+	tracer := otel.Tracer("op-acceptance-tests")
+	ctx, span := tracer.Start(ctx, "op-acceptance-tests")
+	defer span.End()
+
+	steps := []func(ctx context.Context) error{
+		func(ctx context.Context) error {
+			return deployDevnet(ctx, tracer, devnet, absKurtosisDir)
+		},
+		func(ctx context.Context) error {
+			return runOpAcceptor(ctx, tracer, devnet, gate, absTestDir, absValidators, logLevel, acceptor)
+		},
+	}
+
+	for _, step := range steps {
+		if err := step(ctx); err != nil {
+			return fmt.Errorf("failed to run step: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deployDevnet(ctx context.Context, tracer trace.Tracer, devnet string, kurtosisDir string) error {
+	ctx, span := tracer.Start(ctx, "deploy devnet")
+	defer span.End()
+
+	env := telemetry.InstrumentEnvironment(ctx, os.Environ())
+	devnetCmd := exec.CommandContext(ctx, "just", devnet)
+	devnetCmd.Dir = kurtosisDir
+	devnetCmd.Stdout = os.Stdout
+	devnetCmd.Stderr = os.Stderr
+	devnetCmd.Env = env
+	if err := devnetCmd.Run(); err != nil {
+		return fmt.Errorf("failed to deploy devnet: %w", err)
+	}
+	return nil
+}
+
+func runOpAcceptor(ctx context.Context, tracer trace.Tracer, devnet string, gate string, testDir string, validators string, logLevel string, acceptor string) error {
+	ctx, span := tracer.Start(ctx, "run acceptance test")
+	defer span.End()
+
+	env := telemetry.InstrumentEnvironment(ctx, os.Environ())
+	acceptorCmd := exec.CommandContext(ctx, acceptor,
+		"--testdir", testDir,
+		"--gate", gate,
+		"--validators", validators,
+		"--log.level", logLevel,
+	)
+	acceptorCmd.Env = append(env, fmt.Sprintf("DEVNET_ENV_URL=kt://%s", devnet))
+	acceptorCmd.Stdout = os.Stdout
+	acceptorCmd.Stderr = os.Stderr
+	if err := acceptorCmd.Run(); err != nil {
+		return fmt.Errorf("failed to run acceptance test: %w", err)
+	}
+	return nil
+}

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -34,19 +34,17 @@ acceptance-test devnet="simple" gate="holocene":
             exit 0
         fi
 
-        # Run the appropriate devnet
-        just {{KURTOSIS_DIR}}/{{ devnet }}-devnet
-
         # Print which binary is being used
         BINARY_PATH=$(mise which op-acceptor)
         echo "Using mise-managed binary: $BINARY_PATH"
-
-        # Run the op-acceptor binary
-        DEVNET_ENV_URL="kt://{{devnet}}-devnet" "$BINARY_PATH" \
-            --testdir "{{REPO_ROOT}}" \
+        go run cmd/main.go \
+            --devnet "{{devnet}}-devnet" \
             --gate {{gate}} \
+            --testdir "{{REPO_ROOT}}" \
             --validators ./acceptance-tests.yaml \
-            --log.level debug
+            --log.level debug \
+            --kurtosis-dir "{{KURTOSIS_DIR}}" \
+            --acceptor "$BINARY_PATH"
     else
         echo "Mise not installed, falling back to Docker..."
         just acceptance-test-docker {{devnet}} {{gate}}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This change basically moves some of the logic (creation of devnet,
followed by test runs) for acceptance tests out of justfile, and into a
trivial Go binary.

This in particular enables us to tie together the telemetry traces
across those 2 phases, and gain full visibility over the various
activities involved.

This means the telemetry is propagated across:
- this top-level binary
- the kt-devnet deployer
- op-acceptor
- the underlying test binaries

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->
This is what it looks like (most details folded to fit in a reasonable screenshot :))
![Screenshot 2025-05-09 at 16 24 05](https://github.com/user-attachments/assets/ae2e96aa-c152-4a6b-ba9c-5995adf9ebe8)

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
