### PR TITLE
chore: Bump `kona` + `asterisc`

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,11 +7,11 @@ variable "REPOSITORY" {
 }
 
 variable "KONA_VERSION" {
-  default = "0.1.0-beta.18"
+  default = "1.0.1"
 }
 
 variable "ASTERISC_VERSION" {
-  default = "v1.2.0"
+  default = "v1.3.0"
 }
 
 variable "GIT_COMMIT" {

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -34,7 +34,7 @@ op-batcher-image TAG='op-batcher:devnet': (_docker_build_stack TAG "op-batcher-t
 # TODO: this is a temporary hack to get the kona + asterisc version right.
 # Ideally the Dockerfile should be self-sufficient (right now we depend on
 # docker-bake.hcl to do the right thing).
-op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=0.1.0-beta.18" "--build-arg" "ASTERISC_VERSION=v1.2.0")
+op-challenger-image TAG='op-challenger:devnet': (_docker_build_stack TAG "op-challenger-target" "--build-arg" "KONA_VERSION=1.0.1" "--build-arg" "ASTERISC_VERSION=v1.3.0")
 op-conductor-image TAG='op-conductor:devnet': (_docker_build_stack TAG "op-conductor-target")
 op-deployer-image TAG='op-deployer:devnet': (_docker_build_stack TAG "op-deployer-target")
 op-dispute-mon-image TAG='op-dispute-mon:devnet': (_docker_build_stack TAG "op-dispute-mon-target")

--- a/mise.toml
+++ b/mise.toml
@@ -44,7 +44,7 @@ op-acceptor = "op-acceptor/v0.1.10"
 # Put things here if you need to track versions of tools or projects that can't
 # actually be managed by mise (yet). Make sure that anything you put in here is
 # also found inside of disabled_tools or mise will try to install it.
-asterisc = "1.2.0"
+asterisc = "1.3.0"
 kontrol = "1.0.90"
 binary_signer = "1.0.4"
 

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -204,8 +204,8 @@
     "sourceCodeHash": "0x42151e2547ec5270353977fd66e78fa1fde18f362d7021cf7ddce16d5201b3ec"
   },
   "src/vendor/asterisc/RISCV.sol:RISCV": {
-    "initCodeHash": "0x7329cca924e189eeaa2d883234f6cb5fd787c8bf3339d8298e721778c2947ce5",
-    "sourceCodeHash": "0x02025b303a8f37b4e541f8c7936a8651402a60ea0147a53176e06b51b15a1f84"
+    "initCodeHash": "0x4cd639f7da4eaf86a98eb3227fe285c0e8380ff5c79c4745aefed804cef52162",
+    "sourceCodeHash": "0x1d18c55a910212cc7572d2e8673c5f092db8352dda1137739c71df18d4ee1db1"
   },
   "src/vendor/eas/EAS.sol:EAS": {
     "initCodeHash": "0xbd79d6fff128b3da3e09ead84b805b7540740190488f2791a6b4e5b7aabf9cff",


### PR DESCRIPTION
## Overview

Bumps `kona` to `v1.0.1` and `asterisc` to `v1.3.0`