### PR TITLE
op-deployer: support L2 contract verification

### DIFF
--- a/op-deployer/isthmus-predeploys.json
+++ b/op-deployer/isthmus-predeploys.json
@@ -1,0 +1,5 @@
+{
+    "L1Block": "0xff256497d61dcd71a9e9ff43967c13fde1f72d12",
+    "GasPriceOracle": "0x93e57a196454cb919193fa9946f14943cf733845",
+    "OperatorFeeVault":"0x4fa2be8cd41504037f1838bce3bcc93bc68ff537"
+}

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -42,6 +42,8 @@ func getAPIEndpoint(l1ChainID uint64) (string, error) {
 		return "https://api-sepolia.etherscan.io/api", nil // eth-sepolia
 	case 84532:
 		return "https://api-sepolia.basescan.org/api", nil // base-sepolia
+	case 10:
+		return "https://api-optimistic.etherscan.io/api", nil // optimism-mainnet
 	default:
 		return "", fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -44,6 +44,8 @@ func getAPIEndpoint(l1ChainID uint64) (string, error) {
 		return "https://api-sepolia.basescan.org/api", nil // base-sepolia
 	case 10:
 		return "https://api-optimistic.etherscan.io/api", nil // optimism-mainnet
+	case 8453:
+		return "https://api.basescan.org/api", nil // base-mainnet
 	default:
 		return "", fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -46,6 +46,8 @@ func getAPIEndpoint(l1ChainID uint64) (string, error) {
 		return "https://api-optimistic.etherscan.io/api", nil // optimism-mainnet
 	case 8453:
 		return "https://api.basescan.org/api", nil // base-mainnet
+	case 57073:
+		return "https://explorer.inkonchain.com/api", nil // ink-mainnet (blockscout)
 	default:
 		return "", fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}


### PR DESCRIPTION
Still need to update references to "L1 chain ID", although this may start to pollute other parts of the op-deployer codebase.

Also, I don't want to commit the input.json file so let's remove that. 

Would like to the verification on Ink, but that requires Blockscout support.

