### PR TITLE
op-node,op-supervisor: support emitter/executor prioritization

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -175,7 +175,7 @@ func (n *OpNode) initEventSystem() {
 	executor := event.NewGlobalSynchronous(n.resourcesCtx)
 	sys := event.NewSystem(n.log, executor)
 	sys.AddTracer(event.NewMetricsTracer(n.metrics))
-	sys.Register("node", event.DeriverFunc(n.onEvent), event.DefaultRegisterOpts())
+	sys.Register("node", event.DeriverFunc(n.onEvent))
 	n.eventSys = sys
 	n.eventDrain = executor
 }
@@ -411,7 +411,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 			managedMode = ok
 		}
 		n.interopSys = sys
-		n.eventSys.Register("interop", n.interopSys, event.DefaultRegisterOpts())
+		n.eventSys.Register("interop", n.interopSys)
 	}
 
 	var sequencerConductor conductor.SequencerConductor = &conductor.NoOpConductor{}

--- a/op-node/rollup/event/executor.go
+++ b/op-node/rollup/event/executor.go
@@ -14,6 +14,6 @@ func (fn ExecutableFunc) RunEvent(ev AnnotatedEvent) {
 }
 
 type Executor interface {
-	Add(d Executable, opts *ExecutorOpts) (leaveExecutor func())
+	Add(d Executable, cfg *ExecutorConfig) (leaveExecutor func())
 	Enqueue(ev AnnotatedEvent) error
 }

--- a/op-node/rollup/event/executor_global.go
+++ b/op-node/rollup/event/executor_global.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sort"
 	"sync"
 	"sync/atomic"
 )
@@ -13,10 +14,84 @@ import (
 // At some point it's better to drop events and warn something is exploding the number of events.
 const sanityEventLimit = 10_000
 
+type eventsList struct {
+	Events []AnnotatedEvent
+}
+
+type prioritizedEvents struct {
+	// keyed by priority. May contain empty lists.
+	byPriority map[uint64]*eventsList
+	// keys, sorted priorities, high to low
+	keys []uint64
+
+	// number of events
+	count uint64
+
+	// Note: there is a very limited number of different priorities, that continue to show up over time.
+	// And events with equal priority should stay FIFO.
+	// So we don't use a priority-queue, but just statically have a few sub-lists, and never remove keys.
+}
+
+// Add enqueues the given event.
+func (a *prioritizedEvents) Add(event AnnotatedEvent) {
+	p, ok := a.byPriority[event.EmitPriority]
+	if !ok {
+		// Start tracking events with this priority level
+		p = &eventsList{Events: make([]AnnotatedEvent, 0, 100)}
+		a.byPriority[event.EmitPriority] = p
+		// Register the new priority as key, and sort so it's prioritized right.
+		a.keys = append(a.keys, event.EmitPriority)
+		sort.Slice(a.keys, func(i, j int) bool {
+			return a.keys[i] > a.keys[j]
+		})
+	}
+	p.Events = append(p.Events, event)
+	a.count += 1
+}
+
+// Pop returns the highest-priority event, and removes it at the same time.
+// Returns a zeroed AnnotatedEvent if there is no event to pop.
+func (a *prioritizedEvents) Pop() AnnotatedEvent {
+	for _, priority := range a.keys {
+		pe := a.byPriority[priority]
+		if len(pe.Events) > 0 {
+			out := pe.Events[0]
+			pe.Events = pe.Events[1:]
+			a.count -= 1
+			return out
+		}
+	}
+	return AnnotatedEvent{}
+}
+
+// Peek returns the highest-priority event, without removing it.
+// Returns a zeroed AnnotatedEvent if there is no event to peek.
+func (a *prioritizedEvents) Peek() AnnotatedEvent {
+	for _, priority := range a.keys {
+		pe := a.byPriority[priority]
+		if len(pe.Events) > 0 {
+			return pe.Events[0]
+		}
+	}
+	return AnnotatedEvent{}
+}
+
+// Count returns the number of currently queued events
+func (a *prioritizedEvents) Count() uint64 {
+	return a.count
+}
+
 type GlobalSyncExec struct {
 	eventsLock sync.Mutex
-	events     []AnnotatedEvent
+	events     prioritizedEvents // protected by eventsLock
 
+	// queued is closed and replaced whenever a new item is enqueued.
+	// This is used to signal to Await callers when there are events.
+	// It is nil when no reader is awaiting.
+	// This is protected by eventsLock.
+	queued chan struct{}
+
+	// sorted by descending priority
 	handles     []*globalHandle
 	handlesLock sync.RWMutex
 
@@ -26,15 +101,27 @@ type GlobalSyncExec struct {
 var _ Executor = (*GlobalSyncExec)(nil)
 
 func NewGlobalSynchronous(ctx context.Context) *GlobalSyncExec {
-	return &GlobalSyncExec{ctx: ctx}
+	return &GlobalSyncExec{
+		ctx: ctx,
+		events: prioritizedEvents{
+			byPriority: make(map[uint64]*eventsList),
+			keys:       nil,
+			count:      0,
+		},
+		queued: nil,
+	}
 }
 
-func (gs *GlobalSyncExec) Add(d Executable, _ *ExecutorOpts) (leaveExecutor func()) {
+func (gs *GlobalSyncExec) Add(d Executable, cfg *ExecutorConfig) (leaveExecutor func()) {
 	gs.handlesLock.Lock()
 	defer gs.handlesLock.Unlock()
-	h := &globalHandle{d: d}
+	h := &globalHandle{d: d, priority: cfg.Priority}
 	h.g.Store(gs)
 	gs.handles = append(gs.handles, h)
+	// sort by descending priority
+	sort.Slice(gs.handles, func(i, j int) bool {
+		return gs.handles[i].priority > gs.handles[j].priority
+	})
 	return h.leave
 }
 
@@ -55,24 +142,15 @@ func (gs *GlobalSyncExec) Enqueue(ev AnnotatedEvent) error {
 	gs.eventsLock.Lock()
 	defer gs.eventsLock.Unlock()
 	// sanity limit, never queue too many events
-	if len(gs.events) >= sanityEventLimit {
-		return fmt.Errorf("something is very wrong, queued up too many events! Dropping event %q", ev)
+	if gs.events.count >= sanityEventLimit {
+		return fmt.Errorf("something is very wrong, queued up too many events! Dropping event %q", ev.Event)
 	}
-	gs.events = append(gs.events, ev)
+	gs.events.Add(ev)
+	if gs.queued != nil {
+		close(gs.queued) // To everyone waiting so far: let them know we have an event.
+		gs.queued = nil  // To everyone in the future: they will need to Await for a new event again
+	}
 	return nil
-}
-
-func (gs *GlobalSyncExec) pop() AnnotatedEvent {
-	gs.eventsLock.Lock()
-	defer gs.eventsLock.Unlock()
-
-	if len(gs.events) == 0 {
-		return AnnotatedEvent{}
-	}
-
-	first := gs.events[0]
-	gs.events = gs.events[1:]
-	return first
 }
 
 func (gs *GlobalSyncExec) processEvent(ev AnnotatedEvent) {
@@ -83,12 +161,32 @@ func (gs *GlobalSyncExec) processEvent(ev AnnotatedEvent) {
 	}
 }
 
+// Await returns a channel that is closed if and when event(s) have been queued up.
+// This may be used to await when Drain() can be called for event processing.
+func (gs *GlobalSyncExec) Await() <-chan struct{} {
+	gs.eventsLock.Lock()
+	defer gs.eventsLock.Unlock()
+	if gs.queued == nil { // If nobody was awaiting already, initialize.
+		out := make(chan struct{})
+		// If we already have events, close it immediately.
+		if gs.events.Peek().Event != nil {
+			close(out)
+			// gs.queued is already nil: we want to keep the close signal coupled to the enqueuing of events.
+			return out
+		}
+		gs.queued = out
+	}
+	return gs.queued
+}
+
 func (gs *GlobalSyncExec) Drain() error {
 	for {
 		if gs.ctx.Err() != nil {
 			return gs.ctx.Err()
 		}
-		ev := gs.pop()
+		gs.eventsLock.Lock()
+		ev := gs.events.Pop()
+		gs.eventsLock.Unlock()
 		if ev.Event == nil {
 			return nil
 		}
@@ -107,17 +205,16 @@ func (gs *GlobalSyncExec) DrainUntil(fn func(ev Event) bool, excl bool) error {
 		gs.eventsLock.Lock()
 		defer gs.eventsLock.Unlock()
 
-		if len(gs.events) == 0 {
+		ev = gs.events.Peek()
+		if ev.Event == nil {
 			return AnnotatedEvent{}, false, false
 		}
-
-		ev = gs.events[0]
 		stop := fn(ev.Event)
 		if excl && stop {
 			ev = AnnotatedEvent{}
 			stopExcl = true
 		} else {
-			gs.events = gs.events[1:]
+			gs.events.Pop()
 		}
 		if stop {
 			stopIncl = true
@@ -145,8 +242,9 @@ func (gs *GlobalSyncExec) DrainUntil(fn func(ev Event) bool, excl bool) error {
 }
 
 type globalHandle struct {
-	g atomic.Pointer[GlobalSyncExec]
-	d Executable
+	g        atomic.Pointer[GlobalSyncExec]
+	d        Executable
+	priority uint64
 }
 
 func (gh *globalHandle) onEvent(ev AnnotatedEvent) {

--- a/op-node/rollup/event/executor_global.go
+++ b/op-node/rollup/event/executor_global.go
@@ -20,9 +20,7 @@ type eventsList struct {
 
 type prioritizedEvents struct {
 	// keyed by priority. May contain empty lists.
-	byPriority map[uint64]*eventsList
-	// keys, sorted priorities, high to low
-	keys []uint64
+	byPriority [priorityCount]*eventsList
 
 	// number of events
 	count uint64
@@ -34,17 +32,10 @@ type prioritizedEvents struct {
 
 // Add enqueues the given event.
 func (a *prioritizedEvents) Add(event AnnotatedEvent) {
-	p, ok := a.byPriority[event.EmitPriority]
-	if !ok {
-		// Start tracking events with this priority level
-		p = &eventsList{Events: make([]AnnotatedEvent, 0, 100)}
-		a.byPriority[event.EmitPriority] = p
-		// Register the new priority as key, and sort so it's prioritized right.
-		a.keys = append(a.keys, event.EmitPriority)
-		sort.Slice(a.keys, func(i, j int) bool {
-			return a.keys[i] > a.keys[j]
-		})
+	if !event.EmitPriority.Valid() {
+		event.EmitPriority = Normal // if the priority is invalid, try to correct it
 	}
+	p := a.byPriority[event.EmitPriority-priorityMin]
 	p.Events = append(p.Events, event)
 	a.count += 1
 }
@@ -52,8 +43,8 @@ func (a *prioritizedEvents) Add(event AnnotatedEvent) {
 // Pop returns the highest-priority event, and removes it at the same time.
 // Returns a zeroed AnnotatedEvent if there is no event to pop.
 func (a *prioritizedEvents) Pop() AnnotatedEvent {
-	for _, priority := range a.keys {
-		pe := a.byPriority[priority]
+	for i := range a.byPriority {
+		pe := a.byPriority[priorityCount-1-i] // highest priority first
 		if len(pe.Events) > 0 {
 			out := pe.Events[0]
 			pe.Events = pe.Events[1:]
@@ -67,8 +58,8 @@ func (a *prioritizedEvents) Pop() AnnotatedEvent {
 // Peek returns the highest-priority event, without removing it.
 // Returns a zeroed AnnotatedEvent if there is no event to peek.
 func (a *prioritizedEvents) Peek() AnnotatedEvent {
-	for _, priority := range a.keys {
-		pe := a.byPriority[priority]
+	for i := range a.byPriority {
+		pe := a.byPriority[priorityCount-1-i] // highest priority first
 		if len(pe.Events) > 0 {
 			return pe.Events[0]
 		}
@@ -101,11 +92,15 @@ type GlobalSyncExec struct {
 var _ Executor = (*GlobalSyncExec)(nil)
 
 func NewGlobalSynchronous(ctx context.Context) *GlobalSyncExec {
+	var byPriority [priorityCount]*eventsList
+	for i := range byPriority {
+		// pre-allocate with some default capacity
+		byPriority[i] = &eventsList{make([]AnnotatedEvent, 0, 100)}
+	}
 	return &GlobalSyncExec{
 		ctx: ctx,
 		events: prioritizedEvents{
-			byPriority: make(map[uint64]*eventsList),
-			keys:       nil,
+			byPriority: byPriority,
 			count:      0,
 		},
 		queued: nil,
@@ -142,7 +137,7 @@ func (gs *GlobalSyncExec) Enqueue(ev AnnotatedEvent) error {
 	gs.eventsLock.Lock()
 	defer gs.eventsLock.Unlock()
 	// sanity limit, never queue too many events
-	if gs.events.count >= sanityEventLimit {
+	if gs.events.Count() >= sanityEventLimit {
 		return fmt.Errorf("something is very wrong, queued up too many events! Dropping event %q", ev.Event)
 	}
 	gs.events.Add(ev)
@@ -244,7 +239,7 @@ func (gs *GlobalSyncExec) DrainUntil(fn func(ev Event) bool, excl bool) error {
 type globalHandle struct {
 	g        atomic.Pointer[GlobalSyncExec]
 	d        Executable
-	priority uint64
+	priority Priority
 }
 
 func (gh *globalHandle) onEvent(ev AnnotatedEvent) {

--- a/op-node/rollup/event/executor_global_test.go
+++ b/op-node/rollup/event/executor_global_test.go
@@ -20,7 +20,7 @@ func TestGlobalExecutor(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	require.NoError(t, exec.Drain(), "can drain, even if empty")
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -46,7 +46,7 @@ func TestQueueSanityLimit(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	defer leave()
 	// emit 1 too many events
 	for i := 0; i < sanityEventLimit; i++ {
@@ -85,7 +85,7 @@ func TestSynchronousCyclic(t *testing.T) {
 		}
 	})
 	exec = NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	defer leave()
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: CyclicEvent{Count: 0}}))
 	require.NoError(t, exec.Drain())
@@ -100,7 +100,7 @@ func TestDrainCancel(t *testing.T) {
 		cancel()
 	})
 	exec := NewGlobalSynchronous(ctx)
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	defer leave()
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -121,7 +121,7 @@ func TestDrainUntilCancel(t *testing.T) {
 		}
 	})
 	exec := NewGlobalSynchronous(ctx)
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	defer leave()
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -143,7 +143,7 @@ func TestDrainUntilExcl(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	defer leave()
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -175,10 +175,10 @@ func TestPrioritized(t *testing.T) {
 		items = append(items, fmt.Sprintf("ex4: %d", ev.EmitContext))
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave1 := exec.Add(ex1, &ExecutorConfig{Priority: 100})
-	leave2 := exec.Add(ex2, &ExecutorConfig{Priority: 500})
-	leave3 := exec.Add(ex3, &ExecutorConfig{Priority: 200})
-	leave4 := exec.Add(ex4, &ExecutorConfig{Priority: 200})
+	leave1 := exec.Add(ex1, &ExecutorConfig{Priority: Low})
+	leave2 := exec.Add(ex2, &ExecutorConfig{Priority: High})
+	leave3 := exec.Add(ex3, &ExecutorConfig{Priority: Normal})
+	leave4 := exec.Add(ex4, &ExecutorConfig{Priority: Normal})
 	defer leave1()
 	defer leave2()
 	defer leave3()
@@ -187,17 +187,17 @@ func TestPrioritized(t *testing.T) {
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{
 		Event:        FooEvent{},
 		EmitContext:  0,
-		EmitPriority: 1000,
+		EmitPriority: Low,
 	}))
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{
 		Event:        TestEvent{},
 		EmitContext:  1,
-		EmitPriority: 3000,
+		EmitPriority: High,
 	}))
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{
 		Event:        TestEvent{},
 		EmitContext:  2,
-		EmitPriority: 2000,
+		EmitPriority: Normal,
 	}))
 	require.NoError(t, exec.Drain())
 
@@ -225,13 +225,13 @@ ex1: 0
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{
 		Event:        TestEvent{},
 		EmitContext:  3,
-		EmitPriority: 2000,
+		EmitPriority: High,
 	}))
 	// And another. FIFO.
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{
 		Event:        TestEvent{},
 		EmitContext:  4,
-		EmitPriority: 2000,
+		EmitPriority: High,
 	}))
 	require.NoError(t, exec.Drain())
 	out = "\n" + strings.Join(items, "\n") + "\n"
@@ -254,7 +254,7 @@ func TestAwait(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	leave := exec.Add(ex, &ExecutorConfig{Priority: Normal})
 	defer leave()
 
 	// this event should be picked up as pre-existing queued event

--- a/op-node/rollup/event/executor_global_test.go
+++ b/op-node/rollup/event/executor_global_test.go
@@ -2,7 +2,10 @@ package event
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +20,7 @@ func TestGlobalExecutor(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, nil)
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
 	require.NoError(t, exec.Drain(), "can drain, even if empty")
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -43,7 +46,7 @@ func TestQueueSanityLimit(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, nil)
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
 	defer leave()
 	// emit 1 too many events
 	for i := 0; i < sanityEventLimit; i++ {
@@ -82,7 +85,7 @@ func TestSynchronousCyclic(t *testing.T) {
 		}
 	})
 	exec = NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, nil)
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
 	defer leave()
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: CyclicEvent{Count: 0}}))
 	require.NoError(t, exec.Drain())
@@ -97,7 +100,7 @@ func TestDrainCancel(t *testing.T) {
 		cancel()
 	})
 	exec := NewGlobalSynchronous(ctx)
-	leave := exec.Add(ex, nil)
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
 	defer leave()
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -118,7 +121,7 @@ func TestDrainUntilCancel(t *testing.T) {
 		}
 	})
 	exec := NewGlobalSynchronous(ctx)
-	leave := exec.Add(ex, nil)
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
 	defer leave()
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -140,7 +143,7 @@ func TestDrainUntilExcl(t *testing.T) {
 		count += 1
 	})
 	exec := NewGlobalSynchronous(context.Background())
-	leave := exec.Add(ex, nil)
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
 	defer leave()
 
 	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}}))
@@ -155,4 +158,168 @@ func TestDrainUntilExcl(t *testing.T) {
 	require.Equal(t, 2, count, "Foo is processed, remainder is not, stop is inclusive now")
 	require.NoError(t, exec.Drain())
 	require.Equal(t, 4, count, "Done")
+}
+
+func TestPrioritized(t *testing.T) {
+	items := []string{}
+	ex1 := ExecutableFunc(func(ev AnnotatedEvent) {
+		items = append(items, fmt.Sprintf("ex1: %d", ev.EmitContext))
+	})
+	ex2 := ExecutableFunc(func(ev AnnotatedEvent) {
+		items = append(items, fmt.Sprintf("ex2: %d", ev.EmitContext))
+	})
+	ex3 := ExecutableFunc(func(ev AnnotatedEvent) {
+		items = append(items, fmt.Sprintf("ex3: %d", ev.EmitContext))
+	})
+	ex4 := ExecutableFunc(func(ev AnnotatedEvent) {
+		items = append(items, fmt.Sprintf("ex4: %d", ev.EmitContext))
+	})
+	exec := NewGlobalSynchronous(context.Background())
+	leave1 := exec.Add(ex1, &ExecutorConfig{Priority: 100})
+	leave2 := exec.Add(ex2, &ExecutorConfig{Priority: 500})
+	leave3 := exec.Add(ex3, &ExecutorConfig{Priority: 200})
+	leave4 := exec.Add(ex4, &ExecutorConfig{Priority: 200})
+	defer leave1()
+	defer leave2()
+	defer leave3()
+	defer leave4()
+
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{
+		Event:        FooEvent{},
+		EmitContext:  0,
+		EmitPriority: 1000,
+	}))
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{
+		Event:        TestEvent{},
+		EmitContext:  1,
+		EmitPriority: 3000,
+	}))
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{
+		Event:        TestEvent{},
+		EmitContext:  2,
+		EmitPriority: 2000,
+	}))
+	require.NoError(t, exec.Drain())
+
+	out := "\n" + strings.Join(items, "\n") + "\n"
+	// Enqueued events are executed based on their emit priority.
+	// Once an event is selected, the event is executed by executors in order of executor priority.
+	expected := `
+ex2: 1
+ex3: 1
+ex4: 1
+ex1: 1
+ex2: 2
+ex3: 2
+ex4: 2
+ex1: 2
+ex2: 0
+ex3: 0
+ex4: 0
+ex1: 0
+`
+	require.Equal(t, expected, out)
+	items = []string{}
+	// Try emit another event, with a previously seen priority.
+	// Other priorities may not have any events.
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{
+		Event:        TestEvent{},
+		EmitContext:  3,
+		EmitPriority: 2000,
+	}))
+	// And another. FIFO.
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{
+		Event:        TestEvent{},
+		EmitContext:  4,
+		EmitPriority: 2000,
+	}))
+	require.NoError(t, exec.Drain())
+	out = "\n" + strings.Join(items, "\n") + "\n"
+	expected = `
+ex2: 3
+ex3: 3
+ex4: 3
+ex1: 3
+ex2: 4
+ex3: 4
+ex4: 4
+ex1: 4
+`
+	require.Equal(t, expected, out)
+}
+
+func TestAwait(t *testing.T) {
+	count := 0
+	ex := ExecutableFunc(func(ev AnnotatedEvent) {
+		count += 1
+	})
+	exec := NewGlobalSynchronous(context.Background())
+	leave := exec.Add(ex, &ExecutorConfig{Priority: defaultEmitPriority})
+	defer leave()
+
+	// this event should be picked up as pre-existing queued event
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}, EmitContext: 1}))
+	require.NotZero(t, exec.events.Count())
+	ch := exec.Await()
+	select {
+	case <-time.After(time.Second * 10):
+		t.Fatal("timeout")
+	case _, ok := <-ch:
+		require.False(t, ok, "should be unblocked now")
+	}
+	require.NoError(t, exec.Drain())
+	require.Zero(t, exec.events.Count())
+
+	// Here we expect to not have any events, yet.
+	ch = exec.Await()
+	select {
+	case <-ch:
+		t.Fatal("should not be unlocked yet")
+	default:
+	}
+	// Enqueue an event, see if it unblocks the await as expected
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}, EmitContext: 2}))
+	require.NotZero(t, exec.events.Count())
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "should be unblocked now")
+	default:
+		t.Fatal("should not be blocked")
+	}
+	require.NoError(t, exec.Drain())
+	require.Zero(t, exec.events.Count())
+
+	// Now try a pre-existing await, followed by multiple queued events, to drain all at once.
+	ch = exec.Await()
+	select {
+	case <-ch:
+		t.Fatal("should not be unlocked yet")
+	default:
+	}
+	ch2 := exec.Await()
+	require.Equal(t, ch, ch2, "should reuse the same channel")
+
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}, EmitContext: 3}))
+
+	ch3 := exec.Await()
+	require.NotEqual(t, ch, ch3, "enqueue should replace the await channel")
+
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}, EmitContext: 4}))
+	require.NoError(t, exec.Enqueue(AnnotatedEvent{Event: TestEvent{}, EmitContext: 5}))
+	require.Equal(t, uint64(3), exec.events.Count())
+
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "original should be unblocked since a while")
+	default:
+		t.Fatal("should not be blocked")
+	}
+	select {
+	case _, ok := <-ch3:
+		require.False(t, ok, "later channel should be unblocked also")
+	default:
+		t.Fatal("should not be blocked")
+	}
+	require.NoError(t, exec.Drain())
+	require.Zero(t, exec.events.Count())
 }

--- a/op-node/rollup/event/options.go
+++ b/op-node/rollup/event/options.go
@@ -5,12 +5,12 @@ import "golang.org/x/time/rate"
 type ExecutorConfig struct {
 	// Priority. Higher = more important.
 	// For synchronous executors this may help decide which deriver receives the event first.
-	Priority uint64
+	Priority Priority
 }
 
 // WithExecPriority sets the executor priority. Higher = more important.
 // This directs which deriver first executes an event, if there is a synchronous choice.
-func WithExecPriority(priority uint64) RegisterOption {
+func WithExecPriority(priority Priority) RegisterOption {
 	return func(cfg *RegisterConfig) {
 		cfg.Executor.Priority = priority
 	}
@@ -25,7 +25,7 @@ type EmitterConfig struct {
 	// Priority. Higher = more important.
 	// Events from more important emitters will be prioritized
 	// for execution over queued up events with lower priority.
-	Priority uint64
+	Priority Priority
 }
 
 func WithEmitLimiter(rate rate.Limit, burst int, onLimited func()) RegisterOption {
@@ -46,7 +46,7 @@ func WithNoEmitLimiter() RegisterOption {
 // WithEmitPriority sets the emitter priority. Higher = more important.
 // This directs when an emitted event is processed:
 // it may be prioritized over other emitters of lesser importance.
-func WithEmitPriority(priority uint64) RegisterOption {
+func WithEmitPriority(priority Priority) RegisterOption {
 	return func(cfg *RegisterConfig) {
 		cfg.Emitter.Priority = priority
 	}
@@ -70,22 +70,17 @@ const eventsLimit = rate.Limit(10_000)
 // past the rate limit before the rate limit becomes applicable.
 const eventsBurst = 500
 
-const (
-	defaultExecPriority = 100
-	defaultEmitPriority = 100
-)
-
 func defaultRegisterConfig() *RegisterConfig {
 	return &RegisterConfig{
 		Executor: ExecutorConfig{
-			Priority: defaultExecPriority,
+			Priority: Normal,
 		},
 		Emitter: EmitterConfig{
 			Limiting:  true,
 			Rate:      eventsLimit,
 			Burst:     eventsBurst,
 			OnLimited: nil,
-			Priority:  defaultEmitPriority,
+			Priority:  Normal,
 		},
 	}
 }

--- a/op-node/rollup/event/options.go
+++ b/op-node/rollup/event/options.go
@@ -2,27 +2,65 @@ package event
 
 import "golang.org/x/time/rate"
 
-type ExecutorOpts struct {
-	Capacity int // If there is a local buffer capacity
+type ExecutorConfig struct {
+	// Priority. Higher = more important.
+	// For synchronous executors this may help decide which deriver receives the event first.
+	Priority uint64
 }
 
-type EmitterOpts struct {
+// WithExecPriority sets the executor priority. Higher = more important.
+// This directs which deriver first executes an event, if there is a synchronous choice.
+func WithExecPriority(priority uint64) RegisterOption {
+	return func(cfg *RegisterConfig) {
+		cfg.Executor.Priority = priority
+	}
+}
+
+type EmitterConfig struct {
 	Limiting  bool
 	Rate      rate.Limit
 	Burst     int
 	OnLimited func()
+
+	// Priority. Higher = more important.
+	// Events from more important emitters will be prioritized
+	// for execution over queued up events with lower priority.
+	Priority uint64
 }
 
-// RegisterOpts represents the set of parameters to configure a
+func WithEmitLimiter(rate rate.Limit, burst int, onLimited func()) RegisterOption {
+	return func(cfg *RegisterConfig) {
+		cfg.Emitter.Limiting = true
+		cfg.Emitter.Rate = rate
+		cfg.Emitter.Burst = burst
+		cfg.Emitter.OnLimited = onLimited
+	}
+}
+
+func WithNoEmitLimiter() RegisterOption {
+	return func(cfg *RegisterConfig) {
+		cfg.Emitter.Limiting = false
+	}
+}
+
+// WithEmitPriority sets the emitter priority. Higher = more important.
+// This directs when an emitted event is processed:
+// it may be prioritized over other emitters of lesser importance.
+func WithEmitPriority(priority uint64) RegisterOption {
+	return func(cfg *RegisterConfig) {
+		cfg.Emitter.Priority = priority
+	}
+}
+
+// RegisterConfig represents the set of parameters to configure a
 // new deriver/emitter with that is registered with an event System.
 // These options may be reused for multiple registrations.
-type RegisterOpts struct {
-	Executor ExecutorOpts
-	Emitter  EmitterOpts
+type RegisterConfig struct {
+	Executor ExecutorConfig
+	Emitter  EmitterConfig
 }
 
-// 200 events may be buffered per deriver before back-pressure has to kick in
-const eventsBuffer = 200
+type RegisterOption func(cfg *RegisterConfig)
 
 // 10,000 events per second is plenty.
 // If we are going through more events, the driver needs to breathe, and warn the user of a potential issue.
@@ -32,16 +70,22 @@ const eventsLimit = rate.Limit(10_000)
 // past the rate limit before the rate limit becomes applicable.
 const eventsBurst = 500
 
-func DefaultRegisterOpts() *RegisterOpts {
-	return &RegisterOpts{
-		Executor: ExecutorOpts{
-			Capacity: eventsBuffer,
+const (
+	defaultExecPriority = 100
+	defaultEmitPriority = 100
+)
+
+func defaultRegisterConfig() *RegisterConfig {
+	return &RegisterConfig{
+		Executor: ExecutorConfig{
+			Priority: defaultExecPriority,
 		},
-		Emitter: EmitterOpts{
+		Emitter: EmitterConfig{
 			Limiting:  true,
 			Rate:      eventsLimit,
 			Burst:     eventsBurst,
 			OnLimited: nil,
+			Priority:  defaultEmitPriority,
 		},
 	}
 }

--- a/op-node/rollup/event/priority.go
+++ b/op-node/rollup/event/priority.go
@@ -1,0 +1,35 @@
+package event
+
+import "fmt"
+
+// Priority applies to events,
+// to process the more important events first,
+// when and if there is a synchronous choice.
+// The default priority is 0, the normal.
+type Priority int8
+
+const (
+	priorityMin            = -1
+	Low           Priority = -1
+	Normal        Priority = 0
+	High          Priority = 1
+	priorityMax            = 1
+	priorityCount          = priorityMax + 1 - priorityMin
+)
+
+func (p Priority) String() string {
+	switch p {
+	case Low:
+		return "low"
+	case Normal:
+		return "normal"
+	case High:
+		return "high"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(p))
+	}
+}
+
+func (p Priority) Valid() bool {
+	return priorityMin <= p && p <= priorityMax
+}

--- a/op-node/rollup/event/system.go
+++ b/op-node/rollup/event/system.go
@@ -40,8 +40,8 @@ type AttachEmitter interface {
 
 type AnnotatedEvent struct {
 	Event        Event
-	EmitContext  uint64 // uniquely identifies the emission of the event, useful for debugging and creating diagrams
-	EmitPriority uint64 // how important the emitter is, higher is more important
+	EmitContext  uint64   // uniquely identifies the emission of the event, useful for debugging and creating diagrams
+	EmitPriority Priority // how important the emitter is, higher is more important
 }
 
 // systemActor is a deriver and/or emitter, registered in System with a name.
@@ -63,7 +63,7 @@ type systemActor struct {
 	// How important this actor is as emitter. Higher is more important.
 	// Emitted events from actors with a higher emit priority
 	// will be prioritized over other queued up events.
-	emitPriority uint64
+	emitPriority Priority
 }
 
 // Emit is called by the end-user
@@ -261,7 +261,7 @@ func (s *Sys) recordEmit(name string, ev AnnotatedEvent, derivContext uint64, em
 // emit an event [ev] during the derivation of another event, referenced by derivContext.
 // If the event was emitted not as part of deriver event execution, then the derivContext is 0.
 // The name of the emitter is provided to further contextualize the event.
-func (s *Sys) emit(name string, derivContext uint64, ev Event, emitPriority uint64) {
+func (s *Sys) emit(name string, derivContext uint64, ev Event, emitPriority Priority) {
 	emitContext := s.emitContext.Add(1)
 	annotated := AnnotatedEvent{Event: ev, EmitContext: emitContext, EmitPriority: emitPriority}
 

--- a/op-node/rollup/event/system.go
+++ b/op-node/rollup/event/system.go
@@ -16,7 +16,7 @@ type Registry interface {
 	// deriver may be nil, not all registrants have to process events.
 	// A non-nil deriver may implement AttachEmitter to automatically attach the Emitter to it,
 	// before the deriver itself becomes executable.
-	Register(name string, deriver Deriver, opts *RegisterOpts) Emitter
+	Register(name string, deriver Deriver, opts ...RegisterOption) Emitter
 	// Unregister removes a named emitter,
 	// also removing it from the set of events-receiving derivers (if registered with non-nil deriver).
 	Unregister(name string) (old Emitter)
@@ -39,8 +39,9 @@ type AttachEmitter interface {
 }
 
 type AnnotatedEvent struct {
-	Event       Event
-	EmitContext uint64 // uniquely identifies the emission of the event, useful for debugging and creating diagrams
+	Event        Event
+	EmitContext  uint64 // uniquely identifies the emission of the event, useful for debugging and creating diagrams
+	EmitPriority uint64 // how important the emitter is, higher is more important
 }
 
 // systemActor is a deriver and/or emitter, registered in System with a name.
@@ -58,6 +59,11 @@ type systemActor struct {
 
 	// 0 if event does not originate from Deriver-handling of another event
 	currentEvent uint64
+
+	// How important this actor is as emitter. Higher is more important.
+	// Emitted events from actors with a higher emit priority
+	// will be prioritized over other queued up events.
+	emitPriority uint64
 }
 
 // Emit is called by the end-user
@@ -65,7 +71,7 @@ func (r *systemActor) Emit(ev Event) {
 	if r.ctx.Err() != nil {
 		return
 	}
-	r.sys.emit(r.name, r.currentEvent, ev)
+	r.sys.emit(r.name, r.currentEvent, ev, r.emitPriority)
 }
 
 // RunEvent is called by the events executor.
@@ -120,12 +126,17 @@ func NewSystem(log log.Logger, ex Executor) *Sys {
 	}
 }
 
-func (s *Sys) Register(name string, deriver Deriver, opts *RegisterOpts) Emitter {
+func (s *Sys) Register(name string, deriver Deriver, opts ...RegisterOption) Emitter {
 	s.regsLock.Lock()
 	defer s.regsLock.Unlock()
 
 	if _, ok := s.regs[name]; ok {
 		panic(fmt.Errorf("a deriver/emitter with name %q already exists", name))
+	}
+
+	cfg := defaultRegisterConfig()
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -135,12 +146,14 @@ func (s *Sys) Register(name string, deriver Deriver, opts *RegisterOpts) Emitter
 		sys:    s,
 		ctx:    ctx,
 		cancel: cancel,
+		// prioritize the outgoing messages
+		emitPriority: cfg.Emitter.Priority,
 	}
 	s.regs[name] = r
 	var em Emitter = r
-	if opts.Emitter.Limiting {
-		limitedCallback := opts.Emitter.OnLimited
-		em = NewLimiter(ctx, r, opts.Emitter.Rate, opts.Emitter.Burst, func() {
+	if cfg.Emitter.Limiting {
+		limitedCallback := cfg.Emitter.OnLimited
+		em = NewLimiter(ctx, r, cfg.Emitter.Rate, cfg.Emitter.Burst, func() {
 			r.sys.recordRateLimited(name, r.currentEvent)
 			if limitedCallback != nil {
 				limitedCallback()
@@ -154,7 +167,7 @@ func (s *Sys) Register(name string, deriver Deriver, opts *RegisterOpts) Emitter
 		if attachTo, ok := deriver.(AttachEmitter); ok {
 			attachTo.AttachEmitter(em)
 		}
-		r.leaveExecutor = s.executor.Add(r, &opts.Executor)
+		r.leaveExecutor = s.executor.Add(r, &cfg.Executor)
 	}
 	return em
 }
@@ -248,9 +261,9 @@ func (s *Sys) recordEmit(name string, ev AnnotatedEvent, derivContext uint64, em
 // emit an event [ev] during the derivation of another event, referenced by derivContext.
 // If the event was emitted not as part of deriver event execution, then the derivContext is 0.
 // The name of the emitter is provided to further contextualize the event.
-func (s *Sys) emit(name string, derivContext uint64, ev Event) {
+func (s *Sys) emit(name string, derivContext uint64, ev Event, emitPriority uint64) {
 	emitContext := s.emitContext.Add(1)
-	annotated := AnnotatedEvent{Event: ev, EmitContext: emitContext}
+	annotated := AnnotatedEvent{Event: ev, EmitContext: emitContext, EmitPriority: emitPriority}
 
 	// As soon as anything emits a critical event,
 	// make the system aware, before the executor event schedules it for processing.

--- a/op-node/rollup/event/system_test.go
+++ b/op-node/rollup/event/system_test.go
@@ -29,7 +29,7 @@ func TestSysTracing(t *testing.T) {
 	logTracer := NewLogTracer(lgr, log.LevelDebug)
 	sys.AddTracer(logTracer)
 
-	em := sys.Register("foo", foo, DefaultRegisterOpts())
+	em := sys.Register("foo", foo)
 	em.Emit(TestEvent{})
 	require.Equal(t, 0, count, "no event processing before synchronous executor explicitly drains")
 	require.NoError(t, ex.Drain())
@@ -86,9 +86,9 @@ func TestSystemBroadcast(t *testing.T) {
 		}
 		return true
 	})
-	fooEm := sys.Register("foo", foo, DefaultRegisterOpts())
+	fooEm := sys.Register("foo", foo)
 	fooEm.Emit(TestEvent{})
-	barEm := sys.Register("bar", bar, DefaultRegisterOpts())
+	barEm := sys.Register("bar", bar)
 	barEm.Emit(TestEvent{})
 	// events are broadcast to every deriver, regardless who sends them
 	require.NoError(t, ex.Drain())
@@ -121,8 +121,8 @@ func TestCriticalError(t *testing.T) {
 	})
 	exec := NewGlobalSynchronous(context.Background())
 	sys := NewSystem(logger, exec)
-	emitterA := sys.Register("a", deriverFn, DefaultRegisterOpts())
-	emitterB := sys.Register("b", deriverFn, DefaultRegisterOpts())
+	emitterA := sys.Register("a", deriverFn)
+	emitterB := sys.Register("b", deriverFn)
 
 	require.NoError(t, exec.Drain(), "can drain, even if empty")
 	emitterA.Emit(TestEvent{})

--- a/op-node/rollup/sequencing/sequencer_chaos_test.go
+++ b/op-node/rollup/sequencing/sequencer_chaos_test.go
@@ -262,15 +262,8 @@ func testSequencerChaosWithSeed(t *testing.T, seed int64) {
 	ex := event.NewGlobalSynchronous(context.Background())
 	sys := event.NewSystem(logger, ex)
 	sys.AddTracer(event.NewLogTracer(logger, log.LevelInfo))
-
-	opts := &event.RegisterOpts{
-		Executor: event.ExecutorOpts{
-			Capacity: 200,
-		},
-		Emitter: event.EmitterOpts{
-			Limiting: false, // We're rapidly simulating with fake clock, so don't rate-limit
-		},
-	}
+	// We're rapidly simulating with fake clock, so don't rate-limit
+	opts := event.WithNoEmitLimiter()
 	sys.Register("sequencer", seq, opts)
 
 	rng := rand.New(rand.NewSource(seed))

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -129,10 +129,10 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 
 	// create initial per-chain resources
 	chainsDBs := db.NewChainsDB(logger, depSet, m)
-	eventSys.Register("chainsDBs", chainsDBs, event.DefaultRegisterOpts())
+	eventSys.Register("chainsDBs", chainsDBs)
 
 	l1Accessor := l1access.NewL1Accessor(sysCtx, logger, nil)
-	eventSys.Register("l1Accessor", l1Accessor, event.DefaultRegisterOpts())
+	eventSys.Register("l1Accessor", l1Accessor)
 
 	// create the supervisor backend
 	super := &SupervisorBackend{
@@ -152,16 +152,16 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 
 		rpcVerificationWarnings: cfg.RPCVerificationWarnings,
 	}
-	eventSys.Register("backend", super, event.DefaultRegisterOpts())
-	eventSys.Register("rewinder", super.rewinder, event.DefaultRegisterOpts())
+	eventSys.Register("backend", super)
+	eventSys.Register("rewinder", super.rewinder)
 
 	// create node controller
 	super.syncNodesController = syncnode.NewSyncNodesController(logger, depSet, eventSys, super)
-	eventSys.Register("sync-controller", super.syncNodesController, event.DefaultRegisterOpts())
+	eventSys.Register("sync-controller", super.syncNodesController)
 
 	// create status tracker
 	super.statusTracker = status.NewStatusTracker(depSet.Chains())
-	eventSys.Register("status", super.statusTracker, event.DefaultRegisterOpts())
+	eventSys.Register("status", super.statusTracker)
 
 	// Initialize the resources of the supervisor backend.
 	// Stop the supervisor if any of the resources fails to be initialized.
@@ -219,23 +219,22 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 		}
 	}
 
-	eventOpts := event.DefaultRegisterOpts()
 	// initialize all cross-unsafe processors
 	for _, chainID := range chains {
 		worker := cross.NewCrossUnsafeWorker(su.logger, chainID, su.chainDBs)
-		su.eventSys.Register(fmt.Sprintf("cross-unsafe-%s", chainID), worker, eventOpts)
+		su.eventSys.Register(fmt.Sprintf("cross-unsafe-%s", chainID), worker)
 	}
 	// initialize all cross-safe processors
 	for _, chainID := range chains {
 		worker := cross.NewCrossSafeWorker(su.logger, chainID, su.chainDBs)
-		su.eventSys.Register(fmt.Sprintf("cross-safe-%s", chainID), worker, eventOpts)
+		su.eventSys.Register(fmt.Sprintf("cross-safe-%s", chainID), worker)
 	}
 	// For each chain initialize a chain processor service,
 	// after cross-unsafe workers are ready to receive updates
 	for _, chainID := range chains {
 		logProcessor := processors.NewLogProcessor(chainID, su.chainDBs, su.depSet)
 		chainProcessor := processors.NewChainProcessor(su.sysContext, su.logger, chainID, logProcessor, su.chainDBs)
-		su.eventSys.Register(fmt.Sprintf("events-%s", chainID), chainProcessor, eventOpts)
+		su.eventSys.Register(fmt.Sprintf("events-%s", chainID), chainProcessor)
 		su.chainProcessors.Set(chainID, chainProcessor)
 	}
 	// initialize sync sources

--- a/op-supervisor/supervisor/backend/syncnode/controller.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller.go
@@ -82,7 +82,7 @@ func (snc *SyncNodesController) AttachNodeController(chainID eth.ChainID, ctrl S
 
 	// create the managed node, register and return
 	node := NewManagedNode(logger, chainID, ctrl, snc.backend, noSubscribe)
-	snc.eventSys.Register(name, node, event.DefaultRegisterOpts())
+	snc.eventSys.Register(name, node)
 	controllersForChain.Set(node, struct{}{})
 	node.Start()
 	return node, nil

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -239,7 +239,7 @@ func TestAttachNodeController(t *testing.T) {
 	ex := event.NewGlobalSynchronous(context.Background())
 	eventSys := event.NewSystem(logger, ex)
 	controller := NewSyncNodesController(logger, depSet, eventSys, &mockBackend{})
-	eventSys.Register("controller", controller, event.DefaultRegisterOpts())
+	eventSys.Register("controller", controller)
 	require.Zero(t, controller.controllers.Len(), "controllers should be empty to start")
 
 	// Attach a controller for chain 900

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -25,12 +25,12 @@ func TestEventResponse(t *testing.T) {
 	eventSys := event.NewSystem(logger, ex)
 
 	mon := &eventMonitor{}
-	eventSys.Register("monitor", mon, event.DefaultRegisterOpts())
+	eventSys.Register("monitor", mon)
 
 	node := NewManagedNode(logger, chainID, syncCtrl, backend, false)
-	eventSys.Register("node", node, event.DefaultRegisterOpts())
+	eventSys.Register("node", node)
 
-	emitter := eventSys.Register("test", nil, event.DefaultRegisterOpts())
+	emitter := eventSys.Register("test", nil)
 
 	crossUnsafe := 0
 	crossSafe := 0
@@ -100,10 +100,10 @@ func TestPrepareReset(t *testing.T) {
 	eventSys := event.NewSystem(logger, ex)
 
 	mon := &eventMonitor{}
-	eventSys.Register("monitor", mon, event.DefaultRegisterOpts())
+	eventSys.Register("monitor", mon)
 
 	node := NewManagedNode(logger, chainID, syncCtrl, backend, false)
-	eventSys.Register("node", node, event.DefaultRegisterOpts())
+	eventSys.Register("node", node)
 
 	// mock: return a block of the same number as requested
 	syncCtrl.blockRefByNumFn = func(ctx context.Context, number uint64) (eth.BlockRef, error) {


### PR DESCRIPTION
**Description**

Implements some improvements for the synchronous executor of the event-system:
- basic support for prioritization
  - emitters can be prioritized (e.g. events from the engine may be really important)
  - execution can be prioritized (e.g. we may want to prioritize the sequencing to always get notified first)
- ability to await when new events are available to be processed
- improved configuration, using an option pattern now

This PR does not yet make any changes to the op-node, but helps unblock some follow up op-node improvements.

**Tests**

- unit-tested the priority logic
- unit-tested the await functionality

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/15812
