### PR TITLE
op-devstack, op-acceptance-tests: interop: minimal messaging test for sysgo + sysext with dsl

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -2,6 +2,7 @@ package descriptors
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
@@ -10,11 +11,20 @@ import (
 
 type PortInfo struct {
 	Host        string `json:"host"`
+	Path        string `json:"path,omitempty"`
 	Scheme      string `json:"scheme,omitempty"`
 	Port        int    `json:"port,omitempty"`
 	PrivatePort int    `json:"private_port,omitempty"`
 
 	ReverseProxyHeader http.Header `json:"reverse_proxy_header,omitempty"`
+}
+
+func AppendPath(baseURL, path string) string {
+	url := baseURL
+	if path != "" {
+		url += fmt.Sprintf("/%s", path)
+	}
+	return url
 }
 
 // EndpointMap is a map of service names to their endpoints.

--- a/op-acceptance-tests/tests/interop/message/init_test.go
+++ b/op-acceptance-tests/tests/interop/message/init_test.go
@@ -1,0 +1,14 @@
+package msg
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+var SimpleInterop presets.TestSetup[*presets.SimpleInterop]
+
+func TestMain(m *testing.M) {
+	SimpleInterop = presets.NewSimpleInterop
+	presets.DoMain(m, presets.ConfigureSimpleInterop())
+}

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -1,0 +1,27 @@
+package msg
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TestInitExecMsg tests basic interop messaging
+func TestInitExecMsg(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := SimpleInterop(t)
+	rng := rand.New(rand.NewSource(1234))
+	alice := sys.FunderA.NewFundedEOA(eth.ThousandEther)
+	bob := sys.FunderB.NewFundedEOA(eth.ThousandEther)
+
+	eventLoggerAddress := alice.DeployEventLogger()
+	// Trigger random init message at chain A
+	initIntent, _ := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
+	// Make sure supervisor indexs block which includes init message
+	sys.Supervisor.AdvanceUnsafeHead(alice.ChainID(), 2)
+	// Single event in tx so index is 0
+	bob.SendExecMessage(initIntent, 0)
+}

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -75,14 +75,15 @@ func (orch *Orchestrator) findProtocolService(service *descriptors.Service, prot
 	for proto, endpoint := range service.Endpoints {
 		if proto == protocol {
 			if orch.env.Env.ReverseProxyURL != "" && !orch.useDirectCnx {
-				return orch.env.Env.ReverseProxyURL, endpoint.ReverseProxyHeader, nil
+				return descriptors.AppendPath(orch.env.Env.ReverseProxyURL, endpoint.Path), endpoint.ReverseProxyHeader, nil
 			}
 
 			port := endpoint.Port
 			if orch.usePrivatePorts {
 				port = endpoint.PrivatePort
 			}
-			return fmt.Sprintf("http://%s:%d", endpoint.Host, port), nil, nil
+			url := descriptors.AppendPath(fmt.Sprintf("http://%s:%d", endpoint.Host, port), endpoint.Path)
+			return url, nil, nil
 		}
 	}
 	return "", nil, fmt.Errorf("protocol %s not found", protocol)

--- a/op-devstack/sysext/l1.go
+++ b/op-devstack/sysext/l1.go
@@ -1,6 +1,8 @@
 package sysext
 
 import (
+	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -52,6 +54,9 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 	}
 
 	if faucet, ok := env.Env.L1.Services["faucet"]; ok {
+		for _, endpoint := range faucet.Endpoints {
+			endpoint.Path = fmt.Sprintf("chain/%s", l1.ChainID().String())
+		}
 		l1.AddFaucet(shim.NewFaucet(shim.FaucetConfig{
 			CommonConfig: commonConfig,
 			Client:       o.rpcClient(t, faucet, RPCProtocol),

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -1,6 +1,7 @@
 package sysext
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
@@ -57,6 +58,9 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 	o.hydrateL2ProxydMaybe(net, l2)
 
 	if faucet, ok := net.Services["faucet"]; ok {
+		for _, endpoint := range faucet.Endpoints {
+			endpoint.Path = fmt.Sprintf("chain/%s", l2.ChainID().String())
+		}
 		l2.AddFaucet(shim.NewFaucet(shim.FaucetConfig{
 			CommonConfig: commonConfig,
 			Client:       o.rpcClient(t, faucet, RPCProtocol),


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Ports the simplest interop message test which was written using the legacy, using the devstack. Did not remove the original test because currently the subdirectories are not targeted at develop CI acceptance test. Let the original one stay, but eventually the legacy one will be removed.

**Tests**

Ported [op-acceptance-tests/tests/interop/interop_txplan_test.go](https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/tests/interop/interop_txplan_test.go): `TestInteropInitAndExecMsg` to `TestInitExecMsg`.

This new test can be targeting both modes: `cd optimism/op-acceptance-tests/tests/interop/message`
Sysgo: `go test -run ^TestInitExecMsg$ -v -count=1  | grep -E "deployed EventLogger|init message included|exec message included|AdvanceUnsafeHead|Sync status not ready|Supervisor view of unsafe head"`
Logs
```
    eoa.go:128:                 INFO [05-12|23:50:17.294] deployed EventLogger                     chainID=901 address=0xB9CAF71A40C0dBcD97EdCb2162085B73B1D23B97
    eoa.go:137:                 INFO [05-12|23:50:18.525] init message included                    chain=901 block=7
    supervisor.go:114:          INFO [05-12|23:50:18.525] Supervisor view of unsafe head           chain=901 unsafe=1e844a..060918:7
    supervisor.go:114:          INFO [05-12|23:50:20.526] Supervisor view of unsafe head           chain=901 unsafe=c7b14c..459b99:8
    supervisor.go:114:          INFO [05-12|23:50:22.533] Supervisor view of unsafe head           chain=901 unsafe=67f128..bdb1b1:9
    eoa.go:147:                 INFO [05-12|23:50:25.620] exec message included                    chain=902 block=10
```

Sysext: `DEVSTACK_ORCHESTRATOR=sysext DEVNET_ENV_URL=kt://interop-devnet go test -run ^TestInitExecMsg$ -v -count=1`
```
INFO [05-12|23:29:56.833] Detected                                 backend=sysext
INFO [05-12|23:29:56.833] initializing orchestrator                backend=sysext
=== RUN   TestInitExecMsg
    eoa.go:128:                 INFO [05-12|23:30:07.261] deployed EventLogger                     chainID=2151908 address=0xB9CAF71A40C0dBcD97EdCb2162085B73B1D23B97
    eoa.go:137:                 INFO [05-12|23:30:10.588] init message included                    chain=2151908 block=10547
    supervisor.go:83:           INFO [05-12|23:30:10.592] Fetched supervisor sync status           minSyncedL1=7138be..4002b8:2692 safeTimestamp=1,747,060,166 finalizedTimestamp=1,747,060,058
    supervisor.go:83:           INFO [05-12|23:30:10.594] Fetched supervisor sync status           minSyncedL1=7138be..4002b8:2692 safeTimestamp=1,747,060,166 finalizedTimestamp=1,747,060,058
    supervisor.go:114:          INFO [05-12|23:30:10.594] Supervisor view of unsafe head           chain=2151908 unsafe=a54a98..62ff7f:10547
    supervisor.go:116:          INFO [05-12|23:30:10.594] Unsafe head sync status not ready        chain=2151908 initialUnsafe=a54a98..62ff7f:10547 currentUnsafe=a54a98..62ff7f:10547 minRequired=10549
    supervisor.go:83:           INFO [05-12|23:30:12.598] Fetched supervisor sync status           minSyncedL1=f6c3e1..965133:2694 safeTimestamp=1,747,060,178 finalizedTimestamp=1,747,060,058
    supervisor.go:114:          INFO [05-12|23:30:12.598] Supervisor view of unsafe head           chain=2151908 unsafe=48160d..97ff39:10548
    supervisor.go:116:          INFO [05-12|23:30:12.598] Unsafe head sync status not ready        chain=2151908 initialUnsafe=a54a98..62ff7f:10547 currentUnsafe=48160d..97ff39:10548 minRequired=10549
    supervisor.go:83:           INFO [05-12|23:30:14.602] Fetched supervisor sync status           minSyncedL1=f6c3e1..965133:2694 safeTimestamp=1,747,060,178 finalizedTimestamp=1,747,060,058
    supervisor.go:114:          INFO [05-12|23:30:14.602] Supervisor view of unsafe head           chain=2151908 unsafe=fa2174..a830f5:10549
    eoa.go:147:                 INFO [05-12|23:30:17.991] exec message included                    chain=2151909 block=10551
--- PASS: TestInitExecMsg (21.06s)
PASS
```

**Additional context**

I believe this is the first test which uses op-faucet with sysext(local kt devnet). Op faucet is multiplexed using the url path, and the sysext did not know about it. Tracked https://github.com/ethereum-optimism/optimism/issues/15838. [op-faucet docs](https://github.com/ethereum-optimism/optimism/tree/develop/op-faucet#overview)

I gave a temporal fix to remediate this, but wondering is there a better approach.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15839
