### PR TITLE
op-deployer: use op-supervisor StaticConfigDependencySet struct

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/proofs/prestate"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func GenerateInteropDepset(ctx context.Context, pEnv *Env, globalIntent *state.Intent, st *state.State) error {
@@ -16,14 +18,21 @@ func GenerateInteropDepset(ctx context.Context, pEnv *Env, globalIntent *state.I
 		return nil
 	}
 
-	var chains []string
-	for _, chain := range globalIntent.Chains {
-		chains = append(chains, chain.ID.Big().String())
+	lgr.Info("creating interop dependency set...")
+	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
+	for i, chain := range globalIntent.Chains {
+		id, err := eth.ParseDecimalChainID(chain.ID.String())
+		if err != nil {
+			return fmt.Errorf("failed to parse chain ID: %w", err)
+		}
+		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
 	}
 
-	lgr.Info("rendering the interop dependency set...")
-	depSet := prestate.RenderInteropDepSet(chains)
-	st.InteropDepSet = &depSet
+	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)
+	if err != nil {
+		return fmt.Errorf("failed to create interop dependency set: %w", err)
+	}
+	st.InteropDepSet = interopDepSet
 
 	if err := pEnv.StateWriter.WriteState(st); err != nil {
 		return fmt.Errorf("failed to write state: %w", err)

--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -21,10 +21,7 @@ func GenerateInteropDepset(ctx context.Context, pEnv *Env, globalIntent *state.I
 	lgr.Info("creating interop dependency set...")
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for i, chain := range globalIntent.Chains {
-		id, err := eth.ParseDecimalChainID(chain.ID.String())
-		if err != nil {
-			return fmt.Errorf("failed to parse chain ID: %w", err)
-		}
+		id := eth.ChainIDFromBytes32(chain.ID)
 		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
 	}
 

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/proofs/prestate"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
@@ -37,7 +38,7 @@ type State struct {
 	PrestateManifest *prestate.PrestateManifest `json:"prestateManifest"`
 
 	// InteropDepSet contains the interop dependency set render by the prestate SDK if interop is enabled
-	InteropDepSet *prestate.DependencySet `json:"interopDepSet,omitempty"`
+	InteropDepSet *depset.StaticConfigDependencySet `json:"interopDepSet,omitempty"`
 
 	// SuperchainDeployment contains the addresses of the Superchain
 	// deployment. It only contains the proxies because the implementations


### PR DESCRIPTION
Prior to this pr devnet-sdk and op-deployer used a custom `DependencySet` struct that lived in devnet-sdk. This was awkward for op-deployer (a production component) to import from devnet-sdk (a testing sdk), and could lead to circular dependencies in the future.

This pr updates both packages such that they import and use the standard op-supervisor `StaticConfigDependencySet` struct instead. This will help us keep our software components compatible, included future compatibility with superchain-registry