### PR TITLE
fix(devstack): honor RPC endpoint path

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -2,7 +2,6 @@ package descriptors
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
@@ -11,20 +10,11 @@ import (
 
 type PortInfo struct {
 	Host        string `json:"host"`
-	Path        string `json:"path,omitempty"`
 	Scheme      string `json:"scheme,omitempty"`
 	Port        int    `json:"port,omitempty"`
 	PrivatePort int    `json:"private_port,omitempty"`
 
 	ReverseProxyHeader http.Header `json:"reverse_proxy_header,omitempty"`
-}
-
-func AppendPath(baseURL, path string) string {
-	url := baseURL
-	if path != "" {
-		url += fmt.Sprintf("/%s", path)
-	}
-	return url
 }
 
 // EndpointMap is a map of service names to their endpoints.

--- a/op-devstack/sysext/l1.go
+++ b/op-devstack/sysext/l1.go
@@ -31,7 +31,7 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 		l1.AddL1ELNode(shim.NewL1ELNode(shim.L1ELNodeConfig{
 			ELNodeConfig: shim.ELNodeConfig{
 				CommonConfig: commonConfig,
-				Client:       o.rpcClient(t, elService, RPCProtocol),
+				Client:       o.rpcClient(t, elService, RPCProtocol, "/"),
 				ChainID:      l1ID,
 			},
 			ID: stack.L1ELNodeID{
@@ -49,18 +49,15 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 				ChainID: l1ID,
 			},
 			CommonConfig: commonConfig,
-			Client:       o.httpClient(t, clService, HTTPProtocol),
+			Client:       o.httpClient(t, clService, HTTPProtocol, "/"),
 		}))
 	}
 
 	if faucet, ok := env.Env.L1.Services["faucet"]; ok {
 		for _, instance := range faucet {
-			for _, endpoint := range instance.Endpoints {
-				endpoint.Path = fmt.Sprintf("chain/%s", l1.ChainID().String())
-			}
 			l1.AddFaucet(shim.NewFaucet(shim.FaucetConfig{
 				CommonConfig: commonConfig,
-				Client:       o.rpcClient(t, instance, RPCProtocol),
+				Client:       o.rpcClient(t, instance, RPCProtocol, fmt.Sprintf("/chain/%s", env.Env.L1.Config.ChainID.String())),
 				ID:           stack.FaucetID{Key: instance.Name, ChainID: l1ID},
 			}))
 		}

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -59,12 +59,9 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 
 	if faucet, ok := net.Services["faucet"]; ok {
 		for _, instance := range faucet {
-			for _, endpoint := range instance.Endpoints {
-				endpoint.Path = fmt.Sprintf("chain/%s", l2.ChainID().String())
-			}
 			l2.AddFaucet(shim.NewFaucet(shim.FaucetConfig{
 				CommonConfig: commonConfig,
-				Client:       o.rpcClient(t, instance, RPCProtocol),
+				Client:       o.rpcClient(t, instance, RPCProtocol, fmt.Sprintf("/chain/%s", l2.ChainID().String())),
 				ID:           stack.FaucetID{Key: instance.Name, ChainID: l2.ChainID()},
 			}))
 		}
@@ -79,7 +76,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 
 	elService, ok := node.Services[ELServiceName]
 	require.True(ok, "need L2 EL service for chain", l2ID)
-	elClient := o.rpcClient(l2Net.T(), elService, RPCProtocol)
+	elClient := o.rpcClient(l2Net.T(), elService, RPCProtocol, "/")
 	l2EL := shim.NewL2ELNode(shim.L2ELNodeConfig{
 		ELNodeConfig: shim.ELNodeConfig{
 			CommonConfig: shim.NewCommonConfig(l2Net.T()),
@@ -103,7 +100,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 	require.True(ok, "need L2 CL service for chain", l2ID)
 
 	// it's an RPC, but 'http' in kurtosis descriptor
-	clClient := o.rpcClient(l2Net.T(), clService, HTTPProtocol)
+	clClient := o.rpcClient(l2Net.T(), clService, HTTPProtocol, "/")
 	l2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
 		ID: stack.L2CLNodeID{
 			Key:     clService.Name,
@@ -131,7 +128,7 @@ func (o *Orchestrator) hydrateL2ProxydMaybe(net *descriptors.L2Chain, l2Net stac
 		l2Proxyd := shim.NewL2ELNode(shim.L2ELNodeConfig{
 			ELNodeConfig: shim.ELNodeConfig{
 				CommonConfig: shim.NewCommonConfig(l2Net.T()),
-				Client:       o.rpcClient(l2Net.T(), instance, HTTPProtocol),
+				Client:       o.rpcClient(l2Net.T(), instance, HTTPProtocol, "/"),
 				ChainID:      l2ID.ChainID(),
 			},
 			ID: stack.L2ELNodeID{
@@ -162,7 +159,7 @@ func (o *Orchestrator) hydrateBatcherMaybe(net *descriptors.L2Chain, l2Net stack
 				Key:     instance.Name,
 				ChainID: l2ID.ChainID(),
 			},
-			Client: o.rpcClient(l2Net.T(), instance, HTTPProtocol),
+			Client: o.rpcClient(l2Net.T(), instance, HTTPProtocol, "/"),
 		}))
 	}
 }
@@ -185,7 +182,7 @@ func (o *Orchestrator) hydrateProposerMaybe(net *descriptors.L2Chain, l2Net stac
 				Key:     instance.Name,
 				ChainID: l2ID.ChainID(),
 			},
-			Client: o.rpcClient(l2Net.T(), instance, HTTPProtocol),
+			Client: o.rpcClient(l2Net.T(), instance, HTTPProtocol, "/"),
 		}))
 	}
 }

--- a/op-devstack/sysext/system.go
+++ b/op-devstack/sysext/system.go
@@ -60,7 +60,7 @@ func (o *Orchestrator) hydrateSupervisorsMaybe(sys stack.ExtensibleSystem) {
 				sys.AddSupervisor(shim.NewSupervisor(shim.SupervisorConfig{
 					CommonConfig: shim.NewCommonConfig(sys.T()),
 					ID:           id,
-					Client:       o.rpcClient(sys.T(), instance, RPCProtocol),
+					Client:       o.rpcClient(sys.T(), instance, RPCProtocol, "/"),
 				}))
 			}
 		}


### PR DESCRIPTION
**Description**

Ensure we don't mutate the environment descriptor with information
that doesn't come from kurtosis, as it gets in the way of passing it
around in a stable form.

Instead, teach the client generation code to take path into
consideration.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Fixes #15838
