### PR TITLE
Increase `MAX_GAS_LIMIT` to a higher value that's safe with MT Cannon

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x19e352bb99cab389e0eead6178746c49b14d061bea89c444f26e768f601bd6d8",
-    "sourceCodeHash": "0x5ab5f6a63e40b3c491167afa4a207daebc87286829e3cf07cc2a8ce04abe70e9"
+    "initCodeHash": "0x07b7039de5b8a4dc57642ee9696e949d70516b7f6dce41dde4920efb17105ef2",
+    "sourceCodeHash": "0x997212ceadabb306c2abd31918b09bccbba0b21662c1d8930a3599831c374b13"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -170,7 +170,7 @@ contract StandardValidator {
 
     /// @notice Returns the expected SystemConfig version.
     function systemConfigVersion() public pure returns (string memory) {
-        return "3.3.0";
+        return "3.4.0";
     }
 
     /// @notice Returns the expected OptimismPortal version.
@@ -267,7 +267,7 @@ contract StandardValidator {
     {
         ISemver _semver = ISemver(address(_sysCfg));
         _errors = internalRequire(LibString.eq(_semver.version(), systemConfigVersion()), "SYSCON-10", _errors);
-        _errors = internalRequire(_sysCfg.gasLimit() <= uint64(200_000_000), "SYSCON-20", _errors);
+        _errors = internalRequire(_sysCfg.gasLimit() <= uint64(500_000_000), "SYSCON-20", _errors);
         _errors = internalRequire(_sysCfg.scalar() != 0, "SYSCON-30", _errors);
         _errors =
             internalRequire(_admin.getProxyImplementation(address(_sysCfg)) == systemConfigImpl, "SYSCON-40", _errors);

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -87,7 +87,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @notice The maximum gas limit that can be set for L2 blocks. This limit is used to enforce that the blocks
     ///         on L2 are not too large to process and prove. Over time, this value can be increased as various
     ///         optimizations and improvements are made to the system at large.
-    uint64 internal constant MAX_GAS_LIMIT = 200_000_000;
+    uint64 internal constant MAX_GAS_LIMIT = 500_000_000;
 
     /// @notice Fixed L2 gas overhead. Used as part of the L2 fee calculation.
     ///         Deprecated since the Ecotone network upgrade
@@ -142,9 +142,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 3.3.0
+    /// @custom:semver 3.4.0
     function version() public pure virtual returns (string memory) {
-        return "3.3.0";
+        return "3.4.0";
     }
 
     /// @notice Constructs the SystemConfig contract.

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -603,7 +603,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Make sure that the SystemConfig is upgraded to the right version. It must also have the
         // right l2ChainId and must be properly initialized.
-        assertEq(ISemver(address(systemConfig)).version(), "3.3.0");
+        assertEq(ISemver(address(systemConfig)).version(), "3.4.0");
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(systemConfig.l2ChainId(), l2ChainId);
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -313,7 +313,7 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         SystemConfig gas limit is invalid.
     function test_validate_systemConfigInvalidGasLimit_succeeds() public {
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.gasLimit, ()), abi.encode(uint64(200_000_001)));
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.gasLimit, ()), abi.encode(uint64(500_000_001)));
         assertEq("SYSCON-20", _validate(true));
     }
 


### PR DESCRIPTION
`MAX_GAS_LIMIT` sets an upper bound on the gas limit that a chain can configure. It's intended to be higher than what most chains are currently using.

Before [MT Cannon](https://gov.optimism.io/t/upgrade-proposal-14-isthmus-l1-contracts-mt-cannon/9796/1) there was a limit to the amount of memory that was available to op-program when generating a fault proof trace within Cannon, and so MAX_GAS_LIMIT was set to 200 Mgas to ensure that no chains set their gas limit to an unsafe value. 

MT Cannon increased the available memory by many orders of magnitude and it's now safer to prove much larger blocks, so MAX_GAS_LIMIT can be increased.

There will be an FMA associated with this change.