### PR TITLE
fix(kt-devnet): explicitly enable interop

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -21,7 +21,8 @@ optimism_package:
     enabled: true
     image: {{ $local_images.op_faucet }}
   superchains:
-    superchain: {}
+    superchain:
+      enabled: true
   supervisors:
     supervisor:
       superchain: superchain


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This shouldn't be needed, a proper fix will follow.

Despite interop being implicitly enabled whenever superchains are
declared, kt-devnet code relies on that flag being explicit.

This will unblock interop-devnet acceptance tests in the meantime.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
