### PR TITLE
op-supervisor: dont toml encode depset.OverrideMessageExpiryWindow

### DIFF
--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -97,8 +97,8 @@ func testDependencySetSerialization(
 
 			var newDepSet StaticConfigDependencySet
 			err = unmarshal(fileData, &newDepSet)
-			require.NoError(t, err)
 			result = &newDepSet
+			require.NoError(t, err)
 		}
 
 		chainIDs := result.Chains()
@@ -123,6 +123,7 @@ func testDependencySetSerialization(
 			loader := &JsonDependencySetLoader{Path: d}
 			result, err = loader.LoadDependencySet(context.Background())
 			require.NoError(t, err)
+			require.Equal(t, uint64(15), result.MessageExpiryWindow())
 		} else {
 			fileData, err := os.ReadFile(d)
 			require.NoError(t, err)
@@ -131,9 +132,9 @@ func testDependencySetSerialization(
 			err = unmarshal(fileData, &newDepSet)
 			require.NoError(t, err)
 			result = &newDepSet
+			require.Equal(t, uint64(params.MessageExpiryTimeSecondsInterop), result.MessageExpiryWindow())
 		}
 
-		require.Equal(t, uint64(15), result.MessageExpiryWindow())
 		testChainCapabilities(t, result)
 	})
 

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -110,10 +110,11 @@ func (ds *StaticConfigDependencySet) MarshalTOML() ([]byte, error) {
 	for id, dep := range ds.dependencies {
 		stringMap[id.String()] = dep
 	}
-
+	// Always set to OverrideMessageExpiryWindow to 0 to avoid encoding it to TOML
+	// (due to the `omitempty` tag on that field)
 	payload := &minStaticConfigDependencySet{
 		Dependencies:                stringMap,
-		OverrideMessageExpiryWindow: ds.overrideMessageExpiryWindow,
+		OverrideMessageExpiryWindow: 0,
 	}
 
 	var buf bytes.Buffer

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -110,7 +110,8 @@ func (ds *StaticConfigDependencySet) MarshalTOML() ([]byte, error) {
 	for id, dep := range ds.dependencies {
 		stringMap[id.String()] = dep
 	}
-	// Always set to OverrideMessageExpiryWindow to 0 to avoid encoding it to TOML
+
+	// Always set OverrideMessageExpiryWindow to 0 to avoid encoding it to TOML
 	// (due to the `omitempty` tag on that field)
 	payload := &minStaticConfigDependencySet{
 		Dependencies:                stringMap,


### PR DESCRIPTION
Addresses [this comment](https://www.notion.so/Superchain-Registry-Integration-1eff153ee16280e8a0b7dd6e7ed4213d?d=1f2f153ee16280359ee8001cdf5e513a&pvs=4#1f2f153ee1628026999ec0a104f86dff).

We never want to write the `depset.OverrideMessageExpiryWindow` to our superchain-registry chain config .toml files. However, we may want to read that field from toml (e.g. op-deployer intent.toml) in test scenarios.