### PR TITLE
refactor(test): cleanup of L1 test structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -12,7 +12,6 @@ import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
-import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Target contract dependencies
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -20,6 +19,8 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
+/// @title Encoding_Harness
+/// @notice A harness contract for testing internal functions of the Encoding library.
 contract Encoding_Harness {
     function encodeCrossDomainMessage(
         uint256 nonce,
@@ -37,7 +38,9 @@ contract Encoding_Harness {
     }
 }
 
-contract L1CrossDomainMessenger_Test is CommonTest {
+/// @title L1CrossDomainMessenger_TestInit
+/// @notice Reusable test initialization for L1CrossDomainMessenger tests.
+contract L1CrossDomainMessenger_TestInit is CommonTest {
     /// @dev The receiver address
     address recipient = address(0xabbaacdc);
 
@@ -47,13 +50,17 @@ contract L1CrossDomainMessenger_Test is CommonTest {
     /// @dev Encoding library harness.
     Encoding_Harness encoding;
 
-    function setUp() public override {
+    function setUp() public override virtual {
         super.setUp();
         senderSlotIndex = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender").slot;
         encoding = new Encoding_Harness();
     }
+}
 
-    /// @dev Tests that the implementation is initialized correctly.
+/// @title L1CrossDomainMessenger_Constructor_Test
+/// @notice Tests for the `constructor` of the L1CrossDomainMessenger.
+contract L1CrossDomainMessenger_Constructor_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that the implementation is initialized correctly.
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_constructor_succeeds() external virtual {
@@ -62,13 +69,18 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertEq(address(impl.PORTAL()), address(0));
         assertEq(address(impl.portal()), address(0));
 
-        // The constructor now uses _disableInitializers, whereas OP Mainnet has the other messenger in storage
+        // The constructor now uses _disableInitializers, whereas OP Mainnet has the other
+        // messenger in storage
         returnIfForkTest("L1CrossDomainMessenger_Test: impl storage differs on forked network");
         assertEq(address(impl.OTHER_MESSENGER()), address(0));
         assertEq(address(impl.otherMessenger()), address(0));
     }
+}
 
-    /// @dev Tests that the proxy is initialized correctly.
+/// @title L1CrossDomainMessenger_Initialize_Test
+/// @notice Tests for the `initialize` function of the L1CrossDomainMessenger.
+contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that the proxy is initialized correctly.
     function test_initialize_succeeds() external view {
         assertEq(address(l1CrossDomainMessenger.systemConfig()), address(systemConfig));
         assertEq(address(l1CrossDomainMessenger.PORTAL()), address(optimismPortal2));
@@ -113,14 +125,127 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         vm.prank(_sender);
         l1CrossDomainMessenger.initialize(systemConfig, optimismPortal2);
     }
+}
 
-    /// @dev Tests that the version can be decoded from the message nonce.
-    function test_messageVersion_succeeds() external view {
-        (, uint16 version) = Encoding.decodeVersionedNonce(l1CrossDomainMessenger.messageNonce());
-        assertEq(version, l1CrossDomainMessenger.MESSAGE_VERSION());
+/// @title L1CrossDomainMessenger_Upgrade_Test
+/// @notice Reusable test for the current `upgrade` function in the L1CrossDomainMessenger
+///         contract. If the `upgrade` function is changed, tests inside of this contract should be
+///         updated to reflect the new function. If the `upgrade` function is removed, remove the
+///         corresponding tests but leave this contract in place so it\'s easy to add tests back
+///         in the future.
+contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that the upgrade() function succeeds.
+    function test_upgrade_succeeds() external {
+        // Get the slot for _initial.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        // Verify the initial systemConfig slot is non-zero.
+        StorageSlot memory systemConfigSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "systemConfig");
+        vm.store(address(l1CrossDomainMessenger), bytes32(systemConfigSlot.slot), bytes32(uint256(1)));
+        assertNotEq(address(l1CrossDomainMessenger.systemConfig()), address(0));
+        assertNotEq(vm.load(address(l1CrossDomainMessenger), bytes32(systemConfigSlot.slot)), bytes32(0));
+
+        ISystemConfig newSystemConfig = ISystemConfig(address(0xdeadbeef));
+
+        // Trigger upgrade().
+        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
+        l1CrossDomainMessenger.upgrade(newSystemConfig);
+
+        // Verify that the systemConfig was updated.
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(newSystemConfig));
+
+        // Verify that the spacer was cleared.
+        StorageSlot memory spacerSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "spacer_251_0_20");
+        assertEq(vm.load(address(l1CrossDomainMessenger), bytes32(spacerSlot.slot)), bytes32(0));
     }
 
-    /// @dev Tests that the sendMessage function is able to send a single message.
+    /// @notice Tests that the upgrade() function reverts if called a second time.
+    function test_upgrade_upgradeTwice_reverts() external {
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        // Create a new SystemConfig contract
+        ISystemConfig newSystemConfig = ISystemConfig(address(0xdeadbeef));
+
+        // Trigger first upgrade.
+        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
+        l1CrossDomainMessenger.upgrade(newSystemConfig);
+
+        // Try to trigger second upgrade.
+        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
+        vm.expectRevert("Initializable: contract is already initialized");
+        l1CrossDomainMessenger.upgrade(newSystemConfig);
+    }
+
+    /// @notice Tests that the upgrade() function reverts if called by a non-proxy admin or owner.
+    /// @param _sender The address of the sender to test.
+    function testFuzz_upgrade_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
+        // Prank as the not ProxyAdmin or ProxyAdmin owner.
+        vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
+
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        // Create a new SystemConfig contract
+        ISystemConfig newSystemConfig = ISystemConfig(address(0xdeadbeef));
+
+        // Call the `upgrade` function with the sender
+        // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector
+        vm.prank(_sender);
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
+        l1CrossDomainMessenger.upgrade(newSystemConfig);
+    }
+}
+
+/// @title L1CrossDomainMessenger_Paused_Test
+/// @notice Tests for the `paused` functionality of the L1CrossDomainMessenger.
+contract L1CrossDomainMessenger_Paused_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that the superchain config is called by the messenger's paused function.
+    function test_pause_callsSuperchainConfig_succeeds() external {
+        vm.expectCall(address(superchainConfig), abi.encodeCall(ISuperchainConfig.paused, (address(0))));
+        l1CrossDomainMessenger.paused();
+    }
+
+    /// @notice Tests that changing the superchain config paused status changes the return value
+    ///         of the messenger.
+    function test_pause_matchesSuperchainConfig_succeeds() external {
+        assertFalse(l1CrossDomainMessenger.paused());
+        assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused(address(0)));
+
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+
+        assertTrue(l1CrossDomainMessenger.paused());
+        assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused(address(0)));
+    }
+}
+
+/// @title L1CrossDomainMessenger_SuperchainConfig_Test
+/// @notice Tests for the `superchainConfig` function of the L1CrossDomainMessenger.
+contract L1CrossDomainMessenger_SuperchainConfig_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that `superchainConfig` returns the correct address.
+    function test_superchainConfig_succeeds() external view {
+        assertEq(address(l1CrossDomainMessenger.superchainConfig()), address(superchainConfig));
+    }
+}
+
+/// @notice The following tests are not testing any function of the L1CrossDomainMessenger
+///         contract directly, but are testing the functionality of the CrossDomainMessenger
+///         contract that is inherited from.
+
+/// @title L1CrossDomainMessenger_SendMessage_Test
+/// @notice Tests for the `sendMessage` functionality of the L1CrossDomainMessenger.
+contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that the `sendMessage` function is able to send a single message.
     /// TODO: this same test needs to be done with the legacy message type
     ///       by setting the message version to 0
     function test_sendMessage_succeeds() external {
@@ -165,8 +290,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         l1CrossDomainMessenger.sendMessage(recipient, hex"ff", uint32(100));
     }
 
-    /// @dev Tests that the sendMessage function is able to send
-    ///      the same message twice.
+    /// @notice Tests that the sendMessage function is able to send the same message twice.
     function test_sendMessage_twice_succeeds() external {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
         l1CrossDomainMessenger.sendMessage(recipient, hex"aa", uint32(500_000));
@@ -174,15 +298,26 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         // the nonce increments for each message sent
         assertEq(nonce + 2, l1CrossDomainMessenger.messageNonce());
     }
+}
 
-    /// @dev Tests that the xDomainMessageSender reverts when not set.
+/// @title L1CrossDomainMessenger_Test
+/// @notice General tests for L1CrossDomainMessenger functionality, including inherited
+///         CrossDomainMessenger behavior.
+contract L1CrossDomainMessenger_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that the version can be decoded from the message nonce.
+    function test_messageVersion_succeeds() external view {
+        (, uint16 version) = Encoding.decodeVersionedNonce(l1CrossDomainMessenger.messageNonce());
+        assertEq(version, l1CrossDomainMessenger.MESSAGE_VERSION());
+    }
+
+    /// @notice Tests that the xDomainMessageSender reverts when not set.
     function test_xDomainSender_notSet_reverts() external {
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l1CrossDomainMessenger.xDomainMessageSender();
     }
 
-    /// @dev Tests that the relayMessage function reverts when
-    ///      the message version is not 0 or 1.
+    /// @notice Tests that the `relayMessage` function reverts when the message version is not 0 or
+    ///         1.
     /// @notice Marked virtual to be overridden in
     ///         test/kontrol/deployment/DeploymentSummary.t.sol
     function test_relayMessage_v2_reverts() external virtual {
@@ -207,8 +342,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that the relayMessage function is able to relay a message
-    ///      successfully by calling the target contract.
+    /// @notice Tests that the `relayMessage` function is able to relay a message
+    ///         successfully by calling the target contract.
     function test_relayMessage_succeeds() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -242,7 +377,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
     }
 
-    /// @dev Tests that relayMessage reverts if caller is optimismPortal2 and the value sent does not match the amount
+    /// @notice Tests that `relayMessage` reverts if the caller is optimismPortal2 and the value
+    ///         sent does not match the amount.
     function test_relayMessage_fromOtherMessengerValueMismatch_reverts() external {
         address target = alice;
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -260,7 +396,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that relayMessage reverts if a failed message is attempted to be replayed via the optimismPortal2
+    /// @notice Tests that `relayMessage` reverts if a failed message is attempted to be replayed
+    ///         via the optimismPortal2.
     function test_relayMessage_fromOtherMessengerFailedMessageReplay_reverts() external {
         address target = alice;
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -284,8 +421,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that relayMessage reverts if attempting to relay a message
-    ///      with l1CrossDomainMessenger as the target
+    /// @notice Tests that `relayMessage` reverts if attempting to relay a message with
+    ///         l1CrossDomainMessenger as the target.
     function test_relayMessage_toSelf_reverts() external {
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
@@ -304,8 +441,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that relayMessage reverts if attempting to relay a message
-    ///      with optimismPortal as the target
+    /// @notice Tests that `relayMessage` reverts if attempting to relay a message with
+    ///         optimismPortal as the target.
     function test_relayMessage_toOptimismPortal_reverts() external {
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
@@ -319,8 +456,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that the relayMessage function reverts if the message called by non-optimismPortal2 but not a failed
-    /// message
+    /// @notice Tests that `relayMessage` reverts if the message is called by a non-optimismPortal2
+    ///         address and is not a failed message eligible for replay.
     function test_relayMessage_relayingNewMessageByExternalUser_reverts() external {
         address target = address(alice);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -335,7 +472,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @notice Tests that the relayMessage function on L2 will always succeed for any potential
+    /// @notice Tests that the `relayMessage` function on L2 will always succeed for any potential
     ///         message, regardless of the size of the message, the minimum gas limit, or the
     ///         amount of gas used by the target contract.
     function testFuzz_relayMessage_baseGasSufficient_succeeds(
@@ -424,8 +561,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that the relayMessage function reverts if eth is
-    ///      sent from a contract other than the standard bridge.
+    /// @notice Tests that the `relayMessage` function reverts if ETH is sent from a contract other
+    ///         than the standard bridge.
     function test_replayMessage_withValue_reverts() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -437,12 +574,12 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @notice Tests that the ENCODING_OVERHEAD is always greater than or equal to the number of
+    /// @notice Tests that the `ENCODING_OVERHEAD` is always greater than or equal to the number of
     ///         bytes in an encoded message OTHER than the size of the data field.
-    ///         ENCODING_OVERHEAD needs to account for these other bytes so that the total message
-    ///         size used in the baseGas function is accurate. This test ensures that if the
-    ///         encoding ever changes, this test will fail and the developer will need to update
-    ///         the ENCODING_OVERHEAD constant.
+    ///         `ENCODING_OVERHEAD` needs to account for these other bytes so that the total
+    ///         message size used in the `baseGas` function is accurate. This test ensures that if
+    ///         the encoding ever changes, this test will fail and the developer will need to
+    ///         update the `ENCODING_OVERHEAD` constant.
     /// @param _nonce The nonce to encode into the message.
     /// @param _version The version to encode into the message.
     /// @param _sender The sender to encode into the message.
@@ -492,8 +629,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertGe(l1CrossDomainMessenger.ENCODING_OVERHEAD(), encoded.length - _message.length);
     }
 
-    /// @dev Tests that the xDomainMessageSender is reset to the original value
-    ///      after a message is relayed.
+    /// @notice Tests that the xDomainMessageSender is reset to the original value
+    ///         after a message is relayed.
     function test_xDomainMessageSender_reset_succeeds() external {
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l1CrossDomainMessenger.xDomainMessageSender();
@@ -510,9 +647,9 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         l1CrossDomainMessenger.xDomainMessageSender();
     }
 
-    /// @dev Tests that relayMessage should successfully call the target contract after
-    ///      the first message fails and ETH is stuck, but the second message succeeds
-    ///      with a version 1 message.
+    /// @notice Tests that `relayMessage` should successfully call the target contract after the
+    ///         first message fails and ETH is stuck, but the second message succeeds with a
+    ///         version 1 message.
     function test_relayMessage_retryAfterFailure_succeeds() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -563,9 +700,9 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
     }
 
-    /// @dev Tests that relayMessage should successfully call the target contract after
-    ///      the first message fails and ETH is stuck, but the second message succeeds
-    ///      with a legacy message.
+    /// @notice Tests that `relayMessage` should successfully call the target contract after the
+    ///         first message fails and ETH is stuck, but the second message succeeds with a
+    ///         legacy message (version 0).
     function test_relayMessage_legacy_succeeds() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -607,7 +744,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
     }
 
-    /// @dev Tests that relayMessage should revert if the message is already replayed.
+    /// @notice Tests that `relayMessage` should revert if the message is already replayed.
     function test_relayMessage_legacyOldReplay_reverts() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -650,7 +787,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
     }
 
-    /// @dev Tests that relayMessage can be retried after a failure with a legacy message.
+    /// @notice Tests that `relayMessage` can be retried after a failure with a legacy message.
     function test_relayMessage_legacyRetryAfterFailure_succeeds() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -726,7 +863,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         assertEq(l1CrossDomainMessenger.failedMessages(hash), true);
     }
 
-    /// @dev Tests that relayMessage cannot be retried after success with a legacy message.
+    /// @notice Tests that `relayMessage` cannot be retried after success with a legacy message.
     function test_relayMessage_legacyRetryAfterSuccess_reverts() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -786,7 +923,7 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that relayMessage cannot be called after a failure and a successful replay.
+    /// @notice Tests that `relayMessage` cannot be called after a failure and a successful replay.
     function test_relayMessage_legacyRetryAfterFailureThenSuccess_reverts() external {
         address target = address(0xabcd);
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
@@ -872,8 +1009,8 @@ contract L1CrossDomainMessenger_Test is CommonTest {
         );
     }
 
-    /// @dev Tests that the relayMessage function is able to relay a message
-    ///      successfully by calling the target contract.
+    /// @notice Tests that the relayMessage function is able to relay a message successfully by
+    ///         calling the target contract.
     function test_relayMessage_paused_reverts() external {
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause(address(0));
@@ -888,36 +1025,13 @@ contract L1CrossDomainMessenger_Test is CommonTest {
             hex"1111"
         );
     }
-
-    /// @dev Tests that the superchain config is called by the messengers paused function
-    function test_pause_callsSuperchainConfig_succeeds() external {
-        // We use abi.encodeWithSignature because paused is overloaded.
-        // nosemgrep: sol-style-use-abi-encodecall
-        vm.expectCall(address(superchainConfig), abi.encodeWithSignature("paused(address)", address(0)));
-        l1CrossDomainMessenger.paused();
-    }
-
-    /// @dev Tests that changing the superchain config paused status changes the return value of the messenger
-    function test_pause_matchesSuperchainConfig_succeeds() external {
-        assertFalse(l1CrossDomainMessenger.paused());
-        assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused(address(0)));
-
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(0));
-
-        assertTrue(l1CrossDomainMessenger.paused());
-        assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused(address(0)));
-    }
-
-    /// @dev Tests that `superchainConfig` returns the correct address.
-    function test_superchainConfig_succeeds() external view {
-        assertEq(address(l1CrossDomainMessenger.superchainConfig()), address(superchainConfig));
-    }
 }
 
-/// @dev A regression test against a reentrancy vulnerability in the CrossDomainMessenger contract, which
-///      was possible by intercepting and sandwhiching a signed Safe Transaction to upgrade it.
-contract L1CrossDomainMessenger_ReinitReentryTest is CommonTest {
+/// @title L1CrossDomainMessenger_ReinitReentryTest
+/// @notice A regression test against a reentrancy vulnerability in the `CrossDomainMessenger`
+///         contract, which was possible by intercepting and sandwiching a signed Safe Transaction
+///         to upgrade it.
+contract L1CrossDomainMessenger_ReinitReentryTest is L1CrossDomainMessenger_TestInit {
     bool attacked;
 
     // Common values used across functions
@@ -937,8 +1051,8 @@ contract L1CrossDomainMessenger_ReinitReentryTest is CommonTest {
         vm.deal(address(l1CrossDomainMessenger), messageValue * 2);
     }
 
-    /// @dev This method will be called by the relayed message, and will attempt to reenter the relayMessage function
-    ///      exactly once.
+    /// @notice This method will be called by the relayed message, and will attempt to reenter the
+    ///         `relayMessage` function exactly one.
     function reinitAndReenter() external payable {
         // only attempt the attack once
         if (!attacked) {
@@ -963,14 +1077,14 @@ contract L1CrossDomainMessenger_ReinitReentryTest is CommonTest {
         }
     }
 
-    /// @dev Tests that the relayMessage function cannot be reentered by calling the `initialize()` function within the
-    ///      relayed message.
+    /// @notice Tests that the `relayMessage` function cannot be reentered by calling the
+    ///         `initialize` function within the relayed message.
     function test_relayMessage_replayStraddlingReinit_reverts() external {
         uint256 balanceBeforeThis = address(this).balance;
         uint256 balanceBeforeMessenger = address(l1CrossDomainMessenger).balance;
 
-        // A requisite for the attack is that the message has already been attempted and written to the failedMessages
-        // mapping, so that it can be replayed.
+        // A requisite for the attack is that the message has already been attempted and written
+        // to the failedMessages mapping, so that it can be replayed.
         vm.store(address(l1CrossDomainMessenger), keccak256(abi.encode(hash, 206)), bytes32(uint256(1)));
         assertTrue(l1CrossDomainMessenger.failedMessages(hash));
 
@@ -991,80 +1105,5 @@ contract L1CrossDomainMessenger_ReinitReentryTest is CommonTest {
         assertEq(address(this).balance, balanceBeforeThis);
         // The balance of the messenger contract is unchanged.
         assertEq(address(l1CrossDomainMessenger).balance, balanceBeforeMessenger);
-    }
-}
-
-/// @title L1CrossDomainMessenger_upgrade_Test
-/// @notice Reusable test for the current upgrade() function in the L1CrossDomainMessenger contract. If
-///         the upgrade() function is changed, tests inside of this contract should be updated to
-///         reflect the new function. If the upgrade() function is removed, remove the
-///         corresponding tests but leave this contract in place so it's easy to add tests back
-///         in the future.
-contract L1CrossDomainMessenger_Upgrade_Test is CommonTest {
-    /// @notice Tests that the upgrade() function succeeds.
-    function test_upgrade_succeeds() external {
-        // Get the slot for _initial.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
-
-        // Verify the initial systemConfig slot is non-zero.
-        StorageSlot memory systemConfigSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "systemConfig");
-        vm.store(address(l1CrossDomainMessenger), bytes32(systemConfigSlot.slot), bytes32(uint256(1)));
-        assertNotEq(address(l1CrossDomainMessenger.systemConfig()), address(0));
-        assertNotEq(vm.load(address(l1CrossDomainMessenger), bytes32(systemConfigSlot.slot)), bytes32(0));
-
-        ISystemConfig newSystemConfig = ISystemConfig(address(0xdeadbeef));
-
-        // Trigger upgrade().
-        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
-        l1CrossDomainMessenger.upgrade(newSystemConfig);
-
-        // Verify that the systemConfig was updated.
-        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(newSystemConfig));
-    }
-
-    /// @notice Tests that the upgrade() function reverts if called a second time.
-    function test_upgrade_upgradeTwice_reverts() external {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
-
-        // Create a new SystemConfig contract
-        ISystemConfig newSystemConfig = ISystemConfig(address(0xdeadbeef));
-
-        // Trigger first upgrade.
-        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
-        l1CrossDomainMessenger.upgrade(newSystemConfig);
-
-        // Try to trigger second upgrade.
-        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
-        vm.expectRevert("Initializable: contract is already initialized");
-        l1CrossDomainMessenger.upgrade(newSystemConfig);
-    }
-
-    /// @notice Tests that the upgrade() function reverts if called by a non-proxy admin or owner.
-    /// @param _sender The address of the sender to test.
-    function testFuzz_upgrade_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin or ProxyAdmin owner.
-        vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
-
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
-
-        // Create a new SystemConfig contract
-        ISystemConfig newSystemConfig = ISystemConfig(address(0xdeadbeef));
-
-        // Call the `upgrade` function with the sender
-        // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector
-        vm.prank(_sender);
-        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
-        l1CrossDomainMessenger.upgrade(newSystemConfig);
     }
 }

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -50,7 +50,7 @@ contract L1CrossDomainMessenger_TestInit is CommonTest {
     /// @dev Encoding library harness.
     Encoding_Harness encoding;
 
-    function setUp() public override virtual {
+    function setUp() public virtual override {
         super.setUp();
         senderSlotIndex = ForgeArtifacts.getSlot("OptimismPortal2", "l2Sender").slot;
         encoding = new Encoding_Harness();
@@ -300,10 +300,11 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
     }
 }
 
-/// @title L1CrossDomainMessenger_Test
-/// @notice General tests for L1CrossDomainMessenger functionality, including inherited
-///         CrossDomainMessenger behavior.
-contract L1CrossDomainMessenger_Test is L1CrossDomainMessenger_TestInit {
+/// @title L1CrossDomainMessenger_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the L1CrossDomainMessenger
+///         but are testing functionality of the CrossDomainMessenger contract that is inherited
+///         from.
+contract L1CrossDomainMessenger_Unclassified_Test is L1CrossDomainMessenger_TestInit {
     /// @notice Tests that the version can be decoded from the message nonce.
     function test_messageVersion_succeeds() external view {
         (, uint16 version) = Encoding.decodeVersionedNonce(l1CrossDomainMessenger.messageNonce());

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -154,8 +154,8 @@ contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit 
         vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
         l1CrossDomainMessenger.upgrade(newSystemConfig);
 
-        StorageSlot memory spacerSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "spacer_251_0_20");
-        assertEq(vm.load(address(l1CrossDomainMessenger), bytes32(spacerSlot.slot)), bytes32(0));
+        // Verify that the systemConfig was updated.
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(newSystemConfig));
     }
 
     /// @notice Tests that the upgrade() function reverts if called a second time.

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -154,10 +154,6 @@ contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit 
         vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
         l1CrossDomainMessenger.upgrade(newSystemConfig);
 
-        // Verify that the systemConfig was updated.
-        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(newSystemConfig));
-
-        // Verify that the spacer was cleared.
         StorageSlot memory spacerSlot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "spacer_251_0_20");
         assertEq(vm.load(address(l1CrossDomainMessenger), bytes32(spacerSlot.slot)), bytes32(0));
     }

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -211,7 +211,9 @@ contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit 
 contract L1CrossDomainMessenger_Paused_Test is L1CrossDomainMessenger_TestInit {
     /// @notice Tests that the superchain config is called by the messenger's paused function.
     function test_pause_callsSuperchainConfig_succeeds() external {
-        vm.expectCall(address(superchainConfig), abi.encodeCall(ISuperchainConfig.paused, (address(0))));
+        // We use abi.encodeWithSignature because paused is overloaded.
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.expectCall(address(superchainConfig), abi.encodeWithSignature("paused(address)", address(0)));
         l1CrossDomainMessenger.paused();
     }
 

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -22,219 +22,11 @@ import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
-contract L1StandardBridge_Getter_Test is CommonTest {
-    /// @dev Test that the accessors return the correct initialized values.
-    function test_getters_succeeds() external view {
-        assert(l1StandardBridge.l2TokenBridge() == address(l2StandardBridge));
-        assert(address(l1StandardBridge.OTHER_BRIDGE()) == address(l2StandardBridge));
-        assert(address(l1StandardBridge.messenger()) == address(l1CrossDomainMessenger));
-        assert(address(l1StandardBridge.MESSENGER()) == address(l1CrossDomainMessenger));
-        assert(l1StandardBridge.systemConfig() == systemConfig);
-        assert(l1StandardBridge.superchainConfig() == systemConfig.superchainConfig());
-    }
-}
-
-contract L1StandardBridge_Initialize_Test is CommonTest {
-    /// @dev Test that the constructor sets the correct values.
-    /// @notice Marked virtual to be overridden in
-    ///         test/kontrol/deployment/DeploymentSummary.t.sol
-    function test_constructor_succeeds() external virtual {
-        IL1StandardBridge impl = IL1StandardBridge(payable(EIP1967Helper.getImplementation(address(l1StandardBridge))));
-        assertEq(address(impl.systemConfig()), address(0));
-
-        // The constructor now uses _disableInitializers, whereas OP Mainnet has these values in storage
-        returnIfForkTest("L1StandardBridge_Initialize_Test: impl storage differs on forked network");
-        assertEq(address(impl.MESSENGER()), address(0));
-        assertEq(address(impl.messenger()), address(0));
-        assertEq(address(impl.OTHER_BRIDGE()), address(0));
-        assertEq(address(impl.otherBridge()), address(0));
-        assertEq(address(l2StandardBridge), Predeploys.L2_STANDARD_BRIDGE);
-    }
-
-    /// @dev Test that the initialize function sets the correct values.
-    function test_initialize_succeeds() external view {
-        assertEq(address(l1StandardBridge.systemConfig()), address(systemConfig));
-        assertEq(address(l1StandardBridge.MESSENGER()), address(l1CrossDomainMessenger));
-        assertEq(address(l1StandardBridge.messenger()), address(l1CrossDomainMessenger));
-        assertEq(address(l1StandardBridge.OTHER_BRIDGE()), Predeploys.L2_STANDARD_BRIDGE);
-        assertEq(address(l1StandardBridge.otherBridge()), Predeploys.L2_STANDARD_BRIDGE);
-        assertEq(address(l2StandardBridge), Predeploys.L2_STANDARD_BRIDGE);
-    }
-}
-
-contract L1StandardBridge_Pause_Test is CommonTest {
-    /// @dev Verifies that the `paused` accessor returns the same value as the `paused` function of the
-    ///      `superchainConfig`.
-    function test_paused_succeeds() external view {
-        assertEq(l1StandardBridge.paused(), systemConfig.paused());
-    }
-
-    /// @dev Ensures that the `paused` function of the bridge contract actually calls the `paused` function of the
-    ///      `superchainConfig`.
-    function test_pause_callsSuperchainConfig_succeeds() external {
-        vm.expectCall(address(systemConfig), abi.encodeCall(ISystemConfig.paused, ()));
-        l1StandardBridge.paused();
-    }
-
-    /// @dev Checks that the `paused` state of the bridge matches the `paused` state of the `superchainConfig` after
-    ///      it's been changed.
-    function test_pause_matchesSuperchainConfig_succeeds() external {
-        assertFalse(l1StandardBridge.paused());
-        assertEq(l1StandardBridge.paused(), systemConfig.paused());
-
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(0));
-
-        assertTrue(l1StandardBridge.paused());
-        assertEq(l1StandardBridge.paused(), systemConfig.paused());
-    }
-}
-
-contract L1StandardBridge_Pause_TestFail is CommonTest {
-    /// @dev Sets up the test by pausing the bridge, giving ether to the bridge and mocking
-    ///      the calls to the xDomainMessageSender so that it returns the correct value.
-    function setUp() public override {
-        super.setUp();
-        vm.startPrank(systemConfig.guardian());
-        systemConfig.superchainConfig().pause(address(0));
-        vm.stopPrank();
-        assertTrue(l1StandardBridge.paused());
-
-        vm.deal(address(l1StandardBridge.messenger()), 1 ether);
-
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.otherBridge()))
-        );
-    }
-
-    /// @dev Confirms that the `finalizeBridgeETH` function reverts when the bridge is paused.
-    function test_pause_finalizeBridgeETH_reverts() external {
-        vm.prank(address(l1StandardBridge.messenger()));
-        vm.expectRevert("StandardBridge: paused");
-        l1StandardBridge.finalizeBridgeETH{ value: 100 }({
-            _from: address(2),
-            _to: address(3),
-            _amount: 100,
-            _extraData: hex""
-        });
-    }
-
-    /// @dev Confirms that the `finalizeETHWithdrawal` function reverts when the bridge is paused.
-    function test_pause_finalizeETHWithdrawal_reverts() external {
-        vm.prank(address(l1StandardBridge.messenger()));
-        vm.expectRevert("StandardBridge: paused");
-        l1StandardBridge.finalizeETHWithdrawal{ value: 100 }({
-            _from: address(2),
-            _to: address(3),
-            _amount: 100,
-            _extraData: hex""
-        });
-    }
-
-    /// @dev Confirms that the `finalizeERC20Withdrawal` function reverts when the bridge is paused.
-    function test_pause_finalizeERC20Withdrawal_reverts() external {
-        vm.prank(address(l1StandardBridge.messenger()));
-        vm.expectRevert("StandardBridge: paused");
-        l1StandardBridge.finalizeERC20Withdrawal({
-            _l1Token: address(0),
-            _l2Token: address(0),
-            _from: address(0),
-            _to: address(0),
-            _amount: 0,
-            _extraData: hex""
-        });
-    }
-
-    /// @dev Confirms that the `finalizeBridgeERC20` function reverts when the bridge is paused.
-    function test_pause_finalizeBridgeERC20_reverts() external {
-        vm.prank(address(l1StandardBridge.messenger()));
-        vm.expectRevert("StandardBridge: paused");
-        l1StandardBridge.finalizeBridgeERC20({
-            _localToken: address(0),
-            _remoteToken: address(0),
-            _from: address(0),
-            _to: address(0),
-            _amount: 0,
-            _extraData: hex""
-        });
-    }
-}
-
-contract L1StandardBridge_Initialize_TestFail is CommonTest {
-    /// @notice Tests that the initialize function reverts if called by a non-proxy admin or owner.
-    /// @param _sender The address of the sender to test.
-    function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin or ProxyAdmin owner.
-        vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
-
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1StandardBridge), bytes32(slot.slot), bytes32(0));
-
-        // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector.
-        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
-
-        // Call the `initialize` function with the sender
-        vm.prank(_sender);
-        l1StandardBridge.initialize(l1CrossDomainMessenger, systemConfig);
-    }
-
-    /// @notice Tests that the initializer value is correct. Trivial test for normal
-    ///         initialization but confirms that the initValue is not incremented incorrectly if
-    ///         an upgrade function is not present.
-    function test_initialize_correctInitializerValue_succeeds() public {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
-
-        // Get the initializer value.
-        bytes32 slotVal = vm.load(address(l1StandardBridge), bytes32(slot.slot));
-        uint8 val = uint8(uint256(slotVal) & 0xFF);
-
-        // Assert that the initializer value matches the expected value.
-        assertEq(val, l1StandardBridge.initVersion());
-    }
-}
-
-contract L1StandardBridge_Receive_Test is CommonTest {
-    /// @dev Tests receive bridges ETH successfully.
-    function test_receive_succeeds() external {
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
-
-        // The legacy event must be emitted for backwards compatibility
-        vm.expectEmit(address(l1StandardBridge));
-        emit ETHDepositInitiated(alice, alice, 100, hex"");
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ETHBridgeInitiated(alice, alice, 100, hex"");
-
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(
-                ICrossDomainMessenger.sendMessage,
-                (
-                    address(l2StandardBridge),
-                    abi.encodeCall(StandardBridge.finalizeBridgeETH, (alice, alice, 100, hex"")),
-                    200_000
-                )
-            )
-        );
-
-        vm.prank(alice, alice);
-        (bool success,) = address(l1StandardBridge).call{ value: 100 }(hex"");
-        assertEq(success, true);
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 100);
-    }
-}
-
-contract PreBridgeETH is CommonTest {
-    /// @dev Asserts the expected calls and events for bridging ETH depending
-    ///      on whether the bridge call is legacy or not.
+/// @title L1StandardBridge_TestInit
+/// @notice Reusable test initialization for `L1StandardBridge` tests.
+contract L1StandardBridge_TestInit is CommonTest {
+    /// @notice Asserts the expected calls and events for bridging ETH depending on whether the
+    ///         bridge call is legacy or not.
     function _preBridgeETH(bool isLegacy, uint256 value) internal {
         if (!isForkTest()) {
             assertEq(address(optimismPortal2).balance, 0, "OptimismPortal2 balance should be 0");
@@ -297,66 +89,9 @@ contract PreBridgeETH is CommonTest {
 
         vm.prank(alice, alice);
     }
-}
 
-contract L1StandardBridge_DepositETH_Test is PreBridgeETH {
-    /// @dev Tests that depositing ETH succeeds.
-    ///      Emits ETHDepositInitiated and ETHBridgeInitiated events.
-    ///      Calls depositTransaction on the OptimismPortal.
-    ///      Only EOA can call depositETH.
-    ///      ETH ends up in the optimismPortal.
-    function test_depositETH_fromEOA_succeeds() external {
-        _preBridgeETH({ isLegacy: true, value: 500 });
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
-        l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
-    }
-
-    /// @dev Tests that depositing ETH succeeds for an EOA using 7702 delegation.
-    function test_depositETH_fromEOA7702_succeeds() external {
-        // Set alice to have 7702 code.
-        vm.etch(alice, abi.encodePacked(hex"EF0100", address(0)));
-
-        _preBridgeETH({ isLegacy: true, value: 500 });
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
-        l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
-    }
-}
-
-contract L1StandardBridge_DepositETH_TestFail is CommonTest {
-    /// @dev Tests that depositing ETH reverts if the call is not from an EOA.
-    function test_depositETH_notEoa_reverts() external {
-        vm.etch(alice, address(L1Token).code);
-        vm.expectRevert("StandardBridge: function can only be called from an EOA");
-        vm.prank(alice);
-        l1StandardBridge.depositETH{ value: 1 }(300, hex"");
-    }
-}
-
-contract L1StandardBridge_BridgeETH_Test is PreBridgeETH {
-    /// @dev Tests that bridging ETH succeeds.
-    ///      Emits ETHDepositInitiated and ETHBridgeInitiated events.
-    ///      Calls depositTransaction on the OptimismPortal.
-    ///      Only EOA can call bridgeETH.
-    ///      ETH ends up in the optimismPortal.
-    function test_bridgeETH_succeeds() external {
-        _preBridgeETH({ isLegacy: false, value: 500 });
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
-        l1StandardBridge.bridgeETH{ value: 500 }(50000, hex"dead");
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
-    }
-}
-
-contract PreBridgeETHTo is CommonTest {
-    /// @dev Asserts the expected calls and events for bridging ETH to a different
-    ///      address depending on whether the bridge call is legacy or not.
+    /// @notice Asserts the expected calls and events for bridging ETH to a different address
+    ///         depending on whether the bridge call is legacy or not.
     function _preBridgeETHTo(bool isLegacy, uint256 value) internal {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
@@ -420,358 +155,76 @@ contract PreBridgeETHTo is CommonTest {
     }
 }
 
-contract L1StandardBridge_DepositETHTo_Test is PreBridgeETHTo {
-    /// @dev Tests that depositing ETH to a different address succeeds.
-    ///      Emits ETHDepositInitiated event.
-    ///      Calls depositTransaction on the OptimismPortal.
-    ///      EOA or contract can call depositETHTo.
-    ///      ETH ends up in the optimismPortal.
-    function test_depositETHTo_succeeds() external {
-        _preBridgeETHTo({ isLegacy: true, value: 600 });
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
-        l1StandardBridge.depositETHTo{ value: 600 }(bob, 60000, hex"dead");
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 600);
+/// @title L1StandardBridge_Constructor_Test
+/// @notice Tests the `constructor` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_Constructor_Test is CommonTest {
+    /// @notice Test that the constructor sets the correct values.
+    /// @dev Marked virtual to be overridden in test/kontrol/deployment/DeploymentSummary.t.sol
+    function test_constructor_succeeds() external virtual {
+        IL1StandardBridge impl = IL1StandardBridge(payable(EIP1967Helper.getImplementation(address(l1StandardBridge))));
+        assertEq(address(impl.systemConfig()), address(0));
+
+        // The constructor now uses _disableInitializers, whereas OP Mainnet has these values in
+        // storage.
+        returnIfForkTest("L1StandardBridge_Initialize_Test: impl storage differs on forked network");
+        assertEq(address(impl.MESSENGER()), address(0));
+        assertEq(address(impl.messenger()), address(0));
+        assertEq(address(impl.OTHER_BRIDGE()), address(0));
+        assertEq(address(impl.otherBridge()), address(0));
+        assertEq(address(l2StandardBridge), Predeploys.L2_STANDARD_BRIDGE);
     }
 }
 
-contract L1StandardBridge_BridgeETHTo_Test is PreBridgeETHTo {
-    /// @dev Tests that bridging ETH to a different address succeeds.
-    ///      Emits ETHDepositInitiated and ETHBridgeInitiated events.
-    ///      Calls depositTransaction on the OptimismPortal.
-    ///      Only EOA can call bridgeETHTo.
-    ///      ETH ends up in the optimismPortal.
-    function test_bridgeETHTo_succeeds() external {
-        _preBridgeETHTo({ isLegacy: false, value: 600 });
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
-        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
-        l1StandardBridge.bridgeETHTo{ value: 600 }(bob, 60000, hex"dead");
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
-        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 600);
+/// @title L1StandardBridge_Initialize_Test
+/// @notice Tests the `initialize` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_Initialize_Test is CommonTest {
+    /// @notice Test that the initialize function sets the correct values.
+    function test_initialize_succeeds() external view {
+        assertEq(address(l1StandardBridge.systemConfig()), address(systemConfig));
+        assertEq(address(l1StandardBridge.MESSENGER()), address(l1CrossDomainMessenger));
+        assertEq(address(l1StandardBridge.messenger()), address(l1CrossDomainMessenger));
+        assertEq(address(l1StandardBridge.OTHER_BRIDGE()), Predeploys.L2_STANDARD_BRIDGE);
+        assertEq(address(l1StandardBridge.otherBridge()), Predeploys.L2_STANDARD_BRIDGE);
+        assertEq(address(l2StandardBridge), Predeploys.L2_STANDARD_BRIDGE);
+    }
+
+    /// @notice Tests that the initialize function reverts if called by a non-proxy admin or owner.
+    /// @param _sender The address of the sender to test.
+    function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
+        // Prank as the not ProxyAdmin or ProxyAdmin owner.
+        vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
+
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1StandardBridge), bytes32(slot.slot), bytes32(0));
+
+        // Expect the revert with `ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner` selector.
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
+
+        // Call the `initialize` function with the sender
+        vm.prank(_sender);
+        l1StandardBridge.initialize(l1CrossDomainMessenger, systemConfig);
+    }
+
+    /// @notice Tests that the initializer value is correct. Trivial test for normal initialization
+    ///         but confirms that the initValue is not incremented incorrectly if an upgrade
+    ///         function is not present.
+    function test_initialize_correctInitializerValue_succeeds() public {
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1StandardBridge", "_initialized");
+
+        // Get the initializer value.
+        bytes32 slotVal = vm.load(address(l1StandardBridge), bytes32(slot.slot));
+        uint8 val = uint8(uint256(slotVal) & 0xFF);
+
+        // Assert that the initializer value matches the expected value.
+        assertEq(val, l1StandardBridge.initVersion());
     }
 }
 
-contract L1StandardBridge_DepositERC20_Test is CommonTest {
-    using stdStorage for StdStorage;
-
-    // depositERC20
-    // - updates bridge.deposits
-    // - emits ERC20DepositInitiated
-    // - calls optimismPortal.depositTransaction
-    // - only callable by EOA
-
-    /// @dev Tests that depositing ERC20 to the bridge succeeds.
-    ///      Bridge deposits are updated.
-    ///      Emits ERC20DepositInitiated event.
-    ///      Calls depositTransaction on the OptimismPortal.
-    ///      Only EOA can call depositERC20.
-    function test_depositERC20_succeeds() external {
-        uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
-        address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
-
-        // Deal Alice's ERC20 State
-        deal(address(L1Token), alice, 100000, true);
-        vm.prank(alice);
-        L1Token.approve(address(l1StandardBridge), type(uint256).max);
-
-        // The l1StandardBridge should transfer alice's tokens to itself
-        vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transferFrom, (alice, address(l1StandardBridge), 100)));
-
-        bytes memory message = abi.encodeCall(
-            StandardBridge.finalizeBridgeERC20, (address(L2Token), address(L1Token), alice, alice, 100, hex"")
-        );
-
-        // the L1 bridge should call L1CrossDomainMessenger.sendMessage
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l2StandardBridge), message, 10000))
-        );
-
-        bytes memory innerMessage = abi.encodeCall(
-            ICrossDomainMessenger.relayMessage,
-            (nonce, address(l1StandardBridge), address(l2StandardBridge), 0, 10000, message)
-        );
-
-        uint64 baseGas = l1CrossDomainMessenger.baseGas(message, 10000);
-        vm.expectCall(
-            address(optimismPortal2),
-            abi.encodeCall(
-                IOptimismPortal2.depositTransaction, (address(l2CrossDomainMessenger), 0, baseGas, false, innerMessage)
-            )
-        );
-
-        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
-
-        // Should emit both the bedrock and legacy events
-        vm.expectEmit(address(l1StandardBridge));
-        emit ERC20DepositInitiated(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ERC20BridgeInitiated(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-
-        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
-        vm.expectEmit(address(optimismPortal2));
-        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
-
-        // SentMessage event emitted by the CrossDomainMessenger
-        vm.expectEmit(address(l1CrossDomainMessenger));
-        emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 10000);
-
-        // SentMessageExtension1 event emitted by the CrossDomainMessenger
-        vm.expectEmit(address(l1CrossDomainMessenger));
-        emit SentMessageExtension1(address(l1StandardBridge), 0);
-
-        vm.prank(alice, alice);
-        l1StandardBridge.depositERC20(address(L1Token), address(L2Token), 100, 10000, hex"");
-        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 100);
-    }
-}
-
-contract L1StandardBridge_DepositERC20_TestFail is CommonTest {
-    /// @dev Tests that depositing an ERC20 to the bridge reverts
-    ///      if the caller is not an EOA.
-    function test_depositERC20_notEoa_reverts() external {
-        // turn alice into a contract
-        vm.etch(alice, hex"ffff");
-
-        vm.expectRevert("StandardBridge: function can only be called from an EOA");
-        vm.prank(alice);
-        l1StandardBridge.depositERC20(address(0), address(0), 100, 100, hex"");
-    }
-}
-
-contract L1StandardBridge_DepositERC20To_Test is CommonTest {
-    /// @dev Tests that depositing ERC20 to the bridge succeeds when
-    ///      sent to a different address.
-    ///      Bridge deposits are updated.
-    ///      Emits ERC20DepositInitiated event.
-    ///      Calls depositTransaction on the OptimismPortal.
-    ///      Contracts can call depositERC20.
-    function test_depositERC20To_succeeds() external {
-        uint256 nonce = l1CrossDomainMessenger.messageNonce();
-        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
-        address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
-
-        bytes memory message = abi.encodeCall(
-            StandardBridge.finalizeBridgeERC20, (address(L2Token), address(L1Token), alice, bob, 1000, hex"")
-        );
-
-        bytes memory innerMessage = abi.encodeCall(
-            ICrossDomainMessenger.relayMessage,
-            (nonce, address(l1StandardBridge), address(l2StandardBridge), 0, 10000, message)
-        );
-
-        uint64 baseGas = l1CrossDomainMessenger.baseGas(message, 10000);
-        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
-
-        deal(address(L1Token), alice, 100000, true);
-
-        vm.prank(alice);
-        L1Token.approve(address(l1StandardBridge), type(uint256).max);
-
-        // Should emit both the bedrock and legacy events
-        vm.expectEmit(address(l1StandardBridge));
-        emit ERC20DepositInitiated(address(L1Token), address(L2Token), alice, bob, 1000, hex"");
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ERC20BridgeInitiated(address(L1Token), address(L2Token), alice, bob, 1000, hex"");
-
-        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
-        vm.expectEmit(address(optimismPortal2));
-        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
-
-        // SentMessage event emitted by the CrossDomainMessenger
-        vm.expectEmit(address(l1CrossDomainMessenger));
-        emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 10000);
-
-        // SentMessageExtension1 event emitted by the CrossDomainMessenger
-        vm.expectEmit(address(l1CrossDomainMessenger));
-        emit SentMessageExtension1(address(l1StandardBridge), 0);
-
-        // the L1 bridge should call L1CrossDomainMessenger.sendMessage
-        vm.expectCall(
-            address(l1CrossDomainMessenger),
-            abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l2StandardBridge), message, 10000))
-        );
-        // The L1 XDM should call OptimismPortal.depositTransaction
-        vm.expectCall(
-            address(optimismPortal2),
-            abi.encodeCall(
-                IOptimismPortal2.depositTransaction, (address(l2CrossDomainMessenger), 0, baseGas, false, innerMessage)
-            )
-        );
-        vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transferFrom, (alice, address(l1StandardBridge), 1000)));
-
-        vm.prank(alice);
-        l1StandardBridge.depositERC20To(address(L1Token), address(L2Token), bob, 1000, 10000, hex"");
-
-        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 1000);
-    }
-}
-
-contract L1StandardBridge_FinalizeETHWithdrawal_Test is CommonTest {
-    using stdStorage for StdStorage;
-
-    /// @dev Tests that finalizing an ETH withdrawal succeeds.
-    ///      Emits ETHWithdrawalFinalized event.
-    ///      Only callable by the L2 bridge.
-    function test_finalizeETHWithdrawal_succeeds() external {
-        uint256 aliceBalance = alice.balance;
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ETHWithdrawalFinalized(alice, alice, 100, hex"");
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ETHBridgeFinalized(alice, alice, 100, hex"");
-
-        vm.expectCall(alice, hex"");
-
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        // ensure that the messenger has ETH to call with
-        vm.deal(address(l1StandardBridge.messenger()), 100);
-        vm.prank(address(l1StandardBridge.messenger()));
-        l1StandardBridge.finalizeETHWithdrawal{ value: 100 }(alice, alice, 100, hex"");
-
-        assertEq(address(l1StandardBridge.messenger()).balance, 0);
-        assertEq(aliceBalance + 100, alice.balance);
-    }
-}
-
-contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
-    using stdStorage for StdStorage;
-
-    /// @dev Tests that finalizing an ERC20 withdrawal succeeds.
-    ///      Bridge deposits are updated.
-    ///      Emits ERC20WithdrawalFinalized event.
-    ///      Only callable by the L2 bridge.
-    function test_finalizeERC20Withdrawal_succeeds() external {
-        deal(address(L1Token), address(l1StandardBridge), 100, true);
-
-        uint256 slot = stdstore.target(address(l1StandardBridge)).sig("deposits(address,address)").with_key(
-            address(L1Token)
-        ).with_key(address(L2Token)).find();
-
-        // Give the L1 bridge some ERC20 tokens
-        vm.store(address(l1StandardBridge), bytes32(slot), bytes32(uint256(100)));
-        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 100);
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ERC20WithdrawalFinalized(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ERC20BridgeFinalized(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-
-        vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transfer, (alice, 100)));
-
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.prank(address(l1StandardBridge.messenger()));
-        l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-
-        assertEq(L1Token.balanceOf(address(l1StandardBridge)), 0);
-        assertEq(L1Token.balanceOf(address(alice)), 100);
-    }
-}
-
-contract L1StandardBridge_FinalizeERC20Withdrawal_TestFail is CommonTest {
-    /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
-    function test_finalizeERC20Withdrawal_notMessenger_reverts() external {
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.prank(address(28));
-        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
-        l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-    }
-
-    /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
-    function test_finalizeERC20Withdrawal_notOtherBridge_reverts() external {
-        vm.mockCall(
-            address(l1StandardBridge.messenger()),
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(address(0)))
-        );
-        vm.prank(address(l1StandardBridge.messenger()));
-        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
-        l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
-    }
-}
-
-contract L1StandardBridge_FinalizeBridgeETH_Test is CommonTest {
-    /// @dev Tests that finalizing bridged ETH succeeds.
-    function test_finalizeBridgeETH_succeeds() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
-        vm.prank(messenger);
-
-        vm.expectEmit(address(l1StandardBridge));
-        emit ETHBridgeFinalized(alice, alice, 100, hex"");
-
-        l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, alice, 100, hex"");
-    }
-}
-
-contract L1StandardBridge_FinalizeBridgeETH_TestFail is CommonTest {
-    /// @dev Tests that finalizing bridged ETH reverts if the amount is incorrect.
-    function test_finalizeBridgeETH_incorrectValue_reverts() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
-        vm.prank(messenger);
-        vm.expectRevert("StandardBridge: amount sent does not match amount required");
-        l1StandardBridge.finalizeBridgeETH{ value: 50 }(alice, alice, 100, hex"");
-    }
-
-    /// @dev Tests that finalizing bridged ETH reverts if the destination is the L1 bridge.
-    function test_finalizeBridgeETH_sendToSelf_reverts() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
-        vm.prank(messenger);
-        vm.expectRevert("StandardBridge: cannot send to self");
-        l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, address(l1StandardBridge), 100, hex"");
-    }
-
-    /// @dev Tests that finalizing bridged ETH reverts if the destination is the messenger.
-    function test_finalizeBridgeETH_sendToMessenger_reverts() external {
-        address messenger = address(l1StandardBridge.messenger());
-        vm.mockCall(
-            messenger,
-            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
-            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
-        );
-        vm.deal(messenger, 100);
-        vm.prank(messenger);
-        vm.expectRevert("StandardBridge: cannot send to messenger");
-        l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, messenger, 100, hex"");
-    }
-}
-
-/// @title L1StandardBridge_upgrade_Test
+/// @title L1StandardBridge_Upgrade_Test
 /// @notice Reusable test for the current upgrade() function in the L1StandardBridge contract. If
 ///         the upgrade() function is changed, tests inside of this contract should be updated to
 ///         reflect the new function. If the upgrade() function is removed, remove the
@@ -840,5 +293,568 @@ contract L1StandardBridge_Upgrade_Test is CommonTest {
         // Call the `upgrade` function with the sender
         vm.prank(_sender);
         l1StandardBridge.upgrade(ISystemConfig(address(0xdeadbeef)));
+    }
+}
+
+/// @title L1StandardBridge_Paused_Test
+/// @notice Tests the `paused` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_Paused_Test is CommonTest {
+    /// @notice Sets up the test by pausing the bridge, giving ether to the bridge and mocking the
+    ///         calls to the xDomainMessageSender so that it returns the correct value.
+    function _setupPausedBridge() internal {
+        vm.startPrank(systemConfig.guardian());
+        systemConfig.superchainConfig().pause(address(0));
+        vm.stopPrank();
+        assertTrue(l1StandardBridge.paused());
+
+        vm.deal(address(l1StandardBridge.messenger()), 1 ether);
+
+        vm.mockCall(
+            address(l1StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.otherBridge()))
+        );
+    }
+
+    /// @notice Verifies that the `paused` accessor returns the same value as the `paused` function
+    ///         of the `superchainConfig`.
+    function test_paused_succeeds() external view {
+        assertEq(l1StandardBridge.paused(), systemConfig.paused());
+    }
+
+    /// @notice Ensures that the `paused` function of the bridge contract actually calls the
+    ///         `paused` function of the `superchainConfig`.
+    function test_paused_callsSuperchainConfig_succeeds() external {
+        vm.expectCall(address(systemConfig), abi.encodeCall(ISystemConfig.paused, ()));
+        l1StandardBridge.paused();
+    }
+
+    /// @notice Checks that the `paused` state of the bridge matches the `paused` state of the
+    ///         `superchainConfig` after it's been changed.
+    function test_paused_matchesSuperchainConfig_succeeds() external {
+        assertFalse(l1StandardBridge.paused());
+        assertEq(l1StandardBridge.paused(), systemConfig.paused());
+
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+
+        assertTrue(l1StandardBridge.paused());
+        assertEq(l1StandardBridge.paused(), systemConfig.paused());
+    }
+
+    /// @notice Confirms that the `finalizeBridgeETH` function reverts when the bridge is paused.
+    function test_paused_finalizeBridgeETH_reverts() external {
+        _setupPausedBridge();
+
+        vm.prank(address(l1StandardBridge.messenger()));
+        vm.expectRevert("StandardBridge: paused");
+        l1StandardBridge.finalizeBridgeETH{ value: 100 }({
+            _from: address(2),
+            _to: address(3),
+            _amount: 100,
+            _extraData: hex""
+        });
+    }
+
+    /// @notice Confirms that the `finalizeETHWithdrawal` function reverts when the bridge is
+    ///         paused.
+    function test_paused_finalizeETHWithdrawal_reverts() external {
+        _setupPausedBridge();
+
+        vm.prank(address(l1StandardBridge.messenger()));
+        vm.expectRevert("StandardBridge: paused");
+        l1StandardBridge.finalizeETHWithdrawal{ value: 100 }({
+            _from: address(2),
+            _to: address(3),
+            _amount: 100,
+            _extraData: hex""
+        });
+    }
+
+    /// @notice Confirms that the `finalizeERC20Withdrawal` function reverts when the bridge is
+    ///         paused.
+    function test_paused_finalizeERC20Withdrawal_reverts() external {
+        _setupPausedBridge();
+
+        vm.prank(address(l1StandardBridge.messenger()));
+        vm.expectRevert("StandardBridge: paused");
+        l1StandardBridge.finalizeERC20Withdrawal({
+            _l1Token: address(0),
+            _l2Token: address(0),
+            _from: address(0),
+            _to: address(0),
+            _amount: 0,
+            _extraData: hex""
+        });
+    }
+
+    /// @notice Confirms that the `finalizeBridgeERC20` function reverts when the bridge is paused.
+    function test_paused_finalizeBridgeERC20_reverts() external {
+        _setupPausedBridge();
+
+        vm.prank(address(l1StandardBridge.messenger()));
+        vm.expectRevert("StandardBridge: paused");
+        l1StandardBridge.finalizeBridgeERC20({
+            _localToken: address(0),
+            _remoteToken: address(0),
+            _from: address(0),
+            _to: address(0),
+            _amount: 0,
+            _extraData: hex""
+        });
+    }
+}
+
+/// @title L1StandardBridge_Receive_Test
+/// @notice Tests the `receive` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_Receive_Test is CommonTest {
+    /// @notice Tests receive bridges ETH successfully.
+    function test_receive_succeeds() external {
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
+
+        // The legacy event must be emitted for backwards compatibility
+        vm.expectEmit(address(l1StandardBridge));
+        emit ETHDepositInitiated(alice, alice, 100, hex"");
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ETHBridgeInitiated(alice, alice, 100, hex"");
+
+        vm.expectCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(
+                ICrossDomainMessenger.sendMessage,
+                (
+                    address(l2StandardBridge),
+                    abi.encodeCall(StandardBridge.finalizeBridgeETH, (alice, alice, 100, hex"")),
+                    200_000
+                )
+            )
+        );
+
+        vm.prank(alice, alice);
+        (bool success,) = address(l1StandardBridge).call{ value: 100 }(hex"");
+        assertEq(success, true);
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 100);
+    }
+}
+
+/// @title L1StandardBridge_DepositETH_Test
+/// @notice Tests the `depositETH` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_DepositETH_Test is L1StandardBridge_TestInit {
+    /// @notice Tests that depositing ETH succeeds.
+    ///         Emits ETHDepositInitiated and ETHBridgeInitiated events.
+    ///         Calls depositTransaction on the OptimismPortal.
+    ///         Only EOA can call depositETH.
+    ///         ETH ends up in the optimismPortal.
+    function test_depositETH_fromEOA_succeeds() external {
+        _preBridgeETH({ isLegacy: true, value: 500 });
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
+        l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
+    }
+
+    /// @notice Tests that depositing ETH succeeds for an EOA using 7702 delegation.
+    function test_depositETH_fromEOA7702_succeeds() external {
+        // Set alice to have 7702 code.
+        vm.etch(alice, abi.encodePacked(hex"EF0100", address(0)));
+
+        _preBridgeETH({ isLegacy: true, value: 500 });
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
+        l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
+    }
+
+    /// @notice Tests that depositing ETH reverts if the call is not from an EOA.
+    function test_depositETH_notEoa_reverts() external {
+        vm.etch(alice, address(L1Token).code);
+        vm.expectRevert("StandardBridge: function can only be called from an EOA");
+        vm.prank(alice);
+        l1StandardBridge.depositETH{ value: 1 }(300, hex"");
+    }
+}
+
+/// @title L1StandardBridge_DepositETHTo_Test
+/// @notice Tests the `depositETHTo` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_DepositETHTo_Test is L1StandardBridge_TestInit {
+    /// @notice Tests that depositing ETH to a different address succeeds.
+    ///         Emits ETHDepositInitiated event.
+    ///         Calls depositTransaction on the OptimismPortal.
+    ///         EOA or contract can call depositETHTo.
+    ///         ETH ends up in the optimismPortal.
+    function test_depositETHTo_succeeds() external {
+        _preBridgeETHTo({ isLegacy: true, value: 600 });
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
+        l1StandardBridge.depositETHTo{ value: 600 }(bob, 60000, hex"dead");
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 600);
+    }
+}
+
+/// @title L1StandardBridge_DepositERC20_Test
+/// @notice Tests the `depositERC20` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_DepositERC20_Test is CommonTest {
+    using stdStorage for StdStorage;
+
+    // depositERC20
+    // - updates bridge.deposits
+    // - emits ERC20DepositInitiated
+    // - calls optimismPortal.depositTransaction
+    // - only callable by EOA
+
+    /// @notice Tests that depositing ERC20 to the bridge succeeds.
+    ///         Bridge deposits are updated.
+    ///         Emits ERC20DepositInitiated event.
+    ///         Calls depositTransaction on the OptimismPortal.
+    ///         Only EOA can call depositERC20.
+    function test_depositERC20_succeeds() external {
+        uint256 nonce = l1CrossDomainMessenger.messageNonce();
+        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
+        address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+
+        // Deal Alice's ERC20 State
+        deal(address(L1Token), alice, 100000, true);
+        vm.prank(alice);
+        L1Token.approve(address(l1StandardBridge), type(uint256).max);
+
+        // The l1StandardBridge should transfer alice's tokens to itself
+        vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transferFrom, (alice, address(l1StandardBridge), 100)));
+
+        bytes memory message = abi.encodeCall(
+            StandardBridge.finalizeBridgeERC20, (address(L2Token), address(L1Token), alice, alice, 100, hex"")
+        );
+
+        // the L1 bridge should call L1CrossDomainMessenger.sendMessage
+        vm.expectCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l2StandardBridge), message, 10000))
+        );
+
+        bytes memory innerMessage = abi.encodeCall(
+            ICrossDomainMessenger.relayMessage,
+            (nonce, address(l1StandardBridge), address(l2StandardBridge), 0, 10000, message)
+        );
+
+        uint64 baseGas = l1CrossDomainMessenger.baseGas(message, 10000);
+        vm.expectCall(
+            address(optimismPortal2),
+            abi.encodeCall(
+                IOptimismPortal2.depositTransaction, (address(l2CrossDomainMessenger), 0, baseGas, false, innerMessage)
+            )
+        );
+
+        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
+
+        // Should emit both the bedrock and legacy events
+        vm.expectEmit(address(l1StandardBridge));
+        emit ERC20DepositInitiated(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ERC20BridgeInitiated(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+
+        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
+        vm.expectEmit(address(optimismPortal2));
+        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
+
+        // SentMessage event emitted by the CrossDomainMessenger
+        vm.expectEmit(address(l1CrossDomainMessenger));
+        emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 10000);
+
+        // SentMessageExtension1 event emitted by the CrossDomainMessenger
+        vm.expectEmit(address(l1CrossDomainMessenger));
+        emit SentMessageExtension1(address(l1StandardBridge), 0);
+
+        vm.prank(alice, alice);
+        l1StandardBridge.depositERC20(address(L1Token), address(L2Token), 100, 10000, hex"");
+        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 100);
+    }
+
+    /// @notice Tests that depositing an ERC20 to the bridge reverts if the caller is not an EOA.
+    function test_depositERC20_notEoa_reverts() external {
+        // Turn alice into a contract
+        vm.etch(alice, hex"ffff");
+
+        vm.expectRevert("StandardBridge: function can only be called from an EOA");
+        vm.prank(alice);
+        l1StandardBridge.depositERC20(address(0), address(0), 100, 100, hex"");
+    }
+}
+
+/// @title L1StandardBridge_DepositERC20To_Test
+/// @notice Tests the `depositERC20To` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_DepositERC20To_Test is CommonTest {
+    /// @notice Tests that depositing ERC20 to the bridge succeeds when sent to a different address.
+    ///         Bridge deposits are updated.
+    ///         Emits ERC20DepositInitiated event.
+    ///         Calls depositTransaction on the OptimismPortal.
+    ///         Contracts can call depositERC20.
+    function test_depositERC20To_succeeds() external {
+        uint256 nonce = l1CrossDomainMessenger.messageNonce();
+        uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
+        address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(l1CrossDomainMessenger));
+
+        bytes memory message = abi.encodeCall(
+            StandardBridge.finalizeBridgeERC20, (address(L2Token), address(L1Token), alice, bob, 1000, hex"")
+        );
+
+        bytes memory innerMessage = abi.encodeCall(
+            ICrossDomainMessenger.relayMessage,
+            (nonce, address(l1StandardBridge), address(l2StandardBridge), 0, 10000, message)
+        );
+
+        uint64 baseGas = l1CrossDomainMessenger.baseGas(message, 10000);
+        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
+
+        deal(address(L1Token), alice, 100000, true);
+
+        vm.prank(alice);
+        L1Token.approve(address(l1StandardBridge), type(uint256).max);
+
+        // Should emit both the bedrock and legacy events
+        vm.expectEmit(address(l1StandardBridge));
+        emit ERC20DepositInitiated(address(L1Token), address(L2Token), alice, bob, 1000, hex"");
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ERC20BridgeInitiated(address(L1Token), address(L2Token), alice, bob, 1000, hex"");
+
+        // OptimismPortal emits a TransactionDeposited event on `depositTransaction` call
+        vm.expectEmit(address(optimismPortal2));
+        emit TransactionDeposited(l1MessengerAliased, address(l2CrossDomainMessenger), version, opaqueData);
+
+        // SentMessage event emitted by the CrossDomainMessenger
+        vm.expectEmit(address(l1CrossDomainMessenger));
+        emit SentMessage(address(l2StandardBridge), address(l1StandardBridge), message, nonce, 10000);
+
+        // SentMessageExtension1 event emitted by the CrossDomainMessenger
+        vm.expectEmit(address(l1CrossDomainMessenger));
+        emit SentMessageExtension1(address(l1StandardBridge), 0);
+
+        // the L1 bridge should call L1CrossDomainMessenger.sendMessage
+        vm.expectCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(ICrossDomainMessenger.sendMessage, (address(l2StandardBridge), message, 10000))
+        );
+        // The L1 XDM should call OptimismPortal.depositTransaction
+        vm.expectCall(
+            address(optimismPortal2),
+            abi.encodeCall(
+                IOptimismPortal2.depositTransaction, (address(l2CrossDomainMessenger), 0, baseGas, false, innerMessage)
+            )
+        );
+        vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transferFrom, (alice, address(l1StandardBridge), 1000)));
+
+        vm.prank(alice);
+        l1StandardBridge.depositERC20To(address(L1Token), address(L2Token), bob, 1000, 10000, hex"");
+
+        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 1000);
+    }
+}
+
+/// @title L1StandardBridge_FinalizeETHWithdrawal_Test
+/// @notice Tests the `finalizeETHWithdrawal` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_FinalizeETHWithdrawal_Test is CommonTest {
+    using stdStorage for StdStorage;
+
+    /// @notice Tests that finalizing an ETH withdrawal succeeds.
+    ///         Emits ETHWithdrawalFinalized event.
+    ///         Only callable by the L2 bridge.
+    function test_finalizeETHWithdrawal_succeeds() external {
+        uint256 aliceBalance = alice.balance;
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ETHWithdrawalFinalized(alice, alice, 100, hex"");
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ETHBridgeFinalized(alice, alice, 100, hex"");
+
+        vm.expectCall(alice, hex"");
+
+        vm.mockCall(
+            address(l1StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        // ensure that the messenger has ETH to call with
+        vm.deal(address(l1StandardBridge.messenger()), 100);
+        vm.prank(address(l1StandardBridge.messenger()));
+        l1StandardBridge.finalizeETHWithdrawal{ value: 100 }(alice, alice, 100, hex"");
+
+        assertEq(address(l1StandardBridge.messenger()).balance, 0);
+        assertEq(aliceBalance + 100, alice.balance);
+    }
+}
+
+/// @title L1StandardBridge_FinalizeERC20Withdrawal_Test
+/// @notice Tests the `finalizeERC20Withdrawal` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_FinalizeERC20Withdrawal_Test is CommonTest {
+    using stdStorage for StdStorage;
+
+    /// @notice Tests that finalizing an ERC20 withdrawal succeeds.
+    ///         Bridge deposits are updated.
+    ///         Emits ERC20WithdrawalFinalized event.
+    ///         Only callable by the L2 bridge.
+    function test_finalizeERC20Withdrawal_succeeds() external {
+        deal(address(L1Token), address(l1StandardBridge), 100, true);
+
+        uint256 slot = stdstore.target(address(l1StandardBridge)).sig("deposits(address,address)").with_key(
+            address(L1Token)
+        ).with_key(address(L2Token)).find();
+
+        // Give the L1 bridge some ERC20 tokens
+        vm.store(address(l1StandardBridge), bytes32(slot), bytes32(uint256(100)));
+        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), 100);
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ERC20WithdrawalFinalized(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ERC20BridgeFinalized(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+
+        vm.expectCall(address(L1Token), abi.encodeCall(ERC20.transfer, (alice, 100)));
+
+        vm.mockCall(
+            address(l1StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        vm.prank(address(l1StandardBridge.messenger()));
+        l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+
+        assertEq(L1Token.balanceOf(address(l1StandardBridge)), 0);
+        assertEq(L1Token.balanceOf(address(alice)), 100);
+    }
+
+    /// @notice Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2
+    ///         bridge.
+    function test_finalizeERC20Withdrawal_notMessenger_reverts() external {
+        vm.mockCall(
+            address(l1StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        vm.prank(address(28));
+        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
+        l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+    }
+
+    /// @notice Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2
+    ///         bridge.
+    function test_finalizeERC20Withdrawal_notOtherBridge_reverts() external {
+        vm.mockCall(
+            address(l1StandardBridge.messenger()),
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(address(0)))
+        );
+        vm.prank(address(l1StandardBridge.messenger()));
+        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
+        l1StandardBridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
+    }
+}
+
+/// @title L1StandardBridge_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `L1StandardBridge`
+///         contract or are testing multiple functions.
+contract L1StandardBridge_Unclassified_Test is L1StandardBridge_TestInit {
+    /// @notice Test that the accessors return the correct initialized values.
+    function test_getters_succeeds() external view {
+        assert(l1StandardBridge.l2TokenBridge() == address(l2StandardBridge));
+        assert(address(l1StandardBridge.OTHER_BRIDGE()) == address(l2StandardBridge));
+        assert(address(l1StandardBridge.messenger()) == address(l1CrossDomainMessenger));
+        assert(address(l1StandardBridge.MESSENGER()) == address(l1CrossDomainMessenger));
+        assert(l1StandardBridge.systemConfig() == systemConfig);
+        assert(l1StandardBridge.superchainConfig() == systemConfig.superchainConfig());
+    }
+
+    /// @notice Tests that bridging ETH succeeds.
+    ///         Emits ETHDepositInitiated and ETHBridgeInitiated events.
+    ///         Calls depositTransaction on the OptimismPortal.
+    ///         Only EOA can call bridgeETH.
+    ///         ETH ends up in the optimismPortal.
+    function test_bridgeETH_succeeds() external {
+        _preBridgeETH({ isLegacy: false, value: 500 });
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
+        l1StandardBridge.bridgeETH{ value: 500 }(50000, hex"dead");
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 500);
+    }
+
+    /// @notice Tests that bridging ETH to a different address succeeds.
+    ///         Emits ETHDepositInitiated and ETHBridgeInitiated events.
+    ///         Calls depositTransaction on the OptimismPortal.
+    ///         Only EOA can call bridgeETHTo.
+    ///         ETH ends up in the optimismPortal.
+    function test_bridgeETHTo_succeeds() external {
+        _preBridgeETHTo({ isLegacy: false, value: 600 });
+        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 ethLockboxBalanceBefore = address(ethLockbox).balance;
+        l1StandardBridge.bridgeETHTo{ value: 600 }(bob, 60000, hex"dead");
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore);
+        assertEq(address(ethLockbox).balance, ethLockboxBalanceBefore + 600);
+    }
+
+    /// @notice Tests that finalizing bridged ETH succeeds.
+    function test_finalizeBridgeETH_succeeds() external {
+        address messenger = address(l1StandardBridge.messenger());
+        vm.mockCall(
+            messenger,
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        vm.deal(messenger, 100);
+        vm.prank(messenger);
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit ETHBridgeFinalized(alice, alice, 100, hex"");
+
+        l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, alice, 100, hex"");
+    }
+
+    /// @notice Tests that finalizing bridged ETH reverts if the amount is incorrect.
+    function test_finalizeBridgeETH_incorrectValue_reverts() external {
+        address messenger = address(l1StandardBridge.messenger());
+        vm.mockCall(
+            messenger,
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        vm.deal(messenger, 100);
+        vm.prank(messenger);
+        vm.expectRevert("StandardBridge: amount sent does not match amount required");
+        l1StandardBridge.finalizeBridgeETH{ value: 50 }(alice, alice, 100, hex"");
+    }
+
+    /// @notice Tests that finalizing bridged ETH reverts if the destination is the L1 bridge.
+    function test_finalizeBridgeETH_sendToSelf_reverts() external {
+        address messenger = address(l1StandardBridge.messenger());
+        vm.mockCall(
+            messenger,
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        vm.deal(messenger, 100);
+        vm.prank(messenger);
+        vm.expectRevert("StandardBridge: cannot send to self");
+        l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, address(l1StandardBridge), 100, hex"");
+    }
+
+    /// @notice Tests that finalizing bridged ETH reverts if the destination is the messenger.
+    function test_finalizeBridgeETH_sendToMessenger_reverts() external {
+        address messenger = address(l1StandardBridge.messenger());
+        vm.mockCall(
+            messenger,
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+        vm.deal(messenger, 100);
+        vm.prank(messenger);
+        vm.expectRevert("StandardBridge: cannot send to messenger");
+        l1StandardBridge.finalizeBridgeETH{ value: 100 }(alice, messenger, 100, hex"");
     }
 }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -69,7 +69,8 @@ import {
     OPContractsManagerInteropMigrator
 } from "src/L1/OPContractsManager.sol";
 
-// Exposes internal functions for testing.
+/// @title OPContractsManager_Harness
+/// @notice Exposes internal functions for testing.
 contract OPContractsManager_Harness is OPContractsManager {
     constructor(
         OPContractsManagerGameTypeAdder _opcmGameTypeAdder,
@@ -100,139 +101,8 @@ contract OPContractsManager_Harness is OPContractsManager {
     }
 }
 
-// Unlike other test suites, we intentionally do not inherit from CommonTest or Setup. This is
-// because OPContractsManager acts as a deploy script, so we start from a clean slate here and
-// work OPContractsManager's deployment into the existing test setup, instead of using the existing
-// test setup to deploy OPContractsManager. We do however inherit from DeployOPChain_TestBase so
-// we can use its setup to deploy the implementations similarly to how a real deployment would
-// happen.
-contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
-    using stdStorage for StdStorage;
-
-    event Deployed(uint256 indexed l2ChainId, address indexed deployer, bytes deployOutput);
-
-    function setUp() public override {
-        DeployOPChain_TestBase.setUp();
-
-        doi.set(doi.opChainProxyAdminOwner.selector, opChainProxyAdminOwner);
-        doi.set(doi.systemConfigOwner.selector, systemConfigOwner);
-        doi.set(doi.batcher.selector, batcher);
-        doi.set(doi.unsafeBlockSigner.selector, unsafeBlockSigner);
-        doi.set(doi.proposer.selector, proposer);
-        doi.set(doi.challenger.selector, challenger);
-        doi.set(doi.basefeeScalar.selector, basefeeScalar);
-        doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
-        doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcm.selector, address(opcm));
-        doi.set(doi.gasLimit.selector, gasLimit);
-
-        doi.set(doi.disputeGameType.selector, disputeGameType);
-        doi.set(doi.disputeAbsolutePrestate.selector, disputeAbsolutePrestate);
-        doi.set(doi.disputeMaxGameDepth.selector, disputeMaxGameDepth);
-        doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
-        doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
-        doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
-    }
-
-    // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol
-    // to the input struct type defined in OPContractsManager.sol.
-    function toOPCMDeployInput(DeployOPChainInput _doi)
-        internal
-        view
-        returns (IOPContractsManager.DeployInput memory)
-    {
-        return IOPContractsManager.DeployInput({
-            roles: IOPContractsManager.Roles({
-                opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
-                systemConfigOwner: _doi.systemConfigOwner(),
-                batcher: _doi.batcher(),
-                unsafeBlockSigner: _doi.unsafeBlockSigner(),
-                proposer: _doi.proposer(),
-                challenger: _doi.challenger()
-            }),
-            basefeeScalar: _doi.basefeeScalar(),
-            blobBasefeeScalar: _doi.blobBaseFeeScalar(),
-            l2ChainId: _doi.l2ChainId(),
-            startingAnchorRoot: _doi.startingAnchorRoot(),
-            saltMixer: _doi.saltMixer(),
-            gasLimit: _doi.gasLimit(),
-            disputeGameType: _doi.disputeGameType(),
-            disputeAbsolutePrestate: _doi.disputeAbsolutePrestate(),
-            disputeMaxGameDepth: _doi.disputeMaxGameDepth(),
-            disputeSplitDepth: _doi.disputeSplitDepth(),
-            disputeClockExtension: _doi.disputeClockExtension(),
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration()
-        });
-    }
-
-    function test_deploy_l2ChainIdEqualsZero_reverts() public {
-        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
-        deployInput.l2ChainId = 0;
-        vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
-        opcm.deploy(deployInput);
-    }
-
-    function test_deploy_l2ChainIdEqualsCurrentChainId_reverts() public {
-        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
-        deployInput.l2ChainId = block.chainid;
-
-        vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
-        opcm.deploy(deployInput);
-    }
-
-    function test_deploy_succeeds() public {
-        vm.expectEmit(true, true, true, false); // TODO precompute the expected `deployOutput`.
-        emit Deployed(doi.l2ChainId(), address(this), bytes(""));
-        opcm.deploy(toOPCMDeployInput(doi));
-    }
-}
-
-// These tests use the harness which exposes internal functions for testing.
-contract OPContractsManager_InternalMethods_Test is Test {
-    OPContractsManager_Harness opcmHarness;
-
-    function setUp() public {
-        ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfig"));
-        IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersions"));
-        IProxyAdmin superchainProxyAdmin = IProxyAdmin(makeAddr("superchainProxyAdmin"));
-        address upgradeController = makeAddr("upgradeController");
-        OPContractsManager.Blueprints memory emptyBlueprints;
-        OPContractsManager.Implementations memory emptyImpls;
-        vm.etch(address(superchainConfigProxy), hex"01");
-        vm.etch(address(protocolVersionsProxy), hex"01");
-
-        OPContractsManagerContractsContainer container =
-            new OPContractsManagerContractsContainer(emptyBlueprints, emptyImpls);
-
-        opcmHarness = new OPContractsManager_Harness({
-            _opcmGameTypeAdder: new OPContractsManagerGameTypeAdder(container),
-            _opcmDeployer: new OPContractsManagerDeployer(container),
-            _opcmUpgrader: new OPContractsManagerUpgrader(container),
-            _opcmInteropMigrator: new OPContractsManagerInteropMigrator(container),
-            _superchainConfig: superchainConfigProxy,
-            _protocolVersions: protocolVersionsProxy,
-            _superchainProxyAdmin: superchainProxyAdmin,
-            _l1ContractsRelease: "dev",
-            _upgradeController: upgradeController
-        });
-    }
-
-    function test_calculatesBatchInboxAddress_succeeds() public view {
-        // These test vectors were calculated manually:
-        //   1. Compute the bytes32 encoding of the chainId: bytes32(uint256(chainId));
-        //   2. Hash it and manually take the first 19 bytes, and prefixed it with 0x00.
-        uint256 chainId = 1234;
-        address expected = 0x0017FA14b0d73Aa6A26D6b8720c1c84b50984f5C;
-        address actual = opcmHarness.chainIdToBatchInboxAddress_exposed(chainId);
-        vm.assertEq(expected, actual);
-
-        chainId = type(uint256).max;
-        expected = 0x00a9C584056064687E149968cBaB758a3376D22A;
-        actual = opcmHarness.chainIdToBatchInboxAddress_exposed(chainId);
-        vm.assertEq(expected, actual);
-    }
-}
-
+/// @title OPContractsManager_Upgrade_Harness
+/// @notice Exposes internal functions for testing.
 contract OPContractsManager_Upgrade_Harness is CommonTest {
     // The Upgraded event emitted by the Proxy contract.
     event Upgraded(address indexed implementation);
@@ -243,7 +113,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
     // The AddressSet event emitted by the AddressManager contract.
     event AddressSet(string indexed name, address newAddress, address oldAddress);
 
-    // The AdminChanged event emitted by the Proxy contract at init time or when the admin is changed.
+    // The AdminChanged event emitted by the Proxy contract at init time or when the admin is
+    // changed.
     event AdminChanged(address previousAdmin, address newAdmin);
 
     // The ImplementationSet event emitted by the DisputeGameFactory contract.
@@ -284,8 +155,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             })
         );
 
-        // Retrieve the l2ChainId, which was read from the superchain-registry, and saved in Artifacts
-        // encoded as an address.
+        // Retrieve the l2ChainId, which was read from the superchain-registry, and saved in
+        // Artifacts encoded as an address.
         l2ChainId = uint256(uint160(address(artifacts.mustGetAddress("L2ChainId"))));
 
         delayedWETHPermissionedGameProxy =
@@ -413,8 +284,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         if (address(oldFDG) != address(0)) {
             // Check that the PermissionlessDisputeGame is upgraded to the expected version
             IFaultDisputeGame newFDG = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
-            // Check that the PermissionlessDisputeGame is upgraded to the expected version, references
-            // the correct anchor state and has the mipsImpl.
+            // Check that the PermissionlessDisputeGame is upgraded to the expected version,
+            // references the correct anchor state and has the mipsImpl.
             assertEq(impls.delayedWETHImpl, EIP1967Helper.getImplementation(address(newFDG.weth())));
             assertEq(ISemver(address(newFDG)).version(), "1.4.1");
             assertEq(address(newFDG.anchorStateRegistry()), address(newAnchorStateRegistryProxy));
@@ -431,7 +302,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         address mainnetPAO = artifacts.mustGetAddress("SuperchainConfigProxy");
 
-        // If the delegate caller is not the mainnet PAO, we need to call upgrade as the mainnet PAO first.
+        // If the delegate caller is not the mainnet PAO, we need to call upgrade as the mainnet
+        // PAO first.
         if (_delegateCaller != mainnetPAO) {
             IOPContractsManager.OpChainConfig[] memory opmChain = new IOPContractsManager.OpChainConfig[](0);
             ISuperchainConfig superchainConfig = ISuperchainConfig(mainnetPAO);
@@ -495,8 +367,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         if (address(oldFDG) != address(0)) {
             // Check that the PermissionlessDisputeGame is upgraded to the expected version
             IFaultDisputeGame newFDG = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
-            // Check that the PermissionlessDisputeGame is upgraded to the expected version, references
-            // the correct anchor state and has the mipsImpl.
+            // Check that the PermissionlessDisputeGame is upgraded to the expected version,
+            // references the correct anchor state and has the mipsImpl.
             assertEq(ISemver(address(newFDG)).version(), "1.4.1");
             assertEq(address(newFDG.vm()), impls.mipsImpl);
         }
@@ -636,252 +508,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
     }
 }
 
-contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
-    function test_upgradeOPChainOnly_succeeds() public {
-        skipIfNotOpFork("test_upgradeOPChainOnly_succeeds");
-        // Run the upgrade test and checks
-        runUpgradeTestAndChecks(upgrader);
-    }
-
-    function test_verifyOpcmCorrectness_succeeds() public {
-        skipIfNotOpFork("test_verifyOpcmCorrectness_succeeds");
-        skipIfCoverage(); // Coverage changes bytecode and breaks the verification script.
-
-        // Run the upgrade test and checks
-        runUpgradeTestAndChecks(upgrader);
-
-        // Run the verification script without etherscan verificatin. Hard to run with etherscan
-        // verification in these tests, can do it but means we add even more dependencies to the
-        // test environment.
-        VerifyOPCM verify = new VerifyOPCM();
-        verify.run(address(opcm), true);
-    }
-
-    function test_isRcFalseAfterCalledByUpgrader_works() public {
-        skipIfNotOpFork("test_isRcFalseAfterCalledByUpgrader_works");
-        assertTrue(opcm.isRC());
-        bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
-        assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
-
-        runUpgradeTestAndChecks(upgrader);
-
-        assertFalse(opcm.isRC(), "isRC should be false");
-        releaseBytes = bytes(opcm.l1ContractsRelease());
-        assertNotEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should not end with '-rc'");
-    }
-
-    function testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works(
-        address _nonUpgradeController
-    )
-        public
-    {
-        skipIfNotOpFork("testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works");
-        if (
-            _nonUpgradeController == upgrader || _nonUpgradeController == address(0)
-                || _nonUpgradeController < address(0x4200000000000000000000000000000000000000)
-                || _nonUpgradeController > address(0x4200000000000000000000000000000000000800)
-                || _nonUpgradeController == address(vm)
-                || _nonUpgradeController == 0x000000000000000000636F6e736F6c652e6c6f67
-                || _nonUpgradeController == 0x4e59b44847b379578588920cA78FbF26c0B4956C
-        ) {
-            _nonUpgradeController = makeAddr("nonUpgradeController");
-        }
-
-        // Set the proxy admin owner to be the non-upgrade controller
-        vm.store(
-            address(proxyAdmin),
-            bytes32(ForgeArtifacts.getSlot("ProxyAdmin", "_owner").slot),
-            bytes32(uint256(uint160(_nonUpgradeController)))
-        );
-        vm.store(
-            address(disputeGameFactory),
-            bytes32(ForgeArtifacts.getSlot("DisputeGameFactory", "_owner").slot),
-            bytes32(uint256(uint160(_nonUpgradeController)))
-        );
-
-        // Run the upgrade test and checks
-        runUpgradeTestAndChecks(_nonUpgradeController);
-    }
-
-    function test_upgrade_duplicateL2ChainId_succeeds() public {
-        skipIfNotOpFork("test_upgrade_duplicateL2ChainId_succeeds");
-
-        // Deploy a new OPChain with the same L2 chain ID as the current OPChain
-        Deploy deploy = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
-        IOPContractsManager.DeployInput memory deployInput = deploy.getDeployInput();
-        deployInput.l2ChainId = l2ChainId;
-        deployInput.saltMixer = "v2.0.0";
-        opcm.deploy(deployInput);
-
-        // Try to upgrade the current OPChain
-        runUpgradeTestAndChecks(upgrader);
-    }
-
-    /// @notice Tests that the absolute prestate can be overridden using the upgrade config.
-    function test_upgrade_absolutePrestateOverride_succeeds() public {
-        // Run Upgrade 13 and 14 to get us to a state where we can run Upgrade 15.
-        // Can remove these two calls as Upgrade 13 and 14 are executed in prod.
-        runUpgrade13UpgradeAndChecks(upgrader);
-        runUpgrade14UpgradeAndChecks(upgrader);
-
-        // Get the pdg and fdg before the upgrade
-        Claim pdgPrestateBefore = IPermissionedDisputeGame(
-            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
-        ).absolutePrestate();
-        Claim fdgPrestateBefore =
-            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
-
-        // Assert that the prestate is not zero.
-        assertNotEq(pdgPrestateBefore.raw(), bytes32(0));
-        assertNotEq(fdgPrestateBefore.raw(), bytes32(0));
-
-        // Set the absolute prestate input to something non-zero.
-        opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(uint256(1)));
-
-        // Now run Upgrade 15.
-        runUpgrade15UpgradeAndChecks(upgrader);
-
-        // Get the absolute prestate after the upgrade
-        Claim pdgPrestateAfter = IPermissionedDisputeGame(
-            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
-        ).absolutePrestate();
-        Claim fdgPrestateAfter =
-            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
-
-        // Assert that the absolute prestate is the non-zero value we set.
-        assertEq(pdgPrestateAfter.raw(), bytes32(uint256(1)));
-        assertEq(fdgPrestateAfter.raw(), bytes32(uint256(1)));
-    }
-
-    /// @notice Tests that the old absolute prestate is used if the upgrade config does not set an
-    ///         absolute prestate.
-    function test_upgrade_absolutePrestateNotSet_succeeds() public {
-        // Run Upgrade 13 and 14 to get us to a state where we can run Upgrade 15.
-        // Can remove these two calls as Upgrade 13 and 14 are executed in prod.
-        runUpgrade13UpgradeAndChecks(upgrader);
-        runUpgrade14UpgradeAndChecks(upgrader);
-
-        // Get the pdg and fdg before the upgrade
-        Claim pdgPrestateBefore = IPermissionedDisputeGame(
-            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
-        ).absolutePrestate();
-        Claim fdgPrestateBefore =
-            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
-
-        // Assert that the prestate is not zero.
-        assertNotEq(pdgPrestateBefore.raw(), bytes32(0));
-        assertNotEq(fdgPrestateBefore.raw(), bytes32(0));
-
-        // Set the absolute prestate input to zero.
-        opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(0));
-
-        // Now run Upgrade 15.
-        runUpgrade15UpgradeAndChecks(upgrader);
-
-        // Get the absolute prestate after the upgrade
-        Claim pdgPrestateAfter = IPermissionedDisputeGame(
-            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
-        ).absolutePrestate();
-        Claim fdgPrestateAfter =
-            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
-
-        // Assert that the absolute prestate is the same as before the upgrade.
-        assertEq(pdgPrestateAfter.raw(), pdgPrestateBefore.raw());
-        assertEq(fdgPrestateAfter.raw(), fdgPrestateBefore.raw());
-    }
-}
-
-contract OPContractsManager_Upgrade_TestFails is OPContractsManager_Upgrade_Harness {
-    // Upgrade to U14 first
-    function setUp() public override {
-        skipIfNotOpFork("test_upgrade_notDelegateCalled_reverts");
-        super.setUp();
-        runUpgrade13UpgradeAndChecks(upgrader);
-    }
-
-    function test_upgrade_notDelegateCalled_reverts() public {
-        vm.prank(upgrader);
-        vm.expectRevert(IOPContractsManager.OnlyDelegatecall.selector);
-        opcm.upgrade(opChainConfigs);
-    }
-
-    function test_upgrade_notProxyAdminOwner_reverts() public {
-        address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
-        assertNotEq(superchainProxyAdmin.owner(), delegateCaller);
-        assertNotEq(proxyAdmin.owner(), delegateCaller);
-
-        vm.expectRevert("Ownable: caller is not the owner");
-        DelegateCaller(delegateCaller).dcForward(
-            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChainConfigs))
-        );
-    }
-
-    /// @notice Tests that upgrade reverts when absolutePrestate is zero and the existing game also
-    ///         has an absolute prestate of zero.
-    function test_upgrade_absolutePrestateNotSet_reverts() public {
-        // Set the config to try to update the absolutePrestate to zero.
-        opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(0));
-
-        // Get the address of the PermissionedDisputeGame.
-        IPermissionedDisputeGame pdg =
-            IPermissionedDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
-
-        // Mock the PDG to return a prestate of zero.
-        vm.mockCall(
-            address(pdg),
-            abi.encodeCall(IPermissionedDisputeGame.absolutePrestate, ()),
-            abi.encode(Claim.wrap(bytes32(0)))
-        );
-
-        // Expect the upgrade to revert with PrestateNotSet.
-        vm.expectRevert(IOPContractsManager.PrestateNotSet.selector);
-        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChainConfigs)));
-    }
-}
-
-contract OPContractsManager_SetRC_Test is OPContractsManager_Upgrade_Harness {
-    /// @notice Tests the setRC function can be set by the upgrade controller.
-    function test_setRC_succeeds(bool _isRC) public {
-        skipIfNotOpFork("test_setRC_succeeds");
-
-        vm.prank(upgrader);
-
-        opcm.setRC(_isRC);
-        assertTrue(opcm.isRC() == _isRC, "isRC should be true");
-        bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
-        if (_isRC) {
-            assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
-        } else {
-            assertNotEq(
-                Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should not end with '-rc'"
-            );
-        }
-    }
-
-    /// @notice Tests the setRC function can not be set by non-upgrade controller.
-    function test_setRC_nonUpgradeController_reverts(address _nonUpgradeController) public {
-        // Disallow the upgrade controller to have code, or be a 'special' address.
-        if (
-            _nonUpgradeController == upgrader || _nonUpgradeController == address(0)
-                || _nonUpgradeController < address(0x4200000000000000000000000000000000000000)
-                || _nonUpgradeController > address(0x4200000000000000000000000000000000000800)
-                || _nonUpgradeController == address(vm)
-                || _nonUpgradeController == 0x000000000000000000636F6e736F6c652e6c6f67
-                || _nonUpgradeController == 0x4e59b44847b379578588920cA78FbF26c0B4956C
-                || _nonUpgradeController.code.length > 0
-        ) {
-            _nonUpgradeController = makeAddr("nonUpgradeController");
-        }
-
-        vm.prank(_nonUpgradeController);
-
-        vm.expectRevert(IOPContractsManager.OnlyUpgradeController.selector);
-        opcm.setRC(true);
-    }
-}
-
+/// @title OPContractsManager_TestInit
+/// @notice Reusable test initialization for `OPContractsManager` tests.
 contract OPContractsManager_TestInit is Test {
     IOPContractsManager internal opcm;
     IOPContractsManager.DeployOutput internal chainDeployOutput1;
@@ -1091,6 +719,56 @@ contract OPContractsManager_TestInit is Test {
     }
 }
 
+/// @title OPContractsManager_ChainIdToBatchInboxAddress_Test
+/// @notice Tests the `chainIdToBatchInboxAddress` function of the `OPContractsManager` contract.
+/// @dev These tests use the harness which exposes internal functions for testing.
+contract OPContractsManager_ChainIdToBatchInboxAddress_Test is Test {
+    OPContractsManager_Harness opcmHarness;
+
+    function setUp() public {
+        ISuperchainConfig superchainConfigProxy = ISuperchainConfig(makeAddr("superchainConfig"));
+        IProtocolVersions protocolVersionsProxy = IProtocolVersions(makeAddr("protocolVersions"));
+        IProxyAdmin superchainProxyAdmin = IProxyAdmin(makeAddr("superchainProxyAdmin"));
+        address upgradeController = makeAddr("upgradeController");
+        OPContractsManager.Blueprints memory emptyBlueprints;
+        OPContractsManager.Implementations memory emptyImpls;
+        vm.etch(address(superchainConfigProxy), hex"01");
+        vm.etch(address(protocolVersionsProxy), hex"01");
+
+        OPContractsManagerContractsContainer container =
+            new OPContractsManagerContractsContainer(emptyBlueprints, emptyImpls);
+
+        opcmHarness = new OPContractsManager_Harness({
+            _opcmGameTypeAdder: new OPContractsManagerGameTypeAdder(container),
+            _opcmDeployer: new OPContractsManagerDeployer(container),
+            _opcmUpgrader: new OPContractsManagerUpgrader(container),
+            _opcmInteropMigrator: new OPContractsManagerInteropMigrator(container),
+            _superchainConfig: superchainConfigProxy,
+            _protocolVersions: protocolVersionsProxy,
+            _superchainProxyAdmin: superchainProxyAdmin,
+            _l1ContractsRelease: "dev",
+            _upgradeController: upgradeController
+        });
+    }
+
+    function test_calculatesBatchInboxAddress_succeeds() public view {
+        // These test vectors were calculated manually:
+        //   1. Compute the bytes32 encoding of the chainId: bytes32(uint256(chainId));
+        //   2. Hash it and manually take the first 19 bytes, and prefixed it with 0x00.
+        uint256 chainId = 1234;
+        address expected = 0x0017FA14b0d73Aa6A26D6b8720c1c84b50984f5C;
+        address actual = opcmHarness.chainIdToBatchInboxAddress_exposed(chainId);
+        vm.assertEq(expected, actual);
+
+        chainId = type(uint256).max;
+        expected = 0x00a9C584056064687E149968cBaB758a3376D22A;
+        actual = opcmHarness.chainIdToBatchInboxAddress_exposed(chainId);
+        vm.assertEq(expected, actual);
+    }
+}
+
+/// @title OPContractsManager_AddGameType_Test
+/// @notice Tests the `addGameType` function of the `OPContractsManager` contract.
 contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     event GameTypeAdded(
         uint256 indexed l2ChainId, GameType indexed gameType, IDisputeGame newDisputeGame, IDisputeGame oldDisputeGame
@@ -1369,6 +1047,8 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     }
 }
 
+/// @title OPContractsManager_UpdatePrestate_Test
+/// @notice Tests the `updatePrestate` function of the `OPContractsManager` contract.
 contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     IOPContractsManager internal prestateUpdater;
     OPContractsManager.AddGameInput[] internal gameInput;
@@ -1376,10 +1056,6 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     function setUp() public override {
         super.setUp();
         prestateUpdater = opcm;
-    }
-
-    function test_semver_works() public view {
-        assertNotEq(abi.encode(prestateUpdater.version()), abi.encode(0));
     }
 
     /// @notice Tests that we can update the prestate when only the PermissionedDisputeGame exists.
@@ -1470,8 +1146,9 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     /// @notice Tests that we can update the prestate when a SuperFaultDisputeGame exists. Note
     ///         that this test isn't ideal because the system starts with a PermissionedDisputeGame
     ///         and then adds a SuperPermissionedDisputeGame and SuperFaultDisputeGame. In the real
-    ///         system we wouldn't have that PermissionedDisputeGame to start with, but it shouldn't
-    ///         matter because the function is independent of other game types that exist.
+    ///         system we wouldn't have that PermissionedDisputeGame to start with, but it
+    ///         shouldn't matter because the function is independent of other game types that
+    ///         exist.
     function test_updatePrestate_withSuperGame_succeeds() public {
         // Mock out the existence of a previous SuperPermissionedDisputeGame so we can add a real
         // SuperPermissionedDisputeGame implementation.
@@ -1628,7 +1305,200 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     }
 }
 
-contract OPContractsManager_InteropMigrator_Test is OPContractsManager_TestInit {
+/// @title OPContractsManager_Upgrade_Test
+/// @notice Tests the `upgrade` function of the `OPContractsManager` contract.
+contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
+    // Upgrade to U14 first
+    function setUp() public override {
+        skipIfNotOpFork("test_upgrade_notDelegateCalled_reverts");
+        super.setUp();
+        runUpgrade13UpgradeAndChecks(upgrader);
+    }
+
+    function test_upgradeOPChainOnly_succeeds() public {
+        skipIfNotOpFork("test_upgradeOPChainOnly_succeeds");
+        // Run the upgrade test and checks
+        runUpgradeTestAndChecks(upgrader);
+    }
+
+    function test_isRcFalseAfterCalledByUpgrader_works() public {
+        skipIfNotOpFork("test_isRcFalseAfterCalledByUpgrader_works");
+        assertTrue(opcm.isRC());
+        bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
+        assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
+
+        runUpgradeTestAndChecks(upgrader);
+
+        assertFalse(opcm.isRC(), "isRC should be false");
+        releaseBytes = bytes(opcm.l1ContractsRelease());
+        assertNotEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should not end with '-rc'");
+    }
+
+    function testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works(
+        address _nonUpgradeController
+    )
+        public
+    {
+        skipIfNotOpFork("testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works");
+        if (
+            _nonUpgradeController == upgrader || _nonUpgradeController == address(0)
+                || _nonUpgradeController < address(0x4200000000000000000000000000000000000000)
+                || _nonUpgradeController > address(0x4200000000000000000000000000000000000800)
+                || _nonUpgradeController == address(vm)
+                || _nonUpgradeController == 0x000000000000000000636F6e736F6c652e6c6f67
+                || _nonUpgradeController == 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        ) {
+            _nonUpgradeController = makeAddr("nonUpgradeController");
+        }
+
+        // Set the proxy admin owner to be the non-upgrade controller
+        vm.store(
+            address(proxyAdmin),
+            bytes32(ForgeArtifacts.getSlot("ProxyAdmin", "_owner").slot),
+            bytes32(uint256(uint160(_nonUpgradeController)))
+        );
+        vm.store(
+            address(disputeGameFactory),
+            bytes32(ForgeArtifacts.getSlot("DisputeGameFactory", "_owner").slot),
+            bytes32(uint256(uint160(_nonUpgradeController)))
+        );
+
+        // Run the upgrade test and checks
+        runUpgradeTestAndChecks(_nonUpgradeController);
+    }
+
+    function test_upgrade_duplicateL2ChainId_succeeds() public {
+        skipIfNotOpFork("test_upgrade_duplicateL2ChainId_succeeds");
+
+        // Deploy a new OPChain with the same L2 chain ID as the current OPChain
+        Deploy deploy = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
+        IOPContractsManager.DeployInput memory deployInput = deploy.getDeployInput();
+        deployInput.l2ChainId = l2ChainId;
+        deployInput.saltMixer = "v2.0.0";
+        opcm.deploy(deployInput);
+
+        // Try to upgrade the current OPChain
+        runUpgradeTestAndChecks(upgrader);
+    }
+
+    /// @notice Tests that the absolute prestate can be overridden using the upgrade config.
+    function test_upgrade_absolutePrestateOverride_succeeds() public {
+        // Run Upgrade 13 and 14 to get us to a state where we can run Upgrade 15.
+        // Can remove these two calls as Upgrade 13 and 14 are executed in prod.
+        runUpgrade13UpgradeAndChecks(upgrader);
+        runUpgrade14UpgradeAndChecks(upgrader);
+
+        // Get the pdg and fdg before the upgrade
+        Claim pdgPrestateBefore = IPermissionedDisputeGame(
+            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
+        ).absolutePrestate();
+        Claim fdgPrestateBefore =
+            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
+
+        // Assert that the prestate is not zero.
+        assertNotEq(pdgPrestateBefore.raw(), bytes32(0));
+        assertNotEq(fdgPrestateBefore.raw(), bytes32(0));
+
+        // Set the absolute prestate input to something non-zero.
+        opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(uint256(1)));
+
+        // Now run Upgrade 15.
+        runUpgrade15UpgradeAndChecks(upgrader);
+
+        // Get the absolute prestate after the upgrade
+        Claim pdgPrestateAfter = IPermissionedDisputeGame(
+            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
+        ).absolutePrestate();
+        Claim fdgPrestateAfter =
+            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
+
+        // Assert that the absolute prestate is the non-zero value we set.
+        assertEq(pdgPrestateAfter.raw(), bytes32(uint256(1)));
+        assertEq(fdgPrestateAfter.raw(), bytes32(uint256(1)));
+    }
+
+    /// @notice Tests that the old absolute prestate is used if the upgrade config does not set an
+    ///         absolute prestate.
+    function test_upgrade_absolutePrestateNotSet_succeeds() public {
+        // Run Upgrade 13 and 14 to get us to a state where we can run Upgrade 15.
+        // Can remove these two calls as Upgrade 13 and 14 are executed in prod.
+        runUpgrade13UpgradeAndChecks(upgrader);
+        runUpgrade14UpgradeAndChecks(upgrader);
+
+        // Get the pdg and fdg before the upgrade
+        Claim pdgPrestateBefore = IPermissionedDisputeGame(
+            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
+        ).absolutePrestate();
+        Claim fdgPrestateBefore =
+            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
+
+        // Assert that the prestate is not zero.
+        assertNotEq(pdgPrestateBefore.raw(), bytes32(0));
+        assertNotEq(fdgPrestateBefore.raw(), bytes32(0));
+
+        // Set the absolute prestate input to zero.
+        opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(0));
+
+        // Now run Upgrade 15.
+        runUpgrade15UpgradeAndChecks(upgrader);
+
+        // Get the absolute prestate after the upgrade
+        Claim pdgPrestateAfter = IPermissionedDisputeGame(
+            address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON))
+        ).absolutePrestate();
+        Claim fdgPrestateAfter =
+            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON))).absolutePrestate();
+
+        // Assert that the absolute prestate is the same as before the upgrade.
+        assertEq(pdgPrestateAfter.raw(), pdgPrestateBefore.raw());
+        assertEq(fdgPrestateAfter.raw(), fdgPrestateBefore.raw());
+    }
+
+    function test_upgrade_notDelegateCalled_reverts() public {
+        vm.prank(upgrader);
+        vm.expectRevert(IOPContractsManager.OnlyDelegatecall.selector);
+        opcm.upgrade(opChainConfigs);
+    }
+
+    function test_upgrade_notProxyAdminOwner_reverts() public {
+        address delegateCaller = makeAddr("delegateCaller");
+        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+
+        assertNotEq(superchainProxyAdmin.owner(), delegateCaller);
+        assertNotEq(proxyAdmin.owner(), delegateCaller);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        DelegateCaller(delegateCaller).dcForward(
+            address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChainConfigs))
+        );
+    }
+
+    /// @notice Tests that upgrade reverts when absolutePrestate is zero and the existing game also
+    ///         has an absolute prestate of zero.
+    function test_upgrade_absolutePrestateNotSet_reverts() public {
+        // Set the config to try to update the absolutePrestate to zero.
+        opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(0));
+
+        // Get the address of the PermissionedDisputeGame.
+        IPermissionedDisputeGame pdg =
+            IPermissionedDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
+
+        // Mock the PDG to return a prestate of zero.
+        vm.mockCall(
+            address(pdg),
+            abi.encodeCall(IPermissionedDisputeGame.absolutePrestate, ()),
+            abi.encode(Claim.wrap(bytes32(0)))
+        );
+
+        // Expect the upgrade to revert with PrestateNotSet.
+        vm.expectRevert(IOPContractsManager.PrestateNotSet.selector);
+        DelegateCaller(upgrader).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChainConfigs)));
+    }
+}
+
+/// @title OPContractsManager_Migrate_Test
+/// @notice Tests the `migrate` function of the `OPContractsManager` contract.
+contract OPContractsManager_Migrate_Test is OPContractsManager_TestInit {
     Claim absolutePrestate1 = Claim.wrap(bytes32(hex"ABBA"));
     Claim absolutePrestate2 = Claim.wrap(bytes32(hex"DEAD"));
 
@@ -1932,7 +1802,8 @@ contract OPContractsManager_InteropMigrator_Test is OPContractsManager_TestInit 
         assertEq(superPdg.absolutePrestate().raw(), absolutePrestate1.raw());
     }
 
-    /// @notice Tests that the migration function reverts when the ProxyAdmin owners are mismatched.
+    /// @notice Tests that the migration function reverts when the ProxyAdmin owners are
+    ///         mismatched.
     function test_migrate_mismatchedProxyAdminOwners_reverts() public {
         IOPContractsManagerInteropMigrator.MigrateInput memory input = _getDefaultInput();
 
@@ -1954,7 +1825,8 @@ contract OPContractsManager_InteropMigrator_Test is OPContractsManager_TestInit 
         );
     }
 
-    /// @notice Tests that the migration function reverts when the absolute prestates are mismatched.
+    /// @notice Tests that the migration function reverts when the absolute prestates are
+    ///         mismatched.
     function test_migrate_mismatchedAbsolutePrestates_reverts() public {
         IOPContractsManagerInteropMigrator.MigrateInput memory input = _getDefaultInput();
 
@@ -1968,7 +1840,8 @@ contract OPContractsManager_InteropMigrator_Test is OPContractsManager_TestInit 
         );
     }
 
-    /// @notice Tests that the migration function reverts when the SuperchainConfig addresses are mismatched.
+    /// @notice Tests that the migration function reverts when the SuperchainConfig addresses are
+    ///         mismatched.
     function test_migrate_mismatchedSuperchainConfig_reverts() public {
         IOPContractsManagerInteropMigrator.MigrateInput memory input = _getDefaultInput();
 
@@ -1988,5 +1861,153 @@ contract OPContractsManager_InteropMigrator_Test is OPContractsManager_TestInit 
         _doMigration(
             input, OPContractsManagerInteropMigrator.OPContractsManagerInteropMigrator_SuperchainConfigMismatch.selector
         );
+    }
+}
+
+/// @title OPContractsManager_Deploy_Test
+/// @notice Tests the `deploy` function of the `OPContractsManager` contract.
+/// @dev Unlike other test suites, we intentionally do not inherit from CommonTest or Setup. This
+///      is because OPContractsManager acts as a deploy script, so we start from a clean slate here
+///      and work OPContractsManager's deployment into the existing test setup, instead of using
+///      the existing test setup to deploy OPContractsManager. We do however inherit from
+///      DeployOPChain_TestBase so we can use its setup to deploy the implementations similarly
+///      to how a real deployment would happen.
+contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
+    using stdStorage for StdStorage;
+
+    event Deployed(uint256 indexed l2ChainId, address indexed deployer, bytes deployOutput);
+
+    function setUp() public override {
+        DeployOPChain_TestBase.setUp();
+
+        doi.set(doi.opChainProxyAdminOwner.selector, opChainProxyAdminOwner);
+        doi.set(doi.systemConfigOwner.selector, systemConfigOwner);
+        doi.set(doi.batcher.selector, batcher);
+        doi.set(doi.unsafeBlockSigner.selector, unsafeBlockSigner);
+        doi.set(doi.proposer.selector, proposer);
+        doi.set(doi.challenger.selector, challenger);
+        doi.set(doi.basefeeScalar.selector, basefeeScalar);
+        doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
+        doi.set(doi.l2ChainId.selector, l2ChainId);
+        doi.set(doi.opcm.selector, address(opcm));
+        doi.set(doi.gasLimit.selector, gasLimit);
+
+        doi.set(doi.disputeGameType.selector, disputeGameType);
+        doi.set(doi.disputeAbsolutePrestate.selector, disputeAbsolutePrestate);
+        doi.set(doi.disputeMaxGameDepth.selector, disputeMaxGameDepth);
+        doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
+        doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
+        doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
+    }
+
+    // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol
+    // to the input struct type defined in OPContractsManager.sol.
+    function toOPCMDeployInput(DeployOPChainInput _doi)
+        internal
+        view
+        returns (IOPContractsManager.DeployInput memory)
+    {
+        return IOPContractsManager.DeployInput({
+            roles: IOPContractsManager.Roles({
+                opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
+                systemConfigOwner: _doi.systemConfigOwner(),
+                batcher: _doi.batcher(),
+                unsafeBlockSigner: _doi.unsafeBlockSigner(),
+                proposer: _doi.proposer(),
+                challenger: _doi.challenger()
+            }),
+            basefeeScalar: _doi.basefeeScalar(),
+            blobBasefeeScalar: _doi.blobBaseFeeScalar(),
+            l2ChainId: _doi.l2ChainId(),
+            startingAnchorRoot: _doi.startingAnchorRoot(),
+            saltMixer: _doi.saltMixer(),
+            gasLimit: _doi.gasLimit(),
+            disputeGameType: _doi.disputeGameType(),
+            disputeAbsolutePrestate: _doi.disputeAbsolutePrestate(),
+            disputeMaxGameDepth: _doi.disputeMaxGameDepth(),
+            disputeSplitDepth: _doi.disputeSplitDepth(),
+            disputeClockExtension: _doi.disputeClockExtension(),
+            disputeMaxClockDuration: _doi.disputeMaxClockDuration()
+        });
+    }
+
+    function test_deploy_l2ChainIdEqualsZero_reverts() public {
+        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
+        deployInput.l2ChainId = 0;
+        vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
+        opcm.deploy(deployInput);
+    }
+
+    function test_deploy_l2ChainIdEqualsCurrentChainId_reverts() public {
+        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
+        deployInput.l2ChainId = block.chainid;
+
+        vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
+        opcm.deploy(deployInput);
+    }
+
+    function test_deploy_succeeds() public {
+        vm.expectEmit(true, true, true, false); // TODO precompute the expected `deployOutput`.
+        emit Deployed(doi.l2ChainId(), address(this), bytes(""));
+        opcm.deploy(toOPCMDeployInput(doi));
+    }
+}
+
+/// @title OPContractsManager_Version_Test
+/// @notice Tests the `version` function of the `OPContractsManager` contract.
+contract OPContractsManager_Version_Test is OPContractsManager_TestInit {
+    IOPContractsManager internal prestateUpdater;
+    OPContractsManager.AddGameInput[] internal gameInput;
+
+    function setUp() public override {
+        super.setUp();
+        prestateUpdater = opcm;
+    }
+
+    function test_semver_works() public view {
+        assertNotEq(abi.encode(prestateUpdater.version()), abi.encode(0));
+    }
+}
+
+/// @title OPContractsManager_SetRC_Test
+/// @notice Tests the `setRC` function of the `OPContractsManager` contract.
+contract OPContractsManager_SetRC_Test is OPContractsManager_Upgrade_Harness {
+    /// @notice Tests the setRC function can be set by the upgrade controller.
+    function test_setRC_succeeds(bool _isRC) public {
+        skipIfNotOpFork("test_setRC_succeeds");
+
+        vm.prank(upgrader);
+
+        opcm.setRC(_isRC);
+        assertTrue(opcm.isRC() == _isRC, "isRC should be true");
+        bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
+        if (_isRC) {
+            assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
+        } else {
+            assertNotEq(
+                Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should not end with '-rc'"
+            );
+        }
+    }
+
+    /// @notice Tests the setRC function can not be set by non-upgrade controller.
+    function test_setRC_nonUpgradeController_reverts(address _nonUpgradeController) public {
+        // Disallow the upgrade controller to have code, or be a 'special' address.
+        if (
+            _nonUpgradeController == upgrader || _nonUpgradeController == address(0)
+                || _nonUpgradeController < address(0x4200000000000000000000000000000000000000)
+                || _nonUpgradeController > address(0x4200000000000000000000000000000000000800)
+                || _nonUpgradeController == address(vm)
+                || _nonUpgradeController == 0x000000000000000000636F6e736F6c652e6c6f67
+                || _nonUpgradeController == 0x4e59b44847b379578588920cA78FbF26c0B4956C
+                || _nonUpgradeController.code.length > 0
+        ) {
+            _nonUpgradeController = makeAddr("nonUpgradeController");
+        }
+
+        vm.prank(_nonUpgradeController);
+
+        vm.expectRevert(IOPContractsManager.OnlyUpgradeController.selector);
+        opcm.setRC(true);
     }
 }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1308,21 +1308,17 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
 /// @title OPContractsManager_Upgrade_Test
 /// @notice Tests the `upgrade` function of the `OPContractsManager` contract.
 contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
-    // Upgrade to U14 first
     function setUp() public override {
-        skipIfNotOpFork("test_upgrade_notDelegateCalled_reverts");
+        skipIfNotOpFork("OPContractsManager_Upgrade_Test");
         super.setUp();
-        runUpgrade13UpgradeAndChecks(upgrader);
     }
 
     function test_upgradeOPChainOnly_succeeds() public {
-        skipIfNotOpFork("test_upgradeOPChainOnly_succeeds");
         // Run the upgrade test and checks
         runUpgradeTestAndChecks(upgrader);
     }
 
     function test_verifyOpcmCorrectness_succeeds() public {
-        skipIfNotOpFork("test_verifyOpcmCorrectness_succeeds");
         skipIfCoverage(); // Coverage changes bytecode and breaks the verification script.
 
         // Run the upgrade test and checks
@@ -1336,7 +1332,6 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     }
 
     function test_isRcFalseAfterCalledByUpgrader_works() public {
-        skipIfNotOpFork("test_isRcFalseAfterCalledByUpgrader_works");
         assertTrue(opcm.isRC());
         bytes memory releaseBytes = bytes(opcm.l1ContractsRelease());
         assertEq(Bytes.slice(releaseBytes, releaseBytes.length - 3, 3), "-rc", "release should end with '-rc'");
@@ -1353,7 +1348,6 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     )
         public
     {
-        skipIfNotOpFork("testFuzz_upgrade_nonUpgradeControllerDelegatecallerShouldNotSetIsRCToFalse_works");
         if (
             _nonUpgradeController == upgrader || _nonUpgradeController == address(0)
                 || _nonUpgradeController < address(0x4200000000000000000000000000000000000000)
@@ -1382,8 +1376,6 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     }
 
     function test_upgrade_duplicateL2ChainId_succeeds() public {
-        skipIfNotOpFork("test_upgrade_duplicateL2ChainId_succeeds");
-
         // Deploy a new OPChain with the same L2 chain ID as the current OPChain
         Deploy deploy = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
         IOPContractsManager.DeployInput memory deployInput = deploy.getDeployInput();
@@ -1469,12 +1461,16 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     }
 
     function test_upgrade_notDelegateCalled_reverts() public {
+        runUpgrade13UpgradeAndChecks(upgrader);
+
         vm.prank(upgrader);
         vm.expectRevert(IOPContractsManager.OnlyDelegatecall.selector);
         opcm.upgrade(opChainConfigs);
     }
 
     function test_upgrade_notProxyAdminOwner_reverts() public {
+        runUpgrade13UpgradeAndChecks(upgrader);
+
         address delegateCaller = makeAddr("delegateCaller");
         vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
@@ -1490,6 +1486,8 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
     /// @notice Tests that upgrade reverts when absolutePrestate is zero and the existing game also
     ///         has an absolute prestate of zero.
     function test_upgrade_absolutePrestateNotSet_reverts() public {
+        runUpgrade13UpgradeAndChecks(upgrader);
+
         // Set the config to try to update the absolutePrestate to zero.
         opChainConfigs[0].absolutePrestate = Claim.wrap(bytes32(0));
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1321,6 +1321,20 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
         runUpgradeTestAndChecks(upgrader);
     }
 
+    function test_verifyOpcmCorrectness_succeeds() public {
+        skipIfNotOpFork("test_verifyOpcmCorrectness_succeeds");
+        skipIfCoverage(); // Coverage changes bytecode and breaks the verification script.
+
+        // Run the upgrade test and checks
+        runUpgradeTestAndChecks(upgrader);
+
+        // Run the verification script without etherscan verificatin. Hard to run with etherscan
+        // verification in these tests, can do it but means we add even more dependencies to the
+        // test environment.
+        VerifyOPCM verify = new VerifyOPCM();
+        verify.run(address(opcm), true);
+    }
+
     function test_isRcFalseAfterCalledByUpgrader_works() public {
         skipIfNotOpFork("test_isRcFalseAfterCalledByUpgrader_works");
         assertTrue(opcm.isRC());

--- a/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
@@ -56,21 +56,24 @@ contract MeterUser is ResourceMetering {
     }
 }
 
-/// @title ResourceMetering_Test
-/// @dev Tests are based on the default config values.
-///      It is expected that these config values are used in production.
-contract ResourceMetering_Test is Test {
+/// @title ResourceMetering_TestInit
+/// @notice Reusable test initialization for `ResourceMetering` tests.
+contract ResourceMetering_TestInit is Test {
     MeterUser internal meter;
     uint64 initialBlockNum;
 
-    /// @dev Sets up the test contract.
+    /// @notice Sets up the test contract.
     function setUp() public {
         meter = new MeterUser();
         initialBlockNum = uint64(block.number);
     }
+}
 
-    /// @dev Tests that the initial resource params are set correctly.
-    function test_meter_initialResourceParams_succeeds() external view {
+/// @title ResourceMetering_ResourceMeteringInit_Test
+/// @notice Tests the `__ResourceMeteringInit` contract's initialization.
+contract ResourceMetering_ResourceMeteringInit_Test is ResourceMetering_TestInit {
+    /// @notice Tests that the initial resource params are set correctly.
+    function test_resourceMeteringInit_initialResourceParams_succeeds() external view {
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
 
@@ -79,8 +82,8 @@ contract ResourceMetering_Test is Test {
         assertEq(prevBlockNum, initialBlockNum);
     }
 
-    /// @dev Tests that reinitializing the resource params are set correctly.
-    function test_meter_reinitializedResourceParams_succeeds() external {
+    /// @notice Tests that reinitializing the resource params are set correctly.
+    function test_resourceMeteringInit_reinitializedResourceParams_succeeds() external {
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
 
         // Reset the initialized slot to enable reinitialization.
@@ -92,9 +95,15 @@ contract ResourceMetering_Test is Test {
         assertEq(prevBoughtGas, postBoughtGas);
         assertEq(prevBlockNum, postBlockNum);
     }
+}
 
-    /// @dev Tests that updating the resource params to the same values works correctly.
-    function test_meter_updateParamsNoChange_succeeds() external {
+/// @title ResourceMetering_Metered_Test
+/// @notice Tests the `metered` modifier on the `ResourceMetering` contract.
+/// @dev Tests are based on the default config values. It is expected that these config values are
+///      used in production.
+contract ResourceMetering_Metered_Test is ResourceMetering_TestInit {
+    /// @notice Tests that updating the resource params to the same values works correctly.
+    function test_metered_updateParamsNoChange_succeeds() external {
         meter.use(0); // equivalent to just updating the base fee and block number
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
         meter.use(0);
@@ -105,8 +114,8 @@ contract ResourceMetering_Test is Test {
         assertEq(postBlockNum, prevBlockNum);
     }
 
-    /// @dev Tests that updating the initial block number sets the meter params correctly.
-    function test_meter_updateOneEmptyBlock_succeeds() external {
+    /// @notice Tests that updating the initial block number sets the meter params correctly.
+    function test_metered_updateOneEmptyBlock_succeeds() external {
         vm.roll(initialBlockNum + 1);
         meter.use(0);
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
@@ -116,8 +125,8 @@ contract ResourceMetering_Test is Test {
         assertEq(prevBlockNum, initialBlockNum + 1);
     }
 
-    /// @dev Tests that updating the initial block number sets the meter params correctly.
-    function test_meter_updateTwoEmptyBlocks_succeeds() external {
+    /// @notice Tests that updating the initial block number sets the meter params correctly.
+    function test_metered_updateTwoEmptyBlocks_succeeds() external {
         vm.roll(initialBlockNum + 2);
         meter.use(0);
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
@@ -127,8 +136,8 @@ contract ResourceMetering_Test is Test {
         assertEq(prevBlockNum, initialBlockNum + 2);
     }
 
-    /// @dev Tests that updating the initial block number sets the meter params correctly.
-    function test_meter_updateTenEmptyBlocks_succeeds() external {
+    /// @notice Tests that updating the initial block number sets the meter params correctly.
+    function test_metered_updateTenEmptyBlocks_succeeds() external {
         vm.roll(initialBlockNum + 10);
         meter.use(0);
         (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = meter.params();
@@ -138,8 +147,8 @@ contract ResourceMetering_Test is Test {
         assertEq(prevBlockNum, initialBlockNum + 10);
     }
 
-    /// @dev Tests that updating the gas delta sets the meter params correctly.
-    function test_meter_updateNoGasDelta_succeeds() external {
+    /// @notice Tests that updating the gas delta sets the meter params correctly.
+    function test_metered_updateNoGasDelta_succeeds() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
         uint256 target = uint256(rcfg.maxResourceLimit) / uint256(rcfg.elasticityMultiplier);
         meter.use(uint64(target));
@@ -150,8 +159,8 @@ contract ResourceMetering_Test is Test {
         assertEq(prevBlockNum, initialBlockNum);
     }
 
-    /// @dev Tests that the meter params are set correctly for the maximum gas delta.
-    function test_meter_useMax_succeeds() external {
+    /// @notice Tests that the meter params are set correctly for the maximum gas delta.
+    function test_metered_useMax_succeeds() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
         uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
         uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
@@ -167,10 +176,11 @@ contract ResourceMetering_Test is Test {
         assertEq(postBaseFee, 2125000000);
     }
 
-    /// @dev Tests that the metered modifier reverts if the baseFeeMaxChangeDenominator is set to 1.
-    ///      Since the metered modifier internally calls solmate's powWad function, it will revert
-    ///      with the error string "UNDEFINED" since the first parameter will be computed as 0.
-    function test_meter_denominatorEq1_reverts() external {
+    /// @notice Tests that the metered modifier reverts if the baseFeeMaxChangeDenominator is set
+    ///         to 1. Since the metered modifier internally calls solmate's powWad function, it
+    ///         will revert with the error string "UNDEFINED" since the first parameter will be
+    ///         computed as 0.
+    function test_metered_denominatorEq1_reverts() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
         uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
         uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
@@ -187,8 +197,8 @@ contract ResourceMetering_Test is Test {
         meter.use(0);
     }
 
-    /// @dev Tests that the metered modifier reverts if the value is greater than allowed.
-    function test_meter_useMoreThanMax_reverts() external {
+    /// @notice Tests that the metered modifier reverts if the value is greater than allowed.
+    function test_metered_useMoreThanMax_reverts() external {
         ResourceMetering.ResourceConfig memory rcfg = meter.resourceConfig();
         uint64 target = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
         uint64 elasticityMultiplier = uint64(rcfg.elasticityMultiplier);
@@ -197,8 +207,8 @@ contract ResourceMetering_Test is Test {
         meter.use(target * elasticityMultiplier + 1);
     }
 
-    /// @dev Tests that resource metering can handle large gaps between deposits.
-    function testFuzz_meter_largeBlockDiff_succeeds(uint64 _amount, uint256 _blockDiff) external {
+    /// @notice Tests that resource metering can handle large gaps between deposits.
+    function testFuzz_metered_largeBlockDiff_succeeds(uint64 _amount, uint256 _blockDiff) external {
         // This test fails if the following line is commented out.
         // At 12 seconds per block, this number is effectively unreachable.
         _blockDiff = uint256(bound(_blockDiff, 0, 433576281058164217753225238677900874458690));
@@ -213,7 +223,7 @@ contract ResourceMetering_Test is Test {
         meter.use(_amount);
     }
 
-    function testFuzz_meter_useGas_succeeds(uint64 _amount) external {
+    function testFuzz_metered_useGas_succeeds(uint64 _amount) external {
         (, uint64 prevBoughtGas,) = meter.params();
         _amount = uint64(bound(_amount, 0, meter.resourceConfig().maxResourceLimit - prevBoughtGas));
 
@@ -225,8 +235,8 @@ contract ResourceMetering_Test is Test {
 }
 
 /// @title CustomMeterUser
-/// @notice A simple wrapper around `ResourceMetering` that allows the initial
-///         params to be set in the constructor.
+/// @notice A simple wrapper around `ResourceMetering` that allows the initial params to be set in
+///         the constructor.
 contract CustomMeterUser is ResourceMetering {
     uint256 public startGas;
     uint256 public endGas;
@@ -259,13 +269,12 @@ contract CustomMeterUser is ResourceMetering {
 }
 
 /// @title ArtifactResourceMetering_Test
-/// @notice A table test that sets the state of the ResourceParams and then requests
-///         various amounts of gas. This test ensures that a wide range of values
-///         can safely be used with the `ResourceMetering` contract.
-///         It also writes a CSV file to disk that includes useful information
-///         about how much gas is used and how expensive it is in USD terms to
-///         purchase the deposit gas.
-contract ArtifactResourceMetering_Test is Test {
+/// @notice A table test that sets the state of the ResourceParams and then requests various
+///         amounts of gas. This test ensures that a wide range of values can safely be used with
+///         the `ResourceMetering` contract. It also writes a CSV file to disk that includes useful
+///         information about how much gas is used and how expensive it is in USD terms to purchase
+///         the deposit gas.
+contract ArtifactResourceMetering_Metered_Test is Test {
     uint128 internal minimumBaseFee;
     uint128 internal maximumBaseFee;
     uint64 internal maxResourceLimit;
@@ -273,15 +282,15 @@ contract ArtifactResourceMetering_Test is Test {
 
     string internal outfile;
 
-    // keccak256(abi.encodeWithSignature("Error(string)", "ResourceMetering: cannot buy more gas than available gas
-    // limit"))
+    // keccak256(abi.encodeWithSignature("Error(string)", "ResourceMetering: cannot buy more gas
+    // than available gas limit"))
     bytes32 internal cannotBuyMoreGas = 0x84edc668cfd5e050b8999f43ff87a1faaa93e5f935b20bc1dd4d3ff157ccf429;
     // keccak256(abi.encodeWithSignature("Panic(uint256)", 0x11))
     bytes32 internal overflowErr = 0x1ca389f2c8264faa4377de9ce8e14d6263ef29c68044a9272d405761bab2db27;
     // keccak256(hex"")
     bytes32 internal emptyReturnData = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
 
-    /// @dev Sets up the tests with constants from the ResourceMetering contract.
+    /// @notice Sets up the tests with constants from the ResourceMetering contract.
     function setUp() public {
         vm.roll(1_000_000);
 
@@ -296,12 +305,11 @@ contract ArtifactResourceMetering_Test is Test {
         try vm.removeFile(outfile) { } catch { }
     }
 
-    /// @dev Generates a CSV file. No more than the L1 block gas limit should
-    ///      be supplied to the `meter` function to avoid long execution time.
-    ///      This test is skipped because there is no need to run it every time.
-    ///      It generates a CSV file on disk that can be used to analyze the
-    ///      gas usage and cost of the `ResourceMetering` contract. The next time
-    ///      that the gas usage needs to be analyzed, the skip may be removed.
+    /// @notice Generates a CSV file. No more than the L1 block gas limit should be supplied to the
+    ///         `meter` function to avoid long execution time. This test is skipped because there
+    ///         is no need to run it every time. It generates a CSV file on disk that can be used
+    ///         to analyze the gas usage and cost of the `ResourceMetering` contract. The next time
+    ///         that the gas usage needs to be analyzed, the skip may be removed.
     function test_meter_generateArtifact_succeeds() external {
         vm.skip({ skipTest: true });
 


### PR DESCRIPTION
This PR refactors a portion of the test suite within the `/L1` folder as part of a broader initiative to improve consistency, clarity, and structure across the codebase.

### Changes applied to each file:
- Centralized common setup into `*_TestInit` contracts
- Grouped tests by function into dedicated contracts inheriting from the init contract
- Standardized doc tags by adding `@title` and `@notice` headers
- Replaced `@dev` with `@notice` where applicable
- Applied 100-character line limit to all inline comments
- Maintained exact logic and comment wording per contribution guidelines

### Progress

Refactored 13 of 13 test files (**100% complete**)

- [x] `DataAvailabilityChallenge.t.sol`
- [x] `ETHLockbox.t.sol`
- [x] `L1CrossDomainMessenger.t.sol`
- [x] `L1ERC721Bridge.t.sol`
- [x] `L1StandardBridge.t.sol`
- [x] `OptimismPortal2.t.sol`
- [x] `OPContractsManager.t.sol`
- [x] `ProtocolVersions.t.sol`
- [x] `ProxyAdminOwnedBase.t.sol` ✅ No change needed
- [x] `ResourceMetering.t.sol`
- [x] `StandardValidator.t.sol` Refactored in #16068
- [x] `SuperchainConfig.t.sol`
- [x] `SystemConfig.t.sol`