### PR TITLE
op-acceptance-tests, op-devstack: use proxyd in load test if available

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func TestMain(m *testing.M) {
@@ -27,8 +30,27 @@ func TestExecFromSameAddressInALoop(gt *testing.T) {
 	}
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
-	eoaA := sys.FunderA.NewFundedEOA(eth.MillionEther)
-	eoaB := sys.FunderB.NewFundedEOA(eth.MillionEther)
+
+	// Use proxyd if available.
+	l2ELA := sys.L2ELA
+	l2ELB := sys.L2ELB
+	if proxydsA := match.Proxyd.Match(sys.L2ChainA.Escape().L2ELNodes()); len(proxydsA) > 0 {
+		l2ELA = dsl.NewL2ELNode(proxydsA[0])
+	}
+	if proxydsB := match.Proxyd.Match(sys.L2ChainB.Escape().L2ELNodes()); len(proxydsB) > 0 {
+		l2ELB = dsl.NewL2ELNode(proxydsB[0])
+	}
+
+	// Setup EOAs. We are careful to use the specific ELs configured above to ensure we
+	// hit proxyd (if configured) to simulate real load.
+	skA, err := crypto.GenerateKey()
+	t.Require().NoError(err)
+	skB, err := crypto.GenerateKey()
+	t.Require().NoError(err)
+	eoaA := dsl.NewEOA(dsl.NewKey(t, skA), l2ELA)
+	eoaB := dsl.NewEOA(dsl.NewKey(t, skB), l2ELB)
+	sys.FaucetA.Fund(eoaA.Address(), eth.MillionEther)
+	sys.FaucetB.Fund(eoaB.Address(), eth.MillionEther)
 
 	eventLoggerAddress := eoaA.DeployEventLogger()
 
@@ -53,8 +75,8 @@ func TestExecFromSameAddressInALoop(gt *testing.T) {
 	// Wait to include the exec txs until we know it will be included at a higher timestamp than initMsgsTx, modulo reorgs.
 	// NOTE: this should be `<`, but the mempool filtering in op-geth currently uses the unsafe head's timestamp instead of
 	// the pending timestamp. See https://github.com/ethereum-optimism/op-geth/issues/603.
-	for sys.L2ChainB.UnsafeHeadRef().Time <= initMsgsTx.PlannedTx.IncludedBlock.Value().Time {
-		sys.L2ChainB.WaitForBlock()
+	for l2ELA.BlockRefByLabel(eth.Unsafe).Time <= initMsgsTx.PlannedTx.IncludedBlock.Value().Time {
+		l2ELA.WaitForBlock()
 	}
 
 	execCalls := make([]txintent.Call, 0, numMsgs)
@@ -67,7 +89,7 @@ func TestExecFromSameAddressInALoop(gt *testing.T) {
 	const numExecTxs = 1_000
 	execMsgsTxs := make([]*txintent.IntentTx[*txintent.MultiTrigger, txintent.Result], 0, numExecTxs)
 	for i := range numExecTxs {
-		execMsgsTx := txintent.NewIntent[*txintent.MultiTrigger, txintent.Result](eoaB.Plan(), txplan.WithRetryInclusion(sys.L2ELB.Escape().EthClient(), 50, retry.Exponential()))
+		execMsgsTx := txintent.NewIntent[*txintent.MultiTrigger, txintent.Result](eoaB.Plan(), txplan.WithRetryInclusion(l2ELB.Escape().EthClient(), 50, retry.Exponential()))
 		execMsgsTx.Content.Set(&txintent.MultiTrigger{
 			Emitter: constants.MultiCall3,
 			Calls:   execCalls,
@@ -100,15 +122,16 @@ func TestExecFromSameAddressInALoop(gt *testing.T) {
 			includedBlock, err := tx.IncludedBlock.Eval(t.Ctx())
 			t.Require().NoError(err)
 			for {
-				crossSafeID, err := sys.Supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), sys.L2ChainB.ChainID())
+				// TODO can we use proxyd to see if something is crossafe?
+				crossSafeID, err := sys.Supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), l2ELB.ChainID())
 				t.Require().NoError(err)
 				if includedBlock.ID().Number <= crossSafeID.Derived.Number {
 					break
 				}
-				sys.L2ChainB.WaitForBlock()
+				l2ELB.WaitForBlock()
 			}
 			// Sanity check that includedBlock is still in the canonical chain.
-			_, err = sys.L2ELB.Escape().EthClient().BlockRefByHash(t.Ctx(), includedBlock.Hash)
+			_, err = l2ELB.Escape().EthClient().BlockRefByHash(t.Ctx(), includedBlock.Hash)
 			t.Require().NoError(err)
 		}(execMsgsTx.PlannedTx)
 	}

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -122,7 +122,7 @@ func TestExecFromSameAddressInALoop(gt *testing.T) {
 			includedBlock, err := tx.IncludedBlock.Eval(t.Ctx())
 			t.Require().NoError(err)
 			for {
-				// TODO can we use proxyd to see if something is crossafe?
+				// NOTE: it may be desirable to query proxyd instead of the supervisor if/when the devstack supports it.
 				crossSafeID, err := sys.Supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), l2ELB.ChainID())
 				t.Require().NoError(err)
 				if includedBlock.ID().Number <= crossSafeID.Derived.Number {

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -124,7 +124,7 @@ and returns a typed output that the test then may use.
 ## Design choices
 
 - Interfaces FIRST. Composes much better.
-- Incremental system composition.
+- Incremental system composition. In the DSL package, maximize reusability by implementing DSL methods on the "lowest common denominator", e.g. prefer EL over Network. In tests, maximize readability by using the highest level of abstraction possible.
 - Type-safety is important. Internals may be more verbose where needed.
 - Everything is a resource and has a typed ID
 - Embedding and composition de-dup a lot of code.

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -1,7 +1,10 @@
 package dsl
 
 import (
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -12,13 +15,43 @@ type ELNode interface {
 
 // elNode implements DSL common between L1 and L2 EL nodes.
 type elNode struct {
+	commonImpl
 	inner stack.ELNode
 }
 
 var _ ELNode = (*elNode)(nil)
 
+func newELNode(common commonImpl, inner stack.ELNode) *elNode {
+	return &elNode{
+		commonImpl: common,
+		inner:      inner,
+	}
+}
+
 func (el *elNode) ChainID() eth.ChainID {
 	return el.inner.ChainID()
+}
+
+func (el *elNode) WaitForBlock() {
+	initial, err := el.inner.EthClient().InfoByLabel(el.ctx, "latest")
+	el.require.NoError(err, "Expected to get latest block from execution client")
+
+	err = wait.For(el.ctx, 500*time.Millisecond, func() (bool, error) {
+		newBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, "latest")
+		if err != nil {
+			return false, err
+		}
+
+		if initial.Hash().Cmp(newBlock.Hash()) == 0 {
+			el.log.Info("Still same block detected as initial", "block", eth.InfoToL1BlockRef(newBlock))
+
+			return false, nil
+		}
+
+		el.log.Info("New block detected", "new_block", eth.InfoToL1BlockRef(newBlock), "prev_block", eth.InfoToL1BlockRef(initial))
+		return true, nil
+	})
+	el.require.NoError(err, "Expected to get latest block from execution client for comparison")
 }
 
 func (el *elNode) stackEL() stack.ELNode {

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -33,11 +33,11 @@ func (el *elNode) ChainID() eth.ChainID {
 }
 
 func (el *elNode) WaitForBlock() {
-	initial, err := el.inner.EthClient().InfoByLabel(el.ctx, "latest")
+	initial, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Unsafe)
 	el.require.NoError(err, "Expected to get latest block from execution client")
 
 	err = wait.For(el.ctx, 500*time.Millisecond, func() (bool, error) {
-		newBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, "latest")
+		newBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Unsafe)
 		if err != nil {
 			return false, err
 		}

--- a/op-devstack/dsl/l1_el.go
+++ b/op-devstack/dsl/l1_el.go
@@ -4,18 +4,15 @@ import "github.com/ethereum-optimism/optimism/op-devstack/stack"
 
 // L1ELNode wraps a stack.L1ELNode interface for DSL operations
 type L1ELNode struct {
-	commonImpl
 	*elNode
 	inner stack.L1ELNode
 }
 
 // NewL1ELNode creates a new L1ELNode DSL wrapper
 func NewL1ELNode(inner stack.L1ELNode) *L1ELNode {
-	common := commonFromT(inner.T())
 	return &L1ELNode{
-		commonImpl: common,
-		elNode:     newELNode(common, inner),
-		inner:      inner,
+		elNode: newELNode(commonFromT(inner.T()), inner),
+		inner:  inner,
 	}
 }
 

--- a/op-devstack/dsl/l1_el.go
+++ b/op-devstack/dsl/l1_el.go
@@ -5,15 +5,16 @@ import "github.com/ethereum-optimism/optimism/op-devstack/stack"
 // L1ELNode wraps a stack.L1ELNode interface for DSL operations
 type L1ELNode struct {
 	commonImpl
-	elNode
+	*elNode
 	inner stack.L1ELNode
 }
 
 // NewL1ELNode creates a new L1ELNode DSL wrapper
 func NewL1ELNode(inner stack.L1ELNode) *L1ELNode {
+	common := commonFromT(inner.T())
 	return &L1ELNode{
-		commonImpl: commonFromT(inner.T()),
-		elNode:     elNode{inner: inner},
+		commonImpl: common,
+		elNode:     newELNode(common, inner),
 		inner:      inner,
 	}
 }

--- a/op-devstack/dsl/l1_network.go
+++ b/op-devstack/dsl/l1_network.go
@@ -1,11 +1,8 @@
 package dsl
 
 import (
-	"time"
-
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -37,25 +34,5 @@ func (n *L1Network) Escape() stack.L1Network {
 }
 
 func (n *L1Network) WaitForBlock() {
-	l1_el := n.inner.L1ELNode(match.FirstL1EL)
-
-	initial, err := l1_el.EthClient().InfoByLabel(n.ctx, "latest")
-	n.require.NoError(err, "Expected to get latest block from L1 execution client")
-
-	err = wait.For(n.ctx, 500*time.Millisecond, func() (bool, error) {
-		newBlock, err := l1_el.EthClient().InfoByLabel(n.ctx, "latest")
-		if err != nil {
-			return false, err
-		}
-
-		if initial.Hash().Cmp(newBlock.Hash()) == 0 {
-			n.log.Info("Still same L1 block detected as initial", "block", eth.InfoToL1BlockRef(newBlock))
-
-			return false, nil
-		}
-
-		n.log.Info("New L1 block detected", "new_block", eth.InfoToL1BlockRef(newBlock), "prev_block", eth.InfoToL1BlockRef(initial))
-		return true, nil
-	})
-	n.require.NoError(err, "Expected to get latest block from L1 execution client for comparison")
+	NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForBlock()
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -12,18 +12,15 @@ import (
 
 // L2ELNode wraps a stack.L2ELNode interface for DSL operations
 type L2ELNode struct {
-	commonImpl
 	*elNode
 	inner stack.L2ELNode
 }
 
 // NewL2ELNode creates a new L2ELNode DSL wrapper
 func NewL2ELNode(inner stack.L2ELNode) *L2ELNode {
-	common := commonFromT(inner.T())
 	return &L2ELNode{
-		commonImpl: common,
-		elNode:     newELNode(common, inner),
-		inner:      inner,
+		elNode: newELNode(commonFromT(inner.T()), inner),
+		inner:  inner,
 	}
 }
 

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -13,15 +13,16 @@ import (
 // L2ELNode wraps a stack.L2ELNode interface for DSL operations
 type L2ELNode struct {
 	commonImpl
-	elNode
+	*elNode
 	inner stack.L2ELNode
 }
 
 // NewL2ELNode creates a new L2ELNode DSL wrapper
 func NewL2ELNode(inner stack.L2ELNode) *L2ELNode {
+	common := commonFromT(inner.T())
 	return &L2ELNode{
-		commonImpl: commonFromT(inner.T()),
-		elNode:     elNode{inner: inner},
+		commonImpl: common,
+		elNode:     newELNode(common, inner),
 		inner:      inner,
 	}
 }

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -67,31 +67,7 @@ func (n *L2Network) CatchUpTo(o *L2Network) {
 }
 
 func (n *L2Network) WaitForBlock() {
-	l2_el := n.inner.L2ELNode(match.FirstL2EL)
-
-	initial, err := l2_el.EthClient().InfoByLabel(n.ctx, eth.Unsafe)
-	n.require.NoError(err, "Expected to get latest block from L2 execution client")
-
-	initialHash := initial.Hash()
-
-	err = wait.For(n.ctx, 1000*time.Millisecond, func() (bool, error) {
-		latest, err := l2_el.EthClient().InfoByLabel(n.ctx, eth.Unsafe)
-		if err != nil {
-			return false, err
-		}
-
-		newHash := latest.Hash()
-
-		if initialHash.Cmp(newHash) == 0 {
-			n.log.Info("Still same block detected", "number", latest.NumberU64(), "chain", n.ChainID(), "initial_block_hash", initialHash, "new_block_hash", newHash)
-
-			return false, nil
-		}
-
-		n.log.Info("New block detected", "chain", n.ChainID(), "prev_block_hash", initialHash, "new_block_hash", newHash, "time", latest.Time())
-		return true, nil
-	})
-	n.require.NoError(err, "Expected to get latest block from L2 execution client for comparison")
+	NewL2ELNode(n.inner.L2ELNode(match.FirstL2EL)).WaitForBlock()
 }
 
 // PrintChain is used for testing/debugging, it prints the blockchain hashes and parent hashes to logs, which is useful when developing reorg tests


### PR DESCRIPTION
Fall back to a standard EL if unavailable.

Also expands on a design principle in op-devstack/README.md to highlight a papercut encountered by and partially fixed in this PR.