### PR TITLE
op-acceptance-tests: interop sequencing window expiry test

### DIFF
--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -1,0 +1,107 @@
+package seqwindow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TestSequencingWindowExpiry tests that the sequencing window may expire,
+// the chain reorgs because of it, and that the chain then recovers.
+func TestSequencingWindowExpiry(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	// TODO(#15769): fix sequencing-window expiry interop functionality
+	t.Skip("Interop sequencing-window expiry interaction is known to not fully work yet.")
+
+	sys := presets.NewSimpleInterop(t)
+	require := t.Require()
+
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+
+	// Send a random tx, to ensure there is some activity pre-reorg
+	tx1 := alice.Transfer(common.HexToAddress("0x7777"), eth.GWei(100))
+	receipt1, err := tx1.Included.Eval(t.Ctx())
+	require.NoError(err)
+	t.Logger().Info("Confirmed tx 1", "tx", receipt1.TxHash, "block", receipt1.BlockHash)
+
+	// Wait for the first tx to become cross-safe.
+	// We are not interested in the sequencing window to expire and revert all the way back to 0.
+	require.Eventually(func() bool {
+		stat, err := sys.L2CLA.Escape().RollupAPI().SyncStatus(t.Ctx())
+		require.NoError(err)
+		return stat.SafeL2.Number > receipt1.BlockNumber.Uint64()
+	}, time.Second*30, time.Second, "wait for tx 1 to be safe")
+	t.Logger().Info("Tx 1 is safe now")
+
+	// Stop the batcher of chain A, so the L2 unsafe blocks will not get submitted.
+	require.NoError(sys.L2BatcherA.ActivityAPI().StopBatcher(t.Ctx()))
+	stoppedAt := sys.L1Network.WaitForBlock() // wait for new block, in case there is any batch left
+	// Make sure the supervisor has synced enough of the L1, for the local-safe query to work.
+	sys.Supervisor.AwaitMinL1(stoppedAt.Number)
+
+	// The latest local-safe L2 block is derived from the L1 block with the last batch.
+	// After this L1 block the sequence-window expiry starts ticking.
+	last, err := sys.Supervisor.Escape().QueryAPI().LocalSafe(t.Ctx(), sys.L2ChainA.ChainID())
+	require.NoError(err)
+
+	t.Logger().Info("Safe when stopping batch-submitter",
+		"source", last.Source, "derived", last.Derived)
+	seqWindowSize := sys.L2ChainA.Escape().RollupConfig().SeqWindowSize
+	estimatedExpiryNum := last.Source.Number + seqWindowSize
+	lastRef, err := sys.L1EL.Escape().EthClient().BlockRefByHash(t.Ctx(), last.Source.Hash)
+	require.NoError(err)
+	lastTime := time.Unix(int64(lastRef.Time), 0)
+	l1BlockTime := sys.L1EL.EstimateBlockTime()
+	windowDuration := l1BlockTime * time.Duration(seqWindowSize)
+	t.Logger().Info("Sequencing window expiry",
+		"estimateL1Num", estimatedExpiryNum, "windowDuration", windowDuration,
+		"fromNow", time.Until(lastTime.Add(windowDuration)))
+
+	// The unsafe L2 block after this last safe block is going to be reorged out
+	// once the sequencing window expires.
+	// However, since it is empty, it may stay around, because it would be compatible.
+	// So let's insert a transaction, then we can be sure it is different.
+	tx2 := alice.Transfer(common.HexToAddress("0xdead"), eth.GWei(42))
+	receipt2, err := tx2.Included.Eval(t.Ctx())
+	require.NoError(err)
+	// Now get the block that included the tx. This block will change.
+	old := eth.BlockID{Hash: receipt2.BlockHash, Number: receipt2.BlockNumber.Uint64()}
+	t.Logger().Info("Confirmed tx 2, which will be reorged out later",
+		"tx", receipt2.TxHash, "l2Block", old)
+	// The logs will show a "Chain reorg detected" from op-geth.
+
+	t.Logger().Info("Waiting for sequencing window expiry induced reorg now")
+	// Monitor that the old unsafe chain is reorged out as expected
+	require.Eventually(func() bool {
+		latest := sys.L2ELA.BlockRefByNumber(old.Number)
+		return latest.Hash != old.Hash
+	}, windowDuration+time.Second*20, time.Second, "expecting old block to be reorged out")
+
+	t.Logger().Info("Waiting for supervisor to surpass pre-reorg chain now")
+	// Monitor that the supervisor can continue to sync.
+	// A lot more blocks will expire first; the local-safe chain will be entirely force-derived blocks.
+	require.Eventually(func() bool {
+		safe, err := sys.Supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), sys.L2ChainA.ChainID())
+		require.NoError(err)
+		return safe.Source.Number > estimatedExpiryNum
+	}, windowDuration+time.Second*20, time.Second, "expecting supervisor to sync cross-safe data, after resolving sequencing window expiry")
+
+	t.Logger().Info("Sanity-checking now")
+	// Sanity-check the unsafe head of the supervisor is also updated
+	tip, err := sys.Supervisor.Escape().QueryAPI().LocalUnsafe(t.Ctx(), sys.L2ChainA.ChainID())
+	require.NoError(err)
+	require.True(tip.Number > estimatedExpiryNum)
+	// Sanity-check the supervisor is on the right chain
+	safe, err := sys.Supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), sys.L2ChainA.ChainID())
+	require.NoError(err)
+	other := sys.L2ELA.BlockRefByNumber(safe.Derived.Number)
+	require.Equal(safe.Derived.Hash, other.Hash, "supervisor must match chain with EL")
+
+	// re-enable the batcher now that we are done with the test.
+	t.Require().NoError(sys.L2BatcherA.ActivityAPI().StartBatcher(t.Ctx()))
+}

--- a/op-acceptance-tests/tests/interop/seqwindow/init_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/init_test.go
@@ -1,0 +1,15 @@
+package seqwindow
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithSimpleInterop(),
+		// Short enough that we can run the test,
+		// long enough that the batcher can still submit something before we make things expire.
+		presets.WithSequencingWindow(10, 30))
+}

--- a/op-devstack/dsl/l1_el.go
+++ b/op-devstack/dsl/l1_el.go
@@ -1,6 +1,11 @@
 package dsl
 
-import "github.com/ethereum-optimism/optimism/op-devstack/stack"
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 // L1ELNode wraps a stack.L1ELNode interface for DSL operations
 type L1ELNode struct {
@@ -23,4 +28,23 @@ func (el *L1ELNode) String() string {
 // Escape returns the underlying stack.L1ELNode
 func (el *L1ELNode) Escape() stack.L1ELNode {
 	return el.inner
+}
+
+// EstimateBlockTime estimates the L1 block based on the last 1000 blocks
+// (or since genesis, if insufficient blocks).
+func (el *L1ELNode) EstimateBlockTime() time.Duration {
+	latest, err := el.inner.EthClient().BlockRefByLabel(el.t.Ctx(), eth.Unsafe)
+	el.require.NoError(err)
+	if latest.Number == 0 {
+		return time.Second * 12
+	}
+	lowerNum := uint64(0)
+	if latest.Number > 1000 {
+		lowerNum = latest.Number - 1000
+	}
+	lowerBlock, err := el.inner.EthClient().BlockRefByNumber(el.t.Ctx(), lowerNum)
+	el.require.NoError(err)
+	deltaTime := latest.Time - lowerBlock.Time
+	deltaNum := latest.Number - lowerBlock.Number
+	return time.Duration(deltaTime) * time.Second / time.Duration(deltaNum)
 }

--- a/op-devstack/dsl/l1_network.go
+++ b/op-devstack/dsl/l1_network.go
@@ -33,6 +33,6 @@ func (n *L1Network) Escape() stack.L1Network {
 	return n.inner
 }
 
-func (n *L1Network) WaitForBlock() {
-	NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForBlock()
+func (n *L1Network) WaitForBlock() eth.BlockRef {
+	return NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForBlock()
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -82,6 +82,6 @@ func (el *L2ELNode) BlockRefByNumber(num uint64) eth.BlockRef {
 	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
 	defer cancel()
 	block, err := el.inner.EthClient().BlockRefByNumber(ctx, num)
-	el.require.NoError(err, "block not found using block label")
+	el.require.NoError(err, "block not found using block number %d", num)
 	return block
 }

--- a/op-devstack/dsl/supervisor.go
+++ b/op-devstack/dsl/supervisor.go
@@ -71,6 +71,15 @@ func (s *Supervisor) VerifySyncStatus(opts ...func(config *VerifySyncStatusConfi
 	s.require.NoError(err, "Expected sync status not found")
 }
 
+func (s *Supervisor) AwaitMinL1(minL1 uint64) {
+	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		return s.FetchSyncStatus().MinSyncedL1.Number >= minL1, nil
+	})
+	s.require.NoError(err, "Expected sync status not found")
+}
+
 func (s *Supervisor) FetchSyncStatus() eth.SupervisorSyncStatus {
 	s.log.Debug("Fetching supervisor sync status")
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)

--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -106,7 +106,6 @@ func initOrchestrator(ctx context.Context, p devtest.P, opt stack.CommonOption) 
 	if lockedOrchestrator.Value != nil {
 		return
 	}
-
 	backend := backendKindSysGo
 	if override, ok := os.LookupEnv("DEVSTACK_ORCHESTRATOR"); ok {
 		backend = backendKind(override)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -219,6 +219,13 @@ func WithInteropAtGenesis() DeployerOption {
 	}
 }
 
+// WithSequencingWindow overrides the number of L1 blocks in a sequencing window, applied to all L2s.
+func WithSequencingWindow(n uint64) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		builder.WithGlobalOverride("sequencerWindowSize", uint64(n))
+	}
+}
+
 func (wb *worldBuilder) buildL1Genesis() {
 	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
 	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -95,6 +95,8 @@ type Builder interface {
 	WithL2(l2ChainID eth.ChainID) (Builder, L2Configurator)
 	L2s() (out []L2Configurator)
 	Build() (*state.Intent, error)
+
+	WithGlobalOverride(key string, value any) Builder
 }
 
 func WithDevkeyVaults(t require.TestingT, dk devkeys.Keys, configurator L2Configurator) {
@@ -190,6 +192,16 @@ func (b *intentBuilder) L2s() (out []L2Configurator) {
 		out = append(out, &l2Configurator{builder: b, chainIndex: i})
 	}
 	return out
+}
+
+// WithGlobalOverride sets a global override.
+// This is generally discouraged, but may be needed to work around legacy configuration constraints.
+func (b *intentBuilder) WithGlobalOverride(key string, value any) Builder {
+	if b.intent.GlobalDeployOverrides == nil {
+		b.intent.GlobalDeployOverrides = make(map[string]any)
+	}
+	b.intent.GlobalDeployOverrides[key] = value
+	return b
 }
 
 func (b *intentBuilder) Build() (*state.Intent, error) {

--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -27,6 +27,7 @@ type SupervisorQueryAPI interface {
 		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error
 	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
+	LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error)
 	CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error)
 	Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	FinalizedL1(ctx context.Context) (eth.BlockRef, error)

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -71,6 +71,11 @@ func (cl *SupervisorClient) LocalUnsafe(ctx context.Context, chainID eth.ChainID
 	return result, err
 }
 
+func (cl *SupervisorClient) LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error) {
+	err = cl.client.CallContext(ctx, &result, "supervisor_localSafe", chainID)
+	return result, err
+}
+
 func (cl *SupervisorClient) CrossSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error) {
 	err = cl.client.CallContext(ctx, &result, "supervisor_crossSafe", chainID)
 	return result, err

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -55,6 +55,10 @@ func (m *MockBackend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth
 	return eth.BlockID{}, nil
 }
 
+func (m *MockBackend) LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error) {
+	return types.DerivedIDPair{}, nil
+}
+
 func (m *MockBackend) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
 	return types.DerivedIDPair{}, nil
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -31,6 +31,10 @@ func (q *QueryFrontend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (e
 	return q.Supervisor.LocalUnsafe(ctx, chainID)
 }
 
+func (q *QueryFrontend) LocalSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
+	return q.Supervisor.LocalSafe(ctx, chainID)
+}
+
 func (q *QueryFrontend) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
 	return q.Supervisor.CrossSafe(ctx, chainID)
 }


### PR DESCRIPTION
**Description**

This PR tests the sequencing window expiry in an interop network.

It includes some devstack option configuration improvements, that I may split out into its own PR.

The test is not passing yet; without the L2 tx and cross-safe block at the start is passes (while doing the expiry reorg as expected), but with it included (more similar to a real network) it fails.

It appears to correctly detect sequencing window expiry in the op-node, and forces empty blocks.
Those blocks then fail to consolidate with the pre-existing unsafe blocks, and thus create a reorg.

The supervisor then detects the inconsistency, but instead of following the post-reorg chain it seems to want to stick to the pre-reorg chain, and issues a reset to the op-node to sync to the conflicting block as target, instead of a common block.
Ideally the supervisor issues no reset at all; the unsafe chain should be rewound, and the local-safe chain was extended with the force-derived block; the op-node may differ with the older op-supervisor state, but the supervisor has no reason to stay on the old chain.

Possible things that are going wrong:
- Reset-tracker bug in supervisor; it should prioritize the local-safe chain, but maybe it does not properly
- It tries to target a known conflicting block, the one of the chain before the reorg, the first conflicting block, even if the reset was determined correctly, this is not right to target.

I think we should park this PR, and invest in some improvements of the `resetTracker`. It overlaps with the upgrade-activation support work. And once that is cleaned up there is a good chance that this works properly.

**Tests**

Test-only

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/16000
