### PR TITLE
op-devstack: fix orchestrator option system hooks

### DIFF
--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -113,9 +113,9 @@ func initOrchestrator(ctx context.Context, p devtest.P, opt stack.CommonOption) 
 	}
 	switch backend {
 	case backendKindSysGo:
-		lockedOrchestrator.Value = sysgo.NewOrchestrator(p)
+		lockedOrchestrator.Value = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
 	case backendKindSysExt:
-		lockedOrchestrator.Value = sysext.NewOrchestrator(p)
+		lockedOrchestrator.Value = sysext.NewOrchestrator(p, stack.SystemHook(opt))
 	default:
 		panic(fmt.Sprintf("Unknown backend for initializing orchestrator: %s", backend))
 	}

--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -35,7 +35,7 @@ func TestControlPlane(gt *testing.T) {
 	)
 	gt.Cleanup(p.Close)
 
-	orch := NewOrchestrator(p)
+	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
 	stack.ApplyOptionLifecycle(opt, orch)
 
 	control := orch.ControlPlane()

--- a/op-devstack/sysgo/sync_test.go
+++ b/op-devstack/sysgo/sync_test.go
@@ -30,7 +30,7 @@ func TestL2CLSyncP2P(gt *testing.T) {
 	})
 	gt.Cleanup(p.Close)
 
-	orch := NewOrchestrator(p)
+	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
 	stack.ApplyOptionLifecycle(opt, orch)
 
 	t := devtest.SerialT(gt)
@@ -146,7 +146,7 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 	})
 	gt.Cleanup(p.Close)
 
-	orch := NewOrchestrator(p)
+	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
 	stack.ApplyOptionLifecycle(opt, orch)
 
 	t := devtest.SerialT(gt)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -109,7 +109,7 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
-	opt.Add(stack.Finally(func(orch *Orchestrator, hook stack.SystemHook) {
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))
 
@@ -149,7 +149,7 @@ func DefaultRedundancyInteropSystem(dest *DefaultRedundancyInteropSystemIDs) sta
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
-	opt.Add(stack.Finally(func(orch *Orchestrator, hook stack.SystemHook) {
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))
 

--- a/op-devstack/sysgo/system_test.go
+++ b/op-devstack/sysgo/system_test.go
@@ -26,7 +26,7 @@ func TestSystem(gt *testing.T) {
 	})
 	gt.Cleanup(p.Close)
 
-	orch := NewOrchestrator(p)
+	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
 	stack.ApplyOptionLifecycle(opt, orch)
 
 	// Run two tests in parallel: see if we can share the same orchestrator


### PR DESCRIPTION
**Description**

Previously `SystemHook` was attached to `Finally` stage of orchestrator options, to make whatever final stage aware of it, to run the hooks. But that doesn't work properly, since we want to couple it to the test-scope.

Instead, we now split it out, and pass it to the orchestrator constructor, to run these hooks eventually, when the test-scope system is created.

Also includes some go doc improvements.

**Tests**

Updated existing tests to pass a no-op system hook for now. The sequencing-window-expiry test PR uses this to validate the system and apply test-gating there.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
