### PR TITLE
op-batcher: only load cross-unsafe blocks

### DIFF
--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -62,6 +62,7 @@ func computeSyncActions[T channelStatuser](
 		"syncStatus.localSafeL2", newSyncStatus.LocalSafeL2.TerminalString(),
 		"syncStatus.safeL2", newSyncStatus.SafeL2.TerminalString(),
 		"syncStatus.unsafeL2", newSyncStatus.UnsafeL2.TerminalString(),
+		"syncStatus.crossUnsafeL2", newSyncStatus.CrossUnsafeL2.TerminalString(),
 	)
 
 	safeL2 := newSyncStatus.SafeL2
@@ -69,6 +70,10 @@ func computeSyncActions[T channelStatuser](
 		// This is preffered when running interop, but not yet enabled by default.
 		safeL2 = newSyncStatus.LocalSafeL2
 	}
+
+	// Pre-interop, all unsafe blocks are cross-unsafe.
+	// Post-interop, we don't want to submit local unsafe blocks until they are cross unsafe.
+	unsafeL2 := newSyncStatus.CrossUnsafeL2
 
 	// PART 1: Initial checks on the sync status
 	if newSyncStatus.HeadL1 == (eth.L1BlockRef{}) {
@@ -83,8 +88,8 @@ func computeSyncActions[T channelStatuser](
 	}
 
 	var allUnsafeBlocks *inclusiveBlockRange
-	if newSyncStatus.UnsafeL2.Number > safeL2.Number {
-		allUnsafeBlocks = &inclusiveBlockRange{safeL2.Number + 1, newSyncStatus.UnsafeL2.Number}
+	if unsafeL2.Number > safeL2.Number {
+		allUnsafeBlocks = &inclusiveBlockRange{safeL2.Number + 1, unsafeL2.Number}
 	}
 
 	// PART 2: checks involving only the oldest block in the state
@@ -170,8 +175,8 @@ func computeSyncActions[T channelStatuser](
 	}
 
 	var allUnsafeBlocksAboveState *inclusiveBlockRange
-	if newSyncStatus.UnsafeL2.Number > newestBlockInStateNum {
-		allUnsafeBlocksAboveState = &inclusiveBlockRange{newestBlockInStateNum + 1, newSyncStatus.UnsafeL2.Number}
+	if unsafeL2.Number > newestBlockInStateNum {
+		allUnsafeBlocksAboveState = &inclusiveBlockRange{newestBlockInStateNum + 1, unsafeL2.Number}
 	}
 
 	a := syncActions{

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -97,10 +97,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// although the sequencer has derived up the same
 			// L1 block height, it derived fewer safe L2 blocks.
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 6},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 6},
+				CurrentL1:     eth.BlockRef{Number: 1},
+				SafeL2:        eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block102, block103}, // note absence of block101
@@ -115,10 +115,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen if another batcher instance got some blocks
 			// included in the safe chain:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 6},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 6},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 1}},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -133,10 +133,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen if there is an L1 reorg, the safe chain is at an acceptable
 			// height but it does not descend from the blocks in state:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}}, // note hash mismatch
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}}, // note hash mismatch
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -151,10 +151,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This could happen if the batcher unexpectedly violates the
 			// Holocene derivation rules:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 3},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 3},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -168,10 +168,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "failed to make expected progress (unsafe=safe)",
 			// Edge case where unsafe = safe
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 3},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:        eth.BlockRef{Number: 3},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block102, block103},
@@ -187,10 +187,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// and we didn't submit or have any txs confirmed since
 			// the last sync.
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 4},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 4},
+				CurrentL1:     eth.BlockRef{Number: 1},
+				SafeL2:        eth.L2BlockRef{Number: 100},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -203,10 +203,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "no blocks",
 			// This happens when the batcher is starting up for the first time
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -219,10 +219,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "happy path",
 			// This happens when the safe chain is being progressed as expected:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -236,10 +236,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "happy path + multiple channels",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103, block104},
@@ -253,10 +253,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "no progress + unsafe=safe",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 100},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 100},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 100},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -266,10 +266,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "no progress + unsafe=safe + blocks in state",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 101, Hash: block101.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101},
@@ -281,11 +281,11 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "localSafeL2 > safeL2, preferLocalSafeL2=false",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:      eth.BlockRef{Number: 5},
-				CurrentL1:   eth.BlockRef{Number: 2},
-				SafeL2:      eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				LocalSafeL2: eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
-				UnsafeL2:    eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				LocalSafeL2:   eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -298,11 +298,11 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "localSafeL2 > safeL2, preferLocalSafeL2=true",
 			preferLocalSafeL2: true,
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:      eth.BlockRef{Number: 5},
-				CurrentL1:   eth.BlockRef{Number: 2},
-				SafeL2:      eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				LocalSafeL2: eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
-				UnsafeL2:    eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				LocalSafeL2:   eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -314,10 +314,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "LocalSafeL2=0,SafeL2>0", // This shouldn't ever happen, but has occurred due to bugs
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -327,6 +327,25 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			},
 			expectedLogs: noBlocksLogs,
 		},
+		{name: "CrossUnsafeL2>LocalUnsafeL2",
+			// We do not want to load the local unsafe but not cross unsafe blocks
+			newSyncStatus: eth.SyncStatus{
+				HeadL1:        eth.BlockRef{Number: 5},
+				CurrentL1:     eth.BlockRef{Number: 2},
+				SafeL2:        eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:      eth.L2BlockRef{Number: 109},
+				CrossUnsafeL2: eth.L2BlockRef{Number: 108},
+			},
+			prevCurrentL1: eth.BlockRef{Number: 1},
+			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
+			channels:      []channelStatuser{channel103},
+			expected: syncActions{
+				blocksToPrune:   3,
+				channelsToPrune: 1,
+				blocksToLoad:    &inclusiveBlockRange{104, 108}, // note that we load up to 108, not 109
+			},
+			expectedLogs: happyCaseLogs,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes #15415 

- [ ] TODO allow behaviour to be configured via CLI flag