### PR TITLE
fix(kt-devnet): expose L2 rollup config

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -55,8 +56,9 @@ type Chain struct {
 
 type L2Chain struct {
 	*Chain
-	L1Addresses AddressMap `json:"l1_addresses,omitempty"`
-	L1Wallets   WalletMap  `json:"l1_wallets,omitempty"`
+	L1Addresses  AddressMap     `json:"l1_addresses,omitempty"`
+	L1Wallets    WalletMap      `json:"l1_wallets,omitempty"`
+	RollupConfig *rollup.Config `json:"rollup_config"`
 }
 
 // Wallet represents a wallet with an address and optional private key.

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -247,6 +247,7 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 				chain.L1Addresses = descriptors.AddressMap(deployment.L1Addresses)
 				chain.Addresses = descriptors.AddressMap(deployment.L2Addresses)
 				chain.Config = deployment.Config
+				chain.RollupConfig = deployment.RollupConfig
 				chain.Wallets = d.getWallets(deployment.L2Wallets)
 				chain.L1Wallets = d.getWallets(deployment.L1Wallets)
 			}

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -32,16 +31,12 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 			CommonConfig: commonConfig,
 			ChainConfig:  net.Config,
 		},
-		ID: l2ID,
-		RollupConfig: &rollup.Config{
-			L1ChainID: l1.ChainID().ToBig(),
-			L2ChainID: l2ID.ChainID().ToBig(),
-			// TODO this rollup config should be loaded from kurtosis artifacts
-		},
-		Deployment: newL2AddressBook(t, net.L1Addresses),
-		Keys:       o.defineSystemKeys(t),
-		Superchain: system.Superchain(stack.SuperchainID(env.Env.Name)),
-		L1:         l1,
+		ID:           l2ID,
+		RollupConfig: net.RollupConfig,
+		Deployment:   newL2AddressBook(t, net.L1Addresses),
+		Keys:         o.defineSystemKeys(t),
+		Superchain:   system.Superchain(stack.SuperchainID(env.Env.Name)),
+		L1:           l1,
 	}
 	if o.isInterop() {
 		cfg.Cluster = system.Cluster(stack.ClusterID(env.Env.Name))


### PR DESCRIPTION
**Description**

This adds:
- in kt-devnet: extraction logic to gather rollup information from op-deployer outputs
- in descriptors: a field to convey that rollup config information per L2
- in devstack: proper populating of the RollupConfig info

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->
verified that the tests introduced in #15842 now expose the right block time

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Fix #15931 
