### PR TITLE
fix(op-acceptor): local acceptance tests paths

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -9,25 +9,25 @@ gates:
     description: "Sanity/smoke acceptance tests for all networks."
     tests:
       - name: TestRPCConnectivity
-        package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base
+        package: ./op-acceptance-tests/tests/base
       - name: TestChainFork
-        package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base
+        package: ./op-acceptance-tests/tests/base
 
   - id: holocene
     inherits:
       - base
     description: "Holocene network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord
+      - package: ./op-acceptance-tests/tests/fjord
 
   - id: isthmus
     inherits:
       - base
     description: "Isthmus network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
+      - package: ./op-acceptance-tests/tests/isthmus
         timeout: 6h
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee
+      - package: ./op-acceptance-tests/tests/isthmus/operator_fee
         timeout: 6h
 
   - id: pre-interop
@@ -36,7 +36,7 @@ gates:
     description: "Pre-interop network tests."
     tests:
       - name: TestInteropReadiness
-        package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/preinterop
+        package: ./op-acceptance-tests/tests/isthmus/preinterop
         timeout: 20m
 
   - id: interop
@@ -44,4 +44,4 @@ gates:
       - base
     description: "Interop network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
+      - package: ./op-acceptance-tests/tests/interop

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -67,6 +67,7 @@ acceptance-test-docker devnet="simple" gate="holocene":
     docker run \
         -v "$(pwd)/acceptance-tests.yaml:/acceptance-tests.yaml" \
         -v "{{REPO_ROOT}}:/go/src/github.com/ethereum-optimism/optimism" \
+        --network host \
         {{ACCEPTOR_IMAGE}} \
         --testdir "/go/src/github.com/ethereum-optimism/optimism" \
         --gate {{gate}} \


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We previously were using the github package paths in the acceptance-tests yaml. This had the following detrimental effects:

- It would not allow for local development (unless changed) as it would be constantly pulling the package from develop
- It would not allow easily to run these tests on a pre-build environment (e.g. if the optimism repo was checked out).

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
