### PR TITLE
op-supervisor: add StaticConfigDependencySet.Dependencies() getter

### DIFF
--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -222,7 +222,7 @@ func (ds *StaticConfigDependencySet) MessageExpiryWindow() uint64 {
 	return ds.overrideMessageExpiryWindow
 }
 
-// Dependencies returns a copy of the dependencies map
+// Dependencies returns a deep copy of the dependencies map
 func (ds *StaticConfigDependencySet) Dependencies() map[eth.ChainID]*StaticConfigDependency {
 	copied := make(map[eth.ChainID]*StaticConfigDependency, len(ds.dependencies))
 	for chainId, dep := range ds.dependencies {

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -221,3 +221,7 @@ func (ds *StaticConfigDependencySet) MessageExpiryWindow() uint64 {
 	}
 	return ds.overrideMessageExpiryWindow
 }
+
+func (ds *StaticConfigDependencySet) Dependencies() map[eth.ChainID]*StaticConfigDependency {
+	return ds.dependencies
+}

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -222,6 +222,15 @@ func (ds *StaticConfigDependencySet) MessageExpiryWindow() uint64 {
 	return ds.overrideMessageExpiryWindow
 }
 
+// Dependencies returns a copy of the dependencies map
 func (ds *StaticConfigDependencySet) Dependencies() map[eth.ChainID]*StaticConfigDependency {
-	return ds.dependencies
+	copied := make(map[eth.ChainID]*StaticConfigDependency, len(ds.dependencies))
+	for chainId, dep := range ds.dependencies {
+		copied[chainId] = &StaticConfigDependency{
+			ChainIndex:     dep.ChainIndex,
+			ActivationTime: dep.ActivationTime,
+			HistoryMinTime: dep.HistoryMinTime,
+		}
+	}
+	return copied
 }


### PR DESCRIPTION
Adds a method to return deep copy of StaticConfigDependencySet.dependencies