### PR TITLE
[txmgr / batcher] Retry tx submission for blob pool gapped nonce errors

### DIFF
--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -37,6 +37,8 @@ const (
 	MaxTipCapFlagName                  = "txmgr.max-tip-cap"
 	ResubmissionTimeoutFlagName        = "resubmission-timeout"
 	NetworkTimeoutFlagName             = "network-timeout"
+	RetryIntervalFlagName              = "txmgr.retry-interval"
+	MaxRetriesFlagName                 = "txmgr.max-retries"
 	TxSendTimeoutFlagName              = "txmgr.send-timeout"
 	TxNotInMempoolTimeoutFlagName      = "txmgr.not-in-mempool-timeout"
 	ReceiptQueryIntervalFlagName       = "txmgr.receipt-query-interval"
@@ -67,6 +69,8 @@ type DefaultFlagValues struct {
 	MinBaseFeeGwei            float64
 	ResubmissionTimeout       time.Duration
 	NetworkTimeout            time.Duration
+	RetryInterval             time.Duration
+	MaxRetries                uint64
 	TxSendTimeout             time.Duration
 	TxNotInMempoolTimeout     time.Duration
 	ReceiptQueryInterval      time.Duration
@@ -82,6 +86,8 @@ var (
 		MinBaseFeeGwei:            1.0,
 		ResubmissionTimeout:       48 * time.Second,
 		NetworkTimeout:            10 * time.Second,
+		RetryInterval:             1 * time.Second,
+		MaxRetries:                uint64(10),
 		TxSendTimeout:             0, // Try sending txs indefinitely, to preserve tx ordering for Holocene
 		TxNotInMempoolTimeout:     2 * time.Minute,
 		ReceiptQueryInterval:      12 * time.Second,
@@ -95,6 +101,8 @@ var (
 		MinBaseFeeGwei:            1.0,
 		ResubmissionTimeout:       24 * time.Second,
 		NetworkTimeout:            10 * time.Second,
+		RetryInterval:             1 * time.Second,
+		MaxRetries:                uint64(10),
 		TxSendTimeout:             2 * time.Minute,
 		TxNotInMempoolTimeout:     1 * time.Minute,
 		ReceiptQueryInterval:      12 * time.Second,
@@ -187,6 +195,18 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 			EnvVars: prefixEnvVars("NETWORK_TIMEOUT"),
 		},
 		&cli.DurationFlag{
+			Name:    RetryIntervalFlagName,
+			Usage:   "Duration we will wait before resubmitting a transaction to L1 on a transient error",
+			Value:   defaults.RetryInterval,
+			EnvVars: prefixEnvVars("TXMGR_RETRY_INTERVAL"),
+		},
+		&cli.Uint64Flag{
+			Name:    MaxRetriesFlagName,
+			Usage:   "Maximum number of times to resubmit a transaction to L1 on a transient error",
+			Value:   defaults.MaxRetries,
+			EnvVars: prefixEnvVars("TXMGR_MAX_RETRIES"),
+		},
+		&cli.DurationFlag{
 			Name:    TxSendTimeoutFlagName,
 			Usage:   "Timeout for sending transactions. If 0 it is disabled.",
 			Value:   defaults.TxSendTimeout,
@@ -231,6 +251,8 @@ type CLIConfig struct {
 	ResubmissionTimeout        time.Duration
 	ReceiptQueryInterval       time.Duration
 	NetworkTimeout             time.Duration
+	RetryInterval              time.Duration
+	MaxRetries                 uint64
 	TxSendTimeout              time.Duration
 	TxNotInMempoolTimeout      time.Duration
 	AlreadyPublishedCustomErrs []string
@@ -247,6 +269,8 @@ func NewCLIConfig(l1RPCURL string, defaults DefaultFlagValues) CLIConfig {
 		MinBaseFeeGwei:            defaults.MinBaseFeeGwei,
 		ResubmissionTimeout:       defaults.ResubmissionTimeout,
 		NetworkTimeout:            defaults.NetworkTimeout,
+		RetryInterval:             defaults.RetryInterval,
+		MaxRetries:                defaults.MaxRetries,
 		TxSendTimeout:             defaults.TxSendTimeout,
 		TxNotInMempoolTimeout:     defaults.TxNotInMempoolTimeout,
 		ReceiptQueryInterval:      defaults.ReceiptQueryInterval,
@@ -309,6 +333,8 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		ResubmissionTimeout:        ctx.Duration(ResubmissionTimeoutFlagName),
 		ReceiptQueryInterval:       ctx.Duration(ReceiptQueryIntervalFlagName),
 		NetworkTimeout:             ctx.Duration(NetworkTimeoutFlagName),
+		RetryInterval:              ctx.Duration(RetryIntervalFlagName),
+		MaxRetries:                 ctx.Uint64(MaxRetriesFlagName),
 		TxSendTimeout:              ctx.Duration(TxSendTimeoutFlagName),
 		TxNotInMempoolTimeout:      ctx.Duration(TxNotInMempoolTimeoutFlagName),
 		AlreadyPublishedCustomErrs: ctx.StringSlice(AlreadyPublishedCustomErrsFlagName),
@@ -388,6 +414,8 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 		TxSendTimeout:              cfg.TxSendTimeout,
 		TxNotInMempoolTimeout:      cfg.TxNotInMempoolTimeout,
 		NetworkTimeout:             cfg.NetworkTimeout,
+		RetryInterval:              cfg.RetryInterval,
+		MaxRetries:                 cfg.MaxRetries,
 		ReceiptQueryInterval:       cfg.ReceiptQueryInterval,
 		NumConfirmations:           cfg.NumConfirmations,
 		SafeAbortNonceTooLowCount:  cfg.SafeAbortNonceTooLowCount,
@@ -449,6 +477,17 @@ type Config struct {
 	// NetworkTimeout is the allowed duration for a single network request.
 	// This is intended to be used for network requests that can be replayed.
 	NetworkTimeout time.Duration
+
+	// RetryInterval is the interval at which the tx manager will retry
+	// sending a transaction if it fails with a non-fatal error (e.g. the
+	// gapped nonce error in the blob pool).
+	RetryInterval time.Duration
+
+	// MaxRetries is the maximum number of times to retry sending a
+	// transaction. This is used to limit the number of times we retry
+	// sending a transaction if it fails with a non-fatal error (e.g. the
+	// gapped nonce error in the blob pool).
+	MaxRetries uint64
 
 	// ReceiptQueryInterval is the interval at which the tx manager will
 	// query the backend to check for confirmations after a tx at a

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -196,13 +196,13 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 		},
 		&cli.DurationFlag{
 			Name:    RetryIntervalFlagName,
-			Usage:   "Duration we will wait before resubmitting a transaction to L1 on a transient error",
+			Usage:   "Duration we will wait before resubmitting a transaction to L1 on a transient error. Values <= 0 will result in retrying immediately.",
 			Value:   defaults.RetryInterval,
 			EnvVars: prefixEnvVars("TXMGR_RETRY_INTERVAL"),
 		},
 		&cli.Uint64Flag{
 			Name:    MaxRetriesFlagName,
-			Usage:   "Maximum number of times to resubmit a transaction to L1 on a transient error",
+			Usage:   "Maximum number of times to resubmit a transaction to L1 on a transient error. Set to 0 to disable retries.",
 			Value:   defaults.MaxRetries,
 			EnvVars: prefixEnvVars("TXMGR_MAX_RETRIES"),
 		},

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -196,7 +196,7 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 		},
 		&cli.DurationFlag{
 			Name:    RetryIntervalFlagName,
-			Usage:   "Duration we will wait before resubmitting a transaction to L1 on a transient error. Values <= 0 will result in retrying immediately.",
+			Usage:   "Duration we will wait before resubmitting a transaction to L1 on a transient error. Values <= 0 will result in retrying immediately. Should be less than ResubmissionTimeout to have an effect.",
 			Value:   defaults.RetryInterval,
 			EnvVars: prefixEnvVars("TXMGR_RETRY_INTERVAL"),
 		},

--- a/op-service/txmgr/send_state.go
+++ b/op-service/txmgr/send_state.go
@@ -27,12 +27,12 @@ type SendState struct {
 	now      func() time.Time
 
 	// Config
-	nonceTooLowCount    uint64
-	txInMempoolDeadline time.Time // deadline to abort at if no transactions are in the mempool
+	safeAbortNonceTooLowCount uint64
+	txInMempoolDeadline       time.Time // deadline to abort at if no transactions are in the mempool
 
 	// Counts of the different types of errors
-	successFullPublishCount   uint64 // nil error => tx made it to the mempool
-	safeAbortNonceTooLowCount uint64 // nonce too low error
+	successFullPublishCount uint64 // nil error => tx made it to the mempool
+	nonceTooLowCount        uint64 // nonce too low error
 
 	// Whether any attempt to send the tx resulted in ErrAlreadyReserved
 	alreadyReserved bool

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -113,7 +113,9 @@ func configWithNumConfs(numConfirmations uint64) *Config {
 		Signer: func(ctx context.Context, from common.Address, tx *types.Transaction) (*types.Transaction, error) {
 			return tx, nil
 		},
-		From: common.Address{},
+		From:          common.Address{},
+		RetryInterval: 1 * time.Millisecond,
+		MaxRetries:    5,
 	}
 
 	cfg.ResubmissionTimeout.Store(int64(time.Second))
@@ -1654,6 +1656,31 @@ func TestTxMgrCustomPublishError(t *testing.T) {
 		receipt, err := send(ctx, h, h.createTxCandidate())
 		require.Nil(t, err)
 		require.NotNil(t, receipt)
+	})
+}
+
+func TestTxMgrRetryOnError(t *testing.T) {
+	sendErr := core.ErrNonceTooHigh
+
+	testSendVariants(t, func(t *testing.T, send testSendVariantsFn) {
+		cfg := configWithNumConfs(1)
+		h := newTestHarnessWithConfig(t, cfg)
+		sendAttempts := uint64(0)
+
+		sendTx := func(ctx context.Context, tx *types.Transaction) error {
+			txHash := tx.Hash()
+			h.backend.mine(&txHash, tx.GasFeeCap(), nil)
+			sendAttempts++
+			return sendErr
+		}
+		h.backend.setTxSender(sendTx)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		receipt, err := send(ctx, h, h.createTxCandidate())
+		require.ErrorIs(t, sendErr, err)
+		require.Nil(t, receipt)
+		require.Equal(t, cfg.MaxRetries, sendAttempts-1)
 	})
 }
 

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -1680,7 +1680,7 @@ func TestTxMgrRetryOnError(t *testing.T) {
 		receipt, err := send(ctx, h, h.createTxCandidate())
 		require.ErrorIs(t, sendErr, err)
 		require.Nil(t, receipt)
-		require.Equal(t, cfg.MaxRetries, sendAttempts-1)
+		require.Equal(t, cfg.MaxRetries+1, sendAttempts)
 	})
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR introduces a new "retry interval", and immediately retries (after the interval) tx submission on certain errors (the only one for now is the `nonce too high` error which is returned by geth for gapped nonce blob txs).

**Tests**

Added a new test for this.

**Additional context**

We noticed the batcher failing with `gapped nonce` errors when submitting more than one blob transaction per block. These should be treated as transient errors and retried, but right now it waits the entire resubmission period to retry, which causes significant slowdown in batch submission.