### PR TITLE
feat(op-acceptance-tests): run for all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1180,6 +1180,10 @@ jobs:
             - discord-notification-failures-on-develop:
                 mentions: "<@&1346448413172170807>" # Protocol DevX Pod
                 message: "Devnet <<parameters.devnet>>-devnet failed to start"
+      - run:
+          name: Stop the job if the devnet failed to start
+          command: circleci-agent step halt
+          when: on_fail
       # Restore cached Go modules
       - restore_cache:
           keys:
@@ -1194,11 +1198,7 @@ jobs:
       - run:
           name: Prepare test environment (compile tests and cache results)
           working_directory: op-acceptance-tests
-          command: go test -v ./... || true # ignore failures; we're just compiling the tests
-      - run:
-          name: Stop the job if the devnet failed to start
-          command: circleci-agent step halt
-          when: on_fail
+          command: go test -run=^$ ./tests/...
       # Run the acceptance tests (if the devnet is running)
       - run:
           name: Run acceptance tests (gate=<<parameters.gate>>)
@@ -1207,6 +1207,7 @@ jobs:
           environment:
             GOFLAGS: "-mod=mod"
             GO111MODULE: "on"
+            GOGC: "0"
           command: |
             # Check if the devnet is running before attempting to run tests
             if ! kurtosis enclave ls | grep -q "<<parameters.devnet>>-devnet"; then
@@ -1238,6 +1239,7 @@ jobs:
       - run:
           name: Generate JUnit XML test report for CircleCI
           working_directory: op-acceptance-tests
+          when: always
           command: |
             LOG_DIR=$(ls -td -- logs/* | head -1)
             gotestsum --junitfile results/results.xml --raw-command cat $LOG_DIR/raw_go_events.log || true
@@ -1307,7 +1309,6 @@ jobs:
           name: Sanitize op-program client
           command: make sanitize-program GUEST_PROGRAM=../op-program/bin/op-program-client64.elf
           working_directory: cannon
-
 
   cannon-prestate-quick:
     machine: true
@@ -1703,6 +1704,21 @@ jobs:
           command: |
             gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics
             gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics-$CIRCLE_SHA1
+
+  # Helper job to check if we're running on a PR
+  run-on-pr-only:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run:
+          name: Check if running on a PR
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "This is not a pull request. Exiting with error."
+              exit 1
+            else
+              echo "Running on pull request: $CIRCLE_PULL_REQUEST"
+            fi
 
 workflows:
   main:
@@ -2255,6 +2271,7 @@ workflows:
           context:
             - circleci-repo-optimism
 
+  # Acceptance tests (post-merge to develop)
   acceptance-tests:
     when:
       or:
@@ -2271,7 +2288,6 @@ workflows:
           name: kurtosis-simple
           devnet: simple
           gate: base
-
           # CircleCI params
           no_output_timeout: 60m
           context:
@@ -2283,7 +2299,6 @@ workflows:
           name: kurtosis-isthmus
           devnet: isthmus
           gate: isthmus
-
           # CircleCI params
           no_output_timeout: 60m
           context:
@@ -2295,12 +2310,35 @@ workflows:
           name: kurtosis-interop
           devnet: interop
           gate: interop
-
           # CircleCI params
           no_output_timeout: 60m
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
+
+  # Acceptance tests (pre-merge to develop)
+  acceptance-tests-pr:
+    when:
+      not:
+        equal: [<< pipeline.git.branch >>, "develop"]
+    jobs:
+      - run-on-pr-only:
+          name: check-for-pr
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - op-acceptance-tests:
+          # Acceptance Testing params
+          name: kurtosis-interop
+          devnet: interop
+          gate: interop
+          # CircleCI params
+          no_output_timeout: 10m
+          requires:
+            - check-for-pr
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+
   close-issue-workflow:
     when:
       and:


### PR DESCRIPTION
**Description**

Re-introduces a subset of the acceptance tests for all branches with an accompanying PR. This will allow us to shift-left our testing and stop bugs earlier.
Note that this check will not be enforced in Github, so one can merge without it passing at their discretion.

Of note, also includes a big optimisation which reduces the running time of the acceptance tests (pre and post merge) by at least 5 minutes (!!).

<img width="1705" alt="Screenshot 2025-05-15 at 19 28 08" src="https://github.com/user-attachments/assets/9cb97517-1751-4a20-9bd0-84a562c70c3c" />

