### PR TITLE
testing: fakePoS module: add control for stop/start of subscription event loop

### DIFF
--- a/op-devstack/stack/orchestrator.go
+++ b/op-devstack/stack/orchestrator.go
@@ -21,6 +21,7 @@ const (
 type ControlPlane interface {
 	SupervisorState(id SupervisorID, action ControlAction)
 	L2CLNodeState(id L2CLNodeID, action ControlAction)
+	FakePoSState(id L1CLNodeID, action ControlAction)
 }
 
 // Orchestrator is the base interface for all system orchestrators.

--- a/op-devstack/sysext/control_plane.go
+++ b/op-devstack/sysext/control_plane.go
@@ -34,4 +34,8 @@ func (c *ControlPlane) L2CLNodeState(id stack.L2CLNodeID, mode stack.ControlActi
 	c.setLifecycleState(id.Key, mode)
 }
 
+func (c *ControlPlane) FakePoSState(id stack.L1CLNodeID, mode stack.ControlAction) {
+	panic("not implemented: plug in kurtosis wrapper, or gate for the test that uses this method to not run in kurtosis")
+}
+
 var _ stack.ControlPlane = (*ControlPlane)(nil)

--- a/op-devstack/sysgo/control_plane.go
+++ b/op-devstack/sysgo/control_plane.go
@@ -29,4 +29,11 @@ func (c *ControlPlane) L2CLNodeState(id stack.L2CLNodeID, mode stack.ControlActi
 	control(s, mode)
 }
 
+func (c *ControlPlane) FakePoSState(id stack.L1CLNodeID, mode stack.ControlAction) {
+	s, ok := c.o.l1CLs.Get(id)
+	c.o.P().Require().True(ok, "need l1cl node to change state of fakePoS module")
+
+	control(s.fakepos, mode)
+}
+
 var _ stack.ControlPlane = (*ControlPlane)(nil)

--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -149,7 +149,7 @@ func testL2CLRestart(ids DefaultInteropSystemIDs, system stack.System, control s
 	}
 }
 
-// TestControlPlaneFakePoS tests start/stop functionality provided control plane for the fakePos module
+// TestControlPlaneFakePoS tests the start/stop functionality provided by the control plane for the fakePoS module
 func TestControlPlaneFakePoS(gt *testing.T) {
 	var ids DefaultInteropSystemIDs
 	opt := DefaultInteropSystem(&ids)

--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -146,4 +147,75 @@ func testL2CLRestart(ids DefaultInteropSystemIDs, system stack.System, control s
 		require.NoError(t, err)
 		cancel()
 	}
+}
+
+// TestControlPlaneFakePoS tests start/stop functionality provided control plane for the fakePos module
+func TestControlPlaneFakePoS(gt *testing.T) {
+	var ids DefaultInteropSystemIDs
+	opt := DefaultInteropSystem(&ids)
+
+	logger := testlog.Logger(gt, log.LevelInfo)
+
+	p := devtest.NewP(
+		context.Background(),
+		logger,
+		func() {
+			gt.Helper()
+			gt.FailNow()
+		},
+	)
+	gt.Cleanup(p.Close)
+
+	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
+	stack.ApplyOptionLifecycle(opt, orch)
+
+	control := orch.ControlPlane()
+
+	t := devtest.SerialT(gt)
+	system := shim.NewSystem(t)
+	orch.Hydrate(system)
+
+	ctx := t.Ctx()
+
+	el := system.L1Network(ids.L1).L1ELNode(match.FirstL1EL)
+
+	// progress chain
+	for range 2 {
+		time.Sleep(time.Second * 6)
+
+		head, err := el.EthClient().InfoByLabel(ctx, "latest")
+		require.NoError(t, err)
+		logger.Info("L1 chain", "number", head.NumberU64(), "hash", head.Hash())
+	}
+
+	logger.Info("Stopping fakePoS service")
+	control.FakePoSState(ids.L1CL, stack.Stop)
+
+	head, err := el.EthClient().InfoByLabel(ctx, "latest")
+	require.NoError(t, err)
+
+	// L1 chain won't progress since fakePoS is stopped
+	// Wait and check that L1 chain won't progress
+	for range 2 {
+		time.Sleep(time.Second * 6)
+
+		other, err := el.EthClient().InfoByLabel(ctx, "latest")
+		require.NoError(t, err)
+		logger.Info("L1 chain", "number", other.NumberU64(), "hash", other.Hash(), "previous", head.Hash())
+
+		require.Equal(t, other.Hash(), head.Hash())
+	}
+
+	// Restart fakePoS
+	logger.Info("Starting fakePoS service")
+	control.FakePoSState(ids.L1CL, stack.Start)
+
+	// L1 chain should progress again eventually
+	require.Eventually(t, func() bool {
+		other, err := el.EthClient().InfoByLabel(ctx, "latest")
+		require.NoError(t, err)
+		logger.Info("L1 chain", "number", other.NumberU64(), "hash", other.Hash(), "previous", head.Hash())
+
+		return other.Hash() != head.Hash() && other.NumberU64() > head.NumberU64()
+	}, time.Second*20, time.Second*2)
 }

--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -180,8 +180,9 @@ func TestControlPlaneFakePoS(gt *testing.T) {
 	el := system.L1Network(ids.L1).L1ELNode(match.FirstL1EL)
 
 	// progress chain
+	blockTime := time.Second * 6
 	for range 2 {
-		time.Sleep(time.Second * 6)
+		time.Sleep(blockTime)
 
 		head, err := el.EthClient().InfoByLabel(ctx, "latest")
 		require.NoError(t, err)
@@ -197,7 +198,7 @@ func TestControlPlaneFakePoS(gt *testing.T) {
 	// L1 chain won't progress since fakePoS is stopped
 	// Wait and check that L1 chain won't progress
 	for range 2 {
-		time.Sleep(time.Second * 6)
+		time.Sleep(blockTime)
 
 		other, err := el.EthClient().InfoByLabel(ctx, "latest")
 		require.NoError(t, err)

--- a/op-devstack/sysgo/fakepos.go
+++ b/op-devstack/sysgo/fakepos.go
@@ -1,0 +1,19 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+)
+
+type FakePoS struct {
+	p       devtest.P
+	fakepos *geth.FakePoS
+}
+
+func (f *FakePoS) Start() {
+	f.p.Require().NoError(f.fakepos.Start(), "fakePoS failed to start")
+}
+
+func (f *FakePoS) Stop() {
+	f.p.Require().NoError(f.fakepos.Stop(), "fakePoS failed to stop")
+}

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -40,6 +40,7 @@ type L1CLNode struct {
 	id             stack.L1CLNodeID
 	beaconHTTPAddr string
 	beacon         *fakebeacon.FakeBeacon
+	fakepos        *geth.FakePoS
 }
 
 func (n *L1CLNode) hydrate(system stack.ExtensibleSystem) {
@@ -78,7 +79,7 @@ func WithL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stack.Option[
 		beaconApiAddr := bcn.BeaconAddr()
 		require.NotEmpty(beaconApiAddr, "beacon API listener must be up")
 
-		l1Geth, err := geth.InitL1(
+		l1Geth, fakepos, err := geth.InitL1(
 			blockTimeL1,
 			l1FinalizedDistance,
 			l1Net.genesis,
@@ -104,6 +105,7 @@ func WithL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stack.Option[
 			id:             l1CLID,
 			beaconHTTPAddr: beaconApiAddr,
 			beacon:         bcn,
+			fakepos:        fakepos,
 		}
 		require.True(orch.l1CLs.SetIfMissing(l1CLID, l1CLNode), "must not already exist")
 	})

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -40,7 +40,7 @@ type L1CLNode struct {
 	id             stack.L1CLNodeID
 	beaconHTTPAddr string
 	beacon         *fakebeacon.FakeBeacon
-	fakepos        *geth.FakePoS
+	fakepos        *FakePoS
 }
 
 func (n *L1CLNode) hydrate(system stack.ExtensibleSystem) {
@@ -79,7 +79,7 @@ func WithL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stack.Option[
 		beaconApiAddr := bcn.BeaconAddr()
 		require.NotEmpty(beaconApiAddr, "beacon API listener must be up")
 
-		l1Geth, fakepos, err := geth.InitL1(
+		l1Geth, fp, err := geth.InitL1(
 			blockTimeL1,
 			l1FinalizedDistance,
 			l1Net.genesis,
@@ -105,7 +105,7 @@ func WithL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stack.Option[
 			id:             l1CLID,
 			beaconHTTPAddr: beaconApiAddr,
 			beacon:         bcn,
-			fakepos:        fakepos,
+			fakepos:        &FakePoS{fakepos: fp, p: orch.p},
 		}
 		require.True(orch.l1CLs.SetIfMissing(l1CLID, l1CLNode), "must not already exist")
 	})

--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -26,6 +26,20 @@ type Beacon interface {
 	StoreBlobsBundle(slot uint64, bundle *engine.BlobsBundleV1) error
 }
 
+// FakePoS is a testing-only utility to attach to Geth
+// the exported struct is used by the devstack to control the fakePoS module, and adheres to the devstack.Lifecycle interface
+type FakePoS struct {
+	fakePoS *fakePoS
+}
+
+func (f *FakePoS) Start() {
+	_ = f.fakePoS.Start()
+}
+
+func (f *FakePoS) Stop() {
+	_ = f.fakePoS.Stop()
+}
+
 // fakePoS is a testing-only utility to attach to Geth,
 // to build a fake proof-of-stake L1 chain with fixed block time and basic lagging safe/finalized blocks.
 type fakePoS struct {
@@ -212,9 +226,13 @@ func (f *fakePoS) Start() error {
 }
 
 func (f *fakePoS) Stop() error {
-	f.sub.Unsubscribe()
-	if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
-		advancing.Stop()
+	if f.sub != nil {
+		f.sub.Unsubscribe()
+	}
+	if f.clock != nil {
+		if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
+			advancing.Stop()
+		}
 	}
 	return nil
 }

--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -2,6 +2,7 @@ package geth
 
 import (
 	"encoding/binary"
+	"errors"
 	"math/big"
 	"math/rand"
 	"time"
@@ -226,13 +227,12 @@ func (f *fakePoS) Start() error {
 }
 
 func (f *fakePoS) Stop() error {
-	if f.sub != nil {
-		f.sub.Unsubscribe()
+	if f.sub == nil || f.clock == nil {
+		return errors.New("fakePoS not started, but stop was called")
 	}
-	if f.clock != nil {
-		if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
-			advancing.Stop()
-		}
+	f.sub.Unsubscribe()
+	if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
+		advancing.Stop()
 	}
 	return nil
 }

--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -27,23 +27,9 @@ type Beacon interface {
 	StoreBlobsBundle(slot uint64, bundle *engine.BlobsBundleV1) error
 }
 
-// FakePoS is a testing-only utility to attach to Geth
-// the exported struct is used by the devstack to control the fakePoS module, and adheres to the devstack.Lifecycle interface
-type FakePoS struct {
-	fakePoS *fakePoS
-}
-
-func (f *FakePoS) Start() {
-	_ = f.fakePoS.Start()
-}
-
-func (f *FakePoS) Stop() {
-	_ = f.fakePoS.Stop()
-}
-
 // fakePoS is a testing-only utility to attach to Geth,
 // to build a fake proof-of-stake L1 chain with fixed block time and basic lagging safe/finalized blocks.
-type fakePoS struct {
+type FakePoS struct {
 	clock     clock.Clock
 	eth       *eth.Ethereum
 	log       log.Logger
@@ -60,13 +46,13 @@ type fakePoS struct {
 	beacon Beacon
 }
 
-func (f *fakePoS) FakeBeaconBlockRoot(time uint64) common.Hash {
+func (f *FakePoS) FakeBeaconBlockRoot(time uint64) common.Hash {
 	var dat [8]byte
 	binary.LittleEndian.PutUint64(dat[:], time)
 	return crypto.Keccak256Hash(dat[:])
 }
 
-func (f *fakePoS) Start() error {
+func (f *FakePoS) Start() error {
 	if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
 		advancing.Start()
 	}
@@ -226,7 +212,7 @@ func (f *fakePoS) Start() error {
 	return nil
 }
 
-func (f *fakePoS) Stop() error {
+func (f *FakePoS) Stop() error {
 	if f.sub == nil || f.clock == nil {
 		return errors.New("fakePoS not started, but stop was called")
 	}

--- a/op-e2e/e2eutils/geth/geth.go
+++ b/op-e2e/e2eutils/geth/geth.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 )
 
-func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c clock.Clock, blobPoolDir string, beaconSrv Beacon, opts ...GethOption) (*GethInstance, error) {
+func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c clock.Clock, blobPoolDir string, beaconSrv Beacon, opts ...GethOption) (*GethInstance, *FakePoS, error) {
 	ethConfig := &ethconfig.Config{
 		NetworkId: genesis.Config.ChainID.Uint64(),
 		Genesis:   genesis,
@@ -56,11 +56,10 @@ func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c
 
 	gethInstance, err := createGethNode(false, nodeConfig, ethConfig, opts...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Instead of running a whole beacon node, we run this fake-proof-of-stake sidecar that sequences L1 blocks using the Engine API.
-	gethInstance.Node.RegisterLifecycle(&fakePoS{
+	fakepos := &fakePoS{
 		clock:             c,
 		eth:               gethInstance.Backend,
 		log:               log.Root(), // geth logger is global anyway. Would be nice to replace with a local logger though.
@@ -69,9 +68,12 @@ func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c
 		safeDistance:      4,
 		engineAPI:         catalyst.NewConsensusAPI(gethInstance.Backend),
 		beacon:            beaconSrv,
-	})
+	}
 
-	return gethInstance, nil
+	// Instead of running a whole beacon node, we run this fake-proof-of-stake sidecar that sequences L1 blocks using the Engine API.
+	gethInstance.Node.RegisterLifecycle(fakepos)
+
+	return gethInstance, &FakePoS{fakePoS: fakepos}, nil
 }
 
 func defaultNodeConfig(name string, jwtPath string) *node.Config {

--- a/op-e2e/e2eutils/geth/geth.go
+++ b/op-e2e/e2eutils/geth/geth.go
@@ -59,7 +59,7 @@ func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c
 		return nil, nil, err
 	}
 
-	fakepos := &fakePoS{
+	fakepos := &FakePoS{
 		clock:             c,
 		eth:               gethInstance.Backend,
 		log:               log.Root(), // geth logger is global anyway. Would be nice to replace with a local logger though.
@@ -73,7 +73,7 @@ func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c
 	// Instead of running a whole beacon node, we run this fake-proof-of-stake sidecar that sequences L1 blocks using the Engine API.
 	gethInstance.Node.RegisterLifecycle(fakepos)
 
-	return gethInstance, &FakePoS{fakePoS: fakepos}, nil
+	return gethInstance, fakepos, nil
 }
 
 func defaultNodeConfig(name string, jwtPath string) *node.Config {

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -215,7 +215,7 @@ func (s *interopE2ESystem) prepareL1() (*fakebeacon.FakeBeacon, *geth.GethInstan
 		l1Clock = s.timeTravelClock
 	}
 	// Start the L1 chain
-	l1Geth, err := geth.InitL1(
+	l1Geth, _, err := geth.InitL1(
 		blockTimeL1,
 		l1FinalizedDistance,
 		s.worldOutput.L1.Genesis,

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -734,7 +734,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	sys.L1BeaconAPIAddr = endpoint.RestHTTPURL(beaconApiAddr)
 
 	// Initialize nodes
-	l1Geth, err := geth.InitL1(
+	l1Geth, _, err := geth.InitL1(
 		cfg.DeployConfig.L1BlockTime, cfg.L1FinalizedDistance, l1Genesis, c,
 		path.Join(cfg.BlobsPath, "l1_el"), bcn, cfg.GethOptions[RoleL1]...)
 	if err != nil {


### PR DESCRIPTION
**Description**

This PR is modifying the `fakePoS` module within Geth, and is adding a control API so that we can stop/start it on-demand from tests.

**Additional context**

Necessary for https://github.com/ethereum-optimism/optimism/issues/14128