### PR TITLE
fix(op-acceptance-tests): make sure to use provisioned devnet

### DIFF
--- a/op-acceptance-tests/cmd/main.go
+++ b/op-acceptance-tests/cmd/main.go
@@ -176,7 +176,10 @@ func runOpAcceptor(ctx context.Context, tracer trace.Tracer, devnet string, gate
 		"--validators", validators,
 		"--log.level", logLevel,
 	)
-	acceptorCmd.Env = append(env, fmt.Sprintf("DEVNET_ENV_URL=kt://%s", devnet))
+	acceptorCmd.Env = append(env,
+		fmt.Sprintf("DEVNET_ENV_URL=kt://%s", devnet),
+		"DEVSTACK_ORCHESTRATOR=sysext", // make devstack-based tests use the provisioned devnet
+	)
 	acceptorCmd.Stdout = os.Stdout
 	acceptorCmd.Stderr = os.Stderr
 	if err := acceptorCmd.Run(); err != nil {


### PR DESCRIPTION
**Description**

By default devstack-based tests use the sysgo backend.
In the context of acceptance tests we want to make sure the devnet we
just provisioned is being used.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
