### PR TITLE
fix(devnet-sdk): allow overriding ctrl interface detection

### DIFF
--- a/devnet-sdk/shell/env/chain.go
+++ b/devnet-sdk/shell/env/chain.go
@@ -15,6 +15,7 @@ const (
 	ChainNameVar           = "DEVNET_CHAIN_NAME"
 	NodeIndexVar           = "DEVNET_NODE_INDEX"
 	ExpectPreconditionsMet = "DEVNET_EXPECT_PRECONDITIONS_MET"
+	EnvCtrlVar             = "DEVNET_ENV_CTRL"
 )
 
 type ChainConfig struct {


### PR DESCRIPTION
**Description**

In the context of op-acceptor, we now potentially override the
definition of the received devnet to graft add-ons.
This loses the ability to reach the control interface though.

This change re-enables this, by providing an override mechanism that
op-acceptor can make use of.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
