### PR TITLE
refactor(test): cleanup of /universal tests structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/universal/ExtendedPause.t.sol
+++ b/packages/contracts-bedrock/test/universal/ExtendedPause.t.sol
@@ -3,10 +3,12 @@ pragma solidity 0.8.15;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-/// @dev These tests are somewhat redundant with tests in the SuperchainConfig and other pausable contracts, however
-///      it is worthwhile to pull them into one location to ensure that the behavior is consistent.
+/// @title ExtendedPause_Test
+/// @notice These tests are somewhat redundant with tests in the SuperchainConfig and other
+///         pausable contracts, however it is worthwhile to pull them into one location to ensure
+///         that the behavior is consistent.
 contract ExtendedPause_Test is CommonTest {
-    /// @dev Tests that other contracts are paused when the superchain config is paused
+    /// @notice Tests that other contracts are paused when the superchain config is paused
     function test_pause_fullSystem_succeeds() public {
         assertFalse(superchainConfig.paused(address(0)));
 
@@ -21,7 +23,8 @@ contract ExtendedPause_Test is CommonTest {
         assertTrue(l1ERC721Bridge.paused());
     }
 
-    /// @dev Tests that other contracts are unpaused when the superchain config is paused and then unpaused.
+    /// @notice Tests that other contracts are unpaused when the superchain config is paused and
+    ///         then unpaused.
     function test_unpause_fullSystem_succeeds() external {
         // first use the test above to pause the system
         test_pause_fullSystem_succeeds();

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
@@ -6,37 +6,38 @@ import { IOptimismMintableERC20 } from "interfaces/universal/IOptimismMintableER
 import { ILegacyMintableERC20 } from "interfaces/legacy/ILegacyMintableERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-contract OptimismMintableERC20_Test is CommonTest {
+/// @title OptimismMintableERC20_TestInit
+/// @notice Reusable test initialization for `OptimismMintableERC20` tests.
+contract OptimismMintableERC20_TestInit is CommonTest {
     event Mint(address indexed account, uint256 amount);
     event Burn(address indexed account, uint256 amount);
+}
 
-    function test_remoteToken_succeeds() external view {
-        assertEq(L2Token.remoteToken(), address(L1Token));
+/// @title OptimismMintableERC20_Permit2_Test
+/// @notice Tests the `permit2` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_Permit2_Test is OptimismMintableERC20_TestInit {
+    function test_permit2_transferFrom_succeeds() external {
+        vm.prank(address(l2StandardBridge));
+        L2Token.mint(alice, 100);
+
+        assertEq(L2Token.balanceOf(bob), 0);
+        vm.prank(L2Token.PERMIT2());
+        L2Token.transferFrom(alice, bob, 100);
+        assertEq(L2Token.balanceOf(bob), 100);
     }
+}
 
-    function test_bridge_succeeds() external view {
-        assertEq(L2Token.bridge(), address(l2StandardBridge));
+/// @title OptimismMintableERC20_Allowance_Test
+/// @notice Tests the `allowance` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_Allowance_Test is OptimismMintableERC20_TestInit {
+    function test_allowance_permit2Max_works() external view {
+        assertEq(L2Token.allowance(alice, L2Token.PERMIT2()), type(uint256).max);
     }
+}
 
-    function test_l1Token_succeeds() external view {
-        assertEq(L2Token.l1Token(), address(L1Token));
-    }
-
-    function test_l2Bridge_succeeds() external view {
-        assertEq(L2Token.l2Bridge(), address(l2StandardBridge));
-    }
-
-    function test_legacy_succeeds() external view {
-        // Getters for the remote token
-        assertEq(L2Token.REMOTE_TOKEN(), address(L1Token));
-        assertEq(L2Token.remoteToken(), address(L1Token));
-        assertEq(L2Token.l1Token(), address(L1Token));
-        // Getters for the bridge
-        assertEq(L2Token.BRIDGE(), address(l2StandardBridge));
-        assertEq(L2Token.bridge(), address(l2StandardBridge));
-        assertEq(L2Token.l2Bridge(), address(l2StandardBridge));
-    }
-
+/// @title OptimismMintableERC20_Mint_Test
+/// @notice Tests the `mint` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_Mint_Test is OptimismMintableERC20_TestInit {
     function test_mint_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit Mint(alice, 100);
@@ -47,27 +48,17 @@ contract OptimismMintableERC20_Test is CommonTest {
         assertEq(L2Token.balanceOf(alice), 100);
     }
 
-    function test_allowance_permit2Max_works() external view {
-        assertEq(L2Token.allowance(alice, L2Token.PERMIT2()), type(uint256).max);
-    }
-
-    function test_permit2_transferFrom_succeeds() external {
-        vm.prank(address(l2StandardBridge));
-        L2Token.mint(alice, 100);
-
-        assertEq(L2Token.balanceOf(bob), 0);
-        vm.prank(L2Token.PERMIT2());
-        L2Token.transferFrom(alice, bob, 100);
-        assertEq(L2Token.balanceOf(bob), 100);
-    }
-
     function test_mint_notBridge_reverts() external {
         // NOT the bridge
         vm.expectRevert("OptimismMintableERC20: only bridge can mint and burn");
         vm.prank(address(alice));
         L2Token.mint(alice, 100);
     }
+}
 
+/// @title OptimismMintableERC20_Burn_Test
+/// @notice Tests the `burn` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_Burn_Test is OptimismMintableERC20_TestInit {
     function test_burn_succeeds() external {
         vm.prank(address(l2StandardBridge));
         L2Token.mint(alice, 100);
@@ -87,10 +78,14 @@ contract OptimismMintableERC20_Test is CommonTest {
         vm.prank(address(alice));
         L2Token.burn(alice, 100);
     }
+}
 
+/// @title OptimismMintableERC20_SupportsInterface_Test
+/// @notice Tests the `supportsInterface` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_SupportsInterface_Test is OptimismMintableERC20_TestInit {
     function test_erc165_supportsInterface_succeeds() external view {
-        // The assertEq calls in this test are comparing the manual calculation of the iface,
-        // with what is returned by the solidity's type().interfaceId, just to be safe.
+        // The assertEq calls in this test are comparing the manual calculation of the iface, with
+        // what is returned by the solidity's type().interfaceId, just to be safe.
         bytes4 iface1 = bytes4(keccak256("supportsInterface(bytes4)"));
         assertEq(iface1, type(IERC165).interfaceId);
         assert(L2Token.supportsInterface(iface1));
@@ -103,5 +98,53 @@ contract OptimismMintableERC20_Test is CommonTest {
             L2Token.remoteToken.selector ^ L2Token.bridge.selector ^ L2Token.mint.selector ^ L2Token.burn.selector;
         assertEq(iface3, type(IOptimismMintableERC20).interfaceId);
         assert(L2Token.supportsInterface(iface3));
+    }
+}
+
+/// @title OptimismMintableERC20_L1Token_Test
+/// @notice Tests the `l1Token` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_L1Token_Test is OptimismMintableERC20_TestInit {
+    function test_l1Token_succeeds() external view {
+        assertEq(L2Token.l1Token(), address(L1Token));
+    }
+}
+
+/// @title OptimismMintableERC20_L2Bridge_Test
+/// @notice Tests the `l2Bridge` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_L2Bridge_Test is OptimismMintableERC20_TestInit {
+    function test_l2Bridge_succeeds() external view {
+        assertEq(L2Token.l2Bridge(), address(l2StandardBridge));
+    }
+}
+
+/// @title OptimismMintableERC20_RemoteToken_Test
+/// @notice Tests the `remoteToken` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_RemoteToken_Test is OptimismMintableERC20_TestInit {
+    function test_remoteToken_succeeds() external view {
+        assertEq(L2Token.remoteToken(), address(L1Token));
+    }
+}
+
+/// @title OptimismMintableERC20_Bridge_Test
+/// @notice Tests the `bridge` function of the `OptimismMintableERC20` contract.
+contract OptimismMintableERC20_Bridge_Test is OptimismMintableERC20_TestInit {
+    function test_bridge_succeeds() external view {
+        assertEq(L2Token.bridge(), address(l2StandardBridge));
+    }
+}
+
+/// @title OptimismMintableERC20_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `OptimismMintableERC20`
+///         contract.
+contract OptimismMintableERC20_Unclassified_Test is OptimismMintableERC20_TestInit {
+    function test_legacy_succeeds() external view {
+        // Getters for the remote token
+        assertEq(L2Token.REMOTE_TOKEN(), address(L1Token));
+        assertEq(L2Token.remoteToken(), address(L1Token));
+        assertEq(L2Token.l1Token(), address(L1Token));
+        // Getters for the bridge
+        assertEq(L2Token.BRIDGE(), address(l2StandardBridge));
+        assertEq(L2Token.bridge(), address(l2StandardBridge));
+        assertEq(L2Token.l2Bridge(), address(l2StandardBridge));
     }
 }

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -19,6 +19,26 @@ import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMin
 contract OptimismMintableERC20Factory_TestInit is CommonTest {
     event StandardL2TokenCreated(address indexed remoteToken, address indexed localToken);
     event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
+
+    /// @notice Precalculates the address of the token contract.
+    function _calculateTokenAddress(
+        address _remote,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    )
+        internal
+        view
+        returns (address)
+    {
+        bytes memory constructorArgs = abi.encode(address(l2StandardBridge), _remote, _name, _symbol, _decimals);
+        bytes memory bytecode = abi.encodePacked(type(OptimismMintableERC20).creationCode, constructorArgs);
+        bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol, _decimals));
+        bytes32 hash = keccak256(
+            abi.encodePacked(bytes1(0xff), address(l2OptimismMintableERC20Factory), salt, keccak256(bytecode))
+        );
+        return address(uint160(uint256(hash)));
+    }
 }
 
 /// @title OptimismMintableERC20Factory_Constructor_Test
@@ -46,26 +66,6 @@ contract OptimismMintableERC20Factory_Initialize_Test is OptimismMintableERC20Fa
 /// @notice Tests the `createStandardL2Token` function of the `OptimismMintableERC20Factory`
 ///         contract.
 contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMintableERC20Factory_TestInit {
-    /// @notice Precalculates the address of the token contract.
-    function _calculateTokenAddress(
-        address _remote,
-        string memory _name,
-        string memory _symbol,
-        uint8 _decimals
-    )
-        internal
-        view
-        returns (address)
-    {
-        bytes memory constructorArgs = abi.encode(address(l2StandardBridge), _remote, _name, _symbol, _decimals);
-        bytes memory bytecode = abi.encodePacked(type(OptimismMintableERC20).creationCode, constructorArgs);
-        bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol, _decimals));
-        bytes32 hash = keccak256(
-            abi.encodePacked(bytes1(0xff), address(l2OptimismMintableERC20Factory), salt, keccak256(bytecode))
-        );
-        return address(uint160(uint256(hash)));
-    }
-
     /// @notice Test that calling `createStandardL2Token` with valid parameters succeeds.
     function test_createStandardL2Token_succeeds(
         address _caller,

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -14,41 +14,56 @@ import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC2
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 
-contract OptimismMintableTokenFactory_Test is CommonTest {
+/// @title OptimismMintableERC20Factory_TestInit
+/// @notice Reusable test initialization for `OptimismMintableERC20Factory` tests.
+contract OptimismMintableERC20Factory_TestInit is CommonTest {
     event StandardL2TokenCreated(address indexed remoteToken, address indexed localToken);
     event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
+}
 
+/// @title OptimismMintableERC20Factory_Constructor_Test
+/// @notice Tests the `constructor` function of the `OptimismMintableERC20Factory` contract.
+contract OptimismMintableERC20Factory_Constructor_Test is OptimismMintableERC20Factory_TestInit {
     /// @notice Tests that the constructor is initialized correctly.
     function test_constructor_succeeds() external {
         IOptimismMintableERC20Factory impl = IOptimismMintableERC20Factory(address(new OptimismMintableERC20Factory()));
         assertEq(address(impl.BRIDGE()), address(0));
         assertEq(address(impl.bridge()), address(0));
     }
+}
 
+/// @title OptimismMintableERC20Factory_Initialize_Test
+/// @notice Tests the `initialize` function of the `OptimismMintableERC20Factory` contract.
+contract OptimismMintableERC20Factory_Initialize_Test is OptimismMintableERC20Factory_TestInit {
     /// @notice Tests that the proxy is initialized correctly.
     function test_initialize_succeeds() external view {
         assertEq(address(l1OptimismMintableERC20Factory.BRIDGE()), address(l1StandardBridge));
         assertEq(address(l1OptimismMintableERC20Factory.bridge()), address(l1StandardBridge));
     }
+}
 
-    /// @notice Tests that the upgrade is successful.
-    function test_upgrading_succeeds() external {
-        IProxy proxy = IProxy(artifacts.mustGetAddress("OptimismMintableERC20FactoryProxy"));
-        // Check an unused slot before upgrading.
-        bytes32 slot21Before = vm.load(address(l1OptimismMintableERC20Factory), bytes32(uint256(21)));
-        assertEq(bytes32(0), slot21Before);
-
-        NextImpl nextImpl = new NextImpl();
-        vm.startPrank(EIP1967Helper.getAdmin(address(proxy)));
-        // Reviewer note: the NextImpl() still uses reinitializer. If we want to remove that, we'll need to use a
-        //   two step upgrade with the Storage lib.
-        proxy.upgradeToAndCall(address(nextImpl), abi.encodeCall(NextImpl.initialize, (2)));
-        assertEq(proxy.implementation(), address(nextImpl));
-
-        // Verify that the NextImpl contract initialized its values according as expected
-        bytes32 slot21After = vm.load(address(l1OptimismMintableERC20Factory), bytes32(uint256(21)));
-        bytes32 slot21Expected = NextImpl(address(l1OptimismMintableERC20Factory)).slot21Init();
-        assertEq(slot21Expected, slot21After);
+/// @title OptimismMintableERC20Factory_CreateStandardL2Token_Test
+/// @notice Tests the `createStandardL2Token` function of the `OptimismMintableERC20Factory`
+///         contract.
+contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMintableERC20Factory_TestInit {
+    /// @notice Precalculates the address of the token contract.
+    function _calculateTokenAddress(
+        address _remote,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    )
+        internal
+        view
+        returns (address)
+    {
+        bytes memory constructorArgs = abi.encode(address(l2StandardBridge), _remote, _name, _symbol, _decimals);
+        bytes memory bytecode = abi.encodePacked(type(OptimismMintableERC20).creationCode, constructorArgs);
+        bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol, _decimals));
+        bytes32 hash = keccak256(
+            abi.encodePacked(bytes1(0xff), address(l2OptimismMintableERC20Factory), salt, keccak256(bytecode))
+        );
+        return address(uint160(uint256(hash)));
     }
 
     /// @notice Test that calling `createStandardL2Token` with valid parameters succeeds.
@@ -83,7 +98,8 @@ contract OptimismMintableTokenFactory_Test is CommonTest {
         assertEq(l2OptimismMintableERC20Factory.deployments(local), _remoteToken);
     }
 
-    /// @notice Test that calling `createOptimismMintableERC20WithDecimals` with valid parameters succeeds.
+    /// @notice Test that calling `createOptimismMintableERC20WithDecimals` with valid parameters
+    ///         succeeds.
     function test_createStandardL2TokenWithDecimals_succeeds(
         address _caller,
         address _remoteToken,
@@ -140,7 +156,8 @@ contract OptimismMintableTokenFactory_Test is CommonTest {
         l2OptimismMintableERC20Factory.createStandardL2Token(_remoteToken, _name, _symbol);
     }
 
-    /// @notice Test that calling `createStandardL2TokenWithDecimals` with the same parameters twice reverts.
+    /// @notice Test that calling `createStandardL2TokenWithDecimals` with the same parameters
+    ///         twice reverts.
     function test_createStandardL2TokenWithDecimals_sameTwice_reverts(
         address _caller,
         address _remoteToken,
@@ -181,7 +198,8 @@ contract OptimismMintableTokenFactory_Test is CommonTest {
         l2OptimismMintableERC20Factory.createStandardL2Token(remote, _name, _symbol);
     }
 
-    /// @notice Test that calling `createStandardL2TokenWithDecimals` with a zero remote token address reverts.
+    /// @notice Test that calling `createStandardL2TokenWithDecimals` with a zero remote token
+    ///         address reverts.
     function test_createStandardL2TokenWithDecimals_remoteIsZero_reverts(
         address _caller,
         string memory _name,
@@ -198,24 +216,29 @@ contract OptimismMintableTokenFactory_Test is CommonTest {
         vm.prank(_caller);
         l2OptimismMintableERC20Factory.createOptimismMintableERC20WithDecimals(remote, _name, _symbol, _decimals);
     }
+}
 
-    /// @notice Precalculates the address of the token contract.
-    function _calculateTokenAddress(
-        address _remote,
-        string memory _name,
-        string memory _symbol,
-        uint8 _decimals
-    )
-        internal
-        view
-        returns (address)
-    {
-        bytes memory constructorArgs = abi.encode(address(l2StandardBridge), _remote, _name, _symbol, _decimals);
-        bytes memory bytecode = abi.encodePacked(type(OptimismMintableERC20).creationCode, constructorArgs);
-        bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol, _decimals));
-        bytes32 hash = keccak256(
-            abi.encodePacked(bytes1(0xff), address(l2OptimismMintableERC20Factory), salt, keccak256(bytecode))
-        );
-        return address(uint160(uint256(hash)));
+/// @title OptimismMintableERC20Factory_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the
+///         `OptimismMintableERC20Factory` contract.
+contract OptimismMintableERC20Factory_Unclassified_Test is OptimismMintableERC20Factory_TestInit {
+    /// @notice Tests that the upgrade is successful.
+    function test_upgrading_succeeds() external {
+        IProxy proxy = IProxy(artifacts.mustGetAddress("OptimismMintableERC20FactoryProxy"));
+        // Check an unused slot before upgrading.
+        bytes32 slot21Before = vm.load(address(l1OptimismMintableERC20Factory), bytes32(uint256(21)));
+        assertEq(bytes32(0), slot21Before);
+
+        NextImpl nextImpl = new NextImpl();
+        vm.startPrank(EIP1967Helper.getAdmin(address(proxy)));
+        // Reviewer note: the NextImpl() still uses reinitializer. If we want to remove that, we'll
+        // need to use a two step upgrade with the Storage lib.
+        proxy.upgradeToAndCall(address(nextImpl), abi.encodeCall(NextImpl.initialize, (2)));
+        assertEq(proxy.implementation(), address(nextImpl));
+
+        // Verify that the NextImpl contract initialized its values according as expected
+        bytes32 slot21After = vm.load(address(l1OptimismMintableERC20Factory), bytes32(uint256(21)));
+        bytes32 slot21Expected = NextImpl(address(l1OptimismMintableERC20Factory)).slot21Init();
+        assertEq(slot21Expected, slot21After);
     }
 }

--- a/packages/contracts-bedrock/test/universal/ReinitializableBase.t.sol
+++ b/packages/contracts-bedrock/test/universal/ReinitializableBase.t.sol
@@ -7,7 +7,16 @@ import { Test } from "forge-std/Test.sol";
 // Contracts
 import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";
 
-contract ReinitializableBase_Test is Test {
+/// @title ReinitializableBase_Harness
+/// @notice Harness contract to allow direct instantiation and testing of `ReinitializableBase`
+///         logic.
+contract ReinitializableBase_Harness is ReinitializableBase {
+    constructor(uint8 _initVersion) ReinitializableBase(_initVersion) { }
+}
+
+/// @title ReinitializableBase_InitVersion_Test
+/// @notice Tests the `initVersion` function of the `ReinitializableBase` contract.
+contract ReinitializableBase_InitVersion_Test is Test {
     /// @notice Tests that the contract is created correctly and initVersion returns the right
     ///         value when the provided init version is non-zero.
     /// @param _initVersion The init version to use when creating the contract.
@@ -21,16 +30,10 @@ contract ReinitializableBase_Test is Test {
         // Check the init version.
         assertEq(harness.initVersion(), _initVersion);
     }
-}
 
-contract ReinitializableBase_TestFail is Test {
     /// @notice Tests that the contract creation reverts when the init version is zero.
     function test_initVersion_zeroVersion_reverts() public {
         vm.expectRevert(ReinitializableBase.ReinitializableBase_ZeroInitVersion.selector);
         new ReinitializableBase_Harness(0);
     }
-}
-
-contract ReinitializableBase_Harness is ReinitializableBase {
-    constructor(uint8 _initVersion) ReinitializableBase(_initVersion) { }
 }

--- a/packages/contracts-bedrock/test/universal/SafeSend.t.sol
+++ b/packages/contracts-bedrock/test/universal/SafeSend.t.sol
@@ -4,9 +4,11 @@ pragma solidity 0.8.15;
 import { SafeSend } from "src/universal/SafeSend.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-contract SafeSendTest is CommonTest {
+/// @title SafeSend_Constructor_Test
+/// @notice Tests the `constructor` function of the `SafeSend` contract.
+contract SafeSend_Constructor_Test is CommonTest {
     /// @notice Tests that sending to an EOA succeeds.
-    function test_send_toEOA_succeeds() public {
+    function test_constructor_toEOA_succeeds() public {
         assertNotEq(alice, address(0));
         assertNotEq(bob, address(0));
         assertEq(bob.code.length, 0);
@@ -25,10 +27,9 @@ contract SafeSendTest is CommonTest {
         assertEq(bob.balance, bobBalanceBefore + 100 ether);
     }
 
-    /// @notice Tests that sending to a contract succeeds without executing the
-    ///         contract's code.
-    function test_send_toContract_succeeds() public {
-        // etch reverting code into bob
+    /// @notice Tests that sending to a contract succeeds without executing the contract's code
+    function test_constructor_toContract_succeeds() public {
+        // Etch reverting code into bob
         vm.etch(bob, hex"fe");
         vm.deal(alice, 100 ether);
 


### PR DESCRIPTION
This PR refactors a portion of the test suite within the `/universal` folder as part of a broader effort to standardize structure, documentation, and formatting across the codebase.

### Changes applied to each file:
- Consolidated shared test initialization into dedicated `*_TestInit` contracts
- Organized test functions into logically separated contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to all test contracts
- Refactor test function names to follow naming convention
- Replaced `@dev` tags with `@notice` where appropriate
- Enforced a 100-character limit for inline comments

### Progress

Refactored 9 of 9 test files (**100.0% complete**)

Note: `Specs.t.sol` will be refactored in a later PR.

- [x] `CrossDomainMessenger.t.sol`
- [x] `ExtendedPause.t.sol`
- [x] `OptimismMintableERC20.t.sol`
- [x] `OptimismMintableERC20Factory.t.sol`
- [x] `Proxy.t.sol`
- [x] `ProxyAdmin.t.sol`
- [x] `ReinitializableBase.t.sol`
- [x] `SafeSend.t.sol`
- `Specs.t.sol`
- [x] `StandardBridge.t.sol`