### PR TITLE
feat(op-acceptance-tests): base; deposit flow

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -1,0 +1,80 @@
+package deposit
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/lmittmann/w3"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithMinimal())
+}
+
+func TestL1ToL2Deposit(gt *testing.T) {
+	// Create a test environment using op-devstack
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	// Wait for L1 node to be responsive
+	sys.L1Network.WaitForOnline()
+
+	// Fund Alice on L1
+	fundingAmount := eth.ThousandEther
+	alice := sys.FunderL1.NewFundedEOA(fundingAmount)
+	alice.VerifyBalanceExact(fundingAmount)
+
+	alicel2 := dsl.NewEOA(alice.Key(), sys.L2EL)
+
+	// Get the optimism portal address
+	rollupConfig := sys.L2Chain.Escape().RollupConfig()
+	portalAddr := rollupConfig.DepositContractAddress
+
+	depositAmount := eth.OneEther
+
+	// Define the deposit function and encode arguments
+	// TODO: Redo this when the new DSL (#16079) is merged
+	funcDeposit := w3.MustNewFunc(`depositTransaction(address,uint256,uint64,bool,bytes)`, "")
+	args, err := funcDeposit.EncodeArgs(
+		alice.Address(),       // _to
+		depositAmount.ToBig(), // _value
+		uint64(300_000),       // _gasLimit
+		false,                 // _isCreation
+		[]byte{},              // _data
+	)
+	require.NoError(t, err)
+
+	// Create and confirm the transaction (awaits tx inclusion and checks success status)
+	tx := alice.Transact(
+		alice.Plan(),
+		txplan.WithGasLimit(500_000),
+		txplan.WithTo(&portalAddr),
+		txplan.WithData(args),
+		txplan.WithValue(depositAmount.ToBig()))
+
+	receipt := tx.Included.Value()
+	gasPrice := receipt.EffectiveGasPrice // bugfix: use the exact price that was charged
+
+	// Verify the deposit was successful
+	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), gasPrice)
+	expectedFinalL1 := new(big.Int).Sub(fundingAmount.ToBig(), depositAmount.ToBig())
+	expectedFinalL1.Sub(expectedFinalL1, gasCost)
+
+	alice.VerifyBalanceExact(eth.WeiBig(expectedFinalL1))
+
+	// Wait for the sequencer to process the deposit
+	t.Require().Eventually(func() bool {
+		head := sys.L2CL.HeadBlockRef(supervisorTypes.LocalUnsafe)
+		return head.L1Origin.Number >= receipt.BlockNumber.Uint64()
+	}, time.Second*10, time.Second, "awaiting deposit to be processed by L2")
+	alicel2.VerifyBalanceExact(depositAmount)
+}

--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -33,7 +32,7 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	alice := sys.FunderL1.NewFundedEOA(fundingAmount)
 	alice.VerifyBalanceExact(fundingAmount)
 
-	alicel2 := dsl.NewEOA(alice.Key(), sys.L2EL)
+	alicel2 := alice.AsEL(sys.L2EL)
 
 	// Get the optimism portal address
 	rollupConfig := sys.L2Chain.Escape().RollupConfig()

--- a/op-acceptance-tests/tests/base/init_test.go
+++ b/op-acceptance-tests/tests/base/init_test.go
@@ -9,5 +9,4 @@ import (
 // TestMain creates the test-setups against the shared backend
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithMinimal())
-
 }

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -33,10 +33,46 @@ func (el *elNode) ChainID() eth.ChainID {
 }
 
 func (el *elNode) WaitForBlock() eth.BlockRef {
+	return el.waitForNextBlock(1)
+}
+
+func (el *elNode) WaitForFinalization() eth.BlockRef {
+	// Get current block and wait for it to be finalized
+	currentBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Finalized)
+	el.require.NoError(err, "Expected to get current block from execution client")
+
+	var finalizedBlock eth.BlockRef
+	el.require.Eventually(func() bool {
+		el.log.Info("Waiting for finalization")
+		block, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Finalized)
+		if err != nil {
+			return false
+		}
+		if block.NumberU64() > currentBlock.NumberU64() {
+			finalizedBlock = eth.InfoToL1BlockRef(block)
+			return true
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "Expected to be online")
+	return finalizedBlock
+}
+
+func (el *elNode) WaitForOnline() {
+	el.require.Eventually(func() bool {
+		el.log.Info("Waiting for online")
+		_, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Unsafe)
+		return err == nil
+	}, 10*time.Second, 500*time.Millisecond, "Expected to be online")
+}
+
+// waitForNextBlockWithTimeout waits until the specified block number is present
+func (el *elNode) waitForNextBlock(blocksFromNow uint64) eth.BlockRef {
 	initial, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Unsafe)
 	el.require.NoError(err, "Expected to get latest block from execution client")
+	targetBlock := initial.NumberU64() + blocksFromNow
 	initialRef := eth.InfoToL1BlockRef(initial)
 	var newRef eth.BlockRef
+
 	err = wait.For(el.ctx, 500*time.Millisecond, func() (bool, error) {
 		newBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Unsafe)
 		if err != nil {
@@ -44,15 +80,20 @@ func (el *elNode) WaitForBlock() eth.BlockRef {
 		}
 
 		newRef = eth.InfoToL1BlockRef(newBlock)
+		if newBlock.NumberU64() >= targetBlock {
+			el.log.Info("Target block reached", "block", newRef)
+			return true, nil
+		}
+
 		if initialRef == newRef {
 			el.log.Info("Still same block detected as initial", "block", initialRef)
 			return false, nil
+		} else {
+			el.log.Info("New block detected", "new_block", newRef, "prev_block", initialRef)
 		}
-
-		el.log.Info("New block detected", "new_block", newRef, "prev_block", initialRef)
-		return true, nil
+		return false, nil
 	})
-	el.require.NoError(err, "Expected to get latest block from execution client for comparison")
+	el.require.NoError(err, "Expected to reach target block")
 	return newRef
 }
 

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -36,27 +36,6 @@ func (el *elNode) WaitForBlock() eth.BlockRef {
 	return el.waitForNextBlock(1)
 }
 
-func (el *elNode) WaitForFinalization() eth.BlockRef {
-	// Get current block and wait for it to be finalized
-	currentBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Finalized)
-	el.require.NoError(err, "Expected to get current block from execution client")
-
-	var finalizedBlock eth.BlockRef
-	el.require.Eventually(func() bool {
-		el.log.Info("Waiting for finalization")
-		block, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Finalized)
-		if err != nil {
-			return false
-		}
-		if block.NumberU64() > currentBlock.NumberU64() {
-			finalizedBlock = eth.InfoToL1BlockRef(block)
-			return true
-		}
-		return false
-	}, 30*time.Second, 500*time.Millisecond, "Expected to be online")
-	return finalizedBlock
-}
-
 func (el *elNode) WaitForOnline() {
 	el.require.Eventually(func() bool {
 		el.log.Info("Waiting for online")

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -36,6 +36,10 @@ func NewEOA(key *Key, el ELNode) *EOA {
 	}
 }
 
+func (u *EOA) AsEL(el ELNode) *EOA {
+	return NewEOA(u.key, el)
+}
+
 func (u *EOA) String() string {
 	return fmt.Sprintf("EOA(%s @ %s)", u.key.Address(), u.el.ChainID())
 }

--- a/op-devstack/dsl/key.go
+++ b/op-devstack/dsl/key.go
@@ -47,3 +47,8 @@ func (a *Key) Plan() txplan.Option {
 func (a *Key) User(el ELNode) *EOA {
 	return NewEOA(a, el)
 }
+
+// PrivateKey returns the private key for this key.
+func (a *Key) PrivateKey() *ecdsa.PrivateKey {
+	return a.priv
+}

--- a/op-devstack/dsl/key.go
+++ b/op-devstack/dsl/key.go
@@ -47,8 +47,3 @@ func (a *Key) Plan() txplan.Option {
 func (a *Key) User(el ELNode) *EOA {
 	return NewEOA(a, el)
 }
-
-// PrivateKey returns the private key for this key.
-func (a *Key) PrivateKey() *ecdsa.PrivateKey {
-	return a.priv
-}

--- a/op-devstack/dsl/l1_network.go
+++ b/op-devstack/dsl/l1_network.go
@@ -59,3 +59,11 @@ func (n *L1Network) PrintChain() {
 	n.log.Info("Printing block hashes and parent hashes", "network", n.String(), "chain", n.ChainID())
 	spew.Dump(entries)
 }
+
+func (n *L1Network) WaitForFinalization() {
+	NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForFinalization()
+}
+
+func (n *L1Network) WaitForOnline() {
+	NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForOnline()
+}

--- a/op-devstack/dsl/l1_network.go
+++ b/op-devstack/dsl/l1_network.go
@@ -60,10 +60,6 @@ func (n *L1Network) PrintChain() {
 	spew.Dump(entries)
 }
 
-func (n *L1Network) WaitForFinalization() {
-	NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForFinalization()
-}
-
 func (n *L1Network) WaitForOnline() {
 	NewL1ELNode(n.inner.L1ELNode(match.FirstL1EL)).WaitForOnline()
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -40,11 +40,13 @@ type SimpleInterop struct {
 
 	Wallet *dsl.HDWallet
 
-	FaucetA *dsl.Faucet
-	FaucetB *dsl.Faucet
+	FaucetA  *dsl.Faucet
+	FaucetB  *dsl.Faucet
+	FaucetL1 *dsl.Faucet
 
-	FunderA *dsl.Funder
-	FunderB *dsl.Funder
+	FunderL1 *dsl.Funder
+	FunderA  *dsl.Funder
+	FunderB  *dsl.Funder
 }
 
 func (s *SimpleInterop) L2Networks() []*dsl.L2Network {
@@ -94,6 +96,8 @@ func NewSimpleInterop(t devtest.T) *SimpleInterop {
 		L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
 		L2BatcherB:    dsl.NewL2Batcher(l2B.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
 	}
+	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
+	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
 	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
 	out.FunderB = dsl.NewFunder(out.Wallet, out.FaucetB, out.L2ELB)
 	return out


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We'd like to verify a complete deposit flow from L1 to L2, including transaction finality and correct token balances.

This is roughly equivalent to:

```
cast send --rpc-url $ETH_L1_RPC --value 1ether --private-key $USER_PRIVATE_KEY $OPTIMISM_PORTAL_PROXY_ADDR
# wait 1m
cast balance --rpc-url $DEVNET_PUBLIC_RPC_URL $USER_ADDR
```

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

Adds a new deposit test using op-devstack.

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

The test is manually crafting a transaction as the OptimismPortal warpper requires a geth client and our EthClient is not a full implementation of such. We would need to expose a geth client or the RPC endpoint in order to use the existing wrapper or create a new wrapper for op-devstack.

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
