### PR TITLE
feat(test): add CL RPC endpoint + name to devnet-sdk nodes

### DIFF
--- a/devnet-sdk/system/chain.go
+++ b/devnet-sdk/system/chain.go
@@ -189,7 +189,17 @@ func newNodesFromDescriptor(d *descriptors.Chain) []Node {
 		if rpc.Scheme == "" {
 			rpc.Scheme = "http"
 		}
-		nodes[i] = newNode(fmt.Sprintf("%s://%s:%d", rpc.Scheme, rpc.Host, rpc.Port), name, clients)
+
+		clSvc := node.Services["cl"]
+		clName := clSvc.Name
+
+		// Note: it seems that for CL endpoints, the service that serves the RPC endpoint is using HTTP by default in kurtosis.
+		clRpc := clSvc.Endpoints["rpc"]
+		if clRpc.Scheme == "" {
+			clRpc.Scheme = "http"
+		}
+
+		nodes[i] = newNode(fmt.Sprintf("%s://%s:%d", rpc.Scheme, rpc.Host, rpc.Port), name, fmt.Sprintf("%s://%s:%d", clRpc.Scheme, clRpc.Host, clRpc.Port), clName, clients)
 	}
 	return nodes
 }

--- a/devnet-sdk/system/chain_test.go
+++ b/devnet-sdk/system/chain_test.go
@@ -58,6 +58,14 @@ func TestChainFromDescriptor(t *testing.T) {
 							},
 						},
 					},
+					"cl": &descriptors.Service{
+						Endpoints: descriptors.EndpointMap{
+							"http": &descriptors.PortInfo{
+								Host: "localhost",
+								Port: 8543,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -76,6 +84,7 @@ func TestChainFromDescriptor(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, chain)
 	assert.Equal(t, "http://localhost:8545", chain.Nodes()[0].RPCURL())
+	assert.Equal(t, "http://localhost:8543", chain.Nodes()[0].CLRPC())
 
 	// Compare the underlying big.Int values
 	chainID := chain.ID()
@@ -95,6 +104,14 @@ func TestL2ChainFromDescriptor(t *testing.T) {
 								"rpc": &descriptors.PortInfo{
 									Host: "localhost",
 									Port: 8545,
+								},
+							},
+						},
+						"cl": &descriptors.Service{
+							Endpoints: descriptors.EndpointMap{
+								"http": &descriptors.PortInfo{
+									Host: "localhost",
+									Port: 8543,
 								},
 							},
 						},
@@ -126,6 +143,7 @@ func TestL2ChainFromDescriptor(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, chain)
 	assert.Equal(t, "http://localhost:8545", chain.Nodes()[0].RPCURL())
+	assert.Equal(t, "http://localhost:8543", chain.Nodes()[0].CLRPC())
 
 	// Compare the underlying big.Int values
 	chainID := chain.ID()

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -47,12 +47,14 @@ type L2Chain interface {
 
 type Node interface {
 	Name() string
+	CLName() string
 	GasPrice(ctx context.Context) (*big.Int, error)
 	GasLimit(ctx context.Context, tx TransactionData) (uint64, error)
 	PendingNonceAt(ctx context.Context, address common.Address) (uint64, error)
 	BlockByNumber(ctx context.Context, number *big.Int) (eth.BlockInfo, error)
 	ContractsRegistry() interfaces.ContractsRegistry
 	SupportsEIP(ctx context.Context, eip uint64) bool
+	CLRPC() string
 	RPCURL() string
 	Client() (*sources.EthClient, error)
 	GethClient() (*ethclient.Client, error)

--- a/devnet-sdk/system/node.go
+++ b/devnet-sdk/system/node.go
@@ -23,13 +23,15 @@ var (
 type node struct {
 	rpcUrl   string
 	name     string
+	clRpcUrl string
+	clName   string
 	clients  *clientManager
 	mu       sync.Mutex
 	registry interfaces.ContractsRegistry
 }
 
-func newNode(rpcUrl string, name string, clients *clientManager) *node {
-	return &node{rpcUrl: rpcUrl, name: name, clients: clients}
+func newNode(rpcUrl string, name string, clRpcUrl string, clName string, clients *clientManager) *node {
+	return &node{rpcUrl: rpcUrl, name: name, clRpcUrl: clRpcUrl, clName: clName, clients: clients}
 }
 
 func (n *node) GasPrice(ctx context.Context) (*big.Int, error) {
@@ -112,6 +114,14 @@ func (n *node) ContractsRegistry() interfaces.ContractsRegistry {
 
 func (n *node) RPCURL() string {
 	return n.rpcUrl
+}
+
+func (n *node) CLRPC() string {
+	return n.clRpcUrl
+}
+
+func (n *node) CLName() string {
+	return n.clName
 }
 
 func (n *node) SupportsEIP(ctx context.Context, eip uint64) bool {

--- a/devnet-sdk/system/system_test.go
+++ b/devnet-sdk/system/system_test.go
@@ -32,6 +32,15 @@ func TestNewSystemFromEnv(t *testing.T) {
 							},
 						},
 					},
+					"cl": {
+						Name: "lighthouse",
+						Endpoints: descriptors.EndpointMap{
+							"http": &descriptors.PortInfo{
+								Host: "localhost",
+								Port: 8543,
+							},
+						},
+					},
 				},
 			}},
 			Wallets: descriptors.WalletMap{
@@ -56,6 +65,15 @@ func TestNewSystemFromEnv(t *testing.T) {
 									"rpc": &descriptors.PortInfo{
 										Host: "localhost",
 										Port: 8546,
+									},
+								},
+							},
+							"cl": {
+								Name: "op-node",
+								Endpoints: descriptors.EndpointMap{
+									"http": &descriptors.PortInfo{
+										Host: "localhost",
+										Port: 8543,
 									},
 								},
 							},
@@ -103,6 +121,15 @@ func TestSystemFromDevnet(t *testing.T) {
 					"rpc": &descriptors.PortInfo{
 						Host: "localhost",
 						Port: 8545,
+					},
+				},
+			},
+			"cl": {
+				Name: "op-node",
+				Endpoints: descriptors.EndpointMap{
+					"http": &descriptors.PortInfo{
+						Host: "localhost",
+						Port: 8543,
 					},
 				},
 			},

--- a/devnet-sdk/system/txbuilder_test.go
+++ b/devnet-sdk/system/txbuilder_test.go
@@ -182,12 +182,22 @@ func (m *mockNode) RPCURL() string {
 	return args.Get(0).(string)
 }
 
+func (m *mockNode) CLRPC() string {
+	args := m.Called()
+	return args.Get(0).(string)
+}
+
 func (m *mockNode) SupportsEIP(ctx context.Context, eip uint64) bool {
 	args := m.Called(ctx, eip)
 	return args.Bool(0)
 }
 
 func (m *mockNode) Name() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *mockNode) CLName() string {
 	args := m.Called()
 	return args.String(0)
 }

--- a/devnet-sdk/testing/testlib/validators/validators_test.go
+++ b/devnet-sdk/testing/testlib/validators/validators_test.go
@@ -320,11 +320,19 @@ func (m *mockNode) RPCURL() string {
 	return ""
 }
 
+func (m *mockNode) CLRPC() string {
+	return ""
+}
+
 func (m *mockNode) ContractsRegistry() interfaces.ContractsRegistry {
 	return nil
 }
 
 func (m *mockNode) Name() string {
+	return "mock"
+}
+
+func (m *mockNode) CLName() string {
 	return "mock"
 }
 

--- a/op-acceptance-tests/tests/interop/mocks_test.go
+++ b/op-acceptance-tests/tests/interop/mocks_test.go
@@ -187,6 +187,8 @@ func (m *mockFailingNode) SupportsEIP(ctx context.Context, eip uint64) bool {
 	return true
 }
 func (m *mockFailingNode) RPCURL() string                                  { return "mock://failing" }
+func (m *mockFailingNode) CLRPC() string                                   { return "mock://failing" }
+func (m *mockFailingNode) CLName() string                                  { return "mock" }
 func (m *mockFailingNode) ContractsRegistry() interfaces.ContractsRegistry { return m.reg }
 func (m *mockFailingNode) GethClient() (*ethclient.Client, error) {
 	return nil, fmt.Errorf("not implemented")

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -144,6 +144,10 @@ func DeployConfig(allocType AllocType) *genesis.DeployConfig {
 }
 
 func init() {
+	// Used by the rust team, to skip legacy op-e2e init. Not used by devstack acceptance tests.
+	if os.Getenv("DISABLE_OP_E2E_LEGACY") == "true" {
+		return
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Description

This PR adds a couple of methods to the `Node` interface in the `devnet-sdk` to ensure that we can query consensus clients through RPC. In particular, this PR:

- Adds the `CLName` method to retrieve the name of a consensus layer node given a `Node` struct.
- Adds the `CLRPC` method to retrieve the RPC endpoint of a consensus layer node given a `Node` struct.
- Implements the `CLName` and `CLRPC` methods for every implementor of the `Node` interface

## Motivation

This will be used inside [kona](https://github.com/op-rs/kona) (rust consensus client for the OP-stack) to write integration tests using the `devnet-sdk`.