### PR TITLE
op-chain-ops: Add withdrawal helpers

### DIFF
--- a/op-chain-ops/cmd/withdrawal/README.md
+++ b/op-chain-ops/cmd/withdrawal/README.md
@@ -1,0 +1,37 @@
+# withdrawal
+
+The `withdrawal` tool provides utilities for performing withdrawals from an OP Stack.
+
+All subcommands support the
+
+## Usage
+
+### init
+
+The `init` subcommand supports sending a basic transaction to the `L2ToL1MessagePasser` contract to initiate a
+withdrawal.
+
+```shell
+go run . init --l2 <l2-el-rpc> --private-key <private-key> [--value <wei>]
+```
+
+On success, the withdrawal transaction hash is reported which can be used with the `prove` and `finalize` subcommands
+to complete the withdrawal.
+
+### prove
+
+The `prove` subcommand proves the withdrawal transaction against a published output root. It must be called after a
+valid proposal is made for a L2 block at or after the initiating transaction was included.
+
+```shell
+go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>
+```
+
+### finalize
+
+The `finalize` subcommand finalizes a withdrawal that has previously been proven. The dispute game must have resolved as
+defender wins and the air gap period for the game and withdrawal proof must have elapsed. Normally this takes 7 days.
+
+```shell
+go run . finalize --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>
+```

--- a/op-chain-ops/cmd/withdrawal/finalize.go
+++ b/op-chain-ops/cmd/withdrawal/finalize.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
+	"github.com/urfave/cli/v2"
+)
+
+func FinalizeWithdrawal(ctx *cli.Context) error {
+	logger, err := setupLogging(ctx)
+	if err != nil {
+		return err
+	}
+
+	txMgr, err := createTxMgr(ctx, logger, L1Flag.Name)
+	if err != nil {
+		return err
+	}
+
+	txHash := common.HexToHash(ctx.String(TxFlag.Name))
+	if txHash == (common.Hash{}) {
+		return errors.New("must specify tx hash")
+	}
+
+	rpcClient, err := rpc.DialContext(ctx.Context, ctx.String(L2Flag.Name))
+	if err != nil {
+		return fmt.Errorf("failed to connect to L2: %w", err)
+	}
+	l2Client := ethclient.NewClient(rpcClient)
+
+	rcpt, err := l2Client.TransactionReceipt(ctx.Context, txHash)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction receipt: %w", err)
+	}
+	msgEvent, err := withdrawals.ParseMessagePassed(rcpt)
+	if err != nil {
+		return fmt.Errorf("failed to parse message: %w", err)
+	}
+
+	portalAddr := common.HexToAddress(ctx.String(PortalAddressFlag.Name))
+	txData, err := w3.MustNewFunc("finalizeWithdrawalTransaction((uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data))", "").EncodeArgs(
+		bindingspreview.TypesWithdrawalTransaction{
+			Nonce:    msgEvent.Nonce,
+			Sender:   msgEvent.Sender,
+			Target:   msgEvent.Target,
+			Value:    msgEvent.Value,
+			GasLimit: msgEvent.GasLimit,
+			Data:     msgEvent.Data,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to pack finalizeWithdrawalTransaction: %w", err)
+	}
+
+	rcpt, err = txMgr.Send(ctx.Context, txmgr.TxCandidate{
+		TxData: txData,
+		To:     &portalAddr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to prove withdrawal: %w", err)
+	}
+	logger.Info("Finalized withdrawal", "tx", rcpt.TxHash.Hex())
+	return nil
+}
+
+func finalizeFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		L1Flag,
+		L2Flag,
+		TxFlag,
+		PortalAddressFlag,
+	}
+	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(EnvVarPrefix)...)
+	return cliFlags
+}
+
+var FinalizeCommand = &cli.Command{
+	Name:   "finalize",
+	Usage:  "Finalize a proven withdrawal on the L1",
+	Action: interruptible(FinalizeWithdrawal),
+	Flags:  finalizeFlags(),
+}

--- a/op-chain-ops/cmd/withdrawal/init.go
+++ b/op-chain-ops/cmd/withdrawal/init.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	op_service "github.com/ethereum-optimism/optimism/op-service"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	L2Flag = &cli.StringFlag{
+		Name:    "l2",
+		Usage:   "HTTP provider URL for L2.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "L2"),
+	}
+	ValueFlag = &cli.StringFlag{
+		Name:    "value",
+		Usage:   "Value to send with withdrawal",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "VALUE"),
+		Value:   "1",
+	}
+)
+
+func InitWithdrawal(ctx *cli.Context) error {
+	logger, err := setupLogging(ctx)
+	if err != nil {
+		return err
+	}
+	txMgrConfig := txmgr.ReadCLIConfig(ctx)
+	txMgrConfig.L1RPCURL = ctx.String(L2Flag.Name)
+
+	txMgr, err := createTxMgr(ctx, logger, L2Flag.Name)
+	if err != nil {
+		return err
+	}
+
+	valueStr := ctx.String(ValueFlag.Name)
+	value, ok := new(big.Int).SetString(valueStr, 10)
+	if !ok {
+		return fmt.Errorf("invalid value: %s", valueStr)
+	}
+
+	rcpt, err := txMgr.Send(ctx.Context, txmgr.TxCandidate{
+		To:    &predeploys.L2ToL1MessagePasserAddr,
+		Value: value,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send withdrawal transaction: %w", err)
+	}
+	// Force printing full hashes
+	logger.Info("Send withdrawal", "tx", rcpt.TxHash.Hex(), "blockHash", rcpt.BlockHash.Hex(), "blockNumber", rcpt.BlockNumber)
+	return nil
+}
+
+func initFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		L2Flag,
+		ValueFlag,
+	}
+	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(EnvVarPrefix)...)
+	return cliFlags
+}
+
+var InitCommand = &cli.Command{
+	Name:   "init",
+	Usage:  "Initiates a withdrawal on the L2",
+	Action: interruptible(InitWithdrawal),
+	Flags:  initFlags(),
+}

--- a/op-chain-ops/cmd/withdrawal/main.go
+++ b/op-chain-ops/cmd/withdrawal/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Name = "withdrawal"
+	app.Usage = "Tool to perform withdrawals from OP Stack chains"
+	app.Commands = []*cli.Command{
+		InitCommand,
+		ProveCommand,
+		FinalizeCommand,
+	}
+	app.Action = func(c *cli.Context) error {
+		return cli.ShowAppHelp(c)
+	}
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		log.Crit("Application failed", "err", err)
+	}
+}

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/bindings"
+	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	L1Flag = &cli.StringFlag{
+		Name:    "l1",
+		Usage:   "HTTP provider URL for L1.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "L1"),
+	}
+	TxFlag = &cli.StringFlag{
+		Name:    "tx",
+		Usage:   "Transaction hash of withdrawal on L2",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "TX"),
+	}
+	PortalAddressFlag = &cli.StringFlag{
+		Name:    "portal-address",
+		Usage:   "Address of the optimism portal contract.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "PORTAL_ADDRESS"),
+	}
+)
+
+func ProveWithdrawal(ctx *cli.Context) error {
+	logger, err := setupLogging(ctx)
+	if err != nil {
+		return err
+	}
+
+	txMgr, err := createTxMgr(ctx, logger, L1Flag.Name)
+	if err != nil {
+		return err
+	}
+
+	txHash := common.HexToHash(ctx.String(TxFlag.Name))
+	if txHash == (common.Hash{}) {
+		return errors.New("must specify tx hash")
+	}
+
+	rpcClient, err := rpc.DialContext(ctx.Context, ctx.String(L2Flag.Name))
+	if err != nil {
+		return fmt.Errorf("failed to connect to L2: %w", err)
+	}
+	proofClient := gethclient.New(rpcClient)
+	l2Client := ethclient.NewClient(rpcClient)
+
+	l1Client, err := ethclient.DialContext(ctx.Context, ctx.String(L1Flag.Name))
+	if err != nil {
+		return fmt.Errorf("failed to connect to L1: %w", err)
+	}
+
+	rcpt, err := l2Client.TransactionReceipt(ctx.Context, txHash)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction receipt: %w", err)
+	}
+
+	portalAddr := common.HexToAddress(ctx.String(PortalAddressFlag.Name))
+	portal, err := bindingspreview.NewOptimismPortal2(portalAddr, l1Client)
+	if err != nil {
+		return fmt.Errorf("failed to bind portal: %w", err)
+	}
+	factoryAddr, err := portal.DisputeGameFactory(&bind.CallOpts{Context: ctx.Context})
+	if err != nil {
+		return fmt.Errorf("failed to fetch dispute game factory address from portal: %w", err)
+	}
+
+	factory, err := bindings.NewDisputeGameFactoryCaller(factoryAddr, l1Client)
+	if err != nil {
+		return fmt.Errorf("failed to bind dispute game factory: %w", err)
+	}
+
+	_, err = wait.ForGamePublished(ctx.Context, l1Client, portalAddr, factoryAddr, rcpt.BlockNumber)
+	if err != nil {
+		return fmt.Errorf("could not find a dispute game at or above l2 block number %v: %w", rcpt.BlockNumber, err)
+	}
+
+	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(ctx.Context, proofClient, l2Client, l2Client, txHash, factory, &portal.OptimismPortal2Caller)
+	if err != nil {
+		return fmt.Errorf("could not create withdrawal proof parameters: %w", err)
+	}
+
+	txData, err := w3.MustNewFunc("proveWithdrawalTransaction("+
+		"(uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data),"+
+		"uint256,"+
+		"(bytes32 Version, bytes32 StateRoot, bytes32 MessagePasserStorageRoot, bytes32 LatestBlockhash),"+
+		"bytes[])", "").EncodeArgs(
+		bindingspreview.TypesWithdrawalTransaction{
+			Nonce:    params.Nonce,
+			Sender:   params.Sender,
+			Target:   params.Target,
+			Value:    params.Value,
+			GasLimit: params.GasLimit,
+			Data:     params.Data,
+		},
+		params.L2OutputIndex,
+		params.OutputRootProof,
+		params.WithdrawalProof,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to pack withdrawal transaction: %w", err)
+	}
+
+	rcpt, err = txMgr.Send(ctx.Context, txmgr.TxCandidate{
+		TxData: txData,
+		To:     &portalAddr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to prove withdrawal: %w", err)
+	}
+
+	logger.Info("Proved withdrawal", "tx", rcpt.TxHash.Hex())
+	return nil
+}
+
+func proveFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		L1Flag,
+		L2Flag,
+		TxFlag,
+		PortalAddressFlag,
+	}
+	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(EnvVarPrefix)...)
+	return cliFlags
+}
+
+var ProveCommand = &cli.Command{
+	Name:   "prove",
+	Usage:  "Prove a withdrawal on the L1",
+	Action: interruptible(ProveWithdrawal),
+	Flags:  proveFlags(),
+}

--- a/op-chain-ops/cmd/withdrawal/util.go
+++ b/op-chain-ops/cmd/withdrawal/util.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+)
+
+const EnvVarPrefix = "WITHDRAWAL"
+
+func setupLogging(ctx *cli.Context) (log.Logger, error) {
+	logCfg := oplog.ReadCLIConfig(ctx)
+	logger := oplog.NewLogger(oplog.AppOut(ctx), logCfg)
+	oplog.SetGlobalLogHandler(logger.Handler())
+	return logger, nil
+}
+
+func interruptible(action cli.ActionFunc) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		ctx.Context = ctxinterrupt.WithCancelOnInterrupt(ctx.Context)
+		return action(ctx)
+	}
+}
+
+func createTxMgr(ctx *cli.Context, logger log.Logger, rpcUrlFlag string) (*txmgr.SimpleTxManager, error) {
+	txMgrConfig := txmgr.ReadCLIConfig(ctx)
+	txMgrConfig.L1RPCURL = ctx.String(rpcUrlFlag)
+	txMgrConfig.ReceiptQueryInterval = time.Second
+
+	txMgr, err := txmgr.NewSimpleTxManager("challenger", logger, &metrics.NoopTxMetrics{}, txMgrConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the transaction manager: %w", err)
+	}
+	return txMgr, nil
+}


### PR DESCRIPTION
**Description**

Adds withdrawal helpers to op-chain-ops to facilitate manual testing of withdrawals.


**Metadata**

#15967 