### PR TITLE
feat(op-acceptance-tests): base; convert RPC test to devstack.

### DIFF
--- a/op-acceptance-tests/tests/base/rpc_connectivity_test.go
+++ b/op-acceptance-tests/tests/base/rpc_connectivity_test.go
@@ -3,66 +3,73 @@ package base
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
-	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 // TestRPCConnectivity checks we can connect to L2 execution layer RPC endpoints
-func TestRPCConnectivity(t *testing.T) {
-	systest.SystemTest(t,
-		rpcConnectivityTestScenario(),
-	)
+func TestRPCConnectivity(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	logger := testlog.Logger(t, log.LevelInfo).With("Test", "TestRPCConnectivity")
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+	logger.Info("Started L2 RPC connectivity test")
+
+	ctx, span := tracer.Start(ctx, "test chains")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Test all L2 chains in the system
+	for _, l2Chain := range sys.L2Networks() {
+		_, span = tracer.Start(ctx, "test chain")
+		defer span.End()
+
+		networkName := l2Chain.String()
+		t.Run(fmt.Sprintf("L2_Chain_%s", networkName), func(tt devtest.T) {
+			// Get the expected chain ID from the L2Chain
+			expectedChainID := l2Chain.ChainID().ToBig()
+			for _, node := range l2Chain.Escape().L2ELNodes() {
+				testL2ELNode(tt, ctx, logger, networkName, expectedChainID, dsl.NewL2ELNode(node))
+			}
+		})
+	}
 }
 
-func rpcConnectivityTestScenario() systest.SystemTestFunc {
-	return func(t systest.T, sys system.System) {
-		logger := testlog.Logger(t, log.LevelInfo)
-		logger.Info("Started L2 RPC connectivity test")
-		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-		defer cancel()
-
-		// Test each L2 chain's execution RPC
-		logger.Debug("Found %d L2 chains", "chains", len(sys.L2s()))
-		for chainIdx, l2Chain := range sys.L2s() {
-			t.Run(fmt.Sprintf("L2_Chain_%d", chainIdx), func(t systest.T) {
-				require.NotEmpty(t, l2Chain.Nodes(), "L2 chain has no nodes")
-
-				// Get the expected chain ID from the L2Chain
-				expectedChainID := l2Chain.ID()
-
-				// Test connectivity with each node in the L2 chain
-				logger.Debug("Found %d nodes in L2 chain", "nodes", len(l2Chain.Nodes()))
-				for nodeIdx, execNode := range l2Chain.Nodes() {
-					t.Run(fmt.Sprintf("Node_%d", nodeIdx), func(t systest.T) {
-						// Connect to the node's RPC
-						client, err := execNode.GethClient()
-						require.NoError(t, err, "failed to connect to L2 execution RPC")
-
-						// Check if we can get the chain ID
-						chainID, err := client.ChainID(ctx)
-						require.NoError(t, err, "failed to get chain ID from L2 execution RPC")
-						require.Equal(t, expectedChainID, chainID, "L2 chain ID does not match expected value")
-
-						// Check if we can get the latest block number
-						blockNumber, err := client.BlockNumber(ctx)
-						require.NoError(t, err, "failed to get block number from L2 execution RPC")
-						require.Greater(t, blockNumber, uint64(0), "L2 block number should be greater than 0")
-
-						logger.Info("L2 execution RPC connectivity test passed",
-							"chain", chainIdx,
-							"node", execNode.Name(),
-							"node_idx", nodeIdx,
-							"chain_id", chainID,
-							"block_number", blockNumber)
-					})
-				}
-			})
-		}
+// testL2ELNode tests connectivity for a single L2 execution layer node
+func testL2ELNode(t devtest.T, ctx context.Context, logger log.Logger, chainName string, expectedChainID *big.Int, elNode *dsl.L2ELNode) {
+	if elNode == nil {
+		return
 	}
+
+	t.Run(fmt.Sprintf("L2EL_Node_%s", elNode.String()), func(tt devtest.T) {
+		// Get Ethereum client for the node
+		client := elNode.Escape().EthClient()
+
+		// Check if we can get the chain ID
+		chainID, err := client.ChainID(ctx)
+		require.NoError(tt, err, "failed to get chain ID from L2 execution RPC")
+		require.Equal(tt, expectedChainID, chainID, "L2 chain ID does not match expected value")
+
+		// Check if we can get the latest block
+		latestBlockRef, err := client.BlockRefByLabel(ctx, "latest")
+		require.NoError(tt, err, "failed to get latest block from L2 execution RPC")
+		require.NotZero(tt, latestBlockRef.Hash, "L2 block hash seems invalid")
+
+		logger.Info("L2 execution RPC connectivity test passed",
+			"chain", chainName,
+			"node", elNode.String(),
+			"chain_id", chainID,
+		)
+	})
 }


### PR DESCRIPTION
Convert/update the existing base rpc connectivity acceptance test to use the new devstack.

## Tests
* Passes locally using sysgo
* Passes in CI using sysext ([link](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/90479/workflows/7237f169-65de-4798-8ff3-f5906b78d895/jobs/3540193))

<img width="1249" alt="Screenshot 2025-05-19 at 21 28 27" src="https://github.com/user-attachments/assets/6f48f1e4-10aa-4b47-a9ae-6354ad712960" />
