### PR TITLE
op-devstack: contract call DSL interface + impl PoC

### DIFF
--- a/op-acceptance-tests/tests/interop/call/call_test.go
+++ b/op-acceptance-tests/tests/interop/call/call_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -18,73 +17,50 @@ func TestMain(m *testing.M) {
 
 func TestCallViewWriteWETH(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	require := t.Require()
 	sys := presets.NewSimpleInterop(t)
 
 	alice := sys.FunderA.NewFundedEOA(eth.ThousandEther)
 	bob := sys.FunderA.NewFundedEOA(eth.ThousandEther)
 
+	client := sys.L2ELA.Escape().EthClient()
 	wethAddr := common.HexToAddress("0x4200000000000000000000000000000000000006")
 	// dsl prep
-	// TODO: delegate this initialization to somewhere else
-	balanceOf := func(addr common.Address) txintent.View[eth.ETH] {
-		return dsl.BalanceOfCall{Addr: addr}
-	}
-	transfer := func(dest common.Address, amount eth.ETH) txintent.View[bool] {
-		return dsl.TransferCall{Dest: dest, Amount: amount}
-	}
-	unboundWETH := dsl.UnboundWETH{BalanceOf: balanceOf, Transfer: transfer}
+	factory := &dsl.WETHCallFactory{}
+	factory = factory.WithTo(wethAddr).WithClient(client).WithTest(t)
+	weth := dsl.NewWETH(factory)
 
-	weth := &dsl.WETH{UnboundWETH: unboundWETH}
-	// hydration phase
-	client := sys.L2ELA.Escape().EthClient()
-	weth = weth.WithTo(wethAddr).WithClient(client)
-
-	var balance eth.ETH
 	var err error
 	// alice and bob has zero WETH
-	t.Require().NotEqual(alice.Address(), bob.Address())
+	require.NotEqual(alice.Address(), bob.Address())
 
-	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.ZeroWei, balance)
-	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.ZeroWei, balance)
+	require.Equal(eth.ZeroWei, dsl.TestView(weth.BalanceOf(alice.Address())))
+	require.Equal(eth.ZeroWei, dsl.TestView(weth.BalanceOf(bob.Address())))
 
 	// alice wraps 1 WETH
 	alice.Transfer(wethAddr, eth.OneEther)
 
 	// view
 	// alice has 1 WETH
-	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.OneEther, balance)
+	require.Equal(eth.OneEther, dsl.TestView(weth.BalanceOf(alice.Address())))
 	// bob has 0 WETH.
-	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.ZeroWei, balance)
+	require.Equal(eth.ZeroWei, dsl.TestView(weth.BalanceOf(bob.Address())))
 
 	// alice wraps 1 WETH again
 	alice.Transfer(wethAddr, eth.OneEther)
 
 	// view
 	// alice has 2 WETH
-	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.Ether(2), balance)
+	require.Equal(eth.Ether(2), dsl.TestView(weth.BalanceOf(alice.Address())))
 	// bob has 0 WETH.
-	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.ZeroWei, balance)
+	require.Equal(eth.ZeroWei, dsl.TestView(weth.BalanceOf(bob.Address())))
 
 	// view
 	// without address sender so failure
 	_, err = dsl.View(weth.Transfer(bob.Address(), eth.OneEther))
 	t.Require().Error(err)
 	// with address, msg.sender set
-	res, err := dsl.View(weth.Transfer(bob.Address(), eth.OneEther), txplan.WithSender(alice.Address()))
-	t.Require().NoError(err)
-	t.Require().True(res)
+	require.True(dsl.TestView(weth.Transfer(bob.Address(), eth.OneEther), txplan.WithSender(alice.Address())))
 
 	// write
 	// alice sends bob 1 WETH
@@ -92,11 +68,7 @@ func TestCallViewWriteWETH(gt *testing.T) {
 
 	// view
 	// alice has 1 WETH
-	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.OneEther, balance)
+	require.Equal(eth.OneEther, dsl.TestView(weth.BalanceOf(alice.Address())))
 	// bob has 1 WETH.
-	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
-	t.Require().NoError(err)
-	t.Require().Equal(eth.OneEther, balance)
+	require.Equal(eth.OneEther, dsl.TestView(weth.BalanceOf(bob.Address())))
 }

--- a/op-acceptance-tests/tests/interop/call/call_test.go
+++ b/op-acceptance-tests/tests/interop/call/call_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -25,44 +26,77 @@ func TestCallViewWriteWETH(gt *testing.T) {
 	wethAddr := common.HexToAddress("0x4200000000000000000000000000000000000006")
 	// dsl prep
 	// TODO: delegate this initialization to somewhere else
-	balanceOf := func(addr common.Address) dsl.Call[eth.ETH] {
+	balanceOf := func(addr common.Address) txintent.View[eth.ETH] {
 		return dsl.BalanceOfCall{Addr: addr}
 	}
-	transfer := func(dest common.Address, amount eth.ETH) dsl.Call[bool] {
+	transfer := func(dest common.Address, amount eth.ETH) txintent.View[bool] {
 		return dsl.TransferCall{Dest: dest, Amount: amount}
 	}
-	weth := dsl.WETH{BalanceOf: balanceOf, Transfer: transfer}
+	unboundWETH := dsl.UnboundWETH{BalanceOf: balanceOf, Transfer: transfer}
 
+	weth := &dsl.WETH{UnboundWETH: unboundWETH}
+	// hydration phase
+	client := sys.L2ELA.Escape().EthClient()
+	weth = weth.WithTo(wethAddr).WithClient(client)
+
+	var balance eth.ETH
+	var err error
 	// alice and bob has zero WETH
 	t.Require().NotEqual(alice.Address(), bob.Address())
-	t.Require().Equal(eth.ZeroWei, dsl.View(alice, wethAddr, weth.BalanceOf(alice.Address())))
-	t.Require().Equal(eth.ZeroWei, dsl.View(bob, wethAddr, weth.BalanceOf(bob.Address())))
 
-	// TODO: abstract away: alice wraps 1 eth to 1 WETH
-	{
-		val := eth.OneEther
-		tx := txplan.NewPlannedTx(
-			alice.Plan(),
-			txplan.WithValue(val.ToBig()),
-			txplan.WithTo(&wethAddr),
-		)
-		_, err := tx.Included.Eval(t.Ctx())
-		t.Require().NoError(err, "tx inclusion error")
-	}
+	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.ZeroWei, balance)
+	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.ZeroWei, balance)
+
+	// alice wraps 1 WETH
+	alice.Transfer(wethAddr, eth.OneEther)
 
 	// view
 	// alice has 1 WETH
-	t.Require().Equal(eth.OneEther, dsl.View(alice, wethAddr, weth.BalanceOf(alice.Address())))
+	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.OneEther, balance)
 	// bob has 0 WETH.
-	t.Require().Equal(eth.ZeroWei, dsl.View(bob, wethAddr, weth.BalanceOf(bob.Address())))
+	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.ZeroWei, balance)
+
+	// alice wraps 1 WETH again
+	alice.Transfer(wethAddr, eth.OneEther)
+
+	// view
+	// alice has 2 WETH
+	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.Ether(2), balance)
+	// bob has 0 WETH.
+	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.ZeroWei, balance)
+
+	// view
+	// without address sender so failure
+	_, err = dsl.View(weth.Transfer(bob.Address(), eth.OneEther))
+	t.Require().Error(err)
+	// with address, msg.sender set
+	res, err := dsl.View(weth.Transfer(bob.Address(), eth.OneEther), txplan.WithSender(alice.Address()))
+	t.Require().NoError(err)
+	t.Require().True(res)
 
 	// write
 	// alice sends bob 1 WETH
-	dsl.Write(alice, wethAddr, weth.Transfer(bob.Address(), eth.OneEther))
+	dsl.Write(alice, weth.Transfer(bob.Address(), eth.OneEther))
 
 	// view
-	// alice has 0 WETH
-	t.Require().Equal(eth.ZeroWei, dsl.View(alice, wethAddr, weth.BalanceOf(alice.Address())))
-	// bob has 1 WETH
-	t.Require().Equal(eth.OneEther, dsl.View(bob, wethAddr, weth.BalanceOf(bob.Address())))
+	// alice has 1 WETH
+	balance, err = dsl.View(weth.BalanceOf(alice.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.OneEther, balance)
+	// bob has 1 WETH.
+	balance, err = dsl.View(weth.BalanceOf(bob.Address()))
+	t.Require().NoError(err)
+	t.Require().Equal(eth.OneEther, balance)
 }

--- a/op-acceptance-tests/tests/interop/call/call_test.go
+++ b/op-acceptance-tests/tests/interop/call/call_test.go
@@ -1,0 +1,68 @@
+package call
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSimpleInterop())
+}
+
+func TestCallViewWriteWETH(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+
+	alice := sys.FunderA.NewFundedEOA(eth.ThousandEther)
+	bob := sys.FunderA.NewFundedEOA(eth.ThousandEther)
+
+	wethAddr := common.HexToAddress("0x4200000000000000000000000000000000000006")
+	// dsl prep
+	// TODO: delegate this initialization to somewhere else
+	balanceOf := func(addr common.Address) dsl.Call[eth.ETH] {
+		return dsl.BalanceOfCall{Addr: addr}
+	}
+	transfer := func(dest common.Address, amount eth.ETH) dsl.Call[bool] {
+		return dsl.TransferCall{Dest: dest, Amount: amount}
+	}
+	weth := dsl.WETH{BalanceOf: balanceOf, Transfer: transfer}
+
+	// alice and bob has zero WETH
+	t.Require().NotEqual(alice.Address(), bob.Address())
+	t.Require().Equal(eth.ZeroWei, dsl.View(alice, wethAddr, weth.BalanceOf(alice.Address())))
+	t.Require().Equal(eth.ZeroWei, dsl.View(bob, wethAddr, weth.BalanceOf(bob.Address())))
+
+	// TODO: abstract away: alice wraps 1 eth to 1 WETH
+	{
+		val := eth.OneEther
+		tx := txplan.NewPlannedTx(
+			alice.Plan(),
+			txplan.WithValue(val.ToBig()),
+			txplan.WithTo(&wethAddr),
+		)
+		_, err := tx.Included.Eval(t.Ctx())
+		t.Require().NoError(err, "tx inclusion error")
+	}
+
+	// view
+	// alice has 1 WETH
+	t.Require().Equal(eth.OneEther, dsl.View(alice, wethAddr, weth.BalanceOf(alice.Address())))
+	// bob has 0 WETH.
+	t.Require().Equal(eth.ZeroWei, dsl.View(bob, wethAddr, weth.BalanceOf(bob.Address())))
+
+	// write
+	// alice sends bob 1 WETH
+	dsl.Write(alice, wethAddr, weth.Transfer(bob.Address(), eth.OneEther))
+
+	// view
+	// alice has 0 WETH
+	t.Require().Equal(eth.ZeroWei, dsl.View(alice, wethAddr, weth.BalanceOf(alice.Address())))
+	// bob has 1 WETH
+	t.Require().Equal(eth.OneEther, dsl.View(bob, wethAddr, weth.BalanceOf(bob.Address())))
+}

--- a/op-acceptance-tests/tests/interop/call/call_test.go
+++ b/op-acceptance-tests/tests/interop/call/call_test.go
@@ -64,7 +64,7 @@ func TestCallViewWriteWETH(gt *testing.T) {
 
 	// write
 	// alice sends bob 1 WETH
-	dsl.Write(alice, weth.Transfer(bob.Address(), eth.OneEther))
+	dsl.TestWrite(alice, weth.Transfer(bob.Address(), eth.OneEther))
 
 	// view
 	// alice has 1 WETH

--- a/op-acceptance-tests/tests/interop/call/call_test.go
+++ b/op-acceptance-tests/tests/interop/call/call_test.go
@@ -25,10 +25,10 @@ func TestCallViewWriteWETH(gt *testing.T) {
 
 	client := sys.L2ELA.Escape().EthClient()
 	wethAddr := common.HexToAddress("0x4200000000000000000000000000000000000006")
+
 	// dsl prep
-	factory := &dsl.WETHCallFactory{}
-	factory = factory.WithTo(wethAddr).WithClient(client).WithTest(t)
-	weth := dsl.NewWETH(factory)
+	factory := dsl.NewWETHCallFactory(&dsl.BaseCallFactory{Target: wethAddr, Client: client})
+	weth := dsl.NewWETH(factory.WithTest(t))
 
 	var err error
 	// alice and bob has zero WETH
@@ -55,7 +55,7 @@ func TestCallViewWriteWETH(gt *testing.T) {
 	// bob has 0 WETH.
 	require.Equal(eth.ZeroWei, dsl.TestView(weth.BalanceOf(bob.Address())))
 
-	// view
+	// view(manual error handling)
 	// without address sender so failure
 	_, err = dsl.View(weth.Transfer(bob.Address(), eth.OneEther))
 	t.Require().Error(err)
@@ -71,4 +71,13 @@ func TestCallViewWriteWETH(gt *testing.T) {
 	require.Equal(eth.OneEther, dsl.TestView(weth.BalanceOf(alice.Address())))
 	// bob has 1 WETH.
 	require.Equal(eth.OneEther, dsl.TestView(weth.BalanceOf(bob.Address())))
+
+	// write(manual error handling)
+	// alice sends bob 1 WETH
+	_, err = dsl.Write(alice, weth.Transfer(bob.Address(), eth.OneEther))
+	require.NoError(err)
+	// alice has 0 WETH
+	require.Equal(eth.ZeroWei, dsl.TestView(weth.BalanceOf(alice.Address())))
+	// bob has 2 WETH.
+	require.Equal(eth.Ether(2), dsl.TestView(weth.BalanceOf(bob.Address())))
 }

--- a/op-devstack/dsl/call.go
+++ b/op-devstack/dsl/call.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -14,43 +15,65 @@ import (
 	"github.com/lmittmann/w3"
 )
 
-type UnboundWETH struct {
+type BaseCallFactory struct {
+	Target common.Address
+	Client apis.EthClient
+	T      devtest.T // optional
+}
+
+func (f *BaseCallFactory) WithTo(target common.Address) *BaseCallFactory {
+	f.Target = target
+	return f
+}
+
+func (f *BaseCallFactory) WithClient(client apis.EthClient) *BaseCallFactory {
+	f.Client = client
+	return f
+}
+
+func (f *BaseCallFactory) WithTest(t devtest.T) *BaseCallFactory {
+	f.T = t
+	return f
+}
+
+type WETHCallFactory struct {
+	BaseCallFactory
+}
+
+func (f *WETHCallFactory) WithTo(addr common.Address) *WETHCallFactory {
+	f.BaseCallFactory.WithTo(addr)
+	return f
+}
+
+func (f *WETHCallFactory) WithClient(c apis.EthClient) *WETHCallFactory {
+	f.BaseCallFactory.WithClient(c)
+	return f
+}
+
+func (f *WETHCallFactory) WithTest(t devtest.T) *WETHCallFactory {
+	f.BaseCallFactory.WithTest(t)
+	return f
+}
+
+func (f *WETHCallFactory) BalanceOf(addr common.Address) txintent.View[eth.ETH] {
+	return BalanceOfCall{Addr: addr, target: f.Target, client: f.Client, t: f.T}
+}
+
+func (f *WETHCallFactory) Transfer(dest common.Address, amount eth.ETH) txintent.View[bool] {
+	return TransferCall{Dest: dest, Amount: amount, target: f.Target, client: f.Client, t: f.T}
+}
+
+type WETH struct {
 	// Each field is a function, that is set up automatically with some reflection
 	BalanceOf func(addr common.Address) txintent.View[eth.ETH]
 	Transfer  func(dest common.Address, amount eth.ETH) txintent.View[bool]
 }
 
-type WETH struct {
-	UnboundWETH
-
-	target common.Address
-	client apis.EthClient
-}
-
-func (c *WETH) WithTo(target common.Address) *WETH {
-	c.target = target
-	originalBalanceOf := c.BalanceOf
-	c.BalanceOf = func(addr common.Address) txintent.View[eth.ETH] {
-		return originalBalanceOf(addr).WithTo(c.target)
+func NewWETH(f *WETHCallFactory) *WETH {
+	return &WETH{
+		BalanceOf: f.BalanceOf,
+		Transfer:  f.Transfer,
 	}
-	originalTransfer := c.Transfer
-	c.Transfer = func(dest common.Address, amount eth.ETH) txintent.View[bool] {
-		return originalTransfer(dest, amount).WithTo(c.target)
-	}
-	return c
-}
-
-func (c *WETH) WithClient(client apis.EthClient) *WETH {
-	c.client = client
-	originalBalanceOf := c.BalanceOf
-	c.BalanceOf = func(addr common.Address) txintent.View[eth.ETH] {
-		return originalBalanceOf(addr).WithClient(c.client)
-	}
-	originalTransfer := c.Transfer
-	c.Transfer = func(dest common.Address, amount eth.ETH) txintent.View[bool] {
-		return originalTransfer(dest, amount).WithClient(c.client)
-	}
-	return c
 }
 
 type BalanceOfCall struct {
@@ -58,6 +81,7 @@ type BalanceOfCall struct {
 
 	target common.Address
 	client apis.EthClient
+	t      devtest.T // optional
 }
 
 func (c BalanceOfCall) EncodeInput() ([]byte, error) {
@@ -104,12 +128,17 @@ func (c BalanceOfCall) AccessList() (gethTypes.AccessList, error) {
 	return gethTypes.AccessList{}, nil
 }
 
+func (c BalanceOfCall) Test() devtest.T {
+	return c.t
+}
+
 type TransferCall struct {
 	Dest   common.Address
 	Amount eth.ETH
 
 	target common.Address
 	client apis.EthClient
+	t      devtest.T // optional
 }
 
 func (c TransferCall) EncodeInput() ([]byte, error) {
@@ -151,6 +180,10 @@ func (c TransferCall) Client() apis.EthClient {
 
 func (c TransferCall) AccessList() (gethTypes.AccessList, error) {
 	return gethTypes.AccessList{}, nil
+}
+
+func (c TransferCall) Test() devtest.T {
+	return c.t
 }
 
 // type check
@@ -243,6 +276,16 @@ func View[O any](call txintent.View[O], opts ...txplan.Option) (O, error) {
 	return decoded, nil
 }
 
+func TestView[O any](call txintent.View[O], opts ...txplan.Option) O {
+	callTest, ok := call.(txintent.TestView[O])
+	if !ok {
+		panic("call does not support testing")
+	}
+	o, err := View(call, opts...)
+	callTest.Test().Require().NoError(err)
+	return o
+}
+
 // Write calls does not return values. just success/failure
 func Write[O any](user *EOA, call txintent.View[O]) (*gethTypes.Receipt, error) {
 	target, _ := call.To()
@@ -264,16 +307,15 @@ func Write[O any](user *EOA, call txintent.View[O]) (*gethTypes.Receipt, error) 
 	return receipt, nil
 }
 
-// TODO: bind user and address to call
-func Plan[O any](call txintent.View[O]) txplan.Option {
+func Plan[O any](call txintent.View[O]) (txplan.Option, error) {
+	target, _ := call.To()
 	calldata, err := call.EncodeInput()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	target, _ := call.To()
 	opt := txplan.Combine(
 		txplan.WithData(calldata),
 		txplan.WithTo(target),
 	)
-	return opt
+	return opt, nil
 }

--- a/op-devstack/dsl/call.go
+++ b/op-devstack/dsl/call.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lmittmann/w3"
 )
 
+// never change this
 type BaseCallFactory struct {
 	Target common.Address
 	Client apis.EthClient
@@ -36,8 +37,13 @@ func (f *BaseCallFactory) WithTest(t devtest.T) *BaseCallFactory {
 	return f
 }
 
+// implement this per contract
 type WETHCallFactory struct {
 	BaseCallFactory
+}
+
+func NewWETHCallFactory(b *BaseCallFactory) *WETHCallFactory {
+	return &WETHCallFactory{*b}
 }
 
 func (f *WETHCallFactory) WithTo(addr common.Address) *WETHCallFactory {
@@ -106,18 +112,8 @@ func (c BalanceOfCall) DecodeOutput(data []byte) (eth.ETH, error) {
 	return res, err
 }
 
-func (c BalanceOfCall) WithTo(target common.Address) txintent.View[eth.ETH] {
-	c.target = target
-	return c
-}
-
 func (c BalanceOfCall) To() (*common.Address, error) {
 	return &c.target, nil
-}
-
-func (c BalanceOfCall) WithClient(client apis.EthClient) txintent.View[eth.ETH] {
-	c.client = client
-	return c
 }
 
 func (c BalanceOfCall) Client() apis.EthClient {
@@ -160,18 +156,8 @@ func (c TransferCall) DecodeOutput(data []byte) (bool, error) {
 	return result, err
 }
 
-func (c TransferCall) WithTo(target common.Address) txintent.View[bool] {
-	c.target = target
-	return c
-}
-
 func (c TransferCall) To() (*common.Address, error) {
 	return &c.target, nil
-}
-
-func (c TransferCall) WithClient(client apis.EthClient) txintent.View[bool] {
-	c.client = client
-	return c
 }
 
 func (c TransferCall) Client() apis.EthClient {
@@ -189,6 +175,8 @@ func (c TransferCall) Test() devtest.T {
 // type check
 var _ txintent.View[eth.ETH] = (*BalanceOfCall)(nil)
 var _ txintent.View[bool] = (*TransferCall)(nil)
+var _ txintent.TestView[eth.ETH] = (*BalanceOfCall)(nil)
+var _ txintent.TestView[bool] = (*TransferCall)(nil)
 
 // // TODO: fill me
 // type EventLogger struct {
@@ -277,10 +265,7 @@ func View[O any](call txintent.View[O], opts ...txplan.Option) (O, error) {
 }
 
 func TestView[O any](call txintent.View[O], opts ...txplan.Option) O {
-	callTest, ok := call.(txintent.TestView[O])
-	if !ok || callTest.Test() == nil {
-		panic("call does not support testing")
-	}
+	callTest := toTestView(call)
 	o, err := View(call, opts...)
 	callTest.Test().Require().NoError(err)
 	return o
@@ -309,11 +294,16 @@ func Write[O any](user *EOA, call txintent.View[O], opts ...txplan.Option) (*get
 	return receipt, nil
 }
 
-func TestWrite[O any](user *EOA, call txintent.View[O], opts ...txplan.Option) *gethTypes.Receipt {
+func toTestView[O any](call txintent.View[O]) txintent.TestView[O] {
 	callTest, ok := call.(txintent.TestView[O])
 	if !ok || callTest.Test() == nil {
 		panic("call does not support testing")
 	}
+	return callTest
+}
+
+func TestWrite[O any](user *EOA, call txintent.View[O], opts ...txplan.Option) *gethTypes.Receipt {
+	callTest := toTestView(call)
 	o, err := Write(user, call, opts...)
 	callTest.Test().Require().NoError(err)
 	return o

--- a/op-devstack/dsl/call.go
+++ b/op-devstack/dsl/call.go
@@ -1,0 +1,131 @@
+package dsl
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/lmittmann/w3"
+)
+
+type Call[O any] interface {
+	EncodeInput() ([]byte, error)
+	DecodeOutput([]byte) (O, error)
+}
+
+// Simple Go types, with strong typing (e.g. eth.ETH instead of *big.Int)
+type WETH struct {
+	// Each field is a function, that is set up automatically with some reflection
+	BalanceOf func(addr common.Address) Call[eth.ETH]
+	Transfer  func(dest common.Address, amount eth.ETH) Call[bool]
+}
+
+type BalanceOfCall struct {
+	Addr common.Address
+}
+
+func (c BalanceOfCall) EncodeInput() ([]byte, error) {
+	// no full type safety yet
+	// TODO: rid of w3
+	abi := w3.MustNewFunc("balanceOf(address)", "uint256")
+	calldata, err := abi.EncodeArgs(c.Addr)
+	return calldata, err
+}
+
+func (c BalanceOfCall) DecodeOutput(data []byte) (eth.ETH, error) {
+	// no full type safety yet
+	// TODO: rid of w3
+	abi := w3.MustNewFunc("balanceOf(address)", "uint256")
+	var result *big.Int // w3 does not like static types and panics
+	err := abi.DecodeReturns(data, &result)
+	var res eth.ETH
+	// TODO: fix manual conversion
+	if (*uint256.Int)(&res).SetFromBig(result) {
+		panic("not fit in uint256")
+	}
+	return res, err
+}
+
+type TransferCall struct {
+	Dest   common.Address
+	Amount eth.ETH
+}
+
+func (c TransferCall) EncodeInput() ([]byte, error) {
+	// no full type safety yet
+	// TODO: fix manual conversioin
+	// TODO: rid of w3
+	amount := c.Amount.ToBig()
+	abi := w3.MustNewFunc("transfer(address, uint256)", "bool")
+	calldata, err := abi.EncodeArgs(c.Dest, amount)
+	return calldata, err
+}
+
+func (c TransferCall) DecodeOutput(data []byte) (bool, error) {
+	// no full type safety yet
+	// TODO: rid of w3
+	abi := w3.MustNewFunc("transfer(address, uint256)", "bool")
+	var result bool
+	err := abi.DecodeReturns(data, &result)
+	return result, err
+}
+
+// type check
+var _ Call[eth.ETH] = (*BalanceOfCall)(nil)
+var _ Call[bool] = (*TransferCall)(nil)
+
+// TODO: fill me
+type EventLogger struct {
+	// no return type
+	EmitLog func(topics []eth.Bytes32, data []byte)
+}
+
+// TODO: fill me
+type CrossL2Inbox struct {
+	// no return type
+	ValidateMessage func(identifier stypes.Identifier, msgHash eth.Bytes32)
+}
+
+// TODO: fill me
+type L2ToL2CrossDomainMessenger struct {
+	SendMessage  func(dest eth.ChainID, target common.Address, message []byte) Call[eth.Bytes32]
+	RelayMessage func(identifier stypes.Identifier, sentMessage []byte) Call[[]byte]
+}
+
+// Read calls
+func View[O any](user *EOA, address common.Address, call Call[O]) O {
+	calldata, err := call.EncodeInput()
+	user.t.Require().NoError(err)
+	// TODO: abstract away below tx planner
+	elClient := user.el.stackEL().EthClient()
+	tx := txplan.NewPlannedTx(
+		user.key.Plan(),
+		txplan.WithAgainstLatestBlock(elClient),
+		txplan.WithChainID(elClient),
+		txplan.WithData(calldata),
+		txplan.WithTo(&address),
+		txplan.WithContractCall(elClient),
+	)
+	res, err := tx.Called.Eval(user.ctx)
+	user.t.Require().NoError(err, "call error")
+	decoded, err := call.DecodeOutput(res)
+	user.t.Require().NoError(err, "result decoding error")
+	return decoded
+}
+
+// Write calls does not return values. just success/failure
+func Write[O any](user *EOA, address common.Address, call Call[O]) {
+	calldata, err := call.EncodeInput()
+	user.t.Require().NoError(err)
+	// TODO: abstract away below tx planner
+	tx := txplan.NewPlannedTx(
+		user.Plan(),
+		txplan.WithData(calldata),
+		txplan.WithTo(&address),
+	)
+	_, err = tx.Included.Eval(user.ctx)
+	user.t.Require().NoError(err, "tx inclusion error")
+}

--- a/op-devstack/dsl/call.go
+++ b/op-devstack/dsl/call.go
@@ -1,30 +1,63 @@
 package dsl
 
 import (
+	"context"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/lmittmann/w3"
 )
 
-type Call[O any] interface {
-	EncodeInput() ([]byte, error)
-	DecodeOutput([]byte) (O, error)
+type UnboundWETH struct {
+	// Each field is a function, that is set up automatically with some reflection
+	BalanceOf func(addr common.Address) txintent.View[eth.ETH]
+	Transfer  func(dest common.Address, amount eth.ETH) txintent.View[bool]
 }
 
-// Simple Go types, with strong typing (e.g. eth.ETH instead of *big.Int)
 type WETH struct {
-	// Each field is a function, that is set up automatically with some reflection
-	BalanceOf func(addr common.Address) Call[eth.ETH]
-	Transfer  func(dest common.Address, amount eth.ETH) Call[bool]
+	UnboundWETH
+
+	target common.Address
+	client apis.EthClient
+}
+
+func (c *WETH) WithTo(target common.Address) *WETH {
+	c.target = target
+	originalBalanceOf := c.BalanceOf
+	c.BalanceOf = func(addr common.Address) txintent.View[eth.ETH] {
+		return originalBalanceOf(addr).WithTo(c.target)
+	}
+	originalTransfer := c.Transfer
+	c.Transfer = func(dest common.Address, amount eth.ETH) txintent.View[bool] {
+		return originalTransfer(dest, amount).WithTo(c.target)
+	}
+	return c
+}
+
+func (c *WETH) WithClient(client apis.EthClient) *WETH {
+	c.client = client
+	originalBalanceOf := c.BalanceOf
+	c.BalanceOf = func(addr common.Address) txintent.View[eth.ETH] {
+		return originalBalanceOf(addr).WithClient(c.client)
+	}
+	originalTransfer := c.Transfer
+	c.Transfer = func(dest common.Address, amount eth.ETH) txintent.View[bool] {
+		return originalTransfer(dest, amount).WithClient(c.client)
+	}
+	return c
 }
 
 type BalanceOfCall struct {
 	Addr common.Address
+
+	target common.Address
+	client apis.EthClient
 }
 
 func (c BalanceOfCall) EncodeInput() ([]byte, error) {
@@ -49,9 +82,34 @@ func (c BalanceOfCall) DecodeOutput(data []byte) (eth.ETH, error) {
 	return res, err
 }
 
+func (c BalanceOfCall) WithTo(target common.Address) txintent.View[eth.ETH] {
+	c.target = target
+	return c
+}
+
+func (c BalanceOfCall) To() (*common.Address, error) {
+	return &c.target, nil
+}
+
+func (c BalanceOfCall) WithClient(client apis.EthClient) txintent.View[eth.ETH] {
+	c.client = client
+	return c
+}
+
+func (c BalanceOfCall) Client() apis.EthClient {
+	return c.client
+}
+
+func (c BalanceOfCall) AccessList() (gethTypes.AccessList, error) {
+	return gethTypes.AccessList{}, nil
+}
+
 type TransferCall struct {
 	Dest   common.Address
 	Amount eth.ETH
+
+	target common.Address
+	client apis.EthClient
 }
 
 func (c TransferCall) EncodeInput() ([]byte, error) {
@@ -73,59 +131,149 @@ func (c TransferCall) DecodeOutput(data []byte) (bool, error) {
 	return result, err
 }
 
+func (c TransferCall) WithTo(target common.Address) txintent.View[bool] {
+	c.target = target
+	return c
+}
+
+func (c TransferCall) To() (*common.Address, error) {
+	return &c.target, nil
+}
+
+func (c TransferCall) WithClient(client apis.EthClient) txintent.View[bool] {
+	c.client = client
+	return c
+}
+
+func (c TransferCall) Client() apis.EthClient {
+	return c.client
+}
+
+func (c TransferCall) AccessList() (gethTypes.AccessList, error) {
+	return gethTypes.AccessList{}, nil
+}
+
 // type check
-var _ Call[eth.ETH] = (*BalanceOfCall)(nil)
-var _ Call[bool] = (*TransferCall)(nil)
+var _ txintent.View[eth.ETH] = (*BalanceOfCall)(nil)
+var _ txintent.View[bool] = (*TransferCall)(nil)
+
+// // TODO: fill me
+// type EventLogger struct {
+// 	// no return type
+// 	EmitLog func(topics []eth.Bytes32, data []byte)
+// }
+
+// type EmitLogCall struct {
+// 	Topics     []eth.Bytes32
+// 	OpaqueData []byte
+
+// 	Target common.Address
+// }
+
+// func (c EmitLogCall) EncodeInput() ([]byte, error) {
+// 	abi := w3.MustNewFunc("emitLog(bytes32[] topics, bytes data)", "")
+// 	calldata, err := abi.EncodeArgs(c.Topics, c.OpaqueData)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to construct calldata: %w", err)
+// 	}
+// 	return calldata, nil
+// }
+
+// func (c EmitLogCall) DecodeOutput(data []byte) (any, error) {
+// 	// no full type safety yet
+// 	// TODO: rid of w3
+// 	abi := w3.MustNewFunc("emitLog(bytes32[] topics, bytes data)", "")
+// 	var result bool
+// 	err := abi.DecodeReturns(data, &result)
+// 	return result, err
+// }
+
+// func (c EmitLogCall) To(target common.Address) {
+// 	c.Target = target
+// }
+
+// func (c EmitLogCall) WithTo() common.Address {
+// 	return c.Target
+// }
+
+// var _ Call[any] = (*EmitLogCall)(nil)
 
 // TODO: fill me
-type EventLogger struct {
-	// no return type
-	EmitLog func(topics []eth.Bytes32, data []byte)
-}
+// type CrossL2Inbox struct {
+// 	// no return type
+// 	ValidateMessage func(identifier stypes.Identifier, msgHash eth.Bytes32)
+// }
 
-// TODO: fill me
-type CrossL2Inbox struct {
-	// no return type
-	ValidateMessage func(identifier stypes.Identifier, msgHash eth.Bytes32)
-}
-
-// TODO: fill me
-type L2ToL2CrossDomainMessenger struct {
-	SendMessage  func(dest eth.ChainID, target common.Address, message []byte) Call[eth.Bytes32]
-	RelayMessage func(identifier stypes.Identifier, sentMessage []byte) Call[[]byte]
-}
+// // TODO: fill me
+// type L2ToL2CrossDomainMessenger struct {
+// 	SendMessage  func(dest eth.ChainID, target common.Address, message []byte) Call[eth.Bytes32]
+// 	RelayMessage func(identifier stypes.Identifier, sentMessage []byte) Call[[]byte]
+// }
 
 // Read calls
-func View[O any](user *EOA, address common.Address, call Call[O]) O {
+func View[O any](call txintent.View[O], opts ...txplan.Option) (O, error) {
+	target, _ := call.To()
 	calldata, err := call.EncodeInput()
-	user.t.Require().NoError(err)
+	if err != nil {
+		return *new(O), err
+	}
 	// TODO: abstract away below tx planner
-	elClient := user.el.stackEL().EthClient()
+	elClient := call.Client()
 	tx := txplan.NewPlannedTx(
-		user.key.Plan(),
 		txplan.WithAgainstLatestBlock(elClient),
-		txplan.WithChainID(elClient),
-		txplan.WithData(calldata),
-		txplan.WithTo(&address),
 		txplan.WithContractCall(elClient),
+		// can be filled in
+		txplan.WithData(calldata),
+		txplan.WithTo(target),
+		// sender is optional when view
+		txplan.WithSender(common.Address{}),
+		// add optional tx options
+		txplan.Combine(opts...),
 	)
-	res, err := tx.Called.Eval(user.ctx)
-	user.t.Require().NoError(err, "call error")
+
+	// fixme for context
+	res, err := tx.Called.Eval(context.Background())
+	if err != nil {
+		return *new(O), err
+	}
 	decoded, err := call.DecodeOutput(res)
-	user.t.Require().NoError(err, "result decoding error")
-	return decoded
+	if err != nil {
+		return *new(O), err
+	}
+	return decoded, nil
 }
 
 // Write calls does not return values. just success/failure
-func Write[O any](user *EOA, address common.Address, call Call[O]) {
+func Write[O any](user *EOA, call txintent.View[O]) (*gethTypes.Receipt, error) {
+	target, _ := call.To()
 	calldata, err := call.EncodeInput()
+	if err != nil {
+		return nil, err
+	}
 	user.t.Require().NoError(err)
 	// TODO: abstract away below tx planner
 	tx := txplan.NewPlannedTx(
 		user.Plan(),
 		txplan.WithData(calldata),
-		txplan.WithTo(&address),
+		txplan.WithTo(target),
 	)
-	_, err = tx.Included.Eval(user.ctx)
-	user.t.Require().NoError(err, "tx inclusion error")
+	receipt, err := tx.Included.Eval(user.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return receipt, nil
+}
+
+// TODO: bind user and address to call
+func Plan[O any](call txintent.View[O]) txplan.Option {
+	calldata, err := call.EncodeInput()
+	if err != nil {
+		panic(err)
+	}
+	target, _ := call.To()
+	opt := txplan.Combine(
+		txplan.WithData(calldata),
+		txplan.WithTo(target),
+	)
+	return opt
 }

--- a/op-devstack/dsl/call.go
+++ b/op-devstack/dsl/call.go
@@ -278,7 +278,7 @@ func View[O any](call txintent.View[O], opts ...txplan.Option) (O, error) {
 
 func TestView[O any](call txintent.View[O], opts ...txplan.Option) O {
 	callTest, ok := call.(txintent.TestView[O])
-	if !ok {
+	if !ok || callTest.Test() == nil {
 		panic("call does not support testing")
 	}
 	o, err := View(call, opts...)
@@ -287,7 +287,7 @@ func TestView[O any](call txintent.View[O], opts ...txplan.Option) O {
 }
 
 // Write calls does not return values. just success/failure
-func Write[O any](user *EOA, call txintent.View[O]) (*gethTypes.Receipt, error) {
+func Write[O any](user *EOA, call txintent.View[O], opts ...txplan.Option) (*gethTypes.Receipt, error) {
 	target, _ := call.To()
 	calldata, err := call.EncodeInput()
 	if err != nil {
@@ -299,12 +299,24 @@ func Write[O any](user *EOA, call txintent.View[O]) (*gethTypes.Receipt, error) 
 		user.Plan(),
 		txplan.WithData(calldata),
 		txplan.WithTo(target),
+		// add optional tx options
+		txplan.Combine(opts...),
 	)
 	receipt, err := tx.Included.Eval(user.ctx)
 	if err != nil {
 		return nil, err
 	}
 	return receipt, nil
+}
+
+func TestWrite[O any](user *EOA, call txintent.View[O], opts ...txplan.Option) *gethTypes.Receipt {
+	callTest, ok := call.(txintent.TestView[O])
+	if !ok || callTest.Test() == nil {
+		panic("call does not support testing")
+	}
+	o, err := Write(user, call, opts...)
+	callTest.Test().Require().NoError(err)
+	return o
 }
 
 func Plan[O any](call txintent.View[O]) (txplan.Option, error) {

--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -39,9 +39,10 @@ var (
 	MillionEther  = Ether(1000_000)
 	ThousandEther = Ether(1000)
 	OneEther      = Ether(1)
-	OneGWei       = GWei(1)
-	OneWei        = WeiU64(1)
-	ZeroWei       = WeiU64(0)
+
+	OneGWei = GWei(1)
+	OneWei  = WeiU64(1)
+	ZeroWei = WeiU64(0)
 )
 
 // some internal helper constant values

--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -39,10 +39,9 @@ var (
 	MillionEther  = Ether(1000_000)
 	ThousandEther = Ether(1000)
 	OneEther      = Ether(1)
-
-	OneGWei = GWei(1)
-	OneWei  = WeiU64(1)
-	ZeroWei = WeiU64(0)
+	OneGWei       = GWei(1)
+	OneWei        = WeiU64(1)
+	ZeroWei       = WeiU64(0)
 )
 
 // some internal helper constant values

--- a/op-service/txintent/interop_call.go
+++ b/op-service/txintent/interop_call.go
@@ -30,7 +30,7 @@ func (v *InitTrigger) To() (*common.Address, error) {
 	return &v.Emitter, nil
 }
 
-func (v *InitTrigger) Data() ([]byte, error) {
+func (v *InitTrigger) EncodeInput() ([]byte, error) {
 	// TODO(15005): Need to do better construct call input than this
 	emitLog := w3.MustNewFunc("emitLog(bytes32[] topics, bytes data)", "")
 	calldata, err := emitLog.EncodeArgs(v.Topics, v.OpaqueData)
@@ -56,7 +56,7 @@ func (v *SendTrigger) To() (*common.Address, error) {
 	return &v.Emitter, nil
 }
 
-func (v *SendTrigger) Data() ([]byte, error) {
+func (v *SendTrigger) EncodeInput() ([]byte, error) {
 	// TODO(15005): Need to do better construct call input than this
 	sendMessage := w3.MustNewFunc("sendMessage(uint256, address, bytes calldata)", "bytes32")
 	calldata, err := sendMessage.EncodeArgs(v.DestChainID.ToBig(), v.Target, v.RelayedCalldata)
@@ -81,7 +81,7 @@ func (v *ExecTrigger) To() (*common.Address, error) {
 	return &v.Executor, nil
 }
 
-func (v *ExecTrigger) Data() ([]byte, error) {
+func (v *ExecTrigger) EncodeInput() ([]byte, error) {
 	// TODO(15005): Need to do better construct call input than this
 	validateMessage := w3.MustNewFunc("validateMessage((address Origin, uint256 BlockNumber, uint256 LogIndex, uint256 Timestamp, uint256 ChainId), bytes32)", "")
 	type Identifier struct {
@@ -120,7 +120,7 @@ type RelayTrigger struct {
 	Payload []byte
 }
 
-func (v *RelayTrigger) Data() ([]byte, error) {
+func (v *RelayTrigger) EncodeInput() ([]byte, error) {
 	// TODO(15005): Need to do better construct call input than this
 	relayMessage := w3.MustNewFunc("relayMessage((address Origin, uint256 BlockNumber, uint256 LogIndex, uint256 Timestamp, uint256 ChainId), bytes sentMessage)", "bytes returnData")
 	type Identifier struct {

--- a/op-service/txintent/multi_call.go
+++ b/op-service/txintent/multi_call.go
@@ -20,7 +20,7 @@ func (m *MultiTrigger) To() (*common.Address, error) {
 	return &m.Emitter, nil
 }
 
-func (v *MultiTrigger) Data() ([]byte, error) {
+func (v *MultiTrigger) EncodeInput() ([]byte, error) {
 	type Call3Value struct {
 		Target       common.Address
 		AllowFailure bool
@@ -32,7 +32,7 @@ func (v *MultiTrigger) Data() ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to aggregate to: %w", err)
 		}
-		calldata, err := call.Data()
+		calldata, err := call.EncodeInput()
 		if err != nil {
 			return nil, fmt.Errorf("failed to aggregate calldata: %w", err)
 		}

--- a/op-service/txintent/txintent.go
+++ b/op-service/txintent/txintent.go
@@ -3,6 +3,7 @@ package txintent
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -11,10 +12,30 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+type Input interface {
+	EncodeInput() ([]byte, error)
+}
+
+type Output[O any] interface {
+	DecodeOutput(data []byte) (dest O, err error)
+}
+
 type Call interface {
 	To() (*common.Address, error)
-	Data() ([]byte, error)
 	AccessList() (types.AccessList, error)
+	Input
+}
+
+type View[O any] interface {
+	Call
+	Endpoint
+	WithTo(target common.Address) View[O]
+	WithClient(client apis.EthClient) View[O]
+	Output[O]
+}
+
+type Endpoint interface {
+	Client() apis.EthClient
 }
 
 type Result interface {
@@ -38,7 +59,7 @@ func NewIntent[V Call, R Result](opts ...txplan.Option) *IntentTx[V, R] {
 	})
 	v.PlannedTx.Data.DependOn(&v.Content)
 	v.PlannedTx.Data.Fn(func(ctx context.Context) (hexutil.Bytes, error) {
-		return v.Content.Value().Data()
+		return v.Content.Value().EncodeInput()
 	})
 	v.PlannedTx.AccessList.DependOn(&v.Content)
 	v.PlannedTx.AccessList.Fn(func(ctx context.Context) (types.AccessList, error) {

--- a/op-service/txintent/txintent.go
+++ b/op-service/txintent/txintent.go
@@ -3,6 +3,7 @@ package txintent
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
@@ -28,14 +29,13 @@ type Call interface {
 
 type View[O any] interface {
 	Call
-	Endpoint
-	WithTo(target common.Address) View[O]
-	WithClient(client apis.EthClient) View[O]
+	Client() apis.EthClient
 	Output[O]
 }
 
-type Endpoint interface {
-	Client() apis.EthClient
+type TestView[O any] interface {
+	View[O]
+	Test() devtest.T
 }
 
 type Result interface {

--- a/op-service/txintent/txintent_test.go
+++ b/op-service/txintent/txintent_test.go
@@ -20,7 +20,7 @@ type call struct {
 }
 
 func (c *call) To() (*common.Address, error)          { return c.to, nil }
-func (c *call) Data() ([]byte, error)                 { return c.data, nil }
+func (c *call) EncodeInput() ([]byte, error)          { return c.data, nil }
 func (c *call) AccessList() (types.AccessList, error) { return c.accessList, nil }
 
 type result struct {
@@ -125,7 +125,7 @@ func TestTxIntentMultiCall(t *testing.T) {
 	var stackedAccessList types.AccessList
 	for _, call := range multiTrigger.Calls {
 		// Check batched tx contains each calldata
-		subData, err := call.Data()
+		subData, err := call.EncodeInput()
 		require.NoError(t, err)
 		require.True(t, bytes.Contains(data, subData))
 		// Check batched tx contains each accesslist

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -99,6 +99,12 @@ func WithNonce(nonce uint64) Option {
 	}
 }
 
+func WithSender(sender common.Address) Option {
+	return func(tx *PlannedTx) {
+		tx.Sender.Set(sender)
+	}
+}
+
 func WithStaticNonce(nonce uint64) Option {
 	return func(tx *PlannedTx) {
 		tx.Nonce.Set(nonce)
@@ -217,7 +223,6 @@ func WithContractCall(cl ContractCaller) Option {
 			&tx.GasTipCap,
 			&tx.Value,
 			&tx.Data,
-			&tx.AccessList,
 		)
 		tx.Called.Fn(func(ctx context.Context) ([]byte, error) {
 			msg := ethereum.CallMsg{
@@ -231,6 +236,8 @@ func WithContractCall(cl ContractCaller) Option {
 				Data:       tx.Data.Value(),
 				AccessList: tx.AccessList.Value(),
 			}
+			// s := fmt.Sprintf("%s %s %s", msg.From.Hex(), msg.To.Hex(), hex.EncodeToString(msg.Data))
+
 			return cl.Call(ctx, msg)
 		})
 	}

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -25,6 +25,7 @@ type PlannedTx struct {
 	// Block that we schedule against
 	AgainstBlock  plan.Lazy[eth.BlockInfo]
 	Unsigned      plan.Lazy[types.TxData]
+	Called        plan.Lazy[[]byte]
 	Signed        plan.Lazy[*types.Transaction]
 	Submitted     plan.Lazy[struct{}]
 	Included      plan.Lazy[*types.Receipt]
@@ -199,6 +200,38 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 			ratio := tx.GasRatio.Value()
 			gas = uint64(float64(gas) * ratio)
 			return gas, nil
+		})
+	}
+}
+
+type ContractCaller interface {
+	Call(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
+}
+
+func WithContractCall(cl ContractCaller) Option {
+	return func(tx *PlannedTx) {
+		tx.Called.DependOn(
+			&tx.Sender,
+			&tx.To,
+			&tx.GasFeeCap,
+			&tx.GasTipCap,
+			&tx.Value,
+			&tx.Data,
+			&tx.AccessList,
+		)
+		tx.Called.Fn(func(ctx context.Context) ([]byte, error) {
+			msg := ethereum.CallMsg{
+				From:       tx.Sender.Value(),
+				To:         tx.To.Value(),
+				Gas:        0, // auto estimated by the node
+				GasPrice:   nil,
+				GasFeeCap:  tx.GasFeeCap.Value(),
+				GasTipCap:  tx.GasTipCap.Value(),
+				Value:      tx.Value.Value(),
+				Data:       tx.Data.Value(),
+				AccessList: tx.AccessList.Value(),
+			}
+			return cl.Call(ctx, msg)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

DSL PoC using `Call` interface, implementing basic `Call` interface and simple implementation (WETH).

Note that this is a PoC implementation and definitely needs a clean up.

**Tests**

Added `TestCallViewWriteWETH`, which is a superset of `TestSystemWrapETH` at
https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/tests/interop/interop_smoke_test.go#L53C6-L53C23. The original `TestSystemWrapETH` was written using the legacy bindings and not using devstack. This `TestCallViewWriteWETH` attempts to rewrite using op-devstack with a poc of contract call DSL.

**Additional context**

Note that there are bunch of TODOs. For PoCing I used [w3](https://github.com/lmittmann/w3/tree/main) but this is desired to be isolated and abstracted using tools like abigenv2.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16001
