### PR TITLE
circleci: run acceptance-test-pr job only on premerge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1705,21 +1705,6 @@ jobs:
             gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics
             gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics-$CIRCLE_SHA1
 
-  # Helper job to check if we're running on a PR
-  run-on-pr-only:
-    docker:
-      - image: cimg/base:current
-    steps:
-      - run:
-          name: Check if running on a PR
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              echo "This is not a pull request. Exiting with error."
-              exit 1
-            else
-              echo "Running on pull request: $CIRCLE_PULL_REQUEST"
-            fi
-
 workflows:
   main:
     when:
@@ -2318,13 +2303,11 @@ workflows:
   # Acceptance tests (pre-merge to develop)
   acceptance-tests-pr:
     when:
-      not:
-        equal: [<< pipeline.git.branch >>, "develop"]
+      and:
+        - not:
+            equal: [<< pipeline.git.branch >>, "develop"]
+        - equal: [<< pipeline.parameters.github-event-type >>, "pull_request"]
     jobs:
-      - run-on-pr-only:
-          name: check-for-pr
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - op-acceptance-tests:
           # Acceptance Testing params
           name: kurtosis-interop
@@ -2332,8 +2315,6 @@ workflows:
           gate: interop
           # CircleCI params
           no_output_timeout: 10m
-          requires:
-            - check-for-pr
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord


### PR DESCRIPTION
Prior to this pr all post-merge ci runs had a failed test for `check-for-pr `. This pr updates the circleci workflows such that there is not a failure for that job. Rather, the job is only run as part of pre-merge checks, and it is skipped during post-merge runs