### PR TITLE
op-supervisor,op-node: Handle non-genesis Interop

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/redundant_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/redundant_interop/interop_sync_test.go
@@ -13,6 +13,7 @@ import (
 // TestUnsafeChainKnownToL2CL tests the below scenario:
 // supervisor cross-safe ahead of L2CL cross-safe, aka L2CL can "skip" forward to match safety of supervisor.
 func TestUnsafeChainKnownToL2CL(gt *testing.T) {
+	gt.Skip() // TODO(#16187): Fix to use multi-supervisor (not multi-node) setup.
 	t := devtest.SerialT(gt)
 
 	// Sequencer and verifier are connected via P2P, which makes their unsafe heads in sync.
@@ -84,6 +85,7 @@ func TestUnsafeChainKnownToL2CL(gt *testing.T) {
 // TestUnsafeChainUnknownToL2CL tests the below scenario:
 // supervisor unsafe ahead of L2CL unsafe, aka L2CL processes new blocks first.
 func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
+	gt.Skip() // TODO(#16187): Fix to use multi-supervisor (not multi-node) setup.
 	t := devtest.SerialT(gt)
 
 	// Sequencer and verifier are connected via P2P, which makes their unsafe heads in sync.

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -176,6 +176,8 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 }
 
 func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
+	// TODO(#16166): Fix non-genesis Interop activation proofs
+	gt.Skip()
 	t := helpers.NewDefaultTesting(gt)
 	system := dsl.NewInteropDSL(t, dsl.SetInteropForkScheduledButInactive())
 

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -364,6 +364,7 @@ func TestInteropBlockBuilding(t *testing.T) {
 }
 
 func TestMultiNode(t *testing.T) {
+	t.Skip() // TODO(#16174): Decide on future of multi-node support
 	t.Parallel()
 	test := func(t *testing.T, s2 SuperSystem) {
 		supervisor := s2.SupervisorClient()

--- a/op-node/rollup/interop/managed/api.go
+++ b/op-node/rollup/interop/managed/api.go
@@ -39,12 +39,17 @@ func (ib *InteropAPI) InvalidateBlock(ctx context.Context, seal supervisortypes.
 	return ib.backend.InvalidateBlock(ctx, seal)
 }
 
+// TODO(#16140): remove
 func (ib *InteropAPI) AnchorPoint(ctx context.Context) (supervisortypes.DerivedBlockRefPair, error) {
 	return ib.backend.AnchorPoint(ctx)
 }
 
 func (ib *InteropAPI) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID) error {
 	return ib.backend.Reset(ctx, lUnsafe, xUnsafe, lSafe, xSafe, finalized)
+}
+
+func (ib *InteropAPI) ResetPreInterop(ctx context.Context) error {
+	return ib.backend.ResetPreInterop(ctx)
 }
 
 func (ib *InteropAPI) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -48,9 +48,11 @@ type L2Chain interface {
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 }
 
-var ReorgFinalizedErr = errors.New("cannot reorg finalized block")
-var WrongChainErr = errors.New("wrong chain")
-var TooDeepReorgErr = errors.New("reorg is too deep")
+var (
+	ReorgFinalizedErr = errors.New("cannot reorg finalized block")
+	WrongChainErr     = errors.New("wrong chain")
+	TooDeepReorgErr   = errors.New("reorg is too deep")
+)
 
 const MaxReorgSeqWindows = 5
 
@@ -156,6 +158,8 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 	// Once we pass the previous safe head and we have seen enough canonical L1 origins to fill a sequence window worth of data,
 	// then we return the last L2 block of the epoch before that as safe head.
 	// Each loop iteration we traverse a single L2 block, and we check if the L1 origins are consistent.
+	// TODO(#16141): maybe check inside here not to go over Interop activation, this should be handled by supervisor
+	// Fine to keep unsafe chain. Safe chain should be capped to stay pre-Interop.
 	for {
 		// Fetch L1 information if we never had it, or if we do not have it for the current origin.
 		// Optimization: as soon as we have a previous L1 block, try to traverse L1 by hash instead of by number, to fill the cache.

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -55,7 +55,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
 					Source:  eth.BlockRef{},
-					Derived: eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})}},
+					Derived: eth.BlockRef{Number: 3, Hash: common.BytesToHash([]byte{0x01})},
+				},
 				errors.New("some error")
 		}
 		l1Source := eth.BlockID{}
@@ -94,7 +95,8 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
 			return types.DerivedBlockRefPair{
 					Source:  eth.BlockRef{Number: 9},
-					Derived: eth.BlockRef{}},
+					Derived: eth.BlockRef{},
+				},
 				nil
 		}
 		l1Source := eth.BlockID{Number: 8}

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -79,7 +79,15 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps, li
 	if err != nil {
 		return fmt.Errorf("cannot find parent-block of cross-safe: %w", err)
 	}
-	crossSafeRef := currentCrossSafe.Derived.MustWithParent(parent.ID())
+
+	var crossSafeRef eth.BlockRef
+	// During non-genesis Interop activation, the parent may be zero, which is ok.
+	if parent.ID() == (eth.BlockID{}) {
+		crossSafeRef = currentCrossSafe.Derived.WithZeroParent()
+	} else {
+		crossSafeRef = currentCrossSafe.Derived.MustWithParent(parent.ID())
+	}
+
 	// If any of the reads were invalidated due to reorg,
 	// don't attempt to proceed with an update, as the reasoning for the update may be wrong.
 	if !h.IsValid() {

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -12,6 +12,12 @@ import (
 
 var errInvalidateMismatch = fmt.Errorf("cannot invalidate mismatching block")
 
+func (db *DB) IsEmpty() bool {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	return db.store.Size() == 0
+}
+
 func (db *DB) AddDerived(source eth.BlockRef, derived eth.BlockRef, revision types.Revision) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
@@ -21,7 +27,8 @@ func (db *DB) AddDerived(source eth.BlockRef, derived eth.BlockRef, revision typ
 // ReplaceInvalidatedBlock replaces the current Invalidated block with the given replacement.
 // The to-be invalidated hash must be provided for consistency checks.
 func (db *DB) ReplaceInvalidatedBlock(inv reads.Invalidator, replacementDerived eth.BlockRef, invalidated common.Hash) (
-	out types.DerivedBlockRefPair, err error) {
+	out types.DerivedBlockRefPair, err error,
+) {
 	release, err := inv.TryInvalidate(reads.InvalidationRules{
 		reads.DerivedInvalidation{Timestamp: replacementDerived.Time},
 		// source block stays the same, so nothing to invalidate there.

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -200,8 +200,8 @@ func (db *DB) OpenBlock(blockNum uint64) (ref eth.BlockRef, logCount uint32, exe
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 
-	// TODO: need to fix assumption that the first block is block 0
-	// This is only true for genesis-Interop chains.
+	// Note: newIteratorAt below handles the not-at-genesis interop start case.
+	// But here we explicitly handle blockNum 0 to avoid a block number underflow.
 	if blockNum == 0 {
 		seal, err := db.FirstSealedBlock()
 		if err != nil {
@@ -209,7 +209,7 @@ func (db *DB) OpenBlock(blockNum uint64) (ref eth.BlockRef, logCount uint32, exe
 			return
 		}
 		if seal.Number != 0 {
-			db.log.Warn("The first block is not block 0", "block", seal.Number)
+			return eth.BlockRef{}, 0, nil, fmt.Errorf("looked for block 0 but got %s: %w", seal, types.ErrSkipped)
 		}
 		ref = eth.BlockRef{
 			Hash:       seal.Hash,

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -134,6 +134,12 @@ func (db *DB) updateEntryCountMetric() {
 	db.m.RecordDBEntryCount("log", db.store.Size())
 }
 
+func (db *DB) IsEmpty() bool {
+	db.rwLock.RLock()
+	defer db.rwLock.RUnlock()
+	return db.lastEntryContext.nextEntryIndex == 0
+}
+
 func (db *DB) IteratorStartingAt(sealedNum uint64, logsSince uint32) (Iterator, error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
@@ -171,8 +177,8 @@ func (db *DB) FindSealedBlock(number uint64) (seal types.BlockSeal, err error) {
 	}, nil
 }
 
-// StartingBlock returns the first block seal in the DB, if any.
-func (db *DB) StartingBlock() (seal types.BlockSeal, err error) {
+// FirstSealedBlock returns the first block seal in the DB, if any.
+func (db *DB) FirstSealedBlock() (seal types.BlockSeal, err error) {
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 	iter := db.newIterator(0)
@@ -185,7 +191,7 @@ func (db *DB) StartingBlock() (seal types.BlockSeal, err error) {
 		Hash:      h,
 		Number:    n,
 		Timestamp: t,
-	}, err
+	}, nil
 }
 
 // OpenBlock returns the Executing Messages for the block at the given number.
@@ -194,8 +200,10 @@ func (db *DB) OpenBlock(blockNum uint64) (ref eth.BlockRef, logCount uint32, exe
 	db.rwLock.RLock()
 	defer db.rwLock.RUnlock()
 
+	// TODO: need to fix assumption that the first block is block 0
+	// This is only true for genesis-Interop chains.
 	if blockNum == 0 {
-		seal, err := db.StartingBlock()
+		seal, err := db.FirstSealedBlock()
 		if err != nil {
 			retErr = err
 			return

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -769,7 +769,6 @@ func TestContains(t *testing.T) {
 
 			// when the timestamp invariant is broken, ErrConflict is returned
 			requireConflicts(t, db, 51, 2, 4000, createHash(2)) // 4000 != 5001
-
 		})
 }
 

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -105,7 +105,12 @@ func (db *ChainsDB) findRevision(chainID eth.ChainID, block eth.BlockID) (types.
 		if !ok {
 			return types.Revision(0), types.ErrUnknownChain
 		}
-		return ldb.LastRevision()
+		rev, err := ldb.LastRevision()
+		// During non-Genesis Interop activation, there may not be any safe data yet.
+		if errors.Is(err, types.ErrFuture) {
+			return types.Revision(0), nil
+		}
+		return rev, err
 	}
 	return rev, nil
 }

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/log"
+
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
@@ -71,6 +73,8 @@ func (su *StatusTracker) OnEvent(ev event.Event) bool {
 	case superevents.FinalizedL2UpdateEvent:
 		status := loadStatusRef(x.ChainID)
 		status.Finalized = x.FinalizedL2
+	case superevents.FinalizedL1UpdateEvent:
+		log.Debug("Updated finalized L1", "finalizedL1", x.FinalizedL1)
 	default:
 		return false
 	}

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -119,13 +119,30 @@ func (ev LocalDerivedOriginUpdateEvent) String() string {
 	return "local-derived-origin-update"
 }
 
-type AnchorEvent struct {
+type ResetPreInteropRequestEvent struct {
 	ChainID eth.ChainID
-	Anchor  types.DerivedBlockRefPair
 }
 
-func (ev AnchorEvent) String() string {
-	return "anchor"
+func (ev ResetPreInteropRequestEvent) String() string {
+	return "reset-pre-interop-request"
+}
+
+type UnsafeActivationBlockEvent struct {
+	Unsafe  eth.BlockRef
+	ChainID eth.ChainID
+}
+
+func (ev UnsafeActivationBlockEvent) String() string {
+	return "unsafe-activation-block-received"
+}
+
+type SafeActivationBlockEvent struct {
+	Safe    types.DerivedBlockRefPair
+	ChainID eth.ChainID
+}
+
+func (ev SafeActivationBlockEvent) String() string {
+	return "safe-activation-block-received"
 }
 
 type InvalidateLocalSafeEvent struct {

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -47,6 +47,7 @@ type SyncControl interface {
 	InvalidateBlock(ctx context.Context, seal types.BlockSeal) error
 
 	Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID) error
+	ResetPreInterop(ctx context.Context) error
 	ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error
 	AnchorPoint(ctx context.Context) (types.DerivedBlockRefPair, error)
 

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -88,97 +87,4 @@ func TestEventResponse(t *testing.T) {
 			nodeExhausted >= 1 &&
 			mon.localDerivedOriginUpdate >= 1
 	}, 4*time.Second, 250*time.Millisecond)
-}
-
-func TestPrepareReset(t *testing.T) {
-	chainID := eth.ChainIDFromUInt64(1)
-	logger := testlog.Logger(t, log.LvlDebug)
-	syncCtrl := &mockSyncControl{}
-	backend := &mockBackend{}
-
-	ex := event.NewGlobalSynchronous(context.Background())
-	eventSys := event.NewSystem(logger, ex)
-
-	mon := &eventMonitor{}
-	eventSys.Register("monitor", mon)
-
-	node := NewManagedNode(logger, chainID, syncCtrl, backend, false)
-	eventSys.Register("node", node)
-
-	// mock: return a block of the same number as requested
-	syncCtrl.blockRefByNumFn = func(ctx context.Context, number uint64) (eth.BlockRef, error) {
-		return eth.BlockRef{Number: number, Hash: common.Hash{0xaa}}, nil
-	}
-
-	// mock: control whether the blocks appear valid or not
-	var pivot uint64
-	backend.isLocalSafeFn = func(ctx context.Context, chainID eth.ChainID, id eth.BlockID) error {
-		if id.Number > uint64(pivot) {
-			return types.ErrConflict
-		}
-		return nil
-	}
-
-	// mock: record the reset signal given to the node
-	var unsafe, safe, finalized eth.BlockID
-	var resetCalled int
-	syncCtrl.resetFn = func(ctx context.Context, u, s, f eth.BlockID) error {
-		unsafe = u
-		safe = s
-		finalized = f
-		resetCalled++
-		return nil
-	}
-
-	// test that the bisection finds the correct block,
-	// anywhere inside the min-max range
-	min, max := uint64(1), uint64(235)
-	for i := min; i < max; i++ {
-		node.resetTracker.a = eth.BlockID{Number: min, Hash: common.Hash{0xaa}}
-		node.resetTracker.z = eth.BlockID{Number: max}
-		pivot = i
-		node.resetTracker.bisectToTarget()
-		require.Equal(t, i, unsafe.Number)
-		require.Equal(t, i, safe.Number)
-		require.Equal(t, uint64(0), finalized.Number)
-	}
-
-	// test that when the end of range (z) is known to the node,
-	// the reset request is made with the end of the range as the safe block
-	for i := min; i < max; i++ {
-		node.resetTracker.a = eth.BlockID{Number: min}
-		node.resetTracker.z = eth.BlockID{Number: max, Hash: common.Hash{0xaa}}
-		pivot = 0
-		node.resetTracker.bisectToTarget()
-		require.Equal(t, max, unsafe.Number)
-	}
-
-	// mock: return local safe and finalized blocks which are *ahead* of the pivot
-	backend.localSafeFn = func(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
-		return types.DerivedIDPair{
-			Derived: eth.BlockID{Number: pivot + 1},
-		}, nil
-	}
-	backend.finalizedFn = func(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
-		return eth.BlockID{Number: pivot + 1}, nil
-	}
-	// test that the bisection finds the correct block,
-	// AND that the safe and finalized blocks are updated to match the unsafe block
-	for i := min; i < max; i++ {
-		node.resetTracker.a = eth.BlockID{Number: min, Hash: common.Hash{0xaa}}
-		node.resetTracker.z = eth.BlockID{Number: max}
-		pivot = i
-		node.resetTracker.bisectToTarget()
-		require.Equal(t, i, unsafe.Number)
-		require.Equal(t, i, safe.Number)
-		require.Equal(t, i, finalized.Number)
-	}
-
-	// test that the reset function is not called if start of the range (a) is unknown
-	resetCount := resetCalled
-	node.resetTracker.a = eth.BlockID{Number: 0, Hash: common.Hash{0xbb}}
-	node.resetTracker.z = eth.BlockID{Number: max}
-	pivot = 40
-	node.resetTracker.bisectToTarget()
-	require.Equal(t, resetCount, resetCalled)
 }

--- a/op-supervisor/supervisor/backend/syncnode/reset_tracker.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset_tracker.go
@@ -1,0 +1,125 @@
+package syncnode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// resetTracker manages a bisection between consistent and inconsistent blocks
+// and is used to prepare a reset request to be handled by a managed node.
+type resetTracker struct {
+	a eth.BlockID
+	z eth.BlockID
+
+	log     log.Logger
+	backend resetBackend
+}
+
+type resetBackend interface {
+	BlockIDByNumber(ctx context.Context, n uint64) (eth.BlockID, error)
+	IsLocalSafe(ctx context.Context, block eth.BlockID) error
+}
+
+// init initializes the reset tracker with
+// empty start and end of range, and no reset in progress
+func newResetTracker(logger log.Logger, b resetBackend) *resetTracker {
+	return &resetTracker{
+		log:     logger,
+		backend: b,
+	}
+}
+
+type resetTarget struct {
+	Target     eth.BlockID
+	PreInterop bool
+}
+
+// FindResetTarget initializes the reset tracker
+// and starts the bisection process at the given block
+// which will lead to a reset request
+func (t *resetTracker) FindResetTarget(ctx context.Context, a, z eth.BlockID) (resetTarget, error) {
+	t.log.Info("beginning reset", "a", a, "z", z)
+	t.a = a
+	t.z = z
+
+	nodeCtx, nCancel := context.WithTimeout(ctx, nodeTimeout)
+	defer nCancel()
+
+	// before starting bisection, check if z is already consistent (i.e. the node is ahead but otherwise consistent)
+	nodeZ, err := t.backend.BlockIDByNumber(nodeCtx, t.z.Number)
+	// if z is already consistent, we can skip the bisection
+	// and move straight to a targeted reset
+	if err == nil && nodeZ == t.z {
+		return resetTarget{Target: t.z}, nil
+	}
+
+	// before starting bisection, check if a is inconsistent (i.e. the node has no common reference point)
+	// if the first block in the range can't be found or is inconsistent, we initiate a pre-Interop reset
+	nodeA, err := t.backend.BlockIDByNumber(nodeCtx, t.a.Number)
+	if errors.Is(err, ethereum.NotFound) {
+		t.log.Debug("start of range is not known to node, returning pre-Interop reset target", "a", t.a)
+		return resetTarget{PreInterop: true}, nil
+	} else if err != nil {
+		return resetTarget{}, fmt.Errorf("failed to query start block: %w", err)
+	} else if nodeA != t.a {
+		t.log.Debug("start of range mismatch between node and supervisor, returning pre-Interop reset target", "a", t.a)
+		return resetTarget{PreInterop: true}, nil
+	}
+
+	// repeatedly bisect the range until the last consistent block is found
+	for {
+		// covers both cases where a+1 == z and a == z
+		if t.a.Number+1 >= t.z.Number {
+			t.log.Debug("reset target converged. Resetting to start of range", "a", t.a, "z", t.z)
+			return resetTarget{Target: t.a}, nil
+		}
+		err := t.bisect(ctx)
+		if err != nil {
+			return resetTarget{}, fmt.Errorf("failed to bisect range [%s, %s]: %w", t.a, t.z, err)
+		}
+	}
+}
+
+// bisect halves the search range of the ongoing reset to narrow down
+// where the reset will target. It bisects the range and constrains either
+// the start or the end of the range, based on the consistency of the midpoint
+// with the logs db.
+func (t *resetTracker) bisect(ctx context.Context) error {
+	internalCtx, iCancel := context.WithTimeout(ctx, internalTimeout)
+	defer iCancel()
+	nodeCtx, nCancel := context.WithTimeout(ctx, nodeTimeout)
+	defer nCancel()
+
+	// attempt to get the block at the midpoint of the range
+	i := (t.a.Number + t.z.Number) / 2
+	nodeI, err := t.backend.BlockIDByNumber(nodeCtx, i)
+
+	// if the block is not known to the node, it is defacto inconsistent
+	if errors.Is(err, ethereum.NotFound) {
+		t.log.Debug("midpoint of range is not known to node. pulling back end of range", "i", i)
+		t.z = eth.BlockID{Number: i}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to query midpoint block number %d: %w", i, err)
+	}
+
+	// Check if the block at i is consistent with the local-safe DB,
+	if err = t.backend.IsLocalSafe(internalCtx, nodeI); errors.Is(err, types.ErrFuture) || errors.Is(err, types.ErrConflict) {
+		// TODO: do we need to add more sentinel errors here?
+		// TODO(#16026): could gracefully exit on block-replacement (no need to reset what is already being built replacement for)
+		t.log.Debug("midpoint of range is inconsistent. pulling back end of range", "i", i)
+		t.z = nodeI
+	} else if err != nil {
+		return fmt.Errorf("failed to check if midpoint %d is local safe: %w", i, err)
+	} else {
+		t.log.Debug("midpoint of range is consistent. pushing up start of range", "i", i)
+		t.a = nodeI
+	}
+	return nil
+}

--- a/op-supervisor/supervisor/backend/syncnode/reset_tracker_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset_tracker_test.go
@@ -1,0 +1,149 @@
+package syncnode
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// mockResetBackend implements the resetBackend interface for testing
+type mockResetBackend struct {
+	// nodeBlocks represents blocks known to the node
+	nodeBlocks map[uint64]eth.BlockID
+	// safeBlocks represents blocks marked as safe in the local DB
+	safeBlocks map[uint64]eth.BlockID
+}
+
+func (m *mockResetBackend) reset() {
+	m.nodeBlocks = make(map[uint64]eth.BlockID)
+	m.safeBlocks = make(map[uint64]eth.BlockID)
+}
+
+func (m *mockResetBackend) BlockIDByNumber(ctx context.Context, n uint64) (eth.BlockID, error) {
+	if block, ok := m.nodeBlocks[n]; ok {
+		return block, nil
+	}
+	return eth.BlockID{}, ethereum.NotFound
+}
+
+func (m *mockResetBackend) IsLocalSafe(ctx context.Context, block eth.BlockID) error {
+	if safeBlock, ok := m.safeBlocks[block.Number]; ok {
+		if safeBlock == block {
+			return nil
+		}
+		return types.ErrConflict
+	}
+	return types.ErrFuture
+}
+
+func TestResetTracker(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlDebug)
+	backend := new(mockResetBackend)
+	tracker := newResetTracker(logger, backend)
+	ctx := context.Background()
+
+	// Helper to create a block ID with a specific hash
+	mkBlock := func(n uint64, nodeDivHash bool) eth.BlockID {
+		hash := common.Hash{byte(n)}
+		if nodeDivHash {
+			hash[1] = 0xff
+		}
+		return eth.BlockID{Number: n, Hash: hash}
+	}
+
+	// Helper to set up a range of blocks
+	// start: first block number in range
+	// endNode: last block number in node
+	// endLocal: last block number in local DB
+	// divergence: block number at which node and safe DB hashes start to differ
+	setupRange := func(start, endNode, endLocal, divergence uint64) {
+		for i := start; i <= endNode; i++ {
+			backend.nodeBlocks[i] = mkBlock(i, i >= divergence)
+		}
+
+		for i := start; i <= endLocal; i++ {
+			backend.safeBlocks[i] = mkBlock(i, false)
+		}
+	}
+
+	t.Run("pre-interop start block not found in node", func(t *testing.T) {
+		backend.reset()
+		target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(10, false))
+		require.NoError(t, err)
+		require.True(t, target.PreInterop, "target is instead %v", target.Target)
+	})
+
+	t.Run("pre-interop start block inconsistent", func(t *testing.T) {
+		backend.reset()
+		setupRange(1, 10, 10, 1) // divergence at start, so all blocks are inconsistent
+		target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(10, false))
+		require.NoError(t, err)
+		require.True(t, target.PreInterop, "target is instead %v", target.Target)
+	})
+
+	t.Run("target found when end block is consistent", func(t *testing.T) {
+		backend.reset()
+		setupRange(1, 10, 10, 11) // divergence after range, so all blocks are consistent
+		target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(10, false))
+		require.NoError(t, err)
+		require.False(t, target.PreInterop)
+		require.Equal(t, uint64(10), target.Target.Number)
+		require.Equal(t, common.Hash{0x0a}, target.Target.Hash)
+	})
+
+	t.Run("bisection finds last consistent block", func(t *testing.T) {
+		const rangeEnd = uint64(17)
+		for divergence := uint64(2); divergence <= rangeEnd; divergence++ {
+			t.Run(fmt.Sprintf("divergence at %d", divergence), func(t *testing.T) {
+				backend.reset()
+				setupRange(1, rangeEnd, rangeEnd, divergence)
+				target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(rangeEnd, false))
+				require.NoError(t, err)
+				require.False(t, target.PreInterop)
+				require.Equal(t, divergence-1, target.Target.Number)
+				require.Equal(t, common.Hash{byte(divergence - 1)}, target.Target.Hash)
+			})
+		}
+	})
+
+	t.Run("converges to start when range is small", func(t *testing.T) {
+		backend.reset()
+		// Set up a small range where only the start is consistent
+		setupRange(1, 2, 2, 2)
+		target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(2, false))
+		require.NoError(t, err)
+		require.False(t, target.PreInterop)
+		require.Equal(t, uint64(1), target.Target.Number)
+		require.Equal(t, common.Hash{0x01}, target.Target.Hash)
+	})
+
+	t.Run("handles node ahead of local DB", func(t *testing.T) {
+		backend.reset()
+		// Node has more blocks than local DB
+		setupRange(1, 10, 5, 11) // node has 1-10, local has 1-5
+		target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(5, false))
+		require.NoError(t, err)
+		require.False(t, target.PreInterop)
+		require.Equal(t, uint64(5), target.Target.Number)
+		require.Equal(t, common.Hash{0x05}, target.Target.Hash)
+	})
+
+	t.Run("handles local DB ahead of node", func(t *testing.T) {
+		backend.reset()
+		// Local DB has more blocks than node
+		setupRange(1, 5, 10, 11) // node has 1-5, local has 1-10
+		target, err := tracker.FindResetTarget(ctx, mkBlock(1, false), mkBlock(10, false))
+		require.NoError(t, err)
+		require.False(t, target.PreInterop)
+		require.Equal(t, uint64(5), target.Target.Number)
+		require.Equal(t, common.Hash{0x05}, target.Target.Hash)
+	})
+}

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -418,6 +418,17 @@ func (s BlockSeal) WithParent(parent eth.BlockID) (eth.BlockRef, error) {
 	}, nil
 }
 
+// WithZeroParent returns [s] with a zero parent hash. This should only be used
+// where a BlockRef is required, but from the calling context it is guaranteed that
+// the parent hash is not needed.
+func (s BlockSeal) WithZeroParent() eth.BlockRef {
+	return eth.BlockRef{
+		Hash:   s.Hash,
+		Number: s.Number,
+		Time:   s.Timestamp,
+	}
+}
+
 func (s BlockSeal) ForceWithParent(parent eth.BlockID) eth.BlockRef {
 	return eth.BlockRef{
 		Hash:       s.Hash,


### PR DESCRIPTION
**Description**

The op-node and op-supervisor are taught to handle a non-Genesis Interop activation timestamp properly in managed mode. In essence, the op-supervisor _just does less_ while the op-node does _a bit more_ pre-Interop:

* Before Interop is active, the op-node locally auto-promotes _local_-(un)safe to _cross_(un)safe blocks (as before).
* Only L1 derivation is driven by the op-supervisor pre-Interop.
    * ExhaustL1 events are answered by new L1 blocks as they become available.
    * Reset requests are answered by the supervisor with a special `ResetPreInterop` response.
* When the supervisor detects the (unsafe and safe) activation blocks, it initiates the (events and derivation) DBs.
* If a post-Interop reset bisection cannot find a consistent block, i.e. not even the anchor block stored in the DB is consistent with the node's view, then a pre-Interop reset is initiated as well.

The explicit notion of the anchor block is also mostly removed already in this PR.
* The full supervisor config set includes genesis information, so the op-supervisor tests at startup whether the genesis block already has Interop active. If so, it will locally initiate the DB from genesis information, not querying `AnchorBlock` on the managed nodes.
* If genesis hasn't Interop active yet, it is assumed that the activation block passes by the supervisor via its block subscription on its manages nodes.

This PR also makes the logs DB check itself whether it is initialized so that the ChainsDB initialized markers are only used to denote a fully initialized ChainsDB from a safe activation block.

**Tests**

The action test `TestInteropUpgrade` at `op-e2e/actions/interop/interop_fork_test.go` already runs Interop through an activation and asserts that the Interop activation block is properly sequenced and derived. This implicitly confirms that the activation logic in op-node/op-supervisor functions properly around the Interop activation timestamp. Some modifications were done to this test since it had some false logic that only worked with the previous pseudo-pre-Interop logic that the supervisor was following.

A post-genesis Interop variant of `TestBackendLifetime` was also added, and the previous tests adapted.

More action and acceptance tests will be added in future work.

**Additional context**

In a followup, full reorg support around the activation block is added. It probably wouldn't work right now, will be worked out in https://github.com/ethereum-optimism/optimism/issues/15774

A few proofs tests or checks had to be commented out because the op-challenger (and probably other bits) still need some more work to make non-genesis activation work. This will be resolved with https://github.com/ethereum-optimism/optimism/issues/16166

This PR breaks mutli-node support, which we decided to drop. So a few tests had to be skipped because of this. They will either be removed or fixed (https://github.com/ethereum-optimism/optimism/issues/16187).

This PR also doesn't fully remove the notion of the anchor block yet. This is reserved for future work https://github.com/ethereum-optimism/optimism/issues/16140

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/13732
