### PR TITLE
feat(op-acceptance-tests): remove test precompile.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1194,11 +1194,6 @@ jobs:
           name: Download Go dependencies
           working_directory: op-acceptance-tests
           command: go mod download
-      # Prepare the test environment
-      - run:
-          name: Prepare test environment (compile tests and cache results)
-          working_directory: op-acceptance-tests
-          command: go test -run=^$ ./tests/...
       # Run the acceptance tests (if the devnet is running)
       - run:
           name: Run acceptance tests (gate=<<parameters.gate>>)


### PR DESCRIPTION
Removes the go test precompilation stage (used to cache the build artifacts), as it also runs the test init() code, which can cause tricky issues with instantiating op-devstack against the incorrect backend.
With this precompilation stage removed, the first test runs about a minute slower but the complexity of instantiating op-devstack incorrectly is significantly eased.

The total runtime, based on a sample of 1 seems unaffected. Comparing runtimes:

Previous workflow ([link](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/90570/workflows/2702cf1d-116f-4d7e-9d59-c9851488396b/jobs/3542871)):
* Precompile = 2m25s
* Run tests = 8m17s
* TOTAL = 10m42s

This workflow ([link](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/90579/workflows/aae0677d-12fd-46cd-93cd-b32a2961c26c/jobs/3543014)):
* Run tests = 10m35s
* TOTAL = 10m35s