### PR TITLE
op-devstack: minimal preset: add support for test-sequencer

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -32,7 +32,7 @@ func TestReorgInitExecMsg(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 	l := sys.Log
 
-	ia := sys.Sequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
+	ia := sys.TestSequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
 
 	// three EOAs for triggering the init and exec interop txs, as well as a simple transfer tx
 	var alice, bob, cathrine *dsl.EOA

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -55,7 +55,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 	sys := presets.NewSimpleInterop(t)
 	l := sys.Log
 
-	ia := sys.Sequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
+	ia := sys.TestSequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
 
 	// three EOAs for triggering the init and exec interop txs, as well as a simple transfer tx
 	var alice, bob, cathrine *dsl.EOA

--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -21,7 +21,7 @@ func TestReorgUnsafeHead(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 	l := sys.Log
 
-	ia := sys.Sequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
+	ia := sys.TestSequencer.Escape().IndividualAPI(sys.L2ChainA.ChainID())
 
 	// stop batcher on chain A
 	sys.L2BatcherA.Stop()

--- a/op-devstack/dsl/sequencer.go
+++ b/op-devstack/dsl/sequencer.go
@@ -4,23 +4,23 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 )
 
-type Sequencer struct {
+type TestSequencer struct {
 	commonImpl
 
-	inner stack.Sequencer
+	inner stack.TestSequencer
 }
 
-func NewSequencer(inner stack.Sequencer) *Sequencer {
-	return &Sequencer{
+func NewTestSequencer(inner stack.TestSequencer) *TestSequencer {
+	return &TestSequencer{
 		commonImpl: commonFromT(inner.T()),
 		inner:      inner,
 	}
 }
 
-func (s *Sequencer) String() string {
+func (s *TestSequencer) String() string {
 	return s.inner.ID().String()
 }
 
-func (s *Sequencer) Escape() stack.Sequencer {
+func (s *TestSequencer) Escape() stack.TestSequencer {
 	return s.inner
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -19,9 +19,9 @@ type SimpleInterop struct {
 	T      devtest.T
 	system stack.ExtensibleSystem
 
-	Supervisor   *dsl.Supervisor
-	Sequencer    *dsl.Sequencer
-	ControlPlane stack.ControlPlane
+	Supervisor    *dsl.Supervisor
+	TestSequencer *dsl.TestSequencer
+	ControlPlane  stack.ControlPlane
 
 	L1Network *dsl.L1Network
 	L1EL      *dsl.L1ELNode
@@ -68,31 +68,31 @@ func NewSimpleInterop(t devtest.T) *SimpleInterop {
 	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
 	// since currently there's no way to tell which nodes are using which supervisor.
 
-	t.Gate().Equal(len(system.Sequencers()), 1, "expected exactly one sequencer")
+	t.Gate().Equal(len(system.TestSequencers()), 1, "expected exactly one test sequencer")
 
 	l1Net := system.L1Network(match.FirstL1Network)
 	l2A := system.L2Network(match.Assume(t, match.L2ChainA))
 	l2B := system.L2Network(match.Assume(t, match.L2ChainB))
 	out := &SimpleInterop{
-		Log:          t.Logger(),
-		T:            t,
-		system:       system,
-		Sequencer:    dsl.NewSequencer(system.Sequencer(match.Assume(t, match.FirstSequencer))),
-		Supervisor:   dsl.NewSupervisor(system.Supervisor(match.Assume(t, match.FirstSupervisor)), orch.ControlPlane()),
-		ControlPlane: orch.ControlPlane(),
-		L1Network:    dsl.NewL1Network(l1Net),
-		L1EL:         dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2ChainA:     dsl.NewL2Network(l2A),
-		L2ChainB:     dsl.NewL2Network(l2B),
-		L2ELA:        dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL))),
-		L2ELB:        dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.FirstL2EL))),
-		L2CLA:        dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-		L2CLB:        dsl.NewL2CLNode(l2B.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-		Wallet:       dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
-		FaucetA:      dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
-		FaucetB:      dsl.NewFaucet(l2B.Faucet(match.Assume(t, match.FirstFaucet))),
-		L2BatcherA:   dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
-		L2BatcherB:   dsl.NewL2Batcher(l2B.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		Log:           t.Logger(),
+		T:             t,
+		system:        system,
+		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
+		Supervisor:    dsl.NewSupervisor(system.Supervisor(match.Assume(t, match.FirstSupervisor)), orch.ControlPlane()),
+		ControlPlane:  orch.ControlPlane(),
+		L1Network:     dsl.NewL1Network(l1Net),
+		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
+		L2ChainA:      dsl.NewL2Network(l2A),
+		L2ChainB:      dsl.NewL2Network(l2B),
+		L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2ELB:         dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		L2CLB:         dsl.NewL2CLNode(l2B.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
+		FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
+		FaucetB:       dsl.NewFaucet(l2B.Faucet(match.Assume(t, match.FirstFaucet))),
+		L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		L2BatcherB:    dsl.NewL2Batcher(l2B.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
 	}
 	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
 	out.FunderB = dsl.NewFunder(out.Wallet, out.FaucetB, out.L2ELB)

--- a/op-devstack/presets/minimal.go
+++ b/op-devstack/presets/minimal.go
@@ -47,6 +47,8 @@ func NewMinimal(t devtest.T) *Minimal {
 	orch := Orchestrator()
 	orch.Hydrate(system)
 
+	t.Gate().Equal(len(system.TestSequencers()), 1, "expected exactly one test sequencer")
+
 	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
 	out := &Minimal{
 		Log:           t.Logger(),

--- a/op-devstack/presets/minimal.go
+++ b/op-devstack/presets/minimal.go
@@ -24,6 +24,8 @@ type Minimal struct {
 	L2EL      *dsl.L2ELNode
 	L2CL      *dsl.L2CLNode
 
+	TestSequencer *dsl.TestSequencer
+
 	Wallet *dsl.HDWallet
 
 	Faucet *dsl.Faucet
@@ -47,16 +49,17 @@ func NewMinimal(t devtest.T) *Minimal {
 
 	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
 	out := &Minimal{
-		Log:          t.Logger(),
-		T:            t,
-		ControlPlane: orch.ControlPlane(),
-		L1Network:    dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
-		L2Chain:      dsl.NewL2Network(l2),
-		L2Batcher:    dsl.NewL2Batcher(l2.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
-		L2EL:         dsl.NewL2ELNode(l2.L2ELNode(match.Assume(t, match.FirstL2EL))),
-		L2CL:         dsl.NewL2CLNode(l2.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-		Wallet:       dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
-		Faucet:       dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
+		Log:           t.Logger(),
+		T:             t,
+		ControlPlane:  orch.ControlPlane(),
+		L1Network:     dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
+		L2Chain:       dsl.NewL2Network(l2),
+		L2Batcher:     dsl.NewL2Batcher(l2.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		L2EL:          dsl.NewL2ELNode(l2.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2CL:          dsl.NewL2CLNode(l2.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
+		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
+		Faucet:        dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
 	}
 	out.Funder = dsl.NewFunder(out.Wallet, out.Faucet, out.L2EL)
 	return out

--- a/op-devstack/shim/sequencer.go
+++ b/op-devstack/shim/sequencer.go
@@ -8,52 +8,52 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
-type SequencerConfig struct {
+type TestSequencerConfig struct {
 	CommonConfig
-	ID                 stack.SequencerID
+	ID                 stack.TestSequencerID
 	Client             client.RPC
 	L2SequencerClients map[eth.ChainID]client.RPC
 }
 
-type rpcSequencer struct {
+type rpcTestSequencer struct {
 	commonImpl
-	id stack.SequencerID
+	id stack.TestSequencerID
 
 	client       client.RPC
-	api          apis.SequencerAPI
-	l2sequencers map[eth.ChainID]apis.SequencerIndividualAPI
+	api          apis.TestSequencerAPI
+	l2sequencers map[eth.ChainID]apis.TestSequencerIndividualAPI
 }
 
-var _ stack.Sequencer = (*rpcSequencer)(nil)
+var _ stack.TestSequencer = (*rpcTestSequencer)(nil)
 
-func NewSequencer(cfg SequencerConfig) stack.Sequencer {
+func NewTestSequencer(cfg TestSequencerConfig) stack.TestSequencer {
 	cfg.Log = cfg.Log.New("id", cfg.ID)
-	s := &rpcSequencer{
+	s := &rpcTestSequencer{
 		commonImpl: newCommon(cfg.CommonConfig),
 		id:         cfg.ID,
 		client:     cfg.Client,
 		api:        sources.NewBuilderClient(cfg.Client),
 	}
 
-	s.l2sequencers = make(map[eth.ChainID]apis.SequencerIndividualAPI)
+	s.l2sequencers = make(map[eth.ChainID]apis.TestSequencerIndividualAPI)
 	for k, v := range cfg.L2SequencerClients {
 		s.l2sequencers[k] = sources.NewIndividualClient(v)
 	}
 	return s
 }
 
-func (r *rpcSequencer) ID() stack.SequencerID {
+func (r *rpcTestSequencer) ID() stack.TestSequencerID {
 	return r.id
 }
 
-func (r *rpcSequencer) AdminAPI() apis.SequencerAdminAPI {
+func (r *rpcTestSequencer) AdminAPI() apis.TestSequencerAdminAPI {
 	return r.api
 }
 
-func (r *rpcSequencer) BuildAPI() apis.SequencerBuildAPI {
+func (r *rpcTestSequencer) BuildAPI() apis.TestSequencerBuildAPI {
 	return r.api
 }
 
-func (r *rpcSequencer) IndividualAPI(chainID eth.ChainID) apis.SequencerIndividualAPI {
+func (r *rpcTestSequencer) IndividualAPI(chainID eth.ChainID) apis.TestSequencerIndividualAPI {
 	return r.l2sequencers[chainID]
 }

--- a/op-devstack/shim/system.go
+++ b/op-devstack/shim/system.go
@@ -28,7 +28,7 @@ type presetSystem struct {
 	networks locks.RWMap[eth.ChainID, stack.Network]
 
 	supervisors locks.RWMap[stack.SupervisorID, stack.Supervisor]
-	sequencers  locks.RWMap[stack.SequencerID, stack.Sequencer]
+	sequencers  locks.RWMap[stack.TestSequencerID, stack.TestSequencer]
 }
 
 var _ stack.ExtensibleSystem = (*presetSystem)(nil)
@@ -105,13 +105,13 @@ func (p *presetSystem) AddSupervisor(v stack.Supervisor) {
 	p.require().True(p.supervisors.SetIfMissing(v.ID(), v), "supervisor %s must not already exist", v.ID())
 }
 
-func (p *presetSystem) Sequencer(m stack.SequencerMatcher) stack.Sequencer {
-	v, ok := findMatch(m, p.sequencers.Get, p.Sequencers)
+func (p *presetSystem) TestSequencer(m stack.TestSequencerMatcher) stack.TestSequencer {
+	v, ok := findMatch(m, p.sequencers.Get, p.TestSequencers)
 	p.require().True(ok, "must find sequencer %s", m)
 	return v
 }
 
-func (p *presetSystem) AddSequencer(v stack.Sequencer) {
+func (p *presetSystem) AddTestSequencer(v stack.TestSequencer) {
 	p.require().True(p.sequencers.SetIfMissing(v.ID(), v), "sequencer %s must not already exist", v.ID())
 }
 
@@ -155,6 +155,6 @@ func (p *presetSystem) Supervisors() []stack.Supervisor {
 	return stack.SortSupervisors(p.supervisors.Values())
 }
 
-func (p *presetSystem) Sequencers() []stack.Sequencer {
-	return stack.SortSequencers(p.sequencers.Values())
+func (p *presetSystem) TestSequencers() []stack.TestSequencer {
+	return stack.SortTestSequencers(p.sequencers.Values())
 }

--- a/op-devstack/stack/match/first.go
+++ b/op-devstack/stack/match/first.go
@@ -8,7 +8,7 @@ var FirstL2Batcher = First[stack.L2BatcherID, stack.L2Batcher]()
 var FirstL2Proposer = First[stack.L2ProposerID, stack.L2Proposer]()
 var FirstL2Challenger = First[stack.L2ChallengerID, stack.L2Challenger]()
 
-var FirstSequencer = First[stack.SequencerID, stack.Sequencer]()
+var FirstTestSequencer = First[stack.TestSequencerID, stack.TestSequencer]()
 var FirstSupervisor = First[stack.SupervisorID, stack.Supervisor]()
 
 var FirstL1EL = First[stack.L1ELNodeID, stack.L1ELNode]()

--- a/op-devstack/stack/matcher.go
+++ b/op-devstack/stack/matcher.go
@@ -51,7 +51,7 @@ type L2CLMatcher = Matcher[L2CLNodeID, L2CLNode]
 
 type SupervisorMatcher = Matcher[SupervisorID, Supervisor]
 
-type SequencerMatcher = Matcher[SequencerID, Sequencer]
+type TestSequencerMatcher = Matcher[TestSequencerID, TestSequencer]
 
 type L2ELMatcher = Matcher[L2ELNodeID, L2ELNode]
 

--- a/op-devstack/stack/sequencer.go
+++ b/op-devstack/stack/sequencer.go
@@ -5,37 +5,37 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// SequencerID identifies a Sequencer by name and chainID, is type-safe, and can be value-copied and used as map key.
-type SequencerID genericID
+// TestSequencerID identifies a TestSequencer by name and chainID, is type-safe, and can be value-copied and used as map key.
+type TestSequencerID genericID
 
-const SequencerKind Kind = "Sequencer"
+const TestSequencerKind Kind = "TestSequencer"
 
-func (id SequencerID) String() string {
-	return genericID(id).string(SequencerKind)
+func (id TestSequencerID) String() string {
+	return genericID(id).string(TestSequencerKind)
 }
 
-func (id SequencerID) MarshalText() ([]byte, error) {
-	return genericID(id).marshalText(SequencerKind)
+func (id TestSequencerID) MarshalText() ([]byte, error) {
+	return genericID(id).marshalText(TestSequencerKind)
 }
 
-func (id *SequencerID) UnmarshalText(data []byte) error {
-	return (*genericID)(id).unmarshalText(SequencerKind, data)
+func (id *TestSequencerID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).unmarshalText(TestSequencerKind, data)
 }
 
-func SortSequencerIDs(ids []SequencerID) []SequencerID {
+func SortTestSequencerIDs(ids []TestSequencerID) []TestSequencerID {
 	return copyAndSortCmp(ids)
 }
 
-func SortSequencers(elems []Sequencer) []Sequencer {
-	return copyAndSort(elems, lessElemOrdered[SequencerID, Sequencer])
+func SortTestSequencers(elems []TestSequencer) []TestSequencer {
+	return copyAndSort(elems, lessElemOrdered[TestSequencerID, TestSequencer])
 }
 
-// Sequencer
-type Sequencer interface {
+// TestSequencer
+type TestSequencer interface {
 	Common
-	ID() SequencerID
+	ID() TestSequencerID
 
-	AdminAPI() apis.SequencerAdminAPI
-	BuildAPI() apis.SequencerBuildAPI
-	IndividualAPI(chainID eth.ChainID) apis.SequencerIndividualAPI
+	AdminAPI() apis.TestSequencerAdminAPI
+	BuildAPI() apis.TestSequencerBuildAPI
+	IndividualAPI(chainID eth.ChainID) apis.TestSequencerIndividualAPI
 }

--- a/op-devstack/stack/system.go
+++ b/op-devstack/stack/system.go
@@ -14,7 +14,7 @@ type System interface {
 	Network(id eth.ChainID) Network
 
 	Supervisor(m SupervisorMatcher) Supervisor
-	Sequencer(id SequencerMatcher) Sequencer
+	TestSequencer(id TestSequencerMatcher) TestSequencer
 
 	SuperchainIDs() []SuperchainID
 	ClusterIDs() []ClusterID
@@ -27,7 +27,7 @@ type System interface {
 	L1Networks() []L1Network
 	L2Networks() []L2Network
 	Supervisors() []Supervisor
-	Sequencers() []Sequencer
+	TestSequencers() []TestSequencer
 }
 
 // ExtensibleSystem is an extension-interface to add new components to the system.
@@ -40,5 +40,5 @@ type ExtensibleSystem interface {
 	AddL1Network(v L1Network)
 	AddL2Network(v L2Network)
 	AddSupervisor(v Supervisor)
-	AddSequencer(v Sequencer)
+	AddTestSequencer(v TestSequencer)
 }

--- a/op-devstack/sysext/orchestrator.go
+++ b/op-devstack/sysext/orchestrator.go
@@ -63,7 +63,7 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.hydrateSuperchain(sys)
 	o.hydrateClustersMaybe(sys)
 	o.hydrateSupervisorsMaybe(sys)
-	o.hydrateSequencersMaybe(sys)
+	o.hydrateTestSequencersMaybe(sys)
 	for _, l2Net := range o.env.Env.L2 {
 		o.hydrateL2(l2Net, sys)
 	}

--- a/op-devstack/sysext/system.go
+++ b/op-devstack/sysext/system.go
@@ -67,11 +67,11 @@ func (o *Orchestrator) hydrateSupervisorsMaybe(sys stack.ExtensibleSystem) {
 	}
 }
 
-func (o *Orchestrator) hydrateSequencersMaybe(sys stack.ExtensibleSystem) {
+func (o *Orchestrator) hydrateTestSequencersMaybe(sys stack.ExtensibleSystem) {
 	// TODO(#15265) op-test-sequencer: add to devnet env and kurtosis
-	sys.AddSequencer(shim.NewSequencer(shim.SequencerConfig{
+	sys.AddTestSequencer(shim.NewTestSequencer(shim.TestSequencerConfig{
 		CommonConfig:       shim.NewCommonConfig(sys.T()),
-		ID:                 stack.SequencerID("dummy"),
+		ID:                 stack.TestSequencerID("dummy"),
 		Client:             nil,
 		L2SequencerClients: nil,
 	}))

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -29,19 +29,19 @@ type Orchestrator struct {
 	// options
 	batcherOptions []BatcherOption
 
-	superchains locks.RWMap[stack.SuperchainID, *Superchain]
-	clusters    locks.RWMap[stack.ClusterID, *Cluster]
-	l1Nets      locks.RWMap[eth.ChainID, *L1Network]
-	l2Nets      locks.RWMap[eth.ChainID, *L2Network]
-	l1ELs       locks.RWMap[stack.L1ELNodeID, *L1ELNode]
-	l1CLs       locks.RWMap[stack.L1CLNodeID, *L1CLNode]
-	l2ELs       locks.RWMap[stack.L2ELNodeID, *L2ELNode]
-	l2CLs       locks.RWMap[stack.L2CLNodeID, *L2CLNode]
-	supervisors locks.RWMap[stack.SupervisorID, *Supervisor]
-	sequencers  locks.RWMap[stack.SequencerID, *Sequencer]
-	batchers    locks.RWMap[stack.L2BatcherID, *L2Batcher]
-	challengers locks.RWMap[stack.L2ChallengerID, *L2Challenger]
-	proposers   locks.RWMap[stack.L2ProposerID, *L2Proposer]
+	superchains    locks.RWMap[stack.SuperchainID, *Superchain]
+	clusters       locks.RWMap[stack.ClusterID, *Cluster]
+	l1Nets         locks.RWMap[eth.ChainID, *L1Network]
+	l2Nets         locks.RWMap[eth.ChainID, *L2Network]
+	l1ELs          locks.RWMap[stack.L1ELNodeID, *L1ELNode]
+	l1CLs          locks.RWMap[stack.L1CLNodeID, *L1CLNode]
+	l2ELs          locks.RWMap[stack.L2ELNodeID, *L2ELNode]
+	l2CLs          locks.RWMap[stack.L2CLNodeID, *L2CLNode]
+	supervisors    locks.RWMap[stack.SupervisorID, *Supervisor]
+	testSequencers locks.RWMap[stack.TestSequencerID, *TestSequencer]
+	batchers       locks.RWMap[stack.L2BatcherID, *L2Batcher]
+	challengers    locks.RWMap[stack.L2ChallengerID, *L2Challenger]
+	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
 
 	faucet *FaucetService
 
@@ -93,7 +93,7 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.l2ELs.Range(rangeHydrateFn[stack.L2ELNodeID, *L2ELNode](sys))
 	o.l2CLs.Range(rangeHydrateFn[stack.L2CLNodeID, *L2CLNode](sys))
 	o.supervisors.Range(rangeHydrateFn[stack.SupervisorID, *Supervisor](sys))
-	o.sequencers.Range(rangeHydrateFn[stack.SequencerID, *Sequencer](sys))
+	o.testSequencers.Range(rangeHydrateFn[stack.TestSequencerID, *TestSequencer](sys))
 	o.batchers.Range(rangeHydrateFn[stack.L2BatcherID, *L2Batcher](sys))
 	o.challengers.Range(rangeHydrateFn[stack.L2ChallengerID, *L2Challenger](sys))
 	o.proposers.Range(rangeHydrateFn[stack.L2ProposerID, *L2Proposer](sys))

--- a/op-devstack/sysgo/sequencer.go
+++ b/op-devstack/sysgo/sequencer.go
@@ -33,14 +33,14 @@ import (
 	gn "github.com/ethereum/go-ethereum/node"
 )
 
-type Sequencer struct {
-	id           stack.SequencerID
+type TestSequencer struct {
+	id           stack.TestSequencerID
 	userRPC      string
 	jwtSecret    [32]byte
 	l2sequencers map[eth.ChainID]seqtypes.SequencerID
 }
 
-func (s *Sequencer) hydrate(sys stack.ExtensibleSystem) {
+func (s *TestSequencer) hydrate(sys stack.ExtensibleSystem) {
 	tlog := sys.Logger().New("id", s.id)
 
 	opts := []client.RPCOption{
@@ -61,7 +61,7 @@ func (s *Sequencer) hydrate(sys stack.ExtensibleSystem) {
 		l2sequencersRpcs[chainID] = seqRpc
 	}
 
-	sys.AddSequencer(shim.NewSequencer(shim.SequencerConfig{
+	sys.AddTestSequencer(shim.NewTestSequencer(shim.TestSequencerConfig{
 		CommonConfig:       shim.NewCommonConfig(sys.T()),
 		ID:                 s.id,
 		Client:             sqClient,
@@ -69,11 +69,11 @@ func (s *Sequencer) hydrate(sys stack.ExtensibleSystem) {
 	}))
 }
 
-func WithSequencer(sequencerID stack.SequencerID, l2CLID stack.L2CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithTestSequencer(testSequencerID stack.TestSequencerID, l2CLID stack.L2CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		require := orch.P().Require()
 
-		logger := orch.P().Logger().New("service", "op-test-sequencer", "id", sequencerID)
+		logger := orch.P().Logger().New("service", "op-test-sequencer", "id", testSequencerID)
 
 		l1EL, ok := orch.l1ELs.Get(l1ELID)
 		require.True(ok, "l1 EL node required")
@@ -203,15 +203,15 @@ func WithSequencer(sequencerID stack.SequencerID, l2CLID stack.L2CLNodeID, l1ELI
 			logger.Info("Closed sequencer", "err", closeErr)
 		})
 
-		sequencerNode := &Sequencer{
-			id:        sequencerID,
+		testSequencerNode := &TestSequencer{
+			id:        testSequencerID,
 			userRPC:   sq.RPC(),
 			jwtSecret: jwtSecret,
 			l2sequencers: map[eth.ChainID]seqtypes.SequencerID{
 				l2CLID.ChainID: l2SequencerID,
 			},
 		}
-		logger.Info("Sequencer User RPC", "http_endpoint", sequencerNode.userRPC)
-		orch.sequencers.Set(sequencerID, sequencerNode)
+		logger.Info("Sequencer User RPC", "http_endpoint", testSequencerNode.userRPC)
+		orch.testSequencers.Set(testSequencerID, testSequencerNode)
 	})
 }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -17,18 +17,21 @@ type DefaultMinimalSystemIDs struct {
 
 	L2Batcher  stack.L2BatcherID
 	L2Proposer stack.L2ProposerID
+
+	TestSequencer stack.TestSequencerID
 }
 
 func NewDefaultMinimalSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimalSystemIDs {
 	ids := DefaultMinimalSystemIDs{
-		L1:         stack.L1NetworkID(l1ID),
-		L1EL:       stack.L1ELNodeID{Key: "l1", ChainID: l1ID},
-		L1CL:       stack.L1CLNodeID{Key: "l1", ChainID: l1ID},
-		L2:         stack.L2NetworkID(l2ID),
-		L2CL:       stack.L2CLNodeID{Key: "sequencer", ChainID: l2ID},
-		L2EL:       stack.L2ELNodeID{Key: "sequencer", ChainID: l2ID},
-		L2Batcher:  stack.L2BatcherID{Key: "main", ChainID: l2ID},
-		L2Proposer: stack.L2ProposerID{Key: "main", ChainID: l2ID},
+		L1:            stack.L1NetworkID(l1ID),
+		L1EL:          stack.L1ELNodeID{Key: "l1", ChainID: l1ID},
+		L1CL:          stack.L1CLNodeID{Key: "l1", ChainID: l1ID},
+		L2:            stack.L2NetworkID(l2ID),
+		L2CL:          stack.L2CLNodeID{Key: "sequencer", ChainID: l2ID},
+		L2EL:          stack.L2ELNodeID{Key: "sequencer", ChainID: l2ID},
+		L2Batcher:     stack.L2BatcherID{Key: "main", ChainID: l2ID},
+		L2Proposer:    stack.L2ProposerID{Key: "main", ChainID: l2ID},
+		TestSequencer: "test-sequencer",
 	}
 	return ids
 }
@@ -63,6 +66,8 @@ func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestra
 
 	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
 
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L2CL, ids.L1EL, ids.L2EL))
+
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))
@@ -79,8 +84,8 @@ type DefaultInteropSystemIDs struct {
 	Superchain stack.SuperchainID
 	Cluster    stack.ClusterID
 
-	Supervisor stack.SupervisorID
-	Sequencer  stack.SequencerID
+	Supervisor    stack.SupervisorID
+	TestSequencer stack.TestSequencerID
 
 	L2A   stack.L2NetworkID
 	L2ACL stack.L2CLNodeID
@@ -108,7 +113,7 @@ func NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultInteropSy
 		Superchain:    "main", // TODO(#15244): hardcoded to match the deployer default ID
 		Cluster:       stack.ClusterID("main"),
 		Supervisor:    "1-primary", // prefix with number for ordering of supervisors
-		Sequencer:     "dev",
+		TestSequencer: "dev",
 		L2A:           stack.L2NetworkID(l2AID),
 		L2ACL:         stack.L2CLNodeID{Key: "sequencer", ChainID: l2AID},
 		L2AEL:         stack.L2ELNodeID{Key: "sequencer", ChainID: l2AID},
@@ -158,7 +163,7 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	opt.Add(WithL2CLNode(ids.L2ACL, true, ids.L1CL, ids.L1EL, ids.L2AEL))
 	opt.Add(WithL2CLNode(ids.L2BCL, true, ids.L1CL, ids.L1EL, ids.L2BEL))
 
-	opt.Add(WithSequencer(ids.Sequencer, ids.L2ACL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L2ACL, ids.L1EL, ids.L2AEL))
 
 	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
 	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))

--- a/op-service/apis/sequencer.go
+++ b/op-service/apis/sequencer.go
@@ -10,12 +10,12 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-type SequencerAPI interface {
-	SequencerAdminAPI
-	SequencerBuildAPI
+type TestSequencerAPI interface {
+	TestSequencerAdminAPI
+	TestSequencerBuildAPI
 }
 
-type SequencerBuildAPI interface {
+type TestSequencerBuildAPI interface {
 	Close()
 	New(context.Context, seqtypes.BuilderID, *seqtypes.BuildOpts) (seqtypes.BuildJobID, error)
 	Open(context.Context, seqtypes.BuildJobID) error
@@ -24,12 +24,12 @@ type SequencerBuildAPI interface {
 	CloseJob(seqtypes.BuildJobID) error
 }
 
-type SequencerAdminAPI interface {
+type TestSequencerAdminAPI interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 }
 
-type SequencerIndividualAPI interface {
+type TestSequencerIndividualAPI interface {
 	BuildJob() (seqtypes.BuildJobID, error)
 	Commit(ctx context.Context) error
 	IncludeTx(ctx context.Context, tx hexutil.Bytes) error

--- a/op-service/sources/sequencer_client.go
+++ b/op-service/sources/sequencer_client.go
@@ -14,7 +14,7 @@ type BuilderClient struct {
 	client client.RPC
 }
 
-var _ apis.SequencerAPI = (*BuilderClient)(nil)
+var _ apis.TestSequencerAPI = (*BuilderClient)(nil)
 
 func NewBuilderClient(client client.RPC) *BuilderClient {
 	return &BuilderClient{

--- a/op-service/sources/sequencer_individual_client.go
+++ b/op-service/sources/sequencer_individual_client.go
@@ -16,7 +16,7 @@ type IndividualClient struct {
 	client client.RPC
 }
 
-var _ apis.SequencerIndividualAPI = (*IndividualClient)(nil)
+var _ apis.TestSequencerIndividualAPI = (*IndividualClient)(nil)
 
 func NewIndividualClient(client client.RPC) *IndividualClient {
 	return &IndividualClient{


### PR DESCRIPTION
**Description**

This PR is adding the `test-sequencer` service to the `minimal` (non-interop) preset deployment for tests.

It is helpful, because we can compare tests between an interop network and non-interop network, and make sure both work fine (where this makes sense of course).

It is also renaming `Sequencer` to `TestSequencer` to be explicit that this is not a production service, and really a service that is used only within networks for the purpose of tests.

**Additional context**

Helpful for: https://github.com/ethereum-optimism/optimism/issues/15331 (and other reorg tests)