### PR TITLE
op-supervisor: resetTracker fixes

### DIFF
--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -1,6 +1,7 @@
 package seqwindow
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -9,14 +10,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
 // TestSequencingWindowExpiry tests that the sequencing window may expire,
 // the chain reorgs because of it, and that the chain then recovers.
+// This test can take 2-3 minutes to run.
 func TestSequencingWindowExpiry(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#15769): fix sequencing-window expiry interop functionality
-	t.Skip("Interop sequencing-window expiry interaction is known to not fully work yet.")
 
 	sys := presets.NewSimpleInterop(t)
 	require := t.Require()
@@ -39,7 +40,14 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 	t.Logger().Info("Tx 1 is safe now")
 
 	// Stop the batcher of chain A, so the L2 unsafe blocks will not get submitted.
-	require.NoError(sys.L2BatcherA.ActivityAPI().StopBatcher(t.Ctx()))
+	// This may take a while, since the batcher is still actively submitting new data.
+	require.NoError(retry.Do0(t.Ctx(), 10, retry.Exponential(), func() error {
+		err := sys.L2BatcherA.ActivityAPI().StopBatcher(t.Ctx())
+		if err != nil && strings.Contains(err.Error(), "batcher is not running") {
+			return nil
+		}
+		return err
+	}))
 	stoppedAt := sys.L1Network.WaitForBlock() // wait for new block, in case there is any batch left
 	// Make sure the supervisor has synced enough of the L1, for the local-safe query to work.
 	sys.Supervisor.AwaitMinL1(stoppedAt.Number)

--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestSequencingWindowExpiry tests that the sequencing window may expire,
 // the chain reorgs because of it, and that the chain then recovers.
-// This test can take 2-3 minutes to run.
+// This test can take 3 minutes to run.
 func TestSequencingWindowExpiry(gt *testing.T) {
 	t := devtest.SerialT(gt)
 
@@ -83,12 +83,33 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 		"tx", receipt2.TxHash, "l2Block", old)
 	// The logs will show a "Chain reorg detected" from op-geth.
 
+	// Once this happens we don't want to continue to try and include the tx in a block again,
+	// since that will then be reorged out again.
+	// We need to enter recovery-mode to not continue to build an incompatible chain that will not get submitted.
+	// It may reorg once more, but then stays compatible.
+	// For a while we'll have to build blocks that are not going to be reorged out due to subtle L1 origin divergence.
+	t.Logger().Info("Turning on recovery-mode")
+	t.Require().NoError(sys.L2CLA.Escape().RollupAPI().SetRecoverMode(t.Ctx(), true))
+
 	t.Logger().Info("Waiting for sequencing window expiry induced reorg now")
 	// Monitor that the old unsafe chain is reorged out as expected
 	require.Eventually(func() bool {
 		latest := sys.L2ELA.BlockRefByNumber(old.Number)
 		return latest.Hash != old.Hash
 	}, windowDuration+time.Second*20, time.Second, "expecting old block to be reorged out")
+
+	// Wait for the tx to no longer be included.
+	// The tx-indexer may still return the old block or be stale.
+	// So instead, lookup the tx nonce
+	require.Eventually(func() bool {
+		latestNonce, err := sys.L2ELA.Escape().EthClient().NonceAt(t.Ctx(), alice.Address(), nil)
+		if err != nil {
+			t.Logger().Error("Failed to look up pending nonce")
+			return false
+		}
+		t.Logger().Info("Checking tx 2 nonce", "latest", latestNonce, "tx2", tx2.Nonce.Value())
+		return latestNonce <= tx2.Nonce.Value()
+	}, windowDuration+time.Second*20, time.Second, "tx should be reorged out and not come back")
 
 	t.Logger().Info("Waiting for supervisor to surpass pre-reorg chain now")
 	// Monitor that the supervisor can continue to sync.
@@ -110,6 +131,38 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 	other := sys.L2ELA.BlockRefByNumber(safe.Derived.Number)
 	require.Equal(safe.Derived.Hash, other.Hash, "supervisor must match chain with EL")
 
+	t.Logger().Info("Re-enabling batch-submitter")
 	// re-enable the batcher now that we are done with the test.
 	t.Require().NoError(sys.L2BatcherA.ActivityAPI().StartBatcher(t.Ctx()))
+	// TODO: batcher submits future span batch, misses a L2 block
+
+	// Build the missing blocks, catch up on local-safe chain
+	t.Require().Eventually(func() bool {
+		status := sys.L2CLA.SyncStatus()
+		return status.LocalSafeL2.Number+10 > status.UnsafeL2.Number
+	}, windowDuration, time.Second*2, "wait for local-safe to recover near unsafe head")
+
+	// Once we have enough margin to not get reorged again before the batch-submitter acts,
+	// exit recovery mode, so we can include txs again.
+	t.Logger().Info("Exiting recovery mode")
+	t.Require().NoError(sys.L2CLA.Escape().RollupAPI().SetRecoverMode(t.Ctx(), false))
+
+	// Now confirm a tx, chain should be healthy again.
+	tx3 := alice.Transfer(common.HexToAddress("0x7777"), eth.GWei(100))
+	receipt3, err := tx3.Included.Eval(t.Ctx())
+	require.NoError(err)
+	t.Logger().Info("Confirmed tx 3", "tx", receipt3.TxHash, "block", receipt3.BlockHash)
+
+	// Wait for the first tx to become cross-safe.
+	// We are not interested in the sequencing window to expire and revert all the way back to 0.
+	require.Eventually(func() bool {
+		status := sys.L2CLA.SyncStatus()
+		t.Logger().Info("Awaiting tx safety",
+			"local-unsafe", status.UnsafeL2, "local-safe", status.LocalSafeL2)
+		return status.SafeL2.Number > receipt3.BlockNumber.Uint64()
+	}, time.Second*60, time.Second, "wait for tx 3 to be safe")
+	t.Logger().Info("Tx 3 is safe now")
+	// Sanity check the block the tx was included is really still canonical
+	got := sys.L2ELA.BlockRefByNumber(receipt3.BlockNumber.Uint64())
+	t.Require().Equal(receipt3.BlockHash, got.Hash, "tx 3 was included in canonical block")
 }

--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -134,7 +134,8 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 	t.Logger().Info("Re-enabling batch-submitter")
 	// re-enable the batcher now that we are done with the test.
 	t.Require().NoError(sys.L2BatcherA.ActivityAPI().StartBatcher(t.Ctx()))
-	// TODO: batcher submits future span batch, misses a L2 block
+	// TODO(#16036): batcher submits future span batch, misses a L2 block.
+	// For now it uses singular batches to work-around.
 
 	// Build the missing blocks, catch up on local-safe chain
 	t.Require().Eventually(func() bool {

--- a/op-acceptance-tests/tests/interop/seqwindow/init_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/init_test.go
@@ -3,7 +3,11 @@ package seqwindow
 import (
 	"testing"
 
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
 
 func TestMain(m *testing.M) {
@@ -11,5 +15,12 @@ func TestMain(m *testing.M) {
 		presets.WithSimpleInterop(),
 		// Short enough that we can run the test,
 		// long enough that the batcher can still submit something before we make things expire.
-		presets.WithSequencingWindow(10, 30))
+		presets.WithSequencingWindow(10, 30),
+		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
+			// Span-batches during recovery don't appear to align well with the starting-point.
+			// It can be off by ~6 L2 blocks, possibly due to off-by-one
+			// in L1 block sync considerations in batcher stop or start.
+			// So we end up having to encode block by block, so the full batch data does not get dropped.
+			cfg.BatchType = derive.SingularBatchType
+		})))
 }

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -26,6 +26,9 @@ type Orchestrator struct {
 	// nil if no time travel is supported
 	timeTravelClock *clock.AdvancingClock
 
+	// options
+	batcherOptions []BatcherOption
+
 	superchains locks.RWMap[stack.SuperchainID, *Superchain]
 	clusters    locks.RWMap[stack.ClusterID, *Cluster]
 	l1Nets      locks.RWMap[eth.ChainID, *L1Network]

--- a/op-node/rollup/derive/base_batch_stage.go
+++ b/op-node/rollup/derive/base_batch_stage.go
@@ -188,7 +188,7 @@ func (bs *baseBatchStage) deriveNextEmptyBatch(ctx context.Context, outOfData bo
 	// to preserve that L2 time >= L1 time. If this is the first block of the epoch, always generate a
 	// batch to ensure that we at least have one batch per epoch.
 	if nextTimestamp < nextEpoch.Time || firstOfEpoch {
-		bs.log.Info("Generating next batch", "epoch", epoch, "timestamp", nextTimestamp)
+		bs.log.Info("Generating next batch", "epoch", epoch, "timestamp", nextTimestamp, "parent", parent)
 		return &SingularBatch{
 			ParentHash:   parent.Hash,
 			EpochNum:     rollup.Epoch(epoch.Number),

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -109,6 +109,9 @@ type TransactionSender interface {
 type EthNonce interface {
 	// PendingNonceAt returns the account nonce of the given account in the pending state.
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
+	// NonceAt returns the account nonce of the given account in the state at the given block number.
+	// A nil block number may be used to get the latest state.
+	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
 }
 
 type EthBalance interface {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -548,6 +548,14 @@ func (s *EthClient) PendingNonceAt(ctx context.Context, account common.Address) 
 	return uint64(result), err
 }
 
+// NonceAt returns the account nonce of the given account in the state at the given block number.
+// A nil block number may be used to get the latest state.
+func (s *EthClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	var result hexutil.Uint64
+	err := s.client.CallContext(ctx, &result, "eth_getTransactionCount", account, toBlockNumArg(blockNumber))
+	return uint64(result), err
+}
+
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -135,6 +135,7 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 		break
 	}
 
+	r.log.Warn("Rewinding logs DB", "chain", ev.ChainID, "target", target)
 	// Try to rewind and stop if it succeeds
 	err = r.db.RewindLogs(ev.ChainID, target)
 	if err != nil {

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -455,24 +455,7 @@ func (m *ManagedNode) resetIfInconsistent() {
 		if seenFromNode == (eth.BlockID{}) {
 			return false // if we haven't seen anything, then don't reset to it
 		}
-		// We know the last block from the op-node.
-		// Ae may have references that:
-		//   - local-unsafe matches, and local-safe matches -> no inconsistency caused by latest signaled local-unsafe!
-		//   - local-unsafe matches, but local-safe differs -> e.g. if local-safe is behind and does not know about this block
-		//   - local-unsafe differs, but local-safe matches  -> we should stick to the local-safe chain, not rewind further, but may need to rewind some
-		//   - local-unsafe differs, and local-safe differs -> we should use the local-safe chain as truth
-		//
-		// And never should we reset if the node is just ahead of us; resetIfAhead handles that.
-
 		m.log.Debug("Checking last seen block from node for consistency", "safety", name, "block", seenFromNode)
-		localUnsafeMatchErr := m.backend.IsLocalUnsafe(ctx, m.chainID, seenFromNode)
-		if errors.Is(localUnsafeMatchErr, types.ErrFuture) {
-			localUnsafeMatchErr = nil // do not count it when the node is ahead of us
-		}
-		if localUnsafeMatchErr != nil {
-			m.log.Warn("Last seen block from node is inconsistent with supervisor local-unsafe blocks",
-				"safety", name, "err", localUnsafeMatchErr)
-		}
 		localSafeMatchErr := m.backend.IsLocalSafe(ctx, m.chainID, seenFromNode)
 		if errors.Is(localSafeMatchErr, types.ErrFuture) {
 			localSafeMatchErr = nil // do not count it when the node is ahead of us
@@ -481,26 +464,18 @@ func (m *ManagedNode) resetIfInconsistent() {
 			m.log.Warn("Last seen block from node is inconsistent with supervisor local-safe blocks",
 				"safety", name, "err", localSafeMatchErr)
 		}
-		if localUnsafeMatchErr != nil || localSafeMatchErr != nil {
+		if localSafeMatchErr != nil {
 			// If either mismatches, we want to reset back no further than latest local-safe
 			localSafe, err := m.backend.LocalSafe(ctx, m.chainID)
 			if err != nil {
 				m.log.Debug("Cannot determine how to handle inconsistency, no local-safe data available",
-					"localUnsafeMatchErr", localUnsafeMatchErr,
 					"localSafeMatchErr", localSafeMatchErr, "err", err)
 				return false
 			}
-			if m.lastNodeLocalUnsafe.Number > localSafe.Derived.Number {
-				m.resetTracker.beginBisectionReset(m.lastNodeLocalUnsafe)
-			} else {
-				m.resetTracker.beginBisectionReset(localSafe.Derived)
-			}
+			m.resetTracker.beginBisectionReset(localSafe.Derived)
 			return true
 		}
 		return false
-	}
-	if handle("local-unsafe", m.lastNodeLocalUnsafe) {
-		return
 	}
 	if handle("local-safe", m.lastNodeLocalSafe) {
 		return

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -449,38 +449,30 @@ func (m *ManagedNode) Close() error {
 func (m *ManagedNode) resetIfInconsistent() {
 	ctx, cancel := context.WithTimeout(m.ctx, internalTimeout)
 	defer cancel()
-
-	// Handle the given seen block from the node if it is an inconsistency.
-	handle := func(name string, seenFromNode eth.BlockID) (inconsistent bool) {
-		if seenFromNode == (eth.BlockID{}) {
-			return false // if we haven't seen anything, then don't reset to it
-		}
-		m.log.Debug("Checking last seen block from node for consistency", "safety", name, "block", seenFromNode)
-		localSafeMatchErr := m.backend.IsLocalSafe(ctx, m.chainID, seenFromNode)
-		if errors.Is(localSafeMatchErr, types.ErrFuture) {
-			localSafeMatchErr = nil // do not count it when the node is ahead of us
-		}
-		if localSafeMatchErr != nil {
-			m.log.Warn("Last seen block from node is inconsistent with supervisor local-safe blocks",
-				"safety", name, "err", localSafeMatchErr)
-		}
-		if localSafeMatchErr != nil {
-			// If either mismatches, we want to reset back no further than latest local-safe
-			localSafe, err := m.backend.LocalSafe(ctx, m.chainID)
-			if err != nil {
-				m.log.Debug("Cannot determine how to handle inconsistency, no local-safe data available",
-					"localSafeMatchErr", localSafeMatchErr, "err", err)
-				return false
-			}
-			m.resetTracker.beginBisectionReset(localSafe.Derived)
-			return true
-		}
-		return false
+	seenFromNode := m.lastNodeLocalSafe
+	name := "local-safe"
+	if seenFromNode == (eth.BlockID{}) {
+		return // if we haven't seen anything, then don't reset to it
 	}
-	if handle("local-safe", m.lastNodeLocalSafe) {
+	m.log.Debug("Checking last seen block from node for consistency", "safety", name, "block", seenFromNode)
+	localSafeMatchErr := m.backend.IsLocalSafe(ctx, m.chainID, seenFromNode)
+	if localSafeMatchErr == nil {
 		return
 	}
-	m.log.Debug("no inconsistency found")
+	if errors.Is(localSafeMatchErr, types.ErrFuture) {
+		m.log.Debug("node is ahead of op-supervisor local-safe data")
+		return // resetIfAhead will handle this
+	}
+	m.log.Warn("Last seen block from node is inconsistent with supervisor local-safe blocks",
+		"safety", name, "err", localSafeMatchErr)
+	// If there is a mismatch, we want to reset back no further than latest local-safe
+	localSafe, err := m.backend.LocalSafe(ctx, m.chainID)
+	if err != nil {
+		m.log.Debug("Cannot determine how to handle inconsistency, no local-safe data available",
+			"localSafeMatchErr", localSafeMatchErr, "err", err)
+		return
+	}
+	m.resetTracker.beginBisectionReset(localSafe.Derived)
 }
 
 // resetIfAhead checks if the node is ahead of the local-safe db

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -139,7 +139,7 @@ func TestPrepareReset(t *testing.T) {
 		pivot = i
 		node.resetTracker.bisectToTarget()
 		require.Equal(t, i, unsafe.Number)
-		require.Equal(t, uint64(0), safe.Number)
+		require.Equal(t, i, safe.Number)
 		require.Equal(t, uint64(0), finalized.Number)
 	}
 

--- a/op-supervisor/supervisor/backend/syncnode/reset.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset.go
@@ -79,11 +79,18 @@ func (t *resetTracker) bisectToTarget() {
 	internalCtx, iCancel := context.WithTimeout(t.managed.ctx, internalTimeout)
 	defer iCancel()
 
+	// TODO: this `if` is an artifact of trying to re-target bisection while the resetTracker is already active.
+	// We can simplify by targeting one thing at a time.
+
 	// initialize the start of the range if it is empty
 	if t.a == (eth.BlockID{}) {
 		t.managed.log.Debug("Start of range is empty, fetching the anchor block as starting point")
+		// TODO: change name: GetActivationBlock, Anchor point = get first block of DB
 		anchor, err := t.managed.backend.AnchorPoint(internalCtx, t.managed.chainID)
 		if err != nil {
+			if errors.Is(err, types.ErrFuture) {
+				// TODO: need to trigger pre-interop reset
+			}
 			t.managed.log.Error("failed to initialize start of bisection range", "err", err)
 			t.endReset()
 			return
@@ -105,11 +112,13 @@ func (t *resetTracker) bisectToTarget() {
 	// if the first block in the range can't be found or is inconsistent, we can't do a reset
 	nodeA, err := t.managed.Node.BlockRefByNumber(nodeCtx, t.a.Number)
 	if err != nil {
+		// TODO: if notFound error -> pre-interop
 		t.managed.log.Error("failed to get block at start of range. cannot reset node", "err", err)
 		t.endReset()
 		return
 	}
 	if nodeA.ID() != t.a {
+		// TODO pre-interop reset, need to re-derive the activation block
 		t.managed.log.Error("start of range is inconsistent with logs db. cannot reset node",
 			"a", t.a,
 			"block", nodeA.ID())
@@ -172,11 +181,10 @@ func (t *resetTracker) bisect() error {
 	// and update the search range accordingly.
 	nodeI := nodeIRef.ID()
 	err = t.managed.backend.IsLocalSafe(internalCtx, t.managed.chainID, nodeI)
-	if errors.Is(err, types.ErrFuture) {
-		t.managed.log.Debug("No local-safe reference for reset bisection, falling back to local-unsafe", "i", i)
-		err = t.managed.backend.IsLocalUnsafe(internalCtx, t.managed.chainID, nodeI)
-	}
 	if err != nil {
+		// TODO: could abort with critical-error on data-corruption
+		// TODO: could gracefully exit on block-replacement (no need to reset what is already being built replacement for)
+		// Primarily we handle ErrFuture and ErrConflict here: where the DB does not have what the node has.
 		t.managed.log.Debug("midpoint of range is inconsistent. pulling back end of range", "i", i)
 		t.z = nodeI
 	} else {
@@ -203,8 +211,30 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 	t.managed.log.Info("reset target identified", "target", target)
 	var lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID
 
-	// the unsafe block is always the last block we found to be consistent
-	lUnsafe = target
+	// Check if target is seen in unsafe DB.
+	// If it is, the tip of the unsafe DB is good to use as unsafe-reset-target.
+	// If it is not, then the unsafe logs DB is inconsistent with our local-safe DB.
+	// So we need to stick to the target block.
+	if err := t.managed.backend.IsLocalUnsafe(internalCtx, t.managed.chainID, target); err != nil {
+		if errors.Is(err, types.ErrConflict) {
+			lUnsafe = target
+		} else {
+			// TODO critical err
+			t.managed.log.Error("failed to check local-unsafe", "target", target, "err", err)
+			t.endReset()
+			return
+		}
+	} else {
+		// TODO tip of unsafe
+		tip, err := t.managed.backend.LocalUnsafe(internalCtx, t.managed.chainID)
+		if err != nil {
+			// TODO
+			t.managed.log.Error("failed to get latest local-unsafe", "err", err)
+			t.endReset()
+			return
+		}
+		lUnsafe = tip
+	}
 
 	// all other blocks are either the last consistent block, or the last block in the db, whichever is earlier
 	// cross unsafe
@@ -220,17 +250,8 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		xUnsafe = target
 	}
 	// local safe
-	lastLSafe, err := t.managed.backend.LocalSafe(internalCtx, t.managed.chainID)
-	if err != nil {
-		t.managed.log.Error("failed to get last safe block. cancelling reset", "err", err)
-		t.endReset()
-		return
-	}
-	if lastLSafe.Derived.Number < target.Number {
-		lSafe = lastLSafe.Derived
-	} else {
-		lSafe = target
-	}
+	lSafe = target
+
 	// cross safe
 	lastXSafe, err := t.managed.backend.CrossSafe(internalCtx, t.managed.chainID)
 	if err != nil {
@@ -242,6 +263,10 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		xSafe = lastXSafe.Derived
 	} else {
 		xSafe = target
+		// TODO: investigate, maybe instead return an error that cross-safe changed.
+		// Resetting to older block should be unneeded.
+		// Note: op-node may not have the same blocks as op-supervisor has,
+		// and thus needs to start from an old forkchoice state.
 	}
 	// finalized
 	lastFinalized, err := t.managed.backend.Finalized(internalCtx, t.managed.chainID)
@@ -257,6 +282,7 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		finalized = lastFinalized
 	} else {
 		finalized = target
+		// TODO: same story as cross-safe.
 	}
 
 	// trigger the reset

--- a/op-supervisor/supervisor/backend/syncnode/reset.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset.go
@@ -79,17 +79,19 @@ func (t *resetTracker) bisectToTarget() {
 	internalCtx, iCancel := context.WithTimeout(t.managed.ctx, internalTimeout)
 	defer iCancel()
 
-	// TODO: this `if` is an artifact of trying to re-target bisection while the resetTracker is already active.
+	// TODO(#16026): this `if` is an artifact of trying to re-target bisection while the resetTracker is already active.
 	// We can simplify by targeting one thing at a time.
 
 	// initialize the start of the range if it is empty
 	if t.a == (eth.BlockID{}) {
 		t.managed.log.Debug("Start of range is empty, fetching the anchor block as starting point")
-		// TODO: change name: GetActivationBlock, Anchor point = get first block of DB
+		// TODO(#16026): change name: GetActivationBlock, Anchor point = get first block of DB
 		anchor, err := t.managed.backend.AnchorPoint(internalCtx, t.managed.chainID)
 		if err != nil {
 			if errors.Is(err, types.ErrFuture) {
-				// TODO: need to trigger pre-interop reset
+				// TODO(#16026): need to trigger pre-interop reset
+				t.managed.log.Info("Missing activation block", "err", err)
+				return
 			}
 			t.managed.log.Error("failed to initialize start of bisection range", "err", err)
 			t.endReset()
@@ -112,13 +114,13 @@ func (t *resetTracker) bisectToTarget() {
 	// if the first block in the range can't be found or is inconsistent, we can't do a reset
 	nodeA, err := t.managed.Node.BlockRefByNumber(nodeCtx, t.a.Number)
 	if err != nil {
-		// TODO: if notFound error -> pre-interop
+		// TODO(#16026): if notFound error -> pre-interop
 		t.managed.log.Error("failed to get block at start of range. cannot reset node", "err", err)
 		t.endReset()
 		return
 	}
 	if nodeA.ID() != t.a {
-		// TODO pre-interop reset, need to re-derive the activation block
+		// TODO(#16026) pre-interop reset, need to re-derive the activation block
 		t.managed.log.Error("start of range is inconsistent with logs db. cannot reset node",
 			"a", t.a,
 			"block", nodeA.ID())
@@ -182,8 +184,8 @@ func (t *resetTracker) bisect() error {
 	nodeI := nodeIRef.ID()
 	err = t.managed.backend.IsLocalSafe(internalCtx, t.managed.chainID, nodeI)
 	if err != nil {
-		// TODO: could abort with critical-error on data-corruption
-		// TODO: could gracefully exit on block-replacement (no need to reset what is already being built replacement for)
+		// TODO(#16026): could abort with critical-error on data-corruption
+		// TODO(#16026): could gracefully exit on block-replacement (no need to reset what is already being built replacement for)
 		// Primarily we handle ErrFuture and ErrConflict here: where the DB does not have what the node has.
 		t.managed.log.Debug("midpoint of range is inconsistent. pulling back end of range", "i", i)
 		t.z = nodeI
@@ -208,6 +210,7 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		return
 	}
 
+	// TODO(#16026): This function should be split off from the resetTracker
 	t.managed.log.Info("reset target identified", "target", target)
 	var lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID
 
@@ -219,17 +222,15 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		if errors.Is(err, types.ErrConflict) {
 			lUnsafe = target
 		} else {
-			// TODO critical err
-			t.managed.log.Error("failed to check local-unsafe", "target", target, "err", err)
+			t.managed.log.Error("Failed to check local-unsafe", "target", target, "err", err)
 			t.endReset()
 			return
 		}
 	} else {
-		// TODO tip of unsafe
+		// TODO(#16026): cleanup how we fall back to the tip of unsafe chain
 		tip, err := t.managed.backend.LocalUnsafe(internalCtx, t.managed.chainID)
 		if err != nil {
-			// TODO
-			t.managed.log.Error("failed to get latest local-unsafe", "err", err)
+			t.managed.log.Error("Failed to get latest local-unsafe", "err", err)
 			t.endReset()
 			return
 		}
@@ -263,7 +264,7 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		xSafe = lastXSafe.Derived
 	} else {
 		xSafe = target
-		// TODO: investigate, maybe instead return an error that cross-safe changed.
+		// TODO(#16026): investigate, maybe instead return an error that cross-safe changed.
 		// Resetting to older block should be unneeded.
 		// Note: op-node may not have the same blocks as op-supervisor has,
 		// and thus needs to start from an old forkchoice state.
@@ -282,7 +283,7 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 		finalized = lastFinalized
 	} else {
 		finalized = target
-		// TODO: same story as cross-safe.
+		// TODO(#16026): same story as cross-safe.
 	}
 
 	// trigger the reset

--- a/op-supervisor/supervisor/backend/syncnode/reset.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset.go
@@ -214,28 +214,11 @@ func (t *resetTracker) resetHeadsFromTarget(target eth.BlockID) {
 	t.managed.log.Info("reset target identified", "target", target)
 	var lUnsafe, xUnsafe, lSafe, xSafe, finalized eth.BlockID
 
-	// Check if target is seen in unsafe DB.
-	// If it is, the tip of the unsafe DB is good to use as unsafe-reset-target.
-	// If it is not, then the unsafe logs DB is inconsistent with our local-safe DB.
-	// So we need to stick to the target block.
-	if err := t.managed.backend.IsLocalUnsafe(internalCtx, t.managed.chainID, target); err != nil {
-		if errors.Is(err, types.ErrConflict) {
-			lUnsafe = target
-		} else {
-			t.managed.log.Error("Failed to check local-unsafe", "target", target, "err", err)
-			t.endReset()
-			return
-		}
-	} else {
-		// TODO(#16026): cleanup how we fall back to the tip of unsafe chain
-		tip, err := t.managed.backend.LocalUnsafe(internalCtx, t.managed.chainID)
-		if err != nil {
-			t.managed.log.Error("Failed to get latest local-unsafe", "err", err)
-			t.endReset()
-			return
-		}
-		lUnsafe = tip
-	}
+	// We set the local unsafe block to our target (the local-safe block we determined to reset to).
+	// The node checks it for consistency, but if it builds on this target,
+	// it does not revert back the existing unsafe chain.
+	// We do not have to pick the latest possible unsafe target here.
+	lUnsafe = target
 
 	// all other blocks are either the last consistent block, or the last block in the db, whichever is earlier
 	// cross unsafe


### PR DESCRIPTION
**Description**

This fixes the resetTracker, but leaves some TODOs for upgrade activation (covered in https://github.com/ethereum-optimism/optimism/pull/16008 ) and some remaining cleanup (tracked in https://github.com/ethereum-optimism/optimism/issues/16026 )

These changes also unlock the sequencing window expiry test.

This PR is extracted from the prior draft in https://github.com/ethereum-optimism/optimism/pull/16013

**Tests**

- existing tests pass (action tests covered)
- sequencing window expiry test no longer needs the skip
- unit-test follow ups tracked in https://github.com/ethereum-optimism/optimism/issues/16026

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15769
