### PR TITLE
op-acceptance-tests: interop: expand load test

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/executor.go
+++ b/op-acceptance-tests/tests/interop/loadtest/executor.go
@@ -1,0 +1,186 @@
+package loadtest
+
+import (
+	"math/big"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+)
+
+type Executor interface {
+	Execute(t devtest.T, msgs []types.Message)
+}
+
+type ValidExecutor struct {
+	el  *dsl.L2ELNode
+	eoa *dsl.EOA
+	// supervisor is used to check if executing messages are cross-safe.
+	supervisor *dsl.Supervisor
+
+	counter *counter
+}
+
+func NewValidExecutor(funder *dsl.Funder, el *dsl.L2ELNode, supervisor *dsl.Supervisor) *ValidExecutor {
+	return &ValidExecutor{
+		el:         el,
+		eoa:        funder.NewFundedEOA(eth.MillionEther),
+		supervisor: supervisor,
+		counter:    new(counter),
+	}
+}
+
+func (e *ValidExecutor) Execute(t devtest.T, msgs []types.Message) {
+	tx := buildExecTx(e.eoa, e.el, msgs, retryForever(e.el.Escape().EthClient()), txplan.WithStaticNonce(e.counter.Next()))
+	receipt, err := tx.Included.Eval(t.Ctx())
+	t.Require().NoError(err)
+	_, err = tx.Success.Eval(t.Ctx())
+	t.Require().NoError(err)
+	t.Require().Len(receipt.Logs, len(msgs))
+
+	// Wait for the transaction to be cross-safe.
+	includedBlock, err := tx.IncludedBlock.Eval(t.Ctx())
+	t.Require().NoError(err)
+	for {
+		// NOTE: it may be desirable to query proxyd instead of the supervisor if/when the devstack supports it.
+		crossSafeID, err := e.supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), e.el.ChainID())
+		t.Require().NoError(err)
+		if includedBlock.ID().Number <= crossSafeID.Derived.Number {
+			break
+		}
+		e.el.WaitForBlock()
+	}
+	// Sanity check that includedBlock is still in the canonical chain.
+	_, err = e.el.Escape().EthClient().BlockRefByHash(t.Ctx(), includedBlock.Hash)
+	t.Require().NoError(err)
+}
+
+// DelayedExecutor executes messages after waiting for a specified period.
+type DelayedExecutor struct {
+	e     *ValidExecutor
+	delay time.Duration
+	wg    *sync.WaitGroup
+}
+
+func NewDelayedExecutor(e *ValidExecutor, wg *sync.WaitGroup, delay time.Duration) *DelayedExecutor {
+	return &DelayedExecutor{
+		e:     e,
+		wg:    wg,
+		delay: delay,
+	}
+}
+
+func (de *DelayedExecutor) Execute(t devtest.T, msgs []types.Message) {
+	de.wg.Add(1)
+	go func() {
+		defer de.wg.Done()
+		select {
+		case <-t.Ctx().Done():
+		case <-time.After(de.delay):
+			de.e.Execute(t, msgs)
+		}
+	}()
+}
+
+type ToInvalidMsgFn func(types.Message) types.Message
+
+type InvalidExecutor struct {
+	eoa         *dsl.EOA
+	el          *dsl.L2ELNode
+	makeInvalid ToInvalidMsgFn
+}
+
+func NewInvalidExecutor(funder *dsl.Funder, el *dsl.L2ELNode, makeInvalid ToInvalidMsgFn) *InvalidExecutor {
+	return &InvalidExecutor{
+		el:          el,
+		eoa:         funder.NewFundedEOA(eth.MillionEther),
+		makeInvalid: makeInvalid,
+	}
+}
+
+func (ie *InvalidExecutor) Execute(t devtest.T, validMsgs []types.Message) {
+	msgs := make([]types.Message, len(validMsgs))
+	copy(msgs, validMsgs)
+	// Replace the last message with the invalid message.
+	// Merely appending can cause us to hit tx size limits if the original slice has a lot of messages.
+	msgs = append(msgs[:len(msgs)-1], ie.makeInvalid(msgs[len(msgs)-1]))
+	tx := buildExecTx(ie.eoa, ie.el, msgs)
+	_, err := tx.Submitted.Eval(t.Ctx())
+	t.Require().ErrorContains(err, core.ErrTxFilteredOut.Error())
+}
+
+func makeInvalidChainID(msg types.Message) types.Message {
+	bigChainID := msg.Identifier.ChainID.ToBig()
+	bigChainID.Add(bigChainID, big.NewInt(1))
+	msg.Identifier.ChainID = eth.ChainIDFromBig(bigChainID)
+	return msg
+}
+
+func makeInvalidOrigin(msg types.Message) types.Message {
+	bigOrigin := msg.Identifier.Origin.Big()
+	bigOrigin.Add(bigOrigin, big.NewInt(1))
+	msg.Identifier.Origin = common.BigToAddress(bigOrigin)
+	return msg
+}
+
+func makeInvalidBlockNumber(msg types.Message) types.Message {
+	msg.Identifier.BlockNumber++
+	return msg
+}
+
+func makeInvalidLogIndex(msg types.Message) types.Message {
+	msg.Identifier.LogIndex++
+	return msg
+}
+
+func makeInvalidTimestamp(msg types.Message) types.Message {
+	msg.Identifier.Timestamp++
+	return msg
+}
+
+func makeInvalidPayloadHash(msg types.Message) types.Message {
+	bigPayloadHash := msg.PayloadHash.Big()
+	bigPayloadHash.Add(bigPayloadHash, big.NewInt(1))
+	msg.PayloadHash = common.BigToHash(bigPayloadHash)
+	return msg
+}
+
+func buildExecTx(eoa *dsl.EOA, el *dsl.L2ELNode, msgs []types.Message, opts ...txplan.Option) *txplan.PlannedTx {
+	execCalls := make([]txintent.Call, 0, len(msgs))
+	for _, msg := range msgs {
+		execCalls = append(execCalls, &txintent.ExecTrigger{
+			Executor: constants.CrossL2Inbox,
+			Msg:      msg,
+		})
+	}
+	tx := txintent.NewIntent[*txintent.MultiTrigger, txintent.Result](eoa.Plan(), txplan.Combine(opts...))
+	tx.Content.Set(&txintent.MultiTrigger{
+		Emitter: constants.MultiCall3,
+		Calls:   execCalls,
+	})
+
+	maxTimestamp := slices.MaxFunc(msgs, func(x, y types.Message) int {
+		if x.Identifier.Timestamp > y.Identifier.Timestamp {
+			return 1
+		} else if x.Identifier.Timestamp < y.Identifier.Timestamp {
+			return -1
+		}
+		return 0
+	}).Identifier.Timestamp
+	// The exec tx is invalid until we know it will be included at a higher timestamp than any of the initiating messages, modulo reorgs.
+	// NOTE: this should be `<`, but the mempool filtering in op-geth currently uses the unsafe head's timestamp instead of
+	// the pending timestamp. See https://github.com/ethereum-optimism/op-geth/issues/603.
+	for el.BlockRefByLabel(eth.Unsafe).Time <= maxTimestamp {
+		el.WaitForBlock()
+	}
+	return tx.PlannedTx
+}

--- a/op-acceptance-tests/tests/interop/loadtest/helpers.go
+++ b/op-acceptance-tests/tests/interop/loadtest/helpers.go
@@ -1,0 +1,26 @@
+package loadtest
+
+import (
+	"math"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+type counter struct {
+	count   uint64
+	countMu sync.Mutex
+}
+
+func (n *counter) Next() uint64 {
+	n.countMu.Lock()
+	defer n.countMu.Unlock()
+	nonce := n.count
+	n.count++
+	return nonce
+}
+
+func retryForever(g txplan.ReceiptGetter) txplan.Option {
+	return txplan.WithRetryInclusion(g, math.MaxInt, retry.Exponential())
+}

--- a/op-acceptance-tests/tests/interop/loadtest/helpers.go
+++ b/op-acceptance-tests/tests/interop/loadtest/helpers.go
@@ -8,12 +8,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
-type counter struct {
+type nonceCounter struct {
 	count   uint64
 	countMu sync.Mutex
 }
 
-func (n *counter) Next() uint64 {
+func (n *nonceCounter) Next() uint64 {
 	n.countMu.Lock()
 	defer n.countMu.Unlock()
 	nonce := n.count

--- a/op-acceptance-tests/tests/interop/loadtest/initiator.go
+++ b/op-acceptance-tests/tests/interop/loadtest/initiator.go
@@ -24,7 +24,7 @@ type ManyMsgsInitiator struct {
 	el          *dsl.L2ELNode
 	eoa         *dsl.EOA
 	eventLogger common.Address
-	counter     *counter
+	counter     *nonceCounter
 }
 
 func NewManyMsgsInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger common.Address) *ManyMsgsInitiator {
@@ -32,7 +32,7 @@ func NewManyMsgsInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger comm
 		eoa:         funder.NewFundedEOA(eth.MillionEther),
 		el:          el,
 		eventLogger: eventLogger,
-		counter:     new(counter),
+		counter:     new(nonceCounter),
 	}
 }
 
@@ -52,7 +52,7 @@ type LargeMsgInitiator struct {
 	eoa         *dsl.EOA
 	el          *dsl.L2ELNode
 	eventLogger common.Address
-	counter     *counter
+	counter     *nonceCounter
 }
 
 func NewLargeMsgInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger common.Address) *LargeMsgInitiator {
@@ -60,12 +60,12 @@ func NewLargeMsgInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger comm
 		eoa:         funder.NewFundedEOA(eth.MillionEther),
 		el:          el,
 		eventLogger: eventLogger,
-		counter:     new(counter),
+		counter:     new(nonceCounter),
 	}
 }
 
 func (lin *LargeMsgInitiator) Initiate(t devtest.T) []types.Message {
-	// TODO: can we create an even larger event without the event logger?
+	// TODO(#16039): can we create an even larger event without the event logger?
 	return buildAndSendInitTx(t, lin.eoa, lin.el, interop.RandomInitTrigger(rng, lin.eventLogger, 4, 75_000), txplan.WithStaticNonce(lin.counter.Next()))
 }
 

--- a/op-acceptance-tests/tests/interop/loadtest/initiator.go
+++ b/op-acceptance-tests/tests/interop/loadtest/initiator.go
@@ -1,0 +1,80 @@
+package loadtest
+
+import (
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var rng = rand.New(rand.NewSource(1234))
+
+type Initiator interface {
+	Initiate(t devtest.T) []types.Message
+}
+
+type ManyMsgsInitiator struct {
+	el          *dsl.L2ELNode
+	eoa         *dsl.EOA
+	eventLogger common.Address
+	counter     *counter
+}
+
+func NewManyMsgsInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger common.Address) *ManyMsgsInitiator {
+	return &ManyMsgsInitiator{
+		eoa:         funder.NewFundedEOA(eth.MillionEther),
+		el:          el,
+		eventLogger: eventLogger,
+		counter:     new(counter),
+	}
+}
+
+func (in *ManyMsgsInitiator) Initiate(t devtest.T) []types.Message {
+	const numMsgs = 275 // About the max number of msgs we can create before hitting tx size limits.
+	initCalls := make([]txintent.Call, 0, numMsgs)
+	for range numMsgs {
+		initCalls = append(initCalls, interop.RandomInitTrigger(rng, in.eventLogger, rng.Intn(5), rng.Intn(10)))
+	}
+	return buildAndSendInitTx(t, in.eoa, in.el, &txintent.MultiTrigger{
+		Emitter: constants.MultiCall3,
+		Calls:   initCalls,
+	}, txplan.WithStaticNonce(in.counter.Next()))
+}
+
+type LargeMsgInitiator struct {
+	eoa         *dsl.EOA
+	el          *dsl.L2ELNode
+	eventLogger common.Address
+	counter     *counter
+}
+
+func NewLargeMsgInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger common.Address) *LargeMsgInitiator {
+	return &LargeMsgInitiator{
+		eoa:         funder.NewFundedEOA(eth.MillionEther),
+		el:          el,
+		eventLogger: eventLogger,
+		counter:     new(counter),
+	}
+}
+
+func (lin *LargeMsgInitiator) Initiate(t devtest.T) []types.Message {
+	// TODO: can we create an even larger event without the event logger?
+	return buildAndSendInitTx(t, lin.eoa, lin.el, interop.RandomInitTrigger(rng, lin.eventLogger, 4, 75_000), txplan.WithStaticNonce(lin.counter.Next()))
+}
+
+func buildAndSendInitTx(t devtest.T, eoa *dsl.EOA, el *dsl.L2ELNode, initCall txintent.Call, opts ...txplan.Option) []types.Message {
+	initMsgsTx := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](eoa.Plan(), retryForever(el.Escape().EthClient()), txplan.Combine(opts...))
+	initMsgsTx.Content.Set(initCall)
+	_, err := initMsgsTx.PlannedTx.Success.Eval(t.Ctx())
+	t.Require().NoError(err)
+	out, err := initMsgsTx.Result.Eval(t.Ctx())
+	t.Require().NoError(err)
+	return out.Entries
+}

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -1,139 +1,109 @@
 package loadtest
 
 import (
-	"context"
-	"math/rand"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
-	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
-	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
+
+const numInitTxsEnvVar = "NAT_LOADTEST_INITTXS"
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleInterop())
 }
 
-// TestExecFromSameAddressInALoop spams transactions that each execute hundreds of initiating messages.
-func TestExecFromSameAddressInALoop(gt *testing.T) {
+type L2 struct {
+	Chain  *dsl.L2Network
+	EL     *dsl.L2ELNode
+	Funder *dsl.Funder
+}
+
+func TestLoad(gt *testing.T) {
 	if testing.Short() {
 		gt.Skip("skipping load test in short mode")
 	}
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 
-	// Use proxyd if available.
-	l2ELA := sys.L2ELA
-	l2ELB := sys.L2ELB
-	if proxydsA := match.Proxyd.Match(sys.L2ChainA.Escape().L2ELNodes()); len(proxydsA) > 0 {
-		l2ELA = dsl.NewL2ELNode(proxydsA[0])
+	var numInitTxs uint64
+	if numInitTxsStr, ok := os.LookupEnv(numInitTxsEnvVar); ok {
+		var err error
+		numInitTxs, err = strconv.ParseUint(numInitTxsStr, 10, 64)
+		t.Require().NoError(err)
 	}
-	if proxydsB := match.Proxyd.Match(sys.L2ChainB.Escape().L2ELNodes()); len(proxydsB) > 0 {
-		l2ELB = dsl.NewL2ELNode(proxydsB[0])
+	t.Gate().NotZero(numInitTxs, "load test only makes sense when "+numInitTxsEnvVar+" is nonzero")
+
+	l2ELA := sys.L2ChainA.PublicRPC()
+	L2A := &L2{
+		Chain:  sys.L2ChainA,
+		EL:     l2ELA,
+		Funder: dsl.NewFunder(sys.Wallet, sys.FaucetA, l2ELA),
+	}
+	l2ELB := sys.L2ChainB.PublicRPC()
+	L2B := &L2{
+		Chain:  sys.L2ChainB,
+		EL:     l2ELB,
+		Funder: dsl.NewFunder(sys.Wallet, sys.FaucetB, l2ELB),
 	}
 
-	// Setup EOAs. We are careful to use the specific ELs configured above to ensure we
-	// hit proxyd (if configured) to simulate real load.
-	skA, err := crypto.GenerateKey()
-	t.Require().NoError(err)
-	skB, err := crypto.GenerateKey()
-	t.Require().NoError(err)
-	eoaA := dsl.NewEOA(dsl.NewKey(t, skA), l2ELA)
-	eoaB := dsl.NewEOA(dsl.NewKey(t, skB), l2ELB)
-	sys.FaucetA.Fund(eoaA.Address(), eth.MillionEther)
-	sys.FaucetB.Fund(eoaB.Address(), eth.MillionEther)
-
-	eventLoggerAddress := eoaA.DeployEventLogger()
-
-	// Create a transaction that emits numMsgs logs in a single transaction using multicall and the event logger.
-	const numMsgs = 275 // About the max number of msgs we can create before hitting tx size limits.
-	initMsgsTx := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](eoaA.Plan())
-	initCalls := make([]txintent.Call, 0, numMsgs)
-	rng := rand.New(rand.NewSource(1234))
-	for range numMsgs {
-		initCalls = append(initCalls, interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(10)))
-	}
-	initMsgsTx.Content.Set(&txintent.MultiTrigger{
-		Emitter: constants.MultiCall3,
-		Calls:   initCalls,
-	})
-	initResult, err := initMsgsTx.Result.Eval(t.Ctx())
-	t.Require().NoError(err)
-	t.Require().Len(initResult.Entries, numMsgs)
-	_, err = initMsgsTx.PlannedTx.Success.Eval(t.Ctx())
-	t.Require().NoError(err)
-
-	// Wait to include the exec txs until we know it will be included at a higher timestamp than initMsgsTx, modulo reorgs.
-	// NOTE: this should be `<`, but the mempool filtering in op-geth currently uses the unsafe head's timestamp instead of
-	// the pending timestamp. See https://github.com/ethereum-optimism/op-geth/issues/603.
-	for l2ELA.BlockRefByLabel(eth.Unsafe).Time <= initMsgsTx.PlannedTx.IncludedBlock.Value().Time {
-		l2ELA.WaitForBlock()
-	}
-
-	execCalls := make([]txintent.Call, 0, numMsgs)
-	for i := range numMsgs {
-		execCalls = append(execCalls, &txintent.ExecTrigger{
-			Executor: constants.CrossL2Inbox,
-			Msg:      initResult.Entries[i],
-		})
-	}
-	const numExecTxs = 1_000
-	execMsgsTxs := make([]*txintent.IntentTx[*txintent.MultiTrigger, txintent.Result], 0, numExecTxs)
-	for i := range numExecTxs {
-		execMsgsTx := txintent.NewIntent[*txintent.MultiTrigger, txintent.Result](eoaB.Plan(), txplan.WithRetryInclusion(l2ELB.Escape().EthClient(), 50, retry.Exponential()))
-		execMsgsTx.Content.Set(&txintent.MultiTrigger{
-			Emitter: constants.MultiCall3,
-			Calls:   execCalls,
-		})
-		if i != 0 {
-			prevNonce := &execMsgsTxs[i-1].PlannedTx.Nonce
-			execMsgsTx.PlannedTx.Nonce.DependOn(prevNonce)
-			execMsgsTx.PlannedTx.Nonce.Fn(func(_ context.Context) (uint64, error) {
-				prevNonceU64, err := prevNonce.Get()
-				if err != nil {
-					return 0, err
-				}
-				return prevNonceU64 + 1, nil
-			})
-		}
-		execMsgsTxs = append(execMsgsTxs, execMsgsTx)
-	}
 	var wg sync.WaitGroup
-	wg.Add(len(execMsgsTxs))
-	for _, execMsgsTx := range execMsgsTxs {
-		go func(tx *txplan.PlannedTx) {
-			defer wg.Done()
-			receipt, err := tx.Included.Eval(t.Ctx())
-			t.Require().NoError(err)
-			t.Require().Len(receipt.Logs, numMsgs)
-			_, err = tx.Success.Eval(t.Ctx())
-			t.Require().NoError(err)
+	defer wg.Wait()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		SpamInteropTxs(t, &wg, numInitTxs, L2A, L2B, sys.Supervisor)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		SpamInteropTxs(t, &wg, numInitTxs, L2B, L2A, sys.Supervisor)
+	}()
+}
 
-			// Wait for the transaction to be cross-safe.
-			includedBlock, err := tx.IncludedBlock.Eval(t.Ctx())
-			t.Require().NoError(err)
-			for {
-				// NOTE: it may be desirable to query proxyd instead of the supervisor if/when the devstack supports it.
-				crossSafeID, err := sys.Supervisor.Escape().QueryAPI().CrossSafe(t.Ctx(), l2ELB.ChainID())
-				t.Require().NoError(err)
-				if includedBlock.ID().Number <= crossSafeID.Derived.Number {
-					break
-				}
-				l2ELB.WaitForBlock()
+func SpamInteropTxs(t devtest.T, wg *sync.WaitGroup, numInitTxs uint64, source *L2, dest *L2, supervisor *dsl.Supervisor) {
+	msgsCh := make(chan []types.Message, 100)
+	defer close(msgsCh)
+
+	// Spam executing messages.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		executors := []Executor{
+			NewValidExecutor(dest.Funder, dest.EL, supervisor),
+			NewDelayedExecutor(NewValidExecutor(dest.Funder, dest.EL, supervisor), wg, time.Minute),
+			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidChainID),
+			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidBlockNumber),
+			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidLogIndex),
+			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidOrigin),
+			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidPayloadHash),
+			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidTimestamp),
+		}
+		for msgs := range msgsCh {
+			for _, executor := range executors {
+				wg.Add(1)
+				go func(executor Executor, msgs []types.Message) {
+					defer wg.Done()
+					executor.Execute(t, msgs)
+				}(executor, msgs)
 			}
-			// Sanity check that includedBlock is still in the canonical chain.
-			_, err = l2ELB.Escape().EthClient().BlockRefByHash(t.Ctx(), includedBlock.Hash)
-			t.Require().NoError(err)
-		}(execMsgsTx.PlannedTx)
+		}
+	}()
+
+	// Spam initiating messages.
+	eventLogger := source.Funder.NewFundedEOA(eth.OneEther).DeployEventLogger()
+	initiators := []Initiator{
+		NewManyMsgsInitiator(source.Funder, source.EL, eventLogger),
+		NewLargeMsgInitiator(source.Funder, source.EL, eventLogger),
 	}
-	wg.Wait()
+	for i := range numInitTxs {
+		msgsCh <- initiators[i%uint64(len(initiators))].Initiate(t)
+	}
 }

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -33,13 +33,12 @@ func TestLoad(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 
-	var numInitTxs uint64
+	numInitTxs := uint64(1)
 	if numInitTxsStr, ok := os.LookupEnv(numInitTxsEnvVar); ok {
 		var err error
 		numInitTxs, err = strconv.ParseUint(numInitTxsStr, 10, 64)
 		t.Require().NoError(err)
 	}
-	t.Gate().NotZero(numInitTxs, "load test only makes sense when "+numInitTxsEnvVar+" is nonzero")
 
 	l2ELA := sys.L2ChainA.PublicRPC()
 	L2A := &L2{
@@ -59,16 +58,18 @@ func TestLoad(gt *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		SpamInteropTxs(t, &wg, numInitTxs, L2A, L2B, sys.Supervisor)
+		SpamInteropTxs(t, numInitTxs, L2A, L2B, sys.Supervisor)
 	}()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		SpamInteropTxs(t, &wg, numInitTxs, L2B, L2A, sys.Supervisor)
+		SpamInteropTxs(t, numInitTxs, L2B, L2A, sys.Supervisor)
 	}()
 }
 
-func SpamInteropTxs(t devtest.T, wg *sync.WaitGroup, numInitTxs uint64, source *L2, dest *L2, supervisor *dsl.Supervisor) {
+func SpamInteropTxs(t devtest.T, numInitTxs uint64, source *L2, dest *L2, supervisor *dsl.Supervisor) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	msgsCh := make(chan []types.Message, 100)
 	defer close(msgsCh)
 
@@ -76,23 +77,24 @@ func SpamInteropTxs(t devtest.T, wg *sync.WaitGroup, numInitTxs uint64, source *
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		executors := []Executor{
-			NewValidExecutor(dest.Funder, dest.EL, supervisor),
-			NewDelayedExecutor(NewValidExecutor(dest.Funder, dest.EL, supervisor), wg, time.Minute),
-			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidChainID),
-			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidBlockNumber),
-			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidLogIndex),
-			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidOrigin),
-			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidPayloadHash),
-			NewInvalidExecutor(dest.Funder, dest.EL, makeInvalidTimestamp),
+		dest.Funder.NewFundedEOA(eth.MillionEther.Mul(100))
+		relayers := []Relayer{
+			NewValidRelayer(dest.Funder, dest.EL, supervisor),
+			NewDelayedRelayer(NewValidRelayer(dest.Funder, dest.EL, supervisor), &wg, time.Minute),
+			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidChainID),
+			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidBlockNumber),
+			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidLogIndex),
+			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidOrigin),
+			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidPayloadHash),
+			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidTimestamp),
 		}
 		for msgs := range msgsCh {
-			for _, executor := range executors {
+			for _, relayer := range relayers {
 				wg.Add(1)
-				go func(executor Executor, msgs []types.Message) {
+				go func() {
 					defer wg.Done()
-					executor.Execute(t, msgs)
-				}(executor, msgs)
+					relayer.Relay(t, msgs)
+				}()
 			}
 		}
 	}()

--- a/op-acceptance-tests/tests/interop/loadtest/relayer.go
+++ b/op-acceptance-tests/tests/interop/loadtest/relayer.go
@@ -17,30 +17,30 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 )
 
-type Executor interface {
-	Execute(t devtest.T, msgs []types.Message)
+type Relayer interface {
+	Relay(t devtest.T, msgs []types.Message)
 }
 
-type ValidExecutor struct {
+type ValidRelayer struct {
 	el  *dsl.L2ELNode
 	eoa *dsl.EOA
 	// supervisor is used to check if executing messages are cross-safe.
 	supervisor *dsl.Supervisor
 
-	counter *counter
+	counter *nonceCounter
 }
 
-func NewValidExecutor(funder *dsl.Funder, el *dsl.L2ELNode, supervisor *dsl.Supervisor) *ValidExecutor {
-	return &ValidExecutor{
+func NewValidRelayer(funder *dsl.Funder, el *dsl.L2ELNode, supervisor *dsl.Supervisor) *ValidRelayer {
+	return &ValidRelayer{
 		el:         el,
 		eoa:        funder.NewFundedEOA(eth.MillionEther),
 		supervisor: supervisor,
-		counter:    new(counter),
+		counter:    new(nonceCounter),
 	}
 }
 
-func (e *ValidExecutor) Execute(t devtest.T, msgs []types.Message) {
-	tx := buildExecTx(e.eoa, e.el, msgs, retryForever(e.el.Escape().EthClient()), txplan.WithStaticNonce(e.counter.Next()))
+func (e *ValidRelayer) Relay(t devtest.T, msgs []types.Message) {
+	tx := buildRelayTx(e.eoa, e.el, msgs, retryForever(e.el.Escape().EthClient()), txplan.WithStaticNonce(e.counter.Next()))
 	receipt, err := tx.Included.Eval(t.Ctx())
 	t.Require().NoError(err)
 	_, err = tx.Success.Eval(t.Ctx())
@@ -64,56 +64,56 @@ func (e *ValidExecutor) Execute(t devtest.T, msgs []types.Message) {
 	t.Require().NoError(err)
 }
 
-// DelayedExecutor executes messages after waiting for a specified period.
-type DelayedExecutor struct {
-	e     *ValidExecutor
+// DelayedRelayer executes messages after waiting for a specified period.
+type DelayedRelayer struct {
+	e     *ValidRelayer
 	delay time.Duration
 	wg    *sync.WaitGroup
 }
 
-func NewDelayedExecutor(e *ValidExecutor, wg *sync.WaitGroup, delay time.Duration) *DelayedExecutor {
-	return &DelayedExecutor{
+func NewDelayedRelayer(e *ValidRelayer, wg *sync.WaitGroup, delay time.Duration) *DelayedRelayer {
+	return &DelayedRelayer{
 		e:     e,
 		wg:    wg,
 		delay: delay,
 	}
 }
 
-func (de *DelayedExecutor) Execute(t devtest.T, msgs []types.Message) {
+func (de *DelayedRelayer) Relay(t devtest.T, msgs []types.Message) {
 	de.wg.Add(1)
 	go func() {
 		defer de.wg.Done()
 		select {
 		case <-t.Ctx().Done():
 		case <-time.After(de.delay):
-			de.e.Execute(t, msgs)
+			de.e.Relay(t, msgs)
 		}
 	}()
 }
 
 type ToInvalidMsgFn func(types.Message) types.Message
 
-type InvalidExecutor struct {
+type InvalidRelayer struct {
 	eoa         *dsl.EOA
 	el          *dsl.L2ELNode
 	makeInvalid ToInvalidMsgFn
 }
 
-func NewInvalidExecutor(funder *dsl.Funder, el *dsl.L2ELNode, makeInvalid ToInvalidMsgFn) *InvalidExecutor {
-	return &InvalidExecutor{
+func NewInvalidRelayer(funder *dsl.Funder, el *dsl.L2ELNode, makeInvalid ToInvalidMsgFn) *InvalidRelayer {
+	return &InvalidRelayer{
 		el:          el,
 		eoa:         funder.NewFundedEOA(eth.MillionEther),
 		makeInvalid: makeInvalid,
 	}
 }
 
-func (ie *InvalidExecutor) Execute(t devtest.T, validMsgs []types.Message) {
+func (ie *InvalidRelayer) Relay(t devtest.T, validMsgs []types.Message) {
 	msgs := make([]types.Message, len(validMsgs))
 	copy(msgs, validMsgs)
 	// Replace the last message with the invalid message.
 	// Merely appending can cause us to hit tx size limits if the original slice has a lot of messages.
 	msgs = append(msgs[:len(msgs)-1], ie.makeInvalid(msgs[len(msgs)-1]))
-	tx := buildExecTx(ie.eoa, ie.el, msgs)
+	tx := buildRelayTx(ie.eoa, ie.el, msgs)
 	_, err := tx.Submitted.Eval(t.Ctx())
 	t.Require().ErrorContains(err, core.ErrTxFilteredOut.Error())
 }
@@ -154,7 +154,7 @@ func makeInvalidPayloadHash(msg types.Message) types.Message {
 	return msg
 }
 
-func buildExecTx(eoa *dsl.EOA, el *dsl.L2ELNode, msgs []types.Message, opts ...txplan.Option) *txplan.PlannedTx {
+func buildRelayTx(eoa *dsl.EOA, el *dsl.L2ELNode, msgs []types.Message, opts ...txplan.Option) *txplan.PlannedTx {
 	execCalls := make([]txintent.Call, 0, len(msgs))
 	for _, msg := range msgs {
 		execCalls = append(execCalls, &txintent.ExecTrigger{
@@ -176,7 +176,7 @@ func buildExecTx(eoa *dsl.EOA, el *dsl.L2ELNode, msgs []types.Message, opts ...t
 		}
 		return 0
 	}).Identifier.Timestamp
-	// The exec tx is invalid until we know it will be included at a higher timestamp than any of the initiating messages, modulo reorgs.
+	// The relay tx is invalid until we know it will be included at a higher timestamp than any of the initiating messages, modulo reorgs.
 	// NOTE: this should be `<`, but the mempool filtering in op-geth currently uses the unsafe head's timestamp instead of
 	// the pending timestamp. See https://github.com/ethereum-optimism/op-geth/issues/603.
 	for el.BlockRefByLabel(eth.Unsafe).Time <= maxTimestamp {

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -70,6 +70,14 @@ func (n *L2Network) WaitForBlock() {
 	NewL2ELNode(n.inner.L2ELNode(match.FirstL2EL)).WaitForBlock()
 }
 
+func (n *L2Network) PublicRPC() *L2ELNode {
+	if proxyds := match.Proxyd.Match(n.Escape().L2ELNodes()); len(proxyds) > 0 {
+		return NewL2ELNode(proxyds[0])
+	}
+	// Fallback since sysgo doesn't have proxyd support at the moment, and may never get it.
+	return NewL2ELNode(n.inner.L2ELNode(match.FirstL2EL))
+}
+
 // PrintChain is used for testing/debugging, it prints the blockchain hashes and parent hashes to logs, which is useful when developing reorg tests
 func (n *L2Network) PrintChain() {
 	l2_el := n.inner.L2ELNode(match.FirstL2EL)


### PR DESCRIPTION
The interop load test now spams initiating and executing messages to and from chain A and chain B.

There are two EOAs that spam initiating messages:

1. Many messages per tx
2. One large initiating message per tx

There are two EOAs that spam valid executing messages:

1. Execute as soon as the initiating message is received
2. Wait for a delay (hardcoded to 1m for now) before executing

Several EOAs spam different kinds of invalid executing messages (invalid chain ID, invalid payload hash, etc.).

The load test is configured via the `NAT_LOADTEST_INITTXS` env var, which sets the number of initiating transactions. The go test timeout may also be configured to ensure the system can withstand load for extended periods.
