### PR TITLE
op-node: Only deploy CrossL2Inbox if there is more than one chain in the dependency set

### DIFF
--- a/op-devstack/sysgo/cluster.go
+++ b/op-devstack/sysgo/cluster.go
@@ -21,5 +21,8 @@ func (c *Cluster) hydrate(system stack.ExtensibleSystem) {
 }
 
 func (c *Cluster) DepSet() *depset.StaticConfigDependencySet {
+	if c.cfgset.DependencySet == nil {
+		return nil
+	}
 	return c.cfgset.DependencySet.(*depset.StaticConfigDependencySet)
 }

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -144,6 +145,11 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 		l2EL, ok := orch.l2ELs.Get(l2ELID)
 		require.True(ok, "l2 EL node required")
 
+		var depSet depset.DependencySet
+		if cluster, ok := orch.ClusterForL2(l2ELID.ChainID); ok {
+			depSet = cluster.DepSet()
+		}
+
 		jwtPath, jwtSecret := orch.writeDefaultJWT()
 
 		logger := p.Logger()
@@ -211,8 +217,9 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			Driver: driver.Config{
 				SequencerEnabled: isSequencer,
 			},
-			Rollup:    *l2Net.rollupCfg,
-			P2PSigner: p2pSignerSetup, // nil when not sequencer
+			Rollup:        *l2Net.rollupCfg,
+			DependencySet: depSet,
+			P2PSigner:     p2pSignerSetup, // nil when not sequencer
 			RPC: node.RPCConfig{
 				ListenAddr: "127.0.0.1",
 				// When L2CL starts, store its RPC port here

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -56,6 +56,15 @@ type Orchestrator struct {
 	jwtPathOnce sync.Once
 }
 
+func (o *Orchestrator) ClusterForL2(chainID eth.ChainID) (*Cluster, bool) {
+	for _, cluster := range o.clusters.Values() {
+		if cluster.DepSet() != nil && cluster.DepSet().HasChain(chainID) {
+			return cluster, true
+		}
+	}
+	return nil, false
+}
+
 func (o *Orchestrator) ControlPlane() stack.ControlPlane {
 	return o.controlPlane
 }

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -59,7 +59,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	altDASrc driver.AltDAIface, eng L2API, cfg *rollup.Config, depSet depset.DependencySet, seqConfDepth uint64,
 ) *L2Sequencer {
 	ver := NewL2Verifier(t, log, l1, blobSrc, altDASrc, eng, cfg, depSet, &sync.Config{}, safedb.Disabled)
-	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, eng)
+	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, depSet, l1, eng)
 	seqConfDepthL1 := confdepth.NewConfDepth(seqConfDepth, ver.syncStatus.L1Head, l1)
 	originSelector := sequencing.NewL1OriginSelector(t.Ctx(), log, cfg, seqConfDepthL1)
 	l1OriginSelector := &MockL1OriginSelector{

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -160,7 +160,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		attributes.NewAttributesHandler(log, cfg, ctx, eng), opts)
 
 	managedMode := interopSys != nil
-	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, altDASrc, eng, metrics, managedMode)
+	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, managedMode)
 	sys.Register("pipeline", derive.NewPipelineDeriver(ctx, pipeline), opts)
 
 	testActionEmitter := sys.Register("test-action", nil, opts)

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -41,9 +41,10 @@ const (
 type Chain struct {
 	ChainID eth.ChainID
 
-	RollupCfg   *rollup.Config
-	L2Genesis   *core.Genesis
-	BatcherAddr common.Address
+	RollupCfg     *rollup.Config
+	DependencySet depset.DependencySet
+	L2Genesis     *core.Genesis
+	BatcherAddr   common.Address
 
 	Sequencer       *helpers.L2Sequencer
 	SequencerEngine *helpers.L2Engine
@@ -329,6 +330,7 @@ func createL2Services(
 	return &Chain{
 		ChainID:         eth.ChainIDFromBig(output.Genesis.Config.ChainID),
 		RollupCfg:       output.RollupCfg,
+		DependencySet:   depSet,
 		L2Genesis:       output.Genesis,
 		BatcherAddr:     crypto.PubkeyToAddress(batcherKey.PublicKey),
 		Sequencer:       seq,

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -1496,7 +1496,7 @@ func WithInteropEnabled(t helpers.StatefulTesting, actors *dsl.InteropActors, de
 		f.DependencySet = depSet
 
 		for _, chain := range []*dsl.Chain{actors.ChainA, actors.ChainB} {
-			verifier, canonicalOnlyEngine := createVerifierWithOnlyCanonicalBlocks(t, actors.L1Miner, chain, depSet)
+			verifier, canonicalOnlyEngine := createVerifierWithOnlyCanonicalBlocks(t, actors.L1Miner, chain)
 			f.L2Sources = append(f.L2Sources, &fpHelpers.FaultProofProgramL2Source{
 				Node:        verifier,
 				Engine:      canonicalOnlyEngine,
@@ -1508,7 +1508,7 @@ func WithInteropEnabled(t helpers.StatefulTesting, actors *dsl.InteropActors, de
 
 // createVerifierWithOnlyCanonicalBlocks creates a new L2Verifier and associated L2Engine that only has the canonical
 // blocks from chain in its database. Non-canonical blocks, their world state, receipts and other data are not available
-func createVerifierWithOnlyCanonicalBlocks(t helpers.StatefulTesting, l1Miner *helpers.L1Miner, chain *dsl.Chain, depSet depset.DependencySet) (*helpers.L2Verifier, *helpers.L2Engine) {
+func createVerifierWithOnlyCanonicalBlocks(t helpers.StatefulTesting, l1Miner *helpers.L1Miner, chain *dsl.Chain) (*helpers.L2Verifier, *helpers.L2Engine) {
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 	canonicalOnlyEngine := helpers.NewL2Engine(t, testlog.Logger(t, log.LvlInfo).New("role", "canonicalOnlyEngine"), chain.L2Genesis, jwtPath)
 	head := chain.Sequencer.L2Unsafe()
@@ -1546,7 +1546,7 @@ func createVerifierWithOnlyCanonicalBlocks(t helpers.StatefulTesting, l1Miner *h
 		altda.Disabled,
 		canonicalOnlyEngine.EngineClient(t, chain.RollupCfg),
 		chain.RollupCfg,
-		depSet,
+		chain.DependencySet,
 		&sync2.Config{},
 		safedb.Disabled)
 	return verifier, canonicalOnlyEngine

--- a/op-e2e/actions/sequencer/l2_sequencer_test.go
+++ b/op-e2e/actions/sequencer/l2_sequencer_test.go
@@ -180,7 +180,7 @@ func TestL2SequencerAPI(gt *testing.T) {
 	l2Cl := seqEng.EngineClient(t, cfg)
 
 	// Prepare a block
-	fb := derive.NewFetchingAttributesBuilder(cfg, l1Cl, l2Cl)
+	fb := derive.NewFetchingAttributesBuilder(cfg, sd.DependencySet, l1Cl, l2Cl)
 	parent, err := l2Cl.L2BlockRefByLabel(t.Ctx(), eth.Unsafe)
 	require.NoError(t, err)
 	l1Origin := parent.L1Origin // repeat the L1 origin

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -404,7 +404,7 @@ func (s *interopE2ESystem) Address(id, username string) common.Address {
 func (s *interopE2ESystem) prepareL2s() map[string]l2Net {
 	l2s := make(map[string]l2Net)
 	for id, l2Out := range s.worldOutput.L2s {
-		l2s[id] = s.newL2(id, l2Out)
+		l2s[id] = s.newL2(id, l2Out, s.DependencySet())
 	}
 	return l2s
 }

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -172,6 +172,9 @@ func (cfg *Config) Check() error {
 			"'--ignore-missing-pectra-blob-schedule' flag or 'IGNORE_MISSING_PECTRA_BLOB_SCHEDULE' env var.")
 		return ErrMissingPectraBlobSchedule
 	}
+	if cfg.Rollup.InteropTime != nil && cfg.DependencySet == nil {
+		return fmt.Errorf("the Interop upgrade is scheduled (timestamp = %d) but not dependency set is configured", *cfg.Rollup.InteropTime)
+	}
 	if err := cfg.Metrics.Check(); err != nil {
 		return fmt.Errorf("metrics config error: %w", err)
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -449,7 +449,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("cfg.Rollup.ChainOpConfig is nil. Please see https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.11.0: %w", err)
 	}
 
-	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source,
+	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, cfg.DependencySet, n.l2Source, n.l1Source,
 		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, managedMode)
 	return nil
 }

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -31,15 +31,17 @@ type SystemConfigL2Fetcher interface {
 // FetchingAttributesBuilder fetches inputs for the building of L2 payload attributes on the fly.
 type FetchingAttributesBuilder struct {
 	rollupCfg *rollup.Config
+	depSet    DependencySet
 	l1        L1ReceiptsFetcher
 	l2        SystemConfigL2Fetcher
 	// whether to skip the L1 origin timestamp check - only for testing purposes
 	testSkipL1OriginCheck bool
 }
 
-func NewFetchingAttributesBuilder(rollupCfg *rollup.Config, l1 L1ReceiptsFetcher, l2 SystemConfigL2Fetcher) *FetchingAttributesBuilder {
+func NewFetchingAttributesBuilder(rollupCfg *rollup.Config, depSet DependencySet, l1 L1ReceiptsFetcher, l2 SystemConfigL2Fetcher) *FetchingAttributesBuilder {
 	return &FetchingAttributesBuilder{
 		rollupCfg: rollupCfg,
+		depSet:    depSet,
 		l1:        l1,
 		l2:        l2,
 	}
@@ -143,6 +145,17 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 			return nil, NewCriticalError(fmt.Errorf("failed to build interop network upgrade txs: %w", err))
 		}
 		upgradeTxs = append(upgradeTxs, interop...)
+
+		if ba.depSet == nil {
+			return nil, NewCriticalError(fmt.Errorf("interop is active but no dependency set provided"))
+		}
+		if len(ba.depSet.Chains()) > 1 {
+			txs, err := InteropActivateCrossL2InboxTransactions()
+			if err != nil {
+				return nil, NewCriticalError(fmt.Errorf("failed to build interop cross l2 inbox txs: %w", err))
+			}
+			upgradeTxs = append(upgradeTxs, txs...)
+		}
 	}
 
 	l1InfoTx, err := L1InfoDepositBytes(ba.rollupCfg, sysConfig, seqNumber, l1Info, nextL2Time)

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -39,6 +39,9 @@ type FetchingAttributesBuilder struct {
 }
 
 func NewFetchingAttributesBuilder(rollupCfg *rollup.Config, depSet DependencySet, l1 L1ReceiptsFetcher, l2 SystemConfigL2Fetcher) *FetchingAttributesBuilder {
+	if rollupCfg.InteropTime != nil && depSet == nil {
+		panic("FetchingAttributesBuilder requires a dependency set when interop fork is scheduled")
+	}
 	return &FetchingAttributesBuilder{
 		rollupCfg: rollupCfg,
 		depSet:    depSet,
@@ -146,9 +149,6 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		}
 		upgradeTxs = append(upgradeTxs, interop...)
 
-		if ba.depSet == nil {
-			return nil, NewCriticalError(fmt.Errorf("interop is active but no dependency set provided"))
-		}
 		if len(ba.depSet.Chains()) > 1 {
 			txs, err := InteropActivateCrossL2InboxTransactions()
 			if err != nil {

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -77,7 +77,7 @@ func TestAttributesQueue(t *testing.T) {
 		NoTxPool:              true,
 		GasLimit:              (*eth.Uint64Quantity)(&expectedL1Cfg.GasLimit),
 	}
-	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l2Fetcher)
+	attrBuilder := NewFetchingAttributesBuilder(cfg, nil, l1Fetcher, l2Fetcher)
 
 	aq := NewAttributesQueue(testlog.Logger(t, log.LevelError), cfg, attrBuilder, nil)
 

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -8,6 +8,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -21,12 +23,15 @@ import (
 
 func TestPreparePayloadAttributes(t *testing.T) {
 	// test sysCfg, only init the necessary fields
-	cfg := &rollup.Config{
-		BlockTime:              2,
-		L1ChainID:              big.NewInt(101),
-		L2ChainID:              big.NewInt(102),
-		DepositContractAddress: common.Address{0xbb},
-		L1SystemConfigAddress:  common.Address{0xcc},
+	// Create a new config each time, otherwise modifications pollute other tests.
+	mkCfg := func() *rollup.Config {
+		return &rollup.Config{
+			BlockTime:              2,
+			L1ChainID:              big.NewInt(101),
+			L2ChainID:              big.NewInt(102),
+			DepositContractAddress: common.Address{0xbb},
+			L1SystemConfigAddress:  common.Address{0xcc},
+		}
 	}
 
 	testSysCfg := eth.SystemConfig{
@@ -47,7 +52,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l1Info.InfoNum = l2Parent.L1Origin.Number + 1
 		epoch := l1Info.ID()
 		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, nil, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(mkCfg(), nil, l1Fetcher, l1CfgFetcher)
 		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NotNil(t, err, "inconsistent L1 origin error expected")
 		require.ErrorIs(t, err, ErrReset, "inconsistent L1 origin transition must be handled like a critical error with reorg")
@@ -63,7 +68,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l1Info := testutils.RandomBlockInfo(rng)
 		l1Info.InfoNum = l2Parent.L1Origin.Number
 		epoch := l1Info.ID()
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(mkCfg(), nil, l1Fetcher, l1CfgFetcher)
 		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NotNil(t, err, "inconsistent L1 origin error expected")
 		require.ErrorIs(t, err, ErrReset, "inconsistent L1 origin transition must be handled like a critical error with reorg")
@@ -80,7 +85,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		epoch.Number += 1
 		mockRPCErr := errors.New("mock rpc error")
 		l1Fetcher.ExpectFetchReceipts(epoch.Hash, nil, nil, mockRPCErr)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(mkCfg(), nil, l1Fetcher, l1CfgFetcher)
 		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.ErrorIs(t, err, mockRPCErr, "mock rpc error expected")
 		require.ErrorIs(t, err, ErrTemporary, "rpc errors should not be critical, it is not necessary to reorg")
@@ -96,13 +101,14 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		epoch := l2Parent.L1Origin
 		mockRPCErr := errors.New("mock rpc error")
 		l1Fetcher.ExpectInfoByHash(epoch.Hash, nil, mockRPCErr)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(mkCfg(), nil, l1Fetcher, l1CfgFetcher)
 		_, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.ErrorIs(t, err, mockRPCErr, "mock rpc error expected")
 		require.ErrorIs(t, err, ErrTemporary, "rpc errors should not be critical, it is not necessary to reorg")
 	})
 	t.Run("next origin without deposits", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
+		cfg := mkCfg()
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
 		l2Parent := testutils.RandomL2BlockRef(rng)
@@ -113,10 +119,10 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l1Info.InfoParentHash = l2Parent.L1Origin.Hash
 		l1Info.InfoNum = l2Parent.L1Origin.Number + 1
 		epoch := l1Info.ID()
-		l1InfoTx, err := L1InfoDepositBytes(cfg, testSysCfg, 0, l1Info, 0)
+		l1InfoTx, err := L1InfoDepositBytes(mkCfg(), testSysCfg, 0, l1Info, 0)
 		require.NoError(t, err)
 		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, nil, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(cfg, nil, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
@@ -130,6 +136,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 	})
 	t.Run("next origin with deposits", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
+		cfg := mkCfg()
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
 		l2Parent := testutils.RandomL2BlockRef(rng)
@@ -157,7 +164,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l2Txs := append(append(make([]eth.Data, 0), l1InfoTx), usedDepositTxs...)
 
 		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, receipts, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(cfg, nil, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
@@ -170,6 +177,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 	})
 	t.Run("same origin again", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
+		cfg := mkCfg()
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
 		l2Parent := testutils.RandomL2BlockRef(rng)
@@ -185,7 +193,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.NoError(t, err)
 
 		l1Fetcher.ExpectInfoByHash(epoch.Hash, l1Info, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(cfg, nil, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
@@ -198,6 +206,9 @@ func TestPreparePayloadAttributes(t *testing.T) {
 	})
 	t.Run("new origin with deposits on post-Interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
+		cfg := mkCfg()
+		depSet, err := depset.NewStaticConfigDependencySet(nil)
+		require.NoError(t, err)
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
 		l2Parent := testutils.RandomL2BlockRef(rng)
@@ -233,7 +244,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l2Txs = append(l2Txs, userDepositTxs...)
 
 		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, receipts, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(cfg, depSet, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
@@ -247,6 +258,9 @@ func TestPreparePayloadAttributes(t *testing.T) {
 
 	t.Run("same origin without deposits on post-Interop", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
+		cfg := mkCfg()
+		depSet, err := depset.NewStaticConfigDependencySet(nil)
+		require.NoError(t, err)
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
 		l2Parent := testutils.RandomL2BlockRef(rng)
@@ -270,7 +284,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l2Txs = append(l2Txs, l1InfoTx)
 
 		l1Fetcher.ExpectInfoByHash(epoch.Hash, l1Info, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(cfg, depSet, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
@@ -283,6 +297,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 	})
 
 	t.Run("holocene 1559 params", func(t *testing.T) {
+		cfg := mkCfg()
 		cfg.ActivateAtGenesis(rollup.Holocene)
 		rng := rand.New(rand.NewSource(1234))
 		l1Fetcher := &testutils.MockL1Source{}
@@ -305,7 +320,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l1InfoTx, err := L1InfoDepositBytes(cfg, testSysCfg, 0, l1Info, 0)
 		require.NoError(t, err)
 		l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, nil, nil)
-		attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+		attrBuilder := NewFetchingAttributesBuilder(cfg, nil, l1Fetcher, l1CfgFetcher)
 		attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 		require.NoError(t, err)
 		require.Equal(t, eip1559Params, *attrs.EIP1559Params)
@@ -314,6 +329,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 
 	// Test that the payload attributes builder changes the deposit format based on L2-time-based regolith activation
 	t.Run("regolith", func(t *testing.T) {
+		cfg := mkCfg()
 		testCases := []struct {
 			name         string
 			l1Time       uint64
@@ -356,12 +372,76 @@ func TestPreparePayloadAttributes(t *testing.T) {
 				l1InfoTx, err := L1InfoDepositBytes(cfg, testSysCfg, 0, l1Info, time)
 				require.NoError(t, err)
 				l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, nil, nil)
-				attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, l1CfgFetcher)
+				attrBuilder := NewFetchingAttributesBuilder(cfg, nil, l1Fetcher, l1CfgFetcher)
 				attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
 				require.NoError(t, err)
 				require.Equal(t, l1InfoTx, []byte(attrs.Transactions[0]))
 			})
 		}
+	})
+
+	t.Run("interop", func(t *testing.T) {
+		prepareActivationAttributes := func(t *testing.T, depSet depset.DependencySet) *eth.PayloadAttributes {
+			cfg := mkCfg()
+			cfg.ActivateAtGenesis(rollup.Isthmus)
+			interopTime := uint64(1000)
+			cfg.InteropTime = &interopTime
+			rng := rand.New(rand.NewSource(1234))
+			l1Fetcher := &testutils.MockL1Source{}
+			defer l1Fetcher.AssertExpectations(t)
+			l2Parent := testutils.RandomL2BlockRef(rng)
+			l2Parent.Time = interopTime - cfg.BlockTime
+
+			l1CfgFetcher := &testutils.MockL2Client{}
+			l1CfgFetcher.ExpectSystemConfigByL2Hash(l2Parent.Hash, testSysCfg, nil)
+			defer l1CfgFetcher.AssertExpectations(t)
+
+			l1Info := testutils.RandomBlockInfo(rng)
+			l1Info.InfoParentHash = l2Parent.L1Origin.Hash
+			l1Info.InfoNum = l2Parent.L1Origin.Number + 1
+			l1Info.InfoTime = l2Parent.Time
+
+			epoch := l1Info.ID()
+			l1Fetcher.ExpectFetchReceipts(epoch.Hash, l1Info, nil, nil)
+			attrBuilder := NewFetchingAttributesBuilder(cfg, depSet, l1Fetcher, l1CfgFetcher)
+			attrs, err := attrBuilder.PreparePayloadAttributes(context.Background(), l2Parent, epoch)
+			require.NoError(t, err)
+			return attrs
+		}
+
+		t.Run("WithSingleChainDepSet", func(t *testing.T) {
+			depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+				eth.ChainIDFromUInt64(42): {},
+			})
+			require.NoError(t, err)
+			attrs := prepareActivationAttributes(t, depSet)
+			upgradeTx, err := InteropNetworkUpgradeTransactions()
+			require.NoError(t, err)
+			require.Len(t, attrs.Transactions, len(upgradeTx)+1) // +1 for L1Info tx
+			for i, tx := range upgradeTx {
+				require.Equal(t, tx, attrs.Transactions[i+1])
+			}
+		})
+
+		t.Run("WithMultiChainDepSet", func(t *testing.T) {
+			depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+				eth.ChainIDFromUInt64(42): {},
+				eth.ChainIDFromUInt64(44): {},
+			})
+			require.NoError(t, err)
+			attrs := prepareActivationAttributes(t, depSet)
+			upgradeTx, err := InteropNetworkUpgradeTransactions()
+			require.NoError(t, err)
+			l2InboxTx, err := InteropActivateCrossL2InboxTransactions()
+			require.NoError(t, err)
+			expectedTx := make([]hexutil.Bytes, 0, len(upgradeTx)+len(l2InboxTx))
+			expectedTx = append(expectedTx, upgradeTx...)
+			expectedTx = append(expectedTx, l2InboxTx...)
+			require.Len(t, attrs.Transactions, len(expectedTx)+1) // +1 for L1Info tx
+			for i, tx := range expectedTx {
+				require.Equal(t, tx, attrs.Transactions[i+1])
+			}
+		})
 	})
 }
 

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -8,17 +8,15 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPreparePayloadAttributes(t *testing.T) {

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -95,7 +95,7 @@ type DerivationPipeline struct {
 }
 
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
-func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
+func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet DependencySet, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
 	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedMode bool,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
@@ -113,7 +113,7 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 	channelMux := NewChannelMux(log, spec, frameQueue, metrics)
 	chInReader := NewChannelInReader(rollupCfg, log, channelMux, metrics)
 	batchMux := NewBatchMux(log, rollupCfg, chInReader, l2Source)
-	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1Fetcher, l2Source)
+	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, depSet, l1Fetcher, l2Source)
 	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux)
 
 	// Reset from ResetEngine then up from L1 Traversal. The stages do not talk to each other during

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -161,6 +161,7 @@ func NewDriver(
 	drain Drain,
 	driverCfg *Config,
 	cfg *rollup.Config,
+	depSet derive.DependencySet,
 	l2 L2Chain,
 	l1 L1Chain,
 	l1Blobs derive.L1BlobsFetcher,
@@ -206,7 +207,7 @@ func NewDriver(
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, driverCtx, l2))
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode)
 
 	sys.Register("pipeline",
 		derive.NewPipelineDeriver(driverCtx, derivationPipeline))
@@ -234,7 +235,7 @@ func NewDriver(
 	var sequencer sequencing.SequencerIface
 	if driverCfg.SequencerEnabled {
 		asyncGossiper := async.NewAsyncGossiper(driverCtx, network, log, metrics)
-		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
+		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, depSet, l1, l2)
 		sequencerConfDepth := confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
 		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
 		sys.Register("origin-selector", findL1Origin)

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -32,14 +32,14 @@ type Driver struct {
 	deriver event.Deriver
 }
 
-func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher,
+func NewDriver(logger log.Logger, cfg *rollup.Config, depSet derive.DependencySet, l1Source derive.L1Fetcher,
 	l1BlobsSource derive.L1BlobsFetcher, l2Source engine.Engine, targetBlockNum uint64) *Driver {
 
 	d := &Driver{
 		logger: logger,
 	}
 
-	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, altda.Disabled, l2Source, metrics.NoopMetrics, false)
+	pipeline := derive.NewDerivationPipeline(logger, cfg, depSet, l1Source, l1BlobsSource, altda.Disabled, l2Source, metrics.NoopMetrics, false)
 	pipelineDeriver := derive.NewPipelineDeriver(context.Background(), pipeline)
 	pipelineDeriver.AttachEmitter(d)
 

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -774,6 +774,7 @@ var _ taskExecutor = (*stubTasks)(nil)
 func (t *stubTasks) RunDerivation(
 	_ log.Logger,
 	_ *rollup.Config,
+	_ depset.DependencySet,
 	_ *params.ChainConfig,
 	_ common.Hash,
 	_ eth.Bytes32,

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -22,6 +22,7 @@ func RunPreInteropProgram(
 	result, err := tasks.RunDerivation(
 		logger,
 		bootInfo.RollupConfig,
+		nil, // No dependency set pre-interop
 		bootInfo.L2ChainConfig,
 		bootInfo.L1Head,
 		bootInfo.L2OutputRoot,

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	cldr "github.com/ethereum-optimism/optimism/op-program/client/driver"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
@@ -44,6 +45,7 @@ type DerivationOptions struct {
 func RunDerivation(
 	logger log.Logger,
 	cfg *rollup.Config,
+	depSet derive.DependencySet,
 	l2Cfg *params.ChainConfig,
 	l1Head common.Hash,
 	l2OutputRoot common.Hash,
@@ -61,7 +63,7 @@ func RunDerivation(
 	l2Source := l2.NewOracleEngine(cfg, logger, engineBackend, l2Oracle.Hinter())
 
 	logger.Info("Starting derivation", "chainID", cfg.L2ChainID)
-	d := cldr.NewDriver(logger, cfg, l1Source, l1BlobsSource, l2Source, l2ClaimBlockNum)
+	d := cldr.NewDriver(logger, cfg, depSet, l1Source, l1BlobsSource, l2Source, l2ClaimBlockNum)
 	result, err := d.RunComplete()
 	if err != nil {
 		return DerivationResult{}, fmt.Errorf("failed to run program to completion: %w", err)

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -165,6 +165,7 @@ func (p *programExecutor) RunProgram(
 	result, err := tasks.RunDerivation(
 		p.logger,
 		rollupConfig,
+		p.cfg.DependencySet,
 		l2ChainConfig,
 		p.cfg.L1Head,
 		outputRoot,

--- a/op-supervisor/supervisor/backend/depset/json.go
+++ b/op-supervisor/supervisor/backend/depset/json.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -31,6 +32,10 @@ func (j *JSONDependencySetLoader) LoadDependencySet(ctx context.Context) (Depend
 		return nil, fmt.Errorf("failed to open dependency set: %w", err)
 	}
 	defer f.Close()
+	return ParseJSONDependencySet(f)
+}
+
+func ParseJSONDependencySet(f io.Reader) (DependencySet, error) {
 	dec := json.NewDecoder(f)
 	var out StaticConfigDependencySet
 	if err := dec.Decode(&out); err != nil {

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
@@ -60,6 +61,22 @@ func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.Se
 		return nil, err
 	}
 
+	var depSet depset.DependencySet
+	// Dependency set is only required if interop is scheduled and the RPC may not be available before then.
+	if cfg.InteropTime != nil {
+		depSet, err = retry.Do(ctx, 10, retry.Exponential(), func() (depset.DependencySet, error) {
+			opts.Log.Info("Fetching rollup-config for block-building")
+			depSet, err := rolCl.DependencySet(ctx)
+			if err != nil {
+				opts.Log.Warn("Failed to fetch dependency set", "err", err)
+			}
+			return depSet, err
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	l1Cl, err := sources.NewL1Client(l1ELRPCClient, opts.Log, nil,
 		sources.L1ClientSimpleConfig(false, sources.RPCKindStandard, 10))
 	if err != nil {
@@ -70,7 +87,7 @@ func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.Se
 	if err != nil {
 		return nil, err
 	}
-	fb := derive.NewFetchingAttributesBuilder(cfg, l1Cl, l2Cl)
+	fb := derive.NewFetchingAttributesBuilder(cfg, depSet, l1Cl, l2Cl)
 
 	fb.TestSkipL1OriginCheck()
 

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
@@ -65,7 +65,7 @@ func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.Se
 	// Dependency set is only required if interop is scheduled and the RPC may not be available before then.
 	if cfg.InteropTime != nil {
 		depSet, err = retry.Do(ctx, 10, retry.Exponential(), func() (depset.DependencySet, error) {
-			opts.Log.Info("Fetching rollup-config for block-building")
+			opts.Log.Info("Fetching dependency set for block-building")
 			depSet, err := rolCl.DependencySet(ctx)
 			if err != nil {
 				opts.Log.Warn("Failed to fetch dependency set", "err", err)


### PR DESCRIPTION
**Description**

Makes the deployment of `CrossL2Inbox` predeploy conditional on their being more than one chain in the dependency set. As there isn't currently support for adding chains to the dependency set, the condition is currently only checked at the interop activation block - when adding chains is supported this will have to be expanded to check at the block the dependency set actually changes. That's not implemented now because there isn't even a mechanism to specify the timestamp that a dependency set change activates at yet.

Most of the changes are plumbing to pass the dependency set through to the attributes builder so it can determine which upgrade transactions are required.

**Metadata**

#16041 
