### PR TITLE
simplify handling of block hash mismatch case

### DIFF
--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -224,7 +224,7 @@ func (m mismatches) Len() int {
 	return len(m.clientIndices)
 }
 
-// verifyFollowersWithRetry checks the hash and state root consistency with retries in case of temporary sync issues
+// verifyFollowersWithRetry checks hash consistency with retries in case of temporary sync issues
 func (mc *MultiClient) verifyFollowersWithRetry(
 	ctx context.Context,
 	blockNum *big.Int,

--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -180,66 +180,27 @@ func (mc *MultiClient) fetchWithConsistencyCheck(
 	number *big.Int,
 	queryFn func(HeaderProvider, *big.Int) (interface{}, *big.Int, common.Hash, error),
 ) (interface{}, error) {
-	// Get from primary client
-	primaryItem, blockNum, primaryHash, err := queryFn(mc.clients[0], number)
+
+	leaderHeader, blockNum, leaderHash, err := queryFn(mc.clients[0], number)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get the block hash for the primary
-	primaryHeader, ok := primaryItem.(*types.Header)
-	if !ok {
-		// If we're fetching a block instead of a header
-		if block, ok := primaryItem.(*types.Block); ok {
-			primaryHeader = block.Header()
-		} else {
-			return nil, fmt.Errorf("expected header or block, got %T", primaryItem)
-		}
-	}
-
 	// Create a hash-only getter for followers
 	getFollowerHash := func(client HeaderProvider, num *big.Int) (common.Hash, error) {
-		item, _, hash, err := queryFn(client, num)
+		followerHeader, _, followerHash, err := queryFn(client, num)
 		if err != nil {
 			return common.Hash{}, err
 		}
-
-		// If hashes don't match, also check state roots
-		// no (hash)divergence situation
-		if hash == primaryHash {
-			return hash, nil
+		if followerHash == leaderHash {
+			return followerHash, nil
+		} else {
+			return followerHash, fmt.Errorf("block hash divergence. PrimaryHeader = %+v, FollowerHeader = %+v", leaderHeader, followerHeader)
 		}
-
-		// from this point, we have divergence, so no matter what, we would return a non-nil error.
-
-		// hash-divergence found but with no primary header to provide more details
-		if primaryHeader == nil {
-			return hash, fmt.Errorf("block hash divergence found at block %s. Unfortunately, couldn't parse more details due to the nil primaryHeader.", num.String())
-		}
-
-		var followerHeader *types.Header
-		if header, ok := item.(*types.Header); ok {
-			followerHeader = header
-		} else if block, ok := item.(*types.Block); ok {
-			followerHeader = block.Header()
-		}
-
-		// hash-divergence found with follower header details but no primary header details
-		if followerHeader == nil {
-			return hash, fmt.Errorf("block hash divergence found at block %s. Unfortunately, couldn't parse the nil followerHeader but the primary Header is: %+v", num.String(), primaryHeader)
-		}
-
-		// hash-divergence found with matching state roots
-		if followerHeader.Root == primaryHeader.Root {
-			return hash, fmt.Errorf("block hash divergence with matching state roots: primary_hash=%s, follower_hash=%s, state_root=%s",
-				primaryHash.Hex(), hash.Hex(), primaryHeader.Root.Hex())
-		}
-		// hash-divergence found with diverging state roots
-		return hash, fmt.Errorf("block hash divergence. PrimaryHeader = %+v, FollowerHeader = %+v", primaryHeader, followerHeader)
 	}
 
 	// Verify consistency with retry for followers
-	mismatches, err := mc.verifyFollowersWithRetry(ctx, blockNum, primaryHash, getFollowerHash)
+	mismatches, err := mc.verifyFollowersWithRetry(ctx, blockNum, leaderHash, getFollowerHash)
 	if err != nil {
 		// If err contains information about matching state roots, format and return it
 		if strings.Contains(err.Error(), "block hash divergence with matching state roots") {
@@ -256,10 +217,10 @@ func (mc *MultiClient) fetchWithConsistencyCheck(
 	// This should no longer occur with the updated verifyFollowersWithRetry implementation
 	// that returns immediately when chain splits are detected
 	if mismatches.Len() > 0 {
-		return nil, formatHashMismatchError(blockNum, primaryHash, mismatches.clientIndices, mismatches.hashes)
+		return nil, formatHashMismatchError(blockNum, leaderHash, mismatches.clientIndices, mismatches.hashes)
 	}
 
-	return primaryItem, nil
+	return leaderHeader, nil
 }
 
 // mismatches holds information about hash mismatches

--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -186,8 +186,7 @@ func (mc *MultiClient) fetchWithConsistencyCheck(
 		return nil, err
 	}
 
-	// Create a hash-only getter for followers
-	getFollowerHash := func(client HeaderProvider, num *big.Int) (common.Hash, error) {
+	getFollowerHeaderWithConsistencyCheck := func(client HeaderProvider, num *big.Int) (common.Hash, error) {
 		followerHeader, _, followerHash, err := queryFn(client, num)
 		if err != nil {
 			return common.Hash{}, err
@@ -200,17 +199,8 @@ func (mc *MultiClient) fetchWithConsistencyCheck(
 	}
 
 	// Verify consistency with retry for followers
-	mismatches, err := mc.verifyFollowersWithRetry(ctx, blockNum, leaderHash, getFollowerHash)
+	mismatches, err := mc.verifyFollowersWithRetry(ctx, blockNum, leaderHash, getFollowerHeaderWithConsistencyCheck)
 	if err != nil {
-		// If err contains information about matching state roots, format and return it
-		if strings.Contains(err.Error(), "block hash divergence with matching state roots") {
-			return nil, fmt.Errorf("at block #%s: %w", blockNum, err)
-		}
-
-		// If err is a chain split error, pass it through
-		if strings.Contains(err.Error(), "chain split detected") {
-			return nil, err
-		}
 		return nil, err
 	}
 

--- a/op-acceptance-tests/tests/base/chain_test.go
+++ b/op-acceptance-tests/tests/base/chain_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestChainFork checks that the chain does not fork and that all nodes maintain consensus on the state root.
+// TestChainFork checks that the chain does not fork (all nodes have the same block hash for a fixed block number).
 func TestChainFork(t *testing.T) {
 	systest.SystemTest(t,
 		chainForkTestScenario(),


### PR DESCRIPTION
This is a simplification, where if we detect a block hash divergence we log out all of the information we have (which will be at least a block header, possibly a block header with additional hydrated transactions). 

This removes the need to do type checking on generic types and to pull out the state root for special treatment, etc. 
