### PR TITLE
feat(op-devstack): add runner log level

### DIFF
--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -143,3 +143,11 @@ and returns a typed output that the test then may use.
 - Orchestrators are configured in the `TestMain`, with generic presets, such that the different backends can support the preset or not.
 - There are no "chains": the word "chain" is reserved for the protocol typing of the onchain / state-transition related logic. Instead, there are "networks", which include the offchain resources and attached services of a chain.
 - Do not abbreviate "client" to "cl", to avoid confusion with "consensus-layer".
+
+## Environment Variables
+
+The following environment variables can be used to configure devstack:
+
+- `TEST_LOG_LEVEL`: Controls the logging level for tests. Defaults to "info" if not set. Valid values are standard log levels (e.g. "debug", "info", "warn", "error").
+- `DEVSTACK_ORCHESTRATOR`: Configures the preferred orchestrator kind (see Orchestrator interface section above).
+- `DEVNET_ENV_URL`: Used when `DEVSTACK_ORCHESTRATOR=sysext` to specify the network descriptor URL.

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -245,7 +245,8 @@ func SerialT(t *testing.T) T {
 	}
 	level, err := log.LevelFromString(logLevel)
 	if err != nil {
-		panic(err)
+		t.Errorf("Invalid log level %q: %v, defaulting to info", logLevel, err)
+		level, _ = log.LevelFromString("info")
 	}
 	logger := NewLogger(ctx, t, level).WithContext(ctx)
 

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -8,11 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-
-	"github.com/ethereum/go-ethereum/log"
 )
 
 const ExpectPreconditionsMet = "DEVNET_EXPECT_PRECONDITIONS_MET"
@@ -240,7 +239,15 @@ func SerialT(t *testing.T) T {
 	t.Cleanup(func() {
 		span.End()
 	})
-	logger := NewLogger(ctx, t, log.LevelInfo).WithContext(ctx)
+	logLevel := os.Getenv("TEST_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = "info" // default to info if not set
+	}
+	level, err := log.LevelFromString(logLevel)
+	if err != nil {
+		panic(err)
+	}
+	logger := NewLogger(ctx, t, level).WithContext(ctx)
 
 	out := &testingT{
 		t:      t,

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 )
 
 const ExpectPreconditionsMet = "DEVNET_EXPECT_PRECONDITIONS_MET"
@@ -243,7 +246,7 @@ func SerialT(t *testing.T) T {
 	if logLevel == "" {
 		logLevel = "info" // default to info if not set
 	}
-	level, err := log.LevelFromString(logLevel)
+	level, err := oplog.LevelFromString(logLevel)
 	if err != nil {
 		t.Errorf("Invalid log level %q: %v, defaulting to info", logLevel, err)
 		level = log.LevelInfo

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -246,7 +246,7 @@ func SerialT(t *testing.T) T {
 	level, err := log.LevelFromString(logLevel)
 	if err != nil {
 		t.Errorf("Invalid log level %q: %v, defaulting to info", logLevel, err)
-		level, _ = log.LevelFromString("info")
+		level = log.LevelInfo
 	}
 	logger := NewLogger(ctx, t, level).WithContext(ctx)
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Enables devstack to set a custom log level using an env variable "TEST_LOG_LEVEL".

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
