### PR TITLE
op-node/rollup/interop: do not ignore local unsafe reset

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -100,8 +100,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	rewind := uint64(3)
 	logger.Info("Check verifier CLs safe head rewinded", "rewind", rewind)
 	dsl.CheckAll(t,
-		sys.L2CLA2.RewindedFn(types.CrossSafe, rewind, 60),
-		sys.L2CLB2.RewindedFn(types.CrossSafe, rewind, 60),
+		sys.L2CLA2.RewindedFn(types.CrossSafe, rewind, 90),
+		sys.L2CLB2.RewindedFn(types.CrossSafe, rewind, 90),
 	)
 
 	// After rewinding(reset), verifier will advance safe heads again because Secondary supervisor gives L1 data to the verifiers.

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -224,7 +224,8 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l
 				BeaconAddr: l1CL.beacon.BeaconAddr(),
 			},
 			Driver: driver.Config{
-				SequencerEnabled: isSequencer,
+				SequencerEnabled:   isSequencer,
+				SequencerConfDepth: 2,
 			},
 			Rollup:        *l2Net.rollupCfg,
 			DependencySet: depSet,

--- a/op-devstack/sysgo/test_sequencer.go
+++ b/op-devstack/sysgo/test_sequencer.go
@@ -149,7 +149,7 @@ func WithTestSequencer(testSequencerID stack.TestSequencerID, l2CLID stack.L2CLN
 						Committer: committerID,
 						Publisher: publisherID,
 
-						SequencerConfDepth:  3,
+						SequencerConfDepth:  2,
 						SequencerEnabled:    true,
 						SequencerStopped:    false,
 						SequencerMaxSafeLag: 0,

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -603,10 +603,8 @@ type ResetEngineControl interface {
 }
 
 func ForceEngineReset(ec ResetEngineControl, x rollup.ForceResetEvent) {
-	// local-unsafe is an optional attribute, empty to preserve the existing latest chain
-	if x.LocalUnsafe != (eth.L2BlockRef{}) {
-		ec.SetUnsafeHead(x.LocalUnsafe)
-	}
+	ec.SetUnsafeHead(x.LocalUnsafe)
+
 	// cross-safe is fine to revert back, it does not affect engine logic, just sync-status
 	ec.SetCrossUnsafeHead(x.CrossUnsafe)
 

--- a/op-node/rollup/event.go
+++ b/op-node/rollup/event.go
@@ -45,10 +45,7 @@ func (ev ResetEvent) String() string {
 // Resets may override local-safe, since post-interop we need the local-safe block derivation to continue.
 // Pre-interop both local and cross values should be set the same.
 type ForceResetEvent struct {
-	// LocalUnsafe is optional: the existing chain local-unsafe head will be preserved if this field is zeroed.
-	LocalUnsafe eth.L2BlockRef
-
-	CrossUnsafe, LocalSafe, CrossSafe, Finalized eth.L2BlockRef
+	LocalUnsafe, CrossUnsafe, LocalSafe, CrossSafe, Finalized eth.L2BlockRef
 }
 
 func (ev ForceResetEvent) String() string {


### PR DESCRIPTION
**Description**

This PR is:
1. Fixing a bug with L2 unsafe head not reorging after a L1 reorg
2. Fixing a config with deployment of interop network in sysgo tests -- `SequencerConfDepth`
3. Fixing the wait times of a few tests due to the change in 2.

---

In `managed-mode` in interop networks, it is the `op-supervisor` that monitors the L1 chain, and is the source-of-truth for the networks view for the `op-node`. At the moment when it issues a reset, the `op-node` is ignoring the `LocalUnsafe` field within the reset event.

This means that if the L2 chain has progressed on an incorrect chain due to L1 reorg, its unsafe ref is not rewound back to a block using a valid L1 ref after the reorg.

**Tests**

This functionality is tested with `TestL2ReorgAfterL1Reorg` from https://github.com/ethereum-optimism/optimism/pull/16105

```
cd op-acceptance-tests/tests/interop/reorgs
go test -count=1 -timeout=30m -failfast -v -run TestL2ReorgAfterL1Reorg ./...
```

If you comment out the update to `LocalUnsafe` field, the test will fail, and you can inspect the logs and see that L1Origin ref for the L2 chain blocks is stuck on a reorged L1 block.

I haven't added the test to this PR, as the `op-test-sequencer` L1-mode needs more work in order to be ready for review, but this bugfix and the test itself are ready.

- [x] add test to this PR to visualize and confirm this bug - test added at https://github.com/ethereum-optimism/optimism/pull/16105 to keep change-sets short and easy to review.

**Follow-up**

In a separate PR, as a follow-up:

- [x] improve `op-test-sequencer` so that we can run the test multiple times. when running with `-count=2`, no reorg on L1 is triggered at the moment
- use `op-supervisor` as source-of-truth for L1 origin selector (`op-node.rollup.sequencing.L1OriginSelector`)

**Additional context**

Found as part of https://github.com/ethereum-optimism/optimism/issues/15331
