### PR TITLE
op-deployer: Replace UseInterop flag with InteropTimeOffset flag.

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -377,9 +377,6 @@ type UpgradeScheduleDeployConfig struct {
 	L1CancunTimeOffset *hexutil.Uint64 `json:"l1CancunTimeOffset,omitempty"`
 	// When Prague activates. Relative to L1 genesis.
 	L1PragueTimeOffset *hexutil.Uint64 `json:"l1PragueTimeOffset,omitempty"`
-
-	// UseInterop is a flag that indicates if the system is using interop
-	UseInterop bool `json:"useInterop,omitempty"`
 }
 
 var _ ConfigChecker = (*UpgradeScheduleDeployConfig)(nil)

--- a/op-chain-ops/interopgen/configs.go
+++ b/op-chain-ops/interopgen/configs.go
@@ -38,8 +38,6 @@ type OPCMImplementationsConfig struct {
 	L1ContractsRelease string
 
 	FaultProof SuperFaultProofConfig
-
-	UseInterop bool // to deploy Interop implementation contracts, instead of the regular ones.
 }
 
 type SuperchainConfig struct {

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -185,7 +185,6 @@ func DeploySuperchainToL1(l1Host *script.Host, superCfg *SuperchainConfig) (*Sup
 		SuperchainConfigProxy:           superDeployment.SuperchainConfigProxy,
 		ProtocolVersionsProxy:           superDeployment.ProtocolVersionsProxy,
 		UpgradeController:               superCfg.ProxyAdminOwner,
-		UseInterop:                      superCfg.Implementations.UseInterop,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy Implementations contracts: %w", err)
@@ -308,9 +307,10 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) err
 		L1FeeVaultWithdrawalNetwork:              big.NewInt(int64(cfg.L1FeeVaultWithdrawalNetwork.ToUint8())),
 		GovernanceTokenOwner:                     cfg.GovernanceTokenOwner,
 		Fork:                                     big.NewInt(cfg.SolidityForkNumber(1)),
-		UseInterop:                               cfg.UseInterop,
-		EnableGovernance:                         cfg.EnableGovernance,
-		FundDevAccounts:                          cfg.FundDevAccounts,
+		// Only include interop predeploys if it is activating at genesis
+		UseInterop:       cfg.L2GenesisInteropTimeOffset != nil && *cfg.L2GenesisIsthmusTimeOffset == 0,
+		EnableGovernance: cfg.EnableGovernance,
+		FundDevAccounts:  cfg.FundDevAccounts,
 	}); err != nil {
 		return fmt.Errorf("failed L2 genesis: %w", err)
 	}

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -308,7 +308,7 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment) err
 		GovernanceTokenOwner:                     cfg.GovernanceTokenOwner,
 		Fork:                                     big.NewInt(cfg.SolidityForkNumber(1)),
 		// Only include interop predeploys if it is activating at genesis
-		UseInterop:       cfg.L2GenesisInteropTimeOffset != nil && *cfg.L2GenesisIsthmusTimeOffset == 0,
+		UseInterop:       cfg.L2GenesisInteropTimeOffset != nil && *cfg.L2GenesisInteropTimeOffset == 0,
 		EnableGovernance: cfg.EnableGovernance,
 		FundDevAccounts:  cfg.FundDevAccounts,
 	}); err != nil {

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -79,7 +79,6 @@ func (recipe *InteropDevRecipe) Build(addrs devkeys.Addresses) (*WorldConfig, er
 				DisputeGameFinalityDelaySeconds: big.NewInt(6),
 				MipsVersion:                     big.NewInt(int64(versions.GetExperimentalVersion())),
 			},
-			UseInterop: true,
 		},
 		SuperchainL1DeployConfig: genesis.SuperchainL1DeployConfig{
 			RequiredProtocolVersion:    params.OPStackSupport,

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -262,8 +262,6 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 				L2GenesisJovianTimeOffset:   nil,
 				L1CancunTimeOffset:          new(hexutil.Uint64),
 				L1PragueTimeOffset:          new(hexutil.Uint64),
-				// Don't deploy interop L2 contracts if interop hard fork isn't active at genesis
-				UseInterop: r.InteropOffset == 0,
 			},
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
 				L1ChainID:                 l1ChainID,

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -390,7 +390,7 @@ func ApplyPipeline(
 	}
 
 	// Generate the interop dependency set if interop is enabled
-	if intent.UseInterop {
+	if intent.InteropTimeOffset != nil {
 		pline = append(pline, pipelineStage{
 			"generate-interop-depset",
 			func() error {

--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -123,11 +123,6 @@ var (
 		Usage:   "Upgrade controller.",
 		EnvVars: deployer.PrefixEnvVar("UPGRADE_CONTROLLER"),
 	}
-	UseInteropFlag = &cli.BoolFlag{
-		Name:    "use-interop",
-		Usage:   "If true, deploy Interop implementations.",
-		EnvVars: deployer.PrefixEnvVar("USE_INTEROP"),
-	}
 	ConfigFileFlag = &cli.StringFlag{
 		Name:    "config",
 		Usage:   "Path to a JSON file",
@@ -149,7 +144,6 @@ var ImplementationsFlags = []cli.Flag{
 	SuperchainConfigProxyFlag,
 	ProtocolVersionsProxyFlag,
 	UpgradeControllerFlag,
-	UseInteropFlag,
 }
 
 var ProxyFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -42,7 +42,6 @@ type ImplementationsConfig struct {
 	SuperchainConfigProxy           common.Address     `cli:"superchain-config-proxy"`
 	ProtocolVersionsProxy           common.Address     `cli:"protocol-versions-proxy"`
 	UpgradeController               common.Address     `cli:"upgrade-controller"`
-	UseInterop                      bool               `cli:"use-interop"`
 	CacheDir                        string             `cli:"cache-dir"`
 
 	Logger log.Logger
@@ -205,7 +204,6 @@ func Implementations(ctx context.Context, cfg ImplementationsConfig) (opcm.Deplo
 			ProtocolVersionsProxy:           cfg.ProtocolVersionsProxy,
 			SuperchainProxyAdmin:            superProxyAdmin,
 			UpgradeController:               cfg.UpgradeController,
-			UseInterop:                      cfg.UseInterop,
 		},
 	); err != nil {
 		return dio, fmt.Errorf("error deploying implementations: %w", err)

--- a/op-deployer/pkg/deployer/bootstrap/implementations_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations_test.go
@@ -80,7 +80,6 @@ func testImplementations(t *testing.T, forkRPCURL string, cacheDir string) {
 			SuperchainConfigProxy:           superchain.SuperchainConfigAddr,
 			ProtocolVersionsProxy:           superchain.ProtocolVersionsAddr,
 			UpgradeController:               proxyAdminOwner,
-			UseInterop:                      false,
 			CacheDir:                        cacheDir,
 		})
 		require.NoError(t, err)

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -294,7 +294,7 @@ func TestGlobalOverrides(t *testing.T) {
 	require.Equal(t, expectedEnableGovernance, cfg.L2InitializationConfig.GovernanceDeployConfig.EnableGovernance, "Governance should be disabled")
 	require.Equal(t, expectedGasPriceOracleBaseFeeScalar, cfg.L2InitializationConfig.GasPriceOracleDeployConfig.GasPriceOracleBaseFeeScalar, "Gas Price Oracle Base Fee Scalar should be the expected value")
 	require.Equal(t, expectedEIP1559Denominator, cfg.L2InitializationConfig.EIP1559DeployConfig.EIP1559Denominator, "EIP-1559 Denominator should be the expected value")
-	require.Equal(t, expectedUseFaultProofs, cfg.L2InitializationConfig.UseInterop, "Fault proofs should be enabled")
+	require.Equal(t, expectedUseFaultProofs, cfg.UseFaultProofs, "Fault proofs should not be enabled")
 }
 
 func TestApplyGenesisStrategy(t *testing.T) {

--- a/op-deployer/pkg/deployer/opcm/implementations.go
+++ b/op-deployer/pkg/deployer/opcm/implementations.go
@@ -22,7 +22,6 @@ type DeployImplementationsInput struct {
 	ProtocolVersionsProxy common.Address
 	SuperchainProxyAdmin  common.Address
 	UpgradeController     common.Address
-	UseInterop            bool // if true, deploy Interop implementations
 }
 
 func (input *DeployImplementationsInput) InputSet() bool {

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -59,7 +59,6 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxy,
 			SuperchainProxyAdmin:            st.SuperchainDeployment.SuperchainProxyAdminImpl,
 			UpgradeController:               st.SuperchainRoles.SuperchainProxyAdminOwner,
-			UseInterop:                      intent.UseInterop,
 		},
 	)
 	if err != nil {

--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -13,7 +13,7 @@ import (
 func GenerateInteropDepset(ctx context.Context, pEnv *Env, globalIntent *state.Intent, st *state.State) error {
 	lgr := pEnv.Logger.New("stage", "generate-interop-depset")
 
-	if !globalIntent.UseInterop {
+	if globalIntent.InteropTimeOffset == nil {
 		lgr.Warn("interop not enabled - skipping interop depset generation")
 		return nil
 	}

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 
-	op_service "github.com/ethereum-optimism/optimism/op-service"
-
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
@@ -93,9 +91,10 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 		SequencerFeeVaultRecipient:               thisIntent.SequencerFeeVaultRecipient,
 		GovernanceTokenOwner:                     overrides.GovernanceTokenOwner,
 		Fork:                                     big.NewInt(schedule.SolidityForkNumber(1)),
-		UseInterop:                               intent.UseInterop,
-		EnableGovernance:                         overrides.EnableGovernance,
-		FundDevAccounts:                          overrides.FundDevAccounts,
+		// Only include interop predeploys if it is activating at genesis
+		UseInterop:       intent.InteropTimeOffset != nil && *intent.InteropTimeOffset == 0,
+		EnableGovernance: overrides.EnableGovernance,
+		FundDevAccounts:  overrides.FundDevAccounts,
 	}); err != nil {
 		return fmt.Errorf("failed to call L2Genesis script: %w", err)
 	}
@@ -116,12 +115,11 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 
 func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIntent) (l2GenesisOverrides, *genesis.UpgradeScheduleDeployConfig, error) {
 	schedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
-	if intent.UseInterop {
+	if intent.InteropTimeOffset != nil {
 		if schedule.L2GenesisIsthmusTimeOffset == nil {
 			return l2GenesisOverrides{}, nil, fmt.Errorf("expecting isthmus fork to be enabled for interop deployments")
 		}
-		schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
-		schedule.UseInterop = true
+		schedule.L2GenesisInteropTimeOffset = intent.InteropTimeOffset
 	}
 
 	overrides := defaultOverrides()

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -138,7 +138,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			name: "interop mode",
 			intent: &state.Intent{
 				L1ContractsLocator: &artifacts.Locator{},
-				UseInterop:         true,
+				InteropTimeOffset:  op_service.U64UtilPtr(0),
 			},
 			chainIntent:       &state.ChainIntent{},
 			expectError:       false,
@@ -146,7 +146,6 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
 				schedule := standard.DefaultHardforkScheduleForTag("")
 				schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
-				schedule.UseInterop = true
 				return schedule
 			},
 		},

--- a/op-deployer/pkg/deployer/pipeline/pre_state.go
+++ b/op-deployer/pkg/deployer/pipeline/pre_state.go
@@ -46,7 +46,7 @@ func GeneratePreState(ctx context.Context, pEnv *Env, globalIntent *state.Intent
 		))
 	}
 
-	if globalIntent.UseInterop {
+	if globalIntent.InteropTimeOffset != nil {
 		lgr.Info("adding the interop deployment set option to the prestate builder")
 		prestateBuilderOpts = append(prestateBuilderOpts, prestate.WithGeneratedInteropDepSet())
 	}

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 
-	op_service "github.com/ethereum-optimism/optimism/op-service"
-
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 
 	"github.com/ethereum/go-ethereum/rpc"
@@ -27,12 +25,6 @@ var (
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
 	upgradeSchedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
-	if intent.UseInterop {
-		if upgradeSchedule.L2GenesisIsthmusTimeOffset == nil {
-			return genesis.DeployConfig{}, errors.New("expecting isthmus fork to be enabled for interop deployments")
-		}
-		upgradeSchedule.UseInterop = true
-	}
 
 	cfg := genesis.DeployConfig{
 		L1DependenciesConfig: genesis.L1DependenciesConfig{
@@ -115,8 +107,11 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		},
 	}
 
-	if intent.UseInterop {
-		cfg.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
+	if intent.InteropTimeOffset != nil {
+		if upgradeSchedule.L2GenesisIsthmusTimeOffset == nil {
+			return genesis.DeployConfig{}, errors.New("expecting isthmus fork to be enabled for interop deployments")
+		}
+		cfg.L2InitializationConfig.UpgradeScheduleDeployConfig.L2GenesisInteropTimeOffset = intent.InteropTimeOffset
 	}
 
 	if chainState.StartBlock == nil {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -66,7 +66,7 @@ type Intent struct {
 	SuperchainConfigProxy *common.Address            `json:"superchainConfigProxy" toml:"superchainConfigProxy"`
 	SuperchainRoles       *addresses.SuperchainRoles `json:"superchainRoles" toml:"superchainRoles,omitempty"`
 	FundDevAccounts       bool                       `json:"fundDevAccounts" toml:"fundDevAccounts"`
-	UseInterop            bool                       `json:"useInterop" toml:"useInterop"`
+	InteropTimeOffset     *hexutil.Uint64            `json:"interopTimeOffset" toml:"interopTimeOffset"`
 	L1ContractsLocator    *artifacts.Locator         `json:"l1ContractsLocator" toml:"l1ContractsLocator"`
 	L2ContractsLocator    *artifacts.Locator         `json:"l2ContractsLocator" toml:"l2ContractsLocator"`
 	Chains                []*ChainIntent             `json:"chains" toml:"chains"`

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -305,7 +305,7 @@ func (wb *worldBuilder) Build() {
 	intent, err := wb.builder.Build()
 	wb.require.NoError(err)
 
-	inDepSetAtGenesis := false
+	var minInteropTimeOffset *hexutil.Uint64
 	for _, ch := range intent.Chains {
 		v, ok := ch.DeployOverrides["l2GenesisInteropTimeOffset"]
 		if !ok {
@@ -315,14 +315,14 @@ func (wb *worldBuilder) Build() {
 		if !ok {
 			continue
 		}
-		if *offset == 0 {
-			inDepSetAtGenesis = true
+		if minInteropTimeOffset == nil || *offset < *minInteropTimeOffset {
+			minInteropTimeOffset = offset
 		}
 	}
-	wb.logger.Info("Dependency set setting", "atGenesis", inDepSetAtGenesis)
+	wb.logger.Info("Dependency set setting", "interopTime", minInteropTimeOffset)
 
 	// If any chains are activating interop at genesis, then set useInterop to true
-	intent.UseInterop = inDepSetAtGenesis
+	intent.InteropTimeOffset = minInteropTimeOffset
 
 	pipelineOpts := deployer.ApplyPipelineOpts{
 		DeploymentTarget:   deployer.DeploymentTargetGenesis,


### PR DESCRIPTION
**Description**

Replace UseInterop flag with InteropTimeOffset flag. First step in normalizing interop as a hard fork.

Remaining steps:

1. just use the interop time override rather than needing a specific flag.
2. use the interop time offset in the generated dependency set file (instead of setting activation time to 0)
3. Only init the CrossL2InboxProxy if there are two or main chains in the dependency set at genesis
4. Some time later actually deploy the SuperDisputeGame instead of the old FaultDisputeGame and used shared DisputeGameFactory and ETHLockbox


**Metadata**

https://github.com/ethereum-optimism/optimism/issues/16041
