### PR TITLE
op-node: managed mode pre-interop

### DIFF
--- a/op-acceptance-tests/tests/interop/prep/init_test.go
+++ b/op-acceptance-tests/tests/interop/prep/init_test.go
@@ -1,0 +1,14 @@
+package msg
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	// Configure a system without interop activation.
+	// We just want to test if we can sync with a supervisor before interop is configured.
+	// The supervisor will not be indexing data yet before interop, and has to handle that interop is not scheduled.
+	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithUnscheduledInterop())
+}

--- a/op-acceptance-tests/tests/interop/prep/prep_test.go
+++ b/op-acceptance-tests/tests/interop/prep/prep_test.go
@@ -1,0 +1,24 @@
+package msg
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TestUnscheduledInterop runs against an interop system (i.e. op-nodes are managed by op-supervisor),
+// before interop is scheduled with an actual hardfork time.
+// And then confirms we can finalize the chains.
+func TestUnscheduledInterop(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+	t.Logger().Info("Checking that chain A and B can sync, even though interop is not scheduled")
+	dsl.CheckAll(t,
+		sys.L2CLA.AdvancedFn(types.Finalized, 5, 100),
+		sys.L2CLB.AdvancedFn(types.Finalized, 5, 100),
+	)
+	// Note: supervisor sync status won't be ready till after interop activation.
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -123,7 +123,7 @@ func (n *L2CLNode) Stop() {
 	n.opNode = nil
 }
 
-func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
 
@@ -195,7 +195,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 		// specify interop config, but do not configure anything, to disable managed mode
 		interopCfg := &interop.Config{}
 
-		if depSet != nil { // start in managed-mode, ready for interop, if we have a dependency set config
+		if managedMode {
 			interopCfg = &interop.Config{
 				RPCAddr: "127.0.0.1",
 				// When L2CL starts, store its RPC port here

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -192,6 +192,19 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 			require.NoError(err, "failed to load p2p config")
 		}
 
+		// specify interop config, but do not configure anything, to disable managed mode
+		interopCfg := &interop.Config{}
+
+		if depSet != nil { // start in managed-mode, ready for interop, if we have a dependency set config
+			interopCfg = &interop.Config{
+				RPCAddr: "127.0.0.1",
+				// When L2CL starts, store its RPC port here
+				// given by the os, to reclaim when restart.
+				RPCPort:          0,
+				RPCJwtSecretPath: jwtPath,
+			}
+		}
+
 		nodeCfg := &node.Config{
 			L1: &node.L1EndpointConfig{
 				L1NodeAddr:       l1EL.userRPC,
@@ -223,13 +236,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, l1CLID stack.L1CLNo
 				ListenPort:  0,
 				EnableAdmin: true,
 			},
-			InteropConfig: &interop.Config{
-				RPCAddr: "127.0.0.1",
-				// When L2CL starts, store its RPC port here
-				// given by the os, to reclaim when restart.
-				RPCPort:          0,
-				RPCJwtSecretPath: jwtPath,
-			},
+			InteropConfig:               interopCfg,
 			P2P:                         p2pConfig,
 			L1EpochPollInterval:         time.Second * 2,
 			RuntimeConfigReloadInterval: 0,

--- a/op-devstack/sysgo/l2_proposer.go
+++ b/op-devstack/sysgo/l2_proposer.go
@@ -82,13 +82,14 @@ func WithProposer(proposerID stack.L2ProposerID, l1ELID stack.L1ELNodeID,
 			WaitNodeSync:                 false,
 		}
 
-		if l2Net.genesis.Config.InteropTime != nil {
+		// If interop is scheduled, or if we cannot do the pre-interop connection, then set up with supervisor
+		if l2Net.genesis.Config.InteropTime != nil || l2CLID == nil {
 			require.NotNil(supervisorID, "need supervisor to connect to in interop")
 			supervisorNode, ok := orch.supervisors.Get(*supervisorID)
 			require.True(ok)
 			proposerCLIConfig.SupervisorRpcs = []string{supervisorNode.userRPC}
 		} else {
-			require.NotNil(*l2CLID, "need L2 CL to connect to pre-interop")
+			require.NotNil(l2CLID, "need L2 CL to connect to pre-interop")
 			l2CL, ok := orch.l2CLs.Get(*l2CLID)
 			require.True(ok)
 			proposerCLIConfig.RollupRpc = l2CL.userRPC

--- a/op-devstack/sysgo/supervisor.go
+++ b/op-devstack/sysgo/supervisor.go
@@ -104,6 +104,7 @@ func WithSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID, 
 		require.True(ok, "need cluster to determine dependency set")
 
 		require.NotNil(cluster.cfgset, "need a full config set")
+		require.NoError(cluster.cfgset.CheckChains(), "config set must be valid")
 		cfg := &supervisorConfig.Config{
 			MetricsConfig: metrics.CLIConfig{
 				Enabled: false,

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -171,15 +171,17 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
 	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
 
-	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, nil, &ids.Supervisor))
-	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, nil, &ids.Supervisor))
+	// Note: we provide L2 CL nodes still, even though they are not used post-interop.
+	// Since we may create an interop infra-setup, before interop is even scheduled to run.
+	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor))
+	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, &ids.Supervisor))
 
 	// Deploy separate challengers for each chain.  Can be reduced to a single challenger when the DisputeGameFactory
 	// is actually shared.
-	opt.Add(WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, nil, []stack.L2ELNodeID{
+	opt.Add(WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
 		ids.L2AEL, ids.L2BEL,
 	}))
-	opt.Add(WithL2Challenger(ids.L2ChallengerB, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, nil, []stack.L2ELNodeID{
+	opt.Add(WithL2Challenger(ids.L2ChallengerB, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2BCL, []stack.L2ELNodeID{
 		ids.L2BEL, ids.L2AEL,
 	}))
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -59,7 +59,7 @@ func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestra
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
 	opt.Add(WithL2ELNode(ids.L2EL, nil))
-	opt.Add(WithL2CLNode(ids.L2CL, true, ids.L1CL, ids.L1EL, ids.L2EL))
+	opt.Add(WithL2CLNode(ids.L2CL, true, false, ids.L1CL, ids.L1EL, ids.L2EL))
 
 	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
 	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
@@ -160,8 +160,8 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
 	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
 
-	opt.Add(WithL2CLNode(ids.L2ACL, true, ids.L1CL, ids.L1EL, ids.L2AEL))
-	opt.Add(WithL2CLNode(ids.L2BCL, true, ids.L1CL, ids.L1EL, ids.L2BEL))
+	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))
 
 	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L2ACL, ids.L1EL, ids.L2AEL))
 
@@ -219,7 +219,7 @@ func RedundantInteropSystem(dest *RedundantInteropSystemIDs) stack.Option[*Orche
 	opt.Add(DefaultInteropSystem(&parentIds))
 
 	opt.Add(WithL2ELNode(ids.L2A2EL, &ids.Supervisor))
-	opt.Add(WithL2CLNode(ids.L2A2CL, false, ids.L1CL, ids.L1EL, ids.L2A2EL))
+	opt.Add(WithL2CLNode(ids.L2A2CL, false, true, ids.L1CL, ids.L1EL, ids.L2A2EL))
 
 	// verifier must be also managed or it cannot advance
 	opt.Add(WithManagedBySupervisor(ids.L2A2CL, ids.Supervisor))
@@ -269,10 +269,10 @@ func MultiSupervisorInteropSystem(dest *MultiSupervisorInteropSystemIDs) stack.O
 	opt.Add(WithSupervisor(ids.SupervisorSecondary, ids.Cluster, ids.L1EL))
 
 	opt.Add(WithL2ELNode(ids.L2A2EL, &ids.SupervisorSecondary))
-	opt.Add(WithL2CLNode(ids.L2A2CL, false, ids.L1CL, ids.L1EL, ids.L2A2EL))
+	opt.Add(WithL2CLNode(ids.L2A2CL, false, true, ids.L1CL, ids.L1EL, ids.L2A2EL))
 
 	opt.Add(WithL2ELNode(ids.L2B2EL, &ids.SupervisorSecondary))
-	opt.Add(WithL2CLNode(ids.L2B2CL, false, ids.L1CL, ids.L1EL, ids.L2B2EL))
+	opt.Add(WithL2CLNode(ids.L2B2CL, false, true, ids.L1CL, ids.L1EL, ids.L2B2EL))
 
 	// verifier must be also managed or it cannot advance
 	// we attach verifier L2CL with backup supervisor

--- a/op-e2e/system/conductor/sequencer_failover_setup.go
+++ b/op-e2e/system/conductor/sequencer_failover_setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -357,6 +358,7 @@ func sequencerCfg(conductorRPCEndpoint rollupNode.ConductorRPCFunc) *rollupNode.
 			ListenPort:  0,
 			EnableAdmin: true,
 		},
+		InteropConfig:               &interop.Config{},
 		L1EpochPollInterval:         time.Second * 2,
 		RuntimeConfigReloadInterval: time.Minute * 10,
 		ConfigPersistence:           &rollupNode.DisabledConfigPersistence{},

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -171,6 +171,7 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 					ListenPort:  0,
 					EnableAdmin: true,
 				},
+				InteropConfig:               &interop.Config{},
 				L1EpochPollInterval:         time.Second * 4,
 				RuntimeConfigReloadInterval: time.Minute * 10,
 				ConfigPersistence:           &rollupNode.DisabledConfigPersistence{},

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -64,6 +64,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -153,6 +154,7 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 					ListenPort:  0,
 					EnableAdmin: true,
 				},
+				InteropConfig:               &interop.Config{},
 				L1EpochPollInterval:         time.Second * 2,
 				RuntimeConfigReloadInterval: time.Minute * 10,
 				ConfigPersistence:           &rollupNode.DisabledConfigPersistence{},

--- a/op-e2e/system/p2p/gossip_test.go
+++ b/op-e2e/system/p2p/gossip_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/common"
@@ -120,6 +121,7 @@ func TestSystemDenseTopology(t *testing.T) {
 			SequencerConfDepth: 0,
 			SequencerEnabled:   false,
 		},
+		InteropConfig:       &interop.Config{},
 		L1EpochPollInterval: time.Second * 4,
 	}
 	cfg.Nodes["verifier3"] = &rollupNode.Config{
@@ -128,6 +130,7 @@ func TestSystemDenseTopology(t *testing.T) {
 			SequencerConfDepth: 0,
 			SequencerEnabled:   false,
 		},
+		InteropConfig:       &interop.Config{},
 		L1EpochPollInterval: time.Second * 4,
 	}
 	cfg.Loggers["verifier2"] = testlog.Logger(t, log.LevelInfo).New("role", "verifier")

--- a/op-e2e/system/p2p/reqresp_test.go
+++ b/op-e2e/system/p2p/reqresp_test.go
@@ -17,6 +17,7 @@ import (
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -45,6 +46,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			SequencerConfDepth: 0,
 			SequencerEnabled:   false,
 		},
+		InteropConfig:       &interop.Config{},
 		L1EpochPollInterval: time.Second * 4,
 	}
 	cfg.Nodes["bob"] = &rollupNode.Config{
@@ -53,6 +55,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			SequencerConfDepth: 0,
 			SequencerEnabled:   false,
 		},
+		InteropConfig:       &interop.Config{},
 		L1EpochPollInterval: time.Second * 4,
 	}
 	cfg.Loggers["alice"] = testlog.Logger(t, log.LevelInfo).New("role", "alice")
@@ -119,6 +122,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			ListenPort:  0,
 			EnableAdmin: true,
 		},
+		InteropConfig:       &interop.Config{},
 		P2P:                 &p2p.Prepared{HostP2P: h, EnableReqRespSync: true},
 		Metrics:             rollupNode.MetricsConfig{Enabled: false}, // no metrics server
 		Pprof:               oppprof.CLIConfig{},

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -402,10 +402,11 @@ var (
 	/* Interop flags, experimental. */
 	InteropRPCAddr = &cli.StringFlag{
 		Name: "interop.rpc.addr",
-		Usage: "Interop Websocket-only RPC listening address, to serve supervisor syncing." +
-			"Applies only to Interop-enabled networks. Optional, alternative to follow-mode.",
+		Usage: "Interop Websocket-only RPC listening address, for supervisor service to manage syncing of the op-node." +
+			"Applies only to Interop-enabled networks. Optional, disabled if left empty. " +
+			"Do not enable if you do not run a supervisor service.",
 		EnvVars:  prefixEnvVars("INTEROP_RPC_ADDR"),
-		Value:    "127.0.0.1",
+		Value:    "",
 		Category: InteropCategory,
 	}
 	InteropRPCPort = &cli.IntFlag{

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -154,13 +154,8 @@ func (cfg *Config) Check() error {
 			return fmt.Errorf("misconfigured L1 Beacon API endpoint: %w", err)
 		}
 	}
-	if cfg.Rollup.InteropTime != nil {
-		if cfg.InteropConfig == nil {
-			return fmt.Errorf("the Interop upgrade is scheduled (timestamp = %d) but no interop node config is set", *cfg.Rollup.InteropTime)
-		}
-		if err := cfg.InteropConfig.Check(); err != nil {
-			return fmt.Errorf("misconfigured interop: %w", err)
-		}
+	if err := cfg.InteropConfig.Check(); err != nil {
+		return fmt.Errorf("misconfigured interop: %w", err)
 	}
 	if err := cfg.Rollup.Check(); err != nil {
 		return fmt.Errorf("rollup config error: %w", err)

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -154,6 +154,9 @@ func (cfg *Config) Check() error {
 			return fmt.Errorf("misconfigured L1 Beacon API endpoint: %w", err)
 		}
 	}
+	if cfg.InteropConfig == nil {
+		return errors.New("missing interop config")
+	}
 	if err := cfg.InteropConfig.Check(); err != nil {
 		return fmt.Errorf("misconfigured interop: %w", err)
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -411,14 +411,11 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 	}
 
 	managedMode := false
-	if cfg.Rollup.InteropTime != nil {
-		sys, err := cfg.InteropConfig.Setup(ctx, n.log, &n.cfg.Rollup, n.l1Source, n.l2Source, n.metrics)
-		if err != nil {
-			return fmt.Errorf("failed to setup interop: %w", err)
-		}
-		if _, ok := sys.(*managed.ManagedMode); ok {
-			managedMode = ok
-		}
+	sys, err := cfg.InteropConfig.Setup(ctx, n.log, &n.cfg.Rollup, n.l1Source, n.l2Source, n.metrics)
+	if err != nil {
+		return fmt.Errorf("failed to setup interop: %w", err)
+	} else if sys != nil { // we continue with legacy mode if no interop sub-system is set up.
+		_, managedMode = sys.(*managed.ManagedMode)
 		n.interopSys = sys
 		n.eventSys.Register("interop", n.interopSys)
 	}

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -14,24 +14,29 @@ import (
 
 type Config struct {
 	// RPCAddr address to bind RPC server to, to serve external supervisor nodes.
-	// Cannot be set if SupervisorAddr is set.
+	// Optional. This will soon be required: running op-node without supervisor is being deprecated.
 	RPCAddr string
 	// RPCPort port to bind RPC server to, to serve external supervisor nodes.
 	// Binds to any available port if set to 0.
-	// Only applicable if RPCAddr is set.
 	RPCPort int
 	// RPCJwtSecretPath path of JWT secret file to apply authentication to the interop server address.
 	RPCJwtSecretPath string
 }
 
 func (cfg *Config) Check() error {
-	if cfg.RPCAddr == "" {
-		return errors.New("must have either a supervisor RPC endpoint to follow, or interop RPC address to serve from")
+	if cfg.RPCAddr != "" && cfg.RPCJwtSecretPath == "" {
+		return errors.New("interop RPC server requires JWT setup, but no JWT path was specified")
 	}
 	return nil
 }
 
+// Setup creates an interop sub-system. This drives the node syncing.
+// If setup returns a nil system (without error) the node should fall back to legacy mode.
 func (cfg *Config) Setup(ctx context.Context, logger log.Logger, rollupCfg *rollup.Config, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) (SubSystem, error) {
+	if cfg.RPCAddr == "" {
+		logger.Warn("No interop RPC configured, falling back to legacy sync mode.")
+		return nil, nil // a `nil` system will result in legacy mode.
+	}
 	logger.Info("Setting up Interop RPC server to serve supervisor sync work")
 	// Load JWT secret, if any, generate one otherwise.
 	jwtSecret, err := rpc.ObtainJWTSecret(logger, cfg.RPCJwtSecretPath, true)

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -85,6 +85,7 @@ func (m *ManagedMode) Start(ctx context.Context) error {
 	if err := m.srv.Start(); err != nil {
 		return fmt.Errorf("failed to start interop RPC server: %w", err)
 	}
+	m.log.Info("Started interop RPC", "endpoint", m.WSEndpoint())
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/depset/full_config_set.go
+++ b/op-supervisor/supervisor/backend/depset/full_config_set.go
@@ -2,6 +2,7 @@ package depset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -42,6 +43,12 @@ func NewFullConfigSetMerged(rollupConfigSet RollupConfigSet, dependencySet Depen
 }
 
 func (f FullConfigSetMerged) CheckChains() error {
+	if f.RollupConfigSet == nil {
+		return errors.New("missing RollupConfigSet")
+	}
+	if f.DependencySet == nil {
+		return errors.New("missing DependencySet")
+	}
 	rollupChains := make(map[eth.ChainID]struct{})
 	for _, chainID := range f.RollupConfigSet.Chains() {
 		rollupChains[chainID] = struct{}{}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Implements some simple changes to configure op-node in managed-mode before an interop activation time is set.

The test-setup needed some changes: to create the interop composition, without configuring interop itself.

**Tests**

Adds a new test that runs the interop-style infra configuration with managed mode and multiple chains, before any interop hardfork time is scheduled. And tests that it finalizes new L2 blocks.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/15756
