### PR TITLE
depsets: rename chainIndex to chainCode

### DIFF
--- a/devnet-sdk/proofs/prestate/client.go
+++ b/devnet-sdk/proofs/prestate/client.go
@@ -74,7 +74,7 @@ func generateInteropDepSet(chains []string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse chain ID: %w", err)
 		}
-		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
+		deps[id] = &depset.StaticConfigDependency{ChainCode: types.ChainCode(i)}
 	}
 
 	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)

--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -196,12 +196,12 @@ func createTestDepSets(t *testing.T) map[string]descriptors.DepSet {
 	// Create the dependency set for the superchain
 	depSetData := map[eth.ChainID]*depset.StaticConfigDependency{
 		eth.ChainIDFromUInt64(2151908): {
-			ChainIndex:     2151908,
+			ChainCode:      2151908,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		},
 		eth.ChainIDFromUInt64(2151909): {
-			ChainIndex:     2151909,
+			ChainCode:      2151909,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		},
@@ -317,8 +317,8 @@ func TestTriageFunctions(t *testing.T) {
 
 		// Create a dependency set
 		depSetData := map[eth.ChainID]*depset.StaticConfigDependency{
-			chain1: {ChainIndex: 123456},
-			chain2: {ChainIndex: 654321},
+			chain1: {ChainCode: 123456},
+			chain2: {ChainCode: 654321},
 		}
 		depSet, err := depset.NewStaticConfigDependencySet(depSetData)
 		require.NoError(t, err)

--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -22,7 +22,7 @@ func GenerateInteropDepset(ctx context.Context, pEnv *Env, globalIntent *state.I
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for i, chain := range globalIntent.Chains {
 		id := eth.ChainIDFromBytes32(chain.ID)
-		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
+		deps[id] = &depset.StaticConfigDependency{ChainCode: types.ChainCode(i)}
 	}
 
 	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -264,7 +264,7 @@ func (wb *worldBuilder) buildDepSet() {
 			continue
 		}
 		depSetContents[id] = &depset.StaticConfigDependency{
-			ChainIndex:     supervisortypes.ChainIndex(chainIndex),
+			ChainCode:      supervisortypes.ChainCode(chainIndex),
 			ActivationTime: *interopTime,
 			HistoryMinTime: *interopTime,
 		}

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -247,7 +247,7 @@ func RecipeToDepSet(t helpers.Testing, recipe *interopgen.InteropDevRecipe) *dep
 	depSetCfg := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for _, out := range recipe.L2s {
 		depSetCfg[eth.ChainIDFromUInt64(out.ChainID)] = &depset.StaticConfigDependency{
-			ChainIndex:     types.ChainIndex(out.ChainID),
+			ChainCode:      types.ChainCode(out.ChainID),
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		}

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -618,9 +618,9 @@ func worldToDepset(world *interopgen.WorldOutput) (*depset.StaticConfigDependenc
 	// Iterate over the L2 chain configs. The L2 nodes don't exist yet.
 	for _, l2Out := range world.L2s {
 		chainID := eth.ChainIDFromBig(l2Out.Genesis.Config.ChainID)
-		chainIndex := supervisortypes.ChainIndex(100 + slices.Index(ids, chainID))
+		chainIndex := supervisortypes.ChainCode(100 + slices.Index(ids, chainID))
 		depSet[chainID] = &depset.StaticConfigDependency{
-			ChainIndex:     chainIndex,
+			ChainCode:      chainIndex,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		}

--- a/op-program/chainconfig/test/configs/depsets.json
+++ b/op-program/chainconfig/test/configs/depsets.json
@@ -2,12 +2,12 @@
   {
     "dependencies": {
       "901": {
-        "chainIndex": "0",
+        "chainCode": "0",
         "activationTime": 1234,
         "historyMinTime": 40
       },
       "902": {
-        "chainIndex": "1",
+        "chainCode": "1",
         "activationTime": 4424,
         "historyMinTime": 456
       }

--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -96,8 +96,8 @@ func TestInteropBootstrap_ChainConfigCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(expected, true)
 	mockOracle.chainCfgs = []*params.ChainConfig{config1, config2}
 	mockOracle.depset, _ = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(config1.ChainID): {ChainIndex: supervisortypes.ChainIndex(config1.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(config2.ChainID): {ChainIndex: supervisortypes.ChainIndex(config2.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config1.ChainID): {ChainCode: supervisortypes.ChainCode(config1.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config2.ChainID): {ChainCode: supervisortypes.ChainCode(config2.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
 	})
 	actual := BootstrapInterop(mockOracle)
 
@@ -122,8 +122,8 @@ func TestInteropBootstrap_DependencySetCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(expected, true)
 	var err error
 	mockOracle.depset, err = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(config1.ChainID): {ChainIndex: supervisortypes.ChainIndex(config1.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(config2.ChainID): {ChainIndex: supervisortypes.ChainIndex(config2.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config1.ChainID): {ChainCode: supervisortypes.ChainCode(config1.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config2.ChainID): {ChainCode: supervisortypes.ChainCode(config2.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
 	})
 	require.NoError(t, err)
 	actual := BootstrapInterop(mockOracle)

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -23,7 +23,7 @@ import (
 var ErrInvalidBlockReplacement = errors.New("invalid block replacement error")
 
 // ReceiptsToExecutingMessages returns the executing messages in the receipts indexed by their position in the log.
-func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
+func ReceiptsToExecutingMessages(depset depset.ChainCodeFromID, receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
 	execMsgs := make(map[uint32]*supervisortypes.ExecutingMessage)
 	var curr uint32
 	for _, rcpt := range receipts {

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -67,13 +67,13 @@ func setupTwoChains(opts ...func(*chainSetupOpts)) (*staticConfigSource, *eth.Su
 	var ds *depset.StaticConfigDependencySet
 	if chainSetupOpts.expiryWindow > 0 {
 		ds, _ = depset.NewStaticConfigDependencySetWithMessageExpiryOverride(map[eth.ChainID]*depset.StaticConfigDependency{
-			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainIndex: chainA, ActivationTime: 0, HistoryMinTime: 0},
-			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainIndex: chainB, ActivationTime: 0, HistoryMinTime: 0},
+			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainCode: chainA, ActivationTime: 0, HistoryMinTime: 0},
+			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainCode: chainB, ActivationTime: 0, HistoryMinTime: 0},
 		}, chainSetupOpts.expiryWindow)
 	} else {
 		ds, _ = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainIndex: chainA, ActivationTime: 0, HistoryMinTime: 0},
-			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainIndex: chainB, ActivationTime: 0, HistoryMinTime: 0},
+			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ChainCode: chainA, ActivationTime: 0, HistoryMinTime: 0},
+			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ChainCode: chainB, ActivationTime: 0, HistoryMinTime: 0},
 		})
 	}
 	configSource := &staticConfigSource{
@@ -164,19 +164,19 @@ var (
 )
 
 const (
-	chainA supervisortypes.ChainIndex = 0
-	chainB supervisortypes.ChainIndex = 1
+	chainA supervisortypes.ChainCode = 0
+	chainB supervisortypes.ChainCode = 1
 )
 
 func TestDeriveBlockForConsolidateStep(t *testing.T) {
-	createExecMessage := func(initIncludedIn uint64, config *staticConfigSource, initChainIndex supervisortypes.ChainIndex) supervisortypes.Message {
+	createExecMessage := func(initIncludedIn uint64, config *staticConfigSource, initChainCode supervisortypes.ChainCode) supervisortypes.Message {
 		exec := supervisortypes.Message{
 			Identifier: supervisortypes.Identifier{
 				Origin:      initiatingMessageOrigin,
 				BlockNumber: initIncludedIn,
 				LogIndex:    0,
-				Timestamp:   initIncludedIn * config.rollupCfgs[initChainIndex].BlockTime,
-				ChainID:     eth.ChainIDFromBig(config.rollupCfgs[initChainIndex].L2ChainID),
+				Timestamp:   initIncludedIn * config.rollupCfgs[initChainCode].BlockTime,
+				ChainID:     eth.ChainIDFromBig(config.rollupCfgs[initChainCode].L2ChainID),
 			},
 			PayloadHash: initPayloadHash,
 		}
@@ -201,28 +201,28 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 		{
 			name: "HappyPathWithValidMessages-ExecOnChainB",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init := createInitLog()
 					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, exec)}}
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, exec)}}
 				},
 			},
 		},
 		{
 			name: "HappyPathWithValidMessages-ExecOnChainA",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init := createInitLog()
 					execMsg := createExecMessage(includeBlockNumbers[chainB], config, chainB)
 					exec := convertExecutingMessageToLog(t, execMsg)
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {exec}, chainB: {init}}
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{chainA: {exec}, chainB: {init}}
 				},
 			},
 		},
 		{
 			name: "HappyPathWithValidMessages-ExecOnChainB-NonZeroLogIndex",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init1 := &gethTypes.Log{
 						Address: initiatingMessageOrigin,
 						Topics:  []common.Hash{initiatingMessageTopic},
@@ -234,7 +234,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.Origin = init2.Address
 					exec.Identifier.LogIndex = 1
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{
 						chainA: {init1, init2},
 						chainB: {convertExecutingMessageToLog(t, exec)},
 					}
@@ -244,7 +244,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 		{
 			name: "HappyPathWithValidMessages-IntraBlockCycle",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					initA := createInitLog()
 					initB := createInitLog()
 
@@ -252,7 +252,7 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 					execA := convertExecutingMessageToLog(t, execMsgA)
 					execMsgB := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					execB := convertExecutingMessageToLog(t, execMsgB)
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{
 						chainA: {initA, execA},
 						chainB: {initB, execB},
 					}
@@ -262,21 +262,21 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 		{
 			name: "ReplaceChainB-UnknownChainID",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init := createInitLog()
 					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.ChainID = eth.ChainIDFromUInt64(0xdeadbeef)
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, exec)}}
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, exec)}}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceChainB-InvalidLogIndex",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init1 := &gethTypes.Log{
 						Address: initiatingMessageOrigin,
 						Topics:  []common.Hash{initiatingMessageTopic},
@@ -288,62 +288,62 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.Origin = init2.Address
 					exec.Identifier.LogIndex = 0
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{
 						chainA: {init1, init2},
 						chainB: {convertExecutingMessageToLog(t, exec)},
 					}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceChainB-InvalidPayloadHash",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init := createInitLog()
 					execMsg := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					execMsg.PayloadHash = crypto.Keccak256Hash([]byte("invalid hash"))
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, execMsg)}}
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, execMsg)}}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceChainB-InvalidTimestamp",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init := createInitLog()
 					execMsg := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					execMsg.Identifier.Timestamp = execMsg.Identifier.Timestamp - 1
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, execMsg)}}
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{chainA: {init}, chainB: {convertExecutingMessageToLog(t, execMsg)}}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceBothChains",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					invalidExecMsg := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					invalidExecMsg.PayloadHash = crypto.Keccak256Hash([]byte("invalid hash"))
 					log := convertExecutingMessageToLog(t, invalidExecMsg)
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{chainA: {log}, chainB: {log}}
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{chainA: {log}, chainB: {log}}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainA, chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainA, chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceBothChains-CascadingReorg",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					initA := createInitLog()
 					initB := createInitLog()
 
@@ -353,20 +353,20 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 					execMsgB.PayloadHash = crypto.Keccak256Hash([]byte("invalid hash"))
 					execB := convertExecutingMessageToLog(t, execMsgB)
 
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{
 						chainA: {initA, execA},
 						chainB: {initB, execB},
 					}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainA, chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainA, chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceChainB-BlockNumberTooBig",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init1 := &gethTypes.Log{
 						Address: initiatingMessageOrigin,
 						Topics:  []common.Hash{initiatingMessageTopic},
@@ -376,20 +376,20 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 						Topics:  []common.Hash{initiatingMessageTopic},
 					}
 					exec := createExecMessage(1_000_000, config, chainA)
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{
 						chainA: {init1, init2},
 						chainB: {convertExecutingMessageToLog(t, exec)},
 					}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainB}
 				},
 			},
 		},
 		{
 			name: "ReplaceChainB-LogIndexTooBig",
 			testCase: consolidationTestCase{
-				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log {
+				logBuilderFn: func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log {
 					init1 := &gethTypes.Log{
 						Address: initiatingMessageOrigin,
 						Topics:  []common.Hash{initiatingMessageTopic},
@@ -401,13 +401,13 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 					exec := createExecMessage(includeBlockNumbers[chainA], config, chainA)
 					exec.Identifier.Origin = init2.Address
 					exec.Identifier.LogIndex = 1_000_000
-					return map[supervisortypes.ChainIndex][]*gethTypes.Log{
+					return map[supervisortypes.ChainCode][]*gethTypes.Log{
 						chainA: {init1, init2},
 						chainB: {convertExecutingMessageToLog(t, exec)},
 					}
 				},
-				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainIndex {
-					return []supervisortypes.ChainIndex{chainB}
+				expectBlockReplacements: func(config *staticConfigSource) []supervisortypes.ChainCode {
+					return []supervisortypes.ChainCode{chainB}
 				},
 			},
 		},
@@ -420,10 +420,10 @@ func TestDeriveBlockForConsolidateStep(t *testing.T) {
 	}
 }
 
-// expectBlockReplacementsFn returns the chain indexes containing an optimistic block that must be replaced
-type expectBlockReplacementsFn func(config *staticConfigSource) (chainIndexesToReplace []supervisortypes.ChainIndex)
+// expectBlockReplacementsFn returns the chain codes containing an optimistic block that must be replaced
+type expectBlockReplacementsFn func(config *staticConfigSource) (chainCodesToReplace []supervisortypes.ChainCode)
 
-type logBuilderFn func(includeBlockNumbers map[supervisortypes.ChainIndex]uint64, config *staticConfigSource) map[supervisortypes.ChainIndex][]*gethTypes.Log
+type logBuilderFn func(includeBlockNumbers map[supervisortypes.ChainCode]uint64, config *staticConfigSource) map[supervisortypes.ChainCode][]*gethTypes.Log
 
 type consolidationTestCase struct {
 	expectBlockReplacements expectBlockReplacementsFn
@@ -445,7 +445,7 @@ func runConsolidationTestCase(t *testing.T, testCase consolidationTestCase) {
 	var logA, logB []*gethTypes.Log
 	if testCase.logBuilderFn != nil {
 		logs := testCase.logBuilderFn(
-			map[supervisortypes.ChainIndex]uint64{0: block1A.NumberU64() + 1, 1: block1B.NumberU64() + 1},
+			map[supervisortypes.ChainCode]uint64{0: block1A.NumberU64() + 1, 1: block1B.NumberU64() + 1},
 			configSource,
 		)
 		logA = logs[chainA]
@@ -484,17 +484,17 @@ func runConsolidationTestCase(t *testing.T, testCase consolidationTestCase) {
 		finalTransitionState.PendingProgress[1].OutputRoot,
 	}
 	if testCase.expectBlockReplacements != nil {
-		for _, chainIndexToReplace := range testCase.expectBlockReplacements(configSource) {
+		for _, chainCodeToReplace := range testCase.expectBlockReplacements(configSource) {
 			// stub output root preimage of the replaced block
-			replacedBlockOutput := pendingOutputs[chainIndexToReplace]
+			replacedBlockOutput := pendingOutputs[chainCodeToReplace]
 			replacedBlockOutputRoot := common.Hash(eth.OutputRoot(replacedBlockOutput))
 			l2PreimageOracle.Outputs[replacedBlockOutputRoot] = replacedBlockOutput
 
-			depositsOnlyBlock, depositsOnlyBlockReceipts := createBlock(rng, configSource.rollupCfgs[chainIndexToReplace], 2, nil)
+			depositsOnlyBlock, depositsOnlyBlockReceipts := createBlock(rng, configSource.rollupCfgs[chainCodeToReplace], 2, nil)
 			depositsOnlyOutput := createOutput(depositsOnlyBlock.Hash())
 			depositsOnlyOutputRoot := eth.OutputRoot(depositsOnlyOutput)
-			tasksStub.ExpectBuildDepositOnlyBlock(common.Hash{}, agreedSuperRoot.Chains[chainIndexToReplace].Output, depositsOnlyBlock.Hash(), depositsOnlyOutputRoot)
-			finalRoots[chainIndexToReplace] = depositsOnlyOutputRoot
+			tasksStub.ExpectBuildDepositOnlyBlock(common.Hash{}, agreedSuperRoot.Chains[chainCodeToReplace].Output, depositsOnlyBlock.Hash(), depositsOnlyOutputRoot)
+			finalRoots[chainCodeToReplace] = depositsOnlyOutputRoot
 			// stub the preimages in the replacement block
 			l2PreimageOracle.Blocks[depositsOnlyBlock.Hash()] = depositsOnlyBlock
 			l2PreimageOracle.Outputs[common.Hash(depositsOnlyOutputRoot)] = depositsOnlyOutput

--- a/op-supervisor/config/config_test.go
+++ b/op-supervisor/config/config_test.go
@@ -59,7 +59,7 @@ func TestValidateRPCConfig(t *testing.T) {
 func validConfig() *Config {
 	depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
 		eth.ChainIDFromUInt64(900): &depset.StaticConfigDependency{
-			ChainIndex:     900,
+			ChainCode:      900,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		},

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -40,12 +40,12 @@ func TestBackendLifetime(t *testing.T) {
 	depSet, err := depset.NewStaticConfigDependencySet(
 		map[eth.ChainID]*depset.StaticConfigDependency{
 			chainA: {
-				ChainIndex:     900,
+				ChainCode:      900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
 			chainB: {
-				ChainIndex:     901,
+				ChainCode:      901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
 			},
@@ -183,7 +183,7 @@ func TestBackendCallsMetrics(t *testing.T) {
 	depSet, err := depset.NewStaticConfigDependencySet(
 		map[eth.ChainID]*depset.StaticConfigDependency{
 			chainA: {
-				ChainIndex:     900,
+				ChainCode:      900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
@@ -361,7 +361,7 @@ func TestAsyncVerifyAccessWithRPC(t *testing.T) {
 	// Setup a single-chain dependency set
 	chainID := eth.ChainIDFromUInt64(1)
 	depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		chainID: {ChainIndex: 1, ActivationTime: 0, HistoryMinTime: 0},
+		chainID: {ChainCode: 1, ActivationTime: 0, HistoryMinTime: 0},
 	})
 	require.NoError(t, err)
 

--- a/op-supervisor/supervisor/backend/cross/cycle.go
+++ b/op-supervisor/supervisor/backend/cross/cycle.go
@@ -29,8 +29,8 @@ type CycleCheckDeps interface {
 // It could be an initiating message, executing message, both, or neither.
 // It is uniquely identified by chain index and the log index within its parent block.
 type node struct {
-	chainIndex types.ChainIndex
-	logIndex   uint32
+	chainCode types.ChainCode
+	logIndex  uint32
 }
 
 // graph is a directed graph of message dependencies.
@@ -72,7 +72,7 @@ func (g *graph) addEdge(from, to node) {
 // succeeds if and only if a graph is acyclic.
 //
 // Returns nil if no cycles are found or ErrCycle if a cycle is detected.
-func HazardCycleChecks(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) error {
+func HazardCycleChecks(depSet depset.ChainIDFromCode, d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) error {
 	g, err := buildGraph(depSet, d, inTimestamp, hazards)
 	if err != nil {
 		return err
@@ -85,16 +85,16 @@ func HazardCycleChecks(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimes
 // Returns:
 // - map of chain index to its log count
 // - map of chain index to map of log index to executing message (nil if doesn't exist or ignored)
-func gatherLogs(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) (
-	map[types.ChainIndex]uint32,
-	map[types.ChainIndex]map[uint32]*types.ExecutingMessage,
+func gatherLogs(depSet depset.ChainIDFromCode, d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) (
+	map[types.ChainCode]uint32,
+	map[types.ChainCode]map[uint32]*types.ExecutingMessage,
 	error,
 ) {
-	logCounts := make(map[types.ChainIndex]uint32)
-	execMsgs := make(map[types.ChainIndex]map[uint32]*types.ExecutingMessage)
+	logCounts := make(map[types.ChainCode]uint32)
+	execMsgs := make(map[types.ChainCode]map[uint32]*types.ExecutingMessage)
 
-	for hazardChainIndex, hazardBlock := range hazards.Entries() {
-		hazardChainID, err := depSet.ChainIDFromIndex(hazardChainIndex)
+	for hazardChainCode, hazardBlock := range hazards.Entries() {
+		hazardChainID, err := depSet.ChainIDFromCode(hazardChainCode)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -115,16 +115,16 @@ func gatherLogs(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 		}
 
 		// Store log count and in-timestamp executing messages
-		logCounts[hazardChainIndex] = logCount
+		logCounts[hazardChainCode] = logCount
 
 		if len(msgs) > 0 {
-			if _, exists := execMsgs[hazardChainIndex]; !exists {
-				execMsgs[hazardChainIndex] = make(map[uint32]*types.ExecutingMessage)
+			if _, exists := execMsgs[hazardChainCode]; !exists {
+				execMsgs[hazardChainCode] = make(map[uint32]*types.ExecutingMessage)
 			}
 		}
 		for logIdx, msg := range msgs {
 			if msg.Timestamp == inTimestamp {
-				execMsgs[hazardChainIndex][logIdx] = msg
+				execMsgs[hazardChainCode][logIdx] = msg
 			}
 		}
 	}
@@ -133,7 +133,7 @@ func gatherLogs(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 }
 
 // buildGraph constructs a dependency graph from the hazard blocks.
-func buildGraph(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) (*graph, error) {
+func buildGraph(depSet depset.ChainIDFromCode, d CycleCheckDeps, inTimestamp uint64, hazards *HazardSet) (*graph, error) {
 	g := &graph{
 		inDegree0:     make(map[node]struct{}),
 		inDegreeNon0:  make(map[node]uint32),
@@ -146,11 +146,11 @@ func buildGraph(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 	}
 
 	// Add nodes for each log in the block, and add edges between sequential logs
-	for hazardChainIndex, logCount := range logCounts {
+	for hazardChainCode, logCount := range logCounts {
 		for i := uint32(0); i < logCount; i++ {
 			k := node{
-				chainIndex: hazardChainIndex,
-				logIndex:   i,
+				chainCode: hazardChainCode,
+				logIndex:  i,
 			}
 
 			if i == 0 {
@@ -159,8 +159,8 @@ func buildGraph(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 			} else {
 				// Add edge: prev log <> current log
 				prevKey := node{
-					chainIndex: hazardChainIndex,
-					logIndex:   i - 1,
+					chainCode: hazardChainCode,
+					logIndex:  i - 1,
 				}
 				g.addEdge(prevKey, k)
 			}
@@ -169,7 +169,7 @@ func buildGraph(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 
 	// Add edges for executing messages to their initiating messages
 	hazardEntries := hazards.Entries()
-	for hazardChainIndex, msgs := range execMsgs {
+	for hazardChainCode, msgs := range execMsgs {
 		for execLogIdx, m := range msgs {
 			// Error if the chain is unknown
 			if _, ok := hazardEntries[m.Chain]; !ok {
@@ -182,12 +182,12 @@ func buildGraph(depSet depset.ChainIDFromIndex, d CycleCheckDeps, inTimestamp ui
 			}
 
 			initKey := node{
-				chainIndex: m.Chain,
-				logIndex:   m.LogIdx,
+				chainCode: m.Chain,
+				logIndex:  m.LogIdx,
 			}
 			execKey := node{
-				chainIndex: hazardChainIndex,
-				logIndex:   execLogIdx,
+				chainCode: hazardChainCode,
+				logIndex:  execLogIdx,
 			}
 
 			// Disallow self-referencing messages
@@ -258,12 +258,12 @@ func GenerateMermaidDiagram(g *graph) string {
 
 	// Helper function to get a unique ID for each node
 	getNodeID := func(k node) string {
-		return fmt.Sprintf("N%d_%d", k.chainIndex, k.logIndex)
+		return fmt.Sprintf("N%d_%d", k.chainCode, k.logIndex)
 	}
 
 	// Helper function to get a label for each node
 	getNodeLabel := func(k node) string {
-		return fmt.Sprintf("C%d:L%d", k.chainIndex, k.logIndex)
+		return fmt.Sprintf("C%d:L%d", k.chainCode, k.logIndex)
 	}
 
 	// Function to add a node to the diagram

--- a/op-supervisor/supervisor/backend/cross/cycle_test.go
+++ b/op-supervisor/supervisor/backend/cross/cycle_test.go
@@ -18,10 +18,10 @@ const testDefaultTimestamp = 100
 var errUnexpectedChain = errors.New("unexpected chain")
 
 type testDepSet struct {
-	mapping map[types.ChainIndex]eth.ChainID
+	mapping map[types.ChainCode]eth.ChainID
 }
 
-func (t testDepSet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
+func (t testDepSet) ChainIDFromCode(index types.ChainCode) (eth.ChainID, error) {
 	v, ok := t.mapping[index]
 	if !ok {
 		return eth.ChainID{}, types.ErrUnknownChain
@@ -29,7 +29,7 @@ func (t testDepSet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error
 	return v, nil
 }
 
-var _ depset.ChainIDFromIndex = (*testDepSet)(nil)
+var _ depset.ChainIDFromCode = (*testDepSet)(nil)
 
 type mockCycleCheckDeps struct {
 	openBlockFn func(chainID eth.ChainID, blockNum uint64) (eth.BlockRef, uint32, map[uint32]*types.ExecutingMessage, error)
@@ -53,7 +53,7 @@ type hazardCycleChecksTestCase struct {
 	msg               string
 
 	// Optional overrides
-	hazards     map[types.ChainIndex]types.BlockSeal
+	hazards     map[types.ChainCode]types.BlockSeal
 	openBlockFn func(chainID eth.ChainID, blockNum uint64) (eth.BlockRef, uint32, map[uint32]*types.ExecutingMessage, error)
 }
 
@@ -88,21 +88,21 @@ func runHazardCycleChecksTestCase(t *testing.T, tc hazardCycleChecksTestCase) {
 	}
 
 	// Generate hazards map automatically if not explicitly provided
-	var hazards map[types.ChainIndex]types.BlockSeal
+	var hazards map[types.ChainCode]types.BlockSeal
 	if tc.hazards != nil {
 		hazards = tc.hazards
 	} else {
-		hazards = make(map[types.ChainIndex]types.BlockSeal)
+		hazards = make(map[types.ChainCode]types.BlockSeal)
 		for chainStr := range tc.chainBlocks {
-			hazards[chainIndex(chainStr)] = types.BlockSeal{Number: 1}
+			hazards[chainCode(chainStr)] = types.BlockSeal{Number: 1}
 		}
 	}
 
 	depSet := &testDepSet{
-		mapping: make(map[types.ChainIndex]eth.ChainID),
+		mapping: make(map[types.ChainCode]eth.ChainID),
 	}
 	for chainStr := range tc.chainBlocks {
-		index := chainIndex(chainStr)
+		index := chainCode(chainStr)
 		depSet.mapping[index] = eth.ChainIDFromUInt64(uint64(index))
 	}
 	// Run the test
@@ -124,12 +124,12 @@ func runHazardCycleChecksTestCase(t *testing.T, tc hazardCycleChecksTestCase) {
 	}
 }
 
-func chainIndex(s string) types.ChainIndex {
+func chainCode(s string) types.ChainCode {
 	id, err := strconv.ParseUint(s, 10, 32)
 	if err != nil {
-		panic(fmt.Sprintf("invalid chain index in test: %v", err))
+		panic(fmt.Sprintf("invalid chain code in test: %v", err))
 	}
-	return types.ChainIndex(id)
+	return types.ChainCode(id)
 }
 
 func execMsg(chain string, logIdx uint32) *types.ExecutingMessage {
@@ -138,7 +138,7 @@ func execMsg(chain string, logIdx uint32) *types.ExecutingMessage {
 
 func execMsgWithTimestamp(chain string, logIdx uint32, timestamp uint64) *types.ExecutingMessage {
 	return &types.ExecutingMessage{
-		Chain:     chainIndex(chain),
+		Chain:     chainCode(chain),
 		LogIdx:    logIdx,
 		Timestamp: timestamp,
 	}
@@ -160,7 +160,7 @@ func TestHazardCycleChecksFailures(t *testing.T) {
 		{
 			name:        "empty hazards",
 			chainBlocks: emptyChainBlocks,
-			hazards:     make(map[types.ChainIndex]types.BlockSeal),
+			hazards:     make(map[types.ChainCode]types.BlockSeal),
 			expectErr:   nil,
 			msg:         "expected no error when there are no hazards",
 		},
@@ -215,7 +215,7 @@ func TestHazardCycleChecksFailures(t *testing.T) {
 					},
 				},
 			},
-			hazards: map[types.ChainIndex]types.BlockSeal{
+			hazards: map[types.ChainCode]types.BlockSeal{
 				1: {Number: 1},
 				2: {Number: 1},
 			},
@@ -258,7 +258,7 @@ func TestHazardCycleChecksFailures(t *testing.T) {
 					},
 				},
 			},
-			hazards: map[types.ChainIndex]types.BlockSeal{
+			hazards: map[types.ChainCode]types.BlockSeal{
 				1: {Number: 1}, // Only include chain 1.
 			},
 			expectErr: ErrExecMsgUnknownChain,
@@ -533,7 +533,7 @@ func TestHazardCycleChecksCycle(t *testing.T) {
 				"3": {},
 			},
 			expectErr: ErrCycle,
-			hazards: map[types.ChainIndex]types.BlockSeal{
+			hazards: map[types.ChainCode]types.BlockSeal{
 				1: {Number: 1},
 				2: {Number: 1},
 				3: {Number: 1},

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -24,7 +24,7 @@ type HazardDeps interface {
 
 // HazardSet tracks blocks that must be checked before a candidate can be promoted
 type HazardSet struct {
-	entries map[types.ChainIndex]types.BlockSeal
+	entries map[types.ChainCode]types.BlockSeal
 }
 
 // NewHazardSet creates a new HazardSet with the given dependencies and initial block
@@ -33,7 +33,7 @@ func NewHazardSet(deps HazardDeps, logger log.Logger, chainID eth.ChainID, block
 		return nil, errHazardSetNilDeps
 	}
 	h := &HazardSet{
-		entries: make(map[types.ChainIndex]types.BlockSeal),
+		entries: make(map[types.ChainCode]types.BlockSeal),
 	}
 	logger.Debug("Building new HazardSet", "chainID", chainID, "block", block)
 	if err := h.build(deps, logger, chainID, block); err != nil {
@@ -43,7 +43,7 @@ func NewHazardSet(deps HazardDeps, logger log.Logger, chainID eth.ChainID, block
 	return h, nil
 }
 
-func NewHazardSetFromEntries(entries map[types.ChainIndex]types.BlockSeal) *HazardSet {
+func NewHazardSetFromEntries(entries map[types.ChainCode]types.BlockSeal) *HazardSet {
 	return &HazardSet{entries: entries}
 }
 
@@ -150,7 +150,7 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 			logger.Debug("Processing message", "chainID", destChainID, "block", candidate, "msg", msg)
 
 			// Get the source chain, ensure it's allowed to initiate messages, and contains the initiating message.
-			srcChainID, err := depSet.ChainIDFromIndex(msg.Chain)
+			srcChainID, err := depSet.ChainIDFromCode(msg.Chain)
 			if err != nil {
 				if errors.Is(err, types.ErrUnknownChain) {
 					err = fmt.Errorf("msg %s may not execute from unknown chain %s: %w", msg, msg.Chain, types.ErrConflict)
@@ -202,7 +202,7 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 	return nil
 }
 
-func (h *HazardSet) Entries() map[types.ChainIndex]types.BlockSeal {
+func (h *HazardSet) Entries() map[types.ChainCode]types.BlockSeal {
 	if h == nil {
 		return nil
 	}

--- a/op-supervisor/supervisor/backend/cross/hazard_set_test.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set_test.go
@@ -22,7 +22,7 @@ func TestHazardSet_Build(t *testing.T) {
 			blocks: []blockDef{
 				makeBlock(0, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{},
+			expected: map[types.ChainCode]types.BlockSeal{},
 		},
 		{
 			name: "Single Dependency",
@@ -30,7 +30,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(0, 100, 1, makeMessage(1, 100, 1, 1)),
 				makeBlock(1, 100, 1), // Referenced block from chain 1
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 			},
 		},
@@ -40,7 +40,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(0, 100, 1, makeMessage(1, 100, 1, 1), makeMessage(1, 100, 1, 2)),
 				makeBlock(1, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 			},
 		},
@@ -51,7 +51,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1),
 				makeBlock(2, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 				2: makeBlockSeal(1, 100, 2),
 			},
@@ -72,7 +72,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1),
 				makeBlock(2, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 				2: makeBlockSeal(1, 100, 2),
 			},
@@ -84,7 +84,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1, makeMessage(2, 100, 1, 1)),
 				makeBlock(2, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 				2: makeBlockSeal(1, 100, 2),
 			},
@@ -144,7 +144,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(2, 100, 1, makeMessage(3, 100, 1, 1)),
 				makeBlock(3, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 				2: makeBlockSeal(1, 100, 2),
 				3: makeBlockSeal(1, 100, 3),
@@ -166,7 +166,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(3, 100, 1),
 				makeBlock(4, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 				2: makeBlockSeal(1, 100, 2),
 				3: makeBlockSeal(1, 100, 3),
@@ -182,7 +182,7 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(2, 100, 1, makeMessage(3, 100, 1, 1)),
 				makeBlock(3, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
+			expected: map[types.ChainCode]types.BlockSeal{
 				1: makeBlockSeal(1, 100, 1),
 				2: makeBlockSeal(1, 100, 2),
 				3: makeBlockSeal(1, 100, 3),
@@ -245,7 +245,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 		num       uint64
 		timestamp uint64
 		msgs      []struct {
-			Chain     types.ChainIndex
+			Chain     types.ChainCode
 			BlockNum  uint64
 			LogIndex  uint32
 			Timestamp uint64
@@ -257,14 +257,14 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 		blockMap := make(map[blockKey]blockDef)
 		for _, block := range blocks {
 			// Extract chain index from chain ID
-			chainIndex, err := depSet.ChainIndexFromID(block.chain)
+			chainCode, err := depSet.ChainCodeFromID(block.chain)
 			if err != nil {
 				// Use a fallback if error
-				chainIndex = types.ChainIndex(block.chain[0])
+				chainCode = types.ChainCode(block.chain[0])
 			}
 
 			key := blockKey{
-				chain:  chainIndex,
+				chain:  chainCode,
 				number: block.num,
 			}
 
@@ -286,7 +286,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 			}
 
 			blockMap[key] = blockDef{
-				chain:     chainIndex,
+				chain:     chainCode,
 				number:    block.num,
 				timestamp: timestamp,
 				hash:      makeBlockHash(block.chain, block.num),
@@ -301,7 +301,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 		name            string
 		blocks          []testBlockDef
 		verifyBlockFn   func(chainID eth.ChainID, block eth.BlockID) error
-		expectedHazards map[types.ChainIndex]types.BlockSeal
+		expectedHazards map[types.ChainCode]types.BlockSeal
 		expectedErr     error
 	}{
 		{
@@ -312,7 +312,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -331,7 +331,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
+			expectedHazards: map[types.ChainCode]types.BlockSeal{
 				1: {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
@@ -350,7 +350,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -369,7 +369,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
+			expectedHazards: map[types.ChainCode]types.BlockSeal{
 				1: {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
@@ -389,7 +389,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -419,7 +419,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
+			expectedHazards: map[types.ChainCode]types.BlockSeal{
 				1: {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
@@ -444,7 +444,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 200,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -463,7 +463,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedErr: fmt.Errorf("failed to build hazard set: msg ExecMsg(chainIndex: 1, block: 5, log: 1, time: 100, logHash: 0x0000000000000000000000000000000000000000000000000000000000000000) included in non-cross-safe block BlockSeal(hash:0x0000000000000005000000000000000100000000000000000000000000000000, number:5, time:100): block 0x0000000000000005000000000000000100000000000000000000000000000000:5 (chain 1) is not cross-valid: verification database error"),
+			expectedErr: fmt.Errorf("failed to build hazard set: msg ExecMsg(chainCode: 1, block: 5, log: 1, time: 100, logHash: 0x0000000000000000000000000000000000000000000000000000000000000000) included in non-cross-safe block BlockSeal(hash:0x0000000000000005000000000000000100000000000000000000000000000000, number:5, time:100): block 0x0000000000000005000000000000000100000000000000000000000000000000:5 (chain 1) is not cross-valid: verification database error"),
 			verifyBlockFn: func(chainID eth.ChainID, block eth.BlockID) error {
 				return fmt.Errorf("verification database error")
 			},
@@ -476,7 +476,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -494,7 +494,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       5,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -513,7 +513,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
+			expectedHazards: map[types.ChainCode]types.BlockSeal{
 				1: {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
@@ -538,7 +538,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -556,7 +556,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       5,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     types.ChainCode
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -629,7 +629,7 @@ func (m *mockHazardDeps) Contains(chain eth.ChainID, query types.ContainsQuery) 
 		return m.containsFn(chain, query)
 	}
 	// Look up the block in our test data
-	chainIndex, err := m.ChainIndexFromID(chain)
+	chainCode, err := m.ChainCodeFromID(chain)
 	if err != nil {
 		return types.BlockSeal{}, err
 	}
@@ -640,7 +640,7 @@ func (m *mockHazardDeps) Contains(chain eth.ChainID, query types.ContainsQuery) 
 	}
 
 	key := blockKey{
-		chain:  chainIndex,
+		chain:  chainCode,
 		number: query.BlockNum,
 	}
 	if block, ok := m.blockMap[key]; ok {
@@ -663,7 +663,7 @@ func (m *mockHazardDeps) IsCrossValidBlock(chainID eth.ChainID, block eth.BlockI
 		if err != nil {
 			// Format a clear error message that includes both the block and chain information
 			// This ensures errors are properly identified and propagated
-			chainIdx, _ := m.deps.ChainIndexFromID(chainID)
+			chainIdx, _ := m.deps.ChainCodeFromID(chainID)
 			return fmt.Errorf("block %s (chain %d) is not cross-valid: %w", block, chainIdx, err)
 		}
 		return nil
@@ -677,12 +677,12 @@ func (m *mockHazardDeps) OpenBlock(chainID eth.ChainID, blockNum uint64) (ref et
 		return m.openBlockFn(chainID, blockNum)
 	}
 	// Look up the block in our test data
-	chainIndex, err := m.ChainIndexFromID(chainID)
+	chainCode, err := m.ChainCodeFromID(chainID)
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, fmt.Errorf("failed to get chain index: %w", err)
 	}
 	key := blockKey{
-		chain:  chainIndex,
+		chain:  chainCode,
 		number: blockNum,
 	}
 	if block, ok := m.blockMap[key]; ok {
@@ -705,15 +705,15 @@ func (m *mockHazardDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockHazardDeps) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
-	return m.deps.ChainIndexFromID(id)
+func (m *mockHazardDeps) ChainCodeFromID(id eth.ChainID) (types.ChainCode, error) {
+	return m.deps.ChainCodeFromID(id)
 }
 
 func (m *mockHazardDeps) Logger() log.Logger {
 	return m.logger
 }
 
-func makeBlock(chain types.ChainIndex, timestamp, number uint64, messages ...*types.ExecutingMessage) blockDef {
+func makeBlock(chain types.ChainCode, timestamp, number uint64, messages ...*types.ExecutingMessage) blockDef {
 	return blockDef{
 		number:    number,
 		timestamp: timestamp,
@@ -723,7 +723,7 @@ func makeBlock(chain types.ChainIndex, timestamp, number uint64, messages ...*ty
 	}
 }
 
-func makeMessage(chain types.ChainIndex, timestamp, blockNum uint64, logIdx uint32) *types.ExecutingMessage {
+func makeMessage(chain types.ChainCode, timestamp, blockNum uint64, logIdx uint32) *types.ExecutingMessage {
 	return &types.ExecutingMessage{
 		Chain:     chain,
 		BlockNum:  blockNum,
@@ -732,7 +732,7 @@ func makeMessage(chain types.ChainIndex, timestamp, blockNum uint64, logIdx uint
 	}
 }
 
-func makeBlockSeal(number, timestamp uint64, chain types.ChainIndex) types.BlockSeal {
+func makeBlockSeal(number, timestamp uint64, chain types.ChainCode) types.BlockSeal {
 	return types.BlockSeal{
 		Number:    number,
 		Timestamp: timestamp,
@@ -743,7 +743,7 @@ func makeBlockSeal(number, timestamp uint64, chain types.ChainIndex) types.Block
 type testVector struct {
 	name          string
 	blocks        []blockDef
-	expected      map[types.ChainIndex]types.BlockSeal
+	expected      map[types.ChainCode]types.BlockSeal
 	expectErr     error
 	verifyBlockFn func(chainID eth.ChainID, block eth.BlockID) error
 }
@@ -752,7 +752,7 @@ type blockDef struct {
 	number    uint64
 	timestamp uint64
 	hash      common.Hash
-	chain     types.ChainIndex
+	chain     types.ChainCode
 	messages  []*types.ExecutingMessage
 }
 
@@ -784,21 +784,21 @@ func newMockHazardDeps(t *testing.T, tc testVector) *mockHazardDeps {
 }
 
 // hazardMockDependencySet wraps mockDependencySet and makes it easier to test
-// with 0 chainIndex values.
+// with 0 chainCode values.
 type hazardMockDependencySet struct {
 	mockDependencySet
 }
 
-func (m hazardMockDependencySet) ChainIDFromIndex(idx types.ChainIndex) (eth.ChainID, error) {
+func (m hazardMockDependencySet) ChainIDFromCode(idx types.ChainCode) (eth.ChainID, error) {
 	return eth.ChainIDFromUInt64(uint64(idx)), nil
 }
 
-func (m hazardMockDependencySet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
-	return types.ChainIndex(id[0]), nil
+func (m hazardMockDependencySet) ChainCodeFromID(id eth.ChainID) (types.ChainCode, error) {
+	return types.ChainCode(id[0]), nil
 }
 
 type blockKey struct {
-	chain  types.ChainIndex
+	chain  types.ChainCode
 	number uint64
 }
 

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -23,11 +23,11 @@ type SafeFrontierCheckDeps interface {
 //     local-safe block, after the cross-safe block.
 func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, hazards *HazardSet) error {
 	depSet := d.DependencySet()
-	for hazardChainIndex, hazardBlock := range hazards.Entries() {
-		hazardChainID, err := depSet.ChainIDFromIndex(hazardChainIndex)
+	for hazardChainCode, hazardBlock := range hazards.Entries() {
+		hazardChainID, err := depSet.ChainIDFromCode(hazardChainCode)
 		if err != nil {
 			if errors.Is(err, types.ErrUnknownChain) {
-				err = fmt.Errorf("cannot cross-safe verify block %s of unknown chain index %s: %w", hazardBlock, hazardChainIndex, types.ErrConflict)
+				err = fmt.Errorf("cannot cross-safe verify block %s of unknown chain index %s: %w", hazardBlock, hazardChainCode, types.ErrConflict)
 			}
 			return err
 		}

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -16,7 +16,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 	t.Run("empty hazards", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
 		l1Source := eth.BlockID{}
-		hazards := map[types.ChainIndex]types.BlockSeal{}
+		hazards := map[types.ChainCode]types.BlockSeal{}
 		// when there are no hazards,
 		// no work is done, and no error is returned
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
@@ -31,7 +31,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 			},
 		}
 		l1Source := eth.BlockID{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {}}
 		// when there is one hazard, and ChainIDFromIndex returns ErrUnknownChain,
 		// an error is returned as a ErrConflict
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
@@ -43,7 +43,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 			return types.BlockSeal{Number: 1}, nil
 		}
 		l1Source := eth.BlockID{Number: 2}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {}}
 		// when there is one hazard, and CrossSource returns a BlockSeal within scope
 		// (ie the hazard's block number is less than or equal to the source block number),
 		// no error is returned
@@ -56,7 +56,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 			return types.BlockSeal{Number: 3}, nil
 		}
 		l1Source := eth.BlockID{Number: 2}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {}}
 		// when there is one hazard, and CrossSource returns a BlockSeal out of scope
 		// (ie the hazard's block number is greater than the source block number),
 		// an error is returned as a ErrOutOfScope
@@ -75,7 +75,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 				errors.New("some error")
 		}
 		l1Source := eth.BlockID{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {}}
 		// when there is one hazard, and CrossSource returns an ErrFuture,
 		// and CandidateCrossSafe returns an error,
 		// the error from CandidateCrossSafe is returned
@@ -94,7 +94,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 			}, nil
 		}
 		l1Source := eth.BlockID{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
 		// when there is one hazard, and CrossSource returns an ErrFuture,
 		// and CandidateCrossSafe returns a candidate that does not match the hazard,
 		// (ie the candidate's block number is the same as the hazard's block number, but the hashes are different),
@@ -114,7 +114,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 				nil
 		}
 		l1Source := eth.BlockID{Number: 8}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
 		// when there is one hazard, and CrossSource returns an ErrFuture,
 		// and the initSource is out of scope,
 		// an error is returned as a ErrOutOfScope
@@ -133,7 +133,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 			}, nil
 		}
 		l1Source := eth.BlockID{Number: 8}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
 		// when there is one hazard, and CrossSource returns an ErrFuture,
 		// and the initSource is out of scope,
 		// an error is returned as a ErrOutOfScope
@@ -187,7 +187,7 @@ func (m mockDependencySet) CanInitiateAt(chain eth.ChainID, timestamp uint64) (b
 	return true, nil
 }
 
-func (m mockDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
+func (m mockDependencySet) ChainIDFromCode(index types.ChainCode) (eth.ChainID, error) {
 	if m.chainIDFromIndexfn != nil {
 		return m.chainIDFromIndexfn()
 	}
@@ -195,13 +195,13 @@ func (m mockDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID
 	return id, nil
 }
 
-func (m mockDependencySet) ChainIndexFromID(chain eth.ChainID) (types.ChainIndex, error) {
+func (m mockDependencySet) ChainCodeFromID(chain eth.ChainID) (types.ChainCode, error) {
 	v := chain.ToBig()
 	if v.BitLen() > 20 {
 		return 0, fmt.Errorf("chain ID is too large for mock dependency set: %s", chain)
 	}
 	// offset, so we catch improper manual conversion that doesn't apply this arbitrary offset
-	return types.ChainIndex(v.Uint64() + 1000), nil
+	return types.ChainCode(v.Uint64() + 1000), nil
 }
 
 func (m mockDependencySet) Chains() []eth.ChainID {

--- a/op-supervisor/supervisor/backend/cross/safe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start_test.go
@@ -132,7 +132,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 10}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 10}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is greater than the candidate,
 		// an error is returned
@@ -150,7 +150,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is equal to the candidate,
 		// and check returns an error,
@@ -170,8 +170,8 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Number: 0, Hash: common.Hash{}, Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
+		em2 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
 		ssd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			if blockNum == candidate.Number {
 				return eth.BlockRef{
@@ -191,7 +191,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		// they load the hazards once, and return no error
 		hazards, err := CrossSafeHazards(ssd, newTestLogger(t), chainID, inL1Source, candidate)
 		require.NoError(t, err)
-		require.Equal(t, map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): sampleBlockSeal}, hazards.Entries())
+		require.Equal(t, map[types.ChainCode]types.BlockSeal{types.ChainCode(0): sampleBlockSeal}, hazards.Entries())
 	})
 	t.Run("timestamp is equal, different hazards", func(t *testing.T) {
 		logger := newTestLogger(t)
@@ -212,8 +212,8 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
+		em2 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
 		ssd.openBlockFn = newOpenBlockFn(em1, em2)
 		// when there are two execMsgs, and both are equal time to the candidate,
 		// and check returns different includedIn for the two,
@@ -233,7 +233,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and check returns an error,
@@ -257,7 +257,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and DerivedToSource returns aan error,
@@ -282,7 +282,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and DerivedToSource returns a BlockSeal with a greater Number than the inL1Source,
@@ -304,7 +304,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{Number: 10}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and DerivedToSource returns a BlockSeal with a smaller Number than the inL1Source,
@@ -325,7 +325,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		inL1Source := eth.BlockID{Number: 1}
 		candidate := types.BlockSeal{Timestamp: 2}
 		ssd.candidate = candidate
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and DerivedToSource returns a BlockSeal with a equal to the Number of inL1Source,
@@ -341,7 +341,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		chainID := eth.ChainIDFromUInt64(0)
 		inL1Source := eth.BlockID{Number: 1}
 		candidate := types.BlockSeal{Timestamp: 12}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and DerivedToSource returns a BlockSeal with a equal to the Number of inL1Source,
@@ -358,7 +358,7 @@ func TestCrossSafeHazards(t *testing.T) {
 		chainID := eth.ChainIDFromUInt64(0)
 		inL1Source := eth.BlockID{Number: 1}
 		candidate := types.BlockSeal{Timestamp: 11}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		ssd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and DerivedToSource returns a BlockSeal with a equal to the Number of inL1Source,

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -395,8 +395,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1, Time: 1}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1, LogIdx: 2}
+		em2 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1, LogIdx: 1}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 3, map[uint32]*types.ExecutingMessage{1: em1, 2: em2}, nil
 		}

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier.go
@@ -24,11 +24,11 @@ type UnsafeFrontierCheckDeps interface {
 //     local-unsafe block, after the cross-unsafe block.
 func HazardUnsafeFrontierChecks(d UnsafeFrontierCheckDeps, hazards *HazardSet) error {
 	depSet := d.DependencySet()
-	for hazardChainIndex, hazardBlock := range hazards.Entries() {
-		hazardChainID, err := depSet.ChainIDFromIndex(hazardChainIndex)
+	for hazardChainCode, hazardBlock := range hazards.Entries() {
+		hazardChainID, err := depSet.ChainIDFromCode(hazardChainCode)
 		if err != nil {
 			if errors.Is(err, types.ErrUnknownChain) {
-				err = fmt.Errorf("cannot cross-safe verify block %s of unknown chain index %s: %w", hazardBlock, hazardChainIndex, types.ErrConflict)
+				err = fmt.Errorf("cannot cross-safe verify block %s of unknown chain index %s: %w", hazardBlock, hazardChainCode, types.ErrConflict)
 			}
 			return err
 		}

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
@@ -14,7 +14,7 @@ import (
 func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	t.Run("empty hazards", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{}
+		hazards := map[types.ChainCode]types.BlockSeal{}
 		// when there are no hazards,
 		// no work is done, and no error is returned
 		err := HazardUnsafeFrontierChecks(ufcd, NewHazardSetFromEntries(hazards))
@@ -28,7 +28,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 				},
 			},
 		}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 0}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 0}}
 		// when there is one hazard, and ChainIDFromIndex returns ErrUnknownChain,
 		// an error is returned as a ErrConflict
 		err := HazardUnsafeFrontierChecks(ufcd, NewHazardSetFromEntries(hazards))
@@ -36,7 +36,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	})
 	t.Run("is cross unsafe", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 0}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 0}}
 		ufcd.isCrossUnsafe = nil
 		// when there is one hazard, and IsCrossUnsafe returns nil (no error)
 		// no error is returned
@@ -45,7 +45,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	})
 	t.Run("errFuture: is not local unsafe", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 0}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 0}}
 		ufcd.isCrossUnsafe = types.ErrFuture
 		ufcd.isLocalUnsafe = errors.New("some error")
 		// when there is one hazard, and IsCrossUnsafe returns an ErrFuture,
@@ -56,7 +56,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	})
 	t.Run("errFuture: genesis block", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 0}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 0}}
 		ufcd.isCrossUnsafe = types.ErrFuture
 		// when there is one hazard, and IsCrossUnsafe returns an ErrFuture,
 		// BUT the hazard's block number is 0,
@@ -66,7 +66,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	})
 	t.Run("errFuture: error getting parent block", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 3}}
 		ufcd.isCrossUnsafe = types.ErrFuture
 		ufcd.findBlockIDFn = func() (parent eth.BlockID, err error) {
 			return eth.BlockID{}, errors.New("some error")
@@ -79,7 +79,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	})
 	t.Run("errFuture: parent block is not cross unsafe", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 3}}
 		ufcd.isCrossUnsafe = types.ErrFuture
 		ufcd.findBlockIDFn = func() (parent eth.BlockID, err error) {
 			// when getting the parent block, prep isCrossSafe to be err
@@ -94,7 +94,7 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 	})
 	t.Run("IsCrossUnsafe Error", func(t *testing.T) {
 		ufcd := &mockUnsafeFrontierCheckDeps{}
-		hazards := map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
+		hazards := map[types.ChainCode]types.BlockSeal{types.ChainCode(0): {Number: 3, Hash: common.BytesToHash([]byte{0x02})}}
 		ufcd.isCrossUnsafe = errors.New("some error")
 		// when there is one hazard, and IsCrossUnsafe returns an error,
 		// the error from IsCrossUnsafe is (wrapped and) returned

--- a/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start_test.go
@@ -123,7 +123,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 10}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 10}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is greater than the candidate,
 		// an error is returned
@@ -139,7 +139,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is equal to the candidate,
 		// and check returns an error,
@@ -157,8 +157,8 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Hash: common.BytesToHash([]byte{0x04}), Number: 4, Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
+		em2 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
 		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			if blockNum == 4 {
 				return eth.BlockRef{
@@ -178,7 +178,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		// they load the hazards once, and return no error
 		hazards, err := CrossUnsafeHazards(usd, newTestLogger(t), chainID, candidate)
 		require.NoError(t, err)
-		require.Equal(t, map[types.ChainIndex]types.BlockSeal{types.ChainIndex(0): sampleBlockSeal}, hazards.Entries())
+		require.Equal(t, map[types.ChainCode]types.BlockSeal{types.ChainCode(0): sampleBlockSeal}, hazards.Entries())
 	})
 	t.Run("timestamp is equal, different hazards", func(t *testing.T) {
 		usd := &mockUnsafeStartDeps{}
@@ -196,8 +196,8 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 2}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
+		em2 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 2}
 		usd.openBlockFn = newOpenBlockFn(em1, em2)
 		// when there are two execMsgs, and both are equal time to the candidate,
 		// and check returns different includedIn for the two,
@@ -214,7 +214,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and check returns an error,
@@ -235,7 +235,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and IsCrossUnsafe returns an error,
@@ -256,7 +256,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		usd.deps = mockDependencySet{}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 2}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 0}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 0}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg, and the timestamp is less than the candidate,
 		// and IsCrossUnsafe returns no error,
@@ -275,7 +275,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 12}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg that has just expired,
 		// ErrExpired is returned
@@ -294,7 +294,7 @@ func TestCrossUnsafeHazards(t *testing.T) {
 		}
 		chainID := eth.ChainIDFromUInt64(0)
 		candidate := types.BlockSeal{Timestamp: 11}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1}
 		usd.openBlockFn = newOpenBlockFn(em1)
 		// when there is one execMsg that is near expiry, then no error is returned
 		hazards, err := CrossUnsafeHazards(usd, logger, chainID, candidate)

--- a/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update_test.go
@@ -133,8 +133,8 @@ func TestCrossUnsafeUpdate(t *testing.T) {
 			return crossUnsafe, nil
 		}
 		bl := eth.BlockRef{ParentHash: common.Hash{0x01}, Number: 1, Time: 1}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 1}
+		em1 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1, LogIdx: 2}
+		em2 := &types.ExecutingMessage{Chain: types.ChainCode(0), Timestamp: 1, LogIdx: 1}
 		usd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return bl, 3, map[uint32]*types.ExecutingMessage{1: em1, 2: em2}, nil
 		}

--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -211,7 +211,7 @@ func (l *logContext) processEntry(entry Entry) error {
 			return err
 		}
 		l.execMsg = &types.ExecutingMessage{
-			Chain:     types.ChainIndex(link.chain),
+			Chain:     types.ChainCode(link.chain),
 			BlockNum:  link.blockNum,
 			LogIdx:    link.logIdx,
 			Timestamp: link.timestamp,

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -34,21 +34,21 @@ type DependencySet interface {
 	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
 	HasChain(chainID eth.ChainID) bool
 
-	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
+	ChainCodeFromID(id eth.ChainID) (types.ChainCode, error)
 
 	// MessageExpiryWindow returns the message expiry window to use for this dependency set.
 	MessageExpiryWindow() uint64
 
-	ChainIndexFromID
-	ChainIDFromIndex
+	ChainCodeFromID
+	ChainIDFromCode
 }
 
-type ChainIndexFromID interface {
-	// ChainIndexFromID converts a ChainID to a ChainIndex.
-	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
+type ChainCodeFromID interface {
+	// ChainCodeFromID converts a ChainID to a ChainCode.
+	ChainCodeFromID(id eth.ChainID) (types.ChainCode, error)
 }
 
-type ChainIDFromIndex interface {
-	// ChainIDFromIndex converts a ChainIndex to a ChainID.
-	ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error)
+type ChainIDFromCode interface {
+	// ChainIDFromCode converts a ChainCode to a ChainID.
+	ChainIDFromCode(chainCode types.ChainCode) (eth.ChainID, error)
 }

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -48,10 +48,10 @@ func TestDependencySet(t *testing.T) {
 
 	t.Run("duplicate index", func(t *testing.T) {
 		_, err := NewStaticConfigDependencySet(map[eth.ChainID]*StaticConfigDependency{
-			eth.ChainIDFromUInt64(900): {ChainIndex: 1},
-			eth.ChainIDFromUInt64(901): {ChainIndex: 1}, // duplicate
+			eth.ChainIDFromUInt64(900): {ChainCode: 1},
+			eth.ChainIDFromUInt64(901): {ChainCode: 1}, // duplicate
 		})
-		require.ErrorIs(t, err, errDuplicateChainIndex)
+		require.ErrorIs(t, err, errDuplicateChainCode)
 	})
 
 }
@@ -67,12 +67,12 @@ func testDependencySetSerialization(
 	depSet, err := NewStaticConfigDependencySet(
 		map[eth.ChainID]*StaticConfigDependency{
 			eth.ChainIDFromUInt64(900): {
-				ChainIndex:     900,
+				ChainCode:      900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
 			eth.ChainIDFromUInt64(901): {
-				ChainIndex:     901,
+				ChainCode:      901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
 			},
@@ -139,11 +139,11 @@ func testDependencySetSerialization(
 
 	t.Run("chain index round trip", func(t *testing.T) {
 		id900 := eth.ChainIDFromUInt64(900)
-		idx, _ := depSet.ChainIndexFromID(id900)
-		idBack, _ := depSet.ChainIDFromIndex(idx)
+		idx, _ := depSet.ChainCodeFromID(id900)
+		idBack, _ := depSet.ChainIDFromCode(idx)
 		require.Equal(t, id900, idBack)
 
-		_, err := depSet.ChainIndexFromID(eth.ChainIDFromUInt64(999))
+		_, err := depSet.ChainCodeFromID(eth.ChainIDFromUInt64(999))
 		require.ErrorContains(t, err, "unknown chain")
 	})
 

--- a/op-supervisor/supervisor/backend/depset/static.go
+++ b/op-supervisor/supervisor/backend/depset/static.go
@@ -15,18 +15,18 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-var errDuplicateChainIndex = errors.New("duplicate chain index")
-var errUsingReservedChainIndex = errors.New("using reserved chain index")
+var errDuplicateChainCode = errors.New("duplicate chain code")
+var errUsingReservedChainCode = errors.New("using reserved chain code")
 
-// NotFoundChainIndex is a reserved chain index signifying that a network is not in the dependency set.
+// NotFoundChainCode is a reserved chain code signifying that a network is not in the dependency set.
 // We are persisting these invalid, but not malformed, executing messages in our internal database, and
-// we need a mapping between all ChainIDs <> ChainIndexs. However ChainID is 32 bytes, and ChainIndex
-// is 4 bytes, so we need a reserved chain index for unknown chains.
-const NotFoundChainIndex = types.ChainIndex(0xFFFF_FFFF)
+// we need a mapping between all ChainIDs <> ChainCodes. However ChainID is 32 bytes, and ChainCode
+// is 4 bytes, so we need a reserved chain code for unknown chains.
+const NotFoundChainCode = types.ChainCode(0xFFFF_FFFF)
 
 type StaticConfigDependency struct {
-	// ChainIndex is the unique short identifier of this chain.
-	ChainIndex types.ChainIndex `json:"chainIndex" toml:"chain_index"`
+	// ChainCode is the unique short identifier of this chain.
+	ChainCode types.ChainCode `json:"chainCode" toml:"chain_code"`
 
 	// ActivationTime is when the chain becomes part of the dependency set.
 	// This is the minimum timestamp of the inclusion of an executing message.
@@ -43,8 +43,8 @@ type StaticConfigDependency struct {
 type StaticConfigDependencySet struct {
 	// dependency info per chain
 	dependencies map[eth.ChainID]*StaticConfigDependency
-	// cached mapping of chain index to chain ID
-	indexToID map[types.ChainIndex]eth.ChainID
+	// cached mapping of chain code to chain ID
+	codeToID map[types.ChainCode]eth.ChainID
 	// cached list of chain IDs, sorted by ID value
 	chainIDs []eth.ChainID
 	// overrideMessageExpiryWindow is the message expiry window to use for this dependency set
@@ -158,16 +158,16 @@ func (ds *StaticConfigDependencySet) UnmarshalTOML(v interface{}) error {
 
 // hydrate sets all the cached values, based on the dependencies attribute
 func (ds *StaticConfigDependencySet) hydrate() error {
-	ds.indexToID = make(map[types.ChainIndex]eth.ChainID)
+	ds.codeToID = make(map[types.ChainCode]eth.ChainID)
 	ds.chainIDs = make([]eth.ChainID, 0, len(ds.dependencies))
 	for id, dep := range ds.dependencies {
-		if dep.ChainIndex.IsTopBitSet() {
-			return fmt.Errorf("%w: chain %s cannot have the top bit set, and this subset is reserved for internal use: %d", errUsingReservedChainIndex, id, dep.ChainIndex)
+		if dep.ChainCode.IsTopBitSet() {
+			return fmt.Errorf("%w: chain %s cannot have the top bit set, and this subset is reserved for internal use: %d", errUsingReservedChainCode, id, dep.ChainCode)
 		}
-		if existing, ok := ds.indexToID[dep.ChainIndex]; ok {
-			return fmt.Errorf("%w: chain %s cannot have the same index (%d) as chain %s", errDuplicateChainIndex, id, dep.ChainIndex, existing)
+		if existing, ok := ds.codeToID[dep.ChainCode]; ok {
+			return fmt.Errorf("%w: chain %s cannot have the same index (%d) as chain %s", errDuplicateChainCode, id, dep.ChainCode, existing)
 		}
-		ds.indexToID[dep.ChainIndex] = id
+		ds.codeToID[dep.ChainCode] = id
 		ds.chainIDs = append(ds.chainIDs, id)
 	}
 	sort.Slice(ds.chainIDs, func(i, j int) bool {
@@ -209,16 +209,16 @@ func (ds *StaticConfigDependencySet) HasChain(chainID eth.ChainID) bool {
 	return ok
 }
 
-func (ds *StaticConfigDependencySet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
+func (ds *StaticConfigDependencySet) ChainCodeFromID(id eth.ChainID) (types.ChainCode, error) {
 	dep, ok := ds.dependencies[id]
 	if !ok {
 		return 0, fmt.Errorf("failed to translate chain ID %s to chain index: %w", id, types.ErrUnknownChain)
 	}
-	return dep.ChainIndex, nil
+	return dep.ChainCode, nil
 }
 
-func (ds *StaticConfigDependencySet) ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error) {
-	id, ok := ds.indexToID[index]
+func (ds *StaticConfigDependencySet) ChainIDFromCode(index types.ChainCode) (eth.ChainID, error) {
+	id, ok := ds.codeToID[index]
 	if !ok {
 		if index.IsTopBitSet() {
 			return eth.ChainID{}, fmt.Errorf("provided index has its top bit set, and this subset is reserved for internal use: %w", types.ErrUnknownChain)
@@ -240,7 +240,7 @@ func (ds *StaticConfigDependencySet) Dependencies() map[eth.ChainID]*StaticConfi
 	copied := make(map[eth.ChainID]*StaticConfigDependency, len(ds.dependencies))
 	for chainId, dep := range ds.dependencies {
 		copied[chainId] = &StaticConfigDependency{
-			ChainIndex:     dep.ChainIndex,
+			ChainCode:      dep.ChainCode,
 			ActivationTime: dep.ActivationTime,
 			HistoryMinTime: dep.HistoryMinTime,
 		}

--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -12,9 +12,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-type EventDecoderFn func(*ethTypes.Log, depset.ChainIndexFromID) (*types.ExecutingMessage, error)
+type EventDecoderFn func(*ethTypes.Log, depset.ChainCodeFromID) (*types.ExecutingMessage, error)
 
-func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) (*types.ExecutingMessage, error) {
+func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainCodeFromID) (*types.ExecutingMessage, error) {
 	if l.Address != params.InteropCrossL2InboxAddress {
 		return nil, nil
 	}
@@ -30,19 +30,19 @@ func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) 
 	}
 	logHash := types.PayloadHashToLogHash(msg.PayloadHash, msg.Identifier.Origin)
 
-	var chainIndex types.ChainIndex
-	index, err := depSet.ChainIndexFromID(eth.ChainID(msg.Identifier.ChainID))
+	var chainCode types.ChainCode
+	index, err := depSet.ChainCodeFromID(eth.ChainID(msg.Identifier.ChainID))
 	if err != nil {
 		if errors.Is(err, types.ErrUnknownChain) {
-			chainIndex = depset.NotFoundChainIndex
+			chainCode = depset.NotFoundChainCode
 		} else {
 			return nil, fmt.Errorf("failed to translate chain ID %s to chain index: %w", msg.Identifier.ChainID, err)
 		}
 	} else {
-		chainIndex = index
+		chainCode = index
 	}
 	return &types.ExecutingMessage{
-		Chain:     chainIndex,
+		Chain:     chainCode,
 		BlockNum:  msg.Identifier.BlockNumber,
 		LogIdx:    msg.Identifier.LogIndex,
 		Timestamp: msg.Identifier.Timestamp,

--- a/op-supervisor/supervisor/backend/processors/executing_message_test.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 type testDepSet struct {
-	mapping map[eth.ChainID]types.ChainIndex
+	mapping map[eth.ChainID]types.ChainCode
 }
 
-func (t *testDepSet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
+func (t *testDepSet) ChainCodeFromID(id eth.ChainID) (types.ChainCode, error) {
 	v, ok := t.mapping[id]
 	if !ok {
 		return 0, types.ErrUnknownChain
@@ -26,7 +26,7 @@ func (t *testDepSet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) 
 	return v, nil
 }
 
-var _ depset.ChainIndexFromID = (*testDepSet)(nil)
+var _ depset.ChainCodeFromID = (*testDepSet)(nil)
 
 func TestDecodeExecutingMessageLog(t *testing.T) {
 	data := `
@@ -49,8 +49,8 @@ func TestDecodeExecutingMessageLog(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(data), &logEvent))
 
 	msg, err := DecodeExecutingMessageLog(&logEvent, &testDepSet{
-		mapping: map[eth.ChainID]types.ChainIndex{
-			eth.ChainIDFromUInt64(900200): types.ChainIndex(123),
+		mapping: map[eth.ChainID]types.ChainCode{
+			eth.ChainIDFromUInt64(900200): types.ChainCode(123),
 		},
 	})
 	require.NoError(t, err)
@@ -73,5 +73,5 @@ func TestDecodeExecutingMessageLog(t *testing.T) {
 	require.Equal(t, uint64(4509), msg.BlockNum)
 	require.Equal(t, uint32(0), msg.LogIdx)
 	require.Equal(t, uint64(1730467171), msg.Timestamp)
-	require.Equal(t, types.ChainIndex(123), msg.Chain)
+	require.Equal(t, types.ChainCode(123), msg.Chain)
 }

--- a/op-supervisor/supervisor/backend/processors/log_processor.go
+++ b/op-supervisor/supervisor/backend/processors/log_processor.go
@@ -22,10 +22,10 @@ type logProcessor struct {
 	chain        eth.ChainID
 	logStore     LogStorage
 	eventDecoder EventDecoderFn
-	depSet       depset.ChainIndexFromID
+	depSet       depset.ChainCodeFromID
 }
 
-func NewLogProcessor(chain eth.ChainID, logStore LogStorage, depSet depset.ChainIndexFromID) LogProcessor {
+func NewLogProcessor(chain eth.ChainID, logStore LogStorage, depSet depset.ChainCodeFromID) LogProcessor {
 	return &logProcessor{
 		chain:        chain,
 		logStore:     logStore,

--- a/op-supervisor/supervisor/backend/processors/log_processor_test.go
+++ b/op-supervisor/supervisor/backend/processors/log_processor_test.go
@@ -27,7 +27,7 @@ func TestLogProcessor(t *testing.T) {
 		Time:       1111,
 	}
 	depSet := &testDepSet{
-		mapping: map[eth.ChainID]types.ChainIndex{
+		mapping: map[eth.ChainID]types.ChainCode{
 			eth.ChainIDFromUInt64(100): 4,
 		},
 	}
@@ -125,7 +125,7 @@ func TestLogProcessor(t *testing.T) {
 		}
 		store := &stubLogStorage{}
 		processor := NewLogProcessor(eth.ChainID{4}, store, depSet).(*logProcessor)
-		processor.eventDecoder = func(l *ethTypes.Log, translator depset.ChainIndexFromID) (*types.ExecutingMessage, error) {
+		processor.eventDecoder = func(l *ethTypes.Log, translator depset.ChainCodeFromID) (*types.ExecutingMessage, error) {
 			require.Equal(t, rcpts[0].Logs[0], l)
 			return execMsg, nil
 		}

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -1427,7 +1427,7 @@ func setupTestChains(t *testing.T, chainIDs ...eth.ChainID) *testSetup {
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for i, chainID := range chainIDs {
 		deps[chainID] = &depset.StaticConfigDependency{
-			ChainIndex:     types.ChainIndex(i + 1),
+			ChainCode:      types.ChainCode(i + 1),
 			ActivationTime: 42,
 			HistoryMinTime: 100,
 		}

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -194,12 +194,12 @@ func sampleDepSet(t *testing.T) depset.DependencySet {
 	depSet, err := depset.NewStaticConfigDependencySet(
 		map[eth.ChainID]*depset.StaticConfigDependency{
 			eth.ChainIDFromUInt64(900): {
-				ChainIndex:     900,
+				ChainCode:      900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
 			eth.ChainIDFromUInt64(901): {
-				ChainIndex:     901,
+				ChainCode:      901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
 			},

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -26,29 +26,29 @@ var (
 
 var ExecutingMessageEventTopic = crypto.Keccak256Hash([]byte("ExecutingMessage(bytes32,(address,uint256,uint256,uint256,uint256))"))
 
-// ChainIndex represents the lifetime of a chain in a dependency set.
+// ChainCode represents the lifetime of a chain in a dependency set.
 // Warning: JSON-encoded as string, in base-10.
-type ChainIndex uint32
+type ChainCode uint32
 
-func (ci ChainIndex) String() string {
+func (ci ChainCode) String() string {
 	return strconv.FormatUint(uint64(ci), 10)
 }
 
-func (ci ChainIndex) MarshalText() ([]byte, error) {
+func (ci ChainCode) MarshalText() ([]byte, error) {
 	return []byte(ci.String()), nil
 }
 
-func (ci *ChainIndex) UnmarshalText(data []byte) error {
+func (ci *ChainCode) UnmarshalText(data []byte) error {
 	v, err := strconv.ParseUint(string(data), 10, 32)
 	if err != nil {
 		return err
 	}
-	*ci = ChainIndex(v)
+	*ci = ChainCode(v)
 	return nil
 }
 
-// IsTopBitSet returns true if the top bit is set. Used to check for reserved values, such as NotFoundChainIndex.
-func (ci ChainIndex) IsTopBitSet() bool {
+// IsTopBitSet returns true if the top bit is set. Used to check for reserved values, such as NotFoundChainCode.
+func (ci ChainCode) IsTopBitSet() bool {
 	return ci&(1<<31) != 0
 }
 
@@ -105,7 +105,7 @@ type ContainsQuery struct {
 }
 
 type ExecutingMessage struct {
-	Chain     ChainIndex // same as ChainID for now, but will be indirect, i.e. translated to full ID, later
+	Chain     ChainCode // same as ChainID for now, but will be indirect, i.e. translated to full ID, later
 	BlockNum  uint64
 	LogIdx    uint32
 	Timestamp uint64
@@ -113,7 +113,7 @@ type ExecutingMessage struct {
 }
 
 func (s *ExecutingMessage) String() string {
-	return fmt.Sprintf("ExecMsg(chainIndex: %s, block: %d, log: %d, time: %d, logHash: %s)",
+	return fmt.Sprintf("ExecMsg(chainCode: %s, block: %d, log: %d, time: %d, logHash: %s)",
 		s.Chain, s.BlockNum, s.LogIdx, s.Timestamp, s.Hash)
 }
 

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -204,16 +204,16 @@ func TestInteropMessageFormatEdgeCases(t *testing.T) {
 	}
 }
 
-func TestChainIndex(t *testing.T) {
-	var x ChainIndex
+func TestChainCode(t *testing.T) {
+	var x ChainCode
 	require.NoError(t, json.Unmarshal([]byte(`"1"`), &x))
-	require.Equal(t, ChainIndex(1), x)
+	require.Equal(t, ChainCode(1), x)
 	data, err := json.Marshal(x)
 	require.NoError(t, err)
 	require.Equal(t, `"1"`, string(data))
 
 	require.NoError(t, json.Unmarshal([]byte(`"4294967295"`), &x))
-	require.Equal(t, ChainIndex(0xff_ff_ff_ff), x)
+	require.Equal(t, ChainCode(0xff_ff_ff_ff), x)
 	data, err = json.Marshal(x)
 	require.NoError(t, err)
 	require.Equal(t, `"4294967295"`, string(data))


### PR DESCRIPTION
Renames the `StaticConfigDependency.ChainIndex` field to ``StaticConfigDependency.ChainCode`. This will help reduce confusion about the purpose of that field. See [this comment](https://github.com/ethereum-optimism/op-geth/pull/610#discussion_r2101071695) for more context.