### PR TITLE
feat(op-acceptance-tests): precompile Go tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1194,6 +1194,11 @@ jobs:
           name: Download Go dependencies
           working_directory: op-acceptance-tests
           command: go mod download
+      # Prepare the test environment
+      - run:
+          name: Prepare test environment (compile tests and cache build results)
+          working_directory: op-acceptance-tests
+          command: go test -v -c -o /dev/null $(go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./tests/...)
       # Run the acceptance tests (if the devnet is running)
       - run:
           name: Run acceptance tests (gate=<<parameters.gate>>)


### PR DESCRIPTION
This shouldn't cause side effects, as it won't run any tests or trigger any test package init()'s either.
