### PR TITLE
op-deployer: Relax l1 contracts release constraint

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -70,8 +70,14 @@ func (c *ImplementationsConfig) Check() error {
 	if c.ArtifactsLocator == nil {
 		return errors.New("artifacts locator must be specified")
 	}
-	if c.L1ContractsRelease == "" {
-		return errors.New("l1 contracts release must be specified")
+	if c.ArtifactsLocator.IsTag() {
+		if c.L1ContractsRelease != "" {
+			return errors.New("l1 contracts release cannot be specified if using an artifacts tag")
+		}
+
+		c.L1ContractsRelease = c.ArtifactsLocator.Tag
+	} else if c.L1ContractsRelease == "" {
+		return errors.New("l1 contracts release must be specified if not using an artifacts tag")
 	}
 	if !mipsVersion.IsSupported(c.MIPSVersion) {
 		return errors.New("MIPS version is not supported")

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -70,10 +70,8 @@ func (c *ImplementationsConfig) Check() error {
 	if c.ArtifactsLocator == nil {
 		return errors.New("artifacts locator must be specified")
 	}
-	if c.ArtifactsLocator.IsTag() {
-		c.L1ContractsRelease = c.ArtifactsLocator.Tag
-	} else {
-		c.L1ContractsRelease = "dev"
+	if c.L1ContractsRelease == "" {
+		return errors.New("l1 contracts release must be specified")
 	}
 	if !mipsVersion.IsSupported(c.MIPSVersion) {
 		return errors.New("MIPS version is not supported")


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/16062.