### PR TITLE
op-acceptance-tests: adds public rpc advance test

### DIFF
--- a/op-acceptance-tests/tests/base/public_rpc_advance_test.go
+++ b/op-acceptance-tests/tests/base/public_rpc_advance_test.go
@@ -1,0 +1,17 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestPublicRpcAdvance(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimal(t)
+
+	dsl.CheckAll(t, sys.L2Chain.PublicRPC().AdvancedFn(eth.Unsafe, 5))
+}


### PR DESCRIPTION
Adds simple test that asserts public rpc unsafe block height is advancing.

https://github.com/ethereum-optimism/infra/issues/285