### PR TITLE
opd: Add support for op-contracts/v4.0.0-rc.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250521132634-76f6d741b33f
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/ethereum-optimism/superchain-registry/validation v0.0.0-2025052113263
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250521132634-76f6d741b33f/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c h1:2LFhyflWNnUPa64lC7DZxTLnXzG3yBZ6i/GgkVvkfcc=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/go.sum
+++ b/go.sum
@@ -228,10 +228,6 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4 h1:dNSl6HTSLsjQH8644PzLijoeMK0vyeQVEMfYVUTxGf4=
 github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250521132634-76f6d741b33f h1:L4Q9iIthJHsrIS1rwEYcZDlMtIeKzwRRByQALNvJ3cQ=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250521132634-76f6d741b33f/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c h1:2LFhyflWNnUPa64lC7DZxTLnXzG3yBZ6i/GgkVvkfcc=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4 h
 github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250521132634-76f6d741b33f h1:L4Q9iIthJHsrIS1rwEYcZDlMtIeKzwRRByQALNvJ3cQ=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250521132634-76f6d741b33f/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c h1:2LFhyflWNnUPa64lC7DZxTLnXzG3yBZ6i/GgkVvkfcc=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250522145302-e4d87153bf1c/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -47,9 +47,9 @@ const (
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
 
-var DefaultL1ContractsTag = ContractsV300Tag
+var DefaultL1ContractsTag = ContractsV400Tag
 
-var DefaultL2ContractsTag = ContractsV300Tag
+var DefaultL2ContractsTag = ContractsV400Tag
 
 var VaultMinWithdrawalAmount = mustHexBigFromHex("0x8ac7230489e80000")
 

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -98,7 +98,7 @@ func IsSupportedL1Version(tag string) bool {
 }
 
 func IsSupportedL2Version(tag string) bool {
-	return tag == ContractsV300Tag
+	return tag == ContractsV400Tag
 }
 
 func L1VersionsFor(chainID uint64) (validation.Versions, error) {

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,6 +42,7 @@ const (
 	ContractsV170Beta1L2Tag = "op-contracts/v1.7.0-beta.1+l2-contracts"
 	ContractsV200Tag        = "op-contracts/v2.0.0"
 	ContractsV300Tag        = "op-contracts/v3.0.0"
+	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
@@ -84,12 +85,16 @@ var taggedReleases = map[string]TaggedRelease{
 		ArtifactsHash: common.HexToHash("40661d078e6efe7106b95d6fc5c4fda8db144487d85a47abd246cb3afcb41ab2"),
 		ContentHash:   common.HexToHash("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb"),
 	},
+	ContractsV400Tag: {
+		ArtifactsHash: common.HexToHash("da1d9ca1a4ebf80c4842ee3414ef1d13db7d1bb9e1fbbded5a21f28479d7cdf4"),
+		ContentHash:   common.HexToHash("67966a2cb9945e1d9ab40e9c61f499e73cdb31d21b8d29a5a5c909b2b13ecd70"),
+	},
 }
 
 var _ embed.FS
 
 func IsSupportedL1Version(tag string) bool {
-	return tag == ContractsV300Tag
+	return tag == ContractsV400Tag
 }
 
 func IsSupportedL2Version(tag string) bool {
@@ -247,6 +252,9 @@ func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployCon
 		return sched
 	case ContractsV180Tag, ContractsV200Tag, ContractsV300Tag:
 		sched.ActivateForkAtGenesis(rollup.Holocene)
+	case ContractsV400Tag:
+		sched.ActivateForkAtGenesis(rollup.Holocene)
+		sched.ActivateForkAtGenesis(rollup.Isthmus)
 	default:
 		sched.ActivateForkAtGenesis(rollup.Holocene)
 		sched.ActivateForkAtGenesis(rollup.Isthmus)

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -10,6 +10,7 @@ const (
 	VersionV180 = "v1.8.0"
 	VersionV200 = "v2.0.0"
 	VersionV300 = "v3.0.0"
+	VersionV400 = "v4.0.0"
 )
 
 var addresses = map[uint64]map[string]common.Address{
@@ -20,6 +21,8 @@ var addresses = map[uint64]map[string]common.Address{
 		VersionV200: common.HexToAddress("0x12a9e38628e5a5b24d18b1956ed68a24fe4e3dc0"),
 		// Bootstrapped on 04/16/2025 using OP Deployer.
 		VersionV300: common.HexToAddress("0xf989Df70FB46c581ba6157Ab335c0833bA60e1f0"),
+		// Bootstrapped on 06/03/2025 using OP Deployer.
+		VersionV400: common.HexToAddress("0x3246b056A3C9B14AA25b75ee133DC3747476DBc5"),
 	},
 	11155111: {
 		// Bootstrapped on 03/02/2025 using OP Deployer.
@@ -28,6 +31,8 @@ var addresses = map[uint64]map[string]common.Address{
 		VersionV200: common.HexToAddress("0x37739a6b0a3f1e7429499a4ec4a0685439daff5c"),
 		// Bootstrapped on 04/03/2025 using OP Deployer.
 		VersionV300: common.HexToAddress("0x2d56022cb84ce6b961c3b4288ca36386bcd9024c"),
+		// Bootstrapped on 06/03/2025 using OP Deployer.
+		VersionV400: common.HexToAddress("0x3246b056A3C9B14AA25b75ee133DC3747476DBc5"),
 	},
 }
 


### PR DESCRIPTION
Follows the devdoc guidance here: https://devdocs.optimism.io/op-deployer/reference-guide/releases.html#adding-support-for-new-contract-versions