### PR TITLE
op-deployer: Always generate a dependency set

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -13,26 +13,13 @@ import (
 func GenerateInteropDepset(_ context.Context, pEnv *Env, globalIntent *state.Intent, st *state.State) error {
 	lgr := pEnv.Logger.New("stage", "generate-interop-depset")
 
-	lgr.Info("creating interop dependency set...")
+	lgr.Info("Creating interop dependency set...")
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for i, chain := range globalIntent.Chains {
 		id := eth.ChainIDFromBytes32(chain.ID)
-		_, config, err := calculateL2GenesisOverrides(globalIntent, chain)
-		if err != nil {
-			return fmt.Errorf("failed to calculate L2 genesis overrides for chain %v: %w", chain.ID, err)
-		}
-		if config.L2GenesisInteropTimeOffset == nil {
-			// Don't add chains to the dep set if they don't have interop scheduled.
-			continue
-		}
-
 		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
 	}
 
-	if len(deps) == 0 {
-		lgr.Info("No interop chains found, skipping dependency set generation")
-		return nil
-	}
 	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)
 	if err != nil {
 		return fmt.Errorf("failed to create interop dependency set: %w", err)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -320,22 +319,6 @@ func (wb *worldBuilder) Build() {
 
 	intent, err := wb.builder.Build()
 	wb.require.NoError(err)
-
-	var minInteropTimeOffset *hexutil.Uint64
-	for _, ch := range intent.Chains {
-		v, ok := ch.DeployOverrides["l2GenesisInteropTimeOffset"]
-		if !ok {
-			continue
-		}
-		offset, ok := v.(*hexutil.Uint64)
-		if !ok {
-			continue
-		}
-		if minInteropTimeOffset == nil || *offset < *minInteropTimeOffset {
-			minInteropTimeOffset = offset
-		}
-	}
-	wb.logger.Info("Dependency set setting", "interopTime", minInteropTimeOffset)
 
 	pipelineOpts := deployer.ApplyPipelineOpts{
 		DeploymentTarget:   deployer.DeploymentTargetGenesis,


### PR DESCRIPTION
**Description**

Modify op-deployer to always create a dependency set when deploying that includes all chains being deployed (even if interop is not scheduled).

This matches the upcoming requirement to run op-supervisor and op-node together even without interop being scheduled and op-supervisor requires a dependency set.

Also removes some overly complex code just to log the minimum interop activation time. That code was more useful originally but is no longer required and not justified by the log statement.


**Metadata**

#16041 