### PR TITLE
op-program: Run derivation task directly

### DIFF
--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -58,19 +58,16 @@ type taskExecutor interface {
 	) (blockHash common.Hash, outputRoot eth.Bytes32, err error)
 }
 
-func RunInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, validateClaim bool) error {
-	return runInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, validateClaim, &interopTaskExecutor{})
+func RunInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle) error {
+	return runInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, &interopTaskExecutor{})
 }
 
-func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, validateClaim bool, tasks taskExecutor) error {
+func runInteropProgram(logger log.Logger, bootInfo *boot.BootInfoInterop, l1PreimageOracle l1.Oracle, l2PreimageOracle l2.Oracle, tasks taskExecutor) error {
 	logger.Info("Interop Program Bootstrapped", "bootInfo", bootInfo)
 
 	expected, err := stateTransition(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, tasks)
 	if err != nil {
 		return err
-	}
-	if !validateClaim {
-		return nil
 	}
 	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.Claim), eth.Bytes32(expected))
 }

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -757,7 +757,7 @@ func verifyResult(t *testing.T, logger log.Logger, tasks *stubTasks, configSourc
 			InfoTime: rollupCfg.Genesis.L2Time,
 		}
 	}
-	err := runInteropProgram(logger, bootInfo, l1Oracle, l2PreimageOracle, true, tasks)
+	err := runInteropProgram(logger, bootInfo, l1Oracle, l2PreimageOracle, tasks)
 	require.NoError(t, err)
 }
 

--- a/op-program/client/preinterop.go
+++ b/op-program/client/preinterop.go
@@ -34,9 +34,5 @@ func RunPreInteropProgram(
 	if err != nil {
 		return err
 	}
-	if opts.SkipValidation {
-		logger.Info("Validation skipped", "blockHash", result.BlockHash, "outputRoot", result.OutputRoot)
-		return nil
-	}
 	return claim.ValidateClaim(logger, eth.Bytes32(bootInfo.L2Claim), result.OutputRoot)
 }

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -21,7 +21,6 @@ import (
 var errInvalidConfig = errors.New("invalid config")
 
 type Config struct {
-	SkipValidation   bool
 	InteropEnabled   bool
 	ForceHintChainID bool
 	DB               l2.KeyValueStore
@@ -68,12 +67,12 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 
 	if cfg.InteropEnabled {
 		bootInfo := boot.BootstrapInterop(pClient)
-		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, !cfg.SkipValidation)
+		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
 	}
 	if cfg.DB == nil {
 		return fmt.Errorf("%w: db config is required", errInvalidConfig)
 	}
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
-	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData, SkipValidation: cfg.SkipValidation}
+	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData}
 	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, cfg.DB, derivationOptions)
 }

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 
@@ -18,13 +17,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var errInvalidConfig = errors.New("invalid config")
-
 type Config struct {
-	InteropEnabled   bool
-	ForceHintChainID bool
-	DB               l2.KeyValueStore
-	StoreBlockData   bool
+	InteropEnabled bool
 }
 
 // Main executes the client program in a detached context and exits the current process.
@@ -44,7 +38,6 @@ func Main(useInterop bool) {
 	preimageHinter := preimage.ClientHinterChannel()
 	config := Config{
 		InteropEnabled: useInterop,
-		DB:             memorydb.New(),
 	}
 	if err := RunProgram(logger, preimageOracle, preimageHinter, config); errors.Is(err, claim.ErrClaimNotValid) {
 		log.Error("Claim is invalid", "err", err)
@@ -63,16 +56,13 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	pClient := preimage.NewOracleClient(preimageOracle)
 	hClient := preimage.NewHintWriter(preimageHinter)
 	l1PreimageOracle := l1.NewCachingOracle(l1.NewPreimageOracle(pClient, hClient))
-	l2PreimageOracle := l2.NewCachingOracle(l2.NewPreimageOracle(pClient, hClient, cfg.InteropEnabled || cfg.ForceHintChainID))
+	l2PreimageOracle := l2.NewCachingOracle(l2.NewPreimageOracle(pClient, hClient, cfg.InteropEnabled))
 
 	if cfg.InteropEnabled {
 		bootInfo := boot.BootstrapInterop(pClient)
 		return interop.RunInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle)
 	}
-	if cfg.DB == nil {
-		return fmt.Errorf("%w: db config is required", errInvalidConfig)
-	}
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
-	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData}
-	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, cfg.DB, derivationOptions)
+	db := memorydb.New()
+	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, db, tasks.DerivationOptions{})
 }

--- a/op-program/client/tasks/derive.go
+++ b/op-program/client/tasks/derive.go
@@ -34,9 +34,6 @@ type DerivationOptions struct {
 	// StoreBlockData controls whether block data, including intermediate trie nodes from transactions and receipts
 	// of the derived block should be stored in the l2.KeyValueStore.
 	StoreBlockData bool
-
-	// SkipValidation controls whether the claim is validated after the block is derived.
-	SkipValidation bool
 }
 
 // RunDerivation executes the L2 state transition, given a minimal interface to retrieve data.

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -82,44 +82,14 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 	if programConfig.prefetcher == nil {
 		panic("prefetcher creator is not set")
 	}
-	var (
-		serverErr chan error
-		pClientRW preimage.FileChannel
-		hClientRW preimage.FileChannel
-	)
-	defer func() {
-		if pClientRW != nil {
-			_ = pClientRW.Close()
-		}
-		if hClientRW != nil {
-			_ = hClientRW.Close()
-		}
-		if serverErr != nil {
-			err := <-serverErr
-			if err != nil {
-				logger.Error("preimage server failed", "err", err)
-			}
-			logger.Debug("Preimage server stopped")
-		}
-	}()
-	// Setup client I/O for preimage oracle interaction
-	pClientRW, pHostRW, err := preimage.CreateBidirectionalChannel()
+	preimageServer, err := StartPreimageServer(ctx, logger, cfg, programConfig.prefetcher)
 	if err != nil {
-		return fmt.Errorf("failed to create preimage pipe: %w", err)
+		return err
 	}
+	defer preimageServer.Close()
 
-	// Setup client I/O for hint comms
-	hClientRW, hHostRW, err := preimage.CreateBidirectionalChannel()
-	if err != nil {
-		return fmt.Errorf("failed to create hints pipe: %w", err)
-	}
-
-	// Use a channel to receive the server result so we can wait for it to complete before returning
-	serverErr = make(chan error)
-	go func() {
-		defer close(serverErr)
-		serverErr <- PreimageServer(ctx, logger, cfg, pHostRW, hHostRW, programConfig.prefetcher)
-	}()
+	hClientRW := preimageServer.HintClientRW()
+	pClientRW := preimageServer.PreimageClientRW()
 
 	var cmd *exec.Cmd
 	if cfg.ExecCmd != "" {
@@ -154,11 +124,73 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 	}
 }
 
-// PreimageServer reads hints and preimage requests from the provided channels and processes those requests.
+type PreimageServer struct {
+	logger    log.Logger
+	serverErr chan error
+
+	pClientRW preimage.FileChannel
+	hClientRW preimage.FileChannel
+}
+
+func StartPreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, prefetcher PrefetcherCreator) (*PreimageServer, error) {
+	server := &PreimageServer{
+		logger: logger,
+	}
+	// Setup client I/O for preimage oracle interaction
+	pClientRW, pHostRW, err := preimage.CreateBidirectionalChannel()
+	if err != nil {
+		server.Close()
+		return nil, fmt.Errorf("failed to create preimage pipe: %w", err)
+	}
+	server.pClientRW = pClientRW
+
+	// Setup client I/O for hint comms
+	hClientRW, hHostRW, err := preimage.CreateBidirectionalChannel()
+	if err != nil {
+		server.Close()
+		return nil, fmt.Errorf("failed to create hints pipe: %w", err)
+	}
+	server.hClientRW = hClientRW
+
+	// Use a channel to receive the server result so we can wait for it to complete before returning
+	server.serverErr = make(chan error)
+	go func() {
+		defer close(server.serverErr)
+		server.serverErr <- RunPreimageServer(ctx, logger, cfg, pHostRW, hHostRW, prefetcher)
+	}()
+
+	return server, nil
+}
+
+func (p *PreimageServer) PreimageClientRW() preimage.FileChannel {
+	return p.pClientRW
+}
+
+func (p *PreimageServer) HintClientRW() preimage.FileChannel {
+	return p.hClientRW
+}
+
+func (p *PreimageServer) Close() {
+	if p.pClientRW != nil {
+		_ = p.pClientRW.Close()
+	}
+	if p.hClientRW != nil {
+		_ = p.hClientRW.Close()
+	}
+	if p.serverErr != nil {
+		err := <-p.serverErr
+		if err != nil {
+			p.logger.Error("preimage server failed", "err", err)
+		}
+		p.logger.Debug("Preimage server stopped")
+	}
+}
+
+// RunPreimageServer reads hints and preimage requests from the provided channels and processes those requests.
 // This method will block until both the hinter and preimage handlers complete.
 // If either returns an error both handlers are stopped.
 // The supplied preimageChannel and hintChannel will be closed before this function returns.
-func PreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, preimageChannel preimage.FileChannel, hintChannel preimage.FileChannel, prefetcherCreator PrefetcherCreator) error {
+func RunPreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, preimageChannel preimage.FileChannel, hintChannel preimage.FileChannel, prefetcherCreator PrefetcherCreator) error {
 	var serverDone chan error
 	var hinterDone chan error
 	logger.Info("Starting preimage server")

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -11,11 +11,9 @@ import (
 
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	cl "github.com/ethereum-optimism/optimism/op-program/client"
-	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -25,10 +23,7 @@ type Prefetcher interface {
 }
 type PrefetcherCreator func(ctx context.Context, logger log.Logger, kv kvstore.KV, cfg *config.Config) (Prefetcher, error)
 type programCfg struct {
-	prefetcher       PrefetcherCreator
-	db               l2.KeyValueStore
-	storeBlockData   bool
-	forceHintChainID bool
+	prefetcher PrefetcherCreator
 }
 
 type ProgramOpt func(c *programCfg)
@@ -40,34 +35,9 @@ func WithPrefetcher(creator PrefetcherCreator) ProgramOpt {
 	}
 }
 
-// WithDB sets the backing state database used by the program.
-// If not set, the program will use an in-memory database.
-func WithDB(db l2.KeyValueStore) ProgramOpt {
-	return func(c *programCfg) {
-		c.db = db
-	}
-}
-
-// WithStoreBlockData controls whether block data, including intermediate trie nodes from transactions and receipts
-// of the derived block should be stored in the database.
-func WithStoreBlockData(store bool) ProgramOpt {
-	return func(c *programCfg) {
-		c.storeBlockData = store
-	}
-}
-
-// WithForceHintChainID controls whether hints are forced to include the chain ID even if interop is disabled.
-func WithForceHintChainID(force bool) ProgramOpt {
-	return func(c *programCfg) {
-		c.forceHintChainID = force
-	}
-}
-
 // FaultProofProgram is the programmatic entry-point for the fault proof program
 func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Config, opts ...ProgramOpt) error {
-	programConfig := &programCfg{
-		db: memorydb.New(),
-	}
+	programConfig := &programCfg{}
 	for _, opt := range opts {
 		opt(programConfig)
 	}
@@ -104,11 +74,9 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		logger.Debug("Client program completed successfully")
 		return nil
 	} else {
-		var clientCfg cl.Config
-		clientCfg.InteropEnabled = cfg.InteropEnabled
-		clientCfg.DB = programConfig.db
-		clientCfg.StoreBlockData = programConfig.storeBlockData
-		clientCfg.ForceHintChainID = programConfig.forceHintChainID
+		clientCfg := cl.Config{
+			InteropEnabled: cfg.InteropEnabled,
+		}
 		return cl.RunProgram(logger, pClientRW, hClientRW, clientCfg)
 	}
 }

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -26,7 +26,6 @@ type Prefetcher interface {
 type PrefetcherCreator func(ctx context.Context, logger log.Logger, kv kvstore.KV, cfg *config.Config) (Prefetcher, error)
 type programCfg struct {
 	prefetcher       PrefetcherCreator
-	skipValidation   bool
 	db               l2.KeyValueStore
 	storeBlockData   bool
 	forceHintChainID bool
@@ -38,13 +37,6 @@ type ProgramOpt func(c *programCfg)
 func WithPrefetcher(creator PrefetcherCreator) ProgramOpt {
 	return func(c *programCfg) {
 		c.prefetcher = creator
-	}
-}
-
-// WithSkipValidation controls whether the program will skip validation of the derived block.
-func WithSkipValidation(skip bool) ProgramOpt {
-	return func(c *programCfg) {
-		c.skipValidation = skip
 	}
 }
 
@@ -113,9 +105,6 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		return nil
 	} else {
 		var clientCfg cl.Config
-		if programConfig.skipValidation {
-			clientCfg.SkipValidation = true
-		}
 		clientCfg.InteropEnabled = cfg.InteropEnabled
 		clientCfg.DB = programConfig.db
 		clientCfg.StoreBlockData = programConfig.storeBlockData

--- a/op-program/host/host_test.go
+++ b/op-program/host/host_test.go
@@ -38,7 +38,7 @@ func TestServerMode(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelTrace)
 	result := make(chan error)
 	go func() {
-		result <- hostcommon.PreimageServer(context.Background(), logger, cfg, preimageServer, hintServer, makeDefaultPrefetcher)
+		result <- hostcommon.RunPreimageServer(context.Background(), logger, cfg, preimageServer, hintServer, makeDefaultPrefetcher)
 	}()
 
 	pClient := preimage.NewOracleClient(preimageClient)


### PR DESCRIPTION
**Description**

Run the derivation task directly when re-executing blocks instead of running the entire fault proof program.

Skips the bootstrap step, avoiding the need to execute pre-interop fault proof code paths.

**Tests**

Existing tests cover regenerating blocks.


**Metadata**

https://github.com/ethereum-optimism/optimism/issues/16041