### PR TITLE
op-node: Add dependency set flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -75,12 +75,6 @@ var (
 		Category: RollupCategory,
 	}
 	/* Optional Flags */
-	DependencySet = &cli.PathFlag{
-		Name:      "dependency-set",
-		Usage:     "Dependency-set configuration, point at JSON file.",
-		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
-		TakesFile: true,
-	}
 	BeaconHeader = &cli.StringFlag{
 		Name:     "l1.beacon-header",
 		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
@@ -432,6 +426,13 @@ var (
 		Destination: new(string),
 		Category:    InteropCategory,
 	}
+	InteropDependencySet = &cli.PathFlag{
+		Name:      "interop.dependency-set",
+		Usage:     "Dependency-set configuration, point at JSON file.",
+		EnvVars:   prefixEnvVars("INTEROP_DEPENDENCY_SET"),
+		TakesFile: true,
+		Category:  InteropCategory,
+	}
 
 	IgnoreMissingPectraBlobSchedule = &cli.BoolFlag{
 		Name: "ignore-missing-pectra-blob-schedule",
@@ -464,7 +465,6 @@ var optionalFlags = []cli.Flag{
 	BeaconFallbackAddrs,
 	BeaconCheckIgnore,
 	BeaconFetchAllSidecars,
-	DependencySet,
 	SyncModeFlag,
 	FetchWithdrawalRootFromState,
 	RPCListenAddr,
@@ -504,6 +504,7 @@ var optionalFlags = []cli.Flag{
 	InteropRPCAddr,
 	InteropRPCPort,
 	InteropJWTSecret,
+	InteropDependencySet,
 	IgnoreMissingPectraBlobSchedule,
 	ExperimentalOPStackAPI,
 }

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -75,6 +75,12 @@ var (
 		Category: RollupCategory,
 	}
 	/* Optional Flags */
+	DependencySet = &cli.PathFlag{
+		Name:      "dependency-set",
+		Usage:     "Dependency-set configuration, point at JSON file.",
+		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
+		TakesFile: true,
+	}
 	BeaconHeader = &cli.StringFlag{
 		Name:     "l1.beacon-header",
 		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
@@ -458,6 +464,7 @@ var optionalFlags = []cli.Flag{
 	BeaconFallbackAddrs,
 	BeaconCheckIgnore,
 	BeaconFetchAllSidecars,
+	DependencySet,
 	SyncModeFlag,
 	FetchWithdrawalRootFromState,
 	RPCListenAddr,

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum/go-ethereum/log"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
@@ -30,6 +31,8 @@ type Config struct {
 	Driver driver.Config
 
 	Rollup rollup.Config
+
+	DependencySet derive.DependencySet
 
 	// P2PSigner will be used for signing off on published content
 	// if the node is sequencing and if the p2p stack is enabled

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 )
 
+type DependencySet interface {
+	// Chains returns the number of chains in the dependency set
+	Chains() []eth.ChainID
+}
+
 // L1ReceiptsFetcher fetches L1 header info and receipts for the payload attributes derivation (the info tx and deposits)
 type L1ReceiptsFetcher interface {
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
@@ -35,6 +36,11 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	}
 
 	rollupConfig, err := NewRollupConfigFromCLI(log, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	depSet, err := NewDependencySetFromCLI(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -85,6 +91,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		L1:            l1Endpoint,
 		L2:            l2Endpoint,
 		Rollup:        *rollupConfig,
+		DependencySet: depSet,
 		Driver:        *driverConfig,
 		Beacon:        NewBeaconEndpointConfig(ctx),
 		InteropConfig: NewSupervisorEndpointConfig(ctx),
@@ -283,6 +290,14 @@ func applyOverrides(ctx *cli.Context, rollupConfig *rollup.Config) {
 		interop := ctx.Uint64(opflags.InteropOverrideFlagName)
 		rollupConfig.InteropTime = &interop
 	}
+}
+
+func NewDependencySetFromCLI(ctx *cli.Context) (depset.DependencySet, error) {
+	if !ctx.IsSet(flags.DependencySet.Name) {
+		return nil, nil
+	}
+	loader := &depset.JSONDependencySetLoader{Path: ctx.Path(flags.DependencySet.Name)}
+	return loader.LoadDependencySet(ctx.Context)
 }
 
 func NewSyncConfig(ctx *cli.Context, log log.Logger) (*sync.Config, error) {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -293,10 +293,10 @@ func applyOverrides(ctx *cli.Context, rollupConfig *rollup.Config) {
 }
 
 func NewDependencySetFromCLI(ctx *cli.Context) (depset.DependencySet, error) {
-	if !ctx.IsSet(flags.DependencySet.Name) {
+	if !ctx.IsSet(flags.InteropDependencySet.Name) {
 		return nil, nil
 	}
-	loader := &depset.JSONDependencySetLoader{Path: ctx.Path(flags.DependencySet.Name)}
+	loader := &depset.JSONDependencySetLoader{Path: ctx.Path(flags.InteropDependencySet.Name)}
 	return loader.LoadDependencySet(ctx.Context)
 }
 


### PR DESCRIPTION
**Description**

Adds a dependency-set CLI flag to op-node.  Currently it is completely optional and unused other than being added to the node Config.

This PR is really just to unblock updating the kurtosis optimism-package so it can set the depset before landing other parts of https://github.com/ethereum-optimism/optimism/pull/16042 which will actually start using it and make it a required arg when interop fork is scheduled.


**Metadata**

#16041 