### PR TITLE
op-acceptance-tests: interop: misc improvements to load test

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/helpers.go
+++ b/op-acceptance-tests/tests/interop/loadtest/helpers.go
@@ -21,6 +21,10 @@ func (n *nonceCounter) Next() uint64 {
 	return nonce
 }
 
-func retryForever(g txplan.ReceiptGetter) txplan.Option {
+func retryInclusionForever(g txplan.ReceiptGetter) txplan.Option {
 	return txplan.WithRetryInclusion(g, math.MaxInt, retry.Exponential())
+}
+
+func retrySubmissionForever(s txplan.TransactionSubmitter) txplan.Option {
+	return txplan.WithRetrySubmission(s, math.MaxInt, retry.Exponential())
 }

--- a/op-acceptance-tests/tests/interop/loadtest/initiator.go
+++ b/op-acceptance-tests/tests/interop/loadtest/initiator.go
@@ -2,6 +2,7 @@ package loadtest
 
 import (
 	"math/rand"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
@@ -14,8 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var rng = rand.New(rand.NewSource(1234))
-
 type Initiator interface {
 	Initiate(t devtest.T) []types.Message
 }
@@ -25,6 +24,8 @@ type ManyMsgsInitiator struct {
 	eoa         *dsl.EOA
 	eventLogger common.Address
 	counter     *nonceCounter
+	rngMu       sync.Mutex
+	rng         *rand.Rand
 }
 
 func NewManyMsgsInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger common.Address) *ManyMsgsInitiator {
@@ -33,18 +34,25 @@ func NewManyMsgsInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger comm
 		el:          el,
 		eventLogger: eventLogger,
 		counter:     new(nonceCounter),
+		rng:         rand.New(rand.NewSource(1234)),
 	}
 }
 
-func (in *ManyMsgsInitiator) Initiate(t devtest.T) []types.Message {
+func (in *ManyMsgsInitiator) randomInitTriggers() []txintent.Call {
 	const numMsgs = 275 // About the max number of msgs we can create before hitting tx size limits.
 	initCalls := make([]txintent.Call, 0, numMsgs)
+	in.rngMu.Lock()
+	defer in.rngMu.Unlock()
 	for range numMsgs {
-		initCalls = append(initCalls, interop.RandomInitTrigger(rng, in.eventLogger, rng.Intn(5), rng.Intn(10)))
+		initCalls = append(initCalls, interop.RandomInitTrigger(in.rng, in.eventLogger, in.rng.Intn(5), in.rng.Intn(10)))
 	}
+	return initCalls
+}
+
+func (in *ManyMsgsInitiator) Initiate(t devtest.T) []types.Message {
 	return buildAndSendInitTx(t, in.eoa, in.el, &txintent.MultiTrigger{
 		Emitter: constants.MultiCall3,
-		Calls:   initCalls,
+		Calls:   in.randomInitTriggers(),
 	}, txplan.WithStaticNonce(in.counter.Next()))
 }
 
@@ -53,6 +61,8 @@ type LargeMsgInitiator struct {
 	el          *dsl.L2ELNode
 	eventLogger common.Address
 	counter     *nonceCounter
+	rngMu       sync.Mutex
+	rng         *rand.Rand
 }
 
 func NewLargeMsgInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger common.Address) *LargeMsgInitiator {
@@ -61,12 +71,19 @@ func NewLargeMsgInitiator(funder *dsl.Funder, el *dsl.L2ELNode, eventLogger comm
 		el:          el,
 		eventLogger: eventLogger,
 		counter:     new(nonceCounter),
+		rng:         rand.New(rand.NewSource(1234)),
 	}
+}
+
+func (lin *LargeMsgInitiator) randomInitTrigger() *txintent.InitTrigger {
+	lin.rngMu.Lock()
+	defer lin.rngMu.Unlock()
+	return interop.RandomInitTrigger(lin.rng, lin.eventLogger, 4, 75_000)
 }
 
 func (lin *LargeMsgInitiator) Initiate(t devtest.T) []types.Message {
 	// TODO(#16039): can we create an even larger event without the event logger?
-	return buildAndSendInitTx(t, lin.eoa, lin.el, interop.RandomInitTrigger(rng, lin.eventLogger, 4, 75_000), txplan.WithStaticNonce(lin.counter.Next()))
+	return buildAndSendInitTx(t, lin.eoa, lin.el, lin.randomInitTrigger(), txplan.WithStaticNonce(lin.counter.Next()))
 }
 
 func buildAndSendInitTx(t devtest.T, eoa *dsl.EOA, el *dsl.L2ELNode, initCall txintent.Call, opts ...txplan.Option) []types.Message {

--- a/op-acceptance-tests/tests/interop/loadtest/initiator.go
+++ b/op-acceptance-tests/tests/interop/loadtest/initiator.go
@@ -87,7 +87,12 @@ func (lin *LargeMsgInitiator) Initiate(t devtest.T) []types.Message {
 }
 
 func buildAndSendInitTx(t devtest.T, eoa *dsl.EOA, el *dsl.L2ELNode, initCall txintent.Call, opts ...txplan.Option) []types.Message {
-	initMsgsTx := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](eoa.Plan(), retryForever(el.Escape().EthClient()), txplan.Combine(opts...))
+	initMsgsTx := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](
+		eoa.Plan(),
+		retrySubmissionForever(el.Escape().EthClient()),
+		retryInclusionForever(el.Escape().EthClient()),
+		txplan.Combine(opts...),
+	)
 	initMsgsTx.Content.Set(initCall)
 	_, err := initMsgsTx.PlannedTx.Success.Eval(t.Ctx())
 	t.Require().NoError(err)

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -71,7 +71,7 @@ func SpamInteropTxs(t devtest.T, numInitTxs uint64, source *L2, dest *L2, superv
 	var relayWg sync.WaitGroup
 	defer relayWg.Wait()
 	msgsCh := make(chan []types.Message, 100)
-	defer close(msgsCh)
+	defer close(msgsCh) // Must be defer'd after the relayWg.Wait() above.
 
 	// Spam executing messages.
 	relayWg.Add(1)

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -68,19 +68,19 @@ func TestLoad(gt *testing.T) {
 }
 
 func SpamInteropTxs(t devtest.T, numInitTxs uint64, source *L2, dest *L2, supervisor *dsl.Supervisor) {
-	var wg sync.WaitGroup
-	defer wg.Wait()
+	var relayWg sync.WaitGroup
+	defer relayWg.Wait()
 	msgsCh := make(chan []types.Message, 100)
 	defer close(msgsCh)
 
 	// Spam executing messages.
-	wg.Add(1)
+	relayWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer relayWg.Done()
 		dest.Funder.NewFundedEOA(eth.MillionEther.Mul(100))
 		relayers := []Relayer{
 			NewValidRelayer(dest.Funder, dest.EL, supervisor),
-			NewDelayedRelayer(NewValidRelayer(dest.Funder, dest.EL, supervisor), &wg, time.Minute),
+			NewDelayedRelayer(NewValidRelayer(dest.Funder, dest.EL, supervisor), &relayWg, time.Minute),
 			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidChainID),
 			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidBlockNumber),
 			NewInvalidRelayer(dest.Funder, dest.EL, makeInvalidLogIndex),
@@ -90,9 +90,9 @@ func SpamInteropTxs(t devtest.T, numInitTxs uint64, source *L2, dest *L2, superv
 		}
 		for msgs := range msgsCh {
 			for _, relayer := range relayers {
-				wg.Add(1)
+				relayWg.Add(1)
 				go func() {
-					defer wg.Done()
+					defer relayWg.Done()
 					relayer.Relay(t, msgs)
 				}()
 			}
@@ -105,7 +105,13 @@ func SpamInteropTxs(t devtest.T, numInitTxs uint64, source *L2, dest *L2, superv
 		NewManyMsgsInitiator(source.Funder, source.EL, eventLogger),
 		NewLargeMsgInitiator(source.Funder, source.EL, eventLogger),
 	}
+	var initWg sync.WaitGroup
+	defer initWg.Wait()
 	for i := range numInitTxs {
-		msgsCh <- initiators[i%uint64(len(initiators))].Initiate(t)
+		initWg.Add(1)
+		go func() {
+			defer initWg.Done()
+			msgsCh <- initiators[i%uint64(len(initiators))].Initiate(t)
+		}()
 	}
 }

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -96,6 +96,9 @@ func SpamInteropTxs(t devtest.T, numInitTxs uint64, source *L2, dest *L2, superv
 					relayer.Relay(t, msgs)
 				}()
 			}
+			if len(msgs) >= cap(msgs)/2 {
+				t.Logger().Warn("Messages buffer is at least half full", "len", len(msgs), "cap", cap(msgs))
+			}
 		}
 	}()
 

--- a/op-acceptance-tests/tests/interop/loadtest/relayer.go
+++ b/op-acceptance-tests/tests/interop/loadtest/relayer.go
@@ -40,7 +40,14 @@ func NewValidRelayer(funder *dsl.Funder, el *dsl.L2ELNode, supervisor *dsl.Super
 }
 
 func (e *ValidRelayer) Relay(t devtest.T, msgs []types.Message) {
-	tx := buildRelayTx(e.eoa, e.el, msgs, retryForever(e.el.Escape().EthClient()), txplan.WithStaticNonce(e.counter.Next()))
+	tx := buildRelayTx(
+		e.eoa,
+		e.el,
+		msgs,
+		retrySubmissionForever(e.el.Escape().EthClient()),
+		retryInclusionForever(e.el.Escape().EthClient()),
+		txplan.WithStaticNonce(e.counter.Next()),
+	)
 	receipt, err := tx.Included.Eval(t.Ctx())
 	t.Require().NoError(err)
 	_, err = tx.Success.Eval(t.Ctx())


### PR DESCRIPTION
- Properly protect the `rand.Source` in initiators
- Spam initiating messages in parallel
- Retry submission forever for valid messages