### PR TITLE
fix: correct Solady library import path in ForkLive.s.sol

### DIFF
--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -15,7 +15,7 @@ import { Config } from "scripts/libraries/Config.sol";
 // Libraries
 import { GameTypes, Claim } from "src/dispute/lib/Types.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
-import { LibString } from "solady/src/utils/LibString.sol";
+import { LibString } from "solady/utils/LibString.sol";
 
 // Interfaces
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -15,7 +15,7 @@ import { Config } from "scripts/libraries/Config.sol";
 // Libraries
 import { GameTypes, Claim } from "src/dispute/lib/Types.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
-import { LibString } from "solady/utils/LibString.sol";
+import { LibString } from "@solady/utils/LibString.sol";
 
 // Interfaces
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";


### PR DESCRIPTION
This PR fixes an issue with the Solady library import path in ForkLive.s.sol that was causing compilation failures. The current import statement includes a redundant 'src' directory which is already handled by Foundry's remapping.

Changes:
- Changed import path from `solady/src/utils/LibString.sol` to `@solady/utils/LibString.sol`

This fix ensures proper compilation through `forge build` by aligning the import path with Foundry's remapping configuration. The change maintains the same functionality while resolving the path resolution issue identified in the Spearbit audit.

Fixes #15220 