### PR TITLE
proofs-ci: Allow publish-cannon-prestates to run on any branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2142,10 +2142,6 @@ workflows:
           requires:
             - cannon-prestate
             - op-e2e-cannon-tests
-          filters:
-            branches:
-              only:
-                - develop
 
   develop-kontrol-tests:
     when:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Remove the branch filter from the `develop-fault-proofs` / `publish-cannon-prestates` CI job.  This allows us to run the publish-prestate job on branches other than `develop`.

This change is useful for testing updates to the `publish-cannon-prestates` task.  For example, [this PR](https://github.com/ethereum-optimism/optimism/pull/15737) modifies this task - it would be helpful to be able to run and validate the updated task before merging.  This also makes it easier to publish experimental prestates from branches. 
