### PR TITLE
fix(kurtosis): avoid autofix exit when mise is upgraded and allow optional devnet on acceptance tests run

### DIFF
--- a/justfiles/prerequisites.just
+++ b/justfiles/prerequisites.just
@@ -52,8 +52,20 @@ _check_mise:
 
     if [ "$RUN_AUTOFIX" = "true" ]; then
         echo "Automatically running mise doctor..."
-        # This will exit if mise is outdated, so better run it only if AUTOFIX is true
-        mise doctor --silent
+        output=$(mise doctor --silent || true)
+        if [ -n "$output" ]; then
+            # Check if there are any problems beyond just version updates
+            if echo "$output" | grep -q "1 problem found:" && echo "$output" | grep -q "new mise version.*available"; then
+                echo "Note: Only mise version update available"
+            else
+                echo "Warning: mise doctor found unexpected issues:"
+                echo "$output"
+                if [ "$RUN_AUTOFIX" != "true" ]; then
+                    echo "Please fix these issues manually or run with AUTOFIX=true"
+                    exit 1
+                fi
+            fi
+        fi
     fi
 
     if mise ls | grep -q "outdated"; then

--- a/justfiles/prerequisites.just
+++ b/justfiles/prerequisites.just
@@ -60,10 +60,7 @@ _check_mise:
             else
                 echo "Warning: mise doctor found unexpected issues:"
                 echo "$output"
-                if [ "$RUN_AUTOFIX" != "true" ]; then
-                    echo "Please fix these issues manually or run with AUTOFIX=true"
-                    exit 1
-                fi
+                exit 1
             fi
         fi
     fi

--- a/op-acceptance-tests/cmd/main.go
+++ b/op-acceptance-tests/cmd/main.go
@@ -65,6 +65,12 @@ var (
 		Value:   defaultAcceptor,
 		EnvVars: []string{"ACCEPTOR"},
 	}
+	reuseDevnetFlag = &cli.BoolFlag{
+		Name:    "reuse-devnet",
+		Usage:   "Reuse the devnet if it already exists",
+		Value:   false,
+		EnvVars: []string{"REUSE_DEVNET"},
+	}
 )
 
 func main() {
@@ -79,6 +85,7 @@ func main() {
 			logLevelFlag,
 			kurtosisDirFlag,
 			acceptorFlag,
+			reuseDevnetFlag,
 		},
 		Action: runAcceptanceTest,
 	}
@@ -98,7 +105,7 @@ func runAcceptanceTest(c *cli.Context) error {
 	logLevel := c.String(logLevelFlag.Name)
 	kurtosisDir := c.String(kurtosisDirFlag.Name)
 	acceptor := c.String(acceptorFlag.Name)
-
+	reuseDevnet := c.Bool(reuseDevnetFlag.Name)
 	// Get the absolute path of the test directory
 	absTestDir, err := filepath.Abs(testDir)
 	if err != nil {
@@ -133,6 +140,9 @@ func runAcceptanceTest(c *cli.Context) error {
 
 	steps := []func(ctx context.Context) error{
 		func(ctx context.Context) error {
+			if reuseDevnet {
+				return nil
+			}
 			return deployDevnet(ctx, tracer, devnet, absKurtosisDir)
 		},
 		func(ctx context.Context) error {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Avoids autofix exiting because only a mise upgrade is available (practically every day).
- Adds a new flag to the op-acceptance-tests runner to reuse the existing devnet, useful when running the tests locally.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

We are running mise doctor as part of the AUTOFIX flag. However, this checks if a mise update is available.
Due to the release cadence of mise this happens almost every day, hence in this PR we parse the error message and skip it if only an update is available.

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
