### PR TITLE
op-devstack: Accept that interop preset hasn't migrated yet

### DIFF
--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -73,10 +73,6 @@ func WithL2Challenger(challengerID stack.L2ChallengerID, l1ELID stack.L1ELNodeID
 				interopScheduled = l2Net.genesis.Config.InteropTime != nil
 			} else {
 				require.Equal(l2Net.genesis.Config.InteropTime != nil, interopScheduled, "Cluster not consistently using interop")
-				// TODO(#15057): Interop chains should have a shared DisputeGameFactory
-				//if interopScheduled {
-				//require.Equal(disputeGameFactoryAddr, factory, "Cluster not using a shared dispute game factory")
-				//}
 			}
 
 			l2Geneses = append(l2Geneses, l2Net.genesis)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -180,7 +180,7 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 		ids.L2AEL, ids.L2BEL,
 	}))
 	opt.Add(WithL2Challenger(ids.L2ChallengerB, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, nil, []stack.L2ELNodeID{
-		ids.L2AEL, ids.L2BEL,
+		ids.L2BEL, ids.L2AEL,
 	}))
 
 	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))


### PR DESCRIPTION
**Description**

Accept that interop preset hasn't migrated yet.
Don't expect to have a single DisputeGameFactory and ensure a challenger runs on each correctly.

**Metadata**

Fixes #15057 