### PR TITLE
chore: `ChainIndexFromID` appears twice in `DependencySet` interface

### DIFF
--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -34,8 +34,6 @@ type DependencySet interface {
 	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
 	HasChain(chainID eth.ChainID) bool
 
-	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
-
 	// MessageExpiryWindow returns the message expiry window to use for this dependency set.
 	MessageExpiryWindow() uint64
 


### PR DESCRIPTION
`DependencySet` inherits `ChainIndexFromID` interface, so no need to explicitly define `ChainIndexFromID()` again.