### PR TITLE
op-supervisor: remove chain index type

### DIFF
--- a/devnet-sdk/proofs/prestate/client.go
+++ b/devnet-sdk/proofs/prestate/client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // These constants should be in sync with op-program/chainconfig/chaincfg.go
@@ -69,12 +68,12 @@ func WithInteropDepSet(content io.Reader) PrestateBuilderOption {
 
 func generateInteropDepSet(chains []string) ([]byte, error) {
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for i, chain := range chains {
+	for _, chain := range chains {
 		id, err := eth.ParseDecimalChainID(chain)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse chain ID: %w", err)
 		}
-		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
+		deps[id] = &depset.StaticConfigDependency{}
 	}
 
 	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)

--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -196,12 +196,10 @@ func createTestDepSets(t *testing.T) map[string]descriptors.DepSet {
 	// Create the dependency set for the superchain
 	depSetData := map[eth.ChainID]*depset.StaticConfigDependency{
 		eth.ChainIDFromUInt64(2151908): {
-			ChainIndex:     2151908,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		},
 		eth.ChainIDFromUInt64(2151909): {
-			ChainIndex:     2151909,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		},
@@ -317,8 +315,8 @@ func TestTriageFunctions(t *testing.T) {
 
 		// Create a dependency set
 		depSetData := map[eth.ChainID]*depset.StaticConfigDependency{
-			chain1: {ChainIndex: 123456},
-			chain2: {ChainIndex: 654321},
+			chain1: {},
+			chain2: {},
 		}
 		depSet, err := depset.NewStaticConfigDependencySet(depSetData)
 		require.NoError(t, err)

--- a/op-deployer/pkg/deployer/pipeline/interop_depset.go
+++ b/op-deployer/pkg/deployer/pipeline/interop_depset.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func GenerateInteropDepset(_ context.Context, pEnv *Env, globalIntent *state.Intent, st *state.State) error {
@@ -15,9 +14,9 @@ func GenerateInteropDepset(_ context.Context, pEnv *Env, globalIntent *state.Int
 
 	lgr.Info("Creating interop dependency set...")
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for i, chain := range globalIntent.Chains {
+	for _, chain := range globalIntent.Chains {
 		id := eth.ChainIDFromBytes32(chain.ID)
-		deps[id] = &depset.StaticConfigDependency{ChainIndex: types.ChainIndex(i)}
+		deps[id] = &depset.StaticConfigDependency{}
 	}
 
 	interopDepSet, err := depset.NewStaticConfigDependencySet(deps)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // funderMnemonicIndex the funding account is not one of the 30 standard account, but still derived from a user-key.
@@ -258,14 +257,13 @@ func (wb *worldBuilder) buildDepSet() {
 
 	// Deployer uses a different type than the dependency-set itself, so we have to convert
 	depSetContents := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for chainIndex, ch := range wb.output.Chains {
+	for _, ch := range wb.output.Chains {
 		id := eth.ChainIDFromBytes32(ch.ID)
 		interopTime := wb.outL2Genesis[id].Config.InteropTime
 		if interopTime == nil {
 			continue
 		}
 		depSetContents[id] = &depset.StaticConfigDependency{
-			ChainIndex:     supervisortypes.ChainIndex(chainIndex),
 			ActivationTime: *interopTime,
 			HistoryMinTime: *interopTime,
 		}

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -251,7 +250,6 @@ func RecipeToDepSet(t helpers.Testing, recipe *interopgen.InteropDevRecipe) *dep
 	depSetCfg := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for _, out := range recipe.L2s {
 		depSetCfg[eth.ChainIDFromUInt64(out.ChainID)] = &depset.StaticConfigDependency{
-			ChainIndex:     types.ChainIndex(out.ChainID),
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		}

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -618,9 +617,7 @@ func worldToDepSet(world *interopgen.WorldOutput) (*depset.StaticConfigDependenc
 	// Iterate over the L2 chain configs. The L2 nodes don't exist yet.
 	for _, l2Out := range world.L2s {
 		chainID := eth.ChainIDFromBig(l2Out.Genesis.Config.ChainID)
-		chainIndex := supervisortypes.ChainIndex(100 + slices.Index(ids, chainID))
 		depSet[chainID] = &depset.StaticConfigDependency{
-			ChainIndex:     chainIndex,
 			ActivationTime: 0,
 			HistoryMinTime: 0,
 		}

--- a/op-program/chainconfig/test/configs/depsets.json
+++ b/op-program/chainconfig/test/configs/depsets.json
@@ -2,12 +2,10 @@
   {
     "dependencies": {
       "901": {
-        "chainIndex": "0",
         "activationTime": 1234,
         "historyMinTime": 40
       },
       "902": {
-        "chainIndex": "1",
         "activationTime": 4424,
         "historyMinTime": 456
       }

--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -96,8 +95,8 @@ func TestInteropBootstrap_ChainConfigCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(expected, true)
 	mockOracle.chainCfgs = []*params.ChainConfig{config1, config2}
 	mockOracle.depset, _ = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(config1.ChainID): {ChainIndex: supervisortypes.ChainIndex(config1.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(config2.ChainID): {ChainIndex: supervisortypes.ChainIndex(config2.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config1.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config2.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
 	})
 	actual := BootstrapInterop(mockOracle)
 
@@ -122,8 +121,8 @@ func TestInteropBootstrap_DependencySetCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(expected, true)
 	var err error
 	mockOracle.depset, err = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(config1.ChainID): {ChainIndex: supervisortypes.ChainIndex(config1.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(config2.ChainID): {ChainIndex: supervisortypes.ChainIndex(config2.ChainID.Uint64()), ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config1.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config2.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
 	})
 	require.NoError(t, err)
 	actual := BootstrapInterop(mockOracle)

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -23,12 +23,12 @@ import (
 var ErrInvalidBlockReplacement = errors.New("invalid block replacement error")
 
 // ReceiptsToExecutingMessages returns the executing messages in the receipts indexed by their position in the log.
-func ReceiptsToExecutingMessages(depset depset.ChainIndexFromID, receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
+func ReceiptsToExecutingMessages(receipts ethtypes.Receipts) (map[uint32]*supervisortypes.ExecutingMessage, uint32, error) {
 	execMsgs := make(map[uint32]*supervisortypes.ExecutingMessage)
 	var curr uint32
 	for _, rcpt := range receipts {
 		for _, l := range rcpt.Logs {
-			execMsg, err := processors.DecodeExecutingMessageLog(l, depset)
+			execMsg, err := processors.DecodeExecutingMessageLog(l)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -223,7 +223,7 @@ func checkHazards(logger log.Logger, deps ConsolidateCheckDeps, candidate superv
 	if err != nil {
 		return err
 	}
-	if err := cross.HazardCycleChecks(deps.DependencySet(), deps, candidate.Timestamp, hazards); err != nil {
+	if err := cross.HazardCycleChecks(deps, candidate.Timestamp, hazards); err != nil {
 		return err
 	}
 	return nil
@@ -363,7 +363,7 @@ func (d *consolidateCheckDeps) OpenBlock(
 	}
 
 	_, receipts := d.oracle.ReceiptsByBlockHash(block.Hash(), chainID)
-	execMsgs, logCount, err = ReceiptsToExecutingMessages(d.depset, receipts)
+	execMsgs, logCount, err = ReceiptsToExecutingMessages(receipts)
 	if err != nil {
 		return eth.BlockRef{}, 0, nil, err
 	}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -236,7 +236,7 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 	// For each chain initialize a chain processor service,
 	// after cross-unsafe workers are ready to receive updates
 	for _, chainID := range chains {
-		logProcessor := processors.NewLogProcessor(chainID, su.chainDBs, su.cfgSet)
+		logProcessor := processors.NewLogProcessor(chainID, su.chainDBs)
 		chainProcessor := processors.NewChainProcessor(su.sysContext, su.logger, chainID, logProcessor, su.chainDBs)
 		su.eventSys.Register(fmt.Sprintf("events-%s", chainID), chainProcessor)
 		su.chainProcessors.Set(chainID, chainProcessor)

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -40,7 +40,6 @@ func fullConfigSet(t *testing.T, size int) depset.FullConfigSetMerged {
 	for i := 0; i < size; i++ {
 		chainID := eth.ChainIDFromUInt64(testChainIDOffset + uint64(i))
 		staticDepSet[chainID] = &depset.StaticConfigDependency{
-			ChainIndex:     testChainIDOffset + types.ChainIndex(i),
 			ActivationTime: 42,
 			HistoryMinTime: 100,
 		}

--- a/op-supervisor/supervisor/backend/cross/hazard_set_test.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set_test.go
@@ -22,7 +22,7 @@ func TestHazardSet_Build(t *testing.T) {
 			blocks: []blockDef{
 				makeBlock(0, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{},
+			expected: map[eth.ChainID]types.BlockSeal{},
 		},
 		{
 			name: "Single Dependency",
@@ -30,8 +30,8 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(0, 100, 1, makeMessage(1, 100, 1, 1)),
 				makeBlock(1, 100, 1), // Referenced block from chain 1
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
 			},
 		},
 		{
@@ -40,8 +40,8 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(0, 100, 1, makeMessage(1, 100, 1, 1), makeMessage(1, 100, 1, 2)),
 				makeBlock(1, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
 			},
 		},
 		{
@@ -51,9 +51,9 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1),
 				makeBlock(2, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
-				2: makeBlockSeal(1, 100, 2),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
+				eth.ChainIDFromUInt64(2): makeBlockSeal(1, 100, 2),
 			},
 		},
 		{
@@ -72,9 +72,9 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1),
 				makeBlock(2, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
-				2: makeBlockSeal(1, 100, 2),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
+				eth.ChainIDFromUInt64(2): makeBlockSeal(1, 100, 2),
 			},
 		},
 		{
@@ -84,9 +84,9 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(1, 100, 1, makeMessage(2, 100, 1, 1)),
 				makeBlock(2, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
-				2: makeBlockSeal(1, 100, 2),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
+				eth.ChainIDFromUInt64(2): makeBlockSeal(1, 100, 2),
 			},
 		},
 		{
@@ -144,10 +144,10 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(2, 100, 1, makeMessage(3, 100, 1, 1)),
 				makeBlock(3, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
-				2: makeBlockSeal(1, 100, 2),
-				3: makeBlockSeal(1, 100, 3),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
+				eth.ChainIDFromUInt64(2): makeBlockSeal(1, 100, 2),
+				eth.ChainIDFromUInt64(3): makeBlockSeal(1, 100, 3),
 			},
 		},
 		{
@@ -166,11 +166,11 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(3, 100, 1),
 				makeBlock(4, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
-				2: makeBlockSeal(1, 100, 2),
-				3: makeBlockSeal(1, 100, 3),
-				4: makeBlockSeal(1, 100, 4),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
+				eth.ChainIDFromUInt64(2): makeBlockSeal(1, 100, 2),
+				eth.ChainIDFromUInt64(3): makeBlockSeal(1, 100, 3),
+				eth.ChainIDFromUInt64(4): makeBlockSeal(1, 100, 4),
 			},
 		},
 		{
@@ -182,10 +182,10 @@ func TestHazardSet_Build(t *testing.T) {
 				makeBlock(2, 100, 1, makeMessage(3, 100, 1, 1)),
 				makeBlock(3, 100, 1),
 			},
-			expected: map[types.ChainIndex]types.BlockSeal{
-				1: makeBlockSeal(1, 100, 1),
-				2: makeBlockSeal(1, 100, 2),
-				3: makeBlockSeal(1, 100, 3),
+			expected: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): makeBlockSeal(1, 100, 1),
+				eth.ChainIDFromUInt64(2): makeBlockSeal(1, 100, 2),
+				eth.ChainIDFromUInt64(3): makeBlockSeal(1, 100, 3),
 			},
 		},
 	}
@@ -209,7 +209,7 @@ func TestHazardSet_Build(t *testing.T) {
 				Timestamp: firstBlock.timestamp,
 				Hash:      firstBlock.hash,
 			}
-			chainID := eth.ChainIDFromUInt64(uint64(firstBlock.chain))
+			chainID := firstBlock.chain
 
 			hs, err := NewHazardSet(deps, logger, chainID, seal)
 			if tc.expectErr != nil {
@@ -225,9 +225,8 @@ func TestHazardSet_Build(t *testing.T) {
 }
 
 func TestHazardSet_CrossValidBlocks(t *testing.T) {
-	require := require.New(t)
 	logger := newTestLogger(t)
-	depSet := &hazardMockDependencySet{}
+	depSet := &mockDependencySet{}
 
 	// Helper function to create block hash
 	makeBlockHash := func(chainID eth.ChainID, num uint64) common.Hash {
@@ -245,7 +244,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 		num       uint64
 		timestamp uint64
 		msgs      []struct {
-			Chain     types.ChainIndex
+			Chain     uint8
 			BlockNum  uint64
 			LogIndex  uint32
 			Timestamp uint64
@@ -256,23 +255,17 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 	makeBlockMap := func(blocks []testBlockDef) map[blockKey]blockDef {
 		blockMap := make(map[blockKey]blockDef)
 		for _, block := range blocks {
-			// Extract chain index from chain ID
-			chainIndex, err := depSet.ChainIndexFromID(block.chain)
-			if err != nil {
-				// Use a fallback if error
-				chainIndex = types.ChainIndex(block.chain[0])
-			}
-
 			key := blockKey{
-				chain:  chainIndex,
+				chain:  block.chain,
 				number: block.num,
 			}
 
 			// Convert messages to the expected format
 			messages := make([]*types.ExecutingMessage, 0, len(block.msgs))
 			for _, msg := range block.msgs {
+				chainID := eth.ChainIDFromUInt64(uint64(msg.Chain))
 				messages = append(messages, &types.ExecutingMessage{
-					Chain:     msg.Chain,
+					ChainID:   chainID,
 					BlockNum:  msg.BlockNum,
 					LogIdx:    msg.LogIndex,
 					Timestamp: msg.Timestamp,
@@ -286,7 +279,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 			}
 
 			blockMap[key] = blockDef{
-				chain:     chainIndex,
+				chain:     block.chain,
 				number:    block.num,
 				timestamp: timestamp,
 				hash:      makeBlockHash(block.chain, block.num),
@@ -301,7 +294,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 		name            string
 		blocks          []testBlockDef
 		verifyBlockFn   func(chainID eth.ChainID, block eth.BlockID) error
-		expectedHazards map[types.ChainIndex]types.BlockSeal
+		expectedHazards map[eth.ChainID]types.BlockSeal
 		expectedErr     error
 	}{
 		{
@@ -312,7 +305,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -331,8 +324,8 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
-				1: {
+			expectedHazards: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
 					Timestamp: 100,
@@ -350,7 +343,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -369,8 +362,8 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
-				1: {
+			expectedHazards: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
 					Timestamp: 100,
@@ -389,7 +382,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -419,13 +412,13 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
-				1: {
+			expectedHazards: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
 					Timestamp: 100,
 				},
-				2: {
+				eth.ChainIDFromUInt64(2): {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(2), 5),
 					Number:    5,
 					Timestamp: 100,
@@ -444,7 +437,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 200,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -463,7 +456,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedErr: fmt.Errorf("failed to build hazard set: msg ExecMsg(chainIndex: 1, block: 5, log: 1, time: 100, logHash: 0x0000000000000000000000000000000000000000000000000000000000000000) included in non-cross-safe block BlockSeal(hash:0x0000000000000005000000000000000100000000000000000000000000000000, number:5, time:100): block 0x0000000000000005000000000000000100000000000000000000000000000000:5 (chain 1) is not cross-valid: verification database error"),
+			expectedErr: fmt.Errorf("failed to build hazard set: msg ExecMsg(chain: 1, block: 5, log: 1, time: 100, checksum: 0x0000000000000000000000000000000000000000000000000000000000000000) included in non-cross-safe block BlockSeal(hash:0x0000000000000005000000000000000100000000000000000000000000000000, number:5, time:100): block 0x0000000000000005000000000000000100000000000000000000000000000000:5 (chain 1) is not cross-valid: verification database error"),
 			verifyBlockFn: func(chainID eth.ChainID, block eth.BlockID) error {
 				return fmt.Errorf("verification database error")
 			},
@@ -476,7 +469,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -494,7 +487,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       5,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -513,13 +506,13 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					timestamp: 100,
 				},
 			},
-			expectedHazards: map[types.ChainIndex]types.BlockSeal{
-				1: {
+			expectedHazards: map[eth.ChainID]types.BlockSeal{
+				eth.ChainIDFromUInt64(1): {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(1), 5),
 					Number:    5,
 					Timestamp: 100,
 				},
-				2: {
+				eth.ChainIDFromUInt64(2): {
 					Hash:      makeBlockHash(eth.ChainIDFromUInt64(2), 5),
 					Number:    5,
 					Timestamp: 100,
@@ -538,7 +531,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       10,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -556,7 +549,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 					num:       5,
 					timestamp: 100,
 					msgs: []struct {
-						Chain     types.ChainIndex
+						Chain     uint8
 						BlockNum  uint64
 						LogIndex  uint32
 						Timestamp uint64
@@ -582,6 +575,7 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 
 	for _, tc := range vectors {
 		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
 			// Create dependency mock
 			mockDeps := &mockHazardDeps{
 				logger:        logger,
@@ -602,6 +596,8 @@ func TestHazardSet_CrossValidBlocks(t *testing.T) {
 			hs, err := NewHazardSet(mockDeps, logger, firstBlock.chain, candidateSeal)
 			if tc.expectedErr != nil {
 				require.Error(err)
+				t.Logf("GOT: %s\n", err.Error())
+				t.Logf("EXPECTED: %s\n", tc.expectedErr.Error())
 				require.Contains(err.Error(), tc.expectedErr.Error())
 				return
 			}
@@ -628,10 +624,8 @@ func (m *mockHazardDeps) Contains(chain eth.ChainID, query types.ContainsQuery) 
 	if m.containsFn != nil {
 		return m.containsFn(chain, query)
 	}
-	// Look up the block in our test data
-	chainIndex, err := m.ChainIndexFromID(chain)
-	if err != nil {
-		return types.BlockSeal{}, err
+	if !m.deps.HasChain(chain) {
+		return types.BlockSeal{}, types.ErrUnknownChain
 	}
 
 	// Validate timestamp is greater than 0
@@ -640,7 +634,7 @@ func (m *mockHazardDeps) Contains(chain eth.ChainID, query types.ContainsQuery) 
 	}
 
 	key := blockKey{
-		chain:  chainIndex,
+		chain:  chain,
 		number: query.BlockNum,
 	}
 	if block, ok := m.blockMap[key]; ok {
@@ -663,8 +657,7 @@ func (m *mockHazardDeps) IsCrossValidBlock(chainID eth.ChainID, block eth.BlockI
 		if err != nil {
 			// Format a clear error message that includes both the block and chain information
 			// This ensures errors are properly identified and propagated
-			chainIdx, _ := m.deps.ChainIndexFromID(chainID)
-			return fmt.Errorf("block %s (chain %d) is not cross-valid: %w", block, chainIdx, err)
+			return fmt.Errorf("block %s (chain %s) is not cross-valid: %w", block, chainID, err)
 		}
 		return nil
 	}
@@ -676,13 +669,11 @@ func (m *mockHazardDeps) OpenBlock(chainID eth.ChainID, blockNum uint64) (ref et
 	if m.openBlockFn != nil {
 		return m.openBlockFn(chainID, blockNum)
 	}
-	// Look up the block in our test data
-	chainIndex, err := m.ChainIndexFromID(chainID)
-	if err != nil {
-		return eth.BlockRef{}, 0, nil, fmt.Errorf("failed to get chain index: %w", err)
+	if !m.deps.HasChain(chainID) {
+		return eth.BlockRef{}, 0, nil, fmt.Errorf("unsupported chain: %s: %w", chainID, err)
 	}
 	key := blockKey{
-		chain:  chainIndex,
+		chain:  chainID,
 		number: blockNum,
 	}
 	if block, ok := m.blockMap[key]; ok {
@@ -705,45 +696,43 @@ func (m *mockHazardDeps) DependencySet() depset.DependencySet {
 	return m.deps
 }
 
-func (m *mockHazardDeps) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
-	return m.deps.ChainIndexFromID(id)
-}
-
 func (m *mockHazardDeps) Logger() log.Logger {
 	return m.logger
 }
 
-func makeBlock(chain types.ChainIndex, timestamp, number uint64, messages ...*types.ExecutingMessage) blockDef {
+func makeBlock(chainTestAlias uint8, timestamp, number uint64, messages ...*types.ExecutingMessage) blockDef {
+	chainID := eth.ChainIDFromUInt64(uint64(chainTestAlias))
 	return blockDef{
 		number:    number,
 		timestamp: timestamp,
-		chain:     chain,
-		hash:      common.Hash{byte(chain), byte(number)}, // Deterministic hash based on chain and number
+		chain:     chainID,
+		hash:      common.Hash{byte(chainTestAlias), byte(number)}, // Deterministic hash based on chain and number
 		messages:  messages,
 	}
 }
 
-func makeMessage(chain types.ChainIndex, timestamp, blockNum uint64, logIdx uint32) *types.ExecutingMessage {
+func makeMessage(chainTestAlias uint8, timestamp, blockNum uint64, logIdx uint32) *types.ExecutingMessage {
+	chainID := eth.ChainIDFromUInt64(uint64(chainTestAlias))
 	return &types.ExecutingMessage{
-		Chain:     chain,
+		ChainID:   chainID,
 		BlockNum:  blockNum,
 		Timestamp: timestamp,
 		LogIdx:    logIdx,
 	}
 }
 
-func makeBlockSeal(number, timestamp uint64, chain types.ChainIndex) types.BlockSeal {
+func makeBlockSeal(number, timestamp uint64, chainTestAlias uint8) types.BlockSeal {
 	return types.BlockSeal{
 		Number:    number,
 		Timestamp: timestamp,
-		Hash:      common.Hash{byte(chain), byte(number)}, // Match block hash generation
+		Hash:      common.Hash{byte(chainTestAlias), byte(number)}, // Match block hash generation
 	}
 }
 
 type testVector struct {
 	name          string
 	blocks        []blockDef
-	expected      map[types.ChainIndex]types.BlockSeal
+	expected      map[eth.ChainID]types.BlockSeal
 	expectErr     error
 	verifyBlockFn func(chainID eth.ChainID, block eth.BlockID) error
 }
@@ -752,7 +741,7 @@ type blockDef struct {
 	number    uint64
 	timestamp uint64
 	hash      common.Hash
-	chain     types.ChainIndex
+	chain     eth.ChainID
 	messages  []*types.ExecutingMessage
 }
 
@@ -771,7 +760,7 @@ func newMockHazardDeps(t *testing.T, tc testVector) *mockHazardDeps {
 
 	mock := &mockHazardDeps{
 		logger:   newTestLogger(t),
-		deps:     &hazardMockDependencySet{},
+		deps:     &mockDependencySet{},
 		blockMap: blockMap,
 	}
 
@@ -783,22 +772,8 @@ func newMockHazardDeps(t *testing.T, tc testVector) *mockHazardDeps {
 	return mock
 }
 
-// hazardMockDependencySet wraps mockDependencySet and makes it easier to test
-// with 0 chainIndex values.
-type hazardMockDependencySet struct {
-	mockDependencySet
-}
-
-func (m hazardMockDependencySet) ChainIDFromIndex(idx types.ChainIndex) (eth.ChainID, error) {
-	return eth.ChainIDFromUInt64(uint64(idx)), nil
-}
-
-func (m hazardMockDependencySet) ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error) {
-	return types.ChainIndex(id[0]), nil
-}
-
 type blockKey struct {
-	chain  types.ChainIndex
+	chain  eth.ChainID
 	number uint64
 }
 

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -13,8 +12,6 @@ type SafeFrontierCheckDeps interface {
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
 
 	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
-
-	DependencySet() depset.DependencySet
 }
 
 // HazardSafeFrontierChecks verifies all the hazard blocks are either:
@@ -22,15 +19,7 @@ type SafeFrontierCheckDeps interface {
 //   - the first (if not first: local blocks to verify before proceeding)
 //     local-safe block, after the cross-safe block.
 func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, hazards *HazardSet) error {
-	depSet := d.DependencySet()
-	for hazardChainIndex, hazardBlock := range hazards.Entries() {
-		hazardChainID, err := depSet.ChainIDFromIndex(hazardChainIndex)
-		if err != nil {
-			if errors.Is(err, types.ErrUnknownChain) {
-				err = fmt.Errorf("cannot cross-safe verify block %s of unknown chain index %s: %w", hazardBlock, hazardChainIndex, types.ErrConflict)
-			}
-			return err
-		}
+	for hazardChainID, hazardBlock := range hazards.Entries() {
 		initSource, err := d.CrossDerivedToSource(hazardChainID, hazardBlock.ID())
 		if err != nil {
 			if errors.Is(err, types.ErrFuture) {
@@ -40,7 +29,7 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, h
 					return fmt.Errorf("failed to determine cross-safe candidate block of hazard dependency %s (chain %s): %w", hazardBlock, hazardChainID, err)
 				}
 				if candidate.Derived.Number == hazardBlock.Number && candidate.Derived.ID() != hazardBlock.ID() {
-					return fmt.Errorf("expected block %s (chain %d) does not match candidate local-safe block %s: %w",
+					return fmt.Errorf("expected block %s (chain %s) does not match candidate local-safe block %s: %w",
 						hazardBlock, hazardChainID, candidate.Derived, types.ErrConflict)
 				}
 				if candidate.Source.Number > inL1Source.Number {

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -98,7 +98,7 @@ func scopedCrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDe
 	if err := HazardSafeFrontierChecks(d, candidate.Source.ID(), hazards); err != nil {
 		return candidate, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate.Derived, err)
 	}
-	if err := HazardCycleChecks(d.DependencySet(), d, candidate.Derived.Time, hazards); err != nil {
+	if err := HazardCycleChecks(d, candidate.Derived.Time, hazards); err != nil {
 		return candidate, fmt.Errorf("failed to verify block %s in cross-safe check for cycle hazards: %w", candidate, err)
 	}
 

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -15,7 +15,7 @@ import (
 func TestCrossSafeUpdate(t *testing.T) {
 	t.Run("scopedCrossSafeUpdate passes", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -41,7 +41,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -63,7 +63,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns ErrAwaitReplacementBlock", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -82,7 +82,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns ErrConflict and triggers invalidate-local-safe", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -110,7 +110,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns ErrExpired and triggers invalidate-local-safe", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1, Time: 11}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -146,7 +146,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("scopedCrossSafeUpdate returns ErrOutOfScope", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -194,7 +194,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("NextSource returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -219,7 +219,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("PreviousDerived returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -244,7 +244,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("UpdateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -272,7 +272,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 func TestScopedCrossSafeUpdate(t *testing.T) {
 	t.Run("CandidateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
 			return types.DerivedBlockRefPair{}, errors.New("some error")
@@ -285,7 +285,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("CandidateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return eth.BlockRef{}, 0, nil, errors.New("some error")
@@ -298,7 +298,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("candidate does not match opened block", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
@@ -319,7 +319,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("CrossSafeHazards returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
@@ -333,10 +333,10 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 10, execs, nil
 		}
-		// cause CrossSafeHazards to return an error by making ChainIDFromIndex return an error
+		// cause CrossSafeHazards to return an error by making Contains return an error
 		csd.deps = mockDependencySet{}
-		csd.deps.chainIDFromIndexfn = func() (eth.ChainID, error) {
-			return eth.ChainID{}, errors.New("some error")
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
+			return types.BlockSeal{}, errors.New("some error")
 		}
 		// when CrossSafeHazards returns an error,
 		// the error is returned
@@ -347,7 +347,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("HazardSafeFrontierChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
@@ -364,27 +364,21 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
 			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
 		}
-		count := 0
 		csd.deps = mockDependencySet{}
-		// cause CrossSafeHazards to return an error by making ChainIDFromIndex return an error
-		// but only on the third call (which will be used by HazardSafeFrontierChecks)
-		csd.deps.chainIDFromIndexfn = func() (eth.ChainID, error) {
-			defer func() { count++ }()
-			if count < 2 {
-				return eth.ChainID{}, nil
-			}
-			return eth.ChainID{}, errors.New("some error")
+		// cause CrossSafeHazards to return an error by making CrossDerivedToSource return an error
+		csd.crossDerivedToSourceFn = func(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error) {
+			return types.BlockSeal{}, errors.New("some error")
 		}
 		// when CrossSafeHazards returns an error,
 		// the error is returned
 		pair, err := scopedCrossSafeUpdate(logger, chainID, csd)
 		require.ErrorContains(t, err, "some error")
-		require.ErrorContains(t, err, "frontier")
+		require.ErrorContains(t, err, "failed to build hazard set")
 		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
 	t.Run("HazardCycleChecks returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1, Time: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -395,8 +389,8 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1, Time: 1}
-		em1 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 2}
-		em2 := &types.ExecutingMessage{Chain: types.ChainIndex(0), Timestamp: 1, LogIdx: 1}
+		em1 := &types.ExecutingMessage{ChainID: chainID, Timestamp: 1, LogIdx: 2}
+		em2 := &types.ExecutingMessage{ChainID: chainID, Timestamp: 1, LogIdx: 1}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
 			return opened, 3, map[uint32]*types.ExecutingMessage{1: em1, 2: em2}, nil
 		}
@@ -413,7 +407,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("UpdateCrossSafe returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -444,7 +438,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("UpdateCrossSafe returns ErrExpired", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		csd.deps.messageExpiryWindow = 10
 		candidate := eth.BlockRef{Number: 1, Time: 11}
@@ -472,7 +466,7 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 	})
 	t.Run("successful update", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
-		chainID := eth.ChainIDFromUInt64(0)
+		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
 		candidate := eth.BlockRef{Number: 1}
 		candidateScope := eth.BlockRef{Number: 2}
@@ -513,15 +507,16 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 }
 
 type mockCrossSafeDeps struct {
-	deps                  mockDependencySet
-	crossSafeFn           func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error)
-	candidateCrossSafeFn  func() (candidate types.DerivedBlockRefPair, err error)
-	openBlockFn           func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
-	updateCrossSafeFn     func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
-	nextSourceFn          func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error)
-	previousDerivedFn     func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
-	checkFn               func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error)
-	invalidateLocalSafeFn func(chainID eth.ChainID, candidate types.DerivedBlockRefPair) error
+	deps                   mockDependencySet
+	crossSafeFn            func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error)
+	crossDerivedToSourceFn func(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
+	candidateCrossSafeFn   func() (candidate types.DerivedBlockRefPair, err error)
+	openBlockFn            func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
+	updateCrossSafeFn      func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error
+	nextSourceFn           func(chain eth.ChainID, source eth.BlockID) (after eth.BlockRef, err error)
+	previousDerivedFn      func(chain eth.ChainID, derived eth.BlockID) (prevDerived types.BlockSeal, err error)
+	checkFn                func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error)
+	invalidateLocalSafeFn  func(chainID eth.ChainID, candidate types.DerivedBlockRefPair) error
 }
 
 var _ CrossSafeDeps = (*mockCrossSafeDeps)(nil)
@@ -545,6 +540,9 @@ func (m *mockCrossSafeDeps) DependencySet() depset.DependencySet {
 }
 
 func (m *mockCrossSafeDeps) CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error) {
+	if m.crossDerivedToSourceFn != nil {
+		return m.crossDerivedToSourceFn(chainID, derived)
+	}
 	return types.BlockSeal{}, nil
 }
 

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -56,7 +56,7 @@ func CrossUnsafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossUnsafeDeps
 	if err := HazardUnsafeFrontierChecks(d, hazards); err != nil {
 		return fmt.Errorf("failed to verify block %s in cross-unsafe frontier: %w", candidate, err)
 	}
-	if err := HazardCycleChecks(d.DependencySet(), d, candidate.Timestamp, hazards); err != nil {
+	if err := HazardCycleChecks(d, candidate.Timestamp, hazards); err != nil {
 		return fmt.Errorf("failed to verify block %s in cross-unsafe check for cycle hazards: %w", candidate, err)
 	}
 

--- a/op-supervisor/supervisor/backend/db/logs/entry.go
+++ b/op-supervisor/supervisor/backend/db/logs/entry.go
@@ -32,17 +32,19 @@ func (EntryBinary) EntrySize() int {
 	return EntrySize
 }
 
-type EntryTypeFlag uint8
+type EntryTypeFlag uint16
 
 const (
 	FlagSearchCheckpoint EntryTypeFlag = 1 << TypeSearchCheckpoint
 	FlagCanonicalHash    EntryTypeFlag = 1 << TypeCanonicalHash
 	FlagInitiatingEvent  EntryTypeFlag = 1 << TypeInitiatingEvent
-	FlagExecutingLink    EntryTypeFlag = 1 << TypeExecutingLink
-	FlagExecutingCheck   EntryTypeFlag = 1 << TypeExecutingCheck
+	FlagExecChainID      EntryTypeFlag = 1 << TypeExecChainID
+	FlagExecPosition     EntryTypeFlag = 1 << TypeExecPosition
+	FlagExecChecksum     EntryTypeFlag = 1 << TypeExecChecksum
 	FlagPadding          EntryTypeFlag = 1 << TypePadding
 	// for additional padding
 	FlagPadding2 EntryTypeFlag = FlagPadding << 1
+	FlagPadding3 EntryTypeFlag = FlagPadding2 << 1
 )
 
 func (x EntryTypeFlag) String() string {
@@ -73,8 +75,9 @@ const (
 	TypeSearchCheckpoint EntryType = iota
 	TypeCanonicalHash
 	TypeInitiatingEvent
-	TypeExecutingLink
-	TypeExecutingCheck
+	TypeExecChainID
+	TypeExecPosition
+	TypeExecChecksum
 	TypePadding
 )
 
@@ -86,10 +89,12 @@ func (x EntryType) String() string {
 		return "canonicalHash"
 	case TypeInitiatingEvent:
 		return "initiatingEvent"
-	case TypeExecutingLink:
-		return "executingLink"
-	case TypeExecutingCheck:
-		return "executingCheck"
+	case TypeExecChainID:
+		return "execChainID"
+	case TypeExecPosition:
+		return "execPosition"
+	case TypeExecChecksum:
+		return "execChecksum"
 	case TypePadding:
 		return "padding"
 	default:

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type DependencySetSource interface {
@@ -34,21 +33,6 @@ type DependencySet interface {
 	// See CanExecuteAt and CanInitiateAt to check if a chain may message at a given time.
 	HasChain(chainID eth.ChainID) bool
 
-	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
-
 	// MessageExpiryWindow returns the message expiry window to use for this dependency set.
 	MessageExpiryWindow() uint64
-
-	ChainIndexFromID
-	ChainIDFromIndex
-}
-
-type ChainIndexFromID interface {
-	// ChainIndexFromID converts a ChainID to a ChainIndex.
-	ChainIndexFromID(id eth.ChainID) (types.ChainIndex, error)
-}
-
-type ChainIDFromIndex interface {
-	// ChainIDFromIndex converts a ChainIndex to a ChainID.
-	ChainIDFromIndex(index types.ChainIndex) (eth.ChainID, error)
 }

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -45,14 +45,6 @@ func TestDependencySet(t *testing.T) {
 		_, err := toml.Decode(string(bad), &ds)
 		require.Error(t, err)
 	})
-
-	t.Run("duplicate index", func(t *testing.T) {
-		_, err := NewStaticConfigDependencySet(map[eth.ChainID]*StaticConfigDependency{
-			eth.ChainIDFromUInt64(900): {ChainIndex: 1},
-			eth.ChainIDFromUInt64(901): {ChainIndex: 1}, // duplicate
-		})
-		require.ErrorIs(t, err, errDuplicateChainIndex)
-	})
 }
 
 func testDependencySetSerialization(
@@ -66,12 +58,10 @@ func testDependencySetSerialization(
 	depSet, err := NewStaticConfigDependencySet(
 		map[eth.ChainID]*StaticConfigDependency{
 			eth.ChainIDFromUInt64(900): {
-				ChainIndex:     900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
 			eth.ChainIDFromUInt64(901): {
-				ChainIndex:     901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
 			},
@@ -134,16 +124,6 @@ func testDependencySetSerialization(
 
 		require.Equal(t, uint64(15), result.MessageExpiryWindow())
 		testChainCapabilities(t, result)
-	})
-
-	t.Run("chain index round trip", func(t *testing.T) {
-		id900 := eth.ChainIDFromUInt64(900)
-		idx, _ := depSet.ChainIndexFromID(id900)
-		idBack, _ := depSet.ChainIDFromIndex(idx)
-		require.Equal(t, id900, idBack)
-
-		_, err := depSet.ChainIndexFromID(eth.ChainIDFromUInt64(999))
-		require.ErrorContains(t, err, "unknown chain")
 	})
 
 	t.Run("HasChain", func(t *testing.T) {

--- a/op-supervisor/supervisor/backend/processors/executing_message.go
+++ b/op-supervisor/supervisor/backend/processors/executing_message.go
@@ -1,20 +1,17 @@
 package processors
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-type EventDecoderFn func(*ethTypes.Log, depset.ChainIndexFromID) (*types.ExecutingMessage, error)
+type EventDecoderFn func(*ethTypes.Log) (*types.ExecutingMessage, error)
 
-func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) (*types.ExecutingMessage, error) {
+func DecodeExecutingMessageLog(l *ethTypes.Log) (*types.ExecutingMessage, error) {
 	if l.Address != params.InteropCrossL2InboxAddress {
 		return nil, nil
 	}
@@ -28,24 +25,11 @@ func DecodeExecutingMessageLog(l *ethTypes.Log, depSet depset.ChainIndexFromID) 
 	if err := msg.DecodeEvent(l.Topics, l.Data); err != nil {
 		return nil, fmt.Errorf("invalid executing message: %w", err)
 	}
-	logHash := types.PayloadHashToLogHash(msg.PayloadHash, msg.Identifier.Origin)
-
-	var chainIndex types.ChainIndex
-	index, err := depSet.ChainIndexFromID(eth.ChainID(msg.Identifier.ChainID))
-	if err != nil {
-		if errors.Is(err, types.ErrUnknownChain) {
-			chainIndex = depset.NotFoundChainIndex
-		} else {
-			return nil, fmt.Errorf("failed to translate chain ID %s to chain index: %w", msg.Identifier.ChainID, err)
-		}
-	} else {
-		chainIndex = index
-	}
 	return &types.ExecutingMessage{
-		Chain:     chainIndex,
+		ChainID:   msg.Identifier.ChainID,
 		BlockNum:  msg.Identifier.BlockNumber,
 		LogIdx:    msg.Identifier.LogIndex,
 		Timestamp: msg.Identifier.Timestamp,
-		Hash:      logHash,
+		Checksum:  msg.Checksum(),
 	}, nil
 }

--- a/op-supervisor/supervisor/backend/processors/log_processor.go
+++ b/op-supervisor/supervisor/backend/processors/log_processor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -22,15 +21,13 @@ type logProcessor struct {
 	chain        eth.ChainID
 	logStore     LogStorage
 	eventDecoder EventDecoderFn
-	depSet       depset.ChainIndexFromID
 }
 
-func NewLogProcessor(chain eth.ChainID, logStore LogStorage, depSet depset.ChainIndexFromID) LogProcessor {
+func NewLogProcessor(chain eth.ChainID, logStore LogStorage) LogProcessor {
 	return &logProcessor{
 		chain:        chain,
 		logStore:     logStore,
 		eventDecoder: DecodeExecutingMessageLog,
-		depSet:       depSet,
 	}
 }
 
@@ -42,7 +39,7 @@ func (p *logProcessor) ProcessLogs(_ context.Context, block eth.BlockRef, rcpts 
 			// log hash represents the hash of *this* log as a potentially initiating message
 			logHash := LogToLogHash(l)
 			// The log may be an executing message emitted by the CrossL2Inbox
-			execMsg, err := p.eventDecoder(l, p.depSet)
+			execMsg, err := p.eventDecoder(l)
 			if err != nil {
 				return fmt.Errorf("invalid log %d from block %s: %w", l.Index, block.ID(), err)
 			}

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -1425,9 +1425,8 @@ func setupTestChains(t *testing.T, chainIDs ...eth.ChainID) *testSetup {
 
 	// Create dependency set for all chains
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
-	for i, chainID := range chainIDs {
+	for _, chainID := range chainIDs {
 		deps[chainID] = &depset.StaticConfigDependency{
-			ChainIndex:     types.ChainIndex(i + 1),
 			ActivationTime: 42,
 			HistoryMinTime: 100,
 		}

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -194,12 +194,10 @@ func sampleDepSet(t *testing.T) depset.DependencySet {
 	depSet, err := depset.NewStaticConfigDependencySet(
 		map[eth.ChainID]*depset.StaticConfigDependency{
 			eth.ChainIDFromUInt64(900): {
-				ChainIndex:     900,
 				ActivationTime: 42,
 				HistoryMinTime: 100,
 			},
 			eth.ChainIDFromUInt64(901): {
-				ChainIndex:     901,
 				ActivationTime: 30,
 				HistoryMinTime: 20,
 			},

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -6,15 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var (
@@ -25,32 +25,6 @@ var (
 )
 
 var ExecutingMessageEventTopic = crypto.Keccak256Hash([]byte("ExecutingMessage(bytes32,(address,uint256,uint256,uint256,uint256))"))
-
-// ChainIndex represents the lifetime of a chain in a dependency set.
-// Warning: JSON-encoded as string, in base-10.
-type ChainIndex uint32
-
-func (ci ChainIndex) String() string {
-	return strconv.FormatUint(uint64(ci), 10)
-}
-
-func (ci ChainIndex) MarshalText() ([]byte, error) {
-	return []byte(ci.String()), nil
-}
-
-func (ci *ChainIndex) UnmarshalText(data []byte) error {
-	v, err := strconv.ParseUint(string(data), 10, 32)
-	if err != nil {
-		return err
-	}
-	*ci = ChainIndex(v)
-	return nil
-}
-
-// IsTopBitSet returns true if the top bit is set. Used to check for reserved values, such as NotFoundChainIndex.
-func (ci ChainIndex) IsTopBitSet() bool {
-	return ci&(1<<31) != 0
-}
 
 type Revision uint64
 
@@ -105,16 +79,16 @@ type ContainsQuery struct {
 }
 
 type ExecutingMessage struct {
-	Chain     ChainIndex // same as ChainID for now, but will be indirect, i.e. translated to full ID, later
+	ChainID   eth.ChainID
 	BlockNum  uint64
 	LogIdx    uint32
 	Timestamp uint64
-	Hash      common.Hash // LogHash (hash of msgHash and origin address)
+	Checksum  MessageChecksum
 }
 
 func (s *ExecutingMessage) String() string {
-	return fmt.Sprintf("ExecMsg(chainIndex: %s, block: %d, log: %d, time: %d, logHash: %s)",
-		s.Chain, s.BlockNum, s.LogIdx, s.Timestamp, s.Hash)
+	return fmt.Sprintf("ExecMsg(chain: %s, block: %d, log: %d, time: %d, checksum: %s)",
+		s.ChainID, s.BlockNum, s.LogIdx, s.Timestamp, s.Checksum)
 }
 
 type Message struct {

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -204,24 +204,6 @@ func TestInteropMessageFormatEdgeCases(t *testing.T) {
 	}
 }
 
-func TestChainIndex(t *testing.T) {
-	var x ChainIndex
-	require.NoError(t, json.Unmarshal([]byte(`"1"`), &x))
-	require.Equal(t, ChainIndex(1), x)
-	data, err := json.Marshal(x)
-	require.NoError(t, err)
-	require.Equal(t, `"1"`, string(data))
-
-	require.NoError(t, json.Unmarshal([]byte(`"4294967295"`), &x))
-	require.Equal(t, ChainIndex(0xff_ff_ff_ff), x)
-	data, err = json.Marshal(x)
-	require.NoError(t, err)
-	require.Equal(t, `"4294967295"`, string(data))
-
-	require.ErrorContains(t, json.Unmarshal([]byte(`"-1"`), &x), "invalid")
-	require.ErrorContains(t, json.Unmarshal([]byte(`"4294967296"`), &x), "out of range")
-}
-
 func TestHashing(t *testing.T) {
 	keccak256 := func(name string, parts ...[]byte) (h common.Hash) {
 		t.Logf("%s = H(", name)


### PR DESCRIPTION
**Description**

The `ChainIndex` type (aka `ChainCode` for a brief while) had the drawback of requiring additional translation between chain ID and chain index.

This was doable with the old config, but as we are changing the config system it showed that "chain index" should not be a thing.

We still want the DB properties of being easy to copy, and equal files across different independently synced nodes. A different solution, with metadata outside the files makes that very difficult. A global enshrined config was easier, but pollutes the global config.

This PR changes the DB format to just store 32 byte chain IDs. The idea here is that we only have to do so for executing-messages. All the initiating messages don't store their chain ID explicitly (as it's indexed on the initiating side, per chain).

The DB may grow a little bit faster, but we gain more forward compatibility and configuration ease.

And while changing the chainID encoding, I also increased the `logIndex` from `uint24` to `uint32` (since there's space for it), and changed the executing messages to store the `checksum` (like the one in the access-list), not the logHash, to be less error prone against data corruption (the checksum commits to all message data).

**Tests**

Removed a type, simplified config, all existing tests still pass.
Some tests needed updating to handle the type change.
Some unit-test cases have been added to cover the minor changes to the logs DB format.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
