### PR TITLE
op-supervisor: unify to single global interop config timestamp

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -195,14 +195,8 @@ func createTestServiceMap() inspect.ServiceMap {
 func createTestDepSets(t *testing.T) map[string]descriptors.DepSet {
 	// Create the dependency set for the superchain
 	depSetData := map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromUInt64(2151908): {
-			ActivationTime: 0,
-			HistoryMinTime: 0,
-		},
-		eth.ChainIDFromUInt64(2151909): {
-			ActivationTime: 0,
-			HistoryMinTime: 0,
-		},
+		eth.ChainIDFromUInt64(2151908): {},
+		eth.ChainIDFromUInt64(2151909): {},
 	}
 
 	depSet, err := depset.NewStaticConfigDependencySet(depSetData)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -263,10 +263,7 @@ func (wb *worldBuilder) buildDepSet() {
 		if interopTime == nil {
 			continue
 		}
-		depSetContents[id] = &depset.StaticConfigDependency{
-			ActivationTime: *interopTime,
-			HistoryMinTime: *interopTime,
-		}
+		depSetContents[id] = &depset.StaticConfigDependency{}
 	}
 	if len(depSetContents) == 0 {
 		return // no dependency set output if no chain had interop active

--- a/op-e2e/actions/interop/dsl/interop.go
+++ b/op-e2e/actions/interop/dsl/interop.go
@@ -249,10 +249,7 @@ func (sa *SupervisorActor) Rewind(chain eth.ChainID, block eth.BlockID) error {
 func RecipeToDepSet(t helpers.Testing, recipe *interopgen.InteropDevRecipe) *depset.StaticConfigDependencySet {
 	depSetCfg := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for _, out := range recipe.L2s {
-		depSetCfg[eth.ChainIDFromUInt64(out.ChainID)] = &depset.StaticConfigDependency{
-			ActivationTime: 0,
-			HistoryMinTime: 0,
-		}
+		depSetCfg[eth.ChainIDFromUInt64(out.ChainID)] = &depset.StaticConfigDependency{}
 	}
 	depSet, err := depset.NewStaticConfigDependencySetWithMessageExpiryOverride(depSetCfg, recipe.ExpiryTime)
 	require.NoError(t, err)

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -617,10 +617,7 @@ func worldToDepSet(world *interopgen.WorldOutput) (*depset.StaticConfigDependenc
 	// Iterate over the L2 chain configs. The L2 nodes don't exist yet.
 	for _, l2Out := range world.L2s {
 		chainID := eth.ChainIDFromBig(l2Out.Genesis.Config.ChainID)
-		depSet[chainID] = &depset.StaticConfigDependency{
-			ActivationTime: 0,
-			HistoryMinTime: 0,
-		}
+		depSet[chainID] = &depset.StaticConfigDependency{}
 	}
 	return depset.NewStaticConfigDependencySet(depSet)
 }

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -31,7 +31,6 @@ type ConfigSource interface {
 	RollupConfig(chainID eth.ChainID) (*rollup.Config, error)
 	ChainConfig(chainID eth.ChainID) (*params.ChainConfig, error)
 	DependencySet(chainID eth.ChainID) (depset.DependencySet, error)
-	FullConfigSet(chainID eth.ChainID) (depset.FullConfigSet, error)
 }
 
 type OracleConfigSource struct {
@@ -98,24 +97,6 @@ func (c *OracleConfigSource) DependencySet(chainID eth.ChainID) (depset.Dependen
 	}
 	c.depset = depSet
 	return c.depset, nil
-}
-
-func (c *OracleConfigSource) FullConfigSet(chainID eth.ChainID) (depset.FullConfigSet, error) {
-	depSet, err := c.DependencySet(chainID)
-	if err != nil {
-		return nil, err
-	}
-	confs := make(depset.StaticRollupConfigSet)
-	for _, chID := range depSet.Chains() {
-		rollupCfg, err := c.RollupConfig(chID)
-		if err != nil {
-			return nil, err
-		}
-		// TODO: we could load the L1 block header here?
-		l1Timestamp := rollupCfg.Genesis.L2Time
-		confs[chID] = depset.StaticRollupConfigFromRollupConfig(rollupCfg, l1Timestamp)
-	}
-	return depset.NewFullConfigSetMerged(confs, depSet)
 }
 
 func (c *OracleConfigSource) loadCustomConfigs() {

--- a/op-program/client/boot/boot_interop.go
+++ b/op-program/client/boot/boot_interop.go
@@ -31,7 +31,9 @@ type ConfigSource interface {
 	RollupConfig(chainID eth.ChainID) (*rollup.Config, error)
 	ChainConfig(chainID eth.ChainID) (*params.ChainConfig, error)
 	DependencySet(chainID eth.ChainID) (depset.DependencySet, error)
+	FullConfigSet(chainID eth.ChainID) (depset.FullConfigSet, error)
 }
+
 type OracleConfigSource struct {
 	oracle oracleClient
 
@@ -96,6 +98,24 @@ func (c *OracleConfigSource) DependencySet(chainID eth.ChainID) (depset.Dependen
 	}
 	c.depset = depSet
 	return c.depset, nil
+}
+
+func (c *OracleConfigSource) FullConfigSet(chainID eth.ChainID) (depset.FullConfigSet, error) {
+	depSet, err := c.DependencySet(chainID)
+	if err != nil {
+		return nil, err
+	}
+	confs := make(depset.StaticRollupConfigSet)
+	for _, chID := range depSet.Chains() {
+		rollupCfg, err := c.RollupConfig(chID)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: we could load the L1 block header here?
+		l1Timestamp := rollupCfg.Genesis.L2Time
+		confs[chID] = depset.StaticRollupConfigFromRollupConfig(rollupCfg, l1Timestamp)
+	}
+	return depset.NewFullConfigSetMerged(confs, depSet)
 }
 
 func (c *OracleConfigSource) loadCustomConfigs() {

--- a/op-program/client/boot/boot_interop_test.go
+++ b/op-program/client/boot/boot_interop_test.go
@@ -95,8 +95,8 @@ func TestInteropBootstrap_ChainConfigCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(expected, true)
 	mockOracle.chainCfgs = []*params.ChainConfig{config1, config2}
 	mockOracle.depset, _ = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(config1.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(config2.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config1.ChainID): {},
+		eth.ChainIDFromBig(config2.ChainID): {},
 	})
 	actual := BootstrapInterop(mockOracle)
 
@@ -121,8 +121,8 @@ func TestInteropBootstrap_DependencySetCustom(t *testing.T) {
 	mockOracle := newMockInteropBootstrapOracle(expected, true)
 	var err error
 	mockOracle.depset, err = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-		eth.ChainIDFromBig(config1.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
-		eth.ChainIDFromBig(config2.ChainID): {ActivationTime: 0, HistoryMinTime: 0},
+		eth.ChainIDFromBig(config1.ChainID): {},
+		eth.ChainIDFromBig(config2.ChainID): {},
 	})
 	require.NoError(t, err)
 	actual := BootstrapInterop(mockOracle)

--- a/op-program/client/interop/config.go
+++ b/op-program/client/interop/config.go
@@ -1,0 +1,22 @@
+package interop
+
+import (
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
+	"github.com/ethereum-optimism/optimism/op-program/client/l1"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+// getFullConfig creates a new depset.FullConfigSet using the boot-info config sources,
+// and a L1 preimage oracle to load the L1 block info of the rollup anchor blocks.
+func getFullConfig(c boot.ConfigSource, l1PreimageOracle l1.Oracle, depSet depset.DependencySet) (depset.FullConfigSet, error) {
+	configs := make(depset.StaticRollupConfigSet)
+	for _, chID := range depSet.Chains() {
+		rollupCfg, err := c.RollupConfig(chID)
+		if err != nil {
+			return nil, err
+		}
+		l1Header := l1PreimageOracle.HeaderByBlockHash(rollupCfg.Genesis.L1.Hash)
+		configs[chID] = depset.StaticRollupConfigFromRollupConfig(rollupCfg, l1Header.Time())
+	}
+	return depset.NewFullConfigSetMerged(configs, depSet)
+}

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -147,15 +147,19 @@ func singleRoundConsolidation(
 	tasks taskExecutor,
 ) error {
 	// The depset is the same for all chains. So it suffices to use any chain ID
-	depset, err := bootInfo.Configs.DependencySet(superRoot.Chains[0].ChainID)
+	depSet, err := bootInfo.Configs.DependencySet(superRoot.Chains[0].ChainID)
 	if err != nil {
 		return fmt.Errorf("failed to get dependency set: %w", err)
 	}
-	deps, err := newConsolidateCheckDeps(depset, bootInfo.Configs, consolidateState.TransitionState, superRoot.Chains, l2PreimageOracle, consolidateState)
+	deps, err := newConsolidateCheckDeps(depSet, bootInfo.Configs, consolidateState.TransitionState, superRoot.Chains, l2PreimageOracle, consolidateState)
 	if err != nil {
 		return fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
-
+	fullConfig, err := bootInfo.Configs.FullConfigSet(superRoot.Chains[0].ChainID)
+	if err != nil {
+		return fmt.Errorf("failed to get full config set: %w", err)
+	}
+	linker := depset.LinkerFromConfig(fullConfig)
 	for i, chain := range superRoot.Chains {
 		// Do not check chains that have been replaced with a deposits-only block.
 		// They are already cross-safe because deposits-only blocks cannot contain executing messages.
@@ -171,7 +175,7 @@ func singleRoundConsolidation(
 			Number:    optimisticBlock.NumberU64(),
 			Timestamp: optimisticBlock.Time(),
 		}
-		if err := checkHazards(logger, deps, candidate, chain.ChainID); err != nil {
+		if err := checkHazards(logger, deps, linker, candidate, chain.ChainID); err != nil {
 			if !isInvalidMessageError(err) {
 				return err
 			}
@@ -218,8 +222,8 @@ type ConsolidateCheckDeps interface {
 	cross.UnsafeStartDeps
 }
 
-func checkHazards(logger log.Logger, deps ConsolidateCheckDeps, candidate supervisortypes.BlockSeal, chainID eth.ChainID) error {
-	hazards, err := cross.CrossUnsafeHazards(deps, logger, chainID, candidate)
+func checkHazards(logger log.Logger, deps ConsolidateCheckDeps, linker depset.LinkChecker, candidate supervisortypes.BlockSeal, chainID eth.ChainID) error {
+	hazards, err := cross.CrossUnsafeHazards(deps, linker, logger, chainID, candidate)
 	if err != nil {
 		return err
 	}
@@ -369,10 +373,6 @@ func (d *consolidateCheckDeps) OpenBlock(
 	}
 	d.consolidateState.setCachedExecMsgs(block.Hash(), execMsgs, logCount)
 	return ref, logCount, execMsgs, nil
-}
-
-func (d *consolidateCheckDeps) DependencySet() depset.DependencySet {
-	return d.depset
 }
 
 func (d *consolidateCheckDeps) CanonBlockByNumber(oracle l2.Oracle, blockNum uint64, chainID eth.ChainID) (*ethtypes.Block, error) {

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -155,7 +155,7 @@ func singleRoundConsolidation(
 	if err != nil {
 		return fmt.Errorf("failed to create consolidate check deps: %w", err)
 	}
-	fullConfig, err := bootInfo.Configs.FullConfigSet(superRoot.Chains[0].ChainID)
+	fullConfig, err := getFullConfig(bootInfo.Configs, l1PreimageOracle, depSet)
 	if err != nil {
 		return fmt.Errorf("failed to get full config set: %w", err)
 	}

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -48,13 +48,17 @@ func setupTwoChains(opts ...func(*chainSetupOpts)) (*staticConfigSource, *eth.Su
 		opt(chainSetupOpts)
 	}
 
-	rollupCfg1 := chaincfg.OPSepolia()
+	rollupCfg1 := *chaincfg.OPSepolia()
 	chainCfg1 := chainconfig.OPSepoliaChainConfig()
 
 	rollupCfg2 := *chaincfg.OPSepolia()
 	rollupCfg2.L2ChainID = new(big.Int).SetUint64(42)
 	chainCfg2 := *chainconfig.OPSepoliaChainConfig()
 	chainCfg2.ChainID = rollupCfg2.L2ChainID
+
+	// activate interop at genesis for both
+	rollupCfg1.InteropTime = new(uint64)
+	rollupCfg2.InteropTime = new(uint64)
 
 	agreedSuperRoot := &eth.SuperV1{
 		Timestamp: rollupCfg1.Genesis.L2Time + 1234,
@@ -67,20 +71,26 @@ func setupTwoChains(opts ...func(*chainSetupOpts)) (*staticConfigSource, *eth.Su
 	var ds *depset.StaticConfigDependencySet
 	if chainSetupOpts.expiryWindow > 0 {
 		ds, _ = depset.NewStaticConfigDependencySetWithMessageExpiryOverride(map[eth.ChainID]*depset.StaticConfigDependency{
-			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ActivationTime: 0, HistoryMinTime: 0},
-			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ActivationTime: 0, HistoryMinTime: 0},
+			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {},
+			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {},
 		}, chainSetupOpts.expiryWindow)
 	} else {
 		ds, _ = depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
-			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {ActivationTime: 0, HistoryMinTime: 0},
-			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {ActivationTime: 0, HistoryMinTime: 0},
+			eth.ChainIDFromBig(rollupCfg1.L2ChainID): {},
+			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {},
 		})
 	}
+	rollupCfgSet := depset.StaticRollupConfigSetFromRollupConfigMap(map[eth.ChainID]*rollup.Config{
+		eth.ChainIDFromBig(rollupCfg1.L2ChainID): &rollupCfg1,
+		eth.ChainIDFromBig(rollupCfg2.L2ChainID): &rollupCfg2,
+	}, depset.StaticTimestamp(agreedSuperRoot.Timestamp)) // TODO review from Seb/Mofi
+	fullCfg, _ := depset.NewFullConfigSetMerged(rollupCfgSet, ds)
 	configSource := &staticConfigSource{
-		rollupCfgs:   []*rollup.Config{rollupCfg1, &rollupCfg2},
-		chainConfigs: []*params.ChainConfig{chainCfg1, &chainCfg2},
-		depset:       ds,
-		chainIDs:     []eth.ChainID{eth.ChainIDFromBig(rollupCfg1.L2ChainID), eth.ChainIDFromBig(rollupCfg2.L2ChainID)},
+		rollupCfgs:    []*rollup.Config{&rollupCfg1, &rollupCfg2},
+		chainConfigs:  []*params.ChainConfig{chainCfg1, &chainCfg2},
+		depset:        ds,
+		fullConfigSet: fullCfg,
+		chainIDs:      []eth.ChainID{eth.ChainIDFromBig(rollupCfg1.L2ChainID), eth.ChainIDFromBig(rollupCfg2.L2ChainID)},
 	}
 	tasksStub := &stubTasks{
 		l2SafeHead: eth.L2BlockRef{Number: 918429823450218}, // Past the claimed block
@@ -695,13 +705,17 @@ func TestHazardSet_ExpiredMessageShortCircuitsInclusionCheck(t *testing.T) {
 			On("Contains", mock.Anything, mock.Anything).Return(supervisortypes.BlockSeal{}, supervisortypes.ErrConflict).
 			Maybe()
 
+		linker := depset.LinkCheckFn(func(execInChain eth.ChainID, execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool {
+			window := configSource.depset.MessageExpiryWindow()
+			return initTimestamp+window >= execInTimestamp
+		})
 		deps := &cross.UnsafeHazardDeps{UnsafeStartDeps: mockConsolidateDeps}
 		candidate := supervisortypes.BlockSeal{
 			Hash:      block2A.Hash(),
 			Number:    block2A.NumberU64(),
 			Timestamp: block2A.Time(),
 		}
-		_, err = cross.NewHazardSet(deps, logger, eth.ChainIDFromBig(configA.L2ChainID), candidate)
+		_, err = cross.NewHazardSet(deps, linker, logger, eth.ChainIDFromBig(configA.L2ChainID), candidate)
 		require.ErrorIs(t, err, supervisortypes.ErrConflict)
 
 		if expectInclusionCheck {
@@ -814,10 +828,11 @@ func (t *stubTasks) ExpectBuildDepositOnlyBlock(
 }
 
 type staticConfigSource struct {
-	rollupCfgs   []*rollup.Config
-	chainConfigs []*params.ChainConfig
-	depset       *depset.StaticConfigDependencySet
-	chainIDs     []eth.ChainID
+	rollupCfgs    []*rollup.Config
+	chainConfigs  []*params.ChainConfig
+	depset        *depset.StaticConfigDependencySet
+	fullConfigSet depset.FullConfigSet
+	chainIDs      []eth.ChainID
 }
 
 func (s *staticConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, error) {
@@ -840,4 +855,8 @@ func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 
 func (s *staticConfigSource) DependencySet(chainID eth.ChainID) (depset.DependencySet, error) {
 	return s.depset, nil
+}
+
+func (s *staticConfigSource) FullConfigSet(chainID eth.ChainID) (depset.FullConfigSet, error) {
+	return s.fullConfigSet, nil
 }

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"encoding/binary"
 	"fmt"
+	test2 "github.com/ethereum-optimism/optimism/op-program/client/l1/test"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -745,7 +746,18 @@ func verifyResult(t *testing.T, logger log.Logger, tasks *stubTasks, configSourc
 		Claim:          expectedClaim,
 		Configs:        configSource,
 	}
-	err := runInteropProgram(logger, bootInfo, nil, l2PreimageOracle, true, tasks)
+	l1Oracle := test2.NewStubOracle(t)
+	for _, chainID := range configSource.chainIDs {
+		rollupCfg, err := configSource.RollupConfig(chainID)
+		require.NoError(t, err)
+		// Assuming the anchor block of the L2 on the L1 is the same timestamp as the genesis block of L1.
+		l1Oracle.Blocks[rollupCfg.Genesis.L1.Hash] = &testutils.MockBlockInfo{
+			InfoHash: rollupCfg.Genesis.L1.Hash,
+			InfoNum:  rollupCfg.Genesis.L1.Number,
+			InfoTime: rollupCfg.Genesis.L2Time,
+		}
+	}
+	err := runInteropProgram(logger, bootInfo, l1Oracle, l2PreimageOracle, true, tasks)
 	require.NoError(t, err)
 }
 

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -3,7 +3,6 @@ package interop
 import (
 	"encoding/binary"
 	"fmt"
-	test2 "github.com/ethereum-optimism/optimism/op-program/client/l1/test"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
+	test2 "github.com/ethereum-optimism/optimism/op-program/client/l1/test"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/test"
 	"github.com/ethereum-optimism/optimism/op-program/client/tasks"

--- a/op-program/client/interop/interop_test.go
+++ b/op-program/client/interop/interop_test.go
@@ -49,7 +49,7 @@ func setupTwoChains(opts ...func(*chainSetupOpts)) (*staticConfigSource, *eth.Su
 	}
 
 	rollupCfg1 := *chaincfg.OPSepolia()
-	chainCfg1 := chainconfig.OPSepoliaChainConfig()
+	chainCfg1 := *chainconfig.OPSepoliaChainConfig()
 
 	rollupCfg2 := *chaincfg.OPSepolia()
 	rollupCfg2.L2ChainID = new(big.Int).SetUint64(42)
@@ -80,17 +80,11 @@ func setupTwoChains(opts ...func(*chainSetupOpts)) (*staticConfigSource, *eth.Su
 			eth.ChainIDFromBig(rollupCfg2.L2ChainID): {},
 		})
 	}
-	rollupCfgSet := depset.StaticRollupConfigSetFromRollupConfigMap(map[eth.ChainID]*rollup.Config{
-		eth.ChainIDFromBig(rollupCfg1.L2ChainID): &rollupCfg1,
-		eth.ChainIDFromBig(rollupCfg2.L2ChainID): &rollupCfg2,
-	}, depset.StaticTimestamp(agreedSuperRoot.Timestamp)) // TODO review from Seb/Mofi
-	fullCfg, _ := depset.NewFullConfigSetMerged(rollupCfgSet, ds)
 	configSource := &staticConfigSource{
-		rollupCfgs:    []*rollup.Config{&rollupCfg1, &rollupCfg2},
-		chainConfigs:  []*params.ChainConfig{chainCfg1, &chainCfg2},
-		depset:        ds,
-		fullConfigSet: fullCfg,
-		chainIDs:      []eth.ChainID{eth.ChainIDFromBig(rollupCfg1.L2ChainID), eth.ChainIDFromBig(rollupCfg2.L2ChainID)},
+		rollupCfgs:   []*rollup.Config{&rollupCfg1, &rollupCfg2},
+		chainConfigs: []*params.ChainConfig{&chainCfg1, &chainCfg2},
+		depset:       ds,
+		chainIDs:     []eth.ChainID{eth.ChainIDFromBig(rollupCfg1.L2ChainID), eth.ChainIDFromBig(rollupCfg2.L2ChainID)},
 	}
 	tasksStub := &stubTasks{
 		l2SafeHead: eth.L2BlockRef{Number: 918429823450218}, // Past the claimed block
@@ -828,11 +822,10 @@ func (t *stubTasks) ExpectBuildDepositOnlyBlock(
 }
 
 type staticConfigSource struct {
-	rollupCfgs    []*rollup.Config
-	chainConfigs  []*params.ChainConfig
-	depset        *depset.StaticConfigDependencySet
-	fullConfigSet depset.FullConfigSet
-	chainIDs      []eth.ChainID
+	rollupCfgs   []*rollup.Config
+	chainConfigs []*params.ChainConfig
+	depset       *depset.StaticConfigDependencySet
+	chainIDs     []eth.ChainID
 }
 
 func (s *staticConfigSource) RollupConfig(chainID eth.ChainID) (*rollup.Config, error) {
@@ -855,8 +848,4 @@ func (s *staticConfigSource) ChainConfig(chainID eth.ChainID) (*params.ChainConf
 
 func (s *staticConfigSource) DependencySet(chainID eth.ChainID) (depset.DependencySet, error) {
 	return s.depset, nil
-}
-
-func (s *staticConfigSource) FullConfigSet(chainID eth.ChainID) (depset.FullConfigSet, error) {
-	return s.fullConfigSet, nil
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -223,14 +223,15 @@ func (su *SupervisorBackend) initResources(ctx context.Context, cfg *config.Conf
 		}
 	}
 
+	linker := depset.LinkerFromConfig(su.cfgSet)
 	// initialize all cross-unsafe processors
 	for _, chainID := range chains {
-		worker := cross.NewCrossUnsafeWorker(su.logger, chainID, su.chainDBs)
+		worker := cross.NewCrossUnsafeWorker(su.logger, chainID, su.chainDBs, linker)
 		su.eventSys.Register(fmt.Sprintf("cross-unsafe-%s", chainID), worker)
 	}
 	// initialize all cross-safe processors
 	for _, chainID := range chains {
-		worker := cross.NewCrossSafeWorker(su.logger, chainID, su.chainDBs)
+		worker := cross.NewCrossSafeWorker(su.logger, chainID, su.chainDBs, linker)
 		su.eventSys.Register(fmt.Sprintf("cross-safe-%s", chainID), worker)
 	}
 	// For each chain initialize a chain processor service,

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -39,10 +39,7 @@ func fullConfigSet(t *testing.T, size int) depset.FullConfigSetMerged {
 	zero := uint64(0)
 	for i := 0; i < size; i++ {
 		chainID := eth.ChainIDFromUInt64(testChainIDOffset + uint64(i))
-		staticDepSet[chainID] = &depset.StaticConfigDependency{
-			ActivationTime: 42,
-			HistoryMinTime: 100,
-		}
+		staticDepSet[chainID] = &depset.StaticConfigDependency{}
 		staticRollupCfgSet[chainID] = &depset.StaticRollupConfig{
 			InteropTime: &zero,
 			BlockTime:   2,

--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -17,7 +17,6 @@ var (
 
 type HazardDeps interface {
 	Contains(chain eth.ChainID, query types.ContainsQuery) (types.BlockSeal, error)
-	DependencySet() depset.DependencySet
 	IsCrossValidBlock(chainID eth.ChainID, block eth.BlockID) error
 	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 }
@@ -28,7 +27,7 @@ type HazardSet struct {
 }
 
 // NewHazardSet creates a new HazardSet with the given dependencies and initial block
-func NewHazardSet(deps HazardDeps, logger log.Logger, chainID eth.ChainID, block types.BlockSeal) (*HazardSet, error) {
+func NewHazardSet(deps HazardDeps, linker depset.LinkChecker, logger log.Logger, chainID eth.ChainID, block types.BlockSeal) (*HazardSet, error) {
 	if deps == nil {
 		return nil, errHazardSetNilDeps
 	}
@@ -36,7 +35,7 @@ func NewHazardSet(deps HazardDeps, logger log.Logger, chainID eth.ChainID, block
 		entries: make(map[eth.ChainID]types.BlockSeal),
 	}
 	logger.Debug("Building new HazardSet", "chainID", chainID, "block", block)
-	if err := h.build(deps, logger, chainID, block); err != nil {
+	if err := h.build(deps, linker, logger, chainID, block); err != nil {
 		return nil, fmt.Errorf("failed to build hazard set: %w", err)
 	}
 	logger.Debug("Successfully built HazardSet", "chainID", chainID, "block", block)
@@ -55,39 +54,22 @@ type potentialHazard struct {
 
 // checkChainCanExecute verifies that a chain can execute messages at a given timestamp.
 // If there are any executing messages, then the chain must be able to execute at the timestamp.
-func (h *HazardSet) checkChainCanExecute(depSet depset.DependencySet, chainID eth.ChainID, block types.BlockSeal, execMsgs map[uint32]*types.ExecutingMessage) error {
-	if len(execMsgs) > 0 {
-		if ok, err := depSet.CanExecuteAt(chainID, block.Timestamp); err != nil {
-			return fmt.Errorf("cannot check message execution of block %s (chain %s): %w", block, chainID, err)
-		} else if !ok {
-			return fmt.Errorf("cannot execute messages in block %s (chain %s): %w", block, chainID, types.ErrConflict)
+func (h *HazardSet) checkChainCanExecute(linker depset.LinkChecker, chainID eth.ChainID, block types.BlockSeal, execMsgs map[uint32]*types.ExecutingMessage) error {
+	for i, msg := range execMsgs {
+		if !linker.CanExecute(chainID, block.Timestamp, msg.ChainID, msg.Timestamp) {
+			return fmt.Errorf("executing message %d in block %s (chain %s) may not execute %s: %w", i, block, chainID, msg, types.ErrConflict)
 		}
-	}
-	return nil
-}
-
-// checkChainCanInitiate verifies that a chain can initiate messages at a given timestamp.
-// The chain must be able to initiate at the timestamp of the message we're referencing.
-func (h *HazardSet) checkChainCanInitiate(depSet depset.DependencySet, initChainID eth.ChainID, msg *types.ExecutingMessage) error {
-	if ok, err := depSet.CanInitiateAt(initChainID, msg.Timestamp); err != nil {
-		return fmt.Errorf("cannot check message initiation of msg %s (chain %s): %w", msg, initChainID, err)
-	} else if !ok {
-		return fmt.Errorf("cannot allow initiating message %s (chain %s): %w", msg, initChainID, types.ErrConflict)
 	}
 	return nil
 }
 
 // checkMessageWithOlderTimestamp handles messages from past blocks.
 // It ensures non-cyclic ordering relative to other messages.
-func (h *HazardSet) checkMessageWithOlderTimestamp(deps HazardDeps, msg *types.ExecutingMessage, initChainID eth.ChainID, includedIn types.BlockSeal, candidateTimestamp uint64) error {
+func (h *HazardSet) checkMessageWithOlderTimestamp(deps HazardDeps, initChainID eth.ChainID, includedIn types.BlockSeal, candidateTimestamp uint64) error {
 	if err := deps.IsCrossValidBlock(initChainID, includedIn.ID()); err != nil {
-		return fmt.Errorf("msg %s included in non-cross-safe block %s: %w", msg, includedIn, err)
+		return fmt.Errorf("included in non-cross valid block %s: %w", includedIn, err)
 	}
-	// Run expiry window invariant check *after* verifying that the message is non-conflicting.
-	expiresAt := msg.Timestamp + deps.DependencySet().MessageExpiryWindow()
-	if expiresAt < candidateTimestamp {
-		return fmt.Errorf("timestamp of message %s (chain %s) has expired: %d < %d: %w", msg, initChainID, expiresAt, candidateTimestamp, types.ErrConflict)
-	}
+	// Time expiry was already checked before; the DB has to support the time range.
 	return nil
 }
 
@@ -97,23 +79,14 @@ func (h *HazardSet) checkMessageWithOlderTimestamp(deps HazardDeps, msg *types.E
 // Thus check that it was included in a local-safe block, and then proceed with transitive block checks,
 // to ensure the local block we depend on is becoming cross-safe also.
 // Also returns a boolean indicating if the message already exists in the hazard set.
-func (h *HazardSet) checkMessageWithCurrentTimestamp(msg *types.ExecutingMessage, initChainID eth.ChainID, includedIn types.BlockSeal) (bool, error) {
-	existing, ok := h.entries[msg.ChainID]
+func (h *HazardSet) checkMessageWithCurrentTimestamp(initChainID eth.ChainID, includedIn types.BlockSeal) (bool, error) {
+	existing, ok := h.entries[initChainID]
 	if ok {
 		if existing.ID() != includedIn.ID() {
 			return true, fmt.Errorf("found dependency on %s (chain %s), but already depend on %s: %w", includedIn, initChainID, existing, types.ErrConflict)
 		}
 	}
 	return ok, nil
-}
-
-// checkMessageForExpiry checks that a message has not expired.
-func (h *HazardSet) checkMessageForExpiry(deps HazardDeps, msg *types.ExecutingMessage, initChainID eth.ChainID, candidateTimestamp uint64) error {
-	expiresAt := msg.Timestamp + deps.DependencySet().MessageExpiryWindow()
-	if expiresAt < candidateTimestamp {
-		return fmt.Errorf("timestamp of message %s (chain %s) has expired: %d < %d: %w", msg, initChainID, expiresAt, candidateTimestamp, types.ErrConflict)
-	}
-	return nil
 }
 
 // build adds a block to the hazard set and recursively adds any blocks that it depends on.
@@ -123,8 +96,7 @@ func (h *HazardSet) checkMessageForExpiry(deps HazardDeps, msg *types.ExecutingM
 // simply by pulling in a block of another chain,
 // which then depends on a block of the original chain,
 // all with the same timestamp, without message cycles.
-func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainID, block types.BlockSeal) error {
-	depSet := deps.DependencySet()
+func (h *HazardSet) build(deps HazardDeps, linker depset.LinkChecker, logger log.Logger, chainID eth.ChainID, block types.BlockSeal) error {
 	stack := []potentialHazard{{chainID: chainID, block: block}}
 
 	for len(stack) > 0 {
@@ -142,51 +114,39 @@ func (h *HazardSet) build(deps HazardDeps, logger log.Logger, chainID eth.ChainI
 		if opened.ID() != candidate.ID() {
 			return fmt.Errorf("unsafe L2 DB has %s, but candidate cross-safe was %s: %w", opened, candidate, types.ErrConflict)
 		}
-		if err := h.checkChainCanExecute(depSet, destChainID, candidate, execMsgs); err != nil {
+		// Performance & safety: check all executing messages can exist (chain ID linking, timestamp invariants) first.
+		if err := h.checkChainCanExecute(linker, destChainID, candidate, execMsgs); err != nil {
 			return err
 		}
-
+		// Now that we have established chains and timestamps are valid things to link, build the hazard set.
 		for _, msg := range execMsgs {
 			logger.Debug("Processing message", "chainID", destChainID, "block", candidate, "msg", msg)
-
-			// Get the source chain, ensure it's allowed to initiate messages, and contains the initiating message.
-			srcChainID := msg.ChainID
-			if !depSet.HasChain(srcChainID) {
-				return fmt.Errorf("msg %s may not execute from unknown chain %s: %w", msg, srcChainID, types.ErrConflict)
-			}
-			if err := h.checkChainCanInitiate(depSet, srcChainID, msg); err != nil {
-				return err
-			}
-			// performance: short-circuit inclusion checks if the message has expired
-			if err := h.checkMessageForExpiry(deps, msg, srcChainID, candidate.Timestamp); err != nil {
-				return err
-			}
 			q := types.ContainsQuery{
 				Timestamp: msg.Timestamp,
 				BlockNum:  msg.BlockNum,
 				LogIdx:    msg.LogIdx,
 				Checksum:  msg.Checksum,
 			}
-			includedIn, err := deps.Contains(srcChainID, q)
+			includedIn, err := deps.Contains(msg.ChainID, q)
 			if err != nil {
 				return fmt.Errorf("executing msg %s failed inclusion check: %w", msg, err)
 			}
 
 			if msg.Timestamp < candidate.Timestamp {
-				if err := h.checkMessageWithOlderTimestamp(deps, msg, srcChainID, includedIn, candidate.Timestamp); err != nil {
-					return err
+				if err := h.checkMessageWithOlderTimestamp(deps, msg.ChainID, includedIn, candidate.Timestamp); err != nil {
+					return fmt.Errorf("executing msg %s failed old-timestamp check: %w", msg, err)
 				}
 			} else if msg.Timestamp == candidate.Timestamp {
-				exists, err := h.checkMessageWithCurrentTimestamp(msg, srcChainID, includedIn)
+				exists, err := h.checkMessageWithCurrentTimestamp(msg.ChainID, includedIn)
 				if err != nil {
-					return err
+					return fmt.Errorf("executing msg %s failed same-timestamp check: %w", msg, err)
 				}
 
 				if !exists {
-					logger.Debug("Adding block to the hazard set", "chainID", srcChainID, "block", includedIn)
+					logger.Debug("Adding block to the hazard set", "chainID", msg.ChainID, "block", includedIn)
 					h.entries[msg.ChainID] = includedIn
 					stack = append(stack, potentialHazard{
-						chainID: srcChainID,
+						chainID: msg.ChainID,
 						block:   includedIn,
 					})
 				}

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestHazardSafeFrontierChecks(t *testing.T) {
@@ -127,7 +127,6 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 }
 
 type mockSafeFrontierCheckDeps struct {
-	deps                 mockDependencySet
 	candidateCrossSafeFn func() (candidate types.DerivedBlockRefPair, err error)
 	crossSourceFn        func() (source types.BlockSeal, err error)
 }
@@ -144,47 +143,4 @@ func (m *mockSafeFrontierCheckDeps) CrossDerivedToSource(chainID eth.ChainID, de
 		return m.crossSourceFn()
 	}
 	return types.BlockSeal{}, nil
-}
-
-func (m *mockSafeFrontierCheckDeps) DependencySet() depset.DependencySet {
-	return m.deps
-}
-
-type mockDependencySet struct {
-	hasChainFn          func(eth.ChainID) bool
-	canExecuteAtfn      func() (bool, error)
-	canInitiateAtfn     func() (bool, error)
-	messageExpiryWindow uint64
-}
-
-func (m mockDependencySet) CanExecuteAt(chain eth.ChainID, timestamp uint64) (bool, error) {
-	if m.canExecuteAtfn != nil {
-		return m.canExecuteAtfn()
-	}
-	return true, nil
-}
-
-func (m mockDependencySet) CanInitiateAt(chain eth.ChainID, timestamp uint64) (bool, error) {
-	if m.canInitiateAtfn != nil {
-		return m.canInitiateAtfn()
-	}
-	return true, nil
-}
-
-func (m mockDependencySet) Chains() []eth.ChainID {
-	return nil
-}
-
-func (m mockDependencySet) HasChain(chain eth.ChainID) bool {
-	if m.hasChainFn != nil {
-		return m.hasChainFn(chain)
-	}
-	return true
-}
-
-func (m mockDependencySet) MessageExpiryWindow() uint64 {
-	if m.messageExpiryWindow == 0 {
-		return 100
-	}
-	return m.messageExpiryWindow
 }

--- a/op-supervisor/supervisor/backend/cross/safe_start.go
+++ b/op-supervisor/supervisor/backend/cross/safe_start.go
@@ -14,17 +14,15 @@ type SafeStartDeps interface {
 
 	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
 
-	DependencySet() depset.DependencySet
-
 	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 }
 
 // CrossSafeHazards checks if the given messages all exist and pass invariants.
 // It returns a hazard-set: if any intra-block messaging happened,
 // these hazard blocks have to be verified.
-func CrossSafeHazards(d SafeStartDeps, logger log.Logger, chainID eth.ChainID, inL1Source eth.BlockID, candidate types.BlockSeal) (*HazardSet, error) {
+func CrossSafeHazards(d SafeStartDeps, linker depset.LinkChecker, logger log.Logger, chainID eth.ChainID, inL1Source eth.BlockID, candidate types.BlockSeal) (*HazardSet, error) {
 	safeDeps := &SafeHazardDeps{SafeStartDeps: d, inL1Source: inL1Source}
-	return NewHazardSet(safeDeps, logger, chainID, candidate)
+	return NewHazardSet(safeDeps, linker, logger, chainID, candidate)
 }
 
 type SafeHazardDeps struct {

--- a/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_frontier_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -90,14 +89,9 @@ func TestHazardUnsafeFrontierChecks(t *testing.T) {
 }
 
 type mockUnsafeFrontierCheckDeps struct {
-	deps          mockDependencySet
 	findBlockIDFn func() (parent eth.BlockID, err error)
 	isCrossUnsafe error
 	isLocalUnsafe error
-}
-
-func (m *mockUnsafeFrontierCheckDeps) DependencySet() depset.DependencySet {
-	return m.deps
 }
 
 func (m *mockUnsafeFrontierCheckDeps) FindBlockID(chainID eth.ChainID, num uint64) (parent eth.BlockID, err error) {

--- a/op-supervisor/supervisor/backend/cross/unsafe_start.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_start.go
@@ -14,18 +14,16 @@ type UnsafeStartDeps interface {
 
 	IsCrossUnsafe(chainID eth.ChainID, block eth.BlockID) error
 
-	DependencySet() depset.DependencySet
-
 	OpenBlock(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error)
 }
 
 // CrossUnsafeHazards checks if the given messages all exist and pass invariants.
 // It returns a hazard-set: if any intra-block messaging happened,
 // these hazard blocks have to be verified.
-func CrossUnsafeHazards(d UnsafeStartDeps, logger log.Logger, chainID eth.ChainID,
+func CrossUnsafeHazards(d UnsafeStartDeps, linker depset.LinkChecker, logger log.Logger, chainID eth.ChainID,
 	candidate types.BlockSeal) (*HazardSet, error) {
 	unsafeDeps := &UnsafeHazardDeps{UnsafeStartDeps: d}
-	return NewHazardSet(unsafeDeps, logger, chainID, candidate)
+	return NewHazardSet(unsafeDeps, linker, logger, chainID, candidate)
 }
 
 // UnsafeHazardDeps adapts UnsafeStartDeps to HazardDeps

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -13,19 +13,6 @@ type DependencySetSource interface {
 // DependencySet is an initialized dependency set, ready to answer queries
 // of what is and what is not part of the dependency set.
 type DependencySet interface {
-
-	// CanExecuteAt determines if an executing message is valid at all.
-	// I.e. if the chain may be executing messages at the given timestamp.
-	// This may return an error if the query temporarily cannot be answered.
-	// E.g. if the DependencySet is syncing new changes.
-	CanExecuteAt(chainID eth.ChainID, execTimestamp uint64) (bool, error)
-
-	// CanInitiateAt determines if an initiating message is valid to pull in.
-	// I.e. if the message of the given chain is readable or not.
-	// This may return an error if the query temporarily cannot be answered.
-	// E.g. if the DependencySet is syncing new changes.
-	CanInitiateAt(chainID eth.ChainID, initTimestamp uint64) (bool, error)
-
 	// Chains returns the list of chains that are part of the dependency set.
 	Chains() []eth.ChainID
 

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -57,14 +57,8 @@ func testDependencySetSerialization(
 
 	depSet, err := NewStaticConfigDependencySet(
 		map[eth.ChainID]*StaticConfigDependency{
-			eth.ChainIDFromUInt64(900): {
-				ActivationTime: 42,
-				HistoryMinTime: 100,
-			},
-			eth.ChainIDFromUInt64(901): {
-				ActivationTime: 30,
-				HistoryMinTime: 20,
-			},
+			eth.ChainIDFromUInt64(900): {},
+			eth.ChainIDFromUInt64(901): {},
 		})
 	require.NoError(t, err)
 
@@ -97,7 +91,6 @@ func testDependencySetSerialization(
 		}, chainIDs)
 
 		require.Equal(t, uint64(params.MessageExpiryTimeSecondsInterop), result.MessageExpiryWindow())
-		testChainCapabilities(t, result)
 	})
 
 	t.Run("CustomExpiryWindow", func(t *testing.T) {
@@ -123,56 +116,10 @@ func testDependencySetSerialization(
 		}
 
 		require.Equal(t, uint64(15), result.MessageExpiryWindow())
-		testChainCapabilities(t, result)
 	})
 
 	t.Run("HasChain", func(t *testing.T) {
 		require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(900)))
 		require.False(t, depSet.HasChain(eth.ChainIDFromUInt64(902)))
 	})
-}
-
-func testChainCapabilities(t *testing.T, result DependencySet) {
-	// Test chain 900
-	v, err := result.CanExecuteAt(eth.ChainIDFromUInt64(900), 42)
-	require.NoError(t, err)
-	require.True(t, v)
-
-	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(900), 41)
-	require.NoError(t, err)
-	require.False(t, v)
-
-	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(900), 100)
-	require.NoError(t, err)
-	require.True(t, v)
-
-	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(900), 99)
-	require.NoError(t, err)
-	require.False(t, v)
-
-	// Test chain 901
-	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(901), 30)
-	require.NoError(t, err)
-	require.True(t, v)
-
-	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(901), 29)
-	require.NoError(t, err)
-	require.False(t, v)
-
-	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(901), 20)
-	require.NoError(t, err)
-	require.True(t, v)
-
-	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(901), 19)
-	require.NoError(t, err)
-	require.False(t, v)
-
-	// Test non-existent chain
-	v, err = result.CanExecuteAt(eth.ChainIDFromUInt64(902), 100000)
-	require.NoError(t, err)
-	require.False(t, v, "902 not a dependency")
-
-	v, err = result.CanInitiateAt(eth.ChainIDFromUInt64(902), 100000)
-	require.NoError(t, err)
-	require.False(t, v, "902 not a dependency")
 }

--- a/op-supervisor/supervisor/backend/depset/links.go
+++ b/op-supervisor/supervisor/backend/depset/links.go
@@ -40,12 +40,14 @@ func (lc *LinkCheckerImpl) CanExecute(execInChain eth.ChainID,
 	if !lc.cfg.IsInterop(execInChain, execInTimestamp) {
 		return false
 	}
+	// Note: this does not cover the genesis block of a chain, but that block is empty anyway.
 	if lc.cfg.IsInteropActivationBlock(execInChain, execInTimestamp) {
 		return false
 	}
 	if !lc.cfg.IsInterop(initChainID, initTimestamp) {
 		return false
 	}
+	// Note: this does not cover the genesis block of a chain, but that block is empty anyway.
 	if lc.cfg.IsInteropActivationBlock(initChainID, initTimestamp) {
 		return false
 	}

--- a/op-supervisor/supervisor/backend/depset/links.go
+++ b/op-supervisor/supervisor/backend/depset/links.go
@@ -1,0 +1,73 @@
+package depset
+
+import "github.com/ethereum-optimism/optimism/op-service/eth"
+
+type LinkChecker interface {
+	// CanExecute determines if an executing message is valid w.r.t. chain and timestamp constraints.
+	// I.e. if the chain may be executing messages at the given timestamp,
+	// from the given chain at the given initiating timestamp.
+	// I.e. this does not check a full message, it merely checks some linking constraints.
+	CanExecute(execInChain eth.ChainID, execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool
+}
+
+// LinkerConfig represents the config dependencies that are needed
+// to create the default LinkChecker implementation LinkCheckerImpl.
+type LinkerConfig interface {
+	ActivationConfig
+	DependencySet
+}
+
+// LinkCheckerImpl implements a LinkChecker using the provided config
+type LinkCheckerImpl struct {
+	cfg LinkerConfig
+}
+
+func LinkerFromConfig(cfg LinkerConfig) *LinkCheckerImpl {
+	return &LinkCheckerImpl{cfg: cfg}
+}
+
+func (lc *LinkCheckerImpl) CanExecute(execInChain eth.ChainID,
+	execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool {
+	// Check the chains exist in the dependency set.
+	if !lc.cfg.HasChain(execInChain) {
+		return false
+	}
+	if !lc.cfg.HasChain(initChainID) {
+		return false
+	}
+	// Note: this function deliberately moves some business logic closer to the config.
+	// What makes a valid/invalid link depends on the interop set, which can change over time.
+	if !lc.cfg.IsInterop(execInChain, execInTimestamp) {
+		return false
+	}
+	if lc.cfg.IsInteropActivationBlock(execInChain, execInTimestamp) {
+		return false
+	}
+	if !lc.cfg.IsInterop(initChainID, initTimestamp) {
+		return false
+	}
+	if lc.cfg.IsInteropActivationBlock(initChainID, initTimestamp) {
+		return false
+	}
+	if initTimestamp > execInTimestamp {
+		return false
+	}
+	window := lc.cfg.MessageExpiryWindow()
+	expiresAt := initTimestamp + window
+	if expiresAt < initTimestamp { // happens upon underflow
+		return false
+	}
+	if expiresAt < execInTimestamp { // expiry check
+		return false
+	}
+	return true
+}
+
+// LinkCheckFn is a function-type that implements LinkChecker, for testing and other special case definitions
+type LinkCheckFn func(execInChain eth.ChainID, execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool
+
+func (lFn LinkCheckFn) CanExecute(execInChain eth.ChainID, execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool {
+	return lFn(execInChain, execInTimestamp, initChainID, initTimestamp)
+}
+
+var _ LinkChecker = (LinkCheckFn)(nil)

--- a/op-supervisor/supervisor/backend/depset/links_test.go
+++ b/op-supervisor/supervisor/backend/depset/links_test.go
@@ -1,0 +1,89 @@
+package depset
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type mockLinkCfg struct {
+	activationTimes map[eth.ChainID]uint64
+	window          uint64
+}
+
+func (m *mockLinkCfg) Chains() (out []eth.ChainID) {
+	for id := range m.activationTimes {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Cmp(out[j]) < 0
+	})
+	return
+}
+
+func (m *mockLinkCfg) HasChain(chainID eth.ChainID) bool {
+	_, ok := m.activationTimes[chainID]
+	return ok
+}
+
+func (m *mockLinkCfg) IsInterop(chainID eth.ChainID, ts uint64) bool {
+	v, ok := m.activationTimes[chainID]
+	if !ok {
+		return false
+	}
+	return ts >= v
+}
+
+func (m *mockLinkCfg) IsInteropActivationBlock(chainID eth.ChainID, ts uint64) bool {
+	v, ok := m.activationTimes[chainID]
+	if !ok {
+		return false
+	}
+	return ts == v
+}
+
+func (m *mockLinkCfg) MessageExpiryWindow() uint64 {
+	return m.window
+}
+
+var _ LinkerConfig = (*mockLinkCfg)(nil)
+
+func TestLinkChecker(t *testing.T) {
+	chainA := eth.ChainIDFromUInt64(900)
+	chainB := eth.ChainIDFromUInt64(901)
+	chainUnknown := eth.ChainIDFromUInt64(700)
+
+	cfg := &mockLinkCfg{
+		activationTimes: map[eth.ChainID]uint64{
+			chainA: 1000,
+			chainB: 900,
+		},
+		window: 400,
+	}
+	linker := LinkerFromConfig(cfg)
+	req := require.New(t)
+
+	req.False(linker.CanExecute(chainA, 999, chainB, 950), "cannot exec pre-interop")
+	req.False(linker.CanExecute(chainA, 1050, chainB, 899), "cannot init pre-interop")
+
+	req.False(linker.CanExecute(chainUnknown, 2050, chainB, 2000), "cannot execute on unknown chain")
+	req.False(linker.CanExecute(chainA, 2050, chainUnknown, 2000), "cannot initiate on unknown chain")
+	req.False(linker.CanExecute(chainUnknown, 2050, chainUnknown, 2000), "cannot both be on unknown chain")
+
+	req.False(linker.CanExecute(chainA, 1050, chainB, 1051), "cannot init after exec")
+
+	req.True(linker.CanExecute(chainA, 2000, chainB, 2000), "simple same timestamp")
+	req.True(linker.CanExecute(chainA, 2050, chainB, 2000), "simple diff timestamp")
+	req.True(linker.CanExecute(chainA, 2399, chainB, 2000), "near expiry")
+	req.True(linker.CanExecute(chainA, 2400, chainB, 2000), "at expiry")
+	req.False(linker.CanExecute(chainA, 2401, chainB, 2000), "expired")
+	req.False(linker.CanExecute(chainA, (^uint64(0))-200, chainB, (^uint64(0))-300), "claimed init msg causes overflow")
+
+	req.True(linker.CanExecute(chainA, 1001, chainA, 1001), "with self")
+	req.False(linker.CanExecute(chainA, 1001, chainA, 1000), "no init at activation")
+	req.False(linker.CanExecute(chainA, 1000, chainA, 1001), "no exec at activation")
+	req.True(linker.CanExecute(chainA, 1001, chainB, 950), "other inits pre-activation of self")
+}

--- a/op-supervisor/supervisor/backend/depset/rollup_config_set.go
+++ b/op-supervisor/supervisor/backend/depset/rollup_config_set.go
@@ -28,6 +28,10 @@ type RollupConfigSet interface {
 	// guarantee of existence isn't provided by the caller context.
 	Genesis(chainID eth.ChainID) Genesis
 
+	ActivationConfig
+}
+
+type ActivationConfig interface {
 	// IsInterop returns true if the Interop hardfork is active for the given chain at the given timestamp.
 	// It panics if the chain is not part of the rollup config set.
 	// Use HasChain first to check if the chain is part of the rollup config set if

--- a/op-supervisor/supervisor/backend/depset/static_depset.go
+++ b/op-supervisor/supervisor/backend/depset/static_depset.go
@@ -14,14 +14,6 @@ import (
 )
 
 type StaticConfigDependency struct {
-	// ActivationTime is when the chain becomes part of the dependency set.
-	// This is the minimum timestamp of the inclusion of an executing message.
-	ActivationTime uint64 `json:"activationTime" toml:"activation_time"`
-
-	// HistoryMinTime is what the lower bound of data is to store.
-	// This is the minimum timestamp of an initiating message to be accessible to others.
-	// This is set to 0 when all data since genesis is executable.
-	HistoryMinTime uint64 `json:"historyMinTime" toml:"history_min_time"`
 }
 
 // StaticConfigDependencySet statically declares a DependencySet.
@@ -160,22 +152,6 @@ func (ds *StaticConfigDependencySet) LoadDependencySet(ctx context.Context) (Dep
 	return ds, nil
 }
 
-func (ds *StaticConfigDependencySet) CanExecuteAt(chainID eth.ChainID, execTimestamp uint64) (bool, error) {
-	dep, ok := ds.dependencies[chainID]
-	if !ok {
-		return false, nil
-	}
-	return execTimestamp >= dep.ActivationTime, nil
-}
-
-func (ds *StaticConfigDependencySet) CanInitiateAt(chainID eth.ChainID, initTimestamp uint64) (bool, error) {
-	dep, ok := ds.dependencies[chainID]
-	if !ok {
-		return false, nil
-	}
-	return initTimestamp >= dep.HistoryMinTime, nil
-}
-
 func (ds *StaticConfigDependencySet) Chains() []eth.ChainID {
 	return slices.Clone(ds.chainIDs)
 }
@@ -195,11 +171,8 @@ func (ds *StaticConfigDependencySet) MessageExpiryWindow() uint64 {
 // Dependencies returns a deep copy of the dependencies map
 func (ds *StaticConfigDependencySet) Dependencies() map[eth.ChainID]*StaticConfigDependency {
 	copied := make(map[eth.ChainID]*StaticConfigDependency, len(ds.dependencies))
-	for chainId, dep := range ds.dependencies {
-		copied[chainId] = &StaticConfigDependency{
-			ActivationTime: dep.ActivationTime,
-			HistoryMinTime: dep.HistoryMinTime,
-		}
+	for chainId := range ds.dependencies {
+		copied[chainId] = &StaticConfigDependency{}
 	}
 	return copied
 }

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -1426,10 +1426,7 @@ func setupTestChains(t *testing.T, chainIDs ...eth.ChainID) *testSetup {
 	// Create dependency set for all chains
 	deps := make(map[eth.ChainID]*depset.StaticConfigDependency)
 	for _, chainID := range chainIDs {
-		deps[chainID] = &depset.StaticConfigDependency{
-			ActivationTime: 42,
-			HistoryMinTime: 100,
-		}
+		deps[chainID] = &depset.StaticConfigDependency{}
 	}
 	depSet, err := depset.NewStaticConfigDependencySet(deps)
 	require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -193,14 +193,8 @@ var _ backend = (*mockBackend)(nil)
 func sampleDepSet(t *testing.T) depset.DependencySet {
 	depSet, err := depset.NewStaticConfigDependencySet(
 		map[eth.ChainID]*depset.StaticConfigDependency{
-			eth.ChainIDFromUInt64(900): {
-				ActivationTime: 42,
-				HistoryMinTime: 100,
-			},
-			eth.ChainIDFromUInt64(901): {
-				ActivationTime: 30,
-				HistoryMinTime: 20,
-			},
+			eth.ChainIDFromUInt64(900): {},
+			eth.ChainIDFromUInt64(901): {},
 		})
 	require.NoError(t, err)
 	return depSet


### PR DESCRIPTION
**Description**

~~This PR is based on https://github.com/ethereum-optimism/optimism/pull/16122 (removal of chain index type)~~ (merged)

This further simplifies the interop config, by removing the need for the timestamps per chain.

This PR introduce a "link checker", or nicknamed "linker" in a few places.

This basically encapsulates the invariant-checks / chain-ID existence checks, so it's not directly part of the other cross-verification anymore.
This nicely simplifies the `cross` package in a few places: invalid is invalid, we don't want all the special cases to be different paths.

The default link checker is created from the full-config-set (introduced last week by @sebastianst).
This will check the chain presence, the interop timestamp, activation block, timestamp invariant, and expiry window condition.

```go
type LinkChecker interface {
	// CanExecute determines if an executing message is valid w.r.t. chain and timestamp constraints.
	// I.e. if the chain may be executing messages at the given timestamp,
	// from the given chain at the given initiating timestamp.
	// I.e. this does not check a full message, it merely checks some linking constraints.
	CanExecute(execInChain eth.ChainID, execInTimestamp uint64, initChainID eth.ChainID, initTimestamp uint64) bool
}
```

Note that this gives us a great deal of flexibility for future config changes that influence which chain can interact with which chain. E.g. when merging or extending interop dependency sets. All without changing the `cross` package.

This also means we don't individually check single-sided chain cases of executing and initiating activeness. It always checks the link with both ends.
And these cheap config checks will always run before any DB lookups happen to check the message checksums etc.

Todos (ideally for follow-up PR):
- op-program initializes the boot-info with a full-config set now, but it can use some cleanup. And the L1 anchor timestamp is not set properly yet; that needs some work.
- maybe change the dependency config format from `{<chainID>: { /* empty map ! */} }` to `[<chainID>...]`  (maps do give us nice de-duplication though)


**Tests**

- Added new unit-testing for the link checker type
- Updated existing testing (no new functionality)

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/16083
