### PR TITLE
op-devstack: contract call DSL backend

### DIFF
--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -6,8 +6,18 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // TestInitExecMsg tests basic interop messaging
@@ -25,4 +35,86 @@ func TestInitExecMsg(gt *testing.T) {
 	sys.Supervisor.AdvancedUnsafeHead(alice.ChainID(), 2)
 	// Single event in tx so index is 0
 	bob.SendExecMessage(initIntent, 0)
+}
+
+// TestInitExecMsgWithDSL tests basic interop messaging with contract DSL
+func TestInitExecMsgWithDSL(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+	rng := rand.New(rand.NewSource(1234))
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	require := t.Require()
+
+	eventLoggerAddress := alice.DeployEventLogger()
+
+	clientA := sys.L2ELA.Escape().EthClient()
+	clientB := sys.L2ELB.Escape().EthClient()
+
+	// Initialize eventLogger binding
+	eventLoggerCallFactory := bindings.NewEventLoggerCallFactory(
+		bindings.WithClient(clientA), bindings.WithTest(t), bindings.WithTo(eventLoggerAddress),
+	)
+	eventLogger := bindings.NewEventLogger(eventLoggerCallFactory)
+
+	// Initialize crossL2Inbox binding
+	crossL2InboxCallFactory := bindings.NewCrossL2InboxCallFactory(
+		bindings.WithClient(clientB), bindings.WithTest(t),
+	)
+	crossL2InboxCallFactory.WithDefaultAddr()
+	crossL2Inbox := bindings.NewCrossL2Inbox(crossL2InboxCallFactory)
+
+	// manually build topics and data for EventLogger
+	topics := []eth.Bytes32{}
+	for range rng.Intn(5) {
+		var topic [32]byte
+		copy(topic[:], testutils.RandomData(rng, 32))
+		topics = append(topics, topic)
+	}
+	data := testutils.RandomData(rng, rng.Intn(30))
+
+	// Write: Alice triggers initiating message
+	receipt := contract.Write(alice, eventLogger.EmitLog(topics, data))
+	block, err := clientA.BlockRefByNumber(t.Ctx(), receipt.BlockNumber.Uint64())
+	require.NoError(err)
+
+	sys.Supervisor.AdvancedUnsafeHead(alice.ChainID(), 2)
+
+	// Manually build identifier, message, accesslist for executing message
+	// Single event in tx so index is 0
+	logIdx := uint32(0)
+	payload := suptypes.LogToMessagePayload(receipt.Logs[logIdx])
+	identifier := suptypes.Identifier{
+		Origin:      eventLoggerAddress,
+		BlockNumber: receipt.BlockNumber.Uint64(),
+		LogIndex:    logIdx,
+		Timestamp:   block.Time,
+		ChainID:     sys.L2ELA.ChainID(),
+	}
+	payloadHash := crypto.Keccak256Hash(payload)
+	msgHash := eth.Bytes32(payloadHash)
+	msg := suptypes.Message{
+		Identifier: identifier, PayloadHash: payloadHash,
+	}
+	accessList := types.AccessList{{
+		Address:     predeploys.CrossL2InboxAddr,
+		StorageKeys: suptypes.EncodeAccessList([]suptypes.Access{msg.Access()}),
+	}}
+
+	call := crossL2Inbox.ValidateMessage(identifier, msgHash)
+
+	// Read not using the DSL. Therefore you need to manually error handle and also set context
+	_, err = contractio.Read(call, t.Ctx())
+	// Will revert because access list not provided
+	require.Error(err)
+	// Provide access list using txplan
+	_, err = contractio.Read(call, t.Ctx(), txplan.WithAccessList(accessList))
+	// Success because access list made storage slot warm
+	require.NoError(err)
+
+	// Read: Trigger executing message
+	contract.Read(call, txplan.WithAccessList(accessList))
+
+	// Write: Bob triggers executing message
+	contract.Write(bob, call, txplan.WithAccessList(accessList))
 }

--- a/op-chain-ops/script/precompile.go
+++ b/op-chain-ops/script/precompile.go
@@ -149,7 +149,7 @@ func makeArgs(argCount int, getType func(i int) reflect.Type) (abi.Arguments, er
 	out := make(abi.Arguments, argCount)
 	for i := 0; i < argCount; i++ {
 		argType := getType(i)
-		abiTyp, err := goTypeToABIType(argType)
+		abiTyp, err := GoTypeToABIType(argType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to determine ABI type of input arg %d: %w", i, err)
 		}
@@ -343,8 +343,8 @@ func convertType(src, dest any) (out any, err error) {
 	return
 }
 
-// goTypeToABIType infers the geth ABI type definition from a Go reflect type definition.
-func goTypeToABIType(typ reflect.Type) (abi.Type, error) {
+// GoTypeToABIType infers the geth ABI type definition from a Go reflect type definition.
+func GoTypeToABIType(typ reflect.Type) (abi.Type, error) {
 	solType, internalType, err := goTypeToSolidityType(typ)
 	if err != nil {
 		return abi.Type{}, err
@@ -494,7 +494,7 @@ func (p *Precompile[E]) setupStructField(fieldDef *reflect.StructField, fieldVal
 			fieldDef.Name, m.abiSignature, m.goName, byte4Sig)
 	}
 	// Determine the type to ABI-encode the Go field value into
-	abiTyp, err := goTypeToABIType(fieldDef.Type)
+	abiTyp, err := GoTypeToABIType(fieldDef.Type)
 	if err != nil {
 		return fmt.Errorf("failed to determine ABI type of struct field of type %s: %w", fieldDef.Type, err)
 	}

--- a/op-chain-ops/script/precompile.go
+++ b/op-chain-ops/script/precompile.go
@@ -345,6 +345,16 @@ func convertType(src, dest any) (out any, err error) {
 
 // GoTypeToABIType infers the geth ABI type definition from a Go reflect type definition.
 func GoTypeToABIType(typ reflect.Type) (abi.Type, error) {
+	// temporal hardcode for tuple types
+	if typ == reflect.TypeFor[ABIIdentifier]() {
+		return abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+			{Name: "Origin", Type: "address"},
+			{Name: "BlockNumber", Type: "uint256"},
+			{Name: "LogIndex", Type: "uint256"},
+			{Name: "Timestamp", Type: "uint256"},
+			{Name: "ChainId", Type: "uint256"},
+		})
+	}
 	solType, internalType, err := goTypeToSolidityType(typ)
 	if err != nil {
 		return abi.Type{}, err
@@ -359,6 +369,14 @@ type ABIInt256 big.Int
 var abiInt256Type = typeFor[ABIInt256]()
 
 var abiUint256Type = typeFor[uint256.Int]()
+
+type ABIIdentifier struct {
+	Origin      common.Address
+	BlockNumber *big.Int
+	LogIndex    *big.Int
+	Timestamp   *big.Int
+	ChainId     *big.Int
+}
 
 // goTypeToSolidityType converts a Go type to the solidity ABI type definition.
 // The "internalType" is a quirk of the Geth ABI utils, for nested structures.

--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -14,35 +12,32 @@ import (
 
 // TestCallView is used in devstack for wrapping errors
 type TestCallView[O any] interface {
-	txintent.CallView[O]
 	Test() bindings.BaseTest
 }
 
-// checkTestable checks whether the Call can be used as a DSL using the testing context
-func checkTestable[O any](call txintent.CallView[O]) TestCallView[O] {
-	callTest, ok := call.(TestCallView[O])
+// checkTestable checks whether the TypedCall can be used as a DSL using the testing context
+func checkTestable[O any](call bindings.TypedCall[O]) {
+	callTest, ok := any(call).(TestCallView[O])
 	if !ok || callTest.Test() == nil {
 		panic(fmt.Sprintf("call of type %T does not support testing", call))
 	}
-	return callTest
 }
 
 // Read executes a new message call without creating a transaction on the blockchain
-func Read[O any](call txintent.CallView[O], opts ...txplan.Option) O {
-	callTest := checkTestable(call)
-	o, err := contractio.Read(call, callTest.Test().Ctx(), opts...)
-	callTest.Test().Require().NoError(err)
+func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
+	checkTestable(call)
+	o, err := contractio.Read(call, call.Test().Ctx(), opts...)
+	call.Test().Require().NoError(err)
 	return o
 }
 
 // Write makes a user to write a tx by using the planned contract bindings
-func Write[O any](user *dsl.EOA, call txintent.CallView[O], opts ...txplan.Option) *types.Receipt {
-	callTest := checkTestable(call)
+func Write[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) *types.Receipt {
+	checkTestable(call)
 	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
-	o, err := contractio.Write(call, callTest.Test().Ctx(), finalOpts)
-	callTest.Test().Require().NoError(err)
+	o, err := contractio.Write(call, call.Test().Ctx(), finalOpts)
+	call.Test().Require().NoError(err)
 	return o
 }
 
-var _ TestCallView[eth.ETH] = (*bindings.BalanceOfCall)(nil)
-var _ TestCallView[bool] = (*bindings.TransferCall)(nil)
+var _ TestCallView[any] = (*bindings.TypedCall[any])(nil)

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -195,12 +195,12 @@ func InitImpl[T any](impl *T) {
 				if len(innerResults) != 1 {
 					panic("expected one return value")
 				}
-				innerλ := innerResults[0]
-				wrap := reflect.New(outputType).Elem()
-				wrap.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
-				wrap.FieldByName("EncodeInputLambda").Set(innerλ)
-				wrap.FieldByName("BaseCallFactory").Set(baseCallFactory.Addr())
-				return []reflect.Value{wrap}
+				encoderLambda := innerResults[0]
+				typedCall := reflect.New(outputType).Elem()
+				typedCall.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
+				typedCall.FieldByName("EncodeInputLambda").Set(encoderLambda)
+				typedCall.FieldByName("BaseCallFactory").Set(baseCallFactory.Addr())
+				return []reflect.Value{typedCall}
 			})
 			v.FieldByName(field.Name).Set(lambda)
 		}

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -99,10 +99,13 @@ func (b *BaseCallFactory) ApplyFactoryOptions(opts ...CallFactoryOption) {
 	}
 }
 
-func CheckImpl(parent any) {
-	t := reflect.TypeOf(parent)
+func CheckImpl(v reflect.Value) reflect.Value {
+	t := v.Type()
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		panic("expected struct")
 	}
 	for i := range t.NumField() {
 		field := t.Field(i)
@@ -118,17 +121,39 @@ func CheckImpl(parent any) {
 			panic("all methods must have single return type")
 		}
 	}
+	baseCallFactory := findBaseCallFactory(v)
+	if !baseCallFactory.IsValid() {
+		panic("BaseCallFactory not found in embedded fields")
+	}
+	return baseCallFactory
 }
 
-func InitImpl[T any](impl *T, factory *BaseCallFactory) {
+func findBaseCallFactory(v reflect.Value) reflect.Value {
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if !field.CanInterface() {
+			continue
+		}
+		t := field.Type()
+		if t == reflect.TypeOf(BaseCallFactory{}) {
+			return field
+		}
+		if t.Kind() == reflect.Struct {
+			if found := findBaseCallFactory(field); found.IsValid() {
+				return found
+			}
+		}
+	}
+	return reflect.Value{}
+}
+
+func InitImpl[T any](impl *T) {
 	v := reflect.ValueOf(impl).Elem()
 	t := v.Type()
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
-	if t.Kind() != reflect.Struct {
-		panic("expected struct")
-	}
+	baseCallFactory := CheckImpl(v)
 	for i := range v.NumField() {
 		field := t.Field(i)
 		fieldType := field.Type
@@ -174,7 +199,7 @@ func InitImpl[T any](impl *T, factory *BaseCallFactory) {
 				wrap := reflect.New(outputType).Elem()
 				wrap.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
 				wrap.FieldByName("EncodeInputLambda").Set(innerλ)
-				wrap.FieldByName("BaseCallFactory").Set(reflect.ValueOf(factory))
+				wrap.FieldByName("BaseCallFactory").Set(baseCallFactory.Addr())
 				return []reflect.Value{wrap}
 			})
 			v.FieldByName(field.Name).Set(lambda)

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// field lambdas corresponding to solidity functions must be tagged with sol
+// tag value is used for initializing solidity function selector
 const MethodTagName string = "sol"
 
 // BaseCall contains fields to populate fields of txplan
@@ -98,6 +100,8 @@ func (b *BaseCallFactory) ApplyFactoryOptions(opts ...CallFactoryOption) {
 	}
 }
 
+// CheckImpl validates that the given binding struct has correctly defined function fields
+// Each function field must have a `sol` tag (MethodTagName) and the struct must embed BaseCallFactory
 func CheckImpl(v reflect.Value) reflect.Value {
 	t := v.Type()
 	if t.Kind() == reflect.Ptr {
@@ -127,6 +131,7 @@ func CheckImpl(v reflect.Value) reflect.Value {
 	return baseCallFactory
 }
 
+// findBaseCallFactory recursively searches the struct for an embedded BaseCallFactory and returns its value
 func findBaseCallFactory(v reflect.Value) reflect.Value {
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
@@ -146,6 +151,8 @@ func findBaseCallFactory(v reflect.Value) reflect.Value {
 	return reflect.Value{}
 }
 
+// InitImpl initializes function fields (lambdas) in the given struct by assigning concrete implementations
+// The struct must be a pointer, and its fields are expected to follow a specific pattern for reflection-based setup
 func InitImpl[T any](impl *T) {
 	v := reflect.ValueOf(impl).Elem()
 	t := v.Type()
@@ -169,13 +176,15 @@ func InitImpl[T any](impl *T) {
 			// outer: func(...args) -> inner: (func() -> (bytes[], error))
 			funcInputWrapper := reflect.FuncOf(inputTypes, []reflect.Type{funcInput}, false)
 
+			// encoderOuter is a higher order function which returns encoderInner
+			// encoderInner is a closure, binded with solidity method arguments and lazily evaluated
 			encoderOuter := reflect.MakeFunc(funcInputWrapper, func(argsOuter []reflect.Value) []reflect.Value {
 				encoderInner := reflect.MakeFunc(funcInput, func(argsInner []reflect.Value) []reflect.Value {
 					callArgs := make([]any, len(argsOuter))
 					for i, a := range argsOuter {
 						callArgs[i] = a.Interface()
 					}
-					v0, v1 := encoder(methodName, callArgs...)
+					v0, v1 := ABIEncoder(methodName, callArgs...)
 					ret := []reflect.Value{reflect.Zero(funcInputRet[0]), reflect.Zero(funcInputRet[1])}
 					if v0 != nil { // bytes[]
 						ret[0] = reflect.ValueOf(v0)
@@ -206,6 +215,7 @@ func InitImpl[T any](impl *T) {
 	}
 }
 
+// Call implements txintent Call interface
 type Call struct {
 	*BaseCallFactory
 
@@ -219,9 +229,12 @@ func (c *Call) EncodeInput() ([]byte, error) {
 
 var _ txintent.Call = (*Call)(nil)
 
+// TypedCall implements txintent CallView interface
 type TypedCall[ReturnType any] struct {
 	Call
 }
+
+var _ txintent.CallView[any] = (*TypedCall[any])(nil)
 
 // OpServiceTypeToGoType converts op-service type to go type
 func OpServiceTypeToGoType(retTyp reflect.Type) reflect.Type {
@@ -295,9 +308,7 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	return val, nil
 }
 
-var _ txintent.CallView[any] = (*TypedCall[any])(nil)
-
-func encoder(name string, args ...any) ([]byte, error) {
+func ABIEncoder(name string, args ...any) ([]byte, error) {
 	inputs := make([]abi.Argument, len(args))
 	argsTranslated := make([]any, len(args))
 	for i, arg := range args {

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -2,12 +2,23 @@ package bindings
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
+
+const MethodTagName string = "sol"
 
 // BaseCall contains fields to populate fields of txplan
 type BaseCall struct {
@@ -86,4 +97,123 @@ func (b *BaseCallFactory) ApplyFactoryOptions(opts ...CallFactoryOption) {
 	for _, opt := range opts {
 		opt(b)
 	}
+}
+
+func CheckFactoryImpl(parent any) {
+	t := reflect.TypeOf(parent)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	for i := range t.NumField() {
+		field := t.Field(i)
+		fieldType := field.Type
+		// check only function fields, which will be automatically inferred for codec
+		if fieldType.Kind() != reflect.Func {
+			continue
+		}
+		if len(field.Tag.Get(MethodTagName)) == 0 {
+			panic(fmt.Sprintf("all methods must have `%s` tags for calldata", MethodTagName))
+		}
+		if fieldType.NumOut() != 1 {
+			panic("all methods must have single return type")
+		}
+	}
+}
+
+type Call struct {
+	*BaseCallFactory
+
+	MethodName        string
+	EncodeInputLambda func() ([]byte, error)
+}
+
+func (c *Call) EncodeInput() ([]byte, error) {
+	return c.EncodeInputLambda()
+}
+
+var _ txintent.Call = (*Call)(nil)
+
+type TypedCall[ReturnType any] struct {
+	Call
+}
+
+func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
+	var zero ReturnType
+	retTyp := reflect.TypeOf(zero)
+
+	// Special handling for eth.ETH
+	var abiTargetType reflect.Type
+	if retTyp == reflect.TypeOf(eth.ETH{}) {
+		abiTargetType = reflect.TypeOf(big.NewInt(0))
+	} else {
+		abiTargetType = retTyp
+	}
+
+	abiType, err := script.GoTypeToABIType(abiTargetType)
+	if err != nil {
+		return zero, fmt.Errorf("failed to convert Go type to ABI type: %w", err)
+	}
+
+	outputs := abi.Arguments{{Type: abiType}}
+	decoded, err := outputs.Unpack(data)
+	if err != nil {
+		return zero, fmt.Errorf("ABI unpack error: %w", err)
+	}
+
+	// TODO: handle multiple returns
+	val := decoded[0]
+
+	// Special handling for eth.ETH
+	switch retTyp {
+	case reflect.TypeOf(eth.ETH{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		var concrete eth.ETH
+		if (*uint256.Int)(&concrete).SetFromBig(bigVal) {
+			return zero, errors.New("result conversion failure: does not fit in uint256")
+		}
+		return any(concrete).(ReturnType), nil
+	default:
+		ptr := abi.ConvertType(val, new(ReturnType)).(*ReturnType)
+		return *ptr, nil
+	}
+}
+
+var _ txintent.CallView[any] = (*TypedCall[any])(nil)
+
+func encoder(name string, args ...any) ([]byte, error) {
+	inputs := []abi.Argument{}
+	args_translated := []any{}
+	for i, arg := range args {
+		var typ reflect.Type
+		// handle op service types
+		switch v := arg.(type) {
+		case eth.ETH:
+			argsTyped := v.ToBig()
+			typ = reflect.TypeOf(argsTyped)
+			args_translated = append(args_translated, argsTyped)
+		default:
+			typ = reflect.TypeOf(arg)
+			args_translated = append(args_translated, arg)
+		}
+		abiTyp, err := script.GoTypeToABIType(typ)
+		if err != nil {
+			panic("go type to abi type")
+		}
+		input := abi.Argument{
+			Name: fmt.Sprintf("arg_%d", i),
+			Type: abiTyp,
+		}
+		inputs = append(inputs, input)
+	}
+
+	// Internally initialise sig and ID
+	// Use dummy vars but calldata does not care
+	method := abi.NewMethod(name, name, abi.Function, "payable", false, false, inputs, abi.Arguments{})
+	arguments, err := method.Inputs.Pack(args_translated...)
+	if err != nil {
+		panic(err)
+	}
+	result := append(method.ID, arguments...)
+
+	return result, err
 }

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// field lambdas corresponding to solidity functions must be tagged with sol
+// function fields(lambdas) corresponding to solidity functions must be tagged with sol
 // tag value is used for initializing solidity function selector
 const MethodTagName string = "sol"
 
@@ -152,7 +152,7 @@ func findBaseCallFactory(v reflect.Value) reflect.Value {
 }
 
 // InitImpl initializes function fields (lambdas) in the given struct by assigning concrete implementations
-// The struct must be a pointer, and its fields are expected to follow a specific pattern for reflection-based setup
+// The input struct must be a pointer, and its fields are expected to follow a specific pattern for reflection-based setup
 func InitImpl[T any](impl *T) {
 	v := reflect.ValueOf(impl).Elem()
 	t := v.Type()
@@ -163,6 +163,7 @@ func InitImpl[T any](impl *T) {
 	for i := range v.NumField() {
 		field := t.Field(i)
 		fieldType := field.Type
+		// Only care about function fields
 		if fieldType.Kind() == reflect.Func {
 			methodName := field.Tag.Get(MethodTagName)
 			inputTypes := []reflect.Type{}
@@ -173,7 +174,7 @@ func InitImpl[T any](impl *T) {
 			// inner: func() -> (bytes[], error)
 			funcInputRet := []reflect.Type{reflect.TypeFor[[]byte](), reflect.TypeFor[error]()}
 			funcInput := reflect.FuncOf([]reflect.Type{}, funcInputRet, false)
-			// outer: func(...args) -> inner: (func() -> (bytes[], error))
+			// outer: func(args...) -> inner: (func() -> (bytes[], error))
 			funcInputWrapper := reflect.FuncOf(inputTypes, []reflect.Type{funcInput}, false)
 
 			// encoderOuter is a higher order function which returns encoderInner
@@ -197,7 +198,7 @@ func InitImpl[T any](impl *T) {
 				return []reflect.Value{encoderInner}
 			})
 
-			// Initialize actual binding lambda fields
+			// Initialize actual binding function fields
 			lambda := reflect.MakeFunc(fieldType, func(args []reflect.Value) []reflect.Value {
 				innerResults := encoderOuter.Call(args)
 				if len(innerResults) != 1 {

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // function fields(lambdas) corresponding to solidity functions must be tagged with sol
@@ -242,6 +244,8 @@ func OpServiceTypeToGoType(retTyp reflect.Type) reflect.Type {
 	switch retTyp {
 	case reflect.TypeOf(eth.ETH{}), reflect.TypeOf(eth.ChainID{}):
 		return reflect.TypeOf(big.NewInt(0))
+	case reflect.TypeOf(suptypes.Identifier{}):
+		return reflect.TypeOf(script.ABIIdentifier{})
 	default:
 		return retTyp
 	}
@@ -255,6 +259,15 @@ func OpServiceValueToABIValue(arg any) any {
 		value = v.ToBig()
 	case eth.ChainID:
 		value = v.ToBig()
+	case suptypes.Identifier:
+		identifier := script.ABIIdentifier{
+			v.Origin,
+			big.NewInt(int64(v.BlockNumber)),
+			big.NewInt(int64(v.LogIndex)),
+			big.NewInt(int64(v.Timestamp)),
+			v.ChainID.ToBig(),
+		}
+		value = identifier
 	default:
 		value = v
 	}

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -284,6 +284,7 @@ func ABIValueToOpServiceValue[ReturnType any](retTyp reflect.Type, val any) Retu
 	}
 }
 
+// DecodeOutput unwraps ReturnType from TypedCall and abi decodes byte string
 func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	var zero ReturnType
 	retTyp := reflect.TypeOf(zero)
@@ -308,6 +309,7 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	return val, nil
 }
 
+// ABIEncoder abi encodes arguments with function name
 func ABIEncoder(name string, args ...any) ([]byte, error) {
 	inputs := make([]abi.Argument, len(args))
 	argsTranslated := make([]any, len(args))

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -275,6 +275,10 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	var zero ReturnType
 	retTyp := reflect.TypeOf(zero)
 
+	if retTyp.Kind() == reflect.Struct {
+		panic("multiple return type using struct is not supported yet")
+	}
+
 	abiTargetType := OpServiceTypeToGoType(retTyp)
 	abiType, err := script.GoTypeToABIType(abiTargetType)
 	if err != nil {
@@ -287,7 +291,6 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 		panic(err)
 	}
 
-	// TODO: handle multiple returns
 	val := ABIValueToOpServiceValue[ReturnType](retTyp, decoded[0])
 	return val, nil
 }

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -134,59 +134,50 @@ func InitImpl[T any](impl *T, factory *BaseCallFactory) {
 		fieldType := field.Type
 		if fieldType.Kind() == reflect.Func {
 			methodName := field.Tag.Get(MethodTagName)
-
 			inputTypes := []reflect.Type{}
 			for j := range fieldType.NumIn() {
 				inputTypes = append(inputTypes, fieldType.In(j))
 			}
 			outputType := fieldType.Out(0)
-
-			// outer: func(...args) -> <inner: (func() -> (bytes[], error))>
 			// inner: func() -> (bytes[], error)
-			funcInput := reflect.FuncOf([]reflect.Type{}, []reflect.Type{reflect.TypeOf([]byte{}), reflect.TypeOf((*error)(nil)).Elem()}, false)
+			funcInputRet := []reflect.Type{reflect.TypeFor[[]byte](), reflect.TypeFor[error]()}
+			funcInput := reflect.FuncOf([]reflect.Type{}, funcInputRet, false)
+			// outer: func(...args) -> inner: (func() -> (bytes[], error))
 			funcInputWrapper := reflect.FuncOf(inputTypes, []reflect.Type{funcInput}, false)
 
-			encoderLambdaLambda := reflect.MakeFunc(funcInputWrapper, func(argsOuter []reflect.Value) []reflect.Value {
-				encoderLambda := reflect.MakeFunc(funcInput, func(argsInner []reflect.Value) []reflect.Value {
+			encoderOuter := reflect.MakeFunc(funcInputWrapper, func(argsOuter []reflect.Value) []reflect.Value {
+				encoderInner := reflect.MakeFunc(funcInput, func(argsInner []reflect.Value) []reflect.Value {
 					callArgs := make([]any, len(argsOuter))
 					for i, a := range argsOuter {
 						callArgs[i] = a.Interface()
 					}
 					v0, v1 := encoder(methodName, callArgs...)
-
-					// guard
-					var val0 reflect.Value
-					if v0 == nil {
-						val0 = reflect.Zero(reflect.TypeOf([]byte{}))
-					} else {
-						val0 = reflect.ValueOf(v0)
+					ret := []reflect.Value{reflect.Zero(funcInputRet[0]), reflect.Zero(funcInputRet[1])}
+					if v0 != nil { // bytes[]
+						ret[0] = reflect.ValueOf(v0)
 					}
-					var val1 reflect.Value
-					if v1 == nil {
-						val1 = reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())
-					} else {
-						val1 = reflect.ValueOf(v1)
+					if v1 != nil { // error
+						ret[1] = reflect.ValueOf(v1)
 					}
-
-					return []reflect.Value{val0, val1}
+					return ret
 				})
-				inner := encoderLambda.Interface().(func() ([]byte, error))
-				return []reflect.Value{reflect.ValueOf(inner)}
+				return []reflect.Value{encoderInner}
 			})
 
-			λ := reflect.MakeFunc(fieldType, func(args []reflect.Value) []reflect.Value {
-				innerResults := encoderLambdaLambda.Call(args)
+			// Initialize actual binding lambda fields
+			lambda := reflect.MakeFunc(fieldType, func(args []reflect.Value) []reflect.Value {
+				innerResults := encoderOuter.Call(args)
 				if len(innerResults) != 1 {
 					panic("expected one return value")
 				}
-				innerλ := innerResults[0].Interface().(func() ([]byte, error))
+				innerλ := innerResults[0]
 				wrap := reflect.New(outputType).Elem()
 				wrap.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
-				wrap.FieldByName("EncodeInputLambda").Set(reflect.ValueOf(innerλ))
+				wrap.FieldByName("EncodeInputLambda").Set(innerλ)
 				wrap.FieldByName("BaseCallFactory").Set(reflect.ValueOf(factory))
 				return []reflect.Value{wrap}
 			})
-			v.FieldByName(field.Name).Set(λ)
+			v.FieldByName(field.Name).Set(lambda)
 		}
 	}
 }
@@ -212,7 +203,7 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	var zero ReturnType
 	retTyp := reflect.TypeOf(zero)
 
-	// Special handling for eth.ETH
+	// Special handling for op-service types
 	var abiTargetType reflect.Type
 	if retTyp == reflect.TypeOf(eth.ETH{}) {
 		abiTargetType = reflect.TypeOf(big.NewInt(0))
@@ -222,19 +213,19 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 
 	abiType, err := script.GoTypeToABIType(abiTargetType)
 	if err != nil {
-		return zero, fmt.Errorf("failed to convert Go type to ABI type: %w", err)
+		panic(err)
 	}
 
 	outputs := abi.Arguments{{Type: abiType}}
 	decoded, err := outputs.Unpack(data)
 	if err != nil {
-		return zero, fmt.Errorf("ABI unpack error: %w", err)
+		panic(err)
 	}
 
 	// TODO: handle multiple returns
 	val := decoded[0]
 
-	// Special handling for eth.ETH
+	// Special handling for op-service types
 	switch retTyp {
 	case reflect.TypeOf(eth.ETH{}):
 		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
@@ -252,35 +243,34 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 var _ txintent.CallView[any] = (*TypedCall[any])(nil)
 
 func encoder(name string, args ...any) ([]byte, error) {
-	inputs := []abi.Argument{}
-	args_translated := []any{}
-	for i, arg := range args {
-		var typ reflect.Type
-		// handle op service types
+	inputs := make([]abi.Argument, 0, len(args))
+	argsTranslated := make([]any, 0, len(args))
+	for _, arg := range args {
+		var (
+			goType reflect.Type
+			value  any
+		)
+		// Special handling for op-service types
 		switch v := arg.(type) {
 		case eth.ETH:
-			argsTyped := v.ToBig()
-			typ = reflect.TypeOf(argsTyped)
-			args_translated = append(args_translated, argsTyped)
+			value = v.ToBig()
+			goType = reflect.TypeOf(value)
 		default:
-			typ = reflect.TypeOf(arg)
-			args_translated = append(args_translated, arg)
+			value = v
+			goType = reflect.TypeOf(v)
 		}
-		abiTyp, err := script.GoTypeToABIType(typ)
+		abiType, err := script.GoTypeToABIType(goType)
 		if err != nil {
-			panic("go type to abi type")
+			panic(err)
 		}
-		input := abi.Argument{
-			Name: fmt.Sprintf("arg_%d", i),
-			Type: abiTyp,
-		}
-		inputs = append(inputs, input)
+		inputs = append(inputs, abi.Argument{Type: abiType})
+		argsTranslated = append(argsTranslated, value)
 	}
 
 	// Internally initialise sig and ID
 	// Use dummy vars but calldata does not care
 	method := abi.NewMethod(name, name, abi.Function, "payable", false, false, inputs, abi.Arguments{})
-	arguments, err := method.Inputs.Pack(args_translated...)
+	arguments, err := method.Inputs.Pack(argsTranslated...)
 	if err != nil {
 		panic(err)
 	}

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -2,7 +2,6 @@ package bindings
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -224,18 +223,59 @@ type TypedCall[ReturnType any] struct {
 	Call
 }
 
+// OpServiceTypeToGoType converts op-service type to go type
+func OpServiceTypeToGoType(retTyp reflect.Type) reflect.Type {
+	switch retTyp {
+	case reflect.TypeOf(eth.ETH{}), reflect.TypeOf(eth.ChainID{}):
+		return reflect.TypeOf(big.NewInt(0))
+	default:
+		return retTyp
+	}
+}
+
+// OpServiceValueToABIValue converts op-service value to abi value
+func OpServiceValueToABIValue(arg any) any {
+	var value any
+	switch v := arg.(type) {
+	case eth.ETH:
+		value = v.ToBig()
+	case eth.ChainID:
+		value = v.ToBig()
+	default:
+		value = v
+	}
+	return value
+}
+
+// ABIValueToOpServiceValue converts abi value to op-service value
+func ABIValueToOpServiceValue[ReturnType any](retTyp reflect.Type, val any) ReturnType {
+	var zero ReturnType
+	switch retTyp {
+	case reflect.TypeOf(eth.ETH{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		var concrete eth.ETH
+		if (*uint256.Int)(&concrete).SetFromBig(bigVal) {
+			return zero
+		}
+		return any(concrete).(ReturnType)
+	case reflect.TypeOf(eth.ChainID{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		var concrete eth.ChainID
+		if (*uint256.Int)(&concrete).SetFromBig(bigVal) {
+			return zero
+		}
+		return any(concrete).(ReturnType)
+	default:
+		ptr := abi.ConvertType(val, new(ReturnType)).(*ReturnType)
+		return *ptr
+	}
+}
+
 func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	var zero ReturnType
 	retTyp := reflect.TypeOf(zero)
 
-	// Special handling for op-service types
-	var abiTargetType reflect.Type
-	if retTyp == reflect.TypeOf(eth.ETH{}) {
-		abiTargetType = reflect.TypeOf(big.NewInt(0))
-	} else {
-		abiTargetType = retTyp
-	}
-
+	abiTargetType := OpServiceTypeToGoType(retTyp)
 	abiType, err := script.GoTypeToABIType(abiTargetType)
 	if err != nil {
 		panic(err)
@@ -248,48 +288,24 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	}
 
 	// TODO: handle multiple returns
-	val := decoded[0]
-
-	// Special handling for op-service types
-	switch retTyp {
-	case reflect.TypeOf(eth.ETH{}):
-		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
-		var concrete eth.ETH
-		if (*uint256.Int)(&concrete).SetFromBig(bigVal) {
-			return zero, errors.New("result conversion failure: does not fit in uint256")
-		}
-		return any(concrete).(ReturnType), nil
-	default:
-		ptr := abi.ConvertType(val, new(ReturnType)).(*ReturnType)
-		return *ptr, nil
-	}
+	val := ABIValueToOpServiceValue[ReturnType](retTyp, decoded[0])
+	return val, nil
 }
 
 var _ txintent.CallView[any] = (*TypedCall[any])(nil)
 
 func encoder(name string, args ...any) ([]byte, error) {
-	inputs := make([]abi.Argument, 0, len(args))
-	argsTranslated := make([]any, 0, len(args))
-	for _, arg := range args {
-		var (
-			goType reflect.Type
-			value  any
-		)
-		// Special handling for op-service types
-		switch v := arg.(type) {
-		case eth.ETH:
-			value = v.ToBig()
-			goType = reflect.TypeOf(value)
-		default:
-			value = v
-			goType = reflect.TypeOf(v)
-		}
+	inputs := make([]abi.Argument, len(args))
+	argsTranslated := make([]any, len(args))
+	for i, arg := range args {
+		goType := OpServiceTypeToGoType(reflect.TypeOf(arg))
+		abiValue := OpServiceValueToABIValue(arg)
 		abiType, err := script.GoTypeToABIType(goType)
 		if err != nil {
 			panic(err)
 		}
-		inputs = append(inputs, abi.Argument{Type: abiType})
-		argsTranslated = append(argsTranslated, value)
+		inputs[i] = abi.Argument{Type: abiType}
+		argsTranslated[i] = abiValue
 	}
 
 	// Internally initialise sig and ID

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -99,7 +99,7 @@ func (b *BaseCallFactory) ApplyFactoryOptions(opts ...CallFactoryOption) {
 	}
 }
 
-func CheckFactoryImpl(parent any) {
+func CheckImpl(parent any) {
 	t := reflect.TypeOf(parent)
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -116,6 +116,77 @@ func CheckFactoryImpl(parent any) {
 		}
 		if fieldType.NumOut() != 1 {
 			panic("all methods must have single return type")
+		}
+	}
+}
+
+func InitImpl[T any](impl *T, factory *BaseCallFactory) {
+	v := reflect.ValueOf(impl).Elem()
+	t := v.Type()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		panic("expected struct")
+	}
+	for i := range v.NumField() {
+		field := t.Field(i)
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Func {
+			methodName := field.Tag.Get(MethodTagName)
+
+			inputTypes := []reflect.Type{}
+			for j := range fieldType.NumIn() {
+				inputTypes = append(inputTypes, fieldType.In(j))
+			}
+			outputType := fieldType.Out(0)
+
+			// outer: func(...args) -> <inner: (func() -> (bytes[], error))>
+			// inner: func() -> (bytes[], error)
+			funcInput := reflect.FuncOf([]reflect.Type{}, []reflect.Type{reflect.TypeOf([]byte{}), reflect.TypeOf((*error)(nil)).Elem()}, false)
+			funcInputWrapper := reflect.FuncOf(inputTypes, []reflect.Type{funcInput}, false)
+
+			encoderLambdaLambda := reflect.MakeFunc(funcInputWrapper, func(argsOuter []reflect.Value) []reflect.Value {
+				encoderLambda := reflect.MakeFunc(funcInput, func(argsInner []reflect.Value) []reflect.Value {
+					callArgs := make([]any, len(argsOuter))
+					for i, a := range argsOuter {
+						callArgs[i] = a.Interface()
+					}
+					v0, v1 := encoder(methodName, callArgs...)
+
+					// guard
+					var val0 reflect.Value
+					if v0 == nil {
+						val0 = reflect.Zero(reflect.TypeOf([]byte{}))
+					} else {
+						val0 = reflect.ValueOf(v0)
+					}
+					var val1 reflect.Value
+					if v1 == nil {
+						val1 = reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())
+					} else {
+						val1 = reflect.ValueOf(v1)
+					}
+
+					return []reflect.Value{val0, val1}
+				})
+				inner := encoderLambda.Interface().(func() ([]byte, error))
+				return []reflect.Value{reflect.ValueOf(inner)}
+			})
+
+			λ := reflect.MakeFunc(fieldType, func(args []reflect.Value) []reflect.Value {
+				innerResults := encoderLambdaLambda.Call(args)
+				if len(innerResults) != 1 {
+					panic("expected one return value")
+				}
+				innerλ := innerResults[0].Interface().(func() ([]byte, error))
+				wrap := reflect.New(outputType).Elem()
+				wrap.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
+				wrap.FieldByName("EncodeInputLambda").Set(reflect.ValueOf(innerλ))
+				wrap.FieldByName("BaseCallFactory").Set(reflect.ValueOf(factory))
+				return []reflect.Value{wrap}
+			})
+			v.FieldByName(field.Name).Set(λ)
 		}
 	}
 }

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -239,8 +239,8 @@ type TypedCall[ReturnType any] struct {
 
 var _ txintent.CallView[any] = (*TypedCall[any])(nil)
 
-// OpServiceTypeToGoType converts op-service type to go type
-func OpServiceTypeToGoType(retTyp reflect.Type) reflect.Type {
+// CustomTypeToGoType converts custom type to go type
+func CustomTypeToGoType(retTyp reflect.Type) reflect.Type {
 	switch retTyp {
 	case reflect.TypeOf(eth.ETH{}), reflect.TypeOf(eth.ChainID{}):
 		return reflect.TypeOf(big.NewInt(0))
@@ -251,8 +251,8 @@ func OpServiceTypeToGoType(retTyp reflect.Type) reflect.Type {
 	}
 }
 
-// OpServiceValueToABIValue converts op-service value to abi value
-func OpServiceValueToABIValue(arg any) any {
+// CustomValueToABIValue converts custom value to abi value
+func CustomValueToABIValue(arg any) any {
 	var value any
 	switch v := arg.(type) {
 	case eth.ETH:
@@ -274,8 +274,8 @@ func OpServiceValueToABIValue(arg any) any {
 	return value
 }
 
-// ABIValueToOpServiceValue converts abi value to op-service value
-func ABIValueToOpServiceValue[ReturnType any](retTyp reflect.Type, val any) ReturnType {
+// ABIValueToCustomValue converts abi value to custom value
+func ABIValueToCustomValue[ReturnType any](retTyp reflect.Type, val any) ReturnType {
 	var zero ReturnType
 	switch retTyp {
 	case reflect.TypeOf(eth.ETH{}):
@@ -312,7 +312,7 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 		panic("multiple return type using struct is not supported yet")
 	}
 
-	abiTargetType := OpServiceTypeToGoType(retTyp)
+	abiTargetType := CustomTypeToGoType(retTyp)
 	abiType, err := script.GoTypeToABIType(abiTargetType)
 	if err != nil {
 		panic(err)
@@ -324,7 +324,7 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 		panic(err)
 	}
 
-	val := ABIValueToOpServiceValue[ReturnType](retTyp, decoded[0])
+	val := ABIValueToCustomValue[ReturnType](retTyp, decoded[0])
 	return val, nil
 }
 
@@ -333,8 +333,8 @@ func ABIEncoder(name string, args ...any) ([]byte, error) {
 	inputs := make([]abi.Argument, len(args))
 	argsTranslated := make([]any, len(args))
 	for i, arg := range args {
-		goType := OpServiceTypeToGoType(reflect.TypeOf(arg))
-		abiValue := OpServiceValueToABIValue(arg)
+		goType := CustomTypeToGoType(reflect.TypeOf(arg))
+		abiValue := CustomValueToABIValue(arg)
 		abiType, err := script.GoTypeToABIType(goType)
 		if err != nil {
 			panic(err)

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -261,11 +261,11 @@ func CustomValueToABIValue(arg any) any {
 		value = v.ToBig()
 	case suptypes.Identifier:
 		identifier := script.ABIIdentifier{
-			v.Origin,
-			big.NewInt(int64(v.BlockNumber)),
-			big.NewInt(int64(v.LogIndex)),
-			big.NewInt(int64(v.Timestamp)),
-			v.ChainID.ToBig(),
+			Origin:      v.Origin,
+			BlockNumber: big.NewInt(int64(v.BlockNumber)),
+			LogIndex:    big.NewInt(int64(v.LogIndex)),
+			Timestamp:   big.NewInt(int64(v.Timestamp)),
+			ChainId:     v.ChainID.ToBig(),
 		}
 		value = identifier
 	default:

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -290,6 +290,11 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	var zero ReturnType
 	retTyp := reflect.TypeOf(zero)
 
+	// nothing to decode since ReturnType was marked as any
+	if retTyp == nil {
+		return *new(ReturnType), nil
+	}
+
 	if retTyp.Kind() == reflect.Struct {
 		panic("multiple return type using struct is not supported yet")
 	}

--- a/op-service/txintent/bindings/crossL2Inbox.go
+++ b/op-service/txintent/bindings/crossL2Inbox.go
@@ -22,7 +22,7 @@ func (f *CrossL2InboxFactory) WithDefaultAddr() {
 type CrossL2Inbox struct {
 	CrossL2InboxFactory
 
-	ValidateMessage func(identifer supTypes.Identifier, msgHash eth.Bytes32) TypedCall[any] `sol:"validateMessage"`
+	ValidateMessage func(identifier supTypes.Identifier, msgHash eth.Bytes32) TypedCall[any] `sol:"validateMessage"`
 }
 
 func NewCrossL2Inbox(f *CrossL2InboxFactory) *CrossL2Inbox {

--- a/op-service/txintent/bindings/crossL2Inbox.go
+++ b/op-service/txintent/bindings/crossL2Inbox.go
@@ -1,0 +1,32 @@
+package bindings
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	supTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type CrossL2InboxFactory struct {
+	BaseCallFactory
+}
+
+func NewCrossL2InboxCallFactory(opts ...CallFactoryOption) *CrossL2InboxFactory {
+	return &CrossL2InboxFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
+}
+
+func (f *CrossL2InboxFactory) WithDefaultAddr() {
+	f.ApplyFactoryOptions(WithTo(common.HexToAddress(predeploys.CrossL2Inbox)))
+}
+
+type CrossL2Inbox struct {
+	CrossL2InboxFactory
+
+	ValidateMessage func(identifer supTypes.Identifier, msgHash eth.Bytes32) TypedCall[any] `sol:"validateMessage"`
+}
+
+func NewCrossL2Inbox(f *CrossL2InboxFactory) *CrossL2Inbox {
+	crossL2Inbox := CrossL2Inbox{CrossL2InboxFactory: *f}
+	InitImpl(&crossL2Inbox)
+	return &crossL2Inbox
+}

--- a/op-service/txintent/bindings/eventLogger.go
+++ b/op-service/txintent/bindings/eventLogger.go
@@ -1,0 +1,25 @@
+package bindings
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type EventLoggerFactory struct {
+	BaseCallFactory
+}
+
+func NewEventLoggerCallFactory(opts ...CallFactoryOption) *EventLoggerFactory {
+	return &EventLoggerFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
+}
+
+type EventLogger struct {
+	EventLoggerFactory
+
+	EmitLog func(topics []eth.Bytes32, data []byte) TypedCall[any] `sol:"emitLog"`
+}
+
+func NewEventLogger(f *EventLoggerFactory) *EventLogger {
+	eventLogger := EventLogger{EventLoggerFactory: *f}
+	InitImpl(&eventLogger)
+	return &eventLogger
+}

--- a/op-service/txintent/bindings/weth.go
+++ b/op-service/txintent/bindings/weth.go
@@ -27,7 +27,6 @@ type WETH struct {
 
 func NewWETH(f *WETHCallFactory) *WETH {
 	weth := WETH{WETHCallFactory: *f}
-	CheckImpl(weth)
-	InitImpl(&weth, &f.BaseCallFactory)
+	InitImpl(&weth)
 	return &weth
 }

--- a/op-service/txintent/bindings/weth.go
+++ b/op-service/txintent/bindings/weth.go
@@ -1,8 +1,6 @@
 package bindings
 
 import (
-	"reflect"
-
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/common"
@@ -29,70 +27,7 @@ type WETH struct {
 
 func NewWETH(f *WETHCallFactory) *WETH {
 	weth := WETH{WETHCallFactory: *f}
-	CheckFactoryImpl(weth)
-
-	wethRef := reflect.ValueOf(&weth).Elem()
-	wethType := reflect.TypeOf(weth)
-
-	for i := range wethRef.NumField() {
-		field := wethType.Field(i)
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Func {
-			methodName := field.Tag.Get(MethodTagName)
-
-			inputTypes := []reflect.Type{}
-			for j := range fieldType.NumIn() {
-				inputTypes = append(inputTypes, fieldType.In(j))
-			}
-			outputType := fieldType.Out(0)
-
-			// outer: func(...args) -> <inner: (func() -> (bytes[], error))>
-			// inner: func() -> (bytes[], error)
-			funcInput := reflect.FuncOf([]reflect.Type{}, []reflect.Type{reflect.TypeOf([]byte{}), reflect.TypeOf((*error)(nil)).Elem()}, false)
-			funcInputWrapper := reflect.FuncOf(inputTypes, []reflect.Type{funcInput}, false)
-
-			encoderLambdaLambda := reflect.MakeFunc(funcInputWrapper, func(argsOuter []reflect.Value) []reflect.Value {
-				encoderLambda := reflect.MakeFunc(funcInput, func(argsInner []reflect.Value) []reflect.Value {
-					callArgs := make([]any, len(argsOuter))
-					for i, a := range argsOuter {
-						callArgs[i] = a.Interface()
-					}
-					v0, v1 := encoder(methodName, callArgs...)
-
-					// guard
-					var val0 reflect.Value
-					if v0 == nil {
-						val0 = reflect.Zero(reflect.TypeOf([]byte{}))
-					} else {
-						val0 = reflect.ValueOf(v0)
-					}
-					var val1 reflect.Value
-					if v1 == nil {
-						val1 = reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())
-					} else {
-						val1 = reflect.ValueOf(v1)
-					}
-
-					return []reflect.Value{val0, val1}
-				})
-				inner := encoderLambda.Interface().(func() ([]byte, error))
-				return []reflect.Value{reflect.ValueOf(inner)}
-			})
-
-			λ := reflect.MakeFunc(fieldType, func(args []reflect.Value) []reflect.Value {
-				innerResults := encoderLambdaLambda.Call(args)
-				if len(innerResults) != 1 {
-					panic("expected one return value")
-				}
-				innerλ := innerResults[0].Interface().(func() ([]byte, error))
-				wrap := reflect.New(outputType).Elem()
-				wrap.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
-				wrap.FieldByName("EncodeInputLambda").Set(reflect.ValueOf(innerλ))
-				wrap.FieldByName("BaseCallFactory").Set(reflect.ValueOf(&f.BaseCallFactory))
-				return []reflect.Value{wrap}
-			})
-			wethRef.FieldByName(field.Name).Set(λ)
-		}
-	}
+	CheckImpl(weth)
+	InitImpl(&weth, &f.BaseCallFactory)
 	return &weth
 }

--- a/op-service/txintent/bindings/weth.go
+++ b/op-service/txintent/bindings/weth.go
@@ -1,14 +1,11 @@
 package bindings
 
 import (
-	"math/big"
+	"reflect"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
-	"github.com/lmittmann/w3"
 )
 
 type WETHCallFactory struct {
@@ -23,72 +20,79 @@ func (f *WETHCallFactory) WithDefaultAddr() {
 	f.ApplyFactoryOptions(WithTo(common.HexToAddress(predeploys.WETH)))
 }
 
-func (f *WETHCallFactory) BalanceOf(addr common.Address) txintent.CallView[eth.ETH] {
-	return &BalanceOfCall{Addr: addr, WETHCallFactory: *f}
-}
-
-func (f *WETHCallFactory) Transfer(dest common.Address, amount eth.ETH) txintent.CallView[bool] {
-	return &TransferCall{Dest: dest, Amount: amount, WETHCallFactory: *f}
-}
-
 type WETH struct {
 	WETHCallFactory
 
-	BalanceOf func(addr common.Address) txintent.CallView[eth.ETH]
-	Transfer  func(dest common.Address, amount eth.ETH) txintent.CallView[bool]
+	BalanceOf func(addr common.Address) TypedCall[eth.ETH]              `sol:"balanceOf"`
+	Transfer  func(dest common.Address, amount eth.ETH) TypedCall[bool] `sol:"transfer"`
 }
 
 func NewWETH(f *WETHCallFactory) *WETH {
-	return &WETH{
-		WETHCallFactory: *f,
-		BalanceOf:       f.BalanceOf,
-		Transfer:        f.Transfer,
+	weth := WETH{WETHCallFactory: *f}
+	CheckFactoryImpl(weth)
+
+	wethRef := reflect.ValueOf(&weth).Elem()
+	wethType := reflect.TypeOf(weth)
+
+	for i := range wethRef.NumField() {
+		field := wethType.Field(i)
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Func {
+			methodName := field.Tag.Get(MethodTagName)
+
+			inputTypes := []reflect.Type{}
+			for j := range fieldType.NumIn() {
+				inputTypes = append(inputTypes, fieldType.In(j))
+			}
+			outputType := fieldType.Out(0)
+
+			// outer: func(...args) -> <inner: (func() -> (bytes[], error))>
+			// inner: func() -> (bytes[], error)
+			funcInput := reflect.FuncOf([]reflect.Type{}, []reflect.Type{reflect.TypeOf([]byte{}), reflect.TypeOf((*error)(nil)).Elem()}, false)
+			funcInputWrapper := reflect.FuncOf(inputTypes, []reflect.Type{funcInput}, false)
+
+			encoderLambdaLambda := reflect.MakeFunc(funcInputWrapper, func(argsOuter []reflect.Value) []reflect.Value {
+				encoderLambda := reflect.MakeFunc(funcInput, func(argsInner []reflect.Value) []reflect.Value {
+					callArgs := make([]any, len(argsOuter))
+					for i, a := range argsOuter {
+						callArgs[i] = a.Interface()
+					}
+					v0, v1 := encoder(methodName, callArgs...)
+
+					// guard
+					var val0 reflect.Value
+					if v0 == nil {
+						val0 = reflect.Zero(reflect.TypeOf([]byte{}))
+					} else {
+						val0 = reflect.ValueOf(v0)
+					}
+					var val1 reflect.Value
+					if v1 == nil {
+						val1 = reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())
+					} else {
+						val1 = reflect.ValueOf(v1)
+					}
+
+					return []reflect.Value{val0, val1}
+				})
+				inner := encoderLambda.Interface().(func() ([]byte, error))
+				return []reflect.Value{reflect.ValueOf(inner)}
+			})
+
+			λ := reflect.MakeFunc(fieldType, func(args []reflect.Value) []reflect.Value {
+				innerResults := encoderLambdaLambda.Call(args)
+				if len(innerResults) != 1 {
+					panic("expected one return value")
+				}
+				innerλ := innerResults[0].Interface().(func() ([]byte, error))
+				wrap := reflect.New(outputType).Elem()
+				wrap.FieldByName("MethodName").Set(reflect.ValueOf(methodName))
+				wrap.FieldByName("EncodeInputLambda").Set(reflect.ValueOf(innerλ))
+				wrap.FieldByName("BaseCallFactory").Set(reflect.ValueOf(&f.BaseCallFactory))
+				return []reflect.Value{wrap}
+			})
+			wethRef.FieldByName(field.Name).Set(λ)
+		}
 	}
+	return &weth
 }
-
-type BalanceOfCall struct {
-	WETHCallFactory
-
-	Addr common.Address
-}
-
-func (c *BalanceOfCall) EncodeInput() ([]byte, error) {
-	abi := w3.MustNewFunc("balanceOf(address)", "uint256")
-	calldata, err := abi.EncodeArgs(c.Addr)
-	return calldata, err
-}
-
-func (c *BalanceOfCall) DecodeOutput(data []byte) (eth.ETH, error) {
-	abi := w3.MustNewFunc("balanceOf(address)", "uint256")
-	var result *big.Int // w3 does not like static types and panics
-	err := abi.DecodeReturns(data, &result)
-	var res eth.ETH
-	if (*uint256.Int)(&res).SetFromBig(result) {
-		panic("balanceOf result conversion failure: does not fit in uint256")
-	}
-	return res, err
-}
-
-type TransferCall struct {
-	WETHCallFactory
-
-	Dest   common.Address
-	Amount eth.ETH
-}
-
-func (c *TransferCall) EncodeInput() ([]byte, error) {
-	amount := c.Amount.ToBig()
-	abi := w3.MustNewFunc("transfer(address, uint256)", "bool")
-	calldata, err := abi.EncodeArgs(c.Dest, amount)
-	return calldata, err
-}
-
-func (c *TransferCall) DecodeOutput(data []byte) (bool, error) {
-	abi := w3.MustNewFunc("transfer(address, uint256)", "bool")
-	var result bool
-	err := abi.DecodeReturns(data, &result)
-	return result, err
-}
-
-var _ txintent.CallView[eth.ETH] = (*BalanceOfCall)(nil)
-var _ txintent.CallView[bool] = (*TransferCall)(nil)

--- a/op-service/txintent/contractio/call.go
+++ b/op-service/txintent/contractio/call.go
@@ -3,14 +3,14 @@ package contractio
 import (
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// Write receives a Call and uses to plan transaction, and attempts to write.
-func Write(call txintent.Call, ctx context.Context, opts ...txplan.Option) (*types.Receipt, error) {
+// Write receives a TypedCall and uses to plan transaction, and attempts to write.
+func Write[O any](call bindings.TypedCall[O], ctx context.Context, opts ...txplan.Option) (*types.Receipt, error) {
 	plan, err := Plan(call)
 	if err != nil {
 		return nil, err
@@ -23,8 +23,8 @@ func Write(call txintent.Call, ctx context.Context, opts ...txplan.Option) (*typ
 	return receipt, nil
 }
 
-// Read receives a CallView and uses to plan transaction, and attempts to read.
-func Read[O any](view txintent.CallView[O], ctx context.Context, opts ...txplan.Option) (O, error) {
+// Read receives a TypedCall and uses to plan transaction, and attempts to read.
+func Read[O any](view bindings.TypedCall[O], ctx context.Context, opts ...txplan.Option) (O, error) {
 	plan, err := Plan(view)
 	if err != nil {
 		return *new(O), err
@@ -49,7 +49,7 @@ func Read[O any](view txintent.CallView[O], ctx context.Context, opts ...txplan.
 	return decoded, nil
 }
 
-func Plan(call txintent.Call) (txplan.Option, error) {
+func Plan[O any](call bindings.TypedCall[O]) (txplan.Option, error) {
 	target, err := call.To()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR enhances contract DSL bindings on op-devstack. Specifically, we fix the DSL backend satisfying below constraints: 
- we do not use generated bindings
- we do not use/hardcode abi json
- we only use function fields like `BalanceOf func(addr common.Address) TypedCall[eth.ETH]` and reflection automates encoding / decoding.
    - Used reflection and higher order functions(or closure) to abstract all the calls, unifying into single TypedCall. 

**Tests**

`TestWrapETH` was added at https://github.com/ethereum-optimism/optimism/pull/16046 for testing DSL frontend. This test had no diffs but still passes, which means the frontend is not changed.

`TestInitExecMsgWithDSL` was added to express how to use bindings for `CrossL2Inbox` and `EventLogger` as an example.

**Binding Writing Walkthrough**

To add more contract bindings, we may refer to `op-service/txintent/bindings/{weth|}.go`. Lets say we need to add a ABI for below example contract.

```solidity
contract Counter { 
    uint public count; 
    function increase(inc uint256) public (uint256) {
        count += inc;
        return count;
    }
}
```

#### STEP 0
we create a `counter.go` at `op-service/txintent`. First create a factory. Note that Counter is prefixed because we are making a binding for the Counter contract.

```go
type CounterCallFactory struct {
	BaseCallFactory
}
```

#### STEP 1
Add basic boilerplates:

```go
func NewCounterCallFactory(opts ...CallFactoryOption) *CounterCallFactory {
	return &CounterCallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
}
```

#### STEP 2

Add struct `EventLogger` to represent a binding which includes function field for the onchain method `increase`, embedding the factory and onchain method arguments.

```go
type Counter struct {
	CounterCallFactory

	Increase func(inc Uint256Quantity) TypedCall[Uint256Quantity] `sol:"increase"`
}
```

Note that we use a custom `sol` tag to map the actual solidity method name. We do this because some methods may start with lowercase, and by simply using the function field names, they may be not exportable.

#### STEP 3

Add a initializer:
```go
func NewEventLogger(f *CounterCallFactory) *EventLogger {
	counter := Counter{CounterCallFactory: *f}
	InitImpl(&counter)
	return &counter
}
```
**Make sure that you call `InitImpl`** to automatically infer, compose, and bind function argument to be initialized.

#### STEP 4

Write test. Below example will be not compilable but this is just for demonstration.

```go
func TestCounter(gt *testing.T) {
	t := devtest.SerialT(gt)
	require := t.Require()
	sys := presets.NewMinimal(t)

	alice := sys.Funder.NewFundedEOA(eth.ThousandEther)
	client := sys.L2EL.Escape().EthClient()

	// deploy contract
	counterContractAddr := ...
        
        // initialize factory
	factory := bindings.CounterCallFactory(bindings.WithClient(client), bindings.WithTo(counterContractAddr), bindings.WithTest(t))

        // initialize binding
	counter := bindings.NewCounter(factory)

	// read
	require.Equal(5, contract.Read(counter.Increase(5))
	// read again
	require.Equal(5, contract.Read(counter.Increase(5))
      
	// write
	contract.Write(alice, counter.Increase(7))

	// read
	require.Equal(12, contract.Read(counter.Increase(5))
}
```

**Additional context**

There are a few limitations of current contract DSL backend limitation.
- Struct fields(or tuple) are not supported, except supervisor's `Identifier` types. Currently identifier encode/decode logic is hardcoded to make the call work.
- Multiple return value is not supported.
^ upper issues should be fixed in the followup PR.
- For adding custom types like `eth.Uint256Quantity`, we need a manual type/value encoder/decoder since geth abigen does not recognize custom types.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/15999
