### PR TITLE
Update CircleCI config to store metrics in date-specific folders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1702,9 +1702,9 @@ jobs:
       - run:
           name: Store artifact in Bucket
           command: |
-            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics
-            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/metrics-$CIRCLE_SHA1
-
+            CURRENT_DATE=$(date '+%Y-%m-%d')
+            FOLDER_NAME="dt=$CURRENT_DATE"
+            gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/$FOLDER_NAME
 
 workflows:
   main:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request updates the artifact storage process in the `.circleci/config.yml` file to organize metrics by date. The most important change is the introduction of a folder structure based on the current date for better organization of stored metrics.

**Artifact storage improvements:**

* Updated the `Store artifact in Bucket` step to create a folder named with the current date (`dt=YYYY-MM-DD`) and store metrics in this folder, replacing the previous flat structure. This change improves the organization of metrics in the bucket.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
