### PR TITLE
kustosis-devnet: Update optimism package to provide depset to op-node

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@3b4f19c84e9c5b7d5a38344b7348b0b0fb9dd89c
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@d8c3640e441ca820e7b393efe51af8ab65919c98
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173


### PR DESCRIPTION
https://github.com/ethpandaops/optimism-package/commit/d8c3640e441ca820e7b393efe51af8ab65919c98 is a backport of https://github.com/ethpandaops/optimism-package/pull/284 onto the current stable branch of the optimism package, curtesy of @janjakubnanista. The latest change provides the depset to op-node.