### PR TITLE
events: Add Event Dequeued Metric

### DIFF
--- a/op-node/rollup/event/tracer_metrics.go
+++ b/op-node/rollup/event/tracer_metrics.go
@@ -16,6 +16,7 @@ func (mt *MetricsTracer) OnDeriveStart(name string, ev AnnotatedEvent, derivCont
 }
 
 func (mt *MetricsTracer) OnDeriveEnd(name string, ev AnnotatedEvent, derivContext uint64, startTime time.Time, duration time.Duration, effect bool) {
+	mt.metrics.RecordDequeuedEvents(ev.Event.String(), name)
 	if !effect { // don't count events that were just pass-through and not of any effect
 		return
 	}


### PR DESCRIPTION
This metric allows one to track Event Leaks in `op-node` and `op-supervisor`.

All events are noted when they are enqueued by way of `_events_emitted`

But the `_events_processed` metric was emitted every time a consumer returns `true`, which could be none of the consumers, or could be multiple.

By always tracking `_events_dequeued` once for each event, you can directly measure event system leaks over time:

![image](https://github.com/user-attachments/assets/0488e4a0-5c68-4405-9668-949c840d7a8c)
