### PR TITLE
feat: implement block ancestor by number hint

### DIFF
--- a/op-preimage/iface.go
+++ b/op-preimage/iface.go
@@ -42,6 +42,8 @@ const (
 	BlobKeyType KeyType = 5
 	// PrecompileKeyType is for precompile result pre-images.
 	PrecompileKeyType KeyType = 6
+	// ProofKeyType is for pre-images that are proofs of some data.
+	ProofKeyType KeyType = 7
 )
 
 // LocalIndexKey is a key local to the program, indexing a special program input.
@@ -118,6 +120,23 @@ func (k PrecompileKey) String() string {
 }
 
 func (k PrecompileKey) TerminalString() string {
+	return "0x" + hex.EncodeToString(k[:])
+}
+
+// PrecompileKey is the hash of precompile address and its input data
+type ProofKey [32]byte
+
+func (k ProofKey) PreimageKey() (out [32]byte) {
+	out = k
+	out[0] = byte(ProofKeyType)
+	return
+}
+
+func (k ProofKey) String() string {
+	return "0x" + hex.EncodeToString(k[:])
+}
+
+func (k ProofKey) TerminalString() string {
 	return "0x" + hex.EncodeToString(k[:])
 }
 

--- a/op-program/client/interop/consolidate.go
+++ b/op-program/client/interop/consolidate.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
 	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -263,7 +262,15 @@ func newConsolidateCheckDeps(
 			return nil, fmt.Errorf("no chain config available for chain ID %v: %w", chain.ChainID, err)
 		}
 		fallback := l2.NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
-		canonBlocks[chain.ChainID] = l2.NewFastCanonicalBlockHeaderOracle(head.Header(), blockByHash, l2ChainConfig, oracle, rawdb.NewMemoryDatabase(), fallback)
+
+		blockNumberSet := make(map[uint64]struct{})
+		for _, logs := range consolidateState.execMessageCache {
+			for _, execMsg := range logs.execMsgs {
+				blockNumberSet[execMsg.BlockNum] = struct{}{}
+			}
+		}
+
+		canonBlocks[chain.ChainID] = l2.NewFastCanonicalBlockHeaderOracle(head.Header(), blockByHash, l2ChainConfig, oracle, fallback, blockNumberSet)
 	}
 
 	return &consolidateCheckDeps{

--- a/op-program/client/interop/oracle.go
+++ b/op-program/client/interop/oracle.go
@@ -111,7 +111,7 @@ func (o *ConsolidateOracle) TransitionStateByRoot(root common.Hash) *interopType
 	return o.ts
 }
 
-func (o *ConsolidateOracle) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+func (o *ConsolidateOracle) BlockAncestorsByNumbers(parentBlockHash eth.BlockID, blockNumbers []uint64, chainID eth.ChainID) map[uint64]common.Hash {
 	return o.o.BlockAncestorsByNumbers(parentBlockHash, blockNumbers, chainID)
 }
 

--- a/op-program/client/interop/oracle.go
+++ b/op-program/client/interop/oracle.go
@@ -111,6 +111,10 @@ func (o *ConsolidateOracle) TransitionStateByRoot(root common.Hash) *interopType
 	return o.ts
 }
 
+func (o *ConsolidateOracle) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+	return o.o.BlockAncestorsByNumbers(parentBlockHash, blockNumbers, chainID)
+}
+
 func (o *ConsolidateOracle) headerByBlockHash(blockHash common.Hash) *types.Header {
 	blockHashKey := preimage.Keccak256Key(blockHash).PreimageKey()
 	headerRlp, err := o.db.Get(blockHashKey[:])

--- a/op-program/client/interop/oracle_test.go
+++ b/op-program/client/interop/oracle_test.go
@@ -236,6 +236,14 @@ func (o *OracleMock) CodeByHash(codeHash common.Hash, chainID eth.ChainID) []byt
 	return args.Get(0).([]byte)
 }
 
+func (o *OracleMock) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+	args := o.Called(parentBlockHash, blockNumbers, chainID)
+	if res, ok := args.Get(0).(map[common.Hash]eth.AccountResult); ok {
+		return res
+	}
+	return nil
+}
+
 func (o *OracleMock) Hinter() l2Types.OracleHinter {
 	args := o.Called()
 	return args.Get(0).(l2Types.OracleHinter)

--- a/op-program/client/interop/oracle_test.go
+++ b/op-program/client/interop/oracle_test.go
@@ -236,9 +236,9 @@ func (o *OracleMock) CodeByHash(codeHash common.Hash, chainID eth.ChainID) []byt
 	return args.Get(0).([]byte)
 }
 
-func (o *OracleMock) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+func (o *OracleMock) BlockAncestorsByNumbers(parentBlockHash eth.BlockID, blockNumbers []uint64, chainID eth.ChainID) map[uint64]common.Hash {
 	args := o.Called(parentBlockHash, blockNumbers, chainID)
-	if res, ok := args.Get(0).(map[common.Hash]eth.AccountResult); ok {
+	if res, ok := args.Get(0).(map[uint64]common.Hash); ok {
 		return res
 	}
 	return nil

--- a/op-program/client/l2/cache.go
+++ b/op-program/client/l2/cache.go
@@ -107,3 +107,8 @@ func (o *CachingOracle) TransitionStateByRoot(root common.Hash) *interopTypes.Tr
 	// Don't bother caching as this is only requested once as part of the bootstrap process
 	return o.oracle.TransitionStateByRoot(root)
 }
+
+func (o *CachingOracle) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+	// Always request from the oracle even on cache hit. as we want the effects of the host oracle hinting
+	return o.oracle.BlockAncestorsByNumbers(parentBlockHash, blockNumbers, chainID)
+}

--- a/op-program/client/l2/cache.go
+++ b/op-program/client/l2/cache.go
@@ -108,7 +108,7 @@ func (o *CachingOracle) TransitionStateByRoot(root common.Hash) *interopTypes.Tr
 	return o.oracle.TransitionStateByRoot(root)
 }
 
-func (o *CachingOracle) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+func (o *CachingOracle) BlockAncestorsByNumbers(parentBlockHash eth.BlockID, blockNumbers []uint64, chainID eth.ChainID) map[uint64]common.Hash {
 	// Always request from the oracle even on cache hit. as we want the effects of the host oracle hinting
 	return o.oracle.BlockAncestorsByNumbers(parentBlockHash, blockNumbers, chainID)
 }

--- a/op-program/client/l2/engine_backend.go
+++ b/op-program/client/l2/engine_backend.go
@@ -37,7 +37,7 @@ type OracleBackedL2Chain struct {
 	finalized  *types.Header
 	vmCfg      vm.Config
 
-	canon *FastCanonicalBlockHeaderOracle
+	canon *CanonicalBlockHeaderOracle
 
 	// Inserted blocks
 	blocks map[common.Hash]*types.Block
@@ -99,8 +99,7 @@ func NewOracleBackedL2ChainFromHead(
 	blockByHash := func(hash common.Hash) *types.Block {
 		return chain.GetBlockByHash(hash)
 	}
-	fallback := NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
-	chain.canon = NewFastCanonicalBlockHeaderOracle(head.Header(), blockByHash, chainCfg, oracle, db, fallback)
+	chain.canon = NewCanonicalBlockHeaderOracle(head.Header(), blockByHash)
 	return chain
 }
 

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -47,15 +47,18 @@ func (o *FastCanonicalBlockHeaderOracle) fetchHistoricalBlockProofs() {
 	chainID := eth.ChainIDFromBig(o.config.ChainID)
 	blockNums := make([]uint64, 0, len(o.blockNumberSet))
 	for n := range o.blockNumberSet {
-		blockNums = append(blockNums, n)
+		if n != o.head.Number.Uint64() {
+			blockNums = append(blockNums, n)
+		}
 	}
 
 	provenBlocks := o.oracle.BlockAncestorsByNumbers(eth.BlockID{
-		Hash:   o.head.Hash(),
-		Number: o.head.Number.Uint64(),
+		Hash:   o.head.ParentHash,
+		Number: o.head.Number.Uint64() - 1,
 	}, blockNums, chainID)
 
 	o.canonicalBlockHashes = provenBlocks
+	o.canonicalBlockHashes[o.head.Number.Uint64()] = o.head.Hash()
 }
 
 func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -52,13 +52,18 @@ func (o *FastCanonicalBlockHeaderOracle) fetchHistoricalBlockProofs() {
 		}
 	}
 
-	provenBlocks := o.oracle.BlockAncestorsByNumbers(eth.BlockID{
-		Hash:   o.head.ParentHash,
-		Number: o.head.Number.Uint64() - 1,
-	}, blockNums, chainID)
+	var provenBlocks map[uint64]common.Hash
+	if o.head.Number.Uint64() != 0 {
+		provenBlocks = o.oracle.BlockAncestorsByNumbers(eth.BlockID{
+			Hash:   o.head.ParentHash,
+			Number: o.head.Number.Uint64() - 1,
+		}, blockNums, chainID)
+	} else {
+		provenBlocks = make(map[uint64]common.Hash)
+	}
+	provenBlocks[o.head.Number.Uint64()] = o.head.Hash()
 
 	o.canonicalBlockHashes = provenBlocks
-	o.canonicalBlockHashes[o.head.Number.Uint64()] = o.head.Hash()
 }
 
 func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -1,8 +1,6 @@
 package l2
 
 import (
-	"math/big"
-
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -52,65 +50,12 @@ func (o *FastCanonicalBlockHeaderOracle) fetchHistoricalBlockProofs() {
 		blockNums = append(blockNums, n)
 	}
 
-	accountProofs := o.oracle.BlockAncestorsByNumbers(o.head.Hash(), blockNums, chainID)
-	stateRoots := make(map[common.Hash]common.Hash, len(accountProofs))
-	for blockHash := range accountProofs {
-		block := o.oracle.BlockByHash(blockHash, chainID)
-		stateRoots[blockHash] = block.Root()
-	}
+	provenBlocks := o.oracle.BlockAncestorsByNumbers(eth.BlockID{
+		Hash:   o.head.Hash(),
+		Number: o.head.Number.Uint64(),
+	}, blockNums, chainID)
 
-	// verify all the account proofs are valid
-	for blockHash, result := range accountProofs {
-		if result.Verify(stateRoots[blockHash]) != nil {
-			panic("failed to verify historical block proof")
-		}
-	}
-
-	currBlockHash := o.head.Hash()
-	currBlockNum := o.head.Number.Uint64()
-
-	o.canonicalBlockHashes[currBlockNum] = currBlockHash
-
-	// verify the merkle proofs indicate the correct block hashes, and store the historical blocks
-	for {
-		firstAccountProof := accountProofs[currBlockHash]
-		currentBlockStorageIdx := currBlockNum % params.HistoryServeWindow
-		earliestBlockStorageIdx := (currentBlockStorageIdx + 1) % params.HistoryServeWindow
-		earliestBlockNum := currBlockNum - (params.HistoryServeWindow - 1)
-
-		storageKeys := make(map[common.Hash]common.Hash)
-		for _, proof := range firstAccountProof.StorageProof {
-			key := common.BytesToHash(common.LeftPadBytes(proof.Key[:], 32))
-			// big endian
-			storageKeys[key] = common.Hash(proof.Value.ToInt().Bytes())
-		}
-
-		for historyIdxKey, historyBlockHash := range storageKeys {
-			historyIdx := historyIdxKey.Big().Uint64()
-			blockNum := ((historyIdx + params.HistoryServeWindow) - earliestBlockStorageIdx) + earliestBlockNum
-			blockHash := common.BigToHash(historyBlockHash.Big())
-
-			if blockHash == (common.Hash{}) {
-				panic("missing historical block hash in storage keys")
-			}
-
-			o.canonicalBlockHashes[blockNum] = blockHash
-		}
-
-		// next block is the storage slot of the earliest block in the history serve window
-		nextBlockHash, ok := storageKeys[common.BigToHash(big.NewInt(int64(earliestBlockStorageIdx)))]
-		if !ok {
-			break
-		}
-		if nextBlockHash == (common.Hash{}) {
-			// If we don't have a next block hash, we cannot serve historical blocks
-			return
-		}
-
-		currBlockNum = earliestBlockNum
-		currBlockHash = nextBlockHash
-	}
-
+	o.canonicalBlockHashes = provenBlocks
 }
 
 func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -1,60 +1,42 @@
 package l2
 
 import (
-	"encoding/binary"
-	"fmt"
-	"math"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus"
-	"github.com/ethereum/go-ethereum/consensus/beacon"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/triedb"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
-// historicalCacheSize is the number of cached eip-2935 historical block lookups
-// This covers 8 weeks worth of blocks on a 2 second block time.
-// We keep a small cache size to ensure cache scans are fast.
-const historicalCacheSize = 320
-
 type FastCanonicalBlockHeaderOracle struct {
-	head          *types.Header
-	blockByHashFn BlockByHashFn
-	config        *params.ChainConfig
-	fallback      *CanonicalBlockHeaderOracle
-	ctx           *chainContext
-	db            ethdb.KeyValueStore
-	cache         *simplelru.LRU[uint64, *types.Header]
+	head                    *types.Header
+	blockByHashFn           func(common.Hash) *types.Block
+	config                  *params.ChainConfig
+	fallback                *CanonicalBlockHeaderOracle
+	blockNumberSet          map[uint64]struct{}
+	canonicalBlockHashes    map[uint64]common.Hash
+	fetchedHistoricalProofs bool
+	oracle                  Oracle
 }
 
 func NewFastCanonicalBlockHeaderOracle(
 	head *types.Header,
-	blockByHashFn BlockByHashFn,
+	blockByHashFn func(common.Hash) *types.Block,
 	chainCfg *params.ChainConfig,
-	stateOracle StateOracle,
-	kvdb KeyValueStore,
+	oracle Oracle,
 	fallback *CanonicalBlockHeaderOracle,
+	blockNumberSet map[uint64]struct{},
 ) *FastCanonicalBlockHeaderOracle {
-	chainID := eth.ChainIDFromBig(chainCfg.ChainID)
-	ctx := &chainContext{engine: beacon.New(nil), config: chainCfg}
-	db := NewOracleBackedDB(kvdb, stateOracle, chainID)
-	cache, _ := simplelru.NewLRU[uint64, *types.Header](historicalCacheSize, nil)
 	return &FastCanonicalBlockHeaderOracle{
-		head:          head,
-		blockByHashFn: blockByHashFn,
-		config:        chainCfg,
-		fallback:      fallback,
-		ctx:           ctx,
-		db:            db,
-		cache:         cache,
+		head:                    head,
+		config:                  chainCfg,
+		blockByHashFn:           blockByHashFn,
+		fallback:                fallback,
+		blockNumberSet:          blockNumberSet,
+		oracle:                  oracle,
+		fetchedHistoricalProofs: false,
+		canonicalBlockHashes:    make(map[uint64]common.Hash),
 	}
 }
 
@@ -62,106 +44,110 @@ func (o *FastCanonicalBlockHeaderOracle) CurrentHeader() *types.Header {
 	return o.head
 }
 
+func (o *FastCanonicalBlockHeaderOracle) fetchHistoricalBlockProofs() {
+	o.fetchedHistoricalProofs = true
+	chainID := eth.ChainIDFromBig(o.config.ChainID)
+	blockNums := make([]uint64, 0, len(o.blockNumberSet))
+	for n := range o.blockNumberSet {
+		blockNums = append(blockNums, n)
+	}
+
+	accountProofs := o.oracle.BlockAncestorsByNumbers(o.head.Hash(), blockNums, chainID)
+	stateRoots := make(map[common.Hash]common.Hash, len(accountProofs))
+	for blockHash := range accountProofs {
+		block := o.oracle.BlockByHash(blockHash, chainID)
+		stateRoots[blockHash] = block.Root()
+	}
+
+	// verify all the account proofs are valid
+	for blockHash, result := range accountProofs {
+		if result.Verify(stateRoots[blockHash]) != nil {
+			panic("failed to verify historical block proof")
+		}
+	}
+
+	currBlockHash := o.head.Hash()
+	currBlockNum := o.head.Number.Uint64()
+
+	o.canonicalBlockHashes[currBlockNum] = currBlockHash
+
+	// verify the merkle proofs indicate the correct block hashes, and store the historical blocks
+	for {
+		firstAccountProof := accountProofs[currBlockHash]
+		currentBlockStorageIdx := currBlockNum % params.HistoryServeWindow
+		earliestBlockStorageIdx := (currentBlockStorageIdx + 1) % params.HistoryServeWindow
+		earliestBlockNum := currBlockNum - (params.HistoryServeWindow - 1)
+
+		storageKeys := make(map[common.Hash]common.Hash)
+		for _, proof := range firstAccountProof.StorageProof {
+			key := common.BytesToHash(common.LeftPadBytes(proof.Key[:], 32))
+			// big endian
+			storageKeys[key] = common.Hash(proof.Value.ToInt().Bytes())
+		}
+
+		for historyIdxKey, historyBlockHash := range storageKeys {
+			historyIdx := historyIdxKey.Big().Uint64()
+			blockNum := ((historyIdx + params.HistoryServeWindow) - earliestBlockStorageIdx) + earliestBlockNum
+			blockHash := common.BigToHash(historyBlockHash.Big())
+
+			if blockHash == (common.Hash{}) {
+				panic("missing historical block hash in storage keys")
+			}
+
+			o.canonicalBlockHashes[blockNum] = blockHash
+		}
+
+		// next block is the storage slot of the earliest block in the history serve window
+		nextBlockHash, ok := storageKeys[common.BigToHash(big.NewInt(int64(earliestBlockStorageIdx)))]
+		if !ok {
+			break
+		}
+		if nextBlockHash == (common.Hash{}) {
+			// If we don't have a next block hash, we cannot serve historical blocks
+			return
+		}
+
+		currBlockNum = earliestBlockNum
+		currBlockHash = nextBlockHash
+	}
+
+}
+
 func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {
+	if !o.fetchedHistoricalProofs {
+		o.fetchHistoricalBlockProofs()
+	}
+
 	if o.head.Number.Uint64() < n {
 		return nil
 	}
 	if o.head.Number.Uint64() == n {
 		return o.head
 	}
+	if _, ok := o.blockNumberSet[n]; !ok {
+		// If the block number is not in the set, we cannot serve it from the cache
+		return o.fallback.GetHeaderByNumber(n)
+	}
 
-	// scan the cache for a header that contains the requested block in its historical block window
-	cover := uint64(math.MaxUint64)
-	for _, number := range o.cache.Keys() {
-		if number >= n && number < cover {
-			cover = number
-		}
-	}
 	h := o.head
-	if cover != math.MaxUint64 {
-		h, _ = o.cache.Get(cover)
-	}
 	if !o.config.IsIsthmus(h.Time) {
 		return o.fallback.GetHeaderByNumber(n)
 	}
 
-	for h.Number.Uint64() > n {
-		headNumber := h.Number.Uint64()
-		var currEarliestHistory uint64
-		if params.HistoryServeWindow-1 < headNumber {
-			currEarliestHistory = headNumber - (params.HistoryServeWindow - 1)
-		}
-		if currEarliestHistory <= n {
-			block := o.getHistoricalBlockHash(h, n)
-			if block == nil {
-				return o.fallback.GetHeaderByNumber(n)
-			}
-			return block.Header()
-		}
-		block := o.getHistoricalBlockHash(h, currEarliestHistory)
-		if block == nil {
-			return o.fallback.GetHeaderByNumber(n)
-		}
-		h = block.Header()
-		o.cache.Add(h.Number.Uint64(), h)
+	blockHash, ok := o.canonicalBlockHashes[n]
+	if !ok {
+		return o.fallback.GetHeaderByNumber(n)
 	}
-	return h
-}
 
-func (o *FastCanonicalBlockHeaderOracle) getHistoricalBlockHash(head *types.Header, n uint64) *types.Block {
-	statedb, err := state.New(head.Root, state.NewDatabase(triedb.NewDatabase(rawdb.NewDatabase(o.db), nil), nil))
-	if err != nil {
-		panic(fmt.Errorf("failed to get state at %v: %w", head.Hash(), err))
-	}
-	// for safety. But it shouldn't be required since we only read from state
-	statedb.MakeSinglethreaded()
+	block := o.blockByHashFn(blockHash)
 
-	context := core.NewEVMBlockContext(head, o.ctx, nil, o.config, statedb)
-	vmenv := vm.NewEVM(context, statedb, o.config, vm.Config{})
-	var caller common.Address // can be anything as long as it's not the system contract
-	gas := uint64(1000000)
-	var input [32]byte
-	binary.BigEndian.PutUint64(input[24:], n)
-	ret, _, err := vmenv.StaticCall(caller, params.HistoryStorageAddress, input[:], gas)
-	if err != nil {
-		panic(fmt.Errorf("failed to get history block hash: %w", err))
-	}
-	if len(ret) != 32 {
-		panic(fmt.Sprintf("invalid history storage result. got %d bytes, expected %d bytes", len(ret), common.HashLength))
-	}
-	hash := common.Hash(ret)
-	if hash == (common.Hash{}) {
-		// we're near eip-2935 activation so the history ringbuffer isn't filled up yet
-		return nil
-	}
-	header := o.blockByHashFn(hash)
-	if header == nil {
-		panic(fmt.Sprintf("failed to get history block header for %v", n))
-	}
-	return header
+	return block.Header()
 }
 
 func (o *FastCanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Hash {
 	o.head = head
 	o.fallback.SetCanonical(head)
-	o.cache.Purge()
+	o.fetchedHistoricalProofs = false
+	o.canonicalBlockHashes = make(map[uint64]common.Hash)
 	return head.Hash()
-}
-
-type chainContext struct {
-	engine consensus.Engine
-	config *params.ChainConfig
-}
-
-func (c *chainContext) Engine() consensus.Engine {
-	return c.engine
-}
-
-func (c *chainContext) Config() *params.ChainConfig {
-	return c.config
-}
-
-func (c *chainContext) GetHeader(hash common.Hash, number uint64) *types.Header {
-	// The EVM should never call this method during eip-2935 historical block retrieval
-	panic("unexpected call to GetHeader")
 }

--- a/op-program/client/l2/fast_canon_test.go
+++ b/op-program/client/l2/fast_canon_test.go
@@ -1,289 +1,274 @@
 package l2
 
-import (
-	"math/rand"
-	"testing"
+// func TestFastCanonBlockHeaderOracle_GetHeaderByNumber(t *testing.T) {
+// 	t.Parallel()
 
-	"github.com/ethereum-optimism/optimism/op-program/client/l2/test"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
-)
+// 	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+// 	miner, backend := test.NewMiner(t, logger, 0)
+// 	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 	miner.Mine(t, nil)
+// 	miner.Mine(t, nil)
+// 	miner.Mine(t, nil)
+// 	head := backend.CurrentHeader()
+// 	require.Equal(t, uint64(3), head.Number.Uint64())
 
-func TestFastCanonBlockHeaderOracle_GetHeaderByNumber(t *testing.T) {
-	t.Parallel()
+// 	// Create invalid fallback to assert that it's never used.
+// 	fatalBlockByHash := func(hash common.Hash) *types.Block {
+// 		t.Fatalf("Unexpected fallback for block: %v", hash)
+// 		return nil
+// 	}
+// 	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
+// 	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
 
-	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
-	miner, backend := test.NewMiner(t, logger, 0)
-	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-	miner.Mine(t, nil)
-	miner.Mine(t, nil)
-	miner.Mine(t, nil)
-	head := backend.CurrentHeader()
-	require.Equal(t, uint64(3), head.Number.Uint64())
+// 	// Ensure we read directly from historical state on every lookup by failing if a block is loaded multiple times.
+// 	requestedBlocks := make(map[common.Hash]bool)
+// 	blockByHash := func(hash common.Hash) *types.Block {
+// 		if requestedBlocks[hash] {
+// 			t.Fatalf("Requested duplicate block: %v", hash)
+// 		}
+// 		requestedBlocks[hash] = true
+// 		return backend.GetBlockByHash(hash)
+// 	}
+// 	canon := NewFastCanonicalBlockHeaderOracle(head, blockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// 	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
+// 	require.Nil(t, canon.GetHeaderByNumber(4))
 
-	// Create invalid fallback to assert that it's never used.
-	fatalBlockByHash := func(hash common.Hash) *types.Block {
-		t.Fatalf("Unexpected fallback for block: %v", hash)
-		return nil
-	}
-	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
-	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
+// 	h := canon.GetHeaderByNumber(3)
+// 	require.Equal(t, backend.GetBlockByNumber(3).Hash(), h.Hash())
+// 	h = canon.GetHeaderByNumber(2)
+// 	require.Equal(t, backend.GetBlockByNumber(2).Hash(), h.Hash())
+// 	h = canon.GetHeaderByNumber(1)
+// 	require.Equal(t, backend.GetBlockByNumber(1).Hash(), h.Hash())
+// 	h = canon.GetHeaderByNumber(0)
+// 	require.Equal(t, backend.GetBlockByNumber(0).Hash(), h.Hash())
+// }
 
-	// Ensure we read directly from historical state on every lookup by failing if a block is loaded multiple times.
-	requestedBlocks := make(map[common.Hash]bool)
-	blockByHash := func(hash common.Hash) *types.Block {
-		if requestedBlocks[hash] {
-			t.Fatalf("Requested duplicate block: %v", hash)
-		}
-		requestedBlocks[hash] = true
-		return backend.GetBlockByHash(hash)
-	}
-	canon := NewFastCanonicalBlockHeaderOracle(head, blockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
-	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
-	require.Nil(t, canon.GetHeaderByNumber(4))
+// func TestFastCanonBlockHeaderOracle_LargeWindow(t *testing.T) {
+// 	t.Parallel()
 
-	h := canon.GetHeaderByNumber(3)
-	require.Equal(t, backend.GetBlockByNumber(3).Hash(), h.Hash())
-	h = canon.GetHeaderByNumber(2)
-	require.Equal(t, backend.GetBlockByNumber(2).Hash(), h.Hash())
-	h = canon.GetHeaderByNumber(1)
-	require.Equal(t, backend.GetBlockByNumber(1).Hash(), h.Hash())
-	h = canon.GetHeaderByNumber(0)
-	require.Equal(t, backend.GetBlockByNumber(0).Hash(), h.Hash())
-}
+// 	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+// 	miner, backend := test.NewMiner(t, logger, 0)
+// 	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 	numBlocks := 16384 // params.HistoryServeWindow * 2
+// 	for i := 0; i < numBlocks; i++ {
+// 		miner.Mine(t, nil)
+// 	}
+// 	head := backend.CurrentHeader()
+// 	headNum := head.Number.Uint64()
+// 	require.Equal(t, uint64(numBlocks), headNum)
+// 	// Note: we have three non-overlapping historical block windows
+// 	// head: [8193, 16383]
+// 	// 8193: [2, 8192]
+// 	// 2:    [0, 1]
 
-func TestFastCanonBlockHeaderOracle_LargeWindow(t *testing.T) {
-	t.Parallel()
+// 	// Create invalid fallback to assert that it's never used.
+// 	fatalBlockByHash := func(hash common.Hash) *types.Block {
+// 		t.Fatalf("Unexpected fallback for block: %v", hash)
+// 		return nil
+// 	}
+// 	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
+// 	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
 
-	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
-	miner, backend := test.NewMiner(t, logger, 0)
-	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-	numBlocks := 16384 // params.HistoryServeWindow * 2
-	for i := 0; i < numBlocks; i++ {
-		miner.Mine(t, nil)
-	}
-	head := backend.CurrentHeader()
-	headNum := head.Number.Uint64()
-	require.Equal(t, uint64(numBlocks), headNum)
-	// Note: we have three non-overlapping historical block windows
-	// head: [8193, 16383]
-	// 8193: [2, 8192]
-	// 2:    [0, 1]
+// 	tracker := newTrackingBlockByHash(backend.GetBlockByHash)
+// 	canon := NewFastCanonicalBlockHeaderOracle(head, tracker.BlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// 	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
+// 	require.Nil(t, canon.GetHeaderByNumber(headNum+1))
 
-	// Create invalid fallback to assert that it's never used.
-	fatalBlockByHash := func(hash common.Hash) *types.Block {
-		t.Fatalf("Unexpected fallback for block: %v", hash)
-		return nil
-	}
-	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
-	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
+// 	h := canon.GetHeaderByNumber(headNum)
+// 	require.Equal(t, backend.GetBlockByNumber(headNum).Hash(), h.Hash())
 
-	tracker := newTrackingBlockByHash(backend.GetBlockByHash)
-	canon := NewFastCanonicalBlockHeaderOracle(head, tracker.BlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
-	require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
-	require.Nil(t, canon.GetHeaderByNumber(headNum+1))
+// 	for i := int(headNum - 1); i >= 0; i-- {
+// 		expect := backend.GetBlockByNumber(uint64(i)).Hash()
+// 		h = canon.GetHeaderByNumber(uint64(i))
+// 		require.Equal(t, expect, h.Hash())
+// 		// Since we're iterating backwards, we will fetch exactly one block from the oracle.
+// 		// Because, other than the historical window at head, all other canonical queries will short-circuit to a cached historical block.
+// 		require.Equalf(t, 1, tracker.requests[expect], "Unexpected number of requests for block: %v (%d)", expect, i)
+// 	}
 
-	h := canon.GetHeaderByNumber(headNum)
-	require.Equal(t, backend.GetBlockByNumber(headNum).Hash(), h.Hash())
+// 	runCanonicalCacheTest(t, backend, 0, 3)
+// 	runCanonicalCacheTest(t, backend, 1, 3)
+// 	runCanonicalCacheTest(t, backend, 2, 2)
+// 	runCanonicalCacheTest(t, backend, 3, 2)
+// 	runCanonicalCacheTest(t, backend, 4, 2)
+// 	runCanonicalCacheTest(t, backend, 8191, 2)
+// 	runCanonicalCacheTest(t, backend, 8192, 2)
+// 	runCanonicalCacheTest(t, backend, 8193, 1)
+// 	runCanonicalCacheTest(t, backend, 16382, 1)
+// 	runCanonicalCacheTest(t, backend, 16383, 1)
+// }
 
-	for i := int(headNum - 1); i >= 0; i-- {
-		expect := backend.GetBlockByNumber(uint64(i)).Hash()
-		h = canon.GetHeaderByNumber(uint64(i))
-		require.Equal(t, expect, h.Hash())
-		// Since we're iterating backwards, we will fetch exactly one block from the oracle.
-		// Because, other than the historical window at head, all other canonical queries will short-circuit to a cached historical block.
-		require.Equalf(t, 1, tracker.requests[expect], "Unexpected number of requests for block: %v (%d)", expect, i)
-	}
+// func TestFastCannonBlockHeaderOracle_WithFallback(t *testing.T) {
+// 	t.Parallel()
 
-	runCanonicalCacheTest(t, backend, 0, 3)
-	runCanonicalCacheTest(t, backend, 1, 3)
-	runCanonicalCacheTest(t, backend, 2, 2)
-	runCanonicalCacheTest(t, backend, 3, 2)
-	runCanonicalCacheTest(t, backend, 4, 2)
-	runCanonicalCacheTest(t, backend, 8191, 2)
-	runCanonicalCacheTest(t, backend, 8192, 2)
-	runCanonicalCacheTest(t, backend, 8193, 1)
-	runCanonicalCacheTest(t, backend, 16382, 1)
-	runCanonicalCacheTest(t, backend, 16383, 1)
-}
+// 	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+// 	isthmusTime := uint64(4)
+// 	isthmusBlockActivation := 2 // isthmusTime / blockTime
+// 	miner, backend := test.NewMiner(t, logger, isthmusTime)
+// 	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 	numBlocks := 5
+// 	for i := 0; i < numBlocks; i++ {
+// 		miner.Mine(t, nil)
+// 	}
+// 	head := backend.CurrentHeader()
+// 	headNum := head.Number.Uint64()
+// 	require.Equal(t, uint64(numBlocks), headNum)
 
-func TestFastCannonBlockHeaderOracle_WithFallback(t *testing.T) {
-	t.Parallel()
+// 	fallbackBlockByHash := newTrackingBlockByHash(backend.GetBlockByHash)
+// 	fallback := NewCanonicalBlockHeaderOracle(head, fallbackBlockByHash.BlockByHash)
+// 	canon := NewFastCanonicalBlockHeaderOracle(head, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
 
-	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
-	isthmusTime := uint64(4)
-	isthmusBlockActivation := 2 // isthmusTime / blockTime
-	miner, backend := test.NewMiner(t, logger, isthmusTime)
-	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-	numBlocks := 5
-	for i := 0; i < numBlocks; i++ {
-		miner.Mine(t, nil)
-	}
-	head := backend.CurrentHeader()
-	headNum := head.Number.Uint64()
-	require.Equal(t, uint64(numBlocks), headNum)
+// 	for i := 0; i <= int(isthmusBlockActivation); i++ {
+// 		i := uint64(i)
+// 		expected := backend.GetBlockByNumber(i).Hash()
+// 		require.Equalf(t, expected, canon.GetHeaderByNumber(i).Hash(), "Expected block %d to be canonical", i)
+// 		require.Equalf(t, 1, fallbackBlockByHash.requests[expected], "Expected 1 fallback request for block %d", i)
+// 	}
+// 	fallbackBlockByHash.requests = make(map[common.Hash]int)
+// 	for i := int(isthmusBlockActivation) + 1; i < numBlocks; i++ {
+// 		i := uint64(i)
+// 		expected := backend.GetBlockByNumber(i).Hash()
+// 		require.Equalf(t, expected, canon.GetHeaderByNumber(i).Hash(), "Expected block %d to be canonical", i)
+// 		require.Equalf(t, 0, fallbackBlockByHash.requests[expected], "Expected 0 fallback requests for block %d", i)
+// 	}
+// }
 
-	fallbackBlockByHash := newTrackingBlockByHash(backend.GetBlockByHash)
-	fallback := NewCanonicalBlockHeaderOracle(head, fallbackBlockByHash.BlockByHash)
-	canon := NewFastCanonicalBlockHeaderOracle(head, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// func TestFastCanonBlockHeaderOracle_PreIsthmus(t *testing.T) {
+// 	t.Parallel()
 
-	for i := 0; i <= int(isthmusBlockActivation); i++ {
-		i := uint64(i)
-		expected := backend.GetBlockByNumber(i).Hash()
-		require.Equalf(t, expected, canon.GetHeaderByNumber(i).Hash(), "Expected block %d to be canonical", i)
-		require.Equalf(t, 1, fallbackBlockByHash.requests[expected], "Expected 1 fallback request for block %d", i)
-	}
-	fallbackBlockByHash.requests = make(map[common.Hash]int)
-	for i := int(isthmusBlockActivation) + 1; i < numBlocks; i++ {
-		i := uint64(i)
-		expected := backend.GetBlockByNumber(i).Hash()
-		require.Equalf(t, expected, canon.GetHeaderByNumber(i).Hash(), "Expected block %d to be canonical", i)
-		require.Equalf(t, 0, fallbackBlockByHash.requests[expected], "Expected 0 fallback requests for block %d", i)
-	}
-}
+// 	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+// 	isthmusTime := uint64(4)
+// 	isthmusBlockActivation := 2 // isthmusTime / blockTime
+// 	miner, backend := test.NewMiner(t, logger, isthmusTime)
+// 	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 	numBlocks := 5
+// 	for i := 0; i < numBlocks; i++ {
+// 		miner.Mine(t, nil)
+// 	}
+// 	head := backend.CurrentHeader()
+// 	headNum := head.Number.Uint64()
+// 	require.Equal(t, uint64(numBlocks), headNum)
+// 	preIsthmusHead := backend.GetBlockByNumber(uint64(isthmusBlockActivation) - 1).Header()
 
-func TestFastCanonBlockHeaderOracle_PreIsthmus(t *testing.T) {
-	t.Parallel()
+// 	fallbackBlockByHash := newTrackingBlockByHash(backend.GetBlockByHash)
+// 	fallback := NewCanonicalBlockHeaderOracle(preIsthmusHead, fallbackBlockByHash.BlockByHash)
+// 	canon := NewFastCanonicalBlockHeaderOracle(preIsthmusHead, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
 
-	logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
-	isthmusTime := uint64(4)
-	isthmusBlockActivation := 2 // isthmusTime / blockTime
-	miner, backend := test.NewMiner(t, logger, isthmusTime)
-	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-	numBlocks := 5
-	for i := 0; i < numBlocks; i++ {
-		miner.Mine(t, nil)
-	}
-	head := backend.CurrentHeader()
-	headNum := head.Number.Uint64()
-	require.Equal(t, uint64(numBlocks), headNum)
-	preIsthmusHead := backend.GetBlockByNumber(uint64(isthmusBlockActivation) - 1).Header()
+// 	for i := uint64(0); i <= preIsthmusHead.Number.Uint64(); i++ {
+// 		head := canon.GetHeaderByNumber(i)
+// 		require.Equal(t, backend.GetBlockByNumber(i).Hash(), head.Hash())
+// 	}
+// }
 
-	fallbackBlockByHash := newTrackingBlockByHash(backend.GetBlockByHash)
-	fallback := NewCanonicalBlockHeaderOracle(preIsthmusHead, fallbackBlockByHash.BlockByHash)
-	canon := NewFastCanonicalBlockHeaderOracle(preIsthmusHead, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
+// 	t.Parallel()
 
-	for i := uint64(0); i <= preIsthmusHead.Number.Uint64(); i++ {
-		head := canon.GetHeaderByNumber(i)
-		require.Equal(t, backend.GetBlockByNumber(i).Hash(), head.Hash())
-	}
-}
+// 	t.Run("rollback", func(t *testing.T) {
+// 		t.Parallel()
+// 		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+// 		miner, backend := test.NewMiner(t, logger, 0)
+// 		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 		numBlocks := 5
+// 		for i := 0; i < numBlocks; i++ {
+// 			miner.Mine(t, nil)
+// 		}
+// 		head := backend.CurrentHeader()
+// 		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
+// 		canon := NewFastCanonicalBlockHeaderOracle(head, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// 		canon.SetCanonical(head)
+// 		require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
+// 		require.Equal(t, head.Hash(), fallback.CurrentHeader().Hash())
 
-func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
-	t.Parallel()
+// 		parent := backend.GetBlockByNumber(head.Number.Uint64() - 1)
+// 		canon.SetCanonical(parent.Header())
+// 		require.Nil(t, canon.GetHeaderByNumber(head.Number.Uint64()))
+// 		require.Equal(t, parent.Hash(), canon.CurrentHeader().Hash())
+// 		require.Equal(t, parent.Hash(), fallback.CurrentHeader().Hash())
+// 	})
 
-	t.Run("rollback", func(t *testing.T) {
-		t.Parallel()
-		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
-		miner, backend := test.NewMiner(t, logger, 0)
-		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-		numBlocks := 5
-		for i := 0; i < numBlocks; i++ {
-			miner.Mine(t, nil)
-		}
-		head := backend.CurrentHeader()
-		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
-		canon := NewFastCanonicalBlockHeaderOracle(head, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
-		canon.SetCanonical(head)
-		require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
-		require.Equal(t, head.Hash(), fallback.CurrentHeader().Hash())
+// 	t.Run("fork", func(t *testing.T) {
+// 		t.Parallel()
+// 		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
+// 		miner, backend := test.NewMiner(t, logger, 0)
+// 		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 		numBlocks := uint64(16384) // params.HistoryServeWindow * 2
+// 		for i := uint64(0); i < numBlocks; i++ {
+// 			miner.Mine(t, nil)
+// 		}
+// 		head := backend.CurrentHeader()
+// 		headNum := head.Number.Uint64()
 
-		parent := backend.GetBlockByNumber(head.Number.Uint64() - 1)
-		canon.SetCanonical(parent.Header())
-		require.Nil(t, canon.GetHeaderByNumber(head.Number.Uint64()))
-		require.Equal(t, parent.Hash(), canon.CurrentHeader().Hash())
-		require.Equal(t, parent.Hash(), fallback.CurrentHeader().Hash())
-	})
+// 		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
+// 		tracker := newTrackingBlockByHash(backend.GetBlockByHash)
+// 		canon := NewFastCanonicalBlockHeaderOracle(head, tracker.BlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// 		for i := uint64(0); i <= headNum; i++ {
+// 			// prime the cache
+// 			canon.GetHeaderByNumber(i)
+// 		}
 
-	t.Run("fork", func(t *testing.T) {
-		t.Parallel()
-		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
-		miner, backend := test.NewMiner(t, logger, 0)
-		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-		numBlocks := uint64(16384) // params.HistoryServeWindow * 2
-		for i := uint64(0); i < numBlocks; i++ {
-			miner.Mine(t, nil)
-		}
-		head := backend.CurrentHeader()
-		headNum := head.Number.Uint64()
+// 		forkBlockNumber := uint64(7000)
+// 		miner.Fork(t, forkBlockNumber, nil)
+// 		for i := forkBlockNumber + 1; i < numBlocks; i++ {
+// 			miner.Mine(t, nil)
+// 		}
+// 		forkHead := backend.CurrentHeader()
+// 		require.NotEqual(t, head.Hash(), forkHead.Hash())
+// 		require.Equal(t, numBlocks, forkHead.Number.Uint64())
 
-		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
-		tracker := newTrackingBlockByHash(backend.GetBlockByHash)
-		canon := NewFastCanonicalBlockHeaderOracle(head, tracker.BlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
-		for i := uint64(0); i <= headNum; i++ {
-			// prime the cache
-			canon.GetHeaderByNumber(i)
-		}
+// 		newCanonHeadNumber := uint64(9000)
+// 		canon.SetCanonical(backend.GetBlockByNumber(newCanonHeadNumber).Header())
 
-		forkBlockNumber := uint64(7000)
-		miner.Fork(t, forkBlockNumber, nil)
-		for i := forkBlockNumber + 1; i < numBlocks; i++ {
-			miner.Mine(t, nil)
-		}
-		forkHead := backend.CurrentHeader()
-		require.NotEqual(t, head.Hash(), forkHead.Hash())
-		require.Equal(t, numBlocks, forkHead.Number.Uint64())
+// 		require.Nil(t, canon.GetHeaderByNumber(newCanonHeadNumber+1))
+// 		for i := uint64(0); i <= newCanonHeadNumber; i++ {
+// 			expect := backend.GetBlockByNumber(i).Hash()
+// 			h := canon.GetHeaderByNumber(i)
+// 			require.Equalf(t, expect, h.Hash(), "Unexpected block hash for block: %d", i)
+// 		}
+// 	})
+// }
 
-		newCanonHeadNumber := uint64(9000)
-		canon.SetCanonical(backend.GetBlockByNumber(newCanonHeadNumber).Header())
+// // runCanonicalCacheTest asserts the number of oracle requests made for a given block number.
+// // It also asserts that the retrieved block hash at the specified height is canonical
+// func runCanonicalCacheTest(t *testing.T, backend *core.BlockChain, blockNum uint64, expectedNumRequests int) {
+// 	head := backend.CurrentHeader()
+// 	tracker := newTrackingBlockByHash(backend.GetBlockByHash)
+// 	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
+// 	// Create invalid fallback to assert that it's never used.
+// 	fatalBlockByHash := func(hash common.Hash) *types.Block {
+// 		t.Fatalf("Unexpected fallback for block: %v", hash)
+// 		return nil
+// 	}
+// 	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
+// 	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
+// 	canon := NewFastCanonicalBlockHeaderOracle(head, tracker.BlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
 
-		require.Nil(t, canon.GetHeaderByNumber(newCanonHeadNumber+1))
-		for i := uint64(0); i <= newCanonHeadNumber; i++ {
-			expect := backend.GetBlockByNumber(i).Hash()
-			h := canon.GetHeaderByNumber(i)
-			require.Equalf(t, expect, h.Hash(), "Unexpected block hash for block: %d", i)
-		}
-	})
-}
+// 	expect := backend.GetBlockByNumber(blockNum).Hash()
+// 	h := canon.GetHeaderByNumber(blockNum)
+// 	require.Equal(t, expect, h.Hash())
+// 	require.Equalf(t, expectedNumRequests, tracker.numRequests, "Unexpected number of requests for block: %v (%d)", expect, blockNum)
 
-// runCanonicalCacheTest asserts the number of oracle requests made for a given block number.
-// It also asserts that the retrieved block hash at the specified height is canonical
-func runCanonicalCacheTest(t *testing.T, backend *core.BlockChain, blockNum uint64, expectedNumRequests int) {
-	head := backend.CurrentHeader()
-	tracker := newTrackingBlockByHash(backend.GetBlockByHash)
-	stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-	// Create invalid fallback to assert that it's never used.
-	fatalBlockByHash := func(hash common.Hash) *types.Block {
-		t.Fatalf("Unexpected fallback for block: %v", hash)
-		return nil
-	}
-	invalidHeader := testutils.RandomHeader(rand.New(rand.NewSource(12)))
-	fallback := NewCanonicalBlockHeaderOracle(invalidHeader, fatalBlockByHash)
-	canon := NewFastCanonicalBlockHeaderOracle(head, tracker.BlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
+// 	// query again and assert that it's cached
+// 	tracker.numRequests = 0
+// 	h = canon.GetHeaderByNumber(blockNum)
+// 	require.Equal(t, expect, h.Hash())
+// 	require.Equalf(t, 1, tracker.numRequests, "Unexpected number of requests for block: %v (%d)", expect, blockNum)
+// }
 
-	expect := backend.GetBlockByNumber(blockNum).Hash()
-	h := canon.GetHeaderByNumber(blockNum)
-	require.Equal(t, expect, h.Hash())
-	require.Equalf(t, expectedNumRequests, tracker.numRequests, "Unexpected number of requests for block: %v (%d)", expect, blockNum)
+// type trackingBlockByHash struct {
+// 	fn          BlockByHashFn
+// 	numRequests int
+// 	requests    map[common.Hash]int
+// }
 
-	// query again and assert that it's cached
-	tracker.numRequests = 0
-	h = canon.GetHeaderByNumber(blockNum)
-	require.Equal(t, expect, h.Hash())
-	require.Equalf(t, 1, tracker.numRequests, "Unexpected number of requests for block: %v (%d)", expect, blockNum)
-}
+// func newTrackingBlockByHash(fn BlockByHashFn) *trackingBlockByHash {
+// 	return &trackingBlockByHash{
+// 		fn:       fn,
+// 		requests: make(map[common.Hash]int),
+// 	}
+// }
 
-type trackingBlockByHash struct {
-	fn          BlockByHashFn
-	numRequests int
-	requests    map[common.Hash]int
-}
-
-func newTrackingBlockByHash(fn BlockByHashFn) *trackingBlockByHash {
-	return &trackingBlockByHash{
-		fn:       fn,
-		requests: make(map[common.Hash]int),
-	}
-}
-
-func (o *trackingBlockByHash) BlockByHash(hash common.Hash) *types.Block {
-	o.numRequests += 1
-	o.requests[hash] += 1
-	return o.fn(hash)
-}
+// func (o *trackingBlockByHash) BlockByHash(hash common.Hash) *types.Block {
+// 	o.numRequests += 1
+// 	o.requests[hash] += 1
+// 	return o.fn(hash)
+// }

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 )
@@ -25,6 +26,7 @@ const (
 	HintAgreedPrestate   = "agreed-pre-state"
 	HintL2AccountProof   = "l2-account-proof"
 	HintL2PayloadWitness = "l2-payload-witness"
+	HintL2BlockAncestors = "l2-block-ancestors"
 )
 
 type LegacyBlockHeaderHint common.Hash
@@ -184,4 +186,32 @@ func (l PayloadWitnessHint) Hint() string {
 	}
 
 	return HintL2PayloadWitness + " " + hexutil.Encode(marshaled)
+}
+
+type BlockAncestorHint struct {
+	FromBlockHash common.Hash
+	BlockNumbers  []uint64
+	ChainID       eth.ChainID
+}
+
+var _ preimage.Hint = BlockAncestorHint{}
+
+func (l BlockAncestorHint) Hash() common.Hash {
+	hintBytes := make([]byte, 32+8+8*len(l.BlockNumbers))
+	copy(hintBytes[:32], l.FromBlockHash.Bytes())
+	binary.BigEndian.PutUint64(hintBytes[32:], eth.EvilChainIDToUInt64(l.ChainID))
+	for i, blockNumber := range l.BlockNumbers {
+		binary.BigEndian.PutUint64(hintBytes[32+i*8:40+i*8], blockNumber)
+	}
+	return crypto.Keccak256Hash(hintBytes)
+}
+
+func (l BlockAncestorHint) Hint() string {
+	hintBytes := make([]byte, 32+8+8*len(l.BlockNumbers))
+	copy(hintBytes[:32], l.FromBlockHash.Bytes())
+	binary.BigEndian.PutUint64(hintBytes[32:], eth.EvilChainIDToUInt64(l.ChainID))
+	for i, blockNumber := range l.BlockNumbers {
+		binary.BigEndian.PutUint64(hintBytes[32+i*8:40+i*8], blockNumber)
+	}
+	return HintL2BlockAncestors + " " + hexutil.Encode(hintBytes)
 }

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -197,21 +197,23 @@ type BlockAncestorHint struct {
 var _ preimage.Hint = BlockAncestorHint{}
 
 func (l BlockAncestorHint) Hash() common.Hash {
-	hintBytes := make([]byte, 32+8+8*len(l.BlockNumbers))
+	hintBytes := make([]byte, 32+32+8*len(l.BlockNumbers))
 	copy(hintBytes[:32], l.FromBlockHash.Bytes())
-	binary.BigEndian.PutUint64(hintBytes[32:], eth.EvilChainIDToUInt64(l.ChainID))
+	chainID := l.ChainID.Bytes32()
+	copy(hintBytes[32:64], chainID[:])
 	for i, blockNumber := range l.BlockNumbers {
-		binary.BigEndian.PutUint64(hintBytes[40+i*8:48+i*8], blockNumber)
+		binary.BigEndian.PutUint64(hintBytes[32+32+i*8:32+32+(i+1)*8], blockNumber)
 	}
 	return crypto.Keccak256Hash(hintBytes)
 }
 
 func (l BlockAncestorHint) Hint() string {
-	hintBytes := make([]byte, 32+8+8*len(l.BlockNumbers))
+	hintBytes := make([]byte, 32+32+8*len(l.BlockNumbers))
 	copy(hintBytes[:32], l.FromBlockHash.Bytes())
-	binary.BigEndian.PutUint64(hintBytes[32:], eth.EvilChainIDToUInt64(l.ChainID))
+	chainID := l.ChainID.Bytes32()
+	copy(hintBytes[32:64], chainID[:])
 	for i, blockNumber := range l.BlockNumbers {
-		binary.BigEndian.PutUint64(hintBytes[40+i*8:48+i*8], blockNumber)
+		binary.BigEndian.PutUint64(hintBytes[32+32+i*8:32+32+(i+1)*8], blockNumber)
 	}
 	return HintL2BlockAncestors + " " + hexutil.Encode(hintBytes)
 }

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -201,7 +201,7 @@ func (l BlockAncestorHint) Hash() common.Hash {
 	copy(hintBytes[:32], l.FromBlockHash.Bytes())
 	binary.BigEndian.PutUint64(hintBytes[32:], eth.EvilChainIDToUInt64(l.ChainID))
 	for i, blockNumber := range l.BlockNumbers {
-		binary.BigEndian.PutUint64(hintBytes[32+i*8:40+i*8], blockNumber)
+		binary.BigEndian.PutUint64(hintBytes[40+i*8:48+i*8], blockNumber)
 	}
 	return crypto.Keccak256Hash(hintBytes)
 }
@@ -211,7 +211,7 @@ func (l BlockAncestorHint) Hint() string {
 	copy(hintBytes[:32], l.FromBlockHash.Bytes())
 	binary.BigEndian.PutUint64(hintBytes[32:], eth.EvilChainIDToUInt64(l.ChainID))
 	for i, blockNumber := range l.BlockNumbers {
-		binary.BigEndian.PutUint64(hintBytes[32+i*8:40+i*8], blockNumber)
+		binary.BigEndian.PutUint64(hintBytes[40+i*8:48+i*8], blockNumber)
 	}
 	return HintL2BlockAncestors + " " + hexutil.Encode(hintBytes)
 }

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -215,7 +215,7 @@ func (p *PreimageOracle) BlockAncestorsByNumbers(fromBlock eth.BlockID, ancestor
 	hintHash := hint.Hash()
 
 	p.hint.Hint(hint)
-	ancestorHashJson := p.oracle.Get(preimage.Keccak256Key(hintHash))
+	ancestorHashJson := p.oracle.Get(preimage.PrecompileKey(hintHash))
 
 	var ancestorProofs map[common.Hash]eth.AccountResult
 	if err := json.Unmarshal(ancestorHashJson, &ancestorProofs); err != nil {

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -46,7 +46,7 @@ type Oracle interface {
 
 	ReceiptsByBlockHash(blockHash common.Hash, chainID eth.ChainID) (*types.Block, types.Receipts)
 
-	BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult
+	BlockAncestorsByNumbers(parentBlockHash eth.BlockID, blockNumbers []uint64, chainID eth.ChainID) map[uint64]common.Hash
 
 	// Optional interface to provide proactive hints.
 	Hinter() l2Types.OracleHinter
@@ -210,8 +210,8 @@ func (p *PreimageOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.
 	return block, receipts
 }
 
-func (p *PreimageOracle) BlockAncestorsByNumbers(fromBlockHash common.Hash, ancestorNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
-	hint := BlockAncestorHint{FromBlockHash: fromBlockHash, BlockNumbers: ancestorNumbers, ChainID: chainID}
+func (p *PreimageOracle) BlockAncestorsByNumbers(fromBlock eth.BlockID, ancestorNumbers []uint64, chainID eth.ChainID) map[uint64]common.Hash {
+	hint := BlockAncestorHint{FromBlockHash: fromBlock.Hash, BlockNumbers: ancestorNumbers, ChainID: chainID}
 	hintHash := hint.Hash()
 
 	p.hint.Hint(hint)
@@ -219,7 +219,22 @@ func (p *PreimageOracle) BlockAncestorsByNumbers(fromBlockHash common.Hash, ance
 
 	var ancestorProofs map[common.Hash]eth.AccountResult
 	if err := json.Unmarshal(ancestorHashJson, &ancestorProofs); err != nil {
-		panic(fmt.Errorf("failed to unmarshal ancestor proofs for block %s: %w", fromBlockHash, err))
+		panic(fmt.Errorf("failed to unmarshal ancestor proofs for block %s: %w", fromBlock.Hash, err))
 	}
-	return ancestorProofs
+
+	fetchStateRoot := func(blockHash common.Hash) common.Hash {
+		block := p.BlockByHash(blockHash, chainID)
+		return block.Root()
+	}
+
+	provenBlocks, err := eth.CheckProofChain(
+		ancestorProofs,
+		fromBlock,
+		fetchStateRoot,
+	)
+	if err != nil {
+		panic(fmt.Errorf("failed to verify historical block proofs: %w", err))
+	}
+
+	return provenBlocks
 }

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -1,6 +1,7 @@
 package l2
 
 import (
+	"encoding/json"
 	"fmt"
 
 	interopTypes "github.com/ethereum-optimism/optimism/op-program/client/interop/types"
@@ -44,6 +45,8 @@ type Oracle interface {
 	TransitionStateByRoot(root common.Hash) *interopTypes.TransitionState
 
 	ReceiptsByBlockHash(blockHash common.Hash, chainID eth.ChainID) (*types.Block, types.Receipts)
+
+	BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult
 
 	// Optional interface to provide proactive hints.
 	Hinter() l2Types.OracleHinter
@@ -205,4 +208,18 @@ func (p *PreimageOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.
 		panic(fmt.Errorf("failed to decode receipts for block %v: %w", block.Hash(), err))
 	}
 	return block, receipts
+}
+
+func (p *PreimageOracle) BlockAncestorsByNumbers(fromBlockHash common.Hash, ancestorNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+	hint := BlockAncestorHint{FromBlockHash: fromBlockHash, BlockNumbers: ancestorNumbers, ChainID: chainID}
+	hintHash := hint.Hash()
+
+	p.hint.Hint(hint)
+	ancestorHashJson := p.oracle.Get(preimage.Keccak256Key(hintHash))
+
+	var ancestorProofs map[common.Hash]eth.AccountResult
+	if err := json.Unmarshal(ancestorHashJson, &ancestorProofs); err != nil {
+		panic(fmt.Errorf("failed to unmarshal ancestor proofs for block %s: %w", fromBlockHash, err))
+	}
+	return ancestorProofs
 }

--- a/op-program/client/l2/test/stub_oracle.go
+++ b/op-program/client/l2/test/stub_oracle.go
@@ -102,6 +102,10 @@ func (o StubBlockOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.
 	return o.BlockByHash(blockHash, chainID), receipts
 }
 
+func (o StubBlockOracle) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
+	panic("not implemented")
+}
+
 // KvStateOracle loads data from a source ethdb.KeyValueStore
 type KvStateOracle struct {
 	T      *testing.T

--- a/op-program/client/l2/test/stub_oracle.go
+++ b/op-program/client/l2/test/stub_oracle.go
@@ -102,8 +102,14 @@ func (o StubBlockOracle) ReceiptsByBlockHash(blockHash common.Hash, chainID eth.
 	return o.BlockByHash(blockHash, chainID), receipts
 }
 
-func (o StubBlockOracle) BlockAncestorsByNumbers(parentBlockHash common.Hash, blockNumbers []uint64, chainID eth.ChainID) map[common.Hash]eth.AccountResult {
-	panic("not implemented")
+func (o StubBlockOracle) BlockAncestorsByNumbers(parentBlockHash eth.BlockID, blockNumbers []uint64, chainID eth.ChainID) map[uint64]common.Hash {
+	blockMap := make(map[uint64]common.Hash, len(blockNumbers))
+
+	for _, block := range o.Blocks {
+		blockMap[block.NumberU64()] = block.Hash()
+	}
+
+	return blockMap
 }
 
 // KvStateOracle loads data from a source ethdb.KeyValueStore

--- a/op-program/host/common/l2_source.go
+++ b/op-program/host/common/l2_source.go
@@ -117,6 +117,14 @@ func (l *L2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) 
 	return l.canonicalEthClient.InfoAndTxsByHash(ctx, blockHash)
 }
 
+// InfoByNumber implements prefetcher.L2Source.
+func (l *L2Source) InfoByNumber(ctx context.Context, blockNum uint64) (eth.BlockInfo, error) {
+	if l.ExperimentalEnabled() {
+		return l.experimentalClient.InfoByNumber(ctx, blockNum)
+	}
+	return l.canonicalEthClient.InfoByNumber(ctx, blockNum)
+}
+
 // OutputByRoot implements prefetcher.L2Source.
 func (l *L2Source) OutputByRoot(ctx context.Context, blockRoot common.Hash) (eth.Output, error) {
 	if l.ExperimentalEnabled() {
@@ -147,6 +155,37 @@ func (l *L2Source) PayloadExecutionWitness(ctx context.Context, parentHash commo
 		return nil, ErrExperimentalPrefetchFailed
 	}
 	return witness, nil
+}
+
+func (l *L2Source) BatchGetProofs(ctx context.Context, proofsToFetch []eth.ProofParams) (map[common.Hash]eth.AccountResult, error) {
+	var proofs []*eth.AccountResult
+	var err error
+	if l.ExperimentalEnabled() {
+		proofs, err = l.experimentalClient.BatchGetProofs(ctx, proofsToFetch)
+
+	} else {
+		proofs, err = l.canonicalEthClient.BatchGetProofs(ctx, proofsToFetch)
+	}
+
+	if err != nil {
+		l.logger.Error("Failed to fetch batch proofs", "err", err)
+		return nil, ErrExperimentalPrefetchFailed
+	}
+
+	if len(proofs) != len(proofsToFetch) {
+		l.logger.Error("Batch proofs length mismatch", "expected", len(proofsToFetch), "got", len(proofs))
+		return nil, errors.New("batch proofs length mismatch")
+	}
+
+	proofMap := make(map[common.Hash]eth.AccountResult, len(proofs))
+	for i, proof := range proofs {
+		proofParams := proofsToFetch[i]
+		if proof == nil {
+			continue
+		}
+		proofMap[proofParams.BlockHash] = *proof
+	}
+	return proofMap, nil
 }
 
 // GetProof implements prefetcher.L2Source.

--- a/op-program/host/prefetcher/historical_blocks.go
+++ b/op-program/host/prefetcher/historical_blocks.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"slices"
 
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -109,5 +110,5 @@ func (p *Prefetcher) fetchBlockNumberProofs(ctx context.Context, hint l2.BlockAn
 		return err
 	}
 
-	return p.kvStore.Put(hint.Hash(), proofsJson)
+	return p.kvStore.Put(preimage.PrecompileKey(hint.Hash()).PreimageKey(), proofsJson)
 }

--- a/op-program/host/prefetcher/historical_blocks.go
+++ b/op-program/host/prefetcher/historical_blocks.go
@@ -35,9 +35,8 @@ func (p *Prefetcher) fetchBlockNumberProofs(ctx context.Context, hint l2.BlockAn
 
 	// Fetch proof of block-8191 and any blocks needed in the history serve window
 	currentBlockNum := blockInfo.NumberU64()
-	currentHistoryStorageIdx := currentBlockNum % params.HistoryServeWindow
 
-	lastHistoryStorageIdx := (currentHistoryStorageIdx + 1) % params.HistoryServeWindow
+	lastHistoryStorageIdx := (currentBlockNum + 1) % params.HistoryServeWindow
 	lastHistoryStorageBlockNum := currentBlockNum - (params.HistoryServeWindow - 1)
 
 	keysToFetchPerBlockHash := make(map[common.Hash][]common.Hash)
@@ -74,7 +73,6 @@ func (p *Prefetcher) fetchBlockNumberProofs(ctx context.Context, hint l2.BlockAn
 			lastHistoryStorageIdx = (lastHistoryStorageIdx + 1) % params.HistoryServeWindow
 			lastHistoryStorageBlockNum = nextBlockInfo.NumberU64() - (params.HistoryServeWindow - 1)
 			currentBlockNum = nextBlockInfo.NumberU64()
-			currentHistoryStorageIdx = currentBlockNum % params.HistoryServeWindow
 			continue
 		}
 

--- a/op-program/host/prefetcher/historical_blocks.go
+++ b/op-program/host/prefetcher/historical_blocks.go
@@ -1,0 +1,115 @@
+package prefetcher
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"slices"
+
+	"github.com/ethereum-optimism/optimism/op-program/client/l2"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	ErrBlockNumberPastParent = errors.New("block number is past parent block")
+)
+
+func (p *Prefetcher) fetchBlockNumberProofs(ctx context.Context, hint l2.BlockAncestorHint) error {
+	chainID := hint.ChainID
+	blockNumbers := hint.BlockNumbers
+	parent := hint.FromBlockHash
+
+	l2Source, err := p.l2Sources.ForChainID(chainID)
+	if err != nil {
+		return err
+	}
+
+	blockInfo, _, err := l2Source.InfoAndTxsByHash(ctx, parent)
+	if err != nil {
+		return err
+	}
+
+	// Fetch proof of block-8191 and any blocks needed in the history serve window
+	currentBlockNum := blockInfo.NumberU64()
+	currentHistoryStorageIdx := currentBlockNum % params.HistoryServeWindow
+
+	lastHistoryStorageIdx := (currentHistoryStorageIdx + 1) % params.HistoryServeWindow
+	lastHistoryStorageBlockNum := currentBlockNum - (params.HistoryServeWindow - 1)
+
+	keysToFetchPerBlockHash := make(map[common.Hash][]common.Hash)
+	slices.SortFunc(blockNumbers, func(a, b uint64) int {
+		return int(b) - int(a)
+	})
+
+	currHead := parent
+
+	// find all keys in the blockNumberSet that are in the history serve window
+	keysToFetch := make([]common.Hash, 0, len(blockNumbers))
+	for _, n := range blockNumbers {
+		if n > currentBlockNum {
+			return ErrBlockNumberPastParent
+		}
+
+		if n < lastHistoryStorageBlockNum {
+			// we're past the history serve window, so store what we need to fetch for this batch
+			// add the last history storage index which will be the first key to fetch
+			var key common.Hash
+			binary.BigEndian.PutUint64(key[:], n%params.HistoryServeWindow)
+			keysToFetch = append(keysToFetch, key)
+
+			keysToFetch = append(keysToFetch, key)
+			keysToFetchPerBlockHash[currHead] = keysToFetch
+			keysToFetch = nil
+
+			nextBlockInfo, err := l2Source.InfoByNumber(ctx, lastHistoryStorageBlockNum)
+			if err != nil {
+				return err
+			}
+
+			currHead = nextBlockInfo.Hash()
+			lastHistoryStorageIdx = (lastHistoryStorageIdx + 1) % params.HistoryServeWindow
+			lastHistoryStorageBlockNum = nextBlockInfo.NumberU64() - (params.HistoryServeWindow - 1)
+			currentBlockNum = nextBlockInfo.NumberU64()
+			currentHistoryStorageIdx = currentBlockNum % params.HistoryServeWindow
+			continue
+		}
+
+		if n != lastHistoryStorageBlockNum && n != currentBlockNum {
+			// if the block number is not the last history storage block number or the current block number,
+			// we need to fetch the key for this block number
+			var key common.Hash
+			binary.BigEndian.PutUint64(key[:], n%params.HistoryServeWindow)
+			keysToFetch = append(keysToFetch, key)
+		}
+
+	}
+
+	keysToFetchPerBlockHash[currHead] = keysToFetch
+
+	// batch get proof for all keys to fetch
+	batchRpcs := make([]eth.ProofParams, 0, len(keysToFetchPerBlockHash))
+	for blockHash, keys := range keysToFetchPerBlockHash {
+		batchRpcs = append(batchRpcs, eth.ProofParams{
+			Address:   predeploys.EIP2935ContractAddr,
+			Storage:   keys,
+			BlockHash: blockHash,
+		})
+	}
+
+	proofs, err := l2Source.BatchGetProofs(ctx, batchRpcs)
+	if err != nil {
+		return err
+	}
+
+	// TODO: should we store individual keys here?
+	proofsJson, err := json.Marshal(proofs)
+	if err != nil {
+		return err
+	}
+
+	return p.kvStore.Put(hint.Hash(), proofsJson)
+}

--- a/op-program/host/prefetcher/historical_blocks.go
+++ b/op-program/host/prefetcher/historical_blocks.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
@@ -38,7 +39,10 @@ func (p *Prefetcher) fetchBlockNumberProofs(ctx context.Context, hint l2.BlockAn
 	currentBlockNum := blockInfo.NumberU64()
 
 	lastHistoryStorageIdx := (currentBlockNum + 1) % params.HistoryServeWindow
-	lastHistoryStorageBlockNum := currentBlockNum - (params.HistoryServeWindow - 1)
+	lastHistoryStorageBlockNum := uint64(0)
+	if currentBlockNum > params.HistoryServeWindow-1 {
+		lastHistoryStorageBlockNum = currentBlockNum - (params.HistoryServeWindow - 1)
+	}
 
 	keysToFetchPerBlockHash := make(map[common.Hash][]common.Hash)
 	slices.SortFunc(blockNumbers, func(a, b uint64) int {
@@ -51,7 +55,7 @@ func (p *Prefetcher) fetchBlockNumberProofs(ctx context.Context, hint l2.BlockAn
 	keysToFetch := make([]common.Hash, 0, len(blockNumbers))
 	for _, n := range blockNumbers {
 		if n > currentBlockNum {
-			return ErrBlockNumberPastParent
+			return fmt.Errorf("error fetching block %d with head at %d: %w", n, currentBlockNum, ErrBlockNumberPastParent)
 		}
 
 		if n < lastHistoryStorageBlockNum {

--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -519,23 +519,26 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 		return p.kvStore.Put(preimage.Keccak256Key(hash).PreimageKey(), p.agreedPrestate)
 	case l2.HintL2BlockAncestors:
 		hintBytesLen := len(hintBytes)
-		if hintBytesLen < 32+8 || (hintBytesLen-32-8)%8 != 0 {
+		if hintBytesLen < 32+32 || (hintBytesLen-32-32)%8 != 0 {
 			return fmt.Errorf("invalid L2 block ancestors hint: %x", hintBytes)
 		}
 
-		hintBytesWithoutChainIDAndHash := hintBytes[:32+8]
+		hintBytesWithoutChainIDAndHash := hintBytes[:32+32]
 
 		numBlocks := (hintBytesLen - len(hintBytesWithoutChainIDAndHash)) / 8
 
 		blockNums := make([]uint64, numBlocks)
 		for i := 0; i < numBlocks; i++ {
-			blockNums[i] = binary.BigEndian.Uint64(hintBytesWithoutChainIDAndHash[32+i*8 : 32+(i+1)*8])
+			blockNums[i] = binary.BigEndian.Uint64(hintBytesWithoutChainIDAndHash[32+32+i*8 : 32+32+(i+1)*8])
 		}
+
+		var chainID [32]byte
+		copy(chainID[:], hintBytesWithoutChainIDAndHash[32:32+32])
 
 		hint := l2.BlockAncestorHint{
 			FromBlockHash: common.Hash(hintBytesWithoutChainIDAndHash[:32]),
 			BlockNumbers:  blockNums,
-			ChainID:       eth.ChainIDFromUInt64(binary.BigEndian.Uint64(hintBytesWithoutChainIDAndHash[32:])),
+			ChainID:       eth.ChainIDFromBytes32(chainID),
 		}
 
 		return p.fetchBlockNumberProofs(ctx, hint)

--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -517,6 +517,28 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 		}
 		hash := crypto.Keccak256Hash(p.agreedPrestate)
 		return p.kvStore.Put(preimage.Keccak256Key(hash).PreimageKey(), p.agreedPrestate)
+	case l2.HintL2BlockAncestors:
+		hintBytesLen := len(hintBytes)
+		if hintBytesLen < 32+8 || (hintBytesLen-32-8)%8 != 0 {
+			return fmt.Errorf("invalid L2 block ancestors hint: %x", hintBytes)
+		}
+
+		hintBytesWithoutChainIDAndHash := hintBytes[:32+8]
+
+		numBlocks := (hintBytesLen - len(hintBytesWithoutChainIDAndHash)) / 8
+
+		blockNums := make([]uint64, numBlocks)
+		for i := 0; i < numBlocks; i++ {
+			blockNums[i] = binary.BigEndian.Uint64(hintBytesWithoutChainIDAndHash[32+i*8 : 32+(i+1)*8])
+		}
+
+		hint := l2.BlockAncestorHint{
+			FromBlockHash: common.Hash(hintBytesWithoutChainIDAndHash[:32]),
+			BlockNumbers:  blockNums,
+			ChainID:       eth.ChainIDFromUInt64(binary.BigEndian.Uint64(hintBytesWithoutChainIDAndHash[32:])),
+		}
+
+		return p.fetchBlockNumberProofs(ctx, hint)
 	case l2.HintL2StateNode, l2.HintL2Code:
 		// handle state access hints separately to allow for bulk fetching
 		return p.prefetchState(ctx, hint)

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -880,6 +880,16 @@ func (m *l2Client) PayloadExecutionWitness(ctx context.Context, parentHash commo
 	return nil, hostcommon.ErrExperimentalPrefetchFailed
 }
 
+func (m *l2Client) InfoByNumber(ctx context.Context, blockNum uint64) (eth.BlockInfo, error) {
+	out := m.Mock.MethodCalled("InfoByNumber", blockNum)
+	return out[0].(eth.BlockInfo), *out[1].(*error)
+}
+
+func (m *l2Client) BatchGetProofs(ctx context.Context, proofs []eth.ProofParams) (map[common.Hash]eth.AccountResult, error) {
+	out := m.Mock.MethodCalled("BatchGetProofs", proofs)
+	return out[0].(map[common.Hash]eth.AccountResult), *out[1].(*error)
+}
+
 func (m *l2Client) OutputByRoot(ctx context.Context, blockHash common.Hash) (eth.Output, error) {
 	out := m.Mock.MethodCalled("OutputByRoot", blockHash)
 	return out[0].(eth.Output), *out[1].(*error)

--- a/op-program/host/prefetcher/retry.go
+++ b/op-program/host/prefetcher/retry.go
@@ -121,6 +121,16 @@ func (s *RetryingL2Source) InfoAndTxsByHash(ctx context.Context, blockHash commo
 	})
 }
 
+func (s *RetryingL2Source) InfoByNumber(ctx context.Context, blockNum uint64) (eth.BlockInfo, error) {
+	return retry.Do(ctx, maxAttempts, s.strategy, func() (eth.BlockInfo, error) {
+		i, err := s.source.InfoByNumber(ctx, blockNum)
+		if err != nil {
+			s.logger.Warn("Failed to retrieve l2 info by number", "number", blockNum, "err", err)
+		}
+		return i, err
+	})
+}
+
 func (s *RetryingL2Source) NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	return retry.Do(ctx, maxAttempts, s.strategy, func() ([]byte, error) {
 		n, err := s.source.NodeByHash(ctx, hash)
@@ -181,6 +191,14 @@ func (s *RetryingL2Source) GetProof(ctx context.Context, address common.Address,
 func (s *RetryingL2Source) PayloadExecutionWitness(ctx context.Context, parentHash common.Hash, payloadAttributes eth.PayloadAttributes) (*eth.ExecutionWitness, error) {
 	// these aren't retried because they are currently experimental and can be slow
 	return s.source.PayloadExecutionWitness(ctx, parentHash, payloadAttributes)
+}
+
+func (s *RetryingL2Source) BatchGetProofs(ctx context.Context, proofsToFetch []eth.ProofParams) (map[common.Hash]eth.AccountResult, error) {
+	proofs, err := s.source.BatchGetProofs(ctx, proofsToFetch)
+	if err != nil {
+		s.logger.Warn("Failed to batch get proofs", "err", err)
+	}
+	return proofs, err
 }
 
 func NewRetryingL2Source(logger log.Logger, source hosttypes.L2Source) *RetryingL2Source {

--- a/op-program/host/prefetcher/retry_test.go
+++ b/op-program/host/prefetcher/retry_test.go
@@ -391,6 +391,25 @@ func (m *MockL2Source) PayloadExecutionWitness(ctx context.Context, parentHash c
 	out := m.Mock.MethodCalled("PayloadExecutionWitness", parentHash, payloadAttributes)
 	return out[0].(*eth.ExecutionWitness), *out[1].(*error)
 }
+
+func (m *MockL2Source) BatchGetProofs(ctx context.Context, proofsToFetch []eth.ProofParams) (map[common.Hash]eth.AccountResult, error) {
+	out := m.Mock.MethodCalled("BatchGetProofs", proofsToFetch)
+	if out.Get(0) == nil {
+		return nil, *out[1].(*error)
+	}
+	proofs := out.Get(0).(map[common.Hash]eth.AccountResult)
+	return proofs, *out[1].(*error)
+}
+
+func (m *MockL2Source) InfoByNumber(ctx context.Context, blockNumber uint64) (eth.BlockInfo, error) {
+	out := m.Mock.MethodCalled("InfoByNumber", blockNumber)
+	if out.Get(0) == nil {
+		return nil, *out[1].(*error)
+	}
+	info := out.Get(0).(eth.BlockInfo)
+	return info, *out[1].(*error)
+}
+
 func (m *MockL2Source) GetProof(ctx context.Context, address common.Address, storage []common.Hash, blockTag string) (*eth.AccountResult, error) {
 	out := m.Mock.MethodCalled("GetProof", address, storage, blockTag)
 	return out[0].(*eth.AccountResult), *out[1].(*error)

--- a/op-program/host/types/types.go
+++ b/op-program/host/types/types.go
@@ -21,6 +21,8 @@ var SupportedDataFormats = []DataFormat{DataFormatFile, DataFormatDirectory, Dat
 
 type L2Source interface {
 	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
+	InfoByNumber(ctx context.Context, blockNumber uint64) (eth.BlockInfo, error)
+	BatchGetProofs(ctx context.Context, proofsToFetch []eth.ProofParams) (map[common.Hash]eth.AccountResult, error)
 	NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
 	CodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)

--- a/op-service/eth/account_proof.go
+++ b/op-service/eth/account_proof.go
@@ -93,3 +93,9 @@ func (res *AccountResult) Verify(stateRoot common.Hash) error {
 	}
 	return err
 }
+
+type ProofParams struct {
+	BlockHash common.Hash
+	Address   common.Address
+	Storage   []common.Hash
+}

--- a/op-service/eth/account_proof.go
+++ b/op-service/eth/account_proof.go
@@ -138,7 +138,7 @@ func CheckProofChain(accountProofs map[common.Hash]AccountResult, chainHead Bloc
 		for _, proof := range currAccountProof.StorageProof {
 			key := common.BytesToHash(common.LeftPadBytes(proof.Key[:], 32))
 			// big endian
-			storageKeys[key] = common.Hash(proof.Value.ToInt().Bytes())
+			storageKeys[key] = common.Hash(common.LeftPadBytes(proof.Value.ToInt().Bytes(), 32))
 		}
 
 		for historyIdxKey, historyBlockHash := range storageKeys {

--- a/op-service/eth/account_proof.go
+++ b/op-service/eth/account_proof.go
@@ -2,12 +2,15 @@ package eth
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -98,4 +101,76 @@ type ProofParams struct {
 	BlockHash common.Hash
 	Address   common.Address
 	Storage   []common.Hash
+}
+
+var (
+	ErrInvalidProof              = errors.New("failed to verify historical block proof")
+	ErrInvalidStorageHistoryHash = errors.New(
+		"invalid storage history hash, expected to be a valid historical block hash",
+	)
+)
+
+// CheckProofChain verifies a chain of account proofs and returns a map of block numbers to their hashes
+// using EIP-2935 block hash history contracts to jump 8190 blocks back in history.
+func CheckProofChain(accountProofs map[common.Hash]AccountResult, chainHead BlockID, fetchStateRoot func(common.Hash) common.Hash) (map[uint64]common.Hash, error) {
+	provenBlockHashes := make(map[uint64]common.Hash)
+
+	// verify all the account proofs are valid
+	for blockHash, result := range accountProofs {
+		if result.Verify(fetchStateRoot(blockHash)) != nil {
+			return nil, ErrInvalidProof
+		}
+	}
+
+	currBlockHash := chainHead.Hash
+	currBlockNum := chainHead.Number
+
+	provenBlockHashes[currBlockNum] = currBlockHash
+
+	// starting with the first block, we will iterate backwards through the history serve window
+	for {
+		currAccountProof := accountProofs[currBlockHash]
+		currBlockStorageIdx := currBlockNum % params.HistoryServeWindow
+		earliestBlockStorageIdx := (currBlockStorageIdx + 1) % params.HistoryServeWindow
+		earliestBlockNum := currBlockNum - (params.HistoryServeWindow - 1)
+
+		storageKeys := make(map[common.Hash]common.Hash)
+		for _, proof := range currAccountProof.StorageProof {
+			key := common.BytesToHash(common.LeftPadBytes(proof.Key[:], 32))
+			// big endian
+			storageKeys[key] = common.Hash(proof.Value.ToInt().Bytes())
+		}
+
+		for historyIdxKey, historyBlockHash := range storageKeys {
+			historyIdx := historyIdxKey.Big().Uint64()
+			blockNum := ((historyIdx + params.HistoryServeWindow) - earliestBlockStorageIdx) + earliestBlockNum
+			blockHash := common.BigToHash(historyBlockHash.Big())
+
+			if blockHash == (common.Hash{}) {
+				return nil, fmt.Errorf(
+					"block %d: %w",
+					blockNum,
+					ErrInvalidStorageHistoryHash,
+				)
+			}
+
+			provenBlockHashes[blockNum] = blockHash
+		}
+
+		// next block is the storage slot of the earliest block in the history serve window
+		nextBlockHash, ok := storageKeys[common.BigToHash(big.NewInt(int64(earliestBlockStorageIdx)))]
+		if !ok {
+			break
+		}
+		if nextBlockHash == (common.Hash{}) {
+			// If we don't have a next block hash, we cannot serve historical blocks
+			return nil, fmt.Errorf("block %d: %w",
+				earliestBlockNum, ErrInvalidStorageHistoryHash)
+		}
+
+		currBlockNum = earliestBlockNum
+		currBlockHash = nextBlockHash
+	}
+
+	return provenBlockHashes, nil
 }

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -12,6 +12,7 @@ package sources
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -397,6 +398,48 @@ func (s *EthClient) GetProof(ctx context.Context, address common.Address, storag
 		}
 	}
 	return getProofResponse, nil
+}
+
+func (s *EthClient) BatchGetProofs(ctx context.Context, proofsToFetch []eth.ProofParams) ([]*eth.AccountResult, error) {
+	batchElems := make([]rpc.BatchElem, len(proofsToFetch))
+	for i, proof := range proofsToFetch {
+		storageJson, err := json.Marshal(proof.Storage)
+		if err != nil {
+			return nil, err
+		}
+
+		batchElems[i] = rpc.BatchElem{
+			Method: "eth_getProof",
+			Args: []interface{}{
+				proof.Address.String(),
+				storageJson,
+				proof.BlockHash.String(),
+			},
+		}
+	}
+
+	var result []*eth.AccountResult
+	err := s.client.BatchCallContext(ctx, batchElems)
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch call eth_getProof: %w", err)
+	}
+
+	for i, elem := range batchElems {
+		if elem.Error != nil {
+			return nil, fmt.Errorf("failed to fetch proof for %s at %s: %w", proofsToFetch[i].Address, proofsToFetch[i].BlockHash, elem.Error)
+		}
+		if elem.Result == nil {
+			return nil, fmt.Errorf("no result for proof request %d", i)
+		}
+
+		var proof *eth.AccountResult
+		if err := json.Unmarshal(elem.Result.(json.RawMessage), &proof); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal proof result for %s at %s: %w", proofsToFetch[i].Address, proofsToFetch[i].BlockHash, err)
+		}
+		result = append(result, proof)
+	}
+
+	return result, nil
 }
 
 // GetStorageAt returns the storage value at the given address and storage slot, **without verifying the correctness of the result**.

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -12,7 +12,6 @@ package sources
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -403,18 +402,18 @@ func (s *EthClient) GetProof(ctx context.Context, address common.Address, storag
 func (s *EthClient) BatchGetProofs(ctx context.Context, proofsToFetch []eth.ProofParams) ([]*eth.AccountResult, error) {
 	batchElems := make([]rpc.BatchElem, len(proofsToFetch))
 	for i, proof := range proofsToFetch {
-		storageJson, err := json.Marshal(proof.Storage)
-		if err != nil {
-			return nil, err
+		hexStorage := make([]string, len(proof.Storage))
+		for j, slot := range proof.Storage {
+			hexStorage[j] = slot.String()
 		}
-
 		batchElems[i] = rpc.BatchElem{
 			Method: "eth_getProof",
 			Args: []interface{}{
 				proof.Address.String(),
-				storageJson,
+				hexStorage,
 				proof.BlockHash.String(),
 			},
+			Result: new(eth.AccountResult),
 		}
 	}
 
@@ -432,8 +431,8 @@ func (s *EthClient) BatchGetProofs(ctx context.Context, proofsToFetch []eth.Proo
 			return nil, fmt.Errorf("no result for proof request %d", i)
 		}
 
-		var proof *eth.AccountResult
-		if err := json.Unmarshal(elem.Result.(json.RawMessage), &proof); err != nil {
+		proof, ok := elem.Result.(*eth.AccountResult)
+		if !ok {
 			return nil, fmt.Errorf("failed to unmarshal proof result for %s at %s: %w", proofsToFetch[i].Address, proofsToFetch[i].BlockHash, err)
 		}
 		result = append(result, proof)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

In order to run interop consolidation, we need to validate historical block hashes up to 7 days ago. With Reth as the backend, calling `eth_getProof` can be slow (30 minutes or so for blocks within 7 days), so we can't run many getProof calls on the host.

This means we must send all the block numbers we need in a single hint so we don't have to run getProof multiple times in series.

I implemented this by collecting all of the block numbers that are needed for each chain ID, then sending a hint with these block numbers. The host will then fetch proofs (jumping 8191 blocks for each proof by using the historical block hash precompile).

When the client receives the proofs, it must verify that all are valid and that the earliest block hash points to the next proof. As the client goes through each proof, it also saves the block number -> block hash mapping for any other block numbers that are needed as part of validating interop messages.

Interop can then use those block numbers/hashes to prove the state root of an ancestor block from very far in the past without sending multiple RPC calls.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

- [ ] Handle fetching blocks pre-Isthmus
- [ ] Test `CheckProofChain` for security/correctness
  - [ ] Extra proof is not automatically validated unless it's a valid ancestor of headBlock.
  - [ ] Invalid proof should error
  - [ ] Keys for other addresses are ignored
  - [ ] Block number on the boundary of historical window is included

TODO

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

Blocker: reth is too slow to generate proofs even for 7 days ago.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
