### PR TITLE
Refactor CI go-test execution to use shared Makefile targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1050,9 +1050,10 @@ jobs:
         description: Environment overrides
         type: string
         default: ""
-      packages:
-        description: List of packages to test
+      rule:
+        description: Rule to run the tests
         type: string
+        default: "go-tests-ci"
     machine: true
     resource_class: <<parameters.resource_class>>
     steps:
@@ -1060,50 +1061,12 @@ jobs:
       - attach_workspace:
           at: "."
       - run:
-          name: build op-program-client
-          command: make op-program-client
-          working_directory: op-program
-      - run:
-          name: build op-program-host
-          command: make op-program-host
-          working_directory: op-program
-      - run:
-          name: build cannon
-          command: make cannon
-      - run:
-          name: run tests
+          name: Run all Go tests via Makefile
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
-            mkdir -p ./tmp/test-results && mkdir -p ./tmp/testlogs
-            cd op-e2e && make pre-test && cd ..
-
-            packages=(
-              <<parameters.packages>>
-            )
-            formatted_packages=""
-            for package in "${packages[@]}"; do
-              formatted_packages="$formatted_packages ./$package/..."
-            done
-
-            export ENABLE_KURTOSIS=true
-            export OP_E2E_CANNON_ENABLED="false"
-            export OP_E2E_SKIP_SLOW_TEST=true
-            export OP_E2E_USE_HTTP=true
-            export ENABLE_ANVIL=true
-            export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
-            export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
-            export PARALLEL=$(nproc)
-            export OP_TESTLOG_FILE_LOGGER_OUTDIR=$(realpath ./tmp/testlogs)
-
             <<parameters.environment_overrides>>
-
-            gotestsum --format=testname \
-              --junitfile=./tmp/test-results/results.xml \
-              --jsonfile=./tmp/testlogs/log.json \
-              --rerun-fails=3 \
-              --rerun-fails-max-failures=50 \
-              --packages="$formatted_packages" \
-              -- -parallel=$PARALLEL -coverprofile=coverage.out -timeout=<<parameters.test_timeout>>
+            export TEST_TIMEOUT=<<parameters.test_timeout>>
+            make <<parameters.rule>>
       - codecov/upload:
           disable_search: true
           files: ./coverage.out
@@ -1333,6 +1296,8 @@ jobs:
           paths:
             - "op-program/bin/prestate*"
             - "op-program/bin/meta*"
+            - "op-program/bin/op-program"
+            - "op-program/bin/op-program-client"
             - "cannon/bin"
 
   cannon-prestate:
@@ -1848,37 +1813,6 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - go-tests:
-          environment_overrides: |
-            export PARALLEL=24
-          packages: |
-            op-alt-da
-            op-batcher
-            op-chain-ops
-            op-node
-            op-proposer
-            op-challenger
-            op-faucet
-            op-dispute-mon
-            op-conductor
-            op-program
-            op-service
-            op-supervisor
-            op-test-sequencer
-            op-deployer
-            op-fetcher
-            op-validator
-            op-e2e/system
-            op-e2e/e2eutils
-            op-e2e/opgeth
-            op-e2e/interop
-            op-e2e/actions
-            op-e2e/faultproofs
-            packages/contracts-bedrock/scripts/checks
-            op-dripper
-            devnet-sdk
-            op-acceptance-tests
-            kurtosis-devnet
-            op-devstack
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
@@ -2123,16 +2057,12 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
       - go-tests:
           name: op-e2e-cannon-tests
+          rule: go-tests-fraud-proofs-ci
           notify: true
           mentions: "@proofs-team"
           no_output_timeout: 60m
           test_timeout: 90m
           resource_class: ethereum-optimism/latitude-fps-1
-          environment_overrides: |
-            export OP_E2E_CANNON_ENABLED="true"
-            export PARALLEL=24
-          packages: |
-            op-e2e/faultproofs
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -1,4 +1,5 @@
-num_cores := $(shell nproc)
+# nproc is for linux, sysctl for Mac and then fallback to 4 if neither is available
+num_cores := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
 # Generally, JUNIT_FILE is set in CI but may be specified to an arbitrary file location to emulate CI locally
 # If JUNIT_FILE is set, JSON_LOG_FILE should also be set


### PR DESCRIPTION
This PR extracts the Go test execution logic from CircleCI into reusable Makefile targets, enabling local test execution with the same configuration used in CI.

**Description**

Makefile:
- Add `go-tests` target that runs all tests locally with caching enabled (fast repeated runs)
- Add `go-tests-short` variant for quick local testing  
- Add `go-tests-ci` and `go-tests-rpc-ci` targets that use `gotestsum` for structured output, retries, and coverage reports
- Extract common environment variables (`TEST_ENV_VARS`) and package lists (`TEST_PKGS`, `RPC_TEST_PKGS`) to reduce duplication
- Support configurable test timeout via `TEST_TIMEOUT` environment variable
- Fix macOS compatibility by using `sysctl -n hw.ncpu` as fallback for `nproc`

CircleCI:
- Replace inline test script with simple `make go-tests-ci go-tests-rpc-ci` invocation
- Remove redundant binary build steps (handled by Makefile dependencies for local runs, by job dependencies in CI)
- Pass `test_timeout` parameter through to Makefile

**Benefits**

1. **Local testing**: Developers can now run `make go-tests` locally with the same test configuration as CI
2. **Consistency**: Single source of truth for test execution logic reduces drift between local and CI environments  
3. **Maintainability**: Environment variables and package lists defined once, easier to add/remove packages
4. **Performance**: Local tests use Go's test caching; CI tests include retries and structured output
5. **Flexibility**: Separate targets for cached vs full test runs, with optional RPC-dependent tests

The changes preserve all existing CI functionality while making the test infrastructure more accessible for local development.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

If CI passes on this PR and based on logs it appears to be running tests properly (and handling coverage interpretation etc.), then it can be merged.