### PR TITLE
fix: correct @return comments for readMem and readMemUnchecked

### DIFF
--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
@@ -13,7 +13,7 @@ library MIPS64Memory {
     /// @param _memRoot The current memory root
     /// @param _addr The address to read from.
     /// @param _proofOffset The offset of the memory proof in calldata.
-    /// @return out_ The hashed MIPS state.
+    /// @return out_ The read memory word.
     function readMem(bytes32 _memRoot, uint64 _addr, uint256 _proofOffset) internal pure returns (uint64 out_) {
         bool valid;
         (out_, valid) = readMemUnchecked(_memRoot, _addr, _proofOffset);
@@ -26,7 +26,7 @@ library MIPS64Memory {
     /// @param _memRoot The current memory root
     /// @param _addr The address to read from.
     /// @param _proofOffset The offset of the memory proof in calldata.
-    /// @return out_ The hashed MIPS state.
+    /// @return out_ The read memory word.
     ///         valid_ Whether the proof is valid.
     function readMemUnchecked(
         bytes32 _memRoot,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR fixes incorrect structured comments for the `readMem` and `readMemUnchecked` functions in `MIPS64Memory.sol`. The @return annotations have been updated to accurately describe the return values.
closes https://github.com/ethereum-optimism/optimism/issues/13436

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
