### PR TITLE
feat(devstack): salt key creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/spf13/afero v1.12.0
 	github.com/stretchr/testify v1.10.0
+	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli/v2 v2.27.6
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
@@ -253,7 +254,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/wlynxg/anet v0.0.4 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect

--- a/op-chain-ops/devkeys/hd.go
+++ b/op-chain-ops/devkeys/hd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	hdwallet "github.com/ethereum-optimism/go-ethereum-hdwallet"
+	"github.com/tyler-smith/go-bip39"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -23,6 +24,18 @@ func NewMnemonicDevKeys(mnemonic string) (*MnemonicDevKeys, error) {
 	w, err := hdwallet.NewFromMnemonic(mnemonic)
 	if err != nil {
 		return nil, fmt.Errorf("invalid mnemonic: %w", err)
+	}
+	return &MnemonicDevKeys{w: w}, nil
+}
+
+func NewSaltedDevKeys(mnemonic string, salt string) (*MnemonicDevKeys, error) {
+	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, salt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create seed: %w", err)
+	}
+	w, err := hdwallet.NewFromSeed(seed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create wallet: %w", err)
 	}
 	return &MnemonicDevKeys{w: w}, nil
 }

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -150,4 +150,5 @@ The following environment variables can be used to configure devstack:
 
 - `TEST_LOG_LEVEL`: Controls the logging level for tests. Defaults to "info" if not set. Valid values are standard log levels (e.g. "debug", "info", "warn", "error").
 - `DEVSTACK_ORCHESTRATOR`: Configures the preferred orchestrator kind (see Orchestrator interface section above).
+- `DEVSTACK_KEYS_SALT`: Seeds the keys generated with `NewHDWallet`. This is useful for "isolating" test runs, and might be needed to reproduce CI and/or acceptance test runs. It can be any string, including the empty one to use the "usual" devkeys.
 - `DEVNET_ENV_URL`: Used when `DEVSTACK_ORCHESTRATOR=sysext` to specify the network descriptor URL.

--- a/op-devstack/dsl/hd_wallet.go
+++ b/op-devstack/dsl/hd_wallet.go
@@ -2,12 +2,17 @@ package dsl
 
 import (
 	"fmt"
+	"os"
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+)
+
+const (
+	SaltEnvVar = "DEVSTACK_KEYS_SALT"
 )
 
 // HDWallet is a collection of deterministic accounts,
@@ -21,7 +26,7 @@ type HDWallet struct {
 }
 
 func NewHDWallet(t devtest.T, mnemonic string, startIndex uint64) *HDWallet {
-	hd, err := devkeys.NewMnemonicDevKeys(mnemonic)
+	hd, err := devkeys.NewSaltedDevKeys(mnemonic, os.Getenv(SaltEnvVar))
 	t.Require().NoError(err, "must have valid mnemonic")
 	w := &HDWallet{
 		commonImpl: commonFromT(t),


### PR DESCRIPTION
**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
This allows test runners to "scope" runs by salting the creation of accounts, enabling:
- separate runs not to interfere with each other
- still reproducibility as the impact of the salt is deterministic

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- needed for #15885 