### PR TITLE
op-devstack: refactor: suffix Fn for DSL lambdas

### DIFF
--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -42,11 +42,11 @@ func TestInteropHappyTx(gt *testing.T) {
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
-		sys.L2CLA.ReachedRef(stypes.CrossSafe, eth.BlockID{
+		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
 			Number: initReceipt.BlockNumber.Uint64(),
 			Hash:   initReceipt.BlockHash,
 		}, 30),
-		sys.L2CLB.ReachedRef(stypes.CrossSafe, eth.BlockID{
+		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
 			Number: execReceipt.BlockNumber.Uint64(),
 			Hash:   execReceipt.BlockHash,
 		}, 30),

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -215,13 +214,11 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 	sys.L2BatcherA.Start()
 
 	// wait for reorg on chain A
-	dsl.CheckAll(t,
-		sys.L2ELA.ReorgTriggeredFn(eth.L2BlockRef{
-			Number:     divergenceBlockNumber_A,
-			Hash:       originalHash_A,
-			ParentHash: originalParentHash_A,
-		}, 30),
-	)
+	sys.L2ELA.ReorgTriggered(eth.L2BlockRef{
+		Number:     divergenceBlockNumber_A,
+		Hash:       originalHash_A,
+		ParentHash: originalParentHash_A,
+	}, 30)
 
 	err := wait.For(ctx, 5*time.Second, func() (bool, error) {
 		safeL2Head_supervisor_A := sys.Supervisor.SafeBlockID(sys.L2ChainA.ChainID()).Hash

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -216,7 +216,7 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 
 	// wait for reorg on chain A
 	dsl.CheckAll(t,
-		sys.L2ELA.ReorgTriggered(eth.L2BlockRef{
+		sys.L2ELA.ReorgTriggeredFn(eth.L2BlockRef{
 			Number:     divergenceBlockNumber_A,
 			Hash:       originalHash_A,
 			ParentHash: originalParentHash_A,

--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -28,8 +28,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	delta := uint64(10)
 	logger.Info("Make sure verifiers advances unsafe head", "delta", delta)
 	dsl.CheckAll(t,
-		sys.L2CLA.Advanced(types.LocalUnsafe, delta, 30), sys.L2CLA2.Advanced(types.LocalUnsafe, delta, 30),
-		sys.L2CLB.Advanced(types.LocalUnsafe, delta, 30), sys.L2CLB2.Advanced(types.LocalUnsafe, delta, 30),
+		sys.L2CLA.AdvancedFn(types.LocalUnsafe, delta, 30), sys.L2CLA2.AdvancedFn(types.LocalUnsafe, delta, 30),
+		sys.L2CLB.AdvancedFn(types.LocalUnsafe, delta, 30), sys.L2CLB2.AdvancedFn(types.LocalUnsafe, delta, 30),
 	)
 
 	safeHeadViewA2 := sys.SupervisorSecondary.SafeBlockID(sys.L2CLA.ChainID())
@@ -48,13 +48,13 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	logger.Info("Sequencers advances safe heads but not verifiers", "delta", delta)
 	dsl.CheckAll(t,
 		// verifier CLs cannot advance their safe head because secondary supervisor is down, no supervisor to provide them L1 data.
-		sys.L2CLA2.NotAdvanced(types.CrossSafe, 30), sys.L2CLB2.NotAdvanced(types.CrossSafe, 30),
+		sys.L2CLA2.NotAdvancedFn(types.CrossSafe, 30), sys.L2CLB2.NotAdvancedFn(types.CrossSafe, 30),
 		// sequencer CLs advance their safe heads
-		sys.L2CLA.Advanced(types.CrossSafe, delta, 30), sys.L2CLB.Advanced(types.CrossSafe, delta, 30),
+		sys.L2CLA.AdvancedFn(types.CrossSafe, delta, 30), sys.L2CLB.AdvancedFn(types.CrossSafe, delta, 30),
 		// All the L2CLs advance their unsafe heads
 		// Verifiers advances unsafe head because they still have P2P connection with each sequencers
-		sys.L2CLA.Advanced(types.LocalUnsafe, delta, 30), sys.L2CLB.Advanced(types.LocalUnsafe, delta, 30),
-		sys.L2CLA2.Advanced(types.LocalUnsafe, delta, 30), sys.L2CLB2.Advanced(types.LocalUnsafe, delta, 30),
+		sys.L2CLA.AdvancedFn(types.LocalUnsafe, delta, 30), sys.L2CLB.AdvancedFn(types.LocalUnsafe, delta, 30),
+		sys.L2CLA2.AdvancedFn(types.LocalUnsafe, delta, 30), sys.L2CLB2.AdvancedFn(types.LocalUnsafe, delta, 30),
 	)
 
 	// Primary supervisor has safe heads synced with sequencers.
@@ -67,8 +67,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	target := max(sys.L2CLA.SafeL2BlockRef().Number, sys.L2CLB.SafeL2BlockRef().Number) + delta
 	logger.Info("Every CLs advance safe heads", "delta", delta, "target", target)
 	dsl.CheckAll(t,
-		sys.L2CLA.Reached(types.CrossSafe, target, 30), sys.L2CLA2.Reached(types.CrossSafe, target, 30),
-		sys.L2CLB.Reached(types.CrossSafe, target, 30), sys.L2CLB2.Reached(types.CrossSafe, target, 30),
+		sys.L2CLA.ReachedFn(types.CrossSafe, target, 30), sys.L2CLA2.ReachedFn(types.CrossSafe, target, 30),
+		sys.L2CLB.ReachedFn(types.CrossSafe, target, 30), sys.L2CLB2.ReachedFn(types.CrossSafe, target, 30),
 	)
 
 	logger.Info("Stop primary supervisor to disconnect every CL connection")
@@ -79,8 +79,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 
 	logger.Info("No CL connected to supervisor so every CL safe head will not advance")
 	dsl.CheckAll(t,
-		sys.L2CLA.NotAdvanced(types.CrossSafe, 30), sys.L2CLA2.NotAdvanced(types.CrossSafe, 30),
-		sys.L2CLB.NotAdvanced(types.CrossSafe, 30), sys.L2CLB2.NotAdvanced(types.CrossSafe, 30),
+		sys.L2CLA.NotAdvancedFn(types.CrossSafe, 30), sys.L2CLA2.NotAdvancedFn(types.CrossSafe, 30),
+		sys.L2CLB.NotAdvancedFn(types.CrossSafe, 30), sys.L2CLB2.NotAdvancedFn(types.CrossSafe, 30),
 	)
 
 	// Sequencers will resume advancing safe heads, but not verifiers.
@@ -100,8 +100,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	rewind := uint64(3)
 	logger.Info("Check verifier CLs safe head rewinded", "rewind", rewind)
 	dsl.CheckAll(t,
-		sys.L2CLA2.Rewinded(types.CrossSafe, rewind, 60),
-		sys.L2CLB2.Rewinded(types.CrossSafe, rewind, 60),
+		sys.L2CLA2.RewindedFn(types.CrossSafe, rewind, 60),
+		sys.L2CLB2.RewindedFn(types.CrossSafe, rewind, 60),
 	)
 
 	// After rewinding(reset), verifier will advance safe heads again because Secondary supervisor gives L1 data to the verifiers.
@@ -109,8 +109,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	target = max(sys.L2CLA.SafeL2BlockRef().Number, sys.L2CLB.SafeL2BlockRef().Number) + delta
 	logger.Info("Every CLs advance safe heads", "delta", delta, "target", target)
 	dsl.CheckAll(t,
-		sys.L2CLA.Reached(types.CrossSafe, target, 30), sys.L2CLA2.Reached(types.CrossSafe, target, 30),
-		sys.L2CLB.Reached(types.CrossSafe, target, 30), sys.L2CLB2.Reached(types.CrossSafe, target, 30),
+		sys.L2CLA.ReachedFn(types.CrossSafe, target, 30), sys.L2CLA2.ReachedFn(types.CrossSafe, target, 30),
+		sys.L2CLB.ReachedFn(types.CrossSafe, target, 30), sys.L2CLB2.ReachedFn(types.CrossSafe, target, 30),
 	)
 
 	// Make sure each chain did not diverge

--- a/op-acceptance-tests/tests/interop/sync/redundant_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/redundant_interop/interop_sync_test.go
@@ -65,12 +65,12 @@ func TestUnsafeChainKnownToL2CL(gt *testing.T) {
 	// The verifier will quickly catch up with the sequencer safe head as well as the supervisor.
 	// The verifier will "skip" processing already known unsafe blocks, and consolidate them into safe blocks.
 	logger.Info("Make sure verifier unsafe head was consolidated to safe")
-	dsl.CheckAll(t, sys.L2CLA2.ReachedFn(types.CrossSafe, unsafeA2.Number, 30))
+	sys.L2CLA2.Reached(types.CrossSafe, unsafeA2.Number, 30)
 
 	safeA := sys.L2ELA.BlockRefByLabel(eth.Safe)
 	target := safeA.Number + delta
 	logger.Info("Make sure verifier unsafe head advances due to safe head advances", "target", target, "delta", delta)
-	dsl.CheckAll(t, sys.L2CLA2.ReachedFn(types.LocalUnsafe, target, 30))
+	sys.L2CLA2.Reached(types.LocalUnsafe, target, 30)
 
 	block := sys.L2ELA2.BlockRefByNumber(unsafeA2.Number)
 	require.Equal(unsafeA2.Hash, block.Hash)

--- a/op-acceptance-tests/tests/interop/sync/redundant_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/redundant_interop/interop_sync_test.go
@@ -23,8 +23,8 @@ func TestUnsafeChainKnownToL2CL(gt *testing.T) {
 
 	logger.Info("Make sure verifier safe head advances")
 	dsl.CheckAll(t,
-		sys.L2CLA.Advanced(types.CrossSafe, 5, 30),
-		sys.L2CLA2.Advanced(types.CrossSafe, 5, 30),
+		sys.L2CLA.AdvancedFn(types.CrossSafe, 5, 30),
+		sys.L2CLA2.AdvancedFn(types.CrossSafe, 5, 30),
 	)
 
 	safeA2 := sys.L2ELA2.BlockRefByLabel(eth.Safe)
@@ -65,12 +65,12 @@ func TestUnsafeChainKnownToL2CL(gt *testing.T) {
 	// The verifier will quickly catch up with the sequencer safe head as well as the supervisor.
 	// The verifier will "skip" processing already known unsafe blocks, and consolidate them into safe blocks.
 	logger.Info("Make sure verifier unsafe head was consolidated to safe")
-	dsl.CheckAll(t, sys.L2CLA2.Reached(types.CrossSafe, unsafeA2.Number, 30))
+	dsl.CheckAll(t, sys.L2CLA2.ReachedFn(types.CrossSafe, unsafeA2.Number, 30))
 
 	safeA := sys.L2ELA.BlockRefByLabel(eth.Safe)
 	target := safeA.Number + delta
 	logger.Info("Make sure verifier unsafe head advances due to safe head advances", "target", target, "delta", delta)
-	dsl.CheckAll(t, sys.L2CLA2.Reached(types.LocalUnsafe, target, 30))
+	dsl.CheckAll(t, sys.L2CLA2.ReachedFn(types.LocalUnsafe, target, 30))
 
 	block := sys.L2ELA2.BlockRefByNumber(unsafeA2.Number)
 	require.Equal(unsafeA2.Hash, block.Hash)

--- a/op-acceptance-tests/tests/interop/sync/simple_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/simple_interop/interop_sync_test.go
@@ -18,8 +18,8 @@ func TestL2CLResync(gt *testing.T) {
 
 	logger.Info("Check unsafe chains are advancing")
 	dsl.CheckAll(t,
-		sys.L2ELA.Advance(eth.Unsafe, 5),
-		sys.L2ELB.Advance(eth.Unsafe, 5),
+		sys.L2ELA.AdvancedFn(eth.Unsafe, 5),
+		sys.L2ELB.AdvancedFn(eth.Unsafe, 5),
 	)
 
 	logger.Info("Stop L2CL nodes")
@@ -28,8 +28,8 @@ func TestL2CLResync(gt *testing.T) {
 
 	logger.Info("Make sure L2ELs does not advance")
 	dsl.CheckAll(t,
-		sys.L2ELA.DoesNotAdvance(eth.Unsafe),
-		sys.L2ELB.DoesNotAdvance(eth.Unsafe),
+		sys.L2ELA.NotAdvancedFn(eth.Unsafe),
+		sys.L2ELB.NotAdvancedFn(eth.Unsafe),
 	)
 
 	logger.Info("Restart L2CL nodes")
@@ -40,15 +40,15 @@ func TestL2CLResync(gt *testing.T) {
 	// we must check that unsafe head is advancing due to reconnection
 	logger.Info("Boot up L2CL nodes")
 	dsl.CheckAll(t,
-		sys.L2ELA.Advance(eth.Unsafe, 10),
-		sys.L2ELB.Advance(eth.Unsafe, 10),
+		sys.L2ELA.AdvancedFn(eth.Unsafe, 10),
+		sys.L2ELB.AdvancedFn(eth.Unsafe, 10),
 	)
 
 	// supervisor will attempt to reconnect with L2CLs at this point because L2CL ws endpoint is recovered
 	logger.Info("Check unsafe chains are advancing again")
 	dsl.CheckAll(t,
-		sys.L2ELA.Advance(eth.Unsafe, 10),
-		sys.L2ELB.Advance(eth.Unsafe, 10),
+		sys.L2ELA.AdvancedFn(eth.Unsafe, 10),
+		sys.L2ELB.AdvancedFn(eth.Unsafe, 10),
 	)
 
 	// supervisor successfully connected with managed L2CLs

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -208,6 +208,26 @@ func (cl *L2CLNode) RewindedFn(lvl types.SafetyLevel, delta uint64, attempts int
 	}
 }
 
+func (cl *L2CLNode) Advanced(lvl types.SafetyLevel, delta uint64, attempts int) {
+	cl.require.NoError(cl.AdvancedFn(lvl, delta, attempts)())
+}
+
+func (cl *L2CLNode) NotAdvanced(lvl types.SafetyLevel, attempts int) {
+	cl.require.NoError(cl.NotAdvancedFn(lvl, attempts)())
+}
+
+func (cl *L2CLNode) Reached(lvl types.SafetyLevel, target uint64, attempts int) {
+	cl.require.NoError(cl.ReachedFn(lvl, target, attempts)())
+}
+
+func (cl *L2CLNode) ReachedRef(lvl types.SafetyLevel, target eth.BlockID, attempts int) {
+	cl.require.NoError(cl.ReachedRefFn(lvl, target, attempts)())
+}
+
+func (cl *L2CLNode) Rewinded(lvl types.SafetyLevel, delta uint64, attempts int) {
+	cl.require.NoError(cl.RewindedFn(lvl, delta, attempts)())
+}
+
 func (cl *L2CLNode) PeerInfo() *apis.PeerInfo {
 	peerInfo, err := cl.inner.P2PAPI().Self(cl.ctx)
 	cl.require.NoError(err, "failed to get peer info")

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -119,18 +119,18 @@ func (cl *L2CLNode) ChainID() eth.ChainID {
 	return cl.inner.ID().ChainID
 }
 
-// Advanced returns a lambda that checks the L2CL chain head with given safety level advanced more than delta block number
+// AdvancedFn returns a lambda that checks the L2CL chain head with given safety level advanced more than delta block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) Advanced(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) AdvancedFn(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		target := initial.Number + delta
 		cl.log.Info("expecting chain to advance", "id", cl.inner.ID(), "chain", cl.ChainID(), "label", lvl, "delta", delta)
-		return cl.Reached(lvl, target, attempts)()
+		return cl.ReachedFn(lvl, target, attempts)()
 	}
 }
 
-func (cl *L2CLNode) NotAdvanced(lvl types.SafetyLevel, attempts int) CheckFunc {
+func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		cl.log.Info("expecting chain not to advance", "id", cl.inner.ID(), "chain", cl.ChainID(), "label", lvl, "target", initial.Number)
@@ -147,9 +147,9 @@ func (cl *L2CLNode) NotAdvanced(lvl types.SafetyLevel, attempts int) CheckFunc {
 	}
 }
 
-// Reached returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
+// ReachedFn returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) Reached(lvl types.SafetyLevel, target uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) ReachedFn(lvl types.SafetyLevel, target uint64, attempts int) CheckFunc {
 	return func() error {
 		cl.log.Info("expecting chain to reach", "id", cl.inner.ID(), "chain", cl.ChainID(), "label", lvl, "target", target)
 		return retry.Do0(cl.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
@@ -165,11 +165,11 @@ func (cl *L2CLNode) Reached(lvl types.SafetyLevel, target uint64, attempts int) 
 	}
 }
 
-// ReachedRef is same as Reached, but has an additional check to ensure that the block referenced is not reorged
+// ReachedRefFn is same as Reached, but has an additional check to ensure that the block referenced is not reorged
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) ReachedRef(lvl types.SafetyLevel, target eth.BlockID, attempts int) CheckFunc {
+func (cl *L2CLNode) ReachedRefFn(lvl types.SafetyLevel, target eth.BlockID, attempts int) CheckFunc {
 	return func() error {
-		err := cl.Reached(lvl, target.Number, attempts)()
+		err := cl.ReachedFn(lvl, target.Number, attempts)()
 		if err != nil {
 			return err
 		}
@@ -186,9 +186,9 @@ func (cl *L2CLNode) ReachedRef(lvl types.SafetyLevel, target eth.BlockID, attemp
 	}
 }
 
-// Rewinded returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
+// RewindedFn returns a lambda that checks the L2CL chain head with given safety level rewinded more than the delta block number
 // Composable with other lambdas to wait in parallel
-func (cl *L2CLNode) Rewinded(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
+func (cl *L2CLNode) RewindedFn(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
 	return func() error {
 		initial := cl.HeadBlockRef(lvl)
 		cl.require.GreaterOrEqual(initial.Number, delta, "cannot rewind before genesis")

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -119,3 +119,15 @@ func (el *L2ELNode) ReorgTriggeredFn(target eth.L2BlockRef, attempts int) CheckF
 			})
 	}
 }
+
+func (el *L2ELNode) Advanced(label eth.BlockLabel, block uint64) {
+	el.require.NoError(el.AdvancedFn(label, block)())
+}
+
+func (el *L2ELNode) NotAdvanced(label eth.BlockLabel) {
+	el.require.NoError(el.NotAdvancedFn(label)())
+}
+
+func (el *L2ELNode) ReorgTriggered(target eth.L2BlockRef, attempts int) {
+	el.require.NoError(el.ReorgTriggeredFn(target, attempts)())
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -42,7 +42,7 @@ func (el *L2ELNode) BlockRefByLabel(label eth.BlockLabel) eth.BlockRef {
 	return block
 }
 
-func (el *L2ELNode) Advance(label eth.BlockLabel, block uint64) CheckFunc {
+func (el *L2ELNode) AdvancedFn(label eth.BlockLabel, block uint64) CheckFunc {
 	return func() error {
 		initial := el.BlockRefByLabel(label)
 		target := initial.Number + block
@@ -61,7 +61,7 @@ func (el *L2ELNode) Advance(label eth.BlockLabel, block uint64) CheckFunc {
 	}
 }
 
-func (el *L2ELNode) DoesNotAdvance(label eth.BlockLabel) CheckFunc {
+func (el *L2ELNode) NotAdvancedFn(label eth.BlockLabel) CheckFunc {
 	return func() error {
 		el.log.Info("expecting chain not to advance", "chain", el.inner.ChainID(), "label", label)
 		initial := el.BlockRefByLabel(label)
@@ -87,9 +87,9 @@ func (el *L2ELNode) BlockRefByNumber(num uint64) eth.BlockRef {
 	return block
 }
 
-// ReorgTriggered returns a lambda that checks that a L2 reorg occurred on the expected block
+// ReorgTriggeredFn returns a lambda that checks that a L2 reorg occurred on the expected block
 // Composable with other lambdas to wait in parallel
-func (el *L2ELNode) ReorgTriggered(target eth.L2BlockRef, attempts int) CheckFunc {
+func (el *L2ELNode) ReorgTriggeredFn(target eth.L2BlockRef, attempts int) CheckFunc {
 	return func() error {
 		el.log.Info("expecting chain to reorg on block ref", "id", el.inner.ID(), "chain", el.inner.ID().ChainID, "target", target)
 		return retry.Do0(el.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Suffixing all the DSL methods that return a lambda with `Fn` to avoid mis-use by not actually invoking lambdas. Also add lambda wrappers to use when DSL lambda methods' composability is not needed.
