### PR TITLE
supervisor: implement and test correct RPC error code mapping for conflicting_data

### DIFF
--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -36,11 +36,12 @@ func (c ErrorCode) IsGenericRPCError() bool {
 const (
 	MethodNotFound           ErrorCode = -32601 // RPC method not found or not available.
 	InvalidParams            ErrorCode = -32602
-	UnknownPayload           ErrorCode = -38001 // Payload does not exist / is not available.
-	InvalidForkchoiceState   ErrorCode = -38002 // Forkchoice state is invalid / inconsistent.
-	InvalidPayloadAttributes ErrorCode = -38003 // Payload attributes are invalid / inconsistent.
-	TooLargeEngineRequest    ErrorCode = -38004 // Unused, here for completeness, only used by engine_getPayloadBodiesByHashV1
-	UnsupportedFork          ErrorCode = -38005 // Unused, see issue #11130.
+	UnknownPayload           ErrorCode = -38001  // Payload does not exist / is not available.
+	InvalidForkchoiceState   ErrorCode = -38002  // Forkchoice state is invalid / inconsistent.
+	InvalidPayloadAttributes ErrorCode = -38003  // Payload attributes are invalid / inconsistent.
+	TooLargeEngineRequest    ErrorCode = -38004  // Unused, here for completeness, only used by engine_getPayloadBodiesByHashV1
+	UnsupportedFork          ErrorCode = -38005  // Unused, see issue #11130.
+	ConflictingDataErrorCode ErrorCode = -320600 // See https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
 )
 
 var ErrBedrockScalarPaddingNotEmpty = errors.New("version 0 scalar value has non-empty padding")

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -484,6 +484,7 @@ func (su *SupervisorBackend) asyncVerifyAccessWithRPC(ctx context.Context, acc t
 // fetched, receipts are fetched, log exists) but the log checksum does not
 // match. Returns ad-hoc errors for the mechanical failures listed above. Returns
 // the block ID and nil if the log is found and the checksum matches.
+// Will be mapped to -320600 (conflicting_data) in the frontend, see https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
 func (su *SupervisorBackend) checkAccessWithRPC(ctx context.Context, acc types.Access) (eth.BlockID, error) {
 	src, ok := su.syncSources.Get(acc.ChainID)
 	if !ok {
@@ -550,12 +551,14 @@ func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries [
 		// Check if message passes time checks
 		if err := executingDescriptor.AccessCheck(su.cfgSet.MessageExpiryWindow(), acc.Timestamp); err != nil {
 			su.logger.Warn("Access-list time check failed", "err", err)
+			// Will be mapped to -320600 (conflicting_data) in the frontend, see https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
 			return types.ErrConflict // TODO: Do we want to do this?
 		}
 
 		msgBlockFromDB, err := su.checkAccessWithDB(acc)
 		if err != nil {
 			su.logger.Debug("Access-list inclusion check failed", "err", err)
+			// Will be mapped to -320600 (conflicting_data) in the frontend, see https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
 			return types.ErrConflict
 		}
 
@@ -568,6 +571,7 @@ func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries [
 		// TODO(#14800): this can be deferred to only check the latest block of all access entries
 		if err := su.checkSafety(acc.ChainID, msgBlockFromDB, minSafety); err != nil {
 			su.logger.Debug("Access-list safety check failed", "err", err)
+			// Will be mapped to -320600 (conflicting_data) in the frontend, see https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
 			return types.ErrConflict
 		}
 	}

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -25,10 +25,9 @@ var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
-	const ConflictingDataErrorCode eth.ErrorCode = -320600 // See https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
 	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
 	if err != nil && errors.Is(err, types.ErrConflict) {
-		return eth.InputError{Inner: err, Code: ConflictingDataErrorCode}
+		return eth.InputError{Inner: err, Code: eth.ConflictingDataErrorCode}
 	}
 	return err
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -24,7 +25,12 @@ var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
-	return q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+	const ConflictingDataErrorCode eth.ErrorCode = -320600 // See https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#-320600-conflicting_data
+	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+	if err != nil && errors.Is(err, types.ErrConflict) {
+		return eth.InputError{Inner: err, Code: ConflictingDataErrorCode}
+	}
+	return err
 }
 
 func (q *QueryFrontend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {

--- a/op-supervisor/supervisor/frontend/frontend_test.go
+++ b/op-supervisor/supervisor/frontend/frontend_test.go
@@ -1,0 +1,74 @@
+package frontend
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSupervisor struct {
+	returnErr error
+}
+
+func (m *mockSupervisor) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	return m.returnErr
+}
+
+// implement other methods as stubs (not used in this test)
+func (m *mockSupervisor) CrossDerivedToSource(context.Context, eth.ChainID, eth.BlockID) (eth.BlockRef, error) {
+	return eth.BlockRef{}, nil
+}
+func (m *mockSupervisor) LocalUnsafe(context.Context, eth.ChainID) (eth.BlockID, error) {
+	return eth.BlockID{}, nil
+}
+func (m *mockSupervisor) LocalSafe(context.Context, eth.ChainID) (types.DerivedIDPair, error) {
+	return types.DerivedIDPair{}, nil
+}
+func (m *mockSupervisor) CrossSafe(context.Context, eth.ChainID) (types.DerivedIDPair, error) {
+	return types.DerivedIDPair{}, nil
+}
+func (m *mockSupervisor) Finalized(context.Context, eth.ChainID) (eth.BlockID, error) {
+	return eth.BlockID{}, nil
+}
+func (m *mockSupervisor) FinalizedL1(context.Context) (eth.BlockRef, error) {
+	return eth.BlockRef{}, nil
+}
+func (m *mockSupervisor) SuperRootAtTimestamp(context.Context, eth.Uint64Quantity) (eth.SuperRootResponse, error) {
+	return eth.SuperRootResponse{}, nil
+}
+func (m *mockSupervisor) AllSafeDerivedAt(context.Context, eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
+	return nil, nil
+}
+func (m *mockSupervisor) SyncStatus(context.Context) (eth.SupervisorSyncStatus, error) {
+	return eth.SupervisorSyncStatus{}, nil
+}
+
+func TestCheckAccessList_ConflictMapping(t *testing.T) {
+	const ConflictingDataErrorCode eth.ErrorCode = -320600
+	qf := &QueryFrontend{Supervisor: &mockSupervisor{returnErr: types.ErrConflict}}
+
+	err := qf.CheckAccessList(context.Background(), nil, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.Error(t, err)
+	var inputErr eth.InputError
+	require.True(t, errors.As(err, &inputErr), "error should be of type eth.InputError")
+	require.Equal(t, ConflictingDataErrorCode, inputErr.Code, "error code should match -320600 for conflicting_data")
+}
+
+func TestCheckAccessList_OtherErrorPassthrough(t *testing.T) {
+	customErr := errors.New("some other error")
+	qf := &QueryFrontend{Supervisor: &mockSupervisor{returnErr: customErr}}
+
+	err := qf.CheckAccessList(context.Background(), nil, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.ErrorIs(t, err, customErr)
+}
+
+func TestCheckAccessList_NoError(t *testing.T) {
+	qf := &QueryFrontend{Supervisor: &mockSupervisor{returnErr: nil}}
+	err := qf.CheckAccessList(context.Background(), nil, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**Description**

- CheckAccessList now returns eth.InputError with code -320600 for conflicting data errors.
- Added documentation comments in backend.

**Tests**

- Added unit tests to cover the new error mapping logic.

**Metadata**

- Fixes #15771 
       https://github.com/ethereum-optimism/optimism/issues/15771

