### PR TITLE
[BACKPORT v0.3.0] fix(op-deployer): default cache dir (#14810)

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 
@@ -52,15 +53,14 @@ func NewDeploymentTarget(s string) (DeploymentTarget, error) {
 	}
 }
 
-var DefaultCacheDir string
-
-func init() {
-	var err error
+func GetDefaultCacheDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		panic(fmt.Sprintf("failed to get home directory: %s", err))
+		fallbackDir := ".op-deployer/cache"
+		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, fallbackDir)
+		return fallbackDir
 	}
-	DefaultCacheDir = path.Join(homeDir, ".op-deployer/cache")
+	return path.Join(homeDir, ".op-deployer/cache")
 }
 
 var (
@@ -82,7 +82,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   DefaultCacheDir,
+		Value:   GetDefaultCacheDir(),
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -87,7 +87,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse l1 contracts release locator: %w", err)
 	}
-	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.DefaultCacheDir)
+	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.GetDefaultCacheDir())
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}


### PR DESCRIPTION
* fix(op-deployer): default cache dir

* add explanatory fallback log