### PR TITLE
[BACKPORT v0.2.0] fix(op-deployer): default cache dir (#14810)

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 
@@ -48,14 +49,14 @@ func NewDeploymentTarget(s string) (DeploymentTarget, error) {
 	}
 }
 
-var homeDir string
-
-func init() {
-	var err error
-	homeDir, err = os.UserHomeDir()
+func GetDefaultCacheDir() string {
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		panic(fmt.Sprintf("failed to get home directory: %s", err))
+		fallbackDir := ".op-deployer/cache"
+		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, fallbackDir)
+		return fallbackDir
 	}
+	return path.Join(homeDir, ".op-deployer/cache")
 }
 
 var (
@@ -72,7 +73,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   path.Join(homeDir, ".op-deployer/cache"),
+		Value:   GetDefaultCacheDir(),
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,


### PR DESCRIPTION
* fix(op-deployer): default cache dir

* add explanatory fallback log
