### PR TITLE
cannon: Address cannon-full-test timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,10 @@ jobs:
       skip_slow_tests:
         type: boolean
         default: false
+      no_output_timeout:
+        description: Timeout for when CircleCI kills the job if there's no output
+        type: string
+        default: 10m
       notify:
         description: Whether to notify on failure
         type: boolean
@@ -268,6 +272,7 @@ jobs:
           working_directory: cannon
       - run:
           name: Cannon Go 64-bit tests
+          no_output_timeout: <<parameters.no_output_timeout>>
           command: |
             export SKIP_SLOW_TESTS="<<parameters.skip_slow_tests>>"
             TIMEOUT="10m"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2173,6 +2173,7 @@ workflows:
           requires:
             - contracts-bedrock-build
           skip_slow_tests: false
+          no_output_timeout: 30m
           notify: true
           context:
             - slack


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Try to address `scheduled-cannon-full-tests` intermittent timeouts by extending the `no-output-timeout` to 30m. 

**Metadata**

This issue was introduced in https://github.com/ethereum-optimism/optimism/pull/15737
