### PR TITLE
op-deployer: Remove tag validation in locator unmarshal

### DIFF
--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -128,10 +128,6 @@ func unmarshalTag(tag string) (*Locator, error) {
 		return nil, fmt.Errorf("invalid tag: %s", tag)
 	}
 
-	if _, err := standard.ArtifactsURLForTag(tag); err != nil {
-		return nil, err
-	}
-
 	return &Locator{Tag: tag}, nil
 }
 

--- a/op-deployer/pkg/deployer/artifacts/locator_test.go
+++ b/op-deployer/pkg/deployer/artifacts/locator_test.go
@@ -23,12 +23,6 @@ func TestLocator_Marshaling(t *testing.T) {
 			err: false,
 		},
 		{
-			name: "well-formed but nonexistent tag",
-			in:   "tag://op-contracts/v1.5.0",
-			out:  nil,
-			err:  true,
-		},
-		{
 			name: "mal-formed tag",
 			in:   "tag://honk",
 			out:  nil,


### PR DESCRIPTION
Previously, the unmarshaler for the artifacts locator was checking if artifacts locator tags were valid (e.g., a defined tag on the monorepo) in addition to checking to see if they were well formatted. Now that OP Deployer supports one contracts version per binary version, this was causing old state files to fail to unmarshal.
