### PR TITLE
perf: parallelize `fullTxs` processing under high TPS 

### DIFF
--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -2,16 +2,19 @@ package derive
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"math/big"
+	"runtime"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
+	"golang.org/x/sync/errgroup"
 )
 
 type spanBatchTxs struct {
@@ -338,37 +341,73 @@ func (btx *spanBatchTxs) decode(r *bytes.Reader) error {
 }
 
 func (btx *spanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
-	var txs [][]byte
+	num_txs := int(btx.totalBlockTxCount)
+	txs := make([][]byte, num_txs)
+	jobs := make(chan int, num_txs)
+
+	toMap := make(map[int]*common.Address)
 	toIdx := 0
-	for idx := 0; idx < int(btx.totalBlockTxCount); idx++ {
-		var stx spanBatchTx
-		if err := stx.UnmarshalBinary(btx.txDatas[idx]); err != nil {
-			return nil, err
-		}
-		nonce := btx.txNonces[idx]
-		gas := btx.txGases[idx]
-		var to *common.Address = nil
-		bit := btx.contractCreationBits.Bit(idx)
-		if bit == 0 {
+	for idx := range num_txs {
+		if btx.contractCreationBits.Bit(idx) == 0 {
 			if len(btx.txTos) <= toIdx {
 				return nil, errors.New("tx to not enough")
 			}
-			to = &btx.txTos[toIdx]
+			toMap[idx] = &btx.txTos[toIdx]
 			toIdx++
 		}
-		v := new(big.Int).SetUint64(btx.txSigs[idx].v)
-		r := btx.txSigs[idx].r.ToBig()
-		s := btx.txSigs[idx].s.ToBig()
-		tx, err := stx.convertToFullTx(nonce, gas, to, chainID, v, r, s)
-		if err != nil {
-			return nil, err
-		}
-		encodedTx, err := tx.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		txs = append(txs, encodedTx)
 	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	workerCount := min(runtime.NumCPU(), num_txs)
+	for range workerCount {
+		g.Go(func() error {
+			for idx := range jobs {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+
+				var stx spanBatchTx
+				if err := stx.UnmarshalBinary(btx.txDatas[idx]); err != nil {
+					return err
+				}
+
+				nonce := btx.txNonces[idx]
+				gas := btx.txGases[idx]
+				to := toMap[idx]
+
+				v := new(big.Int).SetUint64(btx.txSigs[idx].v)
+				r := btx.txSigs[idx].r.ToBig()
+				s := btx.txSigs[idx].s.ToBig()
+
+				tx, err := stx.convertToFullTx(nonce, gas, to, chainID, v, r, s)
+				if err != nil {
+					return err
+				}
+
+				encodedTx, err := tx.MarshalBinary()
+				if err != nil {
+					return err
+				}
+
+				txs[idx] = encodedTx
+			}
+			return nil
+		})
+	}
+
+	for idx := range num_txs {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		jobs <- idx
+	}
+	close(jobs)
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
 	return txs, nil
 }
 


### PR DESCRIPTION
While profiling the derivation process under high TPS conditions using `pprof`, I identified a significant bottleneck in the `fullTxs` function — specifically in the marshaling and unmarshaling steps.

In a test using **43,000** raw transfer transactions per second, the `fullTxs` phase alone took around **800–1000ms** to complete. By parallelizing this part of the code, we were able to reduce that duration to **150–300ms**, achieving up to about **70%** performance improvement.

It’s also worth noting that without parallelization, `fullTxs` often causes chain lag, which leads the derivation process to handle fewer transactions per block.

I implemented this parallelism using a fixed number of workers (proportional to `runtime.NumCPU()`) and a buffered job channel. Workers fetch and process transactions concurrently. To handle cancellation on the first error,  used `errgroup.WithContext`, which cancels all ongoing goroutines if any one of them fails.

Here are graphs:

**[Original]**
![og](https://github.com/user-attachments/assets/bd591555-ec91-4e71-b07a-9bced110d37f)

**[Parallelization]**
![final](https://github.com/user-attachments/assets/5e2cfbe6-16cc-4f0d-8648-578034e243cf)


In the graphs:

“Total Block Tx Count” refers to `btx.totalBlockTxCount`.

The first chart shows performance with the original implementation.
The second shows performance after applying parallelization.

Please feel free to share any feedback or suggestions for improvement.
