### PR TITLE
op-devstack: Migrate `TestInteropRandomDirectedGraph` using DSL

### DIFF
--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -1,21 +1,28 @@
 package msg
 
 import (
+	"context"
+	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/sync/errgroup"
 
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -117,4 +124,126 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 
 	// Write: Bob triggers executing message
 	contract.Write(bob, call, txplan.WithAccessList(accessList))
+}
+
+// TestRandomDirectedGraph tests below scenario:
+// Construct random directed graph of messages.
+func TestRandomDirectedGraph(gt *testing.T) {
+	t := devtest.SerialT(gt)
+
+	sys := presets.NewSimpleInterop(t)
+	logger := sys.Log.With("Test", "TestRandomDirectedGraph")
+	rng := rand.New(rand.NewSource(1234))
+	require := sys.T.Require()
+
+	// interop network has at least two chains
+	l2ChainNum := 2
+
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+
+	// Deploy eventLoggers per every L2 chains because initiating messages can happen on any L2 chains
+	eventLoggerAddresses := []common.Address{alice.DeployEventLogger(), bob.DeployEventLogger()}
+
+	// pubSubPairCnt is the count of (publisher, subscriber) pairs which
+	// - publisher initiates messages
+	// - subscriber validates messages
+	pubSubPairCnt := 10
+	// txCnt is the count of transactions that each publisher emits
+	txCnt := 3
+	// fundAmount is the ETH amount to fund publishers and subscribers
+	fundAmount := eth.OneTenthEther
+
+	// jitter randomizes tx
+	jitter := func(rng *rand.Rand) {
+		time.Sleep(time.Duration(rng.Intn(250)) * time.Millisecond)
+	}
+
+	// fund EOAs per chain
+	eoasPerChain := make([][]*dsl.EOA, l2ChainNum)
+	for chainIdx, funder := range []*dsl.Funder{sys.FunderA, sys.FunderB} {
+		eoas := funder.NewFundedEOAs(pubSubPairCnt, fundAmount)
+		eoasPerChain[chainIdx] = eoas
+	}
+
+	// runPubSubPair spawns publisher goroutine, paired with subscriber goroutine
+	runPubSubPair := func(pubEOA, subEOA *dsl.EOA, eventLoggerAddress common.Address, localRng *rand.Rand) error {
+		ctx, cancel := context.WithCancel(t.Ctx())
+		defer cancel()
+
+		g, ctx := errgroup.WithContext(ctx)
+
+		ch := make(chan *txintent.IntentTx[*txintent.MultiTrigger, *txintent.InteropOutput])
+
+		publisherRng := rand.New(rand.NewSource(localRng.Int63()))
+		subscriberRng := rand.New(rand.NewSource(localRng.Int63()))
+
+		// publisher initiates txCnt transactions that includes multiple random messages
+		g.Go(func() error {
+			defer close(ch)
+			for range txCnt {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+					tx, receipt, err := pubEOA.SendPackedRandomInitMessages(publisherRng, eventLoggerAddress)
+					if err != nil {
+						return fmt.Errorf("publisher error: %w", err)
+					}
+					logger.Info("Initiate messages included", "chainID", tx.PlannedTx.ChainID.Value(), "blockNumber", receipt.BlockNumber, "block", receipt.BlockHash)
+					select {
+					case ch <- tx:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					jitter(publisherRng)
+				}
+			}
+			return nil
+		})
+
+		// subscriber validates every messages that was initiated by the publisher
+		g.Go(func() error {
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case dependsOn, ok := <-ch:
+					if !ok {
+						return nil
+					}
+					tx, receipt, err := subEOA.SendPackedExecMessages(dependsOn)
+					if err != nil {
+						return fmt.Errorf("subscriber error: %w", err)
+					}
+					logger.Info("Validate messages included", "blockNumber", receipt.BlockNumber, "block", receipt.BlockHash)
+					logger.Info("Message dependency",
+						"sourceChainID", dependsOn.PlannedTx.ChainID.Value(),
+						"destChainID", tx.PlannedTx.ChainID.Value(),
+						"sourceBlockNum", dependsOn.PlannedTx.IncludedBlock.Value().Number,
+						"destBlockNum", receipt.BlockNumber)
+					jitter(subscriberRng)
+				}
+			}
+		})
+		return g.Wait()
+	}
+
+	var g errgroup.Group
+
+	runPubSubPairWrapper := func(sourceIdx, destIdx, pairIdx int, localRng *rand.Rand) error {
+		return runPubSubPair(eoasPerChain[sourceIdx][pairIdx], eoasPerChain[destIdx][pairIdx], eventLoggerAddresses[sourceIdx], localRng)
+	}
+
+	for pairIdx := range pubSubPairCnt {
+		// randomize source and destination L2 chain
+		sourceIdx := rng.Intn(2)
+		destIdx := 1 - sourceIdx
+		// localRng is needed per pubsub pair because rng cannot be shared without mutex
+		localRng := rand.New(rand.NewSource(rng.Int63()))
+		g.Go(func() error {
+			return runPubSubPairWrapper(sourceIdx, destIdx, pairIdx, localRng)
+		})
+	}
+	require.NoError(g.Wait())
 }

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -148,7 +148,7 @@ func TestRandomDirectedGraph(gt *testing.T) {
 	// pubSubPairCnt is the count of (publisher, subscriber) pairs which
 	// - publisher initiates messages
 	// - subscriber validates messages
-	pubSubPairCnt := 10
+	pubSubPairCnt := 5
 	// txCnt is the count of transactions that each publisher emits
 	txCnt := 3
 	// fundAmount is the ETH amount to fund publishers and subscribers

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"fmt"
 	"math/big"
+	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -157,4 +159,42 @@ func (u *EOA) SendExecMessage(initIntent *txintent.IntentTx[*txintent.InitTrigge
 	// Check single ExecutingMessage triggered
 	u.t.Require().Equal(1, len(receipt.Logs))
 	return tx, receipt
+}
+
+// SendPackedRandomInitMessages batches random messages and initiates them via a single multicall
+func (u *EOA) SendPackedRandomInitMessages(rng *rand.Rand, eventLoggerAddress common.Address) (*txintent.IntentTx[*txintent.MultiTrigger, *txintent.InteropOutput], *types.Receipt, error) {
+	// Intent to initiate messages
+	eventCnt := 1 + rng.Intn(9)
+	initCalls := make([]txintent.Call, eventCnt)
+	for index := range eventCnt {
+		initCalls[index] = interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(100))
+	}
+	tx := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](u.Plan())
+	tx.Content.Set(&txintent.MultiTrigger{Emitter: constants.MultiCall3, Calls: initCalls})
+	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tx, receipt, nil
+}
+
+// SendPackedExecMessages batches every message and validates them via a single multicall
+func (u *EOA) SendPackedExecMessages(dependOn *txintent.IntentTx[*txintent.MultiTrigger, *txintent.InteropOutput]) (*txintent.IntentTx[*txintent.MultiTrigger, *txintent.InteropOutput], *types.Receipt, error) {
+	// Intent to validate message
+	tx := txintent.NewIntent[*txintent.MultiTrigger, *txintent.InteropOutput](u.Plan())
+	tx.Content.DependOn(&dependOn.Result)
+	indexes := []int{}
+	result, err := dependOn.Result.Eval(u.ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	for idx := range len(result.Entries) {
+		indexes = append(indexes, idx)
+	}
+	tx.Content.Fn(txintent.ExecuteIndexeds(constants.MultiCall3, constants.CrossL2Inbox, &dependOn.Result, indexes))
+	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tx, receipt, nil
 }

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -69,7 +69,7 @@ func (u *EOA) Plan() txplan.Option {
 		txplan.WithPendingNonce(elClient),
 		txplan.WithAgainstLatestBlock(elClient),
 		txplan.WithEstimator(elClient, true),
-		txplan.WithTransactionSubmitter(elClient),
+		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(elClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(elClient),
 	)

--- a/op-devstack/dsl/funder.go
+++ b/op-devstack/dsl/funder.go
@@ -1,6 +1,8 @@
 package dsl
 
-import "github.com/ethereum-optimism/optimism/op-service/eth"
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 type Funder struct {
 	commonImpl
@@ -23,6 +25,16 @@ func (f *Funder) NewFundedEOA(amount eth.ETH) *EOA {
 	eoa := f.wallet.NewEOA(f.el)
 	f.faucet.Fund(eoa.Address(), amount)
 	return eoa
+}
+
+func (f *Funder) NewFundedEOAs(count int, amount eth.ETH) []*EOA {
+	eoas := make([]*EOA, count)
+	for idx := range count {
+		eoa := f.wallet.NewEOA(f.el)
+		f.faucet.Fund(eoa.Address(), amount)
+		eoas[idx] = eoa
+	}
+	return eoas
 }
 
 func (f *Funder) Fund(wallet *EOA, amount eth.ETH) eth.ETH {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Ports `TestInteropRandomDirectedGraph` to `TestRandomDirectedGraph`, with using op-devstack and DSL.

**Additional context**

The main change is to retry execution message tx submission by adding below retry txplan:
```go
txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
```
at the default txplan provided by devstack EOA. Executing messages were never included in the blockchain, since it was filtered out at the L2EL(op-geth) side, because of the supervisor check. Specific code: op-geth's `core/txpool/ingress_filters.go`'s `FilterTx` method.

Also the test was checking the error with `require.NoError` but originally it was tested inside goroutine, which did not made the test halt. Fixed this issue by using `errGroup`.

**Test**

Ran op-acceptance-pr multiple times (7): at https://app.circleci.com/pipelines/github/ethereum-optimism/optimism?branch=pcw109550%2Finterop-msg-test-TestRandomDirectedGraph-devstack and it never failed.


