### PR TITLE
feat: add toRpcHexString function to dispute helper

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/DisputeMonitorHelper.json
+++ b/packages/contracts-bedrock/snapshots/abi/DisputeMonitorHelper.json
@@ -82,6 +82,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "toRpcHexString",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "hexString_",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "DisputeMonitorHelper_InvalidSearchRange",
     "type": "error"

--- a/packages/contracts-bedrock/src/periphery/monitoring/DisputeMonitorHelper.sol
+++ b/packages/contracts-bedrock/src/periphery/monitoring/DisputeMonitorHelper.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+// Libraries
+import { Strings } from "openzeppelin-contracts/contracts/utils/Strings.sol";
+
 // Interfaces
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
@@ -153,5 +156,12 @@ contract DisputeMonitorHelper {
                 }
             }
         }
+    }
+
+    /// @notice Converts a uint256 to an RPC hex string.
+    /// @param _value The value to convert.
+    /// @return hexString_ The hex string.
+    function toRpcHexString(uint256 _value) public pure returns (string memory hexString_) {
+        hexString_ = Strings.toHexString(_value);
     }
 }

--- a/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
+++ b/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
@@ -409,3 +409,13 @@ contract DisputeMonitorHelper_getUnresolvedGames_Test is DisputeMonitorHelper_Te
         assertEq(results.length, _numGames, "expected 5 games");
     }
 }
+
+contract DisputeMonitorHelper_toRpcHexString_Test is DisputeMonitorHelper_TestInit {
+    /// @notice Test that the toRpcHexString function converts a uint256 to a hex string that
+    ///         starts with 0x and doesn't have any leading zeros.
+    function test_toRpcHexString_succeeds() external view {
+        uint256 value = 1234567890;
+        string memory hexString = helper.toRpcHexString(value);
+        assertEq(hexString, "0x499602d2");
+    }
+}


### PR DESCRIPTION
Adds another helper function to the DisputeMonitorHelper contract so we can use it in Hexagate monitoring.