### PR TITLE
refactor(test): cleanup /integration test structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/integration/EventLogger.t.sol
+++ b/packages/contracts-bedrock/test/integration/EventLogger.t.sol
@@ -13,7 +13,9 @@ import { ICrossL2Inbox, Identifier as ImplIdentifier } from "interfaces/L2/ICros
 import { VmSafe } from "forge-std/Vm.sol";
 import { CrossL2Inbox } from "src/L2/CrossL2Inbox.sol";
 
-contract EventLogger_Initializer is Test {
+/// @title EventLogger_TestInit
+/// @notice Reusable test initialization for `EventLogger` tests.
+contract EventLogger_TestInit is Test {
     event ExecutingMessage(bytes32 indexed msgHash, ImplIdentifier id);
 
     EventLogger eventLogger;
@@ -28,7 +30,9 @@ contract EventLogger_Initializer is Test {
     }
 }
 
-contract EventLoggerTest is EventLogger_Initializer {
+/// @title EventLogger_EmitLog_Test
+/// @notice Tests the `emitLog` function of the `EventLogger` contract.
+contract EventLogger_EmitLog_Test is EventLogger_TestInit {
     /// @notice Test logging
     function test_emitLog_succeeds(
         uint256 topicCount,
@@ -87,7 +91,11 @@ contract EventLoggerTest is EventLogger_Initializer {
         vm.expectRevert(empty);
         eventLogger.emitLog(topics, empty);
     }
+}
 
+/// @title EventLogger_ValidateMessage_Test
+/// @notice Tests the `validateMessage` function of the `EventLogger` contract.
+contract EventLogger_ValidateMessage_Test is EventLogger_TestInit {
     /// @notice It should succeed with any Identifier
     /// forge-config: default.isolate = true
     function test_validateMessage_succeeds(


### PR DESCRIPTION
This PR refactors the `EventLogger.t.sol` file within the `/integration` folder as part of a broader effort to standardize structure, documentation, and formatting across the test suite.

### Changes applied:
- Renamed test initializer to `EventLogger_TestInit` contract
- Organized individual test functions into separate contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to all test contracts

### Progress

Refactored 1 of 1 test files (**100.0% complete**)

- [x] EventLogger.t.sol