### PR TITLE
fix: correct leading zero handling in helper

### DIFF
--- a/packages/contracts-bedrock/src/periphery/monitoring/DisputeMonitorHelper.sol
+++ b/packages/contracts-bedrock/src/periphery/monitoring/DisputeMonitorHelper.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 // Libraries
-import { Strings } from "openzeppelin-contracts/contracts/utils/Strings.sol";
+import { LibString } from "@solady/utils/LibString.sol";
 
 // Interfaces
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -162,6 +162,6 @@ contract DisputeMonitorHelper {
     /// @param _value The value to convert.
     /// @return hexString_ The hex string.
     function toRpcHexString(uint256 _value) public pure returns (string memory hexString_) {
-        hexString_ = Strings.toHexString(_value);
+        hexString_ = LibString.toMinimalHexString(_value);
     }
 }

--- a/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
+++ b/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
@@ -418,4 +418,12 @@ contract DisputeMonitorHelper_toRpcHexString_Test is DisputeMonitorHelper_TestIn
         string memory hexString = helper.toRpcHexString(value);
         assertEq(hexString, "0x499602d2");
     }
+
+    /// @notice Test that the toRpcHexString function converts a uint256 to a hex string that
+    ///         doesn't have any leading zeros.
+    function test_toRpcHexString_noLeadingZero_succeeds() external view {
+        uint256 value = 136210625;
+        string memory hexString = helper.toRpcHexString(value);
+        assertEq(hexString, "0x81e68c1");
+    }
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug in the DisputeMonitorHelper by using the Solady version of the function that actually does what we want it to do.