### PR TITLE
refactor(test): cleanup /vendor test structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
@@ -4,7 +4,10 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
-contract AddressAliasHelper_applyAndUndo_Test is Test {
+/// @title AddressAliasHelper_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `AddressAliasHelper`
+///         contract or are testing multiple functions at once.
+contract AddressAliasHelper_Unclassified_Test is Test {
     /// @notice Tests that applying and then undoing an alias results in the original address.
     function testFuzz_applyAndUndo_succeeds(address _address) external pure {
         address aliased = AddressAliasHelper.applyL1ToL2Alias(_address);


### PR DESCRIPTION
This PR refactors a portion of the test suite within the `/vendor` folder as part of a broader effort to standardize structure, documentation, and formatting across the codebase.

### Changes applied to each file:
- Consolidated shared test initialization into dedicated `*_TestInit` contracts
- Organized test functions into logically separated contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to all test contracts
- Added function-level `@notice` comments describing expected behavior under test
- Replaced `@dev` tags with `@notice` where appropriate
- Enforced a 100-character limit for inline comments

### Progress

Refactored 1 of 1 test files (**100.0% complete**)

- [x] AddressAliasHelper.t.sol