### PR TITLE
refactor(test): cleanup /legacy test structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
@@ -8,7 +8,9 @@ import { Test } from "forge-std/Test.sol";
 import { IDeployerWhitelist } from "interfaces/legacy/IDeployerWhitelist.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
-contract DeployerWhitelist_Test is Test {
+/// @title DeployerWhitelist_TestInit
+/// @notice Reusable test initialization for `DeployerWhitelist` tests.
+contract DeployerWhitelist_TestInit is Test {
     IDeployerWhitelist list;
     address owner = address(12345);
 
@@ -16,7 +18,7 @@ contract DeployerWhitelist_Test is Test {
     event WhitelistDisabled(address oldOwner);
     event WhitelistStatusChanged(address deployer, bool whitelisted);
 
-    /// @dev Sets up the test suite.
+    /// @notice Sets up the test suite.
     function setUp() public {
         list = IDeployerWhitelist(
             DeployUtils.create1({
@@ -25,78 +27,22 @@ contract DeployerWhitelist_Test is Test {
             })
         );
     }
+}
 
-    /// @dev Tests that `owner` is initialized to the zero address.
+/// @title DeployerWhitelist_Owner_Test
+/// @notice Tests the `owner` function of the `DeployerWhitelist` contract.
+contract DeployerWhitelist_Owner_Test is DeployerWhitelist_TestInit {
+    /// @notice Tests that `owner` is initialized to the zero address.
     function test_owner_succeeds() external view {
         assertEq(list.owner(), address(0));
     }
+}
 
-    /// @dev Tests that `setOwner` correctly sets the contract owner.
-    function test_setOwner_succeeds(address _owner) external {
-        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
-        assertEq(list.owner(), owner);
-        _owner = address(uint160(bound(uint160(_owner), 1, type(uint160).max)));
-
-        vm.prank(owner);
-        vm.expectEmit(true, true, true, true);
-        emit OwnerChanged(owner, _owner);
-        list.setOwner(_owner);
-
-        assertEq(list.owner(), _owner);
-    }
-
-    /// @dev Tests that `setOwner` reverts when the caller is not the owner.
-    function test_setOwner_callerNotOwner_reverts(address _caller, address _owner) external {
-        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
-        assertEq(list.owner(), owner);
-
-        vm.assume(_caller != owner);
-
-        vm.prank(_caller);
-        vm.expectRevert(bytes("DeployerWhitelist: function can only be called by the owner of this contract"));
-        list.setOwner(_owner);
-    }
-
-    /// @dev Tests that `setOwner` reverts when the new owner is the zero address.
-    function test_setOwner_zeroAddress_reverts() external {
-        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
-        assertEq(list.owner(), owner);
-
-        vm.prank(owner);
-        vm.expectRevert(bytes("DeployerWhitelist: can only be disabled via enableArbitraryContractDeployment"));
-        list.setOwner(address(0));
-    }
-
-    /// @dev Tests that `enableArbitraryContractDeployment` correctly disables the whitelist.
-    function test_enableArbitraryContractDeployment_succeeds() external {
-        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
-        assertEq(list.owner(), owner);
-
-        vm.prank(owner);
-        vm.expectEmit(true, true, true, true);
-        emit WhitelistDisabled(owner);
-        list.enableArbitraryContractDeployment();
-
-        assertEq(list.owner(), address(0));
-
-        // Any address is allowed to deploy contracts even if they are not whitelisted
-        assertEq(list.whitelist(address(1)), false);
-        assertEq(list.isDeployerAllowed(address(1)), true);
-    }
-
-    /// @dev Tests that `enableArbitraryContractDeployment` reverts when the caller is not the owner.
-    function test_enableArbitraryContractDeployment_callerNotOwner_reverts(address _caller) external {
-        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
-        assertEq(list.owner(), owner);
-
-        vm.assume(_caller != owner);
-
-        vm.prank(_caller);
-        vm.expectRevert(bytes("DeployerWhitelist: function can only be called by the owner of this contract"));
-        list.enableArbitraryContractDeployment();
-    }
-
-    /// @dev Tests that `setWhitelistedDeployer` correctly sets the whitelist status of a deployer.
+/// @title DeployerWhitelist_SetWhitelistedDeployer_Test
+/// @notice Tests the `setWhitelistedDeployer` function of the `DeployerWhitelist` contract.
+contract DeployerWhitelist_SetWhitelistedDeployer_Test is DeployerWhitelist_TestInit {
+    /// @notice Tests that `setWhitelistedDeployer` correctly sets the whitelist status of a
+    ///         deployer.
     function test_setWhitelistedDeployer_succeeds(address _deployer, bool _isWhitelisted) external {
         vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
         assertEq(list.owner(), owner);
@@ -113,7 +59,7 @@ contract DeployerWhitelist_Test is Test {
         assertEq(list.isDeployerAllowed(_deployer), _isWhitelisted);
     }
 
-    /// @dev Tests that `setWhitelistedDeployer` reverts when the caller is not the owner.
+    /// @notice Tests that `setWhitelistedDeployer` reverts when the caller is not the owner.
     function test_setWhitelistedDeployer_callerNotOwner_reverts(
         address _caller,
         address _deployer,
@@ -129,5 +75,80 @@ contract DeployerWhitelist_Test is Test {
         vm.prank(_caller);
         vm.expectRevert(bytes("DeployerWhitelist: function can only be called by the owner of this contract"));
         list.setWhitelistedDeployer(_deployer, _isWhitelisted);
+    }
+}
+
+/// @title DeployerWhitelist_SetOwner_Test
+/// @notice Tests the `setOwner` function of the `DeployerWhitelist` contract.
+contract DeployerWhitelist_SetOwner_Test is DeployerWhitelist_TestInit {
+    /// @notice Tests that `setOwner` correctly sets the contract owner.
+    function test_setOwner_succeeds(address _owner) external {
+        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
+        assertEq(list.owner(), owner);
+        _owner = address(uint160(bound(uint160(_owner), 1, type(uint160).max)));
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit OwnerChanged(owner, _owner);
+        list.setOwner(_owner);
+
+        assertEq(list.owner(), _owner);
+    }
+
+    /// @notice Tests that `setOwner` reverts when the caller is not the owner.
+    function test_setOwner_callerNotOwner_reverts(address _caller, address _owner) external {
+        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
+        assertEq(list.owner(), owner);
+
+        vm.assume(_caller != owner);
+
+        vm.prank(_caller);
+        vm.expectRevert(bytes("DeployerWhitelist: function can only be called by the owner of this contract"));
+        list.setOwner(_owner);
+    }
+
+    /// @notice Tests that `setOwner` reverts when the new owner is the zero address.
+    function test_setOwner_zeroAddress_reverts() external {
+        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
+        assertEq(list.owner(), owner);
+
+        vm.prank(owner);
+        vm.expectRevert(bytes("DeployerWhitelist: can only be disabled via enableArbitraryContractDeployment"));
+        list.setOwner(address(0));
+    }
+}
+
+/// @title DeployerWhitelist_EnableArbitraryContractDeployment_Test
+/// @notice Tests the `enableArbitraryContractDeployment` function of the `DeployerWhitelist`
+///         contract.
+contract DeployerWhitelist_EnableArbitraryContractDeployment_Test is DeployerWhitelist_TestInit {
+    /// @notice Tests that `enableArbitraryContractDeployment` correctly disables the whitelist.
+    function test_enableArbitraryContractDeployment_succeeds() external {
+        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
+        assertEq(list.owner(), owner);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit WhitelistDisabled(owner);
+        list.enableArbitraryContractDeployment();
+
+        assertEq(list.owner(), address(0));
+
+        // Any address is allowed to deploy contracts even if they are not whitelisted
+        assertEq(list.whitelist(address(1)), false);
+        assertEq(list.isDeployerAllowed(address(1)), true);
+    }
+
+    /// @notice Tests that `enableArbitraryContractDeployment` reverts when the caller is not the
+    ///         owner.
+    function test_enableArbitraryContractDeployment_callerNotOwner_reverts(address _caller) external {
+        vm.store(address(list), bytes32(uint256(0)), bytes32(uint256(uint160(owner))));
+        assertEq(list.owner(), owner);
+
+        vm.assume(_caller != owner);
+
+        vm.prank(_caller);
+        vm.expectRevert(bytes("DeployerWhitelist: function can only be called by the owner of this contract"));
+        list.enableArbitraryContractDeployment();
     }
 }

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -12,13 +12,15 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { IL1BlockNumber } from "interfaces/legacy/IL1BlockNumber.sol";
 import { IL1Block } from "interfaces/L2/IL1Block.sol";
 
-contract L1BlockNumberTest is Test {
+/// @title L1BlockNumber_TestInit
+/// @notice Reusable test initialization for `L1BlockNumber` tests.
+contract L1BlockNumber_TestInit is Test {
     IL1Block lb;
     IL1BlockNumber bn;
 
     uint64 constant number = 99;
 
-    /// @dev Sets up the test suite.
+    /// @notice Sets up the test suite.
     function setUp() external {
         vm.etch(Predeploys.L1_BLOCK_ATTRIBUTES, vm.getDeployedCode("L1Block.sol:L1Block"));
         lb = IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
@@ -41,23 +43,35 @@ contract L1BlockNumberTest is Test {
             _l1FeeScalar: 3
         });
     }
+}
 
-    /// @dev Tests that `getL1BlockNumber` returns the set block number.
-    function test_getL1BlockNumber_succeeds() external view {
-        assertEq(bn.getL1BlockNumber(), number);
+/// @title L1BlockNumber_Receive_Test
+/// @notice Tests the `receive` function of the `L1BlockNumber` contract.
+contract L1BlockNumber_Receive_Test is L1BlockNumber_TestInit {
+    /// @notice Tests that `receive` is correctly dispatched.
+    function test_receive_succeeds() external {
+        (bool success, bytes memory ret) = address(bn).call{ value: 1 }(hex"");
+        assertEq(success, true);
+        assertEq(ret, abi.encode(number));
     }
+}
 
-    /// @dev Tests that `fallback` is correctly dispatched.
+/// @title L1BlockNumber_Fallback_Test
+/// @notice Tests the `fallback` function of the `L1BlockNumber` contract.
+contract L1BlockNumber_Fallback_Test is L1BlockNumber_TestInit {
+    /// @notice Tests that `fallback` is correctly dispatched.
     function test_fallback_succeeds() external {
         (bool success, bytes memory ret) = address(bn).call(hex"11");
         assertEq(success, true);
         assertEq(ret, abi.encode(number));
     }
+}
 
-    /// @dev Tests that `receive` is correctly dispatched.
-    function test_receive_succeeds() external {
-        (bool success, bytes memory ret) = address(bn).call{ value: 1 }(hex"");
-        assertEq(success, true);
-        assertEq(ret, abi.encode(number));
+/// @title L1BlockNumber_GetL1BlockNumber_Test
+/// @notice Tests the `getL1BlockNumber` function of the `L1BlockNumber` contract.
+contract L1BlockNumber_GetL1BlockNumber_Test is L1BlockNumber_TestInit {
+    /// @notice Tests that `getL1BlockNumber` returns the set block number.
+    function test_getL1BlockNumber_succeeds() external view {
+        assertEq(bn.getL1BlockNumber(), number);
     }
 }

--- a/packages/contracts-bedrock/test/legacy/LegacyMessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/legacy/LegacyMessagePasser.t.sol
@@ -4,8 +4,10 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-contract LegacyMessagePasser_Test is CommonTest {
-    /// @dev Tests that `passMessageToL1` succeeds.
+/// @title LegacyMessagePasser_PassMessageToL1_Test
+/// @notice Tests the `passMessageToL1` function of the `LegacyMessagePasser` contract.
+contract LegacyMessagePasser_PassMessageToL1_Test is CommonTest {
+    /// @notice Tests that `passMessageToL1` succeeds.
     function test_passMessageToL1_succeeds() external {
         vm.prank(alice);
         legacyMessagePasser.passMessageToL1(hex"ff");

--- a/packages/contracts-bedrock/test/legacy/LegacyMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/legacy/LegacyMintableERC20.t.sol
@@ -7,7 +7,9 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { LegacyMintableERC20 } from "src/legacy/LegacyMintableERC20.sol";
 import { ILegacyMintableERC20 } from "interfaces/legacy/ILegacyMintableERC20.sol";
 
-contract LegacyMintableERC20_Test is CommonTest {
+/// @title LegacyMintableERC20_TestInit
+/// @notice Reusable test initialization for `LegacyMintableERC20` tests.
+contract LegacyMintableERC20_TestInit is CommonTest {
     LegacyMintableERC20 legacyMintableERC20;
 
     function setUp() public override {
@@ -15,7 +17,11 @@ contract LegacyMintableERC20_Test is CommonTest {
 
         legacyMintableERC20 = new LegacyMintableERC20(address(l2StandardBridge), address(L1Token), "_L2Token_", "_L2T_");
     }
+}
 
+/// @title LegacyMintableERC20_Constructor_Test
+/// @notice Tests the constructor of the `LegacyMintableERC20` contract.
+contract LegacyMintableERC20_Constructor_Test is LegacyMintableERC20_TestInit {
     /// @notice Tests that the constructor sets the correct values
     function test_constructor_works() public view {
         assertEq(legacyMintableERC20.l2Bridge(), address(l2StandardBridge));
@@ -24,7 +30,11 @@ contract LegacyMintableERC20_Test is CommonTest {
         assertEq(legacyMintableERC20.symbol(), "_L2T_");
         assertEq(legacyMintableERC20.decimals(), 18);
     }
+}
 
+/// @title LegacyMintableERC20_SupportsInterface_Test
+/// @notice Tests the `supportsInterface` function of the `LegacyMintableERC20` contract.
+contract LegacyMintableERC20_SupportsInterface_Test is LegacyMintableERC20_TestInit {
     /// @notice Tests that the contract supports the correct interfaces
     function test_supportsInterface_works() public view {
         assertEq(legacyMintableERC20.supportsInterface(bytes4(keccak256("supportsInterface(bytes4)"))), true);
@@ -36,7 +46,11 @@ contract LegacyMintableERC20_Test is CommonTest {
             true
         );
     }
+}
 
+/// @title LegacyMintableERC20_Mint_Test
+/// @notice Tests the `mint` function of the `LegacyMintableERC20` contract.
+contract LegacyMintableERC20_Mint_Test is LegacyMintableERC20_TestInit {
     /// @notice Tests that the mint function works when called by the bridge
     function test_mint_byBridge_succeeds() public {
         vm.prank(address(l2StandardBridge));
@@ -49,7 +63,11 @@ contract LegacyMintableERC20_Test is CommonTest {
         vm.expectRevert(bytes("Only L2 Bridge can mint and burn"));
         legacyMintableERC20.mint(address(this), 1000);
     }
+}
 
+/// @title LegacyMintableERC20_Burn_Test
+/// @notice Tests the `burn` function of the `LegacyMintableERC20` contract.
+contract LegacyMintableERC20_Burn_Test is LegacyMintableERC20_TestInit {
     /// @notice Tests that the burn function works when called by the bridge
     function test_burn_byBridge_succeeds() public {
         vm.prank(address(l2StandardBridge));


### PR DESCRIPTION
This PR refactors a portion of the test suite within the `/legacy` folder as part of a broader effort to standardize structure, documentation, and formatting across the codebase.

### Changes applied to each file:
- Consolidated shared test initialization into dedicated `*_TestInit` contracts
- Organized test functions into logically separated contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to all test contracts
- Added function-level `@notice` comments describing expected behavior under test
- Replaced `@dev` tags with `@notice` where appropriate
- Enforced a 100-character limit for inline comments

### Progress

Refactored 6 of 6 test files (**100.0% complete**)

- [x] DeployerWhitelist.t.sol  
- [x] L1BlockNumber.t.sol  
- [x] L1ChugSplashProxy.t.sol  
- [x] LegacyMessagePasser.t.sol  
- [x] LegacyMintableERC20.t.sol  
- [x] ResolvedDelegateProxy.t.sol