### PR TITLE
op-acceptance-tests: fixes for chain split and cl advance

### DIFF
--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -134,7 +134,7 @@ func (mc *MultiClient) HeaderByNumber(ctx context.Context, number *big.Int) (*ty
 	}
 
 	// Verify consistency with retry for followers
-	err = mc.verifyFollowersWithRetry(ctx, number, header.Hash())
+	err = mc.verifyFollowersWithRetry(ctx, header.Number, header.Hash())
 
 	return header, err
 }

--- a/op-acceptance-tests/tests/base/advance_test.go
+++ b/op-acceptance-tests/tests/base/advance_test.go
@@ -18,14 +18,14 @@ func TestCLAdvance(gt *testing.T) {
 	blockTime := sys.L2Chain.Escape().RollupConfig().BlockTime
 	waitTime := time.Duration(blockTime+1) * time.Second
 
-	num := sys.L2CL.SafeL2BlockRef().Number
+	num := sys.L2CL.SyncStatus().UnsafeL2.Number
 	new_num := num
 	require.Eventually(t, func() bool {
 		ctx, span := tracer.Start(ctx, "check head")
 		defer span.End()
 
-		new_num, num = sys.L2CL.SafeL2BlockRef().Number, new_num
-		t.Logger().InfoContext(ctx, "safe head", "number", new_num)
+		new_num, num = sys.L2CL.SyncStatus().UnsafeL2.Number, new_num
+		t.Logger().InfoContext(ctx, "unsafe head", "number", new_num)
 		return new_num > num
 	}, 30*time.Second, waitTime)
 }


### PR DESCRIPTION
**Description**

* Fixes follower verify checks potentially not using the same reference block in chain split test
* Updates CLAdvance test to check unsafe head since safe head progression is not guaranteed within the timeout on persistent devnets