### PR TITLE
refactor(test): cleanup /cannon test structure and documentation

### DIFF
--- a/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
@@ -8,7 +8,9 @@ import { UnsupportedStateVersion } from "src/cannon/libraries/CannonErrors.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { IMIPS2 } from "interfaces/cannon/IMIPS2.sol";
 
-contract MIPS64_Test is Test {
+/// @title MIPS64_TestInit
+/// @notice Reusable test initialization for `MIPS64` tests.
+contract MIPS64_TestInit is Test {
     IPreimageOracle oracle;
 
     // Store some data about acceptable versions
@@ -36,6 +38,21 @@ contract MIPS64_Test is Test {
         }
     }
 
+    /// @notice Deploys new MIPS64 contract with the given version parameter.
+    function deployVm(uint256 version) internal returns (IMIPS2) {
+        return IMIPS2(
+            DeployUtils.create1({
+                _name: "MIPS64",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS2.__constructor__, (oracle, version)))
+            })
+        );
+    }
+}
+
+/// @title MIPS64_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `MIPS64` contract or
+///         are testing multiple functions at once.
+contract MIPS64_Unclassified_Test is MIPS64_TestInit {
     /// @notice Test the we can deploy MIPS64 with a valid version parameter.
     function test_deploy_supportedVersions_succeeds() external {
         for (uint256 i = 0; i < validVersions.length; i++) {
@@ -55,15 +72,5 @@ contract MIPS64_Test is Test {
             vm.expectRevert(abi.encodeWithSelector(UnsupportedStateVersion.selector));
             deployVm(ver);
         }
-    }
-
-    /// @notice Deploys new MIPS64 contract with the given version parameter.
-    function deployVm(uint256 version) internal returns (IMIPS2) {
-        return IMIPS2(
-            DeployUtils.create1({
-                _name: "MIPS64",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IMIPS2.__constructor__, (oracle, version)))
-            })
-        );
     }
 }

--- a/packages/contracts-bedrock/test/cannon/MIPS64Memory.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64Memory.t.sol
@@ -5,179 +5,6 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";
 import { InvalidMemoryProof } from "src/cannon/libraries/CannonErrors.sol";
 
-contract MIPS64Memory_Test is CommonTest {
-    MIPS64MemoryWithCalldata mem;
-
-    error InvalidAddress();
-
-    function setUp() public virtual override {
-        super.setUp();
-        mem = new MIPS64MemoryWithCalldata();
-    }
-
-    /// @dev Static unit test for basic memory access
-    function test_readMem_succeeds() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        bytes32 root;
-        bytes memory proof;
-        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
-        uint64 readWord = mem.readMem(root, addr, 0, proof);
-        assertEq(readWord, word);
-    }
-
-    /// @dev Static unit test asserting that reading from the zero address succeeds
-    function test_readMemAtZero_succeeds() external {
-        uint64 addr = 0x0;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        bytes32 root;
-        bytes memory proof;
-        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
-        uint64 readWord = mem.readMem(root, addr, 0, proof);
-        assertEq(readWord, word);
-    }
-
-    /// @dev Static unit test asserting that reading from high memory area succeeds
-    function test_readMemHighMem_succeeds() external {
-        uint64 addr = 0xFF_FF_FF_FF_00_00_00_88;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        bytes32 root;
-        bytes memory proof;
-        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
-        uint64 readWord = mem.readMem(root, addr, 0, proof);
-        assertEq(readWord, word);
-    }
-
-    /// @dev Static unit test asserting that reads revert when a misaligned memory address is provided
-    function test_readMem_readInvalidAddress_reverts() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        bytes32 root;
-        bytes memory proof;
-        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
-        vm.expectRevert(InvalidAddress.selector);
-        mem.readMem(root, addr + 4, 0, proof);
-    }
-
-    /// @dev Static unit test asserting that reads revert when an invalid proof is provided
-    function test_readMem_readInvalidProof_reverts() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        bytes32 root;
-        bytes memory proof;
-        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
-        vm.assertTrue(proof[64] != 0x0); // make sure the proof is tampered
-        proof[64] = 0x00;
-        vm.expectRevert(InvalidMemoryProof.selector);
-        mem.readMem(root, addr, 0, proof);
-    }
-
-    /// @dev Static unit test asserting that reads from a non-zero proof index succeeds
-    function test_readMemNonZeroProofIndex_succeeds() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        uint64 addr2 = 0xFF_FF_FF_FF_00_00_00_88;
-        uint64 word2 = 0xF1_F2_F3_F4_F5_F6_F7_F8;
-        bytes32 root;
-        bytes memory proof;
-        (root, proof) = ffi.getCannonMemory64Proof(addr, word, addr2, word2);
-
-        uint64 readWord = mem.readMem(root, addr, 0, proof);
-        assertEq(readWord, word);
-
-        readWord = mem.readMem(root, addr2, 1, proof);
-        assertEq(readWord, word2);
-    }
-
-    /// @dev Static unit test asserting basic memory write functionality
-    function test_writeMem_succeeds() external {
-        uint64 addr = 0x100;
-        bytes memory zeroProof;
-        (, zeroProof) = ffi.getCannonMemory64Proof(addr, 0);
-
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word);
-
-        bytes32 newRoot = mem.writeMem(addr, word, 0, zeroProof);
-        assertEq(newRoot, expectedRoot);
-    }
-
-    // @dev Static unit test asserting that writes to high memory succeeds
-    function test_writeMemHighMem_succeeds() external {
-        uint64 addr = 0xFF_FF_FF_FF_00_00_00_88;
-        bytes memory zeroProof;
-        (, zeroProof) = ffi.getCannonMemory64Proof(addr, 0);
-
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word);
-
-        bytes32 newRoot = mem.writeMem(addr, word, 0, zeroProof);
-        assertEq(newRoot, expectedRoot);
-    }
-
-    /// @dev Static unit test asserting that non-zero memory word is overwritten
-    function test_writeMemNonZeroProofOffset_succeeds() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        uint64 addr2 = 0x108;
-        uint64 word2 = 0x55_55_55_55_77_77_77_77;
-        bytes memory initProof;
-        (, initProof) = ffi.getCannonMemory64Proof(addr, word, addr2, word2);
-
-        uint64 word3 = 0x44_44_44_44_44_44_44_44;
-        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word, addr2, word2, addr2, word3);
-
-        bytes32 newRoot = mem.writeMem(addr2, word3, 1, initProof);
-        assertEq(newRoot, expectedRoot);
-    }
-
-    /// @dev Static unit test asserting that a zerod memory word is set for a non-zero memory proof
-    function test_writeMemUniqueAccess_succeeds() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        uint64 addr2 = 0x108;
-        uint64 word2 = 0x55_55_55_55_77_77_77_77;
-        bytes memory initProof;
-        (, initProof) = ffi.getCannonMemory64Proof(addr, word, addr2, word2);
-
-        uint64 addr3 = 0xAA_AA_AA_AA_00;
-        uint64 word3 = 0x44_44_44_44_44_44_44_44;
-        (, bytes memory addr3Proof) = ffi.getCannonMemory64Proof2(addr, word, addr2, word2, addr3);
-        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word, addr2, word2, addr3, word3);
-
-        bytes32 newRoot = mem.writeMem(addr3, word3, 0, addr3Proof);
-        assertEq(newRoot, expectedRoot);
-
-        newRoot = mem.writeMem(addr3 + 8, word3, 0, addr3Proof);
-        assertNotEq(newRoot, expectedRoot);
-
-        newRoot = mem.writeMem(addr3, word3 + 1, 0, addr3Proof);
-        assertNotEq(newRoot, expectedRoot);
-    }
-
-    /// @dev Static unit test asserting that writes succeeds in overwriting a non-zero memory word
-    function test_writeMemNonZeroMem_succeeds() external {
-        uint64 addr = 0x100;
-        uint64 word = 0x11_22_33_44_55_66_77_88;
-        bytes memory initProof;
-        (, initProof) = ffi.getCannonMemory64Proof(addr, word);
-
-        uint64 word2 = 0x55_55_55_55_77_77_77_77;
-        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word, addr + 8, word2);
-
-        bytes32 newRoot = mem.writeMem(addr + 8, word2, 0, initProof);
-        assertEq(newRoot, expectedRoot);
-    }
-
-    /// @dev Static unit test asserting that writes revert when a misaligned memory address is provided
-    function test_writeMem_writeMemInvalidAddress_reverts() external {
-        bytes memory zeroProof;
-        (, zeroProof) = ffi.getCannonMemory64Proof(0x100, 0);
-        vm.expectRevert(InvalidAddress.selector);
-        mem.writeMem(0x104, 0x0, 0, zeroProof);
-    }
-}
-
 contract MIPS64MemoryWithCalldata {
     function readMem(
         bytes32 _root,
@@ -207,5 +34,192 @@ contract MIPS64MemoryWithCalldata {
         uint256 proofDataOffset = 4 + 32 + 32 + 32 + 32 + 32;
         uint256 proofOffset = MIPS64Memory.memoryProofOffset(proofDataOffset, _proofIndex);
         return MIPS64Memory.writeMem(_addr, proofOffset, _value);
+    }
+}
+
+/// @title MIPS64Memory_TestInit
+/// @notice Reusable test initialization for `MIPS64Memory` tests.
+contract MIPS64Memory_TestInit is CommonTest {
+    MIPS64MemoryWithCalldata mem;
+
+    error InvalidAddress();
+
+    function setUp() public virtual override {
+        super.setUp();
+        mem = new MIPS64MemoryWithCalldata();
+    }
+}
+
+/// @title MIPS64Memory_ReadMem_Test
+/// @notice Tests the `readMem` function of the `MIPS64Memory` contract.
+contract MIPS64Memory_ReadMem_Test is MIPS64Memory_TestInit {
+    /// @notice Static unit test for basic memory access
+    function test_readMem_succeeds() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        bytes32 root;
+        bytes memory proof;
+        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
+        uint64 readWord = mem.readMem(root, addr, 0, proof);
+        assertEq(readWord, word);
+    }
+
+    /// @notice Static unit test asserting that reading from the zero address succeeds.
+    function test_readMemAtZero_succeeds() external {
+        uint64 addr = 0x0;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        bytes32 root;
+        bytes memory proof;
+        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
+        uint64 readWord = mem.readMem(root, addr, 0, proof);
+        assertEq(readWord, word);
+    }
+
+    /// @notice Static unit test asserting that reading from high memory area succeeds.
+    function test_readMemHighMem_succeeds() external {
+        uint64 addr = 0xFF_FF_FF_FF_00_00_00_88;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        bytes32 root;
+        bytes memory proof;
+        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
+        uint64 readWord = mem.readMem(root, addr, 0, proof);
+        assertEq(readWord, word);
+    }
+
+    /// @notice Static unit test asserting that reads revert when a misaligned memory address is
+    ///         provided.
+    function test_readMem_readInvalidAddress_reverts() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        bytes32 root;
+        bytes memory proof;
+        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
+        vm.expectRevert(InvalidAddress.selector);
+        mem.readMem(root, addr + 4, 0, proof);
+    }
+
+    /// @notice Static unit test asserting that reads revert when an invalid proof is provided.
+    function test_readMem_readInvalidProof_reverts() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        bytes32 root;
+        bytes memory proof;
+        (root, proof) = ffi.getCannonMemory64Proof(addr, word);
+        vm.assertTrue(proof[64] != 0x0); // make sure the proof is tampered
+        proof[64] = 0x00;
+        vm.expectRevert(InvalidMemoryProof.selector);
+        mem.readMem(root, addr, 0, proof);
+    }
+
+    /// @notice Static unit test asserting that reads from a non-zero proof index succeeds.
+    function test_readMem_nonZeroProofIndex_succeeds() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        uint64 addr2 = 0xFF_FF_FF_FF_00_00_00_88;
+        uint64 word2 = 0xF1_F2_F3_F4_F5_F6_F7_F8;
+        bytes32 root;
+        bytes memory proof;
+        (root, proof) = ffi.getCannonMemory64Proof(addr, word, addr2, word2);
+
+        uint64 readWord = mem.readMem(root, addr, 0, proof);
+        assertEq(readWord, word);
+
+        readWord = mem.readMem(root, addr2, 1, proof);
+        assertEq(readWord, word2);
+    }
+}
+
+/// @title MIPS64Memory_WriteMem_Test
+/// @notice Tests the `writeMem` function of the `MIPS64Memory` contract.
+contract MIPS64Memory_WriteMem_Test is MIPS64Memory_TestInit {
+    /// @notice Static unit test asserting basic memory write functionality.
+    function test_writeMem_succeeds() external {
+        uint64 addr = 0x100;
+        bytes memory zeroProof;
+        (, zeroProof) = ffi.getCannonMemory64Proof(addr, 0);
+
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word);
+
+        bytes32 newRoot = mem.writeMem(addr, word, 0, zeroProof);
+        assertEq(newRoot, expectedRoot);
+    }
+
+    /// @notice Static unit test asserting that writes to high memory succeeds.
+    function test_writeMem_highMem_succeeds() external {
+        uint64 addr = 0xFF_FF_FF_FF_00_00_00_88;
+        bytes memory zeroProof;
+        (, zeroProof) = ffi.getCannonMemory64Proof(addr, 0);
+
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word);
+
+        bytes32 newRoot = mem.writeMem(addr, word, 0, zeroProof);
+        assertEq(newRoot, expectedRoot);
+    }
+
+    /// @notice Static unit test asserting that non-zero memory word is overwritten.
+    function test_writeMem_nonZeroProofOffset_succeeds() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        uint64 addr2 = 0x108;
+        uint64 word2 = 0x55_55_55_55_77_77_77_77;
+        bytes memory initProof;
+        (, initProof) = ffi.getCannonMemory64Proof(addr, word, addr2, word2);
+
+        uint64 word3 = 0x44_44_44_44_44_44_44_44;
+        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word, addr2, word2, addr2, word3);
+
+        bytes32 newRoot = mem.writeMem(addr2, word3, 1, initProof);
+        assertEq(newRoot, expectedRoot);
+    }
+
+    /// @notice Static unit test asserting that a zerod memory word is set for a non-zero memory
+    ///         proof.
+    function test_writeMem_uniqueAccess_succeeds() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        uint64 addr2 = 0x108;
+        uint64 word2 = 0x55_55_55_55_77_77_77_77;
+        bytes memory initProof;
+        (, initProof) = ffi.getCannonMemory64Proof(addr, word, addr2, word2);
+
+        uint64 addr3 = 0xAA_AA_AA_AA_00;
+        uint64 word3 = 0x44_44_44_44_44_44_44_44;
+        (, bytes memory addr3Proof) = ffi.getCannonMemory64Proof2(addr, word, addr2, word2, addr3);
+        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word, addr2, word2, addr3, word3);
+
+        bytes32 newRoot = mem.writeMem(addr3, word3, 0, addr3Proof);
+        assertEq(newRoot, expectedRoot);
+
+        newRoot = mem.writeMem(addr3 + 8, word3, 0, addr3Proof);
+        assertNotEq(newRoot, expectedRoot);
+
+        newRoot = mem.writeMem(addr3, word3 + 1, 0, addr3Proof);
+        assertNotEq(newRoot, expectedRoot);
+    }
+
+    /// @notice Static unit test asserting that writes succeeds in overwriting a non-zero memory
+    ///         word.
+    function test_writeMem_nonZeroMem_succeeds() external {
+        uint64 addr = 0x100;
+        uint64 word = 0x11_22_33_44_55_66_77_88;
+        bytes memory initProof;
+        (, initProof) = ffi.getCannonMemory64Proof(addr, word);
+
+        uint64 word2 = 0x55_55_55_55_77_77_77_77;
+        (bytes32 expectedRoot,) = ffi.getCannonMemory64Proof(addr, word, addr + 8, word2);
+
+        bytes32 newRoot = mem.writeMem(addr + 8, word2, 0, initProof);
+        assertEq(newRoot, expectedRoot);
+    }
+
+    /// @notice Static unit test asserting that writes revert when a misaligned memory address is
+    ///         provided.
+    function test_writeMem_writeMemInvalidAddress_reverts() external {
+        bytes memory zeroProof;
+        (, zeroProof) = ffi.getCannonMemory64Proof(0x100, 0);
+        vm.expectRevert(InvalidAddress.selector);
+        mem.writeMem(0x104, 0x0, 0, zeroProof);
     }
 }


### PR DESCRIPTION
This PR refactors part of the test suite within the `/cannon` folder as part of a broader effort to standardize structure, documentation, and formatting across the codebase.

The goal of this PR is to land the straightforward refactors first. More complex files, due to custom setup logic, heavy internal dependencies, or unclear structure, will be handled in a follow-up PR to avoid blocking progress and reduce review scope.

### Common changes applied where applicable:
- Consolidated shared test initialization into dedicated `*_TestInit` contracts
- Organized test functions into logically separated contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to all test contracts
- Added function-level `@notice` comments describing expected behavior under test
- Replaced `@dev` tags with `@notice` where appropriate
- Enforced a 100-character limit for inline comments

### Progress

Refactored 2 of 3 test files (**66.6% complete**)

- [x] `MIPS64.t.sol`
- [x] `MIPS64Memory.t.sol`
- `PreimageOracle.t.sol` _(deferred)_

This remaining file will be refactored in a future PR.