### PR TITLE
op-node: fix log level of p2p peering

### DIFF
--- a/op-node/p2p/notifications.go
+++ b/op-node/p2p/notifications.go
@@ -24,22 +24,27 @@ type notifications struct {
 func (notif *notifications) Listen(n network.Network, a ma.Multiaddr) {
 	notif.log.Info("started listening network address", "addr", a)
 }
+
 func (notif *notifications) ListenClose(n network.Network, a ma.Multiaddr) {
 	notif.log.Info("stopped listening network address", "addr", a)
 }
+
 func (notif *notifications) Connected(n network.Network, v network.Conn) {
 	notif.m.IncPeerCount()
-	notif.log.Info("connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	notif.log.Debug("connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
 }
+
 func (notif *notifications) Disconnected(n network.Network, v network.Conn) {
 	notif.m.DecPeerCount()
-	notif.log.Info("disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	notif.log.Debug("disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
 }
+
 func (notif *notifications) OpenedStream(n network.Network, v network.Stream) {
 	notif.m.IncStreamCount()
 	c := v.Conn()
 	notif.log.Trace("opened stream", "protocol", v.Protocol(), "peer", c.RemotePeer(), "addr", c.RemoteMultiaddr())
 }
+
 func (notif *notifications) ClosedStream(n network.Network, v network.Stream) {
 	notif.m.DecStreamCount()
 	c := v.Conn()

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -560,7 +560,7 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	}()
 
 	log := s.log.New("peer", id)
-	log.Info("Starting P2P sync client event loop")
+	log.Debug("Starting P2P sync client event loop")
 
 	// Implement the same rate limits as the server does per-peer,
 	// so we don't be too aggressive to the server.


### PR DESCRIPTION
**Description**

P2P related logging is too noisy.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
