### PR TITLE
fix(op-acceptance-tests): base; ChainFork.

### DIFF
--- a/devnet-sdk/testing/systest/multi_client.go
+++ b/devnet-sdk/testing/systest/multi_client.go
@@ -129,8 +129,14 @@ func (mc *MultiClient) HeaderByNumber(ctx context.Context, number *big.Int) (*ty
 	}
 
 	header, err := mc.clients[0].HeaderByNumber(ctx, number)
-	if err != nil || len(mc.clients) == 1 {
-		return header, err
+	if err != nil {
+		return nil, err
+	}
+	if header == nil {
+		return nil, fmt.Errorf("no header found for block number %v", number)
+	}
+	if len(mc.clients) == 1 {
+		return header, nil
 	}
 
 	// Verify consistency with retry for followers


### PR DESCRIPTION
# Description
Fixes ChainFork nil flake.

# Test
Tested locally with `DEVSTACK_ORCHESTRATOR=sysext DEVNET_ENV_URL=kt://interop-devnet go test -v -run TestChainFork -count 50`

