### PR TITLE
op-e2e: Fix and re-enable super game tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1005,6 +1005,7 @@ jobs:
           if: ${{ uses_artifacts }}
       - run:
           name: Fuzz
+          no_output_timeout: 15m
           command: |
             make fuzz
           working_directory: "<<parameters.package_name>>"

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -258,6 +258,9 @@ func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestam
 
 	extraData := h.CreateSuperGameExtraData(ctx, rootProvider, timestamp, cfg)
 
+	// Gas estimation will fail if the current L1 head is genesis
+	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1), "Wait for L1 to advance past genesis")
+
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -258,9 +258,6 @@ func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestam
 
 	extraData := h.CreateSuperGameExtraData(ctx, rootProvider, timestamp, cfg)
 
-	// Gas estimation will fail if the current L1 head is genesis
-	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1), "Wait for L1 to advance past genesis")
-
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 

--- a/op-e2e/e2eutils/transactions/gas.go
+++ b/op-e2e/e2eutils/transactions/gas.go
@@ -3,6 +3,7 @@ package transactions
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -22,7 +23,7 @@ func PadGasEstimate(opts *bind.TransactOpts, paddingFactor float64, builder TxBu
 	o.NoSend = true
 	tx, err := builder(o)
 	if err != nil {
-		return nil, fmt.Errorf("failed to estimate gas: %w", err)
+		return nil, fmt.Errorf("failed to estimate gas: %w", errutil.TryAddRevertReason(err))
 	}
 	gas := float64(tx.Gas()) * paddingFactor
 	o.GasLimit = uint64(gas)

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -25,13 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func temporarilySkip(t *testing.T) {
-	// TODO(#16166) Reenable these tests
-	t.Skip("Skip temporarily while #16166 is in progress")
-}
-
 func TestCreateSuperCannonGame(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -42,7 +36,6 @@ func TestCreateSuperCannonGame(t *testing.T) {
 }
 
 func TestSuperCannonGame(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -52,7 +45,6 @@ func TestSuperCannonGame(t *testing.T) {
 }
 
 func TestSuperCannonGame_ChallengeAllZeroClaim(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -62,7 +54,6 @@ func TestSuperCannonGame_ChallengeAllZeroClaim(t *testing.T) {
 }
 
 func TestSuperCannonPublishCannonRootClaim(t *testing.T) {
-	temporarilySkip(t)
 	type TestCase struct {
 		disputeL2SequenceNumberOffset uint64
 	}
@@ -124,7 +115,6 @@ func TestSuperCannonPublishCannonRootClaim(t *testing.T) {
 }
 
 func TestSuperCannonDisputeGame(t *testing.T) {
-	temporarilySkip(t)
 	type TestCase struct {
 		name             string
 		defendClaimDepth types.Depth
@@ -177,7 +167,6 @@ func TestSuperCannonDisputeGame(t *testing.T) {
 }
 
 func TestSuperCannonDefendStep(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -233,7 +222,6 @@ func TestSuperCannonStepWithLargePreimage(t *testing.T) {
 }
 
 func TestSuperCannonStepWithPreimage_nonExistingPreimage(t *testing.T) {
-	temporarilySkip(t)
 	preimageConditions := []string{"keccak", "sha256", "blob"}
 	testName := func(vm string, preimageType string) string {
 		return fmt.Sprintf("%v-%v", preimageType, vm)
@@ -248,7 +236,6 @@ func TestSuperCannonStepWithPreimage_nonExistingPreimage(t *testing.T) {
 }
 
 func TestSuperCannonStepWithPreimage_existingPreimage(t *testing.T) {
-	temporarilySkip(t)
 	// Only test pre-existing images with one type to save runtime
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		testSuperPreimageStep(t, utils.FirstKeccakPreimageLoad(), true, allocType)
@@ -256,7 +243,6 @@ func TestSuperCannonStepWithPreimage_existingPreimage(t *testing.T) {
 }
 
 func testSuperPreimageStep(t *testing.T, preimageType utils.PreimageOpt, preloadPreimage bool, allocType config.AllocType) {
-	temporarilySkip(t)
 	ctx := context.Background()
 	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
 
@@ -283,7 +269,6 @@ func testSuperPreimageStep(t *testing.T, preimageType utils.PreimageOpt, preload
 }
 
 func TestSuperCannonProposalValid_AttackWithCorrectTrace(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -293,7 +278,6 @@ func TestSuperCannonProposalValid_AttackWithCorrectTrace(t *testing.T) {
 }
 
 func TestSuperCannonProposalValid_DefendWithCorrectTrace(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -303,7 +287,6 @@ func TestSuperCannonProposalValid_DefendWithCorrectTrace(t *testing.T) {
 }
 
 func TestSuperCannonPoisonedPostState(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -313,7 +296,6 @@ func TestSuperCannonPoisonedPostState(t *testing.T) {
 }
 
 func TestSuperCannonRootBeyondProposedBlock_ValidRoot(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -323,7 +305,6 @@ func TestSuperCannonRootBeyondProposedBlock_ValidRoot(t *testing.T) {
 }
 
 func TestSuperCannonRootBeyondProposedBlock_InvalidRoot(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -333,7 +314,6 @@ func TestSuperCannonRootBeyondProposedBlock_InvalidRoot(t *testing.T) {
 }
 
 func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
@@ -343,7 +323,6 @@ func TestSuperCannonRootChangeClaimedRoot(t *testing.T) {
 }
 
 func TestSuperInvalidateUnsafeProposal(t *testing.T) {
-	temporarilySkip(t)
 	ctx := context.Background()
 	type TestCase struct {
 		name     string
@@ -429,7 +408,6 @@ func TestSuperInvalidateUnsafeProposal(t *testing.T) {
 }
 
 func TestSuperInvalidateProposalForFutureBlock(t *testing.T) {
-	temporarilySkip(t)
 	ctx := context.Background()
 	type TestCase struct {
 		name     string
@@ -492,7 +470,6 @@ func TestSuperInvalidateProposalForFutureBlock(t *testing.T) {
 }
 
 func TestSuperInvalidateCorrectProposalFutureBlock(t *testing.T) {
-	temporarilySkip(t)
 	ctx := context.Background()
 	type TestCase struct {
 		name     string
@@ -570,7 +547,6 @@ func TestSuperInvalidateCorrectProposalFutureBlock(t *testing.T) {
 }
 
 func TestSuperCannonHonestSafeTraceExtensionValidRoot(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 
@@ -624,7 +600,6 @@ func TestSuperCannonHonestSafeTraceExtensionValidRoot(t *testing.T) {
 }
 
 func TestSuperCannonHonestSafeTraceExtensionInvalidRoot(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 
@@ -684,7 +659,6 @@ func TestSuperCannonHonestSafeTraceExtensionInvalidRoot(t *testing.T) {
 }
 
 func TestSuperCannonGame_HonestCallsSteps(t *testing.T) {
-	temporarilySkip(t)
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()
 		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))


### PR DESCRIPTION
**Description**

Super dispute game tests were disabled with a supervisor update, but they start with interop from genesis so shouldn't have been affected by the supervisor change. 

This unskips them and updates the wait condition that ensured the supervisor had actually processed genesis before starting the test. Previously the supervisor reported the safe timestamp as 0 until it had started processing but now it appears to start from the genesis timestamp. Creating a new proposal at the genesis timestamp is invalid because that's the same timestamp as the anchor state. For good measure it also makes sure it has processed at least one L1 block which ensures that the first proposal's gas estimation doesn't happen against the L1 genesis block which causes an underflow in the contract (block.number - 1).

Also increases the no output time for e2e fuzz tests. They only print output when they have all completed and for whatever reason (maybe just compile time?) after https://github.com/ethereum-optimism/optimism/pull/16139 they now take longer so were failing on develop.

Cannon tests are now all passing https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/91963/workflows/a79039cd-c950-4c1d-b07c-94e4948a49a4 I just didn't rerun on the last commit as it only increased the e2e fuzz timeout.