### PR TITLE
devtest: use consistent logging, handle all test exit funcs

### DIFF
--- a/op-devstack/devtest/common.go
+++ b/op-devstack/devtest/common.go
@@ -16,11 +16,14 @@ import (
 // This CommonT interface is minimal enough such that it can be implemented by tooling,
 // and a *testing.T can be used with minimal wrapping.
 type CommonT interface {
-	Errorf(format string, args ...interface{})
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
 	FailNow()
 
 	TempDir() string
 	Cleanup(fn func())
+	Log(args ...any)
 	Logf(format string, args ...any)
 	Helper()
 	Name() string

--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -84,10 +84,13 @@ func DoMain(m *testing.M, opts ...stack.CommonOption) {
 		// Make the package-level logger use this context
 		logger.SetContext(ctx)
 
-		p := devtest.NewP(ctx, logger, func() {
+		p := devtest.NewP(ctx, logger, func(now bool) {
+			logger.Error("Main failed")
 			debug.PrintStack()
 			failed.Store(true)
-			panic("setup fail")
+			if now {
+				panic("critical Main fail")
+			}
 		})
 		defer p.Close()
 

--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -29,9 +29,13 @@ func TestControlPlane(gt *testing.T) {
 	p := devtest.NewP(
 		context.Background(),
 		logger,
-		func() {
+		func(now bool) {
 			gt.Helper()
-			gt.FailNow()
+			if now {
+				gt.FailNow()
+			} else {
+				gt.Fail()
+			}
 		},
 	)
 	gt.Cleanup(p.Close)
@@ -159,9 +163,13 @@ func TestControlPlaneFakePoS(gt *testing.T) {
 	p := devtest.NewP(
 		context.Background(),
 		logger,
-		func() {
+		func(now bool) {
 			gt.Helper()
-			gt.FailNow()
+			if now {
+				gt.FailNow()
+			} else {
+				gt.Fail()
+			}
 		},
 	)
 	gt.Cleanup(p.Close)

--- a/op-devstack/sysgo/system_test.go
+++ b/op-devstack/sysgo/system_test.go
@@ -20,10 +20,15 @@ func TestSystem(gt *testing.T) {
 
 	logger := testlog.Logger(gt, log.LevelInfo)
 
-	p := devtest.NewP(context.Background(), logger, func() {
-		gt.Helper()
-		gt.FailNow()
-	})
+	p := devtest.NewP(context.Background(), logger,
+		func(now bool) {
+			gt.Helper()
+			if now {
+				gt.FailNow()
+			} else {
+				gt.Fail()
+			}
+		})
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())


### PR DESCRIPTION
**Description**

- Always use the test-logger, don't log directly to the underlying Go test object, since that one does not handle late logs (causes panic).
- Support `Error`/`Log` variants of `Errorf`/`Logf`
- Fix package-level non-critical error to be reported up correctly

**Tests**

This should fix some flakes where `require.Eventually` uses the `Error` function (in a separate Go routine!), which used to log via `t.Error`, and bypass the panic recovery.


**Additional context**

`require.Eventually` is not safe to use with regular `t.Error` when there are multiple test exit conditions.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
