### PR TITLE
op-devstack: catch devtest late sub-test fails, and fix require.Eventually

### DIFF
--- a/op-devstack/devtest/common.go
+++ b/op-devstack/devtest/common.go
@@ -3,11 +3,12 @@ package devtest
 import (
 	"context"
 
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
 
 // CommonT is a subset of testing.T, extended with a few common utils.
@@ -31,7 +32,7 @@ type CommonT interface {
 	Logger() log.Logger
 	Tracer() trace.Tracer
 	Ctx() context.Context
-	Require() *require.Assertions
+	Require() *testreq.Assertions
 }
 
 type testScopeCtxKeyType struct{}

--- a/op-devstack/devtest/gate.go
+++ b/op-devstack/devtest/gate.go
@@ -25,3 +25,7 @@ func (g *gateAdapter) FailNow() {
 	g.inner.Helper()
 	g.inner.SkipNow()
 }
+
+func (g *gateAdapter) Helper() {
+	g.inner.Helper()
+}

--- a/op-devstack/devtest/package.go
+++ b/op-devstack/devtest/package.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
 
 // P is used by the preset package and system backends as testing interface, to host package-wide resources.
@@ -62,7 +64,7 @@ type implP struct {
 	cleanupLock    sync.Mutex
 	cleanupBacklog []func()
 
-	req *require.Assertions
+	req *testreq.Assertions
 }
 
 var _ P = (*implP)(nil)
@@ -139,7 +141,7 @@ func (t *implP) Ctx() context.Context {
 type wrapP struct {
 	ctx    context.Context
 	logger log.Logger
-	req    *require.Assertions
+	req    *testreq.Assertions
 	P
 }
 
@@ -160,11 +162,11 @@ func (t *implP) WithCtx(ctx context.Context, args ...any) P {
 	logger := t.logger.New(args...)
 	logger.SetContext(ctx)
 	out := &wrapP{ctx: ctx, logger: logger, P: t}
-	out.req = require.New(out)
+	out.req = testreq.New(out)
 	return out
 }
 
-func (t *implP) Require() *require.Assertions {
+func (t *implP) Require() *testreq.Assertions {
 	return t.req
 }
 
@@ -220,6 +222,6 @@ func NewP(ctx context.Context, logger log.Logger, onFail func(now bool)) P {
 		ctx:       AddTestScope(ctx, "pkg"),
 		cancel:    cancel,
 	}
-	out.req = require.New(out)
+	out.req = testreq.New(out)
 	return out
 }

--- a/op-devstack/dsl/common.go
+++ b/op-devstack/dsl/common.go
@@ -3,11 +3,10 @@ package dsl
 import (
 	"context"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
 
 // commonImpl provides a set of common values and methods inherited by all DSL structs.
@@ -24,7 +23,7 @@ type commonImpl struct {
 	// T is a minimal test interface for panic-checks / assertions.
 	t devtest.T
 	// Require is a helper around the above T, ready to assert against.
-	require *require.Assertions
+	require *testreq.Assertions
 }
 
 func commonFromT(t devtest.T) commonImpl {

--- a/op-devstack/shim/common.go
+++ b/op-devstack/shim/common.go
@@ -1,8 +1,7 @@
 package shim
 
 import (
-	"github.com/stretchr/testify/require"
-
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -28,13 +27,13 @@ func NewCommonConfig(t devtest.T) CommonConfig {
 type commonImpl struct {
 	log    log.Logger
 	t      devtest.T
-	req    *require.Assertions
+	req    *testreq.Assertions
 	labels *locks.RWMap[string, string]
 }
 
 var _ interface {
 	stack.Common
-	require() *require.Assertions
+	require() *testreq.Assertions
 } = (*commonImpl)(nil)
 
 // newCommon creates an object to hold on to common component data, safe to embed in other structs
@@ -55,7 +54,7 @@ func (c *commonImpl) Logger() log.Logger {
 	return c.log
 }
 
-func (c *commonImpl) require() *require.Assertions {
+func (c *commonImpl) require() *testreq.Assertions {
 	return c.req
 }
 

--- a/op-devstack/shim/keyring.go
+++ b/op-devstack/shim/keyring.go
@@ -3,22 +3,21 @@ package shim
 import (
 	"crypto/ecdsa"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
 
 type keyringImpl struct {
 	keys    devkeys.Keys
-	require *require.Assertions
+	require *testreq.Assertions
 }
 
 var _ stack.Keys = (*keyringImpl)(nil)
 
-func NewKeyring(keys devkeys.Keys, req *require.Assertions) stack.Keys {
+func NewKeyring(keys devkeys.Keys, req *testreq.Assertions) stack.Keys {
 	return &keyringImpl{
 		keys:    keys,
 		require: req,

--- a/op-devstack/stack/match/gate_test.go
+++ b/op-devstack/stack/match/gate_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
 
 type gateTesting struct {
@@ -22,13 +23,16 @@ func (g *gateTesting) FailNow() {
 	panic("gate hit")
 }
 
+func (g *gateTesting) Helper() {
+}
+
 type fakeTesting struct {
 	devtest.T // embedded but nil, to inherit interface
 	g         *gateTesting
 }
 
-func (f *fakeTesting) Gate() *require.Assertions {
-	return require.New(f.g)
+func (f *fakeTesting) Gate() *testreq.Assertions {
+	return testreq.New(f.g)
 }
 
 func TestAssume(t *testing.T) {

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -7,11 +7,9 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
@@ -23,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 )
 
@@ -123,7 +122,7 @@ type worldBuilder struct {
 	p devtest.P
 
 	logger  log.Logger
-	require *require.Assertions
+	require *testreq.Assertions
 	keys    devkeys.Keys
 
 	builder intentbuilder.Builder

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -27,10 +27,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
 
@@ -300,7 +300,7 @@ type p2pClientsAndPeers struct {
 	peerInfo2 *apis.PeerInfo
 }
 
-func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *require.Assertions, l2CL1, l2CL2 *L2CLNode) *p2pClientsAndPeers {
+func getP2PClientsAndPeers(ctx context.Context, logger log.Logger, require *testreq.Assertions, l2CL1, l2CL2 *L2CLNode) *p2pClientsAndPeers {
 	p2pClient1, err := GetP2PClient(ctx, logger, l2CL1)
 	require.NoError(err)
 	p2pClient2, err := GetP2PClient(ctx, logger, l2CL2)

--- a/op-service/README.md
+++ b/op-service/README.md
@@ -41,6 +41,7 @@ Pull requests: [monorepo](https://github.com/ethereum-optimism/optimism/pulls?q=
 ├── solabi          - Utils to encode/decode Solidity ABI formatted data
 ├── sources         - RPC client bindings
 ├── tasks           - Err-group with panic handling
+├── testreq         - Extension and improvement of the common `testify/require` package.
 ├── testlog         - Test logger and log-capture utils for testing
 ├── testutils       - Simplified Ethereum types, mock RPC bindings, utils for testing.
 ├── tls             - CLI flags and utils to work with TLS connections

--- a/op-service/testreq/require.go
+++ b/op-service/testreq/require.go
@@ -1,0 +1,90 @@
+package testreq
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestingT interface {
+	require.TestingT
+	Helper()
+}
+
+// Assertions extends and improves require.Assertions
+type Assertions struct {
+	require.Assertions
+	t TestingT
+}
+
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		Assertions: *require.New(t),
+		t:          t,
+	}
+}
+
+// wrapCondition protects against panics in the test-condition, and then turns them into test fails.
+// Used by Assertions.Eventually and Assertions.Eventuallyf.
+func wrapCondition(fn func() bool, panicV *any) func() bool {
+	// condition runs on its own go-routine, and would crash the whole test-suite if a panic is not caught
+	return func() (met bool) {
+		defer func() {
+			if v := recover(); v != nil {
+				*panicV = v
+				// consider it met; we want the condition to exit, not to retry
+				met = true
+			}
+		}()
+		return fn()
+	}
+}
+
+// wrapConditionCollectT protects against panics in the test-condition, and then turns them into test fails.
+// Used by Assertions.EventuallyWithT and Assertions.EventuallyWithTf.
+func wrapConditionCollectT(fn func(collect *assert.CollectT), panicV *any) func(collect *assert.CollectT) {
+	// condition runs on its own go-routine, and would crash the whole test-suite if a panic is not caught
+	return func(collect *assert.CollectT) {
+		defer func() {
+			if v := recover(); v != nil {
+				*panicV = v
+				// collect no error; we want the condition to exit, not to retry
+			}
+		}()
+		fn(collect)
+	}
+}
+
+// Eventually implements require.Eventually, with panic-protection for the condition.
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	a.t.Helper()
+	var panicV any
+	a.Assertions.Eventually(wrapCondition(condition, &panicV), waitFor, tick, msgAndArgs...)
+	a.Assertions.Nil(panicV, "condition must not panic, condition: "+fmt.Sprintln(msgAndArgs...))
+}
+
+// Eventuallyf implements require.Eventuallyf, with panic-protection for the condition.
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	a.t.Helper()
+	var panicV any
+	a.Assertions.Eventuallyf(wrapCondition(condition, &panicV), waitFor, tick, msg, args...)
+	a.Assertions.Nil(panicV, "condition must not panic, condition: "+fmt.Sprintf(msg, args...))
+}
+
+// EventuallyWithT implements require.EventuallyWithT, with panic-protection for the condition.
+func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	a.t.Helper()
+	var panicV any
+	a.Assertions.EventuallyWithT(wrapConditionCollectT(condition, &panicV), waitFor, tick, msgAndArgs...)
+	a.Assertions.Nil(panicV, "condition must not panic, condition: "+fmt.Sprintln(msgAndArgs...))
+}
+
+// EventuallyWithTf implements require.EventuallyWithTf, with panic-protection for the condition.
+func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	a.t.Helper()
+	var panicV any
+	a.Assertions.EventuallyWithTf(wrapConditionCollectT(condition, &panicV), waitFor, tick, msg, args...)
+	a.Assertions.Nil(panicV, "condition must not panic, condition: "+fmt.Sprintf(msg, args...))
+}

--- a/op-service/testreq/require_test.go
+++ b/op-service/testreq/require_test.go
@@ -1,0 +1,79 @@
+package testreq
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTester struct {
+	errStr  []string
+	failNow bool
+}
+
+func (f *mockTester) Errorf(format string, args ...interface{}) {
+	f.errStr = append(f.errStr, fmt.Sprintf(format, args...))
+}
+
+func (f *mockTester) FailNow() {
+	f.failNow = true
+}
+
+func (f *mockTester) Helper() {
+}
+
+var _ TestingT = (*mockTester)(nil)
+
+func TestEventually(t *testing.T) {
+	t.Run("Eventually", func(t *testing.T) {
+		m := &mockTester{}
+		req := New(m)
+		req.Eventually(func() bool {
+			panic("testing the panic")
+		}, time.Second, time.Millisecond*50, "abc")
+		require.Len(t, m.errStr, 1)
+		require.Contains(t, m.errStr[0], "testing the panic")
+		require.Contains(t, m.errStr[0], "condition must not panic")
+		require.Contains(t, m.errStr[0], "abc")
+		require.True(t, m.failNow)
+	})
+	t.Run("Eventuallyf", func(t *testing.T) {
+		m := &mockTester{}
+		req := New(m)
+		req.Eventuallyf(func() bool {
+			panic("testing the panic")
+		}, time.Second, time.Millisecond*50, "abc")
+		require.Len(t, m.errStr, 1)
+		require.Contains(t, m.errStr[0], "testing the panic")
+		require.Contains(t, m.errStr[0], "condition must not panic")
+		require.Contains(t, m.errStr[0], "abc")
+		require.True(t, m.failNow)
+	})
+	t.Run("EventuallyWithT", func(t *testing.T) {
+		m := &mockTester{}
+		req := New(m)
+		req.EventuallyWithT(func(t *assert.CollectT) {
+			panic("testing the panic")
+		}, time.Second, time.Millisecond*50, "abc")
+		require.Len(t, m.errStr, 1)
+		require.Contains(t, m.errStr[0], "testing the panic")
+		require.Contains(t, m.errStr[0], "condition must not panic")
+		require.Contains(t, m.errStr[0], "abc")
+		require.True(t, m.failNow)
+	})
+	t.Run("EventuallyWithTf", func(t *testing.T) {
+		m := &mockTester{}
+		req := New(m)
+		req.EventuallyWithTf(func(t *assert.CollectT) {
+			panic("testing the panic")
+		}, time.Second, time.Millisecond*50, "abc")
+		require.Len(t, m.errStr, 1)
+		require.Contains(t, m.errStr[0], "testing the panic")
+		require.Contains(t, m.errStr[0], "condition must not panic")
+		require.Contains(t, m.errStr[0], "abc")
+		require.True(t, m.failNow)
+	})
+}

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -9,14 +9,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/require"
-
-	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 // function fields(lambdas) corresponding to solidity functions must be tagged with sol
@@ -48,7 +47,7 @@ func (c *BaseCallView) Client() apis.EthClient {
 
 // BaseCall represents minimal testing interface
 type BaseTest interface {
-	Require() *require.Assertions
+	Require() *testreq.Assertions
 	Ctx() context.Context
 }
 


### PR DESCRIPTION
**Description**

The `condition` of `require.Eventually` runs on its own go-routine.
This go-routine can interact with the test, but the test can exit before the routine exits.
This causes panics on the go-routine, which makes the whole test suite blow up with noisy errors.

So I fixed it in two ways:
- by wrapping the eventually-functions, and catching the panic in the condition, to then mark the eventually check as failed by panic.
- by catching the case where the test-scope is already closed and failing: new fails are redundant and can be safely ignored.

This way we have good error reporting for the panics on the eventually functions, and we catch the more generalized case.

Future fixes/extensions may be added to the `testreq.Assertions` type.

**Tests**

Tested the require customizations that pickup the panic.


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
