### PR TITLE
op-e2e: work around for rust team

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -144,6 +144,10 @@ func DeployConfig(allocType AllocType) *genesis.DeployConfig {
 }
 
 func init() {
+	// Used by the rust team, to skip legacy op-e2e init. Not used by devstack acceptance tests.
+	if os.Getenv("DISABLE_OP_E2E_LEGACY") == "true" {
+		return
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**Description**

Introduces the ability to disable op-e2e allocs loading with an env var.
No guarantees, but useful for the rust team.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
