### PR TITLE
Cherry pick StandardValidator changes into the v4.0.0 proposal branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ commands:
             git reset --hard
             git clean -df
             just <<parameters.command>>
+            git diff
             [ -z "$(git status --porcelain)" ] || exit 1
           working_directory: packages/contracts-bedrock
           when: always

--- a/packages/contracts-bedrock/interfaces/L1/IStandardValidator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IStandardValidator.sol
@@ -33,6 +33,7 @@ interface IStandardValidator {
         address challenger;
     }
 
+    function version() external view returns (string memory);
     function anchorStateRegistryImpl() external view returns (address);
     function anchorStateRegistryVersion() external pure returns (string memory);
     function challenger() external view returns (address);

--- a/packages/contracts-bedrock/interfaces/cannon/IMIPS64.sol
+++ b/packages/contracts-bedrock/interfaces/cannon/IMIPS64.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
+
+/// @title IMIPS64
+/// @notice Interface for the MIPS64 contract.
+interface IMIPS64 is ISemver {
+    struct State {
+        bytes32 memRoot;
+        bytes32 preimageKey;
+        uint32 preimageOffset;
+        uint32 pc;
+        uint32 nextPC;
+        uint32 lo;
+        uint32 hi;
+        uint32 heap;
+        uint8 exitCode;
+        bool exited;
+        uint64 step;
+        uint32[32] registers;
+    }
+
+    error InvalidExitedValue();
+    error InvalidPC();
+    error InvalidSecondMemoryProof();
+    error UnsupportedStateVersion();
+    error InvalidMemoryProof();
+    error InvalidRMWInstruction();
+
+    function version() external view returns (string memory);
+    function oracle() external view returns (IPreimageOracle oracle_);
+    function stateVersion() external view returns (uint256 stateVersion_);
+    function step(bytes memory _stateData, bytes memory _proof, bytes32 _localContext) external returns (bytes32 postState_);
+
+    function __constructor__(IPreimageOracle _oracle, uint256 _stateVersion) external;
+}

--- a/packages/contracts-bedrock/scripts/checks/check-frozen-files.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-frozen-files.sh
@@ -48,6 +48,7 @@ changed_contracts=$(jq -r '
 # In order to prevent a file from being modified, comment it out. Do not delete it.
 # All files in semver-lock.json should be in this list.
 ALLOWED_FILES=(
+  "src/L1/StandardValidator.sol:StandardValidator"
   "src/L1/DataAvailabilityChallenge.sol:DataAvailabilityChallenge"
   # "src/L1/ETHLockbox.sol:ETHLockbox"
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger"

--- a/packages/contracts-bedrock/snapshots/abi/StandardValidator.json
+++ b/packages/contracts-bedrock/snapshots/abi/StandardValidator.json
@@ -549,6 +549,19 @@
   },
   {
     "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "withdrawalDelaySeconds",
     "outputs": [
       {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -31,6 +31,10 @@
     "initCodeHash": "0x5a76c8530cb24cf23d3baacc6eefaac226382af13f1e2a35535d2ec2b0573b29",
     "sourceCodeHash": "0xb3e32b18c95d4940980333e1e99b4dcf42d8a8bfce78139db4dc3fb06e9349d0"
   },
+  "src/L1/StandardValidator.sol:StandardValidator": {
+    "initCodeHash": "0x035d23030f111046ba1d4daa5d7c3f476716e828e8eba8849554b61d9bbeb117",
+    "sourceCodeHash": "0x9b48cde5b2fcd6e5399ed3fa27be48ae071891dba93d4ff393e81345298eb6da"
+  },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x0ea921059d71fd19ac9c6e29c05b9724ad584eb27f74231de6df9551e9b13084",
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -32,7 +32,7 @@
     "sourceCodeHash": "0xb3e32b18c95d4940980333e1e99b4dcf42d8a8bfce78139db4dc3fb06e9349d0"
   },
   "src/L1/StandardValidator.sol:StandardValidator": {
-    "initCodeHash": "0x2f62a134cff1c82a5a7aa2f2f7ff93fcbf48f5ff16f3fea4f06a8ce5a85f2dbd",
+    "initCodeHash": "0x13e15cc4ba947a46c7bf4e3bf764a2b142b8e5cb3e12a9bbddc63058d00430dd",
     "sourceCodeHash": "0x3fb114ff0219b0541ee9ec8c287f167a27546270c01b9ac235c574c7df28361c"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xb3e32b18c95d4940980333e1e99b4dcf42d8a8bfce78139db4dc3fb06e9349d0"
   },
   "src/L1/StandardValidator.sol:StandardValidator": {
-    "initCodeHash": "0x035d23030f111046ba1d4daa5d7c3f476716e828e8eba8849554b61d9bbeb117",
-    "sourceCodeHash": "0x9b48cde5b2fcd6e5399ed3fa27be48ae071891dba93d4ff393e81345298eb6da"
+    "initCodeHash": "0x2f62a134cff1c82a5a7aa2f2f7ff93fcbf48f5ff16f3fea4f06a8ce5a85f2dbd",
+    "sourceCodeHash": "0x3fb114ff0219b0541ee9ec8c287f167a27546270c01b9ac235c574c7df28361c"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x0ea921059d71fd19ac9c6e29c05b9724ad584eb27f74231de6df9551e9b13084",

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -200,7 +200,7 @@ contract StandardValidator is ISemver {
 
     /// @notice Returns the expected MIPS version.
     function mipsVersion() public pure returns (string memory) {
-        return "1.5.0";
+        return "1.4.0";
     }
 
     /// @notice Returns the expected OptimismMintableERC20Factory version.

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -35,8 +35,8 @@ import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 /// before and after an upgrade.
 contract StandardValidator is ISemver {
     /// @notice The semantic version of the StandardValidator contract.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.1.0-patch.1
+    string public constant version = "1.1.0-patch.1";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -32,6 +32,7 @@ import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { IStandardBridge } from "interfaces/universal/IStandardBridge.sol";
 import { IStandardValidator } from "interfaces/L1/IStandardValidator.sol";
+import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 
 /// @title BadDisputeGameFactoryReturner
 /// @notice Used to return a bad DisputeGameFactory address to the StandardValidator. Far easier
@@ -862,7 +863,17 @@ contract StandardValidator_PermissionedDisputeGame_Test is StandardValidator_Tes
     ///         PermissionedDisputeGame VM address is invalid.
     function test_validate_permissionedDisputeGameInvalidVM_succeeds() public {
         vm.mockCall(address(pdg), abi.encodeCall(IPermissionedDisputeGame.vm, ()), abi.encode(address(0xbad)));
-        assertEq("PDDG-50", _validate(true));
+        vm.mockCall(address(0xbad), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
+        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(7));
+        assertEq("PDDG-VM-10,PDDG-VM-20", _validate(true));
+    }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         PermissionedDisputeGame VM's state version is invalid.
+    function test_validate_permissionedDisputeGameInvalidVMStateVersion_succeeds() public {
+        vm.mockCall(address(pdg), abi.encodeCall(IPermissionedDisputeGame.vm, ()), abi.encode(address(mips)));
+        vm.mockCall(address(mips), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(6));
+        assertEq("PDDG-VM-30,PLDG-VM-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1166,7 +1177,17 @@ contract StandardValidator_FaultDisputeGame_Test is StandardValidator_TestInit {
     ///         FaultDisputeGame (permissionless) VM address is invalid.
     function test_validate_faultDisputeGameInvalidVM_succeeds() public {
         vm.mockCall(address(fdg), abi.encodeCall(IFaultDisputeGame.vm, ()), abi.encode(address(0xbad)));
-        assertEq("PLDG-50", _validate(true));
+        vm.mockCall(address(0xbad), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
+        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(7));
+        assertEq("PLDG-VM-10,PLDG-VM-20", _validate(true));
+    }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         FaultDisputeGame (permissionless) VM's state version is invalid.
+    function test_validate_faultDisputeGameInvalidVMStateVersion_succeeds() public {
+        vm.mockCall(address(fdg), abi.encodeCall(IFaultDisputeGame.vm, ()), abi.encode(address(mips)));
+        vm.mockCall(address(mips), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(6));
+        assertEq("PDDG-VM-30,PLDG-VM-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the

--- a/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/StandardValidator.t.sol
@@ -37,7 +37,6 @@ import { IStandardValidator } from "interfaces/L1/IStandardValidator.sol";
 /// @notice Used to return a bad DisputeGameFactory address to the StandardValidator. Far easier
 ///         than the alternative ways of mocking this value since the normal vm.mockCall will cause
 ///         the validation function to revert.
-
 contract BadDisputeGameFactoryReturner {
     /// @notice Address of the StandardValidator instance.
     IStandardValidator public immutable validator;
@@ -72,7 +71,7 @@ contract BadDisputeGameFactoryReturner {
 }
 
 /// @title StandardValidator_TestInit
-/// @notice Base contract for StandardValidator tests, handles common setup.
+/// @notice Base contract for `StandardValidator` tests, handles common setup.
 contract StandardValidator_TestInit is CommonTest {
     /// @notice StandardValidator instance, used for testing.
     IStandardValidator validator;
@@ -247,9 +246,9 @@ contract StandardValidator_TestInit is CommonTest {
     }
 }
 
-/// @title StandardValidator_validate_Test
-/// @notice Tests the StandardValidator.validate function.
-contract StandardValidator_validate_Test is StandardValidator_TestInit {
+/// @title StandardValidator_CoreValidation_Test
+/// @notice Tests the basic functionality of the `validate` function when all parameters are valid
+contract StandardValidator_CoreValidation_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function succeeds when all parameters are valid.
     function test_validate_succeeds() public view {
         string memory errors = _validate(false);
@@ -262,7 +261,61 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         string memory errors = _validate(true);
         assertEq(errors, "");
     }
+}
 
+/// @title StandardValidator_GeneralOverride_Test
+/// @notice Tests behavior of validation overrides when multiple parameters are overridden
+///         simultaneously
+contract StandardValidator_GeneralOverride_Test is StandardValidator_TestInit {
+    /// @notice Tests that the validate function (with the L1PAOMultisig and Challenger overridden)
+    ///         successfully returns the right error when both are invalid.
+    function test_validateL1PAOMultisigAndChallengerOverrides_succeeds() public view {
+        IStandardValidator.ValidationOverrides memory overrides = _defaultValidationOverrides();
+        overrides.l1PAOMultisig = address(0xace);
+        overrides.challenger = address(0xbad);
+        assertEq(
+            "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30",
+            _validate(true, overrides)
+        );
+    }
+
+    /// @notice Tests that the validate function (with the L1PAOMultisig and Challenger overridden)
+    ///         successfully returns no error when there is none. That is, it never returns the
+    ///         overridden strings alone.
+    function test_validateOverrides_noErrors_succeeds() public {
+        IStandardValidator.ValidationOverrides memory overrides =
+            IStandardValidator.ValidationOverrides({ l1PAOMultisig: address(0xbad), challenger: address(0xc0ffee) });
+        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(overrides.l1PAOMultisig));
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.owner, ()),
+            abi.encode(overrides.l1PAOMultisig)
+        );
+        vm.mockCall(
+            address(pdg), abi.encodeCall(IPermissionedDisputeGame.challenger, ()), abi.encode(overrides.challenger)
+        );
+
+        assertEq("OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER", _validate(true, overrides));
+    }
+
+    /// @notice Tests that the validate function (with overrides) and allow failure set to false,
+    ///         returns the errors with the overrides prepended.
+    function test_validateOverrides_notAllowFailurePrependsOverrides_succeeds() public {
+        IStandardValidator.ValidationOverrides memory overrides =
+            IStandardValidator.ValidationOverrides({ l1PAOMultisig: address(0xbad), challenger: address(0xc0ffee) });
+
+        vm.expectRevert(
+            bytes(
+                "StandardValidator: OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30"
+            )
+        );
+        _validate(false, overrides);
+    }
+}
+/// @title StandardValidator_SuperchainConfig_Test
+/// @notice Tests validation of `SuperchainConfig` contract configuration
+
+contract StandardValidator_SuperchainConfig_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         SuperchainConfig contract is paused.
     function test_validate_superchainConfigPaused_succeeds() public {
@@ -273,7 +326,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("SPRCFG-10", _validate(true));
     }
+}
 
+/// @title StandardValidator_ProxyAdmin_Test
+/// @notice Tests validation of `ProxyAdmin` configuration
+contract StandardValidator_ProxyAdmin_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         ProxyAdmin owner is not correct.
     function test_validate_invalidProxyAdminOwner_succeeds() public {
@@ -281,8 +338,8 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         assertEq("PROXYA-10,PDDG-DWETH-30,PLDG-DWETH-30", _validate(true));
     }
 
-    /// @notice Tests that the validate function successfully returns the right overrides error when the
-    ///         ProxyAdmin owner is overriden but is correct.
+    /// @notice Tests that the validate function successfully returns the right overrides error
+    ///         when the ProxyAdmin owner is overridden but is correct.
     function test_validate_overridenProxyAdminOwner_succeeds() public {
         IStandardValidator.ValidationOverrides memory overrides = _defaultValidationOverrides();
         overrides.l1PAOMultisig = address(0xbad);
@@ -302,7 +359,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         overrides.l1PAOMultisig = address(0xbad);
         assertEq("OVERRIDES-L1PAOMULTISIG,PROXYA-10,DF-30,PDDG-DWETH-30,PLDG-DWETH-30", _validate(true, overrides));
     }
+}
 
+/// @title StandardValidator_SystemConfig_Test
+/// @notice Tests validation of `SystemConfig` configuration
+contract StandardValidator_SystemConfig_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         SystemConfig version is invalid.
     function test_validate_systemConfigInvalidVersion_succeeds() public {
@@ -420,7 +481,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("SYSCON-140", _validate(true));
     }
+}
 
+/// @title StandardValidator_L1CrossDomainMessenger_Test
+/// @notice Tests validation of `L1CrossDomainMessenger` configuration
+contract StandardValidator_L1CrossDomainMessenger_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         L1CrossDomainMessenger version is invalid.
     function test_validate_l1CrossDomainMessengerInvalidVersion_succeeds() public {
@@ -504,7 +569,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("L1xDM-80", _validate(true));
     }
+}
 
+/// @title StandardValidator_OptimismMintableERC20Factory_Test
+/// @notice Tests validation of `OptimismMintableERC20Factory` configuration
+contract StandardValidator_OptimismMintableERC20Factory_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         OptimismMintableERC20Factory version is invalid.
     function test_validate_optimismMintableERC20FactoryInvalidVersion_succeeds() public {
@@ -544,7 +613,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("MERC20F-40", _validate(true));
     }
+}
 
+/// @title StandardValidator_L1ERC721Bridge_Test
+/// @notice Tests validation of `L1ERC721Bridge` configuration
+contract StandardValidator_L1ERC721Bridge_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         L1ERC721Bridge version is invalid.
     function test_validate_l1ERC721BridgeInvalidVersion_succeeds() public {
@@ -608,7 +681,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("L721B-80", _validate(true));
     }
+}
 
+/// @title StandardValidator_OptimismPortal_Test
+/// @notice Tests validation of `OptimismPortal` configuration
+contract StandardValidator_OptimismPortal_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         OptimismPortal version is invalid.
     function test_validate_optimismPortalInvalidVersion_succeeds() public {
@@ -662,7 +739,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("PORTAL-90", _validate(true));
     }
+}
 
+/// @title StandardValidator_ETHLockbox_Test
+/// @notice Tests validation of `ETHLockbox` configuration
+contract StandardValidator_ETHLockbox_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         ETHLockbox version is invalid.
     function test_validate_ethLockboxInvalidVersion_succeeds() public {
@@ -705,7 +786,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("LOCKBOX-50", _validate(true));
     }
+}
 
+/// @title StandardValidator_DisputeGameFactory_Test
+/// @notice Tests validation of `DisputeGameFactory` configuration
+contract StandardValidator_DisputeGameFactory_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         DisputeGameFactory version is invalid.
     function test_validate_disputeGameFactoryInvalidVersion_succeeds() public {
@@ -732,7 +817,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("DF-30", _validate(true));
     }
+}
 
+/// @title StandardValidator_PermissionedDisputeGame_Test
+/// @notice Tests validation of `PermissionedDisputeGame` configuration
+contract StandardValidator_PermissionedDisputeGame_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         PermissionedDisputeGame implementation is null.
     function test_validate_permissionedDisputeGameNullImplementation_succeeds() public {
@@ -856,7 +945,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         overrides.challenger = address(0xbad);
         assertEq("OVERRIDES-CHALLENGER,PDDG-130", _validate(true, overrides));
     }
+}
 
+/// @title StandardValidator_AnchorStateRegistry_Test
+/// @notice Tests validation of `AnchorStateRegistry` configuration
+contract StandardValidator_AnchorStateRegistry_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         AnchorStateRegistry version is invalid.
     function test_validate_anchorStateRegistryInvalidVersion_succeeds() public {
@@ -916,7 +1009,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("PDDG-ANCHORP-60,PLDG-ANCHORP-60", _validate(true));
     }
+}
 
+/// @title StandardValidator_DelayedWETH_Test
+/// @notice Tests validation of `DelayedWETH` configuration
+contract StandardValidator_DelayedWETH_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         DelayedWETH version is invalid.
     function test_validate_delayedWETHInvalidVersion_succeeds() public {
@@ -999,7 +1096,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
             assertEq("PLDG-DWETH-60", _validate(true));
         }
     }
+}
 
+/// @title StandardValidator_PreimageOracle_Test
+/// @notice Tests validation of `PreimageOracle` configuration
+contract StandardValidator_PreimageOracle_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         PreimageOracle version is invalid.
     function test_validate_preimageOracleInvalidVersion_succeeds() public {
@@ -1020,7 +1121,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         vm.mockCall(address(preimageOracle), abi.encodeCall(IPreimageOracle.minProposalSize, ()), abi.encode(1000));
         assertEq("PDDG-PIMGO-30,PLDG-PIMGO-30", _validate(true));
     }
+}
 
+/// @title StandardValidator_FaultDisputeGame_Test
+/// @notice Tests validation of `FaultDisputeGame` configuration
+contract StandardValidator_FaultDisputeGame_Test is StandardValidator_TestInit {
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         FaultDisputeGame (permissionless) implementation is null.
     function test_validate_faultDisputeGameNullImplementation_succeeds() public {
@@ -1107,7 +1212,11 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("PLDG-110", _validate(true));
     }
+}
 
+/// @title StandardValidator_L1StandardBridge_Test
+/// @notice Tests validation of `L1StandardBridge` configuration
+contract StandardValidator_L1StandardBridge_Test is StandardValidator_TestInit {
     // L1StandardBridge Tests
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         L1StandardBridge version is invalid.
@@ -1169,53 +1278,12 @@ contract StandardValidator_validate_Test is StandardValidator_TestInit {
         );
         assertEq("L1SB-80", _validate(true));
     }
+}
 
-    /// @notice Tests that the validate function (with the L1PAOMultisig and Challenger overriden)
-    ///         successfully returns the right error when both are invalid.
-    function test_validateL1PAOMultisigAndChallengerOverrides_succeeds() public view {
-        IStandardValidator.ValidationOverrides memory overrides = _defaultValidationOverrides();
-        overrides.l1PAOMultisig = address(0xace);
-        overrides.challenger = address(0xbad);
-        assertEq(
-            "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30",
-            _validate(true, overrides)
-        );
-    }
-
-    /// @notice Tests that the validate function (with the L1PAOMultisig and Challenger overriden)
-    ///         successfully returns no error when there is none. That is, it never returns the
-    ///         overriden strings alone.
-    function test_validateOverrides_noErrors_succeeds() public {
-        IStandardValidator.ValidationOverrides memory overrides =
-            IStandardValidator.ValidationOverrides({ l1PAOMultisig: address(0xbad), challenger: address(0xc0ffee) });
-        vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(overrides.l1PAOMultisig));
-        vm.mockCall(
-            address(disputeGameFactory),
-            abi.encodeCall(IDisputeGameFactory.owner, ()),
-            abi.encode(overrides.l1PAOMultisig)
-        );
-        vm.mockCall(
-            address(pdg), abi.encodeCall(IPermissionedDisputeGame.challenger, ()), abi.encode(overrides.challenger)
-        );
-
-        assertEq("OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER", _validate(true, overrides));
-    }
-
-    /// @notice Tests that the validate function (with overrides) and allow failure set to false,
-    ///         returns the errors with the overrides prepended.
-    function test_validateOverrides_notAllowFailurePrependsOverrides_succeeds() public {
-        IStandardValidator.ValidationOverrides memory overrides =
-            IStandardValidator.ValidationOverrides({ l1PAOMultisig: address(0xbad), challenger: address(0xc0ffee) });
-
-        vm.expectRevert(
-            bytes(
-                "StandardValidator: OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30"
-            )
-        );
-        _validate(false, overrides);
-    }
-
-    /// @notice Tests that the version getter functions on StandardValidator return non-empty
+/// @title StandardValidator_Versions_Test
+/// @notice Tests the `version` functions on `StandardValidator`.
+contract StandardValidator_Versions_Test is StandardValidator_TestInit {
+    /// @notice Tests that the version getter functions on `StandardValidator` return non-empty
     ///         strings.
     function test_versions_succeeds() public view {
         assertTrue(bytes(validator.systemConfigVersion()).length > 0, "systemConfigVersion empty");

--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -937,6 +937,7 @@ contract Specification_Test is CommonTest {
             _name: "StandardValidator",
             _sel: _getSel("validate((address,address,bytes32,uint256),bool,(address,address))")
         });
+        _addSpec({ _name: "StandardValidator", _sel: _getSel("version()") });
     }
 
     /// @dev Computes the selector from a function signature.


### PR DESCRIPTION
This PR includes 5 commits: 

- dc2c32fea910cad42abd6a186767b25e9f203574 cherry picks a refactor to `StandardValidator.t.sol`. Although this doesn't affect release code, it makes the next commit easier to apply.
- 81c9d3843b7610380afee5b74f404a3702477265 brings over changes to the StandardValidator from `develop`
- 4ce3ea3b98adb301f0f0d459e4f4763de7a25814 minimally modifies those changes to make them work against the release version of MIPS64.
- df2777d67fb4 fixes a failing test in Specs.t.sol (which has been removed from `develop`.
- 61928d9b867f0902024b23461ae6d4d9d6717442 adds `-patch.1` to the StandardValidator semver