### PR TITLE
chore(kt-devnet): rework parsing logic

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -193,8 +193,27 @@ func (f *ServiceFinder) triageUniversalL2Service(name string) serviceParser {
 	}
 }
 
+type serviceParserRules map[string]serviceParser
+
+func (spr serviceParserRules) apply(serviceName string, endpoints descriptors.EndpointMap) *triagedService {
+	for tag, rule := range spr {
+		if idx, accept, ok := rule(serviceName); ok {
+			return &triagedService{
+				tag:    tag,
+				idx:    idx,
+				accept: accept,
+				svc: &descriptors.Service{
+					Name:      serviceName,
+					Endpoints: endpoints,
+				},
+			}
+		}
+	}
+	return nil
+}
+
 func (f *ServiceFinder) triage() {
-	rules := map[string]serviceParser{
+	rules := serviceParserRules{
 		"el":         f.triageNode("el-"),
 		"cl":         f.triageNode("cl-"),
 		"batcher":    f.triageExclusiveL2Service("op-batcher-"),
@@ -211,19 +230,11 @@ func (f *ServiceFinder) triage() {
 		for portName, portInfo := range svc.Ports {
 			endpoints[portName] = portInfo
 		}
-		svc := &descriptors.Service{
-			Name:      serviceName,
-			Endpoints: endpoints,
-		}
-		for tag, rule := range rules {
-			if idx, accept, ok := rule(serviceName); ok {
-				triagedServices = append(triagedServices, &triagedService{
-					tag:    tag,
-					idx:    idx,
-					accept: accept,
-					svc:    svc,
-				})
-			}
+
+		svc := rules.apply(serviceName, endpoints)
+
+		if svc != nil {
+			triagedServices = append(triagedServices, svc)
 		}
 	}
 


### PR DESCRIPTION
**Description**

This doesn't change functionality.

Isolate the service name parsing logic into a function, so that:
- we easily stop after the first match
- we make some room for an alternate strategy in the main triaging procedure.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
