### PR TITLE
feat(kt-devnet): activate labels-based triaging as backup

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -25,6 +25,10 @@ type ServiceFinder struct {
 	depsets  map[string]descriptors.DepSet
 
 	triagedServices []*triagedService
+
+	// TODO: remove once we move node services recognition to labels
+	nodeNames2Index map[string]int
+	nodeNextIndex   int
 }
 
 // ServiceFinderOption configures a ServiceFinder
@@ -212,6 +216,47 @@ func (spr serviceParserRules) apply(serviceName string, endpoints descriptors.En
 	return nil
 }
 
+// TODO: this might need some adjustments as we stabilize labels in optimism-package
+const (
+	kindLabel      = "op.kind"
+	networkIDLabel = "op.network.id"
+	nodeNameLabel  = "op.network.participant.name"
+)
+
+func (f *ServiceFinder) triageByLabels(svc *inspect.Service, name string, endpoints descriptors.EndpointMap) *triagedService {
+	tag, ok := svc.Labels[kindLabel]
+	if !ok {
+		return nil
+	}
+	id, ok := svc.Labels[networkIDLabel]
+	if !ok {
+		return nil
+	}
+
+	// TODO: we really don't need numeric index for nodes, but it's a quick fix until
+	// we move node services recognition to labels entirely.
+	idx := -1
+	if name, ok := svc.Labels[nodeNameLabel]; ok {
+		if val, ok := f.nodeNames2Index[name]; ok {
+			idx = val
+		} else {
+			idx = f.nodeNextIndex
+			f.nodeNames2Index[name] = idx
+			f.nodeNextIndex++
+		}
+	}
+	return &triagedService{
+		tag: tag,
+		idx: idx,
+		// TODO: eventually we can retire the "name" part, but it doesn't hurt for now
+		accept: acceptNamesOrIDs(strings.Split(id, ",")...),
+		svc: &descriptors.Service{
+			Name:      name,
+			Endpoints: endpoints,
+		},
+	}
+}
+
 func (f *ServiceFinder) triage() {
 	rules := serviceParserRules{
 		"el":         f.triageNode("el-"),
@@ -231,10 +276,17 @@ func (f *ServiceFinder) triage() {
 			endpoints[portName] = portInfo
 		}
 
-		svc := rules.apply(serviceName, endpoints)
+		// TODO: for now, use labels as a fallback, so it's currently inactive.
+		// We should expect the rules to be gradually removed to make way for
+		// this code path. Ultimately we'll rely only on labels, and most of the
+		// code in this file will disappear as a result.
+		triaged := rules.apply(serviceName, endpoints)
+		if triaged == nil {
+			triaged = f.triageByLabels(svc, serviceName, endpoints)
+		}
 
-		if svc != nil {
-			triagedServices = append(triagedServices, svc)
+		if triaged != nil {
+			triagedServices = append(triagedServices, triaged)
 		}
 	}
 

--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -2,6 +2,7 @@ package kurtosis
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
@@ -73,19 +74,21 @@ func TestFindChainServices(t *testing.T) {
 	})
 
 	// Test L2 services for both chains
-	t.Run("L2 chain1 services", func(t *testing.T) {
-		nodes, services := finder.FindL2Services(chain1)
+	for _, chain := range chains {
+		t.Run(fmt.Sprintf("L2 %s services", chain), func(t *testing.T) {
+			nodes, services := finder.FindL2Services(chain)
 
-		assert.Equal(t, 1, len(nodes), "Should have exactly 1 node")
-		assert.Equal(t, 6, len(services), "Should have exactly 6 services")
+			assert.Equal(t, 1, len(nodes), "Should have exactly 1 node")
+			assert.Equal(t, 6, len(services), "Should have exactly 6 services")
 
-		assert.Contains(t, services, "batcher", "Should have batcher service")
-		assert.Contains(t, services, "proposer", "Should have proposer service")
-		assert.Contains(t, services, "proxyd", "Should have proxyd service")
-		assert.Contains(t, services, "challenger", "Should have challenger service")
-		assert.Contains(t, services, "supervisor", "Should have supervisor service")
-		assert.Contains(t, services, "faucet", "Should have faucet service")
-	})
+			assert.Contains(t, services, "batcher", "Should have batcher service")
+			assert.Contains(t, services, "proposer", "Should have proposer service")
+			assert.Contains(t, services, "proxyd", "Should have proxyd service")
+			assert.Contains(t, services, "challenger", "Should have challenger service")
+			assert.Contains(t, services, "supervisor", "Should have supervisor service")
+			assert.Contains(t, services, "faucet", "Should have faucet service")
+		})
+	}
 }
 
 // createTestServiceMap creates a service map based on the provided scenario output
@@ -210,9 +213,13 @@ func createTestServiceMap() inspect.ServiceMap {
 				"rpc": &descriptors.PortInfo{Port: 32813},
 			},
 		},
-		"op-challenger-service-2151908-2151909": &inspect.Service{
+		"challenger-service": &inspect.Service{ // intentionally not following conventions, to force use of labels.
 			Ports: inspect.PortMap{
 				"metrics": &descriptors.PortInfo{Port: 32812},
+			},
+			Labels: map[string]string{
+				kindLabel:      "challenger",
+				networkIDLabel: "2151908,2151909",
 			},
 		},
 		"op-supervisor-service-superchain": &inspect.Service{


### PR DESCRIPTION
**Description**

This activates a labels-based strategy for service identification, as
a backup for the current name-parsing logic.

Right now, this is mostly disabled as all services of interest are
handled on the basis of their name. But with incoming changes in
optimism-package, it'll be convenient to gradually phase out
name-parsing in favor of explicit annotations.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
