### PR TITLE
Print any diff output in run-contracts-check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ commands:
             git reset --hard
             git clean -df
             just <<parameters.command>>
+            git status --porcelain
             [ -z "$(git status --porcelain)" ] || exit 1
           working_directory: packages/contracts-bedrock
           when: always


### PR DESCRIPTION
Just makes sure that if the diff is non-empty, it is also displayed in CI