### PR TITLE
op-program: Load dependency set from the superchain registry when available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250603002020-3e5073a7b5a4
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70 h1:MoVbCEm9cvkRfVBuAQ8UqhhLvqtnP7XGEadXnzDb+5o=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250603002020-3e5073a7b5a4 h1:mBptFUULdsqoqN8sDTgqHYmDzFl17jbzYqMgZx1X6SU=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250603002020-3e5073a7b5a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4 h1:dNSl6HTSLsjQH8644PzLijoeMK0vyeQVEMfYVUTxGf4=
-github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70 h1:MoVbCEm9cvkRfVBuAQ8UqhhLvqtnP7XGEadXnzDb+5o=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/op-program/chainconfig/chaincfg.go
+++ b/op-program/chainconfig/chaincfg.go
@@ -8,12 +8,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-service/superutil"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/superutil"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -119,7 +118,10 @@ func mustLoadChainConfig(name string) *params.ChainConfig {
 // DependencySetByChainID locates the dependency set from either the superchain-registry or the embed.
 // Returns ErrMissingChainConfig if the dependency set is not found.
 func DependencySetByChainID(chainID eth.ChainID) (depset.DependencySet, error) {
-	// TODO(#14771): Load from the superchain registry when available.
+	depSet, err := depset.FromRegistry(chainID)
+	if err == nil {
+		return depSet, nil
+	}
 	return dependencySetByChainID(chainID, customChainConfigFS)
 }
 

--- a/op-program/chainconfig/chaincfg_test.go
+++ b/op-program/chainconfig/chaincfg_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig/test"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +64,12 @@ func TestListCustomChainIDs(t *testing.T) {
 	actual, err := customChainIDs(test.TestCustomChainConfigFS)
 	require.NoError(t, err)
 	require.Equal(t, []eth.ChainID{eth.ChainIDFromUInt64(901)}, actual)
+}
+
+func TestLoadDependencySetFromRegistry(t *testing.T) {
+	chainID, err := superchain.ChainIDByName("op-mainnet")
+	require.NoError(t, err)
+	depSet, err := DependencySetByChainID(eth.ChainIDFromUInt64(chainID))
+	require.NoError(t, err)
+	require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(chainID)))
 }

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,4 +123,12 @@ func testDependencySetSerialization(
 		require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(900)))
 		require.False(t, depSet.HasChain(eth.ChainIDFromUInt64(902)))
 	})
+}
+
+func TestLoadDependencySetFromRegistry(t *testing.T) {
+	chainID, err := superchain.ChainIDByName("op-mainnet")
+	require.NoError(t, err)
+	depSet, err := FromRegistry(eth.ChainIDFromUInt64(chainID))
+	require.NoError(t, err)
+	require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(chainID)))
 }


### PR DESCRIPTION
**Description**

Updates op-program to load dependency set config from the superchain-registry when possible. It falls back to custom config if not like it does for rollup configs.

**Tests**

Added unit test for loading dependency set config.

**Additional context**

Updates op-geth to pull in changes from https://github.com/ethereum-optimism/op-geth/pull/622

**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/15915