### PR TITLE
op-supervisor: Load dependency set and rollup configs from superchain-registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250603002020-3e5073a7b5a4
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70 h1:MoVbCEm9cvkRfVBuAQ8UqhhLvqtnP7XGEadXnzDb+5o=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250603002020-3e5073a7b5a4 h1:mBptFUULdsqoqN8sDTgqHYmDzFl17jbzYqMgZx1X6SU=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250603002020-3e5073a7b5a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4 h1:dNSl6HTSLsjQH8644PzLijoeMK0vyeQVEMfYVUTxGf4=
-github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70 h1:MoVbCEm9cvkRfVBuAQ8UqhhLvqtnP7XGEadXnzDb+5o=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250602235513-58e6de9c5b70/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/op-program/chainconfig/chaincfg.go
+++ b/op-program/chainconfig/chaincfg.go
@@ -8,12 +8,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-service/superutil"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/superutil"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -119,7 +118,10 @@ func mustLoadChainConfig(name string) *params.ChainConfig {
 // DependencySetByChainID locates the dependency set from either the superchain-registry or the embed.
 // Returns ErrMissingChainConfig if the dependency set is not found.
 func DependencySetByChainID(chainID eth.ChainID) (depset.DependencySet, error) {
-	// TODO(#14771): Load from the superchain registry when available.
+	depSet, err := depset.FromRegistry(chainID)
+	if err == nil {
+		return depSet, nil
+	}
 	return dependencySetByChainID(chainID, customChainConfigFS)
 }
 

--- a/op-program/chainconfig/chaincfg_test.go
+++ b/op-program/chainconfig/chaincfg_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig/test"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +64,12 @@ func TestListCustomChainIDs(t *testing.T) {
 	actual, err := customChainIDs(test.TestCustomChainConfigFS)
 	require.NoError(t, err)
 	require.Equal(t, []eth.ChainID{eth.ChainIDFromUInt64(901)}, actual)
+}
+
+func TestLoadDependencySetFromRegistry(t *testing.T) {
+	chainID, err := superchain.ChainIDByName("op-mainnet")
+	require.NoError(t, err)
+	depSet, err := DependencySetByChainID(eth.ChainIDFromUInt64(chainID))
+	require.NoError(t, err)
+	require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(chainID)))
 }

--- a/op-supervisor/cmd/main_test.go
+++ b/op-supervisor/cmd/main_test.go
@@ -106,13 +106,13 @@ func TestConfig(t *testing.T) {
 
 	t.Run("RollupConfigRequiredWhenNoNetwork", func(t *testing.T) {
 		verifyArgsInvalid(t,
-			"required flag is missing: either network or dependency-set and one of rollup-config-set, rollup-config-paths must be set",
+			"required flag is missing: either networks or dependency-set and one of rollup-config-set, rollup-config-paths must be set",
 			addRequiredArgsExcept("--rollup-config-set"))
 	})
 
 	t.Run("DependencySetRequiredWhenNoNetwork", func(t *testing.T) {
 		verifyArgsInvalid(t,
-			"required flag is missing: either network or dependency-set and one of rollup-config-set, rollup-config-paths must be set",
+			"required flag is missing: either networks or dependency-set and one of rollup-config-set, rollup-config-paths must be set",
 			addRequiredArgsExcept("--dependency-set"))
 	})
 

--- a/op-supervisor/cmd/main_test.go
+++ b/op-supervisor/cmd/main_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -83,6 +84,58 @@ func TestMockRun(t *testing.T) {
 	})
 }
 
+func TestConfig(t *testing.T) {
+	t.Run("SingleNetwork", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgsExceptConfig(
+			"--network", "op-mainnet"))
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("MultipleNetworks", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgsExceptConfig(
+			"--network", "op-mainnet,unichain-mainnet"))
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("UnknownNetwork", func(t *testing.T) {
+		verifyArgsInvalid(t,
+			superchain.ErrUnknownChain.Error(),
+			addRequiredArgsExceptConfig(
+				"--network", "unknown-chain"))
+	})
+
+	t.Run("RollupConfigRequiredWhenNoNetwork", func(t *testing.T) {
+		verifyArgsInvalid(t,
+			"required flag is missing: either network or dependency-set and one of rollup-config-set, rollup-config-paths must be set",
+			addRequiredArgsExcept("--rollup-config-set"))
+	})
+
+	t.Run("DependencySetRequiredWhenNoNetwork", func(t *testing.T) {
+		verifyArgsInvalid(t,
+			"required flag is missing: either network or dependency-set and one of rollup-config-set, rollup-config-paths must be set",
+			addRequiredArgsExcept("--dependency-set"))
+	})
+
+	t.Run("DependencySetAndRollupConfigPaths", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgsExceptConfig(
+			"--dependency-set", "depset.json", "--rollup-config-paths", "test-paths"))
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("DependencySetAndRollupConfigSet", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgsExceptConfig(
+			"--dependency-set", "depset.json", "--rollup-config-set", "test-set"))
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("MustNotSetRollupConfigSetAndRollupConfigPathsTogether", func(t *testing.T) {
+		verifyArgsInvalid(t,
+			"conflicting flags: only one of rollup-config-paths, rollup-config-set can be set",
+			addRequiredArgsExceptConfig(
+				"--dependency-set", "depset.json", "--rollup-config-set", "test-set", "--rollup-config-paths", "test-paths"))
+	})
+}
+
 func verifyArgsInvalid(t *testing.T, messageContains string, cliArgs []string) {
 	_, _, err := dryRunWithArgs(cliArgs)
 	require.ErrorContains(t, err, messageContains)
@@ -119,6 +172,18 @@ func addRequiredArgs(args ...string) []string {
 func addRequiredArgsExcept(name string, optionalArgs ...string) []string {
 	req := requiredArgs()
 	delete(req, name)
+	return append(toArgList(req), optionalArgs...)
+}
+
+func addRequiredArgsExceptConfig(optionalArgs ...string) []string {
+	return addRequiredArgsExceptMultiple([]string{"--rollup-config-set", "--dependency-set"}, optionalArgs...)
+}
+
+func addRequiredArgsExceptMultiple(names []string, optionalArgs ...string) []string {
+	req := requiredArgs()
+	for _, name := range names {
+		delete(req, name)
+	}
 	return append(toArgList(req), optionalArgs...)
 }
 

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -2,7 +2,9 @@ package flags
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
@@ -17,7 +19,10 @@ import (
 
 const EnvVarPrefix = "OP_SUPERVISOR"
 
-var ErrRequiredFlagMissing = fmt.Errorf("required flag is missing")
+var (
+	ErrRequiredFlagMissing = fmt.Errorf("required flag is missing")
+	ErrConflictingFlags    = fmt.Errorf("conflicting flags")
+)
 
 func prefixEnvVars(name string) []string {
 	return opservice.PrefixEnvVar(EnvVarPrefix, name)
@@ -51,6 +56,11 @@ var (
 		Name:    "datadir.sync-endpoint",
 		Usage:   "op-supervisor endpoint to sync databases from",
 		EnvVars: prefixEnvVars("DATADIR_SYNC_ENDPOINT"),
+	}
+	NetworkFlag = &cli.StringSliceFlag{
+		Name:    "network",
+		Usage:   fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
+		EnvVars: prefixEnvVars("NETWORK"),
 	}
 	DependencySetFlag = &cli.PathFlag{
 		Name:      "dependency-set",
@@ -91,20 +101,16 @@ var requiredFlags = []cli.Flag{
 	L2ConsensusNodesFlag,
 	L2ConsensusJWTSecret,
 	DataDirFlag,
-	DependencySetFlag,
-}
-
-var requiredFlagGroups = [][]cli.Flag{
-	{
-		RollupConfigPathsFlag,
-		RollupConfigSetFlag,
-	},
 }
 
 var optionalFlags = []cli.Flag{
+	NetworkFlag,
 	MockRunFlag,
 	DataDirSyncEndpointFlag,
 	RPCVerificationWarningsFlag,
+	DependencySetFlag,
+	RollupConfigPathsFlag,
+	RollupConfigSetFlag,
 }
 
 func init() {
@@ -114,48 +120,65 @@ func init() {
 	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
 
 	Flags = append(Flags, requiredFlags...)
-	for _, group := range requiredFlagGroups {
-		Flags = append(Flags, group...)
-	}
 	Flags = append(Flags, optionalFlags...)
 }
 
 // Flags contains the list of configuration options available to the binary.
 var Flags []cli.Flag
 
-func CheckRequired(ctx *cli.Context) error {
+func checkRequired(ctx *cli.Context) error {
 	for _, f := range requiredFlags {
 		if !ctx.IsSet(f.Names()[0]) {
 			return fmt.Errorf("%w: %s", ErrRequiredFlagMissing, f.Names()[0])
 		}
 	}
-
-	for _, group := range requiredFlagGroups {
-		var set int
-		for _, f := range group {
-			if ctx.IsSet(f.Names()[0]) {
-				set++
-			}
+	if ctx.IsSet(NetworkFlag.Name) {
+		if err := checkNotSet(ctx, DependencySetFlag, RollupConfigPathsFlag, RollupConfigSetFlag); err != nil {
+			return fmt.Errorf("%w must not be set with %s", err, NetworkFlag.Name)
 		}
-		if set == 0 {
-			return fmt.Errorf("%w: one of %s must be set", ErrRequiredFlagMissing, flagNames(group))
-		} else if set > 1 {
-			return fmt.Errorf("%w: only one of %s can be set", ErrRequiredFlagMissing, flagNames(group))
-		}
+	} else if !ctx.IsSet(DependencySetFlag.Name) || (!ctx.IsSet(RollupConfigSetFlag.Name) && !ctx.IsSet(RollupConfigPathsFlag.Name)) {
+		return fmt.Errorf("%w: either %s or %s and one of %s must be set", ErrRequiredFlagMissing,
+			NetworkFlag.Name, DependencySetFlag.Name, flagNames(RollupConfigSetFlag, RollupConfigPathsFlag))
+	} else if err := checkGroupUnique(ctx, RollupConfigPathsFlag, RollupConfigSetFlag); err != nil {
+		return err
 	}
-
 	return nil
 }
 
-func flagNames(flags []cli.Flag) []string {
+func checkGroupUnique(ctx *cli.Context, group ...cli.Flag) error {
+	var set int
+	for _, f := range group {
+		if ctx.IsSet(f.Names()[0]) {
+			set++
+		}
+	}
+	if set > 1 {
+		return fmt.Errorf("%w: only one of %s can be set", ErrConflictingFlags, flagNames(group...))
+	}
+	return nil
+}
+
+func checkNotSet(ctx *cli.Context, flags ...cli.Flag) error {
+	for _, flag := range flags {
+		if ctx.IsSet(flag.Names()[0]) {
+			return fmt.Errorf("%w: %s", ErrConflictingFlags, flagNames(flags...))
+		}
+	}
+	return nil
+}
+
+func flagNames(flags ...cli.Flag) string {
 	names := make([]string, 0, len(flags))
 	for _, f := range flags {
 		names = append(names, f.Names()[0])
 	}
-	return names
+	return strings.Join(names, ", ")
 }
 
-func ConfigFromCLI(ctx *cli.Context, version string) *config.Config {
+func ConfigFromCLI(ctx *cli.Context, version string) (*config.Config, error) {
+	if err := checkRequired(ctx); err != nil {
+		return nil, err
+	}
 	c := &config.Config{
 		Version:                 version,
 		LogConfig:               oplog.ReadCLIConfig(ctx),
@@ -182,8 +205,18 @@ func ConfigFromCLI(ctx *cli.Context, version string) *config.Config {
 			},
 			DependencySetSource: &depset.JSONDependencySetLoader{Path: ctx.Path(DependencySetFlag.Name)},
 		}
+	} else if ctx.IsSet(NetworkFlag.Name) {
+		networks := ctx.StringSlice(NetworkFlag.Name)
+		source, err := depset.NewRegistryFullConfigSetSource(ctx.String(L1RPCFlag.Name), networks)
+		if err != nil {
+			return nil, err
+		}
+		c.FullConfigSetSource = source
+	} else {
+		return nil, fmt.Errorf("%w: either %s or %s and one of %s must be set", ErrRequiredFlagMissing,
+			NetworkFlag.Name, DependencySetFlag.Name, flagNames(RollupConfigSetFlag, RollupConfigPathsFlag))
 	}
-	return c
+	return c, nil
 }
 
 // syncSourceSetups creates a sync source collection, from CLI arguments.

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -58,9 +58,10 @@ var (
 		EnvVars: prefixEnvVars("DATADIR_SYNC_ENDPOINT"),
 	}
 	NetworkFlag = &cli.StringSliceFlag{
-		Name:    "network",
+		Name:    "networks",
+		Aliases: []string{"network"},
 		Usage:   fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
-		EnvVars: prefixEnvVars("NETWORK"),
+		EnvVars: append(prefixEnvVars("NETWORKS"), prefixEnvVars("NETWORK")...),
 	}
 	DependencySetFlag = &cli.PathFlag{
 		Name:      "dependency-set",

--- a/op-supervisor/flags/flags_test.go
+++ b/op-supervisor/flags/flags_test.go
@@ -65,7 +65,7 @@ func TestHasEnvVar(t *testing.T) {
 			})
 			envFlags := envFlagGetter.GetEnvVars()
 			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
-			require.Equal(t, 1, len(envFlags), "flags should have exactly one env var")
+			require.Equal(t, len(flag.Names()), len(envFlags), "flag should have same number of env vars as names")
 		})
 	}
 }
@@ -81,9 +81,11 @@ func TestEnvVarFormat(t *testing.T) {
 			})
 			envFlags := envFlagGetter.GetEnvVars()
 			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
-			require.Equal(t, 1, len(envFlags), "flags should have exactly one env var")
-			expectedEnvVar := opservice.FlagNameToEnvVarName(flagName, "OP_SUPERVISOR")
-			require.Equal(t, expectedEnvVar, envFlags[0])
+			require.Equal(t, len(flag.Names()), len(envFlags), "flag should have same number of env vars as names")
+			for i, name := range flag.Names() {
+				expectedEnvVar := opservice.FlagNameToEnvVarName(name, "OP_SUPERVISOR")
+				require.Equal(t, expectedEnvVar, envFlags[i])
+			}
 		})
 	}
 }

--- a/op-supervisor/supervisor/backend/depset/depset_test.go
+++ b/op-supervisor/supervisor/backend/depset/depset_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,4 +123,12 @@ func testDependencySetSerialization(
 		require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(900)))
 		require.False(t, depSet.HasChain(eth.ChainIDFromUInt64(902)))
 	})
+}
+
+func TestLoadDependencySetFromRegistry(t *testing.T) {
+	chainID, err := superchain.ChainIDByName("op-mainnet")
+	require.NoError(t, err)
+	depSet, err := FromRegistry(eth.ChainIDFromUInt64(chainID))
+	require.NoError(t, err)
+	require.True(t, depSet.HasChain(eth.ChainIDFromUInt64(chainID)))
 }

--- a/op-supervisor/supervisor/backend/depset/registry_config.go
+++ b/op-supervisor/supervisor/backend/depset/registry_config.go
@@ -24,7 +24,7 @@ func NewRegistryFullConfigSetSource(l1RPCURL string, networks []string) (*Regist
 		if err != nil {
 			return nil, err
 		}
-		// Use the dependency set from the fist chain.
+		// Use the dependency set from the first chain.
 		// superchain-registry has checks to ensure consistency for all chains in the same set
 		if dependencySet == nil {
 			depSet, err := FromRegistry(eth.ChainIDFromUInt64(chainID))

--- a/op-supervisor/supervisor/backend/depset/registry_config.go
+++ b/op-supervisor/supervisor/backend/depset/registry_config.go
@@ -1,0 +1,68 @@
+package depset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/superchain"
+)
+
+type RegistryFullConfigSetSource struct {
+	l1RPCURL      string
+	rollupCfgs    []*rollup.Config
+	dependencySet DependencySet
+}
+
+func NewRegistryFullConfigSetSource(l1RPCURL string, networks []string) (*RegistryFullConfigSetSource, error) {
+	rollupCfgs := make([]*rollup.Config, 0, len(networks))
+	var dependencySet DependencySet
+	for _, network := range networks {
+		chainID, err := superchain.ChainIDByName(network)
+		if err != nil {
+			return nil, err
+		}
+		// Use the dependency set from the fist chain.
+		// superchain-registry has checks to ensure consistency for all chains in the same set
+		if dependencySet == nil {
+			depSet, err := FromRegistry(eth.ChainIDFromUInt64(chainID))
+			if err != nil {
+				return nil, fmt.Errorf("failed to load dependency set for network %s: %w", network, err)
+			}
+			dependencySet = depSet
+		}
+
+		rollupCfg, err := rollup.LoadOPStackRollupConfig(chainID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load rollup config for network %s: %w", network, err)
+		}
+
+		rollupCfgs = append(rollupCfgs, rollupCfg)
+	}
+	return &RegistryFullConfigSetSource{
+		l1RPCURL:      l1RPCURL,
+		rollupCfgs:    rollupCfgs,
+		dependencySet: dependencySet,
+	}, nil
+}
+
+func (s *RegistryFullConfigSetSource) LoadFullConfigSet(ctx context.Context) (FullConfigSet, error) {
+	client, err := ethclient.Dial(s.l1RPCURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+	}
+	defer client.Close()
+
+	rollupConfigs := make(map[eth.ChainID]*StaticRollupConfig, len(s.rollupCfgs))
+	for _, rollupCfg := range s.rollupCfgs {
+		l1Genesis, err := client.HeaderByHash(ctx, rollupCfg.Genesis.L1.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get L1 genesis header for hash %s (chainID: %s): %w", rollupCfg.Genesis.L1.Hash, rollupCfg.L2ChainID, err)
+		}
+
+		rollupConfigs[eth.ChainIDFromBig(rollupCfg.L2ChainID)] = StaticRollupConfigFromRollupConfig(rollupCfg, l1Genesis.Time)
+	}
+	return NewFullConfigSetMerged(StaticRollupConfigSet(rollupConfigs), s.dependencySet)
+}

--- a/op-supervisor/supervisor/entrypoint.go
+++ b/op-supervisor/supervisor/entrypoint.go
@@ -21,10 +21,10 @@ type MainFn func(ctx context.Context, cfg *config.Config, logger log.Logger) (cl
 // This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed supervisor with.
 func Main(version string, fn MainFn) cliapp.LifecycleAction {
 	return func(cliCtx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
-		if err := flags.CheckRequired(cliCtx); err != nil {
+		cfg, err := flags.ConfigFromCLI(cliCtx, version)
+		if err != nil {
 			return nil, err
 		}
-		cfg := flags.ConfigFromCLI(cliCtx, version)
 		if err := cfg.Check(); err != nil {
 			return nil, fmt.Errorf("invalid CLI flags: %w", err)
 		}


### PR DESCRIPTION
**Description**

Load dependency set and rollup configs from superchain-registry.

Adds ` --networks` flag to op-supervisor. Plural is used because this is a new flag and supports multiple network names, but an alias `--network` is supported since people are so used to that working with op-node.  Similarly env vars are supported with both singular and plural.

**Tests**

Added unit tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/16250

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/15889
