### PR TITLE
proofs: Extend test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2130,7 +2130,7 @@ workflows:
           notify: true
           mentions: "@proofs-team"
           no_output_timeout: 60m
-          test_timeout: 90m
+          test_timeout: 120m
           resource_class: ethereum-optimism/latitude-fps-1
           context:
             - slack


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Extend fault proofs e2e test timeout.


