### PR TITLE
op-program: Err on non-200 HTTP status during prestates build

### DIFF
--- a/op-program/prestates/fetcher.go
+++ b/op-program/prestates/fetcher.go
@@ -27,6 +27,9 @@ func LoadReleases(overrideFile string) (*Prestates, error) {
 			return nil, fmt.Errorf("failed to download standard prestates from %v: %w", standardPrestatesUrl, err)
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to download standard prestates from %v: received status code %d", standardPrestatesUrl, resp.StatusCode)
+		}
 		data, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read standard prestates from %v: %w", standardPrestatesUrl, err)


### PR DESCRIPTION
Sometimes the prestates.toml fetch fails when github is down. This just surfaces the HTTP error earlier so it's clearer when this occurs.