### PR TITLE
op-acceptance-tests: Add test for single chain upgrade process

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
@@ -26,18 +26,17 @@ func TestPostInbox(gt *testing.T) {
 
 		pre := activationBlock.Number - 1
 
-		// Should not have CrossL2Inbox implementation before activation
-		implAddrBytes, err := el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
-			genesis.ImplementationSlot, hexutil.Uint64(pre).String())
-		require.NoError(err)
-		implAddr := common.BytesToAddress(implAddrBytes[:])
-		require.Equal(common.Address{}, implAddr, "Should not have CrossL2Inbox implementation")
+		verifyNoCrossL2InboxAtBlock := func(blockNum uint64) {
+			net.PublicRPC().WaitForBlockNumber(blockNum)
+			implAddrBytes, err := el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
+				genesis.ImplementationSlot, hexutil.Uint64(blockNum).String())
+			require.NoError(err)
+			implAddr := common.BytesToAddress(implAddrBytes[:])
+			require.Equal(common.Address{}, implAddr, "Should not have CrossL2Inbox implementation")
+		}
 
-		// Should not have CrossL2Inbox implementation after activation
-		implAddrBytes, err = el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
-			genesis.ImplementationSlot, activationBlock.Hash.String())
-		require.NoError(err)
-		implAddr = common.BytesToAddress(implAddrBytes[:])
-		require.Equal(common.Address{}, implAddr, "Should not have CrossL2Inbox implementation")
+		verifyNoCrossL2InboxAtBlock(pre)
+		verifyNoCrossL2InboxAtBlock(activationBlock.Number)
+		verifyNoCrossL2InboxAtBlock(activationBlock.Number + 1)
 	})
 }

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
@@ -17,7 +17,6 @@ import (
 func TestPostInbox(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainInterop(t)
-	t.Gate().Len(sys.L2Networks(), 1, "only applies with a single network")
 	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
 		require := t.Require()
 		el := net.Escape().L2ELNode(match.FirstL2EL)

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
@@ -1,0 +1,44 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+func TestPostInbox(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSingleChainInterop(t)
+	t.Gate().Len(sys.L2Networks(), 1, "only applies with a single network")
+	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
+		require := t.Require()
+		el := net.Escape().L2ELNode(match.FirstL2EL)
+
+		activationBlock := net.AwaitActivation(t, rollup.Interop)
+		require.NotZero(activationBlock, "must not activate interop at genesis")
+
+		pre := activationBlock.Number - 1
+
+		// Should not have CrossL2Inbox implementation before activation
+		implAddrBytes, err := el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
+			genesis.ImplementationSlot, hexutil.Uint64(pre).String())
+		require.NoError(err)
+		implAddr := common.BytesToAddress(implAddrBytes[:])
+		require.Equal(common.Address{}, implAddr, "Should not have CrossL2Inbox implementation")
+
+		// Should not have CrossL2Inbox implementation after activation
+		implAddrBytes, err = el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
+			genesis.ImplementationSlot, activationBlock.Hash.String())
+		require.NoError(err)
+		implAddr = common.BytesToAddress(implAddrBytes[:])
+		require.Equal(common.Address{}, implAddr, "Should not have CrossL2Inbox implementation")
+	})
+}

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
@@ -10,5 +10,7 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSingleChainInterop(),
 		presets.WithSuggestedInteropActivationOffset(30),
-		presets.WithInteropNotAtGenesis())
+		presets.WithInteropNotAtGenesis(),
+		presets.WithL2NetworkCount(1), // Specifically testing dependency set of 1 upgrade
+	)
 }

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
@@ -1,0 +1,14 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithSingleChainInterop(),
+		presets.WithSuggestedInteropActivationOffset(30),
+		presets.WithInteropNotAtGenesis())
+}

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -44,10 +44,10 @@ func NewSingleChainInterop(t devtest.T) *SingleChainInterop {
 	orch := Orchestrator()
 	orch.Hydrate(system)
 
-	t.Gate().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
 	// At this point, any supervisor is acceptable but as the DSL gets fleshed out this should be selecting supervisors
 	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
 	// since currently there's no way to tell which nodes are using which supervisor.
+	t.Gate().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
 
 	t.Gate().Equal(len(system.TestSequencers()), 1, "expected exactly one test sequencer")
 
@@ -189,6 +189,12 @@ func WithInteropNotAtGenesis() stack.CommonOption {
 			sys.T().Gate().NotNil(interopTime, "must have interop")
 			sys.T().Gate().NotZero(*interopTime, "must not be at genesis")
 		}
+	})
+}
+
+func WithL2NetworkCount(count int) stack.CommonOption {
+	return stack.PostHydrate[stack.Orchestrator](func(sys stack.System) {
+		sys.T().Gate().Lenf(sys.L2Networks(), count, "Must have exactly %v chains", count)
 	})
 }
 

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
-type SimpleInterop struct {
+type SingleChainInterop struct {
 	Log    log.Logger
 	T      devtest.T
 	system stack.ExtensibleSystem
@@ -26,27 +26,76 @@ type SimpleInterop struct {
 	L1Network *dsl.L1Network
 	L1EL      *dsl.L1ELNode
 
-	L2ChainA *dsl.L2Network
-	L2ChainB *dsl.L2Network
-
+	L2ChainA   *dsl.L2Network
 	L2BatcherA *dsl.L2Batcher
-	L2BatcherB *dsl.L2Batcher
-
-	L2ELA *dsl.L2ELNode
-	L2ELB *dsl.L2ELNode
-
-	L2CLA *dsl.L2CLNode
-	L2CLB *dsl.L2CLNode
+	L2ELA      *dsl.L2ELNode
+	L2CLA      *dsl.L2CLNode
 
 	Wallet *dsl.HDWallet
 
 	FaucetA  *dsl.Faucet
-	FaucetB  *dsl.Faucet
 	FaucetL1 *dsl.Faucet
-
 	FunderL1 *dsl.Funder
 	FunderA  *dsl.Funder
-	FunderB  *dsl.Funder
+}
+
+func NewSingleChainInterop(t devtest.T) *SingleChainInterop {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+
+	t.Gate().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
+	// At this point, any supervisor is acceptable but as the DSL gets fleshed out this should be selecting supervisors
+	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
+	// since currently there's no way to tell which nodes are using which supervisor.
+
+	t.Gate().Equal(len(system.TestSequencers()), 1, "expected exactly one test sequencer")
+
+	l1Net := system.L1Network(match.FirstL1Network)
+	l2A := system.L2Network(match.Assume(t, match.L2ChainA))
+	out := &SingleChainInterop{
+		Log:           t.Logger(),
+		T:             t,
+		system:        system,
+		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
+		Supervisor:    dsl.NewSupervisor(system.Supervisor(match.Assume(t, match.FirstSupervisor)), orch.ControlPlane()),
+		ControlPlane:  orch.ControlPlane(),
+		L1Network:     dsl.NewL1Network(l1Net),
+		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
+		L2ChainA:      dsl.NewL2Network(l2A),
+		L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
+		FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
+		L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+	}
+	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
+	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
+	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
+	return out
+}
+
+func (s *SingleChainInterop) L2Networks() []*dsl.L2Network {
+	return []*dsl.L2Network{
+		s.L2ChainA,
+	}
+}
+
+// WithSingleChainInterop specifies a system that meets the SingleChainInterop criteria.
+func WithSingleChainInterop() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainInteropSystem(&sysgo.DefaultSingleChainInteropSystemIDs{}))
+}
+
+type SimpleInterop struct {
+	SingleChainInterop
+
+	L2ChainB   *dsl.L2Network
+	L2BatcherB *dsl.L2Batcher
+	L2ELB      *dsl.L2ELNode
+	L2CLB      *dsl.L2CLNode
+
+	FaucetB *dsl.Faucet
+	FunderB *dsl.Funder
 }
 
 func (s *SimpleInterop) L2Networks() []*dsl.L2Network {
@@ -84,44 +133,17 @@ func WithUnscheduledInterop() stack.CommonOption {
 }
 
 func NewSimpleInterop(t devtest.T) *SimpleInterop {
-	system := shim.NewSystem(t)
+	singleChain := NewSingleChainInterop(t)
 	orch := Orchestrator()
-	orch.Hydrate(system)
-
-	t.Gate().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
-	// At this point, any supervisor is acceptable but as the DSL gets fleshed out this should be selecting supervisors
-	// that fit with specific networks and nodes. That will likely require expanding the metadata exposed by the system
-	// since currently there's no way to tell which nodes are using which supervisor.
-
-	t.Gate().Equal(len(system.TestSequencers()), 1, "expected exactly one test sequencer")
-
-	l1Net := system.L1Network(match.FirstL1Network)
-	l2A := system.L2Network(match.Assume(t, match.L2ChainA))
-	l2B := system.L2Network(match.Assume(t, match.L2ChainB))
+	l2B := singleChain.system.L2Network(match.Assume(t, match.L2ChainB))
 	out := &SimpleInterop{
-		Log:           t.Logger(),
-		T:             t,
-		system:        system,
-		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
-		Supervisor:    dsl.NewSupervisor(system.Supervisor(match.Assume(t, match.FirstSupervisor)), orch.ControlPlane()),
-		ControlPlane:  orch.ControlPlane(),
-		L1Network:     dsl.NewL1Network(l1Net),
-		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2ChainA:      dsl.NewL2Network(l2A),
-		L2ChainB:      dsl.NewL2Network(l2B),
-		L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL))),
-		L2ELB:         dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.FirstL2EL))),
-		L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-		L2CLB:         dsl.NewL2CLNode(l2B.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
-		FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
-		FaucetB:       dsl.NewFaucet(l2B.Faucet(match.Assume(t, match.FirstFaucet))),
-		L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
-		L2BatcherB:    dsl.NewL2Batcher(l2B.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		SingleChainInterop: *singleChain,
+		L2ChainB:           dsl.NewL2Network(l2B),
+		L2ELB:              dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2CLB:              dsl.NewL2CLNode(l2B.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		FaucetB:            dsl.NewFaucet(l2B.Faucet(match.Assume(t, match.FirstFaucet))),
+		L2BatcherB:         dsl.NewL2Batcher(l2B.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
 	}
-	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
-	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
-	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
 	out.FunderB = dsl.NewFunder(out.Wallet, out.FaucetB, out.L2ELB)
 	return out
 }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -206,6 +206,7 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 
 	opt.Add(WithDeployerOptions(
 		WithPrefundedL2(ids.L2B.ChainID()),
+		WithInteropAtGenesis(), // this can be overridden by later options
 	))
 	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
 	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -118,7 +118,8 @@ func DefaultSingleChainInteropSystem(dest *DefaultSingleChainInteropSystemIDs) s
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2AID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSingleChainInteropSystemIDs(l1ID, l2AID)
-	opt := defaultSingleChainInteropWithoutShared(&ids)
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(baseInteropSystem(&ids))
 
 	opt.Add(WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
 		ids.L2AEL,
@@ -135,7 +136,10 @@ func DefaultSingleChainInteropSystem(dest *DefaultSingleChainInteropSystemIDs) s
 	return opt
 }
 
-func defaultSingleChainInteropWithoutShared(ids *DefaultSingleChainInteropSystemIDs) stack.CombinedOption[*Orchestrator] {
+// baseInteropSystem defines a system that supports interop with a single chain
+// Components which are shared across multiple chains are not started, allowing them to be added later including
+// any additional chains that have been added.
+func baseInteropSystem(ids *DefaultSingleChainInteropSystemIDs) stack.Option[*Orchestrator] {
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
 		o.P().Logger().Info("Setting up")
@@ -200,9 +204,10 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	l2AID := eth.ChainIDFromUInt64(901)
 	l2BID := eth.ChainIDFromUInt64(902)
 	ids := NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID)
+	opt := stack.Combine[*Orchestrator]()
 
 	// start with single chain interop system
-	opt := defaultSingleChainInteropWithoutShared(&ids.DefaultSingleChainInteropSystemIDs)
+	opt.Add(baseInteropSystem(&ids.DefaultSingleChainInteropSystemIDs))
 
 	opt.Add(WithDeployerOptions(
 		WithPrefundedL2(ids.L2B.ChainID()),

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -75,8 +75,7 @@ func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestra
 	return opt
 }
 
-// struct of the services, so we can access them later and do not have to guess their IDs.
-type DefaultInteropSystemIDs struct {
+type DefaultSingleChainInteropSystemIDs struct {
 	L1   stack.L1NetworkID
 	L1EL stack.L1ELNodeID
 	L1CL stack.L1CLNodeID
@@ -91,22 +90,13 @@ type DefaultInteropSystemIDs struct {
 	L2ACL stack.L2CLNodeID
 	L2AEL stack.L2ELNodeID
 
-	L2B   stack.L2NetworkID
-	L2BCL stack.L2CLNodeID
-	L2BEL stack.L2ELNodeID
-
-	L2ABatcher stack.L2BatcherID
-	L2BBatcher stack.L2BatcherID
-
-	L2AProposer stack.L2ProposerID
-	L2BProposer stack.L2ProposerID
-
+	L2ABatcher    stack.L2BatcherID
+	L2AProposer   stack.L2ProposerID
 	L2ChallengerA stack.L2ChallengerID
-	L2ChallengerB stack.L2ChallengerID
 }
 
-func NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultInteropSystemIDs {
-	ids := DefaultInteropSystemIDs{
+func NewDefaultSingleChainInteropSystemIDs(l1ID, l2AID eth.ChainID) DefaultSingleChainInteropSystemIDs {
+	ids := DefaultSingleChainInteropSystemIDs{
 		L1:            stack.L1NetworkID(l1ID),
 		L1EL:          stack.NewL1ELNodeID("l1", l1ID),
 		L1CL:          stack.NewL1CLNodeID("l1", l1ID),
@@ -117,25 +107,35 @@ func NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultInteropSy
 		L2A:           stack.L2NetworkID(l2AID),
 		L2ACL:         stack.NewL2CLNodeID("sequencer", l2AID),
 		L2AEL:         stack.NewL2ELNodeID("sequencer", l2AID),
-		L2B:           stack.L2NetworkID(l2BID),
-		L2BCL:         stack.NewL2CLNodeID("sequencer", l2BID),
-		L2BEL:         stack.NewL2ELNodeID("sequencer", l2BID),
 		L2ABatcher:    stack.NewL2BatcherID("main", l2AID),
-		L2BBatcher:    stack.NewL2BatcherID("main", l2BID),
 		L2AProposer:   stack.NewL2ProposerID("main", l2AID),
-		L2BProposer:   stack.NewL2ProposerID("main", l2BID),
 		L2ChallengerA: "chainA",
-		L2ChallengerB: "chainB",
 	}
 	return ids
 }
 
-func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestrator] {
+func DefaultSingleChainInteropSystem(dest *DefaultSingleChainInteropSystemIDs) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2AID := eth.ChainIDFromUInt64(901)
-	l2BID := eth.ChainIDFromUInt64(902)
-	ids := NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID)
+	ids := NewDefaultSingleChainInteropSystemIDs(l1ID, l2AID)
+	opt := defaultSingleChainInteropWithoutShared(&ids)
 
+	opt.Add(WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
+		ids.L2AEL,
+	}))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL}))
+
+	// Upon evaluation of the option, export the contents we created.
+	// Ids here are static, but other things may be exported too.
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}
+
+func defaultSingleChainInteropWithoutShared(ids *DefaultSingleChainInteropSystemIDs) stack.CombinedOption[*Orchestrator] {
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
 		o.P().Logger().Info("Setting up")
@@ -148,7 +148,6 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 			WithLocalContractSources(),
 			WithCommons(ids.L1.ChainID()),
 			WithPrefundedL2(ids.L2A.ChainID()),
-			WithPrefundedL2(ids.L2B.ChainID()),
 			WithInteropAtGenesis(), // this can be overridden by later options
 		),
 	)
@@ -158,22 +157,64 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
 
 	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
-	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
-
 	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, ids.L2AEL))
-	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))
-
 	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
-
 	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
 
 	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
-	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
 
 	// Note: we provide L2 CL nodes still, even though they are not used post-interop.
 	// Since we may create an interop infra-setup, before interop is even scheduled to run.
 	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor))
+	return opt
+}
+
+// struct of the services, so we can access them later and do not have to guess their IDs.
+type DefaultInteropSystemIDs struct {
+	DefaultSingleChainInteropSystemIDs
+
+	L2B   stack.L2NetworkID
+	L2BCL stack.L2CLNodeID
+	L2BEL stack.L2ELNodeID
+
+	L2BBatcher    stack.L2BatcherID
+	L2BProposer   stack.L2ProposerID
+	L2ChallengerB stack.L2ChallengerID
+}
+
+func NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultInteropSystemIDs {
+	ids := DefaultInteropSystemIDs{
+		DefaultSingleChainInteropSystemIDs: NewDefaultSingleChainInteropSystemIDs(l1ID, l2AID),
+		L2B:                                stack.L2NetworkID(l2BID),
+		L2BCL:                              stack.NewL2CLNodeID("sequencer", l2BID),
+		L2BEL:                              stack.NewL2ELNodeID("sequencer", l2BID),
+		L2BBatcher:                         stack.NewL2BatcherID("main", l2BID),
+		L2BProposer:                        stack.NewL2ProposerID("main", l2BID),
+		L2ChallengerB:                      "chainB",
+	}
+	return ids
+}
+
+func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestrator] {
+	l1ID := eth.ChainIDFromUInt64(900)
+	l2AID := eth.ChainIDFromUInt64(901)
+	l2BID := eth.ChainIDFromUInt64(902)
+	ids := NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID)
+
+	// start with single chain interop system
+	opt := defaultSingleChainInteropWithoutShared(&ids.DefaultSingleChainInteropSystemIDs)
+
+	opt.Add(WithDeployerOptions(
+		WithPrefundedL2(ids.L2B.ChainID()),
+	))
+	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
+	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))
+	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
+
+	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
+
+	// Note: we provide L2 CL nodes still, even though they are not used post-interop.
+	// Since we may create an interop infra-setup, before interop is even scheduled to run.
 	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, &ids.Supervisor))
 
 	// Deploy separate challengers for each chain.  Can be reduced to a single challenger when the DisputeGameFactory

--- a/op-node/rollup/derive/interop_upgrade_transactions.go
+++ b/op-node/rollup/derive/interop_upgrade_transactions.go
@@ -92,8 +92,7 @@ func InteropActivateCrossL2InboxTransactions() ([]hexutil.Bytes, error) {
 		Value:               big.NewInt(0),
 		Gas:                 50_000,
 		IsSystemTransaction: false,
-		// TODO(#16041): op-deployer genesis generation does NOT store the implementation at this address
-		Data: upgradeToCalldata(CrossL2InboxAddress),
+		Data:                upgradeToCalldata(CrossL2InboxAddress),
 	}).MarshalBinary()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description**

Adds a test to confirm that CrossL2Inbox is not deployed when there is only a single chain in the interop set.

This introduces a SingleChainInterop system which has op-supervisor deployed so it can support the interop fork but only has a single chain.  As much as possible the DefaultInteropSystem is an extension of SingleChainInterop and just adds an additional chain, but shared components like Faucet and Challenger require an L2 EL on each chain to work properly and so they can't be added in the shared single chain system or they'd only point to one of the two ELs. Hence a `baseInteropSystem` opt is provided to define all the reusable pieces and the shared components need to be added once the specific number of chains to run is known.

**Metadata**

Fxies #16041 