### PR TITLE
Update pre-merge CI checks to only run short golang tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1060,7 +1060,7 @@ jobs:
       rule:
         description: Rule to run the tests
         type: string
-        default: "go-tests-ci"
+        default: "go-tests-short-ci"
     machine: true
     resource_class: <<parameters.resource_class>>
     steps:

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,21 @@ go-tests-short: $(TEST_DEPS) ## Runs comprehensive Go tests with -short flag
 	go test -short -parallel=$$PARALLEL -timeout=$(TEST_TIMEOUT) $(TEST_PKGS)
 .PHONY: go-tests-short
 
+go-tests-short-ci: ## Runs short Go tests with gotestsum for CI (assumes deps built by CI)
+	@echo "Setting up test directories..."
+	mkdir -p ./tmp/test-results ./tmp/testlogs
+	@echo "Running Go tests with gotestsum..."
+	$(DEFAULT_TEST_ENV_VARS) && \
+	$(CI_ENV_VARS) && \
+	gotestsum --format=testname \
+		--junitfile=./tmp/test-results/results.xml \
+		--jsonfile=./tmp/testlogs/log.json \
+		--rerun-fails=3 \
+		--rerun-fails-max-failures=50 \
+		--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
+		-- -parallel=$$PARALLEL -coverprofile=coverage.out -short -timeout=$(TEST_TIMEOUT)
+.PHONY: go-tests-short-ci
+
 go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps built by CI)
 	@echo "Setting up test directories..."
 	mkdir -p ./tmp/test-results ./tmp/testlogs


### PR DESCRIPTION
This succeeds https://github.com/ethereum-optimism/optimism/pull/16261 as a way to avoid running time-consuming tests pre-merge. Will follow up with another PR to run all go-tests post-merge.