### PR TITLE
op-node/rollup: binary search for latest valid local unsafe block

### DIFF
--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -423,7 +423,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 	}
 
 	// In the following walkback loop, the following two cases are covered:
-	// 1. x == 0 or x < 1 (i.e. target == latestUnsafe), or
+	// 1. targetDiff == 0 or targetDiff < 0 (i.e. target == latestUnsafe), or
 	// 2. all blocks checked by binary search were invalid, so we have to go from `target` backwards indefinitely
 	//    until we find a valid block
 	for n := target; ; n-- {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/binary"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
@@ -405,7 +406,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
 		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
 		// ------------------------------------------------------------------------------------
-		offset, err := localUnsafeSearch(targetDiff, func(i int) (bool, eth.L2BlockRef, error) {
+		offset, _, err := binary.SearchFirst(targetDiff, func(i int) (bool, eth.L2BlockRef, error) {
 			block, err := m.verifyBlock(ctx, logger, target+1+uint64(i))
 			return block == (eth.L2BlockRef{}), block, err
 		})
@@ -450,28 +451,6 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 			return valid, nil
 		}
 	}
-}
-
-// localUnsafeSearch is a copy-paste from sort.Search, but also stops on and returns error
-func localUnsafeSearch(n int, f func(int) (bool, eth.L2BlockRef, error)) (int, error) {
-	// Define f(-1) == false and f(n) == true.
-	// Invariant: f(i-1) == false, f(j) == true.
-	i, j := 0, n
-	for i < j {
-		h := int(uint(i+j) >> 1) // avoid overflow when computing h
-		// i ≤ h < j
-		ok, _, err := f(h)
-		if err != nil {
-			return -1, err
-		}
-		if !ok {
-			i = h + 1 // preserves f(i-1) == false
-		} else {
-			j = h // preserves f(j) == true
-		}
-	}
-	// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
-	return i, nil
 }
 
 // verifyBlock

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -394,38 +394,28 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 
 	targetDiff := int(latestUnsafe.Number - target)
 	if targetDiff > 0 {
-		// Binary search to find and return the smallest index i in [0, x) at which f(i) is true.
-		// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid.
-		// This means that `offset+1` is the index of the first invalid block.
-		// This means that `offset` is the index of the last valid block, which we are searching for.
+		// Binary search to find and return the last valid block for idx in [0, targetDiff)
 		// We don't check validity of `target`, `target` is not in the search space, it is checked
 		// in the walkback loop section below if necessary.
 
 		// Search space:
-		// ------------------------------------------------------------------------------------
-		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
-		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
-		// ------------------------------------------------------------------------------------
-		offset, _, err := binary.SearchFirst(targetDiff, func(i int) (bool, eth.L2BlockRef, error) {
+		// ------------------------------------------------------------------------------------------
+		// target.Number |  idx=0      idx=1      idx=2     ...  idx = targetDiff-1 = latestUnsafe   |
+		// false         |  t/f        t/f        t/f       ...  t/f                                 |
+		// ------------------------------------------------------------------------------------------
+		idx, valid, err := binary.SearchL(targetDiff, func(i int) (bool, eth.L2BlockRef, error) {
 			block, err := m.verifyBlock(ctx, logger, target+1+uint64(i))
-			return block == (eth.L2BlockRef{}), block, err
+			return block != (eth.L2BlockRef{}), block, err
 		})
 		if err != nil {
 			return eth.L2BlockRef{}, err
 		}
-		// offset == 0 => search returns 0 if f(i) returned true for all i in [0, x) => all blocks we checked are invalid
-		// offset == x => search returns x if f(i) returned false for all i in [0, x) => all blocks we checked are valid
 
-		if offset != 0 {
-			logger.Info("Found last valid block with binary search", "validNum", target+uint64(offset))
-
-			valid, err := m.l2.L2BlockRefByNumber(ctx, target+uint64(offset))
-			if err != nil {
-				return eth.L2BlockRef{}, err
-			}
-
-			logger.Info("Last valid L2 block ref", "valid", valid)
+		if idx != -1 {
+			logger.Info("Found last valid block with binary search", "valid", valid)
 			return valid, nil
+		} else {
+			logger.Info("All blocks checked by binary search are invalid between target and latestUnsafe")
 		}
 	} else if targetDiff < 0 {
 		logger.Warn("Latest unsafe block is older than target, using latest unsafe for search")
@@ -434,7 +424,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 
 	// In the following walkback loop, the following two cases are covered:
 	// 1. x == 0 or x < 1 (i.e. target == latestUnsafe), or
-	// 2. binary search returned offset == 0 (i.e. all blocks we checked are invalid), so we have to go from `target` backwards indefinitely
+	// 2. all blocks checked by binary search were invalid, so we have to go from `target` backwards indefinitely
 	//    until we find a valid block
 	for n := target; ; n-- {
 		if n == target-1 {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -378,6 +378,86 @@ func (m *ManagedMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe,
 	return nil
 }
 
+// findLatestValidLocalUnsafe searches and returns the latest valid block of the L2 chain
+// starting from `l2UnsafeTarget` and checking until the latest unsafe block.
+func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
+	latestUnsafe, err := m.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		return eth.L2BlockRef{}, err
+	}
+
+	logger := m.log.New("target", l2UnsafeTarget, "latestUnsafe", latestUnsafe)
+	target := l2UnsafeTarget.Number
+
+	// Binary search to find and return the smallest index i in [0, x) at which f(i) is true
+	// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid
+	// This means that `offset+1` is the index of the first invalid block
+	// This means that `offset` is the index of the last valid block, which we are searching for
+	// We don't check `target`
+	logger.Info("Searching for latest valid local unsafe")
+
+	x := int(latestUnsafe.Number - target)
+	if x != 0 {
+		// search space:
+		// ------------------------------------------------------------------------------------
+		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
+		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
+		// ------------------------------------------------------------------------------------
+		offset, err := localUnsafeSearch(x, func(i int) (bool, error) {
+			return m.isInvalidBlock(ctx, logger, target+1+uint64(i))
+		})
+		if err != nil {
+			return eth.L2BlockRef{}, err
+		}
+		// offset == 0 => search returns 0 if f(i) returned true for all i in [0, x) => all blocks we checked are invalid
+		// offset == x => search returns x if f(i) returned false for all i in [0, x) => all blocks we checked are valid
+
+		if offset != 0 {
+			logger.Info("Found last valid block with binary search", "validNum", target+uint64(offset))
+
+			valid, err := m.l2.L2BlockRefByNumber(ctx, target+uint64(offset))
+			if err != nil {
+				return eth.L2BlockRef{}, err
+			}
+
+			logger.Info("Last valid L2 block ref", "valid", valid)
+			return valid, nil
+		}
+	} else if x < 0 {
+		logger.Warn("Latest unsafe block is older than target, using latest unsafe for search")
+		target = latestUnsafe.Number
+	}
+
+	// offset == 0 or x == 0, so go from target backwards indefinitely until we find a valid block
+	// since L1 reorgs aren't usually that deep.
+	for n := target; ; n-- {
+		if n == target-1 {
+			logger.Warn("No valid unsafe block found up to target, searching further")
+		}
+		// Exit loop if context is done - other errors are only logged and loop continues.
+		if cerr := ctx.Err(); cerr != nil {
+			return eth.L2BlockRef{}, fmt.Errorf("context done: %w", cerr)
+		}
+
+		isInvalid, err := m.isInvalidBlock(ctx, logger, n)
+		if err != nil {
+			return eth.L2BlockRef{}, err
+		}
+
+		if !isInvalid {
+			logger.Info("Found last valid block", "validNum", n)
+
+			valid, err := m.l2.L2BlockRefByNumber(ctx, n)
+			if err != nil {
+				return eth.L2BlockRef{}, err
+			}
+
+			logger.Info("Last valid L2 block ref", "valid", valid)
+			return valid, nil
+		}
+	}
+}
+
 // localUnsafeSearch is a copy-paste from sort.Search, but also stops on and returns error
 func localUnsafeSearch(n int, f func(int) (bool, error)) (int, error) {
 	// Define f(-1) == false and f(n) == true.
@@ -400,107 +480,26 @@ func localUnsafeSearch(n int, f func(int) (bool, error)) (int, error) {
 	return i, nil
 }
 
-// findLatestValidLocalUnsafe searches and returns the latest valid block of the L2 chain
-// starting from `l2UnsafeTarget` and checking until the latest unsafe block.
-func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
-	latestUnsafe, err := m.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
+// isInvalidBlock returns:
+// - false: if the L1Origin field for the block belongs to the canonical chain
+// - true: if the L1Origin field for the block is invalid/outdated/reorged
+func (m *ManagedMode) isInvalidBlock(ctx context.Context, logger log.Logger, blockNum uint64) (bool, error) {
+	current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 	if err != nil {
-		return eth.L2BlockRef{}, err
+		return true, err
 	}
 
-	logger := m.log.New("target", l2UnsafeTarget, "latestUnsafe", latestUnsafe)
-	target := l2UnsafeTarget.Number
-
-	// isInvalidBlock returns:
-	// - false: if the L1Origin field for the block belongs to the canonical chain
-	// - true: if the L1Origin field for the block is invalid/outdated/reorged
-	isInvalidBlock := func(blockNum uint64) (bool, error) {
-		current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
-		if err != nil {
-			return true, err
-		}
-
-		// Check if L1Origin has been reorged
-		l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
-		if err != nil {
-			return true, err
-		}
-		if l1Blk.Hash != current.L1Origin.Hash {
-			logger.Debug("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "currentNumber", current.Number, "currentL1Origin", current.L1Origin, "newL1Origin", l1Blk)
-			return true, nil
-		}
-		logger.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
-		return false, nil
+	// Check if L1Origin has been reorged
+	l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
+	if err != nil {
+		return true, err
 	}
-
-	// Binary search to find and return the smallest index i in [0, x) at which f(i) is true
-	// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid
-	// This means that `offset+1` is the index of the first invalid block
-	// This means that `offset` is the index of the last valid block, which we are searching for
-	// We don't check `target`
-	logger.Info("Searching for latest valid local unsafe")
-
-	x := int(latestUnsafe.Number - target)
-	if x < 0 {
-		logger.Warn("Latest unsafe block is older than target, using latest unsafe for search")
-		target = latestUnsafe.Number
-	} else if x != 0 {
-		// search space:
-		// ------------------------------------------------------------------------------------
-		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
-		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
-		// ------------------------------------------------------------------------------------
-		offset, err := localUnsafeSearch(x, func(i int) (bool, error) {
-			return isInvalidBlock(target + 1 + uint64(i))
-		})
-		if err != nil {
-			return eth.L2BlockRef{}, err
-		}
-		// offset == 0 => search returns 0 if f(i) returned true for all i in [0, x) => all blocks we checked are invalid
-		// offset == x => search returns x if f(i) returned false for all i in [0, x) => all blocks we checked are valid
-
-		if offset != 0 {
-			logger.Info("Found last valid block with binary search", "validNum", target+uint64(offset))
-
-			valid, err := m.l2.L2BlockRefByNumber(ctx, target+uint64(offset))
-			if err != nil {
-				return eth.L2BlockRef{}, err
-			}
-
-			logger.Info("Last valid L2 block ref", "valid", valid)
-			return valid, nil
-		}
+	if l1Blk.Hash != current.L1Origin.Hash {
+		logger.Debug("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "currentNumber", current.Number, "currentL1Origin", current.L1Origin, "newL1Origin", l1Blk)
+		return true, nil
 	}
-
-	// offset == 0 or x == 0, so go from target backwards indefinitely until we find a valid block
-	// since L1 reorgs aren't usually that deep.
-	for n := target; ; n-- {
-		if n == target-1 {
-			logger.Warn("No valid unsafe block found up to target, searching further")
-		}
-		// Exit loop if context is done - other errors are only logged and loop continues.
-		if cerr := ctx.Err(); cerr != nil {
-			return eth.L2BlockRef{}, fmt.Errorf("context done: %w", cerr)
-		}
-
-		isInvalid, err := isInvalidBlock(n)
-		if err != nil {
-			return eth.L2BlockRef{}, err
-		}
-
-		if !isInvalid {
-			logger.Info("Found last valid block", "validNum", n)
-
-			valid, err := m.l2.L2BlockRefByNumber(ctx, n)
-			if err != nil {
-				return eth.L2BlockRef{}, err
-			}
-
-			logger.Info("Last valid L2 block ref", "valid", valid)
-			return valid, nil
-		}
-	}
-
+	logger.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
+	return false, nil
 }
 
 func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -406,7 +406,8 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
 		// ------------------------------------------------------------------------------------
 		offset, err := localUnsafeSearch(x, func(i int) (bool, eth.L2BlockRef, error) {
-			return m.isInvalidBlock(ctx, logger, target+1+uint64(i))
+			block, err := m.verifyBlock(ctx, logger, target+1+uint64(i))
+			return block == (eth.L2BlockRef{}), block, err
 		})
 		if err != nil {
 			return eth.L2BlockRef{}, err
@@ -439,12 +440,12 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 			logger.Warn("No valid unsafe block found up to target, searching further")
 		}
 
-		isInvalid, valid, err := m.isInvalidBlock(ctx, logger, n)
+		valid, err := m.verifyBlock(ctx, logger, n)
 		if err != nil {
 			return eth.L2BlockRef{}, err
 		}
 
-		if !isInvalid {
+		if valid != (eth.L2BlockRef{}) {
 			logger.Info("Fould last valid block", "valid", valid)
 			return valid, nil
 		}
@@ -473,26 +474,24 @@ func localUnsafeSearch(n int, f func(int) (bool, eth.L2BlockRef, error)) (int, e
 	return i, nil
 }
 
-// isInvalidBlock returns:
-// - false: if the L1Origin field for the block belongs to the canonical chain; in this case we also return the block ref
-// - true: if the L1Origin field for the block is invalid/outdated/reorged
-func (m *ManagedMode) isInvalidBlock(ctx context.Context, logger log.Logger, blockNum uint64) (bool, eth.L2BlockRef, error) {
+// verifyBlock
+func (m *ManagedMode) verifyBlock(ctx context.Context, logger log.Logger, blockNum uint64) (eth.L2BlockRef, error) {
 	current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 	if err != nil {
-		return true, eth.L2BlockRef{}, err
+		return eth.L2BlockRef{}, err
 	}
 
 	// Check if L1Origin has been reorged
 	l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
 	if err != nil {
-		return true, eth.L2BlockRef{}, err
+		return eth.L2BlockRef{}, err
 	}
 	if l1Blk.Hash != current.L1Origin.Hash {
 		logger.Debug("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "currentNumber", current.Number, "currentL1Origin", current.L1Origin, "newL1Origin", l1Blk)
-		return true, eth.L2BlockRef{}, nil
+		return eth.L2BlockRef{}, nil
 	}
 	logger.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
-	return false, current, nil
+	return current, nil
 }
 
 func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -378,6 +378,28 @@ func (m *ManagedMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe,
 	return nil
 }
 
+// localUnsafeSearch is a copy-paste from sort.Search, but also stops on and returns error
+func localUnsafeSearch(n int, f func(int) (bool, error)) (int, error) {
+	// Define f(-1) == false and f(n) == true.
+	// Invariant: f(i-1) == false, f(j) == true.
+	i, j := 0, n
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		ok, err := f(h)
+		if err != nil {
+			return -1, err
+		}
+		if !ok {
+			i = h + 1 // preserves f(i-1) == false
+		} else {
+			j = h // preserves f(j) == true
+		}
+	}
+	// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
+	return i, nil
+}
+
 // findLatestValidLocalUnsafe searches and returns the latest valid block of the L2 chain
 // starting from `l2UnsafeTarget` and checking until the latest unsafe block.
 func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
@@ -388,28 +410,6 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 
 	logger := m.log.New("target", l2UnsafeTarget, "latestUnsafe", latestUnsafe)
 	target := l2UnsafeTarget.Number
-
-	// Copy-paste from sort.Search, but also stops on and returns error
-	search := func(n int, f func(int) (bool, error)) (int, error) {
-		// Define f(-1) == false and f(n) == true.
-		// Invariant: f(i-1) == false, f(j) == true.
-		i, j := 0, n
-		for i < j {
-			h := int(uint(i+j) >> 1) // avoid overflow when computing h
-			// i ≤ h < j
-			ok, err := f(h)
-			if err != nil {
-				return -1, err
-			}
-			if !ok {
-				i = h + 1 // preserves f(i-1) == false
-			} else {
-				j = h // preserves f(j) == true
-			}
-		}
-		// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
-		return i, nil
-	}
 
 	// isInvalidBlock returns:
 	// - false: if the L1Origin field for the block belongs to the canonical chain
@@ -450,7 +450,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
 		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
 		// ------------------------------------------------------------------------------------
-		offset, err := search(x, func(i int) (bool, error) {
+		offset, err := localUnsafeSearch(x, func(i int) (bool, error) {
 			return isInvalidBlock(target + 1 + uint64(i))
 		})
 		if err != nil {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -391,8 +391,8 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 
 	logger.Info("Searching for latest valid local unsafe")
 
-	x := int(latestUnsafe.Number - target)
-	if x > 0 {
+	targetDiff := int(latestUnsafe.Number - target)
+	if targetDiff > 0 {
 		// Binary search to find and return the smallest index i in [0, x) at which f(i) is true.
 		// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid.
 		// This means that `offset+1` is the index of the first invalid block.
@@ -405,7 +405,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
 		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
 		// ------------------------------------------------------------------------------------
-		offset, err := localUnsafeSearch(x, func(i int) (bool, eth.L2BlockRef, error) {
+		offset, err := localUnsafeSearch(targetDiff, func(i int) (bool, eth.L2BlockRef, error) {
 			block, err := m.verifyBlock(ctx, logger, target+1+uint64(i))
 			return block == (eth.L2BlockRef{}), block, err
 		})
@@ -426,7 +426,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 			logger.Info("Last valid L2 block ref", "valid", valid)
 			return valid, nil
 		}
-	} else if x < 0 {
+	} else if targetDiff < 0 {
 		logger.Warn("Latest unsafe block is older than target, using latest unsafe for search")
 		target = latestUnsafe.Number
 	}

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -417,18 +417,16 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 	isInvalidBlock := func(blockNum uint64) (bool, error) {
 		current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 		if err != nil {
-			logger.Error("Failed to get L2 block ref", "err", err, "blocknum", blockNum)
 			return true, err
 		}
 
 		// Check if L1Origin has been reorged
 		l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
 		if err != nil {
-			logger.Error("Failed to get L1 block ref", "err", err, "blocknum", current.L1Origin.Number)
 			return true, err
 		}
 		if l1Blk.Hash != current.L1Origin.Hash {
-			logger.Trace("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "current.number", current.Number, "current.L1Origin", current.L1Origin, "new-L1Origin", l1Blk)
+			logger.Debug("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "currentNumber", current.Number, "currentL1Origin", current.L1Origin, "newL1Origin", l1Blk)
 			return true, nil
 		}
 		logger.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -379,20 +379,15 @@ func (m *ManagedMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe,
 }
 
 // findLatestValidLocalUnsafe searches and returns the latest valid block of the L2 chain
-// starting from `l2Unsafe` (which we trust is valid because it's given by the supervisor)
-// and checking until the latest unsafe block.
-func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2Unsafe eth.BlockID) (eth.L2BlockRef, error) {
-	valid, err := m.l2.L2BlockRefByHash(ctx, l2Unsafe.Hash)
-	if err != nil {
-		return eth.L2BlockRef{}, err
-	}
-
+// starting from `l2UnsafeTarget` and checking until the latest unsafe block.
+func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
 	latestUnsafe, err := m.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
 
-	m.log.Info("Searching for latest valid local unsafe", "valid", valid, "latestUnsafe", latestUnsafe)
+	logger := m.log.New("target", l2UnsafeTarget, "latestUnsafe", latestUnsafe)
+	target := l2UnsafeTarget.Number
 
 	// Copy-paste from sort.Search, but also stops on and returns error
 	search := func(n int, f func(int) (bool, error)) (int, error) {
@@ -422,21 +417,21 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2Unsafe e
 	isInvalidBlock := func(blockNum uint64) (bool, error) {
 		current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 		if err != nil {
-			m.log.Error("Failed to get L2 block ref", "err", err, "blocknum", blockNum)
+			logger.Error("Failed to get L2 block ref", "err", err, "blocknum", blockNum)
 			return true, err
 		}
 
 		// Check if L1Origin has been reorged
 		l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
 		if err != nil {
-			m.log.Error("Failed to get L1 block ref", "err", err, "blocknum", current.L1Origin.Number)
+			logger.Error("Failed to get L1 block ref", "err", err, "blocknum", current.L1Origin.Number)
 			return true, err
 		}
 		if l1Blk.Hash != current.L1Origin.Hash {
-			m.log.Trace("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "current.number", current.Number, "current.L1Origin", current.L1Origin, "new-L1Origin", l1Blk)
+			logger.Trace("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "current.number", current.Number, "current.L1Origin", current.L1Origin, "new-L1Origin", l1Blk)
 			return true, nil
 		}
-		m.log.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
+		logger.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
 		return false, nil
 	}
 
@@ -444,23 +439,21 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2Unsafe e
 	// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid
 	// This means that `offset+1` is the index of the first invalid block
 	// This means that `offset` is the index of the last valid block, which we are searching for
-	// We don't check `valid` because it's already known to be valid
-	{
-		x := int(latestUnsafe.Number - valid.Number)
-		if x < 0 {
-			return eth.L2BlockRef{}, fmt.Errorf("valid.Number is greater than latestUnsafe.Number, this should never happen, valid: %v, latestUnsafe: %v", valid, latestUnsafe)
-		}
-		if x == 0 {
-			return valid, nil
-		}
+	// We don't check `target`
+	logger.Info("Searching for latest valid local unsafe")
 
+	x := int(latestUnsafe.Number - target)
+	if x < 0 {
+		logger.Warn("Latest unsafe block is older than target, using latest unsafe for search")
+		target = latestUnsafe.Number
+	} else if x != 0 {
 		// search space:
 		// ------------------------------------------------------------------------------------
-		// valid.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
-		// false        |  t/f        t/f        t/f       ...  t/f                           |  true
+		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
+		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
 		// ------------------------------------------------------------------------------------
 		offset, err := search(x, func(i int) (bool, error) {
-			return isInvalidBlock(valid.Number + 1 + uint64(i))
+			return isInvalidBlock(target + 1 + uint64(i))
 		})
 		if err != nil {
 			return eth.L2BlockRef{}, err
@@ -468,19 +461,48 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2Unsafe e
 		// offset == 0 => search returns 0 if f(i) returned true for all i in [0, x) => all blocks we checked are invalid
 		// offset == x => search returns x if f(i) returned false for all i in [0, x) => all blocks we checked are valid
 
-		m.log.Info("Found last valid block", "blockNum", valid.Number+uint64(offset), "latestUnsafe", latestUnsafe)
+		if offset != 0 {
+			logger.Info("Found last valid block with binary search", "validNum", target+uint64(offset))
 
-		valid, err = m.l2.L2BlockRefByNumber(ctx, valid.Number+uint64(offset))
+			valid, err := m.l2.L2BlockRefByNumber(ctx, target+uint64(offset))
+			if err != nil {
+				return eth.L2BlockRef{}, err
+			}
+
+			logger.Info("Last valid L2 block ref", "valid", valid)
+			return valid, nil
+		}
+	}
+
+	// offset == 0 or x == 0, so go from target backwards indefinitely until we find a valid block
+	// since L1 reorgs aren't usually that deep.
+	for n := target; ; n-- {
+		if n == target-1 {
+			logger.Warn("No valid unsafe block found up to target, searching further")
+		}
+		// Exit loop if context is done - other errors are only logged and loop continues.
+		if cerr := ctx.Err(); cerr != nil {
+			return eth.L2BlockRef{}, fmt.Errorf("context done: %w", cerr)
+		}
+
+		isInvalid, err := isInvalidBlock(n)
 		if err != nil {
 			return eth.L2BlockRef{}, err
 		}
 
-		m.log.Info("Last valid L2 block ref", "valid", valid, "latestUnsafe", latestUnsafe)
+		if !isInvalid {
+			logger.Info("Found last valid block", "validNum", n)
+
+			valid, err := m.l2.L2BlockRefByNumber(ctx, n)
+			if err != nil {
+				return eth.L2BlockRef{}, err
+			}
+
+			logger.Info("Last valid L2 block ref", "valid", valid)
+			return valid, nil
+		}
 	}
 
-	// we return the most recent valid block
-	// in this context the definition of valid is that it's L1Origin is valid
-	return valid, nil
 }
 
 func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -403,7 +403,7 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
 		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
 		// ------------------------------------------------------------------------------------
-		offset, err := localUnsafeSearch(x, func(i int) (bool, error) {
+		offset, err := localUnsafeSearch(x, func(i int) (bool, eth.L2BlockRef, error) {
 			return m.isInvalidBlock(ctx, logger, target+1+uint64(i))
 		})
 		if err != nil {
@@ -439,34 +439,27 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 			return eth.L2BlockRef{}, fmt.Errorf("context done: %w", cerr)
 		}
 
-		isInvalid, err := m.isInvalidBlock(ctx, logger, n)
+		isInvalid, valid, err := m.isInvalidBlock(ctx, logger, n)
 		if err != nil {
 			return eth.L2BlockRef{}, err
 		}
 
 		if !isInvalid {
-			logger.Info("Found last valid block", "validNum", n)
-
-			valid, err := m.l2.L2BlockRefByNumber(ctx, n)
-			if err != nil {
-				return eth.L2BlockRef{}, err
-			}
-
-			logger.Info("Last valid L2 block ref", "valid", valid)
+			logger.Info("Fould last valid block", "valid", valid)
 			return valid, nil
 		}
 	}
 }
 
 // localUnsafeSearch is a copy-paste from sort.Search, but also stops on and returns error
-func localUnsafeSearch(n int, f func(int) (bool, error)) (int, error) {
+func localUnsafeSearch(n int, f func(int) (bool, eth.L2BlockRef, error)) (int, error) {
 	// Define f(-1) == false and f(n) == true.
 	// Invariant: f(i-1) == false, f(j) == true.
 	i, j := 0, n
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		ok, err := f(h)
+		ok, _, err := f(h)
 		if err != nil {
 			return -1, err
 		}
@@ -483,23 +476,23 @@ func localUnsafeSearch(n int, f func(int) (bool, error)) (int, error) {
 // isInvalidBlock returns:
 // - false: if the L1Origin field for the block belongs to the canonical chain
 // - true: if the L1Origin field for the block is invalid/outdated/reorged
-func (m *ManagedMode) isInvalidBlock(ctx context.Context, logger log.Logger, blockNum uint64) (bool, error) {
+func (m *ManagedMode) isInvalidBlock(ctx context.Context, logger log.Logger, blockNum uint64) (bool, eth.L2BlockRef, error) {
 	current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 	if err != nil {
-		return true, err
+		return true, eth.L2BlockRef{}, err
 	}
 
 	// Check if L1Origin has been reorged
 	l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
 	if err != nil {
-		return true, err
+		return true, eth.L2BlockRef{}, err
 	}
 	if l1Blk.Hash != current.L1Origin.Hash {
 		logger.Debug("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "currentNumber", current.Number, "currentL1Origin", current.L1Origin, "newL1Origin", l1Blk)
-		return true, nil
+		return true, eth.L2BlockRef{}, nil
 	}
 	logger.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
-	return false, nil
+	return false, current, nil
 }
 
 func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -378,60 +378,109 @@ func (m *ManagedMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe,
 	return nil
 }
 
-// findLatestValidLocalUnsafe scans the L2 unsafe chain for the latest block with a valid L1 origin,
-// starting from its latest unsafe and going back until the target provided by the supervisor.
-// If the supervisor's target is ahead, the latest unsafe is returned.
-func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTarget eth.BlockID) (eth.L2BlockRef, error) {
+// findLatestValidLocalUnsafe searches and returns the latest valid block of the L2 chain
+// starting from `l2Unsafe` (which we trust is valid because it's given by the supervisor)
+// and checking until the latest unsafe block.
+func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2Unsafe eth.BlockID) (eth.L2BlockRef, error) {
+	valid, err := m.l2.L2BlockRefByHash(ctx, l2Unsafe.Hash)
+	if err != nil {
+		return eth.L2BlockRef{}, err
+	}
+
 	latestUnsafe, err := m.l2.L2BlockRefByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
-	logger := m.log.New("target", l2UnsafeTarget, "latestUnsafe", latestUnsafe)
-	if latestUnsafe.Number < l2UnsafeTarget.Number {
-		logger.Warn("Latest unsafe block is older than target, using latest unsafe")
-		return latestUnsafe, nil
-	}
 
-	unsafeTarget, err := m.l2.L2BlockRefByHash(ctx, l2UnsafeTarget.Hash)
-	if err != nil {
-		return eth.L2BlockRef{}, err
-	}
+	m.log.Info("Searching for latest valid local unsafe", "valid", valid, "latestUnsafe", latestUnsafe)
 
-	logger.Info("Searching for latest valid local unsafe")
-	if latestUnsafe.Number-unsafeTarget.Number > 20 {
-		logger.Warn("We may scan more than 20 blocks, this loop might need to be optimised")
-	}
-
-	// Start from latestUnsafe and go down to find the latest valid block, since L1 reorgs aren't usually that deep.
-	for n := latestUnsafe.Number; ; n-- {
-		if n == l2UnsafeTarget.Number-1 {
-			logger.Warn("No valid unsafe block found up to target, searching further")
+	// Copy-paste from sort.Search, but also stops on and returns error
+	search := func(n int, f func(int) (bool, error)) (int, error) {
+		// Define f(-1) == false and f(n) == true.
+		// Invariant: f(i-1) == false, f(j) == true.
+		i, j := 0, n
+		for i < j {
+			h := int(uint(i+j) >> 1) // avoid overflow when computing h
+			// i ≤ h < j
+			ok, err := f(h)
+			if err != nil {
+				return -1, err
+			}
+			if !ok {
+				i = h + 1 // preserves f(i-1) == false
+			} else {
+				j = h // preserves f(j) == true
+			}
 		}
-		// Exit loop if context is done - other errors are only logged and loop continues.
-		if cerr := ctx.Err(); cerr != nil {
-			return eth.L2BlockRef{}, fmt.Errorf("context done: %w", cerr)
-		}
+		// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
+		return i, nil
+	}
 
-		current, err := m.l2.L2BlockRefByNumber(ctx, n)
+	// isInvalidBlock returns:
+	// - false: if the L1Origin field for the block belongs to the canonical chain
+	// - true: if the L1Origin field for the block is invalid/outdated/reorged
+	isInvalidBlock := func(blockNum uint64) (bool, error) {
+		current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)
 		if err != nil {
-			logger.Warn("Failed to get L2 block ref, trying previous", "err", err, "current", n)
-			continue
+			m.log.Error("Failed to get L2 block ref", "err", err, "blocknum", blockNum)
+			return true, err
 		}
 
-		logger := logger.New("current", current, "currentL1Origin", current.L1Origin)
-		// make sure L1 origin hasn't been reorged
-		l1Origin, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
+		// Check if L1Origin has been reorged
+		l1Blk, err := m.l1.L1BlockRefByNumber(ctx, current.L1Origin.Number)
 		if err != nil {
-			logger.Warn("Failed to get origin L1 block ref, trying previous", "err", err)
-			continue
+			m.log.Error("Failed to get L1 block ref", "err", err, "blocknum", current.L1Origin.Number)
+			return true, err
 		}
-		if l1Origin.Hash != current.L1Origin.Hash {
-			logger.Warn("L1 block was reorged on this block, trying previous", "newL1Origin", l1Origin)
-			continue
+		if l1Blk.Hash != current.L1Origin.Hash {
+			m.log.Trace("L1Origin field is invalid/outdated, so block is invalid and should be reorged", "current.number", current.Number, "current.L1Origin", current.L1Origin, "new-L1Origin", l1Blk)
+			return true, nil
 		}
-		logger.Info("Latest valid L2 block found", "valid", current)
-		return current, nil
+		m.log.Trace("L1Origin field points to canonical L1 block, so block is valid", "blocknum", blockNum, "l1Blk", l1Blk)
+		return false, nil
 	}
+
+	// Binary search to find and return the smallest index i in [0, x) at which f(i) is true
+	// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid
+	// This means that `offset+1` is the index of the first invalid block
+	// This means that `offset` is the index of the last valid block, which we are searching for
+	// We don't check `valid` because it's already known to be valid
+	{
+		x := int(latestUnsafe.Number - valid.Number)
+		if x < 0 {
+			return eth.L2BlockRef{}, fmt.Errorf("valid.Number is greater than latestUnsafe.Number, this should never happen, valid: %v, latestUnsafe: %v", valid, latestUnsafe)
+		}
+		if x == 0 {
+			return valid, nil
+		}
+
+		// search space:
+		// ------------------------------------------------------------------------------------
+		// valid.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
+		// false        |  t/f        t/f        t/f       ...  t/f                           |  true
+		// ------------------------------------------------------------------------------------
+		offset, err := search(x, func(i int) (bool, error) {
+			return isInvalidBlock(valid.Number + 1 + uint64(i))
+		})
+		if err != nil {
+			return eth.L2BlockRef{}, err
+		}
+		// offset == 0 => search returns 0 if f(i) returned true for all i in [0, x) => all blocks we checked are invalid
+		// offset == x => search returns x if f(i) returned false for all i in [0, x) => all blocks we checked are valid
+
+		m.log.Info("Found last valid block", "blockNum", valid.Number+uint64(offset), "latestUnsafe", latestUnsafe)
+
+		valid, err = m.l2.L2BlockRefByNumber(ctx, valid.Number+uint64(offset))
+		if err != nil {
+			return eth.L2BlockRef{}, err
+		}
+
+		m.log.Info("Last valid L2 block ref", "valid", valid, "latestUnsafe", latestUnsafe)
+	}
+
+	// we return the most recent valid block
+	// in this context the definition of valid is that it's L1Origin is valid
+	return valid, nil
 }
 
 func (m *ManagedMode) ProvideL1(ctx context.Context, nextL1 eth.BlockRef) error {

--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -389,16 +389,18 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 	logger := m.log.New("target", l2UnsafeTarget, "latestUnsafe", latestUnsafe)
 	target := l2UnsafeTarget.Number
 
-	// Binary search to find and return the smallest index i in [0, x) at which f(i) is true
-	// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid
-	// This means that `offset+1` is the index of the first invalid block
-	// This means that `offset` is the index of the last valid block, which we are searching for
-	// We don't check `target`
 	logger.Info("Searching for latest valid local unsafe")
 
 	x := int(latestUnsafe.Number - target)
-	if x != 0 {
-		// search space:
+	if x > 0 {
+		// Binary search to find and return the smallest index i in [0, x) at which f(i) is true.
+		// In this context, binary search returns the first block which is invalid, and we infer that the previous block is valid.
+		// This means that `offset+1` is the index of the first invalid block.
+		// This means that `offset` is the index of the last valid block, which we are searching for.
+		// We don't check validity of `target`, `target` is not in the search space, it is checked
+		// in the walkback loop section below if necessary.
+
+		// Search space:
 		// ------------------------------------------------------------------------------------
 		// target.Number |  offset=0   offset=1   offset=2  ...  offset = x-1 = latestUnsafe   |  offset=x  (doesn't exist)
 		// false         |  t/f        t/f        t/f       ...  t/f                           |  true
@@ -428,15 +430,13 @@ func (m *ManagedMode) findLatestValidLocalUnsafe(ctx context.Context, l2UnsafeTa
 		target = latestUnsafe.Number
 	}
 
-	// offset == 0 or x == 0, so go from target backwards indefinitely until we find a valid block
-	// since L1 reorgs aren't usually that deep.
+	// In the following walkback loop, the following two cases are covered:
+	// 1. x == 0 or x < 1 (i.e. target == latestUnsafe), or
+	// 2. binary search returned offset == 0 (i.e. all blocks we checked are invalid), so we have to go from `target` backwards indefinitely
+	//    until we find a valid block
 	for n := target; ; n-- {
 		if n == target-1 {
 			logger.Warn("No valid unsafe block found up to target, searching further")
-		}
-		// Exit loop if context is done - other errors are only logged and loop continues.
-		if cerr := ctx.Err(); cerr != nil {
-			return eth.L2BlockRef{}, fmt.Errorf("context done: %w", cerr)
 		}
 
 		isInvalid, valid, err := m.isInvalidBlock(ctx, logger, n)
@@ -474,7 +474,7 @@ func localUnsafeSearch(n int, f func(int) (bool, eth.L2BlockRef, error)) (int, e
 }
 
 // isInvalidBlock returns:
-// - false: if the L1Origin field for the block belongs to the canonical chain
+// - false: if the L1Origin field for the block belongs to the canonical chain; in this case we also return the block ref
 // - true: if the L1Origin field for the block is invalid/outdated/reorged
 func (m *ManagedMode) isInvalidBlock(ctx context.Context, logger log.Logger, blockNum uint64) (bool, eth.L2BlockRef, error) {
 	current, err := m.l2.L2BlockRefByNumber(ctx, blockNum)

--- a/op-node/rollup/interop/managed/system_test.go
+++ b/op-node/rollup/interop/managed/system_test.go
@@ -100,7 +100,7 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 			ctx := context.Background()
 			logger := testlog.Logger(t, log.LevelDebug)
 
-			mockL1 := &testutils.MockL1Client{}
+			mockL1 := &testutils.MockL1Source{}
 			mockL2 := &testutils.MockL2Client{}
 
 			var nilErr error
@@ -139,11 +139,11 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 				if validBlocksMap[blockNum] {
 					// Valid: return matching hash
 					mockL1.On("L1BlockRefByNumber", l1OriginNum).
-						Return(createL1BlockRef(l1OriginNum, l1OriginHash), &nilErr).Maybe()
+						Return(createL1BlockRef(l1OriginNum, l1OriginHash), nilErr).Maybe()
 				} else {
 					// Invalid: return different hash (reorg)
 					mockL1.On("L1BlockRefByNumber", l1OriginNum).
-						Return(createL1BlockRef(l1OriginNum, fmt.Sprintf("0x%x", l1OriginNum+1000)), &nilErr).Maybe()
+						Return(createL1BlockRef(l1OriginNum, fmt.Sprintf("0x%x", l1OriginNum+1000)), nilErr).Maybe()
 				}
 			}
 

--- a/op-node/rollup/interop/managed/system_test.go
+++ b/op-node/rollup/interop/managed/system_test.go
@@ -25,7 +25,7 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 		expectedError  string
 	}{
 		{
-			name:           "l2unsafe_equals_latest",
+			name:           "target_equals_latest",
 			l2Unsafe:       100,
 			latestUnsafe:   100,
 			validBlocks:    []uint64{100},
@@ -67,11 +67,25 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 			expectedResult: 100,
 		},
 		{
-			name:           "l2unsafe_not_at_100",
+			name:           "target_not_at_100",
 			l2Unsafe:       95,
 			latestUnsafe:   100,
 			validBlocks:    []uint64{95, 96, 97}, // 98-100 invalid
 			expectedResult: 97,
+		},
+		{
+			name:           "target_is_invalid",
+			l2Unsafe:       100,
+			latestUnsafe:   100,
+			validBlocks:    []uint64{96, 97, 98, 99}, // 96-99 valid
+			expectedResult: 99,
+		},
+		{
+			name:           "target_is_larger_than_latest",
+			l2Unsafe:       101,
+			latestUnsafe:   100,
+			validBlocks:    []uint64{96, 97, 98, 99}, // 96-99 valid
+			expectedResult: 99,
 		},
 	}
 
@@ -106,7 +120,7 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 			}
 
 			// Setup specific expectations for each possible block
-			for blockNum := tt.l2Unsafe; blockNum <= tt.latestUnsafe; blockNum++ {
+			for blockNum := tt.l2Unsafe - 10; blockNum <= tt.latestUnsafe; blockNum++ {
 				l1OriginNum := 10 + blockNum - tt.l2Unsafe
 				l1OriginHash := fmt.Sprintf("0x%x", l1OriginNum)
 				l1Origin := eth.BlockID{Hash: common.HexToHash(l1OriginHash), Number: l1OriginNum}

--- a/op-node/rollup/interop/managed/system_test.go
+++ b/op-node/rollup/interop/managed/system_test.go
@@ -87,6 +87,13 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 			validBlocks:    []uint64{96, 97, 98, 99}, // 96-99 valid
 			expectedResult: 99,
 		},
+		{
+			name:           "walkback_after_binary_search",
+			l2Unsafe:       95,
+			latestUnsafe:   105,
+			validBlocks:    []uint64{92, 93}, // 92-93 valid
+			expectedResult: 93,
+		},
 	}
 
 	for _, tt := range tests {

--- a/op-node/rollup/interop/managed/system_test.go
+++ b/op-node/rollup/interop/managed/system_test.go
@@ -1,0 +1,231 @@
+package managed
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
+	tests := []struct {
+		name           string
+		l2Unsafe       uint64   // starting point (trusted valid)
+		latestUnsafe   uint64   // current chain tip
+		validBlocks    []uint64 // blocks with valid L1 origins
+		expectedResult uint64
+		expectedError  string
+	}{
+		{
+			name:           "l2unsafe_equals_latest",
+			l2Unsafe:       100,
+			latestUnsafe:   100,
+			validBlocks:    []uint64{100},
+			expectedResult: 100,
+		},
+		{
+			name:           "all_blocks_valid",
+			l2Unsafe:       100,
+			latestUnsafe:   105,
+			validBlocks:    []uint64{100, 101, 102, 103, 104, 105},
+			expectedResult: 105,
+		},
+		{
+			name:           "all_blocks_invalid",
+			l2Unsafe:       100,
+			latestUnsafe:   105,
+			validBlocks:    []uint64{100}, // only l2Unsafe is valid
+			expectedResult: 100,
+		},
+		{
+			name:           "mixed_validity_case1",
+			l2Unsafe:       100,
+			latestUnsafe:   105,
+			validBlocks:    []uint64{100, 101, 102}, // 103-105 invalid
+			expectedResult: 102,
+		},
+		{
+			name:           "single_block_ahead_valid",
+			l2Unsafe:       100,
+			latestUnsafe:   101,
+			validBlocks:    []uint64{100, 101},
+			expectedResult: 101,
+		},
+		{
+			name:           "single_block_ahead_invalid",
+			l2Unsafe:       100,
+			latestUnsafe:   101,
+			validBlocks:    []uint64{100}, // 101 invalid
+			expectedResult: 100,
+		},
+		{
+			name:           "l2unsafe_not_at_100",
+			l2Unsafe:       95,
+			latestUnsafe:   100,
+			validBlocks:    []uint64{95, 96, 97}, // 98-100 invalid
+			expectedResult: 97,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := testlog.Logger(t, log.LevelDebug)
+
+			mockL1 := &MockL1Source{}
+			mockL2 := &MockL2Source{}
+
+			// Setup l2Unsafe block
+			l2UnsafeHash := common.HexToHash(fmt.Sprintf("0x%x", tt.l2Unsafe))
+			l2UnsafeL1Origin := eth.BlockID{Hash: common.HexToHash("0xa"), Number: 10}
+			l2UnsafeBlockRef := createL2BlockRef(tt.l2Unsafe, l2UnsafeHash.Hex(), l2UnsafeL1Origin)
+
+			mockL2.On("L2BlockRefByHash", mock.Anything, l2UnsafeHash).Return(l2UnsafeBlockRef, nil)
+
+			// Setup latest unsafe block
+			latestHash := common.HexToHash(fmt.Sprintf("0x%x", tt.latestUnsafe))
+			latestL1Origin := eth.BlockID{Hash: common.HexToHash("0xf"), Number: 10 + tt.latestUnsafe - tt.l2Unsafe}
+			latestBlockRef := createL2BlockRef(tt.latestUnsafe, latestHash.Hex(), latestL1Origin)
+
+			mockL2.On("L2BlockRefByLabel", mock.Anything, mock.MatchedBy(func(label eth.BlockLabel) bool {
+				return label == eth.Unsafe
+			})).Return(latestBlockRef, nil)
+
+			// Setup blocks for binary search
+			validBlocksMap := make(map[uint64]bool)
+			for _, block := range tt.validBlocks {
+				validBlocksMap[block] = true
+			}
+
+			// Setup specific expectations for each possible block
+			for blockNum := tt.l2Unsafe; blockNum <= tt.latestUnsafe; blockNum++ {
+				l1OriginNum := 10 + blockNum - tt.l2Unsafe
+				l1OriginHash := fmt.Sprintf("0x%x", l1OriginNum)
+				l1Origin := eth.BlockID{Hash: common.HexToHash(l1OriginHash), Number: l1OriginNum}
+				l2Block := createL2BlockRef(blockNum, fmt.Sprintf("0x%x", blockNum), l1Origin)
+
+				logger.Info("Setting up block", "l2Block", l2Block, "l1Origin", l1Origin)
+
+				mockL2.On("L2BlockRefByNumber", mock.Anything, blockNum).Return(l2Block, nil).Maybe()
+
+				if validBlocksMap[blockNum] {
+					// Valid: return matching hash
+					mockL1.On("L1BlockRefByNumber", mock.Anything, l1OriginNum).
+						Return(createL1BlockRef(l1OriginNum, l1OriginHash), nil).Maybe()
+				} else {
+					// Invalid: return different hash (reorg)
+					mockL1.On("L1BlockRefByNumber", mock.Anything, l1OriginNum).
+						Return(createL1BlockRef(l1OriginNum, fmt.Sprintf("0x%x", l1OriginNum+1000)), nil).Maybe()
+				}
+			}
+
+			managedMode := &ManagedMode{
+				log: logger,
+				l1:  mockL1,
+				l2:  mockL2,
+			}
+
+			result, err := managedMode.findLatestValidLocalUnsafe(ctx, eth.BlockID{
+				Hash:   l2UnsafeHash,
+				Number: tt.l2Unsafe,
+			})
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedResult, result.Number)
+			}
+		})
+	}
+}
+
+// MockL1Source implements L1Source interface for testing
+type MockL1Source struct {
+	mock.Mock
+}
+
+func (m *MockL1Source) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
+	args := m.Called(ctx, hash)
+	return args.Get(0).(eth.L1BlockRef), args.Error(1)
+}
+
+func (m *MockL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
+	args := m.Called(ctx, num)
+	return args.Get(0).(eth.L1BlockRef), args.Error(1)
+}
+
+// MockL2Source implements L2Source interface for testing
+type MockL2Source struct {
+	mock.Mock
+}
+
+func (m *MockL2Source) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
+	args := m.Called(ctx, hash)
+	return args.Get(0).(eth.L2BlockRef), args.Error(1)
+}
+
+func (m *MockL2Source) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
+	args := m.Called(ctx, num)
+	return args.Get(0).(eth.L2BlockRef), args.Error(1)
+}
+
+func (m *MockL2Source) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	args := m.Called(ctx, label)
+	return args.Get(0).(eth.L2BlockRef), args.Error(1)
+}
+
+func (m *MockL2Source) BlockRefByHash(ctx context.Context, hash common.Hash) (eth.BlockRef, error) {
+	args := m.Called(ctx, hash)
+	return args.Get(0).(eth.BlockRef), args.Error(1)
+}
+
+func (m *MockL2Source) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	args := m.Called(ctx, hash)
+	return args.Get(0).(*eth.ExecutionPayloadEnvelope), args.Error(1)
+}
+
+func (m *MockL2Source) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
+	args := m.Called(ctx, num)
+	return args.Get(0).(eth.BlockRef), args.Error(1)
+}
+
+func (m *MockL2Source) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	args := m.Called(ctx, blockHash)
+	return args.Get(0).(eth.BlockInfo), args.Get(1).(types.Receipts), args.Error(2)
+}
+
+func (m *MockL2Source) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
+	args := m.Called(ctx, blockHash)
+	return args.Get(0).(*eth.OutputV0), args.Error(1)
+}
+
+// Helper functions to create test data
+func createL1BlockRef(number uint64, hash string) eth.L1BlockRef {
+	return eth.L1BlockRef{
+		Hash:       common.HexToHash(hash),
+		Number:     number,
+		ParentHash: common.HexToHash("0x0"),
+		Time:       1000000 + number*12, // 12 second block time
+	}
+}
+
+func createL2BlockRef(number uint64, hash string, l1Origin eth.BlockID) eth.L2BlockRef {
+	return eth.L2BlockRef{
+		Hash:           common.HexToHash(hash),
+		Number:         number,
+		ParentHash:     common.HexToHash("0x0"),
+		Time:           1000000 + number*2, // 2 second block time
+		L1Origin:       l1Origin,
+		SequenceNumber: 0,
+	}
+}

--- a/op-node/rollup/interop/managed/system_test.go
+++ b/op-node/rollup/interop/managed/system_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
@@ -101,24 +100,24 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 			ctx := context.Background()
 			logger := testlog.Logger(t, log.LevelDebug)
 
-			mockL1 := &MockL1Source{}
-			mockL2 := &MockL2Source{}
+			mockL1 := &testutils.MockL1Client{}
+			mockL2 := &testutils.MockL2Client{}
+
+			var nilErr error
 
 			// Setup l2Unsafe block
 			l2UnsafeHash := common.HexToHash(fmt.Sprintf("0x%x", tt.l2Unsafe))
 			l2UnsafeL1Origin := eth.BlockID{Hash: common.HexToHash("0xa"), Number: 10}
 			l2UnsafeBlockRef := createL2BlockRef(tt.l2Unsafe, l2UnsafeHash.Hex(), l2UnsafeL1Origin)
 
-			mockL2.On("L2BlockRefByHash", mock.Anything, l2UnsafeHash).Return(l2UnsafeBlockRef, nil)
+			mockL2.ExpectL2BlockRefByHash(l2UnsafeHash, l2UnsafeBlockRef, nilErr)
 
 			// Setup latest unsafe block
 			latestHash := common.HexToHash(fmt.Sprintf("0x%x", tt.latestUnsafe))
 			latestL1Origin := eth.BlockID{Hash: common.HexToHash("0xf"), Number: 10 + tt.latestUnsafe - tt.l2Unsafe}
 			latestBlockRef := createL2BlockRef(tt.latestUnsafe, latestHash.Hex(), latestL1Origin)
 
-			mockL2.On("L2BlockRefByLabel", mock.Anything, mock.MatchedBy(func(label eth.BlockLabel) bool {
-				return label == eth.Unsafe
-			})).Return(latestBlockRef, nil)
+			mockL2.ExpectL2BlockRefByLabel(eth.Unsafe, latestBlockRef, nilErr)
 
 			// Setup blocks for binary search
 			validBlocksMap := make(map[uint64]bool)
@@ -135,16 +134,16 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 
 				logger.Info("Setting up block", "l2Block", l2Block, "l1Origin", l1Origin)
 
-				mockL2.On("L2BlockRefByNumber", mock.Anything, blockNum).Return(l2Block, nil).Maybe()
+				mockL2.On("L2BlockRefByNumber", blockNum).Return(l2Block, &nilErr).Maybe()
 
 				if validBlocksMap[blockNum] {
 					// Valid: return matching hash
-					mockL1.On("L1BlockRefByNumber", mock.Anything, l1OriginNum).
-						Return(createL1BlockRef(l1OriginNum, l1OriginHash), nil).Maybe()
+					mockL1.On("L1BlockRefByNumber", l1OriginNum).
+						Return(createL1BlockRef(l1OriginNum, l1OriginHash), &nilErr).Maybe()
 				} else {
 					// Invalid: return different hash (reorg)
-					mockL1.On("L1BlockRefByNumber", mock.Anything, l1OriginNum).
-						Return(createL1BlockRef(l1OriginNum, fmt.Sprintf("0x%x", l1OriginNum+1000)), nil).Maybe()
+					mockL1.On("L1BlockRefByNumber", l1OriginNum).
+						Return(createL1BlockRef(l1OriginNum, fmt.Sprintf("0x%x", l1OriginNum+1000)), &nilErr).Maybe()
 				}
 			}
 
@@ -168,66 +167,6 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 			}
 		})
 	}
-}
-
-// MockL1Source implements L1Source interface for testing
-type MockL1Source struct {
-	mock.Mock
-}
-
-func (m *MockL1Source) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
-	args := m.Called(ctx, hash)
-	return args.Get(0).(eth.L1BlockRef), args.Error(1)
-}
-
-func (m *MockL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
-	args := m.Called(ctx, num)
-	return args.Get(0).(eth.L1BlockRef), args.Error(1)
-}
-
-// MockL2Source implements L2Source interface for testing
-type MockL2Source struct {
-	mock.Mock
-}
-
-func (m *MockL2Source) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
-	args := m.Called(ctx, hash)
-	return args.Get(0).(eth.L2BlockRef), args.Error(1)
-}
-
-func (m *MockL2Source) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
-	args := m.Called(ctx, num)
-	return args.Get(0).(eth.L2BlockRef), args.Error(1)
-}
-
-func (m *MockL2Source) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	args := m.Called(ctx, label)
-	return args.Get(0).(eth.L2BlockRef), args.Error(1)
-}
-
-func (m *MockL2Source) BlockRefByHash(ctx context.Context, hash common.Hash) (eth.BlockRef, error) {
-	args := m.Called(ctx, hash)
-	return args.Get(0).(eth.BlockRef), args.Error(1)
-}
-
-func (m *MockL2Source) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
-	args := m.Called(ctx, hash)
-	return args.Get(0).(*eth.ExecutionPayloadEnvelope), args.Error(1)
-}
-
-func (m *MockL2Source) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
-	args := m.Called(ctx, num)
-	return args.Get(0).(eth.BlockRef), args.Error(1)
-}
-
-func (m *MockL2Source) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
-	args := m.Called(ctx, blockHash)
-	return args.Get(0).(eth.BlockInfo), args.Get(1).(types.Receipts), args.Error(2)
-}
-
-func (m *MockL2Source) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
-	args := m.Called(ctx, blockHash)
-	return args.Get(0).(*eth.OutputV0), args.Error(1)
 }
 
 // Helper functions to create test data

--- a/op-service/binary/binary.go
+++ b/op-service/binary/binary.go
@@ -33,7 +33,7 @@ func SearchL[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
 	return l, elLeft, nil
 }
 
-// SearchR is the same as SearchL, but returns the index of the first element, which returns false.
+// SearchR is the same as SearchL, but returns the index of the first element which returns false.
 //
 // Example search space:
 // index:  0, 1, 2, 3, 4, 5, 6, 7, 8, 9

--- a/op-service/binary/binary.go
+++ b/op-service/binary/binary.go
@@ -1,39 +1,20 @@
 package binary
 
-// SearchFirst is a copy-paste from sort.Search, but includes memoization and stops on and returns error
-// Returns the first index when f(i) within [0,n) return true
-// Returns n if f(i) returns false for all i in [0,n)
-// Returns 0 if f(i) returns true for all i in [0,n)
-func SearchFirst[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
-	mem := make(map[int]T)
-	var zero T
-	// Define f(-1) == false and f(n) == true.
-	// Invariant: f(i-1) == false, f(j) == true.
-	i, j := 0, n
-	for i < j {
-		h := int(uint(i+j) >> 1) // avoid overflow when computing h
-		// i ≤ h < j
-		ok, current, err := f(h)
-		if err != nil {
-			return -1, zero, err
-		}
-		mem[h] = current
-		if !ok {
-			i = h + 1 // preserves f(i-1) == false
-		} else {
-			j = h // preserves f(j) == true
-		}
-	}
-	// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
-	return i, mem[i], nil
-}
-
-// SearchL is based on https://pesho-ivanov.github.io/#Binary%20search, includes memoization and returns the element on the left of the border
+// SearchL is a binary search variant, which uses an indicator func f(i), and finds the index of the
+// last element, and the element itself, which returns true.
+//
+// Example search space:
+// index:  0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+// values: 1, 1, 1, 1, 1, 0, 0, 0, 0, 0
+//
+// SearchL would return: index 4 and f(4)
 // Returns -1, if f(i) returns false for all i in [0,n)
-// Returns n, if f(i) returns true for all i in [0,n)
+// Returns n-1, if f(i) returns true for all i in [0,n)
+//
+// Based on: https://pesho-ivanov.github.io/#Binary%20search
+// This variant can easily be updated to return the first element, which returns false if necessary, (i.e. the SearchR variant)
 func SearchL[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
-	mem := make(map[int]T)
-	var zero T
+	var zero, elLeft T
 	l, r := -1, n
 	for r-l > 1 {
 		m := int(uint(r+l) >> 1) // avoid overflow when computing m; always in [0,...,n)
@@ -41,20 +22,17 @@ func SearchL[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
 		if err != nil {
 			return -1, zero, err
 		}
-		mem[m] = current
 		if ok {
 			l = m // l<m => shrinking
+			elLeft = current
 		} else {
 			r = m // r>m => shrinking
 		}
 	}
 
-	if r == n { // all true
-		return n, zero, nil
-	}
 	if l == -1 { // all false
 		return -1, zero, nil
 	}
 
-	return l, mem[l], nil
+	return l, elLeft, nil
 }

--- a/op-service/binary/binary.go
+++ b/op-service/binary/binary.go
@@ -12,7 +12,6 @@ package binary
 // Returns n-1, if f(i) returns true for all i in [0,n)
 //
 // Based on: https://pesho-ivanov.github.io/#Binary%20search
-// This variant can easily be updated to return the first element, which returns false if necessary, (i.e. the SearchR variant)
 func SearchL[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
 	var zero, elLeft T
 	l, r := -1, n
@@ -30,9 +29,37 @@ func SearchL[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
 		}
 	}
 
-	if l == -1 { // all false
-		return -1, zero, nil
+	// caller must check `l` for out of bounds
+	return l, elLeft, nil
+}
+
+// SearchR is the same as SearchL, but returns the index of the first element, which returns false.
+//
+// Example search space:
+// index:  0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+// values: 1, 1, 1, 1, 1, 0, 0, 0, 0, 0
+//
+// SearchR would return: index 5 and f(5)
+// Returns 0, if f(i) returns false for all i in [0,n)
+// Returns n, if f(i) returns true for all i in [0,n)
+
+func SearchR[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
+	var zero, elRight T
+	l, r := -1, n
+	for r-l > 1 {
+		m := int(uint(r+l) >> 1) // avoid overflow when computing m; always in [0,...,n)
+		ok, current, err := f(m)
+		if err != nil {
+			return -1, zero, err
+		}
+		if ok {
+			l = m // l<m => shrinking
+		} else {
+			r = m // r>m => shrinking
+			elRight = current
+		}
 	}
 
-	return l, elLeft, nil
+	// caller must check `r` for out of bounds
+	return r, elRight, nil
 }

--- a/op-service/binary/binary.go
+++ b/op-service/binary/binary.go
@@ -1,0 +1,60 @@
+package binary
+
+// SearchFirst is a copy-paste from sort.Search, but includes memoization and stops on and returns error
+// Returns the first index when f(i) within [0,n) return true
+// Returns n if f(i) returns false for all i in [0,n)
+// Returns 0 if f(i) returns true for all i in [0,n)
+func SearchFirst[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
+	mem := make(map[int]T)
+	var zero T
+	// Define f(-1) == false and f(n) == true.
+	// Invariant: f(i-1) == false, f(j) == true.
+	i, j := 0, n
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		ok, current, err := f(h)
+		if err != nil {
+			return -1, zero, err
+		}
+		mem[h] = current
+		if !ok {
+			i = h + 1 // preserves f(i-1) == false
+		} else {
+			j = h // preserves f(j) == true
+		}
+	}
+	// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
+	return i, mem[i], nil
+}
+
+// SearchL is based on https://pesho-ivanov.github.io/#Binary%20search, includes memoization and returns the element on the left of the border
+// Returns -1, if f(i) returns false for all i in [0,n)
+// Returns n, if f(i) returns true for all i in [0,n)
+func SearchL[T any](n int, f func(int) (bool, T, error)) (int, T, error) {
+	mem := make(map[int]T)
+	var zero T
+	l, r := -1, n
+	for r-l > 1 {
+		m := int(uint(r+l) >> 1) // avoid overflow when computing m; always in [0,...,n)
+		ok, current, err := f(m)
+		if err != nil {
+			return -1, zero, err
+		}
+		mem[m] = current
+		if ok {
+			l = m // l<m => shrinking
+		} else {
+			r = m // r>m => shrinking
+		}
+	}
+
+	if r == n { // all true
+		return n, zero, nil
+	}
+	if l == -1 { // all false
+		return -1, zero, nil
+	}
+
+	return l, mem[l], nil
+}

--- a/op-service/binary/binary_test.go
+++ b/op-service/binary/binary_test.go
@@ -1,0 +1,79 @@
+package binary
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearch(t *testing.T) {
+	tests := []struct {
+		name           string
+		n              int
+		pattern        []bool
+		values         []string
+		expectedError  string
+		expectedIndexL int
+		expectedValueL string
+		expectedIndexR int
+		expectedValueR string
+	}{
+		{"empty", 0, []bool{}, []string{}, "",
+			-1, "",
+			0, ""},
+		{"all_false", 5, []bool{false, false, false, false, false}, []string{"a", "b", "c", "d", "e"}, "",
+			-1, "",
+			0, "a"},
+		{"all_true", 5, []bool{true, true, true, true, true}, []string{"a", "b", "c", "d", "e"}, "",
+			4, "e",
+			5, ""},
+		{"single_true", 1, []bool{true}, []string{"x"}, "",
+			0, "x",
+			1, ""},
+		{"single_false", 1, []bool{false}, []string{"x"}, "",
+			-1, "",
+			0, "x"},
+		{"classic_pattern", 8, []bool{true, true, true, true, false, false, false, false}, []string{"a", "b", "c", "d", "e", "f", "g", "h"}, "",
+			3, "d",
+			4, "e"},
+		{"first_only", 5, []bool{true, false, false, false, false}, []string{"first", "b", "c", "d", "e"}, "",
+			0, "first",
+			1, "b"},
+		{"last_only", 5, []bool{true, true, true, true, false}, []string{"a", "b", "c", "d", "last"}, "",
+			3, "d",
+			4, "last"},
+		{"error_case", 5, []bool{true, true, false, false, false}, []string{"a", "b", "c", "d", "e"}, "test error",
+			-1, "",
+			-1, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := func(i int) (bool, string, error) {
+				if tt.expectedError != "" {
+					return false, "", errors.New(tt.expectedError)
+				}
+				return tt.pattern[i], tt.values[i], nil
+			}
+
+			indexL, valueL, errL := SearchL(tt.n, f)
+			indexR, valueR, errR := SearchR(tt.n, f)
+
+			if tt.expectedError != "" {
+				require.Error(t, errL)
+				require.Contains(t, errL.Error(), tt.expectedError)
+				require.Error(t, errR)
+				require.Contains(t, errR.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, errL)
+				require.Equal(t, tt.expectedIndexL, indexL)
+				require.Equal(t, tt.expectedValueL, valueL)
+
+				require.NoError(t, errR)
+				require.Equal(t, tt.expectedIndexR, indexR)
+				require.Equal(t, tt.expectedValueR, valueR)
+			}
+		})
+	}
+}

--- a/op-service/testutils/mock_l1.go
+++ b/op-service/testutils/mock_l1.go
@@ -37,34 +37,3 @@ func (m *MockL1Source) L1BlockRefByHash(ctx context.Context, hash common.Hash) (
 func (m *MockL1Source) ExpectL1BlockRefByHash(hash common.Hash, ref eth.L1BlockRef, err error) {
 	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, err)
 }
-
-type MockL1Client struct {
-	MockEthClient
-}
-
-func (m *MockL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByLabel", label)
-	return out[0].(eth.L1BlockRef), *out[1].(*error)
-}
-
-func (m *MockL1Client) ExpectL1BlockRefByLabel(label eth.BlockLabel, ref eth.L1BlockRef, err error) {
-	m.Mock.On("L1BlockRefByLabel", label).Once().Return(ref, err)
-}
-
-func (m *MockL1Client) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByNumber", num)
-	return out[0].(eth.L1BlockRef), *out[1].(*error)
-}
-
-func (m *MockL1Client) ExpectL1BlockRefByNumber(num uint64, ref eth.L1BlockRef, err error) {
-	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, err)
-}
-
-func (m *MockL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByHash", hash)
-	return out[0].(eth.L1BlockRef), *out[1].(*error)
-}
-
-func (m *MockL1Client) ExpectL1BlockRefByHash(hash common.Hash, ref eth.L1BlockRef, err error) {
-	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, err)
-}

--- a/op-service/testutils/mock_l1.go
+++ b/op-service/testutils/mock_l1.go
@@ -37,3 +37,34 @@ func (m *MockL1Source) L1BlockRefByHash(ctx context.Context, hash common.Hash) (
 func (m *MockL1Source) ExpectL1BlockRefByHash(hash common.Hash, ref eth.L1BlockRef, err error) {
 	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, err)
 }
+
+type MockL1Client struct {
+	MockEthClient
+}
+
+func (m *MockL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
+	out := m.Mock.MethodCalled("L1BlockRefByLabel", label)
+	return out[0].(eth.L1BlockRef), *out[1].(*error)
+}
+
+func (m *MockL1Client) ExpectL1BlockRefByLabel(label eth.BlockLabel, ref eth.L1BlockRef, err error) {
+	m.Mock.On("L1BlockRefByLabel", label).Once().Return(ref, err)
+}
+
+func (m *MockL1Client) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
+	out := m.Mock.MethodCalled("L1BlockRefByNumber", num)
+	return out[0].(eth.L1BlockRef), *out[1].(*error)
+}
+
+func (m *MockL1Client) ExpectL1BlockRefByNumber(num uint64, ref eth.L1BlockRef, err error) {
+	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, err)
+}
+
+func (m *MockL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
+	out := m.Mock.MethodCalled("L1BlockRefByHash", hash)
+	return out[0].(eth.L1BlockRef), *out[1].(*error)
+}
+
+func (m *MockL1Client) ExpectL1BlockRefByHash(hash common.Hash, ref eth.L1BlockRef, err error) {
+	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, err)
+}


### PR DESCRIPTION
**Description**

https://github.com/ethereum-optimism/optimism/pull/16052 introduced changes to `ManagedMode`, so that `LocalUnsafe` ref is also updated by the `op-supervisor`.

It introduced a method `ManagedMode.scanL2ForLatestLocalUnsafe`, which finds the latest valid `LocalUnsafe` block, after the `op-supervisor` provides a best-effort `LocalUnsafe` as a reference.

This PR is improving on that method and making it more efficient, by replacing a naive loop that checks every block with a binary search version.

@pcw109550 also noted that during the review, but I opted to make more complex changes in a follow-up PR, so here it is -- https://github.com/ethereum-optimism/optimism/pull/16052/files#r2111367711