### PR TITLE
 Fix silent logging failures when context values don't implement slog.LogValuer

### DIFF
--- a/op-service/log/context_handler.go
+++ b/op-service/log/context_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/ethereum-optimism/optimism/op-service/logmods"
 )
@@ -78,7 +79,10 @@ func (c *contextHandler) Handle(ctx context.Context, record slog.Record) error {
 		if attr, ok := value.(slog.LogValuer); ok {
 			record.Add(name, attr)
 		} else {
-			return fmt.Errorf("invalid value %v in context for key of type %T, expected value to implement slog.LogValuer", value, key)
+			// Log the error to stderr to make the problem visible instead of silently failing
+			fmt.Fprintf(os.Stderr, "ERROR: invalid value %v in context for key of type %T, expected value to implement slog.LogValuer\n", value, key)
+			// Still continue processing other attributes to avoid complete logging failure
+			continue
 		}
 	}
 	return c.inner.Handle(ctx, record)


### PR DESCRIPTION
**Problem:**
Context values stored without implementing `slog.LogValuer` caused `contextHandler.Handle()` to return errors that were silently swallowed by the slog system, resulting in missing log messages with no indication of the problem.

**Solution:**
- Modified `contextHandler.Handle()` to log errors to stderr instead of returning them
- Invalid context values are now skipped with visible error messages rather than causing silent failures
- Updated `devtest.AddTestScope()` to use `testScopeValue` type that implements `slog.LogValuer`
- Maintained backwards compatibility in `TestScope()` for existing plain string values

**Changes:**
- `op-service/log/context_handler.go`: Error logging instead of silent returns
- `op-devstack/devtest/common.go`: Proper `slog.LogValuer` implementation
- Updated tests to reflect new behavior

**Result:**
Interface contract violations are now immediately visible to developers while preserving log output functionality.
