### PR TITLE
op-supervisor: Check for Sufficient Data prior to Hazard Frontier Checks

### DIFF
--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -10,8 +10,25 @@ import (
 
 type SafeFrontierCheckDeps interface {
 	CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error)
-
+	CrossSafe(chainID eth.ChainID) (latest types.DerivedBlockSealPair, err error)
 	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
+}
+
+// SufficientDataChecks verifies that the dependent chains have safe data to cross-safe verify the block at L1 block `inL1Source`.
+// If a chain has not synced as far as `inL1Source`, we know the database will not have the data to cross-safe verify the block.
+// Rather than bumping scope, we should just wait for the chain to catch up.
+func SufficientDataChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, hazards *HazardSet) error {
+	for hazardChainID := range hazards.Entries() {
+		latest, err := d.CrossSafe(hazardChainID)
+		if err != nil {
+			return fmt.Errorf("failed to get latest cross-safe block of referenced chain %s: %w", hazardChainID, err)
+		}
+		if latest.Source.Number < inL1Source.Number {
+			return fmt.Errorf("referenced chain %s does not have safe data to cross-safe verify block at L1 block %s: %w",
+				hazardChainID, inL1Source, types.ErrFuture)
+		}
+	}
+	return nil
 }
 
 // HazardSafeFrontierChecks verifies all the hazard blocks are either:

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -25,8 +25,8 @@ func TestSufficientDataChecks(t *testing.T) {
 		hazards := map[eth.ChainID]types.BlockSeal{}
 		sfcd.crossSafeFn = func(chain eth.ChainID) (latest types.DerivedBlockSealPair, err error) {
 			return types.DerivedBlockSealPair{
-				Source:  types.BlockSeal{Number: 1},
-				Derived: types.BlockSeal{Number: 1},
+				Source:  types.BlockSeal{Number: 2},
+				Derived: types.BlockSeal{Number: 2},
 			}, nil
 		}
 		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
@@ -56,6 +56,33 @@ func TestSufficientDataChecks(t *testing.T) {
 			}, nil
 		}
 		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.ErrorIs(t, err, types.ErrFuture)
+	})
+	t.Run("second dep behind scope", func(t *testing.T) {
+		sfcd := &mockSafeFrontierCheckDeps{}
+		l1Source := eth.BlockID{Number: 5}
+		hazards := map[eth.ChainID]types.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 10}, eth.ChainIDFromUInt64(456): {Number: 2}}
+		checked123 := false
+		checked456 := false
+		sfcd.crossSafeFn = func(chain eth.ChainID) (latest types.DerivedBlockSealPair, err error) {
+			if chain == eth.ChainIDFromUInt64(123) {
+				checked123 = true
+				return types.DerivedBlockSealPair{
+					Source:  types.BlockSeal{Number: 10},
+					Derived: types.BlockSeal{Number: 10},
+				}, nil
+			}
+			if chain == eth.ChainIDFromUInt64(456) {
+				checked456 = true
+				return types.DerivedBlockSealPair{
+					Source:  types.BlockSeal{Number: 2},
+					Derived: types.BlockSeal{Number: 2},
+				}, nil
+			}
+			return types.DerivedBlockSealPair{}, nil
+		}
+		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.True(t, checked123 && checked456, "expected both chains to be checked")
 		require.ErrorIs(t, err, types.ErrFuture)
 	})
 }

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -11,6 +11,55 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+func TestSufficientDataChecks(t *testing.T) {
+	t.Run("empty hazards", func(t *testing.T) {
+		sfcd := &mockSafeFrontierCheckDeps{}
+		l1Source := eth.BlockID{}
+		hazards := map[eth.ChainID]types.BlockSeal{}
+		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.NoError(t, err)
+	})
+	t.Run("latest ahead of scope", func(t *testing.T) {
+		sfcd := &mockSafeFrontierCheckDeps{}
+		l1Source := eth.BlockID{Number: 1}
+		hazards := map[eth.ChainID]types.BlockSeal{}
+		sfcd.crossSafeFn = func(chain eth.ChainID) (latest types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 1},
+				Derived: types.BlockSeal{Number: 1},
+			}, nil
+		}
+		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.NoError(t, err)
+	})
+	t.Run("latest equal to scope", func(t *testing.T) {
+		sfcd := &mockSafeFrontierCheckDeps{}
+		l1Source := eth.BlockID{Number: 1}
+		hazards := map[eth.ChainID]types.BlockSeal{}
+		sfcd.crossSafeFn = func(chain eth.ChainID) (latest types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 1},
+				Derived: types.BlockSeal{Number: 1},
+			}, nil
+		}
+		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.NoError(t, err)
+	})
+	t.Run("latest behind scope", func(t *testing.T) {
+		sfcd := &mockSafeFrontierCheckDeps{}
+		l1Source := eth.BlockID{Number: 5}
+		hazards := map[eth.ChainID]types.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 2}}
+		sfcd.crossSafeFn = func(chain eth.ChainID) (latest types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 2},
+				Derived: types.BlockSeal{Number: 2},
+			}, nil
+		}
+		err := SufficientDataChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.ErrorIs(t, err, types.ErrFuture)
+	})
+}
+
 func TestHazardSafeFrontierChecks(t *testing.T) {
 	t.Run("empty hazards", func(t *testing.T) {
 		sfcd := &mockSafeFrontierCheckDeps{}
@@ -131,6 +180,7 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 type mockSafeFrontierCheckDeps struct {
 	candidateCrossSafeFn func() (candidate types.DerivedBlockRefPair, err error)
 	crossSourceFn        func() (source types.BlockSeal, err error)
+	crossSafeFn          func(chain eth.ChainID) (latest types.DerivedBlockSealPair, err error)
 }
 
 func (m *mockSafeFrontierCheckDeps) CandidateCrossSafe(chain eth.ChainID) (candidate types.DerivedBlockRefPair, err error) {
@@ -145,4 +195,11 @@ func (m *mockSafeFrontierCheckDeps) CrossDerivedToSource(chainID eth.ChainID, de
 		return m.crossSourceFn()
 	}
 	return types.BlockSeal{}, nil
+}
+
+func (m *mockSafeFrontierCheckDeps) CrossSafe(chainID eth.ChainID) (latest types.DerivedBlockSealPair, err error) {
+	if m.crossSafeFn != nil {
+		return m.crossSafeFn(chainID)
+	}
+	return types.DerivedBlockSealPair{}, nil
 }

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -119,7 +119,7 @@ func scopedCrossSafeUpdate(h reads.Handle, logger log.Logger, chainID eth.ChainI
 		return candidate, fmt.Errorf("failed to determine dependencies of cross-safe candidate %s: %w", candidate.Derived, err)
 	}
 	if err := SufficientDataChecks(d, candidate.Source.ID(), hazards); err != nil {
-		return candidate, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate.Derived, err)
+		return candidate, fmt.Errorf("insufficient data to verify block %s: %w", candidate.Derived, err)
 	}
 	if err := HazardSafeFrontierChecks(d, candidate.Source.ID(), hazards); err != nil {
 		return candidate, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate.Derived, err)

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -118,6 +118,9 @@ func scopedCrossSafeUpdate(h reads.Handle, logger log.Logger, chainID eth.ChainI
 	if err != nil {
 		return candidate, fmt.Errorf("failed to determine dependencies of cross-safe candidate %s: %w", candidate.Derived, err)
 	}
+	if err := SufficientDataChecks(d, candidate.Source.ID(), hazards); err != nil {
+		return candidate, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate.Derived, err)
+	}
 	if err := HazardSafeFrontierChecks(d, candidate.Source.ID(), hazards); err != nil {
 		return candidate, fmt.Errorf("failed to verify block %s in cross-safe frontier: %w", candidate.Derived, err)
 	}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -380,6 +380,12 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 				Derived: candidate,
 			}, nil
 		}
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 3},
+				Derived: types.BlockSeal{Number: 1},
+			}, nil
+		}
 		opened := eth.BlockRef{Number: 1, Time: 1}
 		em1 := &types.ExecutingMessage{ChainID: chainID, Timestamp: 1, LogIdx: 2}
 		em2 := &types.ExecutingMessage{ChainID: chainID, Timestamp: 1, LogIdx: 1}
@@ -406,6 +412,12 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 			return types.DerivedBlockRefPair{
 				Source:  candidateScope,
 				Derived: candidate,
+			}, nil
+		}
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 3},
+				Derived: types.BlockSeal{Number: 1},
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -26,6 +26,12 @@ func TestCrossSafeUpdate(t *testing.T) {
 				Derived: candidate,
 			}, nil
 		}
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 3},
+				Derived: types.BlockSeal{Number: 3},
+			}, nil
+		}
 		opened := eth.BlockRef{Number: 1}
 		execs := map[uint32]*types.ExecutingMessage{1: {}}
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
@@ -38,6 +44,37 @@ func TestCrossSafeUpdate(t *testing.T) {
 		// no error is returned
 		err := CrossSafeUpdate(logger, chainID, csd, linkerAny{})
 		require.NoError(t, err)
+	})
+	t.Run("scopedCrossSafeUpdate has insufficient data", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		chainID := eth.ChainIDFromUInt64(123)
+		csd := &mockCrossSafeDeps{}
+		candidate := eth.BlockRef{Number: 1}
+		candidateScope := eth.BlockRef{Number: 2}
+		csd.candidateCrossSafeFn = func() (pair types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+				Source:  candidateScope,
+				Derived: candidate,
+			}, nil
+		}
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 1},
+				Derived: types.BlockSeal{Number: 9},
+			}, nil
+		}
+		opened := eth.BlockRef{Number: 1}
+		execs := map[uint32]*types.ExecutingMessage{1: {}}
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+			return opened, 10, execs, nil
+		}
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
+			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
+		}
+		// when scopedCrossSafeUpdate returns no error,
+		// no error is returned
+		err := CrossSafeUpdate(logger, chainID, csd, linkerAny{})
+		require.ErrorContains(t, err, "insufficient data")
 	})
 	t.Run("scopedCrossSafeUpdate returns error", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
@@ -415,6 +452,41 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrConflict)
 		require.Equal(t, eth.BlockRef{}, pair.Source)
 	})
+	t.Run("insufficient data", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelDebug)
+		chainID := eth.ChainIDFromUInt64(123)
+		csd := &mockCrossSafeDeps{}
+		candidate := eth.BlockRef{Number: 1}
+		candidateScope := eth.BlockRef{Number: 2}
+		csd.candidateCrossSafeFn = func() (types.DerivedBlockRefPair, error) {
+			return types.DerivedBlockRefPair{
+				Source:  candidateScope,
+				Derived: candidate,
+			}, nil
+		}
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 1},
+				Derived: types.BlockSeal{Number: 1},
+			}, nil
+		}
+		opened := eth.BlockRef{Number: 1}
+		execs := map[uint32]*types.ExecutingMessage{1: {}}
+		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
+			return opened, 10, execs, nil
+		}
+		csd.updateCrossSafeFn = func(chain eth.ChainID, l1View eth.BlockRef, lastCrossDerived eth.BlockRef) error {
+			return nil
+		}
+		// when no errors occur, the update is carried out
+		// the used candidate and scope are from CandidateCrossSafe
+		// the candidateScope is returned
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
+			return types.BlockSeal{Number: 1, Timestamp: 1}, nil
+		}
+		_, err := scopedCrossSafeUpdate(reads.NoopHandle{}, logger, chainID, csd, linkerAny{})
+		require.ErrorContains(t, err, "insufficient data")
+	})
 	t.Run("successful update", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(123)
@@ -425,6 +497,12 @@ func TestScopedCrossSafeUpdate(t *testing.T) {
 			return types.DerivedBlockRefPair{
 				Source:  candidateScope,
 				Derived: candidate,
+			}, nil
+		}
+		csd.crossSafeFn = func(chainID eth.ChainID) (pair types.DerivedBlockSealPair, err error) {
+			return types.DerivedBlockSealPair{
+				Source:  types.BlockSeal{Number: 3},
+				Derived: types.BlockSeal{Number: 1},
 			}, nil
 		}
 		opened := eth.BlockRef{Number: 1}


### PR DESCRIPTION
Based on a finding located here:

https://github.com/ethereum-optimism/optimism/issues/16016

## Problem
When checking doing `HazardSafeFontierChecks`, each dependency checks `CandidateCrossSafe`, which has the potential to return `ErrOutOfScope`.

If `ErrOutOfScope` is returned, it is bubbled up to the canddiate-scoping of the *original* chain, creating an inappropriate scope bump.

## Solution
To fix, I've added a new check for Safe Hazards called `SufficientDataChecks` - this checks each chain's latest `Cross Safe` for each chain and ensures that the latest L1 for this chain is not behind the L1 scope we are trying to use. If any chain *is* behind the required scope, we know we cannot proceed with Hazard Checks due to missing data.

If all chains *are* synced up to the L1 height in question, then we can proceed with Frontier checks, including scope bumping if some dependency really does need a more advanced L1 to see all data.

## Testing
I have had a very difficult time building a test which exposes the issue described above. However, I did add new unit tests to the `SufficientDataChecks` to demonstrate that when a chain's Cross Safe head isn't L1-synced far enough, an `ErrFuture` is returned`.

## Note
I was torn on whether to use the latest `LocalSafe` or `CrossSafe` to check sufficient data. I ultimately went with `CrossSafe` for the following reasons:
- Already included in SafeDepChecks, where `LocalSafe` would expand the interface
- Arguably the L1 is only truly "synced" for some given chain once Cross Validity is considered.

Open to second opinions here.
