### PR TITLE
op-node: Fix pipeline transformer

### DIFF
--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -42,10 +42,10 @@ const (
 	Granite  ForkName = "granite"
 	Holocene ForkName = "holocene"
 	Isthmus  ForkName = "isthmus"
-	Jovian   ForkName = "jovian"
 	Interop  ForkName = "interop"
+	Jovian   ForkName = "jovian"
 	// ADD NEW FORKS TO AllForks BELOW!
-	None ForkName = "none"
+	None ForkName = ""
 )
 
 var AllForks = []ForkName{

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -271,7 +271,7 @@ func (dp *DerivationPipeline) initialReset(ctx context.Context, resetL2Safe eth.
 
 func (db *DerivationPipeline) transformStages(oldOrigin, newOrigin eth.L1BlockRef) {
 	fork := db.rollupCfg.IsActivationBlock(oldOrigin.Time, newOrigin.Time)
-	if fork == "" {
+	if fork == rollup.None {
 		return
 	}
 


### PR DESCRIPTION

**Description**

Changes None ForkName to equal empty, so that the pipeline doesn't try to transform stages on every single L1 origin advancement.

**Additional context**

The derivation pipeline currently tries to transform stages on every single L1 origin advancement 😅 it's ineffective since no stage has a `none` transformer though.