### PR TITLE
op-acceptance-tests: op-proposer smoke test for super devstack

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/funccall_dsl.go
+++ b/op-acceptance-tests/tests/interop/proofs/funccall_dsl.go
@@ -1,0 +1,39 @@
+package proofs
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lmittmann/w3"
+)
+
+type funcCallDSL struct {
+	t       devtest.T
+	client  apis.EthClient
+	fn      *w3.Func
+	args    []any
+	returns []any
+}
+
+func newFuncCallDSL(t devtest.T, client apis.EthClient, fn *w3.Func) *funcCallDSL {
+	return &funcCallDSL{t: t, client: client, fn: fn}
+}
+
+func (c *funcCallDSL) WithArgs(args ...any) *funcCallDSL {
+	c.args = args
+	return c
+}
+
+func (c *funcCallDSL) WithReturns(returns ...any) *funcCallDSL {
+	c.returns = returns
+	return c
+}
+
+func (c *funcCallDSL) Call(target common.Address) {
+	callArgs, err := c.fn.EncodeArgs(c.args...)
+	c.t.Require().NoError(err)
+	callResult, err := c.client.Call(c.t.Ctx(), ethereum.CallMsg{To: &target, Data: callArgs})
+	c.t.Require().NoError(err)
+	c.t.Require().NoError(c.fn.DecodeReturns(callResult, c.returns...))
+}

--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -22,9 +22,8 @@ func TestProposer(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 
-	deployment := sys.L2Networks()[0].Escape().Deployment()
 	// The DGF is shared across all L2 networks. So pick the first one.
-	disputeGameFactoryAddr := deployment.DisputeGameFactoryProxyAddr()
+	disputeGameFactoryAddr := sys.L2Networks()[0].DisputeGameFactoryProxyAddr()
 	l1Client := sys.L1EL.EthClient()
 
 	var gameCount *big.Int

--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -1,14 +1,12 @@
 package proofs
 
 import (
-	"context"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lmittmann/w3"
 )
@@ -25,29 +23,24 @@ func TestProposer(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 
 	deployment := sys.L2Networks()[0].Escape().Deployment()
+	// The DGF is shared across all L2 networks. So pick the first one.
 	disputeGameFactoryAddr := deployment.DisputeGameFactoryProxyAddr()
-
-	l1Client := sys.L1EL.Escape().EthClient()
+	l1Client := sys.L1EL.EthClient()
 
 	var gameCount *big.Int
 	newFuncCallDSL(t, l1Client, gameCountFn).
 		WithReturns(&gameCount).
 		Call(disputeGameFactoryAddr)
 
-	waitCtx, cancel := context.WithTimeout(t.Ctx(), time.Minute*30)
-	err := wait.For(waitCtx, time.Second*5, func() (bool, error) {
+	t.Require().Eventually(func() bool {
 		var newGameCount *big.Int
 		newFuncCallDSL(t, l1Client, gameCountFn).
 			WithReturns(&newGameCount).
 			Call(disputeGameFactoryAddr)
-		if newGameCount.Cmp(gameCount) > 0 {
-			t.Logf("game count increased from %d to %d", gameCount, newGameCount)
-			return true, nil
-		}
-		return false, nil
-	})
-	cancel()
-	t.Require().NoError(err, "waiting for game count to increase")
+		check := newGameCount.Cmp(gameCount) > 0
+		t.Logf("waiting for game count to increase. current=%d new=%d", gameCount, newGameCount)
+		return check
+	}, time.Minute*10, time.Second*5)
 
 	var gameType uint32
 	var timestamp uint64

--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -1,0 +1,68 @@
+package proofs
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lmittmann/w3"
+)
+
+var (
+	gameCountFn        = w3.MustNewFunc("gameCount()", "uint256")
+	gameAtIndexFn      = w3.MustNewFunc("gameAtIndex(uint256)", "uint32, uint64, address")
+	rootClaimFn        = w3.MustNewFunc("rootClaim()", "bytes32")
+	l2SequenceNumberFn = w3.MustNewFunc("l2SequenceNumber()", "uint256")
+)
+
+func TestProposer(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+
+	deployment := sys.L2Networks()[0].Escape().Deployment()
+	disputeGameFactoryAddr := deployment.DisputeGameFactoryProxyAddr()
+
+	l1Client := sys.L1EL.Escape().EthClient()
+
+	var gameCount *big.Int
+	newFuncCallDSL(t, l1Client, gameCountFn).
+		WithReturns(&gameCount).
+		Call(disputeGameFactoryAddr)
+
+	waitCtx, cancel := context.WithTimeout(t.Ctx(), time.Minute*30)
+	err := wait.For(waitCtx, time.Second*5, func() (bool, error) {
+		var newGameCount *big.Int
+		newFuncCallDSL(t, l1Client, gameCountFn).
+			WithReturns(&newGameCount).
+			Call(disputeGameFactoryAddr)
+		if newGameCount.Cmp(gameCount) > 0 {
+			t.Logf("game count increased from %d to %d", gameCount, newGameCount)
+			return true, nil
+		}
+		return false, nil
+	})
+	cancel()
+	t.Require().NoError(err, "waiting for game count to increase")
+
+	var gameType uint32
+	var timestamp uint64
+	var gameAddress common.Address
+	newFuncCallDSL(t, l1Client, gameAtIndexFn).
+		WithArgs(gameCount).
+		WithReturns(&gameType, &timestamp, &gameAddress).
+		Call(disputeGameFactoryAddr)
+
+	var rootClaim [32]byte
+	newFuncCallDSL(t, l1Client, rootClaimFn).WithReturns(&rootClaim).Call(gameAddress)
+
+	var l2SequenceNumber *big.Int
+	newFuncCallDSL(t, l1Client, l2SequenceNumberFn).WithReturns(&l2SequenceNumber).Call(gameAddress)
+
+	superRoot := sys.Supervisor.FetchSuperRootAtTimestamp(l2SequenceNumber.Uint64())
+	t.Require().Equal(superRoot.SuperRoot[:], rootClaim[:])
+}

--- a/op-devstack/dsl/l1_el.go
+++ b/op-devstack/dsl/l1_el.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
@@ -32,6 +33,10 @@ func (el *L1ELNode) String() string {
 // Escape returns the underlying stack.L1ELNode
 func (el *L1ELNode) Escape() stack.L1ELNode {
 	return el.inner
+}
+
+func (el *L1ELNode) EthClient() apis.EthClient {
+	return el.inner.EthClient()
 }
 
 // EstimateBlockTime estimates the L1 block based on the last 1000 blocks

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // L2Network wraps a stack.L2Network interface for DSL operations
@@ -204,6 +205,6 @@ func (n *L2Network) AwaitActivation(t devtest.T, forkName rollup.ForkName) eth.B
 	return unsafeHead.ID()
 }
 
-func (n *L2Network) Deployment() stack.L2Deployment {
-	return n.inner.Deployment()
+func (n *L2Network) DisputeGameFactoryProxyAddr() common.Address {
+	return n.inner.Deployment().DisputeGameFactoryProxyAddr()
 }

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -203,3 +203,7 @@ func (n *L2Network) AwaitActivation(t devtest.T, forkName rollup.ForkName) eth.B
 
 	return unsafeHead.ID()
 }
+
+func (n *L2Network) Deployment() stack.L2Deployment {
+	return n.inner.Deployment()
+}

--- a/op-devstack/dsl/supervisor.go
+++ b/op-devstack/dsl/supervisor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/status"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type Supervisor struct {
@@ -180,6 +181,12 @@ func (s *Supervisor) WaitForUnsafeHeadToAdvance(chainID eth.ChainID, delta uint6
 
 func (s *Supervisor) AdvancedSafeHead(chainID eth.ChainID, delta uint64, attempts int) {
 	s.WaitForL2HeadToAdvance(chainID, delta, types.CrossSafe, attempts)
+}
+
+func (s *Supervisor) FetchSuperRootAtTimestamp(timestamp uint64) eth.SuperRootResponse {
+	response, err := s.inner.QueryAPI().SuperRootAtTimestamp(s.ctx, hexutil.Uint64(timestamp))
+	s.require.NoError(err, "Unable to fetch super root at timestamp")
+	return response
 }
 
 func (s *Supervisor) Start() {


### PR DESCRIPTION
Add an acceptance test for the op-proposer configured for super roots.

- [ ] Pre-interop w/ super roots - follow up in another PR
- [x] Post-interop activation w/ super roots

### Meta

part of https://github.com/ethereum-optimism/optimism/issues/15950