### PR TITLE
refactor(test): continue cleanup of /dispute test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -765,7 +765,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
         - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     parameters:
       test_flags:
         description: Additional flags to pass to the test command

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -9,7 +9,7 @@ import { console2 as console } from "forge-std/console2.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { NextImpl } from "test/mocks/NextImpl.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 
 // Scripts
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
@@ -32,7 +32,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
-contract OptimismPortal2_TestInit is DisputeGameFactory_Init {
+contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     address depositor;
 
     Types.WithdrawalTransaction _defaultTx;

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 // Testing
-import { FaultDisputeGame_Init, _changeClaimStatus } from "test/dispute/FaultDisputeGame.t.sol";
+import { BaseFaultDisputeGame_TestInit, _changeClaimStatus } from "test/dispute/FaultDisputeGame.t.sol";
 
 // Libraries
 import { GameType, GameStatus, Hash, Claim, VMStatuses, Proposal } from "src/dispute/lib/Types.sol";
@@ -16,7 +16,7 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
 /// @title AnchorStateRegistry_TestInit
 /// @notice Reusable test initialization for `AnchorStateRegistry` tests.
-contract AnchorStateRegistry_TestInit is FaultDisputeGame_Init {
+contract AnchorStateRegistry_TestInit is BaseFaultDisputeGame_TestInit {
     /// @dev A valid l2BlockNumber that comes after the current anchor root block.
     uint256 validL2BlockNumber;
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 // Testing
 import { Vm } from "forge-std/Vm.sol";
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 import { stdError } from "forge-std/StdError.sol";
 
@@ -64,7 +64,7 @@ function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim 
 
 /// @title BaseFaultDisputeGame_TestInit
 /// @notice Base test initializer that can be used by other contracts outside of this test suite.
-contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_Init {
+contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @dev The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.CANNON;
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -29,7 +29,42 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
-contract FaultDisputeGame_Init is DisputeGameFactory_Init {
+contract ClaimCreditReenter {
+    Vm internal immutable vm;
+    IFaultDisputeGame internal immutable GAME;
+    uint256 public numCalls;
+
+    constructor(IFaultDisputeGame _gameProxy, Vm _vm) {
+        GAME = _gameProxy;
+        vm = _vm;
+    }
+
+    function claimCredit(address _recipient) public {
+        numCalls += 1;
+        if (numCalls > 1) {
+            vm.expectRevert(NoCreditToClaim.selector);
+        }
+        GAME.claimCredit(_recipient);
+    }
+
+    receive() external payable {
+        if (numCalls == 5) {
+            return;
+        }
+        claimCredit(address(this));
+    }
+}
+
+/// @notice Helper to change the VM status byte of a claim.
+function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
+    assembly {
+        out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+    }
+}
+
+/// @title BaseFaultDisputeGame_TestInit
+/// @notice Base test initializer that can be used by other contracts outside of this test suite.
+contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_Init {
     /// @dev The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.CANNON;
 
@@ -94,7 +129,9 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
     receive() external payable { }
 }
 
-contract FaultDisputeGame_Test is FaultDisputeGame_Init {
+/// @title FaultDisputeGame_TestInit
+/// @notice Reusable test initialization for `FaultDisputeGame` tests.
+contract FaultDisputeGame_TestInit is BaseFaultDisputeGame_TestInit {
     /// @dev The root claim of the game.
     Claim internal ROOT_CLAIM;
     /// @dev An arbitrary root claim for testing.
@@ -107,7 +144,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev A valid l2BlockNumber that comes after the current anchor root block.
     uint256 internal validL2BlockNumber;
 
-    function setUp() public override {
+    function setUp() public virtual override {
         absolutePrestateData = abi.encode(0);
         absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
 
@@ -122,12 +159,73 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         super.init({ rootClaim: ROOT_CLAIM, absolutePrestate: absolutePrestate, l2BlockNumber: validL2BlockNumber });
     }
 
-    ////////////////////////////////////////////////////////////////
-    //            `IDisputeGame` Implementation Tests             //
-    ////////////////////////////////////////////////////////////////
+    /// @notice Helper to generate a mock RLP encoded header (with only a real block number) & an
+    ///         output root proof.
+    function _generateOutputRootProof(
+        bytes32 _storageRoot,
+        bytes32 _withdrawalRoot,
+        bytes memory _l2BlockNumber
+    )
+        internal
+        pure
+        returns (Types.OutputRootProof memory proof_, bytes32 root_, bytes memory rlp_)
+    {
+        // L2 Block header
+        bytes[] memory rawHeaderRLP = new bytes[](9);
+        rawHeaderRLP[0] = hex"83FACADE";
+        rawHeaderRLP[1] = hex"83FACADE";
+        rawHeaderRLP[2] = hex"83FACADE";
+        rawHeaderRLP[3] = hex"83FACADE";
+        rawHeaderRLP[4] = hex"83FACADE";
+        rawHeaderRLP[5] = hex"83FACADE";
+        rawHeaderRLP[6] = hex"83FACADE";
+        rawHeaderRLP[7] = hex"83FACADE";
+        rawHeaderRLP[8] = RLPWriter.writeBytes(_l2BlockNumber);
+        rlp_ = RLPWriter.writeList(rawHeaderRLP);
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
-    ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
+        // Output root
+        proof_ = Types.OutputRootProof({
+            version: 0,
+            stateRoot: _storageRoot,
+            messagePasserStorageRoot: _withdrawalRoot,
+            latestBlockhash: keccak256(rlp_)
+        });
+        root_ = Hashing.hashOutputRootProof(proof_);
+    }
+
+    /// @notice Helper to get the required bond for the given claim index.
+    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
+        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
+        Position pos = parent.move(true);
+        bond_ = gameProxy.getRequiredBond(pos);
+    }
+
+    /// @notice Helper to return a pseudo-random claim
+    function _dummyClaim() internal view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(gasleft())));
+    }
+
+    /// @notice Helper to get the localized key for an identifier in the context of the game proxy.
+    function _getKey(uint256 _ident, bytes32 _localContext) internal view returns (bytes32) {
+        bytes32 h = keccak256(abi.encode(_ident | (1 << 248), address(gameProxy), _localContext));
+        return bytes32((uint256(h) & ~uint256(0xFF << 248)) | (1 << 248));
+    }
+}
+
+/// @title FaultDisputeGame_Version_Test
+/// @notice Tests the `version` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_Version_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game's version function returns a string.
+    function test_version_works() public view {
+        assertTrue(bytes(gameProxy.version()).length > 0);
+    }
+}
+
+/// @title FaultDisputeGame_Constructor_Test
+/// @notice Tests the constructor of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_Constructor_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the
+    ///         `MAX_GAME_DEPTH` parameter is greater than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
         IPreimageOracle oracle = IPreimageOracle(
             DeployUtils.create1({
@@ -163,8 +261,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the challenge period
-    //       of the preimage oracle being used by the game's VM is too large.
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the challenge
+    ///         period of the preimage oracle being used by the game's VM is too large.
     /// @param _challengePeriod The challenge period of the preimage oracle.
     function testFuzz_constructor_oracleChallengePeriodTooLarge_reverts(uint256 _challengePeriod) public {
         _challengePeriod = bound(_challengePeriod, uint256(type(uint64).max) + 1, type(uint256).max);
@@ -207,8 +305,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
-    ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
+    ///         parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
         AlphabetVM alphabetVM = new AlphabetVM(
             absolutePrestate,
@@ -247,8 +345,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
-    ///      parameter is less than the minimum split depth (currently 2).
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
+    ///         parameter is less than the minimum split depth (currently 2).
     function testFuzz_constructor_lowSplitDepth_reverts(uint256 _splitDepth) public {
         AlphabetVM alphabetVM = new AlphabetVM(
             absolutePrestate,
@@ -287,8 +385,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when clock extension * 2 is greater than
-    ///      the max clock duration.
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when clock
+    ///         extension * 2 is greater than the max clock duration.
     function testFuzz_constructor_clockExtensionTooLong_reverts(
         uint64 _maxClockDuration,
         uint64 _clockExtension
@@ -305,8 +403,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
             )
         );
 
-        // Force the clock extension * 2 to be greater than the max clock duration, but keep things within
-        // bounds of the uint64 type.
+        // Force the clock extension * 2 to be greater than the max clock duration, but keep things
+        // within bounds of the uint64 type.
         _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max / 2 - 1));
         _clockExtension = uint64(bound(_clockExtension, _maxClockDuration / 2 + 1, type(uint64).max / 2));
 
@@ -335,8 +433,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_gameType`
-    ///      parameter is set to the reserved `type(uint32).max` game type.
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_gameType`
+    ///         parameter is set to the reserved `type(uint32).max` game type.
     function test_constructor_reservedGameType_reverts() public {
         AlphabetVM alphabetVM = new AlphabetVM(
             absolutePrestate,
@@ -372,47 +470,13 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
             )
         });
     }
+}
 
-    /// @dev Tests that the game's version function returns a string.
-    function test_version_works() public view {
-        assertTrue(bytes(gameProxy.version()).length > 0);
-    }
-
-    /// @dev Tests that the game's root claim is set correctly.
-    function test_rootClaim_succeeds() public view {
-        assertEq(gameProxy.rootClaim().raw(), ROOT_CLAIM.raw());
-    }
-
-    /// @dev Tests that the game's extra data is set correctly.
-    function test_extraData_succeeds() public view {
-        assertEq(gameProxy.extraData(), extraData);
-    }
-
-    /// @dev Tests that the game's starting timestamp is set correctly.
-    function test_createdAt_succeeds() public view {
-        assertEq(gameProxy.createdAt().raw(), block.timestamp);
-    }
-
-    /// @dev Tests that the game's type is set correctly.
-    function test_gameType_succeeds() public view {
-        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
-    }
-
-    /// @dev Tests that the game's data is set correctly.
-    function test_gameData_succeeds() public view {
-        (GameType gameType, Claim rootClaim, bytes memory _extraData) = gameProxy.gameData();
-
-        assertEq(gameType.raw(), GAME_TYPE.raw());
-        assertEq(rootClaim.raw(), ROOT_CLAIM.raw());
-        assertEq(_extraData, extraData);
-    }
-
-    ////////////////////////////////////////////////////////////////
-    //          `IFaultDisputeGame` Implementation Tests       //
-    ////////////////////////////////////////////////////////////////
-
-    /// @dev Tests that the game cannot be initialized with an output root that commits to <= the configured starting
-    ///      block number
+/// @title FaultDisputeGame_Initialize_Test
+/// @notice Tests the initialization of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_Initialize_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game cannot be initialized with an output root that commits to <=
+    ///         the configured starting block number
     function testFuzz_initialize_cannotProposeGenesis_reverts(uint256 _blockNumber) public {
         (, uint256 startingL2Block) = gameProxy.startingOutputRoot();
         _blockNumber = bound(_blockNumber, 0, startingL2Block);
@@ -424,7 +488,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the proxy receives ETH from the dispute game factory.
+    /// @notice Tests that the proxy receives ETH from the dispute game factory.
     function test_initialize_receivesETH_succeeds() public {
         uint256 _value = disputeGameFactory.initBonds(GAME_TYPE);
         vm.deal(address(this), _value);
@@ -443,12 +507,14 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(delayedWeth.balanceOf(address(gameProxy)), _value);
     }
 
-    /// @dev Tests that the game cannot be initialized with extra data of the incorrect length (must be 32 bytes)
+    /// @notice Tests that the game cannot be initialized with extra data of the incorrect length
+    ///         (must be 32 bytes)
     function testFuzz_initialize_badExtraData_reverts(uint256 _extraDataLen) public {
-        // The `DisputeGameFactory` will pack the root claim and the extra data into a single array, which is enforced
-        // to be at least 64 bytes long.
-        // We bound the upper end to 23.5KB to ensure that the minimal proxy never surpasses the contract size limit
-        // in this test, as CWIA proxies store the immutable args in their bytecode.
+        // The `DisputeGameFactory` will pack the root claim and the extra data into a single
+        // array, which is enforced to be at least 64 bytes long.
+        // We bound the upper end to 23.5KB to ensure that the minimal proxy never surpasses the
+        // contract size limit in this test, as CWIA proxies store the immutable args in their
+        // bytecode.
         // [0 bytes, 31 bytes] u [33 bytes, 23.5 KB]
         _extraDataLen = bound(_extraDataLen, 0, 23_500);
         if (_extraDataLen == 32) {
@@ -456,7 +522,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         }
         bytes memory _extraData = new bytes(_extraDataLen);
 
-        // Assign the first 32 bytes in `extraData` to a valid L2 block number passed the starting block.
+        // Assign the first 32 bytes in `extraData` to a valid L2 block number passed the starting
+        // block.
         (, uint256 startingL2Block) = gameProxy.startingOutputRoot();
         assembly {
             mstore(add(_extraData, 0x20), add(startingL2Block, 1))
@@ -469,7 +536,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the game is initialized with the correct data.
+    /// @notice Tests that the game is initialized with the correct data.
     function test_initialize_correctData_succeeds() public view {
         // Assert that the root claim is initialized correctly.
         (
@@ -496,7 +563,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(gameProxy.l1Head().raw(), blockhash(block.number - 1));
     }
 
-    /// @dev Tests that the game cannot be initialized when the anchor root is not found.
+    /// @notice Tests that the game cannot be initialized when the anchor root is not found.
     function test_initialize_anchorRootNotFound_reverts() public {
         // Mock the AnchorStateRegistry to return a zero root.
         vm.mockCall(
@@ -512,75 +579,213 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the game cannot be initialized twice.
+    /// @notice Tests that the game cannot be initialized twice.
     function test_initialize_onlyOnce_succeeds() public {
         vm.expectRevert(AlreadyInitialized.selector);
         gameProxy.initialize();
     }
+}
 
-    /// @dev Tests that startingOutputRoot and it's getters are set correctly.
-    function test_startingOutputRootGetters_succeeds() public view {
-        (Hash root, uint256 l2BlockNumber) = gameProxy.startingOutputRoot();
-        (Hash anchorRoot, uint256 anchorRootBlockNumber) = anchorStateRegistry.anchors(GAME_TYPE);
+/// @title FaultDisputeGame_Step_Test
+/// @notice Tests the step functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_Step_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that a claim cannot be stepped against twice.
+    function test_step_duplicateStep_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
 
-        assertEq(gameProxy.startingBlockNumber(), l2BlockNumber);
-        assertEq(gameProxy.startingBlockNumber(), anchorRootBlockNumber);
-        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(root));
-        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(anchorRoot));
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.attack{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+
+        vm.expectRevert(DuplicateStep.selector);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
     }
 
-    /// @dev Tests that the user cannot control the first 4 bytes of the CWIA data, disallowing them to control the
-    ///      entrypoint when no calldata is provided to a call.
-    function test_cwiaCalldata_userCannotControlSelector_succeeds() public {
-        // Construct the expected CWIA data that the proxy will pass to the implementation, alongside any extra
-        // calldata passed by the user.
-        Hash l1Head = gameProxy.l1Head();
-        bytes memory cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+    /// @notice Tests that successfully step with true attacking claim when there is a true defend
+    ///         claim(claim5) in the middle of the dispute game.
+    function test_stepAttackDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
 
-        // We expect a `ReceiveETH` event to be emitted when 0 bytes of calldata are sent; The fallback is always
-        // reached *within the minimal proxy* in `LibClone`'s version of `clones-with-immutable-args`
-        vm.expectEmit(false, false, false, true);
-        emit ReceiveETH(0);
-        // We expect no delegatecall to the implementation contract if 0 bytes are sent. Assert that this happens
-        // 0 times.
-        vm.expectCall(address(gameImpl), cwiaData, 0);
-        (bool successA,) = address(gameProxy).call(hex"");
-        assertTrue(successA);
-
-        // When calldata is forwarded, we do expect a delegatecall to the implementation.
-        bytes memory data = abi.encodePacked(gameProxy.l1Head.selector);
-        vm.expectCall(address(gameImpl), abi.encodePacked(data, cwiaData), 1);
-        (bool successB, bytes memory returnData) = address(gameProxy).call(data);
-        assertTrue(successB);
-        assertEq(returnData, abi.encode(l1Head));
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bytes memory claimData5 = abi.encode(5, 5);
+        Claim claim5 = Claim.wrap(keccak256(claimData5));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, claimData5, hex"");
     }
 
-    /// @dev Tests that the bond during the bisection game depths is correct.
-    function test_getRequiredBond_succeeds() public view {
-        for (uint8 i = 0; i < uint8(gameProxy.splitDepth()); i++) {
-            Position pos = LibPosition.wrap(i, 0);
-            uint256 bond = gameProxy.getRequiredBond(pos);
+    /// @notice Tests that successfully step with true defend claim when there is a true defend
+    ///         claim(claim7) in the middle of the dispute game.
+    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
 
-            // Reasonable approximation for a max depth of 8.
-            uint256 expected = 0.08 ether;
-            for (uint64 j = 0; j < i; j++) {
-                expected = expected * 22876;
-                expected = expected / 10000;
-            }
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
 
-            assertApproxEqAbs(bond, expected, 0.01 ether);
-        }
+        bytes memory claimData7 = abi.encode(7, 7);
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(7);
+
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, Claim.wrap(keccak256(claimData7)));
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, false, claimData7, hex"");
     }
 
-    /// @dev Tests that the bond at a depth greater than the maximum game depth reverts.
-    function test_getRequiredBond_outOfBounds_reverts() public {
-        Position pos = LibPosition.wrap(uint8(gameProxy.maxGameDepth() + 1), 0);
-        vm.expectRevert(GameDepthExceeded.selector);
-        gameProxy.getRequiredBond(pos);
+    /// @notice Tests that step reverts with false attacking claim when there is a true defend
+    ///         claim(claim5) in the middle of the dispute game.
+    function test_stepAttackTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bytes memory claimData5 = abi.encode(5, 5);
+        Claim claim5 = Claim.wrap(keccak256(claimData5));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, true, claimData5, hex"");
     }
 
-    /// @dev Tests that a move while the game status is not `IN_PROGRESS` causes the call to revert
-    ///      with the `GameNotInProgress` error
+    /// @notice Tests that step reverts with false defending claim when there is a true defend
+    ///         claim(postState_) in the middle of the dispute game.
+    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(5, 5);
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+
+        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
+        Claim dummyClaim7 = Claim.wrap(keccak256(_dummyClaimData));
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, dummyClaim7);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, false, _dummyClaimData, hex"");
+    }
+
+    /// @notice Tests that step reverts with true defending claim when there is a true defend
+    ///         claim(postState_) in the middle of the dispute game.
+    function test_stepDefendTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(5, 5);
+        Claim claim7 = Claim.wrap(keccak256(claimData7));
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, claim7);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, false, claimData7, hex"");
+    }
+}
+
+/// @title FaultDisputeGame_Move_Test
+/// @notice Tests the move functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_Move_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that a move while the game status is not `IN_PROGRESS` causes the call to
+    ///         revert with the `GameNotInProgress` error
     function test_move_gameNotInProgress_reverts() public {
         uint256 chalWins = uint256(GameStatus.CHALLENGER_WINS);
 
@@ -602,15 +807,16 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.attack(root, 0, Claim.wrap(0));
     }
 
-    /// @dev Tests that an attempt to defend the root claim reverts with the `CannotDefendRootClaim` error.
+    /// @notice Tests that an attempt to defend the root claim reverts with the
+    ///         `CannotDefendRootClaim` error.
     function test_move_defendRoot_reverts() public {
         (,,,, Claim root,,) = gameProxy.claimData(0);
         vm.expectRevert(CannotDefendRootClaim.selector);
         gameProxy.defend(root, 0, _dummyClaim());
     }
 
-    /// @dev Tests that an attempt to move against a claim that does not exist reverts with the
-    ///      `ParentDoesNotExist` error.
+    /// @notice Tests that an attempt to move against a claim that does not exist reverts with the
+    ///         `ParentDoesNotExist` error.
     function test_move_nonExistentParent_reverts() public {
         Claim claim = _dummyClaim();
 
@@ -623,8 +829,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.defend(_dummyClaim(), 1, claim);
     }
 
-    /// @dev Tests that an attempt to move at the maximum game depth reverts with the
-    ///      `GameDepthExceeded` error.
+    /// @notice Tests that an attempt to move at the maximum game depth reverts with the
+    ///         `GameDepthExceeded` error.
     function test_move_gameDepthExceeded_reverts() public {
         Claim claim = _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC);
 
@@ -643,8 +849,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         }
     }
 
-    /// @dev Tests that a move made after the clock time has exceeded reverts with the
-    ///      `ClockTimeExceeded` error.
+    /// @notice Tests that a move made after the clock time has exceeded reverts with the
+    ///         `ClockTimeExceeded` error.
     function test_move_clockTimeExceeded_reverts() public {
         // Warp ahead past the clock time for the first move (3 1/2 days)
         vm.warp(block.timestamp + 3 days + 12 hours + 1);
@@ -675,8 +881,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         (,,,,,, clock) = gameProxy.claimData(2);
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(10), Timestamp.wrap(uint64(block.timestamp))).raw());
 
-        // We are at the split depth, so we need to set the status byte of the claim
-        // for the next move.
+        // We are at the split depth, so we need to set the status byte of the claim for the next
+        // move.
         claim = _changeClaimStatus(claim, VMStatuses.PANIC);
 
         vm.warp(block.timestamp + 10);
@@ -694,8 +900,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(20), Timestamp.wrap(uint64(block.timestamp))).raw());
     }
 
-    /// @dev Tests that the standard clock extension is triggered for a move that is not the
-    ///      split depth or the max game depth.
+    /// @notice Tests that the standard clock extension is triggered for a move that is not the
+    ///         split depth or the max game depth.
     function test_move_standardClockExtension_succeeds() public {
         (,,,,,, Clock clock) = gameProxy.claimData(0);
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
@@ -814,8 +1020,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that an identical claim cannot be made twice. The duplicate claim attempt should
-    ///      revert with the `ClaimAlreadyExists` error.
+    /// @notice Tests that an identical claim cannot be made twice. The duplicate claim attempt
+    ///         should revert with the `ClaimAlreadyExists` error.
     function test_move_duplicateClaim_reverts() public {
         Claim claim = _dummyClaim();
 
@@ -829,7 +1035,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.attack{ value: bond }(disputed, 0, claim);
     }
 
-    /// @dev Static unit test asserting that identical claims at the same position can be made in different subgames.
+    /// @notice Static unit test asserting that identical claims at the same position can be made
+    ///         in different subgames.
     function test_move_duplicateClaimsDifferentSubgames_succeeds() public {
         Claim claimA = _dummyClaim();
         Claim claimB = _dummyClaim();
@@ -850,7 +1057,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.attack{ value: bond }(disputed, 2, claimA);
     }
 
-    /// @dev Static unit test for the correctness of an opening attack.
+    /// @notice Static unit test for the correctness of an opening attack.
     function test_move_simpleAttack_succeeds() public {
         // Warp ahead 5 seconds.
         vm.warp(block.timestamp + 5);
@@ -897,8 +1104,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp - 5))).raw());
     }
 
-    /// @dev Tests that making a claim at the execution trace bisection root level with an invalid status
-    ///      byte reverts with the `UnexpectedRootClaim` error.
+    /// @notice Tests that making a claim at the execution trace bisection root level with an
+    ///         invalid status byte reverts with the `UnexpectedRootClaim` error.
     function test_move_incorrectStatusExecRoot_reverts() public {
         Claim disputed;
         for (uint256 i; i < 4; i++) {
@@ -912,8 +1119,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.attack{ value: bond }(disputed, 4, Claim.wrap(bytes32(0)));
     }
 
-    /// @dev Tests that making a claim at the execution trace bisection root level with a valid status
-    ///      byte succeeds.
+    /// @notice Tests that making a claim at the execution trace bisection root level with a valid
+    ///         status byte succeeds.
     function test_move_correctStatusExecRoot_succeeds() public {
         Claim disputed;
         for (uint256 i; i < 4; i++) {
@@ -926,14 +1133,15 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
     }
 
-    /// @dev Static unit test asserting that a move reverts when the bonded amount is incorrect.
+    /// @notice Static unit test asserting that a move reverts when the bonded amount is incorrect.
     function test_move_incorrectBondAmount_reverts() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         vm.expectRevert(IncorrectBondAmount.selector);
         gameProxy.attack{ value: 0 }(disputed, 0, _dummyClaim());
     }
 
-    /// @dev Static unit test asserting that a move reverts when the disputed claim does not match its index.
+    /// @notice Static unit test asserting that a move reverts when the disputed claim does not
+    ///         match its index.
     function test_move_incorrectDisputedIndex_reverts() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -941,9 +1149,208 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         vm.expectRevert(InvalidDisputedClaimIndex.selector);
         gameProxy.attack{ value: bond }(disputed, 1, _dummyClaim());
     }
+}
 
-    /// @dev Tests that challenging the root claim's L2 block number by providing the real preimage of the output root
-    ///      succeeds.
+/// @title FaultDisputeGame_AddLocalData_Test
+/// @notice Tests the addLocalData functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_AddLocalData_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that adding local data with an out of bounds identifier reverts.
+    function testFuzz_addLocalData_oob_reverts(uint256 _ident) public {
+        Claim disputed;
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, _dummyClaim());
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        // [1, 5] are valid local data identifiers.
+        if (_ident <= 5) _ident = 0;
+
+        vm.expectRevert(InvalidLocalIdent.selector);
+        gameProxy.addLocalData(_ident, 5, 0);
+    }
+
+    /// @notice Tests that local data is loaded into the preimage oracle correctly in the subgame
+    ///         that is disputing the transition from `GENESIS -> GENESIS + 1`
+    function test_addLocalDataGenesisTransition_static_succeeds() public {
+        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
+        Claim disputed;
+
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        // Expected start/disputed claims
+        (Hash root,) = gameProxy.startingOutputRoot();
+        bytes32 startingClaim = root.raw();
+        bytes32 disputedClaim = bytes32(uint256(3));
+        Position disputedPos = LibPosition.wrap(4, 0);
+
+        // Expected local data
+        bytes32[5] memory data = [
+            gameProxy.l1Head().raw(),
+            startingClaim,
+            disputedClaim,
+            bytes32(validL2BlockNumber << 0xC0),
+            bytes32(gameProxy.l2ChainId() << 0xC0)
+        ];
+
+        for (uint256 i = 1; i <= 5; i++) {
+            uint256 expectedLen = i > 3 ? 8 : 32;
+            bytes32 key = _getKey(i, keccak256(abi.encode(disputedClaim, disputedPos)));
+
+            gameProxy.addLocalData(i, 5, 0);
+            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+            assertEq(dat >> 0xC0, bytes32(expectedLen));
+            // Account for the length prefix if i > 3 (the data stored at identifiers i <= 3 are
+            // 32 bytes long, so the expected length is already correct. If i > 3, the data is only
+            // 8 bytes long, so the length prefix + the data is 16 bytes total.)
+            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
+
+            gameProxy.addLocalData(i, 5, 8);
+            (dat, datLen) = oracle.readPreimage(key, 8);
+            assertEq(dat, data[i - 1]);
+            assertEq(datLen, expectedLen);
+        }
+    }
+
+    /// @notice Tests that local data is loaded into the preimage oracle correctly.
+    function test_addLocalDataMiddle_static_succeeds() public {
+        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
+        Claim disputed;
+
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID));
+
+        // Expected start/disputed claims
+        bytes32 startingClaim = bytes32(uint256(3));
+        Position startingPos = LibPosition.wrap(4, 0);
+        bytes32 disputedClaim = bytes32(uint256(2));
+        Position disputedPos = LibPosition.wrap(3, 0);
+
+        // Expected local data
+        bytes32[5] memory data = [
+            gameProxy.l1Head().raw(),
+            startingClaim,
+            disputedClaim,
+            bytes32(validL2BlockNumber << 0xC0),
+            bytes32(gameProxy.l2ChainId() << 0xC0)
+        ];
+
+        for (uint256 i = 1; i <= 5; i++) {
+            uint256 expectedLen = i > 3 ? 8 : 32;
+            bytes32 key = _getKey(i, keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos)));
+
+            gameProxy.addLocalData(i, 5, 0);
+            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+            assertEq(dat >> 0xC0, bytes32(expectedLen));
+            // Account for the length prefix if i > 3 (the data stored at identifiers i <= 3 are
+            // 32 bytes long, so the expected length is already correct. If i > 3, the data is only
+            // 8 bytes long, so the length prefix + the data is 16 bytes total.)
+            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
+
+            gameProxy.addLocalData(i, 5, 8);
+            (dat, datLen) = oracle.readPreimage(key, 8);
+            assertEq(dat, data[i - 1]);
+            assertEq(datLen, expectedLen);
+        }
+    }
+
+    /// @notice Tests that the L2 block number claim is favored over the bisected-to block when
+    ///         adding data.
+    function test_addLocalData_l2BlockNumberExtension_succeeds() public {
+        // Deploy a new dispute game with a L2 block number claim of 8. This is directly in the
+        // middle of the leaves in our output bisection test tree, at SPLIT_DEPTH = 2 ** 2
+        IFaultDisputeGame game = IFaultDisputeGame(
+            address(
+                disputeGameFactory.create{ value: initBond }(
+                    GAME_TYPE, Claim.wrap(bytes32(uint256(0xFF))), abi.encode(validL2BlockNumber)
+                )
+            )
+        );
+
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        {
+            Claim disputed;
+            Position parent;
+            Position pos;
+
+            for (uint256 i; i < 4; i++) {
+                (,,,,, parent,) = game.claimData(i);
+                pos = parent.move(true);
+                uint256 bond = game.getRequiredBond(pos);
+
+                (,,,, disputed,,) = game.claimData(i);
+                if (i == 0) {
+                    game.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+                } else {
+                    game.defend{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+                }
+            }
+            (,,,,, parent,) = game.claimData(4);
+            pos = parent.move(true);
+            uint256 lastBond = game.getRequiredBond(pos);
+            (,,,, disputed,,) = game.claimData(4);
+            game.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.INVALID));
+        }
+
+        // Expected start/disputed claims
+        bytes32 startingClaim = bytes32(uint256(3));
+        Position startingPos = LibPosition.wrap(4, 14);
+        bytes32 disputedClaim = bytes32(uint256(0xFF));
+        Position disputedPos = LibPosition.wrap(0, 0);
+
+        // Expected local data. This should be `l2BlockNumber`, and not the actual bisected-to
+        // block, as we choose the minimum between the two.
+        bytes32 expectedNumber = bytes32(validL2BlockNumber << 0xC0);
+        uint256 expectedLen = 8;
+        uint256 l2NumberIdent = LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER;
+
+        // Compute the preimage key for the local data
+        bytes32 localContext = keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos));
+        bytes32 rawKey = keccak256(abi.encode(l2NumberIdent | (1 << 248), address(game), localContext));
+        bytes32 key = bytes32((uint256(rawKey) & ~uint256(0xFF << 248)) | (1 << 248));
+
+        IPreimageOracle oracle = IPreimageOracle(address(game.vm().oracle()));
+        game.addLocalData(l2NumberIdent, 5, 0);
+
+        (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+        assertEq(dat >> 0xC0, bytes32(expectedLen));
+        assertEq(datLen, expectedLen + 8);
+
+        game.addLocalData(l2NumberIdent, 5, 8);
+        (dat, datLen) = oracle.readPreimage(key, 8);
+        assertEq(dat, expectedNumber);
+        assertEq(datLen, expectedLen);
+    }
+}
+
+/// @title FaultDisputeGame_ChallengeRootL2Block_Test
+/// @notice Tests the challengeRootL2Block functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_ChallengeRootL2Block_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that challenging the root claim's L2 block number by providing the real
+    ///         preimage of the output root succeeds.
     function testFuzz_challengeRootL2Block_succeeds(
         bytes32 _storageRoot,
         bytes32 _withdrawalRoot,
@@ -980,9 +1387,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertTrue(fdg.l2BlockNumberChallenged());
     }
 
-    /// @dev Tests that challenging the root claim's L2 block number by providing the real preimage of the output root
-    ///      succeeds. Also, this claim should always receive the bond when there is another counter that is as far left
-    ///      as possible.
+    /// @notice Tests that challenging the root claim's L2 block number by providing the real
+    ///         preimage of the output root succeeds. Also, this claim should always receive the
+    ///         bond when there is another counter that is as far left as possible.
     function testFuzz_challengeRootL2Block_receivesBond_succeeds(
         bytes32 _storageRoot,
         bytes32 _withdrawalRoot,
@@ -1043,7 +1450,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         fdg.claimCredit(address(0xb0b));
         fdg.claimCredit(address(0xace));
 
-        // Ensure that the party who challenged the L2 block number with the special move received the bond.
+        // Ensure that the party who challenged the L2 block number with the special move received
+        // the bond.
         // - Root claim loses their bond
         // - 0xace receives the root claim's bond
         // - 0xb0b receives their bond back
@@ -1052,8 +1460,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(address(0xace).balance, 0.1 ether);
     }
 
-    /// @dev Tests that challenging the root claim's L2 block number by providing the real preimage of the output root
-    ///      never succeeds.
+    /// @notice Tests that challenging the root claim's L2 block number by providing the real
+    ///         preimage of the output root never succeeds.
     function testFuzz_challengeRootL2Block_rightBlockNumber_reverts(
         bytes32 _storageRoot,
         bytes32 _withdrawalRoot,
@@ -1084,7 +1492,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(fdg.status()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Tests that challenging the root claim's L2 block number with a bad output root proof reverts.
+    /// @notice Tests that challenging the root claim's L2 block number with a bad output root
+    ///         proof reverts.
     function test_challengeRootL2Block_badProof_reverts() public {
         Types.OutputRootProof memory outputRootProof =
             Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 });
@@ -1093,7 +1502,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.challengeRootL2Block(outputRootProof, hex"");
     }
 
-    /// @dev Tests that challenging the root claim's L2 block number with a bad output root proof reverts.
+    /// @notice Tests that challenging the root claim's L2 block number with a bad output root
+    ///         proof reverts.
     function test_challengeRootL2Block_badHeaderRLP_reverts() public {
         Types.OutputRootProof memory outputRootProof =
             Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 });
@@ -1109,7 +1519,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         fdg.challengeRootL2Block(outputRootProof, hex"");
     }
 
-    /// @dev Tests that challenging the root claim's L2 block number with a bad output root proof reverts.
+    /// @notice Tests that challenging the root claim's L2 block number with a bad output root
+    ///         proof reverts.
     function test_challengeRootL2Block_badHeaderRLPBlockNumberLength_reverts() public {
         (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot,) =
             _generateOutputRootProof(0, 0, new bytes(64));
@@ -1123,213 +1534,26 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         vm.expectRevert(InvalidHeaderRLP.selector);
         fdg.challengeRootL2Block(outputRootProof, hex"");
     }
+}
 
-    /// @dev Tests that a claim cannot be stepped against twice.
-    function test_step_duplicateStep_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.attack{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, true, absolutePrestateData, hex"");
-
-        vm.expectRevert(DuplicateStep.selector);
-        gameProxy.step(8, true, absolutePrestateData, hex"");
-    }
-
-    /// @dev Tests that successfully step with true attacking claim when there is a true defend claim(claim5) in the
-    /// middle of the dispute game.
-    function test_stepAttackDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        bytes memory claimData5 = abi.encode(5, 5);
-        Claim claim5 = Claim.wrap(keccak256(claimData5));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, true, claimData5, hex"");
-    }
-
-    /// @dev Tests that successfully step with true defend claim when there is a true defend claim(claim7) in the
-    /// middle of the dispute game.
-    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(7, 7);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(7);
-
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, Claim.wrap(keccak256(claimData7)));
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, false, claimData7, hex"");
-    }
-
-    /// @dev Tests that step reverts with false attacking claim when there is a true defend claim(claim5) in the middle
-    /// of the dispute game.
-    function test_stepAttackTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        bytes memory claimData5 = abi.encode(5, 5);
-        Claim claim5 = Claim.wrap(keccak256(claimData5));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, true, claimData5, hex"");
-    }
-
-    /// @dev Tests that step reverts with false defending claim when there is a true defend claim(postState_) in the
-    /// middle of the dispute game.
-    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(5, 5);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-
-        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
-        Claim dummyClaim7 = Claim.wrap(keccak256(_dummyClaimData));
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, dummyClaim7);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, false, _dummyClaimData, hex"");
-    }
-
-    /// @dev Tests that step reverts with true defending claim when there is a true defend claim(postState_) in the
-    /// middle of the dispute game.
-    function test_stepDefendTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(5, 5);
-        Claim claim7 = Claim.wrap(keccak256(claimData7));
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, claim7);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, false, claimData7, hex"");
-    }
-
-    /// @dev Static unit test for the correctness an uncontested root resolution.
+/// @title FaultDisputeGame_Resolve_Test
+/// @notice Tests the resolve functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_Resolve_Test is FaultDisputeGame_TestInit {
+    /// @notice Static unit test for the correctness an uncontested root resolution.
     function test_resolve_rootUncontested_succeeds() public {
         vm.warp(block.timestamp + 3 days + 12 hours);
         gameProxy.resolveClaim(0, 0);
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Static unit test for the correctness an uncontested root resolution.
+    /// @notice Static unit test for the correctness an uncontested root resolution.
     function test_resolve_rootUncontestedClockNotExpired_succeeds() public {
         vm.warp(block.timestamp + 3 days + 12 hours - 1 seconds);
         vm.expectRevert(ClockNotExpired.selector);
         gameProxy.resolveClaim(0, 0);
     }
 
-    /// @dev Static unit test for the correctness of a multi-part resolution of a single claim.
+    /// @notice Static unit test for the correctness of a multi-part resolution of a single claim.
     function test_resolve_multiPart_succeeds() public {
         vm.deal(address(this), 10_000 ether);
 
@@ -1380,7 +1604,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
     }
 
-    /// @dev Static unit test asserting that resolve reverts when the absolute root
+    /// @notice Static unit test asserting that resolve reverts when the absolute root
     ///      subgame has not been resolved.
     function test_resolve_rootUncontestedButUnresolved_reverts() public {
         vm.warp(block.timestamp + 3 days + 12 hours);
@@ -1388,7 +1612,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolve();
     }
 
-    /// @dev Static unit test asserting that resolve reverts when the game state is
+    /// @notice Static unit test asserting that resolve reverts when the game state is
     ///      not in progress.
     function test_resolve_notInProgress_reverts() public {
         uint256 chalWins = uint256(GameStatus.CHALLENGER_WINS);
@@ -1405,7 +1629,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(0, 0);
     }
 
-    /// @dev Static unit test for the correctness of resolving a single attack game state.
+    /// @notice Static unit test for the correctness of resolving a single attack game state.
     function test_resolve_rootContested_succeeds() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1417,7 +1641,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
     }
 
-    /// @dev Static unit test for the correctness of resolving a game with a contested challenge claim.
+    /// @notice Static unit test for the correctness of resolving a game with a contested challenge
+    ///         claim.
     function test_resolve_challengeContested_succeeds() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1432,7 +1657,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Static unit test for the correctness of resolving a game with multiplayer moves.
+    /// @notice Static unit test for the correctness of resolving a game with multiplayer moves.
     function test_resolve_teamDeathmatch_succeeds() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1451,7 +1676,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
     }
 
-    /// @dev Static unit test for the correctness of resolving a game that reaches max game depth.
+    /// @notice Static unit test for the correctness of resolving a game that reaches max game
+    ///         depth.
     function test_resolve_stepReached_succeeds() public {
         Claim claim = _dummyClaim();
         for (uint256 i; i < gameProxy.splitDepth(); i++) {
@@ -1473,7 +1699,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Static unit test asserting that resolve reverts when attempting to resolve a subgame multiple times
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve a
+    ///         subgame multiple times
     function test_resolve_claimAlreadyResolved_reverts() public {
         Claim claim = _dummyClaim();
         uint256 firstBond = _getRequiredBond(0);
@@ -1494,7 +1721,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(1, 0);
     }
 
-    /// @dev Static unit test asserting that resolve reverts when attempting to resolve a subgame at max depth
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve a
+    ///         subgame at max depth
     function test_resolve_claimAtMaxDepthAlreadyResolved_reverts() public {
         Claim claim = _dummyClaim();
         for (uint256 i; i < gameProxy.splitDepth(); i++) {
@@ -1517,7 +1745,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(8, 0);
     }
 
-    /// @dev Static unit test asserting that resolve reverts when attempting to resolve subgames out of order
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve
+    ///         subgames out of order
     function test_resolve_outOfOrderResolution_reverts() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1530,8 +1759,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.resolveClaim(0, 0);
     }
 
-    /// @dev Static unit test asserting that resolve pays out bonds on step, output bisection, and execution trace
-    /// moves.
+    /// @notice Static unit test asserting that resolve pays out bonds on step, output bisection,
+    ///         and execution trace moves.
     function test_resolve_bondPayouts_succeeds() public {
         // Give the test contract some ether
         uint256 bal = 1000 ether;
@@ -1610,12 +1839,13 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(address(gameProxy).balance, 0);
         assertEq(delayedWeth.balanceOf(address(gameProxy)), 0);
 
-        // Ensure that the init bond for the game is 0, in case we change it in the test suite in the future.
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
         assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
     }
 
-    /// @dev Static unit test asserting that resolve pays out bonds on step, output bisection, and execution trace
-    /// moves with 2 actors and a dishonest root claim.
+    /// @notice Static unit test asserting that resolve pays out bonds on step, output bisection,
+    ///         and execution trace moves with 2 actors and a dishonest root claim.
     function test_resolve_bondPayoutsSeveralActors_succeeds() public {
         // Give the test contract and bob some ether
         // We use the "1000 ether" literal for `bal`, the initial balance, to avoid stack too deep
@@ -1718,12 +1948,13 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(address(gameProxy).balance, 0);
         assertEq(delayedWeth.balanceOf(address(gameProxy)), 0);
 
-        // Ensure that the init bond for the game is 0, in case we change it in the test suite in the future.
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
         assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
     }
 
-    /// @dev Static unit test asserting that resolve pays out bonds on moves to the leftmost actor
-    /// in subgames containing successful counters.
+    /// @notice Static unit test asserting that resolve pays out bonds on moves to the leftmost
+    ///         actor in subgames containing successful counters.
     function test_resolve_leftmostBondPayout_succeeds() public {
         uint256 bal = 1000 ether;
         address alice = address(0xa11ce);
@@ -1734,9 +1965,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         vm.deal(bob, bal);
         vm.deal(charlie, bal);
 
-        // Make claims with bob, charlie and the test contract on defense, and alice as the challenger
-        // charlie is successfully countered by alice
-        // alice is successfully countered by both bob and the test contract
+        // Make claims with bob, charlie and the test contract on defense, and alice as the
+        // challenger charlie is successfully countered by alice alice is successfully countered by
+        // both bob and the test contract
         uint256 firstBond = _getRequiredBond(0);
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         vm.prank(alice);
@@ -1796,12 +2027,13 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(charlie.balance, bal - charlieLosses, "incorrect charlie balance");
         assertEq(address(gameProxy).balance, 0);
 
-        // Ensure that the init bond for the game is 0, in case we change it in the test suite in the future.
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
         assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
     }
 
-    /// @dev Static unit test asserting that the anchor state updates when the game resolves in
-    /// favor of the defender and the anchor state is older than the game state.
+    /// @notice Static unit test asserting that the anchor state updates when the game resolves in
+    ///         favor of the defender and the anchor state is older than the game state.
     function test_resolve_validNewerStateUpdatesAnchor_succeeds() public {
         // Confirm that the anchor state is older than the game state.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
@@ -1824,8 +2056,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(root.raw(), gameProxy.rootClaim().raw());
     }
 
-    /// @dev Static unit test asserting that the anchor state does not change when the game
-    /// resolves in favor of the defender but the game state is not newer than the anchor state.
+    /// @notice Static unit test asserting that the anchor state does not change when the game
+    ///         resolves in favor of the defender but the game state is not newer than the anchor
+    ///         state.
     function test_resolve_validOlderStateSameAnchor_succeeds() public {
         // Mock the game block to be older than the game state.
         vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(0));
@@ -1852,8 +2085,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(updatedRoot.raw(), root.raw());
     }
 
-    /// @dev Static unit test asserting that the anchor state does not change when the game
-    /// resolves in favor of the challenger, even if the game state is newer than the anchor.
+    /// @notice Static unit test asserting that the anchor state does not change when the game
+    ///         resolves in favor of the challenger, even if the game state is newer than the
+    ///         anchor state.
     function test_resolve_invalidStateSameAnchor_succeeds() public {
         // Confirm that the anchor state is older than the game state.
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
@@ -1878,7 +2112,79 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(updatedL2BlockNumber, l2BlockNumber);
         assertEq(updatedRoot.raw(), root.raw());
     }
+}
 
+/// @title FaultDisputeGame_GameType_Test
+/// @notice Tests the `gameType` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_GameType_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game's type is set correctly.
+    function test_gameType_succeeds() public view {
+        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
+    }
+}
+
+/// @title FaultDisputeGame_RootClaim_Test
+/// @notice Tests the `rootClaim` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_RootClaim_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game's root claim is set correctly.
+    function test_rootClaim_succeeds() public view {
+        assertEq(gameProxy.rootClaim().raw(), ROOT_CLAIM.raw());
+    }
+}
+
+/// @title FaultDisputeGame_ExtraData_Test
+/// @notice Tests the `extraData` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_ExtraData_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game's extra data is set correctly.
+    function test_extraData_succeeds() public view {
+        assertEq(gameProxy.extraData(), extraData);
+    }
+}
+
+/// @title FaultDisputeGame_GameData_Test
+/// @notice Tests the `gameData` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_GameData_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game's data is set correctly.
+    function test_gameData_succeeds() public view {
+        (GameType gameType, Claim rootClaim, bytes memory _extraData) = gameProxy.gameData();
+
+        assertEq(gameType.raw(), GAME_TYPE.raw());
+        assertEq(rootClaim.raw(), ROOT_CLAIM.raw());
+        assertEq(_extraData, extraData);
+    }
+}
+
+/// @title FaultDisputeGame_GetRequiredBond_Test
+/// @notice Tests the `getRequiredBond` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_GetRequiredBond_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the bond during the bisection game depths is correct.
+    function test_getRequiredBond_succeeds() public view {
+        for (uint8 i = 0; i < uint8(gameProxy.splitDepth()); i++) {
+            Position pos = LibPosition.wrap(i, 0);
+            uint256 bond = gameProxy.getRequiredBond(pos);
+
+            // Reasonable approximation for a max depth of 8.
+            uint256 expected = 0.08 ether;
+            for (uint64 j = 0; j < i; j++) {
+                expected = expected * 22876;
+                expected = expected / 10000;
+            }
+
+            assertApproxEqAbs(bond, expected, 0.01 ether);
+        }
+    }
+
+    /// @notice Tests that the bond at a depth greater than the maximum game depth reverts.
+    function test_getRequiredBond_outOfBounds_reverts() public {
+        Position pos = LibPosition.wrap(uint8(gameProxy.maxGameDepth() + 1), 0);
+        vm.expectRevert(GameDepthExceeded.selector);
+        gameProxy.getRequiredBond(pos);
+    }
+}
+
+/// @title FaultDisputeGame_ClaimCredit_Test
+/// @notice Tests the claimCredit functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_ClaimCredit_Test is FaultDisputeGame_TestInit {
     function test_claimCredit_refundMode_succeeds() public {
         // Set up actors.
         address alice = address(0xa11ce);
@@ -1950,7 +2256,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(bob.balance, bobBalanceBefore + secondBond);
     }
 
-    /// @dev Tests that claimCredit reverts if the game is paused.
+    /// @notice Tests that claimCredit reverts if the game is paused.
     function test_claimCredit_gamePaused_reverts() public {
         // Pause the system with the Superchain-wide identifier (address(0)).
         vm.prank(superchainConfig.guardian());
@@ -1961,7 +2267,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.claimCredit(address(0));
     }
 
-    /// @dev Static unit test asserting that credit may not be drained past allowance through reentrancy.
+    /// @notice Static unit test asserting that credit may not be drained past allowance through
+    ///         reentrancy.
     function test_claimCredit_claimAlreadyResolved_reverts() public {
         ClaimCreditReenter reenter = new ClaimCreditReenter(gameProxy, vm);
         vm.startPrank(address(reenter));
@@ -2022,7 +2329,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         reenter.claimCredit(address(reenter));
 
         // The reenter contract should have performed 2 calls to `claimCredit`.
-        // Once all the credit is claimed, all subsequent calls will revert since there is 0 credit left to claim.
+        // Once all the credit is claimed, all subsequent calls will revert since there is 0 credit
+        // left to claim.
         // The claimant must only have received the amount bonded for the gindex 1 subgame.
         // The root claim bond and the unregistered ETH should still exist in the game proxy.
         assertEq(reenter.numCalls(), 2);
@@ -2033,7 +2341,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         vm.stopPrank();
     }
 
-    /// @dev Tests that claimCredit reverts when recipient can't receive value.
+    /// @notice Tests that claimCredit reverts when recipient can't receive value.
     function test_claimCredit_recipientCantReceiveValue_reverts() public {
         // Set up actors.
         address alice = address(0xa11ce);
@@ -2082,313 +2390,25 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
 
-        // make bob not be able to receive value by setting his contract code to something without `receive`
+        // Make bob not be able to receive value by setting his contract code to something without
+        // `receive`
         vm.etch(address(bob), address(L1Token).code);
 
         vm.expectRevert(BondTransferFailed.selector);
         gameProxy.claimCredit(address(bob));
     }
+}
 
-    /// @dev Tests that adding local data with an out of bounds identifier reverts.
-    function testFuzz_addLocalData_oob_reverts(uint256 _ident) public {
-        Claim disputed;
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        for (uint256 i; i < 4; i++) {
-            uint256 bond = _getRequiredBond(i);
-            (,,,, disputed,,) = gameProxy.claimData(i);
-            gameProxy.attack{ value: bond }(disputed, i, _dummyClaim());
-        }
-        uint256 lastBond = _getRequiredBond(4);
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        // [1, 5] are valid local data identifiers.
-        if (_ident <= 5) _ident = 0;
-
-        vm.expectRevert(InvalidLocalIdent.selector);
-        gameProxy.addLocalData(_ident, 5, 0);
-    }
-
-    /// @dev Tests that local data is loaded into the preimage oracle correctly in the subgame
-    ///      that is disputing the transition from `GENESIS -> GENESIS + 1`
-    function test_addLocalDataGenesisTransition_static_succeeds() public {
-        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
-        Claim disputed;
-
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        for (uint256 i; i < 4; i++) {
-            uint256 bond = _getRequiredBond(i);
-            (,,,, disputed,,) = gameProxy.claimData(i);
-            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-        }
-        uint256 lastBond = _getRequiredBond(4);
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        // Expected start/disputed claims
-        (Hash root,) = gameProxy.startingOutputRoot();
-        bytes32 startingClaim = root.raw();
-        bytes32 disputedClaim = bytes32(uint256(3));
-        Position disputedPos = LibPosition.wrap(4, 0);
-
-        // Expected local data
-        bytes32[5] memory data = [
-            gameProxy.l1Head().raw(),
-            startingClaim,
-            disputedClaim,
-            bytes32(validL2BlockNumber << 0xC0),
-            bytes32(gameProxy.l2ChainId() << 0xC0)
-        ];
-
-        for (uint256 i = 1; i <= 5; i++) {
-            uint256 expectedLen = i > 3 ? 8 : 32;
-            bytes32 key = _getKey(i, keccak256(abi.encode(disputedClaim, disputedPos)));
-
-            gameProxy.addLocalData(i, 5, 0);
-            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
-            assertEq(dat >> 0xC0, bytes32(expectedLen));
-            // Account for the length prefix if i > 3 (the data stored
-            // at identifiers i <= 3 are 32 bytes long, so the expected
-            // length is already correct. If i > 3, the data is only 8
-            // bytes long, so the length prefix + the data is 16 bytes
-            // total.)
-            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
-
-            gameProxy.addLocalData(i, 5, 8);
-            (dat, datLen) = oracle.readPreimage(key, 8);
-            assertEq(dat, data[i - 1]);
-            assertEq(datLen, expectedLen);
-        }
-    }
-
-    /// @dev Tests that local data is loaded into the preimage oracle correctly.
-    function test_addLocalDataMiddle_static_succeeds() public {
-        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
-        Claim disputed;
-
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        for (uint256 i; i < 4; i++) {
-            uint256 bond = _getRequiredBond(i);
-            (,,,, disputed,,) = gameProxy.claimData(i);
-            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-        }
-        uint256 lastBond = _getRequiredBond(4);
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID));
-
-        // Expected start/disputed claims
-        bytes32 startingClaim = bytes32(uint256(3));
-        Position startingPos = LibPosition.wrap(4, 0);
-        bytes32 disputedClaim = bytes32(uint256(2));
-        Position disputedPos = LibPosition.wrap(3, 0);
-
-        // Expected local data
-        bytes32[5] memory data = [
-            gameProxy.l1Head().raw(),
-            startingClaim,
-            disputedClaim,
-            bytes32(validL2BlockNumber << 0xC0),
-            bytes32(gameProxy.l2ChainId() << 0xC0)
-        ];
-
-        for (uint256 i = 1; i <= 5; i++) {
-            uint256 expectedLen = i > 3 ? 8 : 32;
-            bytes32 key = _getKey(i, keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos)));
-
-            gameProxy.addLocalData(i, 5, 0);
-            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
-            assertEq(dat >> 0xC0, bytes32(expectedLen));
-            // Account for the length prefix if i > 3 (the data stored
-            // at identifiers i <= 3 are 32 bytes long, so the expected
-            // length is already correct. If i > 3, the data is only 8
-            // bytes long, so the length prefix + the data is 16 bytes
-            // total.)
-            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
-
-            gameProxy.addLocalData(i, 5, 8);
-            (dat, datLen) = oracle.readPreimage(key, 8);
-            assertEq(dat, data[i - 1]);
-            assertEq(datLen, expectedLen);
-        }
-    }
-
-    /// @dev Tests that the L2 block number claim is favored over the bisected-to block when adding data
-    ///
-    function test_addLocalData_l2BlockNumberExtension_succeeds() public {
-        // Deploy a new dispute game with a L2 block number claim of 8. This is directly in the middle of
-        // the leaves in our output bisection test tree, at SPLIT_DEPTH = 2 ** 2
-        IFaultDisputeGame game = IFaultDisputeGame(
-            address(
-                disputeGameFactory.create{ value: initBond }(
-                    GAME_TYPE, Claim.wrap(bytes32(uint256(0xFF))), abi.encode(validL2BlockNumber)
-                )
-            )
-        );
-
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        {
-            Claim disputed;
-            Position parent;
-            Position pos;
-
-            for (uint256 i; i < 4; i++) {
-                (,,,,, parent,) = game.claimData(i);
-                pos = parent.move(true);
-                uint256 bond = game.getRequiredBond(pos);
-
-                (,,,, disputed,,) = game.claimData(i);
-                if (i == 0) {
-                    game.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-                } else {
-                    game.defend{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-                }
-            }
-            (,,,,, parent,) = game.claimData(4);
-            pos = parent.move(true);
-            uint256 lastBond = game.getRequiredBond(pos);
-            (,,,, disputed,,) = game.claimData(4);
-            game.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.INVALID));
-        }
-
-        // Expected start/disputed claims
-        bytes32 startingClaim = bytes32(uint256(3));
-        Position startingPos = LibPosition.wrap(4, 14);
-        bytes32 disputedClaim = bytes32(uint256(0xFF));
-        Position disputedPos = LibPosition.wrap(0, 0);
-
-        // Expected local data. This should be `l2BlockNumber`, and not the actual bisected-to block,
-        // as we choose the minimum between the two.
-        bytes32 expectedNumber = bytes32(validL2BlockNumber << 0xC0);
-        uint256 expectedLen = 8;
-        uint256 l2NumberIdent = LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER;
-
-        // Compute the preimage key for the local data
-        bytes32 localContext = keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos));
-        bytes32 rawKey = keccak256(abi.encode(l2NumberIdent | (1 << 248), address(game), localContext));
-        bytes32 key = bytes32((uint256(rawKey) & ~uint256(0xFF << 248)) | (1 << 248));
-
-        IPreimageOracle oracle = IPreimageOracle(address(game.vm().oracle()));
-        game.addLocalData(l2NumberIdent, 5, 0);
-
-        (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
-        assertEq(dat >> 0xC0, bytes32(expectedLen));
-        assertEq(datLen, expectedLen + 8);
-
-        game.addLocalData(l2NumberIdent, 5, 8);
-        (dat, datLen) = oracle.readPreimage(key, 8);
-        assertEq(dat, expectedNumber);
-        assertEq(datLen, expectedLen);
-    }
-
-    /// @dev Tests that if the game is not in progress, querying of `getChallengerDuration` reverts
-    function test_getChallengerDuration_gameNotInProgress_reverts() public {
-        // resolve the game
-        vm.warp(block.timestamp + gameProxy.maxClockDuration().raw());
-
-        gameProxy.resolveClaim(0, 0);
-        gameProxy.resolve();
-
-        vm.expectRevert(GameNotInProgress.selector);
-        gameProxy.getChallengerDuration(1);
-    }
-
-    /// @dev Static unit test asserting that resolveClaim isn't possible if there's time
-    ///      left for a counter.
-    function test_resolution_lastSecondDisputes_succeeds() public {
-        // The honest proposer created an honest root claim during setup - node 0
-
-        // Defender's turn
-        vm.warp(block.timestamp + 3.5 days - 1 seconds);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        // Chess clock time accumulated:
-        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days - 1 seconds);
-        assertEq(gameProxy.getChallengerDuration(1).raw(), 0);
-
-        // Advance time by 1 second, so that the root claim challenger clock is expired.
-        vm.warp(block.timestamp + 1 seconds);
-        // Attempt a second attack against the root claim. This should revert since the challenger clock is expired.
-        uint256 expectedBond = _getRequiredBond(0);
-        vm.expectRevert(ClockTimeExceeded.selector);
-        gameProxy.attack{ value: expectedBond }(disputed, 0, _dummyClaim());
-        // Chess clock time accumulated:
-        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
-        assertEq(gameProxy.getChallengerDuration(1).raw(), 1 seconds);
-
-        // Should not be able to resolve the root claim or second counter yet.
-        vm.expectRevert(ClockNotExpired.selector);
-        gameProxy.resolveClaim(1, 0);
-        vm.expectRevert(OutOfOrderResolution.selector);
-        gameProxy.resolveClaim(0, 0);
-
-        // Warp to the last second of the root claim defender clock.
-        vm.warp(block.timestamp + 3.5 days - 2 seconds);
-        // Attack the challenge to the root claim. This should succeed, since the defender clock is not expired.
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        // Chess clock time accumulated:
-        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
-        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days - 1 seconds);
-        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - gameProxy.clockExtension().raw());
-
-        // Should not be able to resolve any claims yet.
-        vm.expectRevert(ClockNotExpired.selector);
-        gameProxy.resolveClaim(2, 0);
-        vm.expectRevert(ClockNotExpired.selector);
-        gameProxy.resolveClaim(1, 0);
-        vm.expectRevert(OutOfOrderResolution.selector);
-        gameProxy.resolveClaim(0, 0);
-
-        vm.warp(block.timestamp + gameProxy.clockExtension().raw() - 1 seconds);
-
-        // Should not be able to resolve any claims yet.
-        vm.expectRevert(ClockNotExpired.selector);
-        gameProxy.resolveClaim(2, 0);
-        vm.expectRevert(OutOfOrderResolution.selector);
-        gameProxy.resolveClaim(1, 0);
-        vm.expectRevert(OutOfOrderResolution.selector);
-        gameProxy.resolveClaim(0, 0);
-
-        // Chess clock time accumulated:
-        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
-        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
-        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - 1 seconds);
-
-        // Warp past the challenge period for the root claim defender. Defending the root claim should now revert.
-        vm.warp(block.timestamp + 1 seconds);
-        expectedBond = _getRequiredBond(1);
-        vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
-        gameProxy.attack{ value: expectedBond }(disputed, 1, _dummyClaim());
-        expectedBond = _getRequiredBond(2);
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
-        gameProxy.attack{ value: expectedBond }(disputed, 2, _dummyClaim());
-        // Chess clock time accumulated:
-        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
-        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
-        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days);
-
-        vm.expectRevert(OutOfOrderResolution.selector);
-        gameProxy.resolveClaim(1, 0);
-        vm.expectRevert(OutOfOrderResolution.selector);
-        gameProxy.resolveClaim(0, 0);
-
-        // All clocks are expired. Resolve the game.
-        gameProxy.resolveClaim(2, 0); // Node 2 is resolved as UNCOUNTERED by default since it has no children
-        gameProxy.resolveClaim(1, 0); // Node 1 is resolved as COUNTERED since it has an UNCOUNTERED child
-        gameProxy.resolveClaim(0, 0); // Node 0 is resolved as UNCOUNTERED since it has no UNCOUNTERED children
-
-        // Defender wins game since the root claim is uncountered
-        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
-    }
-
-    /// @dev Tests that closeGame reverts if the game is not resolved
+/// @title FaultDisputeGame_CloseGame_Test
+/// @notice Tests the closeGame functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGame_CloseGame_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that closeGame reverts if the game is not resolved
     function test_closeGame_gameNotResolved_reverts() public {
         vm.expectRevert(GameNotResolved.selector);
         gameProxy.closeGame();
     }
 
-    /// @dev Tests that closeGame reverts if the game is paused
+    /// @notice Tests that closeGame reverts if the game is paused
     function test_closeGame_gamePaused_reverts() public {
         // Pause the system with the Superchain-wide identifier (address(0)).
         vm.prank(superchainConfig.guardian());
@@ -2399,7 +2419,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.closeGame();
     }
 
-    /// @dev Tests that closeGame reverts if the game is not finalized
+    /// @notice Tests that closeGame reverts if the game is not finalized
     function test_closeGame_gameNotFinalized_reverts() public {
         // Resolve the game
         vm.warp(block.timestamp + 3 days + 12 hours);
@@ -2411,7 +2431,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.closeGame();
     }
 
-    /// @dev Tests that closeGame succeeds for a proper game (normal distribution)
+    /// @notice Tests that closeGame succeeds for a proper game (normal distribution)
     function test_closeGame_properGame_succeeds() public {
         // Resolve the game
         vm.warp(block.timestamp + 3 days + 12 hours);
@@ -2431,7 +2451,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(address(gameProxy.anchorStateRegistry().anchorGame()), address(gameProxy));
     }
 
-    /// @dev Tests that closeGame succeeds for an improper game (refund mode)
+    /// @notice Tests that closeGame succeeds for an improper game (refund mode)
     function test_closeGame_improperGame_succeeds() public {
         // Resolve the game
         vm.warp(block.timestamp + 3 days + 12 hours);
@@ -2455,7 +2475,8 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
     }
 
-    /// @dev Tests that multiple calls to closeGame succeed after initial distribution mode is set
+    /// @notice Tests that multiple calls to closeGame succeed after initial distribution mode is
+    ///         set
     function test_closeGame_multipleCallsAfterSet_succeeds() public {
         // Resolve and close the game first
         vm.warp(block.timestamp + 3 days + 12 hours);
@@ -2477,7 +2498,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
     }
 
-    /// @dev Tests that closeGame called with any amount of gas either reverts (with OOG) or
+    /// @notice Tests that closeGame called with any amount of gas either reverts (with OOG) or
     ///      updates the anchor state. This is specifically to verify that the try/catch inside
     ///      closeGame can't be called with just enough gas to OOG when calling the
     ///      AnchorStateRegistry but successfully execute the remainder of the function.
@@ -2508,63 +2529,170 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
             // Ok, function reverted.
         }
     }
+}
 
-    /// @dev Helper to generate a mock RLP encoded header (with only a real block number) & an output root proof.
-    function _generateOutputRootProof(
-        bytes32 _storageRoot,
-        bytes32 _withdrawalRoot,
-        bytes memory _l2BlockNumber
-    )
-        internal
-        pure
-        returns (Types.OutputRootProof memory proof_, bytes32 root_, bytes memory rlp_)
-    {
-        // L2 Block header
-        bytes[] memory rawHeaderRLP = new bytes[](9);
-        rawHeaderRLP[0] = hex"83FACADE";
-        rawHeaderRLP[1] = hex"83FACADE";
-        rawHeaderRLP[2] = hex"83FACADE";
-        rawHeaderRLP[3] = hex"83FACADE";
-        rawHeaderRLP[4] = hex"83FACADE";
-        rawHeaderRLP[5] = hex"83FACADE";
-        rawHeaderRLP[6] = hex"83FACADE";
-        rawHeaderRLP[7] = hex"83FACADE";
-        rawHeaderRLP[8] = RLPWriter.writeBytes(_l2BlockNumber);
-        rlp_ = RLPWriter.writeList(rawHeaderRLP);
+/// @title FaultDisputeGame_GetChallengerDuration_Test
+/// @notice Tests the getChallengerDuration functionality and related resolution tests.
+contract FaultDisputeGame_GetChallengerDuration_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that if the game is not in progress, querying of `getChallengerDuration`
+    ///         reverts
+    function test_getChallengerDuration_gameNotInProgress_reverts() public {
+        // resolve the game
+        vm.warp(block.timestamp + gameProxy.maxClockDuration().raw());
 
-        // Output root
-        proof_ = Types.OutputRootProof({
-            version: 0,
-            stateRoot: _storageRoot,
-            messagePasserStorageRoot: _withdrawalRoot,
-            latestBlockhash: keccak256(rlp_)
-        });
-        root_ = Hashing.hashOutputRootProof(proof_);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        vm.expectRevert(GameNotInProgress.selector);
+        gameProxy.getChallengerDuration(1);
     }
 
-    /// @dev Helper to get the required bond for the given claim index.
-    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
-    }
+    /// @notice Static unit test asserting that resolveClaim isn't possible if there's time left
+    ///         for a counter.
+    function test_resolution_lastSecondDisputes_succeeds() public {
+        // The honest proposer created an honest root claim during setup - node 0
 
-    /// @dev Helper to return a pseudo-random claim
-    function _dummyClaim() internal view returns (Claim) {
-        return Claim.wrap(keccak256(abi.encode(gasleft())));
-    }
+        // Defender's turn
+        vm.warp(block.timestamp + 3.5 days - 1 seconds);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days - 1 seconds);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 0);
 
-    /// @dev Helper to get the localized key for an identifier in the context of the game proxy.
-    function _getKey(uint256 _ident, bytes32 _localContext) internal view returns (bytes32) {
-        bytes32 h = keccak256(abi.encode(_ident | (1 << 248), address(gameProxy), _localContext));
-        return bytes32((uint256(h) & ~uint256(0xFF << 248)) | (1 << 248));
+        // Advance time by 1 second, so that the root claim challenger clock is expired.
+        vm.warp(block.timestamp + 1 seconds);
+        // Attempt a second attack against the root claim. This should revert since the challenger
+        // clock is expired.
+        uint256 expectedBond = _getRequiredBond(0);
+        vm.expectRevert(ClockTimeExceeded.selector);
+        gameProxy.attack{ value: expectedBond }(disputed, 0, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 1 seconds);
+
+        // Should not be able to resolve the root claim or second counter yet.
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        // Warp to the last second of the root claim defender clock.
+        vm.warp(block.timestamp + 3.5 days - 2 seconds);
+        // Attack the challenge to the root claim. This should succeed, since the defender clock is
+        // not expired.
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days - 1 seconds);
+        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - gameProxy.clockExtension().raw());
+
+        // Should not be able to resolve any claims yet.
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(2, 0);
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        vm.warp(block.timestamp + gameProxy.clockExtension().raw() - 1 seconds);
+
+        // Should not be able to resolve any claims yet.
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(2, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - 1 seconds);
+
+        // Warp past the challenge period for the root claim defender. Defending the root claim
+        // should now revert.
+        vm.warp(block.timestamp + 1 seconds);
+        expectedBond = _getRequiredBond(1);
+        vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
+        gameProxy.attack{ value: expectedBond }(disputed, 1, _dummyClaim());
+        expectedBond = _getRequiredBond(2);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
+        gameProxy.attack{ value: expectedBond }(disputed, 2, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days);
+
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        // All clocks are expired. Resolve the game.
+        gameProxy.resolveClaim(2, 0); // Node 2 is resolved as UNCOUNTERED by default since it has no children
+        gameProxy.resolveClaim(1, 0); // Node 1 is resolved as COUNTERED since it has an UNCOUNTERED child
+        gameProxy.resolveClaim(0, 0); // Node 0 is resolved as UNCOUNTERED since it has no UNCOUNTERED children
+
+        // Defender wins game since the root claim is uncountered
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 }
 
-contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
-    /// @dev The honest actor
+/// @title FaultDisputeGame_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `FaultDisputeGame`
+///         contract or are testing multiple functions at once.
+contract FaultDisputeGame_Unclassified_Test is FaultDisputeGame_TestInit {
+    /// @notice Tests that the game's starting timestamp is set correctly.
+    function test_createdAt_succeeds() public view {
+        assertEq(gameProxy.createdAt().raw(), block.timestamp);
+    }
+
+    /// @notice Tests that startingOutputRoot and it's getters are set correctly.
+    function test_startingOutputRootGetters_succeeds() public view {
+        (Hash root, uint256 l2BlockNumber) = gameProxy.startingOutputRoot();
+        (Hash anchorRoot, uint256 anchorRootBlockNumber) = anchorStateRegistry.anchors(GAME_TYPE);
+
+        assertEq(gameProxy.startingBlockNumber(), l2BlockNumber);
+        assertEq(gameProxy.startingBlockNumber(), anchorRootBlockNumber);
+        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(root));
+        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(anchorRoot));
+    }
+
+    /// @notice Tests that the user cannot control the first 4 bytes of the CWIA data, disallowing
+    ///         them to control the entrypoint when no calldata is provided to a call.
+    function test_cwiaCalldata_userCannotControlSelector_succeeds() public {
+        // Construct the expected CWIA data that the proxy will pass to the implementation,
+        // alongside any extra calldata passed by the user.
+        Hash l1Head = gameProxy.l1Head();
+        bytes memory cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+
+        // We expect a `ReceiveETH` event to be emitted when 0 bytes of calldata are sent; The
+        // fallback is always reached *within the minimal proxy* in `LibClone`'s version of
+        // `clones-with-immutable-args`
+        vm.expectEmit(false, false, false, true);
+        emit ReceiveETH(0);
+        // We expect no delegatecall to the implementation contract if 0 bytes are sent. Assert
+        // that this happens 0 times.
+        vm.expectCall(address(gameImpl), cwiaData, 0);
+        (bool successA,) = address(gameProxy).call(hex"");
+        assertTrue(successA);
+
+        // When calldata is forwarded, we do expect a delegatecall to the implementation.
+        bytes memory data = abi.encodePacked(gameProxy.l1Head.selector);
+        vm.expectCall(address(gameImpl), abi.encodePacked(data, cwiaData), 1);
+        (bool successB, bytes memory returnData) = address(gameProxy).call(data);
+        assertTrue(successB);
+        assertEq(returnData, abi.encode(l1Head));
+    }
+}
+
+contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_TestInit {
+    /// @notice The honest actor
     DisputeActor internal honest;
-    /// @dev The dishonest actor
+    /// @notice The dishonest actor
     DisputeActor internal dishonest;
 
     function setUp() public override {
@@ -2573,11 +2701,11 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
     }
 
     /// @notice Fuzz test for a 1v1 output bisection dispute.
-    /// @dev The alphabet game has a constant status byte, and is not safe from someone being dishonest in
-    ///      output bisection and then posting a correct execution trace bisection root claim. This test
-    ///      does not cover this case (i.e. root claim of output bisection is dishonest, root claim of
-    ///      execution trace bisection is made by the dishonest actor but is honest, honest actor cannot
-    ///      attack it without risk of losing).
+    /// @notice The alphabet game has a constant status byte, and is not safe from someone being
+    ///         dishonest in output bisection and then posting a correct execution trace bisection
+    ///         root claim. This test does not cover this case (i.e. root claim of output bisection
+    ///         is dishonest, root claim of execution trace bisection is made by the dishonest
+    ///         actor but is honest, honest actor cannot attack it without risk of losing).
     function testFuzz_outputBisection1v1honestRoot_succeeds(uint8 _divergeOutput, uint8 _divergeStep) public {
         uint256[] memory honestL2Outputs = new uint256[](16);
         for (uint256 i; i < honestL2Outputs.length; i++) {
@@ -2620,8 +2748,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2632,8 +2760,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 2;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of all set bits.
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all set bits.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = bytes1(0xFF);
@@ -2658,8 +2786,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2708,8 +2836,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 2;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of all zeros.
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all zeros.
         bytes memory dishonestTrace = new bytes(256);
 
         // Run the actor test
@@ -2731,8 +2859,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2743,8 +2871,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 2;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of all zeros.
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all zeros.
         bytes memory dishonestTrace = new bytes(256);
 
         // Run the actor test
@@ -2766,8 +2894,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2803,8 +2931,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2840,8 +2968,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2877,8 +3005,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2914,8 +3042,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2926,8 +3054,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
         }
-        // The dishonest trace is half correct, and correct all the way up to the final instruction of the exec
-        // subgame.
+        // The dishonest trace is half correct, and correct all the way up to the final instruction
+        // of the exec subgame.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = i > (127 + 7) ? bytes1(0xFF) : bytes1(uint8(i));
@@ -2952,8 +3080,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2964,8 +3092,8 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
         }
-        // The dishonest trace is half correct, and correct all the way up to the final instruction of the exec
-        // subgame.
+        // The dishonest trace is half correct, and correct all the way up to the final instruction
+        // of the exec subgame.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = i > (127 + 7) ? bytes1(0xFF) : bytes1(uint8(i));
@@ -2987,7 +3115,7 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
     //                          HELPERS                           //
     ////////////////////////////////////////////////////////////////
 
-    /// @dev Helper to run a 1v1 actor test
+    /// @notice Helper to run a 1v1 actor test
     function _actorTest(
         uint256 _rootClaim,
         uint256 _absolutePrestateData,
@@ -3031,7 +3159,7 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         assertEq(uint8(gameProxy.status()), uint8(_expectedStatus));
     }
 
-    /// @dev Helper to setup the 1v1 test
+    /// @notice Helper to setup the 1v1 test
     function _setup(
         uint256 _absolutePrestateData,
         uint256 _rootClaim
@@ -3046,7 +3174,7 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         super.init({ rootClaim: rootClaim, absolutePrestate: absolutePrestateExec, l2BlockNumber: _rootClaim });
     }
 
-    /// @dev Helper to create actors for the 1v1 dispute.
+    /// @notice Helper to create actors for the 1v1 dispute.
     function _createActors(
         bytes memory _honestTrace,
         bytes memory _honestPreStateData,
@@ -3076,7 +3204,7 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         vm.label(address(dishonest), "DishonestActor");
     }
 
-    /// @dev Helper to exhaust all moves from both actors.
+    /// @notice Helper to exhaust all moves from both actors.
     function _exhaustMoves() internal {
         while (true) {
             // Allow the dishonest actor to make their moves, and then the honest actor.
@@ -3090,13 +3218,13 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
         }
     }
 
-    /// @dev Helper to warp past the chess clock and resolve all claims within the dispute game.
+    /// @notice Helper to warp past the chess clock and resolve all claims within the dispute game.
     function _warpAndResolve() internal {
         // Warp past the chess clock
         vm.warp(block.timestamp + 3 days + 12 hours);
 
-        // Resolve all claims in reverse order. We allow `resolveClaim` calls to fail due to
-        // the check that prevents claims with no subgames attached from being passed to
+        // Resolve all claims in reverse order. We allow `resolveClaim` calls to fail due to the
+        // check that prevents claims with no subgames attached from being passed to
         // `resolveClaim`. There's also a check in `resolve` to ensure all children have been
         // resolved before global resolution, which catches any unresolved subgames here.
         for (uint256 i = gameProxy.claimDataLen(); i > 0; i--) {
@@ -3104,38 +3232,5 @@ contract FaultDispute_1v1_Actors_Test is FaultDisputeGame_Init {
             assertTrue(success);
         }
         gameProxy.resolve();
-    }
-}
-
-contract ClaimCreditReenter {
-    Vm internal immutable vm;
-    IFaultDisputeGame internal immutable GAME;
-    uint256 public numCalls;
-
-    constructor(IFaultDisputeGame _gameProxy, Vm _vm) {
-        GAME = _gameProxy;
-        vm = _vm;
-    }
-
-    function claimCredit(address _recipient) public {
-        numCalls += 1;
-        if (numCalls > 1) {
-            vm.expectRevert(NoCreditToClaim.selector);
-        }
-        GAME.claimCredit(_recipient);
-    }
-
-    receive() external payable {
-        if (numCalls == 5) {
-            return;
-        }
-        claimCredit(address(this));
-    }
-}
-
-/// @dev Helper to change the VM status byte of a claim.
-function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
-    assembly {
-        out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
     }
 }

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 // Testing
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 // Libraries
 import "src/dispute/lib/Types.sol";
@@ -13,7 +13,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 
 /// @title PermissionedDisputeGame_TestInit
 /// @notice Reusable test initialization for `PermissionedDisputeGame` tests.
-contract PermissionedDisputeGame_TestInit is DisputeGameFactory_Init {
+contract PermissionedDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @notice The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
     /// @notice Mock proposer key

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -11,25 +11,41 @@ import "src/dispute/lib/Errors.sol";
 // Interfaces
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 
-contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
-    /// @dev The type of the game being tested.
+/// @title PermissionedDisputeGame_TestInit
+/// @notice Reusable test initialization for `PermissionedDisputeGame` tests.
+contract PermissionedDisputeGame_TestInit is DisputeGameFactory_Init {
+    /// @notice The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
-    /// @dev Mock proposer key
+    /// @notice Mock proposer key
     address internal constant PROPOSER = address(0xfacade9);
-    /// @dev Mock challenger key
+    /// @notice Mock challenger key
     address internal constant CHALLENGER = address(0xfacadec);
 
-    /// @dev The implementation of the game.
+    /// @notice The implementation of the game.
     IPermissionedDisputeGame internal gameImpl;
-    /// @dev The `Clone` proxy of the game.
+    /// @notice The `Clone` proxy of the game.
     IPermissionedDisputeGame internal gameProxy;
 
-    /// @dev The extra data passed to the game for initialization.
+    /// @notice The extra data passed to the game for initialization.
     bytes internal extraData;
+
+    /// @notice The root claim of the game.
+    Claim internal rootClaim;
+    /// @notice An arbitrary root claim for testing.
+    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
+    /// @notice Minimum bond value that covers all possible moves.
+    uint256 internal constant MIN_BOND = 50 ether;
+
+    /// @notice The preimage of the absolute prestate claim
+    bytes internal absolutePrestateData;
+    /// @notice The absolute prestate of the trace.
+    Claim internal absolutePrestate;
+    /// @notice A valid l2BlockNumber that comes after the current anchor root block.
+    uint256 validL2BlockNumber;
 
     event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
 
-    function init(Claim rootClaim, Claim absolutePrestate, uint256 l2BlockNumber) public {
+    function init(Claim _rootClaim, Claim _absolutePrestate, uint256 _l2BlockNumber) public {
         // Set the time to a realistic date.
         if (!isForkTest()) {
             vm.warp(1690906994);
@@ -39,9 +55,9 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         vm.deal(PROPOSER, 100 ether);
 
         // Set the extra data for the game creation
-        extraData = abi.encode(l2BlockNumber);
+        extraData = abi.encode(_l2BlockNumber);
 
-        (address _impl, AlphabetVM _vm,) = setupPermissionedDisputeGame(absolutePrestate, PROPOSER, CHALLENGER);
+        (address _impl, AlphabetVM _vm,) = setupPermissionedDisputeGame(_absolutePrestate, PROPOSER, CHALLENGER);
         gameImpl = IPermissionedDisputeGame(_impl);
 
         // Register the game implementation with the factory.
@@ -52,18 +68,18 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         vm.mockCall(
             address(anchorStateRegistry),
             abi.encodeCall(anchorStateRegistry.anchors, (GAME_TYPE)),
-            abi.encode(rootClaim, 0)
+            abi.encode(_rootClaim, 0)
         );
         vm.prank(PROPOSER, PROPOSER);
         gameProxy = IPermissionedDisputeGame(
-            payable(address(disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, rootClaim, extraData)))
+            payable(address(disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, _rootClaim, extraData)))
         );
 
         // Check immutables
         assertEq(gameProxy.proposer(), PROPOSER);
         assertEq(gameProxy.challenger(), CHALLENGER);
         assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
-        assertEq(gameProxy.absolutePrestate().raw(), absolutePrestate.raw());
+        assertEq(gameProxy.absolutePrestate().raw(), _absolutePrestate.raw());
         assertEq(gameProxy.maxGameDepth(), 2 ** 3);
         assertEq(gameProxy.splitDepth(), 2 ** 2);
         assertEq(gameProxy.maxClockDuration().raw(), 3.5 days);
@@ -72,26 +88,6 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         // Label the proxy
         vm.label(address(gameProxy), "FaultDisputeGame_Clone");
     }
-
-    fallback() external payable { }
-
-    receive() external payable { }
-}
-
-contract PermissionedDisputeGame_Test is PermissionedDisputeGame_Init {
-    /// @dev The root claim of the game.
-    Claim internal rootClaim;
-    /// @dev An arbitrary root claim for testing.
-    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
-    /// @dev Minimum bond value that covers all possible moves.
-    uint256 internal constant MIN_BOND = 50 ether;
-
-    /// @dev The preimage of the absolute prestate claim
-    bytes internal absolutePrestateData;
-    /// @dev The absolute prestate of the trace.
-    Claim internal absolutePrestate;
-    /// @dev A valid l2BlockNumber that comes after the current anchor root block.
-    uint256 validL2BlockNumber;
 
     function setUp() public override {
         absolutePrestateData = abi.encode(0);
@@ -103,87 +99,46 @@ contract PermissionedDisputeGame_Test is PermissionedDisputeGame_Init {
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
         validL2BlockNumber = l2BlockNumber + 1;
         rootClaim = Claim.wrap(Hash.unwrap(root));
-        super.init({ rootClaim: rootClaim, absolutePrestate: absolutePrestate, l2BlockNumber: validL2BlockNumber });
+        init({ _rootClaim: rootClaim, _absolutePrestate: absolutePrestate, _l2BlockNumber: validL2BlockNumber });
     }
 
-    /// @dev Tests that the game's version function returns a string.
+    /// @dev Helper to return a pseudo-random claim
+    function _dummyClaim() internal view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(gasleft())));
+    }
+
+    /// @dev Helper to get the required bond for the given claim index.
+    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
+        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
+        Position pos = parent.move(true);
+        bond_ = gameProxy.getRequiredBond(pos);
+    }
+
+    /// @dev Helper to change the VM status byte of a claim.
+    function _changeClaimStatus(Claim _claim, VMStatus _status) internal pure returns (Claim out_) {
+        assembly {
+            out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+        }
+    }
+
+    fallback() external payable { }
+
+    receive() external payable { }
+}
+
+/// @title PermissionedDisputeGame_Version_Test
+/// @notice Tests the `version` function of the `PermissionedDisputeGame` contract.
+contract PermissionedDisputeGame_Version_Test is PermissionedDisputeGame_TestInit {
+    /// @notice Tests that the game's version function returns a string.
     function test_version_works() public view {
         assertTrue(bytes(gameProxy.version()).length > 0);
     }
+}
 
-    /// @dev Tests that the proposer can create a permissioned dispute game.
-    function test_createGame_proposer_succeeds() public {
-        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
-        vm.prank(PROPOSER, PROPOSER);
-        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
-    }
-
-    /// @dev Tests that the permissioned game cannot be created by any address other than the proposer.
-    function testFuzz_createGame_notProposer_reverts(address _p) public {
-        vm.assume(_p != PROPOSER);
-
-        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
-        vm.deal(_p, bondAmount);
-        vm.prank(_p, _p);
-        vm.expectRevert(BadAuth.selector);
-        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
-    }
-
-    /// @dev Tests that the challenger can participate in a permissioned dispute game.
-    function test_participateInGame_challenger_succeeds() public {
-        vm.startPrank(CHALLENGER, CHALLENGER);
-        uint256 firstBond = _getRequiredBond(0);
-        vm.deal(CHALLENGER, firstBond);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
-        uint256 secondBond = _getRequiredBond(1);
-        vm.deal(CHALLENGER, secondBond);
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
-        uint256 thirdBond = _getRequiredBond(2);
-        vm.deal(CHALLENGER, thirdBond);
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
-        vm.stopPrank();
-    }
-
-    /// @dev Tests that the proposer can participate in a permissioned dispute game.
-    function test_participateInGame_proposer_succeeds() public {
-        vm.startPrank(PROPOSER, PROPOSER);
-        uint256 firstBond = _getRequiredBond(0);
-        vm.deal(PROPOSER, firstBond);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
-        uint256 secondBond = _getRequiredBond(1);
-        vm.deal(PROPOSER, secondBond);
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
-        uint256 thirdBond = _getRequiredBond(2);
-        vm.deal(PROPOSER, thirdBond);
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
-        vm.stopPrank();
-    }
-
-    /// @dev Tests that addresses that are not the proposer or challenger cannot participate in a permissioned dispute
-    ///      game.
-    function test_participateInGame_notAuthorized_reverts(address _p) public {
-        vm.assume(_p != PROPOSER && _p != CHALLENGER);
-
-        vm.startPrank(_p, _p);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.attack(disputed, 0, Claim.wrap(0));
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.defend(disputed, 0, Claim.wrap(0));
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.move(disputed, 0, Claim.wrap(0), true);
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.step(0, true, absolutePrestateData, hex"");
-        vm.stopPrank();
-    }
-
-    /// @dev Tests that step works properly.
+/// @title PermissionedDisputeGame_Step_Test
+/// @notice Tests the `step` function of the `PermissionedDisputeGame` contract.
+contract PermissionedDisputeGame_Step_Test is PermissionedDisputeGame_TestInit {
+    /// @notice Tests that step works properly.
     function test_step_succeeds() public {
         // Give the test contract some ether
         vm.deal(CHALLENGER, 1_000 ether);
@@ -232,23 +187,82 @@ contract PermissionedDisputeGame_Test is PermissionedDisputeGame_Init {
         (, address counteredBy,,,,,) = gameProxy.claimData(0);
         assertEq(counteredBy, CHALLENGER);
     }
-
-    /// @dev Helper to return a pseudo-random claim
-    function _dummyClaim() internal view returns (Claim) {
-        return Claim.wrap(keccak256(abi.encode(gasleft())));
-    }
-
-    /// @dev Helper to get the required bond for the given claim index.
-    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
-    }
 }
 
-/// @dev Helper to change the VM status byte of a claim.
-function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
-    assembly {
-        out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+/// @title PermissionedDisputeGame_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the
+///         `PermissionedDisputeGame` contract or are testing multiple functions at once.
+contract PermissionedDisputeGame_Unclassified_Test is PermissionedDisputeGame_TestInit {
+    /// @notice Tests that the proposer can create a permissioned dispute game.
+    function test_createGame_proposer_succeeds() public {
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.prank(PROPOSER, PROPOSER);
+        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
+    }
+
+    /// @notice Tests that the permissioned game cannot be created by any address other than the
+    ///         proposer.
+    function testFuzz_createGame_notProposer_reverts(address _p) public {
+        vm.assume(_p != PROPOSER);
+
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.deal(_p, bondAmount);
+        vm.prank(_p, _p);
+        vm.expectRevert(BadAuth.selector);
+        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
+    }
+
+    /// @notice Tests that the challenger can participate in a permissioned dispute game.
+    function test_participateInGame_challenger_succeeds() public {
+        vm.startPrank(CHALLENGER, CHALLENGER);
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(CHALLENGER, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(CHALLENGER, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
+        uint256 thirdBond = _getRequiredBond(2);
+        vm.deal(CHALLENGER, thirdBond);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that the proposer can participate in a permissioned dispute game.
+    function test_participateInGame_proposer_succeeds() public {
+        vm.startPrank(PROPOSER, PROPOSER);
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(PROPOSER, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(PROPOSER, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
+        uint256 thirdBond = _getRequiredBond(2);
+        vm.deal(PROPOSER, thirdBond);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that addresses that are not the proposer or challenger cannot participate in
+    ///         a permissioned dispute game.
+    function test_participateInGame_notAuthorized_reverts(address _p) public {
+        vm.assume(_p != PROPOSER && _p != CHALLENGER);
+
+        vm.startPrank(_p, _p);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.attack(disputed, 0, Claim.wrap(0));
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.defend(disputed, 0, Claim.wrap(0));
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.move(disputed, 0, Claim.wrap(0), true);
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.step(0, true, absolutePrestateData, hex"");
+        vm.stopPrank();
     }
 }

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 // Testing
 import { Vm } from "forge-std/Vm.sol";
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 import { stdError } from "forge-std/StdError.sol";
 
@@ -58,7 +58,7 @@ contract ClaimCreditReenter {
 
 /// @title BaseSuperFaultDisputeGame_TestInit
 /// @notice Base test initializer that can be used by other contracts outside of this test suite.
-contract BaseSuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
+contract BaseSuperFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @dev The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.SUPER_CANNON;
 

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -56,38 +56,26 @@ contract ClaimCreditReenter {
     }
 }
 
-/// @title SuperFaultDisputeGame_TestInit
-/// @notice Reusable test initialization for `SuperFaultDisputeGame` tests.
-contract SuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
-    /// @notice The type of the game being tested.
+/// @title BaseSuperFaultDisputeGame_TestInit
+/// @notice Base test initializer that can be used by other contracts outside of this test suite.
+contract BaseSuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
+    /// @dev The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.SUPER_CANNON;
 
-    /// @notice The initial bond for the game.
+    /// @dev The initial bond for the game.
     uint256 internal initBond;
 
-    /// @notice The implementation of the game.
+    /// @dev The implementation of the game.
     ISuperFaultDisputeGame internal gameImpl;
-    /// @notice The `Clone` proxy of the game.
+
+    /// @dev The `Clone` proxy of the game.
     ISuperFaultDisputeGame internal gameProxy;
 
-    /// @notice The extra data passed to the game for initialization.
+    /// @dev The extra data passed to the game for initialization.
     bytes internal extraData;
-
-    /// @notice The root claim of the game.
-    Claim internal ROOT_CLAIM;
-    /// @notice An arbitrary root claim for testing.
-    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
-
-    /// @notice The preimage of the absolute prestate claim
-    bytes internal absolutePrestateData;
-    /// @notice The absolute prestate of the trace.
-    Claim internal absolutePrestate;
-    /// @notice A valid l2SequenceNumber that comes after the current anchor root block.
-    uint256 validl2SequenceNumber;
 
     event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
     event GameClosed(BondDistributionMode bondDistributionMode);
-
     event ReceiveETH(uint256 amount);
 
     function init(Claim _rootClaim, Claim _absolutePrestate, uint256 _l2SequenceNumber) public {
@@ -132,6 +120,29 @@ contract SuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
         vm.label(address(gameProxy), "SuperFaultDisputeGame_Clone");
     }
 
+    fallback() external payable { }
+
+    receive() external payable { }
+}
+
+/// @title SuperFaultDisputeGame_TestInit
+/// @notice Reusable test initialization for `SuperFaultDisputeGame` tests.
+contract SuperFaultDisputeGame_TestInit is BaseSuperFaultDisputeGame_TestInit {
+    /// @dev The root claim of the game.
+    Claim internal ROOT_CLAIM;
+
+    /// @dev An arbitrary root claim for testing.
+    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
+
+    /// @dev The preimage of the absolute prestate claim
+    bytes internal absolutePrestateData;
+
+    /// @dev The absolute prestate of the trace.
+    Claim internal absolutePrestate;
+
+    /// @dev A valid l2SequenceNumber that comes after the current anchor root block.
+    uint256 validl2SequenceNumber;
+
     function setUp() public virtual override {
         absolutePrestateData = abi.encode(0);
         absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
@@ -142,14 +153,14 @@ contract SuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
         (Hash root, uint256 l2Bn) = anchorStateRegistry.getAnchorRoot();
         validl2SequenceNumber = l2Bn + 1;
 
-        ROOT_CLAIM = Claim.wrap(Hash.unwrap(root));
-
         if (isForkTest()) {
             // Set the init bond of anchor game type 4 to be 0.
             vm.store(
                 address(disputeGameFactory), keccak256(abi.encode(GameType.wrap(4), uint256(102))), bytes32(uint256(0))
             );
         }
+
+        ROOT_CLAIM = Claim.wrap(Hash.unwrap(root));
         init({ _rootClaim: ROOT_CLAIM, _absolutePrestate: absolutePrestate, _l2SequenceNumber: validl2SequenceNumber });
     }
 
@@ -211,10 +222,6 @@ contract SuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
             out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
         }
     }
-
-    fallback() external payable { }
-
-    receive() external payable { }
 }
 
 /// @title SuperFaultDisputeGame_Version_Test

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -30,36 +30,76 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { ISuperFaultDisputeGame } from "interfaces/dispute/ISuperFaultDisputeGame.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
-contract SuperFaultDisputeGame_Init is DisputeGameFactory_Init {
-    /// @dev The type of the game being tested.
+contract ClaimCreditReenter {
+    Vm internal immutable vm;
+    ISuperFaultDisputeGame internal immutable GAME;
+    uint256 public numCalls;
+
+    constructor(ISuperFaultDisputeGame _gameProxy, Vm _vm) {
+        GAME = _gameProxy;
+        vm = _vm;
+    }
+
+    function claimCredit(address _recipient) public {
+        numCalls += 1;
+        if (numCalls > 1) {
+            vm.expectRevert(NoCreditToClaim.selector);
+        }
+        GAME.claimCredit(_recipient);
+    }
+
+    receive() external payable {
+        if (numCalls == 5) {
+            return;
+        }
+        claimCredit(address(this));
+    }
+}
+
+/// @title SuperFaultDisputeGame_TestInit
+/// @notice Reusable test initialization for `SuperFaultDisputeGame` tests.
+contract SuperFaultDisputeGame_TestInit is DisputeGameFactory_Init {
+    /// @notice The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.SUPER_CANNON;
 
-    /// @dev The initial bond for the game.
+    /// @notice The initial bond for the game.
     uint256 internal initBond;
 
-    /// @dev The implementation of the game.
+    /// @notice The implementation of the game.
     ISuperFaultDisputeGame internal gameImpl;
-    /// @dev The `Clone` proxy of the game.
+    /// @notice The `Clone` proxy of the game.
     ISuperFaultDisputeGame internal gameProxy;
 
-    /// @dev The extra data passed to the game for initialization.
+    /// @notice The extra data passed to the game for initialization.
     bytes internal extraData;
+
+    /// @notice The root claim of the game.
+    Claim internal ROOT_CLAIM;
+    /// @notice An arbitrary root claim for testing.
+    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
+
+    /// @notice The preimage of the absolute prestate claim
+    bytes internal absolutePrestateData;
+    /// @notice The absolute prestate of the trace.
+    Claim internal absolutePrestate;
+    /// @notice A valid l2SequenceNumber that comes after the current anchor root block.
+    uint256 validl2SequenceNumber;
 
     event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
     event GameClosed(BondDistributionMode bondDistributionMode);
 
     event ReceiveETH(uint256 amount);
 
-    function init(Claim rootClaim, Claim absolutePrestate, uint256 l2SequenceNumber) public {
+    function init(Claim _rootClaim, Claim _absolutePrestate, uint256 _l2SequenceNumber) public {
         // Set the time to a realistic date.
         if (!isForkTest()) {
             vm.warp(1690906994);
         }
 
         // Set the extra data for the game creation
-        extraData = abi.encode(l2SequenceNumber);
+        extraData = abi.encode(_l2SequenceNumber);
 
-        (address _impl, AlphabetVM _vm,) = setupSuperFaultDisputeGame(absolutePrestate);
+        (address _impl, AlphabetVM _vm,) = setupSuperFaultDisputeGame(_absolutePrestate);
         gameImpl = ISuperFaultDisputeGame(_impl);
 
         initBond = disputeGameFactory.initBonds(GAME_TYPE);
@@ -74,12 +114,12 @@ contract SuperFaultDisputeGame_Init is DisputeGameFactory_Init {
 
         // Create a new game.
         gameProxy = ISuperFaultDisputeGame(
-            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, rootClaim, extraData)))
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, _rootClaim, extraData)))
         );
 
         // Check immutables
         assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
-        assertEq(gameProxy.absolutePrestate().raw(), absolutePrestate.raw());
+        assertEq(gameProxy.absolutePrestate().raw(), _absolutePrestate.raw());
         assertEq(gameProxy.maxGameDepth(), 2 ** 3);
         assertEq(gameProxy.splitDepth(), 2 ** 2);
         assertEq(gameProxy.clockExtension().raw(), 3 hours);
@@ -92,25 +132,7 @@ contract SuperFaultDisputeGame_Init is DisputeGameFactory_Init {
         vm.label(address(gameProxy), "SuperFaultDisputeGame_Clone");
     }
 
-    fallback() external payable { }
-
-    receive() external payable { }
-}
-
-contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
-    /// @dev The root claim of the game.
-    Claim internal ROOT_CLAIM;
-    /// @dev An arbitrary root claim for testing.
-    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
-
-    /// @dev The preimage of the absolute prestate claim
-    bytes internal absolutePrestateData;
-    /// @dev The absolute prestate of the trace.
-    Claim internal absolutePrestate;
-    /// @dev A valid l2SequenceNumber that comes after the current anchor root block.
-    uint256 validl2SequenceNumber;
-
-    function setUp() public override {
+    function setUp() public virtual override {
         absolutePrestateData = abi.encode(0);
         absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
 
@@ -128,15 +150,87 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
                 address(disputeGameFactory), keccak256(abi.encode(GameType.wrap(4), uint256(102))), bytes32(uint256(0))
             );
         }
-        super.init({ rootClaim: ROOT_CLAIM, absolutePrestate: absolutePrestate, l2SequenceNumber: validl2SequenceNumber });
+        init({ _rootClaim: ROOT_CLAIM, _absolutePrestate: absolutePrestate, _l2SequenceNumber: validl2SequenceNumber });
     }
 
-    ////////////////////////////////////////////////////////////////
-    //            `IDisputeGame` Implementation Tests             //
-    ////////////////////////////////////////////////////////////////
+    /// @notice Helper to generate a mock RLP encoded header (with only a real block number) & an
+    ///         output root proof.
+    function _generateOutputRootProof(
+        bytes32 _storageRoot,
+        bytes32 _withdrawalRoot,
+        bytes memory _l2SequenceNumber
+    )
+        internal
+        pure
+        returns (Types.OutputRootProof memory proof_, bytes32 root_, bytes memory rlp_)
+    {
+        // L2 Block header
+        bytes[] memory rawHeaderRLP = new bytes[](9);
+        rawHeaderRLP[0] = hex"83FACADE";
+        rawHeaderRLP[1] = hex"83FACADE";
+        rawHeaderRLP[2] = hex"83FACADE";
+        rawHeaderRLP[3] = hex"83FACADE";
+        rawHeaderRLP[4] = hex"83FACADE";
+        rawHeaderRLP[5] = hex"83FACADE";
+        rawHeaderRLP[6] = hex"83FACADE";
+        rawHeaderRLP[7] = hex"83FACADE";
+        rawHeaderRLP[8] = RLPWriter.writeBytes(_l2SequenceNumber);
+        rlp_ = RLPWriter.writeList(rawHeaderRLP);
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
-    ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
+        // Output root
+        proof_ = Types.OutputRootProof({
+            version: 0,
+            stateRoot: _storageRoot,
+            messagePasserStorageRoot: _withdrawalRoot,
+            latestBlockhash: keccak256(rlp_)
+        });
+        root_ = Hashing.hashOutputRootProof(proof_);
+    }
+
+    /// @notice Helper to get the required bond for the given claim index.
+    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
+        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
+        Position pos = parent.move(true);
+        bond_ = gameProxy.getRequiredBond(pos);
+    }
+
+    /// @notice Helper to return a pseudo-random claim
+    function _dummyClaim() internal view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(gasleft())));
+    }
+
+    /// @notice Helper to get the localized key for an identifier in the context of the game proxy.
+    function _getKey(uint256 _ident, bytes32 _localContext) internal view returns (bytes32) {
+        bytes32 h = keccak256(abi.encode(_ident | (1 << 248), address(gameProxy), _localContext));
+        return bytes32((uint256(h) & ~uint256(0xFF << 248)) | (1 << 248));
+    }
+
+    /// @notice Helper to change the VM status byte of a claim.
+    function _changeClaimStatus(Claim _claim, VMStatus _status) internal pure returns (Claim out_) {
+        assembly {
+            out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+        }
+    }
+
+    fallback() external payable { }
+
+    receive() external payable { }
+}
+
+/// @title SuperFaultDisputeGame_Version_Test
+/// @notice Tests the `version` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_Version_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game's version function returns a string.
+    function test_version_works() public view {
+        assertTrue(bytes(gameProxy.version()).length > 0);
+    }
+}
+
+/// @title SuperFaultDisputeGame_Constructor_Test
+/// @notice Tests the constructor of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_Constructor_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the
+    ///         `MAX_GAME_DEPTH` parameter is greater than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
         IPreimageOracle oracle = IPreimageOracle(
             DeployUtils.create1({
@@ -172,8 +266,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the challenge period
-    //       of the preimage oracle being used by the game's VM is too large.
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the challenge
+    ///         period of the preimage oracle being used by the game's VM is too large.
     /// @param _challengePeriod The challenge period of the preimage oracle.
     function testFuzz_constructor_oracleChallengePeriodTooLarge_reverts(uint256 _challengePeriod) public {
         _challengePeriod = bound(_challengePeriod, uint256(type(uint64).max) + 1, type(uint256).max);
@@ -216,8 +310,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
-    ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
+    ///         parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
         AlphabetVM alphabetVM = new AlphabetVM(
             absolutePrestate,
@@ -256,8 +350,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
-    ///      parameter is less than the minimum split depth (currently 2).
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
+    ///         parameter is less than the minimum split depth (currently 2).
     function testFuzz_constructor_lowSplitDepth_reverts(uint256 _splitDepth) public {
         AlphabetVM alphabetVM = new AlphabetVM(
             absolutePrestate,
@@ -296,8 +390,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when clock extension * 2 is greater than
-    ///      the max clock duration.
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when clock
+    ///         extension * 2 is greater than the max clock duration.
     function testFuzz_constructor_clockExtensionTooLong_reverts(
         uint64 _maxClockDuration,
         uint64 _clockExtension
@@ -314,8 +408,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
             )
         );
 
-        // Force the clock extension * 2 to be greater than the max clock duration, but keep things within
-        // bounds of the uint64 type.
+        // Force the clock extension * 2 to be greater than the max clock duration, but keep things
+        // within bounds of the uint64 type.
         _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max / 2 - 1));
         _clockExtension = uint64(bound(_clockExtension, _maxClockDuration / 2 + 1, type(uint64).max / 2));
 
@@ -344,7 +438,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         });
     }
 
-    /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_gameType`
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_gameType`
     ///      parameter is set to the reserved `type(uint32).max` game type.
     function test_constructor_reservedGameType_reverts() public {
         AlphabetVM alphabetVM = new AlphabetVM(
@@ -381,47 +475,13 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
             )
         });
     }
+}
 
-    /// @dev Tests that the game's version function returns a string.
-    function test_version_works() public view {
-        assertTrue(bytes(gameProxy.version()).length > 0);
-    }
-
-    /// @dev Tests that the game's root claim is set correctly.
-    function test_rootClaim_succeeds() public view {
-        assertEq(gameProxy.rootClaim().raw(), ROOT_CLAIM.raw());
-    }
-
-    /// @dev Tests that the game's extra data is set correctly.
-    function test_extraData_succeeds() public view {
-        assertEq(gameProxy.extraData(), extraData);
-    }
-
-    /// @dev Tests that the game's starting timestamp is set correctly.
-    function test_createdAt_succeeds() public view {
-        assertEq(gameProxy.createdAt().raw(), block.timestamp);
-    }
-
-    /// @dev Tests that the game's type is set correctly.
-    function test_gameType_succeeds() public view {
-        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
-    }
-
-    /// @dev Tests that the game's data is set correctly.
-    function test_gameData_succeeds() public view {
-        (GameType gameType, Claim rootClaim, bytes memory _extraData) = gameProxy.gameData();
-
-        assertEq(gameType.raw(), GAME_TYPE.raw());
-        assertEq(rootClaim.raw(), ROOT_CLAIM.raw());
-        assertEq(_extraData, extraData);
-    }
-
-    ////////////////////////////////////////////////////////////////
-    //          `ISuperFaultDisputeGame` Implementation Tests       //
-    ////////////////////////////////////////////////////////////////
-
-    /// @dev Tests that the game cannot be initialized with an output root that commits to <= the configured starting
-    ///      block number
+/// @title SuperFaultDisputeGame_Initialize_Test
+/// @notice Tests the `initialize` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_Initialize_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game cannot be initialized with an output root that commits to
+    ///         <= the configured starting block number
     function testFuzz_initialize_cannotProposeGenesis_reverts(uint256 _blockNumber) public {
         (, uint256 startingL2Block) = gameProxy.startingProposal();
         _blockNumber = bound(_blockNumber, 0, startingL2Block);
@@ -433,7 +493,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the proxy receives ETH from the dispute game factory.
+    /// @notice Tests that the proxy receives ETH from the dispute game factory.
     function test_initialize_receivesETH_succeeds() public {
         uint256 _value = disputeGameFactory.initBonds(GAME_TYPE);
         vm.deal(address(this), _value);
@@ -452,7 +512,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(delayedWeth.balanceOf(address(gameProxy)), _value);
     }
 
-    /// @dev Tests that the game cannot be initialized with the reserved `keccak256("invalid") reserved root
+    /// @notice Tests that the game cannot be initialized with the reserved `keccak256("invalid")`
+    ///         reserved root
     function test_initialize_invalidRoot_reverts() public {
         Claim claim = Claim.wrap(keccak256("invalid"));
         vm.expectRevert(bytes4(keccak256("SuperFaultDisputeGameInvalidRootClaim()")));
@@ -461,12 +522,14 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the game cannot be initialized with extra data of the incorrect length (must be 32 bytes)
+    /// @notice Tests that the game cannot be initialized with extra data of the incorrect length
+    ///         (must be 32 bytes)
     function testFuzz_initialize_badExtraData_reverts(uint256 _extraDataLen) public {
-        // The `DisputeGameFactory` will pack the root claim and the extra data into a single array, which is enforced
-        // to be at least 64 bytes long.
-        // We bound the upper end to 23.5KB to ensure that the minimal proxy never surpasses the contract size limit
-        // in this test, as CWIA proxies store the immutable args in their bytecode.
+        // The `DisputeGameFactory` will pack the root claim and the extra data into a single
+        // array, which is enforced to be at least 64 bytes long.
+        // We bound the upper end to 23.5KB to ensure that the minimal proxy never surpasses the
+        // contract size limit in this test, as CWIA proxies store the immutable args in their
+        // bytecode.
         // [0 bytes, 31 bytes] u [33 bytes, 23.5 KB]
         _extraDataLen = bound(_extraDataLen, 0, 23_500);
         if (_extraDataLen == 32) {
@@ -474,7 +537,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         }
         bytes memory _extraData = new bytes(_extraDataLen);
 
-        // Assign the first 32 bytes in `extraData` to a valid L2 block number passed the starting block.
+        // Assign the first 32 bytes in `extraData` to a valid L2 block number passed the starting
+        // block.
         (, uint256 startingL2Block) = gameProxy.startingProposal();
         assembly {
             mstore(add(_extraData, 0x20), add(startingL2Block, 1))
@@ -487,7 +551,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the game is initialized with the correct data.
+    /// @notice Tests that the game is initialized with the correct data.
     function test_initialize_correctData_succeeds() public view {
         // Assert that the root claim is initialized correctly.
         (
@@ -514,7 +578,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(gameProxy.l1Head().raw(), blockhash(block.number - 1));
     }
 
-    /// @dev Tests that the game cannot be initialized when the anchor root is not found.
+    /// @notice Tests that the game cannot be initialized when the anchor root is not found.
     function test_initialize_anchorRootNotFound_reverts() public {
         // Mock the AnchorStateRegistry to return a zero root.
         vm.mockCall(
@@ -530,75 +594,213 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that the game cannot be initialized twice.
+    /// @notice Tests that the game cannot be initialized twice.
     function test_initialize_onlyOnce_succeeds() public {
         vm.expectRevert(AlreadyInitialized.selector);
         gameProxy.initialize();
     }
+}
 
-    /// @dev Tests that startingProposal and it's getters are set correctly.
-    function test_startingProposalGetters_succeeds() public view {
-        (Hash root, uint256 l2SequenceNumber) = gameProxy.startingProposal();
-        (Hash anchorRoot, uint256 anchorRootBlockNumber) = anchorStateRegistry.anchors(GAME_TYPE);
+/// @title SuperFaultDisputeGame_Step_Test
+/// @notice Tests the `step` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_Step_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that a claim cannot be stepped against twice.
+    function test_step_duplicateStep_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
 
-        assertEq(gameProxy.startingSequenceNumber(), l2SequenceNumber);
-        assertEq(gameProxy.startingSequenceNumber(), anchorRootBlockNumber);
-        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(root));
-        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(anchorRoot));
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.attack{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+
+        vm.expectRevert(DuplicateStep.selector);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
     }
 
-    /// @dev Tests that the user cannot control the first 4 bytes of the CWIA data, disallowing them to control the
-    ///      entrypoint when no calldata is provided to a call.
-    function test_cwiaCalldata_userCannotControlSelector_succeeds() public {
-        // Construct the expected CWIA data that the proxy will pass to the implementation, alongside any extra
-        // calldata passed by the user.
-        Hash l1Head = gameProxy.l1Head();
-        bytes memory cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+    /// @notice Tests that successfully step with true attacking claim when there is a true defend
+    ///         claim(claim5) in the middle of the dispute game.
+    function test_step_attackDummyClaimDefendTrueClaimInTheMiddle_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
 
-        // We expect a `ReceiveETH` event to be emitted when 0 bytes of calldata are sent; The fallback is always
-        // reached *within the minimal proxy* in `LibClone`'s version of `clones-with-immutable-args`
-        vm.expectEmit(false, false, false, true);
-        emit ReceiveETH(0);
-        // We expect no delegatecall to the implementation contract if 0 bytes are sent. Assert that this happens
-        // 0 times.
-        vm.expectCall(address(gameImpl), cwiaData, 0);
-        (bool successA,) = address(gameProxy).call(hex"");
-        assertTrue(successA);
-
-        // When calldata is forwarded, we do expect a delegatecall to the implementation.
-        bytes memory data = abi.encodePacked(gameProxy.l1Head.selector);
-        vm.expectCall(address(gameImpl), abi.encodePacked(data, cwiaData), 1);
-        (bool successB, bytes memory returnData) = address(gameProxy).call(data);
-        assertTrue(successB);
-        assertEq(returnData, abi.encode(l1Head));
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bytes memory claimData5 = abi.encode(5, 5);
+        Claim claim5 = Claim.wrap(keccak256(claimData5));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, claimData5, hex"");
     }
 
-    /// @dev Tests that the bond during the bisection game depths is correct.
-    function test_getRequiredBond_succeeds() public view {
-        for (uint8 i = 0; i < uint8(gameProxy.splitDepth()); i++) {
-            Position pos = LibPosition.wrap(i, 0);
-            uint256 bond = gameProxy.getRequiredBond(pos);
+    /// @notice Tests that successfully step with true defend claim when there is a true defend
+    ///         claim(claim7) in the middle of the dispute game.
+    function test_step_defendDummyClaimDefendTrueClaimInTheMiddle_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
 
-            // Reasonable approximation for a max depth of 8.
-            uint256 expected = 0.08 ether;
-            for (uint64 j = 0; j < i; j++) {
-                expected = expected * 22876;
-                expected = expected / 10000;
-            }
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
 
-            assertApproxEqAbs(bond, expected, 0.01 ether);
-        }
+        bytes memory claimData7 = abi.encode(7, 7);
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(7);
+
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, Claim.wrap(keccak256(claimData7)));
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, false, claimData7, hex"");
     }
 
-    /// @dev Tests that the bond at a depth greater than the maximum game depth reverts.
-    function test_getRequiredBond_outOfBounds_reverts() public {
-        Position pos = LibPosition.wrap(uint8(gameProxy.maxGameDepth() + 1), 0);
-        vm.expectRevert(GameDepthExceeded.selector);
-        gameProxy.getRequiredBond(pos);
+    /// @notice Tests that step reverts with false attacking claim when there is a true defend
+    ///         claim(claim5) in the middle of the dispute game.
+    function test_step_attackTrueClaimDefendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bytes memory claimData5 = abi.encode(5, 5);
+        Claim claim5 = Claim.wrap(keccak256(claimData5));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, true, claimData5, hex"");
     }
 
-    /// @dev Tests that a move while the game status is not `IN_PROGRESS` causes the call to revert
-    ///      with the `GameNotInProgress` error
+    /// @notice Tests that step reverts with false defending claim when there is a true defend
+    ///         claim(postState_) in the middle of the dispute game.
+    function test_step_defendDummyClaimDefendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(5, 5);
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+
+        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
+        Claim dummyClaim7 = Claim.wrap(keccak256(_dummyClaimData));
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, dummyClaim7);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, false, _dummyClaimData, hex"");
+    }
+
+    /// @notice Tests that step reverts with true defending claim when there is a true defend
+    ///         claim(postState_) in the middle of the dispute game.
+    function test_step_defendTrueClaimDefendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(5, 5);
+        Claim claim7 = Claim.wrap(keccak256(claimData7));
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, claim7);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, false, claimData7, hex"");
+    }
+}
+
+/// @title SuperFaultDisputeGame_Move_Test
+/// @notice Tests the `move` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_Move_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that a move while the game status is not `IN_PROGRESS` causes the call to
+    ///         revert with the `GameNotInProgress` error
     function test_move_gameNotInProgress_reverts() public {
         uint256 chalWins = uint256(GameStatus.CHALLENGER_WINS);
 
@@ -620,15 +822,16 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.attack(root, 0, Claim.wrap(0));
     }
 
-    /// @dev Tests that an attempt to defend the root claim reverts with the `CannotDefendRootClaim` error.
+    /// @notice Tests that an attempt to defend the root claim reverts with the
+    ///         `CannotDefendRootClaim` error.
     function test_move_defendRoot_reverts() public {
         (,,,, Claim root,,) = gameProxy.claimData(0);
         vm.expectRevert(CannotDefendRootClaim.selector);
         gameProxy.defend(root, 0, _dummyClaim());
     }
 
-    /// @dev Tests that an attempt to move against a claim that does not exist reverts with the
-    ///      `ParentDoesNotExist` error.
+    /// @notice Tests that an attempt to move against a claim that does not exist reverts with the
+    ///         `ParentDoesNotExist` error.
     function test_move_nonExistentParent_reverts() public {
         Claim claim = _dummyClaim();
 
@@ -641,8 +844,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.defend(_dummyClaim(), 1, claim);
     }
 
-    /// @dev Tests that an attempt to move at the maximum game depth reverts with the
-    ///      `GameDepthExceeded` error.
+    /// @notice Tests that an attempt to move at the maximum game depth reverts with the
+    ///         `GameDepthExceeded` error.
     function test_move_gameDepthExceeded_reverts() public {
         Claim claim = _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC);
 
@@ -650,8 +853,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
 
         for (uint256 i = 0; i <= maxDepth; i++) {
             (,,,, Claim disputed,,) = gameProxy.claimData(i);
-            // At the max game depth, the `_move` function should revert with
-            // the `GameDepthExceeded` error.
+            // At the max game depth, the `_move` function should revert with the
+            // `GameDepthExceeded` error.
             if (i == maxDepth) {
                 vm.expectRevert(GameDepthExceeded.selector);
                 gameProxy.attack{ value: 100 ether }(disputed, i, claim);
@@ -661,8 +864,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         }
     }
 
-    /// @dev Tests that a move made after the clock time has exceeded reverts with the
-    ///      `ClockTimeExceeded` error.
+    /// @notice Tests that a move made after the clock time has exceeded reverts with the
+    ///         `ClockTimeExceeded` error.
     function test_move_clockTimeExceeded_reverts() public {
         // Warp ahead past the clock time for the first move (3 1/2 days)
         vm.warp(block.timestamp + 3 days + 12 hours + 1);
@@ -693,8 +896,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         (,,,,,, clock) = gameProxy.claimData(2);
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(10), Timestamp.wrap(uint64(block.timestamp))).raw());
 
-        // We are at the split depth, so we need to set the status byte of the claim
-        // for the next move.
+        // We are at the split depth, so we need to set the status byte of the claim for the next
+        // move.
         claim = _changeClaimStatus(claim, VMStatuses.PANIC);
 
         vm.warp(block.timestamp + 10);
@@ -712,8 +915,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(20), Timestamp.wrap(uint64(block.timestamp))).raw());
     }
 
-    /// @dev Tests that the standard clock extension is triggered for a move that is not the
-    ///      split depth or the max game depth.
+    /// @notice Tests that the standard clock extension is triggered for a move that is not the
+    ///         split depth or the max game depth.
     function test_move_standardClockExtension_succeeds() public {
         (,,,,,, Clock clock) = gameProxy.claimData(0);
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
@@ -832,8 +1035,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         );
     }
 
-    /// @dev Tests that an identical claim cannot be made twice. The duplicate claim attempt should
-    ///      revert with the `ClaimAlreadyExists` error.
+    /// @notice Tests that an identical claim cannot be made twice. The duplicate claim attempt
+    ///         should revert with the `ClaimAlreadyExists` error.
     function test_move_duplicateClaim_reverts() public {
         Claim claim = _dummyClaim();
 
@@ -847,7 +1050,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.attack{ value: bond }(disputed, 0, claim);
     }
 
-    /// @dev Static unit test asserting that identical claims at the same position can be made in different subgames.
+    /// @notice Static unit test asserting that identical claims at the same position can be made
+    ///         in different subgames.
     function test_move_duplicateClaimsDifferentSubgames_succeeds() public {
         Claim claimA = _dummyClaim();
         Claim claimB = _dummyClaim();
@@ -868,7 +1072,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.attack{ value: bond }(disputed, 2, claimA);
     }
 
-    /// @dev Static unit test for the correctness of an opening attack.
+    /// @notice Static unit test for the correctness of an opening attack.
     function test_move_simpleAttack_succeeds() public {
         // Warp ahead 5 seconds.
         vm.warp(block.timestamp + 5);
@@ -915,8 +1119,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp - 5))).raw());
     }
 
-    /// @dev Tests that making a claim at the execution trace bisection root level with an invalid status
-    ///      byte reverts with the `UnexpectedRootClaim` error.
+    /// @notice Tests that making a claim at the execution trace bisection root level with an
+    ///         invalid status byte reverts with the `UnexpectedRootClaim` error.
     function test_move_incorrectStatusExecRoot_reverts() public {
         Claim disputed;
         for (uint256 i; i < 4; i++) {
@@ -930,8 +1134,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.attack{ value: bond }(disputed, 4, Claim.wrap(bytes32(0)));
     }
 
-    /// @dev Tests that making a claim at the execution trace bisection root level with a valid status
-    ///      byte succeeds.
+    /// @notice Tests that making a claim at the execution trace bisection root level with a valid
+    ///         status byte succeeds.
     function test_move_correctStatusExecRoot_succeeds() public {
         Claim disputed;
         for (uint256 i; i < 4; i++) {
@@ -944,14 +1148,15 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
     }
 
-    /// @dev Static unit test asserting that a move reverts when the bonded amount is incorrect.
+    /// @notice Static unit test asserting that a move reverts when the bonded amount is incorrect.
     function test_move_incorrectBondAmount_reverts() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         vm.expectRevert(IncorrectBondAmount.selector);
         gameProxy.attack{ value: 0 }(disputed, 0, _dummyClaim());
     }
 
-    /// @dev Static unit test asserting that a move reverts when the disputed claim does not match its index.
+    /// @notice Static unit test asserting that a move reverts when the disputed claim does not
+    ///         match its index.
     function test_move_incorrectDisputedIndex_reverts() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -959,213 +1164,219 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         vm.expectRevert(InvalidDisputedClaimIndex.selector);
         gameProxy.attack{ value: bond }(disputed, 1, _dummyClaim());
     }
+}
 
-    /// @dev Tests that a claim cannot be stepped against twice.
-    function test_step_duplicateStep_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+/// @title SuperFaultDisputeGame_AddLocalData_Test
+/// @notice Tests the `addLocalData` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_AddLocalData_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that adding local data with an out of bounds identifier reverts.
+    function testFuzz_addLocalData_oob_reverts(uint256 _ident) public {
+        Claim disputed;
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, _dummyClaim());
+        }
+        uint256 lastBond = _getRequiredBond(4);
         (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.attack{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, true, absolutePrestateData, hex"");
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
 
-        vm.expectRevert(DuplicateStep.selector);
-        gameProxy.step(8, true, absolutePrestateData, hex"");
+        // [1, 5] are valid local data identifiers.
+        if (_ident <= 5) _ident = 0;
+
+        vm.expectRevert(InvalidLocalIdent.selector);
+        gameProxy.addLocalData(_ident, 5, 0);
     }
 
-    /// @dev Tests that successfully step with true attacking claim when there is a true defend claim(claim5) in the
-    /// middle of the dispute game.
-    function test_stepAttackDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
+    /// @notice Tests that local data is loaded into the preimage oracle correctly in the subgame
+    ///         that is disputing the transition from `GENESIS -> GENESIS + 1`
+    function test_addLocalDataGenesisTransition_static_succeeds() public {
+        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
+        Claim disputed;
 
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+        }
+        uint256 lastBond = _getRequiredBond(4);
         (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        bytes memory claimData5 = abi.encode(5, 5);
-        Claim claim5 = Claim.wrap(keccak256(claimData5));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, true, claimData5, hex"");
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        // Expected start/disputed claims
+        (Hash root,) = gameProxy.startingProposal();
+        bytes32 startingClaim = root.raw();
+        bytes32 disputedClaim = bytes32(uint256(3));
+        Position disputedPos = LibPosition.wrap(4, 0);
+
+        // Expected local data
+        bytes32[4] memory data = [
+            gameProxy.l1Head().raw(),
+            startingClaim,
+            disputedClaim,
+            bytes32(uint256(gameProxy.l2SequenceNumber()) << 0xC0)
+        ];
+
+        for (uint256 i = 1; i <= 4; i++) {
+            uint256 expectedLen = i > 3 ? 8 : 32;
+            bytes32 key = _getKey(i, keccak256(abi.encode(disputedClaim, disputedPos)));
+
+            gameProxy.addLocalData(i, 5, 0);
+            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+            assertEq(dat >> 0xC0, bytes32(expectedLen));
+            // Account for the length prefix if i > 3 (the data stored at identifiers i <= 3 are 32
+            // bytes long, so the expected length is already correct. If i > 3, the data is only 8
+            // bytes long, so the length prefix + the data is 16 bytes total.
+            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
+
+            gameProxy.addLocalData(i, 5, 8);
+            (dat, datLen) = oracle.readPreimage(key, 8);
+            assertEq(dat, data[i - 1]);
+            assertEq(datLen, expectedLen);
+        }
     }
 
-    /// @dev Tests that successfully step with true defend claim when there is a true defend claim(claim7) in the
-    /// middle of the dispute game.
-    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
+    /// @notice Tests that local data is loaded into the preimage oracle correctly.
+    function test_addLocalDataMiddle_static_succeeds() public {
+        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
+        Claim disputed;
 
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+        }
+        uint256 lastBond = _getRequiredBond(4);
         (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        gameProxy.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID));
 
-        bytes memory claimData7 = abi.encode(7, 7);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+        // Expected start/disputed claims
+        bytes32 startingClaim = bytes32(uint256(3));
+        Position startingPos = LibPosition.wrap(4, 0);
+        bytes32 disputedClaim = bytes32(uint256(2));
+        Position disputedPos = LibPosition.wrap(3, 0);
 
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(7);
+        // Expected local data
+        bytes32[4] memory data = [
+            gameProxy.l1Head().raw(),
+            startingClaim,
+            disputedClaim,
+            bytes32(uint256(gameProxy.l2SequenceNumber()) << 0xC0)
+        ];
 
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, Claim.wrap(keccak256(claimData7)));
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, false, claimData7, hex"");
+        for (uint256 i = 1; i <= 4; i++) {
+            uint256 expectedLen = i > 3 ? 8 : 32;
+            bytes32 key = _getKey(i, keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos)));
+
+            gameProxy.addLocalData(i, 5, 0);
+            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+            assertEq(dat >> 0xC0, bytes32(expectedLen));
+            // Account for the length prefix if i > 3 (the data stored at identifiers i <= 3 are 32
+            // bytes long, so the expected length is already correct. If i > 3, the data is only 8
+            // bytes long, so the length prefix + the data is 16 bytes total.
+            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
+
+            gameProxy.addLocalData(i, 5, 8);
+            (dat, datLen) = oracle.readPreimage(key, 8);
+            assertEq(dat, data[i - 1]);
+            assertEq(datLen, expectedLen);
+        }
     }
 
-    /// @dev Tests that step reverts with false attacking claim when there is a true defend claim(claim5) in the middle
-    /// of the dispute game.
-    function test_stepAttackTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
+    /// @notice Tests that the L2 block number claim is favored over the bisected-to block when
+    ///         adding data.
+    function test_addLocalData_l2SequenceNumberExtension_succeeds() public {
+        // Deploy a new dispute game with a L2 block number claim of 8. This is directly in the
+        // middle of the leaves in our output bisection test tree, at SPLIT_DEPTH = 2 ** 2
+        ISuperFaultDisputeGame game = ISuperFaultDisputeGame(
+            address(
+                disputeGameFactory.create{ value: initBond }(
+                    GAME_TYPE, Claim.wrap(bytes32(uint256(0xFF))), abi.encode(uint256(validl2SequenceNumber))
+                )
+            )
+        );
 
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        bytes memory claimData5 = abi.encode(5, 5);
-        Claim claim5 = Claim.wrap(keccak256(claimData5));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        {
+            Claim disputed;
+            Position parent;
+            Position pos;
 
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, true, claimData5, hex"");
+            for (uint256 i; i < 4; i++) {
+                (,,,,, parent,) = game.claimData(i);
+                pos = parent.move(true);
+                uint256 bond = game.getRequiredBond(pos);
+
+                (,,,, disputed,,) = game.claimData(i);
+                if (i == 0) {
+                    game.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+                } else {
+                    game.defend{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+                }
+            }
+            (,,,,, parent,) = game.claimData(4);
+            pos = parent.move(true);
+            uint256 lastBond = game.getRequiredBond(pos);
+            (,,,, disputed,,) = game.claimData(4);
+            game.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.INVALID));
+        }
+
+        // Expected start/disputed claims
+        bytes32 startingClaim = bytes32(uint256(3));
+        Position startingPos = LibPosition.wrap(4, 14);
+        bytes32 disputedClaim = bytes32(uint256(0xFF));
+        Position disputedPos = LibPosition.wrap(0, 0);
+
+        // Expected local data. This should be `l2SequenceNumber`, and not the actual bisected-to
+        // block, as we choose the minimum between the two.
+        bytes32 expectedNumber = bytes32(uint256(validl2SequenceNumber << 0xC0));
+        uint256 expectedLen = 8;
+        uint256 l2NumberIdent = LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER;
+
+        // Compute the preimage key for the local data
+        bytes32 localContext = keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos));
+        bytes32 rawKey = keccak256(abi.encode(l2NumberIdent | (1 << 248), address(game), localContext));
+        bytes32 key = bytes32((uint256(rawKey) & ~uint256(0xFF << 248)) | (1 << 248));
+
+        IPreimageOracle oracle = IPreimageOracle(address(game.vm().oracle()));
+        game.addLocalData(l2NumberIdent, 5, 0);
+
+        (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+        assertEq(dat >> 0xC0, bytes32(expectedLen));
+        assertEq(datLen, expectedLen + 8);
+
+        game.addLocalData(l2NumberIdent, 5, 8);
+        (dat, datLen) = oracle.readPreimage(key, 8);
+        assertEq(dat, expectedNumber);
+        assertEq(datLen, expectedLen);
     }
+}
 
-    /// @dev Tests that step reverts with false defending claim when there is a true defend claim(postState_) in the
-    /// middle of the dispute game.
-    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(5, 5);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-
-        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
-        Claim dummyClaim7 = Claim.wrap(keccak256(_dummyClaimData));
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, dummyClaim7);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, false, _dummyClaimData, hex"");
-    }
-
-    /// @dev Tests that step reverts with true defending claim when there is a true defend claim(postState_) in the
-    /// middle of the dispute game.
-    function test_stepDefendTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(5, 5);
-        Claim claim7 = Claim.wrap(keccak256(claimData7));
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, claim7);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, false, claimData7, hex"");
-    }
-
-    /// @dev Static unit test for the correctness an uncontested root resolution.
+/// @title SuperFaultDisputeGame_Resolve_Test
+/// @notice Tests the `resolve` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_Resolve_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Static unit test for the correctness an uncontested root resolution.
     function test_resolve_rootUncontested_succeeds() public {
         vm.warp(block.timestamp + 3 days + 12 hours);
         gameProxy.resolveClaim(0, 0);
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Static unit test for the correctness an uncontested root resolution.
+    /// @notice Static unit test for the correctness an uncontested root resolution.
     function test_resolve_rootUncontestedClockNotExpired_succeeds() public {
         vm.warp(block.timestamp + 3 days + 12 hours - 1 seconds);
         vm.expectRevert(ClockNotExpired.selector);
         gameProxy.resolveClaim(0, 0);
     }
 
-    /// @dev Static unit test for the correctness of a multi-part resolution of a single claim.
+    /// @notice Static unit test for the correctness of a multi-part resolution of a single claim.
     function test_resolve_multiPart_succeeds() public {
         vm.deal(address(this), 10_000 ether);
 
@@ -1216,16 +1427,16 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
     }
 
-    /// @dev Static unit test asserting that resolve reverts when the absolute root
-    ///      subgame has not been resolved.
+    /// @notice Static unit test asserting that resolve reverts when the absolute root subgame has
+    ///         not been resolved.
     function test_resolve_rootUncontestedButUnresolved_reverts() public {
         vm.warp(block.timestamp + 3 days + 12 hours);
         vm.expectRevert(OutOfOrderResolution.selector);
         gameProxy.resolve();
     }
 
-    /// @dev Static unit test asserting that resolve reverts when the game state is
-    ///      not in progress.
+    /// @notice Static unit test asserting that resolve reverts when the game state is not in
+    ///         progress.
     function test_resolve_notInProgress_reverts() public {
         uint256 chalWins = uint256(GameStatus.CHALLENGER_WINS);
 
@@ -1241,7 +1452,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.resolveClaim(0, 0);
     }
 
-    /// @dev Static unit test for the correctness of resolving a single attack game state.
+    /// @notice Static unit test for the correctness of resolving a single attack game state.
     function test_resolve_rootContested_succeeds() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1253,7 +1464,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
     }
 
-    /// @dev Static unit test for the correctness of resolving a game with a contested challenge claim.
+    /// @notice Static unit test for the correctness of resolving a game with a contested
+    ///         challenge claim.
     function test_resolve_challengeContested_succeeds() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1268,7 +1480,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Static unit test for the correctness of resolving a game with multiplayer moves.
+    /// @notice Static unit test for the correctness of resolving a game with multiplayer moves.
     function test_resolve_teamDeathmatch_succeeds() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1287,7 +1499,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
     }
 
-    /// @dev Static unit test for the correctness of resolving a game that reaches max game depth.
+    /// @notice Static unit test for the correctness of resolving a game that reaches max game
+    ///         depth.
     function test_resolve_stepReached_succeeds() public {
         Claim claim = _dummyClaim();
         for (uint256 i; i < gameProxy.splitDepth(); i++) {
@@ -1309,7 +1522,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
 
-    /// @dev Static unit test asserting that resolve reverts when attempting to resolve a subgame multiple times
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve a
+    ///         subgame multiple times.
     function test_resolve_claimAlreadyResolved_reverts() public {
         Claim claim = _dummyClaim();
         uint256 firstBond = _getRequiredBond(0);
@@ -1330,7 +1544,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.resolveClaim(1, 0);
     }
 
-    /// @dev Static unit test asserting that resolve reverts when attempting to resolve a subgame at max depth
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve a
+    ///         subgame at max depth.
     function test_resolve_claimAtMaxDepthAlreadyResolved_reverts() public {
         Claim claim = _dummyClaim();
         for (uint256 i; i < gameProxy.splitDepth(); i++) {
@@ -1353,7 +1568,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.resolveClaim(8, 0);
     }
 
-    /// @dev Static unit test asserting that resolve reverts when attempting to resolve subgames out of order
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve subgames
+    ///         out of order.
     function test_resolve_outOfOrderResolution_reverts() public {
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
@@ -1366,8 +1582,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         gameProxy.resolveClaim(0, 0);
     }
 
-    /// @dev Static unit test asserting that resolve pays out bonds on step, output bisection, and execution trace
-    /// moves.
+    /// @notice Static unit test asserting that resolve pays out bonds on step, output bisection,
+    ///         and execution trace moves.
     function test_resolve_bondPayouts_succeeds() public {
         // Give the test contract some ether
         uint256 bal = 1000 ether;
@@ -1446,16 +1662,17 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(address(gameProxy).balance, 0);
         assertEq(delayedWeth.balanceOf(address(gameProxy)), 0);
 
-        // Ensure that the init bond for the game is 0, in case we change it in the test suite in the future.
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
         assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
     }
 
-    /// @dev Static unit test asserting that resolve pays out bonds on step, output bisection, and execution trace
-    /// moves with 2 actors and a dishonest root claim.
+    /// @notice Static unit test asserting that resolve pays out bonds on step, output bisection,
+    ///         and execution trace moves with 2 actors and a dishonest root claim.
     function test_resolve_bondPayoutsSeveralActors_succeeds() public {
-        // Give the test contract and bob some ether
+        // Give the test contract and bob some ether.
         // We use the "1000 ether" literal for `bal`, the initial balance, to avoid stack too deep
-        //uint256 bal = 1000 ether;
+        // uint256 bal = 1000 ether;
         address bob = address(0xb0b);
         vm.deal(address(this), 1000 ether);
         vm.deal(bob, 1000 ether);
@@ -1554,12 +1771,13 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(address(gameProxy).balance, 0);
         assertEq(delayedWeth.balanceOf(address(gameProxy)), 0);
 
-        // Ensure that the init bond for the game is 0, in case we change it in the test suite in the future.
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
         assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
     }
 
-    /// @dev Static unit test asserting that resolve pays out bonds on moves to the leftmost actor
-    /// in subgames containing successful counters.
+    /// @notice Static unit test asserting that resolve pays out bonds on moves to the leftmost
+    ///         actor in subgames containing successful counters.
     function test_resolve_leftmostBondPayout_succeeds() public {
         uint256 bal = 1000 ether;
         address alice = address(0xa11ce);
@@ -1570,9 +1788,10 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         vm.deal(bob, bal);
         vm.deal(charlie, bal);
 
-        // Make claims with bob, charlie and the test contract on defense, and alice as the challenger
-        // charlie is successfully countered by alice
-        // alice is successfully countered by both bob and the test contract
+        // Make claims with bob, charlie and the test contract on defense, and alice as the
+        // challenger.
+        // - charlie is successfully countered by alice
+        // - alice is successfully countered by both bob and the test contract
         uint256 firstBond = _getRequiredBond(0);
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         vm.prank(alice);
@@ -1632,12 +1851,13 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(charlie.balance, bal - charlieLosses, "incorrect charlie balance");
         assertEq(address(gameProxy).balance, 0);
 
-        // Ensure that the init bond for the game is 0, in case we change it in the test suite in the future.
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
         assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
     }
 
-    /// @dev Static unit test asserting that the anchor state updates when the game resolves in
-    /// favor of the defender and the anchor state is older than the game state.
+    /// @notice Static unit test asserting that the anchor state updates when the game resolves in
+    ///         favor of the defender and the anchor state is older than the game state.
     function test_resolve_validNewerStateUpdatesAnchor_succeeds() public {
         // Confirm that the anchor state is older than the game state.
         (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
@@ -1660,8 +1880,9 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(root.raw(), gameProxy.rootClaim().raw());
     }
 
-    /// @dev Static unit test asserting that the anchor state does not change when the game
-    /// resolves in favor of the defender but the game state is not newer than the anchor state.
+    /// @notice Static unit test asserting that the anchor state does not change when the game
+    ///         resolves in favor of the defender but the game state is not newer than the anchor
+    ///         state.
     function test_resolve_validOlderStateSameAnchor_succeeds() public {
         // Mock the game block to be older than the game state.
         vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(0));
@@ -1688,8 +1909,9 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(updatedRoot.raw(), root.raw());
     }
 
-    /// @dev Static unit test asserting that the anchor state does not change when the game
-    /// resolves in favor of the challenger, even if the game state is newer than the anchor.
+    /// @notice Static unit test asserting that the anchor state does not change when the game
+    ///         resolves in favor of the challenger, even if the game state is newer than the
+    ///         anchor.
     function test_resolve_invalidStateSameAnchor_succeeds() public {
         // Confirm that the anchor state is older than the game state.
         (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
@@ -1714,7 +1936,79 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(updatedl2SequenceNumber, l2SequenceNumber);
         assertEq(updatedRoot.raw(), root.raw());
     }
+}
 
+/// @title SuperFaultDisputeGame_GameType_Test
+/// @notice Tests the `gameType` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_GameType_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game's type is set correctly.
+    function test_gameType_succeeds() public view {
+        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
+    }
+}
+
+/// @title SuperFaultDisputeGame_RootClaim_Test
+/// @notice Tests the `rootClaim` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_RootClaim_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game's root claim is set correctly.
+    function test_rootClaim_succeeds() public view {
+        assertEq(gameProxy.rootClaim().raw(), ROOT_CLAIM.raw());
+    }
+}
+
+/// @title SuperFaultDisputeGame_ExtraData_Test
+/// @notice Tests the `extraData` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_ExtraData_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game's extra data is set correctly.
+    function test_extraData_succeeds() public view {
+        assertEq(gameProxy.extraData(), extraData);
+    }
+}
+
+/// @title SuperFaultDisputeGame_GameData_Test
+/// @notice Tests the `gameData` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_GameData_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game's data is set correctly.
+    function test_gameData_succeeds() public view {
+        (GameType gameType, Claim rootClaim, bytes memory _extraData) = gameProxy.gameData();
+
+        assertEq(gameType.raw(), GAME_TYPE.raw());
+        assertEq(rootClaim.raw(), ROOT_CLAIM.raw());
+        assertEq(_extraData, extraData);
+    }
+}
+
+/// @title SuperFaultDisputeGame_GetRequiredBond_Test
+/// @notice Tests the `getRequiredBond` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_GetRequiredBond_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the bond during the bisection game depths is correct.
+    function test_getRequiredBond_succeeds() public view {
+        for (uint8 i = 0; i < uint8(gameProxy.splitDepth()); i++) {
+            Position pos = LibPosition.wrap(i, 0);
+            uint256 bond = gameProxy.getRequiredBond(pos);
+
+            // Reasonable approximation for a max depth of 8.
+            uint256 expected = 0.08 ether;
+            for (uint64 j = 0; j < i; j++) {
+                expected = expected * 22876;
+                expected = expected / 10000;
+            }
+
+            assertApproxEqAbs(bond, expected, 0.01 ether);
+        }
+    }
+
+    /// @notice Tests that the bond at a depth greater than the maximum game depth reverts.
+    function test_getRequiredBond_outOfBounds_reverts() public {
+        Position pos = LibPosition.wrap(uint8(gameProxy.maxGameDepth() + 1), 0);
+        vm.expectRevert(GameDepthExceeded.selector);
+        gameProxy.getRequiredBond(pos);
+    }
+}
+
+/// @title SuperFaultDisputeGame_ClaimCredit_Test
+/// @notice Tests the `claimCredit` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_ClaimCredit_Test is SuperFaultDisputeGame_TestInit {
     function test_claimCredit_refundMode_succeeds() public {
         // Set up actors.
         address alice = address(0xa11ce);
@@ -1786,7 +2080,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(bob.balance, bobBalanceBefore + secondBond);
     }
 
-    /// @dev Static unit test asserting that credit may not be drained past allowance through reentrancy.
+    /// @notice Static unit test asserting that credit may not be drained past allowance through
+    ///         reentrancy.
     function test_claimCredit_claimAlreadyResolved_reverts() public {
         ClaimCreditReenter reenter = new ClaimCreditReenter(gameProxy, vm);
         vm.startPrank(address(reenter));
@@ -1847,7 +2142,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         reenter.claimCredit(address(reenter));
 
         // The reenter contract should have performed 2 calls to `claimCredit`.
-        // Once all the credit is claimed, all subsequent calls will revert since there is 0 credit left to claim.
+        // Once all the credit is claimed, all subsequent calls will revert since there is 0 credit
+        // left to claim.
         // The claimant must only have received the amount bonded for the gindex 1 subgame.
         // The root claim bond and the unregistered ETH should still exist in the game proxy.
         assertEq(reenter.numCalls(), 2);
@@ -1858,7 +2154,7 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         vm.stopPrank();
     }
 
-    /// @dev Tests that claimCredit reverts when recipient can't receive value.
+    /// @notice Tests that claimCredit reverts when recipient can't receive value.
     function test_claimCredit_recipientCantReceiveValue_reverts() public {
         // Set up actors.
         address alice = address(0xa11ce);
@@ -1907,203 +2203,109 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         // Wait for the withdrawal delay.
         vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
 
-        // make bob not be able to receive value by setting his contract code to something without `receive`
+        // Make bob not be able to receive value by setting his contract code to something without
+        // `receive`.
         vm.etch(address(bob), address(L1Token).code);
 
         vm.expectRevert(BondTransferFailed.selector);
         gameProxy.claimCredit(address(bob));
     }
+}
 
-    /// @dev Tests that adding local data with an out of bounds identifier reverts.
-    function testFuzz_addLocalData_oob_reverts(uint256 _ident) public {
-        Claim disputed;
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        for (uint256 i; i < 4; i++) {
-            uint256 bond = _getRequiredBond(i);
-            (,,,, disputed,,) = gameProxy.claimData(i);
-            gameProxy.attack{ value: bond }(disputed, i, _dummyClaim());
-        }
-        uint256 lastBond = _getRequiredBond(4);
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        // [1, 5] are valid local data identifiers.
-        if (_ident <= 5) _ident = 0;
-
-        vm.expectRevert(InvalidLocalIdent.selector);
-        gameProxy.addLocalData(_ident, 5, 0);
+/// @title SuperFaultDisputeGame_CloseGame_Test
+/// @notice Tests the `closeGame` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_CloseGame_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that closeGame reverts if the game is not resolved
+    function test_closeGame_gameNotResolved_reverts() public {
+        vm.expectRevert(GameNotResolved.selector);
+        gameProxy.closeGame();
     }
 
-    /// @dev Tests that local data is loaded into the preimage oracle correctly in the subgame
-    ///      that is disputing the transition from `GENESIS -> GENESIS + 1`
-    function test_addLocalDataGenesisTransition_static_succeeds() public {
-        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
-        Claim disputed;
+    /// @notice Tests that closeGame reverts if the game is not finalized
+    function test_closeGame_gameNotFinalized_reverts() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
 
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        for (uint256 i; i < 4; i++) {
-            uint256 bond = _getRequiredBond(i);
-            (,,,, disputed,,) = gameProxy.claimData(i);
-            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-        }
-        uint256 lastBond = _getRequiredBond(4);
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        // Expected start/disputed claims
-        (Hash root,) = gameProxy.startingProposal();
-        bytes32 startingClaim = root.raw();
-        bytes32 disputedClaim = bytes32(uint256(3));
-        Position disputedPos = LibPosition.wrap(4, 0);
-
-        // Expected local data
-        bytes32[4] memory data = [
-            gameProxy.l1Head().raw(),
-            startingClaim,
-            disputedClaim,
-            bytes32(uint256(gameProxy.l2SequenceNumber()) << 0xC0)
-        ];
-
-        for (uint256 i = 1; i <= 4; i++) {
-            uint256 expectedLen = i > 3 ? 8 : 32;
-            bytes32 key = _getKey(i, keccak256(abi.encode(disputedClaim, disputedPos)));
-
-            gameProxy.addLocalData(i, 5, 0);
-            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
-            assertEq(dat >> 0xC0, bytes32(expectedLen));
-            // Account for the length prefix if i > 3 (the data stored
-            // at identifiers i <= 3 are 32 bytes long, so the expected
-            // length is already correct. If i > 3, the data is only 8
-            // bytes long, so the length prefix + the data is 16 bytes
-            // total.)
-            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
-
-            gameProxy.addLocalData(i, 5, 8);
-            (dat, datLen) = oracle.readPreimage(key, 8);
-            assertEq(dat, data[i - 1]);
-            assertEq(datLen, expectedLen);
-        }
+        // Don't wait the finalization delay
+        vm.expectRevert(GameNotFinalized.selector);
+        gameProxy.closeGame();
     }
 
-    /// @dev Tests that local data is loaded into the preimage oracle correctly.
-    function test_addLocalDataMiddle_static_succeeds() public {
-        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
-        Claim disputed;
+    /// @notice Tests that closeGame succeeds for a proper game (normal distribution)
+    function test_closeGame_properGame_succeeds() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
 
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        for (uint256 i; i < 4; i++) {
-            uint256 bond = _getRequiredBond(i);
-            (,,,, disputed,,) = gameProxy.claimData(i);
-            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-        }
-        uint256 lastBond = _getRequiredBond(4);
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID));
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
 
-        // Expected start/disputed claims
-        bytes32 startingClaim = bytes32(uint256(3));
-        Position startingPos = LibPosition.wrap(4, 0);
-        bytes32 disputedClaim = bytes32(uint256(2));
-        Position disputedPos = LibPosition.wrap(3, 0);
+        // Close the game and verify normal distribution mode
+        vm.expectEmit(true, true, true, true);
+        emit GameClosed(BondDistributionMode.NORMAL);
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
 
-        // Expected local data
-        bytes32[4] memory data = [
-            gameProxy.l1Head().raw(),
-            startingClaim,
-            disputedClaim,
-            bytes32(uint256(gameProxy.l2SequenceNumber()) << 0xC0)
-        ];
-
-        for (uint256 i = 1; i <= 4; i++) {
-            uint256 expectedLen = i > 3 ? 8 : 32;
-            bytes32 key = _getKey(i, keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos)));
-
-            gameProxy.addLocalData(i, 5, 0);
-            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
-            assertEq(dat >> 0xC0, bytes32(expectedLen));
-            // Account for the length prefix if i > 3 (the data stored
-            // at identifiers i <= 3 are 32 bytes long, so the expected
-            // length is already correct. If i > 3, the data is only 8
-            // bytes long, so the length prefix + the data is 16 bytes
-            // total.)
-            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
-
-            gameProxy.addLocalData(i, 5, 8);
-            (dat, datLen) = oracle.readPreimage(key, 8);
-            assertEq(dat, data[i - 1]);
-            assertEq(datLen, expectedLen);
-        }
+        // Check that the anchor state was set correctly.
+        assertEq(address(gameProxy.anchorStateRegistry().anchorGame()), address(gameProxy));
     }
 
-    /// @dev Tests that the L2 block number claim is favored over the bisected-to block when adding data
-    ///
-    function test_addLocalData_l2SequenceNumberExtension_succeeds() public {
-        // Deploy a new dispute game with a L2 block number claim of 8. This is directly in the middle of
-        // the leaves in our output bisection test tree, at SPLIT_DEPTH = 2 ** 2
-        ISuperFaultDisputeGame game = ISuperFaultDisputeGame(
-            address(
-                disputeGameFactory.create{ value: initBond }(
-                    GAME_TYPE, Claim.wrap(bytes32(uint256(0xFF))), abi.encode(uint256(validl2SequenceNumber))
-                )
-            )
+    /// @notice Tests that closeGame succeeds for an improper game (refund mode)
+    function test_closeGame_improperGame_succeeds() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Mock the anchor registry to return improper game
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(anchorStateRegistry.isGameProper, (IDisputeGame(address(gameProxy)))),
+            abi.encode(false, "")
         );
 
-        // Get a claim below the split depth so that we can add local data for an execution trace subgame.
-        {
-            Claim disputed;
-            Position parent;
-            Position pos;
-
-            for (uint256 i; i < 4; i++) {
-                (,,,,, parent,) = game.claimData(i);
-                pos = parent.move(true);
-                uint256 bond = game.getRequiredBond(pos);
-
-                (,,,, disputed,,) = game.claimData(i);
-                if (i == 0) {
-                    game.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-                } else {
-                    game.defend{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
-                }
-            }
-            (,,,,, parent,) = game.claimData(4);
-            pos = parent.move(true);
-            uint256 lastBond = game.getRequiredBond(pos);
-            (,,,, disputed,,) = game.claimData(4);
-            game.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.INVALID));
-        }
-
-        // Expected start/disputed claims
-        bytes32 startingClaim = bytes32(uint256(3));
-        Position startingPos = LibPosition.wrap(4, 14);
-        bytes32 disputedClaim = bytes32(uint256(0xFF));
-        Position disputedPos = LibPosition.wrap(0, 0);
-
-        // Expected local data. This should be `l2SequenceNumber`, and not the actual bisected-to block,
-        // as we choose the minimum between the two.
-        bytes32 expectedNumber = bytes32(uint256(validl2SequenceNumber << 0xC0));
-        uint256 expectedLen = 8;
-        uint256 l2NumberIdent = LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER;
-
-        // Compute the preimage key for the local data
-        bytes32 localContext = keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos));
-        bytes32 rawKey = keccak256(abi.encode(l2NumberIdent | (1 << 248), address(game), localContext));
-        bytes32 key = bytes32((uint256(rawKey) & ~uint256(0xFF << 248)) | (1 << 248));
-
-        IPreimageOracle oracle = IPreimageOracle(address(game.vm().oracle()));
-        game.addLocalData(l2NumberIdent, 5, 0);
-
-        (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
-        assertEq(dat >> 0xC0, bytes32(expectedLen));
-        assertEq(datLen, expectedLen + 8);
-
-        game.addLocalData(l2NumberIdent, 5, 8);
-        (dat, datLen) = oracle.readPreimage(key, 8);
-        assertEq(dat, expectedNumber);
-        assertEq(datLen, expectedLen);
+        // Close the game and verify refund mode
+        vm.expectEmit(true, true, true, true);
+        emit GameClosed(BondDistributionMode.REFUND);
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
     }
 
-    /// @dev Tests that if the game is not in progress, querying of `getChallengerDuration` reverts
+    /// @notice Tests that multiple calls to closeGame succeed after initial distribution mode is
+    ///         set.
+    function test_closeGame_multipleCallsAfterSet_succeeds() public {
+        // Resolve and close the game first
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // First close sets the mode
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        // Subsequent closes should succeed without changing the mode
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+    }
+}
+
+/// @title SuperFaultDisputeGame_GetChallengerDuration_Test
+/// @notice Tests the `getChallengerDuration` function of the `SuperFaultDisputeGame` contract.
+contract SuperFaultDisputeGame_GetChallengerDuration_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that if the game is not in progress, querying of `getChallengerDuration`
+    ///         reverts.
     function test_getChallengerDuration_gameNotInProgress_reverts() public {
         // resolve the game
         vm.warp(block.timestamp + gameProxy.maxClockDuration().raw());
@@ -2114,9 +2316,57 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         vm.expectRevert(GameNotInProgress.selector);
         gameProxy.getChallengerDuration(1);
     }
+}
 
-    /// @dev Static unit test asserting that resolveClaim isn't possible if there's time
-    ///      left for a counter.
+/// @title SuperFaultDisputeGame_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `SuperFaultDisputeGame`
+///         contract or are testing multiple functions at once.
+contract SuperFaultDisputeGame_Unclassified_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice Tests that the game's starting timestamp is set correctly.
+    function test_createdAt_succeeds() public view {
+        assertEq(gameProxy.createdAt().raw(), block.timestamp);
+    }
+
+    /// @notice Tests that startingProposal and it's getters are set correctly.
+    function test_startingProposalGetters_succeeds() public view {
+        (Hash root, uint256 l2SequenceNumber) = gameProxy.startingProposal();
+        (Hash anchorRoot, uint256 anchorRootBlockNumber) = anchorStateRegistry.anchors(GAME_TYPE);
+
+        assertEq(gameProxy.startingSequenceNumber(), l2SequenceNumber);
+        assertEq(gameProxy.startingSequenceNumber(), anchorRootBlockNumber);
+        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(root));
+        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(anchorRoot));
+    }
+
+    /// @notice Tests that the user cannot control the first 4 bytes of the CWIA data, disallowing
+    ///         them to control the entrypoint when no calldata is provided to a call.
+    function test_cwiaCalldata_userCannotControlSelector_succeeds() public {
+        // Construct the expected CWIA data that the proxy will pass to the implementation,
+        // alongside any extra calldata passed by the user.
+        Hash l1Head = gameProxy.l1Head();
+        bytes memory cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+
+        // We expect a `ReceiveETH` event to be emitted when 0 bytes of calldata are sent; The
+        // fallback is always reached *within the minimal proxy* in `LibClone`'s version of
+        // `clones-with-immutable-args`.
+        vm.expectEmit(false, false, false, true);
+        emit ReceiveETH(0);
+        // We expect no delegatecall to the implementation contract if 0 bytes are sent. Assert
+        // that this happens 0 times.
+        vm.expectCall(address(gameImpl), cwiaData, 0);
+        (bool successA,) = address(gameProxy).call(hex"");
+        assertTrue(successA);
+
+        // When calldata is forwarded, we do expect a delegatecall to the implementation.
+        bytes memory data = abi.encodePacked(gameProxy.l1Head.selector);
+        vm.expectCall(address(gameImpl), abi.encodePacked(data, cwiaData), 1);
+        (bool successB, bytes memory returnData) = address(gameProxy).call(data);
+        assertTrue(successB);
+        assertEq(returnData, abi.encode(l1Head));
+    }
+
+    /// @notice Static unit test asserting that resolveClaim isn't possible if there's time left
+    ///         for a counter.
     function test_resolution_lastSecondDisputes_succeeds() public {
         // The honest proposer created an honest root claim during setup - node 0
 
@@ -2130,7 +2380,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
 
         // Advance time by 1 second, so that the root claim challenger clock is expired.
         vm.warp(block.timestamp + 1 seconds);
-        // Attempt a second attack against the root claim. This should revert since the challenger clock is expired.
+        // Attempt a second attack against the root claim. This should revert since the challenger
+        // clock is expired.
         uint256 expectedBond = _getRequiredBond(0);
         vm.expectRevert(ClockTimeExceeded.selector);
         gameProxy.attack{ value: expectedBond }(disputed, 0, _dummyClaim());
@@ -2146,7 +2397,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
 
         // Warp to the last second of the root claim defender clock.
         vm.warp(block.timestamp + 3.5 days - 2 seconds);
-        // Attack the challenge to the root claim. This should succeed, since the defender clock is not expired.
+        // Attack the challenge to the root claim. This should succeed, since the defender clock is
+        // not expired.
         (,,,, disputed,,) = gameProxy.claimData(1);
         gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
         // Chess clock time accumulated:
@@ -2177,7 +2429,8 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
         assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - 1 seconds);
 
-        // Warp past the challenge period for the root claim defender. Defending the root claim should now revert.
+        // Warp past the challenge period for the root claim defender. Defending the root claim
+        // should now revert.
         vm.warp(block.timestamp + 1 seconds);
         expectedBond = _getRequiredBond(1);
         vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
@@ -2204,147 +2457,12 @@ contract SuperFaultDisputeGame_Test is SuperFaultDisputeGame_Init {
         // Defender wins game since the root claim is uncountered
         assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
     }
-
-    /// @dev Tests that closeGame reverts if the game is not resolved
-    function test_closeGame_gameNotResolved_reverts() public {
-        vm.expectRevert(GameNotResolved.selector);
-        gameProxy.closeGame();
-    }
-
-    /// @dev Tests that closeGame reverts if the game is not finalized
-    function test_closeGame_gameNotFinalized_reverts() public {
-        // Resolve the game
-        vm.warp(block.timestamp + 3 days + 12 hours);
-        gameProxy.resolveClaim(0, 0);
-        gameProxy.resolve();
-
-        // Don't wait the finalization delay
-        vm.expectRevert(GameNotFinalized.selector);
-        gameProxy.closeGame();
-    }
-
-    /// @dev Tests that closeGame succeeds for a proper game (normal distribution)
-    function test_closeGame_properGame_succeeds() public {
-        // Resolve the game
-        vm.warp(block.timestamp + 3 days + 12 hours);
-        gameProxy.resolveClaim(0, 0);
-        gameProxy.resolve();
-
-        // Wait for finalization delay
-        vm.warp(block.timestamp + 3.5 days + 1 seconds);
-
-        // Close the game and verify normal distribution mode
-        vm.expectEmit(true, true, true, true);
-        emit GameClosed(BondDistributionMode.NORMAL);
-        gameProxy.closeGame();
-        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
-
-        // Check that the anchor state was set correctly.
-        assertEq(address(gameProxy.anchorStateRegistry().anchorGame()), address(gameProxy));
-    }
-
-    /// @dev Tests that closeGame succeeds for an improper game (refund mode)
-    function test_closeGame_improperGame_succeeds() public {
-        // Resolve the game
-        vm.warp(block.timestamp + 3 days + 12 hours);
-        gameProxy.resolveClaim(0, 0);
-        gameProxy.resolve();
-
-        // Wait for finalization delay
-        vm.warp(block.timestamp + 3.5 days + 1 seconds);
-
-        // Mock the anchor registry to return improper game
-        vm.mockCall(
-            address(anchorStateRegistry),
-            abi.encodeCall(anchorStateRegistry.isGameProper, (IDisputeGame(address(gameProxy)))),
-            abi.encode(false, "")
-        );
-
-        // Close the game and verify refund mode
-        vm.expectEmit(true, true, true, true);
-        emit GameClosed(BondDistributionMode.REFUND);
-        gameProxy.closeGame();
-        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
-    }
-
-    /// @dev Tests that multiple calls to closeGame succeed after initial distribution mode is set
-    function test_closeGame_multipleCallsAfterSet_succeeds() public {
-        // Resolve and close the game first
-        vm.warp(block.timestamp + 3 days + 12 hours);
-        gameProxy.resolveClaim(0, 0);
-        gameProxy.resolve();
-
-        // Wait for finalization delay
-        vm.warp(block.timestamp + 3.5 days + 1 seconds);
-
-        // First close sets the mode
-        gameProxy.closeGame();
-        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
-
-        // Subsequent closes should succeed without changing the mode
-        gameProxy.closeGame();
-        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
-
-        gameProxy.closeGame();
-        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
-    }
-
-    /// @dev Helper to generate a mock RLP encoded header (with only a real block number) & an output root proof.
-    function _generateOutputRootProof(
-        bytes32 _storageRoot,
-        bytes32 _withdrawalRoot,
-        bytes memory _l2SequenceNumber
-    )
-        internal
-        pure
-        returns (Types.OutputRootProof memory proof_, bytes32 root_, bytes memory rlp_)
-    {
-        // L2 Block header
-        bytes[] memory rawHeaderRLP = new bytes[](9);
-        rawHeaderRLP[0] = hex"83FACADE";
-        rawHeaderRLP[1] = hex"83FACADE";
-        rawHeaderRLP[2] = hex"83FACADE";
-        rawHeaderRLP[3] = hex"83FACADE";
-        rawHeaderRLP[4] = hex"83FACADE";
-        rawHeaderRLP[5] = hex"83FACADE";
-        rawHeaderRLP[6] = hex"83FACADE";
-        rawHeaderRLP[7] = hex"83FACADE";
-        rawHeaderRLP[8] = RLPWriter.writeBytes(_l2SequenceNumber);
-        rlp_ = RLPWriter.writeList(rawHeaderRLP);
-
-        // Output root
-        proof_ = Types.OutputRootProof({
-            version: 0,
-            stateRoot: _storageRoot,
-            messagePasserStorageRoot: _withdrawalRoot,
-            latestBlockhash: keccak256(rlp_)
-        });
-        root_ = Hashing.hashOutputRootProof(proof_);
-    }
-
-    /// @dev Helper to get the required bond for the given claim index.
-    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
-    }
-
-    /// @dev Helper to return a pseudo-random claim
-    function _dummyClaim() internal view returns (Claim) {
-        return Claim.wrap(keccak256(abi.encode(gasleft())));
-    }
-
-    /// @dev Helper to get the localized key for an identifier in the context of the game proxy.
-    function _getKey(uint256 _ident, bytes32 _localContext) internal view returns (bytes32) {
-        bytes32 h = keccak256(abi.encode(_ident | (1 << 248), address(gameProxy), _localContext));
-        return bytes32((uint256(h) & ~uint256(0xFF << 248)) | (1 << 248));
-    }
 }
 
-contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
-    /// @dev The honest actor
+contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_TestInit {
+    /// @notice The honest actor
     DisputeActor internal honest;
-    /// @dev The dishonest actor
+    /// @notice The dishonest actor
     DisputeActor internal dishonest;
 
     function setUp() public override {
@@ -2359,8 +2477,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2371,8 +2489,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 2;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of all set bits.
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all set bits.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = bytes1(0xFF);
@@ -2397,8 +2515,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2409,8 +2527,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 2;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of all zeros.
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all zeros.
         bytes memory dishonestTrace = new bytes(256);
 
         // Run the actor test
@@ -2432,8 +2550,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2444,8 +2562,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 2;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of all zeros.
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all zeros.
         bytes memory dishonestTrace = new bytes(256);
 
         // Run the actor test
@@ -2467,8 +2585,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2504,8 +2622,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2541,8 +2659,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2578,8 +2696,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2590,8 +2708,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
         }
-        // The dishonest trace is half correct, and correct all the way up to the final instruction of the exec
-        // subgame.
+        // The dishonest trace is half correct, and correct all the way up to the final instruction
+        // of the exec subgame.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = i > (127 + 7) ? bytes1(0xFF) : bytes1(uint8(i));
@@ -2616,8 +2734,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i + 1;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
-        // of bytes [0, 255].
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
         bytes memory honestTrace = new bytes(256);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2628,8 +2746,8 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
         }
-        // The dishonest trace is half correct, and correct all the way up to the final instruction of the exec
-        // subgame.
+        // The dishonest trace is half correct, and correct all the way up to the final instruction
+        // of the exec subgame.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = i > (127 + 7) ? bytes1(0xFF) : bytes1(uint8(i));
@@ -2651,7 +2769,7 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
     //                          HELPERS                           //
     ////////////////////////////////////////////////////////////////
 
-    /// @dev Helper to run a 1v1 actor test
+    /// @notice Helper to run a 1v1 actor test
     function _actorTest(
         uint256 _rootClaim,
         uint256 _absolutePrestateData,
@@ -2695,7 +2813,7 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         assertEq(uint8(gameProxy.status()), uint8(_expectedStatus));
     }
 
-    /// @dev Helper to setup the 1v1 test
+    /// @notice Helper to setup the 1v1 test
     function _setup(
         uint256 _absolutePrestateData,
         uint256 _rootClaim
@@ -2707,10 +2825,10 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         Claim absolutePrestateExec =
             _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData_)), VMStatuses.UNFINISHED);
         Claim rootClaim = Claim.wrap(bytes32(uint256(_rootClaim)));
-        super.init({ rootClaim: rootClaim, absolutePrestate: absolutePrestateExec, l2SequenceNumber: _rootClaim });
+        init({ _rootClaim: rootClaim, _absolutePrestate: absolutePrestateExec, _l2SequenceNumber: _rootClaim });
     }
 
-    /// @dev Helper to create actors for the 1v1 dispute.
+    /// @notice Helper to create actors for the 1v1 dispute.
     function _createActors(
         bytes memory _honestTrace,
         bytes memory _honestPreStateData,
@@ -2740,7 +2858,7 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         vm.label(address(dishonest), "DishonestActor");
     }
 
-    /// @dev Helper to exhaust all moves from both actors.
+    /// @notice Helper to exhaust all moves from both actors.
     function _exhaustMoves() internal {
         while (true) {
             // Allow the dishonest actor to make their moves, and then the honest actor.
@@ -2754,13 +2872,13 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
         }
     }
 
-    /// @dev Helper to warp past the chess clock and resolve all claims within the dispute game.
+    /// @notice Helper to warp past the chess clock and resolve all claims within the dispute game.
     function _warpAndResolve() internal {
         // Warp past the chess clock
         vm.warp(block.timestamp + 3 days + 12 hours);
 
-        // Resolve all claims in reverse order. We allow `resolveClaim` calls to fail due to
-        // the check that prevents claims with no subgames attached from being passed to
+        // Resolve all claims in reverse order. We allow `resolveClaim` calls to fail due to the
+        // check that prevents claims with no subgames attached from being passed to
         // `resolveClaim`. There's also a check in `resolve` to ensure all children have been
         // resolved before global resolution, which catches any unresolved subgames here.
         for (uint256 i = gameProxy.claimDataLen(); i > 0; i--) {
@@ -2768,38 +2886,5 @@ contract SuperFaultDispute_1v1_Actors_Test is SuperFaultDisputeGame_Init {
             assertTrue(success);
         }
         gameProxy.resolve();
-    }
-}
-
-contract ClaimCreditReenter {
-    Vm internal immutable vm;
-    ISuperFaultDisputeGame internal immutable GAME;
-    uint256 public numCalls;
-
-    constructor(ISuperFaultDisputeGame _gameProxy, Vm _vm) {
-        GAME = _gameProxy;
-        vm = _vm;
-    }
-
-    function claimCredit(address _recipient) public {
-        numCalls += 1;
-        if (numCalls > 1) {
-            vm.expectRevert(NoCreditToClaim.selector);
-        }
-        GAME.claimCredit(_recipient);
-    }
-
-    receive() external payable {
-        if (numCalls == 5) {
-            return;
-        }
-        claimCredit(address(this));
-    }
-}
-
-/// @dev Helper to change the VM status byte of a claim.
-function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
-    assembly {
-        out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
     }
 }

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -12,25 +12,41 @@ import "src/dispute/lib/Errors.sol";
 // Interfaces
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 
-contract SuperPermissionedDisputeGame_Init is DisputeGameFactory_Init {
-    /// @dev The type of the game being tested.
+/// @title SuperPermissionedDisputeGame_TestInit
+/// @notice Reusable test initialization for `SuperPermissionedDisputeGame` tests.
+contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_Init {
+    /// @notice The type of the game being tested.
     GameType internal constant GAME_TYPE = GameType.wrap(5);
-    /// @dev Mock proposer key
+    /// @notice Mock proposer key
     address internal constant PROPOSER = address(0xfacade9);
-    /// @dev Mock challenger key
+    /// @notice Mock challenger key
     address internal constant CHALLENGER = address(0xfacadec);
 
-    /// @dev The implementation of the game.
+    /// @notice The implementation of the game.
     IPermissionedDisputeGame internal gameImpl;
-    /// @dev The `Clone` proxy of the game.
+    /// @notice The `Clone` proxy of the game.
     IPermissionedDisputeGame internal gameProxy;
 
-    /// @dev The extra data passed to the game for initialization.
+    /// @notice The extra data passed to the game for initialization.
     bytes internal extraData;
+
+    /// @notice The root claim of the game.
+    Claim internal rootClaim;
+    /// @notice An arbitrary root claim for testing.
+    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
+    /// @notice Minimum bond value that covers all possible moves.
+    uint256 internal constant MIN_BOND = 50 ether;
+
+    /// @notice The preimage of the absolute prestate claim
+    bytes internal absolutePrestateData;
+    /// @notice The absolute prestate of the trace.
+    Claim internal absolutePrestate;
+    /// @notice A valid l2BlockNumber that comes after the current anchor root block.
+    uint256 validL2BlockNumber;
 
     event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
 
-    function init(Claim rootClaim, Claim absolutePrestate, uint256 l2BlockNumber) public {
+    function init(Claim _rootClaim, Claim _absolutePrestate, uint256 _l2BlockNumber) public {
         // Set the time to a realistic date.
         if (!isForkTest()) {
             vm.warp(1690906994);
@@ -40,9 +56,9 @@ contract SuperPermissionedDisputeGame_Init is DisputeGameFactory_Init {
         vm.deal(PROPOSER, 100 ether);
 
         // Set the extra data for the game creation
-        extraData = abi.encode(l2BlockNumber);
+        extraData = abi.encode(_l2BlockNumber);
 
-        (address _impl, AlphabetVM _vm,) = setupSuperPermissionedDisputeGame(absolutePrestate, PROPOSER, CHALLENGER);
+        (address _impl, AlphabetVM _vm,) = setupSuperPermissionedDisputeGame(_absolutePrestate, PROPOSER, CHALLENGER);
         gameImpl = IPermissionedDisputeGame(_impl);
 
         // Create a new game.
@@ -50,18 +66,18 @@ contract SuperPermissionedDisputeGame_Init is DisputeGameFactory_Init {
         vm.mockCall(
             address(anchorStateRegistry),
             abi.encodeCall(anchorStateRegistry.anchors, (GAME_TYPE)),
-            abi.encode(rootClaim, 0)
+            abi.encode(_rootClaim, 0)
         );
         vm.prank(PROPOSER, PROPOSER);
         gameProxy = IPermissionedDisputeGame(
-            payable(address(disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, rootClaim, extraData)))
+            payable(address(disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, _rootClaim, extraData)))
         );
 
         // Check immutables
         assertEq(gameProxy.proposer(), PROPOSER);
         assertEq(gameProxy.challenger(), CHALLENGER);
         assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
-        assertEq(gameProxy.absolutePrestate().raw(), absolutePrestate.raw());
+        assertEq(gameProxy.absolutePrestate().raw(), _absolutePrestate.raw());
         assertEq(gameProxy.maxGameDepth(), 2 ** 3);
         assertEq(gameProxy.splitDepth(), 2 ** 2);
         assertEq(gameProxy.maxClockDuration().raw(), 3.5 days);
@@ -70,26 +86,6 @@ contract SuperPermissionedDisputeGame_Init is DisputeGameFactory_Init {
         // Label the proxy
         vm.label(address(gameProxy), "FaultDisputeGame_Clone");
     }
-
-    fallback() external payable { }
-
-    receive() external payable { }
-}
-
-contract SuperPermissionedDisputeGame_Test is SuperPermissionedDisputeGame_Init {
-    /// @dev The root claim of the game.
-    Claim internal rootClaim;
-    /// @dev An arbitrary root claim for testing.
-    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
-    /// @dev Minimum bond value that covers all possible moves.
-    uint256 internal constant MIN_BOND = 50 ether;
-
-    /// @dev The preimage of the absolute prestate claim
-    bytes internal absolutePrestateData;
-    /// @dev The absolute prestate of the trace.
-    Claim internal absolutePrestate;
-    /// @dev A valid l2BlockNumber that comes after the current anchor root block.
-    uint256 validL2BlockNumber;
 
     function setUp() public override {
         absolutePrestateData = abi.encode(0);
@@ -101,87 +97,46 @@ contract SuperPermissionedDisputeGame_Test is SuperPermissionedDisputeGame_Init 
         (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
         validL2BlockNumber = l2BlockNumber + 1;
         rootClaim = Claim.wrap(Hash.unwrap(root));
-        super.init({ rootClaim: rootClaim, absolutePrestate: absolutePrestate, l2BlockNumber: validL2BlockNumber });
+        init({ _rootClaim: rootClaim, _absolutePrestate: absolutePrestate, _l2BlockNumber: validL2BlockNumber });
     }
 
-    /// @dev Tests that the game's version function returns a string.
+    /// @notice Helper to return a pseudo-random claim
+    function _dummyClaim() internal view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(gasleft())));
+    }
+
+    /// @notice Helper to get the required bond for the given claim index.
+    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
+        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
+        Position pos = parent.move(true);
+        bond_ = gameProxy.getRequiredBond(pos);
+    }
+
+    /// @notice Helper to change the VM status byte of a claim.
+    function _changeClaimStatus(Claim _claim, VMStatus _status) internal pure returns (Claim out_) {
+        assembly {
+            out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+        }
+    }
+
+    fallback() external payable { }
+
+    receive() external payable { }
+}
+
+/// @title SuperPermissionedDisputeGame_Version_Test
+/// @notice Tests the `version` function of the `SuperPermissionedDisputeGame` contract.
+contract SuperPermissionedDisputeGame_Version_Test is SuperPermissionedDisputeGame_TestInit {
+    /// @notice Tests that the game's version function returns a string.
     function test_version_works() public view {
         assertTrue(bytes(gameProxy.version()).length > 0);
     }
+}
 
-    /// @dev Tests that the proposer can create a permissioned dispute game.
-    function test_createGame_proposer_succeeds() public {
-        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
-        vm.prank(PROPOSER, PROPOSER);
-        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
-    }
-
-    /// @dev Tests that the permissioned game cannot be created by any address other than the proposer.
-    function testFuzz_createGame_notProposer_reverts(address _p) public {
-        vm.assume(_p != PROPOSER);
-
-        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
-        vm.deal(_p, bondAmount);
-        vm.prank(_p, _p);
-        vm.expectRevert(BadAuth.selector);
-        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
-    }
-
-    /// @dev Tests that the challenger can participate in a permissioned dispute game.
-    function test_participateInGame_challenger_succeeds() public {
-        vm.startPrank(CHALLENGER, CHALLENGER);
-        uint256 firstBond = _getRequiredBond(0);
-        vm.deal(CHALLENGER, firstBond);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
-        uint256 secondBond = _getRequiredBond(1);
-        vm.deal(CHALLENGER, secondBond);
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
-        uint256 thirdBond = _getRequiredBond(2);
-        vm.deal(CHALLENGER, thirdBond);
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
-        vm.stopPrank();
-    }
-
-    /// @dev Tests that the proposer can participate in a permissioned dispute game.
-    function test_participateInGame_proposer_succeeds() public {
-        vm.startPrank(PROPOSER, PROPOSER);
-        uint256 firstBond = _getRequiredBond(0);
-        vm.deal(PROPOSER, firstBond);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
-        uint256 secondBond = _getRequiredBond(1);
-        vm.deal(PROPOSER, secondBond);
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
-        uint256 thirdBond = _getRequiredBond(2);
-        vm.deal(PROPOSER, thirdBond);
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
-        vm.stopPrank();
-    }
-
-    /// @dev Tests that addresses that are not the proposer or challenger cannot participate in a permissioned dispute
-    ///      game.
-    function test_participateInGame_notAuthorized_reverts(address _p) public {
-        vm.assume(_p != PROPOSER && _p != CHALLENGER);
-
-        vm.startPrank(_p, _p);
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.attack(disputed, 0, Claim.wrap(0));
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.defend(disputed, 0, Claim.wrap(0));
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.move(disputed, 0, Claim.wrap(0), true);
-        vm.expectRevert(BadAuth.selector);
-        gameProxy.step(0, true, absolutePrestateData, hex"");
-        vm.stopPrank();
-    }
-
-    /// @dev Tests that step works properly.
+/// @title SuperPermissionedDisputeGame_Step_Test
+/// @notice Tests the `step` function of the `SuperPermissionedDisputeGame` contract.
+contract SuperPermissionedDisputeGame_Step_Test is SuperPermissionedDisputeGame_TestInit {
+    /// @notice Tests that step works properly.
     function test_step_succeeds() public {
         // Give the test contract some ether
         vm.deal(CHALLENGER, 1_000 ether);
@@ -230,23 +185,82 @@ contract SuperPermissionedDisputeGame_Test is SuperPermissionedDisputeGame_Init 
         (, address counteredBy,,,,,) = gameProxy.claimData(0);
         assertEq(counteredBy, CHALLENGER);
     }
-
-    /// @dev Helper to return a pseudo-random claim
-    function _dummyClaim() internal view returns (Claim) {
-        return Claim.wrap(keccak256(abi.encode(gasleft())));
-    }
-
-    /// @dev Helper to get the required bond for the given claim index.
-    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
-    }
 }
 
-/// @dev Helper to change the VM status byte of a claim.
-function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
-    assembly {
-        out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+/// @title SuperPermissionedDisputeGame_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the
+///         `SuperPermissionedDisputeGame` contract or are testing multiple functions at once.
+contract SuperPermissionedDisputeGame_Unclassified_Test is SuperPermissionedDisputeGame_TestInit {
+    /// @notice Tests that the proposer can create a permissioned dispute game.
+    function test_createGame_proposer_succeeds() public {
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.prank(PROPOSER, PROPOSER);
+        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
+    }
+
+    /// @notice Tests that the permissioned game cannot be created by any address other than the
+    ///         proposer.
+    function testFuzz_createGame_notProposer_reverts(address _p) public {
+        vm.assume(_p != PROPOSER);
+
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.deal(_p, bondAmount);
+        vm.prank(_p, _p);
+        vm.expectRevert(BadAuth.selector);
+        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
+    }
+
+    /// @notice Tests that the challenger can participate in a permissioned dispute game.
+    function test_participateInGame_challenger_succeeds() public {
+        vm.startPrank(CHALLENGER, CHALLENGER);
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(CHALLENGER, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(CHALLENGER, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
+        uint256 thirdBond = _getRequiredBond(2);
+        vm.deal(CHALLENGER, thirdBond);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that the proposer can participate in a permissioned dispute game.
+    function test_participateInGame_proposer_succeeds() public {
+        vm.startPrank(PROPOSER, PROPOSER);
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(PROPOSER, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(PROPOSER, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
+        uint256 thirdBond = _getRequiredBond(2);
+        vm.deal(PROPOSER, thirdBond);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that addresses that are not the proposer or challenger cannot participate in
+    ///         a permissioned dispute game.
+    function test_participateInGame_notAuthorized_reverts(address _p) public {
+        vm.assume(_p != PROPOSER && _p != CHALLENGER);
+
+        vm.startPrank(_p, _p);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.attack(disputed, 0, Claim.wrap(0));
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.defend(disputed, 0, Claim.wrap(0));
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.move(disputed, 0, Claim.wrap(0), true);
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.step(0, true, absolutePrestateData, hex"");
+        vm.stopPrank();
     }
 }

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 // Testing
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 
 // Libraries
@@ -14,7 +14,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 
 /// @title SuperPermissionedDisputeGame_TestInit
 /// @notice Reusable test initialization for `SuperPermissionedDisputeGame` tests.
-contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_Init {
+contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @notice The type of the game being tested.
     GameType internal constant GAME_TYPE = GameType.wrap(5);
     /// @notice Mock proposer key

--- a/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
@@ -5,16 +5,19 @@ import { Test } from "forge-std/Test.sol";
 import { LibClock } from "src/dispute/lib/LibUDT.sol";
 import "src/dispute/lib/Types.sol";
 
-/// @notice Tests for `LibClock`
-contract LibClock_Test is Test {
-    /// @notice Tests that the `duration` function correctly shifts out the `Duration` from a packed `Clock` type.
-    function testFuzz_duration_succeeds(Duration _duration, Timestamp _timestamp) public pure {
+/// @title LibClock_Wrap_Test
+/// @notice Tests the `wrap` function of the `LibClock` library.
+contract LibClock_Wrap_Test is Test {
+    /// @notice Tests that the `wrap` function correctly shifts out the `Duration` from a packed
+    ///         `Clock` type.
+    function testFuzz_wrap_duration_succeeds(Duration _duration, Timestamp _timestamp) public pure {
         Clock clock = LibClock.wrap(_duration, _timestamp);
         assertEq(Duration.unwrap(clock.duration()), Duration.unwrap(_duration));
     }
 
-    /// @notice Tests that the `timestamp` function correctly shifts out the `Timestamp` from a packed `Clock` type.
-    function testFuzz_timestamp_succeeds(Duration _duration, Timestamp _timestamp) public pure {
+    /// @notice Tests that the `wrap` function correctly shifts out the `Timestamp` from a packed
+    ///         `Clock` type.
+    function testFuzz_wrap_timestamp_succeeds(Duration _duration, Timestamp _timestamp) public pure {
         Clock clock = LibClock.wrap(_duration, _timestamp);
         assertEq(Timestamp.unwrap(clock.timestamp()), Timestamp.unwrap(_timestamp));
     }

--- a/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
@@ -5,9 +5,12 @@ import { Test } from "forge-std/Test.sol";
 
 import "src/dispute/lib/Types.sol";
 
-contract LibGameId_Test is Test {
-    /// @dev Tests that a round trip of packing and unpacking a GameId maintains the same values.
-    function testFuzz_gameId_roundTrip_succeeds(
+/// @title LibGameId_Pack_Test
+/// @notice Tests the `pack` and `unpack` functions of the `LibGameId` library.
+contract LibGameId_Pack_Test is Test {
+    /// @notice Tests that a round trip of packing and unpacking a `GameId` maintains the same
+    ///         values.
+    function testFuzz_pack_roundTrip_succeeds(
         GameType _gameType,
         Timestamp _timestamp,
         address _gameProxy

--- a/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 // Testing
 import { Vm } from "forge-std/Vm.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";
-import { FaultDisputeGame_Init } from "test/dispute/FaultDisputeGame.t.sol";
+import { BaseFaultDisputeGame_TestInit } from "test/dispute/FaultDisputeGame.t.sol";
 
 // Libraries
 import "src/dispute/lib/Types.sol";
@@ -13,7 +13,7 @@ import "src/dispute/lib/Errors.sol";
 // Interfaces
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 
-contract FaultDisputeGame_Solvency_Invariant is FaultDisputeGame_Init {
+contract FaultDisputeGame_Solvency_Invariant is BaseFaultDisputeGame_TestInit {
     Claim internal constant ROOT_CLAIM = Claim.wrap(bytes32(uint256(10)));
     Claim internal constant ABSOLUTE_PRESTATE = Claim.wrap(bytes32((uint256(3) << 248) | uint256(0)));
 

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -6,7 +6,7 @@ import { StdUtils } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 
 // Contracts
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";
@@ -82,7 +82,7 @@ contract OptimismPortal2_Depositor is StdUtils, ResourceMetering {
     }
 }
 
-contract OptimismPortal2_Invariant_Harness is DisputeGameFactory_Init {
+contract OptimismPortal2_Invariant_Harness is DisputeGameFactory_TestInit {
     // Reusable default values for a test withdrawal
     Types.WithdrawalTransaction _defaultTx;
 

--- a/packages/contracts-bedrock/test/invariants/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SuperFaultDisputeGame.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { SuperFaultDisputeGame_Init } from "test/dispute/SuperFaultDisputeGame.t.sol";
+import { SuperFaultDisputeGame_TestInit } from "test/dispute/SuperFaultDisputeGame.t.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { RandomClaimActor } from "test/invariants/FaultDisputeGame.t.sol";
 
@@ -10,16 +10,16 @@ import { RandomClaimActor } from "test/invariants/FaultDisputeGame.t.sol";
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";
 
-contract SuperFaultDisputeGame_Solvency_Invariant is SuperFaultDisputeGame_Init {
-    Claim internal constant ROOT_CLAIM = Claim.wrap(bytes32(uint256(10)));
-    Claim internal constant ABSOLUTE_PRESTATE = Claim.wrap(bytes32((uint256(3) << 248) | uint256(0)));
+contract SuperFaultDisputeGame_Solvency_Invariant is SuperFaultDisputeGame_TestInit {
+    Claim internal constant _ROOT_CLAIM = Claim.wrap(bytes32(uint256(10)));
+    Claim internal constant _ABSOLUTE_PRESTATE = Claim.wrap(bytes32((uint256(3) << 248) | uint256(0)));
 
     RandomClaimActor internal actor;
     uint256 internal defaultSenderBalance;
 
     function setUp() public override {
         super.setUp();
-        super.init({ rootClaim: ROOT_CLAIM, absolutePrestate: ABSOLUTE_PRESTATE, l2SequenceNumber: 0x10 });
+        super.init({ _rootClaim: _ROOT_CLAIM, _absolutePrestate: _ABSOLUTE_PRESTATE, _l2SequenceNumber: 0x10 });
 
         actor = new RandomClaimActor(IFaultDisputeGame(address(gameProxy)), vm);
 

--- a/packages/contracts-bedrock/test/invariants/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SuperFaultDisputeGame.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { SuperFaultDisputeGame_TestInit } from "test/dispute/SuperFaultDisputeGame.t.sol";
+import { BaseSuperFaultDisputeGame_TestInit } from "test/dispute/SuperFaultDisputeGame.t.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { RandomClaimActor } from "test/invariants/FaultDisputeGame.t.sol";
 
@@ -10,16 +10,16 @@ import { RandomClaimActor } from "test/invariants/FaultDisputeGame.t.sol";
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";
 
-contract SuperFaultDisputeGame_Solvency_Invariant is SuperFaultDisputeGame_TestInit {
-    Claim internal constant _ROOT_CLAIM = Claim.wrap(bytes32(uint256(10)));
-    Claim internal constant _ABSOLUTE_PRESTATE = Claim.wrap(bytes32((uint256(3) << 248) | uint256(0)));
+contract SuperFaultDisputeGame_Solvency_Invariant is BaseSuperFaultDisputeGame_TestInit {
+    Claim internal constant ROOT_CLAIM = Claim.wrap(bytes32(uint256(10)));
+    Claim internal constant ABSOLUTE_PRESTATE = Claim.wrap(bytes32((uint256(3) << 248) | uint256(0)));
 
     RandomClaimActor internal actor;
     uint256 internal defaultSenderBalance;
 
     function setUp() public override {
         super.setUp();
-        super.init({ _rootClaim: _ROOT_CLAIM, _absolutePrestate: _ABSOLUTE_PRESTATE, _l2SequenceNumber: 0x10 });
+        super.init({ _rootClaim: ROOT_CLAIM, _absolutePrestate: ABSOLUTE_PRESTATE, _l2SequenceNumber: 0x10 });
 
         actor = new RandomClaimActor(IFaultDisputeGame(address(gameProxy)), vm);
 

--- a/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
+++ b/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { DisputeGameFactory_Init } from "test/dispute/DisputeGameFactory.t.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
 import { _changeClaimStatus } from "test/dispute/FaultDisputeGame.t.sol";
 
 // Contracts
@@ -12,7 +12,7 @@ import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 
 /// @title DisputeMonitorHelper_TestInit
 /// @notice Reusable test initialization for `DisputeMonitorHelper` tests.
-contract DisputeMonitorHelper_TestInit is DisputeGameFactory_Init {
+contract DisputeMonitorHelper_TestInit is DisputeGameFactory_TestInit {
     DisputeMonitorHelper helper;
 
     function setUp() public override {


### PR DESCRIPTION
This PR continues the refactor of the `/dispute` test folder as part of the ongoing effort to standardize structure, documentation, and formatting across the test suite.

Some files were already refactored in [#16088](https://github.com/ethereum-optimism/optimism/pull/16088), and the remaining ones are completed in this PR.

### Common changes applied where applicable:
- Extracted shared setup logic into `PermissionedDisputeGame_TestInit`
- Organized test functions into separate contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to the test contract
- Added function-level `@notice` comments
- Replaced legacy `@dev` tags with `@notice` where applicable
- Enforced 100-character limit for inline comments

### Progress

Refactored 10 of 10 test files (**100.0% complete**)

- `AnchorStateRegistry.t.sol` (refactored in [#16088](https://github.com/ethereum-optimism/optimism/pull/16088))
- `DelayedWETH.t.sol` (refactored in [#16088](https://github.com/ethereum-optimism/optimism/pull/16088))
- `LibPosition.t.sol` (refactored in [#16088](https://github.com/ethereum-optimism/optimism/pull/16088))
- [x] `PermissionedDisputeGame.t.sol`
- [x] `DisputeGameFactory.t.sol`
- [x] `FaultDisputeGame.t.sol`
- [x] `LibClock.t.sol`
- [x] `LibGameId.t.sol`
- [x] `SuperFaultDisputeGame.t.sol`
- [x] `SuperPermissionedDisputeGame.t.sol`