### PR TITLE
op-acceptance-tests: interop: load test: add budget tracking to prevent overspending

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/budget.go
+++ b/op-acceptance-tests/tests/interop/loadtest/budget.go
@@ -1,0 +1,81 @@
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/plan"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+type InsufficientBudgetError struct {
+	Remaining eth.ETH
+	Requested eth.ETH
+}
+
+var _ error = (*InsufficientBudgetError)(nil)
+
+func (e *InsufficientBudgetError) Error() string {
+	return fmt.Sprintf("insufficient budget: requested %s, remaining %s", e.Requested, e.Remaining)
+}
+
+// Budget tracks the amount of ETH spent and begins returning errors when it would exceed a certain amount.
+//
+// Limitation: Budget assumes that all submitted transactions are included forever.
+type Budget struct {
+	mu        sync.Mutex
+	remaining eth.ETH
+}
+
+func NewBudget(amount eth.ETH) *Budget {
+	return &Budget{
+		remaining: amount,
+	}
+}
+
+func (b *Budget) Plan() txplan.Option {
+	return b.onSubmit()
+}
+
+func (b *Budget) onSubmit() txplan.Option {
+	return func(tx *txplan.PlannedTx) {
+		tx.Submitted.DependOn(&tx.Signed)
+		tx.Submitted.Wrap(func(inner plan.Fn[struct{}]) plan.Fn[struct{}] {
+			return func(ctx context.Context) (struct{}, error) {
+				cost := eth.WeiBig(tx.Signed.Value().Cost())
+				if err := b.debit(cost); err != nil {
+					return struct{}{}, err
+				}
+				// Assumption: if inner fails, then the transaction will never be included.
+				if _, err := inner(ctx); err != nil {
+					b.credit(cost)
+					return struct{}{}, err
+				}
+				return struct{}{}, nil
+			}
+		})
+	}
+}
+
+func (b *Budget) debit(amount eth.ETH) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	result, underflow := b.remaining.SubUnderflow(amount)
+	if underflow {
+		return &InsufficientBudgetError{
+			Remaining: b.remaining,
+			Requested: amount,
+		}
+	}
+	b.remaining = result
+	return nil
+}
+
+// credit does not check for underflows or overflows.
+func (b *Budget) credit(amount eth.ETH) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.remaining = b.remaining.Add(amount)
+}

--- a/op-acceptance-tests/tests/interop/loadtest/eoa_pool.go
+++ b/op-acceptance-tests/tests/interop/loadtest/eoa_pool.go
@@ -18,16 +18,17 @@ type EOAPool struct {
 	index atomic.Uint64
 }
 
-func NewEOAPool(funder *dsl.Funder, num uint64, amount eth.ETH) *EOAPool {
-	eoas := make([]*SyncEOA, num)
+func NewEOAPool(funder *dsl.Funder, total eth.ETH) *EOAPool {
+	eoas := make([]*SyncEOA, 300)
+	amountPerEOA := total.Div(uint64(len(eoas)))
 	var wg sync.WaitGroup
 	defer wg.Wait()
-	for i := range num {
+	for i := range len(eoas) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			eoas[i] = &SyncEOA{
-				Inner: funder.NewFundedEOA(amount),
+				Inner: funder.NewFundedEOA(amountPerEOA),
 			}
 		}()
 	}

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -1,12 +1,17 @@
 // Package loadtest contains interop load tests.
 //
-// Set NAT_INTEROP_LOADTEST_TARGET to the initial amount of messages that should be passed per L2 slot in each test (default: 100).
+// Configure test behavior with the following environment variables:
+//
+//   - NAT_INTEROP_LOADTEST_TARGET (default: 100): the initial amount of messages that should be passed per L2 slot in each test.
+//   - NAT_INTEROP_LOADTEST_BUDGET (default: 10_000): the max amount of ETH to spend per test, per L2. The test ends right before
+//     the budget is depleted.
 //
 // Each test increases the message throughput until some threshold is reached (e.g., the gas target).
 // The throughput is decreased if the threshold is exceeded or if errors are encountered (e.g., transaction inclusion failures).
 package loadtest
 
 import (
+	"errors"
 	"math"
 	"math/rand"
 	"os"
@@ -44,12 +49,12 @@ func TestSteady(gt *testing.T) {
 		deadline = testCtxDeadline.Add(-10 * time.Second) // Give some time for cleanup.
 	}
 	ctx, cancel := context.WithDeadline(t.Ctx(), deadline)
-	t.Cleanup(cancel) // We only care about the deadline.
+	t.Cleanup(cancel)
 	if timeoutStr, exists := os.LookupEnv("NAT_STEADY_TIMEOUT"); exists {
 		timeout, err := time.ParseDuration(timeoutStr)
 		t.Require().NoError(err)
 		ctx, cancel = context.WithTimeout(ctx, timeout)
-		t.Cleanup(cancel) // We only care about the timeout.
+		t.Cleanup(cancel)
 	}
 
 	aimd, source, dest := setupLoadTest(t, ctx, &wg)
@@ -58,7 +63,8 @@ func TestSteady(gt *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if !relayMessage(t, source, dest) {
+			if err := relayMessage(t, source, dest); err != nil {
+				cancelIfInsufficientBudget(err, cancel)
 				aimd.Adjust(false)
 				return
 			}
@@ -79,22 +85,14 @@ func TestBurst(gt *testing.T) {
 	ctx, cancel := context.WithCancel(t.Ctx())
 	defer cancel()
 	aimd, source, dest := setupLoadTest(t, ctx, &wg)
-	targetBaseFee := eth.OneGWei.ToBig()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-aimd.Ready():
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				success := relayMessage(t, source, dest)
-				if dest.Unsafe().BaseFee().Cmp(targetBaseFee) >= 0 {
-					cancel() // End the test when we've met or exceeded the target base fee.
-				}
-				aimd.Adjust(success)
-			}()
-		}
+	for range aimd.Ready() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := relayMessage(t, source, dest)
+			cancelIfInsufficientBudget(err, cancel)
+			aimd.Adjust(err == nil)
+		}()
 	}
 }
 
@@ -124,21 +122,29 @@ func setupLoadTest(t devtest.T, ctx context.Context, wg *sync.WaitGroup) (*AIMD,
 	}()
 
 	// Chains.
+	budget := eth.TenThousandEther
+	if budgetStr, exists := os.LookupEnv("NAT_INTEROP_LOADTEST_BUDGET"); exists {
+		amount, err := strconv.ParseUint(budgetStr, 10, 64)
+		t.Require().NoError(err)
+		budget = eth.Ether(amount)
+	}
 	l2ELA := sys.L2ChainA.PublicRPC()
 	l2ELB := sys.L2ChainB.PublicRPC()
 	funderA := dsl.NewFunder(sys.Wallet, sys.FaucetA, l2ELA)
-	const numEOAs = 300
+	budgetA := NewBudget(budget)
 	source := &L2{
 		Config:       sys.L2ChainA.Escape().ChainConfig(),
 		RollupConfig: sys.L2ChainA.Escape().RollupConfig(),
-		eoas:         NewEOAPool(funderA, numEOAs, eth.MillionEther),
+		budget:       budgetA,
+		eoas:         NewEOAPool(funderA, budget),
 		el:           l2ELA,
-		eventLogger:  funderA.NewFundedEOA(eth.OneEther).DeployEventLogger(),
+		eventLogger:  funderA.NewFundedEOA(eth.OneEther).DeployEventLogger(budgetA.Plan()),
 	}
 	dest := &L2{
 		Config:       sys.L2ChainB.Escape().ChainConfig(),
 		RollupConfig: sys.L2ChainB.Escape().RollupConfig(),
-		eoas:         NewEOAPool(dsl.NewFunder(sys.Wallet, sys.FaucetB, l2ELB), numEOAs, eth.MillionEther),
+		budget:       NewBudget(budget),
+		eoas:         NewEOAPool(dsl.NewFunder(sys.Wallet, sys.FaucetB, l2ELB), budget),
 		el:           l2ELB,
 	}
 	wg.Add(1)
@@ -163,23 +169,30 @@ func setupLoadTest(t devtest.T, ctx context.Context, wg *sync.WaitGroup) (*AIMD,
 	return aimd, source, dest
 }
 
-func relayMessage(t devtest.T, source, dest *L2) bool {
+func relayMessage(t devtest.T, source, dest *L2) error {
 	rng := rand.New(rand.NewSource(1234))
 	inFlightMessages.Inc()
 	start := time.Now()
-	initMsg := source.SendInitiatingMsg(t, rng)
-	if initMsg == nil {
+	initMsg, err := source.SendInitiatingMsg(t, rng)
+	if err != nil {
 		messageStatusCount.WithLabelValues("init_failed").Inc()
 		inFlightMessages.Dec()
-		return false
+		return err
 	}
-	success := dest.SendExecutingMsg(t, *initMsg)
-	if success {
+	err = dest.SendExecutingMsg(t, initMsg)
+	if err == nil {
 		messageLatency.WithLabelValues("e2e").Observe(time.Since(start).Seconds())
 		messageStatusCount.WithLabelValues("success").Inc()
 	} else {
 		messageStatusCount.WithLabelValues("exec_failed").Inc()
 	}
 	inFlightMessages.Dec()
-	return success
+	return err
+}
+
+func cancelIfInsufficientBudget(err error, cancel context.CancelFunc) {
+	var x *InsufficientBudgetError
+	if errors.As(err, &x) {
+		cancel()
+	}
 }

--- a/op-acceptance-tests/tests/interop/loadtest/l2.go
+++ b/op-acceptance-tests/tests/interop/loadtest/l2.go
@@ -24,6 +24,7 @@ type L2 struct {
 	Config       *params.ChainConfig
 	RollupConfig *rollup.Config
 
+	budget      *Budget
 	eoas        *EOAPool
 	el          *dsl.L2ELNode
 	eventLogger common.Address
@@ -51,14 +52,14 @@ func (l2 *L2) Unsafe() eth.BlockInfo {
 	return l2.unsafe.Load().(eth.BlockInfo)
 }
 
-func (l2 *L2) SendInitiatingMsg(t devtest.T, rng *rand.Rand) *types.Message {
+func (l2 *L2) SendInitiatingMsg(t devtest.T, rng *rand.Rand) (*types.Message, error) {
 	start := time.Now()
 	eoa := l2.eoas.Get()
-	tx := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](eoa.Inner.Plan(), txplan.WithStaticNonce(uint64(eoa.Nonce.Add(1))-1))
+	tx := txintent.NewIntent[txintent.Call, *txintent.InteropOutput](eoa.Inner.Plan(), txplan.WithStaticNonce(uint64(eoa.Nonce.Add(1))-1), l2.budget.Plan())
 	tx.Content.Set(interop.RandomInitTrigger(rng, l2.eventLogger, rng.Intn(2), rng.Intn(5)))
 	if _, err := tx.PlannedTx.Included.Eval(t.Ctx()); err != nil {
 		eoa.Nonce.Add(-1)
-		return nil
+		return nil, err
 	}
 	_, err := tx.PlannedTx.Success.Eval(t.Ctx())
 	t.Require().NoError(err)
@@ -66,16 +67,16 @@ func (l2 *L2) SendInitiatingMsg(t devtest.T, rng *rand.Rand) *types.Message {
 	out, err := tx.Result.Eval(t.Ctx())
 	t.Require().NoError(err)
 	t.Require().Len(out.Entries, 1)
-	return &out.Entries[0]
+	return &out.Entries[0], nil
 }
 
-func (l2 *L2) SendExecutingMsg(t devtest.T, initMsg types.Message) bool {
+func (l2 *L2) SendExecutingMsg(t devtest.T, initMsg *types.Message) error {
 	start := time.Now()
 	eoa := l2.eoas.Get()
-	tx := txintent.NewIntent[*txintent.ExecTrigger, txintent.Result](eoa.Inner.Plan(), txplan.WithStaticNonce(uint64(eoa.Nonce.Add(1))-1), txplan.WithGasRatio(2))
+	tx := txintent.NewIntent[*txintent.ExecTrigger, txintent.Result](eoa.Inner.Plan(), txplan.WithStaticNonce(uint64(eoa.Nonce.Add(1))-1), l2.budget.Plan())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: constants.CrossL2Inbox,
-		Msg:      initMsg,
+		Msg:      *initMsg,
 	})
 	// The tx is invalid until we know it will be included at a higher timestamp than any of the initiating messages, modulo reorgs.
 	// Wait to plan the relay tx against a target block until the timestamp elapses.
@@ -89,10 +90,10 @@ func (l2 *L2) SendExecutingMsg(t devtest.T, initMsg types.Message) bool {
 	})
 	if _, err := tx.PlannedTx.Included.Eval(t.Ctx()); err != nil {
 		eoa.Nonce.Add(-1)
-		return false
+		return err
 	}
 	_, err := tx.PlannedTx.Success.Eval(t.Ctx())
 	t.Require().NoError(err)
 	messageLatency.WithLabelValues("exec").Observe(time.Since(start).Seconds())
-	return true
+	return nil
 }

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -131,8 +131,8 @@ func (u *EOA) VerifyBalanceExact(v eth.ETH) {
 	u.t.Require().Equal(v, actual, "must have expected balance")
 }
 
-func (u *EOA) DeployEventLogger() common.Address {
-	tx := txplan.NewPlannedTx(u.Plan(), txplan.WithData(common.FromHex(bindings.EventloggerBin)))
+func (u *EOA) DeployEventLogger(opts ...txplan.Option) common.Address {
+	tx := txplan.NewPlannedTx(u.Plan(), txplan.WithData(common.FromHex(bindings.EventloggerBin)), txplan.Combine(opts...))
 	res, err := tx.Included.Eval(u.ctx)
 	u.t.Require().NoError(err, "failed to deploy EventLogger")
 	eventLoggerAddress := res.ContractAddress

--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -37,6 +37,7 @@ var (
 	MaxU64Wei            = ETH(uint256.Int{0: ^uint64(0), 1: 0, 2: 0, 3: 0})
 	BillionEther         = Ether(1000_000_000)
 	MillionEther         = Ether(1000_000)
+	TenThousandEther     = Ether(10_000)
 	ThousandEther        = Ether(1000)
 	HundredEther         = Ether(100)
 	TenEther             = Ether(10)


### PR DESCRIPTION
See commit message. Depends on #16267 