### PR TITLE
op-supervisor: Prevent ErrOutOfScope to Bubble Up Across Chains

### DIFF
--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -25,11 +25,10 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, h
 			if errors.Is(err, types.ErrFuture) {
 				// If not in cross-safe scope, then check if it's the candidate cross-safe block.
 				candidate, err := d.CandidateCrossSafe(hazardChainID)
-				if err != nil {
-					// ErrOutOfScope should be translated to an ErrFuture, since the dependency being out of scope does not warrant a Scope Bump of this chain.
-					if errors.Is(err, types.ErrOutOfScope) {
-						return fmt.Errorf("hazard dependency %s (chain %s) is out of scope: %w", hazardBlock, hazardChainID, types.ErrFuture)
-					}
+				// ErrOutOfScope should be translated to an ErrFuture, since the dependency being out of scope does not warrant a Scope Bump of this chain.
+				if errors.Is(err, types.ErrOutOfScope) {
+					return fmt.Errorf("hazard dependency %s (chain %s) is out of scope: %w", hazardBlock, hazardChainID, types.ErrFuture)
+				} else if err != nil {
 					return fmt.Errorf("failed to determine cross-safe candidate block of hazard dependency %s (chain %s): %w", hazardBlock, hazardChainID, err)
 				}
 				if candidate.Derived.Number == hazardBlock.Number && candidate.Derived.ID() != hazardBlock.ID() {

--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -26,6 +26,10 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, h
 				// If not in cross-safe scope, then check if it's the candidate cross-safe block.
 				candidate, err := d.CandidateCrossSafe(hazardChainID)
 				if err != nil {
+					// ErrOutOfScope should be translated to an ErrFuture, since the dependency being out of scope does not warrant a Scope Bump of this chain.
+					if errors.Is(err, types.ErrOutOfScope) {
+						return fmt.Errorf("hazard dependency %s (chain %s) is out of scope: %w", hazardBlock, hazardChainID, types.ErrFuture)
+					}
 					return fmt.Errorf("failed to determine cross-safe candidate block of hazard dependency %s (chain %s): %w", hazardBlock, hazardChainID, err)
 				}
 				if candidate.Derived.Number == hazardBlock.Number && candidate.Derived.ID() != hazardBlock.ID() {


### PR DESCRIPTION
Based on a finding located here:

https://github.com/ethereum-optimism/optimism/issues/16016

## Problem
When checking doing `HazardSafeFontierChecks`, each dependency checks `CandidateCrossSafe`, which has the potential to return `ErrOutOfScope`.

If `ErrOutOfScope` is returned, it is bubbled up to the canddiate-scoping of the *original* chain, creating an inappropriate scope bump.

## Solution

The original fix, [HERE](https://github.com/ethereum-optimism/optimism/pull/16281), attempted to decide if there would be sufficient data to proceed prior to doing Hazard Checks.

However, as I continued to think about all the edge cases to determine "Sufficient Data", I decided that it was overcomplicated, and that the existing logic is already mostly right.

In this solution, I simply catch `ErrOutOfScope` when it comes back and convert it to an `ErrFuture`. The reasoning is thus:

- The logic being modified would *prefer* to use an `initSource` from `CrossDerivedToSource`, which would be if the hazard is already Cross-Safe. This is like an optimistic version of the "Sufficient Data" check.
- If the hazard **Is Not** already Cross-Safe, then it checks if it is at least the *Candidiate Cross Safe*. This is what I had trouble encoding into the Sufficient Data Check.
- If the Hazard *is not* Cross Safe, *nor* is it the upcoming Candidate, then we cannot proceed, as the Hazard is not well known enough to be checked.
- Therefore, an `ErrFuture` is a good signal that we cannot yet use the Hazard.


## Testing
Existing CI, no new unit tests.