### PR TITLE
feat(op-node): Default to modern sync options

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -110,7 +110,7 @@ var (
 		Usage:   fmt.Sprintf("Blockchain sync mode (options: %s)", openum.EnumString(sync.ModeStrings)),
 		EnvVars: prefixEnvVars("SYNCMODE"),
 		Value: func() *sync.Mode {
-			out := sync.CLSync
+			out := sync.ELSync
 			return &out
 		}(),
 		Category: RollupCategory,

--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -388,9 +388,10 @@ func P2PFlags(envPrefix string) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:     SyncReqRespName,
-			Usage:    "Enables P2P req-resp alternative sync method, on both server and client side.",
-			Value:    true,
+			Usage:    "[DEPRECATED] Enables P2P req-resp alternative sync method, on both server and client side.",
+			Value:    false,
 			Required: false,
+			Hidden:   true,
 			EnvVars:  p2pEnv(envPrefix, "SYNC_REQ_RESP"),
 			Category: P2PCategory,
 		},


### PR DESCRIPTION
## Overview

Defaults the `op-node` to use EL sync and not use req-resp sync. This is a minor step on the road to the full deprecation + removal of CL sync and req-resp sync, as proposed by https://github.com/ethereum-optimism/design-docs/pull/189.

Note that this change is a breaking change to the CLI API, and the docs need to be updated (cc @sbvegan):
1. https://docs.optimism.io/operators/node-operators/management/snap-sync
2. https://docs.optimism.io/operators/node-operators/configuration/consensus-config

Also, legacy versions of the `op-node` **will downscore** peers without the req-resp sync protocol active. In the release notes that include this change, this should be mentioned, and upgrading or turning off req-resp sync should be heavily encouraged.