### PR TITLE
refactor: remove DerivationOriginUpdate from node events

### DIFF
--- a/op-node/rollup/interop/managed/system.go
+++ b/op-node/rollup/interop/managed/system.go
@@ -151,7 +151,6 @@ func (m *ManagedMode) OnEvent(ev event.Event) bool {
 				Source:  x.Origin,
 				Derived: x.LastL2.BlockRef(),
 			},
-			DerivationOriginUpdate: &x.Origin,
 		})
 	case derive.ExhaustedL1Event:
 		m.log.Info("Exhausted L1 data", "derivedFrom", x.L1Ref, "derived", x.LastL2)

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -15,7 +14,6 @@ import (
 
 var (
 	ErrStatusTrackerNotReady = errors.New("supervisor status tracker not ready")
-	ErrMinSyncedL1Mismatch   = errors.New("min synced L1 mismatch")
 )
 
 type StatusTracker struct {
@@ -24,7 +22,6 @@ type StatusTracker struct {
 }
 
 type NodeSyncStatus struct {
-	CurrentL1   eth.L1BlockRef
 	LocalUnsafe eth.BlockRef
 	LocalSafe   types.BlockSeal
 	CrossUnsafe types.BlockSeal
@@ -55,9 +52,6 @@ func (su *StatusTracker) OnEvent(ev event.Event) bool {
 		return v
 	}
 	switch x := ev.(type) {
-	case superevents.LocalDerivedOriginUpdateEvent:
-		status := loadStatusRef(x.ChainID)
-		status.CurrentL1 = x.Origin
 	case superevents.LocalUnsafeUpdateEvent:
 		status := loadStatusRef(x.ChainID)
 		status.LocalUnsafe = x.NewLocalUnsafe
@@ -106,23 +100,8 @@ func (su *StatusTracker) SyncStatus() (eth.SupervisorSyncStatus, error) {
 	firstChain := true
 	var supervisorStatus eth.SupervisorSyncStatus
 	supervisorStatus.Chains = make(map[eth.ChainID]*eth.SupervisorChainSyncStatus)
-	// to collect the min synced L1, we need to iterate over all nodes
-	// and compare the current L1 block they each reported.
-	for chainID, nodeStatus := range su.statuses {
-		// if the min synced L1 is not set, or the node's current L1 is lower than the min synced L1, set it
-		if supervisorStatus.MinSyncedL1 == (eth.L1BlockRef{}) || supervisorStatus.MinSyncedL1.Number > nodeStatus.CurrentL1.Number {
-			// even after this update, MinSyncedL1 may still be empty when CurrentL1 was never updated
-			supervisorStatus.MinSyncedL1 = nodeStatus.CurrentL1
-		}
-		// if the height is equal, we need to compare the hash
-		if supervisorStatus.MinSyncedL1.Number == nodeStatus.CurrentL1.Number &&
-			supervisorStatus.MinSyncedL1.Hash != nodeStatus.CurrentL1.Hash {
-			// if the hashes are not equal, return an empty status
-			return eth.SupervisorSyncStatus{}, fmt.Errorf("%w: %v != %v", ErrMinSyncedL1Mismatch, supervisorStatus.MinSyncedL1.Hash, nodeStatus.CurrentL1.Hash)
-		}
-		// if the node's current L1 is higher than the min synced L1, we can skip it,
-		// because we already know a different node isn't synced to it yet
 
+	for chainID, nodeStatus := range su.statuses {
 		if firstChain || supervisorStatus.SafeTimestamp >= nodeStatus.CrossSafe.Timestamp {
 			supervisorStatus.SafeTimestamp = nodeStatus.CrossSafe.Timestamp
 		}

--- a/op-supervisor/supervisor/backend/status/status_test.go
+++ b/op-supervisor/supervisor/backend/status/status_test.go
@@ -17,25 +17,6 @@ func TestInitialSyncStatus(t *testing.T) {
 	require.Error(t, ErrStatusTrackerNotReady, err)
 }
 
-func TestUpdateMinSyncedL1(t *testing.T) {
-	chain1 := eth.ChainIDFromUInt64(1)
-	chain2 := eth.ChainIDFromUInt64(2)
-	chains := []eth.ChainID{chain1, chain2}
-	tracker := NewStatusTracker(chains)
-	minL1 := eth.BlockRef{Number: 204, Hash: common.Hash{0xaa}}
-	tracker.OnEvent(superevents.LocalDerivedOriginUpdateEvent{
-		ChainID: chain1,
-		Origin:  minL1,
-	})
-	tracker.OnEvent(superevents.LocalDerivedOriginUpdateEvent{
-		ChainID: chain2,
-		Origin:  eth.BlockRef{Number: 228, Hash: common.Hash{0xbb}},
-	})
-	status, err := tracker.SyncStatus()
-	require.NoError(t, err)
-	require.EqualValues(t, minL1, status.MinSyncedL1)
-}
-
 func TestUpdateLocalUnsafe(t *testing.T) {
 	chain1 := eth.ChainIDFromUInt64(1)
 	chain2 := eth.ChainIDFromUInt64(2)

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -110,15 +110,6 @@ func (ev LocalDerivedEvent) String() string {
 	return "local-derived"
 }
 
-type LocalDerivedOriginUpdateEvent struct {
-	ChainID eth.ChainID
-	Origin  eth.BlockRef
-}
-
-func (ev LocalDerivedOriginUpdateEvent) String() string {
-	return "local-derived-origin-update"
-}
-
 type ResetPreInteropRequestEvent struct {
 	ChainID eth.ChainID
 }

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -209,9 +209,8 @@ func sampleDepSet(t *testing.T) depset.DependencySet {
 }
 
 type eventMonitor struct {
-	localDerived             int
-	receivedLocalUnsafe      int
-	localDerivedOriginUpdate int
+	localDerived        int
+	receivedLocalUnsafe int
 }
 
 func (m *eventMonitor) OnEvent(ev event.Event) bool {
@@ -220,8 +219,6 @@ func (m *eventMonitor) OnEvent(ev event.Event) bool {
 		m.localDerived += 1
 	case superevents.LocalUnsafeReceivedEvent:
 		m.receivedLocalUnsafe += 1
-	case superevents.LocalDerivedOriginUpdateEvent:
-		m.localDerivedOriginUpdate += 1
 	default:
 		return false
 	}

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -280,9 +280,6 @@ func (m *ManagedNode) onNodeEvent(ev *types.ManagedEvent) {
 	if ev.ReplaceBlock != nil {
 		m.onReplaceBlock(*ev.ReplaceBlock)
 	}
-	if ev.DerivationOriginUpdate != nil {
-		m.onDerivationOriginUpdate(*ev.DerivationOriginUpdate)
-	}
 }
 
 // onResetEvent handles a reset event from the node
@@ -368,14 +365,6 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	})
 	m.lastNodeLocalSafe = pair.Derived.ID()
 	m.resetIfInconsistent()
-}
-
-func (m *ManagedNode) onDerivationOriginUpdate(origin eth.BlockRef) {
-	m.log.Info("Node derived new origin", "origin", origin)
-	m.emitter.Emit(superevents.LocalDerivedOriginUpdateEvent{
-		ChainID: m.chainID,
-		Origin:  origin,
-	})
 }
 
 func (m *ManagedNode) onExhaustL1Event(completed types.DerivedBlockRefPair) {

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -74,8 +74,6 @@ func TestEventResponse(t *testing.T) {
 			DerivationUpdate: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
 		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
 			ExhaustL1: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
-		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
-			DerivationOriginUpdate: &eth.BlockRef{Number: 1}})
 
 		require.NoError(t, ex.Drain())
 
@@ -84,7 +82,6 @@ func TestEventResponse(t *testing.T) {
 			finalized >= 1 &&
 			mon.receivedLocalUnsafe >= 1 &&
 			mon.localDerived >= 1 &&
-			nodeExhausted >= 1 &&
-			mon.localDerivedOriginUpdate >= 1
+			nodeExhausted >= 1
 	}, 4*time.Second, 250*time.Millisecond)
 }

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -488,12 +488,11 @@ type BlockReplacement struct {
 // ManagedEvent is an event sent by the managed node to the supervisor,
 // to share an update. One of the fields will be non-null; different kinds of updates may be sent.
 type ManagedEvent struct {
-	Reset                  *string              `json:"reset,omitempty"`
-	UnsafeBlock            *eth.BlockRef        `json:"unsafeBlock,omitempty"`
-	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
-	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
-	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
-	DerivationOriginUpdate *eth.BlockRef        `json:"derivationOriginUpdate,omitempty"`
+	Reset            *string              `json:"reset,omitempty"`
+	UnsafeBlock      *eth.BlockRef        `json:"unsafeBlock,omitempty"`
+	DerivationUpdate *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
+	ExhaustL1        *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
+	ReplaceBlock     *BlockReplacement    `json:"replaceBlock,omitempty"`
 }
 
 // MessageChecksum represents a message checksum, as used for access-list checks.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes the unused DerivationOriginUpdate field from ManagedEvent structure and all associated handling logic across op-supervisor and op-node components.

- Removed DerivationOriginUpdate field from ManagedEvent struct
- Removed onDerivationOriginUpdate handler and related event processing
- Removed LocalDerivedOriginUpdateEvent struct and its usage
- Simplified status tracking by removing CurrentL1 field and MinSyncedL1 logic
- Updated tests to reflect the removal of deprecated functionality

**Tests**

All existing tests have been updated to remove references to the deleted functionality. The test suite passes completely, confirming that the removal does not break any existing behavior. 

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

- Fixes #16275
