### PR TITLE
op-alt-da: output src IP in logs

### DIFF
--- a/op-alt-da/daserver.go
+++ b/op-alt-da/daserver.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -91,7 +92,7 @@ func (d *DAServer) Start() error {
 }
 
 func (d *DAServer) HandleGet(w http.ResponseWriter, r *http.Request) {
-	d.log.Debug("GET", "url", r.URL)
+	d.log.Debug("GET", "url", r.URL, "src", getSrcIP(r))
 
 	route := path.Dir(r.URL.Path)
 	if route != "/get" {
@@ -126,7 +127,7 @@ func (d *DAServer) HandleGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *DAServer) HandlePut(w http.ResponseWriter, r *http.Request) {
-	d.log.Info("PUT", "url", r.URL)
+	d.log.Info("PUT", "url", r.URL, "src", getSrcIP(r))
 
 	route := path.Dir(r.URL.Path)
 	if route != "/put" && r.URL.Path != "/put" {
@@ -197,4 +198,19 @@ func (b *DAServer) Stop() error {
 	defer cancel()
 	_ = b.httpServer.Shutdown(ctx)
 	return nil
+}
+
+func getSrcIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ips := strings.Split(xff, ",")
+
+		return strings.TrimSpace(ips[0])
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+
+	return host
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Print the source IP in `op-alt-da` logs for both `GET` and `PUT` queries.

Handles `X-Forwarded-For` for cases when the da-server is behind a proxy (like a Kubernetes Ingress).

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
