### PR TITLE
Minor fixes for Cannon automated tests

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -39,10 +39,13 @@ cannon: cannon-embeds
 clean:
 	rm -rf bin multicannon/embeds/cannon*
 
-elf: elf-go-123
+elf: elf-go-123 elf-go-124
 
 elf-go-123:
 	make -C ./testdata/go-1-23 elf
+
+elf-go-124:
+	make -C ./testdata/go-1-24 elf
 
 sanitize-program:
 	mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM > ./bin/dump.txt


### PR DESCRIPTION
**Description**
These changes provide a small fix for the Cannon makefile, following changes in PR https://github.com/ethereum-optimism/optimism/pull/15737

**Tests**
Running `make test` from the `cannon` folder with a fresh checkout.

**Additional context**

The `cannon/Makefile` has been aligned to `cannon/testdata/Makefile` with the inclusion of the Go 1.24 testdata ELF targets.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
