### PR TITLE
op-batcher: more robust detection of not-ready `syncStatus`

### DIFF
--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -71,8 +71,8 @@ func computeSyncActions[T channelStatuser](
 	}
 
 	// PART 1: Initial checks on the sync status
-	if newSyncStatus.HeadL1 == (eth.L1BlockRef{}) {
-		m.Warn("empty sync status")
+	if safeL2 == (eth.L2BlockRef{}) {
+		m.Warn("empty safeL2 L2BlockRef in sync status")
 		return syncActions{}, true
 	}
 

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -43,7 +43,7 @@ func (s syncActions) TerminalString() string {
 		"SyncActions{blocksToPrune: %d, channelsToPrune: %d, clearState: %v, blocksToLoad: %v}", s.blocksToPrune, s.channelsToPrune, cs, btl)
 }
 
-func isZero[T eth.L2BlockRef | eth.L1BlockRef](x T) bool {
+func isZero[T comparable](x T) bool {
 	var y T
 	return (x == y)
 }

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -43,6 +43,11 @@ func (s syncActions) TerminalString() string {
 		"SyncActions{blocksToPrune: %d, channelsToPrune: %d, clearState: %v, blocksToLoad: %v}", s.blocksToPrune, s.channelsToPrune, cs, btl)
 }
 
+func isZero[T eth.L2BlockRef | eth.L1BlockRef](x T) bool {
+	var y T
+	return (x == y)
+}
+
 // computeSyncActions determines the actions that should be taken based on the inputs provided. The inputs are the current
 // state of the batcher (blocks and channels), the new sync status, and the previous current L1 block. The actions are returned
 // in a struct specifying the number of blocks to prune, the number of channels to prune, whether to wait for node sync, the block
@@ -70,9 +75,11 @@ func computeSyncActions[T channelStatuser](
 		safeL2 = newSyncStatus.LocalSafeL2
 	}
 
-	// PART 1: Initial checks on the sync status
-	if safeL2 == (eth.L2BlockRef{}) || newSyncStatus.UnsafeL2 == (eth.L2BlockRef{}) {
-		m.Warn("empty L2BlockRef in sync status")
+	// PART 1: Initial checks on the sync status (on fields which should never be empty)
+	if isZero(safeL2) ||
+		isZero(newSyncStatus.UnsafeL2) ||
+		isZero(newSyncStatus.HeadL1) {
+		m.Warn("empty BlockRef in sync status")
 		return syncActions{}, true
 	}
 

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -71,8 +71,8 @@ func computeSyncActions[T channelStatuser](
 	}
 
 	// PART 1: Initial checks on the sync status
-	if safeL2 == (eth.L2BlockRef{}) {
-		m.Warn("empty safeL2 L2BlockRef in sync status")
+	if safeL2 == (eth.L2BlockRef{}) || newSyncStatus.UnsafeL2 == (eth.L2BlockRef{}) {
+		m.Warn("empty L2BlockRef in sync status")
 		return syncActions{}, true
 	}
 

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -86,7 +86,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			newSyncStatus: eth.SyncStatus{
 				HeadL1:    eth.BlockRef{Number: 2},
 				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
+				SafeL2:    eth.L2BlockRef{Number: 100},
 				UnsafeL2:  eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1:        eth.BlockRef{Number: 2},

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -78,7 +78,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			newSyncStatus:        eth.SyncStatus{},
 			expected:             syncActions{},
 			expectedSeqOutOfSync: true,
-			expectedLogs:         []string{"empty safeL2 L2BlockRef in sync status"},
+			expectedLogs:         []string{"empty L2BlockRef in sync status"},
 		},
 		{name: "current l1 reversed",
 			// This can happen when the sequencer restarts or is switched

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -78,7 +78,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			newSyncStatus:        eth.SyncStatus{},
 			expected:             syncActions{},
 			expectedSeqOutOfSync: true,
-			expectedLogs:         []string{"empty L2BlockRef in sync status"},
+			expectedLogs:         []string{"empty BlockRef in sync status"},
 		},
 		{name: "current l1 reversed",
 			// This can happen when the sequencer restarts or is switched

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -78,7 +78,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			newSyncStatus:        eth.SyncStatus{},
 			expected:             syncActions{},
 			expectedSeqOutOfSync: true,
-			expectedLogs:         []string{"empty sync status"},
+			expectedLogs:         []string{"empty safeL2 L2BlockRef in sync status"},
 		},
 		{name: "current l1 reversed",
 			// This can happen when the sequencer restarts or is switched
@@ -86,6 +86,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			newSyncStatus: eth.SyncStatus{
 				HeadL1:    eth.BlockRef{Number: 2},
 				CurrentL1: eth.BlockRef{Number: 1},
+				SafeL2:    eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
 			},
 			prevCurrentL1:        eth.BlockRef{Number: 2},
 			expected:             syncActions{},

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -87,6 +87,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				HeadL1:    eth.BlockRef{Number: 2},
 				CurrentL1: eth.BlockRef{Number: 1},
 				SafeL2:    eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:  eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1:        eth.BlockRef{Number: 2},
 			expected:             syncActions{},


### PR DESCRIPTION
This is a more robust way of detecting an invalid or "not yet ready" sync status. A valid status may have a `0` L2 safe block number, but the block hash would be the genesis block and therefore nonzero. 

This should also allow us to safely run the batcher with `--prefer-local-safe-l2=true` even before we have fully resolved #14576 