### PR TITLE
fix(op-faucet): add required config arg to test helper function

### DIFF
--- a/op-faucet/cmd/main_test.go
+++ b/op-faucet/cmd/main_test.go
@@ -78,7 +78,7 @@ func toArgList(req map[string]string) []string {
 
 func requiredArgs() map[string]string {
 	args := map[string]string{
-		//"--example": "todo",
+		"--config": "testdata/empty.yaml",
 	}
 	return args
 }


### PR DESCRIPTION
Fixes the `requiredArgs()` function in op-faucet tests by adding the `--config` flag with `testdata/empty.yaml` value.