### PR TITLE
fix op-validator addresses

### DIFF
--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -22,7 +22,7 @@ var addresses = map[uint64]map[string]common.Address{
 		// Bootstrapped on 04/16/2025 using OP Deployer.
 		VersionV300: common.HexToAddress("0xf989Df70FB46c581ba6157Ab335c0833bA60e1f0"),
 		// Bootstrapped on 06/03/2025 using OP Deployer.
-		VersionV400: common.HexToAddress("0x3246b056A3C9B14AA25b75ee133DC3747476DBc5"),
+		VersionV400: common.HexToAddress("0x3dfc5e44043DC5998928E0b8280136b7352d3F70"),
 	},
 	11155111: {
 		// Bootstrapped on 03/02/2025 using OP Deployer.
@@ -32,7 +32,7 @@ var addresses = map[uint64]map[string]common.Address{
 		// Bootstrapped on 04/03/2025 using OP Deployer.
 		VersionV300: common.HexToAddress("0x2d56022cb84ce6b961c3b4288ca36386bcd9024c"),
 		// Bootstrapped on 06/03/2025 using OP Deployer.
-		VersionV400: common.HexToAddress("0x3246b056A3C9B14AA25b75ee133DC3747476DBc5"),
+		VersionV400: common.HexToAddress("0xA8a1529547306FEC7A32a001705160f2110451aE"),
 	},
 }
 


### PR DESCRIPTION
**Description**

The current addresses in op-deployer were incorrectly deploy with `address(0)` for constructor args, this is why they have the same address on both sepolia and mainnet. 