### PR TITLE
op-supervisor: Hazard Blocks beyond Candidate Cross-Safe are Invalid

### DIFF
--- a/op-supervisor/supervisor/backend/cross/safe_frontier.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier.go
@@ -28,6 +28,11 @@ func HazardSafeFrontierChecks(d SafeFrontierCheckDeps, inL1Source eth.BlockID, h
 				if err != nil {
 					return fmt.Errorf("failed to determine cross-safe candidate block of hazard dependency %s (chain %s): %w", hazardBlock, hazardChainID, err)
 				}
+				// if the hazard block is beyond the candidate, then we don't have sufficient information to proceed
+				if hazardBlock.Number > candidate.Derived.Number {
+					return fmt.Errorf("hazard dependency %s (chain %s) is beyond its candidate cross-safe block %s: %w",
+						hazardBlock, hazardChainID, candidate.Derived, types.ErrFuture)
+				}
 				if candidate.Derived.Number == hazardBlock.Number && candidate.Derived.ID() != hazardBlock.ID() {
 					return fmt.Errorf("expected block %s (chain %s) does not match candidate local-safe block %s: %w",
 						hazardBlock, hazardChainID, candidate.Derived, types.ErrConflict)

--- a/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_frontier_test.go
@@ -126,6 +126,25 @@ func TestHazardSafeFrontierChecks(t *testing.T) {
 		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
 		require.ErrorContains(t, err, "some error")
 	})
+	t.Run("Hazards Chains Candidate is Beyond Hazard", func(t *testing.T) {
+		sfcd := &mockSafeFrontierCheckDeps{}
+		sfcd.crossSourceFn = func() (types.BlockSeal, error) {
+			return types.BlockSeal{}, types.ErrFuture
+		}
+		sfcd.candidateCrossSafeFn = func() (candidate types.DerivedBlockRefPair, err error) {
+			return types.DerivedBlockRefPair{
+				Source:  eth.BlockRef{Number: 8},
+				Derived: eth.BlockRef{Number: 2},
+			}, nil
+		}
+		l1Source := eth.BlockID{Number: 8}
+		hazards := map[eth.ChainID]types.BlockSeal{eth.ChainIDFromUInt64(123): {Number: 99, Hash: common.BytesToHash([]byte{0x02})}}
+		// when the hazard chain might need to use the candidate block,
+		// but the candidate block is beyond the hazard, already
+		// the hazard block should be rejected, causing an error
+		err := HazardSafeFrontierChecks(sfcd, l1Source, NewHazardSetFromEntries(hazards))
+		require.Error(t, err)
+	})
 }
 
 type mockSafeFrontierCheckDeps struct {


### PR DESCRIPTION
A failing test to demonstrate a current issue within cross promotion, and a logic fix to `HazardSafeFrontierChecks`.

In `HazardSafeFrontierChecks`, every hazard is checked, such that either:
- The Hazard Block is already Cross Safe for that chain <- this is the happiest path
- The Hazard Block would be the Candidate Cross Safe <- this is the edge of the happy path

However, once we obtain the Candidate Cross Safe, we don't do sufficient checking to confirm that the Hazard block is within it. Rather, we obtain the candidate block, and:
- if it is inconsistent with the Hazard (same number, different hash) we throw an `ErrConflict`
- if the candidate's source is higher than the current scope, we throw an `ErrOutOfScope`

else, we return continue the loop and eventually return `nil`, indicating these Hazards are frontier-safe.

HOWEVER, this is not certainly the case, as it lacks one check:
- if the Hazard block is *beyond* the candidate, then we know that we do not have sufficient data to process these Hazards, as the hazard block may not be known at all, and so we should return `ErrFuture`