### PR TITLE
feat(txmgr / batcher): Rebroadcast transactions without bumping fees

### DIFF
--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -66,6 +66,7 @@ func NewKeyedBroadcaster(cfg KeyedBroadcasterOpts) (*KeyedBroadcaster, error) {
 		panic(err)
 	}
 
+	mgrCfg.RebroadcastInterval.Store(int64(12 * time.Second))
 	mgrCfg.ResubmissionTimeout.Store(int64(48 * time.Second))
 	mgrCfg.FeeLimitMultiplier.Store(5)
 	mgrCfg.FeeLimitThreshold.Store(big.NewInt(100))

--- a/op-e2e/e2eutils/setuputils/utils.go
+++ b/op-e2e/e2eutils/setuputils/utils.go
@@ -24,6 +24,7 @@ func NewTxMgrConfig(l1Addr endpoint.RPC, privKey *ecdsa.PrivateKey) txmgr.CLICon
 		NumConfirmations:          1,
 		SafeAbortNonceTooLowCount: 3,
 		FeeLimitMultiplier:        5,
+		RebroadcastInterval:       2 * time.Second,
 		ResubmissionTimeout:       3 * time.Second,
 		ReceiptQueryInterval:      50 * time.Millisecond,
 		NetworkTimeout:            2 * time.Second,

--- a/op-faucet/faucet/backend/config/static.go
+++ b/op-faucet/faucet/backend/config/static.go
@@ -20,6 +20,7 @@ var DefaultFaucetTxManagerValues = txmgr.DefaultFlagValues{
 	FeeLimitThresholdGwei:     100.0,
 	MinTipCapGwei:             1.0,
 	MinBaseFeeGwei:            1.0,
+	RebroadcastInterval:       12 * time.Second,
 	ResubmissionTimeout:       24 * time.Second,
 	NetworkTimeout:            10 * time.Second,
 	TxSendTimeout:             2 * time.Minute,

--- a/op-faucet/faucet/backend/config/static.go
+++ b/op-faucet/faucet/backend/config/static.go
@@ -20,7 +20,6 @@ var DefaultFaucetTxManagerValues = txmgr.DefaultFlagValues{
 	FeeLimitThresholdGwei:     100.0,
 	MinTipCapGwei:             1.0,
 	MinBaseFeeGwei:            1.0,
-	RebroadcastInterval:       12 * time.Second,
 	ResubmissionTimeout:       24 * time.Second,
 	NetworkTimeout:            10 * time.Second,
 	TxSendTimeout:             2 * time.Minute,

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -35,6 +35,7 @@ const (
 	MaxBaseFeeFlagName                 = "txmgr.max-basefee"
 	MinTipCapFlagName                  = "txmgr.min-tip-cap"
 	MaxTipCapFlagName                  = "txmgr.max-tip-cap"
+	RebroadcastIntervalFlagName        = "txmgr.rebroadcast-interval"
 	ResubmissionTimeoutFlagName        = "resubmission-timeout"
 	NetworkTimeoutFlagName             = "network-timeout"
 	RetryIntervalFlagName              = "txmgr.retry-interval"
@@ -67,6 +68,7 @@ type DefaultFlagValues struct {
 	FeeLimitThresholdGwei     float64
 	MinTipCapGwei             float64
 	MinBaseFeeGwei            float64
+	RebroadcastInterval       time.Duration
 	ResubmissionTimeout       time.Duration
 	NetworkTimeout            time.Duration
 	RetryInterval             time.Duration
@@ -84,6 +86,7 @@ var (
 		FeeLimitThresholdGwei:     100.0,
 		MinTipCapGwei:             1.0,
 		MinBaseFeeGwei:            1.0,
+		RebroadcastInterval:       12 * time.Second,
 		ResubmissionTimeout:       48 * time.Second,
 		NetworkTimeout:            10 * time.Second,
 		RetryInterval:             1 * time.Second,
@@ -99,6 +102,7 @@ var (
 		FeeLimitThresholdGwei:     100.0,
 		MinTipCapGwei:             1.0,
 		MinBaseFeeGwei:            1.0,
+		RebroadcastInterval:       12 * time.Second,
 		ResubmissionTimeout:       24 * time.Second,
 		NetworkTimeout:            10 * time.Second,
 		RetryInterval:             1 * time.Second,
@@ -183,6 +187,12 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 			EnvVars: prefixEnvVars("TXMGR_MAX_BASEFEE"),
 		},
 		&cli.DurationFlag{
+			Name:    RebroadcastIntervalFlagName,
+			Usage:   "Interval at which a published transaction will be rebroadcasted if it has not yet been mined. Should be less than ResubmissionTimeout to have an effect.",
+			Value:   defaults.RebroadcastInterval,
+			EnvVars: prefixEnvVars("TXMGR_REBROADCAST_INTERVAL"),
+		},
+		&cli.DurationFlag{
 			Name:    ResubmissionTimeoutFlagName,
 			Usage:   "Duration we will wait before resubmitting a transaction to L1",
 			Value:   defaults.ResubmissionTimeout,
@@ -248,6 +258,7 @@ type CLIConfig struct {
 	MinTipCapGwei              float64
 	MaxBaseFeeGwei             float64
 	MaxTipCapGwei              float64
+	RebroadcastInterval        time.Duration
 	ResubmissionTimeout        time.Duration
 	ReceiptQueryInterval       time.Duration
 	NetworkTimeout             time.Duration
@@ -267,6 +278,7 @@ func NewCLIConfig(l1RPCURL string, defaults DefaultFlagValues) CLIConfig {
 		FeeLimitThresholdGwei:     defaults.FeeLimitThresholdGwei,
 		MinTipCapGwei:             defaults.MinTipCapGwei,
 		MinBaseFeeGwei:            defaults.MinBaseFeeGwei,
+		RebroadcastInterval:       defaults.RebroadcastInterval,
 		ResubmissionTimeout:       defaults.ResubmissionTimeout,
 		NetworkTimeout:            defaults.NetworkTimeout,
 		RetryInterval:             defaults.RetryInterval,
@@ -294,6 +306,9 @@ func (m CLIConfig) Check() error {
 	if m.MinBaseFeeGwei < m.MinTipCapGwei {
 		return fmt.Errorf("minBaseFee smaller than minTipCap, have %f < %f",
 			m.MinBaseFeeGwei, m.MinTipCapGwei)
+	}
+	if m.RebroadcastInterval == 0 {
+		return errors.New("must provide RebroadcastInterval")
 	}
 	if m.ResubmissionTimeout == 0 {
 		return errors.New("must provide ResubmissionTimeout")
@@ -330,6 +345,7 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		MaxBaseFeeGwei:             ctx.Float64(MaxBaseFeeFlagName),
 		MinTipCapGwei:              ctx.Float64(MinTipCapFlagName),
 		MaxTipCapGwei:              ctx.Float64(MaxTipCapFlagName),
+		RebroadcastInterval:        ctx.Duration(RebroadcastIntervalFlagName),
 		ResubmissionTimeout:        ctx.Duration(ResubmissionTimeoutFlagName),
 		ReceiptQueryInterval:       ctx.Duration(ReceiptQueryIntervalFlagName),
 		NetworkTimeout:             ctx.Duration(NetworkTimeoutFlagName),
@@ -422,6 +438,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 		AlreadyPublishedCustomErrs: cfg.AlreadyPublishedCustomErrs,
 	}
 
+	res.RebroadcastInterval.Store(int64(cfg.RebroadcastInterval))
 	res.ResubmissionTimeout.Store(int64(cfg.ResubmissionTimeout))
 	res.FeeLimitThreshold.Store(feeLimitThreshold)
 	res.FeeLimitMultiplier.Store(cfg.FeeLimitMultiplier)
@@ -437,6 +454,11 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 // Config houses parameters for altering the behavior of a SimpleTxManager.
 type Config struct {
 	Backend ETHBackend
+
+	// RebroadcastInterval is the interval at which a published transaction
+	// will be rebroadcasted if it has not yet been mined.
+	RebroadcastInterval atomic.Int64
+
 	// ResubmissionTimeout is the interval at which, if no previously
 	// published transaction has been mined, the new tx with a bumped gas
 	// price will be published. Only one publication at MaxGasPrice will be
@@ -534,6 +556,9 @@ func (m *Config) Check() error {
 	if minBaseFee != nil && minTipCap != nil && minBaseFee.Cmp(minTipCap) == -1 {
 		return fmt.Errorf("minBaseFee smaller than minTipCap, have %v < %v",
 			minBaseFee, minTipCap)
+	}
+	if m.RebroadcastInterval.Load() == 0 {
+		return errors.New("must provide RebroadcastInterval")
 	}
 	if m.ResubmissionTimeout.Load() == 0 {
 		return errors.New("must provide ResubmissionTimeout")

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -102,7 +102,6 @@ var (
 		FeeLimitThresholdGwei:     100.0,
 		MinTipCapGwei:             1.0,
 		MinBaseFeeGwei:            1.0,
-		RebroadcastInterval:       12 * time.Second,
 		ResubmissionTimeout:       24 * time.Second,
 		NetworkTimeout:            10 * time.Second,
 		RetryInterval:             1 * time.Second,
@@ -306,9 +305,6 @@ func (m CLIConfig) Check() error {
 	if m.MinBaseFeeGwei < m.MinTipCapGwei {
 		return fmt.Errorf("minBaseFee smaller than minTipCap, have %f < %f",
 			m.MinBaseFeeGwei, m.MinTipCapGwei)
-	}
-	if m.RebroadcastInterval == 0 {
-		return errors.New("must provide RebroadcastInterval")
 	}
 	if m.ResubmissionTimeout == 0 {
 		return errors.New("must provide ResubmissionTimeout")
@@ -556,9 +552,6 @@ func (m *Config) Check() error {
 	if minBaseFee != nil && minTipCap != nil && minBaseFee.Cmp(minTipCap) == -1 {
 		return fmt.Errorf("minBaseFee smaller than minTipCap, have %v < %v",
 			minBaseFee, minTipCap)
-	}
-	if m.RebroadcastInterval.Load() == 0 {
-		return errors.New("must provide RebroadcastInterval")
 	}
 	if m.ResubmissionTimeout.Load() == 0 {
 		return errors.New("must provide ResubmissionTimeout")

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -37,7 +37,6 @@ type queueCall struct {
 
 type testTx struct {
 	sendErr bool // error to return from send for this tx
-	noMine  bool // true if the tx should not be mined
 }
 
 type mockBackendWithNonce struct {
@@ -208,9 +207,7 @@ func TestQueue_Send(t *testing.T) {
 
 				txHash := tx.Hash()
 				nonceMu.Lock()
-				if testTx == nil || !testTx.noMine {
-					backend.mine(&txHash, tx.GasFeeCap(), nil)
-				}
+				backend.mine(&txHash, tx.GasFeeCap(), nil)
 				nonceForTxId[uint(index)] = tx.Nonce()
 				nonceMu.Unlock()
 				return nil

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -37,6 +37,7 @@ type queueCall struct {
 
 type testTx struct {
 	sendErr bool // error to return from send for this tx
+	noMine  bool // true if the tx should not be mined
 }
 
 type mockBackendWithNonce struct {
@@ -172,7 +173,8 @@ func TestQueue_Send(t *testing.T) {
 
 			conf := configWithNumConfs(1)
 			conf.ReceiptQueryInterval = 1 * time.Second            // simulate a network send
-			conf.ResubmissionTimeout.Store(int64(2 * time.Second)) // resubmit to detect errors
+			conf.RebroadcastInterval.Store(int64(2 * time.Second)) // possibly rebroadcast once before resubmission if unconfirmed
+			conf.ResubmissionTimeout.Store(int64(3 * time.Second)) // resubmit to detect errors
 			conf.SafeAbortNonceTooLowCount = 1
 			backend := newMockBackendWithNonce(newGasPricer(3))
 			mgr := &SimpleTxManager{
@@ -206,7 +208,9 @@ func TestQueue_Send(t *testing.T) {
 
 				txHash := tx.Hash()
 				nonceMu.Lock()
-				backend.mine(&txHash, tx.GasFeeCap(), nil)
+				if testTx == nil || !testTx.noMine {
+					backend.mine(&txHash, tx.GasFeeCap(), nil)
+				}
 				nonceForTxId[uint(index)] = tx.Nonce()
 				nonceMu.Unlock()
 				return nil

--- a/op-service/txmgr/rpc.go
+++ b/op-service/txmgr/rpc.go
@@ -45,6 +45,14 @@ func (a *SimpleTxmgrAPI) SetFeeThreshold(_ context.Context, val *big.Int) {
 	a.mgr.SetFeeThreshold(val)
 }
 
+func (a *SimpleTxmgrAPI) GetRebroadcastInterval(_ context.Context) time.Duration {
+	return a.mgr.GetRebroadcastInterval()
+}
+
+func (a *SimpleTxmgrAPI) SetRebroadcastInterval(_ context.Context, val time.Duration) {
+	a.mgr.SetRebroadcastInterval(val)
+}
+
 func (a *SimpleTxmgrAPI) GetBumpFeeRetryTime(_ context.Context) time.Duration {
 	return a.mgr.GetBumpFeeRetryTime()
 }

--- a/op-service/txmgr/rpc_test.go
+++ b/op-service/txmgr/rpc_test.go
@@ -15,6 +15,7 @@ func TestTxmgrRPC(t *testing.T) {
 	minPriorityFeeInit := big.NewInt(2000)
 	minBlobFeeInit := big.NewInt(3000)
 	feeThresholdInit := big.NewInt(4000)
+	rebroadcastIntervalInit := int64(25)
 	bumpFeeRetryTimeInit := int64(100)
 
 	cfg := Config{}
@@ -22,6 +23,7 @@ func TestTxmgrRPC(t *testing.T) {
 	cfg.MinTipCap.Store(minPriorityFeeInit)
 	cfg.MinBlobTxFee.Store(minBlobFeeInit)
 	cfg.FeeLimitThreshold.Store(feeThresholdInit)
+	cfg.RebroadcastInterval.Store(rebroadcastIntervalInit)
 	cfg.ResubmissionTimeout.Store(bumpFeeRetryTimeInit)
 
 	h := newTestHarnessWithConfig(t, &cfg)
@@ -51,6 +53,7 @@ func TestTxmgrRPC(t *testing.T) {
 		{"MinPriorityFee", minPriorityFeeInit},
 		{"MinBlobFee", minBlobFeeInit},
 		{"FeeThreshold", feeThresholdInit},
+		{"RebroadcastInterval", big.NewInt(rebroadcastIntervalInit)},
 		{"BumpFeeRetryTime", big.NewInt(bumpFeeRetryTimeInit)},
 	}
 

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -472,6 +472,15 @@ func (m *SimpleTxManager) SetFeeThreshold(val *big.Int) {
 	m.l.Info("txmgr config val changed: SetFeeThreshold", "newVal", val)
 }
 
+func (m *SimpleTxManager) GetRebroadcastInterval() time.Duration {
+	return time.Duration(m.cfg.RebroadcastInterval.Load())
+}
+
+func (m *SimpleTxManager) SetRebroadcastInterval(val time.Duration) {
+	m.cfg.RebroadcastInterval.Store(int64(val))
+	m.l.Info("txmgr config val changed: SetRebroadcastInterval", "newVal", val)
+}
+
 func (m *SimpleTxManager) GetBumpFeeRetryTime() time.Duration {
 	return time.Duration(m.cfg.ResubmissionTimeout.Load())
 }
@@ -567,9 +576,9 @@ func (m *SimpleTxManager) sendTx(ctx context.Context, tx *types.Transaction) (*t
 	sendState := NewSendState(m.cfg.SafeAbortNonceTooLowCount, m.cfg.TxNotInMempoolTimeout)
 	retryCount := uint64(0)
 	receiptChan := make(chan *types.Receipt, 1)
-	resubmissionTimeout := m.GetBumpFeeRetryTime()
-	resubmissionTicker := time.NewTicker(resubmissionTimeout)
-	defer resubmissionTicker.Stop()
+	bumpFeeTimeout := m.GetBumpFeeRetryTime()
+	bumpFeeTicker := time.NewTicker(bumpFeeTimeout)
+	defer bumpFeeTicker.Stop()
 
 	for {
 		retryTicker := &time.Ticker{}
@@ -588,6 +597,7 @@ func (m *SimpleTxManager) sendTx(ctx context.Context, tx *types.Transaction) (*t
 					defer wg.Done()
 					m.waitForTx(ctx, tx, sendState, receiptChan)
 				}()
+				retryTicker = time.NewTicker(m.GetRebroadcastInterval())
 			} else if err != nil {
 				if retryCount >= m.cfg.MaxRetries {
 					m.txLogger(tx, false).Warn("Aborting transaction submission retry", "err", err, "retries", retryCount)
@@ -608,8 +618,11 @@ func (m *SimpleTxManager) sendTx(ctx context.Context, tx *types.Transaction) (*t
 		}
 
 		select {
-		case <-resubmissionTicker.C:
 		case <-retryTicker.C:
+
+		case <-bumpFeeTicker.C:
+			// Enough time has passed, so bump the fees on the next publish attempt in order to avoid delays.
+			sendState.bumpFees = true
 
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -671,9 +684,6 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 			} else {
 				l.Info("Transaction successfully published (custom RPC error)", "tx", tx.Hash(), "err", err)
 			}
-			// Tx made it into the mempool, so we'll need a fee bump if we end up trying to replace
-			// it with another publish attempt.
-			sendState.bumpFees = true
 			return tx, true, nil
 		}
 
@@ -691,8 +701,9 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 			l.Warn("transaction send canceled", "err", err)
 			m.metr.TxPublished("context_canceled")
 		case errStringMatch(err, txpool.ErrAlreadyKnown):
-			l.Warn("resubmitted already known transaction", "err", err)
+			l.Info("resubmitted already known transaction", "err", err)
 			m.metr.TxPublished("tx_already_known")
+			return tx, true, nil
 		case errStringMatch(err, txpool.ErrReplaceUnderpriced):
 			l.Warn("transaction replacement is underpriced", "err", err)
 			m.metr.TxPublished("tx_replacement_underpriced")

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -597,7 +597,10 @@ func (m *SimpleTxManager) sendTx(ctx context.Context, tx *types.Transaction) (*t
 					defer wg.Done()
 					m.waitForTx(ctx, tx, sendState, receiptChan)
 				}()
-				retryTicker = time.NewTicker(m.GetRebroadcastInterval())
+				rebroadcastInterval := m.GetRebroadcastInterval()
+				if rebroadcastInterval > 0 {
+					retryTicker = time.NewTicker(rebroadcastInterval)
+				}
 			} else if err != nil {
 				if retryCount >= m.cfg.MaxRetries {
 					m.txLogger(tx, false).Warn("Aborting transaction submission retry", "err", err, "retries", retryCount)
@@ -677,7 +680,6 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 		sendState.ProcessSendError(err)
 
 		if err == nil || errStringContainsAny(err, m.cfg.AlreadyPublishedCustomErrs) {
-			// only empty error strings are recorded as successful publishes
 			m.metr.TxPublished("")
 			if err == nil {
 				l.Info("Transaction successfully published", "tx", tx.Hash())

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -118,6 +118,7 @@ func configWithNumConfs(numConfirmations uint64) *Config {
 		MaxRetries:    5,
 	}
 
+	cfg.RebroadcastInterval.Store(int64(time.Second / 2))
 	cfg.ResubmissionTimeout.Store(int64(time.Second))
 	cfg.FeeLimitMultiplier.Store(5)
 	cfg.MinBlobTxFee.Store(defaultMinBlobTxFee)
@@ -757,6 +758,49 @@ func TestTxMgrOnlyOnePublicationSucceeds(t *testing.T) {
 	require.Equal(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
 }
 
+// TestTxMgrRebroadcastsWithoutGasPriceIncrease tests that the tx manager will rebroadcast a transaction
+// without increasing the gas price if the transaction is not mined after the resubmission timeout.
+// This is intended to simulate unreliable network conditions where a transaction may be dropped from the mempool.
+func TestTxMgrRebroadcastsWithoutGasPriceIncrease(t *testing.T) {
+	t.Parallel()
+
+	cfg := configWithNumConfs(1)
+	cfg.RebroadcastInterval.Store(int64(time.Second / 2))
+	cfg.ResubmissionTimeout.Store(int64(time.Hour))
+	h := newTestHarnessWithConfig(t, cfg)
+
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
+	txToSend := types.NewTx(&types.DynamicFeeTx{
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+	})
+
+	sameTxPublishAttempts := 0
+	// only mine the tx after receiving it at least 3 times
+	sendTx := func(ctx context.Context, tx *types.Transaction) error {
+		txHash := tx.Hash()
+		if txHash != txToSend.Hash() {
+			return errors.New("unexpected tx hash")
+		}
+		sameTxPublishAttempts++
+		if sameTxPublishAttempts >= 3 {
+			h.backend.mine(&txHash, tx.GasFeeCap(), nil)
+			return nil
+		} else if sameTxPublishAttempts > 1 {
+			return txpool.ErrAlreadyKnown
+		}
+		return nil
+	}
+	h.backend.setTxSender(sendTx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	receipt, err := h.mgr.sendTx(ctx, txToSend)
+	require.Nil(t, err)
+	require.NotNil(t, receipt)
+	require.Equal(t, txToSend.Hash(), receipt.TxHash)
+}
+
 // TestTxMgrConfirmsMinGasPriceAfterBumping delays the mining of the initial tx
 // with the minimum gas price, and asserts that its receipt is returned even
 // if the gas price has been bumped in other goroutines.
@@ -797,7 +841,8 @@ func TestTxMgrRetriesUnbumpableTx(t *testing.T) {
 	t.Parallel()
 
 	cfg := configWithNumConfs(1)
-	cfg.FeeLimitMultiplier.Store(1) // don't allow fees to be bumped over the suggested values
+	cfg.FeeLimitMultiplier.Store(1)                 // don't allow fees to be bumped over the suggested values
+	cfg.RebroadcastInterval.Store(int64(time.Hour)) // do not perform regular rebroadcasts, only rely on resubmission timeout
 	h := newTestHarnessWithConfig(t, cfg)
 
 	// Make the fees unbumpable by starting with fees that will be WAY over the suggested values
@@ -1125,7 +1170,7 @@ func doGasPriceIncrease(t *testing.T, txTipCap, txFeeCap, newTip, newBaseFee int
 }
 
 func TestIncreaseGasPrice(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	require.Equal(t, int64(10), priceBump, "test must be updated if priceBump is adjusted")
 	tests := []struct {
 		name string

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -841,8 +841,7 @@ func TestTxMgrRetriesUnbumpableTx(t *testing.T) {
 	t.Parallel()
 
 	cfg := configWithNumConfs(1)
-	cfg.FeeLimitMultiplier.Store(1)                 // don't allow fees to be bumped over the suggested values
-	cfg.RebroadcastInterval.Store(int64(time.Hour)) // do not perform regular rebroadcasts, only rely on resubmission timeout
+	cfg.FeeLimitMultiplier.Store(1) // don't allow fees to be bumped over the suggested values
 	h := newTestHarnessWithConfig(t, cfg)
 
 	// Make the fees unbumpable by starting with fees that will be WAY over the suggested values


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This change enables the TxMgr to rebroadcast signed transactions without bumping the gas fees. This is particularly relevant to batcher-submitted blob transactions, which empirically may be initially accepted by a mempool node but then silently dropped or fail to propagate throughput the network - this is likely due to restrictive mempool rules, such as geth forbidding blob transactions with gapped nonces.

`RebroadcastInterval` defaults to 12 seconds for both the batcher and challenger, as this matches the receipt polling interval as well as the L1 slot time. This should allow the senders to resubmit the same transaction once per L1 block, and only fall back to the fee-bumping logic after surpassing the existing `ResubmissionTimeout` (still 48s and 24s respectively).

This also updates the handling of the `txpool.AlreadyKnown` error to be treated equivalently to a successful transaction broadcast, as the error signals that the exact transaction is in the mempool with no nonce gaps or fee-related errors.

**Tests**

Adds `TestTxMgrRebroadcastsWithoutGasPriceIncrease`, which only confirms a transaction after it has been submitted 3 times with no modifications / gas bumps.

**Additional context**

This follows up https://github.com/ethereum-optimism/optimism/pull/15952, as Base is still encountering delays whenever submitting a large volume of blob transactions. Once a transaction is silently dropped from the mempool, the TxMgr only recovers by applying the (typically-unnecessary) gas bump logic. This forces us to either wait an extended period before bumping gas prices, or perform excess bumps - which in turn causes more churn in the mempool as net-new transactions replace the existing ones.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
