### PR TITLE
 op-chain-ops: rm `GasTokenDeployConfig`

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -271,26 +271,6 @@ func (d *GasPriceOracleDeployConfig) OperatorFeeParams() [32]byte {
 	})
 }
 
-// GasTokenDeployConfig configures the optional custom gas token functionality.
-type GasTokenDeployConfig struct {
-	// UseCustomGasToken is a flag to indicate that a custom gas token should be used
-	UseCustomGasToken bool `json:"useCustomGasToken"`
-	// CustomGasTokenAddress is the address of the ERC20 token to be used to pay for gas on L2.
-	CustomGasTokenAddress common.Address `json:"customGasTokenAddress"`
-}
-
-var _ ConfigChecker = (*GasTokenDeployConfig)(nil)
-
-func (d *GasTokenDeployConfig) Check(log log.Logger) error {
-	if d.UseCustomGasToken {
-		if d.CustomGasTokenAddress == (common.Address{}) {
-			return fmt.Errorf("%w: CustomGasTokenAddress cannot be address(0)", ErrInvalidDeployConfig)
-		}
-		log.Info("Using custom gas token", "address", d.CustomGasTokenAddress)
-	}
-	return nil
-}
-
 // OperatorDeployConfig configures the hot-key addresses for operations such as sequencing and batch-submission.
 type OperatorDeployConfig struct {
 	// P2PSequencerAddress is the address of the key the sequencer uses to sign blocks on the P2P layer.
@@ -712,7 +692,6 @@ type L2InitializationConfig struct {
 	L2VaultsDeployConfig
 	GovernanceDeployConfig
 	GasPriceOracleDeployConfig
-	GasTokenDeployConfig
 	OperatorDeployConfig
 	EIP1559DeployConfig
 	UpgradeScheduleDeployConfig

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -6,7 +6,6 @@
   "maxSequencerDrift": 20,
   "sequencerWindowSize": 100,
   "channelTimeout": 30,
-  "customGasTokenAddress": "0x0000000000000000000000000000000000000000",
   "p2pSequencerAddress": "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
   "batchInboxAddress": "0x42000000000000000000000000000000000000ff",
   "batchSenderAddress": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -84,7 +84,6 @@
   "proofMaturityDelaySeconds": 12,
   "disputeGameFinalityDelaySeconds": 6,
   "respectedGameType": 0,
-  "useCustomGasToken": false,
   "useFaultProofs": false,
   "useAltDA": false,
   "daBondSize": 0,

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -236,9 +236,6 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 				GasPriceOracleBaseFeeScalar:     1368,
 				GasPriceOracleBlobBaseFeeScalar: 810949,
 			},
-			GasTokenDeployConfig: genesis.GasTokenDeployConfig{
-				UseCustomGasToken: false,
-			},
 			OperatorDeployConfig: genesis.OperatorDeployConfig{
 				P2PSequencerAddress: sequencerP2P,
 				BatchSenderAddress:  batcher,


### PR DESCRIPTION
Now that CGT feature has been removed from the mono-repo, so should the `GasTokenDeployConfig`.

(https://github.com/ethereum-optimism/superchain-registry/pull/1074 needs to be merge first)