### PR TITLE
ci(op-acceptance-tests): install contracts dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1178,6 +1178,7 @@ jobs:
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise
+      - install-contracts-dependencies
       - run:
           name: Setup Kurtosis
           command: |


### PR DESCRIPTION
**Description**

Since a contracts bundle is part of kurtosis deployment, use install-contracts-dependencies.

This sidesteps issues like https://github.com/foundry-rs/foundry/issues/4736

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
