### PR TITLE
refactor(test): continue cleanup of /libraries test suite

### DIFF
--- a/packages/contracts-bedrock/test/libraries/EOA.t.sol
+++ b/packages/contracts-bedrock/test/libraries/EOA.t.sol
@@ -17,18 +17,23 @@ contract EOA_Harness {
     }
 }
 
-/// @title EOA_isEOA_Test
-contract EOA_isEOA_Test is Test {
+/// @title EOA_TestInit
+/// @notice Reusable test initialization for `EOA` tests.
+contract EOA_TestInit is Test {
     EOA_Harness harness;
 
     /// @notice Sets up the test.
     function setUp() public {
         harness = new EOA_Harness();
     }
+}
 
+/// @title EOA_isSenderEOA_Test
+/// @notice Tests the `isSenderEOA` function of the `EOA` library.
+contract EOA_isSenderEOA_Test is EOA_TestInit {
     /// @notice Tests that a standard EOA is detected as an EOA.
     /// @param _privateKey The private key of the sender.
-    function testFuzz_isEOA_isStandardEOA_succeeds(uint256 _privateKey) external {
+    function testFuzz_isSenderEOA_isStandardEOA_succeeds(uint256 _privateKey) external {
         // Make sure that the private key is in the range of a valid secp256k1 private key.
         _privateKey = boundPrivateKey(_privateKey);
 
@@ -44,7 +49,7 @@ contract EOA_isEOA_Test is Test {
     /// @notice Tests that a 7702 EOA is detected as an EOA.
     /// @param _privateKey The private key of the sender.
     /// @param _7702Target The target of the 7702 EOA.
-    function testFuzz_isEOA_is7702EOA_succeeds(uint256 _privateKey, address _7702Target) external {
+    function testFuzz_isSenderEOA_is7702EOA_succeeds(uint256 _privateKey, address _7702Target) external {
         // Make sure that the private key is in the range of a valid secp256k1 private key.
         _privateKey = boundPrivateKey(_privateKey);
 
@@ -64,7 +69,7 @@ contract EOA_isEOA_Test is Test {
     /// @notice Tests that a contract is not detected as an EOA.
     /// @param _privateKey The private key of the sender.
     /// @param _code The code of the sender.
-    function testFuzz_isEOA_isContract_succeeds(uint256 _privateKey, bytes memory _code) external {
+    function testFuzz_isSenderEOA_isContract_succeeds(uint256 _privateKey, bytes memory _code) external {
         // Make sure that the private key is in the range of a valid secp256k1 private key.
         _privateKey = boundPrivateKey(_privateKey);
 
@@ -84,7 +89,7 @@ contract EOA_isEOA_Test is Test {
 
     /// @notice Tests that a contract with 23 bytes of code is not detected as an EOA.
     /// @param _privateKey The private key of the sender.
-    function testFuzz_isEOA_isContract23BytesNot7702_succeeds(uint256 _privateKey) external {
+    function testFuzz_isSenderEOA_isContract23BytesNot7702_succeeds(uint256 _privateKey) external {
         // Make sure that the private key is in the range of a valid secp256k1 private key.
         _privateKey = boundPrivateKey(_privateKey);
 


### PR DESCRIPTION
This PR continues the refactor of the `/libraries` test folder as part of the ongoing effort to standardize structure, documentation, and formatting across the test suite.

Some files were already refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103), and the remaining ones are completed in this PR, except for Storage.t.sol, which will be refactored in a later PR.

### Common changes applied where applicable:
- Extracted shared setup logic into `*_TestInit` contracts
- Organized test functions into logically separated contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to the test contracts
- Added function-level `@notice` comments
- Replaced legacy `@dev` tags with `@notice` where applicable
- Enforced 100-character limit for inline comments

### Progress

Refactored 14 of 15 test files (**93.3% complete**)

- `Blueprint.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `Bytes.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `Constants.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `DeployUtils.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `Encoding.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `GasPayingToken.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `Hashing.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `MerkleTrie.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `RLPReader.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `RLPWriter.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `SafeCall.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `StaticConfig.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- `TransientContext.t.sol` (refactored in [#16103](https://github.com/ethereum-optimism/optimism/pull/16103))
- [x] `EOA.t.sol`
- `Storage.t.sol` (pending, will be refactored in a later PR)