### PR TITLE
fix: VerifyOPCM support tuple arguments

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -619,7 +619,7 @@ contract VerifyOPCM is Script {
             string.concat(
                 "forge inspect ",
                 _contractName,
-                " abi --json | jq -r '.[] | select(.type == \"constructor\") | .inputs | map(.type) | join(\",\")'"
+                " abi --json | jq -r '.[] | select(.type == \"constructor\") | .inputs | map(if .type == \"tuple\" then \"(\" + (.components | map(.type) | join(\",\")) + \")\" else .type end) | join(\",\")'"
             )
         );
 
@@ -634,7 +634,7 @@ contract VerifyOPCM is Script {
                     types,
                     ")\" ",
                     vm.toString(_constructorArgs),
-                    " --json | jq -r 'map(.) | join(\" \")')"
+                    " --json | jq -r 'map(if type == \"string\" and startswith(\"(\") then gsub(\", \"; \",\") else . end) | join(\" \")')"
                 )
             )
         );


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates VerifyOPCM to support tuple constructor arguments