### PR TITLE
refactor(test): cleanup of misplaced test files (pending relocation)

### DIFF
--- a/packages/contracts-bedrock/test/L2/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2Genesis.t.sol
@@ -16,48 +16,15 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IGovernanceToken } from "interfaces/governance/IGovernanceToken.sol";
 import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 
-/// @title L2GenesisTest
-/// @notice Test suite for L2Genesis script.
-contract L2GenesisTest is Test {
+/// @title L2Genesis_TestInit
+/// @notice Reusable test initialization for `L2Genesis` tests.
+contract L2Genesis_TestInit is Test {
     L2Genesis.Input internal input;
 
     L2Genesis internal genesis;
 
     function setUp() public {
         genesis = new L2Genesis();
-    }
-
-    function test_run_succeeds() external {
-        input = L2Genesis.Input({
-            l1ChainID: 1,
-            l2ChainID: 2,
-            l1CrossDomainMessengerProxy: payable(address(0x0000000000000000000000000000000000000001)),
-            l1StandardBridgeProxy: payable(address(0x0000000000000000000000000000000000000002)),
-            l1ERC721BridgeProxy: payable(address(0x0000000000000000000000000000000000000003)),
-            opChainProxyAdminOwner: address(0x0000000000000000000000000000000000000004),
-            sequencerFeeVaultRecipient: address(0x0000000000000000000000000000000000000005),
-            sequencerFeeVaultMinimumWithdrawalAmount: 1,
-            sequencerFeeVaultWithdrawalNetwork: 1,
-            baseFeeVaultRecipient: address(0x0000000000000000000000000000000000000006),
-            baseFeeVaultMinimumWithdrawalAmount: 1,
-            baseFeeVaultWithdrawalNetwork: 1,
-            l1FeeVaultRecipient: address(0x0000000000000000000000000000000000000007),
-            l1FeeVaultMinimumWithdrawalAmount: 1,
-            l1FeeVaultWithdrawalNetwork: 1,
-            governanceTokenOwner: address(0x0000000000000000000000000000000000000008),
-            fork: uint256(LATEST_FORK),
-            deployCrossL2Inbox: true,
-            enableGovernance: true,
-            fundDevAccounts: true
-        });
-        genesis.run(input);
-
-        testProxyAdmin();
-        testPredeploys();
-        testVaults();
-        testGovernance();
-        testFactories();
-        testForks();
     }
 
     function testProxyAdmin() internal view {
@@ -84,7 +51,8 @@ contract L2GenesisTest is Test {
                 continue;
             }
 
-            // All proxied predeploys should have the 1967 admin slot set to the ProxyAdmin predeploy
+            // All proxied predeploys should have the 1967 admin slot set to the ProxyAdmin
+            // predeploy
             address impl = Predeploys.predeployToCodeNamespace(addr);
             assertGt(impl.code.length, 0);
         }
@@ -133,5 +101,42 @@ contract L2GenesisTest is Test {
         assertEq(gasPriceOracle.isEcotone(), true);
         assertEq(gasPriceOracle.isFjord(), true);
         assertEq(gasPriceOracle.isIsthmus(), true);
+    }
+}
+
+/// @title L2Genesis_Run_Test
+/// @notice Tests the `run` function of the `L2Genesis` contract.
+contract L2Genesis_Run_Test is L2Genesis_TestInit {
+    function test_run_succeeds() external {
+        input = L2Genesis.Input({
+            l1ChainID: 1,
+            l2ChainID: 2,
+            l1CrossDomainMessengerProxy: payable(address(0x0000000000000000000000000000000000000001)),
+            l1StandardBridgeProxy: payable(address(0x0000000000000000000000000000000000000002)),
+            l1ERC721BridgeProxy: payable(address(0x0000000000000000000000000000000000000003)),
+            opChainProxyAdminOwner: address(0x0000000000000000000000000000000000000004),
+            sequencerFeeVaultRecipient: address(0x0000000000000000000000000000000000000005),
+            sequencerFeeVaultMinimumWithdrawalAmount: 1,
+            sequencerFeeVaultWithdrawalNetwork: 1,
+            baseFeeVaultRecipient: address(0x0000000000000000000000000000000000000006),
+            baseFeeVaultMinimumWithdrawalAmount: 1,
+            baseFeeVaultWithdrawalNetwork: 1,
+            l1FeeVaultRecipient: address(0x0000000000000000000000000000000000000007),
+            l1FeeVaultMinimumWithdrawalAmount: 1,
+            l1FeeVaultWithdrawalNetwork: 1,
+            governanceTokenOwner: address(0x0000000000000000000000000000000000000008),
+            fork: uint256(LATEST_FORK),
+            deployCrossL2Inbox: true,
+            enableGovernance: true,
+            fundDevAccounts: true
+        });
+        genesis.run(input);
+
+        testProxyAdmin();
+        testPredeploys();
+        testVaults();
+        testGovernance();
+        testFactories();
+        testForks();
     }
 }

--- a/packages/contracts-bedrock/test/L2/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/L2/Predeploys.t.sol
@@ -10,50 +10,38 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 import { Fork } from "scripts/libraries/Config.sol";
 
-/// @title PredeploysTest
-contract PredeploysBaseTest is CommonTest {
+/// @title Predeploys_TestInit
+/// @notice Reusable test initialization for `Predeploys` tests.
+contract Predeploys_TestInit is CommonTest {
     //////////////////////////////////////////////////////
     /// Internal helpers
     //////////////////////////////////////////////////////
 
-    /// @dev Returns true if the address is a predeploy that has a different code in the interop mode.
+    /// @notice Returns true if the address is a predeploy that has a different code in the
+    ///         interop mode.
     function _interopCodeDiffer(address _addr) internal pure returns (bool) {
         return _addr == Predeploys.L1_BLOCK_ATTRIBUTES || _addr == Predeploys.L2_STANDARD_BRIDGE;
     }
 
-    /// @dev Returns true if the account is not meant to be in the L2 genesis anymore.
+    /// @notice Returns true if the account is not meant to be in the L2 genesis anymore.
     function _isOmitted(address _addr) internal pure returns (bool) {
         return _addr == Predeploys.L1_MESSAGE_SENDER;
     }
 
-    /// @dev Returns true if the predeploy is initializable.
+    /// @notice Returns true if the predeploy is initializable.
     function _isInitializable(address _addr) internal pure returns (bool) {
         return _addr == Predeploys.L2_CROSS_DOMAIN_MESSENGER || _addr == Predeploys.L2_STANDARD_BRIDGE
             || _addr == Predeploys.L2_ERC721_BRIDGE || _addr == Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY;
     }
 
-    /// @dev Returns true if the predeploy uses immutables.
+    /// @notice Returns true if the predeploy uses immutables.
     function _usesImmutables(address _addr) internal pure returns (bool) {
         return _addr == Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY || _addr == Predeploys.SEQUENCER_FEE_WALLET
             || _addr == Predeploys.BASE_FEE_VAULT || _addr == Predeploys.L1_FEE_VAULT
             || _addr == Predeploys.OPERATOR_FEE_VAULT || _addr == Predeploys.EAS || _addr == Predeploys.GOVERNANCE_TOKEN;
     }
 
-    function test_predeployToCodeNamespace_works() external pure {
-        assertEq(
-            address(0xc0D3C0d3C0d3C0D3c0d3C0d3c0D3C0d3c0d30000),
-            Predeploys.predeployToCodeNamespace(Predeploys.LEGACY_MESSAGE_PASSER)
-        );
-        assertEq(
-            address(0xc0d3C0d3C0d3c0D3C0D3C0d3C0d3C0D3C0D3000f),
-            Predeploys.predeployToCodeNamespace(Predeploys.GAS_PRICE_ORACLE)
-        );
-        assertEq(
-            address(0xC0d3C0d3c0d3c0d3C0d3c0D3c0D3c0D3C0d30420),
-            Predeploys.predeployToCodeNamespace(address(0x4200000000000000000000000000000000000420))
-        );
-    }
-
+    /// @notice Internal test function for predeploys validation across different forks.
     function _test_predeploys(Fork _fork, bool _enableCrossL2Inbox) internal {
         uint256 count = 2048;
         uint160 prefix = uint160(0x420) << 148;
@@ -118,29 +106,55 @@ contract PredeploysBaseTest is CommonTest {
     }
 }
 
-contract PredeploysTest is PredeploysBaseTest {
-    /// @dev Tests that the predeploy addresses are set correctly. They have code
-    ///      and the proxied accounts have the correct admin.
+/// @title Predeploys_PredeployToCodeNamespace_Test
+/// @notice Tests the `predeployToCodeNamespace` function of the `Predeploys` contract.
+contract Predeploys_PredeployToCodeNamespace_Test is Predeploys_TestInit {
+    /// @notice Tests that predeployToCodeNamespace correctly computes namespace addresses.
+    function test_predeployToCodeNamespace_works() external pure {
+        assertEq(
+            address(0xc0D3C0d3C0d3C0D3c0d3C0d3c0D3C0d3c0d30000),
+            Predeploys.predeployToCodeNamespace(Predeploys.LEGACY_MESSAGE_PASSER)
+        );
+        assertEq(
+            address(0xc0d3C0d3C0d3c0D3C0D3C0d3C0d3C0D3C0D3000f),
+            Predeploys.predeployToCodeNamespace(Predeploys.GAS_PRICE_ORACLE)
+        );
+        assertEq(
+            address(0xC0d3C0d3c0d3c0d3C0d3c0D3c0D3c0D3C0d30420),
+            Predeploys.predeployToCodeNamespace(address(0x4200000000000000000000000000000000000420))
+        );
+    }
+}
+
+/// @title Predeploys_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `Predeploys` contract
+///         or are testing multiple functions at once.
+contract Predeploys_Unclassified_Test is Predeploys_TestInit {
+    /// @notice Tests that the predeploy addresses are set correctly. They have code
+    ///         and the proxied accounts have the correct admin.
     function test_predeploys_succeeds() external {
         _test_predeploys(Fork.ISTHMUS, false);
     }
 }
 
-contract PredeploysInteropTest is PredeploysBaseTest {
+/// @title Predeploys_Interop_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `Predeploys` contract
+///         or are testing multiple functions at once, using interop mode.
+contract Predeploys_UnclassifiedInterop_Test is Predeploys_TestInit {
     /// @notice Test setup. Enabling interop to get all predeploys.
     function setUp() public virtual override {
         super.enableInterop();
         super.setUp();
     }
 
-    /// @dev Tests that the predeploy addresses are set correctly. They have code
-    ///      and the proxied accounts have the correct admin. Using interop.
+    /// @notice Tests that the predeploy addresses are set correctly. They have code and the
+    ///         proxied accounts have the correct admin. Using interop with inbox.
     function test_predeploysWithInbox_succeeds() external {
         _test_predeploys(Fork.INTEROP, true);
     }
 
-    /// @dev Tests that the predeploy addresses are set correctly. They have code
-    ///      and the proxied accounts have the correct admin. Using interop.
+    /// @notice Tests that the predeploy addresses are set correctly. They have code and the
+    ///         proxied accounts have the correct admin. Using interop without inbox.
     function test_predeploysWithoutInbox_succeeds() external {
         _test_predeploys(Fork.INTEROP, false);
     }

--- a/packages/contracts-bedrock/test/dispute/WETH98.t.sol
+++ b/packages/contracts-bedrock/test/dispute/WETH98.t.sol
@@ -8,7 +8,9 @@ import { Test } from "forge-std/Test.sol";
 import { IWETH98 } from "interfaces/universal/IWETH98.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
-contract WETH98_Test is Test {
+/// @title WETH98_TestInit
+/// @notice Reusable test initialization for `WETH98` tests.
+contract WETH98_TestInit is Test {
     event Approval(address indexed src, address indexed guy, uint256 wad);
     event Transfer(address indexed src, address indexed dst, uint256 wad);
     event Deposit(address indexed dst, uint256 wad);
@@ -29,13 +31,11 @@ contract WETH98_Test is Test {
         bob = makeAddr("bob");
         deal(alice, 1 ether);
     }
+}
 
-    function test_getName_succeeds() public view {
-        assertEq(weth.name(), "Wrapped Ether");
-        assertEq(weth.symbol(), "WETH");
-        assertEq(weth.decimals(), 18);
-    }
-
+/// @title WETH98_Receive_Test
+/// @notice Tests the `receive` function of the `WETH98` contract.
+contract WETH98_Receive_Test is WETH98_TestInit {
     function test_receive_succeeds() public {
         vm.expectEmit(address(weth));
         emit Deposit(alice, 1 ether);
@@ -44,7 +44,11 @@ contract WETH98_Test is Test {
         assertTrue(success);
         assertEq(weth.balanceOf(alice), 1 ether);
     }
+}
 
+/// @title WETH98_Fallback_Test
+/// @notice Tests the `fallback` function of the `WETH98` contract.
+contract WETH98_Fallback_Test is WETH98_TestInit {
     function test_fallback_succeeds() public {
         vm.expectEmit(address(weth));
         emit Deposit(alice, 1 ether);
@@ -53,7 +57,11 @@ contract WETH98_Test is Test {
         assertTrue(success);
         assertEq(weth.balanceOf(alice), 1 ether);
     }
+}
 
+/// @title WETH98_Deposit_Test
+/// @notice Tests the `deposit` function of the `WETH98` contract.
+contract WETH98_Deposit_Test is WETH98_TestInit {
     function test_deposit_succeeds() public {
         vm.expectEmit(address(weth));
         emit Deposit(alice, 1 ether);
@@ -61,7 +69,11 @@ contract WETH98_Test is Test {
         weth.deposit{ value: 1 ether }();
         assertEq(weth.balanceOf(alice), 1 ether);
     }
+}
 
+/// @title WETH98_Withdraw_Test
+/// @notice Tests the `withdraw` function of the `WETH98` contract.
+contract WETH98_Withdraw_Test is WETH98_TestInit {
     function test_withdraw_succeeds() public {
         vm.prank(alice);
         weth.deposit{ value: 1 ether }();
@@ -89,7 +101,23 @@ contract WETH98_Test is Test {
         vm.prank(alice);
         weth.withdraw(1 ether + 1);
     }
+}
 
+/// @title WETH98_Approve_Test
+/// @notice Tests the `approve` function of the `WETH98` contract.
+contract WETH98_Approve_Test is WETH98_TestInit {
+    function test_approve_succeeds() public {
+        vm.prank(alice);
+        vm.expectEmit(address(weth));
+        emit Approval(alice, bob, 1 ether);
+        weth.approve(bob, 1 ether);
+        assertEq(weth.allowance(alice, bob), 1 ether);
+    }
+}
+
+/// @title WETH98_Transfer_Test
+/// @notice Tests the `transfer` function of the `WETH98` contract.
+contract WETH98_Transfer_Test is WETH98_TestInit {
     function test_transfer_succeeds() public {
         vm.prank(alice);
         weth.deposit{ value: 1 ether }();
@@ -108,15 +136,11 @@ contract WETH98_Test is Test {
         vm.prank(alice);
         weth.transfer(bob, 1 ether + 1);
     }
+}
 
-    function test_approve_succeeds() public {
-        vm.prank(alice);
-        vm.expectEmit(address(weth));
-        emit Approval(alice, bob, 1 ether);
-        weth.approve(bob, 1 ether);
-        assertEq(weth.allowance(alice, bob), 1 ether);
-    }
-
+/// @title WETH98_TransferFrom_Test
+/// @notice Tests the `transferFrom` function of the `WETH98` contract.
+contract WETH98_TransferFrom_Test is WETH98_TestInit {
     function test_transferFrom_succeeds() public {
         vm.prank(alice);
         weth.deposit{ value: 1 ether }();
@@ -148,5 +172,16 @@ contract WETH98_Test is Test {
         vm.expectRevert();
         vm.prank(bob);
         weth.transferFrom(alice, bob, 1 ether + 1);
+    }
+}
+
+/// @title WETH98_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `WETH98` contract or
+///         are testing multiple functions at once.
+contract WETH98_Unclassified_Test is WETH98_TestInit {
+    function test_getName_succeeds() public view {
+        assertEq(weth.name(), "Wrapped Ether");
+        assertEq(weth.symbol(), "WETH");
+        assertEq(weth.decimals(), 18);
     }
 }


### PR DESCRIPTION
This PR refactors a set of test files that appear to be misplaced within the codebase. These files likely belong to other folders (e.g., `predeploys`, `libraries`, or `scripts`), but for now they remain in their current locations, as moving them is outside the scope of this PR.

The goal is to clean up their structure and documentation while maintaining their existing placement. Once we have clarity or approval on where they should go, we can follow up with a reorganization PR.

### Common changes applied where applicable:
- Consolidated shared setup logic into dedicated `*_TestInit` contracts
- Organized test functions into logically separated contracts inheriting from `TestInit`
- Added `@title` and `@notice` tags to all test contracts
- Added function-level `@notice` comments describing expected behavior under test
- Replaced `@dev` tags with `@notice` where appropriate
- Enforced a 100-character limit for inline comments

### Progress (misplaced, pending relocation)

Refactored 5 of 10 test files (**50.0% complete**)

- `BenchmarkTest.t.sol`
- `DeployOwnership.t.sol`
- [x] `DeployUtils.t.sol`
- `ExecutingMessageEmitted.t.sol`
- `Initializable.t.sol`
- `InitializableOZv5.t.sol`
- [x] `L2Genesis.t.sol`
- [x] `Predeploy.t.sol`
- [x] `Preinstalls.t.sol`
- [x] `WETH98.t.sol`

These remaining files will be added incrementally.