### PR TITLE
op-acceptance-tests, op-devstack: base; withdrawal

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -19,6 +19,9 @@ gates:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/deposit
         timeout: 10m
+      # TODO(infra#401): Re-enable the test when the sysext missing toolset is implemented
+      #- package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal
+      #  timeout: 10m
 
   - id: holocene
     inherits:

--- a/op-acceptance-tests/tests/base/withdrawal/init_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/init_test.go
@@ -1,0 +1,26 @@
+package withdrawal
+
+import (
+	"testing"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithMinimal(),
+		presets.WithProposerGameType(faultTypes.FastGameType),
+		// Fast game for test
+		presets.WithFastGame(),
+		// Deployer must be L1PAO to make op-deployer happy
+		presets.WithDeployerMatchL1PAO(),
+		// Guardian must be L1PAO to make AnchorStateRegistry's setRespectedGameType method work
+		presets.WithGuardianMatchL1PAO(),
+		// Fast finalization for fast withdrawal
+		presets.WithFinalizationPeriodSeconds(2),
+		// Satisfy OptimismPortal2 PROOF_MATURITY_DELAY_SECONDS check, avoid OptimismPortal_ProofNotOldEnough() revert
+		presets.WithProofMaturityDelaySeconds(12),
+		// Satisfy AnchorStateRegistry DISPUTE_GAME_FINALITY_DELAY_SECONDS check, avoid OptimismPortal_InvalidRootClaim() revert
+		presets.WithDisputeGameFinalityDelaySeconds(6),
+	)
+}

--- a/op-acceptance-tests/tests/base/withdrawal/utils/proof.go
+++ b/op-acceptance-tests/tests/base/withdrawal/utils/proof.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type proofDB struct {
+	m map[string][]byte
+}
+
+func (p *proofDB) Has(key []byte) (bool, error) {
+	_, ok := p.m[string(key)]
+	return ok, nil
+}
+
+func (p *proofDB) Get(key []byte) ([]byte, error) {
+	v, ok := p.m[string(key)]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+
+func GenerateProofDB(proof []hexutil.Bytes) *proofDB {
+	p := proofDB{m: make(map[string][]byte)}
+	for _, s := range proof {
+		key := crypto.Keccak256(s)
+		p.m[string(key)] = s
+	}
+	return &p
+}
+
+func VerifyAccountProof(root common.Hash, address common.Address, account types.StateAccount, proof []hexutil.Bytes) error {
+	expected, err := rlp.EncodeToBytes(&account)
+	if err != nil {
+		return fmt.Errorf("failed to encode rlp: %w", err)
+	}
+	secureKey := crypto.Keccak256(address[:])
+	db := GenerateProofDB(proof)
+	value, err := trie.VerifyProof(root, secureKey, db)
+	if err != nil {
+		return fmt.Errorf("failed to verify proof: %w", err)
+	}
+
+	if bytes.Equal(value, expected) {
+		return nil
+	} else {
+		return errors.New("proved value is not the same as the expected value")
+	}
+}
+
+func VerifyStorageProof(root common.Hash, proof eth.StorageProofEntry) error {
+	secureKey := crypto.Keccak256(proof.Key)
+	db := GenerateProofDB(proof.Proof)
+	value, err := trie.VerifyProof(root, secureKey, db)
+	if err != nil {
+		return fmt.Errorf("failed to verify proof: %w", err)
+	}
+
+	expected := proof.Value.ToInt().Bytes()
+	if bytes.Equal(value, expected) {
+		return nil
+	} else {
+		return errors.New("proved value is not the same as the expected value")
+	}
+}
+
+func VerifyProof(stateRoot common.Hash, proof *eth.AccountResult) error {
+	balance, overflow := uint256.FromBig(proof.Balance.ToInt())
+	if overflow {
+		return fmt.Errorf("proof balance overflows uint256: %d", proof.Balance.ToInt())
+	}
+	err := VerifyAccountProof(
+		stateRoot,
+		proof.Address,
+		types.StateAccount{
+			Nonce:    uint64(proof.Nonce),
+			Balance:  balance,
+			Root:     proof.StorageHash,
+			CodeHash: proof.CodeHash[:],
+		},
+		proof.AccountProof,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to validate account: %w", err)
+	}
+	for i, storageProof := range proof.StorageProof {
+		err = VerifyStorageProof(proof.StorageHash, storageProof)
+		if err != nil {
+			return fmt.Errorf("failed to validate storage proof %d: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/op-acceptance-tests/tests/base/withdrawal/utils/proof.go
+++ b/op-acceptance-tests/tests/base/withdrawal/utils/proof.go
@@ -1,89 +1,30 @@
 package utils
 
 import (
-	"bytes"
-	"errors"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 
+	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-type proofDB struct {
-	m map[string][]byte
-}
-
-func (p *proofDB) Has(key []byte) (bool, error) {
-	_, ok := p.m[string(key)]
-	return ok, nil
-}
-
-func (p *proofDB) Get(key []byte) ([]byte, error) {
-	v, ok := p.m[string(key)]
-	if !ok {
-		return nil, errors.New("not found")
-	}
-	return v, nil
-}
-
-func GenerateProofDB(proof []hexutil.Bytes) *proofDB {
-	p := proofDB{m: make(map[string][]byte)}
-	for _, s := range proof {
-		key := crypto.Keccak256(s)
-		p.m[string(key)] = s
-	}
-	return &p
-}
-
-func VerifyAccountProof(root common.Hash, address common.Address, account types.StateAccount, proof []hexutil.Bytes) error {
-	expected, err := rlp.EncodeToBytes(&account)
-	if err != nil {
-		return fmt.Errorf("failed to encode rlp: %w", err)
-	}
-	secureKey := crypto.Keccak256(address[:])
-	db := GenerateProofDB(proof)
-	value, err := trie.VerifyProof(root, secureKey, db)
-	if err != nil {
-		return fmt.Errorf("failed to verify proof: %w", err)
-	}
-
-	if bytes.Equal(value, expected) {
-		return nil
-	} else {
-		return errors.New("proved value is not the same as the expected value")
-	}
-}
-
-func VerifyStorageProof(root common.Hash, proof eth.StorageProofEntry) error {
-	secureKey := crypto.Keccak256(proof.Key)
-	db := GenerateProofDB(proof.Proof)
-	value, err := trie.VerifyProof(root, secureKey, db)
-	if err != nil {
-		return fmt.Errorf("failed to verify proof: %w", err)
-	}
-
-	expected := proof.Value.ToInt().Bytes()
-	if bytes.Equal(value, expected) {
-		return nil
-	} else {
-		return errors.New("proved value is not the same as the expected value")
-	}
-}
-
+// Ported from op-node/withdrawals/proof.go to fit in the op-devstack, using op-service proof types
 func VerifyProof(stateRoot common.Hash, proof *eth.AccountResult) error {
 	balance, overflow := uint256.FromBig(proof.Balance.ToInt())
 	if overflow {
 		return fmt.Errorf("proof balance overflows uint256: %d", proof.Balance.ToInt())
 	}
-	err := VerifyAccountProof(
+	proofHex := []string{}
+	for _, p := range proof.AccountProof {
+		proofHex = append(proofHex, hex.EncodeToString(p))
+	}
+	err := withdrawals.VerifyAccountProof(
 		stateRoot,
 		proof.Address,
 		types.StateAccount{
@@ -92,13 +33,22 @@ func VerifyProof(stateRoot common.Hash, proof *eth.AccountResult) error {
 			Root:     proof.StorageHash,
 			CodeHash: proof.CodeHash[:],
 		},
-		proof.AccountProof,
+		proofHex,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to validate account: %w", err)
 	}
 	for i, storageProof := range proof.StorageProof {
-		err = VerifyStorageProof(proof.StorageHash, storageProof)
+		proofHex := []string{}
+		for _, p := range storageProof.Proof {
+			proofHex = append(proofHex, hex.EncodeToString(p))
+		}
+		convertedProof := gethclient.StorageResult{
+			Key:   storageProof.Key.String(),
+			Value: storageProof.Value.ToInt(),
+			Proof: proofHex,
+		}
+		err = withdrawals.VerifyStorageProof(proof.StorageHash, convertedProof)
 		if err != nil {
 			return fmt.Errorf("failed to validate storage proof %d: %w", i, err)
 		}

--- a/op-acceptance-tests/tests/base/withdrawal/utils/utils.go
+++ b/op-acceptance-tests/tests/base/withdrawal/utils/utils.go
@@ -2,60 +2,30 @@ package utils
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
+	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	bindingsnew "github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 )
 
-var MessagePassedTopic = crypto.Keccak256Hash([]byte("MessagePassed(uint256,address,address,uint256,uint256,bytes,bytes32)"))
-
-type ProofClient interface {
-	GetProof(context.Context, common.Address, []common.Hash, *big.Int) (*gethclient.AccountResult, error)
-}
-
-type ReceiptClient interface {
-	TransactionReceipt(context.Context, common.Hash) (*types.Receipt, error)
-}
-
-type HeaderClient interface {
-	HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
-}
-
-// ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
-// and FinalizeWithdrawalTransaction functions
-type ProvenWithdrawalParameters struct {
-	Nonce           *big.Int
-	Sender          common.Address
-	Target          common.Address
-	Value           *big.Int
-	GasLimit        *big.Int
-	L2OutputIndex   *big.Int
-	Data            []byte
-	OutputRootProof bindings.TypesOutputRootProof
-	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
-}
-
 // ProveWithdrawalParameters calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
-func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt) (ProvenWithdrawalParameters, error) {
+// Ported from op-node/withdrawals/utils.go to fit in the op-devstack
+func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt) (withdrawals.ProvenWithdrawalParameters, error) {
 	latestGame, err := FindLatestGame(t, l2Chain, l1Client)
 	if err != nil {
-		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to find latest game: %w", err)
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to find latest game: %w", err)
 	}
 
 	l2BlockNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
@@ -63,7 +33,7 @@ func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client api
 	// Fetch the block header from the L2 node
 	l2Header, err := l2Client.InfoByNumber(t.Ctx(), l2BlockNumber.Uint64())
 	if err != nil {
-		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2Block: %w", err)
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2Block: %w", err)
 	}
 	return ProveWithdrawalParametersForBlock(t, l2Client, l2WithdrawalReceipt, l2Header, l2OutputIndex)
 }
@@ -71,12 +41,13 @@ func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client api
 // ProveWithdrawalParametersForBlock queries L1 & L2 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.
 // The l2Header provided is very important. It should be a block for which there is a submitted output in the L2 Output Oracle
 // contract. If not, the withdrawal will fail as it the storage proof cannot be verified if there is no submitted state root.
-func ProveWithdrawalParametersForBlock(t devtest.T, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt, l2Header eth.BlockInfo, l2OutputIndex *big.Int) (ProvenWithdrawalParameters, error) {
+// Ported from op-node/withdrawals/utils.go to fit in the op-devstack, using op-service ethclient
+func ProveWithdrawalParametersForBlock(t devtest.T, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt, l2Header eth.BlockInfo, l2OutputIndex *big.Int) (withdrawals.ProvenWithdrawalParameters, error) {
 	// Transaction receipt
 	// Parse the receipt
-	ev, err := ParseMessagePassed(l2WithdrawalReceipt)
+	ev, err := withdrawals.ParseMessagePassed(l2WithdrawalReceipt)
 	if err != nil {
-		return ProvenWithdrawalParameters{}, err
+		return withdrawals.ProvenWithdrawalParameters{}, err
 	}
 	return ProveWithdrawalParametersForEvent(t, l2Client, ev, l2Header, l2OutputIndex)
 }
@@ -84,28 +55,29 @@ func ProveWithdrawalParametersForBlock(t devtest.T, l2Client apis.EthClient, l2W
 // ProveWithdrawalParametersForEvent queries L1 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.
 // The l2Header provided is very important. It should be a block for which there is a submitted output in the L2 Output Oracle
 // contract. If not, the withdrawal will fail as it the storage proof cannot be verified if there is no submitted state root.
-func ProveWithdrawalParametersForEvent(t devtest.T, l2Client apis.EthClient, ev *bindings.L2ToL1MessagePasserMessagePassed, l2Header eth.BlockInfo, l2OutputIndex *big.Int) (ProvenWithdrawalParameters, error) {
+// Ported from op-node/withdrawals/utils.go to fit in the op-devstack, using op-service ethclient
+func ProveWithdrawalParametersForEvent(t devtest.T, l2Client apis.EthClient, ev *bindings.L2ToL1MessagePasserMessagePassed, l2Header eth.BlockInfo, l2OutputIndex *big.Int) (withdrawals.ProvenWithdrawalParameters, error) {
 	// Generate then verify the withdrawal proof
-	withdrawalHash, err := WithdrawalHash(ev)
+	withdrawalHash, err := withdrawals.WithdrawalHash(ev)
 	if !bytes.Equal(withdrawalHash[:], ev.WithdrawalHash[:]) {
-		return ProvenWithdrawalParameters{}, errors.New("computed withdrawal hash incorrectly")
+		return withdrawals.ProvenWithdrawalParameters{}, errors.New("computed withdrawal hash incorrectly")
 	}
 	if err != nil {
-		return ProvenWithdrawalParameters{}, err
+		return withdrawals.ProvenWithdrawalParameters{}, err
 	}
-	slot := StorageSlotOfWithdrawalHash(withdrawalHash)
+	slot := withdrawals.StorageSlotOfWithdrawalHash(withdrawalHash)
 
 	p, err := l2Client.GetProof(t.Ctx(), predeploys.L2ToL1MessagePasserAddr, []common.Hash{slot}, "0x"+fmt.Sprintf("%x", l2Header.NumberU64()))
 	if err != nil {
-		return ProvenWithdrawalParameters{}, err
+		return withdrawals.ProvenWithdrawalParameters{}, err
 	}
 	if len(p.StorageProof) != 1 {
-		return ProvenWithdrawalParameters{}, errors.New("invalid amount of storage proofs")
+		return withdrawals.ProvenWithdrawalParameters{}, errors.New("invalid amount of storage proofs")
 	}
 
 	err = VerifyProof(l2Header.Root(), p)
 	if err != nil {
-		return ProvenWithdrawalParameters{}, err
+		return withdrawals.ProvenWithdrawalParameters{}, err
 	}
 
 	// Encode it as expected by the contract
@@ -114,7 +86,7 @@ func ProveWithdrawalParametersForEvent(t devtest.T, l2Client apis.EthClient, ev 
 		trieNodes[i] = s
 	}
 
-	return ProvenWithdrawalParameters{
+	return withdrawals.ProvenWithdrawalParameters{
 		Nonce:         ev.Nonce,
 		Sender:        ev.Sender,
 		Target:        ev.Target,
@@ -133,6 +105,7 @@ func ProveWithdrawalParametersForEvent(t devtest.T, l2Client apis.EthClient, ev 
 }
 
 // FindLatestGame finds the latest game in the DisputeGameFactory contract.
+// Ported from op-node/withdrawals/utils.go to fit in the op-devstack, using op-service ethclient
 func FindLatestGame(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient) (bindingsnew.GameSearchResult, error) {
 	rollupConfig := l2Chain.Escape().RollupConfig()
 	disputeGameFactoryAddr := l2Chain.Escape().Deployment().DisputeGameFactoryProxyAddr()
@@ -159,83 +132,4 @@ func FindLatestGame(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient
 
 	latestGame := latestGames[0]
 	return latestGame, nil
-}
-
-// Standard ABI types copied from golang ABI tests
-var (
-	Uint256Type, _ = abi.NewType("uint256", "", nil)
-	BytesType, _   = abi.NewType("bytes", "", nil)
-	AddressType, _ = abi.NewType("address", "", nil)
-)
-
-// WithdrawalHash computes the hash of the withdrawal that was stored in the L2toL1MessagePasser
-// contract state.
-// TODO:
-//   - I don't like having to use the ABI Generated struct
-//   - There should be a better way to run the ABI encoding
-//   - These needs to be fuzzed against the solidity
-func WithdrawalHash(ev *bindings.L2ToL1MessagePasserMessagePassed) (common.Hash, error) {
-	//  abi.encode(nonce, msg.sender, _target, msg.value, _gasLimit, _data)
-	args := abi.Arguments{
-		{Name: "nonce", Type: Uint256Type},
-		{Name: "sender", Type: AddressType},
-		{Name: "target", Type: AddressType},
-		{Name: "value", Type: Uint256Type},
-		{Name: "gasLimit", Type: Uint256Type},
-		{Name: "data", Type: BytesType},
-	}
-	enc, err := args.Pack(ev.Nonce, ev.Sender, ev.Target, ev.Value, ev.GasLimit, ev.Data)
-	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to pack for withdrawal hash: %w", err)
-	}
-	return crypto.Keccak256Hash(enc), nil
-}
-
-// ParseMessagePassed parses MessagePassed events from
-// a transaction receipt. It does not support multiple withdrawals
-// per receipt.
-func ParseMessagePassed(receipt *types.Receipt) (*bindings.L2ToL1MessagePasserMessagePassed, error) {
-	events, err := ParseMessagesPassed(receipt)
-	if err != nil {
-		return nil, err
-	}
-	return events[0], nil
-}
-
-// ParseMessagesPassed parses MessagePassed events from
-// a transaction receipt. It supports multiple withdrawals
-// per receipt.
-func ParseMessagesPassed(receipt *types.Receipt) ([]*bindings.L2ToL1MessagePasserMessagePassed, error) {
-	contract, err := bindings.NewL2ToL1MessagePasser(common.Address{}, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var events []*bindings.L2ToL1MessagePasserMessagePassed
-	for _, log := range receipt.Logs {
-		if len(log.Topics) == 0 || log.Topics[0] != MessagePassedTopic {
-			continue
-		}
-
-		ev, err := contract.ParseMessagePassed(*log)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse log: %w", err)
-		}
-		events = append(events, ev)
-	}
-	if len(events) == 0 {
-		return nil, errors.New("unable to find MessagePassed event")
-	}
-	return events, nil
-}
-
-// StorageSlotOfWithdrawalHash determines the storage slot of the L2ToL1MessagePasser contract to look at
-// given a WithdrawalHash
-func StorageSlotOfWithdrawalHash(hash common.Hash) common.Hash {
-	// The withdrawals mapping is the 0th storage slot in the L2ToL1MessagePasser contract.
-	// To determine the storage slot, use keccak256(withdrawalHash ++ p)
-	// Where p is the 32 byte value of the storage slot and ++ is concatenation
-	buf := make([]byte, 64)
-	copy(buf, hash[:])
-	return crypto.Keccak256Hash(buf)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/utils/utils.go
+++ b/op-acceptance-tests/tests/base/withdrawal/utils/utils.go
@@ -110,22 +110,18 @@ func FindLatestGame(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient
 	rollupConfig := l2Chain.Escape().RollupConfig()
 	disputeGameFactoryAddr := l2Chain.Escape().Deployment().DisputeGameFactoryProxyAddr()
 	optimismPortalAddr := rollupConfig.DepositContractAddress
+	portal := bindingsnew.NewBindings[bindingsnew.OptimismPortal2](bindingsnew.WithClient(l1Client), bindingsnew.WithTo(optimismPortalAddr), bindingsnew.WithTest(t))
 
-	portalFactory := bindingsnew.NewOptimismPortal2Factory(bindingsnew.WithClient(l1Client), bindingsnew.WithTo(optimismPortalAddr), bindingsnew.WithTest(t))
-	portal := bindingsnew.NewOptimismPortal2(portalFactory)
-
-	disputeGameFactory := bindingsnew.NewDisputeGameFactory(bindingsnew.WithClient(l1Client), bindingsnew.WithTo(disputeGameFactoryAddr), bindingsnew.WithTest(t))
-	disputeGame := bindingsnew.NewDisputeGame(disputeGameFactory)
-
+	disputeGameFactory := bindingsnew.NewBindings[bindingsnew.DisputeGameFactory](bindingsnew.WithClient(l1Client), bindingsnew.WithTo(disputeGameFactoryAddr), bindingsnew.WithTest(t))
 	respectedGameType := contract.Read(portal.RespectedGameType())
 
-	gameCount := contract.Read(disputeGame.GameCount())
+	gameCount := contract.Read(disputeGameFactory.GameCount())
 	if gameCount.Cmp(common.Big0) == 0 {
 		return bindingsnew.GameSearchResult{}, errors.New("no games")
 	}
 
 	searchStart := new(big.Int).Sub(gameCount, common.Big1)
-	latestGames := contract.Read(disputeGame.FindLatestGames(respectedGameType, searchStart, common.Big1))
+	latestGames := contract.Read(disputeGameFactory.FindLatestGames(respectedGameType, searchStart, common.Big1))
 	if len(latestGames) == 0 {
 		return bindingsnew.GameSearchResult{}, errors.New("no latest games")
 	}

--- a/op-acceptance-tests/tests/base/withdrawal/utils/utils.go
+++ b/op-acceptance-tests/tests/base/withdrawal/utils/utils.go
@@ -1,0 +1,241 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
+	"github.com/ethereum-optimism/optimism/op-node/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	bindingsnew "github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+)
+
+var MessagePassedTopic = crypto.Keccak256Hash([]byte("MessagePassed(uint256,address,address,uint256,uint256,bytes,bytes32)"))
+
+type ProofClient interface {
+	GetProof(context.Context, common.Address, []common.Hash, *big.Int) (*gethclient.AccountResult, error)
+}
+
+type ReceiptClient interface {
+	TransactionReceipt(context.Context, common.Hash) (*types.Receipt, error)
+}
+
+type HeaderClient interface {
+	HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
+}
+
+// ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
+// and FinalizeWithdrawalTransaction functions
+type ProvenWithdrawalParameters struct {
+	Nonce           *big.Int
+	Sender          common.Address
+	Target          common.Address
+	Value           *big.Int
+	GasLimit        *big.Int
+	L2OutputIndex   *big.Int
+	Data            []byte
+	OutputRootProof bindings.TypesOutputRootProof
+	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
+}
+
+// ProveWithdrawalParameters calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
+func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt) (ProvenWithdrawalParameters, error) {
+	latestGame, err := FindLatestGame(t, l2Chain, l1Client)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to find latest game: %w", err)
+	}
+
+	l2BlockNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
+	l2OutputIndex := latestGame.Index
+	// Fetch the block header from the L2 node
+	l2Header, err := l2Client.InfoByNumber(t.Ctx(), l2BlockNumber.Uint64())
+	if err != nil {
+		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2Block: %w", err)
+	}
+	return ProveWithdrawalParametersForBlock(t, l2Client, l2WithdrawalReceipt, l2Header, l2OutputIndex)
+}
+
+// ProveWithdrawalParametersForBlock queries L1 & L2 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.
+// The l2Header provided is very important. It should be a block for which there is a submitted output in the L2 Output Oracle
+// contract. If not, the withdrawal will fail as it the storage proof cannot be verified if there is no submitted state root.
+func ProveWithdrawalParametersForBlock(t devtest.T, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt, l2Header eth.BlockInfo, l2OutputIndex *big.Int) (ProvenWithdrawalParameters, error) {
+	// Transaction receipt
+	// Parse the receipt
+	ev, err := ParseMessagePassed(l2WithdrawalReceipt)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, err
+	}
+	return ProveWithdrawalParametersForEvent(t, l2Client, ev, l2Header, l2OutputIndex)
+}
+
+// ProveWithdrawalParametersForEvent queries L1 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.
+// The l2Header provided is very important. It should be a block for which there is a submitted output in the L2 Output Oracle
+// contract. If not, the withdrawal will fail as it the storage proof cannot be verified if there is no submitted state root.
+func ProveWithdrawalParametersForEvent(t devtest.T, l2Client apis.EthClient, ev *bindings.L2ToL1MessagePasserMessagePassed, l2Header eth.BlockInfo, l2OutputIndex *big.Int) (ProvenWithdrawalParameters, error) {
+	// Generate then verify the withdrawal proof
+	withdrawalHash, err := WithdrawalHash(ev)
+	if !bytes.Equal(withdrawalHash[:], ev.WithdrawalHash[:]) {
+		return ProvenWithdrawalParameters{}, errors.New("computed withdrawal hash incorrectly")
+	}
+	if err != nil {
+		return ProvenWithdrawalParameters{}, err
+	}
+	slot := StorageSlotOfWithdrawalHash(withdrawalHash)
+
+	p, err := l2Client.GetProof(t.Ctx(), predeploys.L2ToL1MessagePasserAddr, []common.Hash{slot}, "0x"+fmt.Sprintf("%x", l2Header.NumberU64()))
+	if err != nil {
+		return ProvenWithdrawalParameters{}, err
+	}
+	if len(p.StorageProof) != 1 {
+		return ProvenWithdrawalParameters{}, errors.New("invalid amount of storage proofs")
+	}
+
+	err = VerifyProof(l2Header.Root(), p)
+	if err != nil {
+		return ProvenWithdrawalParameters{}, err
+	}
+
+	// Encode it as expected by the contract
+	trieNodes := make([][]byte, len(p.StorageProof[0].Proof))
+	for i, s := range p.StorageProof[0].Proof {
+		trieNodes[i] = s
+	}
+
+	return ProvenWithdrawalParameters{
+		Nonce:         ev.Nonce,
+		Sender:        ev.Sender,
+		Target:        ev.Target,
+		Value:         ev.Value,
+		GasLimit:      ev.GasLimit,
+		L2OutputIndex: l2OutputIndex,
+		Data:          ev.Data,
+		OutputRootProof: bindings.TypesOutputRootProof{
+			Version:                  [32]byte{}, // Empty for version 1
+			StateRoot:                eth.Bytes32(l2Header.Root()),
+			MessagePasserStorageRoot: *l2Header.WithdrawalsRoot(),
+			LatestBlockhash:          l2Header.Hash(),
+		},
+		WithdrawalProof: trieNodes,
+	}, nil
+}
+
+// FindLatestGame finds the latest game in the DisputeGameFactory contract.
+func FindLatestGame(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient) (bindingsnew.GameSearchResult, error) {
+	rollupConfig := l2Chain.Escape().RollupConfig()
+	disputeGameFactoryAddr := l2Chain.Escape().Deployment().DisputeGameFactoryProxyAddr()
+	optimismPortalAddr := rollupConfig.DepositContractAddress
+
+	portalFactory := bindingsnew.NewOptimismPortal2Factory(bindingsnew.WithClient(l1Client), bindingsnew.WithTo(optimismPortalAddr), bindingsnew.WithTest(t))
+	portal := bindingsnew.NewOptimismPortal2(portalFactory)
+
+	disputeGameFactory := bindingsnew.NewDisputeGameFactory(bindingsnew.WithClient(l1Client), bindingsnew.WithTo(disputeGameFactoryAddr), bindingsnew.WithTest(t))
+	disputeGame := bindingsnew.NewDisputeGame(disputeGameFactory)
+
+	respectedGameType := contract.Read(portal.RespectedGameType())
+
+	gameCount := contract.Read(disputeGame.GameCount())
+	if gameCount.Cmp(common.Big0) == 0 {
+		return bindingsnew.GameSearchResult{}, errors.New("no games")
+	}
+
+	searchStart := new(big.Int).Sub(gameCount, common.Big1)
+	latestGames := contract.Read(disputeGame.FindLatestGames(respectedGameType, searchStart, common.Big1))
+	if len(latestGames) == 0 {
+		return bindingsnew.GameSearchResult{}, errors.New("no latest games")
+	}
+
+	latestGame := latestGames[0]
+	return latestGame, nil
+}
+
+// Standard ABI types copied from golang ABI tests
+var (
+	Uint256Type, _ = abi.NewType("uint256", "", nil)
+	BytesType, _   = abi.NewType("bytes", "", nil)
+	AddressType, _ = abi.NewType("address", "", nil)
+)
+
+// WithdrawalHash computes the hash of the withdrawal that was stored in the L2toL1MessagePasser
+// contract state.
+// TODO:
+//   - I don't like having to use the ABI Generated struct
+//   - There should be a better way to run the ABI encoding
+//   - These needs to be fuzzed against the solidity
+func WithdrawalHash(ev *bindings.L2ToL1MessagePasserMessagePassed) (common.Hash, error) {
+	//  abi.encode(nonce, msg.sender, _target, msg.value, _gasLimit, _data)
+	args := abi.Arguments{
+		{Name: "nonce", Type: Uint256Type},
+		{Name: "sender", Type: AddressType},
+		{Name: "target", Type: AddressType},
+		{Name: "value", Type: Uint256Type},
+		{Name: "gasLimit", Type: Uint256Type},
+		{Name: "data", Type: BytesType},
+	}
+	enc, err := args.Pack(ev.Nonce, ev.Sender, ev.Target, ev.Value, ev.GasLimit, ev.Data)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to pack for withdrawal hash: %w", err)
+	}
+	return crypto.Keccak256Hash(enc), nil
+}
+
+// ParseMessagePassed parses MessagePassed events from
+// a transaction receipt. It does not support multiple withdrawals
+// per receipt.
+func ParseMessagePassed(receipt *types.Receipt) (*bindings.L2ToL1MessagePasserMessagePassed, error) {
+	events, err := ParseMessagesPassed(receipt)
+	if err != nil {
+		return nil, err
+	}
+	return events[0], nil
+}
+
+// ParseMessagesPassed parses MessagePassed events from
+// a transaction receipt. It supports multiple withdrawals
+// per receipt.
+func ParseMessagesPassed(receipt *types.Receipt) ([]*bindings.L2ToL1MessagePasserMessagePassed, error) {
+	contract, err := bindings.NewL2ToL1MessagePasser(common.Address{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var events []*bindings.L2ToL1MessagePasserMessagePassed
+	for _, log := range receipt.Logs {
+		if len(log.Topics) == 0 || log.Topics[0] != MessagePassedTopic {
+			continue
+		}
+
+		ev, err := contract.ParseMessagePassed(*log)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse log: %w", err)
+		}
+		events = append(events, ev)
+	}
+	if len(events) == 0 {
+		return nil, errors.New("unable to find MessagePassed event")
+	}
+	return events, nil
+}
+
+// StorageSlotOfWithdrawalHash determines the storage slot of the L2ToL1MessagePasser contract to look at
+// given a WithdrawalHash
+func StorageSlotOfWithdrawalHash(hash common.Hash) common.Hash {
+	// The withdrawals mapping is the 0th storage slot in the L2ToL1MessagePasser contract.
+	// To determine the storage slot, use keccak256(withdrawalHash ++ p)
+	// Where p is the 32 byte value of the storage slot and ++ is concatenation
+	buf := make([]byte, 64)
+	copy(buf, hash[:])
+	return crypto.Keccak256Hash(buf)
+}

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_helper.go
@@ -45,11 +45,7 @@ func ForGamePublished(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClie
 	return outputBlockNum.Uint64(), nil
 }
 
-func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt) (withdrawals.ProvenWithdrawalParameters, *types.Receipt) {
-	optimismPortalAddr, err := portal.BaseCall.To()
-	require.NoError(t, err)
-	require.NotNil(t, optimismPortalAddr)
-
+func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, optimismPortalAddr common.Address, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt) (withdrawals.ProvenWithdrawalParameters, *types.Receipt) {
 	l1Client := sys.L1EL.Escape().EthClient()
 	l2Client := sys.L2EL.Escape().EthClient()
 
@@ -64,7 +60,7 @@ func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets
 	t.Logf("proveWithdrawal: proving withdrawal...")
 	require.Eventually(t, func() bool {
 		dgfaddr := contract.Read(portal.DisputeGameFactoryAddr())
-		_, err := ForGamePublished(t, sys.L2Networks()[0], l1Client, *optimismPortalAddr, dgfaddr, l2WithdrawalReceipt.BlockNumber)
+		_, err := ForGamePublished(t, sys.L2Networks()[0], l1Client, optimismPortalAddr, dgfaddr, l2WithdrawalReceipt.BlockNumber)
 		require.NoError(t, err)
 		params, err = ProveWithdrawalParameters(t, sys.L2Chain, l1Client, l2Client, l2WithdrawalReceipt)
 		require.NoError(t, err)

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_helper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 
@@ -44,7 +45,7 @@ func ForGamePublished(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClie
 	return outputBlockNum.Uint64(), nil
 }
 
-func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt) (utils.ProvenWithdrawalParameters, *types.Receipt) {
+func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt) (withdrawals.ProvenWithdrawalParameters, *types.Receipt) {
 	optimismPortalAddr, err := portal.BaseCall.To()
 	require.NoError(t, err)
 	require.NotNil(t, optimismPortalAddr)
@@ -58,7 +59,7 @@ func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets
 	sys.L1Network.WaitForBlock()
 
 	var proveReceipt *types.Receipt
-	var params utils.ProvenWithdrawalParameters
+	var params withdrawals.ProvenWithdrawalParameters
 
 	t.Logf("proveWithdrawal: proving withdrawal...")
 	require.Eventually(t, func() bool {
@@ -93,11 +94,11 @@ func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets
 	return params, proveReceipt
 }
 
-func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt) (utils.ProvenWithdrawalParameters, error) {
+func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt) (withdrawals.ProvenWithdrawalParameters, error) {
 	return utils.ProveWithdrawalParameters(t, l2Chain, l1Client, l2Client, l2WithdrawalReceipt)
 }
 
-func FinalizeWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt, params utils.ProvenWithdrawalParameters) (*types.Receipt, *types.Receipt, *types.Receipt) {
+func FinalizeWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt, params withdrawals.ProvenWithdrawalParameters) (*types.Receipt, *types.Receipt, *types.Receipt) {
 	wd := crossdomain.Withdrawal{
 		Nonce:    params.Nonce,
 		Sender:   &params.Sender,

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_helper.go
@@ -1,0 +1,188 @@
+package withdrawal
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal/utils"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ForGamePublished waits until a game is published on L1 for the given l2BlockNumber.
+func ForGamePublished(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, optimismPortalAddr common.Address, disputeGameFactoryAddr common.Address, l2BlockNumber *big.Int) (uint64, error) {
+	_, cancel := context.WithTimeout(t.Ctx(), 2*time.Minute)
+	defer cancel()
+	var outputBlockNum *big.Int
+	require.Eventually(t, func() bool {
+		latestGame, err := utils.FindLatestGame(t, l2Chain, l1Client)
+		if err != nil {
+			return false
+		}
+		outputBlockNum = new(big.Int).SetBytes(latestGame.ExtraData[0:32])
+		return outputBlockNum.Cmp(l2BlockNumber) >= 0
+	}, 30*time.Second, 100*time.Millisecond, "latest game not found")
+	return outputBlockNum.Uint64(), nil
+}
+
+func ProveWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt) (utils.ProvenWithdrawalParameters, *types.Receipt) {
+	optimismPortalAddr, err := portal.BaseCall.To()
+	require.NoError(t, err)
+	require.NotNil(t, optimismPortalAddr)
+
+	l1Client := sys.L1EL.Escape().EthClient()
+	l2Client := sys.L2EL.Escape().EthClient()
+
+	// Wait for another block to be mined so that the timestamp increases. Otherwise,
+	// proveWithdrawalTransaction gas estimation may fail because the current timestamp is the same
+	// as the dispute game creation timestamp.
+	sys.L1Network.WaitForBlock()
+
+	var proveReceipt *types.Receipt
+	var params utils.ProvenWithdrawalParameters
+
+	t.Logf("proveWithdrawal: proving withdrawal...")
+	require.Eventually(t, func() bool {
+		dgfaddr := contract.Read(portal.DisputeGameFactoryAddr())
+		_, err := ForGamePublished(t, sys.L2Networks()[0], l1Client, *optimismPortalAddr, dgfaddr, l2WithdrawalReceipt.BlockNumber)
+		require.NoError(t, err)
+		params, err = ProveWithdrawalParameters(t, sys.L2Chain, l1Client, l2Client, l2WithdrawalReceipt)
+		require.NoError(t, err)
+		tx := bindings.WithdrawalTransaction{
+			Nonce:    params.Nonce,
+			Sender:   params.Sender,
+			Target:   params.Target,
+			Value:    params.Value,
+			GasLimit: params.GasLimit,
+			Data:     params.Data,
+		}
+		proof := bindings.OutputRootProof{
+			Version:                  [32]byte{},
+			StateRoot:                params.OutputRootProof.StateRoot,
+			MessagePasserStorageRoot: params.OutputRootProof.MessagePasserStorageRoot,
+			LatestBlockhash:          params.OutputRootProof.LatestBlockhash,
+		}
+		call := portal.ProveWithdrawalTransaction(tx, params.L2OutputIndex, proof, params.WithdrawalProof)
+		proveReceipt, err = contractio.Write(call, t.Ctx(), l1User.Plan())
+		if err != nil {
+			return false
+		}
+		return proveReceipt.Status == types.ReceiptStatusSuccessful
+	}, 120*time.Second, 100*time.Millisecond, "withdrawal proof failed")
+	require.Equal(t, 2, len(proveReceipt.Logs)) // emit WithdrawalProven, WithdrawalProvenExtension1
+
+	return params, proveReceipt
+}
+
+func ProveWithdrawalParameters(t devtest.T, l2Chain *dsl.L2Network, l1Client apis.EthClient, l2Client apis.EthClient, l2WithdrawalReceipt *types.Receipt) (utils.ProvenWithdrawalParameters, error) {
+	return utils.ProveWithdrawalParameters(t, l2Chain, l1Client, l2Client, l2WithdrawalReceipt)
+}
+
+func FinalizeWithdrawal(t devtest.T, portal *bindings.OptimismPortal2, sys *presets.Minimal, l1User *dsl.EOA, l2WithdrawalReceipt *types.Receipt, params utils.ProvenWithdrawalParameters) (*types.Receipt, *types.Receipt, *types.Receipt) {
+	wd := crossdomain.Withdrawal{
+		Nonce:    params.Nonce,
+		Sender:   &params.Sender,
+		Target:   &params.Target,
+		Value:    params.Value,
+		GasLimit: params.GasLimit,
+		Data:     params.Data,
+	}
+
+	l1Client := sys.L1EL.Escape().EthClient()
+	wdHash, err := wd.Hash()
+	require.NoError(t, err)
+
+	game := contract.Read(portal.ProvenWithdrawals(wdHash, l1User.Address()))
+	// basic sanity check for unix timestamp
+	require.Greater(t, game.Timestamp, uint64(1700000000))
+
+	gameContract, err := contracts.NewFaultDisputeGameContract(t.Ctx(), metrics.NoopContractMetrics, game.DisputeGameProxy, l1Client.NewMultiCaller(batching.DefaultBatchSize))
+	require.NoError(t, err)
+
+	timedCtx, cancel := context.WithTimeout(t.Ctx(), 120*time.Second)
+	defer cancel()
+	require.NoError(t, wait.For(timedCtx, time.Second, func() (bool, error) {
+		// First check if the game is in a resolvable state
+		status, err := gameContract.GetStatus(t.Ctx())
+		if err != nil {
+			return false, err
+		}
+		if status != gameTypes.GameStatusInProgress {
+			return false, fmt.Errorf("game is not in progress: %v", status)
+		}
+		// Try to resolve the claim
+		err = gameContract.CallResolveClaim(t.Ctx(), 0)
+		if err != nil {
+			t.Logf("Could not resolve dispute game claim: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}))
+
+	t.Logf("FinalizeWithdrawal: resolveClaim...")
+	tx, err := gameContract.ResolveClaimTx(0)
+	require.NoError(t, err)
+	resolveClaimReceipt := l1User.Transact(
+		l1User.Plan(),
+		txplan.WithTo(tx.To),
+		txplan.WithValue(tx.Value),
+		txplan.WithGasLimit(tx.GasLimit),
+		txplan.WithData(tx.TxData),
+	)
+
+	t.Logf("FinalizeWithdrawal: resolve...")
+	tx, err = gameContract.ResolveTx()
+	require.NoError(t, err)
+
+	resolveReceipt := l1User.Transact(
+		l1User.Plan(),
+		txplan.WithTo(tx.To),
+		txplan.WithValue(tx.Value),
+		txplan.WithGasLimit(tx.GasLimit),
+		txplan.WithData(tx.TxData),
+	)
+
+	receipt := resolveReceipt.Included.Value()
+	require.Equal(t, 1, len(receipt.Logs)) // emit Resolved
+
+	if resolveReceipt.Included.Value().Status == types.ReceiptStatusFailed {
+		t.Logf("resolve failed (tx: %s)! But game may have resolved already. Checking now...", resolveReceipt.Included.Value().TxHash)
+		// it may have failed because someone else front-ran this by calling `resolve()` first.
+		status, err := gameContract.GetStatus(t.Ctx())
+		require.NoError(t, err)
+		require.Equal(t, gameTypes.GameStatusDefenderWon, status, "game must have resolved with defender won")
+		t.Logf("resolve was not needed, the game was already resolved")
+	}
+
+	// Finalize withdrawal
+	t.Logf("FinalizeWithdrawal: finalizing withdrawal...")
+	var finalizeWithdrawalReceipt *types.Receipt
+	require.Eventually(t, func() bool {
+		finalizeWithdrawalReceipt, err = contractio.Write(portal.FinalizeWithdrawalTransaction(wd.WithdrawalTransaction()), t.Ctx(), l1User.Plan())
+		if err != nil {
+			return false
+		}
+		return types.ReceiptStatusSuccessful == finalizeWithdrawalReceipt.Status
+	}, 60*time.Second, 100*time.Millisecond, "finalize withdrawal failed")
+
+	return finalizeWithdrawalReceipt, resolveClaimReceipt.Included.Value(), resolveReceipt.Included.Value()
+}

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -27,11 +27,8 @@ func TestWithdrawal(gt *testing.T) {
 
 	// initialize contract bindings
 	optimismPortalAddr := sys.L2Chain.Escape().RollupConfig().DepositContractAddress
-	portalFactory := bindings.NewOptimismPortal2Factory(bindings.WithClient(l1Client), bindings.WithTo(optimismPortalAddr), bindings.WithTest(t))
-	portal := bindings.NewOptimismPortal2(portalFactory)
-
-	l2tol1MessagePasserFactory := bindings.NewL2ToL1MessagePasserFactory(bindings.WithClient(l2Client), bindings.WithTo(predeploys.L2ToL1MessagePasserAddr), bindings.WithTest(t))
-	l2tol1MessagePasser := bindings.NewL2ToL1MessagePasser(l2tol1MessagePasserFactory)
+	portal := bindings.NewBindings[bindings.OptimismPortal2](bindings.WithClient(l1Client), bindings.WithTo(optimismPortalAddr), bindings.WithTest(t))
+	l2tol1MessagePasser := bindings.NewBindings[bindings.L2ToL1MessagePasser](bindings.WithClient(l2Client), bindings.WithTo(predeploys.L2ToL1MessagePasserAddr), bindings.WithTest(t))
 
 	// Make sure fast game is set
 	require.Equal(uint32(faultTypes.FastGameType), contract.Read(portal.RespectedGameType()))
@@ -117,10 +114,10 @@ func TestWithdrawal(gt *testing.T) {
 	}
 
 	// Withdrawal STEP 1: Prove Withdrawal at L1
-	withdrawalParams, proveReceipt := ProveWithdrawal(t, portal, sys, l1User, l2WithdrawalReceipt)
+	withdrawalParams, proveReceipt := ProveWithdrawal(t, &portal, optimismPortalAddr, sys, l1User, l2WithdrawalReceipt)
 
 	// Withdrawal STEP 2: Finalize Withdrawal at L2
-	finalizeReceipt, resolveClaimReceipt, resolveReceipt := FinalizeWithdrawal(t, portal, sys, l1User, proveReceipt, withdrawalParams)
+	finalizeReceipt, resolveClaimReceipt, resolveReceipt := FinalizeWithdrawal(t, &portal, sys, l1User, proveReceipt, withdrawalParams)
 
 	// L1 gas fee check for proving and finalizing
 	{

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -17,24 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimal(),
-		presets.WithProposerGameType(faultTypes.FastGameType),
-		// Fast game for test
-		presets.WithFastGame(),
-		// Deployer must be L1PAO to make op-deployer happy
-		presets.WithDeployerMatchL1PAO(),
-		// Guardian must be L1PAO to make AnchorStateRegistry's setRespectedGameType method work
-		presets.WithGuardianMatchL1PAO(),
-		// Fast finalization for fast withdrawal
-		presets.WithFinalizationPeriodSeconds(2),
-		// Satisfy OptimismPortal2 PROOF_MATURITY_DELAY_SECONDS check, avoid OptimismPortal_ProofNotOldEnough() revert
-		presets.WithProofMaturityDelaySeconds(12),
-		// Satisfy AnchorStateRegistry DISPUTE_GAME_FINALITY_DELAY_SECONDS check, avoid OptimismPortal_InvalidRootClaim() revert
-		presets.WithDisputeGameFinalityDelaySeconds(6),
-	)
-}
-
 func TestWithdrawal(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
@@ -54,7 +36,7 @@ func TestWithdrawal(gt *testing.T) {
 	// Make sure fast game is set
 	require.Equal(uint32(faultTypes.FastGameType), contract.Read(portal.RespectedGameType()))
 
-	initialL1Balance, initialL2Balance := eth.TenEther, eth.OneEther
+	initialL1Balance, initialL2Balance := eth.OneThirdEther, eth.OneTenthEther
 
 	// l1User and l2User share same private key
 	l2User := sys.Funder.NewFundedEOA(initialL2Balance)
@@ -65,8 +47,8 @@ func TestWithdrawal(gt *testing.T) {
 	// The max amount of withdrawal is limited to the total amount of deposit
 	// We trigger deposit first to fund the L1 ETHLockbox to satisfy the invariant
 
-	// Deposit 1 ETH
-	depositAmount := eth.OneEther
+	// Deposit 0.1 ETH
+	depositAmount := eth.OneTenthEther
 	l1DepositReceipt := contract.Write(l1User,
 		portal.DepositTransaction(userAddr, depositAmount, 1_000_000, false, []byte{}),
 		txplan.WithValue(depositAmount.ToBig()),
@@ -102,8 +84,8 @@ func TestWithdrawal(gt *testing.T) {
 		require.True(l1BalanceAfterDeposit.Cmp(diff) == 0)
 	}
 
-	// Withdrawal 1 ETH
-	withdrawalAmount := eth.OneEther
+	// Withdrawal 0.1 ETH
+	withdrawalAmount := eth.OneTenthEther
 	l1BalanceBeforeWithdrawal := l1BalanceAfterDeposit
 	l2BalanceBeforeWithdrawal := l2BalanceAfterDeposit
 

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -1,0 +1,30 @@
+package withdrawal
+
+import (
+	"testing"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithMinimal(),
+		presets.WithProposerGameType(faultTypes.FastGameType),
+		// Fast game for test
+		presets.WithFastGame(),
+		// Deployer must be L1PAO to make op-deployer happy
+		presets.WithDeployerMatchL1PAO(),
+		// Guardian must be L1PAO to make AnchorStateRegistry's setRespectedGameType method work
+		presets.WithGuardianMatchL1PAO(),
+		// Fast finalization for fast withdrawal
+		presets.WithFinalizationPeriodSeconds(2),
+		// Satisfy OptimismPortal2 PROOF_MATURITY_DELAY_SECONDS check, avoid OptimismPortal_ProofNotOldEnough() revert
+		presets.WithProofMaturityDelaySeconds(12),
+		// Satisfy AnchorStateRegistry DISPUTE_GAME_FINALITY_DELAY_SECONDS check, avoid OptimismPortal_InvalidRootClaim() revert
+		presets.WithDisputeGameFinalityDelaySeconds(6),
+	)
+}
+
+func TestWithdrawal(gt *testing.T) {
+
+}

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -72,7 +72,7 @@ func TestWithdrawal(gt *testing.T) {
 		txplan.WithValue(depositAmount.ToBig()),
 	)
 	// L2CL will read L1, fetch TransactionDeposited() event and convert as a deposit transaction at L2
-	// Contruct the L2 deposit tx to check the tx is included at L2
+	// Construct the L2 deposit tx to check the tx is included at L2
 	idx := len(l1DepositReceipt.Logs) - 1
 	l2DepositTx, err := derive.UnmarshalDepositLogEvent(l1DepositReceipt.Logs[idx])
 	require.NoError(err, "Could not reconstruct L2 Deposit")

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -64,7 +64,7 @@ func TestWithdrawal(gt *testing.T) {
 	require.Eventually(func() bool {
 		l2DepositReceipt, err = l2Client.TransactionReceipt(t.Ctx(), l2DepositTxHash)
 		return err == nil
-	}, 12*time.Second, 500*time.Millisecond, "L2 Deposit never found")
+	}, 60*time.Second, 500*time.Millisecond, "L2 Deposit never found")
 	require.Equal(types.ReceiptStatusSuccessful, l2DepositReceipt.Status)
 	// Deposit tx included so L2 user balance must be updated
 

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -1,10 +1,20 @@
 package withdrawal
 
 import (
+	"math/big"
 	"testing"
+	"time"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func TestMain(m *testing.M) {
@@ -26,5 +36,126 @@ func TestMain(m *testing.M) {
 }
 
 func TestWithdrawal(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	require := sys.T.Require()
 
+	l1Client := sys.L1EL.Escape().EthClient()
+	l2Client := sys.L2EL.Escape().EthClient()
+
+	// initialize contract bindings
+	optimismPortalAddr := sys.L2Chain.Escape().RollupConfig().DepositContractAddress
+	portalFactory := bindings.NewOptimismPortal2Factory(bindings.WithClient(l1Client), bindings.WithTo(optimismPortalAddr), bindings.WithTest(t))
+	portal := bindings.NewOptimismPortal2(portalFactory)
+
+	l2tol1MessagePasserFactory := bindings.NewL2ToL1MessagePasserFactory(bindings.WithClient(l2Client), bindings.WithTo(predeploys.L2ToL1MessagePasserAddr), bindings.WithTest(t))
+	l2tol1MessagePasser := bindings.NewL2ToL1MessagePasser(l2tol1MessagePasserFactory)
+
+	// Make sure fast game is set
+	require.Equal(uint32(faultTypes.FastGameType), contract.Read(portal.RespectedGameType()))
+
+	initialL1Balance, initialL2Balance := eth.TenEther, eth.OneEther
+
+	// l1User and l2User share same private key
+	l2User := sys.Funder.NewFundedEOA(initialL2Balance)
+	l1User := l2User.AsEL(sys.L1EL)
+	sys.FunderL1.Fund(l1User, initialL1Balance)
+	userAddr := l1User.Address()
+
+	// The max amount of withdrawal is limited to the total amount of deposit
+	// We trigger deposit first to fund the L1 ETHLockbox to satisfy the invariant
+
+	// Deposit 1 ETH
+	depositAmount := eth.OneEther
+	l1DepositReceipt := contract.Write(l1User,
+		portal.DepositTransaction(userAddr, depositAmount, 1_000_000, false, []byte{}),
+		txplan.WithValue(depositAmount.ToBig()),
+	)
+	// L2CL will read L1, fetch TransactionDeposited() event and convert as a deposit transaction at L2
+	// Contruct the L2 deposit tx to check the tx is included at L2
+	idx := len(l1DepositReceipt.Logs) - 1
+	l2DepositTx, err := derive.UnmarshalDepositLogEvent(l1DepositReceipt.Logs[idx])
+	require.NoError(err, "Could not reconstruct L2 Deposit")
+	l2DepositTxHash := types.NewTx(l2DepositTx).Hash()
+	// Give time for L2CL to include the L2 deposit tx
+	var l2DepositReceipt *types.Receipt
+	require.Eventually(func() bool {
+		l2DepositReceipt, err = l2Client.TransactionReceipt(t.Ctx(), l2DepositTxHash)
+		return err == nil
+	}, 12*time.Second, 500*time.Millisecond, "L2 Deposit never found")
+	require.Equal(types.ReceiptStatusSuccessful, l2DepositReceipt.Status)
+	// Deposit tx included so L2 user balance must be updated
+
+	l1BalanceAfterDeposit, err := l1Client.BalanceAt(t.Ctx(), userAddr, nil)
+	require.NoError(err)
+	l2BalanceAfterDeposit, err := l2Client.BalanceAt(t.Ctx(), userAddr, nil)
+	require.NoError(err)
+
+	require.True(l2BalanceAfterDeposit.Cmp(new(big.Int).Add(initialL2Balance.ToBig(), depositAmount.ToBig())) == 0)
+	// L1 gas fee check
+	{
+		depositGasFee := new(big.Int).Mul(big.NewInt(int64(l1DepositReceipt.GasUsed)), l1DepositReceipt.EffectiveGasPrice)
+		diff := new(big.Int).Sub(
+			new(big.Int).Sub(initialL1Balance.ToBig(), depositAmount.ToBig()),
+			depositGasFee,
+		)
+		require.True(l1BalanceAfterDeposit.Cmp(diff) == 0)
+	}
+
+	// Withdrawal 1 ETH
+	withdrawalAmount := eth.OneEther
+	l1BalanceBeforeWithdrawal := l1BalanceAfterDeposit
+	l2BalanceBeforeWithdrawal := l2BalanceAfterDeposit
+
+	// Satisfy ETHLockbox invariant
+	require.True(depositAmount.ToBig().Cmp(withdrawalAmount.ToBig()) != -1)
+
+	// Withdrawal STEP 0: Trigger L2toL1 Message
+	l2WithdrawalReceipt := contract.Write(l2User,
+		l2tol1MessagePasser.InitiateWithdrawal(userAddr, new(big.Int).SetInt64(500_000), []byte{}),
+		txplan.WithValue(withdrawalAmount.ToBig()),
+	)
+	// Emit MessagePassed event
+	require.Equal(1, len(l2WithdrawalReceipt.Logs))
+
+	l2BalanceAfterWithdrawal, err := l2Client.BalanceAt(t.Ctx(), userAddr, nil)
+	require.NoError(err)
+
+	computeFee := func(receipt *types.Receipt) *big.Int {
+		return new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), receipt.EffectiveGasPrice)
+	}
+
+	// L2 gas fee check
+	{
+		fees := computeFee(l2WithdrawalReceipt)
+		fees = fees.Add(fees, l2WithdrawalReceipt.L1Fee)
+		diff := new(big.Int).Sub(l2BalanceBeforeWithdrawal, l2BalanceAfterWithdrawal)
+		diff = diff.Sub(diff, fees)
+		require.True(withdrawalAmount.ToBig().Cmp(diff) == 0)
+	}
+
+	// Withdrawal STEP 1: Prove Withdrawal at L1
+	withdrawalParams, proveReceipt := ProveWithdrawal(t, portal, sys, l1User, l2WithdrawalReceipt)
+
+	// Withdrawal STEP 2: Finalize Withdrawal at L2
+	finalizeReceipt, resolveClaimReceipt, resolveReceipt := FinalizeWithdrawal(t, portal, sys, l1User, proveReceipt, withdrawalParams)
+
+	// L1 gas fee check for proving and finalizing
+	{
+		receipts := []*types.Receipt{proveReceipt, finalizeReceipt, resolveClaimReceipt, resolveReceipt}
+		fees := new(big.Int)
+		for _, r := range receipts {
+			fees.Add(fees, computeFee(r))
+		}
+		expectedAmount := new(big.Int).Sub(withdrawalAmount.ToBig(), fees)
+		var endBalanceAfterFinalize *big.Int
+		require.Eventually(func() bool {
+			endBalanceAfterFinalize, err = l1Client.BalanceAt(t.Ctx(), userAddr, nil)
+			if err != nil {
+				return false
+			}
+			diff := new(big.Int).Sub(endBalanceAfterFinalize, l1BalanceBeforeWithdrawal)
+			return diff.Cmp(expectedAmount) == 0
+		}, time.Second*60, time.Second, "awaiting balance to be changed")
+	}
 }

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -1,0 +1,16 @@
+package presets
+
+import (
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
+)
+
+func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
+	return stack.Combine(
+		stack.MakeCommon(
+			sysgo.WithProposerOption(func(id stack.L2ProposerID, cfg *ps.CLIConfig) {
+				cfg.DisputeGameType = uint32(gameType)
+			})))
+}

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -25,7 +25,8 @@ func WithFastGame() stack.CommonOption {
 				[]state.AdditionalDisputeGame{
 					{
 						ChainProofParams: state.ChainProofParams{
-							DisputeGameType:         uint32(faultTypes.FastGameType),
+							DisputeGameType: uint32(faultTypes.FastGameType),
+							// Use Alphabet VM prestate which is a pre-determined fixed hash
 							DisputeAbsolutePrestate: common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
 							DisputeMaxGameDepth:     14 + 3 + 1,
 							DisputeSplitDepth:       14,

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -2,9 +2,11 @@ package presets
 
 import (
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
@@ -13,4 +15,30 @@ func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
 			sysgo.WithProposerOption(func(id stack.L2ProposerID, cfg *ps.CLIConfig) {
 				cfg.DisputeGameType = uint32(gameType)
 			})))
+}
+
+func WithFastGame() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithDeployerOptions(
+			sysgo.WithAdditionalDisputeGames(
+				[]state.AdditionalDisputeGame{
+					{
+						ChainProofParams: state.ChainProofParams{
+							DisputeGameType:         uint32(faultTypes.FastGameType),
+							DisputeAbsolutePrestate: common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
+							DisputeMaxGameDepth:     14 + 3 + 1,
+							DisputeSplitDepth:       14,
+							DisputeClockExtension:   0,
+							DisputeMaxClockDuration: 0,
+						},
+						VMType:                       state.VMTypeAlphabet,
+						UseCustomOracle:              true,
+						OracleMinProposalSize:        10000,
+						OracleChallengePeriodSeconds: 0,
+						MakeRespected:                true,
+					},
+				},
+			),
+		),
+	)
 }

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -42,3 +42,19 @@ func WithFastGame() stack.CommonOption {
 		),
 	)
 }
+
+func WithDeployerMatchL1PAO() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithDeployerPipelineOption(
+			sysgo.WithDeployerMatchL1PAO(),
+		),
+	)
+}
+
+func WithGuardianMatchL1PAO() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithDeployerOptions(
+			sysgo.WithGuardianMatchL1PAO(),
+		),
+	)
+}

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -58,3 +58,21 @@ func WithGuardianMatchL1PAO() stack.CommonOption {
 		),
 	)
 }
+
+func WithFinalizationPeriodSeconds(n uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.WithDeployerOptions(
+		sysgo.WithFinalizationPeriodSeconds(n),
+	))
+}
+
+func WithProofMaturityDelaySeconds(seconds uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.WithDeployerOptions(
+		sysgo.WithProofMaturityDelaySeconds(seconds),
+	))
+}
+
+func WithDisputeGameFinalityDelaySeconds(seconds uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.WithDeployerOptions(
+		sysgo.WithDisputeGameFinalityDelaySeconds(seconds),
+	))
+}

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -17,6 +17,7 @@ func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
 			})))
 }
 
+// TODO(infra#401): Implement support in the sysext toolset
 func WithFastGame() stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithDeployerOptions(
@@ -43,6 +44,7 @@ func WithFastGame() stack.CommonOption {
 	)
 }
 
+// TODO(infra#401): Implement support in the sysext toolset
 func WithDeployerMatchL1PAO() stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithDeployerPipelineOption(
@@ -51,6 +53,7 @@ func WithDeployerMatchL1PAO() stack.CommonOption {
 	)
 }
 
+// TODO(infra#401): Implement support in the sysext toolset
 func WithGuardianMatchL1PAO() stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithDeployerOptions(
@@ -59,18 +62,21 @@ func WithGuardianMatchL1PAO() stack.CommonOption {
 	)
 }
 
+// TODO(infra#401): Implement support in the sysext toolset
 func WithFinalizationPeriodSeconds(n uint64) stack.CommonOption {
 	return stack.MakeCommon(sysgo.WithDeployerOptions(
 		sysgo.WithFinalizationPeriodSeconds(n),
 	))
 }
 
+// TODO(infra#401): Implement support in the sysext toolset
 func WithProofMaturityDelaySeconds(seconds uint64) stack.CommonOption {
 	return stack.MakeCommon(sysgo.WithDeployerOptions(
 		sysgo.WithProofMaturityDelaySeconds(seconds),
 	))
 }
 
+// TODO(infra#401): Implement support in the sysext toolset
 func WithDisputeGameFinalityDelaySeconds(seconds uint64) stack.CommonOption {
 	return stack.MakeCommon(sysgo.WithDeployerOptions(
 		sysgo.WithDisputeGameFinalityDelaySeconds(seconds),

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -229,6 +229,15 @@ func WithSequencingWindow(n uint64) DeployerOption {
 	}
 }
 
+// WithAdditionalDisputeGames adds additional dispute games to all L2s.
+func WithAdditionalDisputeGames(games []state.AdditionalDisputeGame) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithAdditionalDisputeGames(games)
+		}
+	}
+}
+
 func (wb *worldBuilder) buildL1Genesis() {
 	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
 	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -192,7 +192,6 @@ func WithCommons(l1ChainID eth.ChainID) DeployerOption {
 
 		// We use the L1 chain ID to identify the superchain-wide roles.
 		addrFor := intentbuilder.RoleToAddrProvider(p, keys, l1ChainID)
-		l1Config.WithPrefundedAccount(addrFor(devkeys.L1ProxyAdminOwnerRole), *millionEth)
 		_, superCfg := builder.WithSuperchain()
 		intentbuilder.WithDevkeySuperRoles(p, keys, l1ChainID, superCfg)
 		l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainProxyAdminOwner), *millionEth)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -39,6 +39,14 @@ func WithDeployerOptions(opts ...DeployerOption) stack.Option[*Orchestrator] {
 	})
 }
 
+type DeployerPipelineOption func(wb *worldBuilder, intent *state.Intent, cfg *deployer.ApplyPipelineOpts)
+
+func WithDeployerPipelineOption(opt DeployerPipelineOption) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.deployerPipelineOptions = append(o.deployerPipelineOptions, opt)
+	})
+}
+
 func WithDeployer() stack.Option[*Orchestrator] {
 	return stack.FnOption[*Orchestrator]{
 		BeforeDeployFn: func(o *Orchestrator) {
@@ -53,6 +61,7 @@ func WithDeployer() stack.Option[*Orchestrator] {
 		},
 		DeployFn: func(o *Orchestrator) {
 			o.P().Require().NotNil(o.wb, "must have a world builder")
+			o.wb.deployerPipelineOptions = o.deployerPipelineOptions
 			o.wb.Build()
 		},
 		AfterDeployFn: func(o *Orchestrator) {
@@ -129,6 +138,9 @@ type worldBuilder struct {
 	require *testreq.Assertions
 	keys    devkeys.Keys
 
+	// options
+	deployerPipelineOptions []DeployerPipelineOption
+
 	builder intentbuilder.Builder
 
 	output          *state.State
@@ -180,6 +192,7 @@ func WithCommons(l1ChainID eth.ChainID) DeployerOption {
 
 		// We use the L1 chain ID to identify the superchain-wide roles.
 		addrFor := intentbuilder.RoleToAddrProvider(p, keys, l1ChainID)
+		l1Config.WithPrefundedAccount(addrFor(devkeys.L1ProxyAdminOwnerRole), *millionEth)
 		_, superCfg := builder.WithSuperchain()
 		intentbuilder.WithDevkeySuperRoles(p, keys, l1ChainID, superCfg)
 		l1Config.WithPrefundedAccount(addrFor(devkeys.SuperchainProxyAdminOwner), *millionEth)
@@ -189,26 +202,32 @@ func WithCommons(l1ChainID eth.ChainID) DeployerOption {
 	}
 }
 
-func WithPrefundedL2(chainID eth.ChainID) DeployerOption {
+func WithGuardianMatchL1PAO() DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
-		_, l2Config := builder.WithL2(chainID)
-		l2Config.ChainID()
+		_, superCfg := builder.WithSuperchain()
+		intentbuilder.WithOverrideGuardianToL1PAO(p, keys, superCfg.L1ChainID(), superCfg)
+	}
+}
 
+func WithPrefundedL2(l1ChainID, l2ChainID eth.ChainID) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		_, l2Config := builder.WithL2(l2ChainID)
 		intentbuilder.WithDevkeyVaults(p, keys, l2Config)
-		intentbuilder.WithDevkeyRoles(p, keys, l2Config)
+		intentbuilder.WithDevkeyL2Roles(p, keys, l2Config)
+		// l2configurator L1ProxyAdminOwner must be also populated
+		intentbuilder.WithDevkeyL1Roles(p, keys, l2Config, l1ChainID)
 		{
 			faucetFunderAddr, err := keys.Address(devkeys.UserKey(funderMnemonicIndex))
 			p.Require().NoError(err, "need funder addr")
 			l2Config.WithPrefundedAccount(faucetFunderAddr, *eth.BillionEther.ToU256())
 		}
 		{
-			addrFor := intentbuilder.RoleToAddrProvider(p, keys, chainID)
+			addrFor := intentbuilder.RoleToAddrProvider(p, keys, l2ChainID)
 			l1Config := l2Config.L1Config()
 			l1Config.WithPrefundedAccount(addrFor(devkeys.BatcherRole), *millionEth)
 			l1Config.WithPrefundedAccount(addrFor(devkeys.ProposerRole), *millionEth)
 			l1Config.WithPrefundedAccount(addrFor(devkeys.ChallengerRole), *millionEth)
 			l1Config.WithPrefundedAccount(addrFor(devkeys.SystemConfigOwner), *millionEth)
-			l1Config.WithPrefundedAccount(addrFor(devkeys.L1ProxyAdminOwnerRole), *millionEth)
 		}
 	}
 }
@@ -235,6 +254,15 @@ func WithAdditionalDisputeGames(games []state.AdditionalDisputeGame) DeployerOpt
 		for _, l2Cfg := range builder.L2s() {
 			l2Cfg.WithAdditionalDisputeGames(games)
 		}
+	}
+}
+
+func WithDeployerMatchL1PAO() DeployerPipelineOption {
+	return func(wb *worldBuilder, intent *state.Intent, cfg *deployer.ApplyPipelineOpts) {
+		l1ChainID := new(big.Int).SetUint64(intent.L1ChainID)
+		deployerKey, err := wb.keys.Secret(devkeys.L1ProxyAdminOwnerRole.Key(l1ChainID))
+		wb.require.NoError(err)
+		cfg.DeployerPrivateKey = deployerKey
 	}
 }
 
@@ -314,6 +342,10 @@ func (wb *worldBuilder) Build() {
 		Logger:             wb.logger,
 		StateWriter:        wb, // direct output back here
 	}
+	for _, opt := range wb.deployerPipelineOptions {
+		opt(wb, intent, &pipelineOpts)
+	}
+
 	err = deployer.ApplyPipeline(wb.p.Ctx(), pipelineOpts)
 	wb.require.NoError(err)
 

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -266,6 +266,27 @@ func WithDeployerMatchL1PAO() DeployerPipelineOption {
 	}
 }
 
+// WithFinalizationPeriodSeconds overrides the number of L1 blocks in a sequencing window, applied to all L2s.
+func WithFinalizationPeriodSeconds(n uint64) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithFinalizationPeriodSeconds(n)
+		}
+	}
+}
+
+func WithProofMaturityDelaySeconds(n uint64) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		builder.WithGlobalOverride("proofMaturityDelaySeconds", uint64(n))
+	}
+}
+
+func WithDisputeGameFinalityDelaySeconds(seconds uint64) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		builder.WithGlobalOverride("disputeGameFinalityDelaySeconds", seconds)
+	}
+}
+
 func (wb *worldBuilder) buildL1Genesis() {
 	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
 	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")

--- a/op-devstack/sysgo/l2_proposer.go
+++ b/op-devstack/sysgo/l2_proposer.go
@@ -110,6 +110,9 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 		ActiveSequencerCheckDuration: time.Second * 5,
 		WaitNodeSync:                 false,
 	}
+	for _, opt := range orch.proposerOptions {
+		opt(proposerID, proposerCLIConfig)
+	}
 
 	// If interop is scheduled, or if we cannot do the pre-interop connection, then set up with supervisor
 	if l2Net.genesis.Config.InteropTime != nil || l2CLID == nil {

--- a/op-devstack/sysgo/l2_proposer.go
+++ b/op-devstack/sysgo/l2_proposer.go
@@ -41,6 +41,14 @@ func (p *L2Proposer) hydrate(system stack.ExtensibleSystem) {
 	l2Net.(stack.ExtensibleL2Network).AddL2Proposer(bFrontend)
 }
 
+type ProposerOption func(id stack.L2ProposerID, cfg *ps.CLIConfig)
+
+func WithProposerOption(opt ProposerOption) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.proposerOptions = append(o.proposerOptions, opt)
+	})
+}
+
 func WithProposer(proposerID stack.L2ProposerID, l1ELID stack.L1ELNodeID,
 	l2CLID *stack.L2CLNodeID, supervisorID *stack.SupervisorID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -27,7 +27,8 @@ type Orchestrator struct {
 	timeTravelClock *clock.AdvancingClock
 
 	// options
-	batcherOptions []BatcherOption
+	batcherOptions  []BatcherOption
+	proposerOptions []ProposerOption
 
 	superchains    locks.RWMap[stack.SuperchainID, *Superchain]
 	clusters       locks.RWMap[stack.ClusterID, *Cluster]

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -27,8 +27,9 @@ type Orchestrator struct {
 	timeTravelClock *clock.AdvancingClock
 
 	// options
-	batcherOptions  []BatcherOption
-	proposerOptions []ProposerOption
+	batcherOptions          []BatcherOption
+	proposerOptions         []ProposerOption
+	deployerPipelineOptions []DeployerPipelineOption
 
 	superchains    locks.RWMap[stack.SuperchainID, *Superchain]
 	clusters       locks.RWMap[stack.ClusterID, *Cluster]

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -121,20 +121,16 @@ func WithSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, l2CLID stack
 
 			oldDisputeGameFactories := make(map[eth.ChainID]common.Address)
 			for i, opChainConfig := range opChainConfigs {
-				chainOpsForL2 := devkeys.ChainOperatorKeys(l2ChainIDs[i].ToBig())
-				l1PAOKeyForL2, err := o.keys.Secret(chainOpsForL2(devkeys.L1ProxyAdminOwnerRole))
-				require.NoError(err, "must have configured L1 proxy admin owner private key")
-
 				var portal common.Address
 				require.NoError(
 					w3Client.Call(
 						w3eth.CallFunc(opChainConfig.SystemConfigProxy, optimismPortalFn).Returns(&portal),
 					))
 				portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
-				transferOwnership(t, l1PAOKeyForL2, client, portalProxyAdmin, delegateCallProxy)
+				transferOwnership(t, l1PAOKey, client, portalProxyAdmin, delegateCallProxy)
 
 				dgf := getDisputeGameFactory(t, w3Client, portal)
-				transferOwnership(t, l1PAOKeyForL2, client, dgf, delegateCallProxy)
+				transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
 				oldDisputeGameFactories[l2ChainIDs[i]] = dgf
 			}
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -52,7 +52,7 @@ func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestra
 		WithDeployerOptions(
 			WithLocalContractSources(),
 			WithCommons(ids.L1.ChainID()),
-			WithPrefundedL2(ids.L2.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2.ChainID()),
 		),
 	)
 
@@ -151,7 +151,7 @@ func baseInteropSystem(ids *DefaultSingleChainInteropSystemIDs) stack.Option[*Or
 		WithDeployerOptions(
 			WithLocalContractSources(),
 			WithCommons(ids.L1.ChainID()),
-			WithPrefundedL2(ids.L2A.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
 			WithInteropAtGenesis(), // this can be overridden by later options
 		),
 	)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -260,8 +260,8 @@ func DefaultInteropProofsSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orc
 		WithDeployerOptions(
 			WithLocalContractSources(),
 			WithCommons(ids.L1.ChainID()),
-			WithPrefundedL2(ids.L2A.ChainID()),
-			WithPrefundedL2(ids.L2B.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2B.ChainID()),
 			WithInteropAtGenesis(), // this can be overridden by later options
 		),
 	)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -210,7 +210,7 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	opt.Add(baseInteropSystem(&ids.DefaultSingleChainInteropSystemIDs))
 
 	opt.Add(WithDeployerOptions(
-		WithPrefundedL2(ids.L2B.ChainID()),
+		WithPrefundedL2(ids.L1.ChainID(), ids.L2B.ChainID()),
 		WithInteropAtGenesis(), // this can be overridden by later options
 	))
 	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -33,6 +33,7 @@ type L1Configurator interface {
 
 type SuperchainConfigurator interface {
 	ID() SuperchainID
+	L1ChainID() eth.ChainID
 	WithSuperchainConfigProxy(address common.Address) SuperchainConfigurator
 	WithProxyAdminOwner(address common.Address) SuperchainConfigurator
 	WithGuardian(address common.Address) SuperchainConfigurator
@@ -107,9 +108,8 @@ func WithDevkeyVaults(t require.TestingT, dk devkeys.Keys, configurator L2Config
 	configurator.WithL1FeeVaultRecipient(addrFor(devkeys.L1FeeVaultRecipientRole))
 }
 
-func WithDevkeyRoles(t require.TestingT, dk devkeys.Keys, configurator L2Configurator) {
+func WithDevkeyL2Roles(t require.TestingT, dk devkeys.Keys, configurator L2Configurator) {
 	addrFor := RoleToAddrProvider(t, dk, configurator.ChainID())
-	configurator.WithL1ProxyAdminOwner(addrFor(devkeys.L1ProxyAdminOwnerRole))
 	configurator.WithL2ProxyAdminOwner(addrFor(devkeys.L2ProxyAdminOwnerRole))
 	configurator.WithSystemConfigOwner(addrFor(devkeys.SystemConfigOwner))
 	configurator.WithUnsafeBlockSigner(addrFor(devkeys.SequencerP2PRole))
@@ -118,11 +118,21 @@ func WithDevkeyRoles(t require.TestingT, dk devkeys.Keys, configurator L2Configu
 	configurator.WithChallenger(addrFor(devkeys.ChallengerRole))
 }
 
+func WithDevkeyL1Roles(t require.TestingT, dk devkeys.Keys, configurator L2Configurator, l1ChainID eth.ChainID) {
+	addrFor := RoleToAddrProvider(t, dk, l1ChainID)
+	configurator.WithL1ProxyAdminOwner(addrFor(devkeys.L1ProxyAdminOwnerRole))
+}
+
 func WithDevkeySuperRoles(t require.TestingT, dk devkeys.Keys, l1ID eth.ChainID, configurator SuperchainConfigurator) {
 	addrFor := RoleToAddrProvider(t, dk, l1ID)
 	configurator.WithGuardian(addrFor(devkeys.SuperchainConfigGuardianKey))
 	configurator.WithProtocolVersionsOwner(addrFor(devkeys.SuperchainDeployerKey))
 	configurator.WithProxyAdminOwner(addrFor(devkeys.L1ProxyAdminOwnerRole))
+}
+
+func WithOverrideGuardianToL1PAO(t require.TestingT, dk devkeys.Keys, l1ID eth.ChainID, configurator SuperchainConfigurator) {
+	addrFor := RoleToAddrProvider(t, dk, l1ID)
+	configurator.WithGuardian(addrFor(devkeys.L1ProxyAdminOwnerRole))
 }
 
 func KeyToAddrProvider(t require.TestingT, dk devkeys.Keys) func(k devkeys.Key) common.Address {
@@ -216,6 +226,10 @@ type superchainConfigurator struct {
 
 func (c *superchainConfigurator) ID() SuperchainID {
 	return "main"
+}
+
+func (c *superchainConfigurator) L1ChainID() eth.ChainID {
+	return eth.ChainIDFromUInt64(c.builder.intent.L1ChainID)
 }
 
 func (c *superchainConfigurator) WithSuperchainConfigProxy(address common.Address) SuperchainConfigurator {

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -46,6 +46,7 @@ type L2Configurator interface {
 	WithBlockTime(uint64)
 	WithL1StartBlockHash(hash common.Hash)
 	WithAdditionalDisputeGames(games []state.AdditionalDisputeGame)
+	WithFinalizationPeriodSeconds(value uint64)
 	ContractsConfigurator
 	L2VaultsConfigurator
 	L2RolesConfigurator
@@ -439,4 +440,8 @@ func (c *l2Configurator) WithAdditionalDisputeGames(games []state.AdditionalDisp
 		chain.AdditionalDisputeGames = make([]state.AdditionalDisputeGame, 0)
 	}
 	chain.AdditionalDisputeGames = append(chain.AdditionalDisputeGames, games...)
+}
+
+func (c *l2Configurator) WithFinalizationPeriodSeconds(value uint64) {
+	c.builder.intent.Chains[c.chainIndex].DeployOverrides["l2FinalizationPeriodSeconds"] = value
 }

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -44,6 +44,7 @@ type L2Configurator interface {
 	ChainID() eth.ChainID
 	WithBlockTime(uint64)
 	WithL1StartBlockHash(hash common.Hash)
+	WithAdditionalDisputeGames(games []state.AdditionalDisputeGame)
 	ContractsConfigurator
 	L2VaultsConfigurator
 	L2RolesConfigurator
@@ -416,4 +417,12 @@ func (c *l2Configurator) initL2DevGenesisParams() *state.L2DevGenesisParams {
 func (c *l2Configurator) WithPrefundedAccount(addr common.Address, amount uint256.Int) L2Configurator {
 	c.initL2DevGenesisParams().Prefund[addr] = (*hexutil.U256)(&amount)
 	return c
+}
+
+func (c *l2Configurator) WithAdditionalDisputeGames(games []state.AdditionalDisputeGame) {
+	chain := c.builder.intent.Chains[c.chainIndex]
+	if chain.AdditionalDisputeGames == nil {
+		chain.AdditionalDisputeGames = make([]state.AdditionalDisputeGame, 0)
+	}
+	chain.AdditionalDisputeGames = append(chain.AdditionalDisputeGames, games...)
 }

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 )
 
 type ChainID interface {
@@ -123,6 +124,10 @@ type EthCode interface {
 	CodeAtHash(ctx context.Context, account common.Address, blockHash common.Hash) ([]byte, error)
 }
 
+type EthMultiCaller interface {
+	NewMultiCaller(batchSize int) *batching.MultiCaller
+}
+
 type EthClient interface {
 	ChainID
 	EthBlockInfo
@@ -137,6 +142,7 @@ type EthClient interface {
 	EthNonce
 	EthBalance
 	EthCode
+	EthMultiCaller
 }
 
 type EthExtendedClient interface {

--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -42,6 +42,7 @@ var (
 	TenEther             = Ether(10)
 	OneEther             = Ether(1)
 	HalfEther            = GWei(500_000_000)
+	OneThirdEther        = GWei(333_333_333)
 	OneTenthEther        = GWei(100_000_000)
 	NineHundredthsEther  = GWei(90_000_000)
 	EightHundredthsEther = GWei(80_000_000)

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 )
 
@@ -593,4 +594,8 @@ func (s *EthClient) CodeAtHash(ctx context.Context, account common.Address, bloc
 	var result hexutil.Bytes
 	err := s.client.CallContext(ctx, &result, "eth_getCode", account, blockHash)
 	return result, err
+}
+
+func (s *EthClient) NewMultiCaller(batchSize int) *batching.MultiCaller {
+	return batching.NewMultiCaller(s.client, batchSize)
 }

--- a/op-service/txintent/bindings/DisputeGameFactory.go
+++ b/op-service/txintent/bindings/DisputeGameFactory.go
@@ -1,0 +1,59 @@
+package bindings
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DisputeGameFactoryCallFactory struct {
+	BaseCallFactory
+}
+
+func NewDisputeGameFactory(opts ...CallFactoryOption) *DisputeGameFactoryCallFactory {
+	return &DisputeGameFactoryCallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
+}
+
+type GameSearchResult struct {
+	Index     *big.Int
+	Metadata  [32]byte
+	Timestamp uint64
+	RootClaim [32]byte
+	ExtraData []byte
+}
+
+type DisputeGame struct {
+	DisputeGameFactoryCallFactory
+
+	// Read-only functions
+	GameCount   func() TypedCall[*big.Int] `sol:"gameCount"`
+	GameAtIndex func(index *big.Int) TypedCall[struct {
+		GameType  uint32
+		Timestamp uint64
+		Proxy     common.Address
+	}] `sol:"gameAtIndex"`
+	GameImpls func(gameType uint32) TypedCall[common.Address] `sol:"gameImpls"`
+	Games     func(gameType uint32, rootClaim [32]byte, extraData []byte) TypedCall[struct {
+		Proxy     common.Address
+		Timestamp uint64
+	}] `sol:"games"`
+	GetGameUUID     func(gameType uint32, rootClaim [32]byte, extraData []byte) TypedCall[[32]byte] `sol:"getGameUUID"`
+	InitBonds       func(gameType uint32) TypedCall[*big.Int]                                       `sol:"initBonds"`
+	Owner           func() TypedCall[common.Address]                                                `sol:"owner"`
+	Version         func() TypedCall[string]                                                        `sol:"version"`
+	FindLatestGames func(gameType uint32, start *big.Int, n *big.Int) TypedCall[[]GameSearchResult] `sol:"findLatestGames"`
+
+	// Write functions
+	Create            func(gameType uint32, rootClaim [32]byte, extraData []byte) TypedCall[common.Address] `sol:"create"`
+	Initialize        func(owner common.Address) TypedCall[any]                                             `sol:"initialize"`
+	RenounceOwnership func() TypedCall[any]                                                                 `sol:"renounceOwnership"`
+	SetImplementation func(gameType uint32, impl common.Address) TypedCall[any]                             `sol:"setImplementation"`
+	SetInitBond       func(gameType uint32, initBond *big.Int) TypedCall[any]                               `sol:"setInitBond"`
+	TransferOwnership func(newOwner common.Address) TypedCall[any]                                          `sol:"transferOwnership"`
+}
+
+func NewDisputeGame(f *DisputeGameFactoryCallFactory) *DisputeGame {
+	disputegame := DisputeGame{DisputeGameFactoryCallFactory: *f}
+	InitImpl(&disputegame)
+	return &disputegame
+}

--- a/op-service/txintent/bindings/DisputeGameFactory.go
+++ b/op-service/txintent/bindings/DisputeGameFactory.go
@@ -6,14 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type DisputeGameFactoryCallFactory struct {
-	BaseCallFactory
-}
-
-func NewDisputeGameFactory(opts ...CallFactoryOption) *DisputeGameFactoryCallFactory {
-	return &DisputeGameFactoryCallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
-}
-
 type GameSearchResult struct {
 	Index     *big.Int
 	Metadata  [32]byte
@@ -22,9 +14,7 @@ type GameSearchResult struct {
 	ExtraData []byte
 }
 
-type DisputeGame struct {
-	DisputeGameFactoryCallFactory
-
+type DisputeGameFactory struct {
 	// Read-only functions
 	GameCount   func() TypedCall[*big.Int] `sol:"gameCount"`
 	GameAtIndex func(index *big.Int) TypedCall[struct {
@@ -50,10 +40,4 @@ type DisputeGame struct {
 	SetImplementation func(gameType uint32, impl common.Address) TypedCall[any]                             `sol:"setImplementation"`
 	SetInitBond       func(gameType uint32, initBond *big.Int) TypedCall[any]                               `sol:"setInitBond"`
 	TransferOwnership func(newOwner common.Address) TypedCall[any]                                          `sol:"transferOwnership"`
-}
-
-func NewDisputeGame(f *DisputeGameFactoryCallFactory) *DisputeGame {
-	disputegame := DisputeGame{DisputeGameFactoryCallFactory: *f}
-	InitImpl(&disputegame)
-	return &disputegame
 }

--- a/op-service/txintent/bindings/L2ToL1MessagePasser.go
+++ b/op-service/txintent/bindings/L2ToL1MessagePasser.go
@@ -1,0 +1,36 @@
+package bindings
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type L2ToL1MessagePasserCallFactory struct {
+	BaseCallFactory
+}
+
+func NewL2ToL1MessagePasserFactory(opts ...CallFactoryOption) *L2ToL1MessagePasserCallFactory {
+	return &L2ToL1MessagePasserCallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
+}
+
+type L2ToL1MessagePasser struct {
+	L2ToL1MessagePasserCallFactory
+
+	// Read-only functions
+	MESSAGEVERSION func() TypedCall[uint16]                   `sol:"MESSAGE_VERSION"`
+	MessageNonce   func() TypedCall[*big.Int]                 `sol:"messageNonce"`
+	SentMessages   func(messageHash [32]byte) TypedCall[bool] `sol:"sentMessages"`
+	Version        func() TypedCall[string]                   `sol:"version"`
+
+	// Write functions
+	Burn               func() TypedCall[any]                                                      `sol:"burn"`
+	InitiateWithdrawal func(target common.Address, gasLimit *big.Int, data []byte) TypedCall[any] `sol:"initiateWithdrawal"`
+	Receive            func() TypedCall[any]                                                      `sol:"receive"`
+}
+
+func NewL2ToL1MessagePasser(f *L2ToL1MessagePasserCallFactory) *L2ToL1MessagePasser {
+	l2tol1messagepasser := L2ToL1MessagePasser{L2ToL1MessagePasserCallFactory: *f}
+	InitImpl(&l2tol1messagepasser)
+	return &l2tol1messagepasser
+}

--- a/op-service/txintent/bindings/L2ToL1MessagePasser.go
+++ b/op-service/txintent/bindings/L2ToL1MessagePasser.go
@@ -6,17 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type L2ToL1MessagePasserCallFactory struct {
-	BaseCallFactory
-}
-
-func NewL2ToL1MessagePasserFactory(opts ...CallFactoryOption) *L2ToL1MessagePasserCallFactory {
-	return &L2ToL1MessagePasserCallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
-}
-
 type L2ToL1MessagePasser struct {
-	L2ToL1MessagePasserCallFactory
-
 	// Read-only functions
 	MESSAGEVERSION func() TypedCall[uint16]                   `sol:"MESSAGE_VERSION"`
 	MessageNonce   func() TypedCall[*big.Int]                 `sol:"messageNonce"`
@@ -27,10 +17,4 @@ type L2ToL1MessagePasser struct {
 	Burn               func() TypedCall[any]                                                      `sol:"burn"`
 	InitiateWithdrawal func(target common.Address, gasLimit *big.Int, data []byte) TypedCall[any] `sol:"initiateWithdrawal"`
 	Receive            func() TypedCall[any]                                                      `sol:"receive"`
-}
-
-func NewL2ToL1MessagePasser(f *L2ToL1MessagePasserCallFactory) *L2ToL1MessagePasser {
-	l2tol1messagepasser := L2ToL1MessagePasser{L2ToL1MessagePasserCallFactory: *f}
-	InitImpl(&l2tol1messagepasser)
-	return &l2tol1messagepasser
 }

--- a/op-service/txintent/bindings/OptimismPortal2.go
+++ b/op-service/txintent/bindings/OptimismPortal2.go
@@ -1,0 +1,97 @@
+package bindings
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type OptimismPortal2CallFactory struct {
+	BaseCallFactory
+}
+
+func NewOptimismPortal2Factory(opts ...CallFactoryOption) *OptimismPortal2CallFactory {
+	return &OptimismPortal2CallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
+}
+
+type ProvenWithdrawalsResult struct {
+	DisputeGameProxy common.Address
+	Timestamp        uint64
+}
+
+type WithdrawalTransaction struct {
+	Nonce    *big.Int
+	Sender   common.Address
+	Target   common.Address
+	Value    *big.Int
+	GasLimit *big.Int
+	Data     []byte
+}
+
+type OutputRootProof struct {
+	Version                  [32]byte
+	StateRoot                [32]byte
+	MessagePasserStorageRoot [32]byte
+	LatestBlockhash          [32]byte
+}
+
+type OptimismPortal2 struct {
+	OptimismPortal2CallFactory
+
+	// Read-only functions
+	CheckWithdrawal                 func(withdrawalHash [32]byte, proofSubmitter common.Address) TypedCall[any] `sol:"checkWithdrawal"`
+	DisputeGameBlacklist            func(disputeGame common.Address) TypedCall[bool]                            `sol:"disputeGameBlacklist"`
+	DisputeGameFactoryAddr          func() TypedCall[common.Address]                                            `sol:"disputeGameFactory"`
+	DisputeGameFinalityDelaySeconds func() TypedCall[*big.Int]                                                  `sol:"disputeGameFinalityDelaySeconds"`
+	FinalizedWithdrawals            func(withdrawalHash [32]byte) TypedCall[bool]                               `sol:"finalizedWithdrawals"`
+	Guardian                        func() TypedCall[common.Address]                                            `sol:"guardian"`
+	L2Sender                        func() TypedCall[common.Address]                                            `sol:"l2Sender"`
+	MinimumGasLimit                 func(byteCount uint64) TypedCall[uint64]                                    `sol:"minimumGasLimit"`
+	NumProofSubmitters              func(withdrawalHash [32]byte) TypedCall[*big.Int]                           `sol:"numProofSubmitters"`
+	Params                          func() TypedCall[struct {
+		PrevBaseFee   *big.Int
+		PrevBoughtGas uint64
+		PrevBlockNum  uint64
+	}] `sol:"params"`
+	Paused                     func() TypedCall[bool]                                                                     `sol:"paused"`
+	ProofMaturityDelaySeconds  func() TypedCall[*big.Int]                                                                 `sol:"proofMaturityDelaySeconds"`
+	ProofSubmitters            func(withdrawalHash [32]byte, index *big.Int) TypedCall[common.Address]                    `sol:"proofSubmitters"`
+	ProvenWithdrawals          func(withdrawalHash [32]byte, submitter common.Address) TypedCall[ProvenWithdrawalsResult] `sol:"provenWithdrawals"`
+	RespectedGameType          func() TypedCall[uint32]                                                                   `sol:"respectedGameType"`
+	RespectedGameTypeUpdatedAt func() TypedCall[uint64]                                                                   `sol:"respectedGameTypeUpdatedAt"`
+	SuperchainConfig           func() TypedCall[common.Address]                                                           `sol:"superchainConfig"`
+	SystemConfig               func() TypedCall[common.Address]                                                           `sol:"systemConfig"`
+	Version                    func() TypedCall[string]                                                                   `sol:"version"`
+
+	// Write functions
+	DepositTransaction            func(to common.Address, value eth.ETH, gaslimit uint64, isCreation bool, data []byte) TypedCall[any] `sol:"depositTransaction"`
+	BlacklistDisputeGame          func(disputeGame common.Address) TypedCall[any]                                                      `sol:"blacklistDisputeGame"`
+	DonateETH                     func() TypedCall[any]                                                                                `sol:"donateETH"`
+	FinalizeWithdrawalTransaction func(tx struct {
+		Nonce    *big.Int
+		Sender   common.Address
+		Target   common.Address
+		Value    *big.Int
+		GasLimit *big.Int
+		Data     []byte
+	}) TypedCall[any] `sol:"finalizeWithdrawalTransaction"`
+	FinalizeWithdrawalTransactionExternalProof func(tx struct {
+		Nonce    *big.Int
+		Sender   common.Address
+		Target   common.Address
+		Value    *big.Int
+		GasLimit *big.Int
+		Data     []byte
+	}, proofSubmitter common.Address) TypedCall[any] `sol:"finalizeWithdrawalTransactionExternalProof"`
+	Initialize                 func(disputeGameFactory common.Address, systemConfig common.Address, superchainConfig common.Address) TypedCall[any]                `sol:"initialize"`
+	ProveWithdrawalTransaction func(tx WithdrawalTransaction, disputeGameIndex *big.Int, outputRootProof OutputRootProof, withdrawalProof [][]byte) TypedCall[any] `sol:"proveWithdrawalTransaction"`
+	SetRespectedGameType       func(gameType uint32) TypedCall[any]                                                                                                `sol:"setRespectedGameType"`
+	Receive                    func() TypedCall[any]                                                                                                               `sol:"receive"`
+}
+
+func NewOptimismPortal2(f *OptimismPortal2CallFactory) *OptimismPortal2 {
+	optimismportal2 := OptimismPortal2{OptimismPortal2CallFactory: *f}
+	InitImpl(&optimismportal2)
+	return &optimismportal2
+}

--- a/op-service/txintent/bindings/OptimismPortal2.go
+++ b/op-service/txintent/bindings/OptimismPortal2.go
@@ -7,14 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type OptimismPortal2CallFactory struct {
-	BaseCallFactory
-}
-
-func NewOptimismPortal2Factory(opts ...CallFactoryOption) *OptimismPortal2CallFactory {
-	return &OptimismPortal2CallFactory{BaseCallFactory: *NewBaseCallFactory(opts...)}
-}
-
 type ProvenWithdrawalsResult struct {
 	DisputeGameProxy common.Address
 	Timestamp        uint64
@@ -37,8 +29,6 @@ type OutputRootProof struct {
 }
 
 type OptimismPortal2 struct {
-	OptimismPortal2CallFactory
-
 	// Read-only functions
 	CheckWithdrawal                 func(withdrawalHash [32]byte, proofSubmitter common.Address) TypedCall[any] `sol:"checkWithdrawal"`
 	DisputeGameBlacklist            func(disputeGame common.Address) TypedCall[bool]                            `sol:"disputeGameBlacklist"`
@@ -88,10 +78,4 @@ type OptimismPortal2 struct {
 	ProveWithdrawalTransaction func(tx WithdrawalTransaction, disputeGameIndex *big.Int, outputRootProof OutputRootProof, withdrawalProof [][]byte) TypedCall[any] `sol:"proveWithdrawalTransaction"`
 	SetRespectedGameType       func(gameType uint32) TypedCall[any]                                                                                                `sol:"setRespectedGameType"`
 	Receive                    func() TypedCall[any]                                                                                                               `sol:"receive"`
-}
-
-func NewOptimismPortal2(f *OptimismPortal2CallFactory) *OptimismPortal2 {
-	optimismportal2 := OptimismPortal2{OptimismPortal2CallFactory: *f}
-	InitImpl(&optimismportal2)
-	return &optimismportal2
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Builds upon the contract DSL for struct at https://github.com/ethereum-optimism/optimism/pull/16254 (base branch). 

The PR adds multiple sysgo presets for testing the withdrawal:
```go
func TestMain(m *testing.M) {
	presets.DoMain(m, presets.WithMinimal(),
		presets.WithProposerGameType(faultTypes.FastGameType),
		// Fast game for test
		presets.WithFastGame(),
		// Deployer must be L1PAO to make op-deployer happy
		presets.WithDeployerMatchL1PAO(),
		// Guardian must be L1PAO to make AnchorStateRegistry's setRespectedGameType method work
		presets.WithGuardianMatchL1PAO(),
		// Fast finalization for fast withdrawal
		presets.WithFinalizationPeriodSeconds(2),
		// Satisfy OptimismPortal2 PROOF_MATURITY_DELAY_SECONDS check, avoid OptimismPortal_ProofNotOldEnough() revert
		presets.WithProofMaturityDelaySeconds(12),
		// Satisfy AnchorStateRegistry DISPUTE_GAME_FINALITY_DELAY_SECONDS check, avoid OptimismPortal_InvalidRootClaim() revert
		presets.WithDisputeGameFinalityDelaySeconds(6),
	)
}
```
which mimics the hardcoded config at `op-e2e/config/init.go` but with minimal preset to pass the test using the fast game type.

Ports withdrawal test from `op-e2e/system/bridge/withdrawal_test.go` using the op-devstack.

**Tests**

Deposit -> Withdrawal(L2toL1 message send, prove, finalize) sequence works at `op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go::TestWithdrawal` test.

Intentionally not added at the `acceptance-tests.yaml` not to target the sysext because presets does not work against sysext.

**Additional context**

There are some logic dups because of the client difference, original withdrawal test used `ethclient.Client`, but our op-devstack uses `api.EthClient`, resulting in different types and manual conversion

**Metadata**

- Fixes https://github.com/ethereum-optimism/infra/issues/327
- Fixes https://github.com/ethereum-optimism/optimism/issues/16294
