### PR TITLE
fix(op-acceptance-tests): reduce eth used

### DIFF
--- a/op-acceptance-tests/tests/interop/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/interop_smoke_test.go
@@ -72,7 +72,7 @@ func TestSmokeTestFailure(t *testing.T) {
 	mockAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	mockWallet := &mockFailingWallet{
 		addr: mockAddr,
-		bal:  sdktypes.NewBalance(big.NewInt(1000000)),
+		bal:  sdktypes.NewBalance(big.NewInt(0.1 * constants.ETH)),
 	}
 	mockL1Chain := newMockFailingL1Chain(
 		sdktypes.ChainID(big.NewInt(1234)),

--- a/op-acceptance-tests/tests/interop/interop_test_helpers.go
+++ b/op-acceptance-tests/tests/interop/interop_test_helpers.go
@@ -152,7 +152,7 @@ func SetupDefaultInteropSystemTest(l2ChainNums int) ([]validators.WalletGetter, 
 	totalValidators := make([]systest.PreconditionValidator, 0)
 	for i := range l2ChainNums {
 		walletGetter, fundsValidator := validators.AcquireL2WalletWithFunds(
-			uint64(i), sdktypes.NewBalance(big.NewInt(1*constants.ETH)),
+			uint64(i), sdktypes.NewBalance(big.NewInt(0.1*constants.ETH)),
 		)
 		walletGetters[i] = walletGetter
 		totalValidators = append(totalValidators, fundsValidator)

--- a/op-acceptance-tests/tests/interop/interop_tx_test.go
+++ b/op-acceptance-tests/tests/interop/interop_tx_test.go
@@ -137,8 +137,8 @@ func messagePassingScenario(sourceChainIdx, destChainIdx uint64, sourceWalletGet
 func TestMessagePassing(t *testing.T) {
 	sourceChainIdx := uint64(0)
 	destChainIdx := uint64(1)
-	sourceWalletGetter, sourcefundsValidator := validators.AcquireL2WalletWithFunds(sourceChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
-	destWalletGetter, destfundsValidator := validators.AcquireL2WalletWithFunds(destChainIdx, sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)))
+	sourceWalletGetter, sourcefundsValidator := validators.AcquireL2WalletWithFunds(sourceChainIdx, sdktypes.NewBalance(big.NewInt(0.1*constants.ETH)))
+	destWalletGetter, destfundsValidator := validators.AcquireL2WalletWithFunds(destChainIdx, sdktypes.NewBalance(big.NewInt(0.1*constants.ETH)))
 
 	systest.InteropSystemTest(t,
 		messagePassingScenario(sourceChainIdx, destChainIdx, sourceWalletGetter, destWalletGetter),

--- a/op-acceptance-tests/tests/isthmus/erc20_bridge_test.go
+++ b/op-acceptance-tests/tests/isthmus/erc20_bridge_test.go
@@ -29,9 +29,9 @@ func TestERC20Bridge(t *testing.T) {
 
 	l2WalletGetter, l2WalletFundsValidator := validators.AcquireL2WalletWithFunds(
 		chainIdx,
-		sdktypes.NewBalance(big.NewInt(1.0*constants.ETH)),
+		sdktypes.NewBalance(big.NewInt(0.1*constants.ETH)),
 	)
-	l1WalletGetter, l1WalletFundsValidator := validators.AcquireL1WalletWithFunds(sdktypes.NewBalance(big.NewInt(1.0 * constants.ETH)))
+	l1WalletGetter, l1WalletFundsValidator := validators.AcquireL1WalletWithFunds(sdktypes.NewBalance(big.NewInt(0.1 * constants.ETH)))
 
 	systest.SystemTest(t,
 		erc20BridgeTestScenario(chainIdx, l1WalletGetter, l2WalletGetter),

--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -28,8 +28,8 @@ func TestOperatorFee(t *testing.T) {
 	logger.Info("Starting operator fee test", "chain", chainIdx)
 
 	// Get validators and getters for accessing the system and wallets
-	l1WalletGetter, l1WalletValidator := validators.AcquireL1WalletWithFunds(types.NewBalance(big.NewInt(params.Ether)))
-	l2WalletGetter, l2WalletValidator := validators.AcquireL2WalletWithFunds(chainIdx, types.NewBalance(big.NewInt(params.Ether)))
+	l1WalletGetter, l1WalletValidator := validators.AcquireL1WalletWithFunds(types.NewBalance(big.NewInt(params.Ether / 10)))
+	l2WalletGetter, l2WalletValidator := validators.AcquireL2WalletWithFunds(chainIdx, types.NewBalance(big.NewInt(params.Ether/10)))
 
 	logger.Info("Acquired test wallets with funds")
 
@@ -174,14 +174,14 @@ func operatorFeeTestProcedure(t systest.T, sys system.System, l1FundingWallet sy
 	require.NoError(t, err)
 	logger.Info("Test wallet 2", "address", l2TestWallet2.Address().Hex(), "private key", hex.EncodeToString(l2TestWallet2.PrivateKey().D.Bytes()))
 
-	fundAmount := new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether))
+	fundAmount := new(big.Int).Mul(big.NewInt(1), big.NewInt(params.Ether/10))
 
 	// ==========
 	// Begin Test
 	// ==========
 
-	logger.Info("Funding owner wallet with ETH", "amount", big.NewInt(params.Ether))
-	err = EnsureSufficientBalance(l1FundingWallet, l1RollupOwnerWallet.Address(), big.NewInt(params.Ether))
+	logger.Info("Funding owner wallet with ETH", "amount", big.NewInt(params.Ether/10))
+	err = EnsureSufficientBalance(l1FundingWallet, l1RollupOwnerWallet.Address(), big.NewInt(params.Ether/10))
 	require.NoError(t, err, "Error funding owner wallet")
 	defer func() {
 		logger.Info("Returning remaining funds to owner wallet")

--- a/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
+++ b/op-acceptance-tests/tests/isthmus/withdrawal_root_test.go
@@ -30,7 +30,7 @@ func TestWithdrawalsRoot(t *testing.T) {
 
 	walletGetter, fundsValidator := validators.AcquireL2WalletWithFunds(
 		chainIdx,
-		types.NewBalance(big.NewInt(1.0*constants.ETH)),
+		types.NewBalance(big.NewInt(0.1*constants.ETH)),
 	)
 	_, forkValidator := validators.AcquireL2WithFork(chainIdx, rollup.Isthmus)
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Reduces the amount of ETH used by the op-acceptance-tests so that, when funding wallets on devnets, 1-2 ETH suffice overall.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
