### PR TITLE
feat(op-acceptance-tests): port deposit test to new dsl

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -5,14 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	"github.com/lmittmann/w3"
 )
 
 func TestMain(m *testing.M) {
@@ -41,31 +40,19 @@ func TestL1ToL2Deposit(gt *testing.T) {
 
 	depositAmount := eth.OneHundredthEther
 
-	// Define the deposit function and encode arguments
-	// TODO: Redo this when the new DSL (#16079) is merged
-	funcDeposit := w3.MustNewFunc(`depositTransaction(address,uint256,uint64,bool,bytes)`, "")
-	args, err := funcDeposit.EncodeArgs(
-		alice.Address(),       // _to
-		depositAmount.ToBig(), // _value
-		uint64(300_000),       // _gasLimit
-		false,                 // _isCreation
-		[]byte{},              // _data
-	)
-	require.NoError(t, err)
+	// Build the transaction
+	factory := bindings.NewOptimismPortal2Factory(bindings.WithClient(sys.L2EL.Escape().EthClient()), bindings.WithTo(portalAddr), bindings.WithTest(t))
 
-	// Create and confirm the transaction (awaits tx inclusion and checks success status)
-	tx := alice.Transact(
-		alice.Plan(),
-		txplan.WithGasLimit(500_000),
-		txplan.WithTo(&portalAddr),
-		txplan.WithData(args),
-		txplan.WithValue(depositAmount.ToBig()))
+	portal := bindings.NewOptimismPortal2(factory)
 
-	receipt := tx.Included.Value()
-	gasPrice := receipt.EffectiveGasPrice // bugfix: use the exact price that was charged
+	args := portal.DepositTransaction(alice.Address(), depositAmount, 300_000, false, []byte{})
+
+	tx := contract.Write(alice, args, txplan.WithValue(depositAmount.ToBig()))
+
+	gasPrice := tx.EffectiveGasPrice
 
 	// Verify the deposit was successful
-	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), gasPrice)
+	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasUsed), gasPrice)
 	expectedFinalL1 := new(big.Int).Sub(initialBalance.ToBig(), depositAmount.ToBig())
 	expectedFinalL1.Sub(expectedFinalL1, gasCost)
 
@@ -74,7 +61,7 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	// Wait for the sequencer to process the deposit
 	t.Require().Eventually(func() bool {
 		head := sys.L2CL.HeadBlockRef(supervisorTypes.LocalUnsafe)
-		return head.L1Origin.Number >= receipt.BlockNumber.Uint64()
+		return head.L1Origin.Number >= tx.BlockNumber.Uint64()
 	}, time.Second*30, time.Second, "awaiting deposit to be processed by L2")
 	alicel2.VerifyBalanceExact(initialL2Balance.Add(depositAmount))
 }

--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -41,18 +41,16 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	depositAmount := eth.OneHundredthEther
 
 	// Build the transaction
-	factory := bindings.NewOptimismPortal2Factory(bindings.WithClient(sys.L2EL.Escape().EthClient()), bindings.WithTo(portalAddr), bindings.WithTest(t))
-
-	portal := bindings.NewOptimismPortal2(factory)
+	portal := bindings.NewBindings[bindings.OptimismPortal2](bindings.WithClient(sys.L2EL.Escape().EthClient()), bindings.WithTo(portalAddr), bindings.WithTest(t))
 
 	args := portal.DepositTransaction(alice.Address(), depositAmount, 300_000, false, []byte{})
 
-	tx := contract.Write(alice, args, txplan.WithValue(depositAmount.ToBig()))
+	receipt := contract.Write(alice, args, txplan.WithValue(depositAmount.ToBig()))
 
-	gasPrice := tx.EffectiveGasPrice
+	gasPrice := receipt.EffectiveGasPrice
 
 	// Verify the deposit was successful
-	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasUsed), gasPrice)
+	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), gasPrice)
 	expectedFinalL1 := new(big.Int).Sub(initialBalance.ToBig(), depositAmount.ToBig())
 	expectedFinalL1.Sub(expectedFinalL1, gasCost)
 
@@ -61,7 +59,7 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	// Wait for the sequencer to process the deposit
 	t.Require().Eventually(func() bool {
 		head := sys.L2CL.HeadBlockRef(supervisorTypes.LocalUnsafe)
-		return head.L1Origin.Number >= tx.BlockNumber.Uint64()
+		return head.L1Origin.Number >= receipt.BlockNumber.Uint64()
 	}, time.Second*30, time.Second, "awaiting deposit to be processed by L2")
 	alicel2.VerifyBalanceExact(initialL2Balance.Add(depositAmount))
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Following #16333, we have a new DSL for contracts and the bindings for OptimismPortal2. This PR ports the current deposit test to use these new bindings.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
Affects Deposit Test.

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
