### PR TITLE
op-deployer: validate intent overrides

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -89,7 +89,11 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		return opcm.DeployOPChainInput{}, fmt.Errorf("error merging proof params from overrides: %w", err)
 	}
 
-	cfg, err := state.CombineDeployConfig(intent, thisIntent, st, nil)
+	chainState, err := st.Chain(thisIntent.ID)
+	if err != nil {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("error getting chain state: %w", err)
+	}
+	cfg, err := state.CombineDeployConfig(intent, thisIntent, st, chainState)
 	if err != nil {
 		return opcm.DeployOPChainInput{}, fmt.Errorf("error combining deploy config: %w", err)
 	}

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -89,6 +89,11 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		return opcm.DeployOPChainInput{}, fmt.Errorf("error merging proof params from overrides: %w", err)
 	}
 
+	cfg, err := state.CombineDeployConfig(intent, thisIntent, st, nil)
+	if err != nil {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("error combining deploy config: %w", err)
+	}
+
 	return opcm.DeployOPChainInput{
 		OpChainProxyAdminOwner:       thisIntent.Roles.L1ProxyAdminOwner,
 		SystemConfigOwner:            thisIntent.Roles.SystemConfigOwner,
@@ -96,12 +101,12 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		UnsafeBlockSigner:            thisIntent.Roles.UnsafeBlockSigner,
 		Proposer:                     thisIntent.Roles.Proposer,
 		Challenger:                   thisIntent.Roles.Challenger,
-		BasefeeScalar:                standard.BasefeeScalar,
-		BlobBaseFeeScalar:            standard.BlobBaseFeeScalar,
+		BasefeeScalar:                cfg.L2InitializationConfig.GasPriceOracleDeployConfig.GasPriceOracleBaseFeeScalar,
+		BlobBaseFeeScalar:            cfg.L2InitializationConfig.GasPriceOracleDeployConfig.GasPriceOracleBlobBaseFeeScalar,
 		L2ChainId:                    chainID.Big(),
 		Opcm:                         st.ImplementationsDeployment.OpcmImpl,
 		SaltMixer:                    st.Create2Salt.String(), // passing through salt generated at state initialization
-		GasLimit:                     standard.GasLimit,
+		GasLimit:                     uint64(cfg.L2InitializationConfig.L2GenesisBlockDeployConfig.L2GenesisBlockGasLimit),
 		DisputeGameType:              proofParams.DisputeGameType,
 		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
 		DisputeMaxGameDepth:          proofParams.DisputeMaxGameDepth,

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -89,13 +89,14 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		return opcm.DeployOPChainInput{}, fmt.Errorf("error merging proof params from overrides: %w", err)
 	}
 
-	chainState, err := st.Chain(thisIntent.ID)
+	gasPriceCfg, err := state.GetGasPriceOracleDeployConfig(intent, thisIntent)
 	if err != nil {
-		return opcm.DeployOPChainInput{}, fmt.Errorf("error getting chain state: %w", err)
+		return opcm.DeployOPChainInput{}, fmt.Errorf("error getting gas price config: %w", err)
 	}
-	cfg, err := state.CombineDeployConfig(intent, thisIntent, st, chainState)
+
+	l2GenesisBlockCfg, err := state.GetL2GenesisBlockDeployConfig(intent, thisIntent)
 	if err != nil {
-		return opcm.DeployOPChainInput{}, fmt.Errorf("error combining deploy config: %w", err)
+		return opcm.DeployOPChainInput{}, fmt.Errorf("error getting l2 genesis block config: %w", err)
 	}
 
 	return opcm.DeployOPChainInput{
@@ -105,12 +106,12 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		UnsafeBlockSigner:            thisIntent.Roles.UnsafeBlockSigner,
 		Proposer:                     thisIntent.Roles.Proposer,
 		Challenger:                   thisIntent.Roles.Challenger,
-		BasefeeScalar:                cfg.L2InitializationConfig.GasPriceOracleDeployConfig.GasPriceOracleBaseFeeScalar,
-		BlobBaseFeeScalar:            cfg.L2InitializationConfig.GasPriceOracleDeployConfig.GasPriceOracleBlobBaseFeeScalar,
+		BasefeeScalar:                gasPriceCfg.GasPriceOracleBaseFeeScalar,
+		BlobBaseFeeScalar:            gasPriceCfg.GasPriceOracleBlobBaseFeeScalar,
 		L2ChainId:                    chainID.Big(),
 		Opcm:                         st.ImplementationsDeployment.OpcmImpl,
 		SaltMixer:                    st.Create2Salt.String(), // passing through salt generated at state initialization
-		GasLimit:                     uint64(cfg.L2InitializationConfig.L2GenesisBlockDeployConfig.L2GenesisBlockGasLimit),
+		GasLimit:                     uint64(l2GenesisBlockCfg.L2GenesisBlockGasLimit),
 		DisputeGameType:              proofParams.DisputeGameType,
 		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
 		DisputeMaxGameDepth:          proofParams.DisputeMaxGameDepth,

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -18,9 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-var (
-	l2GenesisBlockBaseFeePerGas = hexutil.Big(*(big.NewInt(1000000000)))
-)
+var l2GenesisBlockBaseFeePerGas = hexutil.Big(*(big.NewInt(1000000000)))
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
 	upgradeSchedule := standard.DefaultHardforkScheduleForTag(intent.L1ContractsLocator.Tag)
@@ -148,7 +146,6 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		cfg, err = jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging global L2 overrides: %w", err)
-
 		}
 	}
 
@@ -170,4 +167,31 @@ func calculateBatchInboxAddr(chainID common.Hash) common.Address {
 	var out common.Address
 	copy(out[1:], crypto.Keccak256(chainID[:])[:19])
 	return out
+}
+
+func GetGasPriceOracleDeployConfig(intent *Intent, chainIntent *ChainIntent) (genesis.GasPriceOracleDeployConfig, error) {
+	cfg := genesis.GasPriceOracleDeployConfig{
+		GasPriceOracleBaseFeeScalar:       1368,
+		GasPriceOracleBlobBaseFeeScalar:   810949,
+		GasPriceOracleOperatorFeeScalar:   chainIntent.OperatorFeeScalar,
+		GasPriceOracleOperatorFeeConstant: chainIntent.OperatorFeeConstant,
+	}
+	cfg, err := jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides, chainIntent.DeployOverrides)
+	if err != nil {
+		return genesis.GasPriceOracleDeployConfig{}, fmt.Errorf("error merging GasPriceOracleDeployConfig overrides: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func GetL2GenesisBlockDeployConfig(intent *Intent, chainIntent *ChainIntent) (genesis.L2GenesisBlockDeployConfig, error) {
+	cfg := genesis.L2GenesisBlockDeployConfig{
+		L2GenesisBlockGasLimit:      60_000_000,
+		L2GenesisBlockBaseFeePerGas: &l2GenesisBlockBaseFeePerGas,
+	}
+	cfg, err := jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides, chainIntent.DeployOverrides)
+	if err != nil {
+		return genesis.L2GenesisBlockDeployConfig{}, fmt.Errorf("error merging L2GenesisBlockDeployConfig overrides: %w", err)
+	}
+	return cfg, nil
 }

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -25,8 +25,10 @@ const (
 	IntentTypeStandardOverrides IntentType = "standard-overrides"
 )
 
-var emptyAddress common.Address
-var emptyHash common.Hash
+var (
+	emptyAddress common.Address
+	emptyHash    common.Hash
+)
 
 type SuperchainProofParams struct {
 	WithdrawalDelaySeconds          uint64 `json:"faultGameWithdrawalDelay" toml:"faultGameWithdrawalDelay"`
@@ -76,8 +78,10 @@ type Intent struct {
 	L1DevGenesisParams *L1DevGenesisParams `json:"l1DevGenesisParams"`
 }
 
-var ErrL1ContractsLocatorUndefined = errors.New("L1ContractsLocator undefined")
-var ErrL2ContractsLocatorUndefined = errors.New("L2ContractsLocator undefined")
+var (
+	ErrL1ContractsLocatorUndefined = errors.New("L1ContractsLocator undefined")
+	ErrL2ContractsLocatorUndefined = errors.New("L2ContractsLocator undefined")
+)
 
 func (c *Intent) L1ChainIDBig() *big.Int {
 	return big.NewInt(int64(c.L1ChainID))
@@ -211,6 +215,10 @@ func (c *Intent) Check() error {
 		return ErrL2ContractsLocatorUndefined
 	}
 
+	if err := c.validateOverrides(); err != nil {
+		return err
+	}
+
 	var err error
 	switch c.ConfigType {
 	case IntentTypeStandard:
@@ -224,6 +232,20 @@ func (c *Intent) Check() error {
 	}
 	if err != nil {
 		return fmt.Errorf("failed to validate intent-type=%s: %w", c.ConfigType, err)
+	}
+
+	return nil
+}
+
+func (c *Intent) validateOverrides() error {
+	if err := ValidateOverrides(c.GlobalDeployOverrides); err != nil {
+		return fmt.Errorf("invalid global deploy overrides: %w", err)
+	}
+
+	for _, chain := range c.Chains {
+		if err := ValidateOverrides(chain.DeployOverrides); err != nil {
+			return fmt.Errorf("invalid chain deploy overrides: %w", err)
+		}
 	}
 
 	return nil

--- a/op-deployer/pkg/deployer/state/overrides.go
+++ b/op-deployer/pkg/deployer/state/overrides.go
@@ -11,17 +11,18 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 )
 
-// BuildValidOverrideKeys dynamically extracts all field names from a DeployConfig struct
+// buildValidOverrideKeys dynamically extracts all field names from a DeployConfig struct
 func buildValidOverrideKeys() map[string]struct{} {
 	validKeys := make(map[string]struct{})
-	extractFieldNames(reflect.TypeOf(genesis.DeployConfig{}), "", validKeys)
-	extractFieldNames(reflect.TypeOf(SuperchainProofParams{}), "", validKeys)
-	extractFieldNames(reflect.TypeOf(ChainProofParams{}), "", validKeys)
+	extractFieldNames(reflect.TypeOf(genesis.DeployConfig{}), validKeys)
+	extractFieldNames(reflect.TypeOf(SuperchainProofParams{}), validKeys)
+	extractFieldNames(reflect.TypeOf(ChainProofParams{}), validKeys)
 	return validKeys
 }
 
 // extractFieldNames recursively extracts JSON field names from a struct type
-func extractFieldNames(t reflect.Type, prefix string, result map[string]struct{}) {
+// and adds them to the result map as flat keys
+func extractFieldNames(t reflect.Type, result map[string]struct{}) {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
@@ -36,7 +37,7 @@ func extractFieldNames(t reflect.Type, prefix string, result map[string]struct{}
 		// Handle embedded structs (fields without names)
 		if field.Anonymous {
 			// Recursively extract fields from the embedded struct
-			extractFieldNames(field.Type, prefix, result)
+			extractFieldNames(field.Type, result)
 			continue
 		}
 
@@ -48,14 +49,8 @@ func extractFieldNames(t reflect.Type, prefix string, result map[string]struct{}
 
 		fieldName := strings.Split(jsonTag, ",")[0]
 
-		// Add simple field name to support current usage pattern
+		// Add field name to the result map
 		result[fieldName] = struct{}{}
-
-		// Also add fully qualified name if we have a prefix
-		if prefix != "" {
-			fullPath := prefix + "." + fieldName
-			result[fullPath] = struct{}{}
-		}
 
 		// Recursively process nested structs
 		fieldType := field.Type
@@ -64,11 +59,7 @@ func extractFieldNames(t reflect.Type, prefix string, result map[string]struct{}
 		}
 
 		if fieldType.Kind() == reflect.Struct {
-			newPrefix := fieldName
-			if prefix != "" {
-				newPrefix = prefix + "." + fieldName
-			}
-			extractFieldNames(fieldType, newPrefix, result)
+			extractFieldNames(fieldType, result)
 		}
 	}
 }

--- a/op-deployer/pkg/deployer/state/overrides.go
+++ b/op-deployer/pkg/deployer/state/overrides.go
@@ -1,0 +1,98 @@
+// File: op-deployer/pkg/deployer/state/valid_overrides.go
+
+package state
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ValidOverrideKeys is a map of all keys that can be overridden in the deployment config
+var ValidOverrideKeys = map[string]struct{}{
+	// L2 Core parameters
+	"l2BlockTime":               {},
+	"l2GenesisBlockGasLimit":    {},
+	"finalizationPeriodSeconds": {},
+	"maxSequencerDrift":         {},
+	"sequencerWindowSize":       {},
+	"channelTimeoutBedrock":     {},
+
+	// Fee vault parameters
+	"baseFeeVaultRecipient":                    {},
+	"l1FeeVaultRecipient":                      {},
+	"sequencerFeeVaultRecipient":               {},
+	"baseFeeVaultMinimumWithdrawalAmount":      {},
+	"l1FeeVaultMinimumWithdrawalAmount":        {},
+	"sequencerFeeVaultMinimumWithdrawalAmount": {},
+	"baseFeeVaultWithdrawalNetwork":            {},
+	"l1FeeVaultWithdrawalNetwork":              {},
+	"sequencerFeeVaultWithdrawalNetwork":       {},
+
+	// Gas parameters
+	"gasPriceOracleBaseFeeScalar":       {},
+	"gasPriceOracleBlobBaseFeeScalar":   {},
+	"gasPriceOracleOperatorFeeScalar":   {},
+	"gasPriceOracleOperatorFeeConstant": {},
+	"eip1559Denominator":                {},
+	"eip1559DenominatorCanyon":          {},
+	"eip1559Elasticity":                 {},
+
+	// Fault proof parameters
+	"useFaultProofs":                  {},
+	"faultGameWithdrawalDelay":        {},
+	"preimageOracleMinProposalSize":   {},
+	"preimageOracleChallengePeriod":   {},
+	"proofMaturityDelaySeconds":       {},
+	"disputeGameFinalityDelaySeconds": {},
+	"mipsVersion":                     {},
+
+	// Hardfork timing parameters
+	"l2GenesisRegolithTimeOffset":           {},
+	"l2GenesisCanyonTimeOffset":             {},
+	"l2GenesisDeltaTimeOffset":              {},
+	"l2GenesisEcotoneTimeOffset":            {},
+	"l2GenesisFjordTimeOffset":              {},
+	"l2GenesisGraniteTimeOffset":            {},
+	"l2GenesisHoloceneTimeOffset":           {},
+	"l2GenesisIsthmusTimeOffset":            {},
+	"l2GenesisInteropTimeOffset":            {},
+	"l2GenesisJovianTimeOffset":             {},
+	"l2GenesisPectraBlobScheduleTimeOffset": {},
+
+	// Alt DA parameters
+	"useAltDA":          {},
+	"daChallengeWindow": {},
+	"daResolveWindow":   {},
+	"daCommitmentType":  {},
+
+	// Dev parameters
+	"fundDevAccounts": {},
+}
+
+// ValidateOverrides checks if all keys in the overrides map are valid override keys
+func ValidateOverrides(overrides map[string]any) error {
+	var invalidKeys []string
+
+	for key := range overrides {
+		if _, ok := ValidOverrideKeys[key]; !ok {
+			invalidKeys = append(invalidKeys, key)
+		}
+	}
+
+	if len(invalidKeys) > 0 {
+		sort.Strings(invalidKeys)
+
+		// Get valid keys for error message
+		validKeysList := make([]string, 0, len(ValidOverrideKeys))
+		for key := range ValidOverrideKeys {
+			validKeysList = append(validKeysList, key)
+		}
+		sort.Strings(validKeysList)
+
+		return fmt.Errorf("invalid override keys: %s\n\nValid keys are:\n%s\n",
+			strings.Join(invalidKeys, ", "), strings.Join(validKeysList, "\n"))
+	}
+
+	return nil
+}

--- a/op-deployer/pkg/deployer/state/overrides.go
+++ b/op-deployer/pkg/deployer/state/overrides.go
@@ -16,13 +16,8 @@ var ValidOverrideKeys = map[string]struct{}{
 	"finalizationPeriodSeconds": {},
 	"maxSequencerDrift":         {},
 	"sequencerWindowSize":       {},
-	"channelTimeoutBedrock":     {},
 
 	// Fee vault parameters
-	"baseFeeVaultRecipient":                    {},
-	"l1FeeVaultRecipient":                      {},
-	"sequencerFeeVaultRecipient":               {},
-	"baseFeeVaultMinimumWithdrawalAmount":      {},
 	"l1FeeVaultMinimumWithdrawalAmount":        {},
 	"sequencerFeeVaultMinimumWithdrawalAmount": {},
 	"baseFeeVaultWithdrawalNetwork":            {},
@@ -34,18 +29,22 @@ var ValidOverrideKeys = map[string]struct{}{
 	"gasPriceOracleBlobBaseFeeScalar":   {},
 	"gasPriceOracleOperatorFeeScalar":   {},
 	"gasPriceOracleOperatorFeeConstant": {},
-	"eip1559Denominator":                {},
-	"eip1559DenominatorCanyon":          {},
-	"eip1559Elasticity":                 {},
 
 	// Fault proof parameters
-	"useFaultProofs":                  {},
-	"faultGameWithdrawalDelay":        {},
-	"preimageOracleMinProposalSize":   {},
-	"preimageOracleChallengePeriod":   {},
-	"proofMaturityDelaySeconds":       {},
-	"disputeGameFinalityDelaySeconds": {},
-	"mipsVersion":                     {},
+	"useFaultProofs":                          {},
+	"faultGameWithdrawalDelay":                {},
+	"preimageOracleMinProposalSize":           {},
+	"preimageOracleChallengePeriod":           {},
+	"proofMaturityDelaySeconds":               {},
+	"disputeGameFinalityDelaySeconds":         {},
+	"mipsVersion":                             {},
+	"respectedGameType":                       {},
+	"faultGameAbsolutePrestate":               {},
+	"faultGameMaxDepth":                       {},
+	"faultGameSplitDepth":                     {},
+	"faultGameClockExtension":                 {},
+	"faultGameMaxClockDuration":               {},
+	"dangerouslyAllowCustomDisputeParameters": {},
 
 	// Hardfork timing parameters
 	"l2GenesisRegolithTimeOffset":           {},
@@ -59,15 +58,6 @@ var ValidOverrideKeys = map[string]struct{}{
 	"l2GenesisInteropTimeOffset":            {},
 	"l2GenesisJovianTimeOffset":             {},
 	"l2GenesisPectraBlobScheduleTimeOffset": {},
-
-	// Alt DA parameters
-	"useAltDA":          {},
-	"daChallengeWindow": {},
-	"daResolveWindow":   {},
-	"daCommitmentType":  {},
-
-	// Dev parameters
-	"fundDevAccounts": {},
 }
 
 // ValidateOverrides checks if all keys in the overrides map are valid override keys

--- a/op-deployer/pkg/deployer/state/overrides.go
+++ b/op-deployer/pkg/deployer/state/overrides.go
@@ -86,14 +86,6 @@ func ValidateOverrides(overrides map[string]any) error {
 
 	if len(invalidKeys) > 0 {
 		sort.Strings(invalidKeys)
-
-		// Get valid keys for error message
-		validKeysList := make([]string, 0, len(validKeys))
-		for key := range validKeys {
-			validKeysList = append(validKeysList, key)
-		}
-		sort.Strings(validKeysList)
-
 		return fmt.Errorf("invalid override keys:\n%s", strings.Join(invalidKeys, ", "))
 	}
 

--- a/op-deployer/pkg/deployer/state/overrides.go
+++ b/op-deployer/pkg/deployer/state/overrides.go
@@ -4,68 +4,82 @@ package state
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 )
 
-// ValidOverrideKeys is a map of all keys that can be overridden in the deployment config
-var ValidOverrideKeys = map[string]struct{}{
-	// L2 Core parameters
-	"l2BlockTime":               {},
-	"l2GenesisBlockGasLimit":    {},
-	"finalizationPeriodSeconds": {},
-	"maxSequencerDrift":         {},
-	"sequencerWindowSize":       {},
+// BuildValidOverrideKeys dynamically extracts all field names from a DeployConfig struct
+func buildValidOverrideKeys() map[string]struct{} {
+	validKeys := make(map[string]struct{})
+	extractFieldNames(reflect.TypeOf(genesis.DeployConfig{}), "", validKeys)
+	extractFieldNames(reflect.TypeOf(SuperchainProofParams{}), "", validKeys)
+	extractFieldNames(reflect.TypeOf(ChainProofParams{}), "", validKeys)
+	return validKeys
+}
 
-	// Fee vault parameters
-	"l1FeeVaultMinimumWithdrawalAmount":        {},
-	"sequencerFeeVaultMinimumWithdrawalAmount": {},
-	"baseFeeVaultWithdrawalNetwork":            {},
-	"l1FeeVaultWithdrawalNetwork":              {},
-	"sequencerFeeVaultWithdrawalNetwork":       {},
+// extractFieldNames recursively extracts JSON field names from a struct type
+func extractFieldNames(t reflect.Type, prefix string, result map[string]struct{}) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
 
-	// Gas parameters
-	"gasPriceOracleBaseFeeScalar":       {},
-	"gasPriceOracleBlobBaseFeeScalar":   {},
-	"gasPriceOracleOperatorFeeScalar":   {},
-	"gasPriceOracleOperatorFeeConstant": {},
+	if t.Kind() != reflect.Struct {
+		return
+	}
 
-	// Fault proof parameters
-	"useFaultProofs":                          {},
-	"faultGameWithdrawalDelay":                {},
-	"preimageOracleMinProposalSize":           {},
-	"preimageOracleChallengePeriod":           {},
-	"proofMaturityDelaySeconds":               {},
-	"disputeGameFinalityDelaySeconds":         {},
-	"mipsVersion":                             {},
-	"respectedGameType":                       {},
-	"faultGameAbsolutePrestate":               {},
-	"faultGameMaxDepth":                       {},
-	"faultGameSplitDepth":                     {},
-	"faultGameClockExtension":                 {},
-	"faultGameMaxClockDuration":               {},
-	"dangerouslyAllowCustomDisputeParameters": {},
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
 
-	// Hardfork timing parameters
-	"l2GenesisRegolithTimeOffset":           {},
-	"l2GenesisCanyonTimeOffset":             {},
-	"l2GenesisDeltaTimeOffset":              {},
-	"l2GenesisEcotoneTimeOffset":            {},
-	"l2GenesisFjordTimeOffset":              {},
-	"l2GenesisGraniteTimeOffset":            {},
-	"l2GenesisHoloceneTimeOffset":           {},
-	"l2GenesisIsthmusTimeOffset":            {},
-	"l2GenesisInteropTimeOffset":            {},
-	"l2GenesisJovianTimeOffset":             {},
-	"l2GenesisPectraBlobScheduleTimeOffset": {},
+		// Handle embedded structs (fields without names)
+		if field.Anonymous {
+			// Recursively extract fields from the embedded struct
+			extractFieldNames(field.Type, prefix, result)
+			continue
+		}
+
+		// Get JSON field name
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+
+		fieldName := strings.Split(jsonTag, ",")[0]
+
+		// Add simple field name to support current usage pattern
+		result[fieldName] = struct{}{}
+
+		// Also add fully qualified name if we have a prefix
+		if prefix != "" {
+			fullPath := prefix + "." + fieldName
+			result[fullPath] = struct{}{}
+		}
+
+		// Recursively process nested structs
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+
+		if fieldType.Kind() == reflect.Struct {
+			newPrefix := fieldName
+			if prefix != "" {
+				newPrefix = prefix + "." + fieldName
+			}
+			extractFieldNames(fieldType, newPrefix, result)
+		}
+	}
 }
 
 // ValidateOverrides checks if all keys in the overrides map are valid override keys
 func ValidateOverrides(overrides map[string]any) error {
-	var invalidKeys []string
+	validKeys := buildValidOverrideKeys()
 
+	var invalidKeys []string
 	for key := range overrides {
-		if _, ok := ValidOverrideKeys[key]; !ok {
+		if _, ok := validKeys[key]; !ok {
 			invalidKeys = append(invalidKeys, key)
 		}
 	}
@@ -74,14 +88,13 @@ func ValidateOverrides(overrides map[string]any) error {
 		sort.Strings(invalidKeys)
 
 		// Get valid keys for error message
-		validKeysList := make([]string, 0, len(ValidOverrideKeys))
-		for key := range ValidOverrideKeys {
+		validKeysList := make([]string, 0, len(validKeys))
+		for key := range validKeys {
 			validKeysList = append(validKeysList, key)
 		}
 		sort.Strings(validKeysList)
 
-		return fmt.Errorf("invalid override keys: %s\n\nValid keys are:\n%s\n",
-			strings.Join(invalidKeys, ", "), strings.Join(validKeysList, "\n"))
+		return fmt.Errorf("invalid override keys:\n%s", strings.Join(invalidKeys, ", "))
 	}
 
 	return nil

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -543,7 +543,7 @@ contract DeployOPChain is Script {
         require(systemConfig.basefeeScalar() == _doi.basefeeScalar(), "SYSCON-20");
         require(systemConfig.blobbasefeeScalar() == _doi.blobBaseFeeScalar(), "SYSCON-30");
         require(systemConfig.batcherHash() == bytes32(uint256(uint160(_doi.batcher()))), "SYSCON-40");
-        require(systemConfig.gasLimit() == uint64(60_000_000), "SYSCON-50");
+        require(systemConfig.gasLimit() == _doi.gasLimit(), "SYSCON-50");
         require(systemConfig.unsafeBlockSigner() == _doi.unsafeBlockSigner(), "SYSCON-60");
         require(systemConfig.scalar() >> 248 == 1, "SYSCON-70");
 


### PR DESCRIPTION
# Overview
Adds a step to the intent validation that checks all intent overrides fields to confirm that they keys provided in override structs have been explicitly listed as valid override fields. This will improve UX: previously an invalid override key was just silently ignored, whereas now any invalid keys will cause an error and will be printed as part of an error message.
```
➜  op-deployer git:(develop) ✗ go run ./cmd/op-deployer apply \
  --private-key=$OP_DEPLOYER_PRIVATE_KEY \
  --l1-rpc-url $SEPOLIA_RPC_URL \
  --workdir ./.deployer
Application failed: invalid global deploy overrides: invalid override keys: fakeField, fakeField2

exit status 1
```

# Related Issues
Closes https://github.com/ethereum-optimism/optimism/issues/16322