### PR TITLE
cannon: Return EAGAIN error when writing to a EventFd file descriptor

### DIFF
--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -30,7 +30,7 @@ const (
 	FdPreimageRead  = 5
 	FdPreimageWrite = 6
 
-	FdEventFd = ^Word(0)
+	FdEventFd = 100
 )
 
 // Errors

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -29,6 +29,8 @@ const (
 	FdHintWrite     = 4
 	FdPreimageRead  = 5
 	FdPreimageWrite = 6
+
+	FdEventFd = ^Word(0)
 )
 
 // Errors
@@ -175,6 +177,10 @@ func HandleSysRead(
 	case FdHintRead: // hint response
 		// don't actually read into memory, just say we read it all, we ignore the result anyway
 		v0 = a2
+	case FdEventFd:
+		// Always act in non blocking mode as if the counter has not been signalled
+		v0 = MipsEAGAIN
+		v1 = MipsEAGAIN
 	default:
 		v0 = ^Word(0)
 		v1 = MipsEBADF
@@ -239,6 +245,11 @@ func HandleSysWrite(a0, a1, a2 Word,
 		newPreimageOffset = 0
 		//fmt.Printf("updating pre-image key: %s\n", m.state.PreimageKey)
 		v0 = a2
+	case FdEventFd:
+		// Always report that the write could not be completed
+		// This acts as if the counter has already reached the maximum value
+		v0 = MipsEAGAIN
+		v1 = MipsEAGAIN
 	default:
 		v0 = ^Word(0)
 		v1 = MipsEBADF

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -180,7 +180,7 @@ func HandleSysRead(
 	case FdEventFd:
 		// Always act in non blocking mode as if the counter has not been signalled
 		v0 = MipsEAGAIN
-		v1 = MipsEAGAIN
+		v1 = ^Word(0)
 	default:
 		v0 = ^Word(0)
 		v1 = MipsEBADF
@@ -249,7 +249,7 @@ func HandleSysWrite(a0, a1, a2 Word,
 		// Always report that the write could not be completed
 		// This acts as if the counter has already reached the maximum value
 		v0 = MipsEAGAIN
-		v1 = MipsEAGAIN
+		v1 = ^Word(0)
 	default:
 		v0 = ^Word(0)
 		v1 = MipsEBADF

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -122,8 +122,8 @@ func HandleSysMmap(a0, a1, heap Word) (v0, v1, newHeap Word) {
 		newHeap += sz
 		// Fail if new heap exceeds memory limit, newHeap overflows around to low memory, or sz overflows
 		if newHeap > program.HEAP_END || newHeap < heap || sz < a1 {
-			v0 = SysErrorSignal
-			v1 = MipsEINVAL
+			v0 = MipsEINVAL
+			v1 = SysErrorSignal
 			return v0, v1, heap
 		}
 	} else {
@@ -143,7 +143,7 @@ func HandleSysRead(
 	memTracker MemTracker,
 ) (v0, v1, newPreimageOffset Word, memUpdated bool, memAddr Word) {
 	// args: a0 = fd, a1 = addr, a2 = count
-	// returns: v0 = read, v1 = err code
+	// returns: v0 = return value, v1 = error boolean
 	v0 = Word(0)
 	v1 = Word(0)
 	newPreimageOffset = preimageOffset
@@ -180,10 +180,10 @@ func HandleSysRead(
 	case FdEventFd:
 		// Always act in non blocking mode as if the counter has not been signalled
 		v0 = MipsEAGAIN
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	default:
 		v0 = MipsEBADF
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	}
 
 	return v0, v1, newPreimageOffset, memUpdated, memAddr
@@ -199,7 +199,7 @@ func HandleSysWrite(a0, a1, a2 Word,
 	stdOut, stdErr io.Writer,
 ) (v0, v1 Word, newLastHint hexutil.Bytes, newPreimageKey common.Hash, newPreimageOffset Word) {
 	// args: a0 = fd, a1 = addr, a2 = count
-	// returns: v0 = written, v1 = err code
+	// returns: v0 = return value, v1 = error boolean
 	v1 = Word(0)
 	newLastHint = lastHint
 	newPreimageKey = preimageKey
@@ -249,10 +249,10 @@ func HandleSysWrite(a0, a1, a2 Word,
 		// Always report that the write could not be completed
 		// This acts as if the counter has already reached the maximum value
 		v0 = MipsEAGAIN
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	default:
 		v0 = MipsEBADF
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	}
 
 	return v0, v1, newLastHint, newPreimageKey, newPreimageOffset
@@ -267,8 +267,8 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 		case FdStdin, FdStdout, FdStderr, FdPreimageRead, FdHintRead, FdPreimageWrite, FdHintWrite:
 			v0 = 0 // No flags set
 		default:
-			v0 = ^Word(0)
-			v1 = MipsEBADF
+			v0 = MipsEBADF
+			v1 = SysErrorSignal
 		}
 	} else if a1 == 3 { // F_GETFL: get file status flags
 		switch a0 {
@@ -277,12 +277,12 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 		case FdStdout, FdStderr, FdPreimageWrite, FdHintWrite:
 			v0 = 1 // O_WRONLY
 		default:
-			v0 = ^Word(0)
-			v1 = MipsEBADF
+			v0 = MipsEBADF
+			v1 = SysErrorSignal
 		}
 	} else {
-		v0 = ^Word(0)
-		v1 = MipsEINVAL // cmd not recognized by this kernel
+		v0 = MipsEINVAL // cmd not recognized by this kernel
+		v1 = SysErrorSignal
 	}
 
 	return v0, v1

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -182,8 +182,8 @@ func HandleSysRead(
 		v0 = MipsEAGAIN
 		v1 = ^Word(0)
 	default:
-		v0 = ^Word(0)
-		v1 = MipsEBADF
+		v0 = MipsEBADF
+		v1 = ^Word(0)
 	}
 
 	return v0, v1, newPreimageOffset, memUpdated, memAddr
@@ -251,8 +251,8 @@ func HandleSysWrite(a0, a1, a2 Word,
 		v0 = MipsEAGAIN
 		v1 = ^Word(0)
 	default:
-		v0 = ^Word(0)
-		v1 = MipsEBADF
+		v0 = MipsEBADF
+		v1 = ^Word(0)
 	}
 
 	return v0, v1, newLastHint, newPreimageKey, newPreimageOffset

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,7 +74,7 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
-	SupportNoopSysEventFd2     bool
+	SupportMinimalSysEventFd2  bool
 	SupportDclzDclo            bool
 	SupportNoopMprotect        bool
 	SupportWorkingSysGetRandom bool

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -120,7 +120,7 @@ func TestInstrumentedState_SyscallEventFdProgram(t *testing.T) {
 		require.NoError(t, err)
 		matches := re.FindAllStringSubmatch(output, -1)
 		require.Equal(t, 1, len(matches))
-		require.Equal(t, "-1", matches[0][1])
+		require.Equal(t, "100", matches[0][1])
 	})
 }
 

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -331,7 +331,7 @@ func runTestsAcrossVms[T any](t *testing.T, testNamer TestNamer[T], testCases []
 	}
 
 	variations := []VMVariations{
-		{name: "Go 1.23 VM", goTarget: testutil.Go1_23, features: mipsevm.FeatureToggles{SupportNoopSysEventFd2: true, SupportDclzDclo: true}},
+		{name: "Go 1.23 VM", goTarget: testutil.Go1_23, features: mipsevm.FeatureToggles{SupportMinimalSysEventFd2: true, SupportDclzDclo: true}},
 		{name: "Go 1.24 VM", goTarget: testutil.Go1_24, features: allFeaturesEnabled()},
 	}
 

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -83,6 +83,47 @@ func TestInstrumentedState_Random(t *testing.T) {
 	}
 }
 
+func TestInstrumentedState_SyscallEventFdProgram(t *testing.T) {
+	runTestAcrossVms(t, "SyscallEventFdProgram", func(t *testing.T, vmFactory testutil.VMFactory[*State], goTarget testutil.GoTarget) {
+		state, meta := testutil.LoadELFProgram(t, testutil.ProgramPath("syscall-eventfd", goTarget), CreateInitialState)
+
+		var stdOutBuf, stdErrBuf bytes.Buffer
+		us := vmFactory(state, nil, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta)
+		err := us.InitDebug()
+		require.NoError(t, err)
+
+		for i := 0; i < 500_000; i++ {
+			if us.GetState().GetExited() {
+				break
+			}
+			_, err := us.Step(false)
+			require.NoError(t, err)
+		}
+		t.Logf("Completed in %d steps", state.Step)
+
+		require.True(t, state.GetExited(), "must complete program")
+		if state.GetExitCode() != 0 {
+			us.Traceback()
+		}
+		require.Equal(t, uint8(0), state.GetExitCode(), "exit with 0")
+
+		// Check output
+		output := stdOutBuf.String()
+		require.Contains(t, output, "call eventfd")
+		require.Contains(t, output, "write to eventfd object")
+		require.Contains(t, output, "read from eventfd object")
+		require.Contains(t, output, "done")
+
+		// Check fd value
+		pattern := `eventfd2 fd = (.+)`
+		re, err := regexp.Compile(pattern)
+		require.NoError(t, err)
+		matches := re.FindAllStringSubmatch(output, -1)
+		require.Equal(t, 1, len(matches))
+		require.Equal(t, "-1", matches[0][1])
+	})
+}
+
 func TestInstrumentedState_UtilsCheck(t *testing.T) {
 	// Sanity check that test running utilities will return a non-zero exit code on failure
 	type TestCase struct {

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -201,6 +201,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		if !m.features.SupportNoopSysEventFd2 {
 			m.handleUnrecognizedSyscall(syscallNum)
 		}
+		v0 = exec.FdEventFd
 	default:
 		// These syscalls have the same values on 64-bit. So we use if-stmts here to avoid "duplicate case" compiler error for the cannon64 build
 		if arch.IsMips32 && (syscallNum == arch.SysFstat64 || syscallNum == arch.SysStat64 || syscallNum == arch.SysLlseek) {

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -113,8 +113,8 @@ func (m *InstrumentedState) handleSyscall() error {
 			futexVal := m.getFutexValue(effFutexAddr)
 			targetVal := uint32(a2)
 			if futexVal != targetVal {
-				v0 = exec.SysErrorSignal
-				v1 = exec.MipsEAGAIN
+				v0 = exec.MipsEAGAIN
+				v1 = exec.SysErrorSignal
 			} else {
 				m.syscallYield(thread)
 				return nil
@@ -123,15 +123,15 @@ func (m *InstrumentedState) handleSyscall() error {
 			m.syscallYield(thread)
 			return nil
 		default:
-			v0 = exec.SysErrorSignal
-			v1 = exec.MipsEINVAL
+			v0 = exec.MipsEINVAL
+			v1 = exec.SysErrorSignal
 		}
 	case arch.SysSchedYield, arch.SysNanosleep:
 		m.syscallYield(thread)
 		return nil
 	case arch.SysOpen:
-		v0 = exec.SysErrorSignal
-		v1 = exec.MipsEBADF
+		v0 = exec.MipsEBADF
+		v1 = exec.SysErrorSignal
 	case arch.SysClockGetTime:
 		switch a0 {
 		case exec.ClockGettimeRealtimeFlag, exec.ClockGettimeMonotonicFlag:
@@ -152,8 +152,8 @@ func (m *InstrumentedState) handleSyscall() error {
 			m.state.Memory.SetWord(effAddr+arch.WordSizeBytes, nsecs)
 			m.handleMemoryUpdate(effAddr + arch.WordSizeBytes)
 		default:
-			v0 = exec.SysErrorSignal
-			v1 = exec.MipsEINVAL
+			v0 = exec.MipsEINVAL
+			v1 = exec.SysErrorSignal
 		}
 	case arch.SysGetpid:
 		v0 = 0

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -198,7 +198,7 @@ func (m *InstrumentedState) handleSyscall() error {
 	case arch.SysGetRLimit:
 	case arch.SysLseek:
 	case arch.SysEventFd2:
-		if !m.features.SupportNoopSysEventFd2 {
+		if !m.features.SupportMinimalSysEventFd2 {
 			m.handleUnrecognizedSyscall(syscallNum)
 		}
 		v0 = exec.FdEventFd

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1060,6 +1060,66 @@ func TestEVM_RandomProgram(t *testing.T) {
 	}
 }
 
+func TestEVM_SyscallEventFdProgram(t *testing.T) {
+	if os.Getenv("SKIP_SLOW_TESTS") == "true" {
+		t.Skip("Skipping slow test because SKIP_SLOW_TESTS is enabled")
+	}
+
+	t.Parallel()
+	versionCases := GetMipsVersionTestCases(t)
+
+	for _, v := range versionCases {
+		v := v
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+
+			validator := testutil.NewEvmValidator(t, v.StateHashFn, v.Contracts)
+
+			var stdOutBuf, stdErrBuf bytes.Buffer
+			elfFile := testutil.ProgramPath("syscall-eventfd", testutil.Go1_24)
+			goVm := v.ElfVMFactory(t, elfFile, nil, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger())
+			state := goVm.GetState()
+
+			start := time.Now()
+			for i := 0; i < 500_000; i++ {
+				step := goVm.GetState().GetStep()
+				if goVm.GetState().GetExited() {
+					break
+				}
+				insn := testutil.GetInstruction(state.GetMemory(), state.GetPC())
+				if i%100_000 == 0 { // avoid spamming test logs, we are executing many steps
+					t.Logf("step: %4d pc: 0x%08x insn: 0x%08x", state.GetStep(), state.GetPC(), insn)
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+				validator.ValidateEVM(t, stepWitness, step, goVm)
+			}
+			end := time.Now()
+			delta := end.Sub(start)
+			t.Logf("test took %s, %d instructions, %s per instruction", delta, state.GetStep(), delta/time.Duration(state.GetStep()))
+
+			require.True(t, state.GetExited(), "must complete program")
+			require.Equal(t, uint8(0), state.GetExitCode(), "exit with 0")
+
+			// Check output
+			output := stdOutBuf.String()
+			require.Contains(t, output, "call eventfd")
+			require.Contains(t, output, "write to eventfd object")
+			require.Contains(t, output, "read from eventfd object")
+			require.Contains(t, output, "done")
+
+			// Check fd value
+			pattern := `eventfd2 fd = (.+)`
+			re, err := regexp.Compile(pattern)
+			require.NoError(t, err)
+			matches := re.FindAllStringSubmatch(output, -1)
+			require.Equal(t, 1, len(matches))
+			require.Equal(t, "-1", matches[0][1])
+		})
+	}
+}
+
 func TestEVM_HelloProgram(t *testing.T) {
 	if os.Getenv("SKIP_SLOW_TESTS") == "true" {
 		t.Skip("Skipping slow test because SKIP_SLOW_TESTS is enabled")

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1115,7 +1115,7 @@ func TestEVM_SyscallEventFdProgram(t *testing.T) {
 			require.NoError(t, err)
 			matches := re.FindAllStringSubmatch(output, -1)
 			require.Equal(t, 1, len(matches))
-			require.Equal(t, "-1", matches[0][1])
+			require.Equal(t, "100", matches[0][1])
 		})
 	}
 }

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -621,8 +621,8 @@ func TestEVM_MMap(t *testing.T) {
 				expected.PC = state.GetCpu().NextPC
 				expected.NextPC = state.GetCpu().NextPC + 4
 				if c.shouldFail {
-					expected.Registers[2] = exec.SysErrorSignal
-					expected.Registers[7] = exec.MipsEINVAL
+					expected.Registers[2] = exec.MipsEINVAL
+					expected.Registers[7] = exec.SysErrorSignal
 				} else {
 					expected.Heap = c.expectedHeap
 					if c.address == 0 {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -455,7 +455,7 @@ func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = ^Word(0)
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			stepWitness, err := goVm.Step(true)
 			require.NoError(t, err)
@@ -498,7 +498,7 @@ func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = ^Word(0)
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			stepWitness, err := goVm.Step(true)
 			require.NoError(t, err)

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -455,7 +455,7 @@ func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = exec.MipsEAGAIN
+			expected.ActiveThread().Registers[7] = ^Word(0)
 
 			stepWitness, err := goVm.Step(true)
 			require.NoError(t, err)
@@ -498,7 +498,7 @@ func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = exec.MipsEAGAIN
+			expected.ActiveThread().Registers[7] = ^Word(0)
 
 			stepWitness, err := goVm.Step(true)
 			require.NoError(t, err)

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
@@ -423,6 +424,92 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 	testMTSysReadPreimage(t, preimageValue, cases)
 }
 
+func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
+	t.Parallel()
+	vmVersions := GetMipsVersionTestCases(t)
+	for i, ver := range vmVersions {
+		t.Run(ver.Name, func(t *testing.T) {
+			t.Parallel()
+			addr := Word(0x00_00_FF_00)
+			effAddr := arch.AddressMask & addr
+			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)))
+			state := mttestutil.GetMtState(t, goVm)
+			step := state.GetStep()
+
+			// Define LL-related params
+			llAddress := effAddr
+			llOwnerThread := state.GetCurrentThread().ThreadId
+
+			// Set up state
+			state.GetRegistersRef()[2] = arch.SysRead
+			state.GetRegistersRef()[4] = exec.FdEventFd
+			state.GetRegistersRef()[5] = addr
+			state.GetRegistersRef()[6] = 1
+			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+			state.LLReservationStatus = multithreaded.LLStatusNone
+			state.LLAddress = llAddress
+			state.LLOwnerThread = llOwnerThread
+			state.GetMemory().SetWord(effAddr, Word(0x12_EE_EE_EE_FF_FF_FF_FF))
+
+			// Setup expectations
+			expected := mttestutil.NewExpectedMTState(state)
+			expected.ExpectStep()
+			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
+			expected.ActiveThread().Registers[7] = exec.MipsEAGAIN
+
+			stepWitness, err := goVm.Step(true)
+			require.NoError(t, err)
+
+			// Check expectations
+			expected.Validate(t, state)
+			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
+		})
+	}
+}
+
+func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
+	t.Parallel()
+	vmVersions := GetMipsVersionTestCases(t)
+	for i, ver := range vmVersions {
+		t.Run(ver.Name, func(t *testing.T) {
+			t.Parallel()
+			addr := Word(0x00_00_FF_00)
+			effAddr := arch.AddressMask & addr
+			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), testutil.WithRandomization(int64(i)))
+			state := mttestutil.GetMtState(t, goVm)
+			step := state.GetStep()
+
+			// Define LL-related params
+			llAddress := effAddr
+			llOwnerThread := state.GetCurrentThread().ThreadId
+
+			// Set up state
+			state.GetRegistersRef()[2] = arch.SysWrite
+			state.GetRegistersRef()[4] = exec.FdEventFd
+			state.GetRegistersRef()[5] = addr
+			state.GetRegistersRef()[6] = 1
+			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+			state.LLReservationStatus = multithreaded.LLStatusNone
+			state.LLAddress = llAddress
+			state.LLOwnerThread = llOwnerThread
+			state.GetMemory().SetWord(effAddr, Word(0x12_EE_EE_EE_FF_FF_FF_FF))
+
+			// Setup expectations
+			expected := mttestutil.NewExpectedMTState(state)
+			expected.ExpectStep()
+			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
+			expected.ActiveThread().Registers[7] = exec.MipsEAGAIN
+
+			stepWitness, err := goVm.Step(true)
+			require.NoError(t, err)
+
+			// Check expectations
+			expected.Validate(t, state)
+			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
+		})
+	}
+}
+
 func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 	t.Parallel()
 	cases := []testMTStoreOpsClearMemReservationTestCase{
@@ -476,15 +563,11 @@ var NoopSyscalls64 = map[string]uint32{
 	"SysTimerCreate":  5216,
 	"SysTimerSetTime": 5217,
 	"SysTimerDelete":  5220,
-	"SysEventFd2":     5284,
 }
 
 func getNoopSyscalls64(vmVersion versions.StateVersion) map[string]uint32 {
 	noOpCalls := maps.Clone(NoopSyscalls64)
 	features := versions.FeaturesForVersion(vmVersion)
-	if !features.SupportNoopSysEventFd2 {
-		delete(noOpCalls, "SysEventFd2")
-	}
 	if !features.SupportNoopMprotect {
 		delete(noOpCalls, "SysMprotect")
 	}
@@ -495,7 +578,7 @@ func getNoopSyscalls64(vmVersion versions.StateVersion) map[string]uint32 {
 }
 
 func getSupportedSyscalls(vmVersion versions.StateVersion) []uint32 {
-	supportedSyscalls := []uint32{arch.SysMmap, arch.SysBrk, arch.SysClone, arch.SysExitGroup, arch.SysRead, arch.SysWrite, arch.SysFcntl, arch.SysExit, arch.SysSchedYield, arch.SysGetTID, arch.SysFutex, arch.SysOpen, arch.SysNanosleep, arch.SysClockGetTime, arch.SysGetpid}
+	supportedSyscalls := []uint32{arch.SysMmap, arch.SysBrk, arch.SysClone, arch.SysExitGroup, arch.SysRead, arch.SysWrite, arch.SysFcntl, arch.SysExit, arch.SysSchedYield, arch.SysGetTID, arch.SysFutex, arch.SysOpen, arch.SysNanosleep, arch.SysClockGetTime, arch.SysGetpid, arch.SysEventFd2}
 
 	features := versions.FeaturesForVersion(vmVersion)
 	if features.SupportWorkingSysGetRandom {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -517,8 +517,8 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
 				if c.shouldFail {
 					expected.StepsSinceLastContextSwitch += 1
-					expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-					expected.ActiveThread().Registers[7] = exec.MipsEAGAIN
+					expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
+					expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 				} else {
 					// Return empty result and preempt thread
 					expected.ActiveThread().Registers[2] = 0
@@ -663,8 +663,8 @@ func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {
 				expected.StepsSinceLastContextSwitch += 1
 				expected.ActiveThread().PC = state.GetCpu().NextPC
 				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
-				expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-				expected.ActiveThread().Registers[7] = exec.MipsEINVAL
+				expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+				expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 				// State transition
 				var err error
@@ -751,8 +751,8 @@ func TestEVM_SysOpen(t *testing.T) {
 			// Set up post-state expectations
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-			expected.ActiveThread().Registers[7] = exec.MipsEBADF
+			expected.ActiveThread().Registers[2] = exec.MipsEBADF
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			// State transition
 			var err error
@@ -919,8 +919,8 @@ func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
 
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-			expected.ActiveThread().Registers[7] = exec.MipsEINVAL
+			expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			var err error
 			var stepWitness *mipsevm.StepWitness

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -80,8 +80,8 @@ func FuzzStateSyscallMmap(f *testing.F) {
 					}
 					newHeap := heap + sizAlign
 					if newHeap > program.HEAP_END || newHeap < heap || sizAlign < siz {
-						expected.Registers[2] = exec.SysErrorSignal
-						expected.Registers[7] = exec.MipsEINVAL
+						expected.Registers[2] = exec.MipsEINVAL
+						expected.Registers[7] = exec.SysErrorSignal
 					} else {
 						expected.Heap = heap + sizAlign
 						expected.Registers[2] = heap
@@ -157,8 +157,8 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 						expected.Registers[2] = 0
 						expected.Registers[7] = 0
 					default:
-						expected.Registers[2] = ^Word(0)
-						expected.Registers[7] = exec.MipsEBADF
+						expected.Registers[2] = exec.MipsEBADF
+						expected.Registers[7] = exec.SysErrorSignal
 					}
 				} else if cmd == 3 {
 					switch fd {
@@ -169,12 +169,12 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 						expected.Registers[2] = 1
 						expected.Registers[7] = 0
 					default:
-						expected.Registers[2] = ^Word(0)
-						expected.Registers[7] = exec.MipsEBADF
+						expected.Registers[2] = exec.MipsEBADF
+						expected.Registers[7] = exec.SysErrorSignal
 					}
 				} else {
-					expected.Registers[2] = ^Word(0)
-					expected.Registers[7] = exec.MipsEINVAL
+					expected.Registers[2] = exec.MipsEINVAL
+					expected.Registers[7] = exec.SysErrorSignal
 				}
 
 				stepWitness, err := goVm.Step(true)

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -62,7 +62,7 @@ func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
 	if version >= VersionMultiThreaded64_v4 {
-		features.SupportNoopSysEventFd2 = true
+		features.SupportMinimalSysEventFd2 = true
 		features.SupportDclzDclo = true
 		features.SupportNoopMprotect = true
 	}

--- a/cannon/testdata/Makefile
+++ b/cannon/testdata/Makefile
@@ -10,3 +10,8 @@ go1-24:
 
 .PHONY: elf
 elf: go1-23 go1-24
+
+.PHONY: clean
+clean:
+	make -C ./go-1-23 clean
+	make -C ./go-1-24 clean

--- a/cannon/testdata/common/go.mod
+++ b/cannon/testdata/common/go.mod
@@ -1,0 +1,5 @@
+module common
+
+go 1.23
+
+toolchain go1.23.8

--- a/cannon/testdata/common/syscalltests/eventfd.go
+++ b/cannon/testdata/common/syscalltests/eventfd.go
@@ -1,0 +1,67 @@
+//go:build linux && mips64
+// +build linux,mips64
+
+package syscalltests
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+)
+
+func EventfdTest() {
+	fd := callEventfd()
+	writeToEventObject(fd)
+	readFromEventObject(fd)
+
+	fmt.Println("done")
+}
+
+const (
+	EFD_CLOEXEC  = 0x80000
+	EFD_NONBLOCK = 0x80
+)
+
+func callEventfd() int {
+	fmt.Println("call eventfd")
+
+	flags := EFD_CLOEXEC | EFD_NONBLOCK
+	r1, _, errno := syscall.Syscall(syscall.SYS_EVENTFD2, uintptr(0), uintptr(flags), 0)
+	if errno != 0 {
+		panic("eventfd2 call failed")
+	}
+	fd := int(r1)
+	fmt.Printf("eventfd2 fd = %d\n", fd)
+
+	return fd
+}
+
+func writeToEventObject(fd int) {
+	fmt.Println("write to eventfd object")
+
+	writeVal := uint64(1)
+	var writeBuf [8]byte
+	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
+	n, err := syscall.Write(fd, writeBuf[:])
+
+	validateReadWriteResponse(n, err)
+}
+
+func readFromEventObject(fd int) {
+	fmt.Println("read from eventfd object")
+
+	var buf [8]byte
+	n, err := syscall.Read(fd, buf[:])
+
+	validateReadWriteResponse(n, err)
+}
+
+func validateReadWriteResponse(n int, err error) {
+	if err != syscall.EAGAIN {
+		panic(fmt.Sprintf("expected error EAGAIN but got: %v", err))
+	}
+	expectedN := -1
+	if n != expectedN {
+		panic(fmt.Sprintf("expected n=%d but got: %d", expectedN, n))
+	}
+}

--- a/cannon/testdata/go-1-23/Makefile
+++ b/cannon/testdata/go-1-23/Makefile
@@ -9,6 +9,10 @@ elf: elf64
 .PHONY: dump
 dump: $(patsubst %/go.mod,bin/%.dump,$(wildcard */go.mod))
 
+.PHONY: clean
+clean:
+	@[ -d bin ] && find bin -maxdepth 1 -type f -delete
+
 bin:
 	mkdir bin
 

--- a/cannon/testdata/go-1-23/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-23/syscall-eventfd/go.mod
@@ -1,0 +1,9 @@
+module syscalleventfd
+
+go 1.23.0
+
+toolchain go1.23.8
+
+require common v0.0.0
+
+replace common => ./../../common

--- a/cannon/testdata/go-1-23/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-23/syscall-eventfd/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"common/syscalltests"
+)
+
+func main() {
+	syscalltests.EventfdTest()
+}

--- a/cannon/testdata/go-1-24/Makefile
+++ b/cannon/testdata/go-1-24/Makefile
@@ -9,6 +9,10 @@ elf: elf64
 .PHONY: dump
 dump: $(patsubst %/go.mod,bin/%.dump,$(wildcard */go.mod))
 
+.PHONY: clean
+clean:
+	@[ -d bin ] && find bin -maxdepth 1 -type f -delete
+
 bin:
 	mkdir bin
 

--- a/cannon/testdata/go-1-24/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-24/syscall-eventfd/go.mod
@@ -1,0 +1,9 @@
+module syscalleventfd
+
+go 1.24
+
+toolchain go1.24.2
+
+require common v0.0.0
+
+replace common => ./../../common

--- a/cannon/testdata/go-1-24/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-24/syscall-eventfd/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"common/syscalltests"
+)
+
+func main() {
+	syscalltests.EventfdTest()
+}

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xb3e32b18c95d4940980333e1e99b4dcf42d8a8bfce78139db4dc3fb06e9349d0"
   },
   "src/L1/StandardValidator.sol:StandardValidator": {
-    "initCodeHash": "0x035d23030f111046ba1d4daa5d7c3f476716e828e8eba8849554b61d9bbeb117",
-    "sourceCodeHash": "0x9b48cde5b2fcd6e5399ed3fa27be48ae071891dba93d4ff393e81345298eb6da"
+    "initCodeHash": "0x3329000348d6b8a6f7677e8d48f781afa159386a73a01dc3b1ca2216ec104ba3",
+    "sourceCodeHash": "0x397f43082d0b4af4c0ef36bc3db04df1cf6d9687f1b58d319829d6999eeb419b"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x0ea921059d71fd19ac9c6e29c05b9724ad584eb27f74231de6df9551e9b13084",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x4ab4008a9632f2d7d9815188f8fe656361045ad3f7b4b0baf2a762e845e1bd09",
-    "sourceCodeHash": "0x4e0aa4aaa65ab5d97bb582defa4aba64bd56b347e1cd722b669b758b476d8222"
+    "initCodeHash": "0x60a3cc8f819c01541f95e3f9a3e52af8e36ceab47c4bcd6c83db3f755093f0b7",
+    "sourceCodeHash": "0x54fbd97394b12d304ecef63afb5bdb445b449b303cc5906d5b5c5718bb7292dc"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,7 +136,7 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0xe5578e26690cdfe4a80b99e34b5e65d77d38d5fb33c6a38e9d7de6d9248ee1f8",
+    "initCodeHash": "0x4412d69bd2445268b5daf8d0654b47e79687d8e1bd3b0bee9f8570994da35319",
     "sourceCodeHash": "0x401d7ad5e5da974789b2b2ed24ae3fbb10847a52b0d3c347b1056c782a296c12"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x76432efd536550998eaab7f43056cc02ab90d56f2dbab95f9eef69c77ca4e33a",
-    "sourceCodeHash": "0xc97931b0938a6a92e47c7ad7ef6ff7b988f538531d1df25147c694e0ebf408c3"
+    "initCodeHash": "0xe5578e26690cdfe4a80b99e34b5e65d77d38d5fb33c6a38e9d7de6d9248ee1f8",
+    "sourceCodeHash": "0x401d7ad5e5da974789b2b2ed24ae3fbb10847a52b0d3c347b1056c782a296c12"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0xc5cf035ca0663e66337e41195755554e791dd7f45a2ca2f330af2a037cc2619b",
-    "sourceCodeHash": "0x401d7ad5e5da974789b2b2ed24ae3fbb10847a52b0d3c347b1056c782a296c12"
+    "initCodeHash": "0x4ab4008a9632f2d7d9815188f8fe656361045ad3f7b4b0baf2a762e845e1bd09",
+    "sourceCodeHash": "0x4e0aa4aaa65ab5d97bb582defa4aba64bd56b347e1cd722b669b758b476d8222"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,7 +136,7 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x4412d69bd2445268b5daf8d0654b47e79687d8e1bd3b0bee9f8570994da35319",
+    "initCodeHash": "0xc5cf035ca0663e66337e41195755554e791dd7f45a2ca2f330af2a037cc2619b",
     "sourceCodeHash": "0x401d7ad5e5da974789b2b2ed24ae3fbb10847a52b0d3c347b1056c782a296c12"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -35,8 +35,8 @@ import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 /// before and after an upgrade.
 contract StandardValidator is ISemver {
     /// @notice The semantic version of the StandardValidator contract.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -200,7 +200,7 @@ contract StandardValidator is ISemver {
 
     /// @notice Returns the expected MIPS version.
     function mipsVersion() public pure returns (string memory) {
-        return "1.5.0";
+        return "1.6.0";
     }
 
     /// @notice Returns the expected OptimismMintableERC20Factory version.

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.5.0
-    string public constant version = "1.5.0";
+    /// @custom:semver 1.6.0
+    string public constant version = "1.6.0";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -633,6 +633,7 @@ contract MIPS64 is ISemver {
                 if (!st.featuresForVersion(STATE_VERSION).supportNoopSysEventFd2) {
                     revert("MIPS64: unimplemented syscall");
                 }
+                v0 = sys.FD_EVENTFD;
             } else {
                 revert("MIPS64: unimplemented syscall");
             }

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -503,22 +503,22 @@ contract MIPS64 is ISemver {
                     uint32 futexVal = getFutexValue(effFutexAddr);
                     uint32 targetVal = uint32(a2);
                     if (futexVal != targetVal) {
-                        v0 = sys.SYS_ERROR_SIGNAL;
-                        v1 = sys.EAGAIN;
+                        v0 = sys.EAGAIN;
+                        v1 = sys.SYS_ERROR_SIGNAL;
                     } else {
                         return syscallYield(state, thread);
                     }
                 } else if (a1 == sys.FUTEX_WAKE_PRIVATE) {
                     return syscallYield(state, thread);
                 } else {
-                    v0 = sys.SYS_ERROR_SIGNAL;
-                    v1 = sys.EINVAL;
+                    v0 = sys.EINVAL;
+                    v1 = sys.SYS_ERROR_SIGNAL;
                 }
             } else if (syscall_no == sys.SYS_SCHED_YIELD || syscall_no == sys.SYS_NANOSLEEP) {
                 return syscallYield(state, thread);
             } else if (syscall_no == sys.SYS_OPEN) {
-                v0 = sys.SYS_ERROR_SIGNAL;
-                v1 = sys.EBADF;
+                v0 = sys.EBADF;
+                v1 = sys.SYS_ERROR_SIGNAL;
             } else if (syscall_no == sys.SYS_CLOCKGETTIME) {
                 if (a0 == sys.CLOCK_GETTIME_REALTIME_FLAG || a0 == sys.CLOCK_GETTIME_MONOTONIC_FLAG) {
                     v0 = 0;
@@ -554,8 +554,8 @@ contract MIPS64 is ISemver {
                         MIPS64Memory.writeMem(effAddr + 8, MIPS64Memory.memoryProofOffset(MEM_PROOF_OFFSET, 2), nsecs);
                     handleMemoryUpdate(state, effAddr + 8);
                 } else {
-                    v0 = sys.SYS_ERROR_SIGNAL;
-                    v1 = sys.EINVAL;
+                    v0 = sys.EINVAL;
+                    v1 = sys.SYS_ERROR_SIGNAL;
                 }
             } else if (syscall_no == sys.SYS_GETPID) {
                 v0 = 0;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -630,7 +630,7 @@ contract MIPS64 is ISemver {
             } else if (syscall_no == sys.SYS_LSEEK) {
                 // ignored
             } else if (syscall_no == sys.SYS_EVENTFD2) {
-                if (!st.featuresForVersion(STATE_VERSION).supportNoopSysEventFd2) {
+                if (!st.featuresForVersion(STATE_VERSION).supportMinimalSysEventFd2) {
                     revert("MIPS64: unimplemented syscall");
                 }
                 v0 = sys.FD_EVENTFD;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -13,7 +13,7 @@ library MIPS64State {
     }
 
     struct Features {
-        bool supportNoopSysEventFd2;
+        bool supportMinimalSysEventFd2;
         bool supportDclzDclo;
         bool supportNoopMprotect;
         bool supportWorkingSysGetRandom;
@@ -27,7 +27,7 @@ library MIPS64State {
 
     function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
         if (_version >= 7) {
-            features_.supportNoopSysEventFd2 = true;
+            features_.supportMinimalSysEventFd2 = true;
             features_.supportDclzDclo = true;
             features_.supportNoopMprotect = true;
         }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -316,7 +316,7 @@ library MIPS64Syscalls {
             } else if (_args.a0 == FD_EVENTFD) {
                 // Always act in non blocking mode as if the counter has not been signalled
                 v0_ = EAGAIN;
-                v1_ = EAGAIN;
+                v1_ = U64_MASK;
             } else {
                 v0_ = U64_MASK;
                 v1_ = EBADF;
@@ -376,7 +376,7 @@ library MIPS64Syscalls {
                 // Always report that the write could not be completed
                 // This acts as if the counter has already reached the maximum value
                 v0_ = EAGAIN;
-                v1_ = EAGAIN;
+                v1_ = U64_MASK;
             } else {
                 v0_ = U64_MASK;
                 v1_ = EBADF;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -318,8 +318,8 @@ library MIPS64Syscalls {
                 v0_ = EAGAIN;
                 v1_ = U64_MASK;
             } else {
-                v0_ = U64_MASK;
-                v1_ = EBADF;
+                v0_ = EBADF;
+                v1_ = U64_MASK;
             }
 
             return (v0_, v1_, newPreimageOffset_, newMemRoot_, memUpdated_, memAddr_);
@@ -378,8 +378,8 @@ library MIPS64Syscalls {
                 v0_ = EAGAIN;
                 v1_ = U64_MASK;
             } else {
-                v0_ = U64_MASK;
-                v1_ = EBADF;
+                v0_ = EBADF;
+                v1_ = U64_MASK;
             }
 
             return (v0_, v1_, newPreimageKey_, newPreimageOffset_);

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -112,7 +112,7 @@ library MIPS64Syscalls {
     uint32 internal constant FD_HINT_WRITE = 4;
     uint32 internal constant FD_PREIMAGE_READ = 5;
     uint32 internal constant FD_PREIMAGE_WRITE = 6;
-    uint64 internal constant FD_EVENTFD = U64_MASK;
+    uint64 internal constant FD_EVENTFD = 100;
 
     uint64 internal constant SYS_ERROR_SIGNAL = U64_MASK;
     uint64 internal constant EBADF = 0x9;
@@ -316,10 +316,10 @@ library MIPS64Syscalls {
             } else if (_args.a0 == FD_EVENTFD) {
                 // Always act in non blocking mode as if the counter has not been signalled
                 v0_ = EAGAIN;
-                v1_ = U64_MASK;
+                v1_ = SYS_ERROR_SIGNAL;
             } else {
                 v0_ = EBADF;
-                v1_ = U64_MASK;
+                v1_ = SYS_ERROR_SIGNAL;
             }
 
             return (v0_, v1_, newPreimageOffset_, newMemRoot_, memUpdated_, memAddr_);
@@ -376,10 +376,10 @@ library MIPS64Syscalls {
                 // Always report that the write could not be completed
                 // This acts as if the counter has already reached the maximum value
                 v0_ = EAGAIN;
-                v1_ = U64_MASK;
+                v1_ = SYS_ERROR_SIGNAL;
             } else {
                 v0_ = EBADF;
-                v1_ = U64_MASK;
+                v1_ = SYS_ERROR_SIGNAL;
             }
 
             return (v0_, v1_, newPreimageKey_, newPreimageOffset_);

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -112,6 +112,7 @@ library MIPS64Syscalls {
     uint32 internal constant FD_HINT_WRITE = 4;
     uint32 internal constant FD_PREIMAGE_READ = 5;
     uint32 internal constant FD_PREIMAGE_WRITE = 6;
+    uint64 internal constant FD_EVENTFD = U64_MASK;
 
     uint64 internal constant SYS_ERROR_SIGNAL = U64_MASK;
     uint64 internal constant EBADF = 0x9;
@@ -312,6 +313,10 @@ library MIPS64Syscalls {
                 // Don't read into memory, just say we read it all
                 // The result is ignored anyway
                 v0_ = _args.a2;
+            } else if (_args.a0 == FD_EVENTFD) {
+                // Always act in non blocking mode as if the counter has not been signalled
+                v0_ = EAGAIN;
+                v1_ = EAGAIN;
             } else {
                 v0_ = U64_MASK;
                 v1_ = EBADF;
@@ -367,6 +372,11 @@ library MIPS64Syscalls {
                 newPreimageKey_ = key;
                 newPreimageOffset_ = 0; // reset offset, to read new pre-image data from the start
                 v0_ = _args._a2;
+            } else if (_args._a0 == FD_EVENTFD) {
+                // Always report that the write could not be completed
+                // This acts as if the counter has already reached the maximum value
+                v0_ = EAGAIN;
+                v1_ = EAGAIN;
             } else {
                 v0_ = U64_MASK;
                 v1_ = EBADF;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -199,8 +199,8 @@ library MIPS64Syscalls {
     /// @param _a0 The address for the new mapping
     /// @param _a1 The size of the new mapping
     /// @param _heap The current value of the heap pointer
-    /// @return v0_ The address of the new mapping
-    /// @return v1_ Unused error code (0)
+    /// @return v0_ The address of the new mapping or error code on error
+    /// @return v1_ 0 if there is no error, non-zero on error
     /// @return newHeap_ The new value for the heap, may be unchanged
     function handleSysMmap(
         uint64 _a0,
@@ -225,8 +225,8 @@ library MIPS64Syscalls {
                 newHeap_ += sz;
                 // Fail if new heap exceeds memory limit, newHeap overflows to low memory, or sz overflows
                 if (newHeap_ > HEAP_END || newHeap_ < _heap || sz < _a1) {
-                    v0_ = SYS_ERROR_SIGNAL;
-                    v1_ = EINVAL;
+                    v0_ = EINVAL;
+                    v1_ = SYS_ERROR_SIGNAL;
                     return (v0_, v1_, _heap);
                 }
             } else {
@@ -239,8 +239,8 @@ library MIPS64Syscalls {
 
     /// @notice Like a Linux read syscall. Splits unaligned reads into aligned reads.
     ///         Args are provided as a struct to reduce stack pressure.
-    /// @return v0_ The number of bytes read, -1 on error.
-    /// @return v1_ The error code, 0 if there is no error.
+    /// @return v0_ The number of bytes read, error code on error.
+    /// @return v1_ 0 if there is no error, non-zero on error
     /// @return newPreimageOffset_ The new value for the preimage offset.
     /// @return newMemRoot_ The new memory root.
     function handleSysRead(SysReadParams memory _args)
@@ -327,8 +327,8 @@ library MIPS64Syscalls {
     }
 
     /// @notice Like a Linux write syscall. Splits unaligned writes into aligned writes.
-    /// @return v0_ The number of bytes written, or -1 on error.
-    /// @return v1_ The error code, or 0 if empty.
+    /// @return v0_ The number of bytes written, or error code on error.
+    /// @return v1_ 0 if there is no error, non-zero on error
     /// @return newPreimageKey_ The new preimageKey.
     /// @return newPreimageOffset_ The new preimageOffset.
     function handleSysWrite(SysWriteParams memory _args)
@@ -390,8 +390,8 @@ library MIPS64Syscalls {
     /// retrieve the file-descriptor R/W flags.
     /// @param _a0 The file descriptor.
     /// @param _a1 The control command.
-    /// @param v0_ The file status flag (only supported commands are F_GETFD and F_GETFL), or -1 on error.
-    /// @param v1_ An error number, or 0 if there is no error.
+    /// @param v0_ The file status flag (only supported commands are F_GETFD and F_GETFL), or error code on error.
+    /// @param v1_ 0 if there is no error, non-zero on error
     function handleSysFcntl(uint64 _a0, uint64 _a1) internal pure returns (uint64 v0_, uint64 v1_) {
         unchecked {
             v0_ = uint64(0);
@@ -406,8 +406,8 @@ library MIPS64Syscalls {
                 ) {
                     v0_ = 0; // No flags set
                 } else {
-                    v0_ = U64_MASK;
-                    v1_ = EBADF;
+                    v0_ = EBADF;
+                    v1_ = SYS_ERROR_SIGNAL;
                 }
             } else if (_a1 == 3) {
                 // F_GETFL: get file status flags
@@ -416,12 +416,12 @@ library MIPS64Syscalls {
                 } else if (_a0 == FD_STDOUT || _a0 == FD_STDERR || _a0 == FD_PREIMAGE_WRITE || _a0 == FD_HINT_WRITE) {
                     v0_ = 1; // O_WRONLY
                 } else {
-                    v0_ = U64_MASK;
-                    v1_ = EBADF;
+                    v0_ = EBADF;
+                    v1_ = SYS_ERROR_SIGNAL;
                 }
             } else {
-                v0_ = U64_MASK;
-                v1_ = EINVAL; // cmd not recognized by this kernel
+                v0_ = EINVAL; // cmd not recognized by this kernel
+                v1_ = SYS_ERROR_SIGNAL;
             }
 
             return (v0_, v1_);


### PR DESCRIPTION
**Description**

Improve the stubbing of `SysEventFd` sys call by making it return a marker file descriptor (`^Word(0)`) instead of `0`. Read and write calls to that file descriptor always return `EAGAIN` error.

Note that based on the actual observed behaviour of the go runtime, the error code is set in `v0` and `v1` is set as a flag for whether there is an error or not. That is the opposite way around to how it is done on most platforms. In https://man7.org/linux/man-pages/man2/syscall.2.html it confirms this difference (rather subtly) as the first note on behaviour applies to MIPS:
> On a few architectures, a register is used as a boolean (0
          indicating no error, and -1 indicating an error) to signal that
          the system call failed.  The actual error value is still
          contained in the return register.

It's also clear from both the [go assembly for making syscalls](https://github.com/golang/go/blob/go1.23.8/src/internal/runtime/syscall/asm_linux_mips64x.s), the [implementation for mips syscalls in kona](https://github.com/op-rs/kona/blob/main/crates/proof/std-fpvm/src/mips64/syscall.rs#L102-L131) and the observed behaviour that mips64 is one of those architectures.

As a result, this PR also updates the way errors are returned from all sys calls to correctly follow the MIPS convention.

This is changing the behaviour of the state transition for state version 7 (VersionMultiThreaded64_v4). That hasn't shipped anywhere yet and these changes are being back ported to be included in the U16 upgrade that first ships state version 7. Changes aren't feature toggled as state version 7 is now the earliest supported version so should just be the baseline behaviour.  We can remove the existing feature toggles that state version 7 enables in a follow up but that doesn't need to be back ported to U16.

**Tests**

Added some new tests for reading and writing to the EventFd file handle.

Also confirmed that the op-program execution that originally failed due to being unable to write to the file descriptor returned by EventFd now completes successfully and correctly verifies the output root.

**Additional context**

Also need to back port this to the v4.0.0 proposal branch: https://github.com/ethereum-optimism/optimism/pull/16345

**Metadata**

https://github.com/ethereum-optimism/optimism/issues/13447
