### PR TITLE
cannon: Fix registers used to return error values for sys calls (Backport)

### DIFF
--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -122,8 +122,8 @@ func HandleSysMmap(a0, a1, heap Word) (v0, v1, newHeap Word) {
 		newHeap += sz
 		// Fail if new heap exceeds memory limit, newHeap overflows around to low memory, or sz overflows
 		if newHeap > program.HEAP_END || newHeap < heap || sz < a1 {
-			v0 = SysErrorSignal
-			v1 = MipsEINVAL
+			v0 = MipsEINVAL
+			v1 = SysErrorSignal
 			return v0, v1, heap
 		}
 	} else {
@@ -180,10 +180,10 @@ func HandleSysRead(
 	case FdEventFd:
 		// Always act in non blocking mode as if the counter has not been signalled
 		v0 = MipsEAGAIN
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	default:
 		v0 = MipsEBADF
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	}
 
 	return v0, v1, newPreimageOffset, memUpdated, memAddr
@@ -249,10 +249,10 @@ func HandleSysWrite(a0, a1, a2 Word,
 		// Always report that the write could not be completed
 		// This acts as if the counter has already reached the maximum value
 		v0 = MipsEAGAIN
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	default:
 		v0 = MipsEBADF
-		v1 = ^Word(0)
+		v1 = SysErrorSignal
 	}
 
 	return v0, v1, newLastHint, newPreimageKey, newPreimageOffset
@@ -281,8 +281,8 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 			v1 = MipsEBADF
 		}
 	} else {
-		v0 = ^Word(0)
-		v1 = MipsEINVAL // cmd not recognized by this kernel
+		v0 = MipsEINVAL // cmd not recognized by this kernel
+		v1 = SysErrorSignal
 	}
 
 	return v0, v1

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -143,7 +143,7 @@ func HandleSysRead(
 	memTracker MemTracker,
 ) (v0, v1, newPreimageOffset Word, memUpdated bool, memAddr Word) {
 	// args: a0 = fd, a1 = addr, a2 = count
-	// returns: v0 = read, v1 = err code
+	// returns: v0 = return value, v1 = error boolean
 	v0 = Word(0)
 	v1 = Word(0)
 	newPreimageOffset = preimageOffset
@@ -199,7 +199,7 @@ func HandleSysWrite(a0, a1, a2 Word,
 	stdOut, stdErr io.Writer,
 ) (v0, v1 Word, newLastHint hexutil.Bytes, newPreimageKey common.Hash, newPreimageOffset Word) {
 	// args: a0 = fd, a1 = addr, a2 = count
-	// returns: v0 = written, v1 = err code
+	// returns: v0 = return value, v1 = error boolean
 	v1 = Word(0)
 	newLastHint = lastHint
 	newPreimageKey = preimageKey

--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -267,8 +267,8 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 		case FdStdin, FdStdout, FdStderr, FdPreimageRead, FdHintRead, FdPreimageWrite, FdHintWrite:
 			v0 = 0 // No flags set
 		default:
-			v0 = ^Word(0)
-			v1 = MipsEBADF
+			v0 = MipsEBADF
+			v1 = SysErrorSignal
 		}
 	} else if a1 == 3 { // F_GETFL: get file status flags
 		switch a0 {
@@ -277,8 +277,8 @@ func HandleSysFcntl(a0, a1 Word) (v0, v1 Word) {
 		case FdStdout, FdStderr, FdPreimageWrite, FdHintWrite:
 			v0 = 1 // O_WRONLY
 		default:
-			v0 = ^Word(0)
-			v1 = MipsEBADF
+			v0 = MipsEBADF
+			v1 = SysErrorSignal
 		}
 	} else {
 		v0 = MipsEINVAL // cmd not recognized by this kernel

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -113,8 +113,8 @@ func (m *InstrumentedState) handleSyscall() error {
 			futexVal := m.getFutexValue(effFutexAddr)
 			targetVal := uint32(a2)
 			if futexVal != targetVal {
-				v0 = exec.SysErrorSignal
-				v1 = exec.MipsEAGAIN
+				v0 = exec.MipsEAGAIN
+				v1 = exec.SysErrorSignal
 			} else {
 				m.syscallYield(thread)
 				return nil
@@ -123,15 +123,15 @@ func (m *InstrumentedState) handleSyscall() error {
 			m.syscallYield(thread)
 			return nil
 		default:
-			v0 = exec.SysErrorSignal
-			v1 = exec.MipsEINVAL
+			v0 = exec.MipsEINVAL
+			v1 = exec.SysErrorSignal
 		}
 	case arch.SysSchedYield, arch.SysNanosleep:
 		m.syscallYield(thread)
 		return nil
 	case arch.SysOpen:
-		v0 = exec.SysErrorSignal
-		v1 = exec.MipsEBADF
+		v0 = exec.MipsEBADF
+		v1 = exec.SysErrorSignal
 	case arch.SysClockGetTime:
 		switch a0 {
 		case exec.ClockGettimeRealtimeFlag, exec.ClockGettimeMonotonicFlag:
@@ -152,8 +152,8 @@ func (m *InstrumentedState) handleSyscall() error {
 			m.state.Memory.SetWord(effAddr+arch.WordSizeBytes, nsecs)
 			m.handleMemoryUpdate(effAddr + arch.WordSizeBytes)
 		default:
-			v0 = exec.SysErrorSignal
-			v1 = exec.MipsEINVAL
+			v0 = exec.MipsEINVAL
+			v1 = exec.SysErrorSignal
 		}
 	case arch.SysGetpid:
 		v0 = 0

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -616,8 +616,8 @@ func TestEVM_MMap(t *testing.T) {
 				expected.PC = state.GetCpu().NextPC
 				expected.NextPC = state.GetCpu().NextPC + 4
 				if c.shouldFail {
-					expected.Registers[2] = exec.SysErrorSignal
-					expected.Registers[7] = exec.MipsEINVAL
+					expected.Registers[2] = exec.MipsEINVAL
+					expected.Registers[7] = exec.SysErrorSignal
 				} else {
 					expected.Heap = c.expectedHeap
 					if c.address == 0 {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -455,7 +455,7 @@ func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = ^Word(0)
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			stepWitness, err := goVm.Step(true)
 			require.NoError(t, err)
@@ -498,7 +498,7 @@ func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
 			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = ^Word(0)
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			stepWitness, err := goVm.Step(true)
 			require.NoError(t, err)

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -517,8 +517,8 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
 				if c.shouldFail {
 					expected.StepsSinceLastContextSwitch += 1
-					expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-					expected.ActiveThread().Registers[7] = exec.MipsEAGAIN
+					expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
+					expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 				} else {
 					// Return empty result and preempt thread
 					expected.ActiveThread().Registers[2] = 0
@@ -663,8 +663,8 @@ func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {
 				expected.StepsSinceLastContextSwitch += 1
 				expected.ActiveThread().PC = state.GetCpu().NextPC
 				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
-				expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-				expected.ActiveThread().Registers[7] = exec.MipsEINVAL
+				expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+				expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 				// State transition
 				var err error
@@ -751,8 +751,8 @@ func TestEVM_SysOpen(t *testing.T) {
 			// Set up post-state expectations
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-			expected.ActiveThread().Registers[7] = exec.MipsEBADF
+			expected.ActiveThread().Registers[2] = exec.MipsEBADF
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			// State transition
 			var err error
@@ -919,8 +919,8 @@ func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
 
 			expected := mttestutil.NewExpectedMTState(state)
 			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.SysErrorSignal
-			expected.ActiveThread().Registers[7] = exec.MipsEINVAL
+			expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 
 			var err error
 			var stepWitness *mipsevm.StepWitness

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -80,8 +80,8 @@ func FuzzStateSyscallMmap(f *testing.F) {
 					}
 					newHeap := heap + sizAlign
 					if newHeap > program.HEAP_END || newHeap < heap || sizAlign < siz {
-						expected.Registers[2] = exec.SysErrorSignal
-						expected.Registers[7] = exec.MipsEINVAL
+						expected.Registers[2] = exec.MipsEINVAL
+						expected.Registers[7] = exec.SysErrorSignal
 					} else {
 						expected.Heap = heap + sizAlign
 						expected.Registers[2] = heap
@@ -157,8 +157,8 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 						expected.Registers[2] = 0
 						expected.Registers[7] = 0
 					default:
-						expected.Registers[2] = ^Word(0)
-						expected.Registers[7] = exec.MipsEBADF
+						expected.Registers[2] = exec.MipsEBADF
+						expected.Registers[7] = ^Word(0)
 					}
 				} else if cmd == 3 {
 					switch fd {
@@ -169,12 +169,12 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 						expected.Registers[2] = 1
 						expected.Registers[7] = 0
 					default:
-						expected.Registers[2] = ^Word(0)
-						expected.Registers[7] = exec.MipsEBADF
+						expected.Registers[2] = exec.MipsEBADF
+						expected.Registers[7] = ^Word(0)
 					}
 				} else {
-					expected.Registers[2] = ^Word(0)
-					expected.Registers[7] = exec.MipsEINVAL
+					expected.Registers[2] = exec.MipsEINVAL
+					expected.Registers[7] = ^Word(0)
 				}
 
 				stepWitness, err := goVm.Step(true)

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -158,7 +158,7 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 						expected.Registers[7] = 0
 					default:
 						expected.Registers[2] = exec.MipsEBADF
-						expected.Registers[7] = ^Word(0)
+						expected.Registers[7] = exec.SysErrorSignal
 					}
 				} else if cmd == 3 {
 					switch fd {
@@ -170,11 +170,11 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 						expected.Registers[7] = 0
 					default:
 						expected.Registers[2] = exec.MipsEBADF
-						expected.Registers[7] = ^Word(0)
+						expected.Registers[7] = exec.SysErrorSignal
 					}
 				} else {
 					expected.Registers[2] = exec.MipsEINVAL
-					expected.Registers[7] = ^Word(0)
+					expected.Registers[7] = exec.SysErrorSignal
 				}
 
 				stepWitness, err := goVm.Step(true)

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,7 +136,7 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x9d75430415c843626dfa74daee3bec853c513900c6fa616302db8fcde57e6844",
+    "initCodeHash": "0x87abcd93ed88b7792bb8cd239b4ca785e2b368774efe54406c00780374446d11",
     "sourceCodeHash": "0xfb4f60d3a1613acabfad274c00d5e393a072869989117f41a76c3d60c77f96d2"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x87abcd93ed88b7792bb8cd239b4ca785e2b368774efe54406c00780374446d11",
-    "sourceCodeHash": "0xfb4f60d3a1613acabfad274c00d5e393a072869989117f41a76c3d60c77f96d2"
+    "initCodeHash": "0x97b4ac460b6e385d0cea99903d53631a1687c9d835c6076486285304a3e1823d",
+    "sourceCodeHash": "0x42a7b3e77ea630c625ef51d07a5390e86c102f4b4814b17e63a08d09117fdba7"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -503,22 +503,22 @@ contract MIPS64 is ISemver {
                     uint32 futexVal = getFutexValue(effFutexAddr);
                     uint32 targetVal = uint32(a2);
                     if (futexVal != targetVal) {
-                        v0 = sys.SYS_ERROR_SIGNAL;
-                        v1 = sys.EAGAIN;
+                        v0 = sys.EAGAIN;
+                        v1 = sys.SYS_ERROR_SIGNAL;
                     } else {
                         return syscallYield(state, thread);
                     }
                 } else if (a1 == sys.FUTEX_WAKE_PRIVATE) {
                     return syscallYield(state, thread);
                 } else {
-                    v0 = sys.SYS_ERROR_SIGNAL;
-                    v1 = sys.EINVAL;
+                    v0 = sys.EINVAL;
+                    v1 = sys.SYS_ERROR_SIGNAL;
                 }
             } else if (syscall_no == sys.SYS_SCHED_YIELD || syscall_no == sys.SYS_NANOSLEEP) {
                 return syscallYield(state, thread);
             } else if (syscall_no == sys.SYS_OPEN) {
-                v0 = sys.SYS_ERROR_SIGNAL;
-                v1 = sys.EBADF;
+                v0 = sys.EBADF;
+                v1 = sys.SYS_ERROR_SIGNAL;
             } else if (syscall_no == sys.SYS_CLOCKGETTIME) {
                 if (a0 == sys.CLOCK_GETTIME_REALTIME_FLAG || a0 == sys.CLOCK_GETTIME_MONOTONIC_FLAG) {
                     v0 = 0;
@@ -554,8 +554,8 @@ contract MIPS64 is ISemver {
                         MIPS64Memory.writeMem(effAddr + 8, MIPS64Memory.memoryProofOffset(MEM_PROOF_OFFSET, 2), nsecs);
                     handleMemoryUpdate(state, effAddr + 8);
                 } else {
-                    v0 = sys.SYS_ERROR_SIGNAL;
-                    v1 = sys.EINVAL;
+                    v0 = sys.EINVAL;
+                    v1 = sys.SYS_ERROR_SIGNAL;
                 }
             } else if (syscall_no == sys.SYS_GETPID) {
                 v0 = 0;

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -406,8 +406,8 @@ library MIPS64Syscalls {
                 ) {
                     v0_ = 0; // No flags set
                 } else {
-                    v0_ = U64_MASK;
-                    v1_ = EBADF;
+                    v0_ = EBADF;
+                    v1_ = U64_MASK;
                 }
             } else if (_a1 == 3) {
                 // F_GETFL: get file status flags
@@ -416,12 +416,12 @@ library MIPS64Syscalls {
                 } else if (_a0 == FD_STDOUT || _a0 == FD_STDERR || _a0 == FD_PREIMAGE_WRITE || _a0 == FD_HINT_WRITE) {
                     v0_ = 1; // O_WRONLY
                 } else {
-                    v0_ = U64_MASK;
-                    v1_ = EBADF;
+                    v0_ = EBADF;
+                    v1_ = U64_MASK;
                 }
             } else {
-                v0_ = U64_MASK;
-                v1_ = EINVAL; // cmd not recognized by this kernel
+                v0_ = EINVAL; // cmd not recognized by this kernel
+                v1_ = U64_MASK;
             }
 
             return (v0_, v1_);

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -225,8 +225,8 @@ library MIPS64Syscalls {
                 newHeap_ += sz;
                 // Fail if new heap exceeds memory limit, newHeap overflows to low memory, or sz overflows
                 if (newHeap_ > HEAP_END || newHeap_ < _heap || sz < _a1) {
-                    v0_ = SYS_ERROR_SIGNAL;
-                    v1_ = EINVAL;
+                    v0_ = EINVAL;
+                    v1_ = SYS_ERROR_SIGNAL;
                     return (v0_, v1_, _heap);
                 }
             } else {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -199,8 +199,8 @@ library MIPS64Syscalls {
     /// @param _a0 The address for the new mapping
     /// @param _a1 The size of the new mapping
     /// @param _heap The current value of the heap pointer
-    /// @return v0_ The address of the new mapping
-    /// @return v1_ Unused error code (0)
+    /// @return v0_ The address of the new mapping or error code on error
+    /// @return v1_ 0 if there is no error, non-zero on error
     /// @return newHeap_ The new value for the heap, may be unchanged
     function handleSysMmap(
         uint64 _a0,
@@ -239,8 +239,8 @@ library MIPS64Syscalls {
 
     /// @notice Like a Linux read syscall. Splits unaligned reads into aligned reads.
     ///         Args are provided as a struct to reduce stack pressure.
-    /// @return v0_ The number of bytes read, -1 on error.
-    /// @return v1_ The error code, 0 if there is no error.
+    /// @return v0_ The number of bytes read, error code on error.
+    /// @return v1_ 0 if there is no error, non-zero on error
     /// @return newPreimageOffset_ The new value for the preimage offset.
     /// @return newMemRoot_ The new memory root.
     function handleSysRead(SysReadParams memory _args)
@@ -327,8 +327,8 @@ library MIPS64Syscalls {
     }
 
     /// @notice Like a Linux write syscall. Splits unaligned writes into aligned writes.
-    /// @return v0_ The number of bytes written, or -1 on error.
-    /// @return v1_ The error code, or 0 if empty.
+    /// @return v0_ The number of bytes written, or error code on error.
+    /// @return v1_ 0 if there is no error, non-zero on error
     /// @return newPreimageKey_ The new preimageKey.
     /// @return newPreimageOffset_ The new preimageOffset.
     function handleSysWrite(SysWriteParams memory _args)
@@ -390,8 +390,8 @@ library MIPS64Syscalls {
     /// retrieve the file-descriptor R/W flags.
     /// @param _a0 The file descriptor.
     /// @param _a1 The control command.
-    /// @param v0_ The file status flag (only supported commands are F_GETFD and F_GETFL), or -1 on error.
-    /// @param v1_ An error number, or 0 if there is no error.
+    /// @param v0_ The file status flag (only supported commands are F_GETFD and F_GETFL), or error code on error.
+    /// @param v1_ 0 if there is no error, non-zero on error
     function handleSysFcntl(uint64 _a0, uint64 _a1) internal pure returns (uint64 v0_, uint64 v1_) {
         unchecked {
             v0_ = uint64(0);
@@ -407,7 +407,7 @@ library MIPS64Syscalls {
                     v0_ = 0; // No flags set
                 } else {
                     v0_ = EBADF;
-                    v1_ = U64_MASK;
+                    v1_ = SYS_ERROR_SIGNAL;
                 }
             } else if (_a1 == 3) {
                 // F_GETFL: get file status flags
@@ -417,11 +417,11 @@ library MIPS64Syscalls {
                     v0_ = 1; // O_WRONLY
                 } else {
                     v0_ = EBADF;
-                    v1_ = U64_MASK;
+                    v1_ = SYS_ERROR_SIGNAL;
                 }
             } else {
                 v0_ = EINVAL; // cmd not recognized by this kernel
-                v1_ = U64_MASK;
+                v1_ = SYS_ERROR_SIGNAL;
             }
 
             return (v0_, v1_);


### PR DESCRIPTION
**Description**

Backport of https://github.com/ethereum-optimism/optimism/pull/16346 onto https://github.com/ethereum-optimism/optimism/pull/16345
