### PR TITLE
feat(op-devstack): building blocks for flashblocks gate

### DIFF
--- a/op-devstack/dsl/fb_builder.go
+++ b/op-devstack/dsl/fb_builder.go
@@ -1,0 +1,35 @@
+package dsl
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+)
+
+type FlashblocksBuilderSet []*FlashblocksBuilderNode
+
+func NewFlashblocksBuilderSet(inner []stack.FlashblocksBuilderNode) FlashblocksBuilderSet {
+	flashblocksBuilders := make([]*FlashblocksBuilderNode, len(inner))
+	for i, c := range inner {
+		flashblocksBuilders[i] = NewFlashblocksBuilderNode(c)
+	}
+	return flashblocksBuilders
+}
+
+type FlashblocksBuilderNode struct {
+	commonImpl
+	inner stack.FlashblocksBuilderNode
+}
+
+func NewFlashblocksBuilderNode(inner stack.FlashblocksBuilderNode) *FlashblocksBuilderNode {
+	return &FlashblocksBuilderNode{
+		commonImpl: commonFromT(inner.T()),
+		inner:      inner,
+	}
+}
+
+func (c *FlashblocksBuilderNode) String() string {
+	return c.inner.ID().String()
+}
+
+func (c *FlashblocksBuilderNode) Escape() stack.FlashblocksBuilderNode {
+	return c.inner
+}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -1,0 +1,43 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+type SimpleFlashblocks struct {
+	*Minimal
+
+	ConductorSets          map[stack.L2NetworkID]dsl.ConductorSet
+	FlashblocksBuilderSets map[stack.L2NetworkID]dsl.FlashblocksBuilderSet
+}
+
+// TODO: shift this to a different sysgo constructor once the sysgo implementation supports flashblocks / rbuilders
+func WithSimpleFlashblocks() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{}))
+}
+
+func NewSimpleFlashblocks(t devtest.T) *SimpleFlashblocks {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+	chains := system.L2Networks()
+	conductorSets := make(map[stack.L2NetworkID]dsl.ConductorSet)
+	flashblocksBuilderSets := make(map[stack.L2NetworkID]dsl.FlashblocksBuilderSet)
+	for _, chain := range chains {
+		chainMatcher := match.L2ChainById(chain.ID())
+		l2 := system.L2Network(match.Assume(t, chainMatcher))
+
+		conductorSets[chain.ID()] = dsl.NewConductorSet(l2.Conductors())
+		flashblocksBuilderSets[chain.ID()] = dsl.NewFlashblocksBuilderSet(l2.FlashblocksBuilders())
+	}
+	return &SimpleFlashblocks{
+		Minimal:                NewMinimal(t),
+		ConductorSets:          conductorSets,
+		FlashblocksBuilderSets: flashblocksBuilderSets,
+	}
+}

--- a/op-devstack/shim/fb_builder.go
+++ b/op-devstack/shim/fb_builder.go
@@ -1,0 +1,59 @@
+package shim
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+type FlashblocksBuilderNodeConfig struct {
+	ELNodeConfig
+	ID               stack.FlashblocksBuilderID
+	ConductorID      stack.ConductorID
+	FlashblocksWsUrl string
+}
+
+type flashblocksBuilderNode struct {
+	rpcELNode
+	l2Client *sources.L2Client
+
+	id          stack.FlashblocksBuilderID
+	conductorID stack.ConductorID
+
+	flashblocksWsUrl string
+}
+
+var _ stack.FlashblocksBuilderNode = (*flashblocksBuilderNode)(nil)
+
+func NewFlashblocksBuilderNode(cfg FlashblocksBuilderNodeConfig) stack.FlashblocksBuilderNode {
+	require.Equal(cfg.T, cfg.ID.ChainID(), cfg.ELNodeConfig.ChainID, "chainID must be configured to match node chainID")
+	cfg.T = cfg.T.WithCtx(stack.ContextWithID(cfg.T.Ctx(), cfg.ID))
+	l2Client, err := sources.NewL2Client(cfg.ELNodeConfig.Client, cfg.T.Logger(), nil, sources.L2ClientSimpleConfig(nil, false, 10, 10))
+	require.NoError(cfg.T, err)
+
+	return &flashblocksBuilderNode{
+		rpcELNode:        newRpcELNode(cfg.ELNodeConfig),
+		l2Client:         l2Client,
+		id:               cfg.ID,
+		conductorID:      cfg.ConductorID,
+		flashblocksWsUrl: cfg.FlashblocksWsUrl,
+	}
+}
+
+func (r *flashblocksBuilderNode) ID() stack.FlashblocksBuilderID {
+	return r.id
+}
+
+func (r *flashblocksBuilderNode) ConductorID() stack.ConductorID {
+	return r.conductorID
+}
+
+func (r *flashblocksBuilderNode) L2EthClient() apis.L2EthClient {
+	return r.l2Client
+}
+
+func (r *flashblocksBuilderNode) FlashblocksWsUrl() string {
+	return r.flashblocksWsUrl
+}

--- a/op-devstack/shim/l2_network.go
+++ b/op-devstack/shim/l2_network.go
@@ -41,6 +41,7 @@ type presetL2Network struct {
 	cls locks.RWMap[stack.L2CLNodeID, stack.L2CLNode]
 
 	conductors locks.RWMap[stack.ConductorID, stack.Conductor]
+	fbBuilders locks.RWMap[stack.FlashblocksBuilderID, stack.FlashblocksBuilderNode]
 }
 
 var _ stack.L2Network = (*presetL2Network)(nil)
@@ -120,6 +121,17 @@ func (p *presetL2Network) AddConductor(v stack.Conductor) {
 	p.require().True(p.conductors.SetIfMissing(id, v), "conductor %s must not already exist", id)
 }
 
+func (p *presetL2Network) FlashblocksBuilder(m stack.FlashblocksBuilderMatcher) stack.FlashblocksBuilderNode {
+	v, ok := findMatch(m, p.fbBuilders.Get, p.FlashblocksBuilders)
+	p.require().True(ok, "must find flashblocks builder %s", m)
+	return v
+}
+
+func (p *presetL2Network) AddFlashblocksBuilder(v stack.FlashblocksBuilderNode) {
+	id := v.ID()
+	p.require().True(p.fbBuilders.SetIfMissing(id, v), "flashblocks builder %s must not already exist", id)
+}
+
 func (p *presetL2Network) L2Proposer(m stack.L2ProposerMatcher) stack.L2Proposer {
 	v, ok := findMatch(m, p.proposers.Get, p.L2Proposers)
 	p.require().True(ok, "must find L2 proposer %s", m)
@@ -196,6 +208,10 @@ func (p *presetL2Network) Conductors() []stack.Conductor {
 	output := stack.SortConductors(p.conductors.Values())
 	p.require().NotEmpty(output, "l2 chain %s must have at least one conductor", p.ID())
 	return output
+}
+
+func (p *presetL2Network) FlashblocksBuilders() []stack.FlashblocksBuilderNode {
+	return stack.SortFlashblocksBuilders(p.fbBuilders.Values())
 }
 
 func (p *presetL2Network) L2CLNodeIDs() []stack.L2CLNodeID {

--- a/op-devstack/stack/fb_builder.go
+++ b/op-devstack/stack/fb_builder.go
@@ -1,0 +1,65 @@
+package stack
+
+import (
+	"log/slog"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type FlashblocksBuilderNode interface {
+	ELNode
+	ID() FlashblocksBuilderID
+	ConductorID() ConductorID
+	L2EthClient() apis.L2EthClient
+	FlashblocksWsUrl() string
+}
+
+type FlashblocksBuilderID idWithChain
+
+const FlashblocksBuilderKind Kind = "FlashblocksBuilder"
+
+func NewFlashblocksBuilderID(key string, chainID eth.ChainID) FlashblocksBuilderID {
+	return FlashblocksBuilderID{
+		key:     key,
+		chainID: chainID,
+	}
+}
+
+func (id FlashblocksBuilderID) String() string {
+	return idWithChain(id).string(FlashblocksBuilderKind)
+}
+
+func (id FlashblocksBuilderID) ChainID() eth.ChainID {
+	return idWithChain(id).chainID
+}
+
+func (id FlashblocksBuilderID) MarshalText() ([]byte, error) {
+	return idWithChain(id).marshalText(FlashblocksBuilderKind)
+}
+
+func (id FlashblocksBuilderID) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id *FlashblocksBuilderID) UnmarshalText(data []byte) error {
+	return (*idWithChain)(id).unmarshalText(FlashblocksBuilderKind, data)
+}
+
+func SortFlashblocksBuilderIDs(ids []FlashblocksBuilderID) []FlashblocksBuilderID {
+	return copyAndSort(ids, func(a, b FlashblocksBuilderID) bool {
+		return lessIDWithChain(idWithChain(a), idWithChain(b))
+	})
+}
+
+func SortFlashblocksBuilders(elems []FlashblocksBuilderNode) []FlashblocksBuilderNode {
+	return copyAndSort(elems, func(a, b FlashblocksBuilderNode) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ FlashblocksBuilderMatcher = FlashblocksBuilderID{}
+
+func (id FlashblocksBuilderID) Match(elems []FlashblocksBuilderNode) []FlashblocksBuilderNode {
+	return findByID(id, elems)
+}

--- a/op-devstack/stack/l2_network.go
+++ b/op-devstack/stack/l2_network.go
@@ -103,6 +103,8 @@ type L2Network interface {
 	L2CLNodes() []L2CLNode
 	L2ELNodes() []L2ELNode
 	Conductors() []Conductor
+	FlashblocksBuilders() []FlashblocksBuilderNode
+	AddFlashblocksBuilder(v FlashblocksBuilderNode)
 }
 
 // ExtensibleL2Network is an optional extension interface for L2Network,

--- a/op-devstack/stack/matcher.go
+++ b/op-devstack/stack/matcher.go
@@ -55,6 +55,8 @@ type TestSequencerMatcher = Matcher[TestSequencerID, TestSequencer]
 
 type ConductorMatcher = Matcher[ConductorID, Conductor]
 
+type FlashblocksBuilderMatcher = Matcher[FlashblocksBuilderID, FlashblocksBuilderNode]
+
 type L2ELMatcher = Matcher[L2ELNodeID, L2ELNode]
 
 type FaucetMatcher = Matcher[FaucetID, Faucet]

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -18,11 +19,13 @@ const (
 	RBuilderServiceName  = "rbuilder"
 	ConductorServiceName = "conductor"
 
-	HTTPProtocol    = "http"
-	RPCProtocol     = "rpc"
-	MetricsProtocol = "metrics"
+	HTTPProtocol                 = "http"
+	RPCProtocol                  = "rpc"
+	MetricsProtocol              = "metrics"
+	WebsocketFlashblocksProtocol = "ws-flashblocks"
 
-	FeatureInterop = "interop"
+	FeatureInterop     = "interop"
+	FeatureFlashblocks = "flashblocks"
 )
 
 func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, protocol string, path string) client.RPC {
@@ -95,7 +98,14 @@ func (orch *Orchestrator) findProtocolService(service *descriptors.Service, prot
 			if scheme == "" {
 				scheme = HTTPProtocol
 			}
-			return fmt.Sprintf("%s://%s:%d", scheme, endpoint.Host, port), nil, nil
+			host := endpoint.Host
+			path := ""
+			if strings.Contains(host, "/") {
+				parts := strings.SplitN(host, "/", 2)
+				host = parts[0]
+				path = "/" + parts[1]
+			}
+			return fmt.Sprintf("%s://%s:%d%s", scheme, host, port, path), nil, nil
 		}
 	}
 	return "", nil, fmt.Errorf("protocol %s not found", protocol)


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

This PR builds the Preset, stack, DSL and shim for helping write the flashblocks acceptance tests later.

Considerations made in this PR:
- 1-1 mapping between conductor and rbuilder
- rbuilder offering a websocket URL which potentially exposes a stream of flashblocks
- Things like websocket protocol and other assumptions like service name are based off of [this PR](https://github.com/ethereum-optimism/infrastructure-services/pull/447/files) in netchef

Closes https://github.com/ethereum-optimism/optimism/issues/16367