### PR TITLE
feat(op-acceptance-tests): flashblocks streaming acceptance-tests

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -49,6 +49,14 @@ gates:
         package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/preinterop
         timeout: 20m
 
+  - id: flashblocks
+    inherits:
+      - base
+    description: "Flashblocks network tests."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks
+        timeout: 5m
+
   - id: interop
     inherits:
       - base

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -1,0 +1,199 @@
+//go:build !ci
+
+// use a tag prefixed with "!". Such tag ensures that the default behaviour of this test would be to be built/run even when the go toolchain (go test) doesn't specify any tag filter.
+package flashblocks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// Define a struct to represent the flashblock data structure
+type Flashblock struct {
+	PayloadID string `json:"payload_id"`
+	Index     int    `json:"index"`
+	Diff      struct {
+		StateRoot    string `json:"state_root"`
+		ReceiptsRoot string `json:"receipts_root"`
+		LogsBloom    string `json:"logs_bloom"`
+		GasUsed      string `json:"gas_used"`
+		BlockHash    string `json:"block_hash"`
+		Transactions []any  `json:"transactions"`
+		Withdrawals  []any  `json:"withdrawals"`
+	} `json:"diff"`
+	Metadata struct {
+		BlockNumber        int                    `json:"block_number"`
+		NewAccountBalances map[string]string      `json:"new_account_balances"`
+		Receipts           map[string]interface{} `json:"receipts"`
+	} `json:"metadata"`
+}
+
+type FlashblocksStreamMode string
+
+const (
+	FlashblocksStreamMode_Leader   FlashblocksStreamMode = "leader"
+	FlashblocksStreamMode_Follower FlashblocksStreamMode = "follower"
+)
+
+// TestFlashblocksStream checks we can connect to the flashblocks stream
+func TestFlashblocksStream(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleFlashblocks(t)
+	logger := testlog.Logger(t, log.LevelInfo).With("Test", "TestFlashblocksStream")
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+	logger.Info("Started Flashblocks Stream test")
+
+	ctx, span := tracer.Start(ctx, "test chains")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Test all L2 chains in the system
+	for l2Chain, flashblocksBuilderSet := range sys.FlashblocksBuilderSets {
+		_, span = tracer.Start(ctx, "test chain")
+		defer span.End()
+
+		networkName := l2Chain.String()
+		t.Run(fmt.Sprintf("L2_Chain_%s", networkName), func(tt devtest.T) {
+			expectedChainID := l2Chain.ChainID().ToBig()
+			for _, flashblocksBuilderNode := range flashblocksBuilderSet {
+				flashblocksBuilderNodeStack := flashblocksBuilderNode.Escape()
+				require.Equal(t, flashblocksBuilderNodeStack.ChainID().ToBig(), expectedChainID, "flashblocks builder node chain id should match expected chain id")
+
+				var associatedConductor stack.Conductor
+				for _, conductor := range sys.ConductorSets[l2Chain] {
+					if flashblocksBuilderNodeStack.ConductorID() == conductor.Escape().ID() {
+						associatedConductor = conductor.Escape()
+					}
+				}
+				require.NotNil(t, associatedConductor, "there must be a conductor associated with the flashblocks builder node")
+
+				mode := FlashblocksStreamMode_Follower
+				if dsl.NewConductor(associatedConductor).IsLeader() {
+					mode = FlashblocksStreamMode_Leader
+				}
+
+				testFlashblocksStream(tt, logger, dsl.NewFlashblocksBuilderNode(flashblocksBuilderNodeStack), mode)
+			}
+		})
+	}
+}
+
+// testFlashblocksStream tests the presence / absence of a flashblocks stream operating at a 250ms rate
+func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNode *dsl.FlashblocksBuilderNode, mode FlashblocksStreamMode) {
+	t.Run(fmt.Sprintf("Flashblocks_Stream_%s", mode), func(t devtest.T) {
+		require.Contains(t, []FlashblocksStreamMode{FlashblocksStreamMode_Leader, FlashblocksStreamMode_Follower}, mode, "mode should be either leader or follower")
+		require.NotNil(t, flashblocksBuilderNode, "flashblocksBuilderNode should not be nil")
+
+		wsURL := flashblocksBuilderNode.Escape().FlashblocksWsUrl()
+		logger.Info("Testing WebSocket connection to", "url", wsURL)
+
+		dialer := &websocket.Dialer{
+			HandshakeTimeout: 6 * time.Second,
+		}
+
+		conn, _, err := dialer.Dial(wsURL, nil)
+		require.NoError(t, err, "failed to connect to FLashblocks WebSocket endpoint", "url", wsURL)
+		defer conn.Close()
+
+		logger.Info("WebSocket connection established, reading stream for 5 seconds")
+
+		streamedMessages := make([]string, 0)
+
+		timeout := time.After(5 * time.Second)
+		for {
+			select {
+			case <-timeout:
+				goto done
+			default:
+				err = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+				require.NoError(t, err, "failed to set read deadline")
+				_, message, err := conn.ReadMessage()
+				if err != nil && !strings.Contains(err.Error(), "timeout") {
+					logger.Error("Error reading WebSocket message", "error", err)
+					break
+				}
+				if err == nil {
+					streamedMessages = append(streamedMessages, string(message))
+				}
+			}
+		}
+	done:
+
+		logger.Info("Completed WebSocket stream reading", "message_count", len(streamedMessages))
+		if mode == FlashblocksStreamMode_Follower {
+			require.Equal(t, len(streamedMessages), 0, "follower should not receive any messages")
+			return
+		}
+
+		require.Greater(t, len(streamedMessages), 0, "should have received at least one message from WebSocket")
+		flashblocks := make([]Flashblock, len(streamedMessages))
+
+		failureTolerance := 3
+
+		for i, msg := range streamedMessages {
+			var flashblock Flashblock
+			if err := json.Unmarshal([]byte(msg), &flashblock); err != nil {
+				logger.Warn("Failed to unmarshal WebSocket message", "error", err)
+				failureTolerance--
+				if failureTolerance < 0 {
+					logger.Error("failed to unmarshal stramed messages into flashblocks beyond the failure tolerance of %d", failureTolerance)
+					t.FailNow()
+				}
+				continue
+			}
+
+			flashblocks[i] = flashblock
+		}
+
+		totalFlashblocksProduced := 0
+
+		lastIndex := -1
+		lastBlockNumber := -1
+
+		for _, flashblock := range flashblocks {
+			currentIndex, currentBlockNumber := flashblock.Index, flashblock.Metadata.BlockNumber
+
+			if lastBlockNumber == -1 {
+				totalFlashblocksProduced += 1
+				lastIndex = currentIndex
+				lastBlockNumber = currentBlockNumber
+				continue
+			}
+
+			require.Greater(t, lastIndex, -1, "some bug: last index should be greater than -1 by now")
+			require.Greater(t, currentIndex, -1, "some bug: current index should be greater than -1 by now")
+
+			// same block number, just the flashblock incremented
+			if currentBlockNumber == lastBlockNumber {
+				require.Greater(t, currentIndex, lastIndex, "some bug: current index should be greater than last index from the stream")
+
+				totalFlashblocksProduced += (currentIndex - lastIndex)
+			} else if currentBlockNumber > lastBlockNumber { // new block number
+				totalFlashblocksProduced += (currentIndex + 1) // assuming it's a new block number whose flashblocks begin from 0th-index
+			}
+
+			lastIndex = currentIndex
+			lastBlockNumber = currentBlockNumber
+		}
+
+		require.Greater(t, totalFlashblocksProduced, 17, "total flashblocks produced should be greater than 17 (20 over 5s with a 250ms rate with a failure tolerance of 3 flashblocks)")
+
+		logger.Info("Flashblocks stream validation completed", "total_flashblocks_produced", totalFlashblocksProduced)
+	})
+}

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	flashblocksStreamRate  = os.Getenv("FLASHBLOCKS_STREAM_RATE_MS")
+	maxExpectedFlashblocks = 20
 )
 
 // Define a struct to represent the flashblock data structure
@@ -63,6 +70,16 @@ func TestFlashblocksStream(gt *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	if flashblocksStreamRate == "" {
+		logger.Warn("FLASHBLOCKS_STREAM_RATE_MS is not set, using default of 250ms")
+		flashblocksStreamRate = "250"
+	}
+
+	flashblocksStreamRateMs, err := strconv.Atoi(flashblocksStreamRate)
+	require.NoError(t, err, "failed to parse FLASHBLOCKS_STREAM_RATE_MS: %s", err)
+
+	logger.Info("Flashblocks stream rate", "rate", flashblocksStreamRateMs)
+
 	// Test all L2 chains in the system
 	for l2Chain, flashblocksBuilderSet := range sys.FlashblocksBuilderSets {
 		_, span = tracer.Start(ctx, "test chain")
@@ -88,15 +105,20 @@ func TestFlashblocksStream(gt *testing.T) {
 					mode = FlashblocksStreamMode_Leader
 				}
 
-				testFlashblocksStream(tt, logger, dsl.NewFlashblocksBuilderNode(flashblocksBuilderNodeStack), mode)
+				testFlashblocksStream(tt, logger, dsl.NewFlashblocksBuilderNode(flashblocksBuilderNodeStack), mode, flashblocksStreamRateMs)
 			}
 		})
 	}
 }
 
-// testFlashblocksStream tests the presence / absence of a flashblocks stream operating at a 250ms rate
-func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNode *dsl.FlashblocksBuilderNode, mode FlashblocksStreamMode) {
+// testFlashblocksStream tests the presence / absence of a flashblocks stream operating at a 250ms (configurable via env var FLASHBLOCKS_STREAM_RATE) rate
+func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNode *dsl.FlashblocksBuilderNode, mode FlashblocksStreamMode, expectedFlashblocksStreamRateMs int) {
 	t.Run(fmt.Sprintf("Flashblocks_Stream_%s", mode), func(t devtest.T) {
+		testDuration := time.Duration(int64(expectedFlashblocksStreamRateMs*maxExpectedFlashblocks)) * time.Millisecond
+		failureTolerance := int(0.15 * float64(maxExpectedFlashblocks))
+
+		logger.Debug("Test duration", "duration", testDuration, "failure tolerance (of flashblocks)", failureTolerance)
+
 		require.Contains(t, []FlashblocksStreamMode{FlashblocksStreamMode_Leader, FlashblocksStreamMode_Follower}, mode, "mode should be either leader or follower")
 		require.NotNil(t, flashblocksBuilderNode, "flashblocksBuilderNode should not be nil")
 
@@ -144,15 +166,14 @@ func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNod
 		require.Greater(t, len(streamedMessages), 0, "should have received at least one message from WebSocket")
 		flashblocks := make([]Flashblock, len(streamedMessages))
 
-		failureTolerance := 3
-
+		failures := 0
 		for i, msg := range streamedMessages {
 			var flashblock Flashblock
 			if err := json.Unmarshal([]byte(msg), &flashblock); err != nil {
 				logger.Warn("Failed to unmarshal WebSocket message", "error", err)
-				failureTolerance--
-				if failureTolerance < 0 {
-					logger.Error("failed to unmarshal stramed messages into flashblocks beyond the failure tolerance of %d", failureTolerance)
+				failures++
+				if failures > failureTolerance {
+					logger.Error("failed to unmarshal streamed messages into flashblocks beyond the failure tolerance of %d", failureTolerance)
 					t.FailNow()
 				}
 				continue
@@ -192,7 +213,18 @@ func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNod
 			lastBlockNumber = currentBlockNumber
 		}
 
-		require.Greater(t, totalFlashblocksProduced, 17, "total flashblocks produced should be greater than 17 (20 over 5s with a 250ms rate with a failure tolerance of 3 flashblocks)")
+		minExpectedFlashblocks := maxExpectedFlashblocks - failureTolerance
+
+		require.Greater(t,
+			totalFlashblocksProduced, minExpectedFlashblocks,
+			fmt.Sprintf("total flashblocks produced should be greater than %d (%d over %s with a %dms rate with a failure tolerance of %d flashblocks)",
+				minExpectedFlashblocks,
+				maxExpectedFlashblocks,
+				testDuration,
+				expectedFlashblocksStreamRateMs,
+				failureTolerance,
+			),
+		)
 
 		logger.Info("Flashblocks stream validation completed", "total_flashblocks_produced", totalFlashblocksProduced)
 	})

--- a/op-acceptance-tests/tests/flashblocks/init_test.go
+++ b/op-acceptance-tests/tests/flashblocks/init_test.go
@@ -1,0 +1,13 @@
+package flashblocks
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+// TestMain creates the test-setups against the shared backend
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSimpleFlashblocks())
+
+}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -16,7 +16,7 @@ type SimpleFlashblocks struct {
 	FlashblocksBuilderSets map[stack.L2NetworkID]dsl.FlashblocksBuilderSet
 }
 
-// TODO: shift this to a different sysgo constructor once the sysgo implementation supports flashblocks / rbuilders
+// TODO(#16450): shift this to a different sysgo constructor once the sysgo implementation supports flashblocks / rbuilders
 func WithSimpleFlashblocks() stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{}))
 }

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -24,8 +24,7 @@ const (
 	MetricsProtocol              = "metrics"
 	WebsocketFlashblocksProtocol = "ws-flashblocks"
 
-	FeatureInterop     = "interop"
-	FeatureFlashblocks = "flashblocks"
+	FeatureInterop = "interop"
 )
 
 func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, protocol string, path string, opts ...client.RPCOption) client.RPC {


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

**Description**

This acceptance-test:
- Goes through every rbuilder and parses its associated conductor
- If that conductor is a non-leader (follower), it establishes a websocket connection to the rbuilder asserting no production of flashblocks from there
- If that conductor is a leader, it establishes a websocket connection to the rbuilder asserting the production of flashblocks from it.
- The flashblocks production is inspected for 5s expecting a total of 17 flashblocks streamed atleast. This number is derived from the expectation of getting flashblocks generated at a 250ms rate (20 flashblocks in 5s) with a tolerance of 3 blocks being slow/dropped (20-3 = 17)

**Tests**

1. Generate the devnet file via netchef 

```
export MANIFEST=$HOME/OPLabs/Projects/devnets/alphanets/interop-flash/manifest.yaml               
export INVENTORY=$HOME/OPLabs/Projects/devnets/alphanets/interop-flash/inventory.yaml
export DEPLOYER_STATE=$HOME/OPLabs/Projects/devnets/alphanets/interop-flash/op-deployer/state.json
export K8S_REPO=$HOME/OPLabs/Projects/k8s 
```

```
cd /path/to/infrastructure-services
cd netchef
just build
./bin/netchef generate --manifest $MANIFEST --inventory $INVENTORY --deployer-state $DEPLOYER_STATE --k8s-dir $K8S_REPO devnet-env
```

Say the devnet env is generated at `/Users/ykukreja/OPLabs/Projects/infrastructure-services/netchef/devnet-tmp/devnet-env.json`


2. Point to that devnet env and run these acceptance tests

```
cd /path/to/optimism
cd op-acceptance-tests
cd tests/flashblocks && \
DEVSTACK_ORCHESTRATOR=sysext \
DEVNET_ENV_URL="/Users/ykukreja/OPLabs/Projects/infrastructure-services/netchef/devnet-tmp/devnet-env.json" \
go test -v -timeout=5m0s -run=TestFlashblocksStream
```

**Here's how it worked on my end**

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/82ab7434-621f-4398-a0f0-aa6a191cf579" />

<img width="1141" alt="image" src="https://github.com/user-attachments/assets/3e7e813c-8971-4a2c-9769-4d5c7ea3d118" />

**Related Issue**