### PR TITLE
cannon: Add eventfd2 syscall go program tests

### DIFF
--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -83,6 +83,47 @@ func TestInstrumentedState_Random(t *testing.T) {
 	}
 }
 
+func TestInstrumentedState_SyscallEventFdProgram(t *testing.T) {
+	runTestAcrossVms(t, "SyscallEventFdProgram", func(t *testing.T, vmFactory testutil.VMFactory[*State], goTarget testutil.GoTarget) {
+		state, meta := testutil.LoadELFProgram(t, testutil.ProgramPath("syscall-eventfd", goTarget), CreateInitialState)
+
+		var stdOutBuf, stdErrBuf bytes.Buffer
+		us := vmFactory(state, nil, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger(), meta)
+		err := us.InitDebug()
+		require.NoError(t, err)
+
+		for i := 0; i < 500_000; i++ {
+			if us.GetState().GetExited() {
+				break
+			}
+			_, err := us.Step(false)
+			require.NoError(t, err)
+		}
+		t.Logf("Completed in %d steps", state.Step)
+
+		require.True(t, state.GetExited(), "must complete program")
+		if state.GetExitCode() != 0 {
+			us.Traceback()
+		}
+		require.Equal(t, uint8(0), state.GetExitCode(), "exit with 0")
+
+		// Check output
+		output := stdOutBuf.String()
+		require.Contains(t, output, "call eventfd")
+		require.Contains(t, output, "write to eventfd object")
+		require.Contains(t, output, "read from eventfd object")
+		require.Contains(t, output, "done")
+
+		// Check fd value
+		pattern := `eventfd2 fd = (.+)`
+		re, err := regexp.Compile(pattern)
+		require.NoError(t, err)
+		matches := re.FindAllStringSubmatch(output, -1)
+		require.Equal(t, 1, len(matches))
+		require.Equal(t, "-1", matches[0][1])
+	})
+}
+
 func TestInstrumentedState_UtilsCheck(t *testing.T) {
 	// Sanity check that test running utilities will return a non-zero exit code on failure
 	type TestCase struct {

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1060,6 +1060,66 @@ func TestEVM_RandomProgram(t *testing.T) {
 	}
 }
 
+func TestEVM_SyscallEventFdProgram(t *testing.T) {
+	if os.Getenv("SKIP_SLOW_TESTS") == "true" {
+		t.Skip("Skipping slow test because SKIP_SLOW_TESTS is enabled")
+	}
+
+	t.Parallel()
+	versionCases := GetMipsVersionTestCases(t)
+
+	for _, v := range versionCases {
+		v := v
+		t.Run(v.Name, func(t *testing.T) {
+			t.Parallel()
+
+			validator := testutil.NewEvmValidator(t, v.StateHashFn, v.Contracts)
+
+			var stdOutBuf, stdErrBuf bytes.Buffer
+			elfFile := testutil.ProgramPath("syscall-eventfd", testutil.Go1_24)
+			goVm := v.ElfVMFactory(t, elfFile, nil, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger())
+			state := goVm.GetState()
+
+			start := time.Now()
+			for i := 0; i < 500_000; i++ {
+				step := goVm.GetState().GetStep()
+				if goVm.GetState().GetExited() {
+					break
+				}
+				insn := testutil.GetInstruction(state.GetMemory(), state.GetPC())
+				if i%100_000 == 0 { // avoid spamming test logs, we are executing many steps
+					t.Logf("step: %4d pc: 0x%08x insn: 0x%08x", state.GetStep(), state.GetPC(), insn)
+				}
+
+				stepWitness, err := goVm.Step(true)
+				require.NoError(t, err)
+				validator.ValidateEVM(t, stepWitness, step, goVm)
+			}
+			end := time.Now()
+			delta := end.Sub(start)
+			t.Logf("test took %s, %d instructions, %s per instruction", delta, state.GetStep(), delta/time.Duration(state.GetStep()))
+
+			require.True(t, state.GetExited(), "must complete program")
+			require.Equal(t, uint8(0), state.GetExitCode(), "exit with 0")
+
+			// Check output
+			output := stdOutBuf.String()
+			require.Contains(t, output, "call eventfd")
+			require.Contains(t, output, "write to eventfd object")
+			require.Contains(t, output, "read from eventfd object")
+			require.Contains(t, output, "done")
+
+			// Check fd value
+			pattern := `eventfd2 fd = (.+)`
+			re, err := regexp.Compile(pattern)
+			require.NoError(t, err)
+			matches := re.FindAllStringSubmatch(output, -1)
+			require.Equal(t, 1, len(matches))
+			require.Equal(t, "-1", matches[0][1])
+		})
+	}
+}
+
 func TestEVM_HelloProgram(t *testing.T) {
 	if os.Getenv("SKIP_SLOW_TESTS") == "true" {
 		t.Skip("Skipping slow test because SKIP_SLOW_TESTS is enabled")

--- a/cannon/testdata/Makefile
+++ b/cannon/testdata/Makefile
@@ -10,3 +10,8 @@ go1-24:
 
 .PHONY: elf
 elf: go1-23 go1-24
+
+.PHONY: clean
+clean:
+	make -C ./go-1-23 clean
+	make -C ./go-1-24 clean

--- a/cannon/testdata/common/go.mod
+++ b/cannon/testdata/common/go.mod
@@ -1,0 +1,5 @@
+module common
+
+go 1.23
+
+toolchain go1.23.8

--- a/cannon/testdata/common/syscall/eventfd.go
+++ b/cannon/testdata/common/syscall/eventfd.go
@@ -1,0 +1,74 @@
+//go:build linux && mips64
+// +build linux,mips64
+
+package syscall
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+)
+
+func EventfdTest() {
+	fd := callEventfd()
+	writeToEventObject(fd)
+	readFromEventObject(fd)
+
+	fmt.Println("done")
+}
+
+const (
+	EFD_CLOEXEC  = 0x80000
+	EFD_NONBLOCK = 0x80
+)
+
+func callEventfd() int {
+	fmt.Println("call eventfd")
+	const (
+		initVal   = 0
+		flags     = EFD_CLOEXEC | EFD_NONBLOCK
+		sysEvent2 = syscall.SYS_EVENTFD2
+	)
+
+	r1, _, errno := syscall.Syscall(sysEvent2,
+		uintptr(initVal),
+		uintptr(flags),
+		0,
+	)
+	if errno != 0 {
+		panic("eventfd2 call failed")
+	}
+	fd := int(r1)
+	fmt.Printf("eventfd2 fd = %d\n", fd)
+
+	return fd
+}
+
+func writeToEventObject(fd int) {
+	fmt.Println("write to eventfd object")
+
+	writeVal := uint64(2)
+	var writeBuf [8]byte
+	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
+
+	n, err := syscall.Write(fd, writeBuf[:])
+	validateReadWriteResponse(n, err)
+}
+
+func readFromEventObject(fd int) {
+	fmt.Println("read from eventfd object")
+
+	var buf [8]byte
+	n, err := syscall.Read(fd, buf[:])
+	validateReadWriteResponse(n, err)
+}
+
+func validateReadWriteResponse(n int, err error) {
+	if err != syscall.EAGAIN {
+		panic(fmt.Sprintf("expected error EAGAIN but got: %v", err))
+	}
+	expectedN := -1
+	if n != expectedN {
+		panic(fmt.Sprintf("expected n=%d but got: %d", expectedN, n))
+	}
+}

--- a/cannon/testdata/common/syscalltests/eventfd.go
+++ b/cannon/testdata/common/syscalltests/eventfd.go
@@ -24,17 +24,9 @@ const (
 
 func callEventfd() int {
 	fmt.Println("call eventfd")
-	const (
-		initVal   = 0
-		flags     = EFD_CLOEXEC | EFD_NONBLOCK
-		sysEvent2 = syscall.SYS_EVENTFD2
-	)
 
-	r1, _, errno := syscall.Syscall(sysEvent2,
-		uintptr(initVal),
-		uintptr(flags),
-		0,
-	)
+	flags := EFD_CLOEXEC | EFD_NONBLOCK
+	r1, _, errno := syscall.Syscall(syscall.SYS_EVENTFD2, uintptr(0), uintptr(flags), 0)
 	if errno != 0 {
 		panic("eventfd2 call failed")
 	}
@@ -47,11 +39,11 @@ func callEventfd() int {
 func writeToEventObject(fd int) {
 	fmt.Println("write to eventfd object")
 
-	writeVal := uint64(2)
+	writeVal := uint64(1)
 	var writeBuf [8]byte
 	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
-
 	n, err := syscall.Write(fd, writeBuf[:])
+
 	validateReadWriteResponse(n, err)
 }
 
@@ -60,6 +52,7 @@ func readFromEventObject(fd int) {
 
 	var buf [8]byte
 	n, err := syscall.Read(fd, buf[:])
+
 	validateReadWriteResponse(n, err)
 }
 

--- a/cannon/testdata/common/syscalltests/eventfd.go
+++ b/cannon/testdata/common/syscalltests/eventfd.go
@@ -1,7 +1,7 @@
 //go:build linux && mips64
 // +build linux,mips64
 
-package syscall
+package syscalltests
 
 import (
 	"encoding/binary"

--- a/cannon/testdata/go-1-23/Makefile
+++ b/cannon/testdata/go-1-23/Makefile
@@ -9,6 +9,10 @@ elf: elf64
 .PHONY: dump
 dump: $(patsubst %/go.mod,bin/%.dump,$(wildcard */go.mod))
 
+.PHONY: clean
+clean:
+	@[ -d bin ] && find bin -maxdepth 1 -type f -delete
+
 bin:
 	mkdir bin
 

--- a/cannon/testdata/go-1-23/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-23/syscall-eventfd/go.mod
@@ -1,0 +1,5 @@
+module hello
+
+go 1.23.0
+
+toolchain go1.23.8

--- a/cannon/testdata/go-1-23/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-23/syscall-eventfd/go.mod
@@ -1,4 +1,4 @@
-module hello
+module syscalleventfd
 
 go 1.23.0
 

--- a/cannon/testdata/go-1-23/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-23/syscall-eventfd/go.mod
@@ -3,3 +3,7 @@ module hello
 go 1.23.0
 
 toolchain go1.23.8
+
+require common v0.0.0
+
+replace common => ./../../common

--- a/cannon/testdata/go-1-23/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-23/syscall-eventfd/main.go
@@ -1,0 +1,78 @@
+//go:build linux && mips64
+// +build linux,mips64
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+)
+
+func main() {
+	eventfd()
+}
+
+func eventfd() {
+	fd := callEventfd()
+	writeToEventObject(fd)
+	readFromEventObject(fd)
+
+	fmt.Println("done")
+}
+
+const (
+	EFD_CLOEXEC  = 0x80000
+	EFD_NONBLOCK = 0x80
+)
+
+func callEventfd() int {
+	fmt.Println("call eventfd")
+	const (
+		initVal   = 0
+		flags     = EFD_CLOEXEC | EFD_NONBLOCK
+		sysEvent2 = syscall.SYS_EVENTFD2
+	)
+
+	r1, _, errno := syscall.Syscall(sysEvent2,
+		uintptr(initVal),
+		uintptr(flags),
+		0,
+	)
+	if errno != 0 {
+		panic("eventfd2 call failed")
+	}
+	fd := int(r1)
+	fmt.Printf("eventfd2 fd = %d\n", fd)
+
+	return fd
+}
+
+func writeToEventObject(fd int) {
+	fmt.Println("write to eventfd object")
+
+	writeVal := uint64(2)
+	var writeBuf [8]byte
+	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
+
+	n, err := syscall.Write(fd, writeBuf[:])
+	validateReadWriteResponse(n, err)
+}
+
+func readFromEventObject(fd int) {
+	fmt.Println("read from eventfd object")
+
+	var buf [8]byte
+	n, err := syscall.Read(fd, buf[:])
+	validateReadWriteResponse(n, err)
+}
+
+func validateReadWriteResponse(n int, err error) {
+	if err != syscall.EAGAIN {
+		panic(fmt.Sprintf("expected error EAGAIN but got: %v", err))
+	}
+	expectedN := -1
+	if n != expectedN {
+		panic(fmt.Sprintf("expected n=%d but got: %d", expectedN, n))
+	}
+}

--- a/cannon/testdata/go-1-23/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-23/syscall-eventfd/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"common/syscall"
+	"common/syscalltests"
 )
 
 func main() {
-	syscall.EventfdTest()
+	syscalltests.EventfdTest()
 }

--- a/cannon/testdata/go-1-23/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-23/syscall-eventfd/main.go
@@ -1,78 +1,9 @@
-//go:build linux && mips64
-// +build linux,mips64
-
 package main
 
 import (
-	"encoding/binary"
-	"fmt"
-	"syscall"
+	"common/syscall"
 )
 
 func main() {
-	eventfd()
-}
-
-func eventfd() {
-	fd := callEventfd()
-	writeToEventObject(fd)
-	readFromEventObject(fd)
-
-	fmt.Println("done")
-}
-
-const (
-	EFD_CLOEXEC  = 0x80000
-	EFD_NONBLOCK = 0x80
-)
-
-func callEventfd() int {
-	fmt.Println("call eventfd")
-	const (
-		initVal   = 0
-		flags     = EFD_CLOEXEC | EFD_NONBLOCK
-		sysEvent2 = syscall.SYS_EVENTFD2
-	)
-
-	r1, _, errno := syscall.Syscall(sysEvent2,
-		uintptr(initVal),
-		uintptr(flags),
-		0,
-	)
-	if errno != 0 {
-		panic("eventfd2 call failed")
-	}
-	fd := int(r1)
-	fmt.Printf("eventfd2 fd = %d\n", fd)
-
-	return fd
-}
-
-func writeToEventObject(fd int) {
-	fmt.Println("write to eventfd object")
-
-	writeVal := uint64(2)
-	var writeBuf [8]byte
-	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
-
-	n, err := syscall.Write(fd, writeBuf[:])
-	validateReadWriteResponse(n, err)
-}
-
-func readFromEventObject(fd int) {
-	fmt.Println("read from eventfd object")
-
-	var buf [8]byte
-	n, err := syscall.Read(fd, buf[:])
-	validateReadWriteResponse(n, err)
-}
-
-func validateReadWriteResponse(n int, err error) {
-	if err != syscall.EAGAIN {
-		panic(fmt.Sprintf("expected error EAGAIN but got: %v", err))
-	}
-	expectedN := -1
-	if n != expectedN {
-		panic(fmt.Sprintf("expected n=%d but got: %d", expectedN, n))
-	}
+	syscall.EventfdTest()
 }

--- a/cannon/testdata/go-1-24/Makefile
+++ b/cannon/testdata/go-1-24/Makefile
@@ -9,6 +9,10 @@ elf: elf64
 .PHONY: dump
 dump: $(patsubst %/go.mod,bin/%.dump,$(wildcard */go.mod))
 
+.PHONY: clean
+clean:
+	@[ -d bin ] && find bin -maxdepth 1 -type f -delete
+
 bin:
 	mkdir bin
 

--- a/cannon/testdata/go-1-24/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-24/syscall-eventfd/go.mod
@@ -1,0 +1,5 @@
+module hello
+
+go 1.24
+
+toolchain go1.24.2

--- a/cannon/testdata/go-1-24/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-24/syscall-eventfd/go.mod
@@ -1,4 +1,4 @@
-module hello
+module syscalleventfd
 
 go 1.24
 

--- a/cannon/testdata/go-1-24/syscall-eventfd/go.mod
+++ b/cannon/testdata/go-1-24/syscall-eventfd/go.mod
@@ -3,3 +3,7 @@ module hello
 go 1.24
 
 toolchain go1.24.2
+
+require common v0.0.0
+
+replace common => ./../../common

--- a/cannon/testdata/go-1-24/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-24/syscall-eventfd/main.go
@@ -1,0 +1,78 @@
+//go:build linux && mips64
+// +build linux,mips64
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+)
+
+func main() {
+	eventfd()
+}
+
+func eventfd() {
+	fd := callEventfd()
+	writeToEventObject(fd)
+	readFromEventObject(fd)
+
+	fmt.Println("done")
+}
+
+const (
+	EFD_CLOEXEC  = 0x80000
+	EFD_NONBLOCK = 0x80
+)
+
+func callEventfd() int {
+	fmt.Println("call eventfd")
+	const (
+		initVal   = 0
+		flags     = EFD_CLOEXEC | EFD_NONBLOCK
+		sysEvent2 = syscall.SYS_EVENTFD2
+	)
+
+	r1, _, errno := syscall.Syscall(sysEvent2,
+		uintptr(initVal),
+		uintptr(flags),
+		0,
+	)
+	if errno != 0 {
+		panic("eventfd2 call failed")
+	}
+	fd := int(r1)
+	fmt.Printf("eventfd2 fd = %d\n", fd)
+
+	return fd
+}
+
+func writeToEventObject(fd int) {
+	fmt.Println("write to eventfd object")
+
+	writeVal := uint64(2)
+	var writeBuf [8]byte
+	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
+
+	n, err := syscall.Write(fd, writeBuf[:])
+	validateReadWriteResponse(n, err)
+}
+
+func readFromEventObject(fd int) {
+	fmt.Println("read from eventfd object")
+
+	var buf [8]byte
+	n, err := syscall.Read(fd, buf[:])
+	validateReadWriteResponse(n, err)
+}
+
+func validateReadWriteResponse(n int, err error) {
+	if err != syscall.EAGAIN {
+		panic(fmt.Sprintf("expected error EAGAIN but got: %v", err))
+	}
+	expectedN := -1
+	if n != expectedN {
+		panic(fmt.Sprintf("expected n=%d but got: %d", expectedN, n))
+	}
+}

--- a/cannon/testdata/go-1-24/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-24/syscall-eventfd/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"common/syscall"
+	"common/syscalltests"
 )
 
 func main() {
-	syscall.EventfdTest()
+	syscalltests.EventfdTest()
 }

--- a/cannon/testdata/go-1-24/syscall-eventfd/main.go
+++ b/cannon/testdata/go-1-24/syscall-eventfd/main.go
@@ -1,78 +1,9 @@
-//go:build linux && mips64
-// +build linux,mips64
-
 package main
 
 import (
-	"encoding/binary"
-	"fmt"
-	"syscall"
+	"common/syscall"
 )
 
 func main() {
-	eventfd()
-}
-
-func eventfd() {
-	fd := callEventfd()
-	writeToEventObject(fd)
-	readFromEventObject(fd)
-
-	fmt.Println("done")
-}
-
-const (
-	EFD_CLOEXEC  = 0x80000
-	EFD_NONBLOCK = 0x80
-)
-
-func callEventfd() int {
-	fmt.Println("call eventfd")
-	const (
-		initVal   = 0
-		flags     = EFD_CLOEXEC | EFD_NONBLOCK
-		sysEvent2 = syscall.SYS_EVENTFD2
-	)
-
-	r1, _, errno := syscall.Syscall(sysEvent2,
-		uintptr(initVal),
-		uintptr(flags),
-		0,
-	)
-	if errno != 0 {
-		panic("eventfd2 call failed")
-	}
-	fd := int(r1)
-	fmt.Printf("eventfd2 fd = %d\n", fd)
-
-	return fd
-}
-
-func writeToEventObject(fd int) {
-	fmt.Println("write to eventfd object")
-
-	writeVal := uint64(2)
-	var writeBuf [8]byte
-	binary.BigEndian.PutUint64(writeBuf[:], writeVal)
-
-	n, err := syscall.Write(fd, writeBuf[:])
-	validateReadWriteResponse(n, err)
-}
-
-func readFromEventObject(fd int) {
-	fmt.Println("read from eventfd object")
-
-	var buf [8]byte
-	n, err := syscall.Read(fd, buf[:])
-	validateReadWriteResponse(n, err)
-}
-
-func validateReadWriteResponse(n int, err error) {
-	if err != syscall.EAGAIN {
-		panic(fmt.Sprintf("expected error EAGAIN but got: %v", err))
-	}
-	expectedN := -1
-	if n != expectedN {
-		panic(fmt.Sprintf("expected n=%d but got: %d", expectedN, n))
-	}
+	syscall.EventfdTest()
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add some go program VM tests that directly invoke the `eventfd2` syscall and attempt to write to and read from the returned file descriptor. 
