### PR TITLE
feat(devstack): add ability to define preset compatibility

### DIFF
--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -151,3 +151,4 @@ The following environment variables can be used to configure devstack:
 - `DEVSTACK_ORCHESTRATOR`: Configures the preferred orchestrator kind (see Orchestrator interface section above).
 - `DEVSTACK_KEYS_SALT`: Seeds the keys generated with `NewHDWallet`. This is useful for "isolating" test runs, and might be needed to reproduce CI and/or acceptance test runs. It can be any string, including the empty one to use the "usual" devkeys.
 - `DEVNET_ENV_URL`: Used when `DEVSTACK_ORCHESTRATOR=sysext` to specify the network descriptor URL.
+- `DEVNET_EXPECT_PRECONDITIONS_MET`: This can be set of force test failures when their pre-conditions are not met, which would otherwise result in them being skipped. This is helpful in particular for runs that do intend to run specific tests (as opposed to whatever is available). `op-acceptor` does set that variable, for example.

--- a/op-devstack/compat/compat.go
+++ b/op-devstack/compat/compat.go
@@ -1,0 +1,11 @@
+package compat
+
+type Type string
+
+const (
+	SysGo      Type = "sysgo"
+	Kurtosis   Type = "kurtosis"
+	Persistent Type = "persistent"
+
+	CompatErrorCode = 42
+)

--- a/op-devstack/devtest/common.go
+++ b/op-devstack/devtest/common.go
@@ -22,6 +22,7 @@ type CommonT interface {
 	Errorf(format string, args ...any)
 	Fail()
 	FailNow()
+	SkipNow()
 
 	TempDir() string
 	Cleanup(fn func())

--- a/op-devstack/devtest/package.go
+++ b/op-devstack/devtest/package.go
@@ -55,6 +55,8 @@ type implP struct {
 	// The failure is intended to be critical if now==true.
 	// The implementer can choose to panic, crit-log, exit, etc. as preferred.
 	onFail func(now bool)
+	// onSkipNow will be called to skip the test immediately.
+	onSkipNow func()
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -84,6 +86,10 @@ func (t *implP) Fail() {
 
 func (t *implP) FailNow() {
 	t.onFail(true)
+}
+
+func (t *implP) SkipNow() {
+	t.onSkipNow()
 }
 
 func (t *implP) TempDir() string {
@@ -212,12 +218,13 @@ func (t *implP) _PackageOnly() {
 	panic("do not use - this method only forces the interface to be unique")
 }
 
-func NewP(ctx context.Context, logger log.Logger, onFail func(now bool)) P {
+func NewP(ctx context.Context, logger log.Logger, onFail func(now bool), onSkipNow func()) P {
 	ctx, cancel := context.WithCancel(ctx)
 	out := &implP{
 		scopeName: "pkg",
 		logger:    logger,
 		onFail:    onFail,
+		onSkipNow: onSkipNow,
 		ctx:       AddTestScope(ctx, "pkg"),
 		cancel:    cancel,
 	}

--- a/op-devstack/presets/minimal_with_conductors.go
+++ b/op-devstack/presets/minimal_with_conductors.go
@@ -1,6 +1,7 @@
 package presets
 
 import (
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
@@ -18,7 +19,10 @@ type MinimalWithConductors struct {
 
 // TODO: shift this to a different sysgo constructor once the sysgo implementation supports conductors
 func WithMinimalWithConductors() stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{}))
+	return stack.Combine(
+		stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{})),
+		WithCompatibleTypes(compat.Persistent),
+	)
 }
 
 func NewMinimalWithConductors(t devtest.T) *MinimalWithConductors {

--- a/op-devstack/presets/minimal_with_conductors.go
+++ b/op-devstack/presets/minimal_with_conductors.go
@@ -17,10 +17,12 @@ type MinimalWithConductors struct {
 	ConductorSets map[stack.L2NetworkID]dsl.ConductorSet
 }
 
-// TODO: shift this to a different sysgo constructor once the sysgo implementation supports conductors
+// TODO(#16418): shift this to a different sysgo constructor once the sysgo implementation supports conductors
 func WithMinimalWithConductors() stack.CommonOption {
 	return stack.Combine(
 		stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{})),
+		// TODO(#15152): add kurtosis support
+		// TODO(#16418) add sysgo support
 		WithCompatibleTypes(compat.Persistent),
 	)
 }

--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -82,14 +82,20 @@ func DoMain(m *testing.M, opts ...stack.CommonOption) {
 		// Make the package-level logger use this context
 		logger.SetContext(ctx)
 
-		p := devtest.NewP(ctx, logger, func(now bool) {
+		onFail := func(now bool) {
 			logger.Error("Main failed")
 			debug.PrintStack()
 			failed.Store(true)
 			if now {
 				panic("critical Main fail")
 			}
-		})
+		}
+
+		onSkipNow := func() {
+			logger.Info("Main skipped")
+			os.Exit(0)
+		}
+		p := devtest.NewP(ctx, logger, onFail, onSkipNow)
 		defer p.Close()
 
 		p.Require().NotEmpty(opts, "Expecting orchestrator options")
@@ -157,15 +163,23 @@ Add a TestMain to your test package init the orchestrator:
 }
 
 // WithCompatibleTypes is a common option that can be used to ensure that the orchestrator is compatible with the preset.
-// If the orchestrator is not compatible, the test will fail with a non-zero exit code: compat.CompatErrorCode.
+// If the orchestrator is not compatible, the test will either:
+// - fail with a non-zero exit code (42) if DEVNET_EXPECT_PRECONDITIONS_MET is non-empty
+// - skip the whole test otherwise
 // This is useful to ensure that the preset is only used with the correct orchestrator type.
+// Do yourself a favor, if you use this option, add a good comment (or a TODO) justifying it!
 func WithCompatibleTypes(t ...compat.Type) stack.CommonOption {
 	return stack.FnOption[stack.Orchestrator]{
 		BeforeDeployFn: func(orch stack.Orchestrator) {
 			if !slices.Contains(t, orch.Type()) {
 				p := orch.P()
-				p.Errorf("Orchestrator type %s is incompatible with this preset", orch.Type())
-				os.Exit(compat.CompatErrorCode)
+
+				if os.Getenv(devtest.ExpectPreconditionsMet) != "" {
+					p.Errorf("Orchestrator type %s is incompatible with this preset", orch.Type())
+					os.Exit(compat.CompatErrorCode)
+				} else {
+					p.SkipNow()
+				}
 			}
 		},
 	}

--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"slices"
 	"sync/atomic"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/telemetry"
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysext"
@@ -152,4 +154,19 @@ Add a TestMain to your test package init the orchestrator:
 `)
 	}
 	return out
+}
+
+// WithCompatibleTypes is a common option that can be used to ensure that the orchestrator is compatible with the preset.
+// If the orchestrator is not compatible, the test will fail with a non-zero exit code: compat.CompatErrorCode.
+// This is useful to ensure that the preset is only used with the correct orchestrator type.
+func WithCompatibleTypes(t ...compat.Type) stack.CommonOption {
+	return stack.FnOption[stack.Orchestrator]{
+		BeforeDeployFn: func(orch stack.Orchestrator) {
+			if !slices.Contains(t, orch.Type()) {
+				p := orch.P()
+				p.Errorf("Orchestrator type %s is incompatible with this preset", orch.Type())
+				os.Exit(compat.CompatErrorCode)
+			}
+		},
+	}
 }

--- a/op-devstack/stack/orchestrator.go
+++ b/op-devstack/stack/orchestrator.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 )
 
@@ -37,6 +38,8 @@ type Orchestrator interface {
 	Hydrate(sys ExtensibleSystem)
 
 	ControlPlane() ControlPlane
+
+	Type() compat.Type
 }
 
 // GateWithRemediation is an example of a test-gate that checks a system and may use an orchestrator to remediate any shortcomings.

--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -25,19 +25,9 @@ func TestControlPlane(gt *testing.T) {
 	opt := DefaultInteropSystem(&ids)
 
 	logger := testlog.Logger(gt, log.LevelInfo)
+	onFail, onSkipNow := exiters(gt)
 
-	p := devtest.NewP(
-		context.Background(),
-		logger,
-		func(now bool) {
-			gt.Helper()
-			if now {
-				gt.FailNow()
-			} else {
-				gt.Fail()
-			}
-		},
-	)
+	p := devtest.NewP(context.Background(), logger, onFail, onSkipNow)
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
@@ -159,19 +149,8 @@ func TestControlPlaneFakePoS(gt *testing.T) {
 	opt := DefaultInteropSystem(&ids)
 
 	logger := testlog.Logger(gt, log.LevelInfo)
-
-	p := devtest.NewP(
-		context.Background(),
-		logger,
-		func(now bool) {
-			gt.Helper()
-			if now {
-				gt.FailNow()
-			} else {
-				gt.Fail()
-			}
-		},
-	)
+	onFail, onSkipNow := exiters(gt)
+	p := devtest.NewP(context.Background(), logger, onFail, onSkipNow)
 	gt.Cleanup(p.Close)
 
 	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -56,6 +57,10 @@ type Orchestrator struct {
 	jwtPath     string
 	jwtSecret   [32]byte
 	jwtPathOnce sync.Once
+}
+
+func (o *Orchestrator) Type() compat.Type {
+	return compat.SysGo
 }
 
 func (o *Orchestrator) ClusterForL2(chainID eth.ChainID) (*Cluster, bool) {


### PR DESCRIPTION
**Description**

Add the ability to mark a preset as compatible with certain types of orchestrators (devnets).


example:

```go
func WithMultiSupervisorInterop() stack.CommonOption {
	return stack.Combine(
		stack.MakeCommon(sysgo.MultiSupervisorInteropSystem(&sysgo.MultiSupervisorInteropSystemIDs{})),
		WithCompatibleTypes(compat.SysGo),
	)
}
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
