### PR TITLE
op-deployer: Improve add-game-type

### DIFF
--- a/op-deployer/pkg/deployer/manage/add_game_type.go
+++ b/op-deployer/pkg/deployer/manage/add_game_type.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliutil"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
@@ -20,11 +26,25 @@ import (
 )
 
 type AddGameTypeConfig struct {
-	L1RPCUrl         string
-	Logger           log.Logger
-	ArtifactsLocator *artifacts.Locator
-	Input            opcm.AddGameTypeInput
-	CacheDir         string
+	L1RPCUrl                string
+	Logger                  log.Logger
+	ArtifactsLocator        *artifacts.Locator
+	CacheDir                string
+	L1ProxyAdminOwner       common.Address
+	OPCMImpl                common.Address
+	SystemConfigProxy       common.Address
+	OPChainProxyAdmin       common.Address
+	DelayedWETHProxy        common.Address
+	DisputeGameType         uint32
+	DisputeAbsolutePrestate common.Hash
+	DisputeMaxGameDepth     *big.Int
+	DisputeSplitDepth       *big.Int
+	DisputeClockExtension   uint64
+	DisputeMaxClockDuration uint64
+	InitialBond             *big.Int
+	VM                      common.Address
+	Permissionless          bool
+	SaltMixer               string
 }
 
 func (c *AddGameTypeConfig) Check() error {
@@ -37,7 +57,59 @@ func (c *AddGameTypeConfig) Check() error {
 	}
 
 	if c.ArtifactsLocator == nil {
-		return fmt.Errorf("artifacts locator must be specified")
+		return fmt.Errorf("artifactsLocator must be specified")
+	}
+
+	if c.CacheDir == "" {
+		return fmt.Errorf("cacheDir must be specified")
+	}
+
+	if c.L1ProxyAdminOwner == (common.Address{}) {
+		return fmt.Errorf("prank address must be specified")
+	}
+
+	if c.OPCMImpl == (common.Address{}) {
+		return fmt.Errorf("opcmImpl address must be specified")
+	}
+
+	if c.SystemConfigProxy == (common.Address{}) {
+		return fmt.Errorf("systemConfigProxy address must be specified")
+	}
+
+	if c.OPChainProxyAdmin == (common.Address{}) {
+		return fmt.Errorf("opChainProxyAdmin address must be specified")
+	}
+
+	if c.DisputeGameType == 0 {
+		return fmt.Errorf("disputeGameType must be non-zero")
+	}
+
+	if c.DisputeAbsolutePrestate == (common.Hash{}) {
+		return fmt.Errorf("disputeAbsolutePrestate must be specified")
+	}
+
+	if c.DisputeMaxGameDepth == nil || c.DisputeMaxGameDepth.Sign() == 0 {
+		return fmt.Errorf("disputeMaxGameDepth must be non-zero")
+	}
+
+	if c.DisputeSplitDepth == nil || c.DisputeSplitDepth.Sign() == 0 {
+		return fmt.Errorf("disputeSplitDepth must be non-zero")
+	}
+
+	if c.DisputeClockExtension == 0 {
+		return fmt.Errorf("disputeClockExtension must be non-zero")
+	}
+
+	if c.DisputeMaxClockDuration == 0 {
+		return fmt.Errorf("disputeMaxClockDuration must be non-zero")
+	}
+
+	if c.InitialBond == nil || c.InitialBond.Sign() == 0 {
+		return fmt.Errorf("initialBond must be non-zero")
+	}
+
+	if c.SaltMixer == "" {
+		return fmt.Errorf("saltMixer must be specified")
 	}
 
 	return nil
@@ -48,36 +120,52 @@ func AddGameTypeCLI(cliCtx *cli.Context) error {
 	l := oplog.NewLogger(oplog.AppOut(cliCtx), logCfg)
 	oplog.SetGlobalLogHandler(l.Handler())
 
-	l1RPCUrl := cliCtx.String(deployer.L1RPCURLFlagName)
-	configFile := cliCtx.String(ConfigFlag.Name)
 	artifactsLocatorStr := cliCtx.String(deployer.ArtifactsLocatorFlag.Name)
-	cacheDir := cliCtx.String(deployer.CacheDirFlag.Name)
-
 	artifactsLocator := new(artifacts.Locator)
 	if err := artifactsLocator.UnmarshalText([]byte(artifactsLocatorStr)); err != nil {
 		return fmt.Errorf("failed to parse artifacts locator: %w", err)
 	}
 
-	// Read the input configuration from file
-	configData, err := os.ReadFile(configFile)
-	if err != nil {
-		return fmt.Errorf("failed to read config file: %w", err)
+	cfg := AddGameTypeConfig{
+		L1RPCUrl:                cliCtx.String(deployer.L1RPCURLFlagName),
+		Logger:                  l,
+		ArtifactsLocator:        artifactsLocator,
+		CacheDir:                cliCtx.String(deployer.CacheDirFlag.Name),
+		DisputeGameType:         uint32(cliCtx.Uint64(DisputeGameTypeFlag.Name)),
+		DisputeAbsolutePrestate: common.HexToHash(cliCtx.String(DisputeAbsolutePrestateFlag.Name)),
+		DisputeMaxGameDepth:     new(big.Int).SetUint64(cliCtx.Uint64(DisputeMaxGameDepthFlag.Name)),
+		DisputeSplitDepth:       new(big.Int).SetUint64(cliCtx.Uint64(DisputeSplitDepthFlag.Name)),
+		DisputeClockExtension:   cliCtx.Uint64(DisputeClockExtensionFlag.Name),
+		DisputeMaxClockDuration: cliCtx.Uint64(DisputeMaxClockDurationFlag.Name),
+		Permissionless:          cliCtx.Bool(PermissionlessFlag.Name),
+		SaltMixer:               cliCtx.String(SaltMixerFlag.Name),
+		DelayedWETHProxy:        common.HexToAddress(cliCtx.String(DelayedWETHProxyFlag.Name)),
 	}
 
-	var input opcm.AddGameTypeInput
-	if err := json.Unmarshal(configData, &input); err != nil {
-		return fmt.Errorf("failed to parse config file: %w", err)
+	var err error
+	if cliCtx.IsSet(WorkdirFlag.Name) {
+		err = populateConfigFromWorkdir(&cfg, cliCtx)
+	} else {
+		err = populateConfigFromFlags(&cfg, cliCtx)
+	}
+	if err != nil {
+		return err
+	}
+
+	initialBond, err := cliutil.BigIntFlag(cliCtx, InitialBondFlag.Name)
+	if err != nil {
+		cfg.InitialBond = initialBond
+	} else {
+		return fmt.Errorf("failed to parse initial bond: %w", err)
+	}
+
+	if err := cfg.Check(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
 	}
 
 	ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
 
-	_, calldata, err := AddGameType(ctx, AddGameTypeConfig{
-		L1RPCUrl:         l1RPCUrl,
-		Logger:           l,
-		ArtifactsLocator: artifactsLocator,
-		Input:            input,
-		CacheDir:         cacheDir,
-	})
+	_, calldata, err := AddGameType(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to add game type: %w", err)
 	}
@@ -88,6 +176,69 @@ func AddGameTypeCLI(cliCtx *cli.Context) error {
 		return fmt.Errorf("failed to encode calldata: %w", err)
 	}
 
+	return nil
+}
+
+func populateConfigFromWorkdir(cfg *AddGameTypeConfig, cliCtx *cli.Context) error {
+	workdir := cliCtx.String(WorkdirFlag.Name)
+	chainIDStr := cliCtx.String(L2ChainIDFlag.Name)
+
+	if chainIDStr == "" {
+		return fmt.Errorf("flag --%s must be specified when --workdir is set", L2ChainIDFlag.Name)
+	}
+	chainID, err := eth.ChainIDFromString(chainIDStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse chain-id: %w", err)
+	}
+
+	// Ensure these address flags are not provided if the workdir flag is provided
+	addressFlags := []string{
+		L1ProxyAdminOwnerFlag.Name, OPCMImplFlag.Name, SystemConfigProxyFlag.Name,
+		OPChainProxyAdminFlag.Name, DelayedWETHProxyFlag.Name, VMFlag.Name,
+	}
+	for _, flagName := range addressFlags {
+		if cliCtx.String(flagName) != "" {
+			return fmt.Errorf("cannot specify --%s when --%s is set", flagName, WorkdirFlag.Name)
+		}
+	}
+
+	state, err := pipeline.ReadState(workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read state from %s: %w", workdir, err)
+	}
+	if state.AppliedIntent == nil {
+		return fmt.Errorf("no applied intent in state file %s", workdir)
+	}
+	chainState, err := state.Chain(chainID.Bytes32())
+	if err != nil {
+		return fmt.Errorf("failed to get chain config for chain ID %s from state file %s: %w", chainIDStr, workdir, err)
+	}
+	chainIntent, err := state.AppliedIntent.Chain(chainID.Bytes32())
+	if err != nil {
+		return fmt.Errorf("failed to get applied chain intent for chain ID %s from state file %s: %w", chainIDStr, workdir, err)
+	}
+
+	cfg.L1ProxyAdminOwner = chainIntent.Roles.L1ProxyAdminOwner
+	if state.AppliedIntent.OPCMAddress == nil {
+		return fmt.Errorf("OPCMAddress is not set in the applied intent of state file %s", workdir)
+	}
+	cfg.OPCMImpl = *state.AppliedIntent.OPCMAddress
+	cfg.SystemConfigProxy = chainState.SystemConfigProxy
+	cfg.OPChainProxyAdmin = chainState.OpChainProxyAdminImpl
+	cfg.VM = state.ImplementationsDeployment.MipsImpl
+	return nil
+}
+
+func populateConfigFromFlags(cfg *AddGameTypeConfig, cliCtx *cli.Context) error {
+	if cliCtx.String(L2ChainIDFlag.Name) != "" {
+		return fmt.Errorf("--l2-chain-id must not be specified when workdir is not set")
+	}
+
+	cfg.L1ProxyAdminOwner = common.HexToAddress(cliCtx.String(L1ProxyAdminOwnerFlag.Name))
+	cfg.OPCMImpl = common.HexToAddress(cliCtx.String(OPCMImplFlag.Name))
+	cfg.SystemConfigProxy = common.HexToAddress(cliCtx.String(SystemConfigProxyFlag.Name))
+	cfg.OPChainProxyAdmin = common.HexToAddress(cliCtx.String(OPChainProxyAdminFlag.Name))
+	cfg.VM = common.HexToAddress(cliCtx.String(VMFlag.Name))
 	return nil
 }
 
@@ -128,7 +279,23 @@ func AddGameType(ctx context.Context, cfg AddGameTypeConfig) (opcm.AddGameTypeOu
 		return output, nil, fmt.Errorf("failed to create L2 genesis script: %w", err)
 	}
 
-	output, err = script.Run(cfg.Input)
+	output, err = script.Run(opcm.AddGameTypeInput{
+		L1ProxyAdminOwner:       cfg.L1ProxyAdminOwner,
+		OPCMImpl:                cfg.OPCMImpl,
+		SystemConfigProxy:       cfg.SystemConfigProxy,
+		OPChainProxyAdmin:       cfg.OPChainProxyAdmin,
+		DelayedWETHProxy:        cfg.DelayedWETHProxy,
+		DisputeGameType:         cfg.DisputeGameType,
+		DisputeAbsolutePrestate: cfg.DisputeAbsolutePrestate,
+		DisputeMaxGameDepth:     cfg.DisputeMaxGameDepth,
+		DisputeSplitDepth:       cfg.DisputeSplitDepth,
+		DisputeClockExtension:   cfg.DisputeClockExtension,
+		DisputeMaxClockDuration: cfg.DisputeMaxClockDuration,
+		InitialBond:             cfg.InitialBond,
+		VM:                      cfg.VM,
+		SaltMixer:               cfg.SaltMixer,
+		Permissioned:            !cfg.Permissionless,
+	})
 	if err != nil {
 		return output, nil, fmt.Errorf("error adding game type: %w", err)
 	}

--- a/op-deployer/pkg/deployer/manage/add_game_type_test.go
+++ b/op-deployer/pkg/deployer/manage/add_game_type_test.go
@@ -2,22 +2,25 @@ package manage
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum/go-ethereum/superchain"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/superchain-registry/validation"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 func TestAddGameType(t *testing.T) {
@@ -37,25 +40,23 @@ func TestAddGameType(t *testing.T) {
 		L1RPCUrl:         rpcURL,
 		Logger:           testlog.Logger(t, slog.LevelInfo),
 		ArtifactsLocator: afacts,
-		Input: opcm.AddGameTypeInput{
-			SaltMixer: "foo",
-			// The values below were pulled from the Superchain Registry for OP Sepolia.
-			SystemConfigProxy:       *supChainConfig.Addresses.SystemConfigProxy,
-			OPChainProxyAdmin:       *supChainConfig.Addresses.ProxyAdmin,
-			DelayedWETHProxy:        *supChainConfig.Addresses.DelayedWETHProxy,
-			DisputeGameType:         999,
-			DisputeAbsolutePrestate: common.HexToHash("0x1234"),
-			DisputeMaxGameDepth:     big.NewInt(73),
-			DisputeSplitDepth:       big.NewInt(30),
-			DisputeClockExtension:   10800,
-			DisputeMaxClockDuration: 302400,
-			InitialBond:             big.NewInt(0),
-			VM:                      common.Address(*v200SepoliaAddrs.Mips.Address),
-			Permissioned:            false,
-			Prank:                   *supChainConfig.Roles.ProxyAdminOwner,
-			OPCMImpl:                common.Address(*v200SepoliaAddrs.OPContractsManager.Address),
-		},
-		CacheDir: testCacheDir,
+		SaltMixer:        "foo",
+		// The values below were pulled from the Superchain Registry for OP Sepolia.
+		SystemConfigProxy:       *supChainConfig.Addresses.SystemConfigProxy,
+		OPChainProxyAdmin:       *supChainConfig.Addresses.ProxyAdmin,
+		DelayedWETHProxy:        *supChainConfig.Addresses.DelayedWETHProxy,
+		DisputeGameType:         999,
+		DisputeAbsolutePrestate: common.HexToHash("0x1234"),
+		DisputeMaxGameDepth:     big.NewInt(73),
+		DisputeSplitDepth:       big.NewInt(30),
+		DisputeClockExtension:   10800,
+		DisputeMaxClockDuration: 302400,
+		InitialBond:             big.NewInt(1),
+		VM:                      common.Address(*v200SepoliaAddrs.Mips.Address),
+		Permissionless:          false,
+		L1ProxyAdminOwner:       *supChainConfig.Roles.ProxyAdminOwner,
+		OPCMImpl:                common.Address(*v200SepoliaAddrs.OPContractsManager.Address),
+		CacheDir:                testCacheDir,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -69,4 +70,88 @@ func TestAddGameType(t *testing.T) {
 
 	require.NotEqual(t, common.Address{}, output.DelayedWETHProxy)
 	require.NotEqual(t, common.Address{}, output.FaultDisputeGameProxy)
+}
+
+func TestAddGameType_CLI(t *testing.T) {
+	incompatibleFlags := []struct {
+		flag  *cli.StringFlag
+		value string
+	}{
+		{L1ProxyAdminOwnerFlag, common.Address{0x01}.String()},
+		{OPCMImplFlag, common.Address{0x02}.String()},
+		{SystemConfigProxyFlag, common.Address{0x03}.String()},
+		{OPChainProxyAdminFlag, common.Address{0x04}.String()},
+		{VMFlag, common.Address{0x05}.String()},
+	}
+
+	for _, tt := range incompatibleFlags {
+		t.Run(fmt.Sprintf("incompatible flag %s", tt.flag.Name), func(t *testing.T) {
+			flagSet := flag.NewFlagSet(fmt.Sprintf("test-%s", tt.flag.Name), flag.ContinueOnError)
+			flagSet.String(WorkdirFlag.Name, "/tmp/testworkdir", "")
+			flagSet.String(L2ChainIDFlag.Name, "12345", "")
+
+			flagSet.String(tt.flag.Name, tt.value, "doc")
+
+			ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
+
+			err := populateConfigFromWorkdir(new(AddGameTypeConfig), ctx)
+			require.Error(t, err)
+			expectedError := fmt.Sprintf("cannot specify --%s when --workdir is set", tt.flag.Name)
+			require.ErrorContains(t, err, expectedError)
+		})
+	}
+
+	t.Run("missing chain id", func(t *testing.T) {
+		app := cli.NewApp()
+		flagSet := flag.NewFlagSet("test-missing-chainid", flag.ContinueOnError)
+
+		// Set WorkdirFlag
+		flagSet.String(WorkdirFlag.Name, "/tmp/testworkdir", "doc")
+
+		ctx := cli.NewContext(app, flagSet, nil)
+
+		err := populateConfigFromWorkdir(new(AddGameTypeConfig), ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "flag --l2-chain-id must be specified when --workdir is set")
+	})
+
+	t.Run("successful population from workdir", func(t *testing.T) {
+		app := cli.NewApp()
+		flagSet := flag.NewFlagSet("test-success", flag.ContinueOnError)
+		flagSet.String(WorkdirFlag.Name, "./testdata", "doc")
+		flagSet.String(L2ChainIDFlag.Name, "1234", "doc")
+
+		ctx := cli.NewContext(app, flagSet, nil)
+		cfg := &AddGameTypeConfig{}
+		err := populateConfigFromWorkdir(cfg, ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, common.HexToAddress("0x1eb2ffc903729a0f03966b917003800b145f56e2"), cfg.L1ProxyAdminOwner)
+		require.Equal(t, common.HexToAddress("0xfbceed4de885645fbded164910e10f52febfab35"), cfg.OPCMImpl)
+		require.Equal(t, common.HexToAddress("0x7bd8879acf1e74547455c7ddc07f5c3f4a3c133d"), cfg.OPChainProxyAdmin)
+		require.Equal(t, common.HexToAddress("0x02f909cf91c2134e70a67950b7f27db7c8ee55d6"), cfg.SystemConfigProxy)
+		require.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000001"), cfg.VM)
+	})
+
+	t.Run("successful population from CLI", func(t *testing.T) {
+		app := cli.NewApp()
+		flagSet := flag.NewFlagSet("test-success", flag.ContinueOnError)
+
+		flagSet.String(L1ProxyAdminOwnerFlag.Name, "0x1eb2ffc903729a0f03966b917003800b145f56e2", "doc")
+		flagSet.String(OPCMImplFlag.Name, "0xfbceed4de885645fbded164910e10f52febfab35", "doc")
+		flagSet.String(OPChainProxyAdminFlag.Name, "0x7bd8879acf1e74547455c7ddc07f5c3f4a3c133d", "doc")
+		flagSet.String(SystemConfigProxyFlag.Name, "0x02f909cf91c2134e70a67950b7f27db7c8ee55d6", "doc")
+		flagSet.String(VMFlag.Name, "0x0000000000000000000000000000000000000001", "doc")
+
+		ctx := cli.NewContext(app, flagSet, nil)
+		cfg := &AddGameTypeConfig{}
+		err := populateConfigFromFlags(cfg, ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, common.HexToAddress("0x1eb2ffc903729a0f03966b917003800b145f56e2"), cfg.L1ProxyAdminOwner)
+		require.Equal(t, common.HexToAddress("0xfbceed4de885645fbded164910e10f52febfab35"), cfg.OPCMImpl)
+		require.Equal(t, common.HexToAddress("0x7bd8879acf1e74547455c7ddc07f5c3f4a3c133d"), cfg.OPChainProxyAdmin)
+		require.Equal(t, common.HexToAddress("0x02f909cf91c2134e70a67950b7f27db7c8ee55d6"), cfg.SystemConfigProxy)
+		require.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000001"), cfg.VM)
+	})
 }

--- a/op-deployer/pkg/deployer/manage/flags.go
+++ b/op-deployer/pkg/deployer/manage/flags.go
@@ -2,14 +2,105 @@ package manage
 
 import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
 
 var (
-	ConfigFlag = &cli.StringFlag{
-		Name:  "config",
-		Usage: "path to the config file",
+	L1ProxyAdminOwnerFlag = &cli.StringFlag{
+		Name:    "l1-proxy-admin-owner-address",
+		Usage:   "Address to use for as the proxy admin owner. Not compatible with the --workdir flag.",
+		EnvVars: deployer.PrefixEnvVar("PROXY_ADMIN_OWNER"),
+	}
+	OPCMImplFlag = &cli.StringFlag{
+		Name:    "opcm-impl-address",
+		Usage:   "Address of the OPCM implementation contract. Not compatible with the --workdir flag.",
+		EnvVars: deployer.PrefixEnvVar("OPCM_IMPL_ADDRESS"),
+	}
+	SystemConfigProxyFlag = &cli.StringFlag{
+		Name:    "system-config-proxy-address",
+		Usage:   "Address of the SystemConfig proxy contract. Not compatible with the --workdir flag.",
+		EnvVars: deployer.PrefixEnvVar("SYSTEM_CONFIG_PROXY_ADDRESS"),
+	}
+	OPChainProxyAdminFlag = &cli.StringFlag{
+		Name:    "op-chain-proxy-admin-address",
+		Usage:   "Address of the OP Chain's proxy admin on L1. Not compatible with the --workdir flag.",
+		EnvVars: deployer.PrefixEnvVar("OP_CHAIN_PROXY_ADMIN_ADDRESS"),
+	}
+	DelayedWETHProxyFlag = &cli.StringFlag{
+		Name: "delayed-weth-proxy-address",
+		Usage: "Address of the DelayedWETHProxy contract to include as part of this game type. If not specified, " +
+			"one will be deployed for you by the OPCM.",
+		EnvVars: deployer.PrefixEnvVar("DELAYED_WETH_PROXY_ADDRESS"),
+	}
+	DisputeGameTypeFlag = &cli.Uint64Flag{
+		Name:    "dispute-game-type",
+		Usage:   "Numeric type identifier for the dispute game.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_GAME_TYPE"),
+		Value:   uint64(standard.DisputeGameType),
+	}
+	DisputeAbsolutePrestateFlag = &cli.StringFlag{
+		Name:    "dispute-absolute-prestate",
+		Usage:   "The absolute prestate hash for the dispute game. Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_ABSOLUTE_PRESTATE"),
+		Value:   standard.DisputeAbsolutePrestate.Hex(),
+	}
+	DisputeMaxGameDepthFlag = &cli.Uint64Flag{
+		Name:    "dispute-max-game-depth",
+		Usage:   "Maximum depth of the dispute game tree (value as string). Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_MAX_GAME_DEPTH"),
+		Value:   standard.DisputeMaxGameDepth,
+	}
+	DisputeSplitDepthFlag = &cli.Uint64Flag{
+		Name:    "dispute-split-depth",
+		Usage:   "Depth at which the dispute game tree splits (value as string). Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_SPLIT_DEPTH"),
+		Value:   standard.DisputeSplitDepth,
+	}
+	DisputeClockExtensionFlag = &cli.Uint64Flag{
+		Name:    "dispute-clock-extension",
+		Usage:   "Clock extension in seconds for dispute game timing. Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_CLOCK_EXTENSION"),
+		Value:   standard.DisputeClockExtension,
+	}
+	DisputeMaxClockDurationFlag = &cli.Uint64Flag{
+		Name:    "dispute-max-clock-duration",
+		Usage:   "Maximum clock duration in seconds for dispute game timing. Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_MAX_CLOCK_DURATION"),
+		Value:   standard.DisputeMaxClockDuration,
+	}
+	InitialBondFlag = &cli.StringFlag{
+		Name:    "initial-bond",
+		Usage:   "Initial bond amount required for the dispute game (value as string, in wei). Defaults to 1 ETH.",
+		EnvVars: deployer.PrefixEnvVar("INITIAL_BOND"),
+		Value:   "1000000000000000000",
+	}
+	VMFlag = &cli.StringFlag{
+		Name:    "vm-address",
+		Usage:   "Address of the VM contract used by the dispute game.",
+		EnvVars: deployer.PrefixEnvVar("VM_ADDRESS"),
+	}
+	PermissionlessFlag = &cli.BoolFlag{
+		Name:    "permissionless",
+		Usage:   "Boolean indicating if the dispute game should be deployed in permissionless mode.",
+		EnvVars: deployer.PrefixEnvVar("PERMISSIONED"),
+	}
+	SaltMixerFlag = &cli.StringFlag{
+		Name:    "salt-mixer",
+		Usage:   "String value for the salt mixer, used in CREATE2 address calculation. Default to keccak256(\"op-stack-contract-impls-salt-v0\").",
+		EnvVars: deployer.PrefixEnvVar("SALT_MIXER"),
+		Value:   "89fca2352a158519d2daabf7e53686272e828ddbff9487204546d918490b2ecf",
+	}
+	WorkdirFlag = &cli.StringFlag{
+		Name:    "workdir",
+		Usage:   "Path to a working directory containing a state file. Addresses will be retrieved from the state file, and cannot be specified on the command line.",
+		EnvVars: deployer.PrefixEnvVar("WORKDIR"),
+	}
+	L2ChainIDFlag = &cli.StringFlag{
+		Name:    "l2-chain-id",
+		Usage:   "Chain ID of the L2 network to retrieve from state. Must be specified when --workdir is set.",
+		EnvVars: deployer.PrefixEnvVar("CHAIN_ID"),
 	}
 )
 
@@ -20,7 +111,23 @@ var Commands = cli.Commands{
 		Flags: append([]cli.Flag{
 			deployer.L1RPCURLFlag,
 			deployer.ArtifactsLocatorFlag,
-			ConfigFlag,
+			L1ProxyAdminOwnerFlag,
+			OPCMImplFlag,
+			SystemConfigProxyFlag,
+			OPChainProxyAdminFlag,
+			DelayedWETHProxyFlag,
+			DisputeGameTypeFlag,
+			DisputeAbsolutePrestateFlag,
+			DisputeMaxGameDepthFlag,
+			DisputeSplitDepthFlag,
+			DisputeClockExtensionFlag,
+			DisputeMaxClockDurationFlag,
+			InitialBondFlag,
+			VMFlag,
+			PermissionlessFlag,
+			SaltMixerFlag,
+			WorkdirFlag,
+			L2ChainIDFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: AddGameTypeCLI,
 	},

--- a/op-deployer/pkg/deployer/manage/testdata/state.json
+++ b/op-deployer/pkg/deployer/manage/testdata/state.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "create2Salt": "0xe67da0752add941001738a7742b5137ccc4a96913a56bc31a037e4c8244d74ac",
+  "appliedIntent": {
+    "configType": "standard",
+    "l1ChainID": 11155111,
+    "opcmAddress": "0xfBceeD4DE885645fBdED164910E10F52fEBFAB35",
+    "superchainRoles": {
+      "proxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+      "protocolVersionsOwner": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
+      "guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e"
+    },
+    "fundDevAccounts": false,
+    "useInterop": false,
+    "l1ContractsLocator": "tag://op-contracts/v3.0.0-rc.2",
+    "l2ContractsLocator": "tag://op-contracts/v3.0.0-rc.2",
+    "chains": [
+      {
+        "id": "0x00000000000000000000000000000000000000000000000000000000000004d2",
+        "baseFeeVaultRecipient": "0x0000000000000000000000000000000000000001",
+        "l1FeeVaultRecipient": "0x0000000000000000000000000000000000000002",
+        "sequencerFeeVaultRecipient": "0x0000000000000000000000000000000000000003",
+        "eip1559DenominatorCanyon": 250,
+        "eip1559Denominator": 50,
+        "eip1559Elasticity": 6,
+        "roles": {
+          "l1ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+          "l2ProxyAdminOwner": "0x2fc3ffc903729a0f03966b917003800b145f67f3",
+          "systemConfigOwner": "0x0000000000000000000000000000000000000004",
+          "unsafeBlockSigner": "0x0000000000000000000000000000000000000005",
+          "batcher": "0x0000000000000000000000000000000000000006",
+          "proposer": "0x0000000000000000000000000000000000000007",
+          "challenger": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301"
+        }
+      }
+    ],
+    "globalDeployOverrides": null
+  },
+  "superchainDeployment": {
+    "proxyAdminAddress": "0x189abaaaa82dfc015a588a7dbad6f13b1d3485bc",
+    "superchainConfigProxyAddress": "0xc2be75506d5724086deb7245bd260cc9753911be",
+    "superchainConfigImplAddress": "0x0000000000000000000000000000000000000000",
+    "protocolVersionsProxyAddress": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
+    "protocolVersionsImplAddress": "0x0000000000000000000000000000000000000000"
+  },
+  "implementationsDeployment": {
+    "opcmAddress": "0xfbceed4de885645fbded164910e10f52febfab35",
+    "mipsImpl": "0x0000000000000000000000000000000000000001"
+  },
+  "opChainDeployments": [
+    {
+      "id": "0x00000000000000000000000000000000000000000000000000000000000004d2",
+      "OpChainProxyAdminImpl": "0x7bd8879acf1e74547455c7ddc07f5c3f4a3c133d",
+      "SystemConfigProxy": "0x02f909cf91c2134e70a67950b7f27db7c8ee55d6"
+    }
+  ],
+  "l1StateDump": null,
+  "DeploymentCalldata": null
+}
+

--- a/op-deployer/pkg/deployer/opcm/add_game_type.go
+++ b/op-deployer/pkg/deployer/opcm/add_game_type.go
@@ -10,7 +10,7 @@ import (
 )
 
 type AddGameTypeInput struct {
-	Prank                   common.Address
+	L1ProxyAdminOwner       common.Address `abi:"prank"`
 	OPCMImpl                common.Address `abi:"opcmImpl"`
 	SystemConfigProxy       common.Address
 	OPChainProxyAdmin       common.Address `abi:"opChainProxyAdmin"`
@@ -51,7 +51,7 @@ func (a *AddGameTypeInput) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	a.Prank = alias.Prank
+	a.L1ProxyAdminOwner = alias.Prank
 	a.OPCMImpl = alias.OPCMImpl
 	a.SystemConfigProxy = alias.SystemConfigProxy
 	a.OPChainProxyAdmin = alias.OPChainProxyAdmin
@@ -83,7 +83,7 @@ func (a *AddGameTypeInput) UnmarshalJSON(b []byte) error {
 
 func (a AddGameTypeInput) MarshalJSON() ([]byte, error) {
 	alias := addGameTypeInputJSON{
-		Prank:                   a.Prank,
+		Prank:                   a.L1ProxyAdminOwner,
 		OPCMImpl:                a.OPCMImpl,
 		SystemConfigProxy:       a.SystemConfigProxy,
 		OPChainProxyAdmin:       a.OPChainProxyAdmin,

--- a/op-deployer/pkg/deployer/opcm/add_game_type_test.go
+++ b/op-deployer/pkg/deployer/opcm/add_game_type_test.go
@@ -23,7 +23,7 @@ func compareBigInt(a, b *big.Int) bool {
 // use require.Equal directly because zero *big.Int structs can either be nil or a zero value, which trips up the
 // equality checker.
 func compareAddGameTypeInputs(t *testing.T, expected, actual AddGameTypeInput) {
-	require.Equal(t, expected.Prank, actual.Prank)
+	require.Equal(t, expected.L1ProxyAdminOwner, actual.L1ProxyAdminOwner)
 	require.Equal(t, expected.OPCMImpl, actual.OPCMImpl)
 	require.Equal(t, expected.SystemConfigProxy, actual.SystemConfigProxy)
 	require.Equal(t, expected.OPChainProxyAdmin, actual.OPChainProxyAdmin)
@@ -51,7 +51,7 @@ func TestAddGameTypeInput_MarshalUnmarshalJSON(t *testing.T) {
 		{
 			name: "basic",
 			input: AddGameTypeInput{
-				Prank:                   common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				L1ProxyAdminOwner:       common.HexToAddress("0x1111111111111111111111111111111111111111"),
 				OPCMImpl:                common.HexToAddress("0x2222222222222222222222222222222222222222"),
 				SystemConfigProxy:       common.HexToAddress("0x3333333333333333333333333333333333333333"),
 				OPChainProxyAdmin:       common.HexToAddress("0x4444444444444444444444444444444444444444"),
@@ -71,7 +71,7 @@ func TestAddGameTypeInput_MarshalUnmarshalJSON(t *testing.T) {
 		{
 			name: "nil big.Int fields",
 			input: AddGameTypeInput{
-				Prank:                   common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				L1ProxyAdminOwner:       common.HexToAddress("0x1111111111111111111111111111111111111111"),
 				OPCMImpl:                common.HexToAddress("0x2222222222222222222222222222222222222222"),
 				SystemConfigProxy:       common.HexToAddress("0x3333333333333333333333333333333333333333"),
 				OPChainProxyAdmin:       common.HexToAddress("0x4444444444444444444444444444444444444444"),

--- a/op-service/cliutil/big.go
+++ b/op-service/cliutil/big.go
@@ -1,0 +1,29 @@
+package cliutil
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+var ErrFlagBlank = errors.New("cannot parse blank big int flag")
+
+func BigIntFlag(cliCtx *cli.Context, flagName string) (*big.Int, error) {
+	intStr := cliCtx.String(flagName)
+	if intStr == "" {
+		return nil, ErrFlagBlank
+	}
+	base := 10
+	if strings.HasPrefix(intStr, "0x") {
+		base = 16
+		intStr = intStr[2:]
+	}
+	out, ok := new(big.Int).SetString(intStr, base)
+	if !ok {
+		return nil, fmt.Errorf("error parsing bigint flag '%s'", intStr)
+	}
+	return out, nil
+}

--- a/op-service/cliutil/big_test.go
+++ b/op-service/cliutil/big_test.go
@@ -1,0 +1,76 @@
+package cliutil
+
+import (
+	"flag"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestBigIntFlag(t *testing.T) {
+	validBigIntStr := "123456789012345678901234567890"
+	expectedBigInt, _ := new(big.Int).SetString(validBigIntStr, 10)
+
+	tests := []struct {
+		name        string
+		flagValue   string
+		expectedVal *big.Int
+		expectErr   bool
+	}{
+		{
+			name:        "valid big int",
+			flagValue:   validBigIntStr,
+			expectedVal: expectedBigInt,
+			expectErr:   false,
+		},
+		{
+			name:        "valid hex big int",
+			flagValue:   "0x1234",
+			expectedVal: big.NewInt(0x1234),
+			expectErr:   false,
+		},
+		{
+			name:        "invalid hex big int",
+			flagValue:   "0xgibberish",
+			expectedVal: nil,
+			expectErr:   true,
+		},
+		{
+			name:        "empty hex big int",
+			flagValue:   "0x",
+			expectedVal: nil,
+			expectErr:   true,
+		},
+		{
+			name:        "invalid big int string",
+			flagValue:   "not-a-number",
+			expectedVal: nil,
+			expectErr:   true,
+		},
+		{
+			name:        "empty string value for flag",
+			flagValue:   "",
+			expectedVal: nil,
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			flagName := "foo"
+			fs.String(flagName, tt.flagValue, "doc")
+			val, err := BigIntFlag(cli.NewContext(nil, fs, nil), flagName)
+
+			if tt.expectErr {
+				require.Nil(t, val)
+				require.Error(t, err)
+			} else {
+				require.NotNil(t, val)
+				require.Equal(t, 0, tt.expectedVal.Cmp(val), "expected %s, got %s", tt.expectedVal.String(), val.String())
+			}
+		})
+	}
+}

--- a/op-service/eth/chain_id.go
+++ b/op-service/eth/chain_id.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math/big"
 	"sort"
+	"strings"
 
 	"github.com/holiman/uint256"
 )
@@ -21,6 +22,13 @@ func ChainIDFromUInt64(i uint64) ChainID {
 	return ChainID(*uint256.NewInt(i))
 }
 
+func ChainIDFromString(id string) (ChainID, error) {
+	if strings.HasPrefix(id, "0x") {
+		return ParseHexChainID(id)
+	}
+	return ParseDecimalChainID(id)
+}
+
 func ChainIDFromBytes32(b [32]byte) ChainID {
 	val := new(uint256.Int).SetBytes(b[:])
 	return ChainID(*val)
@@ -28,6 +36,14 @@ func ChainIDFromBytes32(b [32]byte) ChainID {
 
 func ParseDecimalChainID(chainID string) (ChainID, error) {
 	v, err := uint256.FromDecimal(chainID)
+	if err != nil {
+		return ChainID{}, err
+	}
+	return ChainID(*v), nil
+}
+
+func ParseHexChainID(chainID string) (ChainID, error) {
+	v, err := uint256.FromHex(chainID)
 	if err != nil {
 		return ChainID{}, err
 	}

--- a/op-service/eth/chain_id_test.go
+++ b/op-service/eth/chain_id_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -60,4 +62,31 @@ func TestSortChainIDs(t *testing.T) {
 	require.NotEqual(t, expected, ids)
 	SortChainID(ids)
 	require.Equal(t, expected, ids)
+}
+
+func TestChainID_FromString(t *testing.T) {
+	hash := "0x23b00f3aae2634f1b35057cca336e1950473a1e037d0b405302d988f360f8268"
+	var h [32]byte
+	dec := hexutil.MustDecode(hash)
+	copy(h[:], dec)
+
+	tests := []struct {
+		input    string
+		expected ChainID
+	}{
+		{"0", ChainIDFromUInt64(0)},
+		{"1", ChainIDFromUInt64(1)},
+		{"871975192374", ChainIDFromUInt64(871975192374)},
+		{"9223372036854775807", ChainIDFromUInt64(math.MaxInt64)},
+		{"18446744073709551615", ChainID(*uint256.NewInt(math.MaxUint64))},
+		{"0x1234", ChainIDFromUInt64(0x1234)},
+		{hash, ChainIDFromBytes32(h)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			id, err := ChainIDFromString(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, id)
+		})
+	}
 }


### PR DESCRIPTION
Improves `manage add-game-type` by adding support for reading values from an existing OP Deployer state file. All values are now read from the environment, or via CLI flags. The config file is removed.

The following addresses are prepopulated from state:

- Prank
- OPCM Impl
- SystemConfigProxy
- OPChainProxyAdmin
- VM

The following still must be specified on the CLI:

- DelayedWETH (optional, will be deployed if not specified)