### PR TITLE
op-interop-mon: add to op-stack-go docker build pipeline

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -93,6 +93,10 @@ variable "OP_FAUCET_VERSION" {
   default = "${GIT_VERSION}"
 }
 
+variable "OP_INTEROP_MON_VERSION" {
+  default = "${GIT_VERSION}"
+}
+
 
 target "op-node" {
   dockerfile = "ops/docker/op-stack-go/Dockerfile"
@@ -286,4 +290,17 @@ target "op-faucet" {
   target = "op-faucet-target"
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-faucet:${tag}"]
+}
+
+target "op-interop-mon" {
+  dockerfile = "ops/docker/op-stack-go/Dockerfile"
+  context = "."
+  args = {
+    GIT_COMMIT = "${GIT_COMMIT}"
+    GIT_DATE = "${GIT_DATE}"
+    OP_INTEROP_MON_VERSION = "${OP_INTEROP_MON_VERSION}"
+  }
+  target = "op-interop-mon-target"
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-interop-mon:${tag}"]
 }

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -44,6 +44,7 @@ op-proposer-image TAG='op-proposer:devnet': (_docker_build_stack TAG "op-propose
 op-supervisor-image TAG='op-supervisor:devnet': (_docker_build_stack TAG "op-supervisor-target")
 op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target")
 op-faucet-image TAG='op-faucet:devnet': (_docker_build_stack TAG "op-faucet-target")
+op-interop-mon-image TAG='op-interop-mon:devnet': (_docker_build_stack TAG "op-interop-mon-target")
 
 op-program-builder-image TAG='op-program-builder:devnet': _prerequisites
     just op-program-svc/op-program-svc {{TAG}}

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -32,7 +32,7 @@ ARG TARGETARCH
 
 # Install yq
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$TARGETARCH -O /usr/local/bin/yq && \
-    chmod +x /usr/local/bin/yq
+  chmod +x /usr/local/bin/yq
 
 # Install versioned toolchain
 COPY ./mise.toml .
@@ -145,7 +145,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_TEST_SEQUENCER_VERSION"
 
 FROM --platform=$BUILDPLATFORM builder AS op-deployer-builder
-ARG OP_NODE_VERSION=v0.0.0
+ARG OP_DEPLOYER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd op-chain-ops && make op-deployer  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_DEPLOYER_VERSION"
 
@@ -159,6 +159,12 @@ ARG OP_FAUCET_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_FAUCET_VERSION" \
   op-faucet/op-faucet
+
+FROM --platform=$BUILDPLATFORM builder AS op-interop-mon-builder
+ARG OP_INTEROP_MON_VERSION=v0.0.0
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
+  GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_INTEROP_MON_VERSION" \
+  op-interop-mon/op-interop-mon
 
 FROM $TARGET_BASE_IMAGE AS cannon-target
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
@@ -237,3 +243,7 @@ CMD ["op-dripper"]
 FROM $TARGET_BASE_IMAGE AS op-faucet-target
 COPY --from=op-faucet-builder /app/op-faucet/bin/op-faucet /usr/local/bin/
 CMD ["op-faucet"]
+
+FROM $TARGET_BASE_IMAGE AS op-interop-mon-target
+COPY --from=op-interop-mon-builder /app/op-interop-mon/bin/op-interop-mon /usr/local/bin/
+CMD ["op-interop-mon"]

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -24,6 +24,7 @@
 !/op-wheel
 !/op-alt-da
 !/op-faucet
+!/op-interop-mon
 !/go.mod
 !/go.sum
 !/justfiles


### PR DESCRIPTION
This work lays the way for having op-interop-mon running in production and in kurtosis devnet.

Towards https://github.com/ethereum-optimism/optimism/issues/16228