### PR TITLE
op-test-sequencer: remove op-e2e dep

### DIFF
--- a/op-devstack/sysgo/test_sequencer.go
+++ b/op-devstack/sysgo/test_sequencer.go
@@ -126,7 +126,7 @@ func WithTestSequencer(testSequencerID stack.TestSequencerID, l1CLID stack.L1CLN
 				},
 				bid_L1: {
 					L1: &fakepos.Config{
-						Geth:              l1EL.l1Geth,
+						GethBackend:       l1EL.l1Geth.Backend,
 						Beacon:            l1CL.beacon,
 						FinalizedDistance: 20,
 						SafeDistance:      10,

--- a/op-test-sequencer/sequencer/backend/work/builders/fakepos/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/fakepos/config.go
@@ -1,13 +1,10 @@
 package fakepos
 
-import (
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
-)
+import "github.com/ethereum/go-ethereum/eth"
 
 type Config struct {
-	Geth              *geth.GethInstance
-	Beacon            *fakebeacon.FakeBeacon
+	GethBackend       *eth.Ethereum
+	Beacon            Beacon
 	FinalizedDistance uint64
 	SafeDistance      uint64
 	BlockTime         uint64

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -19,8 +19,6 @@
 !/op-service
 !/op-supervisor
 !/op-test-sequencer
-!/op-e2e/e2eutils
-!/op-e2e/config
 !/op-wheel
 !/op-alt-da
 !/op-faucet


### PR DESCRIPTION
**Description**

This PR is removing the dependency on op-e2e from the op-test-sequencer.

This should fix the cross-platform issue at: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/92971/workflows/0954d16d-021c-4bcb-b595-a6693f0c91c1/jobs/3622447

The `fakepos` builder within the `op-test-sequencer` is only intended to be instantiated within `sysgo` tests, we don't have L1-mode support for `sysext` at the moment, and it is not planned right now.