### PR TITLE
refactor: decouple AnchorStateRegistry from SystemConfig, use SuperchainConfig instead

### DIFF
--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -8,6 +8,7 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { GameType, Hash, Proposal } from "src/dispute/lib/Types.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     error AnchorStateRegistry_InvalidAnchorGame();
@@ -29,7 +30,8 @@ interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     function disputeGameFinalityDelaySeconds() external view returns (uint256);
     function disputeGameFactory() external view returns (IDisputeGameFactory);
     function initialize(
-        ISystemConfig _systemConfig,
+        ISuperchainConfig _superchainConfig,
+        IETHLockbox _ethLockbox,
         IDisputeGameFactory _disputeGameFactory,
         Proposal memory _startingAnchorRoot,
         GameType _startingRespectedGameType
@@ -48,10 +50,10 @@ interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     function retirementTimestamp() external view returns (uint64);
     function setAnchorState(IDisputeGame _game) external;
     function setRespectedGameType(GameType _gameType) external;
-    function systemConfig() external view returns (ISystemConfig);
     function updateRetirementTimestamp() external;
     function version() external view returns (string memory);
     function superchainConfig() external view returns (ISuperchainConfig);
+    function ethLockbox() external view returns (IETHLockbox);
 
     function __constructor__(
         uint256 _disputeGameFinalityDelaySeconds

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1332,7 +1332,8 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
         return abi.encodeCall(
             IAnchorStateRegistry.initialize,
             (
-                _output.systemConfigProxy,
+                superchainConfig,
+                _output.ethLockboxProxy,
                 _output.disputeGameFactoryProxy,
                 startingAnchorRoot,
                 GameTypes.PERMISSIONED_CANNON
@@ -1495,7 +1496,13 @@ contract OPContractsManagerInteropMigrator is OPContractsManagerBase {
             getImplementations().anchorStateRegistryImpl,
             abi.encodeCall(
                 IAnchorStateRegistry.initialize,
-                (portals[0].systemConfig(), newDisputeGameFactory, _input.startingAnchorRoot, newGameType)
+                (
+                    portals[0].superchainConfig(),
+                    portals[0].ethLockbox(),
+                    newDisputeGameFactory,
+                    _input.startingAnchorRoot,
+                    newGameType
+                )
             )
         );
 

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -14,8 +14,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 /// @custom:proxied true
 /// @title AnchorStateRegistry
@@ -31,8 +31,11 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     /// @notice The dispute game finality delay in seconds.
     uint256 internal immutable DISPUTE_GAME_FINALITY_DELAY_SECONDS;
 
-    /// @notice Address of the SystemConfig contract.
-    ISystemConfig public systemConfig;
+    /// @notice Address of the SuperchainConfig contract.
+    ISuperchainConfig public superchainConfig;
+
+    /// @notice Address of the ETHLockbox contract (pause identifier).
+    IETHLockbox public ethLockbox;
 
     /// @notice Address of the DisputeGameFactory contract.
     IDisputeGameFactory public disputeGameFactory;
@@ -83,11 +86,13 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     }
 
     /// @notice Initializes the contract.
-    /// @param _systemConfig The address of the SystemConfig contract.
+    /// @param _superchainConfig The address of the SuperchainConfig contract.
+    /// @param _ethLockbox The address of the ETHLockbox contract (pause identifier).
     /// @param _disputeGameFactory The address of the DisputeGameFactory contract.
     /// @param _startingAnchorRoot The starting anchor root.
     function initialize(
-        ISystemConfig _systemConfig,
+        ISuperchainConfig _superchainConfig,
+        IETHLockbox _ethLockbox,
         IDisputeGameFactory _disputeGameFactory,
         Proposal memory _startingAnchorRoot,
         GameType _startingRespectedGameType
@@ -99,7 +104,8 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
         // Now perform initialization logic.
-        systemConfig = _systemConfig;
+        superchainConfig = _superchainConfig;
+        ethLockbox = _ethLockbox;
         disputeGameFactory = _disputeGameFactory;
         startingAnchorRoot = _startingAnchorRoot;
         respectedGameType = _startingRespectedGameType;
@@ -108,13 +114,14 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
 
     /// @notice Returns whether the contract is paused.
     function paused() public view returns (bool) {
-        return systemConfig.paused();
+        // Use the ETHLockbox address as the pause identifier
+        return superchainConfig.paused(address(ethLockbox));
     }
 
     /// @notice Returns the SuperchainConfig contract.
     /// @return ISuperchainConfig The SuperchainConfig contract.
-    function superchainConfig() public view returns (ISuperchainConfig) {
-        return systemConfig.superchainConfig();
+    function getSuperchainConfig() public view returns (ISuperchainConfig) {
+        return superchainConfig;
     }
 
     /// @notice Returns the dispute game finality delay in seconds.
@@ -341,9 +348,9 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
         emit AnchorUpdated(game);
     }
 
-    /// @notice Asserts that the caller is the Guardian.
+    /// @dev Internal: checks that the caller is the guardian in SuperchainConfig.
     function _assertOnlyGuardian() internal view {
-        if (msg.sender != systemConfig.guardian()) {
+        if (msg.sender != superchainConfig.guardian()) {
             revert AnchorStateRegistry_Unauthorized();
         }
     }

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -61,9 +61,9 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         assertEq(l2BlockNumber, 0);
 
         // Verify contract addresses.
-        assert(anchorStateRegistry.systemConfig() == systemConfig);
         assert(anchorStateRegistry.disputeGameFactory() == disputeGameFactory);
         assert(anchorStateRegistry.superchainConfig() == superchainConfig);
+        assert(anchorStateRegistry.ethLockbox() == ethLockbox);
     }
 
     /// @notice Tests that the initializer value is correct. Trivial test for normal
@@ -85,7 +85,8 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
     function test_initialize_twice_reverts() public {
         vm.expectRevert("Initializable: contract is already initialized");
         anchorStateRegistry.initialize(
-            systemConfig,
+            superchainConfig,
+            ethLockbox,
             disputeGameFactory,
             Proposal({
                 root: Hash.wrap(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF),
@@ -115,7 +116,8 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         // Call the `initialize` function with the sender
         vm.prank(_sender);
         anchorStateRegistry.initialize(
-            systemConfig,
+            superchainConfig,
+            ethLockbox,
             disputeGameFactory,
             Proposal({
                 root: Hash.wrap(0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF),


### PR DESCRIPTION
**Description**

This PR refactors the AnchorStateRegistry contract to remove its dependency on SystemConfig and instead use SuperchainConfig and ETHLockbox for chain-wide configuration and pause logic. The initialize function and related interfaces have been updated to accept ISuperchainConfig and IETHLockbox instead of ISystemConfig. All logic related to pausing and guardian checks now references SuperchainConfig. Deployment scripts, contract manager logic, and tests have been updated accordingly.
This change is required to support interop mode, where AnchorStateRegistry is shared across multiple chains, but SystemConfig remains chain-specific.

**Tests**

- Updated all existing tests for AnchorStateRegistry to use the new constructor and interface.
- Verified that pause and guardian logic now reference SuperchainConfig as intended.
- All relevant deployment and migration scripts have been updated and checked for compatibility.

**Additional context**

This refactor is necessary to decouple AnchorStateRegistry from chain-specific configuration, ensuring it can be safely used in interop scenarios across multiple chains.
No new features are introduced; this is a structural and architectural improvement to support future multi-chain deployments.

**Metadata**

Closes #16114
