### PR TITLE
cannon: Enforce the non-block flag for eventfd syscalls

### DIFF
--- a/cannon/mipsevm/exec/mips_syscalls.go
+++ b/cannon/mipsevm/exec/mips_syscalls.go
@@ -79,6 +79,12 @@ const (
 		CloneThread
 )
 
+// eventfd flags
+// From: https://github.com/golang/go/blob/7a2cfb70b01f069c2125adcf7126d7f3376cb8b7/src/internal/runtime/syscall/defs_linux_mips64x.go#L18-L18
+const (
+	EFD_NONBLOCK = 0x80
+)
+
 // Other constants
 const (
 	// SchedQuantum is the number of steps dedicated for a thread before it's preempted. Effectively used to emulate thread "time slices"

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -109,18 +109,27 @@ func TestInstrumentedState_SyscallEventFdProgram(t *testing.T) {
 
 		// Check output
 		output := stdOutBuf.String()
-		require.Contains(t, output, "call eventfd")
+		require.Contains(t, output, "call eventfd with valid flags: '0x80080'")
+		require.Contains(t, output, "call eventfd with valid flags: '0xFFFFFFFFFFFFFFFF'")
+		require.Contains(t, output, "call eventfd with valid flags: '0x80'")
+		require.Contains(t, output, "call eventfd with invalid flags: '0x0'")
+		require.Contains(t, output, "call eventfd with invalid flags: '0xFFFFFFFFFFFFFF7F'")
+		require.Contains(t, output, "call eventfd with invalid flags: '0x80000'")
 		require.Contains(t, output, "write to eventfd object")
 		require.Contains(t, output, "read from eventfd object")
 		require.Contains(t, output, "done")
 
 		// Check fd value
-		pattern := `eventfd2 fd = (.+)`
+		pattern := `eventfd2 fd = '(.+)'`
 		re, err := regexp.Compile(pattern)
 		require.NoError(t, err)
 		matches := re.FindAllStringSubmatch(output, -1)
-		require.Equal(t, 1, len(matches))
-		require.Equal(t, "100", matches[0][1])
+
+		expectedMatches := 3
+		require.Equal(t, expectedMatches, len(matches))
+		for i := 0; i < expectedMatches; i++ {
+			require.Equal(t, "100", matches[i][1])
+		}
 	})
 }
 

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -201,7 +201,16 @@ func (m *InstrumentedState) handleSyscall() error {
 		if !m.features.SupportMinimalSysEventFd2 {
 			m.handleUnrecognizedSyscall(syscallNum)
 		}
-		v0 = exec.FdEventFd
+
+		// a0 = initial value, a1 = flags
+		// Validate flags
+		if a1&exec.EFD_NONBLOCK == 0 {
+			// The non-block flag was not set, but we only support non-block requests, so error
+			v0 = exec.MipsEINVAL
+			v1 = exec.SysErrorSignal
+		} else {
+			v0 = exec.FdEventFd
+		}
 	default:
 		// These syscalls have the same values on 64-bit. So we use if-stmts here to avoid "duplicate case" compiler error for the cannon64 build
 		if arch.IsMips32 && (syscallNum == arch.SysFstat64 || syscallNum == arch.SysStat64 || syscallNum == arch.SysLlseek) {

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -1076,7 +1076,7 @@ func TestEVM_SyscallEventFdProgram(t *testing.T) {
 			validator := testutil.NewEvmValidator(t, v.StateHashFn, v.Contracts)
 
 			var stdOutBuf, stdErrBuf bytes.Buffer
-			elfFile := testutil.ProgramPath("syscall-eventfd", testutil.Go1_24)
+			elfFile := testutil.ProgramPath("syscall-eventfd", v.GoTarget)
 			goVm := v.ElfVMFactory(t, elfFile, nil, io.MultiWriter(&stdOutBuf, os.Stdout), io.MultiWriter(&stdErrBuf, os.Stderr), testutil.CreateLogger())
 			state := goVm.GetState()
 
@@ -1104,18 +1104,27 @@ func TestEVM_SyscallEventFdProgram(t *testing.T) {
 
 			// Check output
 			output := stdOutBuf.String()
-			require.Contains(t, output, "call eventfd")
+			require.Contains(t, output, "call eventfd with valid flags: '0x80080'")
+			require.Contains(t, output, "call eventfd with valid flags: '0xFFFFFFFFFFFFFFFF'")
+			require.Contains(t, output, "call eventfd with valid flags: '0x80'")
+			require.Contains(t, output, "call eventfd with invalid flags: '0x0'")
+			require.Contains(t, output, "call eventfd with invalid flags: '0xFFFFFFFFFFFFFF7F'")
+			require.Contains(t, output, "call eventfd with invalid flags: '0x80000'")
 			require.Contains(t, output, "write to eventfd object")
 			require.Contains(t, output, "read from eventfd object")
 			require.Contains(t, output, "done")
 
 			// Check fd value
-			pattern := `eventfd2 fd = (.+)`
+			pattern := `eventfd2 fd = '(.+)'`
 			re, err := regexp.Compile(pattern)
 			require.NoError(t, err)
 			matches := re.FindAllStringSubmatch(output, -1)
-			require.Equal(t, 1, len(matches))
-			require.Equal(t, "100", matches[0][1])
+
+			expectedMatches := 3
+			require.Equal(t, expectedMatches, len(matches))
+			for i := 0; i < expectedMatches; i++ {
+				require.Equal(t, "100", matches[i][1])
+			}
 		})
 	}
 }

--- a/cannon/testdata/common/syscalltests/eventfd.go
+++ b/cannon/testdata/common/syscalltests/eventfd.go
@@ -9,31 +9,52 @@ import (
 	"syscall"
 )
 
+const (
+	EFD_CLOEXEC  = uintptr(0x80000)
+	EFD_NONBLOCK = uintptr(0x80)
+)
+
 func EventfdTest() {
-	fd := callEventfd()
+	// Test a few different valid flag combinations
+	fd := callEventfdWithValidFlags(EFD_CLOEXEC | EFD_NONBLOCK)
+	fd = callEventfdWithValidFlags(^uintptr(0))
+	fd = callEventfdWithValidFlags(EFD_NONBLOCK)
+
+	// Test read/write
 	writeToEventObject(fd)
 	readFromEventObject(fd)
+
+	// Test invalid flags
+	callEventFdWithInvalidFlags(0)
+	callEventFdWithInvalidFlags(^EFD_NONBLOCK)
+	callEventFdWithInvalidFlags(EFD_CLOEXEC)
 
 	fmt.Println("done")
 }
 
-const (
-	EFD_CLOEXEC  = 0x80000
-	EFD_NONBLOCK = 0x80
-)
+func callEventfdWithValidFlags(flags uintptr) int {
+	fmt.Printf("call eventfd with valid flags: '0x%X'\n", flags)
 
-func callEventfd() int {
-	fmt.Println("call eventfd")
-
-	flags := EFD_CLOEXEC | EFD_NONBLOCK
-	r1, _, errno := syscall.Syscall(syscall.SYS_EVENTFD2, uintptr(0), uintptr(flags), 0)
+	r1, _, errno := syscall.Syscall(syscall.SYS_EVENTFD2, uintptr(0), flags, 0)
 	if errno != 0 {
 		panic("eventfd2 call failed")
 	}
 	fd := int(r1)
-	fmt.Printf("eventfd2 fd = %d\n", fd)
+	fmt.Printf("eventfd2 fd = '%d'\n", fd)
 
 	return fd
+}
+
+func callEventFdWithInvalidFlags(flags uintptr) {
+	fmt.Printf("call eventfd with invalid flags: '0x%X'\n", flags)
+
+	r1, _, errno := syscall.Syscall(syscall.SYS_EVENTFD2, uintptr(0), flags, 0)
+	if errno != syscall.EINVAL {
+		panic(fmt.Sprintf("expected error EINVAL but got: %v", errno))
+	}
+	if r1 != ^uintptr(0) {
+		panic(fmt.Sprintf("expected r1 to be -1 but got %d", r1))
+	}
 }
 
 func writeToEventObject(fd int) {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xb3e32b18c95d4940980333e1e99b4dcf42d8a8bfce78139db4dc3fb06e9349d0"
   },
   "src/L1/StandardValidator.sol:StandardValidator": {
-    "initCodeHash": "0x3329000348d6b8a6f7677e8d48f781afa159386a73a01dc3b1ca2216ec104ba3",
-    "sourceCodeHash": "0x397f43082d0b4af4c0ef36bc3db04df1cf6d9687f1b58d319829d6999eeb419b"
+    "initCodeHash": "0x77b6a2becb96a5a77c71974d79d85492fc0d27f48cd11868a1a80ce393a2446a",
+    "sourceCodeHash": "0xe55ea4c8756d4a18f7fd3fd88a6bc7d6b17c6b3409cc94710bfb572d969807d6"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x0ea921059d71fd19ac9c6e29c05b9724ad584eb27f74231de6df9551e9b13084",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x60a3cc8f819c01541f95e3f9a3e52af8e36ceab47c4bcd6c83db3f755093f0b7",
-    "sourceCodeHash": "0x54fbd97394b12d304ecef63afb5bdb445b449b303cc5906d5b5c5718bb7292dc"
+    "initCodeHash": "0x4c62ab095565b59be3e5dcb385c6a65b489e4d35daf060ae44c6add9b75a3681",
+    "sourceCodeHash": "0x476af3b1f1bd924e3bee8e896d2f4adbd2b24464d80519bc7d2b3284a6128c81"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -35,8 +35,8 @@ import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 /// before and after an upgrade.
 contract StandardValidator is ISemver {
     /// @notice The semantic version of the StandardValidator contract.
-    /// @custom:semver 1.2.0
-    string public constant version = "1.2.0";
+    /// @custom:semver 1.3.0
+    string public constant version = "1.3.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -200,7 +200,7 @@ contract StandardValidator is ISemver {
 
     /// @notice Returns the expected MIPS version.
     function mipsVersion() public pure returns (string memory) {
-        return "1.6.0";
+        return "1.7.0";
     }
 
     /// @notice Returns the expected OptimismMintableERC20Factory version.

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.6.0
-    string public constant version = "1.6.0";
+    /// @custom:semver 1.7.0
+    string public constant version = "1.7.0";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -633,7 +633,16 @@ contract MIPS64 is ISemver {
                 if (!st.featuresForVersion(STATE_VERSION).supportMinimalSysEventFd2) {
                     revert("MIPS64: unimplemented syscall");
                 }
-                v0 = sys.FD_EVENTFD;
+
+                // a0 = initial value, a1 = flags
+                // Validate flags
+                if (a1 & sys.EFD_NONBLOCK == 0) {
+                    // The non-block flag was not set, but we only support non-block requests, so error
+                    v0 = sys.EINVAL;
+                    v1 = sys.SYS_ERROR_SIGNAL;
+                } else {
+                    v0 = sys.FD_EVENTFD;
+                }
             } else {
                 revert("MIPS64: unimplemented syscall");
             }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol
@@ -153,6 +153,11 @@ library MIPS64Syscalls {
     uint64 internal constant VALID_SYS_CLONE_FLAGS =
         CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD;
 
+    // eventfd flags
+    // From:
+    // https://github.com/golang/go/blob/7a2cfb70b01f069c2125adcf7126d7f3376cb8b7/src/internal/runtime/syscall/defs_linux_mips64x.go#L18-L18
+    uint64 internal constant EFD_NONBLOCK = 0x80;
+
     // FYI: https://en.wikibooks.org/wiki/MIPS_Assembly/Register_File
     //      https://refspecs.linuxfoundation.org/elf/mipsabi.pdf
     uint32 internal constant REG_V0 = 2;


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Follow-up on [this discussion](https://github.com/ethereum-optimism/optimism/pull/16341#discussion_r2138185328) from https://github.com/ethereum-optimism/optimism/pull/16341: add constraints on what flags we accept for the `eventfd2` syscall.  Specifically, require that that the `EFD_NONBLOCK` flag is set. 

**Tests**

Update go program test to set various valid and invalid flag combinations.

**Additional context**

 Backport to the v4.0.0 proposal branch: https://github.com/ethereum-optimism/optimism/pull/16386

**Metadata**

Relates to https://github.com/ethereum-optimism/optimism/issues/13447
