### PR TITLE
op-acceptance-tests: more robust sequence window expiry test

### DIFF
--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -9,7 +9,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum/go-ethereum/common"
 )
+
+var emptyHash = common.Hash{}
 
 // L2ELNode wraps a stack.L2ELNode interface for DSL operations
 type L2ELNode struct {
@@ -108,7 +111,7 @@ func (el *L2ELNode) ReorgTriggeredFn(target eth.L2BlockRef, attempts int) CheckF
 					return fmt.Errorf("expected head to reorg %s, but got %s", target, reorged)
 				}
 
-				if target.ParentHash != reorged.ParentHash {
+				if target.ParentHash != reorged.ParentHash && target.ParentHash != emptyHash {
 					return fmt.Errorf("expected parent of target to be the same as the parent of the reorged head, but they are different")
 				}
 


### PR DESCRIPTION
**Description**

This PR is modifying the reorg detection logic within the sequence window expiry acceptance test, so that it tolerates a "not found" error.

It is also adding tolerance for empty `ParentHash` check within the reorg detection logic.

---

`TestSequencingWindowExpiry`, the single test in the `seqwindow` package, passed with `-count=20`.