### PR TITLE
Rename dependencySet RPC

### DIFF
--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -167,7 +167,7 @@ func (n *nodeAPI) RollupConfig(_ context.Context) (*rollup.Config, error) {
 	return n.config, nil
 }
 
-func (n *nodeAPI) DependencySet(_ context.Context) (depset.DependencySet, error) {
+func (n *nodeAPI) DependencySetV1(_ context.Context) (depset.DependencySet, error) {
 	if n.depSet != nil {
 		return n.depSet, nil
 	}

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -184,7 +184,7 @@ func TestDependencySet(t *testing.T) {
 	assert.NoError(t, err)
 
 	var out depset.StaticConfigDependencySet
-	err = client.CallContext(context.Background(), &out, "optimism_dependencySet")
+	err = client.CallContext(context.Background(), &out, "optimism_dependencySetV1")
 	assert.NoError(t, err)
 	assert.Equal(t, depSet, &out)
 }

--- a/op-service/apis/rollup.go
+++ b/op-service/apis/rollup.go
@@ -16,7 +16,7 @@ type RollupConfig interface {
 }
 
 type DependencySetConfig interface {
-	DependencySet(ctx context.Context) (depset.DependencySet, error)
+	DependencySetV1(ctx context.Context) (depset.DependencySet, error)
 }
 
 type RollupSyncStatus interface {

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -53,9 +53,9 @@ func (r *RollupClient) RollupConfig(ctx context.Context) (*rollup.Config, error)
 	return output, err
 }
 
-func (r *RollupClient) DependencySet(ctx context.Context) (depset.DependencySet, error) {
+func (r *RollupClient) DependencySetV1(ctx context.Context) (depset.DependencySet, error) {
 	var output *depset.StaticConfigDependencySet
-	err := r.rpc.CallContext(ctx, &output, "optimism_dependencySet")
+	err := r.rpc.CallContext(ctx, &output, "optimism_dependencySetV1")
 	return output, err
 }
 

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/config.go
@@ -66,7 +66,7 @@ func (c *Config) Start(ctx context.Context, id seqtypes.BuilderID, opts *work.Se
 	if cfg.InteropTime != nil {
 		depSet, err = retry.Do(ctx, 10, retry.Exponential(), func() (depset.DependencySet, error) {
 			opts.Log.Info("Fetching dependency set for block-building")
-			depSet, err := rolCl.DependencySet(ctx)
+			depSet, err := rolCl.DependencySetV1(ctx)
 			if err != nil {
 				opts.Log.Warn("Failed to fetch dependency set", "err", err)
 			}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Renames the `optimism_dependencySet` RPC to match the supervisor one in https://github.com/ethereum-optimism/optimism/pull/16156