### PR TITLE
Reenable op-e2e/faultproofs test in CI that was previously not running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,6 @@ RPC_TEST_PKGS := \
 define DEFAULT_TEST_ENV_VARS
 export ENABLE_KURTOSIS=true && \
 export OP_E2E_CANNON_ENABLED="false" && \
-export OP_E2E_SKIP_SLOW_TEST=true && \
 export OP_E2E_USE_HTTP=true && \
 export ENABLE_ANVIL=true && \
 export PARALLEL=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)

--- a/op-e2e/e2e.go
+++ b/op-e2e/e2e.go
@@ -52,13 +52,6 @@ func UsesCannon(t e2eutils.TestingBase) {
 	}
 }
 
-// IsSlow indicates that the test is too expensive to run on the main CI workflow
-func IsSlow(t e2eutils.TestingBase) {
-	if os.Getenv("OP_E2E_SKIP_SLOW_TEST") == "true" {
-		t.Skip("Skipping slow test")
-	}
-}
-
 type executorInfo struct {
 	total      uint64
 	idx        uint64

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -176,7 +176,11 @@ func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 }
 
 func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.IsSlow)
+	op_e2e.InitParallel(t)
+
+	if testing.Short() {
+		t.Skip("Skipping exhaustive test during short run")
+	}
 
 	testCase := func(t *testing.T, isRootCorrect bool) {
 		ctx := context.Background()


### PR DESCRIPTION
Reenable op-e2e/faultproofs TestChallengerCompleteExhaustiveDisputeGame as long test in CI

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
