### PR TITLE
chore: shift conductor hydrate protocol type to rpc

### DIFF
--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -116,7 +116,7 @@ func (o *Orchestrator) hydrateConductors(node *descriptors.Node, l2Net stack.Ext
 		return
 	}
 
-	endpoint, _, err := o.findProtocolService(conductorService, HTTPProtocol)
+	endpoint, _, err := o.findProtocolService(conductorService, RPCProtocol)
 	require.NoError(err, "failed to find RPC service for conductor")
 
 	conductorClient, err := rpc.DialContext(l2Net.T().Ctx(), endpoint)


### PR DESCRIPTION
Relates to https://github.com/ethereum-optimism/infrastructure-services/pull/450