### PR TITLE
feat(kt-devnet): enable conductor interactions in tests

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -53,7 +53,7 @@ func WithDepSets(depsets map[string]descriptors.DepSet) ServiceFinderOption {
 func NewServiceFinder(services inspect.ServiceMap, opts ...ServiceFinderOption) *ServiceFinder {
 	f := &ServiceFinder{
 		services:        services,
-		nodeServices:    []string{"cl", "el"},
+		nodeServices:    []string{"cl", "el", "cl-builder", "el-builder", "conductor", "mev"},
 		l2ServicePrefix: "op-",
 
 		nodeNames2Index: make(map[string]int),


### PR DESCRIPTION
**Description**

- adjust endpoints detection to add node services (including conductor)
- adjust devstack conductor hydrate code to go through the reverse proxy.

**Tests**

validated using TestConductorLeadershipTransfer against flash-devnet (which contains conductor)

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
