### PR TITLE
Make Devstack Orchestrator Logging Configurable

### DIFF
--- a/op-acceptance-tests/README.md
+++ b/op-acceptance-tests/README.md
@@ -67,6 +67,24 @@ This should allow you to tweak your test in a tight loop while the test subject 
 - `acceptance-tests.yaml`: Defines the validation gates and the suites and tests that should be run for each gate.
 - `justfile`: Contains the commands for running the acceptance tests.
 
+### Logging Configuration
+
+When invoked with `go test`, devstack acceptance tests support configuring logging via CLI flags and environment variables. The following options are available:
+
+* `--log.level LEVEL` (env: `LOG_LEVEL`): Sets the minimum log level. Supported levels: `trace`, `debug`, `info`, `warn`, `error`, `crit`. Default: `trace`.
+* `--log.format FORMAT` (env: `LOG_FORMAT`): Chooses the log output format. Supported formats: `text`, `terminal`, `logfmt`, `json`, `json-pretty`. Default: `text`.
+* `--log.color` (env: `LOG_COLOR`): Enables colored output in terminal mode. Default: `true` if STDOUT is a TTY.
+* `--log.pid` (env: `LOG_PID`): Includes the process ID in each log entry. Default: `false`.
+
+Environment variables override CLI flags. For example:
+```bash
+# Override log level via flag
+go test -v ./op-acceptance-tests/tests/interop/sync/multisupervisor_interop/... -run TestL2CLAheadOfSupervisor -log.format=json | logdy
+
+# Override via env var
+LOG_LEVEL=info go test -v ./op-acceptance-tests/tests/interop/sync/multisupervisor_interop/... -run TestL2CLAheadOfSupervisor
+```
+
 ## Adding New Tests
 
 To add new acceptance tests:

--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -55,18 +55,14 @@ func DoMain(m *testing.M, opts ...stack.CommonOption) {
 			}
 		}()
 
-		// This may be tuned with test setup code, to customize test output
-		logHandler := oplog.NewLogHandler(os.Stdout, oplog.CLIConfig{
-			Level:  log.LevelTrace,
-			Color:  true,
-			Format: oplog.FormatTerminal,
-			Pid:    false,
-		})
+		cfg := oplog.ReadTestCLIConfig()
+		logHandler := oplog.NewLogHandler(os.Stdout, cfg)
 		logHandler = logfilter.WrapFilterHandler(logHandler)
 		logHandler.(logfilter.FilterHandler).Set(logfilter.DefaultMute(logfilter.Level(log.LevelInfo).Show()))
 		logHandler = logfilter.WrapContextHandler(logHandler)
 		// The default can be changed using the WithLogFilters option which replaces this default
 		logger := log.NewLogger(logHandler)
+		oplog.SetGlobalLogHandler(logHandler)
 
 		ctx, otelShutdown, err := telemetry.SetupOpenTelemetry(context.Background())
 		if err != nil {

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -251,4 +252,42 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	}
 	cfg.Pid = ctx.Bool(PidFlagName)
 	return cfg
+}
+
+func ReadTestCLIConfig() CLIConfig {
+	cfg := DefaultCLIConfig()
+	cfg.Level = log.LevelTrace // Overriding this default with a new default for tests
+
+	flLevel := flag.String(LevelFlagName, "info", "Lowest log level that will be output")
+	flFormat := flag.String(FormatFlagName, "text", "Log format: text|terminal|logfmt|json|json-pretty")
+	flColor := flag.Bool(ColorFlagName, true, "Color the log output if in terminal mode: true|false")
+	flPID := flag.Bool(PidFlagName, false, "Show pid in the log")
+
+	flag.Parse()
+
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		*flLevel = v
+	}
+	if v := os.Getenv("LOG_FORMAT"); v != "" {
+		*flFormat = v
+	}
+	if v := os.Getenv("LOG_COLOR"); v != "" {
+		*flColor = v == "true"
+	}
+	if v := os.Getenv("LOG_PID"); v != "" {
+		*flPID = v == "true"
+	}
+
+	lvl, err := LevelFromString(*flLevel)
+	if err != nil {
+		panic(err)
+	}
+	cfg.Level = lvl
+
+	cfg.Format = FormatType(*flFormat)
+	cfg.Color = *flColor
+	cfg.Pid = *flPID
+
+	return cfg
+
 }


### PR DESCRIPTION
This change replaces the hard-coded trace/terminal logger in `op-devstack/presets/orchestrator.go` with a dynamic setup powered by a new `ReadTestCLIConfig()` helper in `op-service/log/cli.go`.

We use the stdlib flags library for this because urfav/cli doesn't work well in a testing context.

- **Log flags/env**: `-log.level`, `-log.format`, `-log.color`, `-log.pid` (with `LOG_*` env var fallbacks)  
- **Orchestrator**: reads the CLI config, and passes it into `NewLogHandler` instead of using fixed trace/terminal settings  
- **Existing behavior** (filtering, context wrapping, defaults) remains unchanged but is now tunable at runtime.

Example Usage:
```
go test -v ./op-acceptance-tests/tests/interop/sync/multisupervisor_interop/... -run TestL2CLAheadOfSupervisor -log.format=json | logdy
```