### PR TITLE
op-devstack: Fix issue with duplicate cannon config files

### DIFF
--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -101,31 +101,37 @@ func WithFactoryAddress(addr common.Address) Option {
 	}
 }
 
-func WithCannon(rollupCfgs []*rollup.Config, l2Geneses []*core.Genesis, prestateVariant PrestateVariant) Option {
+func WithCannonConfig(rollupCfgs []*rollup.Config, l2Geneses []*core.Genesis, prestateVariant PrestateVariant) Option {
+	return func(c *config.Config) error {
+		return applyCannonConfig(c, rollupCfgs, l2Geneses, prestateVariant)
+	}
+}
+
+func WithCannonTraceType() Option {
 	return func(c *config.Config) error {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypeCannon)
-		return applyCannonConfig(c, rollupCfgs, l2Geneses, prestateVariant)
+		return nil
 	}
 }
 
-func WithPermissioned(rollupCfgs []*rollup.Config, l2Geneses []*core.Genesis, prestateVariant PrestateVariant) Option {
+func WithPermissionedTraceType() Option {
 	return func(c *config.Config) error {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypePermissioned)
-		return applyCannonConfig(c, rollupCfgs, l2Geneses, prestateVariant)
+		return nil
 	}
 }
 
-func WithSuperCannon(rollupCfgs []*rollup.Config, l2Geneses []*core.Genesis, prestateVariant PrestateVariant) Option {
+func WithSuperCannonTraceType() Option {
 	return func(c *config.Config) error {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypeSuperCannon)
-		return applyCannonConfig(c, rollupCfgs, l2Geneses, prestateVariant)
+		return nil
 	}
 }
 
-func WithSuperPermissioned(rollupCfgs []*rollup.Config, l2Geneses []*core.Genesis, prestateVariant PrestateVariant) Option {
+func WithSuperPermissionedTraceType() Option {
 	return func(c *config.Config) error {
 		c.TraceTypes = append(c.TraceTypes, types.TraceTypeSuperPermissioned)
-		return applyCannonConfig(c, rollupCfgs, l2Geneses, prestateVariant)
+		return nil
 	}
 }
 

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -122,8 +122,9 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 			shared.WithFactoryAddress(disputeGameFactoryAddr),
 			shared.WithPrivKey(challengerSecret),
 			shared.WithDepset(cluster.DepSet()),
-			shared.WithSuperCannon(rollupCfgs, l2Geneses, prestateVariant),
-			shared.WithSuperPermissioned(rollupCfgs, l2Geneses, prestateVariant),
+			shared.WithCannonConfig(rollupCfgs, l2Geneses, prestateVariant),
+			shared.WithSuperCannonTraceType(),
+			shared.WithSuperPermissionedTraceType(),
 		)
 		require.NoError(err, "Failed to create interop challenger config")
 	} else {
@@ -145,8 +146,9 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		cfg, err = shared.NewPreInteropChallengerConfig(dir, l1EL.userRPC, l1CL.beaconHTTPAddr, l2CL.userRPC, l2EL.userRPC,
 			shared.WithFactoryAddress(disputeGameFactoryAddr),
 			shared.WithPrivKey(challengerSecret),
-			shared.WithCannon(rollupCfgs, l2Geneses, prestateVariant),
-			shared.WithPermissioned(rollupCfgs, l2Geneses, prestateVariant),
+			shared.WithCannonConfig(rollupCfgs, l2Geneses, prestateVariant),
+			shared.WithCannonTraceType(),
+			shared.WithPermissionedTraceType(),
 			shared.WithFastGames(),
 		)
 		require.NoError(err, "Failed to create pre-interop challenger config")

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -120,15 +120,24 @@ func handleOptError(t *testing.T, opt shared.Option) Option {
 	}
 }
 func WithCannon(t *testing.T, system System) Option {
-	return handleOptError(t, shared.WithCannon(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
+	return func(c *config.Config) {
+		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
+		handleOptError(t, shared.WithCannonTraceType())
+	}
 }
 
 func WithPermissioned(t *testing.T, system System) Option {
-	return handleOptError(t, shared.WithPermissioned(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
+	return func(c *config.Config) {
+		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
+		handleOptError(t, shared.WithPermissionedTraceType())
+	}
 }
 
 func WithSuperCannon(t *testing.T, system System) Option {
-	return handleOptError(t, shared.WithSuperCannon(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
+	return func(c *config.Config) {
+		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
+		handleOptError(t, shared.WithSuperCannonTraceType())
+	}
 }
 
 func WithAlphabet() Option {

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -121,22 +121,22 @@ func handleOptError(t *testing.T, opt shared.Option) Option {
 }
 func WithCannon(t *testing.T, system System) Option {
 	return func(c *config.Config) {
-		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
-		handleOptError(t, shared.WithCannonTraceType())
+		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))(c)
+		handleOptError(t, shared.WithCannonTraceType())(c)
 	}
 }
 
 func WithPermissioned(t *testing.T, system System) Option {
 	return func(c *config.Config) {
-		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
-		handleOptError(t, shared.WithPermissionedTraceType())
+		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))(c)
+		handleOptError(t, shared.WithPermissionedTraceType())(c)
 	}
 }
 
 func WithSuperCannon(t *testing.T, system System) Option {
 	return func(c *config.Config) {
-		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))
-		handleOptError(t, shared.WithSuperCannonTraceType())
+		handleOptError(t, shared.WithCannonConfig(system.RollupCfgs(), system.L2Geneses(), system.PrestateVariant()))(c)
+		handleOptError(t, shared.WithSuperCannonTraceType())(c)
 	}
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The op-devstack was configuring the op-challenger with duplicate cannon config files causing errors like:
```
ERROR[06-12|15:28:58.409] Failed to schedule game updates          err="failed to create job for game 0xd5C89382242a4510F9873D081FfF78a0A8797dCC: failed to create game player: failed to create trace accessor: failed to load rollup configs: duplicate chain: 902" scope=/pkg kind=L2Challenger  id=L2Challenger-chainA
```

This PR breaks up challenger config options (separating trace type from common cannon configuration) so that we are no longer duplicating cannon config files.  

**Metadata**

Relates to: https://github.com/ethereum-optimism/optimism/issues/15948
