### PR TITLE
op-proposer: add `admin_propose` rpc method

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -452,7 +452,10 @@ func (l *L2OutputSubmitter) loop() {
 				continue
 			}
 
-			l.proposeOutput(ctx, proposal)
+			if err := l.proposeOutput(ctx, proposal); err != nil {
+				// Error already logged inside proposeOutput
+				continue
+			}
 		case <-l.done:
 			return
 		}
@@ -478,7 +481,7 @@ func (l *L2OutputSubmitter) waitNodeSync() error {
 	})
 }
 
-func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Proposal) {
+func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Proposal) error {
 	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
@@ -493,13 +496,14 @@ func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Pro
 			logCtx = append(logCtx, "l1head", output.Legacy.HeadL1.Number)
 		}
 		l.Log.Error("Failed to send proposal transaction", logCtx...)
-		return
+		return err
 	}
 	l.Metr.RecordL2Proposal(output.SequenceNum)
 	if output.Legacy.BlockRef != (eth.L2BlockRef{}) {
 		// Record legacy metrics when available
 		l.Metr.RecordL2BlocksProposed(output.Legacy.BlockRef)
 	}
+	return nil
 }
 
 // ProposeOutput fetches and submits the output for the specified block number.
@@ -521,14 +525,5 @@ func (l *L2OutputSubmitter) ProposeOutput(ctx context.Context, block *uint64) er
 		return err
 	}
 
-	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer cancel()
-	if err := l.sendTransaction(cCtx, output); err != nil {
-		return err
-	}
-	l.Metr.RecordL2Proposal(output.SequenceNum)
-	if output.Legacy.BlockRef != (eth.L2BlockRef{}) {
-		l.Metr.RecordL2BlocksProposed(output.Legacy.BlockRef)
-	}
-	return nil
+	return l.proposeOutput(ctx, output)
 }

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/bindings"
 	"github.com/ethereum-optimism/optimism/op-proposer/contracts"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
+	driverrpc "github.com/ethereum-optimism/optimism/op-proposer/proposer/rpc"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -506,9 +507,9 @@ func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Pro
 	return nil
 }
 
-// ProposeOutput fetches and submits the output for the specified block number.
+// Propose fetches and submits the output for the specified block number.
 // If no block number is provided, the latest synced block is proposed.
-func (l *L2OutputSubmitter) ProposeOutput(ctx context.Context, block *uint64) error {
+func (l *L2OutputSubmitter) Propose(ctx context.Context, block *uint64) error {
 	var blockNum uint64
 	if block == nil {
 		num, err := l.FetchCurrentBlockNumber(ctx)
@@ -527,3 +528,5 @@ func (l *L2OutputSubmitter) ProposeOutput(ctx context.Context, block *uint64) er
 
 	return l.proposeOutput(ctx, output)
 }
+
+var _ driverrpc.ProposerDriver = (*L2OutputSubmitter)(nil)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -501,3 +501,34 @@ func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Pro
 		l.Metr.RecordL2BlocksProposed(output.Legacy.BlockRef)
 	}
 }
+
+// ProposeOutput fetches and submits the output for the specified block number.
+// If no block number is provided, the latest synced block is proposed.
+func (l *L2OutputSubmitter) ProposeOutput(ctx context.Context, block *uint64) error {
+	var blockNum uint64
+	if block == nil {
+		num, err := l.FetchCurrentBlockNumber(ctx)
+		if err != nil {
+			return err
+		}
+		blockNum = num
+	} else {
+		blockNum = *block
+	}
+
+	output, err := l.FetchOutput(ctx, blockNum)
+	if err != nil {
+		return err
+	}
+
+	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	if err := l.sendTransaction(cCtx, output); err != nil {
+		return err
+	}
+	l.Metr.RecordL2Proposal(output.SequenceNum)
+	if output.Legacy.BlockRef != (eth.L2BlockRef{}) {
+		l.Metr.RecordL2BlocksProposed(output.Legacy.BlockRef)
+	}
+	return nil
+}

--- a/op-proposer/proposer/driver_test.go
+++ b/op-proposer/proposer/driver_test.go
@@ -181,7 +181,7 @@ func TestL2OutputSubmitter_OutputRetry(t *testing.T) {
 	}
 }
 
-func TestL2OutputSubmitter_ProposeOutput(t *testing.T) {
+func TestL2OutputSubmitter_Propose(t *testing.T) {
 	ps, ep, _, _, txmgr, logs := setup(t, "L2OO")
 
 	blockNum := uint64(10)
@@ -195,7 +195,7 @@ func TestL2OutputSubmitter_ProposeOutput(t *testing.T) {
 		},
 	}, nil)
 
-	err := ps.ProposeOutput(context.Background(), &blockNum)
+	err := ps.Propose(context.Background(), &blockNum)
 	require.NoError(t, err)
 
 	ep.rollupClient.AssertExpectations(t)

--- a/op-proposer/proposer/driver_test.go
+++ b/op-proposer/proposer/driver_test.go
@@ -180,3 +180,26 @@ func TestL2OutputSubmitter_OutputRetry(t *testing.T) {
 		})
 	}
 }
+
+func TestL2OutputSubmitter_ProposeOutput(t *testing.T) {
+	ps, ep, _, _, txmgr, logs := setup(t, "L2OO")
+
+	blockNum := uint64(10)
+	ep.rollupClient.ExpectOutputAtBlock(blockNum, &eth.OutputResponse{
+		Version:  eth.OutputVersionV0,
+		BlockRef: eth.L2BlockRef{Number: blockNum},
+		Status: &eth.SyncStatus{
+			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{}},
+			FinalizedL2: eth.L2BlockRef{Number: blockNum},
+			HeadL1:      eth.L1BlockRef{Number: 0},
+		},
+	}, nil)
+
+	err := ps.ProposeOutput(context.Background(), &blockNum)
+	require.NoError(t, err)
+
+	ep.rollupClient.AssertExpectations(t)
+	txmgr.AssertExpectations(t)
+
+	require.NotNil(t, logs.FindLog(testlog.NewMessageFilter("Proposer tx successfully published")))
+}

--- a/op-proposer/proposer/rpc/api.go
+++ b/op-proposer/proposer/rpc/api.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"context"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
@@ -46,11 +45,6 @@ func (a *adminAPI) StopProposer(ctx context.Context) error {
 	return a.b.StopL2OutputSubmitting()
 }
 
-func (a *adminAPI) Propose(ctx context.Context, block *hexutil.Uint64) error {
-	var blkPtr *uint64
-	if block != nil {
-		b := uint64(*block)
-		blkPtr = &b
-	}
-	return a.b.Propose(ctx, blkPtr)
+func (a *adminAPI) Propose(ctx context.Context, block *uint64) error {
+	return a.b.Propose(ctx, block)
 }

--- a/op-proposer/proposer/rpc/api.go
+++ b/op-proposer/proposer/rpc/api.go
@@ -14,7 +14,7 @@ import (
 type ProposerDriver interface {
 	StartL2OutputSubmitting() error
 	StopL2OutputSubmitting() error
-	ProposeOutput(ctx context.Context, block *uint64) error
+	Propose(ctx context.Context, block *uint64) error
 }
 
 type adminAPI struct {
@@ -46,11 +46,11 @@ func (a *adminAPI) StopProposer(ctx context.Context) error {
 	return a.b.StopL2OutputSubmitting()
 }
 
-func (a *adminAPI) ProposeOutput(ctx context.Context, block *hexutil.Uint64) error {
+func (a *adminAPI) Propose(ctx context.Context, block *hexutil.Uint64) error {
 	var blkPtr *uint64
 	if block != nil {
 		b := uint64(*block)
 		blkPtr = &b
 	}
-	return a.b.ProposeOutput(ctx, blkPtr)
+	return a.b.Propose(ctx, blkPtr)
 }

--- a/op-proposer/proposer/rpc/api.go
+++ b/op-proposer/proposer/rpc/api.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
@@ -13,6 +14,7 @@ import (
 type ProposerDriver interface {
 	StartL2OutputSubmitting() error
 	StopL2OutputSubmitting() error
+	ProposeOutput(ctx context.Context, block *uint64) error
 }
 
 type adminAPI struct {
@@ -42,4 +44,13 @@ func (a *adminAPI) StartProposer(_ context.Context) error {
 
 func (a *adminAPI) StopProposer(ctx context.Context) error {
 	return a.b.StopL2OutputSubmitting()
+}
+
+func (a *adminAPI) ProposeOutput(ctx context.Context, block *hexutil.Uint64) error {
+	var blkPtr *uint64
+	if block != nil {
+		b := uint64(*block)
+		blkPtr = &b
+	}
+	return a.b.ProposeOutput(ctx, blkPtr)
 }

--- a/op-proposer/proposer/rpc/api.go
+++ b/op-proposer/proposer/rpc/api.go
@@ -13,7 +13,7 @@ import (
 type ProposerDriver interface {
 	StartL2OutputSubmitting() error
 	StopL2OutputSubmitting() error
-	Propose(ctx context.Context, block *uint64) error
+	Propose(ctx context.Context, sequenceNumber *uint64) error
 }
 
 type adminAPI struct {
@@ -45,6 +45,6 @@ func (a *adminAPI) StopProposer(ctx context.Context) error {
 	return a.b.StopL2OutputSubmitting()
 }
 
-func (a *adminAPI) Propose(ctx context.Context, block *uint64) error {
-	return a.b.Propose(ctx, block)
+func (a *adminAPI) Propose(ctx context.Context, sequenceNumber *uint64) error {
+	return a.b.Propose(ctx, sequenceNumber)
 }

--- a/op-service/apis/proposer.go
+++ b/op-service/apis/proposer.go
@@ -9,8 +9,8 @@ import (
 type ProposerActivity interface {
 	StartProposer(ctx context.Context) error
 	StopProposer(ctx context.Context) error
-	// ProposeOutput submits the output for the given block number. If no block is provided, the latest synced block is used.
-	ProposeOutput(ctx context.Context, blockNum *hexutil.Uint64) error
+	// Propose submits the output for the given block number. If no block is provided, the latest synced block is used.
+	Propose(ctx context.Context, blockNum *hexutil.Uint64) error
 }
 
 type ProposerAdminServer interface {

--- a/op-service/apis/proposer.go
+++ b/op-service/apis/proposer.go
@@ -1,10 +1,16 @@
 package apis
 
-import "context"
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
 
 type ProposerActivity interface {
 	StartProposer(ctx context.Context) error
 	StopProposer(ctx context.Context) error
+	// ProposeOutput submits the output for the given block number. If no block is provided, the latest synced block is used.
+	ProposeOutput(ctx context.Context, blockNum *hexutil.Uint64) error
 }
 
 type ProposerAdminServer interface {

--- a/op-service/apis/proposer.go
+++ b/op-service/apis/proposer.go
@@ -2,15 +2,13 @@ package apis
 
 import (
 	"context"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type ProposerActivity interface {
 	StartProposer(ctx context.Context) error
 	StopProposer(ctx context.Context) error
 	// Propose submits the output for the given block number. If no block is provided, the latest synced block is used.
-	Propose(ctx context.Context, blockNum *hexutil.Uint64) error
+	Propose(ctx context.Context, blockNum *uint64) error
 }
 
 type ProposerAdminServer interface {

--- a/op-service/sources/proposer_admin_client.go
+++ b/op-service/sources/proposer_admin_client.go
@@ -1,0 +1,35 @@
+package sources
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+)
+
+type ProposerAdminClient struct {
+	client client.RPC
+}
+
+var _ apis.ProposerActivity = (*ProposerAdminClient)(nil)
+
+func NewProposerAdminClient(client client.RPC) *ProposerAdminClient {
+	return &ProposerAdminClient{client: client}
+}
+
+func (cl *ProposerAdminClient) StartProposer(ctx context.Context) error {
+	return cl.client.CallContext(ctx, nil, "admin_startProposer")
+}
+
+func (cl *ProposerAdminClient) StopProposer(ctx context.Context) error {
+	return cl.client.CallContext(ctx, nil, "admin_stopProposer")
+}
+
+func (cl *ProposerAdminClient) Propose(ctx context.Context, blockNum *hexutil.Uint64) error {
+	if blockNum != nil {
+		return cl.client.CallContext(ctx, nil, "admin_propose", blockNum)
+	}
+	return cl.client.CallContext(ctx, nil, "admin_propose")
+}

--- a/op-service/sources/proposer_admin_client.go
+++ b/op-service/sources/proposer_admin_client.go
@@ -27,9 +27,10 @@ func (cl *ProposerAdminClient) StopProposer(ctx context.Context) error {
 	return cl.client.CallContext(ctx, nil, "admin_stopProposer")
 }
 
-func (cl *ProposerAdminClient) Propose(ctx context.Context, blockNum *hexutil.Uint64) error {
+func (cl *ProposerAdminClient) Propose(ctx context.Context, blockNum *uint64) error {
 	if blockNum != nil {
-		return cl.client.CallContext(ctx, nil, "admin_propose", blockNum)
+		num := hexutil.Uint64(*blockNum)
+		return cl.client.CallContext(ctx, nil, "admin_propose", num)
 	}
 	return cl.client.CallContext(ctx, nil, "admin_propose")
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes https://github.com/ethereum-optimism/optimism/issues/15835

- add `admin_propose` to proposer's RPC API
- implement driver method to submit outputs for a given block
- expose the RPC in `apis` and integrate tests

Slight hack with the logging but optimizing for smaller diff

