### PR TITLE
rollup: Set the interop time when loading from superchain-registry

### DIFF
--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -91,6 +91,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		PectraBlobScheduleTime: hardforks.PectraBlobScheduleTime,
 		IsthmusTime:            hardforks.IsthmusTime,
 		JovianTime:             hardforks.JovianTime,
+		InteropTime:            hardforks.InteropTime,
 		BatchInboxAddress:      chConfig.BatchInboxAddr,
 		DepositContractAddress: *addrs.OptimismPortalProxy,
 		L1SystemConfigAddress:  *addrs.SystemConfigProxy,

--- a/op-program/host/subcmds/configs_cmd.go
+++ b/op-program/host/subcmds/configs_cmd.go
@@ -101,6 +101,13 @@ func listChain(chainID eth.ChainID) error {
 	if err != nil {
 		return err
 	}
+	if cfg.InteropTime != nil {
+		// If interop is scheduled, check the dependency set is available
+		_, err = chainconfig.DependencySetByChainID(chainID)
+		if err != nil {
+			return err
+		}
+	}
 	description := cfg.Description(chaincfg.L2ChainIDToNetworkDisplayName)
 	fmt.Println(description)
 	return nil


### PR DESCRIPTION
**Description**
Set the interop time when creating a rollup.Config from superchain-registry.

Also update `op-program configs` to check dependency set is available when listing supported configs.
