### PR TITLE
ci: Increase resource class for upgrade tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -863,7 +863,7 @@ jobs:
         type: string
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: large
+    resource_class: xlarge
     steps:
       - utils/checkout-with-mise
       - attach_workspace: { at: "." }


### PR DESCRIPTION
**Description**

Increase resource class for upgrade tests. Task is being OOM killed, e.g. https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/93297/workflows/023b1246-5c60-4970-9604-a81053106a0f/jobs/3634760
