### PR TITLE
rollup: Add test that all hardforks from superchain-registry are set on the rollup.Config

### DIFF
--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -56,8 +56,6 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		}
 	}
 
-	hardforks := chConfig.Hardforks
-	regolithTime := uint64(0)
 	cfg := &Config{
 		Genesis: Genesis{
 			L1: eth.BlockID{
@@ -81,24 +79,29 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		ChannelTimeoutBedrock:  300,
 		L1ChainID:              new(big.Int).SetUint64(superConfig.L1.ChainID),
 		L2ChainID:              new(big.Int).SetUint64(chConfig.ChainID),
-		RegolithTime:           &regolithTime,
-		CanyonTime:             hardforks.CanyonTime,
-		DeltaTime:              hardforks.DeltaTime,
-		EcotoneTime:            hardforks.EcotoneTime,
-		FjordTime:              hardforks.FjordTime,
-		GraniteTime:            hardforks.GraniteTime,
-		HoloceneTime:           hardforks.HoloceneTime,
-		PectraBlobScheduleTime: hardforks.PectraBlobScheduleTime,
-		IsthmusTime:            hardforks.IsthmusTime,
-		JovianTime:             hardforks.JovianTime,
-		InteropTime:            hardforks.InteropTime,
 		BatchInboxAddress:      chConfig.BatchInboxAddr,
 		DepositContractAddress: *addrs.OptimismPortalProxy,
 		L1SystemConfigAddress:  *addrs.SystemConfigProxy,
 		AltDAConfig:            altDA,
 		ChainOpConfig:          chOpConfig,
 	}
+	applyHardforks(cfg, chConfig.Hardforks)
 
 	cfg.ProtocolVersionsAddress = superConfig.ProtocolVersionsAddr
 	return cfg, nil
+}
+
+func applyHardforks(cfg *Config, hardforks superchain.HardforkConfig) {
+	regolithTime := uint64(0)
+	cfg.RegolithTime = &regolithTime
+	cfg.CanyonTime = hardforks.CanyonTime
+	cfg.DeltaTime = hardforks.DeltaTime
+	cfg.EcotoneTime = hardforks.EcotoneTime
+	cfg.FjordTime = hardforks.FjordTime
+	cfg.GraniteTime = hardforks.GraniteTime
+	cfg.HoloceneTime = hardforks.HoloceneTime
+	cfg.PectraBlobScheduleTime = hardforks.PectraBlobScheduleTime
+	cfg.IsthmusTime = hardforks.IsthmusTime
+	cfg.InteropTime = hardforks.InteropTime
+	cfg.JovianTime = hardforks.JovianTime
 }

--- a/op-node/rollup/superchain_test.go
+++ b/op-node/rollup/superchain_test.go
@@ -1,0 +1,46 @@
+package rollup
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/superchain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyHardforks_NoForks(t *testing.T) {
+	cfg := Config{}
+	hardforks := superchain.HardforkConfig{}
+	applyHardforks(&cfg, hardforks)
+	requireAllHardforksSetCorrectly(t, cfg, hardforks)
+}
+
+func TestApplyHardforks(t *testing.T) {
+	cfg := Config{}
+	hardforkCfg := superchain.HardforkConfig{}
+
+	// Set all hardforks
+	hardforkVal := reflect.ValueOf(&hardforkCfg).Elem()
+	for i := 0; i < hardforkVal.NumField(); i++ {
+		val := uint64(i + 10) // +10 just so they're all arbitrary non-zero values
+		hardforkVal.Field(i).Set(reflect.ValueOf(&val))
+	}
+
+	applyHardforks(&cfg, hardforkCfg)
+
+	requireAllHardforksSetCorrectly(t, cfg, hardforkCfg)
+}
+
+func requireAllHardforksSetCorrectly(t *testing.T, cfg Config, hardforkCfg superchain.HardforkConfig) {
+	hardforkType := reflect.TypeOf(hardforkCfg)
+	hardforkVal := reflect.ValueOf(hardforkCfg)
+	cfgVal := reflect.ValueOf(&cfg).Elem()
+	for i := 0; i < hardforkVal.NumField(); i++ {
+		hardforkField := hardforkType.Field(i)
+		cfgField := cfgVal.FieldByName(hardforkField.Name)
+		require.Equalf(t, hardforkVal.Field(i).Elem(), cfgField.Elem(), "missing hard fork field %v", hardforkField.Name)
+	}
+	// Regolith is always activated at genesis
+	require.NotNil(t, cfg.RegolithTime)
+	require.Zero(t, *cfg.RegolithTime)
+}


### PR DESCRIPTION
**Description**

Add a test to check that all hard forks from the superchain-registry are correctly set on the rollup.Config. Will catch cases where we add a new hard fork but forget to add it here.

