### PR TITLE
op-batcher: remove `preferLocalSafeL2` flag

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -109,9 +109,6 @@ type CLIConfig struct {
 	// ThrottleAlwaysBlockSize is the total per-block DA limit to always imposing on block building.
 	ThrottleAlwaysBlockSize uint64
 
-	// PreferLocalSafeL2 triggers the batcher to load blocks from the sequencer based on the LocalSafeL2 SyncStatus field (instead of the SafeL2 field).
-	PreferLocalSafeL2 bool
-
 	// TestUseMaxTxSizeForBlobs allows to set the blob size with MaxL1TxSize.
 	// Should only be used for testing purposes.
 	TestUseMaxTxSizeForBlobs bool
@@ -220,7 +217,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ThrottleTxSize:                ctx.Uint64(flags.ThrottleTxSizeFlag.Name),
 		ThrottleBlockSize:             ctx.Uint64(flags.ThrottleBlockSizeFlag.Name),
 		ThrottleAlwaysBlockSize:       ctx.Uint64(flags.ThrottleAlwaysBlockSizeFlag.Name),
-		PreferLocalSafeL2:             ctx.Bool(flags.PreferLocalSafeL2Flag.Name),
 		AdditionalThrottlingEndpoints: ctx.StringSlice(flags.AdditionalThrottlingEndpointsFlag.Name),
 	}
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -424,7 +424,7 @@ func (l *BatchSubmitter) syncAndPrune(syncStatus *eth.SyncStatus) *inclusiveBloc
 	defer l.channelMgrMutex.Unlock()
 
 	// Decide appropriate actions
-	syncActions, outOfSync := computeSyncActions(*syncStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log, l.Config.PreferLocalSafeL2)
+	syncActions, outOfSync := computeSyncActions(*syncStatus, l.prevCurrentL1, l.channelMgr.blocks, l.channelMgr.channelQueue, l.Log)
 
 	if outOfSync {
 		// If the sequencer is out of sync

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -49,8 +49,6 @@ type BatcherConfig struct {
 	ThrottleThreshold, ThrottleTxSize          uint64
 	ThrottleBlockSize, ThrottleAlwaysBlockSize uint64
 	ThrottlingEndpoints                        []string
-
-	PreferLocalSafeL2 bool
 }
 
 // BatcherService represents a full batch-submitter instance and its resources,
@@ -116,8 +114,6 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 
 	// Combine the L2EthRpc and RollupRpc into a single list of endpoints for throttling.
 	bs.ThrottlingEndpoints = slices.Union(cfg.L2EthRpc, cfg.AdditionalThrottlingEndpoints)
-
-	bs.PreferLocalSafeL2 = cfg.PreferLocalSafeL2
 
 	if err := bs.initRPCClients(ctx, cfg); err != nil {
 		return err

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -68,7 +68,7 @@ func computeSyncActions[T channelStatuser](
 		"syncStatus.unsafeL2", newSyncStatus.UnsafeL2.TerminalString(),
 	)
 
-	// We do _not_ want to use the SafeL2 (aka Cross Safe) field.
+	// We do _not_ want to use the SafeL2 (aka Cross Safe) field,
 	// since that introduces extra dependencies post interop.
 	safeL2 := newSyncStatus.LocalSafeL2
 

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -58,7 +58,6 @@ func computeSyncActions[T channelStatuser](
 	blocks queue.Queue[*types.Block],
 	channels []T,
 	l log.Logger,
-	preferLocalSafeL2 bool,
 ) (syncActions, bool) {
 
 	m := l.With(
@@ -69,14 +68,8 @@ func computeSyncActions[T channelStatuser](
 		"syncStatus.unsafeL2", newSyncStatus.UnsafeL2.TerminalString(),
 	)
 
-	safeL2 := newSyncStatus.SafeL2
-	if preferLocalSafeL2 {
-		// This is preferred when running interop, but not yet enabled by default.
-		safeL2 = newSyncStatus.LocalSafeL2
-	}
-
 	// PART 1: Initial checks on the sync status (on fields which should never be empty)
-	if isZero(safeL2) ||
+	if isZero(newSyncStatus.LocalSafeL2) ||
 		isZero(newSyncStatus.UnsafeL2) ||
 		isZero(newSyncStatus.HeadL1) {
 		m.Warn("empty BlockRef in sync status")
@@ -90,8 +83,8 @@ func computeSyncActions[T channelStatuser](
 	}
 
 	var allUnsafeBlocks *inclusiveBlockRange
-	if newSyncStatus.UnsafeL2.Number > safeL2.Number {
-		allUnsafeBlocks = &inclusiveBlockRange{safeL2.Number + 1, newSyncStatus.UnsafeL2.Number}
+	if newSyncStatus.UnsafeL2.Number > newSyncStatus.LocalSafeL2.Number {
+		allUnsafeBlocks = &inclusiveBlockRange{newSyncStatus.LocalSafeL2.Number + 1, newSyncStatus.UnsafeL2.Number}
 	}
 
 	// PART 2: checks involving only the oldest block in the state
@@ -110,12 +103,12 @@ func computeSyncActions[T channelStatuser](
 	// and we need to start over, loading all unsafe blocks
 	// from the sequencer.
 	startAfresh := syncActions{
-		clearState:   &safeL2.L1Origin,
+		clearState:   &newSyncStatus.LocalSafeL2.L1Origin,
 		blocksToLoad: allUnsafeBlocks,
 	}
 
 	oldestBlockInStateNum := oldestBlockInState.NumberU64()
-	nextSafeBlockNum := safeL2.Number + 1
+	nextSafeBlockNum := newSyncStatus.LocalSafeL2.Number + 1
 
 	if nextSafeBlockNum < oldestBlockInStateNum {
 		m.Warn("next safe block is below oldest block in state",
@@ -141,7 +134,7 @@ func computeSyncActions[T channelStatuser](
 		return startAfresh, false
 	}
 
-	if numBlocksToDequeue > 0 && blocks[numBlocksToDequeue-1].Hash() != safeL2.Hash {
+	if numBlocksToDequeue > 0 && blocks[numBlocksToDequeue-1].Hash() != newSyncStatus.LocalSafeL2.Hash {
 		m.Warn("safe chain reorg, clearing channel manager state",
 			"syncActions", startAfresh.TerminalString(),
 			"existingBlock", eth.ToBlockID(blocks[numBlocksToDequeue-1]).TerminalString())
@@ -153,7 +146,7 @@ func computeSyncActions[T channelStatuser](
 		if ch.isFullySubmitted() &&
 			!ch.isTimedOut() &&
 			newSyncStatus.CurrentL1.Number > ch.MaxInclusionBlock() &&
-			safeL2.Number < ch.LatestL2().Number {
+			newSyncStatus.LocalSafeL2.Number < ch.LatestL2().Number {
 			// Safe head did not make the expected progress
 			// for a fully submitted channel. This indicates
 			// that the derivation pipeline may have stalled
@@ -168,7 +161,7 @@ func computeSyncActions[T channelStatuser](
 	// PART 5: happy path
 	numChannelsToPrune := 0
 	for _, ch := range channels {
-		if ch.LatestL2().Number > safeL2.Number {
+		if ch.LatestL2().Number > newSyncStatus.LocalSafeL2.Number {
 			// If the channel has blocks which are not yet safe
 			// we do not want to prune it.
 			break

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -68,8 +68,12 @@ func computeSyncActions[T channelStatuser](
 		"syncStatus.unsafeL2", newSyncStatus.UnsafeL2.TerminalString(),
 	)
 
+	// We do _not_ want to use the SafeL2 (aka Cross Safe) field.
+	// since that introduces extra dependencies post interop.
+	safeL2 := newSyncStatus.LocalSafeL2
+
 	// PART 1: Initial checks on the sync status (on fields which should never be empty)
-	if isZero(newSyncStatus.LocalSafeL2) ||
+	if isZero(safeL2) ||
 		isZero(newSyncStatus.UnsafeL2) ||
 		isZero(newSyncStatus.HeadL1) {
 		m.Warn("empty BlockRef in sync status")
@@ -83,8 +87,8 @@ func computeSyncActions[T channelStatuser](
 	}
 
 	var allUnsafeBlocks *inclusiveBlockRange
-	if newSyncStatus.UnsafeL2.Number > newSyncStatus.LocalSafeL2.Number {
-		allUnsafeBlocks = &inclusiveBlockRange{newSyncStatus.LocalSafeL2.Number + 1, newSyncStatus.UnsafeL2.Number}
+	if newSyncStatus.UnsafeL2.Number > safeL2.Number {
+		allUnsafeBlocks = &inclusiveBlockRange{safeL2.Number + 1, newSyncStatus.UnsafeL2.Number}
 	}
 
 	// PART 2: checks involving only the oldest block in the state
@@ -103,12 +107,12 @@ func computeSyncActions[T channelStatuser](
 	// and we need to start over, loading all unsafe blocks
 	// from the sequencer.
 	startAfresh := syncActions{
-		clearState:   &newSyncStatus.LocalSafeL2.L1Origin,
+		clearState:   &safeL2.L1Origin,
 		blocksToLoad: allUnsafeBlocks,
 	}
 
 	oldestBlockInStateNum := oldestBlockInState.NumberU64()
-	nextSafeBlockNum := newSyncStatus.LocalSafeL2.Number + 1
+	nextSafeBlockNum := safeL2.Number + 1
 
 	if nextSafeBlockNum < oldestBlockInStateNum {
 		m.Warn("next safe block is below oldest block in state",
@@ -134,7 +138,7 @@ func computeSyncActions[T channelStatuser](
 		return startAfresh, false
 	}
 
-	if numBlocksToDequeue > 0 && blocks[numBlocksToDequeue-1].Hash() != newSyncStatus.LocalSafeL2.Hash {
+	if numBlocksToDequeue > 0 && blocks[numBlocksToDequeue-1].Hash() != safeL2.Hash {
 		m.Warn("safe chain reorg, clearing channel manager state",
 			"syncActions", startAfresh.TerminalString(),
 			"existingBlock", eth.ToBlockID(blocks[numBlocksToDequeue-1]).TerminalString())
@@ -146,7 +150,7 @@ func computeSyncActions[T channelStatuser](
 		if ch.isFullySubmitted() &&
 			!ch.isTimedOut() &&
 			newSyncStatus.CurrentL1.Number > ch.MaxInclusionBlock() &&
-			newSyncStatus.LocalSafeL2.Number < ch.LatestL2().Number {
+			safeL2.Number < ch.LatestL2().Number {
 			// Safe head did not make the expected progress
 			// for a fully submitted channel. This indicates
 			// that the derivation pipeline may have stalled
@@ -161,7 +165,7 @@ func computeSyncActions[T channelStatuser](
 	// PART 5: happy path
 	numChannelsToPrune := 0
 	for _, ch := range channels {
-		if ch.LatestL2().Number > newSyncStatus.LocalSafeL2.Number {
+		if ch.LatestL2().Number > safeL2.Number {
 			// If the channel has blocks which are not yet safe
 			// we do not want to prune it.
 			break

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -69,7 +69,6 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		expected             syncActions
 		expectedSeqOutOfSync bool
 		expectedLogs         []string
-		preferLocalSafeL2    bool
 	}
 
 	testCases := []TestCase{
@@ -84,10 +83,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen when the sequencer restarts or is switched
 			// to a backup sequencer:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 2},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:      eth.BlockRef{Number: 2},
+				CurrentL1:   eth.BlockRef{Number: 1},
+				LocalSafeL2: eth.L2BlockRef{Number: 100},
+				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1:        eth.BlockRef{Number: 2},
 			expected:             syncActions{},
@@ -99,10 +98,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// although the sequencer has derived up the same
 			// L1 block height, it derived fewer safe L2 blocks.
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 6},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 6},
+				CurrentL1:   eth.BlockRef{Number: 1},
+				LocalSafeL2: eth.L2BlockRef{Number: 100, L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block102, block103}, // note absence of block101
@@ -117,10 +116,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen if another batcher instance got some blocks
 			// included in the safe chain:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 6},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 6},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 104, L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -135,10 +134,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This can happen if there is an L1 reorg, the safe chain is at an acceptable
 			// height but it does not descend from the blocks in state:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}}, // note hash mismatch
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}}, // note hash mismatch
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -153,10 +152,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// This could happen if the batcher unexpectedly violates the
 			// Holocene derivation rules:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 3},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 3},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -170,10 +169,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "failed to make expected progress (unsafe=safe)",
 			// Edge case where unsafe = safe
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 3},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:      eth.BlockRef{Number: 3},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 101, Hash: block101.Hash(), L1Origin: eth.BlockID{Number: 1}},
+				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block102, block103},
@@ -189,10 +188,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			// and we didn't submit or have any txs confirmed since
 			// the last sync.
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 4},
-				CurrentL1: eth.BlockRef{Number: 1},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 4},
+				CurrentL1:   eth.BlockRef{Number: 1},
+				LocalSafeL2: eth.L2BlockRef{Number: 100},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -205,10 +204,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "no blocks",
 			// This happens when the batcher is starting up for the first time
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -221,10 +220,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		{name: "happy path",
 			// This happens when the safe chain is being progressed as expected:
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
@@ -238,10 +237,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "happy path + multiple channels",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 109},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101, block102, block103, block104},
@@ -255,10 +254,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "no progress + unsafe=safe",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 100},
-				UnsafeL2:  eth.L2BlockRef{Number: 100},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 100},
+				UnsafeL2:    eth.L2BlockRef{Number: 100},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{},
@@ -268,10 +267,10 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		},
 		{name: "no progress + unsafe=safe + blocks in state",
 			newSyncStatus: eth.SyncStatus{
-				HeadL1:    eth.BlockRef{Number: 5},
-				CurrentL1: eth.BlockRef{Number: 2},
-				SafeL2:    eth.L2BlockRef{Number: 101, Hash: block101.Hash()},
-				UnsafeL2:  eth.L2BlockRef{Number: 101},
+				HeadL1:      eth.BlockRef{Number: 5},
+				CurrentL1:   eth.BlockRef{Number: 2},
+				LocalSafeL2: eth.L2BlockRef{Number: 101, Hash: block101.Hash()},
+				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
 			blocks:        queue.Queue[*types.Block]{block101},
@@ -281,24 +280,8 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			},
 			expectedLogs: happyCaseLogs,
 		},
-		{name: "localSafeL2 > safeL2, preferLocalSafeL2=false",
-			newSyncStatus: eth.SyncStatus{
-				HeadL1:      eth.BlockRef{Number: 5},
-				CurrentL1:   eth.BlockRef{Number: 2},
-				SafeL2:      eth.L2BlockRef{Number: 103, Hash: block103.Hash()},
-				LocalSafeL2: eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
-				UnsafeL2:    eth.L2BlockRef{Number: 109},
-			},
-			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{},
-			channels:      []channelStatuser{},
-			expected: syncActions{
-				blocksToLoad: &inclusiveBlockRange{104, 109},
-			},
-			expectedLogs: noBlocksLogs,
-		},
-		{name: "localSafeL2 > safeL2, preferLocalSafeL2=true",
-			preferLocalSafeL2: true,
+
+		{name: "localSafeL2 > safeL2, no blocks in state",
 			newSyncStatus: eth.SyncStatus{
 				HeadL1:      eth.BlockRef{Number: 5},
 				CurrentL1:   eth.BlockRef{Number: 2},
@@ -321,13 +304,12 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				SafeL2:    eth.L2BlockRef{Number: 104, Hash: block104.Hash()},
 				UnsafeL2:  eth.L2BlockRef{Number: 109},
 			},
-			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{},
-			channels:      []channelStatuser{},
-			expected: syncActions{
-				blocksToLoad: &inclusiveBlockRange{105, 109},
-			},
-			expectedLogs: noBlocksLogs,
+			prevCurrentL1:        eth.BlockRef{Number: 1},
+			blocks:               queue.Queue[*types.Block]{},
+			channels:             []channelStatuser{},
+			expected:             syncActions{},
+			expectedLogs:         []string{"empty BlockRef in sync status"},
+			expectedSeqOutOfSync: true,
 		},
 	}
 
@@ -337,7 +319,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 			l, h := testlog.CaptureLogger(t, log.LevelDebug)
 
 			result, outOfSync := computeSyncActions(
-				tc.newSyncStatus, tc.prevCurrentL1, tc.blocks, tc.channels, l, tc.preferLocalSafeL2,
+				tc.newSyncStatus, tc.prevCurrentL1, tc.blocks, tc.channels, l,
 			)
 
 			require.Equal(t, tc.expected, result, "unexpected actions")

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -180,12 +180,6 @@ var (
 		Value:   130_000, // should be larger than the builder's max-l2-tx-size to prevent endlessly throttling some txs
 		EnvVars: prefixEnvVars("THROTTLE_ALWAYS_BLOCK_SIZE"),
 	}
-	PreferLocalSafeL2Flag = &cli.BoolFlag{
-		Name:    "prefer-local-safe-l2",
-		Usage:   "Load unsafe blocks higher than the sequencer's LocalSafeL2 instead of SafeL2",
-		Value:   false,
-		EnvVars: prefixEnvVars("PREFER_LOCAL_SAFE_L2"),
-	}
 	AdditionalThrottlingEndpointsFlag = &cli.StringSliceFlag{
 		Name:    "additional-throttling-endpoints",
 		Usage:   "Comma-separated list of endpoints to distribute throttling configuration to (in addition to the L2 endpoints specified with --l2-eth-rpc).",
@@ -224,7 +218,6 @@ var optionalFlags = []cli.Flag{
 	ThrottleBlockSizeFlag,
 	ThrottleAlwaysBlockSizeFlag,
 	AdditionalThrottlingEndpointsFlag,
-	PreferLocalSafeL2Flag,
 }
 
 func init() {

--- a/op-devstack/sysgo/l2_batcher.go
+++ b/op-devstack/sysgo/l2_batcher.go
@@ -105,7 +105,6 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 			Stopped:               false,
 			BatchType:             derive.SpanBatchType,
 			MaxBlocksPerSpanBatch: 10,
-			PreferLocalSafeL2:     l2CL.cfg.Rollup.InteropTime != nil,
 			DataAvailabilityType:  batcherFlags.CalldataType,
 			CompressionAlgo:       derive.Brotli,
 			RPC: oprpc.CLIConfig{


### PR DESCRIPTION
This behavior now becomes the default (in fact, the only) behavior. We only had this configurable before to cope with bugs in op-node (#14576 ) which we believe are now either fixed or worked around adequately by the batcher.

#16298 
https://github.com/ethereum-optimism/optimism/pull/16296
