### PR TITLE
Up timeout for post-merge go-tests-full job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1907,7 +1907,7 @@ workflows:
           name: go-tests-full
           rule: "go-tests-ci"  # Run full test suite instead of short
           no_output_timeout: 30m  # Longer timeout for full tests
-          test_timeout: 60m
+          test_timeout: 90m
           notify: true
           filters:
             branches:


### PR DESCRIPTION
... in response to [failures](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/93350/workflows/293865aa-746e-4e73-a42a-a165a32afa69/jobs/3636685).