### PR TITLE
feat(op-acceptance-tests): run deposit test on persistent devnets

### DIFF
--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -129,6 +130,19 @@ func (u *EOA) VerifyBalanceLessThan(v eth.ETH) {
 func (u *EOA) VerifyBalanceExact(v eth.ETH) {
 	actual := u.balance()
 	u.t.Require().Equal(v, actual, "must have expected balance")
+}
+
+// VerifyBalanceAtLeast verifies balance >= v
+func (u *EOA) VerifyBalanceAtLeast(v eth.ETH) {
+	actual := u.balance()
+	u.t.Require().GreaterOrEqual(actual, v, "got %s, expecting at least %s", actual, v)
+}
+
+func (u *EOA) WaitForBalance(v eth.ETH) {
+	u.t.Require().Eventually(func() bool {
+		u.VerifyBalanceExact(v)
+		return true
+	}, u.el.stackEL().TransactionTimeout(), time.Second, "awaiting balance to be updated")
 }
 
 func (u *EOA) DeployEventLogger() common.Address {

--- a/op-devstack/dsl/funder.go
+++ b/op-devstack/dsl/funder.go
@@ -65,7 +65,7 @@ func (f *Funder) FundAtLeast(wallet *EOA, amount eth.ETH) eth.ETH {
 		missing := amount.Sub(currentBalance)
 		f.faucet.Fund(wallet.Address(), missing)
 		currentBalance = currentBalance.Add(missing)
-		wallet.VerifyBalanceExact(currentBalance)
+		wallet.WaitForBalance(currentBalance)
 	}
 	return currentBalance
 }

--- a/op-devstack/dsl/l1_el.go
+++ b/op-devstack/dsl/l1_el.go
@@ -110,3 +110,7 @@ func (el *L1ELNode) ReorgTriggeredFn(target eth.L1BlockRef, attempts int) CheckF
 func (el *L1ELNode) ReorgTriggered(target eth.L1BlockRef, attempts int) {
 	el.require.NoError(el.ReorgTriggeredFn(target, attempts)())
 }
+
+func (el *L1ELNode) TransactionTimeout() time.Duration {
+	return el.inner.TransactionTimeout()
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -134,3 +134,7 @@ func (el *L2ELNode) NotAdvanced(label eth.BlockLabel) {
 func (el *L2ELNode) ReorgTriggered(target eth.L2BlockRef, attempts int) {
 	el.require.NoError(el.ReorgTriggeredFn(target, attempts)())
 }
+
+func (el *L2ELNode) TransactionTimeout() time.Duration {
+	return el.inner.TransactionTimeout()
+}

--- a/op-devstack/stack/el.go
+++ b/op-devstack/stack/el.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -9,4 +11,5 @@ type ELNode interface {
 	Common
 	ChainID() eth.ChainID
 	EthClient() apis.EthClient
+	TransactionTimeout() time.Duration
 }

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -28,7 +28,7 @@ const (
 	FeatureFlashblocks = "flashblocks"
 )
 
-func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, protocol string, path string) client.RPC {
+func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, protocol string, path string, opts ...client.RPCOption) client.RPC {
 	t.Helper()
 
 	endpoint, header, err := orch.findProtocolService(service, protocol)
@@ -37,7 +37,6 @@ func (orch *Orchestrator) rpcClient(t devtest.T, service *descriptors.Service, p
 	endpoint, err = url.JoinPath(endpoint, path)
 	t.Require().NoError(err)
 
-	opts := []client.RPCOption{}
 	if !orch.useEagerRPCClients {
 		opts = append(opts, client.WithLazyDial())
 	}

--- a/op-devstack/sysext/l1.go
+++ b/op-devstack/sysext/l1.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -29,13 +30,14 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 	opts := []client.RPCOption{}
 
 	txTimeout := 5 * time.Minute
-	if o.isKurtosis() {
+	switch o.compatType {
+	case compat.Kurtosis:
 		txTimeout = 30 * time.Second
-	}
-
-	// Increase the timeout by default for persistent devnets, but not for kurtosis
-	if !o.isKurtosis() {
+	case compat.Persistent:
+		// Increase the timeout by default for persistent devnets, but not for kurtosis
 		opts = append(opts, client.WithCallTimeout(time.Minute*5), client.WithBatchCallTimeout(time.Minute*10))
+	default:
+		panic(fmt.Sprintf("unknown compat type: %s", o.compatType))
 	}
 
 	for idx, node := range env.Env.L1.Nodes {

--- a/op-devstack/sysext/l1.go
+++ b/op-devstack/sysext/l1.go
@@ -29,15 +29,11 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 
 	opts := []client.RPCOption{}
 
-	txTimeout := 5 * time.Minute
-	switch o.compatType {
-	case compat.Kurtosis:
-		txTimeout = 30 * time.Second
-	case compat.Persistent:
+	txTimeout := 30 * time.Second
+	if o.compatType == compat.Persistent {
+		txTimeout = 5 * time.Minute
 		// Increase the timeout by default for persistent devnets, but not for kurtosis
 		opts = append(opts, client.WithCallTimeout(time.Minute*5), client.WithBatchCallTimeout(time.Minute*10))
-	default:
-		panic(fmt.Sprintf("unknown compat type: %s", o.compatType))
 	}
 
 	for idx, node := range env.Env.L1.Nodes {

--- a/op-devstack/sysext/l1.go
+++ b/op-devstack/sysext/l1.go
@@ -2,9 +2,11 @@ package sysext
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -24,6 +26,18 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 		ID: stack.L1NetworkID(l1ID),
 	})
 
+	opts := []client.RPCOption{}
+
+	txTimeout := 5 * time.Minute
+	if o.isKurtosis() {
+		txTimeout = 30 * time.Second
+	}
+
+	// Increase the timeout by default for persistent devnets, but not for kurtosis
+	if !o.isKurtosis() {
+		opts = append(opts, client.WithCallTimeout(time.Minute*5), client.WithBatchCallTimeout(time.Minute*10))
+	}
+
 	for idx, node := range env.Env.L1.Nodes {
 		elService, ok := node.Services[ELServiceName]
 
@@ -36,9 +50,10 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 
 		l1.AddL1ELNode(shim.NewL1ELNode(shim.L1ELNodeConfig{
 			ELNodeConfig: shim.ELNodeConfig{
-				CommonConfig: commonConfig,
-				Client:       o.rpcClient(t, elService, RPCProtocol, "/"),
-				ChainID:      l1ID,
+				CommonConfig:       commonConfig,
+				Client:             o.rpcClient(t, elService, RPCProtocol, "/", opts...),
+				ChainID:            l1ID,
+				TransactionTimeout: txTimeout,
 			},
 			ID: stack.NewL1ELNodeID(elService.Name, l1ID),
 		}))
@@ -57,7 +72,7 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 		for _, instance := range faucet {
 			l1.AddFaucet(shim.NewFaucet(shim.FaucetConfig{
 				CommonConfig: commonConfig,
-				Client:       o.rpcClient(t, instance, RPCProtocol, fmt.Sprintf("/chain/%s", env.Env.L1.Config.ChainID.String())),
+				Client:       o.rpcClient(t, instance, RPCProtocol, fmt.Sprintf("/chain/%s", env.Env.L1.Config.ChainID.String()), opts...),
 				ID:           stack.NewFaucetID(instance.Name, l1ID),
 			}))
 		}

--- a/op-devstack/sysext/orchestrator.go
+++ b/op-devstack/sysext/orchestrator.go
@@ -113,10 +113,6 @@ func (o *Orchestrator) isInterop() bool {
 	return isInterop(o.env.Env) && len(o.env.Env.L2) > 0
 }
 
-func (o *Orchestrator) isKurtosis() bool {
-	return strings.HasPrefix(os.Getenv("DEVNET_ENV_URL"), "kt://")
-}
-
 func WithPrivatePorts() OrchestratorOption {
 	return func(orchestrator *Orchestrator) {
 		orchestrator.usePrivatePorts = true

--- a/op-devstack/sysext/orchestrator.go
+++ b/op-devstack/sysext/orchestrator.go
@@ -113,6 +113,10 @@ func (o *Orchestrator) isInterop() bool {
 	return isInterop(o.env.Env) && len(o.env.Env.L2) > 0
 }
 
+func (o *Orchestrator) isKurtosis() bool {
+	return strings.HasPrefix(os.Getenv("DEVNET_ENV_URL"), "kt://")
+}
+
 func WithPrivatePorts() OrchestratorOption {
 	return func(orchestrator *Orchestrator) {
 		orchestrator.usePrivatePorts = true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Enables the l1->l2 deposit test to run on persistent devnets.
- L1 transactions in sepolia may take a long time, set a maximum timeout of 5 mins 
- We could potentially calculate the time needed by leveraging `EstimateBlockTime`

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
