### PR TITLE
Disable load tests unless `-loadtest` or `NAT_LOADTEST=true` is set

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -19,12 +19,16 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/flags"
 	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
+
+// Override this with the env var NAT_STEADY_TIMEOUT.
+const defaultSteadyTestTimeout = time.Minute * 3
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleInterop(),
@@ -42,7 +46,7 @@ func TestMain(m *testing.M) {
 // elapses, whichever comes first. Also see: https://github.com/golang/go/issues/48157.
 func TestSteady(gt *testing.T) {
 	t := setupT(gt)
-	t, ctx, cancel := setupDeadline(t, "NAT_STEADY_TIMEOUT")
+	t, ctx, cancel := setupTestDeadline(t, "NAT_STEADY_TIMEOUT")
 
 	var wg sync.WaitGroup
 	defer wg.Wait()
@@ -88,10 +92,12 @@ func TestSteady(gt *testing.T) {
 }
 
 // TestBurst spams interop messages and exits successfully when the budget is depleted, simulating
-// adversarial behavior.
+// adversarial behavior. The test will exit successfully after the global go test deadline or the
+// timeout specified by the NAT_BURST_TIMEOUT environment variable elapses, whichever comes first.
+// Also see: https://github.com/golang/go/issues/48157.
 func TestBurst(gt *testing.T) {
 	t := setupT(gt)
-	t, ctx, cancel := setupDeadline(t, "NAT_BURST_TIMEOUT")
+	t, ctx, cancel := setupTestDeadline(t, "NAT_BURST_TIMEOUT")
 
 	var wg sync.WaitGroup
 	defer wg.Wait()
@@ -115,26 +121,23 @@ func TestBurst(gt *testing.T) {
 }
 
 func setupT(t *testing.T) devtest.T {
-	if testing.Short() {
-		t.Skip("skipping load test in short mode")
+	if testing.Short() || !flags.ReadTestConfig().EnableLoadTests {
+		t.Skip("skipping load test in short mode or if load tests are disabled (enable with -loadtest or NAT_LOADTEST=true)")
 	}
 	return devtest.SerialT(t)
 }
 
-func setupDeadline(t devtest.T, varName string) (devtest.T, context.Context, func()) {
+func setupTestDeadline(t devtest.T, varName string) (devtest.T, context.Context, func()) {
 	// Configure a context that will allow us to exit the test on time.
 	var deadline time.Time
 	if timeoutStr, exists := os.LookupEnv(varName); exists {
 		timeout, err := time.ParseDuration(timeoutStr)
 		t.Require().NoError(err)
 		envVarDeadline := time.Now().Add(timeout)
-		if deadline == (time.Time{}) || envVarDeadline.Before(deadline) {
-			deadline = envVarDeadline
-		}
+		deadline = envVarDeadline
 	}
 	if deadline == (time.Time{}) {
-		// Default to 3 minutes when no timeout is specified.
-		deadline = time.Now().Add(time.Minute * 3)
+		deadline = time.Now().Add(defaultSteadyTestTimeout)
 	}
 	ctx, cancel := context.WithDeadline(t.Ctx(), deadline)
 	t = t.WithCtx(ctx)

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -3,6 +3,7 @@ package loadtest
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -25,7 +27,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleInterop())
+	presets.DoMain(m, presets.WithSimpleInterop(),
+		presets.WithLogFilter(
+			logfilter.DefaultMute(
+				logfilter.Level(slog.LevelWarn).Show(),
+			),
+		),
+	)
 }
 
 // TestSteady attempts to approach but not exceed the gas target in every block by spamming interop
@@ -34,23 +42,10 @@ func TestMain(m *testing.M) {
 // elapses, whichever comes first. Also see: https://github.com/golang/go/issues/48157.
 func TestSteady(gt *testing.T) {
 	t := setupT(gt)
+	t, ctx, cancel := setupDeadline(t, "NAT_STEADY_TIMEOUT")
+
 	var wg sync.WaitGroup
 	defer wg.Wait()
-
-	// Configure a context that will allow us to exit the test on time.
-	deadline := time.Now().Add(time.Hour * 1_000)
-	testCtxDeadline, testCtxDeadlineExists := t.Ctx().Deadline()
-	if testCtxDeadlineExists {
-		deadline = testCtxDeadline.Add(-10 * time.Second) // Give some time for cleanup.
-	}
-	ctx, cancel := context.WithDeadline(t.Ctx(), deadline)
-	t.Cleanup(cancel)
-	if timeoutStr, exists := os.LookupEnv("NAT_STEADY_TIMEOUT"); exists {
-		timeout, err := time.ParseDuration(timeoutStr)
-		t.Require().NoError(err)
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		t.Cleanup(cancel)
-	}
 
 	// The scheduler will adjust every slot to stay within 95-100% of the gas target.
 	aimd, source, dest := setupLoadTest(t, ctx, &wg, WithAdjustWindow(1), WithDecreaseFactor(0.95))
@@ -96,10 +91,10 @@ func TestSteady(gt *testing.T) {
 // adversarial behavior.
 func TestBurst(gt *testing.T) {
 	t := setupT(gt)
+	t, ctx, cancel := setupDeadline(t, "NAT_BURST_TIMEOUT")
+
 	var wg sync.WaitGroup
 	defer wg.Wait()
-	ctx, cancel := context.WithCancel(t.Ctx())
-	defer cancel()
 	aimd, source, dest := setupLoadTest(t, ctx, &wg)
 	for range aimd.Ready() {
 		wg.Add(1)
@@ -124,6 +119,27 @@ func setupT(t *testing.T) devtest.T {
 		t.Skip("skipping load test in short mode")
 	}
 	return devtest.SerialT(t)
+}
+
+func setupDeadline(t devtest.T, varName string) (devtest.T, context.Context, func()) {
+	// Configure a context that will allow us to exit the test on time.
+	var deadline time.Time
+	if timeoutStr, exists := os.LookupEnv(varName); exists {
+		timeout, err := time.ParseDuration(timeoutStr)
+		t.Require().NoError(err)
+		envVarDeadline := time.Now().Add(timeout)
+		if deadline == (time.Time{}) || envVarDeadline.Before(deadline) {
+			deadline = envVarDeadline
+		}
+	}
+	if deadline == (time.Time{}) {
+		// Default to 3 minutes when no timeout is specified.
+		deadline = time.Now().Add(time.Minute * 3)
+	}
+	ctx, cancel := context.WithDeadline(t.Ctx(), deadline)
+	t = t.WithCtx(ctx)
+	t.Cleanup(cancel)
+	return t, ctx, cancel
 }
 
 func setupLoadTest(t devtest.T, ctx context.Context, wg *sync.WaitGroup, aimdOpts ...AIMDOption) (*AIMD, *L2, *L2) {

--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysext"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/flags"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
@@ -57,8 +58,8 @@ func DoMain(m *testing.M, opts ...stack.CommonOption) {
 			}
 		}()
 
-		cfg := oplog.ReadTestCLIConfig()
-		logHandler := oplog.NewLogHandler(os.Stdout, cfg)
+		cfg := flags.ReadTestConfig()
+		logHandler := oplog.NewLogHandler(os.Stdout, cfg.LogConfig)
 		logHandler = logfilter.WrapFilterHandler(logHandler)
 		logHandler.(logfilter.FilterHandler).Set(logfilter.DefaultMute(logfilter.Level(log.LevelInfo).Show()))
 		logHandler = logfilter.WrapContextHandler(logHandler)

--- a/op-service/flags/test.go
+++ b/op-service/flags/test.go
@@ -1,0 +1,30 @@
+package flags
+
+import (
+	"flag"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+var flLoadTest = flag.Bool("loadtest", false, "Enable load tests during test run")
+
+type TestConfig struct {
+	LogConfig       log.CLIConfig
+	EnableLoadTests bool
+}
+
+func ReadTestConfig() TestConfig {
+	flag.Parse()
+
+	loadTest := *flLoadTest
+	if v := os.Getenv("NAT_LOADTEST"); v != "" {
+		loadTest = v == "true"
+	}
+	cfg := log.ReadTestCLIConfig()
+
+	return TestConfig{
+		EnableLoadTests: loadTest,
+		LogConfig:       cfg,
+	}
+}


### PR DESCRIPTION
Also tones down logging and refactors some deadline logic.