### PR TITLE
chore: Update devnet SDK with support for multiple sequencers in kurtosis

### DIFF
--- a/devnet-sdk/shell/env/testdata/kurtosis/args--simple.yaml
+++ b/devnet-sdk/shell/env/testdata/kurtosis/args--simple.yaml
@@ -1,5 +1,6 @@
 optimism_package:
   chains:
-    - whatakey:
+    op-kurtosis:
+      whatakey:
       - el_type: op-geth
         cl_type: op-node

--- a/kurtosis-devnet/flash.yaml
+++ b/kurtosis-devnet/flash.yaml
@@ -14,6 +14,7 @@ optimism_package:
             builder_type: "op-rbuilder"
             builder_image: "us-docker.pkg.dev/oplabs-tools-artifacts/dev-images/op-rbuilder:sha-4aee498"
           mev_params:
+            enabled: true
             type: "rollup-boost"
             image: "docker.io/flashbots/rollup-boost:0.6.2"
         node1: *x-node
@@ -37,9 +38,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      additional_services: [
-        "rollup-boost",
-      ]
   challengers:
     challenger:
       enabled: true

--- a/kurtosis-devnet/flash.yaml
+++ b/kurtosis-devnet/flash.yaml
@@ -3,7 +3,7 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    op_kurtosis:
+    opkurtosis:
       participants:
         node0: &x-node
           el:

--- a/kurtosis-devnet/flash.yaml
+++ b/kurtosis-devnet/flash.yaml
@@ -13,6 +13,9 @@ optimism_package:
             image: {{ localDockerImage "op-node" }}
             builder_type: "op-rbuilder"
             builder_image: "us-docker.pkg.dev/oplabs-tools-artifacts/dev-images/op-rbuilder:sha-4aee498"
+          mev_params:
+            type: "rollup-boost"
+            image: "docker.io/flashbots/rollup-boost:0.6.2"
         node1: *x-node
       network_params:
         network: "kurtosis"
@@ -34,9 +37,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      mev_params:
-        type: "rollup-boost"
-        image: "docker.io/flashbots/rollup-boost:0.6.2"
       additional_services: [
         "rollup-boost",
       ]

--- a/kurtosis-devnet/flash.yaml
+++ b/kurtosis-devnet/flash.yaml
@@ -3,18 +3,21 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    - participants:
-      - el_type: op-geth
-        cl_type: op-node
-        cl_image: {{ localDockerImage "op-node" }}
-        el_builder_type: "op-rbuilder"
-        el_builder_image: "us-docker.pkg.dev/oplabs-tools-artifacts/dev-images/op-rbuilder:sha-4aee498"
-        count: 2
+    op_kurtosis:
+      participants:
+        node0: &x-node
+          el:
+            type: op-geth
+          cl:
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
+            builder_type: "op-rbuilder"
+            builder_image: "us-docker.pkg.dev/oplabs-tools-artifacts/dev-images/op-rbuilder:sha-4aee498"
+        node1: *x-node
       network_params:
         network: "kurtosis"
         network_id: "2151908"
         seconds_per_slot: 2
-        name: "op-kurtosis"
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0

--- a/kurtosis-devnet/flash.yaml
+++ b/kurtosis-devnet/flash.yaml
@@ -3,7 +3,7 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    opkurtosis:
+    op-kurtosis:
       participants:
         node0: &x-node
           el:

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -35,7 +35,7 @@ optimism_package:
       extra_params:
       - {{ $flags.log_level }}
   chains:
-    op_kurtosis_1:
+    opkurtosis1:
       participants:
         node0: &x-node
           el:
@@ -89,7 +89,7 @@ optimism_package:
         game_type: 1
         proposal_interval: 10m
       additional_services: []
-    op_kurtosis_2:
+    opkurtosis2:
       participants:
         node0: *x-node
       network_params:

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -35,7 +35,7 @@ optimism_package:
       extra_params:
       - {{ $flags.log_level }}
   chains:
-    opkurtosis1:
+    op-kurtosis1:
       participants:
         node0: &x-node
           el:
@@ -89,7 +89,7 @@ optimism_package:
         game_type: 1
         proposal_interval: 10m
       additional_services: []
-    opkurtosis2:
+    op-kurtosis2:
       participants:
         node0: *x-node
       network_params:

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -88,7 +88,6 @@ optimism_package:
         - {{ $flags.log_level }}
         game_type: 1
         proposal_interval: 10m
-      additional_services: []
     op-kurtosis2:
       participants:
         node0: *x-node
@@ -111,7 +110,6 @@ optimism_package:
         - {{ $flags.log_level }}
         game_type: 1
         proposal_interval: 10m
-      additional_services: []
   challengers:
     challenger:
       enabled: true

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -64,6 +64,10 @@ optimism_package:
             max_cpu: 0
             min_mem: 0
             max_mem: 0
+          mev_params:
+            image: ""
+            builder_host: ""
+            builder_port: ""
       network_params:
         network: "kurtosis"
         network_id: "2151908"
@@ -84,10 +88,6 @@ optimism_package:
         - {{ $flags.log_level }}
         game_type: 1
         proposal_interval: 10m
-      mev_params:
-        image: ""
-        builder_host: ""
-        builder_port: ""
       additional_services: []
     op_kurtosis_2:
       participants:
@@ -111,10 +111,6 @@ optimism_package:
         - {{ $flags.log_level }}
         game_type: 1
         proposal_interval: 10m
-      mev_params:
-        image: ""
-        builder_host: ""
-        builder_port: ""
       additional_services: []
   challengers:
     challenger:

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -35,39 +35,39 @@ optimism_package:
       extra_params:
       - {{ $flags.log_level }}
   chains:
-    - participants:
-      - el_type: op-geth
-        el_image: ""
-        el_log_level: ""
-        el_extra_env_vars: {}
-        el_extra_labels: {}
-        el_extra_params: []
-        el_tolerations: []
-        el_volume_size: 0
-        el_min_cpu: 0
-        el_max_cpu: 0
-        el_min_mem: 0
-        el_max_mem: 0
-        cl_type: op-node
-        cl_image: {{ $local_images.op_node }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
-        cl_extra_labels: {}
-        cl_extra_params: []
-        cl_tolerations: []
-        cl_volume_size: 0
-        cl_min_cpu: 0
-        cl_max_cpu: 0
-        cl_min_mem: 0
-        cl_max_mem: 0
-        node_selectors: {}
-        tolerations: []
-        count: 1
+    op_kurtosis_1:
+      participants:
+        node0: &x-node
+          el:
+            type: op-geth
+            image: ""
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
+          cl:
+            type: op-node
+            image: {{ $local_images.op_node }}
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
       network_params:
         network: "kurtosis"
         network_id: "2151908"
         seconds_per_slot: 2
-        name: "op-kurtosis-1"
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0
@@ -89,39 +89,13 @@ optimism_package:
         builder_host: ""
         builder_port: ""
       additional_services: []
-    - participants:
-      - el_type: op-geth
-        el_image: ""
-        el_log_level: ""
-        el_extra_env_vars: {}
-        el_extra_labels: {}
-        el_extra_params: []
-        el_tolerations: []
-        el_volume_size: 0
-        el_min_cpu: 0
-        el_max_cpu: 0
-        el_min_mem: 0
-        el_max_mem: 0
-        cl_type: op-node
-        cl_image: {{ $local_images.op_node }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
-        cl_extra_labels: {}
-        cl_extra_params: []
-        cl_tolerations: []
-        cl_volume_size: 0
-        cl_min_cpu: 0
-        cl_max_cpu: 0
-        cl_min_mem: 0
-        cl_max_mem: 0
-        node_selectors: {}
-        tolerations: []
-        count: 1
+    op_kurtosis_2:
+      participants:
+        node0: *x-node
       network_params:
         network: "kurtosis"
         network_id: "2151909"
         seconds_per_slot: 2
-        name: "op-kurtosis-2"
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -3,67 +3,54 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    - participants:
-      - el_type: op-geth
-        el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3"
-        el_log_level: ""
-        el_extra_env_vars: {}
-        el_extra_labels: {}
-        el_extra_params: []
-        el_tolerations: []
-        el_volume_size: 0
-        el_min_cpu: 0
-        el_max_cpu: 0
-        el_min_mem: 0
-        el_max_mem: 0
-        cl_type: op-node
-        cl_image: {{ localDockerImage "op-node" }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
-        cl_extra_labels: {}
-        cl_extra_params: []
-        cl_tolerations: []
-        cl_volume_size: 0
-        cl_min_cpu: 0
-        cl_max_cpu: 0
-        cl_min_mem: 0
-        cl_max_mem: 0
-        node_selectors: {}
-        tolerations: []
-        count: 1
-      - el_type: op-reth
-        # Pinning op-reth nightly image: "Created": "2025-03-31T02:09:09.704214502Z"
-        el_image: "ghcr.io/paradigmxyz/op-reth@sha256:7d83174c900a623897d5cf3a42764f19047ca47034f9726f5a9fad2c7ed32fee"
-        el_log_level: ""
-        el_extra_env_vars: {}
-        el_extra_labels: {}
-        el_extra_params: []
-        el_tolerations: []
-        el_volume_size: 0
-        el_min_cpu: 0
-        el_max_cpu: 0
-        el_min_mem: 0
-        el_max_mem: 0
-        cl_type: op-node
-        cl_image: {{ localDockerImage "op-node" }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
-        cl_extra_labels: {}
-        cl_extra_params: []
-        cl_tolerations: []
-        cl_volume_size: 0
-        cl_min_cpu: 0
-        cl_max_cpu: 0
-        cl_min_mem: 0
-        cl_max_mem: 0
-        node_selectors: {}
-        tolerations: []
-        count: 1
+    op_kurtosis:
+      participants:
+        node0:
+          el:
+            type: op-geth
+            image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3"
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
+          cl: &x-node-cl
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
+        node1:
+          el:
+            type: op-reth
+            image: "ghcr.io/paradigmxyz/op-reth@sha256:7d83174c900a623897d5cf3a42764f19047ca47034f9726f5a9fad2c7ed32fee"
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
+          cl: *x-node-cl
       network_params:
         network: "kurtosis"
         network_id: "2151908"
         seconds_per_slot: 2
-        name: "op-kurtosis"
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -3,7 +3,7 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    opkurtosis:
+    op-kurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -64,10 +64,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      mev_params:
-        image: ""
-        builder_host: ""
-        builder_port: ""
       additional_services: []
   challengers:
     challenger:

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -3,7 +3,7 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    op_kurtosis:
+    opkurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -64,7 +64,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      additional_services: []
   challengers:
     challenger:
       enabled: true

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@494eab8ffb8e09cdc3e6d4b9dc0fb785ed607586
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@66cc8c70256483e21f83cd13e4f976cf0753646a
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@2feb3b9dc6dfe7a9505c94df268e41cc492a0ad8
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@79e05c077f31cbcb4c2be73610710a33233ee2cf
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@bd778bd970967294b32ab1fd89c8bc794f32cd3d
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@d7f3c8bbb666ffa49910f59e9204541c213bb807
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@c6b349ac96bfabe91aab375c88cfde58b8c9d6e7
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@2feb3b9dc6dfe7a9505c94df268e41cc492a0ad8
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@52ed3e6e8f1788adcac15baf4b65b408cf13961a
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@6810e75c24cc26c7255260c184d9782366375466
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@6810e75c24cc26c7255260c184d9782366375466
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@494eab8ffb8e09cdc3e6d4b9dc0fb785ed607586
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@79e05c077f31cbcb4c2be73610710a33233ee2cf
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@bd778bd970967294b32ab1fd89c8bc794f32cd3d
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@66cc8c70256483e21f83cd13e4f976cf0753646a
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@c6b349ac96bfabe91aab375c88cfde58b8c9d6e7
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -45,7 +45,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      additional_services: []
   challengers:
     challenger:
       enabled: true

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -1,38 +1,38 @@
 optimism_package:
   chains:
-    - participants:
-      - el_type: op-geth
-        el_image: ""
-        el_log_level: ""
-        el_extra_env_vars: {}
-        el_extra_labels: {}
-        el_extra_params: []
-        el_tolerations: []
-        el_volume_size: 0
-        el_min_cpu: 0
-        el_max_cpu: 0
-        el_min_mem: 0
-        el_max_mem: 0
-        cl_type: op-node
-        cl_image: {{ localDockerImage "op-node" }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
-        cl_extra_labels: {}
-        cl_extra_params: []
-        cl_tolerations: []
-        cl_volume_size: 0
-        cl_min_cpu: 0
-        cl_max_cpu: 0
-        cl_min_mem: 0
-        cl_max_mem: 0
-        node_selectors: {}
-        tolerations: []
-        count: 1
+    op_kurtosis:
+      participants:
+        node0:
+          el:
+            type: op-geth
+            image: ""
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
+          cl:
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
       network_params:
         network: "kurtosis"
         network_id: "2151908"
         seconds_per_slot: 2
-        name: "op-kurtosis"
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -45,10 +45,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      mev_params:
-        image: ""
-        builder_host: ""
-        builder_port: ""
       additional_services: []
   challengers:
     challenger:

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -1,6 +1,6 @@
 optimism_package:
   chains:
-    op_kurtosis:
+    opkurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/pectra.yaml
+++ b/kurtosis-devnet/pectra.yaml
@@ -1,6 +1,6 @@
 optimism_package:
   chains:
-    opkurtosis:
+    op-kurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -265,10 +265,9 @@ func (f *ServiceFinder) triage() {
 			endpoints[portName] = portInfo
 		}
 
-		// TODO: for now, use labels as a fallback, so it's currently inactive.
-		// We should expect the rules to be gradually removed to make way for
-		// this code path. Ultimately we'll rely only on labels, and most of the
-		// code in this file will disappear as a result.
+		// Ultimately we'll rely only on labels, and most of the code in this file will disappear as a result.
+		//
+		// For now though the L1 services are still not tagged properly so we rely on the name resolution as a fallback
 		triaged := f.triageByLabels(svc, serviceName, endpoints)
 		if triaged == nil {
 			triaged = rules.apply(serviceName, endpoints)

--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -269,9 +269,9 @@ func (f *ServiceFinder) triage() {
 		// We should expect the rules to be gradually removed to make way for
 		// this code path. Ultimately we'll rely only on labels, and most of the
 		// code in this file will disappear as a result.
-		triaged := rules.apply(serviceName, endpoints)
+		triaged := f.triageByLabels(svc, serviceName, endpoints)
 		if triaged == nil {
-			triaged = f.triageByLabels(svc, serviceName, endpoints)
+			triaged = rules.apply(serviceName, endpoints)
 		}
 
 		if triaged != nil {

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec.go
@@ -60,7 +60,7 @@ type FaucetConfig struct {
 type OptimismPackage struct {
 	Faucet      FaucetConfig                `yaml:"faucet"`
 	Superchains map[string]SuperchainConfig `yaml:"superchains"`
-	Chains      []ChainConfig               `yaml:"chains"`
+	Chains      map[string]ChainConfig      `yaml:"chains"`
 }
 
 // YAMLSpec represents the root of the YAML document
@@ -121,9 +121,9 @@ func (s *Spec) ExtractData(r io.Reader) (*EnclaveSpec, error) {
 	}
 
 	// Extract chain specifications
-	for _, chain := range yamlSpec.OptimismPackage.Chains {
+	for name, chain := range yamlSpec.OptimismPackage.Chains {
 		result.Chains = append(result.Chains, &ChainSpec{
-			Name:      chain.NetworkParams.Name,
+			Name:      name,
 			NetworkID: chain.NetworkParams.NetworkID,
 		})
 	}

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -18,7 +18,7 @@ optimism_package:
             type: op-geth
       network_params:
         network_id: "3151909"
-	  blockscout_params:
+      blockscout_params:
 	    enabled: true
     op-rollup-two:
       participants:

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -11,17 +11,21 @@ func TestParseSpec(t *testing.T) {
 	yamlContent := `
 optimism_package:
   chains:
-    - participants:
-        - el_type: op-geth
+    op_rollup_one:
+      participants:
+        node0:
+          el:
+            type: op-geth
       network_params:
-        name: op-rollup-one
         network_id: "3151909"
       additional_services:
         - blockscout
-    - participants:
-        - el_type: op-geth
+    op_rollup_two:
+      participants:
+        node0:
+          el:
+            type: op-geth
       network_params:
-        name: op-rollup-two
         network_id: "3151910"
       additional_services:
         - blockscout
@@ -39,11 +43,11 @@ ethereum_package:
 
 	expectedChains := []ChainSpec{
 		{
-			Name:      "op-rollup-one",
+			Name:      "op_rollup_one",
 			NetworkID: "3151909",
 		},
 		{
-			Name:      "op-rollup-two",
+			Name:      "op_rollup_two",
 			NetworkID: "3151910",
 		},
 	}

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -82,10 +82,13 @@ func TestParseSpecErrors(t *testing.T) {
 			yaml: `
 optimism_package:
   chains:
-    - participants:
-        - el_type: op-geth
-      additional_services:
-        - blockscout`,
+    op_kurtosis:
+      participants:
+        node0:
+          el:
+            type: op-geth
+      blockscout_params:
+        enabled: true`,
 		},
 		{
 			name: "missing chains",

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -19,7 +19,7 @@ optimism_package:
       network_params:
         network_id: "3151909"
       blockscout_params:
-	    enabled: true
+        enabled: true
     op-rollup-two:
       participants:
         node0:

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -18,8 +18,8 @@ optimism_package:
             type: op-geth
       network_params:
         network_id: "3151909"
-      additional_services:
-        - blockscout
+	  blockscout_params:
+	    enabled: true
     op-rollup-two:
       participants:
         node0:
@@ -27,8 +27,6 @@ optimism_package:
             type: op-geth
       network_params:
         network_id: "3151910"
-      additional_services:
-        - blockscout
 ethereum_package:
   participants:
     - el_type: geth

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -11,7 +11,7 @@ func TestParseSpec(t *testing.T) {
 	yamlContent := `
 optimism_package:
   chains:
-    op_rollup_one:
+    op-rollup-one:
       participants:
         node0:
           el:
@@ -20,7 +20,7 @@ optimism_package:
         network_id: "3151909"
       additional_services:
         - blockscout
-    op_rollup_two:
+    op-rollup-two:
       participants:
         node0:
           el:
@@ -43,11 +43,11 @@ ethereum_package:
 
 	expectedChains := []ChainSpec{
 		{
-			Name:      "op_rollup_one",
+			Name:      "op-rollup-one",
 			NetworkID: "3151909",
 		},
 		{
-			Name:      "op_rollup_two",
+			Name:      "op-rollup-two",
 			NetworkID: "3151910",
 		},
 	}
@@ -82,7 +82,7 @@ func TestParseSpecErrors(t *testing.T) {
 			yaml: `
 optimism_package:
   chains:
-    opkurtosis:
+    op-kurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -82,7 +82,7 @@ func TestParseSpecErrors(t *testing.T) {
 			yaml: `
 optimism_package:
   chains:
-    op_kurtosis:
+    opkurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -3,7 +3,7 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    opkurtosis:
+    op-kurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -52,7 +52,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      additional_services: []
   challengers:
     challenger:
       enabled: true

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -3,7 +3,7 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    op_kurtosis:
+    opkurtosis:
       participants:
         node0:
           el:

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -32,6 +32,10 @@ optimism_package:
             max_cpu: 0
             min_mem: 0
             max_mem: 0
+          mev_params:
+            image: ""
+            builder_host: ""
+            builder_port: ""
       network_params:
         network: "kurtosis"
         network_id: "2151908"
@@ -48,10 +52,6 @@ optimism_package:
         extra_params: []
         game_type: 1
         proposal_interval: 10m
-      mev_params:
-        image: ""
-        builder_host: ""
-        builder_port: ""
       additional_services: []
   challengers:
     challenger:

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -3,39 +3,39 @@ optimism_package:
     enabled: true
     image: {{ localDockerImage "op-faucet" }}
   chains:
-    - participants:
-      - el_type: op-geth
-        el_image: ""
-        el_log_level: ""
-        el_extra_env_vars: {}
-        el_extra_labels: {}
-        el_extra_params: []
-        el_tolerations: []
-        el_volume_size: 0
-        el_min_cpu: 0
-        el_max_cpu: 0
-        el_min_mem: 0
-        el_max_mem: 0
-        cl_type: op-node
-        cl_image: {{ localDockerImage "op-node" }}
-        cl_log_level: ""
-        cl_extra_env_vars: {}
-        cl_extra_labels: {}
-        cl_extra_params: []
-        cl_tolerations: []
-        cl_volume_size: 0
-        cl_min_cpu: 0
-        cl_max_cpu: 0
-        cl_min_mem: 0
-        cl_max_mem: 0
-        node_selectors: {}
-        tolerations: []
-        count: 1
+    op_kurtosis:
+      participants:
+        node0:
+          el:
+            type: op-geth
+            image: ""
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
+          cl:
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
+            log_level: ""
+            extra_env_vars: {}
+            extra_labels: {}
+            extra_params: []
+            tolerations: []
+            volume_size: 0
+            min_cpu: 0
+            max_cpu: 0
+            min_mem: 0
+            max_mem: 0
       network_params:
         network: "kurtosis"
         network_id: "2151908"
         seconds_per_slot: 2
-        name: "op-kurtosis"
         fjord_time_offset: 0
         granite_time_offset: 0
         holocene_time_offset: 0

--- a/kurtosis-devnet/templates/devnet.yaml
+++ b/kurtosis-devnet/templates/devnet.yaml
@@ -18,7 +18,7 @@ optimism_package:
 {{ end }}
   chains:
   {{ range $l2_id, $l2 := $l2s }}
-    op_kurtosis_{{ $l2_id }}:
+    opkurtosis{{ $l2_id }}:
       {{ include "l2.yaml" (dict "chain_id" $l2_id "overrides" $overrides "nodes" $l2.nodes) }}
   {{ end }}
   op_contract_deployer_params:

--- a/kurtosis-devnet/templates/devnet.yaml
+++ b/kurtosis-devnet/templates/devnet.yaml
@@ -18,7 +18,8 @@ optimism_package:
 {{ end }}
   chains:
   {{ range $l2_id, $l2 := $l2s }}
-    - {{ include "l2.yaml" (dict "chain_id" $l2_id "overrides" $overrides "nodes" $l2.nodes) }}
+    op_kurtosis_{{ $l2_id }}:
+      {{ include "l2.yaml" (dict "chain_id" $l2_id "overrides" $overrides "nodes" $l2.nodes) }}
   {{ end }}
   op_contract_deployer_params:
     image: {{ dig "overrides" "images" "op_deployer" (localDockerImage "op-deployer") $context }}

--- a/kurtosis-devnet/templates/devnet.yaml
+++ b/kurtosis-devnet/templates/devnet.yaml
@@ -18,7 +18,7 @@ optimism_package:
 {{ end }}
   chains:
   {{ range $l2_id, $l2 := $l2s }}
-    opkurtosis{{ $l2_id }}:
+    op-kurtosis-{{ $l2_id }}:
       {{ include "l2.yaml" (dict "chain_id" $l2_id "overrides" $overrides "nodes" $l2.nodes) }}
   {{ end }}
   op_contract_deployer_params:

--- a/kurtosis-devnet/templates/l2.yaml
+++ b/kurtosis-devnet/templates/l2.yaml
@@ -32,4 +32,3 @@ proposer_params:
   - {{ dig "overrides" "flags" "log_level" "!!str" $context }}
   game_type: 1
   proposal_interval: 10m
-additional_services: []

--- a/kurtosis-devnet/templates/l2.yaml
+++ b/kurtosis-devnet/templates/l2.yaml
@@ -2,14 +2,14 @@
 {{- $nodes := dig "nodes" (list "op-geth") $context -}}
 ---
 participants:
-{{- range $node := $nodes }}
-- {{ include "local-op-node.yaml" (dict "overrides" $context.overrides "el_type" $node) }}
+{{- range $node_id, $node := $nodes }}
+  {{ $node_id }}:
+    {{ include "local-op-node.yaml" (dict "overrides" $context.overrides "el_type" $node) }}
 {{- end }}
 network_params:
   network: "kurtosis"
   network_id: "{{ .chain_id }}"
   seconds_per_slot: 2
-  name: "op-kurtosis-{{ .chain_id }}"
   fjord_time_offset: 0
   granite_time_offset: 0
   holocene_time_offset: 0

--- a/kurtosis-devnet/templates/l2.yaml
+++ b/kurtosis-devnet/templates/l2.yaml
@@ -32,8 +32,4 @@ proposer_params:
   - {{ dig "overrides" "flags" "log_level" "!!str" $context }}
   game_type: 1
   proposal_interval: 10m
-mev_params:
-  rollup_boost_image: ""
-  builder_host: ""
-  builder_port: ""
 additional_services: []

--- a/kurtosis-devnet/templates/local-op-node.yaml
+++ b/kurtosis-devnet/templates/local-op-node.yaml
@@ -1,30 +1,29 @@
 {{- $context := or . (dict)}}
 {{- $el_type := dig "el_type" "op-geth" $context -}}
 ---
-el_type: {{ $el_type }}
-el_image: {{ dig "overrides" "images" $el_type "!!str" $context }}
-el_log_level: ""
-el_extra_env_vars: {}
-el_extra_labels: {}
-el_extra_params: []
-el_tolerations: []
-el_volume_size: 0
-el_min_cpu: 0
-el_max_cpu: 0
-el_min_mem: 0
-el_max_mem: 0
-cl_type: op-node
-cl_image: {{ dig "overrides" "images" "op-node" (localDockerImage "op-node") $context }}
-cl_log_level: ""
-cl_extra_env_vars: {}
-cl_extra_labels: {}
-cl_extra_params: []
-cl_tolerations: []
-cl_volume_size: 0
-cl_min_cpu: 0
-cl_max_cpu: 0
-cl_min_mem: 0
-cl_max_mem: 0
-node_selectors: {}
-tolerations: []
-count: 1
+el:
+  type: {{ $el_type }}
+  image: {{ dig "overrides" "images" $el_type "!!str" $context }}
+  log_level: ""
+  extra_env_vars: {}
+  extra_labels: {}
+  extra_params: []
+  tolerations: []
+  volume_size: 0
+  min_cpu: 0
+  max_cpu: 0
+  min_mem: 0
+  max_mem: 0
+cl:
+  type: op-node
+  image: {{ dig "overrides" "images" "op-node" (localDockerImage "op-node") $context }}
+  log_level: ""
+  extra_env_vars: {}
+  extra_labels: {}
+  extra_params: []
+  tolerations: []
+  volume_size: 0
+  min_cpu: 0
+  max_cpu: 0
+  min_mem: 0
+  max_mem: 0

--- a/kurtosis-devnet/templates/local-op-node.yaml
+++ b/kurtosis-devnet/templates/local-op-node.yaml
@@ -27,3 +27,7 @@ cl:
   max_cpu: 0
   min_mem: 0
   max_mem: 0
+mev_params:
+  image: ""
+  builder_host: ""
+  builder_port: ""

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -97,7 +97,7 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 	require.True(ok, "need L2 CL service for chain", l2ID)
 
 	// it's an RPC, but 'http' in kurtosis descriptor
-	clClient := o.rpcClient(l2Net.T(), clService, HTTPProtocol, "/")
+	clClient := o.rpcClient(l2Net.T(), clService, RPCProtocol, "/")
 	l2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
 		ID:           stack.NewL2CLNodeID(clService.Name, l2ID.ChainID()),
 		CommonConfig: shim.NewCommonConfig(l2Net.T()),

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -96,7 +96,6 @@ func (o *Orchestrator) hydrateL2ELCL(node *descriptors.Node, l2Net stack.Extensi
 	clService, ok := node.Services[CLServiceName]
 	require.True(ok, "need L2 CL service for chain", l2ID)
 
-	// it's an RPC, but 'http' in kurtosis descriptor
 	clClient := o.rpcClient(l2Net.T(), clService, RPCProtocol, "/")
 	l2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
 		ID:           stack.NewL2CLNodeID(clService.Name, l2ID.ChainID()),


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Bump `optimism-package`  to a commit that supports multiple sequencers
- Adjust the static devnet args files
- Adjust the devnet args files templates
- Change the `http` port to `rpc` for CL clients - this was incorrectly set to `http` in kurtosis

**Notes**

- There are stronger constraints places on network names in the new `optimism-package` (no `-`s)  - but since we are now using the label-based component identification, we could relax those

Resolves https://github.com/ethereum-optimism/optimism/issues/15152