### PR TITLE
op-devstack: Support time travel

### DIFF
--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -1,6 +1,8 @@
 package presets
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
@@ -79,6 +81,12 @@ func (s *SingleChainInterop) L2Networks() []*dsl.L2Network {
 	return []*dsl.L2Network{
 		s.L2ChainA,
 	}
+}
+
+func (s *SingleChainInterop) AdvanceTime(amount time.Duration) {
+	ttSys, ok := s.system.(stack.TimeTravelSystem)
+	s.T.Require().True(ok, "attempting to advance time on incompatible system")
+	ttSys.AdvanceTime(amount)
 }
 
 // WithSingleChainInterop specifies a system that meets the SingleChainInterop criteria.

--- a/op-devstack/presets/timetravel.go
+++ b/op-devstack/presets/timetravel.go
@@ -1,0 +1,21 @@
+package presets
+
+import "github.com/ethereum-optimism/optimism/op-devstack/stack"
+
+func WithTimeTravel() stack.Option[stack.Orchestrator] {
+	return stack.Combine(
+		stack.BeforeDeploy[stack.Orchestrator](func(orch stack.Orchestrator) {
+			ttOrch, ok := orch.(stack.TimeTravelOrchestrator)
+			if !ok {
+				return
+			}
+			ttOrch.EnableTimeTravel()
+		}),
+		stack.PostHydrate[stack.Orchestrator](func(sys stack.System) {
+			sys.L1Networks()
+			ttSys, ok := sys.(stack.TimeTravelSystem)
+			sys.T().Gate().True(ok, "Requires system supporting time travel")
+			sys.T().Gate().True(ttSys.TimeTravelEnabled(), "Time travel must be enabled")
+		}),
+	)
+}

--- a/op-devstack/stack/orchestrator.go
+++ b/op-devstack/stack/orchestrator.go
@@ -42,6 +42,10 @@ type Orchestrator interface {
 	Type() compat.Type
 }
 
+type TimeTravelOrchestrator interface {
+	EnableTimeTravel()
+}
+
 // GateWithRemediation is an example of a test-gate that checks a system and may use an orchestrator to remediate any shortcomings.
 // func GateWithRemediation(sys System, orchestrator Orchestrator) {
 // step 1: check if system already does the right thing

--- a/op-devstack/stack/system.go
+++ b/op-devstack/stack/system.go
@@ -1,6 +1,10 @@
 package stack
 
-import "github.com/ethereum-optimism/optimism/op-service/eth"
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 // System represents a collection of L1 and L2 chains, any superchains or clusters, and any peripherals.
 type System interface {
@@ -41,4 +45,16 @@ type ExtensibleSystem interface {
 	AddL2Network(v L2Network)
 	AddSupervisor(v Supervisor)
 	AddTestSequencer(v TestSequencer)
+}
+
+type TimeTravelClock interface {
+	AdvanceTime(d time.Duration)
+}
+
+// TimeTravelSystem is an extension-interface to support time travel.
+type TimeTravelSystem interface {
+	System
+	SetTimeTravelClock(cl TimeTravelClock)
+	TimeTravelEnabled() bool
+	AdvanceTime(amount time.Duration)
 }


### PR DESCRIPTION
**Description**

Add time travel support to the dev stack presets. Only supported in sysgo since kurtosis uses a real L1 CL client.

Provides a preset option to enable time travel (and gate on its availability):
```go
presets.DoMain(m, presets.WithSuperInterop(), presets.WithTimeTravel())
```

and then can be used from the preset system easily:

```go
	sys := presets.NewSimpleInterop(t)
	sys.AdvanceTime(5 * time.Minute)
```

#15958 
