### PR TITLE
fix(kt-devnet): support kt-provided label for node index

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -2,7 +2,6 @@ package kurtosis
 
 import (
 	"encoding/json"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -26,10 +25,6 @@ type ServiceFinder struct {
 	depsets  map[string]descriptors.DepSet
 
 	triagedServices []*triagedService
-
-	// TODO: remove once we move node services recognition to labels
-	nodeNames2Index map[string]int
-	nodeNextIndex   int
 }
 
 // ServiceFinderOption configures a ServiceFinder
@@ -55,9 +50,6 @@ func NewServiceFinder(services inspect.ServiceMap, opts ...ServiceFinderOption) 
 		services:        services,
 		nodeServices:    []string{"cl", "el"},
 		l2ServicePrefix: "op-",
-
-		nodeNames2Index: make(map[string]int),
-		nodeNextIndex:   0,
 	}
 	for _, opt := range opts {
 		opt(f)
@@ -225,6 +217,7 @@ const (
 	kindLabel      = "op.kind"
 	networkIDLabel = "op.network.id"
 	nodeNameLabel  = "op.network.participant.name"
+	nodeIndexLabel = "op.network.participant.index"
 )
 
 func (f *ServiceFinder) triageByLabels(svc *inspect.Service, name string, endpoints descriptors.EndpointMap) *triagedService {
@@ -236,20 +229,13 @@ func (f *ServiceFinder) triageByLabels(svc *inspect.Service, name string, endpoi
 	if !ok {
 		return nil
 	}
-
-	// TODO: we really don't need numeric index for nodes, but it's a quick fix until
-	// we move node services recognition to labels entirely.
 	idx := -1
-	if slices.Contains(f.nodeServices, tag) { // those are grouped into nodes
-		if name, ok := svc.Labels[nodeNameLabel]; ok {
-			if val, ok := f.nodeNames2Index[name]; ok {
-				idx = val
-			} else {
-				idx = f.nodeNextIndex
-				f.nodeNames2Index[name] = idx
-				f.nodeNextIndex++
-			}
+	if val, ok := svc.Labels[nodeIndexLabel]; ok {
+		i, err := strconv.Atoi(val)
+		if err != nil {
+			return nil
 		}
+		idx = i
 	}
 	return &triagedService{
 		tag: tag,

--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -150,7 +150,7 @@ func createTestServiceMap() inspect.ServiceMap {
 				networkIDLabel: "2151908",
 			},
 		},
-		"op-cl-2151908-1-op-node-op-geth-op-kurtosis-1": &inspect.Service{
+		"op-cl-2151908-1": &inspect.Service{
 			Ports: inspect.PortMap{
 				"http":          &descriptors.PortInfo{Port: 32785},
 				"metrics":       &descriptors.PortInfo{Port: 32786},
@@ -158,8 +158,13 @@ func createTestServiceMap() inspect.ServiceMap {
 				"tcp-discovery": &descriptors.PortInfo{Port: 32787},
 				"udp-discovery": &descriptors.PortInfo{Port: 32771},
 			},
+			Labels: map[string]string{
+				kindLabel:      "cl",
+				networkIDLabel: "2151908",
+				nodeIndexLabel: "0",
+			},
 		},
-		"op-el-2151908-1-op-geth-op-node-op-kurtosis-1": &inspect.Service{
+		"op-el-2151908-1": &inspect.Service{
 			Ports: inspect.PortMap{
 				"engine-rpc":    &descriptors.PortInfo{Port: 32782},
 				"metrics":       &descriptors.PortInfo{Port: 32783},
@@ -167,6 +172,11 @@ func createTestServiceMap() inspect.ServiceMap {
 				"tcp-discovery": &descriptors.PortInfo{Port: 32784},
 				"udp-discovery": &descriptors.PortInfo{Port: 32770},
 				"ws":            &descriptors.PortInfo{Port: 32781},
+			},
+			Labels: map[string]string{
+				kindLabel:      "el",
+				networkIDLabel: "2151908",
+				nodeIndexLabel: "0",
 			},
 		},
 		"proxyd-2151908": &inspect.Service{
@@ -201,7 +211,7 @@ func createTestServiceMap() inspect.ServiceMap {
 				networkIDLabel: "2151909",
 			},
 		},
-		"op-cl-2151909-1-op-node-op-geth-op-kurtosis-2": &inspect.Service{
+		"op-cl-2151909-1": &inspect.Service{
 			Ports: inspect.PortMap{
 				"http":          &descriptors.PortInfo{Port: 32800},
 				"metrics":       &descriptors.PortInfo{Port: 32801},
@@ -209,8 +219,13 @@ func createTestServiceMap() inspect.ServiceMap {
 				"tcp-discovery": &descriptors.PortInfo{Port: 32802},
 				"udp-discovery": &descriptors.PortInfo{Port: 32773},
 			},
+			Labels: map[string]string{
+				kindLabel:      "cl",
+				networkIDLabel: "2151909",
+				nodeIndexLabel: "0",
+			},
 		},
-		"op-el-2151909-1-op-geth-op-node-op-kurtosis-2": &inspect.Service{
+		"op-el-2151909-1": &inspect.Service{
 			Ports: inspect.PortMap{
 				"engine-rpc":    &descriptors.PortInfo{Port: 32797},
 				"metrics":       &descriptors.PortInfo{Port: 32798},
@@ -218,6 +233,11 @@ func createTestServiceMap() inspect.ServiceMap {
 				"tcp-discovery": &descriptors.PortInfo{Port: 32799},
 				"udp-discovery": &descriptors.PortInfo{Port: 32772},
 				"ws":            &descriptors.PortInfo{Port: 32796},
+			},
+			Labels: map[string]string{
+				kindLabel:      "el",
+				networkIDLabel: "2151909",
+				nodeIndexLabel: "0",
 			},
 		},
 		"proxyd-2151909": &inspect.Service{


### PR DESCRIPTION
**Description**

When using labels-based service identification, use op.network.participant.index label to define the node index.


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
