### PR TITLE
circleci: config.yml: increase timeout for go test -short

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1895,6 +1895,8 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
       - go-tests:
           name: go-tests-short
+          no_output_timeout: 19m
+          test_timeout: 20m
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick


### PR DESCRIPTION
It appears that `go test -short` is quite close to the 10m mark, so I am increasing the timeout.