### PR TITLE
kurtosis-devnet: fix second-pass templating when no docker build jobs defined

### DIFF
--- a/kurtosis-devnet/pkg/deploy/template.go
+++ b/kurtosis-devnet/pkg/deploy/template.go
@@ -244,17 +244,16 @@ func (f *Templater) Render(ctx context.Context) (*bytes.Buffer, error) {
 				return nil, fmt.Errorf("error building docker image for %s: %w", job.projectName, job.err)
 			}
 		}
-
-		// Now reopen the template file for the second pass
-		tmplFile.Close()
-		tmplFile, err = os.Open(f.templateFile)
-		if err != nil {
-			return nil, fmt.Errorf("error reopening template file: %w", err)
-		}
-		defer tmplFile.Close()
 	} else {
 		buildWg.Wait()
 	}
+	// Now reopen the template file for the second pass
+	tmplFile.Close()
+	tmplFile, err = os.Open(f.templateFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reopening template file: %w", err)
+	}
+	defer tmplFile.Close()
 
 	// Second pass: Render with actual build results
 	buf := bytes.NewBuffer(nil)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
When the `kurtosis-devnet` CLI command is invoked with a template file that does not contain any local docker image builds (`localDockerImage` template function), the resulting deployment-input to kurtosis is empty:

```
Creating a new enclave for Starlark to run inside...
Enclave 'vanilla-devnet' created successfully

2025/06/16 19:07:14 Deployment input:
null
Using existing enclave 'vanilla-devnet'

2025/06/16 19:07:17 Error: error deploying environment: error deploying kurtosis package: interpretation error: Unable to parse package input 'None' into a dictionary. JSON other than dictionaries aren't support right now.
exit status 1
```
This is caused by the templater always reading the template file twice. The first pass is always executed and exhausts the buffer.

In the code-branch that builds the docker-images, the template file buffer is filled again by an additional reopening
of the file.
This however is lacking in the code-branch without any docker builds, thus resulting in the templater consuming an empty buffer:

https://github.com/ethereum-optimism/optimism/blob/92619a068d00f931b7bbc4c8a9a77ca3c8f70053/kurtosis-devnet/pkg/deploy/template.go#L248-L263

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
I manually tested the code from this PR and the kurtosis enclave was started successfully.
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**
This issue was probably never discovered, since all devnet definitions within the optimism repo build some docker image,
and thus the other code path was never executed.

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
