### PR TITLE
op-deployer: remove AddGameType.DisputeGameType validation

### DIFF
--- a/op-deployer/pkg/deployer/manage/add_game_type.go
+++ b/op-deployer/pkg/deployer/manage/add_game_type.go
@@ -80,10 +80,6 @@ func (c *AddGameTypeConfig) Check() error {
 		return fmt.Errorf("opChainProxyAdmin address must be specified")
 	}
 
-	if c.DisputeGameType == 0 {
-		return fmt.Errorf("disputeGameType must be non-zero")
-	}
-
 	if c.DisputeAbsolutePrestate == (common.Hash{}) {
 		return fmt.Errorf("disputeAbsolutePrestate must be specified")
 	}


### PR DESCRIPTION
`DisputeGameType == 0` if using permissionless cannon, therefore the current check against that value is invalid. Solidity source code that defines that value [here](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/dispute/lib/Types.sol#L53).