### PR TITLE
fix(kt-devnet): use dash as network separator

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -255,7 +255,7 @@ func (f *ServiceFinder) triageByLabels(svc *inspect.Service, name string, endpoi
 		tag: tag,
 		idx: idx,
 		// TODO: eventually we can retire the "name" part, but it doesn't hurt for now
-		accept: acceptNamesOrIDs(strings.Split(id, ",")...),
+		accept: acceptNamesOrIDs(strings.Split(id, "-")...),
 		svc: &descriptors.Service{
 			Name:      name,
 			Endpoints: endpoints,

--- a/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints_test.go
@@ -243,7 +243,7 @@ func createTestServiceMap() inspect.ServiceMap {
 			},
 			Labels: map[string]string{
 				kindLabel:      "challenger",
-				networkIDLabel: "2151908,2151909",
+				networkIDLabel: "2151908-2151909",
 			},
 		},
 		"op-supervisor-service-superchain": &inspect.Service{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This follow https://github.com/ethpandaops/optimism-package/pull/337
Kurtosis labels are unfortunately limited in the characters they can use.
<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
