### PR TITLE
op-interop-mon: Refactor Metric Collection and Emission

### DIFF
--- a/op-interop-mon/README.md
+++ b/op-interop-mon/README.md
@@ -20,19 +20,11 @@ The components use a collection of channels, callbacks and visitor-pattern style
 ```mermaid
 flowchart TD
 
-<<<<<<< HEAD
-  subgraph op-geth A
-    ra[RPC]
-  end
-
-  subgraph op-geth B
-=======
   subgraph execution-client A
     ra[RPC]
   end
 
   subgraph execution-client B
->>>>>>> origin
     rb[RPC]
   end
 
@@ -52,13 +44,8 @@ flowchart TD
 
   ra --"New Unsafe and Finalized Blocks"--> fa
   ra --"Receipt Data for EM Validation"--> ua
-<<<<<<< HEAD
-  fa --"Executing Messages and Finality" --> s
-  s --"New Jobs and Expiry Info" --> ub
-=======
   fa --"Executing Messages and Finalized Block Info" --> s
   s --"New Jobs and Finalized Block Info" --> ub
->>>>>>> origin
   rb --"New Unsafe and Finalized Blocks"--> fb
   rb --"Receipt Data for EM Validation"--> ub
   fb --"Executing Messages and Finalized Block Info" --> s

--- a/op-interop-mon/README.md
+++ b/op-interop-mon/README.md
@@ -20,11 +20,11 @@ The components use a collection of channels, callbacks and visitor-pattern style
 ```mermaid
 flowchart TD
 
-  subgraph op-node A
+  subgraph op-geth A
     ra[RPC]
   end
 
-  subgraph op-node B
+  subgraph op-geth B
     rb[RPC]
   end
 
@@ -44,7 +44,7 @@ flowchart TD
 
   ra --"New Unsafe and Finalized Blocks"--> fa
   ra --"Receipt Data for EM Validation"--> ua
-  fa --"Execcuting Messages and Finality" --> s
+  fa --"Executing Messages and Finality" --> s
   s --"New Jobs and Expiry Info" --> ub
   rb --"New Unsafe and Finalized Blocks"--> fb
   rb --"Receipt Data for EM Validation"--> ub

--- a/op-interop-mon/metrics/metrics.go
+++ b/op-interop-mon/metrics/metrics.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -15,9 +13,10 @@ var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
 type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
-	RecordInitiatingMessageStats(chainID string, blockHeight uint64, status string, value float64)
-	RecordExecutingMessageStats(chainID string, blockHeight uint64, blockHash string, status string, value float64)
+	RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64)
 	RecordTerminalStatusChange(executingChainID string, initiatingChainID string, value float64)
+	RecordExecutingBlockRange(chainID string, min uint64, max uint64)
+	RecordInitiatingBlockRange(chainID string, min uint64, max uint64)
 
 	opmetrics.RefMetricer
 	opmetrics.RPCMetricer
@@ -35,9 +34,10 @@ type Metrics struct {
 	up   prometheus.Gauge
 
 	// Message metrics
-	executingMessages     prometheus.GaugeVec
-	initiatingMessages    prometheus.GaugeVec
+	messageStatus         prometheus.GaugeVec
 	terminalStatusChanges prometheus.GaugeVec
+	executingBlockRange   prometheus.GaugeVec
+	initiatingBlockRange  prometheus.GaugeVec
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -71,23 +71,13 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "up",
 			Help:      "1 if the op-interop-mon has finished starting up",
 		}),
-		executingMessages: *factory.NewGaugeVec(prometheus.GaugeOpts{
+		messageStatus: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
-			Name:      "executing_messages",
-			Help:      "Number of messages being executed",
+			Name:      "message_status",
+			Help:      "Number of messages by executing chain, initiating chain, and status",
 		}, []string{
-			"chain_id",
-			"block_height",
-			"block_hash",
-			"status",
-		}),
-		initiatingMessages: *factory.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: ns,
-			Name:      "initiating_messages",
-			Help:      "Number of messages being referenced by executing messages",
-		}, []string{
-			"chain_id",
-			"block_height",
+			"executing_chain_id",
+			"initiating_chain_id",
 			"status",
 		}),
 		terminalStatusChanges: *factory.NewGaugeVec(prometheus.GaugeOpts{
@@ -97,6 +87,22 @@ func NewMetrics(procName string) *Metrics {
 		}, []string{
 			"executing_chain_id",
 			"initiating_chain_id",
+		}),
+		executingBlockRange: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "executing_block_range",
+			Help:      "Range of blocks containing Executing Messages currently tracked by the monitor",
+		}, []string{
+			"chain_id",
+			"range_type",
+		}),
+		initiatingBlockRange: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "initiating_block_range",
+			Help:      "Range of blocks being referenced by Executing Messages currently tracked by the monitor",
+		}, []string{
+			"chain_id",
+			"range_type",
 		}),
 	}
 }
@@ -117,32 +123,16 @@ func (m *Metrics) Document() []opmetrics.DocumentedMetric {
 	return m.factory.Document()
 }
 
-// RecordExecutingMessageStats records metrics for messages being executed
-func (m *Metrics) RecordExecutingMessageStats(
-	chainID string,
-	blockHeight uint64,
-	blockHash string,
+// RecordMessageStatus records metrics for messages by their executing chain, initiating chain, and status
+func (m *Metrics) RecordMessageStatus(
+	executingChainID string,
+	initiatingChainID string,
 	status string,
 	value float64,
 ) {
-	m.executingMessages.WithLabelValues(
-		chainID,
-		fmt.Sprintf("%d", blockHeight),
-		blockHash,
-		status,
-	).Set(value)
-}
-
-// RecordInitiatingMessageStats records metrics for messages being initiated
-func (m *Metrics) RecordInitiatingMessageStats(
-	chainID string,
-	blockHeight uint64,
-	status string,
-	value float64,
-) {
-	m.initiatingMessages.WithLabelValues(
-		chainID,
-		fmt.Sprintf("%d", blockHeight),
+	m.messageStatus.WithLabelValues(
+		executingChainID,
+		initiatingChainID,
 		status,
 	).Set(value)
 }
@@ -157,4 +147,16 @@ func (m *Metrics) RecordTerminalStatusChange(
 		executingChainID,
 		initiatingChainID,
 	).Set(value)
+}
+
+// RecordExecutingBlockRange records the min/max executing block numbers seen for a chain
+func (m *Metrics) RecordExecutingBlockRange(chainID string, min uint64, max uint64) {
+	m.executingBlockRange.WithLabelValues(chainID, "min").Set(float64(min))
+	m.executingBlockRange.WithLabelValues(chainID, "max").Set(float64(max))
+}
+
+// RecordInitiatingBlockRange records the min/max initiating block numbers seen for a chain
+func (m *Metrics) RecordInitiatingBlockRange(chainID string, min uint64, max uint64) {
+	m.initiatingBlockRange.WithLabelValues(chainID, "min").Set(float64(min))
+	m.initiatingBlockRange.WithLabelValues(chainID, "max").Set(float64(max))
 }

--- a/op-interop-mon/metrics/metrics.go
+++ b/op-interop-mon/metrics/metrics.go
@@ -13,8 +13,8 @@ var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
 type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
-	RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64)
-	RecordTerminalStatusChange(executingChainID string, initiatingChainID string, value float64)
+	RecordMessageStatus(executingChainID string, initiatingChainID string, status string, count float64)
+	RecordTerminalStatusChange(executingChainID string, initiatingChainID string, count float64)
 	RecordExecutingBlockRange(chainID string, min uint64, max uint64)
 	RecordInitiatingBlockRange(chainID string, min uint64, max uint64)
 
@@ -128,25 +128,25 @@ func (m *Metrics) RecordMessageStatus(
 	executingChainID string,
 	initiatingChainID string,
 	status string,
-	value float64,
+	count float64,
 ) {
 	m.messageStatus.WithLabelValues(
 		executingChainID,
 		initiatingChainID,
 		status,
-	).Set(value)
+	).Set(count)
 }
 
 // RecordTerminalStatusChange records a terminal status change with detailed logging
 func (m *Metrics) RecordTerminalStatusChange(
 	executingChainID string,
 	initiatingChainID string,
-	value float64,
+	count float64,
 ) {
 	m.terminalStatusChanges.WithLabelValues(
 		executingChainID,
 		initiatingChainID,
-	).Set(value)
+	).Set(count)
 }
 
 // RecordExecutingBlockRange records the min/max executing block numbers seen for a chain

--- a/op-interop-mon/metrics/noop.go
+++ b/op-interop-mon/metrics/noop.go
@@ -13,9 +13,9 @@ var NoopMetrics Metricer = new(noopMetrics)
 
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
-func (*noopMetrics) RecordInitiatingMessageStats(chainID string, blockHeight uint64, status string, value float64) {
-}
-func (*noopMetrics) RecordExecutingMessageStats(chainID string, blockHeight uint64, blockHash string, status string, value float64) {
+func (*noopMetrics) RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64) {
 }
 func (*noopMetrics) RecordTerminalStatusChange(executingChainID string, initiatingChainID string, value float64) {
 }
+func (*noopMetrics) RecordExecutingBlockRange(chainID string, min uint64, max uint64)  {}
+func (*noopMetrics) RecordInitiatingBlockRange(chainID string, min uint64, max uint64) {}

--- a/op-interop-mon/monitor/job.go
+++ b/op-interop-mon/monitor/job.go
@@ -74,7 +74,8 @@ type Job struct {
 	executingBlock   eth.BlockID
 	executingPayload common.Hash
 
-	initiating *supervisortypes.Identifier
+	initiating     *supervisortypes.Identifier
+	initiatingHash []common.Hash
 
 	// track each status seen over time
 	status []jobStatus
@@ -141,7 +142,11 @@ func (j *Job) ID() JobID {
 func (j *Job) Statuses() []jobStatus {
 	j.rwLock.RLock()
 	defer j.rwLock.RUnlock()
-	return j.status
+
+	// Return a copy to prevent external modification
+	statuses := make([]jobStatus, len(j.status))
+	copy(statuses, j.status)
+	return statuses
 }
 
 // LatestStatus returns the latest status of the job
@@ -205,4 +210,30 @@ func (j *Job) DidMetrics() bool {
 // SetDidMetrics sets the did metrics flag of the job
 func (j *Job) SetDidMetrics() {
 	j.didMetrics.Store(true)
+}
+
+// AddInitiatingHash adds a hash to the initiatingHash slice if it hasn't been seen before
+func (j *Job) AddInitiatingHash(hash common.Hash) {
+	j.rwLock.Lock()
+	defer j.rwLock.Unlock()
+
+	// Check if hash already exists
+	for _, existingHash := range j.initiatingHash {
+		if existingHash == hash {
+			return
+		}
+	}
+
+	j.initiatingHash = append(j.initiatingHash, hash)
+}
+
+// InitiatingHashes returns a copy of the initiating hashes
+func (j *Job) InitiatingHashes() []common.Hash {
+	j.rwLock.RLock()
+	defer j.rwLock.RUnlock()
+
+	// Return a copy to prevent external modification
+	hashes := make([]common.Hash, len(j.initiatingHash))
+	copy(hashes, j.initiatingHash)
+	return hashes
 }

--- a/op-interop-mon/monitor/job.go
+++ b/op-interop-mon/monitor/job.go
@@ -217,11 +217,9 @@ func (j *Job) AddInitiatingHash(hash common.Hash) {
 	j.rwLock.Lock()
 	defer j.rwLock.Unlock()
 
-	// Check if hash already exists
-	for _, existingHash := range j.initiatingHash {
-		if existingHash == hash {
-			return
-		}
+	// Check if latest initiating hash is the same as the hash to be added
+	if len(j.initiatingHash) > 0 && j.initiatingHash[len(j.initiatingHash)-1] == hash {
+		return
 	}
 
 	j.initiatingHash = append(j.initiatingHash, hash)

--- a/op-interop-mon/monitor/metric_collector.go
+++ b/op-interop-mon/monitor/metric_collector.go
@@ -8,8 +8,8 @@ import (
 )
 
 type InteropMessageMetrics interface {
-	RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64)
-	RecordTerminalStatusChange(executingChainID string, initiatingChainID string, value float64)
+	RecordMessageStatus(executingChainID string, initiatingChainID string, status string, count float64)
+	RecordTerminalStatusChange(executingChainID string, initiatingChainID string, count float64)
 	RecordExecutingBlockRange(chainID string, min uint64, max uint64)
 	RecordInitiatingBlockRange(chainID string, min uint64, max uint64)
 }
@@ -203,12 +203,22 @@ func (m *MetricCollector) CollectMetrics() {
 	for executingChainID, initiatingChainMap := range messageStatus {
 		for initiatingChainID, statusMap := range initiatingChainMap {
 			for status, count := range statusMap {
-				m.log.Info("updating message status stats",
-					"executing_chain_id", executingChainID,
-					"initiating_chain_id", initiatingChainID,
-					"status", status,
-					"count", count,
-				)
+				if status == jobStatusInvalid.String() {
+					// invalid messages are logged as warnings
+					m.log.Warn("Invalid Executing Messages Detected",
+						"executing_chain_id", executingChainID,
+						"initiating_chain_id", initiatingChainID,
+						"count", count,
+					)
+				} else {
+					// valid or unknown messages are logged as debug
+					m.log.Debug("Updating Executing Message Status Count",
+						"executing_chain_id", executingChainID,
+						"initiating_chain_id", initiatingChainID,
+						"status", status,
+						"count", count,
+					)
+				}
 				m.m.RecordMessageStatus(
 					executingChainID.String(),
 					initiatingChainID.String(),

--- a/op-interop-mon/monitor/metric_collector.go
+++ b/op-interop-mon/monitor/metric_collector.go
@@ -4,14 +4,14 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 type InteropMessageMetrics interface {
-	RecordExecutingMessageStats(chainID string, blockNumber uint64, blockHash string, status string, value float64)
-	RecordInitiatingMessageStats(chainID string, blockNumber uint64, status string, value float64)
+	RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64)
 	RecordTerminalStatusChange(executingChainID string, initiatingChainID string, value float64)
+	RecordExecutingBlockRange(chainID string, min uint64, max uint64)
+	RecordInitiatingBlockRange(chainID string, min uint64, max uint64)
 }
 
 type MetricCollector struct {
@@ -72,46 +72,103 @@ func (m *MetricCollector) CollectMetrics() {
 		jobMap = updater.CollectForMetrics(jobMap)
 	}
 	// message metrics are dimensioned by:
+	// - executing chain id
 	// - initiating chain id
-	// - block number
-	// - block hash (only for executing messages)
 	// - status
-	executingMessages := map[eth.ChainID]map[uint64]map[common.Hash]map[string]int{}
-	initiatingMessages := map[eth.ChainID]map[uint64]map[string]int{}
+	messageStatus := map[eth.ChainID]map[eth.ChainID]map[string]int{}
 	terminalStatusChanges := map[eth.ChainID]map[eth.ChainID]int{}
+
+	// Track block number ranges for each chain
+	executingRanges := map[eth.ChainID]struct {
+		min, max uint64
+	}{}
+	initiatingRanges := map[eth.ChainID]struct {
+		min, max uint64
+	}{}
+
 	for _, job := range jobMap {
+		// Initialize executing ranges for this chain if not seen before
+		if _, exists := executingRanges[job.executingChain]; !exists {
+			executingRanges[job.executingChain] = struct {
+				min, max uint64
+			}{
+				min: job.executingBlock.Number,
+				max: job.executingBlock.Number,
+			}
+		}
+
+		// Initialize initiating ranges for this chain if not seen before
+		if _, exists := initiatingRanges[job.initiating.ChainID]; !exists {
+			initiatingRanges[job.initiating.ChainID] = struct {
+				min, max uint64
+			}{
+				min: job.initiating.BlockNumber,
+				max: job.initiating.BlockNumber,
+			}
+		}
+
+		// Update executing ranges
+		execRange := executingRanges[job.executingChain]
+		if job.executingBlock.Number < execRange.min {
+			execRange.min = job.executingBlock.Number
+		}
+		if job.executingBlock.Number > execRange.max {
+			execRange.max = job.executingBlock.Number
+		}
+		executingRanges[job.executingChain] = execRange
+
+		// Update initiating ranges
+		initRange := initiatingRanges[job.initiating.ChainID]
+		if job.initiating.BlockNumber < initRange.min {
+			initRange.min = job.initiating.BlockNumber
+		}
+		if job.initiating.BlockNumber > initRange.max {
+			initRange.max = job.initiating.BlockNumber
+		}
+		initiatingRanges[job.initiating.ChainID] = initRange
+
 		statuses := job.Statuses()
 		if len(statuses) == 0 {
 			m.log.Warn("Job has no statuses", "job", job)
 			continue
 		}
 		current := statuses[len(statuses)-1].String()
-		// Lazy increment the executing message metrics
-		if _, ok := executingMessages[job.executingChain]; !ok {
-			executingMessages[job.executingChain] = make(map[uint64]map[common.Hash]map[string]int)
-		}
-		if _, ok := executingMessages[job.executingChain][job.executingBlock.Number]; !ok {
-			executingMessages[job.executingChain][job.executingBlock.Number] = make(map[common.Hash]map[string]int)
-		}
-		if _, ok := executingMessages[job.executingChain][job.executingBlock.Number][job.executingBlock.Hash]; !ok {
-			executingMessages[job.executingChain][job.executingBlock.Number][job.executingBlock.Hash] = make(map[string]int)
-		}
-		if _, ok := executingMessages[job.executingChain][job.executingBlock.Number][job.executingBlock.Hash][current]; !ok {
-			executingMessages[job.executingChain][job.executingBlock.Number][job.executingBlock.Hash][current] = 0
-		}
-		executingMessages[job.executingChain][job.executingBlock.Number][job.executingBlock.Hash][current]++
 
-		// Lazy increment the initiating message metrics
-		if _, ok := initiatingMessages[job.initiating.ChainID]; !ok {
-			initiatingMessages[job.initiating.ChainID] = make(map[uint64]map[string]int)
+		// Log invalid statuses
+		if current == jobStatusInvalid.String() {
+			m.log.Warn("Invalid Executing Message Detected",
+				"executing_chain_id", job.executingChain,
+				"initiating_chain_id", job.initiating.ChainID,
+				"executing_block_height", job.executingBlock.Number,
+				"initiating_block_height", job.initiating.BlockNumber,
+				"executing_block_hash", job.executingBlock.Hash,
+			)
 		}
-		if _, ok := initiatingMessages[job.initiating.ChainID][job.initiating.BlockNumber]; !ok {
-			initiatingMessages[job.initiating.ChainID][job.initiating.BlockNumber] = make(map[string]int)
+
+		// Check for multiple initiating hashes
+		initiatingHashes := job.InitiatingHashes()
+		if len(initiatingHashes) > 1 {
+			m.log.Warn("Initiating BlockNumber found multiple Blocks (potential reorg of initiating block)",
+				"executing_chain_id", job.executingChain,
+				"initiating_chain_id", job.initiating.ChainID,
+				"executing_block_height", job.executingBlock.Number,
+				"initiating_block_height", job.initiating.BlockNumber,
+				"executing_block_hash", job.executingBlock.Hash,
+				"initiating_hashes", initiatingHashes,
+			)
 		}
-		if _, ok := initiatingMessages[job.initiating.ChainID][job.initiating.BlockNumber][current]; !ok {
-			initiatingMessages[job.initiating.ChainID][job.initiating.BlockNumber][current] = 0
+
+		// Lazy increment the message status metrics
+		if _, ok := messageStatus[job.executingChain]; !ok {
+			messageStatus[job.executingChain] = make(map[eth.ChainID]map[string]int)
 		}
-		initiatingMessages[job.initiating.ChainID][job.initiating.BlockNumber][current]++
+		if _, ok := messageStatus[job.executingChain][job.initiating.ChainID]; !ok {
+			messageStatus[job.executingChain][job.initiating.ChainID] = make(map[string]int)
+		}
+		if _, ok := messageStatus[job.executingChain][job.initiating.ChainID][current]; !ok {
+			messageStatus[job.executingChain][job.initiating.ChainID][current] = 0
+		}
+		messageStatus[job.executingChain][job.initiating.ChainID][current]++
 
 		// Evaluate the job for a terminal state change
 		hasBeenValid := false
@@ -125,7 +182,7 @@ func (m *MetricCollector) CollectMetrics() {
 			}
 		}
 		if hasBeenValid && hasBeenInvalid {
-			m.log.Warn("Job has been both valid and invalid",
+			m.log.Warn("Executing Message has been both Valid and Invalid",
 				"executing_chain_id", job.executingChain,
 				"initiating_chain_id", job.initiating.ChainID,
 				"executing_block_height", job.executingBlock.Number,
@@ -142,23 +199,22 @@ func (m *MetricCollector) CollectMetrics() {
 		}
 	}
 	// now we have the metrics consolidated, we can update the metrics
-	// executing messages
-	for chainID, blockNumberMap := range executingMessages {
-		for blockNumber, blockHashMap := range blockNumberMap {
-			for blockHash, statusMap := range blockHashMap {
-				for status, count := range statusMap {
-					m.log.Info("updating executing message stats", "chainID", chainID, "blockNumber", blockNumber, "blockHash", blockHash, "status", status, "count", count)
-					m.m.RecordExecutingMessageStats(chainID.String(), blockNumber, blockHash.String(), status, float64(count))
-				}
-			}
-		}
-	}
-	// initiating messages
-	for chainID, blockNumberMap := range initiatingMessages {
-		for blockNumber, statusMap := range blockNumberMap {
+	// message status
+	for executingChainID, initiatingChainMap := range messageStatus {
+		for initiatingChainID, statusMap := range initiatingChainMap {
 			for status, count := range statusMap {
-				m.log.Info("updating initiating message stats", "chainID", chainID, "blockNumber", blockNumber, "status", status, "count", count)
-				m.m.RecordInitiatingMessageStats(chainID.String(), blockNumber, status, float64(count))
+				m.log.Info("updating message status stats",
+					"executing_chain_id", executingChainID,
+					"initiating_chain_id", initiatingChainID,
+					"status", status,
+					"count", count,
+				)
+				m.m.RecordMessageStatus(
+					executingChainID.String(),
+					initiatingChainID.String(),
+					status,
+					float64(count),
+				)
 			}
 		}
 	}
@@ -171,5 +227,21 @@ func (m *MetricCollector) CollectMetrics() {
 				float64(count),
 			)
 		}
+	}
+
+	// Record block number ranges
+	for chainID, ranges := range executingRanges {
+		m.m.RecordExecutingBlockRange(
+			chainID.String(),
+			ranges.min,
+			ranges.max,
+		)
+	}
+	for chainID, ranges := range initiatingRanges {
+		m.m.RecordInitiatingBlockRange(
+			chainID.String(),
+			ranges.min,
+			ranges.max,
+		)
 	}
 }

--- a/op-interop-mon/monitor/metric_collector.go
+++ b/op-interop-mon/monitor/metric_collector.go
@@ -148,7 +148,7 @@ func (m *MetricCollector) CollectMetrics() {
 		// Check for multiple initiating hashes
 		initiatingHashes := job.InitiatingHashes()
 		if len(initiatingHashes) > 1 {
-			m.log.Warn("Initiating BlockNumber found multiple Blocks (potential reorg of initiating block)",
+			m.log.Warn("Initiating BlockNumber found multiple Blocks (reorg of initiating block)",
 				"executing_chain_id", job.executingChain,
 				"initiating_chain_id", job.initiating.ChainID,
 				"executing_block_height", job.executingBlock.Number,

--- a/op-interop-mon/monitor/metric_collector_test.go
+++ b/op-interop-mon/monitor/metric_collector_test.go
@@ -18,13 +18,13 @@ type expectedMessageStatusCall struct {
 	executingChainID  string
 	initiatingChainID string
 	status            string
-	value             float64
+	count             float64
 }
 
 type expectedTerminalCall struct {
 	executingChainID  string
 	initiatingChainID string
-	value             float64
+	count             float64
 }
 
 type expectedBlockRangeCall struct {
@@ -65,8 +65,8 @@ func (m *mockUpdater) Stop() error {
 type mockMetrics struct {
 	recordInfoFn                 func(version string)
 	recordUpFn                   func()
-	recordMessageStatusFn        func(executingChainID string, initiatingChainID string, status string, value float64)
-	recordTerminalStatusChangeFn func(executingChainID string, initiatingChainID string, value float64)
+	recordMessageStatusFn        func(executingChainID string, initiatingChainID string, status string, count float64)
+	recordTerminalStatusChangeFn func(executingChainID string, initiatingChainID string, count float64)
 	recordExecutingBlockRangeFn  func(chainID string, min uint64, max uint64)
 	recordInitiatingBlockRangeFn func(chainID string, min uint64, max uint64)
 
@@ -89,27 +89,27 @@ func (m *mockMetrics) RecordUp() {
 	}
 }
 
-func (m *mockMetrics) RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64) {
+func (m *mockMetrics) RecordMessageStatus(executingChainID string, initiatingChainID string, status string, count float64) {
 	if m.recordMessageStatusFn != nil {
-		m.recordMessageStatusFn(executingChainID, initiatingChainID, status, value)
+		m.recordMessageStatusFn(executingChainID, initiatingChainID, status, count)
 	} else {
 		m.actualMessageStatusCalls = append(m.actualMessageStatusCalls, expectedMessageStatusCall{
 			executingChainID:  executingChainID,
 			initiatingChainID: initiatingChainID,
 			status:            status,
-			value:             value,
+			count:             count,
 		})
 	}
 }
 
-func (m *mockMetrics) RecordTerminalStatusChange(executingChainID string, initiatingChainID string, value float64) {
+func (m *mockMetrics) RecordTerminalStatusChange(executingChainID string, initiatingChainID string, count float64) {
 	if m.recordTerminalStatusChangeFn != nil {
-		m.recordTerminalStatusChangeFn(executingChainID, initiatingChainID, value)
+		m.recordTerminalStatusChangeFn(executingChainID, initiatingChainID, count)
 	} else {
 		m.actualTerminalCalls = append(m.actualTerminalCalls, expectedTerminalCall{
 			executingChainID:  executingChainID,
 			initiatingChainID: initiatingChainID,
-			value:             value,
+			count:             count,
 		})
 	}
 }
@@ -241,7 +241,7 @@ func TestCollectMetrics(t *testing.T) {
 					executingChainID:  "1",
 					initiatingChainID: "2",
 					status:            "future",
-					value:             1,
+					count:             1,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},
@@ -272,14 +272,14 @@ func TestCollectMetrics(t *testing.T) {
 					executingChainID:  "1",
 					initiatingChainID: "2",
 					status:            "invalid",
-					value:             1,
+					count:             1,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{
 				{
 					executingChainID:  "1",
 					initiatingChainID: "2",
-					value:             1,
+					count:             1,
 				},
 			},
 			expectedExecutingRangeCalls: []expectedBlockRangeCall{
@@ -310,7 +310,7 @@ func TestCollectMetrics(t *testing.T) {
 					executingChainID:  "1",
 					initiatingChainID: "2",
 					status:            "future",
-					value:             2,
+					count:             2,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},
@@ -345,19 +345,19 @@ func TestCollectMetrics(t *testing.T) {
 					executingChainID:  "1",
 					initiatingChainID: "2",
 					status:            "future",
-					value:             1,
+					count:             1,
 				},
 				{
 					executingChainID:  "2",
 					initiatingChainID: "3",
 					status:            "valid",
-					value:             1,
+					count:             1,
 				},
 				{
 					executingChainID:  "3",
 					initiatingChainID: "1",
 					status:            "invalid",
-					value:             1,
+					count:             1,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},
@@ -418,19 +418,19 @@ func TestCollectMetrics(t *testing.T) {
 					executingChainID:  "1",
 					initiatingChainID: "2",
 					status:            "future",
-					value:             3,
+					count:             3,
 				},
 				{
 					executingChainID:  "2",
 					initiatingChainID: "1",
 					status:            "valid",
-					value:             3,
+					count:             3,
 				},
 				{
 					executingChainID:  "3",
 					initiatingChainID: "3",
 					status:            "invalid",
-					value:             3,
+					count:             3,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},

--- a/op-interop-mon/monitor/metric_collector_test.go
+++ b/op-interop-mon/monitor/metric_collector_test.go
@@ -14,25 +14,23 @@ import (
 )
 
 // Test helper types
-type expectedExecutingCall struct {
-	chainID   string
-	blockNum  uint64
-	blockHash string
-	status    string
-	value     float64
-}
-
-type expectedInitiatingCall struct {
-	chainID  string
-	blockNum uint64
-	status   string
-	value    float64
+type expectedMessageStatusCall struct {
+	executingChainID  string
+	initiatingChainID string
+	status            string
+	value             float64
 }
 
 type expectedTerminalCall struct {
 	executingChainID  string
 	initiatingChainID string
 	value             float64
+}
+
+type expectedBlockRangeCall struct {
+	chainID string
+	min     uint64
+	max     uint64
 }
 
 // mockUpdater implements the Updater interface with configurable function implementations
@@ -65,16 +63,18 @@ func (m *mockUpdater) Stop() error {
 // mockMetrics implements the metrics.Metricer interface with configurable function implementations
 // by default, it records the calls to the metrics functions
 type mockMetrics struct {
-	recordInfoFn                   func(version string)
-	recordUpFn                     func()
-	recordInitiatingMessageStatsFn func(chainID string, blockHeight uint64, status string, value float64)
-	recordExecutingMessageStatsFn  func(chainID string, blockHeight uint64, blockHash string, status string, value float64)
-	recordTerminalStatusChangeFn   func(executingChainID string, initiatingChainID string, value float64)
+	recordInfoFn                 func(version string)
+	recordUpFn                   func()
+	recordMessageStatusFn        func(executingChainID string, initiatingChainID string, status string, value float64)
+	recordTerminalStatusChangeFn func(executingChainID string, initiatingChainID string, value float64)
+	recordExecutingBlockRangeFn  func(chainID string, min uint64, max uint64)
+	recordInitiatingBlockRangeFn func(chainID string, min uint64, max uint64)
 
 	// Recording slices for test verification
-	actualExecutingCalls  []expectedExecutingCall
-	actualInitiatingCalls []expectedInitiatingCall
-	actualTerminalCalls   []expectedTerminalCall
+	actualMessageStatusCalls   []expectedMessageStatusCall
+	actualTerminalCalls        []expectedTerminalCall
+	actualExecutingRangeCalls  []expectedBlockRangeCall
+	actualInitiatingRangeCalls []expectedBlockRangeCall
 }
 
 func (m *mockMetrics) RecordInfo(version string) {
@@ -89,29 +89,15 @@ func (m *mockMetrics) RecordUp() {
 	}
 }
 
-func (m *mockMetrics) RecordInitiatingMessageStats(chainID string, blockHeight uint64, status string, value float64) {
-	if m.recordInitiatingMessageStatsFn != nil {
-		m.recordInitiatingMessageStatsFn(chainID, blockHeight, status, value)
+func (m *mockMetrics) RecordMessageStatus(executingChainID string, initiatingChainID string, status string, value float64) {
+	if m.recordMessageStatusFn != nil {
+		m.recordMessageStatusFn(executingChainID, initiatingChainID, status, value)
 	} else {
-		m.actualInitiatingCalls = append(m.actualInitiatingCalls, expectedInitiatingCall{
-			chainID:  chainID,
-			blockNum: blockHeight,
-			status:   status,
-			value:    value,
-		})
-	}
-}
-
-func (m *mockMetrics) RecordExecutingMessageStats(chainID string, blockHeight uint64, blockHash string, status string, value float64) {
-	if m.recordExecutingMessageStatsFn != nil {
-		m.recordExecutingMessageStatsFn(chainID, blockHeight, blockHash, status, value)
-	} else {
-		m.actualExecutingCalls = append(m.actualExecutingCalls, expectedExecutingCall{
-			chainID:   chainID,
-			blockNum:  blockHeight,
-			blockHash: blockHash,
-			status:    status,
-			value:     value,
+		m.actualMessageStatusCalls = append(m.actualMessageStatusCalls, expectedMessageStatusCall{
+			executingChainID:  executingChainID,
+			initiatingChainID: initiatingChainID,
+			status:            status,
+			value:             value,
 		})
 	}
 }
@@ -124,6 +110,30 @@ func (m *mockMetrics) RecordTerminalStatusChange(executingChainID string, initia
 			executingChainID:  executingChainID,
 			initiatingChainID: initiatingChainID,
 			value:             value,
+		})
+	}
+}
+
+func (m *mockMetrics) RecordExecutingBlockRange(chainID string, min uint64, max uint64) {
+	if m.recordExecutingBlockRangeFn != nil {
+		m.recordExecutingBlockRangeFn(chainID, min, max)
+	} else {
+		m.actualExecutingRangeCalls = append(m.actualExecutingRangeCalls, expectedBlockRangeCall{
+			chainID: chainID,
+			min:     min,
+			max:     max,
+		})
+	}
+}
+
+func (m *mockMetrics) RecordInitiatingBlockRange(chainID string, min uint64, max uint64) {
+	if m.recordInitiatingBlockRangeFn != nil {
+		m.recordInitiatingBlockRangeFn(chainID, min, max)
+	} else {
+		m.actualInitiatingRangeCalls = append(m.actualInitiatingRangeCalls, expectedBlockRangeCall{
+			chainID: chainID,
+			min:     min,
+			max:     max,
 		})
 	}
 }
@@ -202,20 +212,22 @@ func TestCollectMetrics(t *testing.T) {
 		updater2Jobs map[JobID]*Job
 		updater3Jobs map[JobID]*Job
 		// Expected metric calls
-		expectedExecutingCalls  []expectedExecutingCall
-		expectedInitiatingCalls []expectedInitiatingCall
-		expectedTerminalCalls   []expectedTerminalCall
+		expectedMessageStatusCalls   []expectedMessageStatusCall
+		expectedTerminalCalls        []expectedTerminalCall
+		expectedExecutingRangeCalls  []expectedBlockRangeCall
+		expectedInitiatingRangeCalls []expectedBlockRangeCall
 	}
 
 	tests := []testCase{
 		{
-			name:                    "empty job maps",
-			updater1Jobs:            map[JobID]*Job{},
-			updater2Jobs:            map[JobID]*Job{},
-			updater3Jobs:            map[JobID]*Job{},
-			expectedExecutingCalls:  []expectedExecutingCall{},
-			expectedInitiatingCalls: []expectedInitiatingCall{},
-			expectedTerminalCalls:   []expectedTerminalCall{},
+			name:                         "empty job maps",
+			updater1Jobs:                 map[JobID]*Job{},
+			updater2Jobs:                 map[JobID]*Job{},
+			updater3Jobs:                 map[JobID]*Job{},
+			expectedMessageStatusCalls:   []expectedMessageStatusCall{},
+			expectedTerminalCalls:        []expectedTerminalCall{},
+			expectedExecutingRangeCalls:  []expectedBlockRangeCall{},
+			expectedInitiatingRangeCalls: []expectedBlockRangeCall{},
 		},
 		{
 			name: "single job with future status",
@@ -224,24 +236,29 @@ func TestCollectMetrics(t *testing.T) {
 			},
 			updater2Jobs: map[JobID]*Job{},
 			updater3Jobs: map[JobID]*Job{},
-			expectedExecutingCalls: []expectedExecutingCall{
+			expectedMessageStatusCalls: []expectedMessageStatusCall{
 				{
-					chainID:   "1",
-					blockNum:  100,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000123",
-					status:    "future",
-					value:     1,
-				},
-			},
-			expectedInitiatingCalls: []expectedInitiatingCall{
-				{
-					chainID:  "2",
-					blockNum: 200,
-					status:   "future",
-					value:    1,
+					executingChainID:  "1",
+					initiatingChainID: "2",
+					status:            "future",
+					value:             1,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},
+			expectedExecutingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     100,
+					max:     100,
+				},
+			},
+			expectedInitiatingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "2",
+					min:     200,
+					max:     200,
+				},
+			},
 		},
 		{
 			name: "job with terminal status change",
@@ -250,21 +267,12 @@ func TestCollectMetrics(t *testing.T) {
 			},
 			updater2Jobs: map[JobID]*Job{},
 			updater3Jobs: map[JobID]*Job{},
-			expectedExecutingCalls: []expectedExecutingCall{
+			expectedMessageStatusCalls: []expectedMessageStatusCall{
 				{
-					chainID:   "1",
-					blockNum:  100,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000123",
-					status:    "invalid",
-					value:     1,
-				},
-			},
-			expectedInitiatingCalls: []expectedInitiatingCall{
-				{
-					chainID:  "2",
-					blockNum: 200,
-					status:   "invalid",
-					value:    1,
+					executingChainID:  "1",
+					initiatingChainID: "2",
+					status:            "invalid",
+					value:             1,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{
@@ -272,6 +280,20 @@ func TestCollectMetrics(t *testing.T) {
 					executingChainID:  "1",
 					initiatingChainID: "2",
 					value:             1,
+				},
+			},
+			expectedExecutingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     100,
+					max:     100,
+				},
+			},
+			expectedInitiatingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "2",
+					min:     200,
+					max:     200,
 				},
 			},
 		},
@@ -283,37 +305,29 @@ func TestCollectMetrics(t *testing.T) {
 			},
 			updater2Jobs: map[JobID]*Job{},
 			updater3Jobs: map[JobID]*Job{},
-			expectedExecutingCalls: []expectedExecutingCall{
+			expectedMessageStatusCalls: []expectedMessageStatusCall{
 				{
-					chainID:   "1",
-					blockNum:  100,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000123",
-					status:    "future",
-					value:     1,
-				},
-				{
-					chainID:   "1",
-					blockNum:  101,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000456",
-					status:    "future",
-					value:     1,
-				},
-			},
-			expectedInitiatingCalls: []expectedInitiatingCall{
-				{
-					chainID:  "2",
-					blockNum: 200,
-					status:   "future",
-					value:    1,
-				},
-				{
-					chainID:  "2",
-					blockNum: 201,
-					status:   "future",
-					value:    1,
+					executingChainID:  "1",
+					initiatingChainID: "2",
+					status:            "future",
+					value:             2,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},
+			expectedExecutingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     100,
+					max:     101,
+				},
+			},
+			expectedInitiatingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "2",
+					min:     200,
+					max:     201,
+				},
+			},
 		},
 		{
 			name: "jobs across different chains",
@@ -326,50 +340,134 @@ func TestCollectMetrics(t *testing.T) {
 			updater3Jobs: map[JobID]*Job{
 				"job3": jobForTest(3, 500, "0x789", 1, 600, jobStatusInvalid),
 			},
-			expectedExecutingCalls: []expectedExecutingCall{
+			expectedMessageStatusCalls: []expectedMessageStatusCall{
 				{
-					chainID:   "1",
-					blockNum:  100,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000123",
-					status:    "future",
-					value:     1,
+					executingChainID:  "1",
+					initiatingChainID: "2",
+					status:            "future",
+					value:             1,
 				},
 				{
-					chainID:   "2",
-					blockNum:  300,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000456",
-					status:    "valid",
-					value:     1,
+					executingChainID:  "2",
+					initiatingChainID: "3",
+					status:            "valid",
+					value:             1,
 				},
 				{
-					chainID:   "3",
-					blockNum:  500,
-					blockHash: "0x0000000000000000000000000000000000000000000000000000000000000789",
-					status:    "invalid",
-					value:     1,
-				},
-			},
-			expectedInitiatingCalls: []expectedInitiatingCall{
-				{
-					chainID:  "2",
-					blockNum: 200,
-					status:   "future",
-					value:    1,
-				},
-				{
-					chainID:  "3",
-					blockNum: 400,
-					status:   "valid",
-					value:    1,
-				},
-				{
-					chainID:  "1",
-					blockNum: 600,
-					status:   "invalid",
-					value:    1,
+					executingChainID:  "3",
+					initiatingChainID: "1",
+					status:            "invalid",
+					value:             1,
 				},
 			},
 			expectedTerminalCalls: []expectedTerminalCall{},
+			expectedExecutingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     100,
+					max:     100,
+				},
+				{
+					chainID: "2",
+					min:     300,
+					max:     300,
+				},
+				{
+					chainID: "3",
+					min:     500,
+					max:     500,
+				},
+			},
+			expectedInitiatingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     600,
+					max:     600,
+				},
+				{
+					chainID: "2",
+					min:     200,
+					max:     200,
+				},
+				{
+					chainID: "3",
+					min:     400,
+					max:     400,
+				},
+			},
+		},
+		{
+			name: "complex block ranges",
+			updater1Jobs: map[JobID]*Job{
+				"job1": jobForTest(1, 100, "0x123", 2, 200, jobStatusFuture),
+				"job2": jobForTest(1, 50, "0x456", 2, 250, jobStatusFuture),
+				"job3": jobForTest(1, 150, "0x789", 2, 150, jobStatusFuture),
+			},
+			updater2Jobs: map[JobID]*Job{
+				"job4": jobForTest(2, 300, "0xabc", 1, 400, jobStatusValid),
+				"job5": jobForTest(2, 250, "0xdef", 1, 450, jobStatusValid),
+				"job6": jobForTest(2, 350, "0xghi", 1, 350, jobStatusValid),
+			},
+			updater3Jobs: map[JobID]*Job{
+				"job7": jobForTest(3, 500, "0xjkl", 3, 600, jobStatusInvalid),
+				"job8": jobForTest(3, 450, "0xmno", 3, 650, jobStatusInvalid),
+				"job9": jobForTest(3, 550, "0xpqr", 3, 550, jobStatusInvalid),
+			},
+			expectedMessageStatusCalls: []expectedMessageStatusCall{
+				{
+					executingChainID:  "1",
+					initiatingChainID: "2",
+					status:            "future",
+					value:             3,
+				},
+				{
+					executingChainID:  "2",
+					initiatingChainID: "1",
+					status:            "valid",
+					value:             3,
+				},
+				{
+					executingChainID:  "3",
+					initiatingChainID: "3",
+					status:            "invalid",
+					value:             3,
+				},
+			},
+			expectedTerminalCalls: []expectedTerminalCall{},
+			expectedExecutingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     50,
+					max:     150,
+				},
+				{
+					chainID: "2",
+					min:     250,
+					max:     350,
+				},
+				{
+					chainID: "3",
+					min:     450,
+					max:     550,
+				},
+			},
+			expectedInitiatingRangeCalls: []expectedBlockRangeCall{
+				{
+					chainID: "1",
+					min:     350,
+					max:     450,
+				},
+				{
+					chainID: "2",
+					min:     150,
+					max:     250,
+				},
+				{
+					chainID: "3",
+					min:     550,
+					max:     650,
+				},
+			},
 		},
 	}
 
@@ -416,9 +514,10 @@ func TestCollectMetrics(t *testing.T) {
 			collector.CollectMetrics()
 
 			// Verify metric calls
-			require.ElementsMatch(t, tt.expectedExecutingCalls, mockMetrics.actualExecutingCalls, "executing message stats calls should match")
-			require.ElementsMatch(t, tt.expectedInitiatingCalls, mockMetrics.actualInitiatingCalls, "initiating message stats calls should match")
+			require.ElementsMatch(t, tt.expectedMessageStatusCalls, mockMetrics.actualMessageStatusCalls, "message status calls should match")
 			require.ElementsMatch(t, tt.expectedTerminalCalls, mockMetrics.actualTerminalCalls, "terminal status change calls should match")
+			require.ElementsMatch(t, tt.expectedExecutingRangeCalls, mockMetrics.actualExecutingRangeCalls, "executing block range calls should match")
+			require.ElementsMatch(t, tt.expectedInitiatingRangeCalls, mockMetrics.actualInitiatingRangeCalls, "initiating block range calls should match")
 		})
 	}
 }

--- a/op-interop-mon/monitor/updater.go
+++ b/op-interop-mon/monitor/updater.go
@@ -184,12 +184,16 @@ func (t *RPCUpdater) UpdateJob(job *Job) error {
 }
 
 func (t *RPCUpdater) UpdateJobStatus(job *Job) {
-	_, receipts, err := t.client.FetchReceiptsByNumber(context.Background(), job.initiating.BlockNumber)
+	blockInfo, receipts, err := t.client.FetchReceiptsByNumber(context.Background(), job.initiating.BlockNumber)
 	if err != nil {
 		t.log.Error("error getting block receipts", "error", err)
 		job.UpdateStatus(jobStatusUnknown)
 		return
 	}
+
+	// Add the block hash to the job's initiating hashes
+	job.AddInitiatingHash(blockInfo.Hash())
+
 	log, err := t.findLogEvent(receipts, job)
 	if err == ErrLogNotFound {
 		t.log.Error("log not found", "error", err)


### PR DESCRIPTION
A significant change to the metric emissions of `op-interop-mon`

## The Problem
`op-interop-mon` had been designed to emit message stats with these dimensions:
- Executing Chain ID
- Executing BlockNum
- Executing BlockHash
- Message Validity (unknown, valid, invalid)

The inclusion of BlockNum and BlockHash meant the cardinality of these dimensions is unbounded, and thus we would incur extreme cost by abusing dimensions to store ever-incrementing and changing values.

Additionally, some metrics were redundant.

## The Fix
- BlockNum and BlockHash are removed from the Dimensions of message metrics. This means that message stats will represent totals across the monitor's tracking range (from unsafe to final). Unfortunately this is lower granularity information than we previously had designed for, but is addressed by...
- Emit detailed logs for *each* Invalid Executing Message. These logs should be trackable, and are the most likely actionable data needed by operators anyway.
- Additionally, there had been two separate metrics being tracked for Executing *and* Initiating messages. But actually, only one of those two needed to be tracked, as they can just be two separate dimensions
- For extra value, I've added InitiatingHash tracking into the Updater here, too. Now, when fetching an Initiating Message, the Block Hash is recorded. if a Job collects more than one Hash over time, we now emit a clear Log Message about it. These indicate likely reorgs on the initiating side.
- To get back *some* granularity for the metrics, I added Executing and Initiating "ranges" as metrics. These show what the Min/Max block heights are for both Executing Messages being tracked, *and* for the range being referenced as Initiating Messages.

## Testing
- Unit tests amended to cover changed metrics
- Unit tests expanded to cover new metrics

## Current Cardinality
The metrics emitted now only track Executing and Initiating Chain ID. This is a cardinality of `n^2` for `n` chains being tracked. The block range metrics only track one chain.