### PR TITLE
op-service: txintent binding 128bit uint/int type support

### DIFF
--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -260,6 +260,156 @@ func CustomTypeToGoType(retTyp reflect.Type) reflect.Type {
 	}
 }
 
+// ReplaceCustomInts recursively replaces all Uint128/Int128 (and pointer forms) with *big.Int
+func ReplaceCustomInts(value any) (any, error) {
+	return replaceCustomIntValue(reflect.ValueOf(value))
+}
+
+func unwrapCustomInt(val reflect.Value) (any, bool) {
+	// Unwrap pointer chain
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			// Return zero value *big.Int only for known pointer types
+			if customIntTypes[val.Type()] {
+				return new(big.Int), true
+			}
+			return nil, false
+		}
+		val = val.Elem()
+	}
+	if !val.IsValid() {
+		return nil, false
+	}
+	// Must match known custom int type
+	if !customIntTypes[val.Type()] {
+		return nil, false
+	}
+	// Confirm convertible to big.Int
+	if !val.Type().ConvertibleTo(bigIntType) {
+		return nil, false
+	}
+	converted := val.Convert(bigIntType).Interface().(big.Int)
+	b := new(big.Int)
+	b.Set(&converted)
+	return b, true
+}
+
+func replaceCustomIntValue(val reflect.Value) (any, error) {
+	typ := val.Type()
+	// Skip native *big.Int
+	if typ == reflect.TypeOf((*big.Int)(nil)) {
+		return val.Interface(), nil
+	}
+	// custom ints to *big.Int
+	if converted, ok := unwrapCustomInt(val); ok {
+		return converted, nil
+	}
+	switch typ.Kind() {
+	case reflect.Ptr:
+		if val.IsNil() {
+			return nil, nil
+		}
+		elemConverted, err := replaceCustomIntValue(val.Elem())
+		if err != nil {
+			return nil, err
+		}
+		ptr := reflect.New(reflect.TypeOf(elemConverted))
+		ptr.Elem().Set(reflect.ValueOf(elemConverted))
+		return ptr.Interface(), nil
+	case reflect.Struct:
+		return replaceStruct(val)
+	case reflect.Array:
+		return replaceArray(val)
+	case reflect.Slice:
+		return replaceSlice(val)
+	default:
+		return val.Interface(), nil
+	}
+}
+
+func replaceStruct(val reflect.Value) (any, error) {
+	typ := val.Type()
+	var fields []reflect.StructField
+	var values []reflect.Value
+
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		fieldVal := val.Field(i)
+		if !fieldVal.CanInterface() {
+			return nil, fmt.Errorf("field %s must be exported", field.Name)
+		}
+		converted, err := replaceCustomIntValue(fieldVal)
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, reflect.StructField{
+			Name: field.Name,
+			Type: reflect.TypeOf(converted),
+			Tag:  field.Tag,
+		})
+		values = append(values, reflect.ValueOf(converted))
+	}
+
+	newType := reflect.StructOf(fields)
+	newStruct := reflect.New(newType).Elem()
+	for i := range values {
+		newStruct.Field(i).Set(values[i])
+	}
+	return newStruct.Interface(), nil
+}
+
+func replaceSlice(val reflect.Value) (any, error) {
+	length := val.Len()
+	if length == 0 {
+		return val.Interface(), nil
+	}
+
+	var resultElemType reflect.Type
+	elemValues := make([]reflect.Value, length)
+
+	for i := range length {
+		converted, err := replaceCustomIntValue(val.Index(i))
+		if err != nil {
+			return nil, err
+		}
+		elem := reflect.ValueOf(converted)
+		elemValues[i] = elem
+		resultElemType = elem.Type()
+	}
+
+	newSlice := reflect.MakeSlice(reflect.SliceOf(resultElemType), length, length)
+	for i := range elemValues {
+		newSlice.Index(i).Set(elemValues[i])
+	}
+	return newSlice.Interface(), nil
+}
+
+func replaceArray(val reflect.Value) (any, error) {
+	length := val.Len()
+	if length == 0 {
+		return val.Interface(), nil
+	}
+
+	var resultElemType reflect.Type
+	elemValues := make([]reflect.Value, length)
+
+	for i := range length {
+		converted, err := replaceCustomIntValue(val.Index(i))
+		if err != nil {
+			return nil, err
+		}
+		elem := reflect.ValueOf(converted)
+		elemValues[i] = elem
+		resultElemType = elem.Type()
+	}
+
+	newArray := reflect.New(reflect.ArrayOf(length, resultElemType)).Elem()
+	for i := range elemValues {
+		newArray.Index(i).Set(elemValues[i])
+	}
+	return newArray.Interface(), nil
+}
+
 // CustomValueToABIValue converts custom value to abi value
 func CustomValueToABIValue(arg any) any {
 	var value any
@@ -278,7 +428,11 @@ func CustomValueToABIValue(arg any) any {
 		}
 		value = identifier
 	default:
-		value = v
+		var err error
+		value, err = ReplaceCustomInts(v)
+		if err != nil {
+			panic(fmt.Errorf("failed to replace custom int: %w", err))
+		}
 	}
 	return value
 }
@@ -301,6 +455,18 @@ func ABIValueToCustomValue[ReturnType any](retTyp reflect.Type, val any) ReturnT
 			return zero
 		}
 		return any(concrete).(ReturnType)
+	case reflect.TypeOf(Uint128{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		return any(Uint128(*bigVal)).(ReturnType)
+	case reflect.TypeOf(&Uint128{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		return any((*Uint128)(bigVal)).(ReturnType)
+	case reflect.TypeOf(Int128{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		return any(Int128(*bigVal)).(ReturnType)
+	case reflect.TypeOf(&Int128{}):
+		bigVal := abi.ConvertType(val, new(big.Int)).(*big.Int)
+		return any((*Int128)(bigVal)).(ReturnType)
 	default:
 		ptr := abi.ConvertType(val, new(ReturnType)).(*ReturnType)
 		return *ptr
@@ -354,7 +520,6 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 		}
 		return val, nil
 	}
-
 	val := ABIValueToCustomValue[ReturnType](retTyp, decoded[0])
 	return val, nil
 }

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -358,15 +358,13 @@ func replaceStruct(val reflect.Value) (any, error) {
 	return newStruct.Interface(), nil
 }
 
-func replaceSlice(val reflect.Value) (any, error) {
+func replaceSequence(val reflect.Value, makeContainer func(reflect.Type, int) reflect.Value) (any, error) {
 	length := val.Len()
 	if length == 0 {
 		return val.Interface(), nil
 	}
-
 	var resultElemType reflect.Type
 	elemValues := make([]reflect.Value, length)
-
 	for i := range length {
 		converted, err := replaceCustomIntValue(val.Index(i))
 		if err != nil {
@@ -376,38 +374,23 @@ func replaceSlice(val reflect.Value) (any, error) {
 		elemValues[i] = elem
 		resultElemType = elem.Type()
 	}
-
-	newSlice := reflect.MakeSlice(reflect.SliceOf(resultElemType), length, length)
-	for i := range elemValues {
-		newSlice.Index(i).Set(elemValues[i])
+	container := makeContainer(resultElemType, length)
+	for i := range length {
+		container.Index(i).Set(elemValues[i])
 	}
-	return newSlice.Interface(), nil
+	return container.Interface(), nil
+}
+
+func replaceSlice(val reflect.Value) (any, error) {
+	return replaceSequence(val, func(elemType reflect.Type, length int) reflect.Value {
+		return reflect.MakeSlice(reflect.SliceOf(elemType), length, length)
+	})
 }
 
 func replaceArray(val reflect.Value) (any, error) {
-	length := val.Len()
-	if length == 0 {
-		return val.Interface(), nil
-	}
-
-	var resultElemType reflect.Type
-	elemValues := make([]reflect.Value, length)
-
-	for i := range length {
-		converted, err := replaceCustomIntValue(val.Index(i))
-		if err != nil {
-			return nil, err
-		}
-		elem := reflect.ValueOf(converted)
-		elemValues[i] = elem
-		resultElemType = elem.Type()
-	}
-
-	newArray := reflect.New(reflect.ArrayOf(length, resultElemType)).Elem()
-	for i := range elemValues {
-		newArray.Index(i).Set(elemValues[i])
-	}
-	return newArray.Interface(), nil
+	return replaceSequence(val, func(elemType reflect.Type, length int) reflect.Value {
+		return reflect.New(reflect.ArrayOf(length, elemType)).Elem()
+	})
 }
 
 // CustomValueToABIValue converts custom value to abi value

--- a/op-service/txintent/bindings/base_test.go
+++ b/op-service/txintent/bindings/base_test.go
@@ -273,7 +273,7 @@ func TestEncodeCustomIntStruct(t *testing.T) {
 	testContract := NewBindings[TestContract]()
 
 	{
-		call := testContract.GetRequiredBond((*Uint128)(new(big.Int).SetUint64(1337)))
+		call := testContract.GetRequiredBond((*Uint128)(big.NewInt(1337)))
 		calldata, err := call.EncodeInputLambda()
 		require.NoError(t, err)
 		require.Equal(t, "c395e1ca0000000000000000000000000000000000000000000000000000000000000539",
@@ -282,8 +282,8 @@ func TestEncodeCustomIntStruct(t *testing.T) {
 	}
 	{
 		arg := TestIntStruct{
-			A: (*Uint128)(new(big.Int).SetUint64(1337)),
-			B: Int128(*new(big.Int).SetInt64(-7331)),
+			A: (*Uint128)(big.NewInt(1337)),
+			B: Int128(*big.NewInt(-7331)),
 		}
 		call := testContract.TestFunc9(arg)
 		calldata, err := call.EncodeInputLambda()
@@ -296,15 +296,15 @@ func TestEncodeCustomIntStruct(t *testing.T) {
 		arg := [3]TestIntStruct{
 			{
 				A: (*Uint128)(new(big.Int).SetUint64(1337)),
-				B: Int128(*new(big.Int).SetInt64(-1)),
+				B: Int128(*big.NewInt(-1)),
 			},
 			{
 				A: (*Uint128)(new(big.Int).SetUint64(123456789123456789)),
-				B: Int128(*new(big.Int).SetInt64(-123456789)),
+				B: Int128(*big.NewInt(-123456789)),
 			},
 			{
 				A: (*Uint128)(new(big.Int).SetUint64(13)),
-				B: Int128(*new(big.Int).SetInt64(-37)),
+				B: Int128(*big.NewInt(-37)),
 			},
 		}
 		call := testContract.TestFunc11(arg)
@@ -329,14 +329,14 @@ func TestEncodeCustomIntStructWithDynamic(t *testing.T) {
 	{
 		arg := [2]TestDynamicIntStruct{
 			{
-				A: (*Uint128)(new(big.Int).SetUint64(1337)),
+				A: (*Uint128)(big.NewInt(1337)),
 				B: []byte{0x13, 0x33, 0x37},
-				C: Int128(*new(big.Int).SetInt64(-7331)),
+				C: Int128(*big.NewInt(-7331)),
 			},
 			{
-				A: (*Uint128)(new(big.Int).SetUint64(13)),
+				A: (*Uint128)(big.NewInt(13)),
 				B: []byte{0x37, 0x33, 0x33, 0x31},
-				C: Int128(*new(big.Int).SetInt64(-24)),
+				C: Int128(*big.NewInt(-24)),
 			},
 		}
 		call := testContract.TestFunc12(arg)
@@ -355,28 +355,28 @@ func TestDecodeCustomInt(t *testing.T) {
 		data := hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000539")
 		value, err := call.DecodeOutput(data)
 		require.NoError(t, err)
-		require.True(t, new(big.Int).SetUint64(1337).Cmp(value.ToBig()) == 0)
+		require.True(t, big.NewInt(1337).Cmp(value.ToBig()) == 0)
 	}
 	{
 		call := testContract.TestFunc8()
 		data := hexutil.MustDecode("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d")
 		value, err := call.DecodeOutput(data)
 		require.NoError(t, err)
-		require.True(t, new(big.Int).SetInt64(-7331).Cmp(value.ToBig()) == 0)
+		require.True(t, big.NewInt(-7331).Cmp(value.ToBig()) == 0)
 	}
 	{
 		call := testContract.TestFunc13()
 		data := hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000539")
 		value, err := call.DecodeOutput(data)
 		require.NoError(t, err)
-		require.True(t, new(big.Int).SetInt64(1337).Cmp(value.ToBig()) == 0)
+		require.True(t, big.NewInt(1337).Cmp(value.ToBig()) == 0)
 	}
 	{
 		call := testContract.TestFunc14()
 		data := hexutil.MustDecode("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d")
 		value, err := call.DecodeOutput(data)
 		require.NoError(t, err)
-		require.True(t, new(big.Int).SetInt64(-7331).Cmp(value.ToBig()) == 0)
+		require.True(t, big.NewInt(-7331).Cmp(value.ToBig()) == 0)
 	}
 	{
 		call := testContract.TestFunc9(TestIntStruct{})
@@ -384,6 +384,7 @@ func TestDecodeCustomInt(t *testing.T) {
 		value, err := call.DecodeOutput(data)
 		require.NoError(t, err)
 		_ = value
+		panic(value)
 	}
 }
 

--- a/op-service/txintent/bindings/base_test.go
+++ b/op-service/txintent/bindings/base_test.go
@@ -161,15 +161,15 @@ func TestCustomIntConversion(t *testing.T) {
 	c := &b
 	d := &c
 	arg := ComplexStruct{
-		A: (*Uint128)(new(big.Int).SetUint64(1337)),
-		B: new(big.Int).SetUint64(7331),
+		A: (*Uint128)(big.NewInt(1337)),
+		B: big.NewInt(7331),
 		C: &TestStruct2{
 			B: common.Address{},
 			C: []byte{0x12, 0x34},
 		},
-		D: Int128(*new(big.Int).SetInt64(-7331)),
+		D: Int128(*big.NewInt(-7331)),
 		E: TestRecursivePointerStruct{
-			A: Uint128(*new(big.Int).SetInt64(1234)),
+			A: Uint128(*big.NewInt(1234)),
 			B: d,
 		},
 	}
@@ -295,15 +295,15 @@ func TestEncodeCustomIntStruct(t *testing.T) {
 	{
 		arg := [3]TestIntStruct{
 			{
-				A: (*Uint128)(new(big.Int).SetUint64(1337)),
+				A: (*Uint128)(big.NewInt(1337)),
 				B: Int128(*big.NewInt(-1)),
 			},
 			{
-				A: (*Uint128)(new(big.Int).SetUint64(123456789123456789)),
+				A: (*Uint128)(big.NewInt(123456789123456789)),
 				B: Int128(*big.NewInt(-123456789)),
 			},
 			{
-				A: (*Uint128)(new(big.Int).SetUint64(13)),
+				A: (*Uint128)(big.NewInt(13)),
 				B: Int128(*big.NewInt(-37)),
 			},
 		}

--- a/op-service/txintent/bindings/base_test.go
+++ b/op-service/txintent/bindings/base_test.go
@@ -378,14 +378,6 @@ func TestDecodeCustomInt(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, big.NewInt(-7331).Cmp(value.ToBig()) == 0)
 	}
-	{
-		call := testContract.TestFunc9(TestIntStruct{})
-		data := hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000539ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d")
-		value, err := call.DecodeOutput(data)
-		require.NoError(t, err)
-		_ = value
-		panic(value)
-	}
 }
 
 func TestDecodeArray(t *testing.T) {

--- a/op-service/txintent/bindings/base_test.go
+++ b/op-service/txintent/bindings/base_test.go
@@ -3,6 +3,7 @@ package bindings
 import (
 	"encoding/hex"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -77,6 +78,17 @@ type TestCustomTypeStruct struct {
 	B eth.ChainID
 }
 
+type TestDynamicIntStruct struct {
+	A *Uint128
+	B []byte
+	C Int128
+}
+
+type TestIntStruct struct {
+	A *Uint128
+	B Int128
+}
+
 type TestContract struct {
 	FinalizeWithdrawalTransaction func(tx struct {
 		Nonce    *big.Int
@@ -105,6 +117,8 @@ type TestContract struct {
 
 	ProvenWithdrawals func(withdrawalHash [32]byte, submitter common.Address) TypedCall[TestProvenWithdrawalsResult] `sol:"provenWithdrawals"`
 
+	GetRequiredBond func(position *Uint128) TypedCall[*big.Int] `sol:"getRequiredBond"`
+
 	GameData func() TypedCall[TestGameData] `sol:"gameData"`
 
 	TestFunc1 func() TypedCall[TestNestedDynamicStruct] `sol:"testfunc1"`
@@ -116,6 +130,74 @@ type TestContract struct {
 	TestFunc5 func() TypedCall[[2]TestStruct2]   `sol:"testfunc5"`
 
 	TestFunc6 func() TypedCall[TestDoubleNestedStruct] `sol:"testfunc6"`
+
+	TestFunc7  func() TypedCall[Uint128]               `sol:"testfunc7"`
+	TestFunc8  func() TypedCall[Int128]                `sol:"testfunc8"`
+	TestFunc9  func(t TestIntStruct) TypedCall[any]    `sol:"testfunc9"`
+	TestFunc10 func(t []TestIntStruct) TypedCall[any]  `sol:"testfunc10"`
+	TestFunc11 func(t [3]TestIntStruct) TypedCall[any] `sol:"testfunc11"`
+
+	TestFunc12 func(t [2]TestDynamicIntStruct) TypedCall[any] `sol:"testfunc12"`
+
+	TestFunc13 func() TypedCall[*Uint128] `sol:"testfunc13"`
+	TestFunc14 func() TypedCall[*Int128]  `sol:"testfunc14"`
+}
+
+func TestCustomIntConversion(t *testing.T) {
+	type TestRecursivePointerStruct struct {
+		A Uint128
+		B ****Uint128
+	}
+	type ComplexStruct struct {
+		A *Uint128
+		B *big.Int
+		C *TestStruct2
+		D Int128
+		E TestRecursivePointerStruct
+	}
+	v := Uint128(*big.NewInt(4321))
+	a := &v
+	b := &a
+	c := &b
+	d := &c
+	arg := ComplexStruct{
+		A: (*Uint128)(new(big.Int).SetUint64(1337)),
+		B: new(big.Int).SetUint64(7331),
+		C: &TestStruct2{
+			B: common.Address{},
+			C: []byte{0x12, 0x34},
+		},
+		D: Int128(*new(big.Int).SetInt64(-7331)),
+		E: TestRecursivePointerStruct{
+			A: Uint128(*new(big.Int).SetInt64(1234)),
+			B: d,
+		},
+	}
+	switch v := any(arg).(type) {
+	default:
+		converted, err := ReplaceCustomInts(v)
+		require.NoError(t, err)
+		w := reflect.ValueOf(converted)
+		fieldA := w.FieldByName("A").Interface().(*big.Int)
+		require.True(t, big.NewInt(1337).Cmp(fieldA) == 0, "A mismatch")
+		fieldB := w.FieldByName("B").Interface().(*big.Int)
+		require.True(t, big.NewInt(7331).Cmp(fieldB) == 0, "B mismatch")
+		fieldC := w.FieldByName("C")
+		require.True(t, fieldC.IsValid() && !fieldC.IsNil(), "C is nil")
+		fieldCDeref := fieldC.Elem()
+		fieldCB := fieldCDeref.FieldByName("B").Interface().([20]uint8)
+		require.Equal(t, [20]uint8{}, fieldCB, "C.B mismatch")
+		fieldCC := fieldCDeref.FieldByName("C").Interface().([]byte)
+		require.Equal(t, []byte{0x12, 0x34}, fieldCC, "C.C mismatch")
+		fieldD := w.FieldByName("D").Interface().(*big.Int)
+		require.True(t, big.NewInt(-7331).Cmp(fieldD) == 0, "D mismatch")
+		fieldE := w.FieldByName("E")
+		require.True(t, fieldE.IsValid(), "E invalid")
+		fieldEA := fieldE.FieldByName("A").Interface().(*big.Int)
+		require.True(t, big.NewInt(1234).Cmp(fieldEA) == 0, "E.A mismatch")
+		fieldEB := fieldE.FieldByName("B").Interface().(*big.Int)
+		require.True(t, big.NewInt(4321).Cmp(fieldEB) == 0, "E.B mismatch")
+	}
 }
 
 func TestEncodeStruct(t *testing.T) {
@@ -185,6 +267,124 @@ func TestEncodeStruct(t *testing.T) {
 	require.Equal(t, "4870496f00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000073aa3ddeddee968a18a19312efccd06ebe116f86e3f23961cc83ef26346894bae3f2a88ce530a8dab9f8cafac0ef934b1f126da1041d89e41cb84d46dfa5e841f79e208e723e8ca525558786b4fc73c1c889e9eb0e25917ba5c5ec7640ffc25700000000000000000000000000000000000000000000000000000000000001c0000100000000000000000000000000000000000000000000000000000000000000000000000000000000000015d34aaf54267db7d7c367839aaf71a00a2c6a6500000000000000000000000015d34aaf54267db7d7c367839aaf71a00a2c6a65000000000000000000000000000000000000000000000000000000746a528800000000000000000000000000000000000000000000000000000000000000520800000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000073f8718080808080a08e9a5e2311b6926cff4a3b9b50fd0500e2d68f2d70c62f7b294aec18b62e94d980a08c82f7353a759f9fdf815a3065d8e8b1282d1383398e53f11f8f03bf64f50cfa808080a0f4984a11f61a2921456141df88de6e1a710d28681b91af794c5a721e47839cd78080808080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000053f8518080a0999c5deb49aff57f74c1a5871afb58461105ec7bf684c9716f8ee2c30221bfd78080808080808080a05219be3ea6e6c12cfa6927fd85a1548be9922594ebbd7d8ad717600fbd64f7fe8080808080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023e2a0206c4fd0e580d501e7a56378cab19a4875bba79b4639cdbd1db734feb96f87dd010000000000000000000000000000000000000000000000000000000000",
 		hex.EncodeToString(calldata),
 	)
+}
+
+func TestEncodeCustomIntStruct(t *testing.T) {
+	testContract := NewBindings[TestContract]()
+
+	{
+		call := testContract.GetRequiredBond((*Uint128)(new(big.Int).SetUint64(1337)))
+		calldata, err := call.EncodeInputLambda()
+		require.NoError(t, err)
+		require.Equal(t, "c395e1ca0000000000000000000000000000000000000000000000000000000000000539",
+			hex.EncodeToString(calldata),
+		)
+	}
+	{
+		arg := TestIntStruct{
+			A: (*Uint128)(new(big.Int).SetUint64(1337)),
+			B: Int128(*new(big.Int).SetInt64(-7331)),
+		}
+		call := testContract.TestFunc9(arg)
+		calldata, err := call.EncodeInputLambda()
+		require.NoError(t, err)
+		require.Equal(t, "d24d4e560000000000000000000000000000000000000000000000000000000000000539ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d",
+			hex.EncodeToString(calldata),
+		)
+	}
+	{
+		arg := [3]TestIntStruct{
+			{
+				A: (*Uint128)(new(big.Int).SetUint64(1337)),
+				B: Int128(*new(big.Int).SetInt64(-1)),
+			},
+			{
+				A: (*Uint128)(new(big.Int).SetUint64(123456789123456789)),
+				B: Int128(*new(big.Int).SetInt64(-123456789)),
+			},
+			{
+				A: (*Uint128)(new(big.Int).SetUint64(13)),
+				B: Int128(*new(big.Int).SetInt64(-37)),
+			},
+		}
+		call := testContract.TestFunc11(arg)
+		calldata, err := call.EncodeInputLambda()
+		require.NoError(t, err)
+		require.Equal(t, "a86faa120000000000000000000000000000000000000000000000000000000000000539ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001b69b4bacd05f15fffffffffffffffffffffffffffffffffffffffffffffffffffffffff8a432eb000000000000000000000000000000000000000000000000000000000000000dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdb",
+			hex.EncodeToString(calldata),
+		)
+
+		call = testContract.TestFunc10(arg[:])
+		calldata, err = call.EncodeInputLambda()
+		require.NoError(t, err)
+		require.Equal(t, "b3e163fe000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000539ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000001b69b4bacd05f15fffffffffffffffffffffffffffffffffffffffffffffffffffffffff8a432eb000000000000000000000000000000000000000000000000000000000000000dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdb",
+			hex.EncodeToString(calldata),
+		)
+	}
+}
+
+func TestEncodeCustomIntStructWithDynamic(t *testing.T) {
+	testContract := NewBindings[TestContract]()
+
+	{
+		arg := [2]TestDynamicIntStruct{
+			{
+				A: (*Uint128)(new(big.Int).SetUint64(1337)),
+				B: []byte{0x13, 0x33, 0x37},
+				C: Int128(*new(big.Int).SetInt64(-7331)),
+			},
+			{
+				A: (*Uint128)(new(big.Int).SetUint64(13)),
+				B: []byte{0x37, 0x33, 0x33, 0x31},
+				C: Int128(*new(big.Int).SetInt64(-24)),
+			},
+		}
+		call := testContract.TestFunc12(arg)
+		calldata, err := call.EncodeInputLambda()
+		require.NoError(t, err)
+		require.Equal(t, "286d447b0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000005390000000000000000000000000000000000000000000000000000000000000060ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d00000000000000000000000000000000000000000000000000000000000000031333370000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d0000000000000000000000000000000000000000000000000000000000000060ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe800000000000000000000000000000000000000000000000000000000000000043733333100000000000000000000000000000000000000000000000000000000",
+			hex.EncodeToString(calldata),
+		)
+	}
+}
+
+func TestDecodeCustomInt(t *testing.T) {
+	testContract := NewBindings[TestContract]()
+	{
+		call := testContract.TestFunc7()
+		data := hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000539")
+		value, err := call.DecodeOutput(data)
+		require.NoError(t, err)
+		require.True(t, new(big.Int).SetUint64(1337).Cmp(value.ToBig()) == 0)
+	}
+	{
+		call := testContract.TestFunc8()
+		data := hexutil.MustDecode("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d")
+		value, err := call.DecodeOutput(data)
+		require.NoError(t, err)
+		require.True(t, new(big.Int).SetInt64(-7331).Cmp(value.ToBig()) == 0)
+	}
+	{
+		call := testContract.TestFunc13()
+		data := hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000539")
+		value, err := call.DecodeOutput(data)
+		require.NoError(t, err)
+		require.True(t, new(big.Int).SetInt64(1337).Cmp(value.ToBig()) == 0)
+	}
+	{
+		call := testContract.TestFunc14()
+		data := hexutil.MustDecode("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d")
+		value, err := call.DecodeOutput(data)
+		require.NoError(t, err)
+		require.True(t, new(big.Int).SetInt64(-7331).Cmp(value.ToBig()) == 0)
+	}
+	{
+		call := testContract.TestFunc9(TestIntStruct{})
+		data := hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000539ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe35d")
+		value, err := call.DecodeOutput(data)
+		require.NoError(t, err)
+		_ = value
+	}
 }
 
 func TestDecodeArray(t *testing.T) {

--- a/op-service/txintent/bindings/types.go
+++ b/op-service/txintent/bindings/types.go
@@ -17,6 +17,27 @@ var abiInt256Type = reflect.TypeFor[ABIInt256]()
 
 var abiUint256Type = reflect.TypeFor[uint256.Int]()
 
+type Uint128 big.Int
+type Int128 big.Int
+
+func (u Uint128) ToBig() *big.Int {
+	return new(big.Int).Set((*big.Int)(&u))
+}
+
+func (u Int128) ToBig() *big.Int {
+	return new(big.Int).Set((*big.Int)(&u))
+}
+
+var abiUint128Type = reflect.TypeFor[Uint128]()
+var abiInt128Type = reflect.TypeFor[Int128]()
+
+var bigIntType = reflect.TypeOf(big.Int{})
+
+var customIntTypes = map[reflect.Type]bool{
+	reflect.TypeOf(Uint128{}): true,
+	reflect.TypeOf(Int128{}):  true,
+}
+
 func goStructTypeToABIType(t reflect.Type) (abi.Type, []abi.ArgumentMarshaling, error) {
 	if t.Kind() != reflect.Struct {
 		return abi.Type{}, nil, errors.New("input must be a struct type")
@@ -106,6 +127,14 @@ func goTypeToABIType(typ reflect.Type) (abi.Type, []abi.ArgumentMarshaling, erro
 		abiType, err := abi.NewType(fmt.Sprintf("%s[]", elemType), "", innerComponents)
 		return abiType, innerComponents, err
 	case reflect.Struct:
+		switch {
+		case typ == abiInt128Type:
+			abiType, err := abi.NewType("int128", "", nil)
+			return abiType, nil, err
+		case typ == abiUint128Type:
+			abiType, err := abi.NewType("uint128", "", nil)
+			return abiType, nil, err
+		}
 		if typ.AssignableTo(abiInt256Type) {
 			abiType, err := abi.NewType("int256", "", nil)
 			return abiType, nil, err

--- a/op-service/txintent/bindings/types_test.go
+++ b/op-service/txintent/bindings/types_test.go
@@ -88,6 +88,9 @@ type TestIntTypeStruct struct {
 }
 
 func TestTypeConversion(t *testing.T) {
+	a := (*Uint128)(big.NewInt(0))
+	b := (*Int128)(big.NewInt(0))
+
 	type testCase struct {
 		value    any
 		want     string
@@ -198,12 +201,22 @@ func TestTypeConversion(t *testing.T) {
 		{
 			value:    (*Uint128)(big.NewInt(0)),
 			want:     "uint128",
-			testName: "uint128",
+			testName: "uint128 (value)",
 		},
 		{
 			value:    (*Int128)(big.NewInt(0)),
 			want:     "int128",
-			testName: "int128",
+			testName: "int128 (value)",
+		},
+		{
+			value:    &a,
+			want:     "uint128",
+			testName: "uint128 (pointer)",
+		},
+		{
+			value:    &b,
+			want:     "int128",
+			testName: "int128 (pointer)",
 		},
 		{
 			value:    TestIntTypeStruct{},

--- a/op-service/txintent/bindings/types_test.go
+++ b/op-service/txintent/bindings/types_test.go
@@ -70,6 +70,23 @@ type TestRecursiveStruct3 struct {
 	a TestRecursiveStruct2
 }
 
+//nolint:unused
+type TestIntTypeStruct struct {
+	a uint8
+	b uint16
+	c uint32
+	d uint64
+	e Uint128
+	f uint256.Int
+
+	g int8
+	h int16
+	i int32
+	j int64
+	k Int128
+	l *big.Int
+}
+
 func TestTypeConversion(t *testing.T) {
 	type testCase struct {
 		value    any
@@ -167,6 +184,31 @@ func TestTypeConversion(t *testing.T) {
 			value:    ABIIdentifier{},
 			want:     "(address,uint256,uint256,uint256,uint256)",
 			testName: "supervisor Identifier",
+		},
+		{
+			value:    uint64(0),
+			want:     "uint64",
+			testName: "uint64",
+		},
+		{
+			value:    int64(0),
+			want:     "int64",
+			testName: "int64",
+		},
+		{
+			value:    (*Uint128)(new(big.Int).SetUint64(0)),
+			want:     "uint128",
+			testName: "uint128",
+		},
+		{
+			value:    (*Int128)(new(big.Int).SetUint64(0)),
+			want:     "int128",
+			testName: "int128",
+		},
+		{
+			value:    TestIntTypeStruct{},
+			want:     "(uint8,uint16,uint32,uint64,uint128,uint256,int8,int16,int32,int64,int128,uint256)",
+			testName: "int types",
 		},
 	}
 

--- a/op-service/txintent/bindings/types_test.go
+++ b/op-service/txintent/bindings/types_test.go
@@ -196,12 +196,12 @@ func TestTypeConversion(t *testing.T) {
 			testName: "int64",
 		},
 		{
-			value:    (*Uint128)(new(big.Int).SetUint64(0)),
+			value:    (*Uint128)(big.NewInt(0)),
 			want:     "uint128",
 			testName: "uint128",
 		},
 		{
-			value:    (*Int128)(new(big.Int).SetUint64(0)),
+			value:    (*Int128)(big.NewInt(0)),
 			want:     "int128",
 			testName: "int128",
 		},


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Supports 128bit uint/int type support for abi encoding. Decoding is only supported when we are returning the integer solely, not tuple nor structs, arrays.

Added new types:
```go
type Uint128 big.Int
type Int128 big.Int
```

Dynamically convert any type to `*big.Int` types to use geth's abi library. Also marked abitypes correctly. For example,
```go
	v := Uint128(*big.NewInt(4321))
	a := &v
	b := &a
	c := &b
	d := &c

ComplexStruct{
		A: (*Uint128)(big.NewInt(1337)),
		B: big.NewInt(7331),
		C: &TestStruct2{
			B: common.Address{},
			C: []byte{0x12, 0x34},
		},
		D: Int128(*big.NewInt(-7331)),
		E: TestRecursivePointerStruct{
			A: Uint128(*big.NewInt(1234)),
			B: d,
		},
	}
```
Will be converted to
```go
ComplexStruct{
		A: big.NewInt(1337),
		B: big.NewInt(7331),
		C: &TestStruct2{
			B: common.Address{},
			C: []byte{0x12, 0x34},
		},
		D: big.NewInt(-7331),
		E: TestRecursivePointerStruct{
			A: big.NewInt(1234),
			B: big.NewInt(4321),
```
and will be plugged to the geth abi library for correct calldata / function signature generation.

**Tests**

Added tests which touches the newly added `Uint128`, `Int128`,  as well as inferring
```go
	GetRequiredBond func(position *Uint128) TypedCall[*big.Int] `sol:"getRequiredBond"`
```
which is needed for proofs acceptance tests.

**Additional context**

Although decoding using the custom fixed size integer is not supported, geth abi library does not care, and we may always use `big.Int` type and manually convert. So, if we need solidity struct to be decoded:
```solidity
    struct ClaimData {
        uint32 parentIndex;
        address counteredBy;
        address claimant;
        uint128 bond;
        Claim claim;
        Position position;
        Clock clock;
    }
```
We may decode using struct like
```go
type ClaimData struct {
	ParentIndex uint32
	CounteredBy common.Address
	Claimant    common.Address
	Bond        *big.Int
	Claim       [32]byte
	Position    *big.Int
	Clock       *big.Int
}
```
and plug it at return value of lambda like `TypedCall[ClaimData]`.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16469

https://github.com/ethereum-optimism/optimism/issues/16461 is partially implemented because this PR only supports uint128/int128