### PR TITLE
op-acceptance-tests/interop/reorg: confirm the chain progresses after reorg

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -95,6 +95,8 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	// pre reorg trigger validations and checks
 	preChecks(t, sys)
 
+	tipL2_preReorg := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+
 	// reorg the L1 chain -- sequence an alternative L1 block from divergence block parent
 	sequenceL1Block(t, ts, divergence.ParentHash)
 
@@ -103,6 +105,9 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 
 	// confirm L1 reorged
 	sys.L1EL.ReorgTriggered(divergence, 5)
+
+	// wait until L2 chain A caught up to where it was before the reorg
+	sys.L2ELA.WaitForBlockNumber(tipL2_preReorg.Number)
 
 	// test that latest chain A unsafe is not referencing a reorged L1 block (through the L1Origin field)
 	require.Eventually(t, func() bool {

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -47,7 +47,7 @@ func (el *elNode) WaitForBlockNumber(targetBlock uint64) eth.BlockRef {
 
 		newRef = eth.InfoToL1BlockRef(newBlock)
 		if newBlock.NumberU64() >= targetBlock {
-			el.log.Info("Target block reached", "block", newRef)
+			el.log.Info("Target block reached", "chain", el.ChainID(), "block", newRef)
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
**Description**

Found via: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/93702/workflows/bcc14d53-552c-4401-9ca5-6ffa266b4cf8/jobs/3647441/artifacts

This PR is fixing another flake in the `TestL2ReorgAfterL1Reorg` test - we now wait for the chain to recover up until the blocks it produced before the reorg, before checking various level references (cross-safe, unsafe, etc.)

```
INFO [06-16|23:08:54.805] expecting chain to reorg on block ref    id=L1ELNode-l1-900 chain=900 target=550e9f..10f9a6:51
INFO [06-16|23:08:54.806] reorg on divergence block                chain=900 pre_blockref=550e9f..10f9a6:51
INFO [06-16|23:08:54.806] reorg on divergence block                chain=900 post_blockref=9be422..d140f0:51
INFO [06-16|23:09:01.808] current unsafe ref                       tip=1b3aaa..7cdd30:175 tip_origin=081463..6dffd8:58 l1blk=597a1f..33df3a:58
INFO [06-16|23:09:02.121] Printing block hashes and parent hashes  network=L2Network-901 chain=901
INFO [06-16|23:09:02.193] Printing block hashes and parent hashes  network=L1Network-900 chain=900
INFO [06-16|23:09:08.809] current unsafe ref                       tip=b3d7ba..f1a4e6:156 tip_origin=9be422..d140f0:51 l1blk=9be422..d140f0:51
INFO [06-16|23:09:09.060] Printing block hashes and parent hashes  network=L2Network-901 chain=901
INFO [06-16|23:09:09.129] Printing block hashes and parent hashes  network=L1Network-900 chain=900
INFO [06-16|23:09:14.132] L2 chain progressed, pointing to newer L1 block ref=b3d7ba..f1a4e6:156 ref_origin=9be422..d140f0:51 divergence=550e9f..10f9a6:51
ERROR[06-16|23:09:14.136]
        Error Trace:    /var/opt/circleci/data/workdir/op-devstack/dsl/el.go:69
                                                /var/opt/circleci/data/workdir/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go:47
                                                /var/opt/circleci/data/workdir/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go:153
                                                /var/opt/circleci/data/workdir/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go:52
        Error:          Received unexpected error:
                        failed to fetch header by num 160: not found
        Test:           TestL2ReorgAfterL1Reorg/unsafe,_local-safe,_cross-unsafe,_cross-safe_reorgs
```

I thought I fixed this with https://github.com/ethereum-optimism/optimism/pull/16439 but the problem was slightly different.