### PR TITLE
interop: supervisor, op-node mode renaming

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestL2CLAheadOfSupervisor tests the below scenario:
-// L2CL ahead of supervisor, aka supervisor needs to reset the L2CL, to reproduce old data. Currently supervisor has only managed mode implemented, so the supervisor will ask the L2CL to reset back.
+// L2CL ahead of supervisor, aka supervisor needs to reset the L2CL, to reproduce old data. Currently supervisor has only indexing mode implemented, so the supervisor will ask the L2CL to reset back.
 func TestL2CLAheadOfSupervisor(gt *testing.T) {
 	t := devtest.SerialT(gt)
 
@@ -21,7 +21,7 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 
 	// Make sequencers (L2CL), verifiers (L2CL), and supervisors sync for a few blocks.
 	// Sequencer and verifier are connected via P2P, which makes their unsafe heads in sync.
-	// Both L2CLs are in managed mode, digesting L1 blocks from the supervisor and reporting unsafe and safe blocks back to the supervisor.
+	// Both L2CLs are in indexing mode, digesting L1 blocks from the supervisor and reporting unsafe and safe blocks back to the supervisor.
 	delta := uint64(10)
 	logger.Info("Make sure verifiers advances unsafe head", "delta", delta)
 	dsl.CheckAll(t,

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -125,7 +125,7 @@ func (n *L2CLNode) Stop() {
 	n.opNode = nil
 }
 
-func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
 
@@ -194,10 +194,10 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l
 			require.NoError(err, "failed to load p2p config")
 		}
 
-		// specify interop config, but do not configure anything, to disable managed mode
+		// specify interop config, but do not configure anything, to disable indexing mode
 		interopCfg := &interop.Config{}
 
-		if managedMode {
+		if indexingMode {
 			interopCfg = &interop.Config{
 				RPCAddr: "127.0.0.1",
 				// When L2CL starts, store its RPC port here

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -326,7 +326,7 @@ func TestInteropLocalSafeInvalidation(gt *testing.T) {
 	replacementBlock, err := actors.ChainB.SequencerEngine.EthClient().BlockByHash(t.Ctx(), status.SafeL2.Hash)
 	require.NoError(t, err)
 	txs := replacementBlock.Transactions()
-	out, err := managed.DecodeInvalidatedBlockTx(txs[len(txs)-1])
+	out, err := indexing.DecodeInvalidatedBlockTx(txs[len(txs)-1])
 	require.NoError(t, err)
 	require.Equal(t, originalOutput.OutputRoot, eth.OutputRoot(out))
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -96,13 +96,13 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
 func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, depSet DependencySet, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
-	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedMode bool,
+	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedBySupervisor bool,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
 	// Stages are strung together into a pipeline,
 	// results are pulled from the stage closed to the L2 engine, which pulls from the previous stage, and so on.
 	var l1Traversal l1TraversalStage
-	if managedMode {
+	if managedBySupervisor {
 		l1Traversal = NewL1TraversalManaged(log, rollupCfg, l1Fetcher)
 	} else {
 		l1Traversal = NewL1Traversal(log, rollupCfg, l1Fetcher)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -174,7 +174,7 @@ func NewDriver(
 	syncCfg *sync.Config,
 	sequencerConductor conductor.SequencerConductor,
 	altDA AltDAIface,
-	managedMode bool,
+	indexingMode bool,
 ) *Driver {
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 
@@ -207,23 +207,23 @@ func NewDriver(
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, driverCtx, l2))
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, indexingMode)
 
 	sys.Register("pipeline",
 		derive.NewPipelineDeriver(driverCtx, derivationPipeline))
 
 	syncDeriver := &SyncDeriver{
-		Derivation:     derivationPipeline,
-		SafeHeadNotifs: safeHeadListener,
-		CLSync:         clSync,
-		Engine:         ec,
-		SyncCfg:        syncCfg,
-		Config:         cfg,
-		L1:             l1,
-		L2:             l2,
-		Log:            log,
-		Ctx:            driverCtx,
-		ManagedMode:    managedMode,
+		Derivation:          derivationPipeline,
+		SafeHeadNotifs:      safeHeadListener,
+		CLSync:              clSync,
+		Engine:              ec,
+		SyncCfg:             syncCfg,
+		Config:              cfg,
+		L1:                  l1,
+		L2:                  l2,
+		Log:                 log,
+		Ctx:                 driverCtx,
+		ManagedBySupervisor: indexingMode,
 	}
 	sys.Register("sync", syncDeriver)
 

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -228,7 +228,7 @@ type SyncDeriver struct {
 
 	// When in interop, and managed by an op-supervisor,
 	// the node performs a reset based on the instructions of the op-supervisor.
-	ManagedMode bool
+	ManagedBySupervisor bool
 }
 
 func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
@@ -344,9 +344,9 @@ func (s *SyncDeriver) onEngineConfirmedReset(x engine.EngineResetConfirmedEvent)
 }
 
 func (s *SyncDeriver) onResetEvent(x rollup.ResetEvent) {
-	if s.ManagedMode {
-		s.Log.Warn("Encountered reset in Managed Mode, waiting for op-supervisor", "err", x.Err)
-		// ManagedMode will pick up the ResetEvent
+	if s.ManagedBySupervisor {
+		s.Log.Warn("Encountered reset when managed by op-supervisor, waiting for op-supervisor", "err", x.Err)
+		// IndexingMode will pick up the ResetEvent
 		return
 	}
 	// If the system corrupts, e.g. due to a reorg, simply reset it
@@ -384,7 +384,7 @@ func (s *SyncDeriver) SyncStep() {
 
 	// If interop is configured, we have to run the engine events,
 	// to ensure cross-L2 safety is continuously verified against the interop-backend.
-	if s.Config.InteropTime != nil && !s.ManagedMode {
+	if s.Config.InteropTime != nil && !s.ManagedBySupervisor {
 		s.Emitter.Emit(engine.CrossUpdateRequestEvent{Ctx: event.WrapCtx(s.Ctx)})
 	}
 }

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 )
@@ -43,5 +43,5 @@ func (cfg *Config) Setup(ctx context.Context, logger log.Logger, rollupCfg *roll
 	if err != nil {
 		return nil, err
 	}
-	return managed.NewManagedMode(logger, rollupCfg, cfg.RPCAddr, cfg.RPCPort, jwtSecret, l1, l2, m), nil
+	return indexing.NewIndexingMode(logger, rollupCfg, cfg.RPCAddr, cfg.RPCPort, jwtSecret, l1, l2, m), nil
 }

--- a/op-node/rollup/interop/iface.go
+++ b/op-node/rollup/interop/iface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 )
@@ -18,14 +18,14 @@ type SubSystem interface {
 	Stop(ctx context.Context) error
 }
 
-var _ SubSystem = (*managed.ManagedMode)(nil)
+var _ SubSystem = (*indexing.IndexingMode)(nil)
 
 type L1Source interface {
-	managed.L1Source
+	indexing.L1Source
 }
 
 type L2Source interface {
-	managed.L2Source
+	indexing.L2Source
 }
 
 type Setup interface {

--- a/op-node/rollup/interop/indexing/api.go
+++ b/op-node/rollup/interop/indexing/api.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"context"
@@ -12,10 +12,10 @@ import (
 )
 
 type InteropAPI struct {
-	backend *ManagedMode
+	backend *IndexingMode
 }
 
-func (ib *InteropAPI) PullEvent() (*supervisortypes.ManagedEvent, error) {
+func (ib *InteropAPI) PullEvent() (*supervisortypes.IndexingEvent, error) {
 	return ib.backend.PullEvent()
 }
 

--- a/op-node/rollup/interop/indexing/attributes.go
+++ b/op-node/rollup/interop/indexing/attributes.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"errors"

--- a/op-node/rollup/interop/indexing/attributes_test.go
+++ b/op-node/rollup/interop/indexing/attributes_test.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"math/big"

--- a/op-node/rollup/interop/indexing/event_timestamp.go
+++ b/op-node/rollup/interop/indexing/event_timestamp.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import "time"
 

--- a/op-node/rollup/interop/indexing/event_timestamp_test.go
+++ b/op-node/rollup/interop/indexing/event_timestamp_test.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"testing"

--- a/op-node/rollup/interop/indexing/system_events_test.go
+++ b/op-node/rollup/interop/indexing/system_events_test.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"context"
@@ -22,14 +22,14 @@ import (
 
 // mockEventStream implements ManagedEventStream for testing
 type mockEventStream struct {
-	events []*supervisortypes.ManagedEvent
+	events []*supervisortypes.IndexingEvent
 }
 
-func (m *mockEventStream) Send(event *supervisortypes.ManagedEvent) {
+func (m *mockEventStream) Send(event *supervisortypes.IndexingEvent) {
 	m.events = append(m.events, event)
 }
 
-func (m *mockEventStream) Serve() (*supervisortypes.ManagedEvent, error) {
+func (m *mockEventStream) Serve() (*supervisortypes.IndexingEvent, error) {
 	panic("not implemented")
 }
 
@@ -37,7 +37,7 @@ func (m *mockEventStream) Subscribe(ctx context.Context) (*gethrpc.Subscription,
 	panic("not implemented")
 }
 
-func (m *mockEventStream) drainEvents() []*supervisortypes.ManagedEvent {
+func (m *mockEventStream) drainEvents() []*supervisortypes.IndexingEvent {
 	events := m.events
 	m.events = nil
 	return events
@@ -53,7 +53,7 @@ func TestManagedMode_OnEvent_Deduplication(t *testing.T) {
 	mockStream := &mockEventStream{}
 
 	// Create ManagedMode with only the necessary fields for testing
-	mm := &ManagedMode{
+	mm := &IndexingMode{
 		log:    logger,
 		cfg:    cfg,
 		events: mockStream,
@@ -357,7 +357,7 @@ func TestManagedMode_OnEvent_Deduplication(t *testing.T) {
 			InteropTime: &interopTime,
 		}
 
-		preInteropMM := &ManagedMode{
+		preInteropMM := &IndexingMode{
 			log:        logger,
 			cfg:        preInteropCfg,
 			events:     &mockEventStream{},

--- a/op-node/rollup/interop/indexing/system_test.go
+++ b/op-node/rollup/interop/indexing/system_test.go
@@ -1,4 +1,4 @@
-package managed
+package indexing
 
 import (
 	"context"
@@ -147,7 +147,7 @@ func TestManagedMode_findLatestValidLocalUnsafe(t *testing.T) {
 				}
 			}
 
-			managedMode := &ManagedMode{
+			managedMode := &IndexingMode{
 				log: logger,
 				l1:  mockL1,
 				l2:  mockL2,

--- a/op-program/client/tasks/deposits_block.go
+++ b/op-program/client/tasks/deposits_block.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/l1"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
@@ -128,7 +128,7 @@ func blockToDepositsOnlyAttributes(cfg *rollup.Config, block *types.Block, outpu
 			deposits = append(deposits, txdata)
 		}
 	}
-	invalidatedBlockTx := managed.InvalidatedBlockSourceDepositTx(output.Marshal())
+	invalidatedBlockTx := indexing.InvalidatedBlockSourceDepositTx(output.Marshal())
 	invalidatedBlockTxData, err := invalidatedBlockTx.MarshalBinary()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal deposited tx: %w", err)

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -98,12 +98,12 @@ flowchart TD
 
 Op-nodes, or any compatible consensus-layer L2 node can interact with op-supervisor in two modes:
 
-#### Managed Mode
+#### Indexing Mode
 
-In managed mode, nodes cede control over aspects of the derivation process to the supervisor, which maintains the node's sync status.
+In indexing mode, nodes cede control over aspects of the derivation process to the supervisor, which maintains the node's sync status.
 This is done to give the supervisor a clear picture of the data across multiple chains, and to ensure the supervisor can recover/reset as needed.
 
-Managed nodes can be thought of integral to the supervisor. There must be *at least* one managed node per chain connected
+Indexing nodes can be thought of integral to the supervisor. There must be *at least* one indexing node per chain connected
 to a supervisor for it to supply accurate data.
 
 The Supervisor subscribes to events from the op-node in order to react appropriately.
@@ -123,17 +123,17 @@ Additionally, the supervisor sends control signals to the op-node triggered by *
 | New cross-safe head  | Supervisor sends the head to the node, where it is recorded as the cross-safe head |
 | New finalized head  | Supervisor sends the head to the node, where it is recorded as the finalized head |
 
-Nodes in managed mode *do not* discover their own L1 blocks.
+Nodes in indexing mode *do not* discover their own L1 blocks.
 Instead, the supervisor watches the L1 and sends the block hash to the node, which is used instead of L1 traversal.
-In this way, all managed nodes are guaranteed to share the same L1 chain, and their data can be aggregated consistently.
+In this way, all indexing nodes are guaranteed to share the same L1 chain, and their data can be aggregated consistently.
 
-#### Standard Mode
-(Standard mode is in development)
+#### Following Mode
+(Following mode is in development)
 
-In standard mode, an `op-node` continues to handle derivation and L1 discovery as it would without a supervisor.
-However, it calls out to the supervisor periodically to update its cross-heads. Standard nodes do not affect the supervisor's data in any way.
+In following mode, an `op-node` continues to handle derivation and L1 discovery as it would without a supervisor.
+However, it calls out to the supervisor periodically to update its cross-heads. Following nodes do not affect the supervisor's data in any way.
 
-In this way, standard nodes can optimistically follow cross-safety without requiring the larger infrastructure of multiple nodes and a supervisor.
+In this way, following nodes can optimistically follow cross-safety without requiring the larger infrastructure of multiple nodes and a supervisor.
 
 ### Data Flow Visualization
 
@@ -143,7 +143,7 @@ sequenceDiagram
 autonumber
 
 participant super as op-supervisor
-participant node as op-node (managed)
+participant node as op-node (indexing)
 participant geth as op-geth
 
 super ->> node: RPC connection established
@@ -169,7 +169,7 @@ sequenceDiagram
 autonumber
 
 participant super as op-supervisor
-participant node as op-node (managed)
+participant node as op-node (indexing)
 participant p2p as p2p
 
 p2p ->> node: New unsafe block from gossip network

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -26,10 +26,10 @@ type mockSyncControl struct {
 	updateCrossSafeFn   func(ctx context.Context, derived, source eth.BlockID) error
 	updateCrossUnsafeFn func(ctx context.Context, derived eth.BlockID) error
 	updateFinalizedFn   func(ctx context.Context, id eth.BlockID) error
-	pullEventFn         func(ctx context.Context) (*types.ManagedEvent, error)
+	pullEventFn         func(ctx context.Context) (*types.IndexingEvent, error)
 	blockRefByNumFn     func(ctx context.Context, number uint64) (eth.BlockRef, error)
 
-	subscribeEvents gethevent.FeedOf[*types.ManagedEvent]
+	subscribeEvents gethevent.FeedOf[*types.IndexingEvent]
 }
 
 func (m *mockSyncControl) InvalidateBlock(ctx context.Context, seal types.BlockSeal) error {
@@ -64,14 +64,14 @@ func (m *mockSyncControl) ResetPreInterop(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockSyncControl) PullEvent(ctx context.Context) (*types.ManagedEvent, error) {
+func (m *mockSyncControl) PullEvent(ctx context.Context) (*types.IndexingEvent, error) {
 	if m.pullEventFn != nil {
 		return m.pullEventFn(ctx)
 	}
 	return nil, nil
 }
 
-func (m *mockSyncControl) SubscribeEvents(ctx context.Context, ch chan *types.ManagedEvent) (ethereum.Subscription, error) {
+func (m *mockSyncControl) SubscribeEvents(ctx context.Context, ch chan *types.IndexingEvent) (ethereum.Subscription, error) {
 	return m.subscribeEvents.Subscribe(ch), nil
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -36,8 +36,8 @@ type SyncSource interface {
 }
 
 type SyncControl interface {
-	SubscribeEvents(ctx context.Context, c chan *types.ManagedEvent) (ethereum.Subscription, error)
-	PullEvent(ctx context.Context) (*types.ManagedEvent, error)
+	SubscribeEvents(ctx context.Context, c chan *types.IndexingEvent) (ethereum.Subscription, error)
+	PullEvent(ctx context.Context) (*types.IndexingEvent, error)
 	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
 
 	UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) error

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -53,7 +53,7 @@ type ManagedNode struct {
 
 	// When the node has an update for us
 	// Nil when node events are pulled synchronously.
-	nodeEvents chan *types.ManagedEvent
+	nodeEvents chan *types.IndexingEvent
 
 	subscriptions []gethevent.Subscription
 
@@ -159,7 +159,7 @@ func (m *ManagedNode) OnEvent(ev event.Event) bool {
 }
 
 func (m *ManagedNode) SubscribeToNodeEvents() {
-	m.nodeEvents = make(chan *types.ManagedEvent, 10)
+	m.nodeEvents = make(chan *types.IndexingEvent, 10)
 
 	// Resubscribe, since the RPC subscription might fail intermittently.
 	// And fall back to polling, if RPC subscriptions are not supported.
@@ -178,7 +178,7 @@ func (m *ManagedNode) SubscribeToNodeEvents() {
 					}
 				}
 				// When the subscription fails, the channel may have been immediately closed
-				m.nodeEvents = make(chan *types.ManagedEvent, 10)
+				m.nodeEvents = make(chan *types.IndexingEvent, 10)
 			}
 			sub, err := m.Node.SubscribeEvents(ctx, m.nodeEvents)
 			if err != nil {
@@ -256,7 +256,7 @@ func (m *ManagedNode) PullEvents(ctx context.Context) (pulledAny bool, err error
 }
 
 // onNodeEvents handles the incoming events from the node.
-func (m *ManagedNode) onNodeEvent(ev *types.ManagedEvent) {
+func (m *ManagedNode) onNodeEvent(ev *types.IndexingEvent) {
 	if m.resetCancel != nil {
 		m.log.Debug("Ignoring event during ongoing reset", "event", ev)
 		return

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -69,13 +69,13 @@ func TestEventResponse(t *testing.T) {
 		emitter.Emit(superevents.CrossSafeUpdateEvent{ChainID: chainID, Ctx: testCtx})
 		emitter.Emit(superevents.FinalizedL2UpdateEvent{ChainID: chainID, Ctx: testCtx})
 
-		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
+		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			UnsafeBlock: &eth.BlockRef{Number: 1}})
-		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
+		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			DerivationUpdate: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
-		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
+		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			ExhaustL1: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
-		syncCtrl.subscribeEvents.Send(&types.ManagedEvent{
+		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			DerivationOriginUpdate: &eth.BlockRef{Number: 1}})
 
 		require.NoError(t, ex.Drain())

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/managed"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
 
@@ -115,14 +115,14 @@ func (rs *RPCSyncNode) String() string {
 	return rs.name
 }
 
-func (rs *RPCSyncNode) SubscribeEvents(ctx context.Context, dest chan *types.ManagedEvent) (ethereum.Subscription, error) {
+func (rs *RPCSyncNode) SubscribeEvents(ctx context.Context, dest chan *types.IndexingEvent) (ethereum.Subscription, error) {
 	return rpc.SubscribeStream(ctx, "interop", rs.cl, dest, "events")
 }
 
 // PullEvent pulls an event, as alternative to an event-subscription with SubscribeEvents.
 // This returns an io.EOF error if no new events are available.
-func (rs *RPCSyncNode) PullEvent(ctx context.Context) (*types.ManagedEvent, error) {
-	var out *types.ManagedEvent
+func (rs *RPCSyncNode) PullEvent(ctx context.Context) (*types.IndexingEvent, error) {
+	var out *types.IndexingEvent
 	err := rs.cl.CallContext(ctx, &out, "interop_pullEvent")
 	var x gethrpc.Error
 	if err != nil {
@@ -169,7 +169,7 @@ func (rs *RPCSyncNode) AnchorPoint(ctx context.Context) (types.DerivedBlockRefPa
 	)
 	err := rs.cl.CallContext(ctx, &out, "interop_anchorPoint")
 	// Translate an interop-inactive error into a ErrFuture.
-	if errors.As(err, &jsonErr) && jsonErr.ErrorCode() == managed.InteropInactiveRPCErrCode {
+	if errors.As(err, &jsonErr) && jsonErr.ErrorCode() == indexing.InteropInactiveRPCErrCode {
 		return types.DerivedBlockRefPair{}, types.ErrFuture
 	}
 	return out, err

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -485,9 +485,9 @@ type BlockReplacement struct {
 	Invalidated common.Hash  `json:"invalidated"`
 }
 
-// ManagedEvent is an event sent by the managed node to the supervisor,
+// IndexingEvent is an event sent by the indexing node to the supervisor,
 // to share an update. One of the fields will be non-null; different kinds of updates may be sent.
-type ManagedEvent struct {
+type IndexingEvent struct {
 	Reset                  *string              `json:"reset,omitempty"`
 	UnsafeBlock            *eth.BlockRef        `json:"unsafeBlock,omitempty"`
 	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`


### PR DESCRIPTION
**Description**

This PR is renaming the supervisor <> node mode renaming per [here](https://oplabs.notion.site/Supervisor-Mode-Naming-Convention-20df153ee16280649630c3a55850d906).

Fixes: https://github.com/ethereum-optimism/optimism/issues/16379

**TODO**

- [x] review related repos (docs / specs) and see if we need updating elsewhere apart from in this repo.