### PR TITLE
op-supervisor: metrics: Use `BlockSeal` and record Local Safe/Unsafe heads

### DIFF
--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -17,6 +17,7 @@ type Metricer interface {
 	opmetrics.RPCMetricer
 	RecordCrossUnsafeRef(chainID eth.ChainID, r types.BlockSeal)
 	RecordCrossSafeRef(chainID eth.ChainID, r types.BlockSeal)
+	RecordLocalSafeRef(chainID eth.ChainID, r types.BlockSeal)
 
 	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID eth.ChainID, label string, hit bool)
@@ -168,6 +169,10 @@ func (m *Metrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 
 func (m *Metrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 	m.RefMetrics.RecordRef("l2", "cross_safe", ref.Number, ref.Timestamp, ref.Hash, chainID)
+}
+
+func (m *Metrics) RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "local_safe", ref.Number, ref.Timestamp, ref.Hash, chainID)
 }
 
 func (m *Metrics) CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool) {

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -15,10 +15,10 @@ type Metricer interface {
 	RecordUp()
 
 	opmetrics.RPCMetricer
-	RecordCrossUnsafeRef(chainID eth.ChainID, r types.BlockSeal)
-	RecordCrossSafeRef(chainID eth.ChainID, r types.BlockSeal)
-	RecordLocalSafeRef(chainID eth.ChainID, r types.BlockSeal)
-	RecordLocalUnsafeRef(chainID eth.ChainID, r types.BlockSeal)
+	RecordCrossUnsafe(chainID eth.ChainID, s types.BlockSeal)
+	RecordCrossSafe(chainID eth.ChainID, s types.BlockSeal)
+	RecordLocalSafe(chainID eth.ChainID, s types.BlockSeal)
+	RecordLocalUnsafe(chainID eth.ChainID, s types.BlockSeal)
 
 	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID eth.ChainID, label string, hit bool)
@@ -164,20 +164,20 @@ func (m *Metrics) RecordUp() {
 	m.up.Set(1)
 }
 
-func (m *Metrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.RefMetrics.RecordRef("l2", "cross_unsafe", ref.Number, ref.Timestamp, ref.Hash, chainID)
+func (m *Metrics) RecordCrossUnsafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "cross_unsafe", seal.Number, seal.Timestamp, seal.Hash, chainID)
 }
 
-func (m *Metrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.RefMetrics.RecordRef("l2", "cross_safe", ref.Number, ref.Timestamp, ref.Hash, chainID)
+func (m *Metrics) RecordCrossSafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "cross_safe", seal.Number, seal.Timestamp, seal.Hash, chainID)
 }
 
-func (m *Metrics) RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.RefMetrics.RecordRef("l2", "local_safe", ref.Number, ref.Timestamp, ref.Hash, chainID)
+func (m *Metrics) RecordLocalSafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "local_safe", seal.Number, seal.Timestamp, seal.Hash, chainID)
 }
 
-func (m *Metrics) RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.RefMetrics.RecordRef("l2", "local_unsafe", ref.Number, ref.Timestamp, ref.Hash, chainID)
+func (m *Metrics) RecordLocalUnsafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "local_unsafe", seal.Number, seal.Timestamp, seal.Hash, chainID)
 }
 
 func (m *Metrics) CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool) {

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -14,8 +15,8 @@ type Metricer interface {
 	RecordUp()
 
 	opmetrics.RPCMetricer
-	RecordCrossUnsafeRef(chainID eth.ChainID, r eth.BlockRef)
-	RecordCrossSafeRef(chainID eth.ChainID, r eth.BlockRef)
+	RecordCrossUnsafeRef(chainID eth.ChainID, r types.BlockSeal)
+	RecordCrossSafeRef(chainID eth.ChainID, r types.BlockSeal)
 
 	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID eth.ChainID, label string, hit bool)
@@ -161,12 +162,12 @@ func (m *Metrics) RecordUp() {
 	m.up.Set(1)
 }
 
-func (m *Metrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref eth.BlockRef) {
-	m.RefMetrics.RecordRef("l2", "cross_unsafe", ref.Number, ref.Time, ref.Hash, chainID)
+func (m *Metrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "cross_unsafe", ref.Number, ref.Timestamp, ref.Hash, chainID)
 }
 
-func (m *Metrics) RecordCrossSafeRef(chainID eth.ChainID, ref eth.BlockRef) {
-	m.RefMetrics.RecordRef("l2", "cross_safe", ref.Number, ref.Time, ref.Hash, chainID)
+func (m *Metrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "cross_safe", ref.Number, ref.Timestamp, ref.Hash, chainID)
 }
 
 func (m *Metrics) CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool) {

--- a/op-supervisor/metrics/metrics.go
+++ b/op-supervisor/metrics/metrics.go
@@ -18,6 +18,7 @@ type Metricer interface {
 	RecordCrossUnsafeRef(chainID eth.ChainID, r types.BlockSeal)
 	RecordCrossSafeRef(chainID eth.ChainID, r types.BlockSeal)
 	RecordLocalSafeRef(chainID eth.ChainID, r types.BlockSeal)
+	RecordLocalUnsafeRef(chainID eth.ChainID, r types.BlockSeal)
 
 	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID eth.ChainID, label string, hit bool)
@@ -173,6 +174,10 @@ func (m *Metrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 
 func (m *Metrics) RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 	m.RefMetrics.RecordRef("l2", "local_safe", ref.Number, ref.Timestamp, ref.Hash, chainID)
+}
+
+func (m *Metrics) RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
+	m.RefMetrics.RecordRef("l2", "local_unsafe", ref.Number, ref.Timestamp, ref.Hash, chainID)
 }
 
 func (m *Metrics) CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool) {

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type noopMetrics struct {
@@ -18,8 +19,8 @@ func (*noopMetrics) Document() []opmetrics.DocumentedMetric { return nil }
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
-func (m *noopMetrics) RecordCrossUnsafeRef(_ eth.ChainID, _ eth.BlockRef) {}
-func (m *noopMetrics) RecordCrossSafeRef(_ eth.ChainID, _ eth.BlockRef)   {}
+func (m *noopMetrics) RecordCrossUnsafeRef(_ eth.ChainID, _ types.BlockSeal) {}
+func (m *noopMetrics) RecordCrossSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
 
 func (m *noopMetrics) CacheAdd(_ eth.ChainID, _ string, _ int, _ bool) {}
 func (m *noopMetrics) CacheGet(_ eth.ChainID, _ string, _ bool)        {}

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -22,6 +22,7 @@ func (*noopMetrics) RecordUp()                 {}
 func (m *noopMetrics) RecordCrossUnsafeRef(_ eth.ChainID, _ types.BlockSeal) {}
 func (m *noopMetrics) RecordCrossSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
 func (m *noopMetrics) RecordLocalSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
+func (m *noopMetrics) RecordLocalUnsafeRef(_ eth.ChainID, _ types.BlockSeal) {}
 
 func (m *noopMetrics) CacheAdd(_ eth.ChainID, _ string, _ int, _ bool) {}
 func (m *noopMetrics) CacheGet(_ eth.ChainID, _ string, _ bool)        {}

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -19,10 +19,10 @@ func (*noopMetrics) Document() []opmetrics.DocumentedMetric { return nil }
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
-func (m *noopMetrics) RecordCrossUnsafeRef(_ eth.ChainID, _ types.BlockSeal) {}
-func (m *noopMetrics) RecordCrossSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
-func (m *noopMetrics) RecordLocalSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
-func (m *noopMetrics) RecordLocalUnsafeRef(_ eth.ChainID, _ types.BlockSeal) {}
+func (m *noopMetrics) RecordCrossUnsafe(_ eth.ChainID, _ types.BlockSeal) {}
+func (m *noopMetrics) RecordCrossSafe(_ eth.ChainID, _ types.BlockSeal)   {}
+func (m *noopMetrics) RecordLocalSafe(_ eth.ChainID, _ types.BlockSeal)   {}
+func (m *noopMetrics) RecordLocalUnsafe(_ eth.ChainID, _ types.BlockSeal) {}
 
 func (m *noopMetrics) CacheAdd(_ eth.ChainID, _ string, _ int, _ bool) {}
 func (m *noopMetrics) CacheGet(_ eth.ChainID, _ string, _ bool)        {}

--- a/op-supervisor/metrics/noop.go
+++ b/op-supervisor/metrics/noop.go
@@ -21,6 +21,7 @@ func (*noopMetrics) RecordUp()                 {}
 
 func (m *noopMetrics) RecordCrossUnsafeRef(_ eth.ChainID, _ types.BlockSeal) {}
 func (m *noopMetrics) RecordCrossSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
+func (m *noopMetrics) RecordLocalSafeRef(_ eth.ChainID, _ types.BlockSeal)   {}
 
 func (m *noopMetrics) CacheAdd(_ eth.ChainID, _ string, _ int, _ bool) {}
 func (m *noopMetrics) CacheGet(_ eth.ChainID, _ string, _ bool)        {}

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -333,8 +333,8 @@ func TestBackendCallsMetrics(t *testing.T) {
 
 	// Set up mock metrics
 	mockMetrics.Mock.On("RecordDBEntryCount", chainA, mock.AnythingOfType("string"), mock.AnythingOfType("int64")).Return()
-	mockMetrics.Mock.On("RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(_ eth.BlockRef) bool { return true })).Return()
-	mockMetrics.Mock.On("RecordCrossSafeRef", chainA, mock.MatchedBy(func(_ eth.BlockRef) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordCrossSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 
 	fullCfgSet := fullConfigSet(t, 1)
 	cfg := &config.Config{
@@ -379,15 +379,15 @@ func TestBackendCallsMetrics(t *testing.T) {
 		Timestamp: block.Time,
 	})
 	require.NoError(t, err)
-	mockMetrics.Mock.AssertCalled(t, "RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(ref eth.BlockRef) bool {
-		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Time == block.Time
+	mockMetrics.Mock.AssertCalled(t, "RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
 
 	err = b.chainDBs.UpdateCrossSafe(chainA, block, block)
 	require.NoError(t, err)
 	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "cross_derived", int64(1))
-	mockMetrics.Mock.AssertCalled(t, "RecordCrossSafeRef", chainA, mock.MatchedBy(func(ref eth.BlockRef) bool {
-		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Time == block.Time
+	mockMetrics.Mock.AssertCalled(t, "RecordCrossSafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
 
 	// Stop the backend
@@ -411,11 +411,11 @@ func (m *MockMetrics) CacheGet(chainID eth.ChainID, label string, hit bool) {
 	m.Mock.Called(chainID, label, hit)
 }
 
-func (m *MockMetrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref eth.BlockRef) {
+func (m *MockMetrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 	m.Mock.Called(chainID, ref)
 }
 
-func (m *MockMetrics) RecordCrossSafeRef(chainID eth.ChainID, ref eth.BlockRef) {
+func (m *MockMetrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 	m.Mock.Called(chainID, ref)
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -336,6 +336,7 @@ func TestBackendCallsMetrics(t *testing.T) {
 	mockMetrics.Mock.On("RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 	mockMetrics.Mock.On("RecordCrossSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 	mockMetrics.Mock.On("RecordLocalSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordLocalUnsafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 
 	fullCfgSet := fullConfigSet(t, 1)
 	cfg := &config.Config{
@@ -371,30 +372,32 @@ func TestBackendCallsMetrics(t *testing.T) {
 		ParentHash: common.Hash{0xbb},
 		Time:       10000,
 	}
-
-	b.chainDBs.ForceInitialized(chainA) // force init for test
+	safe := types.DerivedBlockRefPair{
+		Source:  block, // dummy value
+		Derived: block,
+	}
+	// update local unsafe/safe, cross unsafe/safe
+	b.chainDBs.OnEvent(superevents.SafeActivationBlockEvent{
+		Safe:    safe,
+		ChainID: chainA,
+	})
 	// Assert that metrics are called on safety level updates
-	b.chainDBs.UpdateLocalSafe(chainA, block, block, "test")
+	mockMetrics.Mock.AssertCalled(t, "RecordLocalUnsafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
+	}))
 	mockMetrics.Mock.AssertCalled(t, "RecordLocalSafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
-	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "local_derived", int64(1))
-	err = b.chainDBs.UpdateCrossUnsafe(chainA, types.BlockSeal{
-		Hash:      block.Hash,
-		Number:    block.Number,
-		Timestamp: block.Time,
-	})
-	require.NoError(t, err)
 	mockMetrics.Mock.AssertCalled(t, "RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
-
-	err = b.chainDBs.UpdateCrossSafe(chainA, block, block)
-	require.NoError(t, err)
-	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "cross_derived", int64(1))
 	mockMetrics.Mock.AssertCalled(t, "RecordCrossSafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
+	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "cross_derived", int64(1))
+	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "local_derived", int64(1))
+	// db entry: searchCheckpoint, canonicalHash
+	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "log", int64(2))
 
 	// Stop the backend
 	err = b.Stop(context.Background())
@@ -426,6 +429,10 @@ func (m *MockMetrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSea
 }
 
 func (m *MockMetrics) RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
+	m.Mock.Called(chainID, ref)
+}
+
+func (m *MockMetrics) RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 	m.Mock.Called(chainID, ref)
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -333,10 +333,10 @@ func TestBackendCallsMetrics(t *testing.T) {
 
 	// Set up mock metrics
 	mockMetrics.Mock.On("RecordDBEntryCount", chainA, mock.AnythingOfType("string"), mock.AnythingOfType("int64")).Return()
-	mockMetrics.Mock.On("RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
-	mockMetrics.Mock.On("RecordCrossSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
-	mockMetrics.Mock.On("RecordLocalSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
-	mockMetrics.Mock.On("RecordLocalUnsafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordCrossUnsafe", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordCrossSafe", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordLocalSafe", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordLocalUnsafe", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 
 	fullCfgSet := fullConfigSet(t, 1)
 	cfg := &config.Config{
@@ -382,16 +382,16 @@ func TestBackendCallsMetrics(t *testing.T) {
 		ChainID: chainA,
 	})
 	// Assert that metrics are called on safety level updates
-	mockMetrics.Mock.AssertCalled(t, "RecordLocalUnsafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+	mockMetrics.Mock.AssertCalled(t, "RecordLocalUnsafe", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
-	mockMetrics.Mock.AssertCalled(t, "RecordLocalSafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+	mockMetrics.Mock.AssertCalled(t, "RecordLocalSafe", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
-	mockMetrics.Mock.AssertCalled(t, "RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+	mockMetrics.Mock.AssertCalled(t, "RecordCrossUnsafe", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
-	mockMetrics.Mock.AssertCalled(t, "RecordCrossSafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+	mockMetrics.Mock.AssertCalled(t, "RecordCrossSafe", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
 		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
 	}))
 	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "cross_derived", int64(1))
@@ -420,20 +420,20 @@ func (m *MockMetrics) CacheGet(chainID eth.ChainID, label string, hit bool) {
 	m.Mock.Called(chainID, label, hit)
 }
 
-func (m *MockMetrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.Mock.Called(chainID, ref)
+func (m *MockMetrics) RecordCrossUnsafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.Mock.Called(chainID, seal)
 }
 
-func (m *MockMetrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.Mock.Called(chainID, ref)
+func (m *MockMetrics) RecordCrossSafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.Mock.Called(chainID, seal)
 }
 
-func (m *MockMetrics) RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.Mock.Called(chainID, ref)
+func (m *MockMetrics) RecordLocalSafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.Mock.Called(chainID, seal)
 }
 
-func (m *MockMetrics) RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal) {
-	m.Mock.Called(chainID, ref)
+func (m *MockMetrics) RecordLocalUnsafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.Mock.Called(chainID, seal)
 }
 
 func (m *MockMetrics) RecordDBEntryCount(chainID eth.ChainID, kind string, count int64) {

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -335,6 +335,7 @@ func TestBackendCallsMetrics(t *testing.T) {
 	mockMetrics.Mock.On("RecordDBEntryCount", chainA, mock.AnythingOfType("string"), mock.AnythingOfType("int64")).Return()
 	mockMetrics.Mock.On("RecordCrossUnsafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 	mockMetrics.Mock.On("RecordCrossSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
+	mockMetrics.Mock.On("RecordLocalSafeRef", chainA, mock.MatchedBy(func(_ types.BlockSeal) bool { return true })).Return()
 
 	fullCfgSet := fullConfigSet(t, 1)
 	cfg := &config.Config{
@@ -373,6 +374,11 @@ func TestBackendCallsMetrics(t *testing.T) {
 
 	b.chainDBs.ForceInitialized(chainA) // force init for test
 	// Assert that metrics are called on safety level updates
+	b.chainDBs.UpdateLocalSafe(chainA, block, block, "test")
+	mockMetrics.Mock.AssertCalled(t, "RecordLocalSafeRef", chainA, mock.MatchedBy(func(ref types.BlockSeal) bool {
+		return ref.Hash == block.Hash && ref.Number == block.Number && ref.Timestamp == block.Time
+	}))
+	mockMetrics.Mock.AssertCalled(t, "RecordDBEntryCount", chainA, "local_derived", int64(1))
 	err = b.chainDBs.UpdateCrossUnsafe(chainA, types.BlockSeal{
 		Hash:      block.Hash,
 		Number:    block.Number,
@@ -416,6 +422,10 @@ func (m *MockMetrics) RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockS
 }
 
 func (m *MockMetrics) RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
+	m.Mock.Called(chainID, ref)
+}
+
+func (m *MockMetrics) RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal) {
 	m.Mock.Called(chainID, ref)
 }
 

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -15,6 +15,7 @@ type Metrics interface {
 
 	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal)
 
 	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
@@ -45,6 +46,10 @@ func (c *chainMetrics) RecordCrossUnsafeRef(ref types.BlockSeal) {
 
 func (c *chainMetrics) RecordCrossSafeRef(ref types.BlockSeal) {
 	c.delegate.RecordCrossSafeRef(c.chainID, ref)
+}
+
+func (c *chainMetrics) RecordLocalSafeRef(ref types.BlockSeal) {
+	c.delegate.RecordLocalSafeRef(c.chainID, ref)
 }
 
 func (c *chainMetrics) CacheAdd(label string, cacheSize int, evicted bool) {

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -13,10 +13,10 @@ type Metrics interface {
 	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID eth.ChainID, label string, hit bool)
 
-	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
-	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
-	RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal)
-	RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordCrossUnsafe(chainID eth.ChainID, ref types.BlockSeal)
+	RecordCrossSafe(chainID eth.ChainID, ref types.BlockSeal)
+	RecordLocalSafe(chainID eth.ChainID, ref types.BlockSeal)
+	RecordLocalUnsafe(chainID eth.ChainID, ref types.BlockSeal)
 
 	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
@@ -41,20 +41,20 @@ func newChainMetrics(chainID eth.ChainID, delegate Metrics) *chainMetrics {
 	}
 }
 
-func (c *chainMetrics) RecordCrossUnsafeRef(ref types.BlockSeal) {
-	c.delegate.RecordCrossUnsafeRef(c.chainID, ref)
+func (c *chainMetrics) RecordCrossUnsafe(seal types.BlockSeal) {
+	c.delegate.RecordCrossUnsafe(c.chainID, seal)
 }
 
-func (c *chainMetrics) RecordCrossSafeRef(ref types.BlockSeal) {
-	c.delegate.RecordCrossSafeRef(c.chainID, ref)
+func (c *chainMetrics) RecordCrossSafe(seal types.BlockSeal) {
+	c.delegate.RecordCrossSafe(c.chainID, seal)
 }
 
-func (c *chainMetrics) RecordLocalSafeRef(ref types.BlockSeal) {
-	c.delegate.RecordLocalSafeRef(c.chainID, ref)
+func (c *chainMetrics) RecordLocalSafe(seal types.BlockSeal) {
+	c.delegate.RecordLocalSafe(c.chainID, seal)
 }
 
-func (c *chainMetrics) RecordLocalUnsafeRef(ref types.BlockSeal) {
-	c.delegate.RecordLocalUnsafeRef(c.chainID, ref)
+func (c *chainMetrics) RecordLocalUnsafe(seal types.BlockSeal) {
+	c.delegate.RecordLocalUnsafe(c.chainID, seal)
 }
 
 func (c *chainMetrics) CacheAdd(label string, cacheSize int, evicted bool) {

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -6,14 +6,15 @@ import (
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type Metrics interface {
 	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
 	CacheGet(chainID eth.ChainID, label string, hit bool)
 
-	RecordCrossUnsafeRef(chainID eth.ChainID, ref eth.BlockRef)
-	RecordCrossSafeRef(chainID eth.ChainID, ref eth.BlockRef)
+	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
 
 	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
@@ -38,11 +39,11 @@ func newChainMetrics(chainID eth.ChainID, delegate Metrics) *chainMetrics {
 	}
 }
 
-func (c *chainMetrics) RecordCrossUnsafeRef(ref eth.BlockRef) {
+func (c *chainMetrics) RecordCrossUnsafeRef(ref types.BlockSeal) {
 	c.delegate.RecordCrossUnsafeRef(c.chainID, ref)
 }
 
-func (c *chainMetrics) RecordCrossSafeRef(ref eth.BlockRef) {
+func (c *chainMetrics) RecordCrossSafeRef(ref types.BlockSeal) {
 	c.delegate.RecordCrossSafeRef(c.chainID, ref)
 }
 

--- a/op-supervisor/supervisor/backend/chain_metrics.go
+++ b/op-supervisor/supervisor/backend/chain_metrics.go
@@ -16,6 +16,7 @@ type Metrics interface {
 	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
 	RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 
 	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
 	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
@@ -50,6 +51,10 @@ func (c *chainMetrics) RecordCrossSafeRef(ref types.BlockSeal) {
 
 func (c *chainMetrics) RecordLocalSafeRef(ref types.BlockSeal) {
 	c.delegate.RecordLocalSafeRef(c.chainID, ref)
+}
+
+func (c *chainMetrics) RecordLocalUnsafeRef(ref types.BlockSeal) {
+	c.delegate.RecordLocalUnsafeRef(c.chainID, ref)
 }
 
 func (c *chainMetrics) CacheAdd(label string, cacheSize int, evicted bool) {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -102,8 +102,8 @@ var _ DerivationStorage = (*fromda.DB)(nil)
 var _ LogStorage = (*logs.DB)(nil)
 
 type Metrics interface {
-	RecordCrossUnsafeRef(chainID eth.ChainID, ref eth.BlockRef)
-	RecordCrossSafeRef(chainID eth.ChainID, ref eth.BlockRef)
+	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
 }
 
 // ChainsDB is a database that stores logs and derived-from data for multiple chains.

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -102,10 +102,10 @@ var _ DerivationStorage = (*fromda.DB)(nil)
 var _ LogStorage = (*logs.DB)(nil)
 
 type Metrics interface {
-	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
-	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
-	RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal)
-	RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordCrossUnsafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordCrossSafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordLocalSafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordLocalUnsafe(chainID eth.ChainID, seal types.BlockSeal)
 }
 
 // ChainsDB is a database that stores logs and derived-from data for multiple chains.

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -104,6 +104,7 @@ var _ LogStorage = (*logs.DB)(nil)
 type Metrics interface {
 	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal)
 }
 
 // ChainsDB is a database that stores logs and derived-from data for multiple chains.

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -105,6 +105,7 @@ type Metrics interface {
 	RecordCrossUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 	RecordCrossSafeRef(chainID eth.ChainID, ref types.BlockSeal)
 	RecordLocalSafeRef(chainID eth.ChainID, ref types.BlockSeal)
+	RecordLocalUnsafeRef(chainID eth.ChainID, ref types.BlockSeal)
 }
 
 // ChainsDB is a database that stores logs and derived-from data for multiple chains.

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -145,11 +145,7 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.Block
 		ChainID:        chain,
 		NewCrossUnsafe: crossUnsafe,
 	})
-	db.m.RecordCrossUnsafeRef(chain, eth.BlockRef{
-		Number: crossUnsafe.Number,
-		Time:   crossUnsafe.Timestamp,
-		Hash:   crossUnsafe.Hash,
-	})
+	db.m.RecordCrossUnsafeRef(chain, crossUnsafe)
 	return nil
 }
 
@@ -178,14 +174,15 @@ func (db *ChainsDB) initializedUpdateCrossSafe(chain eth.ChainID, l1View eth.Blo
 		return err
 	}
 	db.logger.Info("Updated cross-safe", "chain", chain, "l1View", l1View, "lastCrossDerived", lastCrossDerived)
+	lastCrossDerivedBlockRef := types.BlockSealFromRef(lastCrossDerived)
 	db.emitter.Emit(superevents.CrossSafeUpdateEvent{
 		ChainID: chain,
 		NewCrossSafe: types.DerivedBlockSealPair{
 			Source:  types.BlockSealFromRef(l1View),
-			Derived: types.BlockSealFromRef(lastCrossDerived),
+			Derived: lastCrossDerivedBlockRef,
 		},
 	})
-	db.m.RecordCrossSafeRef(chain, lastCrossDerived)
+	db.m.RecordCrossSafeRef(chain, lastCrossDerivedBlockRef)
 
 	// compare new cross-safe to recorded cross-unsafe
 	crossUnsafe, err := db.CrossUnsafe(chain)

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -48,6 +48,7 @@ func (db *ChainsDB) sealBlock(chain eth.ChainID, block eth.BlockRef, mayInit boo
 		ChainID:        chain,
 		NewLocalUnsafe: block,
 	})
+	db.m.RecordLocalUnsafeRef(chain, types.BlockSealFromRef(block))
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -122,13 +122,15 @@ func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, source eth.Blo
 		return
 	}
 	logger.Info("Updated local safe DB")
+	derived := types.BlockSealFromRef(lastDerived)
 	db.emitter.Emit(superevents.LocalSafeUpdateEvent{
 		ChainID: chain,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source:  types.BlockSealFromRef(source),
-			Derived: types.BlockSealFromRef(lastDerived),
+			Derived: derived,
 		},
 	})
+	db.m.RecordLocalSafeRef(chain, derived)
 }
 
 func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.BlockSeal) error {
@@ -370,10 +372,12 @@ func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef
 		NewLocalUnsafe: replacement,
 	})
 	// The local-safe DB changed, so emit an event, so other sub-systems can react to the change.
+	seals := result.Seals()
 	db.emitter.Emit(superevents.LocalSafeUpdateEvent{
 		ChainID:      chainID,
-		NewLocalSafe: result.Seals(),
+		NewLocalSafe: seals,
 	})
+	db.m.RecordLocalSafeRef(chainID, seals.Derived)
 	// The event-DB will start indexing, and then unblock cross-safe update
 	// of the new replaced block, via regular cross-safe update worker routine.
 }

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -48,7 +48,7 @@ func (db *ChainsDB) sealBlock(chain eth.ChainID, block eth.BlockRef, mayInit boo
 		ChainID:        chain,
 		NewLocalUnsafe: block,
 	})
-	db.m.RecordLocalUnsafeRef(chain, types.BlockSealFromRef(block))
+	db.m.RecordLocalUnsafe(chain, types.BlockSealFromRef(block))
 	return nil
 }
 
@@ -131,7 +131,7 @@ func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, source eth.Blo
 			Derived: derived,
 		},
 	})
-	db.m.RecordLocalSafeRef(chain, derived)
+	db.m.RecordLocalSafe(chain, derived)
 }
 
 func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.BlockSeal) error {
@@ -148,7 +148,7 @@ func (db *ChainsDB) UpdateCrossUnsafe(chain eth.ChainID, crossUnsafe types.Block
 		ChainID:        chain,
 		NewCrossUnsafe: crossUnsafe,
 	})
-	db.m.RecordCrossUnsafeRef(chain, crossUnsafe)
+	db.m.RecordCrossUnsafe(chain, crossUnsafe)
 	return nil
 }
 
@@ -185,7 +185,7 @@ func (db *ChainsDB) initializedUpdateCrossSafe(chain eth.ChainID, l1View eth.Blo
 			Derived: lastCrossDerivedBlockSeal,
 		},
 	})
-	db.m.RecordCrossSafeRef(chain, lastCrossDerivedBlockSeal)
+	db.m.RecordCrossSafe(chain, lastCrossDerivedBlockSeal)
 
 	// compare new cross-safe to recorded cross-unsafe
 	crossUnsafe, err := db.CrossUnsafe(chain)
@@ -378,7 +378,7 @@ func (db *ChainsDB) onReplaceBlock(chainID eth.ChainID, replacement eth.BlockRef
 		ChainID:      chainID,
 		NewLocalSafe: seals,
 	})
-	db.m.RecordLocalSafeRef(chainID, seals.Derived)
+	db.m.RecordLocalSafe(chainID, seals.Derived)
 	// The event-DB will start indexing, and then unblock cross-safe update
 	// of the new replaced block, via regular cross-safe update worker routine.
 }

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -177,15 +177,15 @@ func (db *ChainsDB) initializedUpdateCrossSafe(chain eth.ChainID, l1View eth.Blo
 		return err
 	}
 	db.logger.Info("Updated cross-safe", "chain", chain, "l1View", l1View, "lastCrossDerived", lastCrossDerived)
-	lastCrossDerivedBlockRef := types.BlockSealFromRef(lastCrossDerived)
+	lastCrossDerivedBlockSeal := types.BlockSealFromRef(lastCrossDerived)
 	db.emitter.Emit(superevents.CrossSafeUpdateEvent{
 		ChainID: chain,
 		NewCrossSafe: types.DerivedBlockSealPair{
 			Source:  types.BlockSealFromRef(l1View),
-			Derived: lastCrossDerivedBlockRef,
+			Derived: lastCrossDerivedBlockSeal,
 		},
 	})
-	db.m.RecordCrossSafeRef(chain, lastCrossDerivedBlockRef)
+	db.m.RecordCrossSafeRef(chain, lastCrossDerivedBlockSeal)
 
 	// compare new cross-safe to recorded cross-unsafe
 	crossUnsafe, err := db.CrossUnsafe(chain)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Use `BlockSeal` type to emit metrics for {cross|local}-{safe|unsafe} blocks.
- Refactored cross-{safe|unsafe} metric to use `BlockSeal`
- Added new metric to track local-{safe|unsafe} head.

**Tests**

Updated `TestBackendCallsMetrics` to not manually consolidate blocks, but instead used the `SafeActivationBlockEvent` to initialize the DB, make {cross|local}-{safe|unsafe} blocks recorded at DB. 

Spun up local kurtosis interop net and accessed prometheus HTTP endpoint and validated that the added/existing ref metrics are shown. Below is the relevant logs:
```log
# TYPE op_supervisor_default_refs_hash gauge
op_supervisor_default_refs_hash{chain="2151908",layer="l2",type="cross_safe"} 7.006533277995685e+18
op_supervisor_default_refs_hash{chain="2151908",layer="l2",type="cross_unsafe"} 1.4884111070489504e+19
op_supervisor_default_refs_hash{chain="2151908",layer="l2",type="local_safe"} 7.006533277995685e+18
op_supervisor_default_refs_hash{chain="2151908",layer="l2",type="local_unsafe"} 1.4884111070489504e+19
op_supervisor_default_refs_hash{chain="2151909",layer="l2",type="cross_safe"} 7.641818259083875e+18
op_supervisor_default_refs_hash{chain="2151909",layer="l2",type="cross_unsafe"} 1.648883957356377e+19
op_supervisor_default_refs_hash{chain="2151909",layer="l2",type="local_safe"} 7.641818259083875e+18
op_supervisor_default_refs_hash{chain="2151909",layer="l2",type="local_unsafe"} 1.648883957356377e+19
# HELP op_supervisor_default_refs_latency Gauge representing the different L1/L2 reference block timestamps minus current time, in seconds
# TYPE op_supervisor_default_refs_latency gauge
op_supervisor_default_refs_latency{chain="2151908",layer="l2",type="cross_safe"} -31.705226182937622
op_supervisor_default_refs_latency{chain="2151908",layer="l2",type="cross_unsafe"} -0.011878490447998047
op_supervisor_default_refs_latency{chain="2151908",layer="l2",type="local_safe"} -31.702306747436523
op_supervisor_default_refs_latency{chain="2151908",layer="l2",type="local_unsafe"} -0.011626958847045898
op_supervisor_default_refs_latency{chain="2151909",layer="l2",type="cross_safe"} -44.70593547821045
op_supervisor_default_refs_latency{chain="2151909",layer="l2",type="cross_unsafe"} -0.012111425399780273
op_supervisor_default_refs_latency{chain="2151909",layer="l2",type="local_safe"} -44.703713178634644
op_supervisor_default_refs_latency{chain="2151909",layer="l2",type="local_unsafe"} -0.005936622619628906
# HELP op_supervisor_default_refs_number Gauge representing the different L1/L2 reference block numbers
# TYPE op_supervisor_default_refs_number gauge
op_supervisor_default_refs_number{chain="2151908",layer="l2",type="cross_safe"} 289
op_supervisor_default_refs_number{chain="2151908",layer="l2",type="cross_unsafe"} 308
op_supervisor_default_refs_number{chain="2151908",layer="l2",type="local_safe"} 289
op_supervisor_default_refs_number{chain="2151908",layer="l2",type="local_unsafe"} 308
op_supervisor_default_refs_number{chain="2151909",layer="l2",type="cross_safe"} 284
op_supervisor_default_refs_number{chain="2151909",layer="l2",type="cross_unsafe"} 308
op_supervisor_default_refs_number{chain="2151909",layer="l2",type="local_safe"} 284
op_supervisor_default_refs_number{chain="2151909",layer="l2",type="local_unsafe"} 308
# HELP op_supervisor_default_refs_time Gauge representing the different L1/L2 reference block timestamps
# TYPE op_supervisor_default_refs_time gauge
op_supervisor_default_refs_time{chain="2151908",layer="l2",type="cross_safe"} 1.750166086e+09
op_supervisor_default_refs_time{chain="2151908",layer="l2",type="cross_unsafe"} 1.750166124e+09
op_supervisor_default_refs_time{chain="2151908",layer="l2",type="local_safe"} 1.750166086e+09
op_supervisor_default_refs_time{chain="2151908",layer="l2",type="local_unsafe"} 1.750166124e+09
op_supervisor_default_refs_time{chain="2151909",layer="l2",type="cross_safe"} 1.750166076e+09
op_supervisor_default_refs_time{chain="2151909",layer="l2",type="cross_unsafe"} 1.750166124e+09
op_supervisor_default_refs_time{chain="2151909",layer="l2",type="local_safe"} 1.750166076e+09
op_supervisor_default_refs_time{chain="2151909",layer="l2",type="local_unsafe"} 1.750166124e+09
```

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16274