### PR TITLE
chore(kt-devnet): set L2 nodes name property

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -62,6 +62,7 @@ type serviceParser func(string) (int, chainAcceptor, bool)
 type triagedService struct {
 	tag    string // service tag
 	idx    int    // service index (for nodes)
+	name   string // service name (for nodes)
 	svc    *descriptors.Service
 	accept chainAcceptor
 }
@@ -208,6 +209,7 @@ func (f *ServiceFinder) triageByLabels(svc *inspect.Service, name string, endpoi
 	return &triagedService{
 		tag:    tag,
 		idx:    idx,
+		name:   svc.Labels[nodeNameLabel],
 		accept: accept,
 		svc: &descriptors.Service{
 			Name:      name,
@@ -273,6 +275,7 @@ func (f *ServiceFinder) findChainServices(chain *spec.ChainSpec) ([]descriptors.
 				node.Services = make(descriptors.ServiceMap)
 			}
 			node.Services[svc.tag] = svc.svc
+			node.Name = svc.name
 			nodes[svc.idx] = node
 		} else {
 			services[svc.tag] = append(services[svc.tag], svc.svc)


### PR DESCRIPTION
**Description**

Set the node property to ease traceability from kurtosis specification
to devnet descriptor output.
This change is purely cosmetic.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
