### PR TITLE
op-node/rollup/event: add byType sync.Map

### DIFF
--- a/op-node/rollup/event/executor.go
+++ b/op-node/rollup/event/executor.go
@@ -1,5 +1,7 @@
 package event
 
+import "sync"
+
 type Executable interface {
 	RunEvent(ev AnnotatedEvent)
 }
@@ -16,4 +18,5 @@ func (fn ExecutableFunc) RunEvent(ev AnnotatedEvent) {
 type Executor interface {
 	Add(d Executable, cfg *ExecutorConfig) (leaveExecutor func())
 	Enqueue(ev AnnotatedEvent) error
+	CountByType() *sync.Map // used for debug purposes
 }

--- a/op-node/rollup/event/executor_global.go
+++ b/op-node/rollup/event/executor_global.go
@@ -22,6 +22,9 @@ type prioritizedEvents struct {
 	// keyed by priority. May contain empty lists.
 	byPriority [priorityCount]*eventsList
 
+	// keyed by event type for debug purposes
+	byType sync.Map
+
 	// number of events
 	count uint64
 
@@ -38,6 +41,12 @@ func (a *prioritizedEvents) Add(event AnnotatedEvent) {
 	p := a.byPriority[event.EmitPriority-priorityMin]
 	p.Events = append(p.Events, event)
 	a.count += 1
+
+	// Load, increment, store within byType sync.Map
+	val, _ := a.byType.LoadOrStore(event.Event.String(), 0)
+	count := val.(int)
+	count++
+	a.byType.Store(event.Event.String(), count)
 }
 
 // Pop returns the highest-priority event, and removes it at the same time.
@@ -49,6 +58,13 @@ func (a *prioritizedEvents) Pop() AnnotatedEvent {
 			out := pe.Events[0]
 			pe.Events = pe.Events[1:]
 			a.count -= 1
+
+			// Load, increment, store within byType sync.Map
+			val, _ := a.byType.LoadOrStore(out.Event.String(), 0)
+			count := val.(int)
+			count--
+			a.byType.Store(out.Event.String(), count)
+
 			return out
 		}
 	}
@@ -70,6 +86,10 @@ func (a *prioritizedEvents) Peek() AnnotatedEvent {
 // Count returns the number of currently queued events
 func (a *prioritizedEvents) Count() uint64 {
 	return a.count
+}
+
+func (a *prioritizedEvents) CountByType() *sync.Map {
+	return &a.byType
 }
 
 type GlobalSyncExec struct {
@@ -146,6 +166,10 @@ func (gs *GlobalSyncExec) Enqueue(ev AnnotatedEvent) error {
 		gs.queued = nil  // To everyone in the future: they will need to Await for a new event again
 	}
 	return nil
+}
+
+func (gs *GlobalSyncExec) CountByType() *sync.Map {
+	return gs.events.CountByType()
 }
 
 func (gs *GlobalSyncExec) processEvent(ev AnnotatedEvent) {

--- a/op-node/rollup/event/system.go
+++ b/op-node/rollup/event/system.go
@@ -290,6 +290,13 @@ func (s *Sys) emit(name string, derivContext uint64, ev Event, emitPriority Prio
 	// The Sys cannot decide if an event is important or not, so all events should be considered critical.
 	if err != nil {
 		s.log.Error("Failed to enqueue event", "emitter", name, "event", ev, "context", derivContext)
+
+		byType := s.executor.CountByType()
+		byType.Range(func(key, value any) bool {
+			s.log.Error("Event type count", "event_type", key, "count", value)
+			return true // continue iteration
+		})
+
 		panic(err)
 	}
 }

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -141,8 +141,12 @@ func (s *ChainProcessor) UpdateTarget(newTarget uint64) {
 	s.target = newTarget
 }
 
-// index is the main processing loop. It triggers a r
+// index is the main processing loop. It triggers a rangeUpdate and processes the results.
 func (s *ChainProcessor) index() {
+	defer func(now time.Time) {
+		s.log.Debug("ChainProcessor indexing", "elapsed_ms", fmt.Sprintf("%.3f", float64(time.Since(now).Nanoseconds())/1e6), "target", s.target)
+	}(time.Now())
+
 	// evaluate if indexing is needed
 	target := s.target
 	next := s.nextNum()


### PR DESCRIPTION
**Description**

This PR is adding a `byType` map to the `GlobalSyncExec` so that if we get a panic with too many events enqueued, we also get a list of the different types of events that were enqueued and can fix the corresponding core logic correctly.

Partially addresses: https://github.com/ethereum-optimism/optimism/issues/16335