### PR TITLE
op-node/rollup/event: add gauge for inflight events by type

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -136,6 +136,7 @@ optimism_package:
         - github.com/op-rs/kona/docker/recipes/kona-node/grafana
         - github.com/paradigmxyz/reth/etc/grafana
         - github.com/geoknee/grafana-dashboards/
+        - github.com/nonsense/op-stack-grafana-dashboards/resources
 ethereum_package:
   participants:
     - el_type: geth

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -174,7 +174,7 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config) error {
 
 func (n *OpNode) initEventSystem() {
 	// This executor will be configurable in the future, for parallel event processing
-	executor := event.NewGlobalSynchronous(n.resourcesCtx)
+	executor := event.NewGlobalSynchronous(n.resourcesCtx).WithMetrics(n.metrics)
 	sys := event.NewSystem(n.log, executor)
 	sys.AddTracer(event.NewMetricsTracer(n.metrics))
 	sys.Register("node", event.DeriverFunc(n.onEvent))

--- a/op-service/event/tracer.go
+++ b/op-service/event/tracer.go
@@ -9,4 +9,5 @@ type Tracer interface {
 	OnDeriveEnd(name string, ev AnnotatedEvent, derivContext uint64, startTime time.Time, duration time.Duration, effect bool)
 	OnRateLimited(name string, derivContext uint64)
 	OnEmit(name string, ev AnnotatedEvent, derivContext uint64, emitTime time.Time)
+	OnAfterProcessed(evtype string)
 }

--- a/op-service/event/tracer_log.go
+++ b/op-service/event/tracer_log.go
@@ -38,3 +38,6 @@ func (lt *LogTracer) OnRateLimited(name string, derivContext uint64) {
 func (lt *LogTracer) OnEmit(name string, ev AnnotatedEvent, derivContext uint64, emitTime time.Time) {
 	lt.log.Log(lt.lvl, "Emitting event", "emitter", name, "event", ev.Event, "emit_context", ev.EmitContext, "deriv_context", derivContext)
 }
+
+func (lt *LogTracer) OnAfterProcessed(name string) {
+}

--- a/op-service/event/tracer_metrics.go
+++ b/op-service/event/tracer_metrics.go
@@ -29,4 +29,9 @@ func (mt *MetricsTracer) OnRateLimited(name string, derivContext uint64) {
 
 func (mt *MetricsTracer) OnEmit(name string, ev AnnotatedEvent, derivContext uint64, emitTime time.Time) {
 	mt.metrics.RecordEmittedEvent(ev.Event.String(), name)
+	mt.metrics.EnqueuedEventIncrement(ev.Event.String())
+}
+
+func (mt *MetricsTracer) OnAfterProcessed(evtype string) {
+	mt.metrics.EnqueuedEventDecrement(evtype)
 }

--- a/op-service/event/tracer_struct.go
+++ b/op-service/event/tracer_struct.go
@@ -99,3 +99,5 @@ func (st *StructTracer) OnEmit(name string, ev AnnotatedEvent, derivContext uint
 		EventTime:    emitTime,
 	})
 }
+
+func (st *StructTracer) OnAfterProcessed(name string) {}

--- a/op-supervisor/supervisor/service.go
+++ b/op-supervisor/supervisor/service.go
@@ -82,7 +82,7 @@ func (su *SupervisorService) initFromCLIConfig(ctx context.Context, cfg *config.
 func (su *SupervisorService) initBackend(ctx context.Context, cfg *config.Config) error {
 	// In the future we may introduce other executors.
 	// For now, we just use a synchronous executor, and poll the drain function of it.
-	ex := event.NewGlobalSynchronous(ctx)
+	ex := event.NewGlobalSynchronous(ctx).WithMetrics(su.metrics)
 	su.poller = tasks.NewPoller(func() {
 		if err := ex.Drain(); err != nil {
 			su.log.Warn("Failed to execute events", "err", err)


### PR DESCRIPTION
**Description**

This PR is adding a gauge for enqueued inflight events by event type, so that if we get a panic with too many events enqueued, we also get a list of the different types of events that were enqueued and can fix the corresponding core logic correctly.

Replaces: https://github.com/ethereum-optimism/optimism/pull/16471

Partially addresses: https://github.com/ethereum-optimism/optimism/issues/16335