### PR TITLE
op-devstack: add timeout to sync status call

### DIFF
--- a/op-devstack/dsl/supervisor.go
+++ b/op-devstack/dsl/supervisor.go
@@ -86,7 +86,9 @@ func (s *Supervisor) FetchSyncStatus() eth.SupervisorSyncStatus {
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
 	defer cancel()
 	syncStatus, err := retry.Do(ctx, 2, retry.Fixed(500*time.Millisecond), func() (eth.SupervisorSyncStatus, error) {
-		syncStatus, err := s.inner.QueryAPI().SyncStatus(s.ctx)
+		ctx, cancel := context.WithTimeout(s.ctx, 300*time.Millisecond)
+		defer cancel()
+		syncStatus, err := s.inner.QueryAPI().SyncStatus(ctx)
 		if errors.Is(err, status.ErrStatusTrackerNotReady) {
 			s.log.Debug("Sync status not ready from supervisor")
 		}


### PR DESCRIPTION
**Description**

This PR is adding a timeout to the `SyncStatus` API call. It appears that sometimes the node blocks and we timeout on this call within flaky tests:

```
$ cat TestInitExecMultipleMsg-87048.log
INFO [06-17|10:02:19.336] deployed EventLogger                     chainID=901 address=0x8742e6efaC4F7012894eD7D1C73F482A28bABA51
INFO [06-17|10:02:20.481] Initiate messages included               block=f80cab..bd9f74
INFO [06-17|10:02:20.482] Fetched supervisor sync status           minSyncedL1=f7d50a..9db1f0:14 safeTimestamp=1,750,154,508 finalizedTimestamp=1,750,154,436
INFO [06-17|10:02:20.483] Fetched supervisor sync status           minSyncedL1=f7d50a..9db1f0:14 safeTimestamp=1,750,154,508 finalizedTimestamp=1,750,154,436
INFO [06-17|10:02:20.483] Supervisor view                          chain=901 label=unsafe initial=52 current=52 target=54
INFO [06-17|10:02:22.484] Fetched supervisor sync status           minSyncedL1=f8c45f..c60f77:15 safeTimestamp=1,750,154,514 finalizedTimestamp=1,750,154,436
INFO [06-17|10:02:22.484] Supervisor view                          chain=901 label=unsafe initial=52 current=53 target=54
ERROR[06-17|10:02:44.987]
        Error Trace:    /var/opt/circleci/data/workdir/op-devstack/dsl/supervisor.go:95
                                                /var/opt/circleci/data/workdir/op-devstack/dsl/supervisor.go:114
                                                /var/opt/circleci/data/workdir/op-devstack/dsl/supervisor.go:141
                                                /var/opt/circleci/data/workdir/op-service/retry/operation.go:67
                                                /var/opt/circleci/data/workdir/op-devstack/dsl/supervisor.go:139
                                                /var/opt/circleci/data/workdir/op-devstack/dsl/supervisor.go:179
                                                /var/opt/circleci/data/workdir/op-acceptance-tests/tests/interop/message/interop_msg_test.go:272
        Error:          Received unexpected error:
                        operation failed permanently after 2 attempts: Post "http://127.0.0.1:43129": context deadline exceeded
        Test:           TestInitExecMultipleMsg
        Messages:       Failed to fetch sync status
```
