### PR TITLE
Remove Broken Image Link from README

### DIFF
--- a/cannon/README.md
+++ b/cannon/README.md
@@ -1,7 +1,7 @@
 <!--![cannon](https://upload.wikimedia.org/wikipedia/commons/8/80/Cannon%2C_Château_du_Haut-Koenigsbourg%2C_France.jpg)-->
 <!--![cannon](https://cdn1.epicgames.com/ue/product/Featured/SCIFIWEAPONBUNDLE_featured-894x488-83fbc936b6d86edcbbe892b1a6780224.png)-->
 <!--![cannon](https://static.wikia.nocookie.net/ageofempires/images/8/80/Bombard_cannon_aoe2DE.png/revision/latest/top-crop/width/360/height/360?cb=20200331021834)-->
-<!--![cannon](https://paradacreativa.es/wp-content/uploads/2021/05/Canon-orbital-GTA-01.jpg)-->
+<!--![cannon]()-->
 
 ---
 


### PR DESCRIPTION
The image link in the README is broken and no longer accessible.
I recommend removing this non-functional link to improve the document's clarity and presentation.

<img width="1182" alt="Знімок екрана 2025-06-17 о 17 50 14" src="https://github.com/user-attachments/assets/41553aeb-da78-4624-a72f-e5882433dd15" />

