### PR TITLE
fix(presets): enable MinimalWithConductors on kurtosis

### DIFF
--- a/op-devstack/presets/minimal_with_conductors.go
+++ b/op-devstack/presets/minimal_with_conductors.go
@@ -21,9 +21,11 @@ type MinimalWithConductors struct {
 func WithMinimalWithConductors() stack.CommonOption {
 	return stack.Combine(
 		stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{})),
-		// TODO(#15152): add kurtosis support
 		// TODO(#16418) add sysgo support
-		WithCompatibleTypes(compat.Persistent),
+		WithCompatibleTypes(
+			compat.Persistent,
+			compat.Kurtosis,
+		),
 	)
 }
 


### PR DESCRIPTION
**Description**

With the actual work done on #15152, we can now use
MinimalWithConductors preset against Kurtosis devnets.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
- Fixes #15152
