### PR TITLE
Dispute-mon checks output roots against multiple rollup nodes

### DIFF
--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -24,6 +24,6 @@ shows the available config options and can be accessed by running `./bin/op-disp
 ./bin/op-dispute-mon \
   --network <Predefined-Network> \
   --l1-eth-rpc <L1-Ethereum-RPC-URL> \
-  --rollup-rpc <Optimism-Rollup-RPC-URL>
+  --rollup-rpc <Optimism-Rollup-RPC-URL>,<Secondary-RPC-URL>,<Tertiary-RPC-URL>
 
 ```

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	l1EthRpc                = "http://example.com:8545"
-	rollupRpc               = "http://example.com:8555"
+	rollupRpc               = []string{"http://example.com:8555"}
 	gameFactoryAddressValue = "0xbb00000000000000000000000000000000000000"
 )
 
@@ -71,7 +71,14 @@ func TestRollupRpc(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		url := "http://example.com:9999"
 		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--rollup-rpc", url))
-		require.Equal(t, url, cfg.RollupRpc)
+		require.Equal(t, []string{url}, cfg.RollupRpc)
+	})
+
+	t.Run("MultipleValues", func(t *testing.T) {
+		url1 := "http://example1.com:9999"
+		url2 := "http://example2.com:8888"
+		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--rollup-rpc", url1, "--rollup-rpc", url2))
+		require.Equal(t, []string{url1, url2}, cfg.RollupRpc)
 	})
 }
 
@@ -297,7 +304,7 @@ func addRequiredArgsExcept(name string, optionalArgs ...string) []string {
 func requiredArgs() map[string]string {
 	args := map[string]string{
 		"--l1-eth-rpc":           l1EthRpc,
-		"--rollup-rpc":           rollupRpc,
+		"--rollup-rpc":           rollupRpc[0],
 		"--game-factory-address": gameFactoryAddressValue,
 	}
 	return args

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -304,7 +305,7 @@ func addRequiredArgsExcept(name string, optionalArgs ...string) []string {
 func requiredArgs() map[string]string {
 	args := map[string]string{
 		"--l1-eth-rpc":           l1EthRpc,
-		"--rollup-rpc":           rollupRpc[0],
+		"--rollup-rpc":           strings.Join(rollupRpc, ","),
 		"--game-factory-address": gameFactoryAddressValue,
 	}
 	return args

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -51,7 +51,7 @@ type Config struct {
 }
 
 func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, supervisorRpc string) Config {
-	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, []string{}, supervisorRpc)
+	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, nil, supervisorRpc)
 }
 
 func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string) Config {

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	GameFactoryAddress common.Address // Address of the dispute game factory
 
 	HonestActors    []common.Address // List of honest actors to monitor claims for.
-	RollupRpc       string           // The rollup node RPC URL.
+	RollupRpc       []string         // The rollup node RPC URLs.
 	SupervisorRpc   string           // The supervisor RPC URL.
 	MonitorInterval time.Duration    // Frequency to check for new games to monitor.
 	GameWindow      time.Duration    // Maximum window to look for games to monitor.
@@ -51,14 +51,14 @@ type Config struct {
 }
 
 func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, supervisorRpc string) Config {
-	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, "", supervisorRpc)
+	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, []string{}, supervisorRpc)
 }
 
-func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc string) Config {
+func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string) Config {
 	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, rollupRpc, "")
 }
 
-func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc string, supervisorRpc string) Config {
+func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string, supervisorRpc string) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
 		RollupRpc:          rollupRpc,
@@ -78,7 +78,7 @@ func (c Config) Check() error {
 	if c.L1EthRpc == "" {
 		return ErrMissingL1EthRPC
 	}
-	if c.RollupRpc == "" && c.SupervisorRpc == "" {
+	if len(c.RollupRpc) == 0 && c.SupervisorRpc == "" {
 		return ErrMissingRollupAndSupervisorRpc
 	}
 	if c.GameFactoryAddress == (common.Address{}) {

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -11,7 +11,7 @@ import (
 var (
 	validL1EthRpc           = "http://localhost:8545"
 	validGameFactoryAddress = common.Address{0x23}
-	validRollupRpc          = "http://localhost:8555"
+	validRollupRpc          = []string{"http://localhost:8555"}
 	validSupervisorRpc      = "http://localhost:8999"
 )
 
@@ -37,14 +37,14 @@ func TestGameFactoryAddressRequired(t *testing.T) {
 
 func TestRollupRpcOrSupervisorRpcRequired(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = ""
+	config.RollupRpc = []string{}
 	config.SupervisorRpc = ""
 	require.ErrorIs(t, config.Check(), ErrMissingRollupAndSupervisorRpc)
 }
 
 func TestRollupRpcNotRequiredWhenSupervisorRpcSet(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = ""
+	config.RollupRpc = []string{}
 	config.SupervisorRpc = validSupervisorRpc
 	require.NoError(t, config.Check())
 }

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -168,7 +168,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 	return &config.Config{
 		L1EthRpc:           ctx.String(L1EthRpcFlag.Name),
 		GameFactoryAddress: gameFactoryAddress,
-		RollupRpc:          strings.Join(ctx.StringSlice(RollupRpcFlag.Name), ","),
+		RollupRpc:          ctx.StringSlice(RollupRpcFlag.Name),
 		SupervisorRpc:      ctx.String(SupervisorRpcFlag.Name),
 
 		HonestActors:    actors,

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -33,9 +33,9 @@ var (
 		EnvVars: prefixEnvVars("L1_ETH_RPC"),
 	}
 	// Optional Flags
-	RollupRpcFlag = &cli.StringFlag{
+	RollupRpcFlag = &cli.StringSliceFlag{
 		Name:    "rollup-rpc",
-		Usage:   "HTTP provider URL for the rollup node",
+		Usage:   "HTTP provider URL for the rollup node. Multiple URLs can be specified for redundancy.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
 	SupervisorRpcFlag = &cli.StringFlag{
@@ -119,7 +119,7 @@ func CheckRequired(ctx *cli.Context) error {
 			return fmt.Errorf("flag %s is required", f.Names()[0])
 		}
 	}
-	if !ctx.IsSet(RollupRpcFlag.Name) && !ctx.IsSet(SupervisorRpcFlag.Name) {
+	if len(ctx.StringSlice(RollupRpcFlag.Name)) == 0 && !ctx.IsSet(SupervisorRpcFlag.Name) {
 		return fmt.Errorf("flag %s or %s is required", RollupRpcFlag.Name, SupervisorRpcFlag.Name)
 	}
 	return nil
@@ -168,7 +168,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 	return &config.Config{
 		L1EthRpc:           ctx.String(L1EthRpcFlag.Name),
 		GameFactoryAddress: gameFactoryAddress,
-		RollupRpc:          ctx.String(RollupRpcFlag.Name),
+		RollupRpc:          strings.Join(ctx.StringSlice(RollupRpcFlag.Name), ","),
 		SupervisorRpc:      ctx.String(SupervisorRpcFlag.Name),
 
 		HonestActors:    actors,

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -44,6 +45,13 @@ func NewOutputAgreementEnricher(logger log.Logger, metrics OutputMetrics, client
 	}
 }
 
+type outputResult struct {
+	outputRoot common.Hash
+	isSafe     bool
+	notFound   bool
+	err        error
+}
+
 // Enrich validates the specified root claim against the output at the given block number.
 func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
 	if !game.UsesOutputRoots() {
@@ -59,33 +67,110 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 		game.AgreeWithClaim = false
 		return nil
 	}
-	output, err := o.clients[0].OutputAtBlock(ctx, game.L2BlockNumber)
-	if err != nil {
-		// string match as the error comes from the remote server so we can't use Errors.Is sadly.
-		if strings.Contains(err.Error(), "not found") {
-			// Output root doesn't exist, so we must disagree with it.
-			game.AgreeWithClaim = false
-			return nil
-		}
-		return fmt.Errorf("failed to get output at block: %w", err)
+
+	results := make([]outputResult, len(o.clients))
+	var wg sync.WaitGroup
+	for i, client := range o.clients {
+		wg.Add(1)
+		go func(i int, client OutputRollupClient) {
+			defer wg.Done()
+			output, err := client.OutputAtBlock(ctx, game.L2BlockNumber)
+			if err != nil {
+				// string match as the error comes from the remote server so we can't use Errors.Is sadly.
+				if strings.Contains(err.Error(), "not found") {
+					results[i] = outputResult{notFound: true}
+					return
+				}
+				results[i] = outputResult{err: err}
+				return
+			}
+
+			outputRoot := common.Hash(output.OutputRoot)
+			results[i] = outputResult{outputRoot: outputRoot}
+
+			// Only check if the output root is safe if it matches the game's root claim
+			if outputRoot == game.RootClaim {
+				safeHead, err := client.SafeHeadAtL1Block(ctx, game.L1HeadNum)
+				if err != nil {
+					o.log.Warn("Unable to verify proposed block was safe", "l1HeadNum", game.L1HeadNum, "l2BlockNum", game.L2BlockNumber, "err", err)
+					// If safe head data isn't available, assume the output root was safe
+					// Avoids making the dispute mon dependent on safe head db being available
+					results[i].isSafe = true
+					return
+				}
+				results[i].isSafe = safeHead.SafeHead.Number >= game.L2BlockNumber
+			}
+		}(i, client)
 	}
-	o.metrics.RecordOutputFetchTime(float64(o.clock.Now().Unix()))
-	game.ExpectedRootClaim = common.Hash(output.OutputRoot)
-	rootMatches := game.RootClaim == game.ExpectedRootClaim
-	if !rootMatches {
+	wg.Wait()
+
+	// Filter out results with errors (except "not found")
+	validResults := make([]outputResult, 0, len(results))
+	for _, result := range results {
+		if result.err == nil {
+			validResults = append(validResults, result)
+		}
+	}
+
+	// If all results were errors, return an error
+	if len(validResults) == 0 {
+		return fmt.Errorf("failed to get output at block: all nodes returned errors")
+	}
+
+	// If all remaining nodes returned "not found", set game.AgreeWithClaim = false
+	allNotFound := true
+	for _, result := range validResults {
+		if !result.notFound {
+			allNotFound = false
+			break
+		}
+	}
+	if allNotFound {
 		game.AgreeWithClaim = false
+		game.ExpectedRootClaim = common.Hash{}
 		return nil
 	}
 
-	// If the root matches, also check that l2 block is safe at the L1 head
-	safeHead, err := o.clients[0].SafeHeadAtL1Block(ctx, game.L1HeadNum)
-	if err != nil {
-		o.log.Warn("Unable to verify proposed block was safe", "l1HeadNum", game.L1HeadNum, "l2BlockNum", game.L2BlockNumber, "err", err)
-		// If safe head data isn't available, assume the output root was safe
-		// Avoids making the dispute mon dependent on safe head db being available
-		game.AgreeWithClaim = true
-		return nil
+	// Filter out nodes that returned "not found" as they're out of sync
+	syncedResults := make([]outputResult, 0, len(validResults))
+	for _, result := range validResults {
+		if !result.notFound {
+			syncedResults = append(syncedResults, result)
+		}
 	}
-	game.AgreeWithClaim = safeHead.SafeHead.Number >= game.L2BlockNumber
+	if len(syncedResults) < len(validResults) {
+		o.log.Warn("Some nodes are out of sync", "totalNodes", len(validResults), "syncedNodes", len(syncedResults))
+	}
+
+	// Check if nodes have diverged
+	firstOutputRoot := syncedResults[0].outputRoot
+	diverged := false
+	for _, result := range syncedResults[1:] {
+		if result.outputRoot != firstOutputRoot {
+			diverged = true
+			break
+		}
+	}
+
+	if diverged {
+		o.log.Error("Nodes have diverged", "firstNodeOutput", firstOutputRoot)
+		// Use the result from the first node in the list
+		game.ExpectedRootClaim = firstOutputRoot
+		game.AgreeWithClaim = firstOutputRoot == game.RootClaim && syncedResults[0].isSafe
+	} else {
+		// All nodes agree on the output root
+		game.ExpectedRootClaim = firstOutputRoot
+		// Consider the output root "safe" if any node reported it as safe
+		isSafe := false
+		for _, result := range syncedResults {
+			if result.isSafe {
+				isSafe = true
+				break
+			}
+		}
+		game.AgreeWithClaim = firstOutputRoot == game.RootClaim && isSafe
+	}
+
+	o.metrics.RecordOutputFetchTime(float64(o.clock.Now().Unix()))
 	return nil
 }

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -115,9 +115,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 
 		validResults = append(validResults, result)
 
-		if result.notFound {
-			o.log.Info("Node has not seen block", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber)
-		} else {
+		if !result.notFound {
 			foundResults = append(foundResults, result)
 		}
 	}
@@ -175,8 +173,6 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 
 	// If no node considers the output safe, we disagree.
 	if !atLeastOneSafe {
-		o.log.Warn("All nodes agree on output root, but none consider it safe",
-			"l2BlockNum", game.L2BlockNumber, "root", firstResult.outputRoot)
 		game.AgreeWithClaim = false
 		if firstResult.outputRoot == game.RootClaim {
 			game.ExpectedRootClaim = common.Hash{}

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	ErrRollupRpcRequired = errors.New("rollup rpc required")
+	ErrRollupRpcRequired   = errors.New("rollup rpc required")
+	ErrAllNodesUnavailable = errors.New("all nodes returned errors")
 )
 
 type OutputRollupClient interface {
@@ -104,42 +105,33 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	}
 	wg.Wait()
 
-	// Filter out results with errors (except "not found")
 	validResults := make([]outputResult, 0, len(results))
-	for _, result := range results {
-		if result.err == nil {
-			validResults = append(validResults, result)
+	syncedResults := make([]outputResult, 0, len(results))
+	for idx, result := range results {
+		if result.err != nil {
+			o.log.Error("Failed to fetch output root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
+			continue
+		}
+
+		validResults = append(validResults, result)
+
+		if result.notFound {
+			o.log.Warn("Node is out of sync", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber)
+		} else {
+			syncedResults = append(syncedResults, result)
 		}
 	}
 
 	// If all results were errors, return an error
 	if len(validResults) == 0 {
-		return fmt.Errorf("failed to get output at block: all nodes returned errors")
+		return fmt.Errorf("failed to get output at block: %w", ErrAllNodesUnavailable)
 	}
 
 	// If all remaining nodes returned "not found", set game.AgreeWithClaim = false
-	allNotFound := true
-	for _, result := range validResults {
-		if !result.notFound {
-			allNotFound = false
-			break
-		}
-	}
-	if allNotFound {
+	if len(syncedResults) == 0 {
 		game.AgreeWithClaim = false
 		game.ExpectedRootClaim = common.Hash{}
 		return nil
-	}
-
-	// Filter out nodes that returned "not found" as they're out of sync
-	syncedResults := make([]outputResult, 0, len(validResults))
-	for _, result := range validResults {
-		if !result.notFound {
-			syncedResults = append(syncedResults, result)
-		}
-	}
-	if len(syncedResults) < len(validResults) {
-		o.log.Warn("Some nodes are out of sync", "totalNodes", len(validResults), "syncedNodes", len(syncedResults))
 	}
 
 	// Check if nodes have diverged

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -31,15 +31,15 @@ type OutputMetrics interface {
 type OutputAgreementEnricher struct {
 	log     log.Logger
 	metrics OutputMetrics
-	client  OutputRollupClient
+	clients []OutputRollupClient
 	clock   clock.Clock
 }
 
-func NewOutputAgreementEnricher(logger log.Logger, metrics OutputMetrics, client OutputRollupClient, cl clock.Clock) *OutputAgreementEnricher {
+func NewOutputAgreementEnricher(logger log.Logger, metrics OutputMetrics, clients []OutputRollupClient, cl clock.Clock) *OutputAgreementEnricher {
 	return &OutputAgreementEnricher{
 		log:     logger,
 		metrics: metrics,
-		client:  client,
+		clients: clients,
 		clock:   cl,
 	}
 }
@@ -49,7 +49,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	if !game.UsesOutputRoots() {
 		return nil
 	}
-	if o.client == nil {
+	if len(o.clients) == 0 {
 		return fmt.Errorf("%w but required for game type %v", ErrRollupRpcRequired, game.GameType)
 	}
 	if game.L2BlockNumber > math.MaxInt64 {
@@ -59,7 +59,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 		game.AgreeWithClaim = false
 		return nil
 	}
-	output, err := o.client.OutputAtBlock(ctx, game.L2BlockNumber)
+	output, err := o.clients[0].OutputAtBlock(ctx, game.L2BlockNumber)
 	if err != nil {
 		// string match as the error comes from the remote server so we can't use Errors.Is sadly.
 		if strings.Contains(err.Error(), "not found") {
@@ -78,7 +78,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	}
 
 	// If the root matches, also check that l2 block is safe at the L1 head
-	safeHead, err := o.client.SafeHeadAtL1Block(ctx, game.L1HeadNum)
+	safeHead, err := o.clients[0].SafeHeadAtL1Block(ctx, game.L1HeadNum)
 	if err != nil {
 		o.log.Warn("Unable to verify proposed block was safe", "l1HeadNum", game.L1HeadNum, "l2BlockNum", game.L2BlockNumber, "err", err)
 		// If safe head data isn't available, assume the output root was safe

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -106,7 +106,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	wg.Wait()
 
 	validResults := make([]outputResult, 0, len(results))
-	syncedResults := make([]outputResult, 0, len(results))
+	foundResults := make([]outputResult, 0, len(results))
 	for idx, result := range results {
 		if result.err != nil {
 			o.log.Error("Failed to fetch output root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
@@ -116,9 +116,9 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 		validResults = append(validResults, result)
 
 		if result.notFound {
-			o.log.Warn("Node is out of sync", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber)
+			o.log.Info("Node has not seen block", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber)
 		} else {
-			syncedResults = append(syncedResults, result)
+			foundResults = append(foundResults, result)
 		}
 	}
 
@@ -127,42 +127,68 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 		return fmt.Errorf("failed to get output at block: %w", ErrAllNodesUnavailable)
 	}
 
-	// If all remaining nodes returned "not found", set game.AgreeWithClaim = false
-	if len(syncedResults) == 0 {
+	// If all remaining nodes returned "not found", we disagree with any claim.
+	if len(foundResults) == 0 {
 		game.AgreeWithClaim = false
 		game.ExpectedRootClaim = common.Hash{}
 		return nil
 	}
 
-	// Check if nodes have diverged
-	firstOutputRoot := syncedResults[0].outputRoot
-	diverged := false
-	for _, result := range syncedResults[1:] {
-		if result.outputRoot != firstOutputRoot {
-			diverged = true
-			break
+	// At least one node returned an output root, record the fetch time.
+	o.metrics.RecordOutputFetchTime(float64(o.clock.Now().Unix()))
+
+	// Check for disagreements among nodes.
+	// A disagreement is any of:
+	// - Mixed "found" and "not found" responses.
+	// - Different output roots from nodes that found an output.
+	firstResult := foundResults[0]
+	diverged := len(foundResults) < len(validResults)
+	if !diverged {
+		for _, result := range foundResults[1:] {
+			if result.outputRoot != firstResult.outputRoot {
+				diverged = true
+				break
+			}
 		}
 	}
 
 	if diverged {
-		o.log.Error("Nodes have diverged", "firstNodeOutput", firstOutputRoot)
-		// Use the result from the first node in the list
-		game.ExpectedRootClaim = firstOutputRoot
-		game.AgreeWithClaim = firstOutputRoot == game.RootClaim && syncedResults[0].isSafe
-	} else {
-		// All nodes agree on the output root
-		game.ExpectedRootClaim = firstOutputRoot
-		// Consider the output root "safe" if any node reported it as safe
-		isSafe := false
-		for _, result := range syncedResults {
-			if result.isSafe {
-				isSafe = true
-				break
-			}
-		}
-		game.AgreeWithClaim = firstOutputRoot == game.RootClaim && isSafe
+		o.log.Warn("Nodes disagree on output root",
+			"l2BlockNum", game.L2BlockNumber,
+			"firstOutput", firstResult.outputRoot,
+			"found", len(foundResults),
+			"valid", len(validResults))
+		game.AgreeWithClaim = false
+		game.ExpectedRootClaim = firstResult.outputRoot
+		return nil
 	}
 
-	o.metrics.RecordOutputFetchTime(float64(o.clock.Now().Unix()))
+	// All nodes that found an output agree on the root.
+	// Now check if the output is considered safe by at least one node.
+	atLeastOneSafe := false
+	for _, result := range foundResults {
+		if result.isSafe {
+			atLeastOneSafe = true
+			break
+		}
+	}
+
+	// If no node considers the output safe, we disagree.
+	if !atLeastOneSafe {
+		o.log.Warn("All nodes agree on output root, but none consider it safe",
+			"l2BlockNum", game.L2BlockNumber, "root", firstResult.outputRoot)
+		game.AgreeWithClaim = false
+		if firstResult.outputRoot == game.RootClaim {
+			game.ExpectedRootClaim = common.Hash{}
+		} else {
+			game.ExpectedRootClaim = firstResult.outputRoot
+		}
+		return nil
+	}
+
+	// All nodes agree and at least one considers the output safe.
+	// We agree with the claim if the game's root claim matches.
+	game.ExpectedRootClaim = firstResult.outputRoot
+	game.AgreeWithClaim = game.RootClaim == firstResult.outputRoot
 	return nil
 }

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -128,11 +128,49 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim)
+		require.False(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
 
-	t.Run("NodesDiverged_FirstNodeAgrees", func(t *testing.T) {
+	t.Run("MixedResponses_FoundNodesMatchClaimAndSafe", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 4)
+		clients[0].outputErr = errors.New("not found")
+		clients[1].outputErr = errors.New("not found")
+		clients[2].outputRoot = mockRootClaim
+		clients[2].safeHeadNum = 100
+		clients[3].outputRoot = mockRootClaim
+		clients[3].safeHeadNum = 100
+		game := &types.EnrichedGameData{
+			L1HeadNum:     100,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("MixedResponses_FoundNodesDontMatchClaim", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		differentRoot := common.HexToHash("0x9999")
+		clients[0].outputErr = errors.New("not found")
+		clients[1].outputRoot = differentRoot
+		clients[2].outputRoot = differentRoot
+		game := &types.EnrichedGameData{
+			L1HeadNum:     100,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, differentRoot, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("NodesDiverged", func(t *testing.T) {
 		validator, clients, metrics := setupMultiNodeTest(t, 3)
 		divergedRoot := common.HexToHash("0x5678")
 		clients[0].outputRoot = mockRootClaim
@@ -146,24 +184,6 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim)
-		require.NotZero(t, metrics.fetchTime)
-	})
-
-	t.Run("NodesDiverged_FirstNodeDisagrees", func(t *testing.T) {
-		validator, clients, metrics := setupMultiNodeTest(t, 3)
-		divergedRoot := common.HexToHash("0x5678")
-		clients[0].outputRoot = divergedRoot
-		clients[1].outputRoot = mockRootClaim
-		clients[2].outputRoot = mockRootClaim
-		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
-		}
-		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.NoError(t, err)
-		require.NotEqual(t, mockRootClaim, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
@@ -181,7 +201,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim) // Should be true because at least one node reports it as safe
+		require.True(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
 
@@ -198,25 +218,67 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim) // Should be true because we assume safe on error
+		require.True(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
 
 	t.Run("OutputMatches_NotSafe", func(t *testing.T) {
 		validator, clients, metrics := setupMultiNodeTest(t, 3)
-		// Set safe head numbers below the L2 block number
 		clients[0].safeHeadNum = 50
 		clients[1].safeHeadNum = 60
 		clients[2].safeHeadNum = 70
 		game := &types.EnrichedGameData{
 			L1HeadNum:     100,
-			L2BlockNumber: 80, // Higher than all safe head numbers
+			L2BlockNumber: 80,
 			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
-		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.False(t, game.AgreeWithClaim) // Should be false because not safe
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllNodesAgree_OutputMatchesClaim_NoneReportSafe", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+
+		for _, client := range clients {
+			client.outputRoot = mockRootClaim
+			client.safeHeadNum = 40
+		}
+
+		game := &types.EnrichedGameData{
+			L1HeadNum:     100,
+			L2BlockNumber: 50, // Higher than all safe heads
+			RootClaim:     mockRootClaim,
+		}
+
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim, "Should set ExpectedRootClaim to empty hash when not safe")
+		require.False(t, game.AgreeWithClaim, "Should disagree because none report it as safe")
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllNodesAgree_OutputDifferentFromClaim", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+
+		differentRoot := common.HexToHash("0xdifferent")
+		for _, client := range clients {
+			client.outputRoot = differentRoot
+			// Safe head numbers don't matter here since the output doesn't match the claim
+		}
+
+		game := &types.EnrichedGameData{
+			L1HeadNum:     100,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, differentRoot, game.ExpectedRootClaim, "Should set ExpectedRootClaim to the agreed output")
+		require.False(t, game.AgreeWithClaim, "Should disagree because output doesn't match claim")
 		require.NotZero(t, metrics.fetchTime)
 	})
 

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -24,7 +24,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 	t.Run("ErrorWhenNoRollupClient", func(t *testing.T) {
 		validator, _, _ := setupOutputValidatorTest(t)
-		validator.clients = []OutputRollupClient{}
+		validator.clients = nil
 		game := &types.EnrichedGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
@@ -43,7 +43,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupOutputValidatorTest(t)
-				validator.clients = []OutputRollupClient{} // Should not error even though there's no rollup client
+				validator.clients = nil // Should not error even though there's no rollup client
 				game := &types.EnrichedGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
@@ -92,7 +92,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "all nodes returned errors")
+		require.ErrorIs(t, err, ErrAllNodesUnavailable)
 		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetector_CheckOutputRootAgreement(t *testing.T) {
+func TestOutputAgreementEnricher(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ErrorWhenNoRollupClient", func(t *testing.T) {
 		validator, _, _ := setupOutputValidatorTest(t)
-		validator.client = nil
+		validator.clients = []OutputRollupClient{}
 		game := &types.EnrichedGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
@@ -43,7 +43,7 @@ func TestDetector_CheckOutputRootAgreement(t *testing.T) {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupOutputValidatorTest(t)
-				validator.client = nil // Should not error even though there's no rollup client
+				validator.clients = []OutputRollupClient{} // Should not error even though there's no rollup client
 				game := &types.EnrichedGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
@@ -80,39 +80,48 @@ func TestDetector_CheckOutputRootAgreement(t *testing.T) {
 		}
 	})
 
-	t.Run("OutputFetchFails", func(t *testing.T) {
-		validator, rollup, metrics := setupOutputValidatorTest(t)
-		rollup.outputErr = errors.New("boom")
+	t.Run("AllNodesReturnError", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		for _, client := range clients {
+			client.outputErr = errors.New("boom")
+		}
 		game := &types.EnrichedGameData{
 			L1HeadNum:     100,
 			L2BlockNumber: 0,
 			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.ErrorIs(t, err, rollup.outputErr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "all nodes returned errors")
 		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)
 	})
 
-	t.Run("OutputMismatch_Safe", func(t *testing.T) {
-		validator, _, metrics := setupOutputValidatorTest(t)
+	t.Run("AllNodesReturnNotFound", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		for _, client := range clients {
+			client.outputErr = errors.New("not found")
+		}
 		game := &types.EnrichedGameData{
 			L1HeadNum:     100,
 			L2BlockNumber: 0,
-			RootClaim:     common.Hash{},
+			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
-		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
-		require.NotZero(t, metrics.fetchTime)
+		require.Zero(t, metrics.fetchTime)
 	})
 
-	t.Run("OutputMatches_Safe", func(t *testing.T) {
-		validator, _, metrics := setupOutputValidatorTest(t)
+	t.Run("SomeNodesOutOfSync", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		clients[0].outputErr = errors.New("not found")
+		clients[1].outputErr = nil
+		clients[2].outputErr = nil
 		game := &types.EnrichedGameData{
-			L1HeadNum:     200,
+			L1HeadNum:     100,
 			L2BlockNumber: 0,
 			RootClaim:     mockRootClaim,
 		}
@@ -123,79 +132,92 @@ func TestDetector_CheckOutputRootAgreement(t *testing.T) {
 		require.NotZero(t, metrics.fetchTime)
 	})
 
-	t.Run("OutputMismatch_NotSafe", func(t *testing.T) {
-		validator, client, metrics := setupOutputValidatorTest(t)
-		client.safeHeadNum = 99
+	t.Run("NodesDiverged_FirstNodeAgrees", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		divergedRoot := common.HexToHash("0x5678")
+		clients[0].outputRoot = mockRootClaim
+		clients[1].outputRoot = divergedRoot
+		clients[2].outputRoot = divergedRoot
 		game := &types.EnrichedGameData{
 			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     common.Hash{},
-		}
-		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.NoError(t, err)
-		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.False(t, game.AgreeWithClaim)
-		require.NotZero(t, metrics.fetchTime)
-	})
-
-	t.Run("OutputMatches_SafeHeadError", func(t *testing.T) {
-		validator, client, metrics := setupOutputValidatorTest(t)
-		client.safeHeadErr = errors.New("boom")
-		game := &types.EnrichedGameData{
-			L1HeadNum:     200,
 			L2BlockNumber: 0,
 			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim) // Assume safe if we can't retrieve the safe head so monitoring isn't dependent on safe head db
+		require.True(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
 
-	t.Run("OutputMismatch_SafeHeadError", func(t *testing.T) {
-		validator, client, metrics := setupOutputValidatorTest(t)
-		client.safeHeadErr = errors.New("boom")
+	t.Run("NodesDiverged_FirstNodeDisagrees", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		divergedRoot := common.HexToHash("0x5678")
+		clients[0].outputRoot = divergedRoot
+		clients[1].outputRoot = mockRootClaim
+		clients[2].outputRoot = mockRootClaim
 		game := &types.EnrichedGameData{
 			L1HeadNum:     100,
 			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.NotEqual(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllNodesAgree", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		clients[0].safeHeadNum = 100
+		clients[1].safeHeadNum = 99
+		clients[2].safeHeadNum = 101
+		game := &types.EnrichedGameData{
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.False(t, game.AgreeWithClaim) // Not agreed because the root doesn't match
+		require.True(t, game.AgreeWithClaim) // Should be true because at least one node reports it as safe
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("SafeHeadError", func(t *testing.T) {
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		clients[0].safeHeadErr = errors.New("boom")
+		clients[1].safeHeadErr = nil
+		clients[2].safeHeadErr = nil
+		game := &types.EnrichedGameData{
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.True(t, game.AgreeWithClaim) // Should be true because we assume safe on error
 		require.NotZero(t, metrics.fetchTime)
 	})
 
 	t.Run("OutputMatches_NotSafe", func(t *testing.T) {
-		validator, client, metrics := setupOutputValidatorTest(t)
-		client.safeHeadNum = 99
+		validator, clients, metrics := setupMultiNodeTest(t, 3)
+		// Set safe head numbers below the L2 block number
+		clients[0].safeHeadNum = 50
+		clients[1].safeHeadNum = 60
+		clients[2].safeHeadNum = 70
 		game := &types.EnrichedGameData{
-			L1HeadNum:     200,
-			L2BlockNumber: 100,
+			L1HeadNum:     100,
+			L2BlockNumber: 80, // Higher than all safe head numbers
 			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.False(t, game.AgreeWithClaim)
+		require.False(t, game.AgreeWithClaim) // Should be false because not safe
 		require.NotZero(t, metrics.fetchTime)
-	})
-
-	t.Run("OutputNotFound", func(t *testing.T) {
-		validator, rollup, metrics := setupOutputValidatorTest(t)
-		// This crazy error is what we actually get back from the API
-		rollup.outputErr = errors.New("failed to get L2 block ref with sync status: failed to determine L2BlockRef of height 42984924, could not get payload: not found")
-		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 42984924,
-			RootClaim:     mockRootClaim,
-		}
-		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.NoError(t, err)
-		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
-		require.False(t, game.AgreeWithClaim)
-		require.Zero(t, metrics.fetchTime)
 	})
 
 	t.Run("BlockNumberLargerThanInt64", func(t *testing.T) {
@@ -220,8 +242,24 @@ func setupOutputValidatorTest(t *testing.T) (*OutputAgreementEnricher, *stubRoll
 	logger := testlog.Logger(t, log.LvlInfo)
 	client := &stubRollupClient{safeHeadNum: 99999999999}
 	metrics := &stubOutputMetrics{}
-	validator := NewOutputAgreementEnricher(logger, metrics, client, clock.NewDeterministicClock(time.Unix(9824924, 499)))
+	validator := NewOutputAgreementEnricher(logger, metrics, []OutputRollupClient{client}, clock.NewDeterministicClock(time.Unix(9824924, 499)))
 	return validator, client, metrics
+}
+
+func setupMultiNodeTest(t *testing.T, numNodes int) (*OutputAgreementEnricher, []*stubRollupClient, *stubOutputMetrics) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	clients := make([]*stubRollupClient, numNodes)
+	rollupClients := make([]OutputRollupClient, numNodes)
+	for i := range clients {
+		clients[i] = &stubRollupClient{
+			safeHeadNum: 99999999999,
+			outputRoot:  mockRootClaim,
+		}
+		rollupClients[i] = clients[i]
+	}
+	metrics := &stubOutputMetrics{}
+	validator := NewOutputAgreementEnricher(logger, metrics, rollupClients, clock.NewDeterministicClock(time.Unix(9824924, 499)))
+	return validator, clients, metrics
 }
 
 type stubOutputMetrics struct {
@@ -237,11 +275,15 @@ type stubRollupClient struct {
 	outputErr   error
 	safeHeadErr error
 	safeHeadNum uint64
+	outputRoot  common.Hash
 }
 
 func (s *stubRollupClient) OutputAtBlock(_ context.Context, blockNum uint64) (*eth.OutputResponse, error) {
 	s.blockNum = blockNum
-	return &eth.OutputResponse{OutputRoot: eth.Bytes32(mockRootClaim)}, s.outputErr
+	if s.outputErr != nil {
+		return nil, s.outputErr
+	}
+	return &eth.OutputResponse{OutputRoot: eth.Bytes32(s.outputRoot)}, nil
 }
 
 func (s *stubRollupClient) SafeHeadAtL1Block(_ context.Context, _ uint64) (*eth.SafeHeadResponse, error) {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -129,7 +129,7 @@ func (s *Service) initGameCallerCreator() {
 	s.game = extract.NewGameCallerCreator(s.metrics, s.l1Caller)
 }
 
-func (s *Service) asOutputRollupClients() []extract.OutputRollupClient {
+func (s *Service) outputRollupClients() []extract.OutputRollupClient {
 	clients := make([]extract.OutputRollupClient, len(s.rollupClients))
 	for i, client := range s.rollupClients {
 		clients[i] = client
@@ -152,7 +152,7 @@ func (s *Service) initExtractor(cfg *config.Config) {
 		extract.NewBalanceEnricher(),
 		extract.NewL1HeadBlockNumEnricher(s.l1Client),
 		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.supervisorClient, clock.SystemClock),
-		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.asOutputRollupClients(), clock.SystemClock),
+		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
 	)
 }
 

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -45,7 +45,7 @@ type Service struct {
 	resolutions      *ResolutionMonitor
 	claims           *ClaimMonitor
 	withdrawals      *WithdrawalMonitor
-	rollupClient     *sources.RollupClient
+	rollupClients    []*sources.RollupClient
 	supervisorClient *sources.SupervisorClient
 
 	l1RPC    rpcclient.RPC
@@ -144,7 +144,13 @@ func (s *Service) initExtractor(cfg *config.Config) {
 		extract.NewBalanceEnricher(),
 		extract.NewL1HeadBlockNumEnricher(s.l1Client),
 		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.supervisorClient, clock.SystemClock),
-		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.rollupClient, clock.SystemClock),
+		extract.NewOutputAgreementEnricher(s.logger, s.metrics, func() []extract.OutputRollupClient {
+			clients := make([]extract.OutputRollupClient, len(s.rollupClients))
+			for i, client := range s.rollupClients {
+				clients[i] = client
+			}
+			return clients
+		}(), clock.SystemClock),
 	)
 }
 
@@ -157,14 +163,16 @@ func (s *Service) initBonds() {
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {
-	if cfg.RollupRpc == "" {
+	if len(cfg.RollupRpc) == 0 {
 		return nil
 	}
-	outputRollupClient, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.RollupRpc)
-	if err != nil {
-		return fmt.Errorf("failed to dial rollup client: %w", err)
+	for _, rpc := range cfg.RollupRpc {
+		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
+		if err != nil {
+			return fmt.Errorf("failed to dial rollup client %s: %w", rpc, err)
+		}
+		s.rollupClients = append(s.rollupClients, client)
 	}
-	s.rollupClient = outputRollupClient
 	return nil
 }
 

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -169,7 +169,7 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 		return nil
 	}
 	for _, rpc := range cfg.RollupRpc {
-		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
+		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc, rpcclient.WithLazyDial())
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client %s: %w", rpc, err)
 		}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -129,6 +129,14 @@ func (s *Service) initGameCallerCreator() {
 	s.game = extract.NewGameCallerCreator(s.metrics, s.l1Caller)
 }
 
+func (s *Service) asOutputRollupClients() []extract.OutputRollupClient {
+	clients := make([]extract.OutputRollupClient, len(s.rollupClients))
+	for i, client := range s.rollupClients {
+		clients[i] = client
+	}
+	return clients
+}
+
 func (s *Service) initExtractor(cfg *config.Config) {
 	s.extractor = extract.NewExtractor(
 		s.logger,
@@ -144,13 +152,7 @@ func (s *Service) initExtractor(cfg *config.Config) {
 		extract.NewBalanceEnricher(),
 		extract.NewL1HeadBlockNumEnricher(s.l1Client),
 		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.supervisorClient, clock.SystemClock),
-		extract.NewOutputAgreementEnricher(s.logger, s.metrics, func() []extract.OutputRollupClient {
-			clients := make([]extract.OutputRollupClient, len(s.rollupClients))
-			for i, client := range s.rollupClients {
-				clients[i] = client
-			}
-			return clients
-		}(), clock.SystemClock),
+		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.asOutputRollupClients(), clock.SystemClock),
 	)
 }
 


### PR DESCRIPTION
Dispute-mon takes multiple `--rollup-rpc` arguments, or one with a comma-separated list. 

Implements logic described in https://github.com/ethereum-optimism/optimism/issues/11019, and keeps the assumption of assuming the output root was safe if safe head data isn't available.

This is part of https://github.com/ethereum-optimism/optimism/issues/11019 but does not close it because we also need to support multiple supervisor URLs.