### PR TITLE
op-node: check for cfg.Tracer before emitting trace events

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -588,7 +588,9 @@ func (n *OpNode) onEvent(ev event.Event) bool {
 }
 
 func (n *OpNode) PublishBlock(ctx context.Context, signedEnvelope *opsigner.SignedExecutionPayloadEnvelope) error {
-	n.apiEmitter.Emit(tracer.TracePublishBlockEvent{Envelope: signedEnvelope.Envelope})
+	if n.cfg.Tracer != nil {
+		n.apiEmitter.Emit(tracer.TracePublishBlockEvent{Envelope: signedEnvelope.Envelope})
+	}
 	if p2pNode := n.getP2PNodeIfEnabled(); p2pNode != nil {
 		n.log.Info("Publishing signed execution payload on p2p", "id", signedEnvelope.ID())
 		return p2pNode.GossipOut().PublishSignedL2Payload(ctx, signedEnvelope)
@@ -597,7 +599,9 @@ func (n *OpNode) PublishBlock(ctx context.Context, signedEnvelope *opsigner.Sign
 }
 
 func (n *OpNode) SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
-	n.apiEmitter.Emit(tracer.TracePublishBlockEvent{Envelope: envelope})
+	if n.cfg.Tracer != nil {
+		n.apiEmitter.Emit(tracer.TracePublishBlockEvent{Envelope: envelope})
+	}
 	// publish to p2p, if we are running p2p at all
 	if p2pNode := n.getP2PNodeIfEnabled(); p2pNode != nil {
 		if n.p2pSigner == nil {


### PR DESCRIPTION
**Description**

`Tracer` config is optional, but at the moment we emit those event all the time, no matter if the tracer is initialised or not. If the `Tracer` is not initialised, there is nothing to consume these events, and we might overflow and panic the node.

<img width="655" alt="Screenshot 2025-06-18 at 13 20 12" src="https://github.com/user-attachments/assets/d988bb9c-830c-42c6-819f-ec2f4ac286da" />

**Follow-up**

As a follow-up this shows that we need a gauge on the number of events enqueued but not processed, and an alert if the total goes over some threshold. Any broken consumer of any event could potentially panic the node right now.