### PR TITLE
op-node: fix p2p gossip score setup and application

### DIFF
--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -190,7 +190,7 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, managedMode bool, l
 				require.NoError(err, "failed to load p2p signer")
 				logger.Info("Sequencer key acquired")
 			}
-			p2pConfig, err = p2pcli.NewConfig(cliCtx, l2Net.rollupCfg)
+			p2pConfig, err = p2pcli.NewConfig(cliCtx, l2Net.rollupCfg.BlockTime)
 			require.NoError(err, "failed to load p2p config")
 		}
 

--- a/op-e2e/system/p2p/gossip_test.go
+++ b/op-e2e/system/p2p/gossip_test.go
@@ -145,7 +145,7 @@ func TestSystemDenseTopology(t *testing.T) {
 
 	// Set peer scoring for each node, but without banning
 	for _, node := range cfg.Nodes {
-		params, err := p2p.GetScoringParams("light", &node.Rollup)
+		params, err := p2p.GetScoringParams("light", node.Rollup.BlockTime)
 		require.NoError(t, err)
 		node.P2P = &p2p.Config{
 			ScoringParams:  params,

--- a/op-node/p2p/app_params.go
+++ b/op-node/p2p/app_params.go
@@ -2,8 +2,6 @@ package p2p
 
 import (
 	"time"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 type ApplicationScoreParams struct {
@@ -23,8 +21,8 @@ type ApplicationScoreParams struct {
 	DecayInterval time.Duration
 }
 
-func LightApplicationScoreParams(cfg *rollup.Config) ApplicationScoreParams {
-	slot := time.Duration(cfg.BlockTime) * time.Second
+func LightApplicationScoreParams(blockTime uint64) ApplicationScoreParams {
+	slot := time.Duration(blockTime) * time.Second
 	if slot == 0 {
 		slot = 2 * time.Second
 	}

--- a/op-node/p2p/app_scores.go
+++ b/op-node/p2p/app_scores.go
@@ -20,8 +20,8 @@ type ApplicationScorer interface {
 	onValidResponse(id peer.ID)
 	onResponseError(id peer.ID)
 	onRejectedPayload(id peer.ID)
-	start()
-	stop()
+	Start()
+	Stop()
 }
 
 type peerApplicationScorer struct {
@@ -38,7 +38,7 @@ type peerApplicationScorer struct {
 
 var _ ApplicationScorer = (*peerApplicationScorer)(nil)
 
-func newPeerApplicationScorer(ctx context.Context, logger log.Logger, clock clock.Clock, params *ApplicationScoreParams, scorebook ScoreBook, connectedPeers func() []peer.ID) *peerApplicationScorer {
+func NewPeerApplicationScorer(ctx context.Context, logger log.Logger, clock clock.Clock, params *ApplicationScoreParams, scorebook ScoreBook, connectedPeers func() []peer.ID) *peerApplicationScorer {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	return &peerApplicationScorer{
 		ctx:            ctx,
@@ -106,7 +106,7 @@ func (s *peerApplicationScorer) decayConnectedPeerScores() {
 	}
 }
 
-func (s *peerApplicationScorer) start() {
+func (s *peerApplicationScorer) Start() {
 	s.done.Add(1)
 	go func() {
 		defer s.done.Done()
@@ -123,7 +123,7 @@ func (s *peerApplicationScorer) start() {
 	}()
 }
 
-func (s *peerApplicationScorer) stop() {
+func (s *peerApplicationScorer) Stop() {
 	s.cancelFunc()
 	s.done.Wait()
 }
@@ -143,10 +143,10 @@ func (n *NoopApplicationScorer) onResponseError(_ peer.ID) {
 func (n *NoopApplicationScorer) onRejectedPayload(_ peer.ID) {
 }
 
-func (n *NoopApplicationScorer) start() {
+func (n *NoopApplicationScorer) Start() {
 }
 
-func (n *NoopApplicationScorer) stop() {
+func (n *NoopApplicationScorer) Stop() {
 }
 
 var _ ApplicationScorer = (*NoopApplicationScorer)(nil)

--- a/op-node/p2p/app_scores_test.go
+++ b/op-node/p2p/app_scores_test.go
@@ -71,7 +71,7 @@ func setupPeerApplicationScorerTest(t *testing.T, params *ApplicationScoreParams
 			updates: make(chan stubScoreBookUpdate, 10),
 		},
 	}
-	appScorer := newPeerApplicationScorer(data.ctx, data.logger, data.clock, params, data.scorebook, func() []peer.ID {
+	appScorer := NewPeerApplicationScorer(data.ctx, data.logger, data.clock, params, data.scorebook, func() []peer.ID {
 		return data.peers
 	})
 	return data, appScorer
@@ -155,8 +155,8 @@ func TestDecayScoresAfterDecayInterval(t *testing.T) {
 		DecayToZero:          0.1,
 	}
 
-	appScorer.start()
-	defer appScorer.stop()
+	appScorer.Start()
+	defer appScorer.Stop()
 
 	data.clock.WaitForNewPendingTaskWithTimeout(30 * time.Second)
 

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	leveldb "github.com/ipfs/go-ds-leveldb"
@@ -28,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 )
 
-func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) {
+func NewConfig(ctx *cli.Context, blockTime uint64) (*p2p.Config, error) {
 	conf := &p2p.Config{}
 
 	if ctx.Bool(flags.DisableP2PName) {
@@ -58,7 +57,7 @@ func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) 
 		return nil, fmt.Errorf("failed to load p2p gossip options: %w", err)
 	}
 
-	if err := loadScoringParams(conf, ctx, rollupCfg); err != nil {
+	if err := loadScoringParams(conf, ctx, blockTime); err != nil {
 		return nil, fmt.Errorf("failed to load p2p peer scoring options: %w", err)
 	}
 
@@ -87,7 +86,7 @@ func validatePort(p uint) (uint16, error) {
 }
 
 // loadScoringParams loads the peer scoring options from the CLI context.
-func loadScoringParams(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Config) error {
+func loadScoringParams(conf *p2p.Config, ctx *cli.Context, blockTime uint64) error {
 	scoringLevel := ctx.String(flags.ScoringName)
 	// Check old names for backwards compatibility
 	if scoringLevel == "" {
@@ -97,7 +96,7 @@ func loadScoringParams(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Con
 		scoringLevel = ctx.String(flags.TopicScoringName)
 	}
 	if scoringLevel != "" {
-		params, err := p2p.GetScoringParams(scoringLevel, rollupCfg)
+		params, err := p2p.GetScoringParams(scoringLevel, blockTime)
 		if err != nil {
 			return err
 		}

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -126,7 +126,7 @@ func (n *NodeP2P) init(
 	scoreParams := setup.PeerScoringParams()
 
 	if scoreParams != nil {
-		n.appScorer = newPeerApplicationScorer(resourcesCtx, log, clock.SystemClock, &scoreParams.ApplicationScoring, eps, n.host.Network().Peers)
+		n.appScorer = NewPeerApplicationScorer(resourcesCtx, log, clock.SystemClock, &scoreParams.ApplicationScoring, eps, n.host.Network().Peers)
 	} else {
 		n.appScorer = &NoopApplicationScorer{}
 	}
@@ -156,7 +156,7 @@ func (n *NodeP2P) init(
 			n.host.SetStreamHandler(PayloadByNumberProtocolID(rollupCfg.L2ChainID), payloadByNumber)
 		}
 	}
-	n.scorer = NewScorer(rollupCfg, eps, metrics, n.appScorer, log)
+	n.scorer = NewScorer(eps, metrics, n.appScorer, log)
 	// notify of any new connections/streams/etc.
 	n.host.Network().Notify(NewNetworkNotifier(log, metrics))
 	// note: the IDDelta functionality was removed from libP2P, and no longer needs to be explicitly disabled.
@@ -189,7 +189,7 @@ func (n *NodeP2P) init(
 		n.peerMonitor = monitor.NewPeerMonitor(resourcesCtx, log, clock.SystemClock, n, setup.BanThreshold(), setup.BanDuration())
 		n.peerMonitor.Start()
 	}
-	n.appScorer.start()
+	n.appScorer.Start()
 	return nil
 }
 
@@ -299,7 +299,7 @@ func (n *NodeP2P) Close() error {
 		}
 	}
 	if n.appScorer != nil {
-		n.appScorer.stop()
+		n.appScorer.Stop()
 	}
 	return result.ErrorOrNil()
 }

--- a/op-node/p2p/peer_params.go
+++ b/op-node/p2p/peer_params.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -32,8 +31,8 @@ func ScoreDecay(duration time.Duration, slot time.Duration) float64 {
 // See [PeerScoreParams] for detailed documentation.
 //
 // [PeerScoreParams]: https://pkg.go.dev/github.com/libp2p/go-libp2p-pubsub@v0.8.1#PeerScoreParams
-func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
-	slot := time.Duration(cfg.BlockTime) * time.Second
+func LightPeerScoreParams(blockTime uint64) pubsub.PeerScoreParams {
+	slot := time.Duration(blockTime) * time.Second
 	if slot == 0 {
 		slot = 2 * time.Second
 	}
@@ -65,12 +64,12 @@ func LightPeerScoreParams(cfg *rollup.Config) pubsub.PeerScoreParams {
 	}
 }
 
-func GetScoringParams(name string, cfg *rollup.Config) (*ScoringParams, error) {
+func GetScoringParams(name string, blockTime uint64) (*ScoringParams, error) {
 	switch name {
 	case "light":
 		return &ScoringParams{
-			PeerScoring:        LightPeerScoreParams(cfg),
-			ApplicationScoring: LightApplicationScoreParams(cfg),
+			PeerScoring:        LightPeerScoreParams(blockTime),
+			ApplicationScoring: LightApplicationScoreParams(blockTime),
 		}, nil
 	case "none":
 		return nil, nil

--- a/op-node/p2p/peer_params_test.go
+++ b/op-node/p2p/peer_params_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 )
 
 // PeerParamsTestSuite tests peer parameterization.
@@ -43,7 +44,7 @@ func (testSuite *PeerParamsTestSuite) TestNewPeerScoreThresholds() {
 
 // TestGetPeerScoreParams validates the peer score parameters.
 func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_None() {
-	params, err := GetScoringParams("none", chaincfg.OPSepolia())
+	params, err := GetScoringParams("none", 2)
 	testSuite.NoError(err)
 	testSuite.Nil(params)
 }
@@ -62,7 +63,7 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 	testSuite.Equal(0.9261187281287935, decay)
 
 	// Test the params
-	scoringParams, err := GetScoringParams("light", cfg)
+	scoringParams, err := GetScoringParams("light", cfg.BlockTime)
 	peerParams := scoringParams.PeerScoring
 	testSuite.NoError(err)
 	// Topics should not contain options for any block topic
@@ -100,7 +101,7 @@ func (testSuite *PeerParamsTestSuite) TestParamsZeroBlockTime() {
 	cfg := chaincfg.OPSepolia()
 	cfg.BlockTime = 0
 	slot := 2 * time.Second
-	params, err := GetScoringParams("light", cfg)
+	params, err := GetScoringParams("light", cfg.BlockTime)
 	testSuite.NoError(err)
 	testSuite.Equal(params.PeerScoring.DecayInterval, slot)
 	testSuite.Equal(params.ApplicationScoring.DecayInterval, slot)

--- a/op-node/p2p/peer_scorer.go
+++ b/op-node/p2p/peer_scorer.go
@@ -3,8 +3,6 @@ package p2p
 import (
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	log "github.com/ethereum/go-ethereum/log"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -16,7 +14,6 @@ type scorer struct {
 	metricer  ScoreMetrics
 	appScorer ApplicationScorer
 	log       log.Logger
-	cfg       *rollup.Config
 }
 
 // Peerstore is a subset of the libp2p peerstore.Peerstore interface.
@@ -46,13 +43,12 @@ type ScoreMetrics interface {
 }
 
 // NewScorer returns a new peer scorer.
-func NewScorer(cfg *rollup.Config, peerStore Peerstore, metricer ScoreMetrics, appScorer ApplicationScorer, log log.Logger) Scorer {
+func NewScorer(peerStore Peerstore, metricer ScoreMetrics, appScorer ApplicationScorer, log log.Logger) Scorer {
 	return &scorer{
 		peerStore: peerStore,
 		metricer:  metricer,
 		appScorer: appScorer,
 		log:       log,
-		cfg:       cfg,
 	}
 }
 
@@ -61,7 +57,6 @@ func NewScorer(cfg *rollup.Config, peerStore Peerstore, metricer ScoreMetrics, a
 // The returned [pubsub.ExtendedPeerScoreInspectFn] is called with a mapping of peer IDs to peer score snapshots.
 // The incoming peer score snapshots only contain gossip-score components.
 func (s *scorer) SnapshotHook() pubsub.ExtendedPeerScoreInspectFn {
-	blocksTopicName := blocksTopicV1(s.cfg)
 	return func(m map[peer.ID]*pubsub.PeerScoreSnapshot) {
 		allScores := make([]store.PeerScores, 0, len(m))
 		// Now set the new scores.
@@ -72,11 +67,15 @@ func (s *scorer) SnapshotHook() pubsub.ExtendedPeerScoreInspectFn {
 				IPColocationFactor: snap.IPColocationFactor,
 				BehavioralPenalty:  snap.BehaviourPenalty,
 			}
-			if topSnap, ok := snap.Topics[blocksTopicName]; ok {
-				diff.Blocks.TimeInMesh = float64(topSnap.TimeInMesh) / float64(time.Second)
-				diff.Blocks.MeshMessageDeliveries = topSnap.MeshMessageDeliveries
-				diff.Blocks.FirstMessageDeliveries = topSnap.FirstMessageDeliveries
-				diff.Blocks.InvalidMessageDeliveries = topSnap.InvalidMessageDeliveries
+			// All allow-listed topics are block-topics,
+			// And the total performance is what we care about, regardless of number of past forks.
+			// So add up the data. And consider the time-in-mesh of the most used topic:
+			// alt CL implementations may choose to not stay on legacy topics).
+			for _, topSnap := range snap.Topics {
+				diff.Blocks.TimeInMesh = max(diff.Blocks.TimeInMesh, float64(topSnap.TimeInMesh)/float64(time.Second))
+				diff.Blocks.MeshMessageDeliveries += topSnap.MeshMessageDeliveries
+				diff.Blocks.FirstMessageDeliveries += topSnap.FirstMessageDeliveries
+				diff.Blocks.InvalidMessageDeliveries += topSnap.InvalidMessageDeliveries
 			}
 			if peerScores, err := s.peerStore.SetScore(id, &diff); err != nil {
 				s.log.Warn("Unable to update peer gossip score", "err", err)

--- a/op-node/p2p/peer_scorer.go
+++ b/op-node/p2p/peer_scorer.go
@@ -70,7 +70,7 @@ func (s *scorer) SnapshotHook() pubsub.ExtendedPeerScoreInspectFn {
 			// All allow-listed topics are block-topics,
 			// And the total performance is what we care about, regardless of number of past forks.
 			// So add up the data. And consider the time-in-mesh of the most used topic:
-			// alt CL implementations may choose to not stay on legacy topics).
+			// alt CL implementations may choose to not stay on legacy topics.
 			for _, topSnap := range snap.Topics {
 				diff.Blocks.TimeInMesh = max(diff.Blocks.TimeInMesh, float64(topSnap.TimeInMesh)/float64(time.Second))
 				diff.Blocks.MeshMessageDeliveries += topSnap.MeshMessageDeliveries

--- a/op-node/p2p/peer_scorer_test.go
+++ b/op-node/p2p/peer_scorer_test.go
@@ -1,8 +1,8 @@
 package p2p_test
 
 import (
-	"math/big"
 	"testing"
+	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	peer "github.com/libp2p/go-libp2p/core/peer"
@@ -13,7 +13,6 @@ import (
 	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
 	p2pMocks "github.com/ethereum-optimism/optimism/op-node/p2p/mocks"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -41,7 +40,6 @@ func TestPeerScorer(t *testing.T) {
 // TestScorer_SnapshotHook tests running the snapshot hook on the peer scorer.
 func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 	scorer := p2p.NewScorer(
-		&rollup.Config{L2ChainID: big.NewInt(123)},
 		testSuite.mockStore,
 		testSuite.mockMetricer,
 		&p2p.NoopApplicationScorer{},
@@ -65,7 +63,17 @@ func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 	inspectFn(snapshotMap)
 
 	// Expect updating the peer store
-	testSuite.mockStore.On("SetScore", peer.ID("peer1"), &store.GossipScores{Total: 0}).Return(scores, nil).Once()
+	testSuite.mockStore.On("SetScore", peer.ID("peer1"), &store.GossipScores{
+		Total: 0,
+		Blocks: store.TopicScores{
+			// expect the maximum time in mesh
+			TimeInMesh: 200.0, // float in seconds
+			// expect the sum of deliveries
+			FirstMessageDeliveries:   111,
+			MeshMessageDeliveries:    222,
+			InvalidMessageDeliveries: 333,
+		},
+	}).Return(scores, nil).Once()
 
 	// The metricer should then be called with the peer score band map
 	testSuite.mockMetricer.On("SetPeerScores", []store.PeerScores{scores}).Return(nil).Once()
@@ -74,7 +82,28 @@ func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 	snapshotMap = map[peer.ID]*pubsub.PeerScoreSnapshot{
 		peer.ID("peer1"): {
 			Score: 0,
+			Topics: map[string]*pubsub.TopicScoreSnapshot{
+				"foo": {
+					TimeInMesh:               time.Second * 100,
+					FirstMessageDeliveries:   1,
+					MeshMessageDeliveries:    2,
+					InvalidMessageDeliveries: 3,
+				},
+				"bar": {
+					TimeInMesh:               time.Second * 200,
+					FirstMessageDeliveries:   10,
+					MeshMessageDeliveries:    20,
+					InvalidMessageDeliveries: 30,
+				},
+				"baz": {
+					TimeInMesh:               time.Second * 50,
+					FirstMessageDeliveries:   100,
+					MeshMessageDeliveries:    200,
+					InvalidMessageDeliveries: 300,
+				},
+			},
 		},
 	}
 	inspectFn(snapshotMap)
+	testSuite.T().Log("TODO")
 }

--- a/op-node/p2p/peer_scorer_test.go
+++ b/op-node/p2p/peer_scorer_test.go
@@ -105,5 +105,4 @@ func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 		},
 	}
 	inspectFn(snapshotMap)
-	testSuite.T().Log("TODO")
 }

--- a/op-node/p2p/peer_scores_test.go
+++ b/op-node/p2p/peer_scores_test.go
@@ -3,7 +3,6 @@ package p2p_test
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"math/rand"
 	"testing"
 	"time"
@@ -28,7 +27,6 @@ import (
 	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
 	p2pMocks "github.com/ethereum-optimism/optimism/op-node/p2p/mocks"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	testlog "github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -113,7 +111,6 @@ func newGossipSubs(testSuite *PeerScoresTestSuite, ctx context.Context, hosts []
 		require.NoError(testSuite.T(), err)
 
 		scorer := p2p.NewScorer(
-			&rollup.Config{L2ChainID: big.NewInt(123)},
 			extPeerStore, testSuite.mockMetricer, &discriminatingAppScorer{badPeer: hosts[0].ID()}, logger)
 		opts = append(opts, p2p.ConfigurePeerScoring(&p2p.Config{
 			ScoringParams: &p2p.ScoringParams{

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -61,7 +61,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*config.Config, error) {
 		return nil, fmt.Errorf("failed to load p2p signer: %w", err)
 	}
 
-	p2pConfig, err := p2pcli.NewConfig(ctx, rollupConfig)
+	p2pConfig, err := p2pcli.NewConfig(ctx, rollupConfig.BlockTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load p2p config: %w", err)
 	}


### PR DESCRIPTION
**Description**

This cleans up the P2P scoring code:
- make it reusable by making the start/stop functions public
- decouple from the rollup-config, just pass in the block-time, the only attribute we really use at all
- change the `SnapshotHook` that we attach to gossip to not only extract block-topic-v1 information, but to sum up all topics (all topics are block topics, one per fork), so that the application-layer scoring has access to the combined metrics. We care about the metrics on all forks combined.

**Tests**

Added a test to assert the different topics are combined when the snapshot runs.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
