### PR TITLE
op-supervisor,op-node: resolve duplicate `DerivationOriginUpdate` in indexed node events

### DIFF
--- a/op-node/rollup/interop/indexing/system.go
+++ b/op-node/rollup/interop/indexing/system.go
@@ -214,7 +214,7 @@ func (m *IndexingMode) OnEvent(ctx context.Context, ev event.Event) bool {
 		}
 		logger.Info("Sending derivation update to supervisor (L1 traversal)")
 		m.events.Send(&supervisortypes.IndexingEvent{
-			DerivationOriginUpdate: &supervisortypes.DerivedBlockRefPair{
+			DerivationCurrentL1Update: &supervisortypes.DerivedBlockRefPair{
 				Source:  x.Origin,
 				Derived: x.LastL2.BlockRef(),
 			},

--- a/op-node/rollup/interop/indexing/system.go
+++ b/op-node/rollup/interop/indexing/system.go
@@ -214,11 +214,10 @@ func (m *IndexingMode) OnEvent(ctx context.Context, ev event.Event) bool {
 		}
 		logger.Info("Sending derivation update to supervisor (L1 traversal)")
 		m.events.Send(&supervisortypes.IndexingEvent{
-			DerivationUpdate: &supervisortypes.DerivedBlockRefPair{
+			DerivationOriginUpdate: &supervisortypes.DerivedBlockRefPair{
 				Source:  x.Origin,
 				Derived: x.LastL2.BlockRef(),
 			},
-			DerivationOriginUpdate: &x.Origin,
 		})
 
 	case derive.ExhaustedL1Event:

--- a/op-node/rollup/interop/indexing/system_events_test.go
+++ b/op-node/rollup/interop/indexing/system_events_test.go
@@ -214,10 +214,9 @@ func TestManagedMode_OnEvent_Deduplication(t *testing.T) {
 
 		events := mockStream.drainEvents()
 		require.Len(t, events, 1, "First L1 status event should be sent")
-		require.NotNil(t, events[0].DerivationUpdate)
 		require.NotNil(t, events[0].DerivationOriginUpdate)
-		require.Equal(t, l1Ref1, events[0].DerivationUpdate.Source)
-		require.Equal(t, l1Ref1, *events[0].DerivationOriginUpdate)
+		require.Equal(t, l1Ref1, events[0].DerivationOriginUpdate.Source)
+		require.Equal(t, l2Ref1.BlockRef(), events[0].DerivationOriginUpdate.Derived)
 
 		// Check that no skipping log was generated
 		hasSkipLog := testlog.NewMessageContainsFilter("Skipped sending duplicate derivation update (L1 traversal)")
@@ -241,8 +240,9 @@ func TestManagedMode_OnEvent_Deduplication(t *testing.T) {
 
 		events = mockStream.drainEvents()
 		require.Len(t, events, 1, "L1 status event with different origin should be sent")
-		require.NotNil(t, events[0].DerivationUpdate)
-		require.Equal(t, l1Ref2, events[0].DerivationUpdate.Source)
+		require.NotNil(t, events[0].DerivationOriginUpdate)
+		require.Equal(t, l1Ref2, events[0].DerivationOriginUpdate.Source)
+		require.Equal(t, l2Ref1.BlockRef(), events[0].DerivationOriginUpdate.Derived)
 
 		// Check that no skipping log was generated for different origin
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelWarn), hasSkipLog), "No skip log for different origin")

--- a/op-node/rollup/interop/indexing/system_events_test.go
+++ b/op-node/rollup/interop/indexing/system_events_test.go
@@ -214,9 +214,9 @@ func TestManagedMode_OnEvent_Deduplication(t *testing.T) {
 
 		events := mockStream.drainEvents()
 		require.Len(t, events, 1, "First L1 status event should be sent")
-		require.NotNil(t, events[0].DerivationOriginUpdate)
-		require.Equal(t, l1Ref1, events[0].DerivationOriginUpdate.Source)
-		require.Equal(t, l2Ref1.BlockRef(), events[0].DerivationOriginUpdate.Derived)
+		require.NotNil(t, events[0].DerivationCurrentL1Update)
+		require.Equal(t, l1Ref1, events[0].DerivationCurrentL1Update.Source)
+		require.Equal(t, l2Ref1.BlockRef(), events[0].DerivationCurrentL1Update.Derived)
 
 		// Check that no skipping log was generated
 		hasSkipLog := testlog.NewMessageContainsFilter("Skipped sending duplicate derivation update (L1 traversal)")
@@ -240,9 +240,9 @@ func TestManagedMode_OnEvent_Deduplication(t *testing.T) {
 
 		events = mockStream.drainEvents()
 		require.Len(t, events, 1, "L1 status event with different origin should be sent")
-		require.NotNil(t, events[0].DerivationOriginUpdate)
-		require.Equal(t, l1Ref2, events[0].DerivationOriginUpdate.Source)
-		require.Equal(t, l2Ref1.BlockRef(), events[0].DerivationOriginUpdate.Derived)
+		require.NotNil(t, events[0].DerivationCurrentL1Update)
+		require.Equal(t, l1Ref2, events[0].DerivationCurrentL1Update.Source)
+		require.Equal(t, l2Ref1.BlockRef(), events[0].DerivationCurrentL1Update.Derived)
 
 		// Check that no skipping log was generated for different origin
 		require.Nil(t, logs.FindLog(testlog.NewLevelFilter(log.LevelWarn), hasSkipLog), "No skip log for different origin")

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -370,12 +370,21 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	m.resetIfInconsistent()
 }
 
-func (m *ManagedNode) onDerivationOriginUpdate(origin eth.BlockRef) {
-	m.log.Info("Node derived new origin", "origin", origin)
+func (m *ManagedNode) onDerivationOriginUpdate(pair types.DerivedBlockRefPair) {
+	m.log.Info("Node derived new block with new origin", "derived", pair.Derived,
+		"derivedParent", pair.Derived.ParentID(), "source", pair.Source)
 	m.emitter.Emit(m.ctx, superevents.LocalDerivedOriginUpdateEvent{
 		ChainID: m.chainID,
-		Origin:  origin,
+		Origin:  pair.Source,
 	})
+	m.emitter.Emit(superevents.LocalDerivedEvent{
+		ChainID: m.chainID,
+		Derived: pair,
+		NodeID:  m.Node.String(),
+		Ctx:     event.WrapCtx(m.ctx),
+	})
+	m.lastNodeLocalSafe = pair.Derived.ID()
+	m.resetIfInconsistent()
 }
 
 func (m *ManagedNode) onExhaustL1Event(completed types.DerivedBlockRefPair) {

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -377,11 +377,10 @@ func (m *ManagedNode) onDerivationCurrentL1Update(pair types.DerivedBlockRefPair
 		ChainID: m.chainID,
 		Origin:  pair.Source,
 	})
-	m.emitter.Emit(superevents.LocalDerivedEvent{
+	m.emitter.Emit(m.ctx, superevents.LocalDerivedEvent{
 		ChainID: m.chainID,
 		Derived: pair,
 		NodeID:  m.Node.String(),
-		Ctx:     event.WrapCtx(m.ctx),
 	})
 	m.lastNodeLocalSafe = pair.Derived.ID()
 	m.resetIfInconsistent()

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -280,8 +280,8 @@ func (m *ManagedNode) onNodeEvent(ev *types.IndexingEvent) {
 	if ev.ReplaceBlock != nil {
 		m.onReplaceBlock(*ev.ReplaceBlock)
 	}
-	if ev.DerivationOriginUpdate != nil {
-		m.onDerivationOriginUpdate(*ev.DerivationOriginUpdate)
+	if ev.DerivationCurrentL1Update != nil {
+		m.onDerivationCurrentL1Update(*ev.DerivationCurrentL1Update)
 	}
 }
 
@@ -370,7 +370,7 @@ func (m *ManagedNode) onDerivationUpdate(pair types.DerivedBlockRefPair) {
 	m.resetIfInconsistent()
 }
 
-func (m *ManagedNode) onDerivationOriginUpdate(pair types.DerivedBlockRefPair) {
+func (m *ManagedNode) onDerivationCurrentL1Update(pair types.DerivedBlockRefPair) {
 	m.log.Info("Node derived new block with new origin", "derived", pair.Derived,
 		"derivedParent", pair.Derived.ParentID(), "source", pair.Source)
 	m.emitter.Emit(m.ctx, superevents.LocalDerivedOriginUpdateEvent{

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -76,7 +76,7 @@ func TestEventResponse(t *testing.T) {
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			ExhaustL1: &pair})
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
-			DerivationOriginUpdate: &pair})
+			DerivationCurrentL1Update: &pair})
 
 		require.NoError(t, ex.Drain())
 
@@ -84,7 +84,7 @@ func TestEventResponse(t *testing.T) {
 			crossSafe >= 1 &&
 			finalized >= 1 &&
 			mon.receivedLocalUnsafe >= 1 &&
-			// DerivationUpdate and DerivationOriginUpdate both emits LocalDerivedEvent
+			// DerivationUpdate and DerivationCurrentL1Update both emits LocalDerivedEvent
 			mon.localDerived >= 2 &&
 			nodeExhausted >= 1 &&
 			mon.localDerivedOriginUpdate >= 1

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -72,11 +72,11 @@ func TestEventResponse(t *testing.T) {
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			UnsafeBlock: &eth.BlockRef{Number: 1}})
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
-			DerivationUpdate: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+			DerivationUpdate: &pair})
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
-			ExhaustL1: &types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}})
+			ExhaustL1: &pair})
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
-			DerivationOriginUpdate: &eth.BlockRef{Number: 1}})
+			DerivationOriginUpdate: &pair})
 
 		require.NoError(t, ex.Drain())
 
@@ -84,7 +84,7 @@ func TestEventResponse(t *testing.T) {
 			crossSafe >= 1 &&
 			finalized >= 1 &&
 			mon.receivedLocalUnsafe >= 1 &&
-			mon.localDerived >= 1 &&
+			mon.localDerived >= 2 &&
 			nodeExhausted >= 1 &&
 			mon.localDerivedOriginUpdate >= 1
 	}, 4*time.Second, 250*time.Millisecond)

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -84,6 +84,7 @@ func TestEventResponse(t *testing.T) {
 			crossSafe >= 1 &&
 			finalized >= 1 &&
 			mon.receivedLocalUnsafe >= 1 &&
+			// DerivationUpdate and DerivationOriginUpdate both emits LocalDerivedEvent
 			mon.localDerived >= 2 &&
 			nodeExhausted >= 1 &&
 			mon.localDerivedOriginUpdate >= 1

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -69,8 +69,9 @@ func TestEventResponse(t *testing.T) {
 		emitter.Emit(testCtx, superevents.CrossSafeUpdateEvent{ChainID: chainID})
 		emitter.Emit(testCtx, superevents.FinalizedL2UpdateEvent{ChainID: chainID})
 
+		pair := types.DerivedBlockRefPair{Source: eth.BlockRef{Number: 1}, Derived: eth.BlockRef{Number: 2}}
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
-			UnsafeBlock: &eth.BlockRef{Number: 1}})
+			UnsafeBlock: &pair.Source})
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			DerivationUpdate: &pair})
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -493,7 +493,7 @@ type IndexingEvent struct {
 	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
 	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
-	DerivationOriginUpdate *eth.BlockRef        `json:"derivationOriginUpdate,omitempty"`
+	DerivationOriginUpdate *DerivedBlockRefPair `json:"derivationOriginUpdate,omitempty"`
 }
 
 // MessageChecksum represents a message checksum, as used for access-list checks.

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -488,11 +488,11 @@ type BlockReplacement struct {
 // IndexingEvent is an event sent by the indexing node to the supervisor,
 // to share an update. One of the fields will be non-null; different kinds of updates may be sent.
 type IndexingEvent struct {
-	Reset                  *string              `json:"reset,omitempty"`
-	UnsafeBlock            *eth.BlockRef        `json:"unsafeBlock,omitempty"`
-	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
-	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
-	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
+	Reset                     *string              `json:"reset,omitempty"`
+	UnsafeBlock               *eth.BlockRef        `json:"unsafeBlock,omitempty"`
+	DerivationUpdate          *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
+	ExhaustL1                 *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
+	ReplaceBlock              *BlockReplacement    `json:"replaceBlock,omitempty"`
 	DerivationCurrentL1Update *DerivedBlockRefPair `json:"derivationCurrentL1Update,omitempty"`
 }
 

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -493,7 +493,7 @@ type IndexingEvent struct {
 	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
 	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
-	DerivationCurrentL1Update *DerivedBlockRefPair `json:"DerivationCurrentL1Update,omitempty"`
+	DerivationCurrentL1Update *DerivedBlockRefPair `json:"derivationCurrentL1Update,omitempty"`
 }
 
 // MessageChecksum represents a message checksum, as used for access-list checks.

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -493,7 +493,7 @@ type IndexingEvent struct {
 	DerivationUpdate       *DerivedBlockRefPair `json:"derivationUpdate,omitempty"`
 	ExhaustL1              *DerivedBlockRefPair `json:"exhaustL1,omitempty"`
 	ReplaceBlock           *BlockReplacement    `json:"replaceBlock,omitempty"`
-	DerivationOriginUpdate *DerivedBlockRefPair `json:"derivationOriginUpdate,omitempty"`
+	DerivationCurrentL1Update *DerivedBlockRefPair `json:"DerivationCurrentL1Update,omitempty"`
 }
 
 // MessageChecksum represents a message checksum, as used for access-list checks.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Spec update: https://github.com/ethereum-optimism/specs/pull/733

op-node and op-supervisor communicates with event system, and also progressing each of internal state. Specifically, when op-node loops in a `PipelineStepEvent`, and when it observes a origin update due to pipeline step, it emits a `DeriverL1StatusEvent`.

op-node itself will consume the  `DeriverL1StatusEvent` and updates its `CurrentL1 ` status, and emits a `ManagedEvent` which contained below two fields:
https://github.com/ethereum-optimism/optimism/blob/f273e18a17c655f791671d614620c9541cd5cea5/op-node/rollup/interop/managed/system.go#L207-L212

We want to avoid the complexity and force each `ManagedEvent` to populate single field. `DerivationOriginUpdate` is dedicated to propagate new `CurrentL1` info to the supervisor, so use `DerivationOriginUpdate` but remove the `DerivationUpdate` field. It is now op-supervisor's job to update its chain db by emitting `LocalDerivedEvent` as well.

Note that `DerivationOriginUpdate` type is updated from `BlockRef` to `DerivedBlockRefPair` because it now needs to contain the pair for updating supervisor chain db via `LocalDerivedEvent`.

Also renamed `DerivationOriginUpdate` to `DerivationCurrentL1Update` to be more explicit. This change was also mentioned at https://github.com/ethereum-optimism/optimism/pull/14157#discussion_r1943484865.

**Tests**

All existing tests are updated, especially the `TestEventResponse`. When we send `DerivationCurrentL1Update`, we may check that the `LocalDerivedEvent` is emitted.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16275
