### PR TITLE
Refactor WETHBinding: Use SuperchainETHBridge Instead of SuperchainWETH

### DIFF
--- a/devnet-sdk/contracts/registry/client/weth.go
+++ b/devnet-sdk/contracts/registry/client/weth.go
@@ -12,7 +12,7 @@ import (
 type WETHBinding struct {
 	contractAddress types.Address
 	client          *ethclient.Client
-	binding         *bindings.SuperchainWETH
+	binding         *bindings.SuperchainETHBridge
 }
 
 var _ interfaces.WETH = (*WETHBinding)(nil)


### PR DESCRIPTION

This pull request updates the WETHBinding struct to replace the SuperchainWETH binding with SuperchainETHBridge. 