### PR TITLE
docs: fix typos in bridge and SystemConfig contracts

### DIFF
--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -17,7 +17,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @custom:proxied true
 /// @title L1StandardBridge
-/// @notice The L1StandardBridge is responsible for transfering ETH and ERC20 tokens between L1 and
+/// @notice The L1StandardBridge is responsible for transferring ETH and ERC20 tokens between L1 and
 ///         L2. In the case that an ERC20 token is native to L1, it will be escrowed within this
 ///         contract. If the ERC20 token is native to L2, it will be burnt. Before Bedrock, ETH was
 ///         stored within this contract. After Bedrock, ETH is instead stored inside the

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -27,7 +27,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @custom:value FEE_SCALARS          Represents an update to l1 data fee scalars.
     /// @custom:value GAS_LIMIT            Represents an update to gas limit on L2.
     /// @custom:value UNSAFE_BLOCK_SIGNER  Represents an update to the signer key for unsafe
-    ///                                    block distrubution.
+    ///                                    block distribution.
     enum UpdateType {
         BATCHER,
         FEE_SCALARS,

--- a/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -15,7 +15,7 @@ import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000010
 /// @title L2StandardBridge
-/// @notice The L2StandardBridge is responsible for transfering ETH and ERC20 tokens between L1 and
+/// @notice The L2StandardBridge is responsible for transferring ETH and ERC20 tokens between L1 and
 ///         L2. In the case that an ERC20 token is native to L2, it will be escrowed within this
 ///         contract. If the ERC20 token is native to L1, it will be burnt.
 ///         NOTE: this contract is not intended to support all variations of ERC20 tokens. Examples


### PR DESCRIPTION

This pull request corrects minor spelling errors in the L1/L2 StandardBridge and SystemConfig contracts. Specifically, it fixes the word "transfering" to "transferring" and "distributon" to "distribution" in the relevant comments and documentation sections. 