### PR TITLE
feat(op-acceptance-tests): reduce eth requirements.

### DIFF
--- a/op-acceptance-tests/tests/base/faucet_test.go
+++ b/op-acceptance-tests/tests/base/faucet_test.go
@@ -15,12 +15,12 @@ func TestFaucetFund(gt *testing.T) {
 	ctx := t.Ctx()
 
 	ctx, span := tracer.Start(ctx, "acquire wallets")
-	funded := sys.Funder.NewFundedEOA(eth.Ether(2))
+	funded := sys.Funder.NewFundedEOA(eth.FiveHundredthsEther)
 	unfunded := sys.Wallet.NewEOA(sys.L2EL)
 	span.End()
 
 	_, span = tracer.Start(ctx, "transfer funds")
-	amount := eth.OneEther
+	amount := eth.OneHundredthEther
 	funded.Transfer(unfunded.Address(), amount)
 	t.Logger().InfoContext(ctx, "funds transferred", "amount", amount)
 	span.End()

--- a/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
+++ b/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
@@ -22,7 +22,7 @@ func TestRegularMessage(gt *testing.T) {
 	logger := t.Logger()
 	rng := rand.New(rand.NewSource(1234))
 
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	// deploy event logger at chain B
 	eventLoggerAddress := bob.DeployEventLogger()

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -22,8 +22,8 @@ func TestInteropHappyTx(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 
 	// two EOAs for triggering the init and exec interop txs
-	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
-	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice := sys.FunderA.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -34,8 +34,8 @@ func TestInitExecMsg(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	rng := rand.New(rand.NewSource(1234))
-	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
-	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice := sys.FunderA.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 	// Trigger random init message at chain A
@@ -51,8 +51,8 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	rng := rand.New(rand.NewSource(1234))
-	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
-	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice := sys.FunderA.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 	require := t.Require()
 
 	eventLoggerAddress := alice.DeployEventLogger()
@@ -133,8 +133,8 @@ func TestRandomDirectedGraph(gt *testing.T) {
 	// interop network has at least two chains
 	l2ChainNum := 2
 
-	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
-	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice := sys.FunderA.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	// Deploy eventLoggers per every L2 chains because initiating messages can happen on any L2 chains
 	eventLoggerAddresses := []common.Address{alice.DeployEventLogger(), bob.DeployEventLogger()}
@@ -251,7 +251,7 @@ func TestInitExecMultipleMsg(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 	// Intent to initiate two message(or emit event) on chain A
@@ -296,7 +296,7 @@ func TestExecSameMsgTwice(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 
@@ -340,7 +340,7 @@ func TestExecDifferentTopicCount(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 
@@ -390,7 +390,7 @@ func TestExecMsgOpaqueData(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 
@@ -440,7 +440,7 @@ func TestExecMsgDifferEventIndexInSingleTx(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 
@@ -558,7 +558,7 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	alice, bob := sys.FunderA.NewFundedEOA(eth.OneEther), sys.FunderB.NewFundedEOA(eth.OneEther)
+	alice, bob := sys.FunderA.NewFundedEOA(eth.OneTenthEther), sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 


### PR DESCRIPTION
Reducing the reuired eth for tests. Smaller numbers should still be valid for the test. Yet it'll make funding persistent devnets easier/cheaper.
