### PR TITLE
feat(op-acceptance-tests): increase l2 timeouts and rewrite faucet tests

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -28,9 +28,9 @@ func TestL1ToL2Deposit(gt *testing.T) {
 
 	// Fund Alice on L1
 	fundingAmount := eth.ThreeHundredthsEther
-	alice := sys.Wallet.NewEOA(sys.L1EL)
+	alice := sys.FunderL1.NewFundedEOA(fundingAmount)
 	t.Log("Alice L1 address", alice.Address())
-	initialBalance := sys.FunderL1.FundAtLeast(alice, fundingAmount)
+	initialBalance := alice.GetBalance()
 	t.Log("Alice L1 balance", initialBalance)
 
 	alicel2 := alice.AsEL(sys.L2EL)

--- a/op-acceptance-tests/tests/base/faucet_test.go
+++ b/op-acceptance-tests/tests/base/faucet_test.go
@@ -9,19 +9,27 @@ import (
 )
 
 func TestFaucetFund(gt *testing.T) {
-	t := devtest.ParallelT(gt)
+	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	tracer := t.Tracer()
 	ctx := t.Ctx()
 
 	ctx, span := tracer.Start(ctx, "acquire wallets")
-	funded := sys.Funder.NewFundedEOA(eth.FiveHundredthsEther)
-	unfunded := sys.Wallet.NewEOA(sys.L2EL)
+	alice := sys.Wallet.NewEOA(sys.L1EL)
+	l1Balance := alice.GetBalance()
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	l2Balance := bob.GetBalance()
 	span.End()
 
-	_, span = tracer.Start(ctx, "transfer funds")
-	amount := eth.OneHundredthEther
-	funded.Transfer(unfunded.Address(), amount)
-	t.Logger().InfoContext(ctx, "funds transferred", "amount", amount)
+	_, span = tracer.Start(ctx, "fund wallet")
+	fundAmount := eth.OneHundredthEther
+	sys.FunderL1.FundNoWait(alice, fundAmount)
+	sys.FunderL2.FundNoWait(bob, fundAmount)
+	span.End()
+
+	_, span = tracer.Start(ctx, "wait for balance")
+	t.Logger().InfoContext(ctx, "funds transferred", "amount", fundAmount)
+	alice.WaitForBalance(eth.WeiBig(l1Balance.ToBig().Add(l1Balance.ToBig(), fundAmount.ToBig())))
+	bob.WaitForBalance(eth.WeiBig(l2Balance.ToBig().Add(l2Balance.ToBig(), fundAmount.ToBig())))
 	span.End()
 }

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -36,7 +36,7 @@ func TestWithdrawal(gt *testing.T) {
 	initialL1Balance, initialL2Balance := eth.OneThirdEther, eth.OneTenthEther
 
 	// l1User and l2User share same private key
-	l2User := sys.Funder.NewFundedEOA(initialL2Balance)
+	l2User := sys.FunderL2.NewFundedEOA(initialL2Balance)
 	l1User := l2User.AsEL(sys.L1EL)
 	sys.FunderL1.Fund(l1User, initialL1Balance)
 	userAddr := l1User.Address()

--- a/op-acceptance-tests/tests/interop/smoke/smoke_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/smoke_test.go
@@ -22,8 +22,8 @@ func TestWrapETH(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 
 	// alice and bob are funded with 0.1 ETH
-	alice := sys.Funder.NewFundedEOA(eth.OneTenthEther)
-	bob := sys.Funder.NewFundedEOA(eth.OneTenthEther)
+	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
 
 	client := sys.L2EL.Escape().EthClient()
 

--- a/op-devstack/dsl/funder.go
+++ b/op-devstack/dsl/funder.go
@@ -25,7 +25,7 @@ func NewFunder(w *HDWallet, f *Faucet, el ELNode) *Funder {
 
 func (f *Funder) NewFundedEOA(amount eth.ETH) *EOA {
 	eoa := f.wallet.NewEOA(f.el)
-	f.faucet.Fund(eoa.Address(), amount)
+	f.FundAtLeast(eoa, amount)
 	return eoa
 }
 
@@ -55,8 +55,12 @@ func (f *Funder) Fund(wallet *EOA, amount eth.ETH) eth.ETH {
 	currentBalance := wallet.balance()
 	f.faucet.Fund(wallet.Address(), amount)
 	finalBalance := currentBalance.Add(amount)
-	wallet.VerifyBalanceExact(finalBalance)
+	wallet.WaitForBalance(finalBalance)
 	return finalBalance
+}
+
+func (f *Funder) FundNoWait(wallet *EOA, amount eth.ETH) {
+	f.faucet.Fund(wallet.Address(), amount)
 }
 
 func (f *Funder) FundAtLeast(wallet *EOA, amount eth.ETH) eth.ETH {

--- a/op-devstack/presets/minimal.go
+++ b/op-devstack/presets/minimal.go
@@ -30,9 +30,9 @@ type Minimal struct {
 	Wallet *dsl.HDWallet
 
 	FaucetL1 *dsl.Faucet
-	Faucet   *dsl.Faucet
+	FaucetL2 *dsl.Faucet
 	FunderL1 *dsl.Funder
-	Funder   *dsl.Funder
+	FunderL2 *dsl.Funder
 }
 
 func (m *Minimal) L2Networks() []*dsl.L2Network {
@@ -66,10 +66,10 @@ func NewMinimal(t devtest.T) *Minimal {
 		L2CL:          dsl.NewL2CLNode(l2.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
 		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
 		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
-		Faucet:        dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
+		FaucetL2:      dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
 	}
 	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
 	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
-	out.Funder = dsl.NewFunder(out.Wallet, out.Faucet, out.L2EL)
+	out.FunderL2 = dsl.NewFunder(out.Wallet, out.FaucetL2, out.L2EL)
 	return out
 }

--- a/op-devstack/sysext/l1.go
+++ b/op-devstack/sysext/l1.go
@@ -31,8 +31,8 @@ func (o *Orchestrator) hydrateL1(system stack.ExtensibleSystem) {
 
 	txTimeout := 30 * time.Second
 	if o.compatType == compat.Persistent {
-		txTimeout = 5 * time.Minute
 		// Increase the timeout by default for persistent devnets, but not for kurtosis
+		txTimeout = 5 * time.Minute
 		opts = append(opts, client.WithCallTimeout(time.Minute*5), client.WithBatchCallTimeout(time.Minute*10))
 	}
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR includes the following:
- Increased L2 timeouts for persistent devnets
- Rewrite of the faucet test to better represent a l1 and l2 faucet fund
- Enhance of the l2 transfer test to verify the final balances

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
