### PR TITLE
feat: flashblocks transfer acceptance-tests

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -25,33 +25,6 @@ var (
 	maxExpectedFlashblocks = 20
 )
 
-// Define a struct to represent the flashblock data structure
-type Flashblock struct {
-	PayloadID string `json:"payload_id"`
-	Index     int    `json:"index"`
-	Diff      struct {
-		StateRoot    string `json:"state_root"`
-		ReceiptsRoot string `json:"receipts_root"`
-		LogsBloom    string `json:"logs_bloom"`
-		GasUsed      string `json:"gas_used"`
-		BlockHash    string `json:"block_hash"`
-		Transactions []any  `json:"transactions"`
-		Withdrawals  []any  `json:"withdrawals"`
-	} `json:"diff"`
-	Metadata struct {
-		BlockNumber        int                    `json:"block_number"`
-		NewAccountBalances map[string]string      `json:"new_account_balances"`
-		Receipts           map[string]interface{} `json:"receipts"`
-	} `json:"metadata"`
-}
-
-type FlashblocksStreamMode string
-
-const (
-	FlashblocksStreamMode_Leader   FlashblocksStreamMode = "leader"
-	FlashblocksStreamMode_Follower FlashblocksStreamMode = "follower"
-)
-
 // TestFlashblocksStream checks we can connect to the flashblocks stream
 func TestFlashblocksStream(gt *testing.T) {
 	t := devtest.SerialT(gt)
@@ -84,6 +57,10 @@ func TestFlashblocksStream(gt *testing.T) {
 
 		networkName := l2Chain.String()
 		t.Run(fmt.Sprintf("L2_Chain_%s", networkName), func(tt devtest.T) {
+			if len(flashblocksBuilderSet) == 0 {
+				tt.Skip("no flashblocks builders for chain", l2Chain.String())
+			}
+
 			expectedChainID := l2Chain.ChainID().ToBig()
 			for _, flashblocksBuilderNode := range flashblocksBuilderSet {
 				require.Equal(t, flashblocksBuilderNode.Escape().ChainID().ToBig(), expectedChainID, "flashblocks builder node chain id should match expected chain id")

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -26,6 +26,15 @@ type timedMessage struct {
 }
 
 // TestFlashblocksTransfer checks that a transfer gets reflected in a flashblock before the transaction is confirmed in a block
+// This test concurrently:
+// - listens to the Flashblocks stream for 20s and collects all those streamed Flashblocks along with the timestamp when they were received.
+// - Makes a transaction from Alice to Bob with a pre-known amount and records an approximated txn confirmation time (with upto nanosecond granularity) just after that txn was done.
+
+// Expectations:
+// - After flashblock streaming is done (20s), the transaction's already included in a (real) block.
+// - There must have been a Flashblock containing a new_account_balance corresponding to Bob's account. This flashblock would be representative of the flashblock including Alice-to-Bob transaction.
+// - That Flashblock's time (in seconds) must be less than or equal to the Transaction's block time (in seconds). (Can't check the block time beyond the granularity of seconds)
+// - That Flashblock's time in nanoseconds must be before the approximated transaction confirmation time recorded previously.
 func TestFlashblocksTransfer(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleFlashblocks(t)
@@ -70,7 +79,6 @@ func TestFlashblocksTransfer(gt *testing.T) {
 			// transactor
 			go func() {
 				time.Sleep(6 * time.Second) // warm up for the websocket handshake to be established
-				// Create two L2 wallets
 				bobBalance := bob.GetBalance()
 
 				depositAmount := eth.OneHundredthEther

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -43,14 +43,13 @@ func TestFlashblocksTransfer(gt *testing.T) {
 	ctx := t.Ctx()
 	logger.Info("Started Flashblocks Transfer test")
 
-	ctx, span := tracer.Start(ctx, "test chains")
+	topLevelCtx, span := tracer.Start(ctx, "test chains")
 	defer span.End()
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 
 	// Test all L2 chains in the system
 	for l2Chain, flashblocksBuilderSet := range sys.FlashblocksBuilderSets {
+		ctx, cancel := context.WithTimeout(topLevelCtx, 45*time.Second)
+		defer cancel()
 		_, span = tracer.Start(ctx, fmt.Sprintf("test chain %s", l2Chain.String()))
 		defer span.End()
 
@@ -65,8 +64,8 @@ func TestFlashblocksTransfer(gt *testing.T) {
 			doneListening := make(chan struct{})
 			output := make(chan []byte, 100)
 
-			alice := sys.Funder.NewFundedEOA(eth.ThreeHundredthsEther)
-			bob := sys.Wallet.NewEOA(sys.L2EL)
+			alice := sys.Funders[l2Chain].NewFundedEOA(eth.ThreeHundredthsEther)
+			bob := sys.Wallet.NewEOA(sys.L2ELNodes[l2Chain])
 			bobAddress := bob.Address().Hex()
 
 			// flashblocks listener

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -1,0 +1,137 @@
+//go:build !ci
+
+// use a tag prefixed with "!". Such tag ensures that the default behaviour of this test would be to be built/run even when the go toolchain (go test) doesn't specify any tag filter.
+package flashblocks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type timedMessage struct {
+	message   []byte
+	timestamp time.Time
+}
+
+// TestFlashblocksTransfer checks that a transfer gets reflected in a flashblock before the transaction is confirmed in a block
+func TestFlashblocksTransfer(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleFlashblocks(t)
+	logger := testlog.Logger(t, log.LevelInfo).With("Test", "TestFlashblocksTransfer")
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+	logger.Info("Started Flashblocks Transfer test")
+
+	ctx, span := tracer.Start(ctx, "test chains")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Test all L2 chains in the system
+	for l2Chain, flashblocksBuilderSet := range sys.FlashblocksBuilderSets {
+		_, span = tracer.Start(ctx, fmt.Sprintf("test chain %s", l2Chain.String()))
+		defer span.End()
+
+		t.Run(fmt.Sprintf("L2_Chain_%s", l2Chain.String()), func(tt devtest.T) {
+			if len(flashblocksBuilderSet) == 0 {
+				tt.Skip("no flashblocks builders for chain", l2Chain.String())
+			}
+
+			leaderFbBuilder := flashblocksBuilderSet.Leader()
+			require.NotNil(tt, leaderFbBuilder, "should have a leader", "chain", l2Chain.String())
+
+			doneListening := make(chan struct{})
+			output := make(chan []byte, 100)
+
+			alice := sys.Funder.NewFundedEOA(eth.ThreeHundredthsEther)
+			bob := sys.Wallet.NewEOA(sys.L2EL)
+			bobAddress := bob.Address().Hex()
+
+			// flashblocks listener
+			go leaderFbBuilder.ListenFor(logger, 20*time.Second, output, doneListening) //nolint:errcheck
+
+			var executedTransaction *txplan.PlannedTx
+			var transactionApproxConfirmationTime time.Time
+			var expectedBobBalance string
+
+			// transactor
+			go func() {
+				time.Sleep(6 * time.Second) // warm up for the websocket handshake to be established
+				// Create two L2 wallets
+				bobBalance := bob.GetBalance()
+
+				depositAmount := eth.OneHundredthEther
+				bobAddr := bob.Address()
+				executedTransaction = alice.Transact(
+					alice.Plan(),
+					txplan.WithTo(&bobAddr),
+					txplan.WithValue(depositAmount.ToBig()),
+				)
+				transactionApproxConfirmationTime = time.Now()
+				newBobBalance := bobBalance.Add(depositAmount)
+				expectedBobBalance = newBobBalance.Hex()
+				bob.VerifyBalanceExact(newBobBalance)
+			}()
+
+			streamedMessages := make([]timedMessage, 0)
+			for {
+				select {
+				case <-doneListening:
+					goto done
+				case msg := <-output:
+					streamedMessages = append(streamedMessages, timedMessage{message: msg, timestamp: time.Now()})
+				}
+			}
+		done:
+			require.Greater(tt, len(streamedMessages), 0, "should have received at least one message from the flashblocks stream")
+			require.NotNil(tt, executedTransaction, "should have executed a transaction")
+
+			var bobFlashblockTime time.Time
+			var bobFlashblock *Flashblock
+			var observedBobBalance string
+
+			for _, msg := range streamedMessages {
+				flashblock := &Flashblock{}
+				err := json.Unmarshal(msg.message, flashblock)
+				require.NoError(tt, err, "should be able to unmarshal the message")
+
+				bobBalance := flashblock.Metadata.NewAccountBalances[strings.ToLower(bobAddress)]
+				if bobBalance != "" && bobBalance != "0x0" {
+					bobFlashblockTime = msg.timestamp
+					bobFlashblock = flashblock
+					observedBobBalance = bobBalance
+					break
+				}
+			}
+
+			require.NotNil(tt, bobFlashblock, "should have received a flashblock corresponding to Bob's receival of the funds")
+
+			txBlock, err := executedTransaction.IncludedBlock.Eval(ctx)
+			require.NoError(tt, err, "should be able to evaluate the block in which the transaction was included")
+
+			txBlockNum := int(txBlock.Number)                                   // block number of the block in which the transaction was included / confirmed
+			flashblockParentBlockNum := int(bobFlashblock.Metadata.BlockNumber) // block number of the parent block of the flashblock which first recorded the update in Bob's account balance (representative of the flashblock which included this transaction)
+
+			txBlockTimeSeconds := int64(txBlock.Time)             // timestamp of the block in which the transaction was included / confirmed
+			txFlashblockTimeInSeconds := bobFlashblockTime.Unix() // timestamp of the flashblock which supposedly included Bob's transaction
+
+			require.Equal(tt, observedBobBalance, expectedBobBalance, "Bob's balance must be correct as per exactly what Alice transferred to them")
+			require.Equal(tt, txBlockNum, flashblockParentBlockNum, "the transaction's block number should be the same as the flashblock's parent block number")
+			require.LessOrEqual(tt, txFlashblockTimeInSeconds, txBlockTimeSeconds, "the transaction's block time (in seconds) should be less than or equal to the flashblock's time (in seconds)")
+			require.Less(tt, bobFlashblockTime.UnixNano(), transactionApproxConfirmationTime.UnixNano(), "flashblock time should be before the transaction's (approximated) confirmation time")
+		})
+	}
+}

--- a/op-acceptance-tests/tests/flashblocks/utils.go
+++ b/op-acceptance-tests/tests/flashblocks/utils.go
@@ -31,7 +31,7 @@ const (
 	FlashblocksStreamMode_Follower FlashblocksStreamMode = "follower"
 )
 
-// UnmarshalJSON implements custom unmarshaling for Flashblock to lower case the keys of
+// UnmarshalJSON implements custom unmarshaling for Flashblock to lower case the keys of .metadata.new_account_balances.
 func (f *Flashblock) UnmarshalJSON(data []byte) error {
 	type TempFlashblock Flashblock // need a type alias to avoid infinite recursion
 	temp := (*TempFlashblock)(f)

--- a/op-acceptance-tests/tests/flashblocks/utils.go
+++ b/op-acceptance-tests/tests/flashblocks/utils.go
@@ -1,0 +1,53 @@
+package flashblocks
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type Flashblock struct {
+	PayloadID string `json:"payload_id"`
+	Index     int    `json:"index"`
+	Diff      struct {
+		StateRoot    string `json:"state_root"`
+		ReceiptsRoot string `json:"receipts_root"`
+		LogsBloom    string `json:"logs_bloom"`
+		GasUsed      string `json:"gas_used"`
+		BlockHash    string `json:"block_hash"`
+		Transactions []any  `json:"transactions"`
+		Withdrawals  []any  `json:"withdrawals"`
+	} `json:"diff"`
+	Metadata struct {
+		BlockNumber        int                    `json:"block_number"`
+		NewAccountBalances map[string]string      `json:"new_account_balances"`
+		Receipts           map[string]interface{} `json:"receipts"`
+	} `json:"metadata"`
+}
+
+type FlashblocksStreamMode string
+
+const (
+	FlashblocksStreamMode_Leader   FlashblocksStreamMode = "leader"
+	FlashblocksStreamMode_Follower FlashblocksStreamMode = "follower"
+)
+
+// UnmarshalJSON implements custom unmarshaling for Flashblock to lower case the keys of
+func (f *Flashblock) UnmarshalJSON(data []byte) error {
+	type TempFlashblock Flashblock // need a type alias to avoid infinite recursion
+	temp := (*TempFlashblock)(f)
+
+	if err := json.Unmarshal(data, temp); err != nil {
+		return err
+	}
+	if f.Metadata.NewAccountBalances == nil {
+		return nil
+	}
+
+	loweredBalances := make(map[string]string)
+	for key, value := range f.Metadata.NewAccountBalances {
+		loweredBalances[strings.ToLower(key)] = value
+	}
+	f.Metadata.NewAccountBalances = loweredBalances
+
+	return nil
+}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -15,6 +15,9 @@ type SimpleFlashblocks struct {
 
 	ConductorSets          map[stack.L2NetworkID]dsl.ConductorSet
 	FlashblocksBuilderSets map[stack.L2NetworkID]dsl.FlashblocksBuilderSet
+	Faucets                map[stack.L2NetworkID]*dsl.Faucet
+	Funders                map[stack.L2NetworkID]*dsl.Funder
+	L2ELNodes              map[stack.L2NetworkID]*dsl.L2ELNode
 }
 
 func WithSimpleFlashblocks() stack.CommonOption {
@@ -31,18 +34,33 @@ func NewSimpleFlashblocks(t devtest.T) *SimpleFlashblocks {
 	orch := Orchestrator()
 	orch.Hydrate(system)
 	chains := system.L2Networks()
+
+	minimalPreset := NewMinimal(t)
+
 	conductorSets := make(map[stack.L2NetworkID]dsl.ConductorSet)
 	flashblocksBuilderSets := make(map[stack.L2NetworkID]dsl.FlashblocksBuilderSet)
+	faucets := make(map[stack.L2NetworkID]*dsl.Faucet)
+	funders := make(map[stack.L2NetworkID]*dsl.Funder)
+	l2ELNodes := make(map[stack.L2NetworkID]*dsl.L2ELNode)
+
 	for _, chain := range chains {
 		chainMatcher := match.L2ChainById(chain.ID())
 		l2 := system.L2Network(match.Assume(t, chainMatcher))
+		firstELNode := dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL))
+		firstFaucet := dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet)))
 
 		conductorSets[chain.ID()] = dsl.NewConductorSet(l2.Conductors())
 		flashblocksBuilderSets[chain.ID()] = dsl.NewFlashblocksBuilderSet(l2.FlashblocksBuilders())
+		faucets[chain.ID()] = firstFaucet
+		funders[chain.ID()] = dsl.NewFunder(minimalPreset.Wallet, firstFaucet, firstELNode)
+		l2ELNodes[chain.ID()] = firstELNode
 	}
 	return &SimpleFlashblocks{
-		Minimal:                NewMinimal(t),
+		Minimal:                minimalPreset,
 		ConductorSets:          conductorSets,
 		FlashblocksBuilderSets: flashblocksBuilderSets,
+		Faucets:                faucets,
+		Funders:                funders,
+		L2ELNodes:              l2ELNodes,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

This test concurrently:
- listens to flashblocks stream and collect all the flashblocks across a window of 20s
- Makes a transaction from Alice to Bob with a pre-known amount and records an approximation txn confirmation time (with upto nanosecond granularity) just after that txn was done.

Expectation:
- By the time flashblock streaming is done (20s), the transaction was included in a block.
- There must have been a flashblock containing a new_account_balance corresponding to Bob's account.
- The flashblock's time in seconds must be less than or equal to the transaction's block time (in seconds). (Can't check the block time beyond the granularity of seconds)
- The flashblock time in nanoseconds must be before the approximated transaction confirmation time recorded previously.