### PR TITLE
faucet_balance RPC and fund insufficiency check on requestETH

### DIFF
--- a/op-faucet/faucet/backend/faucet.go
+++ b/op-faucet/faucet/backend/faucet.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-faucet/faucet/backend/config"
 	ftypes "github.com/ethereum-optimism/optimism/op-faucet/faucet/backend/types"
 	"github.com/ethereum-optimism/optimism/op-faucet/faucet/frontend"
 	"github.com/ethereum-optimism/optimism/op-faucet/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
@@ -24,9 +26,10 @@ type Faucet struct {
 	log log.Logger
 	m   metrics.Metricer
 
-	id      ftypes.FaucetID
-	chainID eth.ChainID
-	txMgr   txmgr.TxManager
+	id       ftypes.FaucetID
+	chainID  eth.ChainID
+	txMgr    txmgr.TxManager
+	elClient apis.EthBalance
 
 	// true when the faucet is disabled and may not serve any new faucet requests
 	disabled bool
@@ -44,16 +47,21 @@ func FaucetFromConfig(logger log.Logger, m metrics.Metricer, fID ftypes.FaucetID
 	if err != nil {
 		return nil, fmt.Errorf("failed to start tx manager: %w", err)
 	}
-	return faucetWithTxManager(logger, m, fID, txMgr), nil
+	elClient, err := ethclient.Dial(fCfg.ELRPC.Value.RPC())
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial EL client: %w", err)
+	}
+	return faucetWithTxManager(logger, m, fID, txMgr, elClient), nil
 }
 
-func faucetWithTxManager(logger log.Logger, m metrics.Metricer, fID ftypes.FaucetID, txMgr txmgr.TxManager) *Faucet {
+func faucetWithTxManager(logger log.Logger, m metrics.Metricer, fID ftypes.FaucetID, txMgr txmgr.TxManager, elClient apis.EthBalance) *Faucet {
 	return &Faucet{
 		log:      logger,
 		m:        m,
 		id:       fID,
 		chainID:  txMgr.ChainID(),
 		txMgr:    txMgr,
+		elClient: elClient,
 		disabled: false,
 	}
 }
@@ -78,6 +86,18 @@ func (f *Faucet) Close() {
 	f.txMgr.Close()
 }
 
+func (f *Faucet) Balance() (eth.ETH, error) {
+	wallet := f.txMgr.From()
+	balance, err := f.elClient.BalanceAt(context.Background(), wallet, nil)
+
+	var ethBalance eth.ETH
+	if err != nil {
+		f.log.Error("Failed to get balance", "err", err)
+		return ethBalance, err
+	}
+	return eth.WeiBig(balance), nil
+}
+
 func (f *Faucet) ChainID() eth.ChainID {
 	return f.chainID
 }
@@ -93,6 +113,16 @@ func (f *Faucet) RequestETH(ctx context.Context, request *ftypes.FaucetRequest) 
 	}
 
 	logger.Info("Sending funds")
+
+	balance, err := f.Balance()
+	if err != nil {
+		logger.Warn("Failed to get balance, optimistically continuing the request")
+	} else {
+		if balance.ToBig().Cmp(request.Amount.ToBig()) < 0 {
+			logger.Info("Insufficient balance", "balance", balance.String(), "amount", request.Amount)
+			return errors.New("insufficient balance")
+		}
+	}
 
 	onDone := f.m.RecordFundAction(f.id, f.chainID, request.Amount)
 	defer func() {

--- a/op-faucet/faucet/backend/faucet.go
+++ b/op-faucet/faucet/backend/faucet.go
@@ -119,7 +119,7 @@ func (f *Faucet) RequestETH(ctx context.Context, request *ftypes.FaucetRequest) 
 		logger.Warn("Failed to get balance, optimistically continuing the request")
 	} else {
 		if balance.ToBig().Cmp(request.Amount.ToBig()) < 0 {
-			logger.Info("Insufficient balance", "balance", balance.String(), "amount", request.Amount)
+			logger.Error("Insufficient balance", "balance", balance.String(), "amount", request.Amount)
 			return errors.New("insufficient balance")
 		}
 	}

--- a/op-faucet/faucet/backend/faucet_test.go
+++ b/op-faucet/faucet/backend/faucet_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-faucet/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/mocks"
 )
@@ -22,16 +23,28 @@ import (
 func TestFaucet(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelInfo)
 	m := &metrics.NoopMetrics{}
-	fID := ftypes.FaucetID("foo")
-	txMgr := mocks.NewTxManager(t)
+
 	chainID := eth.ChainIDFromUInt64(123)
+	fID := ftypes.FaucetID("foo")
+	faucetAddr := common.HexToAddress("0x742d35Cc6634C0532925a3b8D0C9964E5Bade11E")
+	intendedFaucetBalance := eth.HundredEther.Add(eth.Ether(1)) // 101 eth
+
+	txMgr := mocks.NewTxManager(t)
+	txMgr.On("From").Return(faucetAddr)
 	txMgr.On("ChainID").Return(chainID)
-	f := faucetWithTxManager(logger, m, fID, txMgr)
+
+	simulatedEthClient := testutils.NewSimulatedEthClient(testutils.WithAccountBalance(txMgr.From(), intendedFaucetBalance.ToBig()))
+	f := faucetWithTxManager(logger, m, fID, txMgr, simulatedEthClient.Client)
+
+	observedFaucetBalance, err := f.Balance()
+	require.NoError(t, err, "faucet balance should be returned successfully")
+	require.Equal(t, intendedFaucetBalance, observedFaucetBalance, "faucet balance should be 100 ether")
+
 	require.Equal(t, chainID, f.ChainID())
 
 	req := &ftypes.FaucetRequest{
 		Target: common.HexToAddress("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"),
-		Amount: eth.Ether(123),
+		Amount: eth.Ether(50),
 	}
 
 	txMgr.On("Send", mock.Anything, mock.Anything).
@@ -40,10 +53,12 @@ func TestFaucet(t *testing.T) {
 			require.Nil(t, candidate.To, "must not do naive eth send")
 			require.Equal(t, req.Amount, eth.WeiBig(candidate.Value))
 		}).
-		Return(&types.Receipt{Status: types.ReceiptStatusSuccessful, TxHash: common.Hash{}}, nil).
-		Once()
+		Return(&types.Receipt{Status: types.ReceiptStatusSuccessful, TxHash: common.Hash{}}, nil)
 
 	require.NoError(t, f.RequestETH(context.Background(), req))
+
+	req.Amount = intendedFaucetBalance.Add(eth.Ether(1)) // making a transfer beyond the faucet's balance
+	require.ErrorContains(t, f.RequestETH(context.Background(), req), "insufficient balance")
 
 	f.Disable()
 	require.ErrorContains(t, f.RequestETH(context.Background(), req), "disabled")

--- a/op-faucet/faucet/frontend/faucet.go
+++ b/op-faucet/faucet/frontend/faucet.go
@@ -14,6 +14,7 @@ import (
 type FaucetBackend interface {
 	ChainID() eth.ChainID
 	RequestETH(ctx context.Context, request *ftypes.FaucetRequest) error
+	Balance() (eth.ETH, error)
 }
 
 type FaucetFrontend struct {
@@ -38,4 +39,8 @@ func (f *FaucetFrontend) RequestETH(ctx context.Context, addr common.Address, am
 		Amount:  amount,
 	}
 	return f.b.RequestETH(ctx, request)
+}
+
+func (f *FaucetFrontend) Balance(ctx context.Context) (eth.ETH, error) {
+	return f.b.Balance()
 }

--- a/op-service/apis/faucet.go
+++ b/op-service/apis/faucet.go
@@ -10,4 +10,5 @@ import (
 type Faucet interface {
 	ChainID(ctx context.Context) (eth.ChainID, error)
 	RequestETH(ctx context.Context, addr common.Address, amount eth.ETH) error
+	Balance(ctx context.Context) (eth.ETH, error)
 }

--- a/op-service/sources/faucet_client.go
+++ b/op-service/sources/faucet_client.go
@@ -30,3 +30,9 @@ func (cl *FaucetClient) ChainID(ctx context.Context) (eth.ChainID, error) {
 func (cl *FaucetClient) RequestETH(ctx context.Context, addr common.Address, amount eth.ETH) error {
 	return cl.client.CallContext(ctx, nil, "faucet_requestETH", addr, amount)
 }
+
+func (cl *FaucetClient) Balance(ctx context.Context) (eth.ETH, error) {
+	var result eth.ETH
+	err := cl.client.CallContext(ctx, &result, "faucet_balance")
+	return result, err
+}

--- a/op-service/testutils/simulated_eth_client.go
+++ b/op-service/testutils/simulated_eth_client.go
@@ -1,0 +1,109 @@
+package testutils
+
+import (
+	"context"
+	"encoding/hex"
+	"log"
+	"maps"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+)
+
+type SimulatedEthClient struct {
+	defaultAccountPvtKey string
+	defaultAccountAddr   common.Address
+	backend              *simulated.Backend
+	simulated.Client
+}
+
+type SimulatedEthClientConfig struct {
+	GenesisAccountsBalances map[common.Address]*big.Int
+	BlockGasLimit           uint64
+}
+
+func defaultSimulatedEthClientConfig() *SimulatedEthClientConfig {
+	return &SimulatedEthClientConfig{
+		GenesisAccountsBalances: map[common.Address]*big.Int{},
+		BlockGasLimit:           10000000,
+	}
+}
+
+func WithAccountBalance(address common.Address, balance *big.Int) func(*SimulatedEthClientConfig) {
+	return func(c *SimulatedEthClientConfig) {
+		c.GenesisAccountsBalances[address] = balance
+	}
+}
+
+func WithAccountsBalances(balances map[common.Address]*big.Int) func(*SimulatedEthClientConfig) {
+	return func(c *SimulatedEthClientConfig) {
+		maps.Copy(balances, c.GenesisAccountsBalances)
+	}
+}
+
+func WithBlockGasLimit(limit uint64) func(*SimulatedEthClientConfig) {
+	return func(c *SimulatedEthClientConfig) {
+		c.BlockGasLimit = limit
+	}
+}
+
+func NewSimulatedEthClient(opts ...func(*SimulatedEthClientConfig)) *SimulatedEthClient {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfg := defaultSimulatedEthClientConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	genesisAlloc := types.GenesisAlloc{
+		auth.From: {
+			Balance: eth.HundredEther.ToBig(),
+		},
+	}
+	for addr, balance := range cfg.GenesisAccountsBalances {
+		genesisAlloc[addr] = types.Account{
+			Balance: balance,
+		}
+	}
+
+	backend := simulated.NewBackend(genesisAlloc, simulated.WithBlockGasLimit(cfg.BlockGasLimit))
+	return &SimulatedEthClient{
+		defaultAccountAddr:   auth.From,
+		defaultAccountPvtKey: hex.EncodeToString(crypto.FromECDSA(privateKey)),
+		backend:              backend,
+		Client:               backend.Client(),
+	}
+}
+
+func (c *SimulatedEthClient) RPC() string {
+	return "https://localhost:8545/apikeyfoobarbizzbuzz"
+}
+
+func (c *SimulatedEthClient) PrivateKey() string {
+	return c.defaultAccountPvtKey
+}
+
+func (c *SimulatedEthClient) Address() common.Address {
+	return c.defaultAccountAddr
+}
+
+func (c *SimulatedEthClient) Commit() {
+	c.backend.Commit()
+}
+
+func (c *SimulatedEthClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

- faucet_balance RPC which provides the current balance of the backing faucet
- faucet_requestETH to check the faucet balance before making the transaction
- Adds a simulated eth client for more realistic testing

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
