### PR TITLE
dispute-mon uses multiple supervisor nodes

### DIFF
--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -26,4 +26,10 @@ shows the available config options and can be accessed by running `./bin/op-disp
   --l1-eth-rpc <L1-Ethereum-RPC-URL> \
   --rollup-rpc <Optimism-Rollup-RPC-URL>,<Secondary-RPC-URL>,<Tertiary-RPC-URL>
 
+# For networks using op-supervisor:
+./bin/op-dispute-mon \
+  --network <Predefined-Network> \
+  --l1-eth-rpc <L1-Ethereum-RPC-URL> \
+  --supervisor-rpc <Supervisor-RPC-URL>,<Secondary-RPC-URL>,<Tertiary-RPC-URL>
+
 ```

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -94,6 +94,13 @@ func TestSupervisorRpc(t *testing.T) {
 		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supervisor-rpc", url))
 		require.Equal(t, []string{url}, cfg.SupervisorRpcs)
 	})
+
+	t.Run("MultipleValues", func(t *testing.T) {
+		url1 := "http://example1.com:9999"
+		url2 := "http://example2.com:8888"
+		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supervisor-rpc", url1, "--supervisor-rpc", url2))
+		require.Equal(t, []string{url1, url2}, cfg.SupervisorRpcs)
+	})
 }
 
 func TestGameFactoryAddress(t *testing.T) {

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	l1EthRpc                = "http://example.com:8545"
-	rollupRpc               = []string{"http://example.com:8555"}
+	rollupRpcs              = []string{"http://example.com:8555"}
 	gameFactoryAddressValue = "0xbb00000000000000000000000000000000000000"
 )
 
@@ -39,12 +39,12 @@ func TestLogLevel(t *testing.T) {
 
 func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs(t, addRequiredArgs())
-	defaultCfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, rollupRpc)
+	defaultCfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, rollupRpcs)
 	require.Equal(t, defaultCfg, cfg)
 }
 
 func TestDefaultConfigIsValid(t *testing.T) {
-	cfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, rollupRpc)
+	cfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, rollupRpcs)
 	require.NoError(t, cfg.Check())
 }
 
@@ -72,14 +72,14 @@ func TestRollupRpc(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		url := "http://example.com:9999"
 		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--rollup-rpc", url))
-		require.Equal(t, []string{url}, cfg.RollupRpc)
+		require.Equal(t, []string{url}, cfg.RollupRpcs)
 	})
 
 	t.Run("MultipleValues", func(t *testing.T) {
 		url1 := "http://example1.com:9999"
 		url2 := "http://example2.com:8888"
 		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--rollup-rpc", url1, "--rollup-rpc", url2))
-		require.Equal(t, []string{url1, url2}, cfg.RollupRpc)
+		require.Equal(t, []string{url1, url2}, cfg.RollupRpcs)
 	})
 }
 
@@ -312,7 +312,7 @@ func addRequiredArgsExcept(name string, optionalArgs ...string) []string {
 func requiredArgs() map[string]string {
 	args := map[string]string{
 		"--l1-eth-rpc":           l1EthRpc,
-		"--rollup-rpc":           strings.Join(rollupRpc, ","),
+		"--rollup-rpc":           strings.Join(rollupRpcs, ","),
 		"--game-factory-address": gameFactoryAddressValue,
 	}
 	return args

--- a/op-dispute-mon/cmd/main_test.go
+++ b/op-dispute-mon/cmd/main_test.go
@@ -92,7 +92,7 @@ func TestSupervisorRpc(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		url := "http://example.com:9999"
 		cfg := configForArgs(t, addRequiredArgsExcept("--rollup-rpc", "--supervisor-rpc", url))
-		require.Equal(t, url, cfg.SupervisorRpc)
+		require.Equal(t, []string{url}, cfg.SupervisorRpcs)
 	})
 }
 

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -40,7 +40,7 @@ type Config struct {
 
 	HonestActors    []common.Address // List of honest actors to monitor claims for.
 	RollupRpc       []string         // The rollup node RPC URLs.
-	SupervisorRpc   string           // The supervisor RPC URL.
+	SupervisorRpcs  []string         // The supervisor RPC URLs.
 	MonitorInterval time.Duration    // Frequency to check for new games to monitor.
 	GameWindow      time.Duration    // Maximum window to look for games to monitor.
 	IgnoredGames    []common.Address // Games to exclude from monitoring
@@ -50,19 +50,19 @@ type Config struct {
 	PprofConfig   oppprof.CLIConfig
 }
 
-func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, supervisorRpc string) Config {
-	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, nil, supervisorRpc)
+func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, supervisorRpcs []string) Config {
+	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, nil, supervisorRpcs)
 }
 
 func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string) Config {
-	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, rollupRpc, "")
+	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, rollupRpc, nil)
 }
 
-func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string, supervisorRpc string) Config {
+func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string, supervisorRpcs []string) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
 		RollupRpc:          rollupRpc,
-		SupervisorRpc:      supervisorRpc,
+		SupervisorRpcs:     supervisorRpcs,
 		GameFactoryAddress: gameFactoryAddress,
 
 		MonitorInterval: DefaultMonitorInterval,
@@ -78,7 +78,7 @@ func (c Config) Check() error {
 	if c.L1EthRpc == "" {
 		return ErrMissingL1EthRPC
 	}
-	if len(c.RollupRpc) == 0 && c.SupervisorRpc == "" {
+	if len(c.RollupRpc) == 0 && len(c.SupervisorRpcs) == 0 {
 		return ErrMissingRollupAndSupervisorRpc
 	}
 	if c.GameFactoryAddress == (common.Address{}) {

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	GameFactoryAddress common.Address // Address of the dispute game factory
 
 	HonestActors    []common.Address // List of honest actors to monitor claims for.
-	RollupRpc       []string         // The rollup node RPC URLs.
+	RollupRpcs      []string         // The rollup node RPC URLs.
 	SupervisorRpcs  []string         // The supervisor RPC URLs.
 	MonitorInterval time.Duration    // Frequency to check for new games to monitor.
 	GameWindow      time.Duration    // Maximum window to look for games to monitor.
@@ -54,14 +54,14 @@ func NewInteropConfig(gameFactoryAddress common.Address, l1EthRpc string, superv
 	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, nil, supervisorRpcs)
 }
 
-func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string) Config {
-	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, rollupRpc, nil)
+func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []string) Config {
+	return NewCombinedConfig(gameFactoryAddress, l1EthRpc, rollupRpcs, nil)
 }
 
-func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpc []string, supervisorRpcs []string) Config {
+func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []string, supervisorRpcs []string) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
-		RollupRpc:          rollupRpc,
+		RollupRpcs:          rollupRpcs,
 		SupervisorRpcs:     supervisorRpcs,
 		GameFactoryAddress: gameFactoryAddress,
 
@@ -78,7 +78,7 @@ func (c Config) Check() error {
 	if c.L1EthRpc == "" {
 		return ErrMissingL1EthRPC
 	}
-	if len(c.RollupRpc) == 0 && len(c.SupervisorRpcs) == 0 {
+	if len(c.RollupRpcs) == 0 && len(c.SupervisorRpcs) == 0 {
 		return ErrMissingRollupAndSupervisorRpc
 	}
 	if c.GameFactoryAddress == (common.Address{}) {

--- a/op-dispute-mon/config/config.go
+++ b/op-dispute-mon/config/config.go
@@ -61,7 +61,7 @@ func NewConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []
 func NewCombinedConfig(gameFactoryAddress common.Address, l1EthRpc string, rollupRpcs []string, supervisorRpcs []string) Config {
 	return Config{
 		L1EthRpc:           l1EthRpc,
-		RollupRpcs:          rollupRpcs,
+		RollupRpcs:         rollupRpcs,
 		SupervisorRpcs:     supervisorRpcs,
 		GameFactoryAddress: gameFactoryAddress,
 

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -61,3 +61,37 @@ func TestMaxConcurrencyRequired(t *testing.T) {
 	config.MaxConcurrency = 0
 	require.ErrorIs(t, config.Check(), ErrMissingMaxConcurrency)
 }
+
+func TestMultipleSupervisorRpcs(t *testing.T) {
+	config := validConfig()
+	config.RollupRpc = nil
+	config.SupervisorRpcs = []string{"http://localhost:8999", "http://localhost:9000", "http://localhost:9001"}
+	require.NoError(t, config.Check())
+}
+
+func TestInteropConfig(t *testing.T) {
+	gameFactoryAddr := common.Address{0x42}
+	l1RPC := "http://localhost:8545"
+	supervisorRpcs := []string{"http://localhost:8999", "http://localhost:9000"}
+
+	config := NewInteropConfig(gameFactoryAddr, l1RPC, supervisorRpcs)
+	require.Equal(t, gameFactoryAddr, config.GameFactoryAddress)
+	require.Equal(t, l1RPC, config.L1EthRpc)
+	require.Equal(t, supervisorRpcs, config.SupervisorRpcs)
+	require.Nil(t, config.RollupRpc)
+	require.NoError(t, config.Check())
+}
+
+func TestCombinedConfig(t *testing.T) {
+	gameFactoryAddr := common.Address{0x42}
+	l1RPC := "http://localhost:8545"
+	rollupRpcs := []string{"http://localhost:8555"}
+	supervisorRpcs := []string{"http://localhost:8999"}
+
+	config := NewCombinedConfig(gameFactoryAddr, l1RPC, rollupRpcs, supervisorRpcs)
+	require.Equal(t, gameFactoryAddr, config.GameFactoryAddress)
+	require.Equal(t, l1RPC, config.L1EthRpc)
+	require.Equal(t, rollupRpcs, config.RollupRpc)
+	require.Equal(t, supervisorRpcs, config.SupervisorRpcs)
+	require.NoError(t, config.Check())
+}

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -11,12 +11,12 @@ import (
 var (
 	validL1EthRpc           = "http://localhost:8545"
 	validGameFactoryAddress = common.Address{0x23}
-	validRollupRpc          = []string{"http://localhost:8555"}
+	validRollupRpcs         = []string{"http://localhost:8555"}
 	validSupervisorRpcs     = []string{"http://localhost:8999"}
 )
 
 func validConfig() Config {
-	return NewConfig(validGameFactoryAddress, validL1EthRpc, validRollupRpc)
+	return NewConfig(validGameFactoryAddress, validL1EthRpc, validRollupRpcs)
 }
 
 func TestValidConfigIsValid(t *testing.T) {
@@ -37,21 +37,21 @@ func TestGameFactoryAddressRequired(t *testing.T) {
 
 func TestRollupRpcOrSupervisorRpcRequired(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = nil
+	config.RollupRpcs = nil
 	config.SupervisorRpcs = nil
 	require.ErrorIs(t, config.Check(), ErrMissingRollupAndSupervisorRpc)
 }
 
 func TestRollupRpcNotRequiredWhenSupervisorRpcSet(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = nil
+	config.RollupRpcs = nil
 	config.SupervisorRpcs = validSupervisorRpcs
 	require.NoError(t, config.Check())
 }
 
 func TestSupervisorRpcNotRequiredWhenRollupRpcSet(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = validRollupRpc
+	config.RollupRpcs = validRollupRpcs
 	config.SupervisorRpcs = nil
 	require.NoError(t, config.Check())
 }
@@ -64,7 +64,7 @@ func TestMaxConcurrencyRequired(t *testing.T) {
 
 func TestMultipleSupervisorRpcs(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = nil
+	config.RollupRpcs = nil
 	config.SupervisorRpcs = []string{"http://localhost:8999", "http://localhost:9000", "http://localhost:9001"}
 	require.NoError(t, config.Check())
 }
@@ -78,7 +78,7 @@ func TestInteropConfig(t *testing.T) {
 	require.Equal(t, gameFactoryAddr, config.GameFactoryAddress)
 	require.Equal(t, l1RPC, config.L1EthRpc)
 	require.Equal(t, supervisorRpcs, config.SupervisorRpcs)
-	require.Nil(t, config.RollupRpc)
+	require.Nil(t, config.RollupRpcs)
 	require.NoError(t, config.Check())
 }
 
@@ -91,7 +91,7 @@ func TestCombinedConfig(t *testing.T) {
 	config := NewCombinedConfig(gameFactoryAddr, l1RPC, rollupRpcs, supervisorRpcs)
 	require.Equal(t, gameFactoryAddr, config.GameFactoryAddress)
 	require.Equal(t, l1RPC, config.L1EthRpc)
-	require.Equal(t, rollupRpcs, config.RollupRpc)
+	require.Equal(t, rollupRpcs, config.RollupRpcs)
 	require.Equal(t, supervisorRpcs, config.SupervisorRpcs)
 	require.NoError(t, config.Check())
 }

--- a/op-dispute-mon/config/config_test.go
+++ b/op-dispute-mon/config/config_test.go
@@ -12,7 +12,7 @@ var (
 	validL1EthRpc           = "http://localhost:8545"
 	validGameFactoryAddress = common.Address{0x23}
 	validRollupRpc          = []string{"http://localhost:8555"}
-	validSupervisorRpc      = "http://localhost:8999"
+	validSupervisorRpcs     = []string{"http://localhost:8999"}
 )
 
 func validConfig() Config {
@@ -37,22 +37,22 @@ func TestGameFactoryAddressRequired(t *testing.T) {
 
 func TestRollupRpcOrSupervisorRpcRequired(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = []string{}
-	config.SupervisorRpc = ""
+	config.RollupRpc = nil
+	config.SupervisorRpcs = nil
 	require.ErrorIs(t, config.Check(), ErrMissingRollupAndSupervisorRpc)
 }
 
 func TestRollupRpcNotRequiredWhenSupervisorRpcSet(t *testing.T) {
 	config := validConfig()
-	config.RollupRpc = []string{}
-	config.SupervisorRpc = validSupervisorRpc
+	config.RollupRpc = nil
+	config.SupervisorRpcs = validSupervisorRpcs
 	require.NoError(t, config.Check())
 }
 
 func TestSupervisorRpcNotRequiredWhenRollupRpcSet(t *testing.T) {
 	config := validConfig()
 	config.RollupRpc = validRollupRpc
-	config.SupervisorRpc = ""
+	config.SupervisorRpcs = nil
 	require.NoError(t, config.Check())
 }
 

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -168,7 +168,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 	return &config.Config{
 		L1EthRpc:           ctx.String(L1EthRpcFlag.Name),
 		GameFactoryAddress: gameFactoryAddress,
-		RollupRpc:          ctx.StringSlice(RollupRpcFlag.Name),
+		RollupRpcs:         ctx.StringSlice(RollupRpcFlag.Name),
 		SupervisorRpcs:     ctx.StringSlice(SupervisorRpcFlag.Name),
 
 		HonestActors:    actors,

--- a/op-dispute-mon/flags/flags.go
+++ b/op-dispute-mon/flags/flags.go
@@ -38,9 +38,9 @@ var (
 		Usage:   "HTTP provider URL for the rollup node. Multiple URLs can be specified for redundancy.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
-	SupervisorRpcFlag = &cli.StringFlag{
+	SupervisorRpcFlag = &cli.StringSliceFlag{
 		Name:    "supervisor-rpc",
-		Usage:   "HTTP provider URL for the supervisor node",
+		Usage:   "HTTP provider URL for supervisor nodes. Multiple URLs can be specified for redundancy.",
 		EnvVars: prefixEnvVars("SUPERVISOR_RPC"),
 	}
 	GameFactoryAddressFlag = &cli.StringFlag{
@@ -119,7 +119,7 @@ func CheckRequired(ctx *cli.Context) error {
 			return fmt.Errorf("flag %s is required", f.Names()[0])
 		}
 	}
-	if len(ctx.StringSlice(RollupRpcFlag.Name)) == 0 && !ctx.IsSet(SupervisorRpcFlag.Name) {
+	if len(ctx.StringSlice(RollupRpcFlag.Name)) == 0 && len(ctx.StringSlice(SupervisorRpcFlag.Name)) == 0 {
 		return fmt.Errorf("flag %s or %s is required", RollupRpcFlag.Name, SupervisorRpcFlag.Name)
 	}
 	return nil
@@ -169,7 +169,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 		L1EthRpc:           ctx.String(L1EthRpcFlag.Name),
 		GameFactoryAddress: gameFactoryAddress,
 		RollupRpc:          ctx.StringSlice(RollupRpcFlag.Name),
-		SupervisorRpc:      ctx.String(SupervisorRpcFlag.Name),
+		SupervisorRpcs:     ctx.StringSlice(SupervisorRpcFlag.Name),
 
 		HonestActors:    actors,
 		MonitorInterval: ctx.Duration(MonitorIntervalFlag.Name),

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -16,7 +17,8 @@ import (
 )
 
 var (
-	ErrSupervisorRpcRequired = errors.New("supervisor rpc required")
+	ErrSupervisorRpcRequired         = errors.New("supervisor rpc required")
+	ErrAllSupervisorNodesUnavailable = errors.New("all supervisor nodes returned errors")
 )
 
 type SuperRootProvider interface {
@@ -26,40 +28,119 @@ type SuperRootProvider interface {
 type SuperAgreementEnricher struct {
 	log     log.Logger
 	metrics OutputMetrics
-	client  SuperRootProvider
+	clients []SuperRootProvider
 	clock   clock.Clock
 }
 
-func NewSuperAgreementEnricher(logger log.Logger, metrics OutputMetrics, client SuperRootProvider, cl clock.Clock) *SuperAgreementEnricher {
+func NewSuperAgreementEnricher(logger log.Logger, metrics OutputMetrics, clients []SuperRootProvider, cl clock.Clock) *SuperAgreementEnricher {
 	return &SuperAgreementEnricher{
 		log:     logger,
 		metrics: metrics,
-		client:  client,
+		clients: clients,
 		clock:   cl,
 	}
+}
+
+type superRootResult struct {
+	superRoot            common.Hash
+	isSafe               bool
+	notFound             bool
+	err                  error
+	crossSafeDerivedFrom uint64
 }
 
 func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
 	if game.UsesOutputRoots() {
 		return nil
 	}
-	if e.client == nil {
+	if len(e.clients) == 0 {
 		return fmt.Errorf("%w but required for game type %v", ErrSupervisorRpcRequired, game.GameType)
 	}
-	response, err := e.client.SuperRootAtTimestamp(ctx, hexutil.Uint64(game.L2BlockNumber))
-	if errors.Is(err, ethereum.NotFound) {
-		// Super root doesn't exist, so we must disagree with it.
-		game.AgreeWithClaim = false
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("failed to retrieve super root at timestamp %v: %w", game.L2BlockNumber, err)
+
+	results := make([]superRootResult, len(e.clients))
+	var wg sync.WaitGroup
+	for i, client := range e.clients {
+		wg.Add(1)
+		go func(i int, client SuperRootProvider) {
+			defer wg.Done()
+			response, err := client.SuperRootAtTimestamp(ctx, hexutil.Uint64(game.L2BlockNumber))
+			if errors.Is(err, ethereum.NotFound) {
+				results[i] = superRootResult{notFound: true}
+				return
+			}
+			if err != nil {
+				results[i] = superRootResult{err: err}
+				return
+			}
+
+			superRoot := common.Hash(response.SuperRoot)
+			results[i] = superRootResult{
+				superRoot:            superRoot,
+				crossSafeDerivedFrom: response.CrossSafeDerivedFrom.Number,
+				isSafe:               response.CrossSafeDerivedFrom.Number <= game.L1HeadNum,
+			}
+		}(i, client)
 	}
+	wg.Wait()
+
+	validResults := make([]superRootResult, 0, len(results))
+	syncedResults := make([]superRootResult, 0, len(results))
+	for idx, result := range results {
+		if result.err != nil {
+			e.log.Error("Failed to fetch super root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
+			continue
+		}
+
+		validResults = append(validResults, result)
+
+		if result.notFound {
+			e.log.Warn("Supervisor node is out of sync", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber)
+		} else {
+			syncedResults = append(syncedResults, result)
+		}
+	}
+
+	// If all results were errors, return an error
+	if len(validResults) == 0 {
+		return fmt.Errorf("failed to get super root at timestamp: %w", ErrAllSupervisorNodesUnavailable)
+	}
+
+	// If all remaining nodes returned "not found", set game.AgreeWithClaim = false
+	if len(syncedResults) == 0 {
+		game.AgreeWithClaim = false
+		game.ExpectedRootClaim = common.Hash{}
+		return nil
+	}
+
+	// Check if nodes have diverged
+	firstSuperRoot := syncedResults[0].superRoot
+	diverged := false
+	for _, result := range syncedResults[1:] {
+		if result.superRoot != firstSuperRoot {
+			diverged = true
+			break
+		}
+	}
+
+	if diverged {
+		e.log.Error("Supervisor nodes have diverged", "firstNodeSuperRoot", firstSuperRoot)
+		// Use the result from the first node in the list
+		game.ExpectedRootClaim = firstSuperRoot
+		game.AgreeWithClaim = firstSuperRoot == game.RootClaim && syncedResults[0].isSafe
+	} else {
+		// All nodes agree on the super root
+		game.ExpectedRootClaim = firstSuperRoot
+		// Consider the super root "safe" if any node reported it as safe
+		isSafe := false
+		for _, result := range syncedResults {
+			if result.isSafe {
+				isSafe = true
+				break
+			}
+		}
+		game.AgreeWithClaim = firstSuperRoot == game.RootClaim && isSafe
+	}
+
 	e.metrics.RecordOutputFetchTime(float64(e.clock.Now().Unix()))
-	game.ExpectedRootClaim = common.Hash(response.SuperRoot)
-	if game.RootClaim != game.ExpectedRootClaim {
-		game.AgreeWithClaim = false
-		return nil
-	}
-	game.AgreeWithClaim = response.CrossSafeDerivedFrom.Number <= game.L1HeadNum
 	return nil
 }

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -103,7 +103,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 		return fmt.Errorf("failed to get super root at timestamp: %w", ErrAllSupervisorNodesUnavailable)
 	}
 
-	// If all remaining nodes returned "not found", set game.AgreeWithClaim = false
+	// If all remaining nodes returned "not found", we disagree with any claim.
 	if len(foundResults) == 0 {
 		game.AgreeWithClaim = false
 		game.ExpectedRootClaim = common.Hash{}

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -84,7 +84,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 	wg.Wait()
 
 	validResults := make([]superRootResult, 0, len(results))
-	syncedResults := make([]superRootResult, 0, len(results))
+	foundResults := make([]superRootResult, 0, len(results))
 	for idx, result := range results {
 		if result.err != nil {
 			e.log.Error("Failed to fetch super root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
@@ -93,10 +93,8 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 
 		validResults = append(validResults, result)
 
-		if result.notFound {
-			e.log.Warn("Supervisor node is out of sync", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber)
-		} else {
-			syncedResults = append(syncedResults, result)
+		if !result.notFound {
+			foundResults = append(foundResults, result)
 		}
 	}
 
@@ -106,41 +104,65 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 	}
 
 	// If all remaining nodes returned "not found", set game.AgreeWithClaim = false
-	if len(syncedResults) == 0 {
+	if len(foundResults) == 0 {
 		game.AgreeWithClaim = false
 		game.ExpectedRootClaim = common.Hash{}
 		return nil
 	}
 
-	// Check if nodes have diverged
-	firstSuperRoot := syncedResults[0].superRoot
-	diverged := false
-	for _, result := range syncedResults[1:] {
-		if result.superRoot != firstSuperRoot {
-			diverged = true
-			break
+	// At least one node returned a super root, record the fetch time.
+	e.metrics.RecordOutputFetchTime(float64(e.clock.Now().Unix()))
+
+	// Check for disagreements among nodes.
+	// A disagreement is any of:
+	// - Mixed "found" and "not found" responses.
+	// - Different super roots from nodes that found data.
+	firstResult := foundResults[0]
+	diverged := len(foundResults) < len(validResults)
+	if !diverged {
+		for _, result := range foundResults[1:] {
+			if result.superRoot != firstResult.superRoot {
+				diverged = true
+				break
+			}
 		}
 	}
 
 	if diverged {
-		e.log.Error("Supervisor nodes have diverged", "firstNodeSuperRoot", firstSuperRoot)
-		// Use the result from the first node in the list
-		game.ExpectedRootClaim = firstSuperRoot
-		game.AgreeWithClaim = firstSuperRoot == game.RootClaim && syncedResults[0].isSafe
-	} else {
-		// All nodes agree on the super root
-		game.ExpectedRootClaim = firstSuperRoot
-		// Consider the super root "safe" if any node reported it as safe
-		isSafe := false
-		for _, result := range syncedResults {
-			if result.isSafe {
-				isSafe = true
-				break
-			}
-		}
-		game.AgreeWithClaim = firstSuperRoot == game.RootClaim && isSafe
+		e.log.Warn("Supervisor nodes disagree on super root",
+			"l2BlockNum", game.L2BlockNumber,
+			"firstSuperRoot", firstResult.superRoot,
+			"found", len(foundResults),
+			"valid", len(validResults))
+		game.AgreeWithClaim = false
+		game.ExpectedRootClaim = firstResult.superRoot
+		return nil
 	}
 
-	e.metrics.RecordOutputFetchTime(float64(e.clock.Now().Unix()))
+	// All nodes that found a super root agree on the root.
+	// Now check if the super root is considered safe by at least one node.
+	atLeastOneSafe := false
+	for _, result := range foundResults {
+		if result.isSafe {
+			atLeastOneSafe = true
+			break
+		}
+	}
+
+	// If no node considers the super root safe, we disagree.
+	if !atLeastOneSafe {
+		game.AgreeWithClaim = false
+		if firstResult.superRoot == game.RootClaim {
+			game.ExpectedRootClaim = common.Hash{}
+		} else {
+			game.ExpectedRootClaim = firstResult.superRoot
+		}
+		return nil
+	}
+
+	// All nodes agree and at least one considers the super root safe.
+	// We agree with the claim if the game's root claim matches.
+	game.ExpectedRootClaim = firstResult.superRoot
+	game.AgreeWithClaim = game.RootClaim == firstResult.superRoot
 	return nil
 }

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -25,7 +25,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 
 	t.Run("ErrorWhenNoSupervisorClient", func(t *testing.T) {
 		validator, _, _ := setupSuperValidatorTest(t)
-		validator.client = nil
+		validator.clients = nil // Set to nil to test the error case
 		game := &types.EnrichedGameData{
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
@@ -44,7 +44,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {
 				validator, _, metrics := setupSuperValidatorTest(t)
-				validator.client = nil // Should not error even though there's no rollup client
+				validator.clients = nil // Should not error even though there's no supervisor client
 				game := &types.EnrichedGameData{
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
@@ -93,7 +93,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			RootClaim:     mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.ErrorIs(t, err, rollup.outputErr)
+		require.ErrorIs(t, err, ErrAllSupervisorNodesUnavailable)
 		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)
@@ -206,20 +206,160 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)
 	})
+
+	t.Run("AllSupervisorNodesReturnError", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		for _, client := range clients {
+			client.outputErr = errors.New("boom")
+		}
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrAllSupervisorNodesUnavailable)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.Zero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllSupervisorNodesReturnNotFound", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		for _, client := range clients {
+			client.outputErr = ethereum.NotFound
+		}
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     100,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.Zero(t, metrics.fetchTime)
+	})
+
+	t.Run("SomeSupervisorNodesOutOfSync", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		clients[0].outputErr = ethereum.NotFound
+		clients[1].outputErr = nil
+		clients[2].outputErr = nil
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.True(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("SupervisorNodesDiverged_FirstNodeAgrees", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		divergedRoot := common.HexToHash("0x5678")
+		clients[0].superRoot = mockRootClaim
+		clients[1].superRoot = divergedRoot
+		clients[2].superRoot = divergedRoot
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.True(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("SupervisorNodesDiverged_FirstNodeDisagrees", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		divergedRoot := common.HexToHash("0x5678")
+		clients[0].superRoot = divergedRoot
+		clients[1].superRoot = mockRootClaim
+		clients[2].superRoot = mockRootClaim
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.NotEqual(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllSupervisorNodesAgree", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		clients[0].derivedFromL1BlockNum = 200
+		clients[1].derivedFromL1BlockNum = 199
+		clients[2].derivedFromL1BlockNum = 201
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 0,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.True(t, game.AgreeWithClaim) // Should be true because at least one node reports it as safe
+		require.NotZero(t, metrics.fetchTime)
+	})
 }
 
 func setupSuperValidatorTest(t *testing.T) (*SuperAgreementEnricher, *stubSupervisorClient, *stubOutputMetrics) {
 	logger := testlog.Logger(t, log.LvlInfo)
-	client := &stubSupervisorClient{derivedFromL1BlockNum: 0}
+	client := &stubSupervisorClient{derivedFromL1BlockNum: 0, superRoot: mockRootClaim}
 	metrics := &stubOutputMetrics{}
-	validator := NewSuperAgreementEnricher(logger, metrics, client, clock.NewDeterministicClock(time.Unix(9824924, 499)))
+	validator := NewSuperAgreementEnricher(logger, metrics, []SuperRootProvider{client}, clock.NewDeterministicClock(time.Unix(9824924, 499)))
 	return validator, client, metrics
+}
+
+func setupMultiSupervisorTest(t *testing.T, numNodes int) (*SuperAgreementEnricher, []*stubSupervisorClient, *stubOutputMetrics) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	clients := make([]*stubSupervisorClient, numNodes)
+	supervisorClients := make([]SuperRootProvider, numNodes)
+	for i := range clients {
+		clients[i] = &stubSupervisorClient{
+			derivedFromL1BlockNum: 0,
+			superRoot:             mockRootClaim,
+		}
+		supervisorClients[i] = clients[i]
+	}
+	metrics := &stubOutputMetrics{}
+	validator := NewSuperAgreementEnricher(logger, metrics, supervisorClients, clock.NewDeterministicClock(time.Unix(9824924, 499)))
+	return validator, clients, metrics
 }
 
 type stubSupervisorClient struct {
 	requestedTimestamp    uint64
 	outputErr             error
 	derivedFromL1BlockNum uint64
+	superRoot             common.Hash
 }
 
 func (s *stubSupervisorClient) SuperRootAtTimestamp(_ context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
@@ -230,7 +370,7 @@ func (s *stubSupervisorClient) SuperRootAtTimestamp(_ context.Context, timestamp
 	return eth.SuperRootResponse{
 		CrossSafeDerivedFrom: eth.BlockID{Number: s.derivedFromL1BlockNum},
 		Timestamp:            uint64(timestamp),
-		SuperRoot:            eth.Bytes32(mockRootClaim),
+		SuperRoot:            eth.Bytes32(s.superRoot),
 		Version:              eth.SuperRootVersionV1,
 	}, nil
 }

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -183,7 +183,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
-		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
@@ -264,11 +264,11 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim)
+		require.False(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
 
-	t.Run("SupervisorNodesDiverged_FirstNodeAgrees", func(t *testing.T) {
+	t.Run("SupervisorNodesDiverged", func(t *testing.T) {
 		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
 		divergedRoot := common.HexToHash("0x5678")
 		clients[0].superRoot = mockRootClaim
@@ -285,27 +285,6 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim)
-		require.NotZero(t, metrics.fetchTime)
-	})
-
-	t.Run("SupervisorNodesDiverged_FirstNodeDisagrees", func(t *testing.T) {
-		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
-		divergedRoot := common.HexToHash("0x5678")
-		clients[0].superRoot = divergedRoot
-		clients[1].superRoot = mockRootClaim
-		clients[2].superRoot = mockRootClaim
-		game := &types.EnrichedGameData{
-			GameMetadata: challengerTypes.GameMetadata{
-				GameType: 999,
-			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
-		}
-		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
-		require.NoError(t, err)
-		require.NotEqual(t, mockRootClaim, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.NotZero(t, metrics.fetchTime)
 	})
@@ -326,7 +305,100 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
-		require.True(t, game.AgreeWithClaim) // Should be true because at least one node reports it as safe
+		require.True(t, game.AgreeWithClaim)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("MixedResponses_FoundNodesMatchClaimAndSafe", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 4)
+		clients[0].outputErr = ethereum.NotFound
+		clients[1].outputErr = ethereum.NotFound
+		clients[2].superRoot = mockRootClaim
+		clients[2].derivedFromL1BlockNum = 100 // Safe because L1HeadNum is 200
+		clients[3].superRoot = mockRootClaim
+		clients[3].derivedFromL1BlockNum = 150 // Safe because L1HeadNum is 200
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim) // Should disagree due to mixed responses (divergence)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("MixedResponses_FoundNodesDontMatchClaim", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+		differentRoot := common.HexToHash("0x9999")
+		clients[0].outputErr = ethereum.NotFound
+		clients[1].superRoot = differentRoot
+		clients[1].derivedFromL1BlockNum = 100
+		clients[2].superRoot = differentRoot
+		clients[2].derivedFromL1BlockNum = 150
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, differentRoot, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim) // Should disagree due to mixed responses (divergence)
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllNodesAgree_SuperRootMatchesClaim_NoneReportSafe", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+
+		for _, client := range clients {
+			client.superRoot = mockRootClaim
+			client.derivedFromL1BlockNum = 250 // Not safe because L1HeadNum is 200
+		}
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{}, game.ExpectedRootClaim, "Should set ExpectedRootClaim to empty hash when not safe")
+		require.False(t, game.AgreeWithClaim, "Should disagree because none report it as safe")
+		require.NotZero(t, metrics.fetchTime)
+	})
+
+	t.Run("AllNodesAgree_SuperRootDifferentFromClaim", func(t *testing.T) {
+		validator, clients, metrics := setupMultiSupervisorTest(t, 3)
+
+		differentRoot := common.HexToHash("0xdifferent")
+		for _, client := range clients {
+			client.superRoot = differentRoot
+			client.derivedFromL1BlockNum = 100 // Safe because L1HeadNum is 200
+		}
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 999,
+			},
+			L1HeadNum:     200,
+			L2BlockNumber: 50,
+			RootClaim:     mockRootClaim,
+		}
+		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.Equal(t, differentRoot, game.ExpectedRootClaim)
+		require.False(t, game.AgreeWithClaim, "Should disagree because super root differs from claim")
 		require.NotZero(t, metrics.fetchTime)
 	})
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -179,10 +179,10 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 }
 
 func (s *Service) initSupervisorClient(ctx context.Context, cfg *config.Config) error {
-	if cfg.SupervisorRpc == "" {
+	if len(cfg.SupervisorRpcs) == 0 {
 		return nil
 	}
-	rpcClient, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.SupervisorRpc)
+	rpcClient, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.SupervisorRpcs[0])
 	if err != nil {
 		return fmt.Errorf("failed to dial supervisor client: %w", err)
 	}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -173,10 +173,10 @@ func (s *Service) initBonds() {
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {
-	if len(cfg.RollupRpc) == 0 {
+	if len(cfg.RollupRpcs) == 0 {
 		return nil
 	}
-	for _, rpc := range cfg.RollupRpc {
+	for _, rpc := range cfg.RollupRpcs {
 		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client %s: %w", rpc, err)

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -38,15 +38,15 @@ type Service struct {
 
 	cl clock.Clock
 
-	extractor        *extract.Extractor
-	forecast         *Forecast
-	bonds            *bonds.Bonds
-	game             *extract.GameCallerCreator
-	resolutions      *ResolutionMonitor
-	claims           *ClaimMonitor
-	withdrawals      *WithdrawalMonitor
-	rollupClients    []*sources.RollupClient
-	supervisorClient *sources.SupervisorClient
+	extractor         *extract.Extractor
+	forecast          *Forecast
+	bonds             *bonds.Bonds
+	game              *extract.GameCallerCreator
+	resolutions       *ResolutionMonitor
+	claims            *ClaimMonitor
+	withdrawals       *WithdrawalMonitor
+	rollupClients     []*sources.RollupClient
+	supervisorClients []*sources.SupervisorClient
 
 	l1RPC    rpcclient.RPC
 	l1Client *sources.L1Client
@@ -90,8 +90,8 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
-	if err := s.initSupervisorClient(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to init supervisor client: %w", err)
+	if err := s.initSupervisorClients(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init supervisor clients: %w", err)
 	}
 
 	s.initClaimMonitor(cfg)
@@ -137,6 +137,14 @@ func (s *Service) outputRollupClients() []extract.OutputRollupClient {
 	return clients
 }
 
+func (s *Service) asSuperRootProviders() []extract.SuperRootProvider {
+	clients := make([]extract.SuperRootProvider, len(s.supervisorClients))
+	for i, client := range s.supervisorClients {
+		clients[i] = client
+	}
+	return clients
+}
+
 func (s *Service) initExtractor(cfg *config.Config) {
 	s.extractor = extract.NewExtractor(
 		s.logger,
@@ -151,8 +159,8 @@ func (s *Service) initExtractor(cfg *config.Config) {
 		extract.NewBondEnricher(),
 		extract.NewBalanceEnricher(),
 		extract.NewL1HeadBlockNumEnricher(s.l1Client),
-		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.supervisorClient, clock.SystemClock),
 		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
+		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
 	)
 }
 
@@ -178,15 +186,18 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 	return nil
 }
 
-func (s *Service) initSupervisorClient(ctx context.Context, cfg *config.Config) error {
+func (s *Service) initSupervisorClients(ctx context.Context, cfg *config.Config) error {
 	if len(cfg.SupervisorRpcs) == 0 {
 		return nil
 	}
-	rpcClient, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.SupervisorRpcs[0])
-	if err != nil {
-		return fmt.Errorf("failed to dial supervisor client: %w", err)
+	for _, rpc := range cfg.SupervisorRpcs {
+		rpcClient, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
+		if err != nil {
+			return fmt.Errorf("failed to dial supervisor client %s: %w", rpc, err)
+		}
+		client := sources.NewSupervisorClient(rpcclient.NewBaseRPCClient(rpcClient))
+		s.supervisorClients = append(s.supervisorClients, client)
 	}
-	s.supervisorClient = sources.NewSupervisorClient(rpcclient.NewBaseRPCClient(rpcClient))
 	return nil
 }
 


### PR DESCRIPTION
Similar to https://github.com/ethereum-optimism/optimism/pull/16490 this adds support to dispute-mon for multiple supervisor RPCs.

This is part of https://github.com/ethereum-optimism/optimism/issues/11019