### PR TITLE
op-supervisor: swap load/store with cas pattern

### DIFF
--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -115,11 +115,12 @@ func (s *ChainProcessor) OnEvent(ev event.Event) bool {
 		}
 		// always update the target
 		s.UpdateTarget(x.Target)
+
 		// and if not already running, begin indexing
-		if !s.running.Load() {
-			s.running.Store(true)
+		if s.running.CompareAndSwap(false, true) {
 			s.index()
 		}
+
 	case superevents.ChainIndexingContinueEvent:
 		if x.ChainID != s.chain {
 			return false


### PR DESCRIPTION
**Description**

While working on https://github.com/ethereum-optimism/optimism/issues/16314 and https://github.com/ethereum-optimism/optimism/issues/16335 I noticed the pattern used to check the atomic value of `running` before triggering `index()` and it looks like it is not race-free, so I am updating it.

The chance of `index()` called concurrently is pretty slim, but still worth fixing I think.