### PR TITLE
cannon: Fix elf make target

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -39,10 +39,8 @@ cannon: cannon-embeds
 clean:
 	rm -rf bin multicannon/embeds/cannon*
 
-elf: elf-go-123
-
-elf-go-123:
-	make -C ./testdata/go-1-23 elf
+elf:
+	make -C ./testdata elf
 
 sanitize-program:
 	mips-linux-gnu-objdump -d -j .text $$GUEST_PROGRAM > ./bin/dump.txt


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fix `elf` make target:  ensure we're building all elf files.  

This is based on PR https://github.com/ethereum-optimism/optimism/pull/16295, which follows up on [this PR](https://github.com/ethereum-optimism/optimism/pull/15737) that adds Go 1.24 support to Cannon. 

