### PR TITLE
cannon: Update getrandom syscall to clear memory reservations

### DIFF
--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -246,9 +246,9 @@ func (m *InstrumentedState) syscallGetRandom(a0, a1 uint64) (v0, v1 uint64) {
 	randDataMask <<= (arch.WordSizeBytes - byteCount) * 8
 	randDataMask >>= targetByteIndex * 8
 	newMemVal := (memVal & ^randDataMask) | (randomWord & randDataMask)
-	m.state.Memory.SetWord(effAddr, newMemVal)
 
 	m.memoryTracker.TrackMemAccess(effAddr)
+	m.state.Memory.SetWord(effAddr, newMemVal)
 	m.handleMemoryUpdate(effAddr)
 
 	v0 = byteCount

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -227,6 +227,7 @@ func (m *InstrumentedState) handleSyscall() error {
 func (m *InstrumentedState) syscallGetRandom(a0, a1 uint64) (v0, v1 uint64) {
 	// Get existing memory value at target address
 	effAddr := a0 & arch.AddressMask
+	m.memoryTracker.TrackMemAccess(effAddr)
 	memVal := m.state.Memory.GetWord(effAddr)
 
 	// Generate some pseudorandom data
@@ -247,7 +248,6 @@ func (m *InstrumentedState) syscallGetRandom(a0, a1 uint64) (v0, v1 uint64) {
 	randDataMask >>= targetByteIndex * 8
 	newMemVal := (memVal & ^randDataMask) | (randomWord & randDataMask)
 
-	m.memoryTracker.TrackMemAccess(effAddr)
 	m.state.Memory.SetWord(effAddr, newMemVal)
 	m.handleMemoryUpdate(effAddr)
 

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -227,7 +227,6 @@ func (m *InstrumentedState) handleSyscall() error {
 func (m *InstrumentedState) syscallGetRandom(a0, a1 uint64) (v0, v1 uint64) {
 	// Get existing memory value at target address
 	effAddr := a0 & arch.AddressMask
-	m.memoryTracker.TrackMemAccess(effAddr)
 	memVal := m.state.Memory.GetWord(effAddr)
 
 	// Generate some pseudorandom data
@@ -248,6 +247,9 @@ func (m *InstrumentedState) syscallGetRandom(a0, a1 uint64) (v0, v1 uint64) {
 	randDataMask >>= targetByteIndex * 8
 	newMemVal := (memVal & ^randDataMask) | (randomWord & randDataMask)
 	m.state.Memory.SetWord(effAddr, newMemVal)
+
+	m.memoryTracker.TrackMemAccess(effAddr)
+	m.handleMemoryUpdate(effAddr)
 
 	v0 = byteCount
 	v1 = 0

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -697,7 +697,7 @@ func TestEVM_SysGetRandom(t *testing.T) {
 	testNamer := func(testCase GetRandomTestCase, vmVersion string, reservationTestCase string) string {
 		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, reservationTestCase)
 	}
-	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase GetRandomTestCase, i int) {
+	MemoryReservationTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase GetRandomTestCase, i int) {
 		isNoop := !versions.FeaturesForVersion(vm.Version).SupportWorkingSysGetRandom
 		expectedMemory := testCase.expectedRandDataMask&randomData | ^testCase.expectedRandDataMask&startingMemory
 

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -650,14 +650,14 @@ func TestEVM_SysGetRandom(t *testing.T) {
 	step := uint64(0x1a2b3c4d5e6f7531) - 1
 	randomData := arch.Word(0x4141302768c9e9d0)
 
-	vmVersions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type GetRandomTestCase struct {
 		name                 string
 		bufAddrOffset        arch.Word
 		bufLen               arch.Word
 		expectedRandDataMask arch.Word
 		expectedReturnValue  arch.Word
-	}{
+	}
+	cases := []GetRandomTestCase{
 		// Test word-aligned buffer address
 		{name: "Word-aligned buffer, zero bytes requested", bufAddrOffset: 0, bufLen: 0, expectedRandDataMask: 0x0000_0000_0000_0000, expectedReturnValue: 0},
 		{name: "Word-aligned buffer, 1 byte requested", bufAddrOffset: 0, bufLen: 1, expectedRandDataMask: 0xFF00_0000_0000_0000, expectedReturnValue: 1},
@@ -683,7 +683,7 @@ func TestEVM_SysGetRandom(t *testing.T) {
 
 	// Assert we have at least one vm with the working getrandom syscall
 	foundVmWithSyscallEnabled := false
-	for _, vers := range vmVersions {
+	for _, vers := range GetMipsVersionTestCases(t) {
 		features := versions.FeaturesForVersion(vers.Version)
 		foundVmWithSyscallEnabled = foundVmWithSyscallEnabled || features.SupportWorkingSysGetRandom
 	}
@@ -693,44 +693,44 @@ func TestEVM_SysGetRandom(t *testing.T) {
 	latestFeatures := versions.FeaturesForVersion(versions.GetExperimentalVersion())
 	require.True(t, latestFeatures.SupportWorkingSysGetRandom)
 
-	// Run test cases
-	for _, v := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				isNoop := !versions.FeaturesForVersion(v.Version).SupportWorkingSysGetRandom
-				expectedMemory := c.expectedRandDataMask&randomData | ^c.expectedRandDataMask&startingMemory
-
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithStep(step))
-				state := goVm.GetState()
-
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				state.GetMemory().SetWord(effAddr, startingMemory)
-				state.GetRegistersRef()[register.RegV0] = arch.SysGetRandom
-				state.GetRegistersRef()[register.RegA0] = effAddr + c.bufAddrOffset
-				state.GetRegistersRef()[register.RegA1] = c.bufLen
-				step := state.GetStep()
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if isNoop {
-					expected.ActiveThread().Registers[register.RegSyscallRet1] = 0
-					expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
-				} else {
-					expected.ActiveThread().Registers[register.RegSyscallRet1] = c.expectedReturnValue
-					expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
-					expected.ExpectMemoryWriteWord(effAddr, expectedMemory)
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	// Run test cases with memory reservation variations
+	testNamer := func(testCase GetRandomTestCase, vmVersion string, reservationTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, reservationTestCase)
 	}
+	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase GetRandomTestCase, i int) {
+		isNoop := !versions.FeaturesForVersion(vm.Version).SupportWorkingSysGetRandom
+		expectedMemory := testCase.expectedRandDataMask&randomData | ^testCase.expectedRandDataMask&startingMemory
+
+		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithStep(step))
+		state := goVm.GetState()
+		step := state.GetStep()
+
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetMemory().SetWord(effAddr, startingMemory)
+		state.GetRegistersRef()[register.RegV0] = arch.SysGetRandom
+		state.GetRegistersRef()[register.RegA0] = effAddr + testCase.bufAddrOffset
+		state.GetRegistersRef()[register.RegA1] = testCase.bufLen
+		reservation.SetupState(mtutil.ToMTState(t, state), effAddr)
+
+		expected := mtutil.NewExpectedState(t, state)
+		expected.ExpectStep()
+		if isNoop {
+			expected.ActiveThread().Registers[register.RegSyscallRet1] = 0
+			expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
+		} else {
+			expected.ActiveThread().Registers[register.RegSyscallRet1] = testCase.expectedReturnValue
+			expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
+			expected.ExpectMemoryWriteWord(effAddr, expectedMemory)
+			reservation.SetExpectations(expected)
+		}
+
+		stepWitness, err := goVm.Step(true)
+		require.NoError(t, err)
+
+		// Check expectations
+		expected.Validate(t, state)
+		testutil.ValidateEVM(t, stepWitness, step, goVm, vm.StateHashFn, vm.Contracts)
+	}, testNamer)
 }
 
 func TestEVM_SysWriteHint(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -8,10 +8,14 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
@@ -382,6 +386,17 @@ func TestEVM_MT64_SCD(t *testing.T) {
 }
 
 func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
+	type testMTSysReadPreimageTestCase struct {
+		name           string
+		addr           Word
+		count          Word
+		writeLen       Word
+		preimageOffset Word
+		prestateMem    Word
+		postateMem     Word
+		shouldPanic    bool
+	}
+
 	preimageValue := make([]byte, 0, 8)
 	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x12_34_56_78)
 	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x98_76_54_32)
@@ -422,7 +437,49 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 		{name: "Offset just out of bounds", addr: 0x00_00_FF_00, count: 4, writeLen: 0, preimageOffset: 16, prestateMem: prestateMem, postateMem: 0xEE_EE_EE_EE_FF_FF_FF_FF, shouldPanic: true},
 		{name: "Offset out of bounds", addr: 0x00_00_FF_00, count: 4, writeLen: 0, preimageOffset: 17, prestateMem: prestateMem, postateMem: 0xEE_EE_EE_EE_FF_FF_FF_FF, shouldPanic: true},
 	}
-	testMTSysReadPreimage(t, preimageValue, cases)
+	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, llTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
+	}
+	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
+		effAddr := arch.AddressMask & testCase.addr
+		preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
+		oracle := testutil.StaticOracle(t, preimageValue)
+		goVm := vm.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
+		state := mtutil.GetMtState(t, goVm)
+		step := state.GetStep()
+
+		// Set up state
+		state.PreimageKey = preimageKey
+		state.PreimageOffset = testCase.preimageOffset
+		state.GetRegistersRef()[2] = arch.SysRead
+		state.GetRegistersRef()[4] = exec.FdPreimageRead
+		state.GetRegistersRef()[5] = testCase.addr
+		state.GetRegistersRef()[6] = testCase.count
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetMemory().SetWord(effAddr, testCase.prestateMem)
+		reservation.SetupState(state, effAddr)
+
+		// Setup expectations
+		expected := mtutil.NewExpectedState(t, state)
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = testCase.writeLen
+		expected.ActiveThread().Registers[7] = 0 // no error
+		expected.PreimageOffset += testCase.writeLen
+		expected.ExpectMemoryWordWrite(effAddr, testCase.postateMem)
+		reservation.SetExpectations(expected)
+
+		if testCase.shouldPanic {
+			require.Panics(t, func() { _, _ = goVm.Step(true) })
+			testutil.AssertPreimageOracleReverts(t, preimageKey, preimageValue, testCase.preimageOffset, vm.Contracts)
+		} else {
+			stepWitness, err := goVm.Step(true)
+			require.NoError(t, err)
+
+			// Check expectations
+			expected.Validate(t, state)
+			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
+		}
+	}, testNamer)
 }
 
 func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
@@ -512,6 +569,23 @@ func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
 }
 
 func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
+	type testMTStoreOpsClearMemReservationTestCase struct {
+		// name is the test name
+		name string
+		// opcode is the instruction opcode
+		opcode uint32
+		// offset is the immediate offset encoded in the instruction
+		offset uint32
+		// base is the base/rs register prestate
+		base Word
+		// effAddr is the address used to set the prestate preMem value. It is also used as the base LLAddress that can be adjusted reservation assertions
+		effAddr Word
+		// premem is the prestate value of the word located at effrAddr
+		preMem Word
+		// postMem is the expected post-state value of the word located at effAddr
+		postMem Word
+	}
+
 	t.Parallel()
 	cases := []testMTStoreOpsClearMemReservationTestCase{
 		{name: "Store byte", opcode: 0b10_1000, base: 0xFF_00_00_00, offset: 0x10, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0x78_FF_FF_FF_FF_FF_FF_FF},
@@ -525,7 +599,40 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 		{name: "Store word right", opcode: 0b10_1110, base: 0xFF_00_00_00, offset: 0x10, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0x78_FF_FF_FF_FF_FF_FF_FF},
 		{name: "Store word right lower", opcode: 0b10_1110, base: 0xFF_00_00_00, offset: 0x14, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0xFF_FF_FF_FF_78_FF_FF_FF},
 	}
-	testMTStoreOpsClearMemReservation(t, cases)
+	rt := Word(0x12_34_56_78)
+	//rt := Word(0x12_34_56_78_12_34_56_78)
+	baseReg := uint32(5)
+	rtReg := uint32(6)
+
+	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, llTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
+	}
+	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
+		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))
+		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x08))
+		state := mtutil.GetMtState(t, goVm)
+		step := state.GetStep()
+
+		// Setup state
+		state.GetRegistersRef()[rtReg] = rt
+		state.GetRegistersRef()[baseReg] = testCase.base
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetMemory().SetWord(testCase.effAddr, testCase.preMem)
+		reservation.SetupState(state, testCase.effAddr)
+
+		// Setup expectations
+		expected := mtutil.NewExpectedState(t, state)
+		expected.ExpectStep()
+		expected.ExpectMemoryWordWrite(testCase.effAddr, testCase.postMem)
+		reservation.SetExpectations(expected)
+
+		stepWitness, err := goVm.Step(true)
+		require.NoError(t, err)
+
+		// Check expectations
+		expected.Validate(t, state)
+		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
+	}, testNamer)
 }
 
 var NoopSyscalls64 = map[string]uint32{

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -440,7 +440,7 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, memoryTestCase string) string {
 		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, memoryTestCase)
 	}
-	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
+	MemoryReservationTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
 		effAddr := arch.AddressMask & testCase.addr
 		preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
 		oracle := testutil.StaticOracle(t, preimageValue)
@@ -607,7 +607,7 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, memoryTestCase string) string {
 		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, memoryTestCase)
 	}
-	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
+	MemoryReservationTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
 		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))
 		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x08))
 		state := mtutil.GetMtState(t, goVm)

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -437,8 +437,8 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 		{name: "Offset just out of bounds", addr: 0x00_00_FF_00, count: 4, writeLen: 0, preimageOffset: 16, prestateMem: prestateMem, postateMem: 0xEE_EE_EE_EE_FF_FF_FF_FF, shouldPanic: true},
 		{name: "Offset out of bounds", addr: 0x00_00_FF_00, count: 4, writeLen: 0, preimageOffset: 17, prestateMem: prestateMem, postateMem: 0xEE_EE_EE_EE_FF_FF_FF_FF, shouldPanic: true},
 	}
-	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, llTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
+	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, memoryTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, memoryTestCase)
 	}
 	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
 		effAddr := arch.AddressMask & testCase.addr
@@ -604,8 +604,8 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 	baseReg := uint32(5)
 	rtReg := uint32(6)
 
-	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, llTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
+	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, memoryTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, memoryTestCase)
 	}
 	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
 		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
@@ -13,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
-	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 )
 
 type operatorTestCase struct {
@@ -247,117 +245,6 @@ func testBranch(t *testing.T, cases []branchTestCase) {
 			})
 		}
 	}
-}
-
-type testMTStoreOpsClearMemReservationTestCase struct {
-	// name is the test name
-	name string
-	// opcode is the instruction opcode
-	opcode uint32
-	// offset is the immediate offset encoded in the instruction
-	offset uint32
-	// base is the base/rs register prestate
-	base Word
-	// effAddr is the address used to set the prestate preMem value. It is also used as the base LLAddress that can be adjusted reservation assertions
-	effAddr Word
-	// premem is the prestate value of the word located at effrAddr
-	preMem Word
-	// postMem is the expected post-state value of the word located at effAddr
-	postMem Word
-}
-
-func testMTStoreOpsClearMemReservation(t *testing.T, cases []testMTStoreOpsClearMemReservationTestCase) {
-	rt := Word(0x12_34_56_78)
-	//rt := Word(0x12_34_56_78_12_34_56_78)
-	baseReg := uint32(5)
-	rtReg := uint32(6)
-
-	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, llTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
-	}
-	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
-		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))
-		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x08))
-		state := mtutil.GetMtState(t, goVm)
-		step := state.GetStep()
-
-		// Setup state
-		state.GetRegistersRef()[rtReg] = rt
-		state.GetRegistersRef()[baseReg] = testCase.base
-		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-		state.GetMemory().SetWord(testCase.effAddr, testCase.preMem)
-		reservation.SetupState(state, testCase.effAddr)
-
-		// Setup expectations
-		expected := mtutil.NewExpectedState(t, state)
-		expected.ExpectStep()
-		expected.ExpectMemoryWordWrite(testCase.effAddr, testCase.postMem)
-		reservation.SetExpectations(expected)
-
-		stepWitness, err := goVm.Step(true)
-		require.NoError(t, err)
-
-		// Check expectations
-		expected.Validate(t, state)
-		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
-	}, testNamer)
-}
-
-type testMTSysReadPreimageTestCase struct {
-	name           string
-	addr           Word
-	count          Word
-	writeLen       Word
-	preimageOffset Word
-	prestateMem    Word
-	postateMem     Word
-	shouldPanic    bool
-}
-
-func testMTSysReadPreimage(t *testing.T, preimageValue []byte, cases []testMTSysReadPreimageTestCase) {
-	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, llTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
-	}
-	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
-		effAddr := arch.AddressMask & testCase.addr
-		preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
-		oracle := testutil.StaticOracle(t, preimageValue)
-		goVm := vm.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-		state := mtutil.GetMtState(t, goVm)
-		step := state.GetStep()
-
-		// Set up state
-		state.PreimageKey = preimageKey
-		state.PreimageOffset = testCase.preimageOffset
-		state.GetRegistersRef()[2] = arch.SysRead
-		state.GetRegistersRef()[4] = exec.FdPreimageRead
-		state.GetRegistersRef()[5] = testCase.addr
-		state.GetRegistersRef()[6] = testCase.count
-		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-		state.GetMemory().SetWord(effAddr, testCase.prestateMem)
-		reservation.SetupState(state, effAddr)
-
-		// Setup expectations
-		expected := mtutil.NewExpectedState(t, state)
-		expected.ExpectStep()
-		expected.ActiveThread().Registers[2] = testCase.writeLen
-		expected.ActiveThread().Registers[7] = 0 // no error
-		expected.PreimageOffset += testCase.writeLen
-		expected.ExpectMemoryWordWrite(effAddr, testCase.postateMem)
-		reservation.SetExpectations(expected)
-
-		if testCase.shouldPanic {
-			require.Panics(t, func() { _, _ = goVm.Step(true) })
-			testutil.AssertPreimageOracleReverts(t, preimageKey, preimageValue, testCase.preimageOffset, vm.Contracts)
-		} else {
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-
-			// Check expectations
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
-		}
-	}, testNamer)
 }
 
 type MemoryReservationTestCase struct {

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -290,8 +290,8 @@ var memoryReservationTestCases = []MemoryReservationTestCase{
 	{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
 }
 
-type MemoryReservationTest[T any] = func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
-type MemoryTestNamer[T any] = func(testCase T, vmVersion string, memoryTestCase string) string
+type MemoryReservationTest[T any] func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
+type MemoryTestNamer[T any] func(testCase T, vmVersion string, memoryTestCase string) string
 
 func MemoryReservationTester[T any](t *testing.T, cases []T, testFn MemoryReservationTest[T], testNamer MemoryTestNamer[T]) {
 	vmVersions := GetMipsVersionTestCases(t)

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -290,10 +290,10 @@ var memoryReservationTestCases = []MemoryReservationTestCase{
 	{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
 }
 
-type MemoryHandlingTest[T any] = func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
+type MemoryReservationTest[T any] = func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
 type MemoryTestNamer[T any] = func(testCase T, vmVersion string, memoryTestCase string) string
 
-func MemoryReservationHandlingTester[T any](t *testing.T, cases []T, testFn MemoryHandlingTest[T], testNamer MemoryTestNamer[T]) {
+func MemoryReservationTester[T any](t *testing.T, cases []T, testFn MemoryReservationTest[T], testNamer MemoryTestNamer[T]) {
 	vmVersions := GetMipsVersionTestCases(t)
 	for _, vmVersion := range vmVersions {
 		for i, c := range cases {

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -390,12 +390,15 @@ func (m MemoryReservationTestCase) SetExpectations(expected *mtutil.ExpectedStat
 
 var memoryReservationTestCases = []MemoryReservationTestCase{
 	{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, shouldClearReservation: true},
-	{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
 	{name: "matching reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, 64-bit, unaligned", llReservationStatus: multithreaded.LLStatusActive64bit, effAddrOffset: 5, matchThreadId: true, shouldClearReservation: true},
 	{name: "matching reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, shouldClearReservation: true},
 	{name: "matching reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, shouldClearReservation: true},
 	{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "mismatched reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
 	{name: "mismatched reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "mismatched reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
 	{name: "no reservation, matching addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, shouldClearReservation: true},
 	{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
 }

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
@@ -268,76 +267,40 @@ type testMTStoreOpsClearMemReservationTestCase struct {
 }
 
 func testMTStoreOpsClearMemReservation(t *testing.T, cases []testMTStoreOpsClearMemReservationTestCase) {
-	llVariations := []struct {
-		name                   string
-		llReservationStatus    multithreaded.LLReservationStatus
-		matchThreadId          bool
-		effAddrOffset          Word
-		shouldClearReservation bool
-	}{
-		{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, shouldClearReservation: true},
-		{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
-		{name: "matching reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, shouldClearReservation: true},
-		{name: "matching reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, shouldClearReservation: true},
-		{name: "matching reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, shouldClearReservation: true},
-		{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
-		{name: "mismatched reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
-		{name: "no reservation, matching addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, shouldClearReservation: true},
-		{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
-	}
-
 	rt := Word(0x12_34_56_78)
 	//rt := Word(0x12_34_56_78_12_34_56_78)
 	baseReg := uint32(5)
 	rtReg := uint32(6)
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			for _, llVariation := range llVariations {
-				tName := fmt.Sprintf("%v (%v,%v)", c.name, ver.Name, llVariation.name)
-				t.Run(tName, func(t *testing.T) {
-					t.Parallel()
-					insn := uint32((c.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x08))
-					state := mtutil.GetMtState(t, goVm)
-					step := state.GetStep()
 
-					// Define LL-related params
-					llAddress := c.effAddr + llVariation.effAddrOffset
-					llOwnerThread := state.GetCurrentThread().ThreadId
-					if !llVariation.matchThreadId {
-						llOwnerThread += 1
-					}
-
-					// Setup state
-					state.GetRegistersRef()[rtReg] = rt
-					state.GetRegistersRef()[baseReg] = c.base
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetMemory().SetWord(c.effAddr, c.preMem)
-					state.LLReservationStatus = llVariation.llReservationStatus
-					state.LLAddress = llAddress
-					state.LLOwnerThread = llOwnerThread
-
-					// Setup expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.ExpectMemoryWordWrite(c.effAddr, c.postMem)
-					if llVariation.shouldClearReservation {
-						expected.LLReservationStatus = multithreaded.LLStatusNone
-						expected.LLAddress = 0
-						expected.LLOwnerThread = 0
-					}
-
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
-		}
+	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, llTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
 	}
+	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
+		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))
+		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x08))
+		state := mtutil.GetMtState(t, goVm)
+		step := state.GetStep()
+
+		// Setup state
+		state.GetRegistersRef()[rtReg] = rt
+		state.GetRegistersRef()[baseReg] = testCase.base
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetMemory().SetWord(testCase.effAddr, testCase.preMem)
+		reservation.SetupState(state, testCase.effAddr)
+
+		// Setup expectations
+		expected := mtutil.NewExpectedState(t, state)
+		expected.ExpectStep()
+		expected.ExpectMemoryWordWrite(testCase.effAddr, testCase.postMem)
+		reservation.SetExpectations(expected)
+
+		stepWitness, err := goVm.Step(true)
+		require.NoError(t, err)
+
+		// Check expectations
+		expected.Validate(t, state)
+		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
+	}, testNamer)
 }
 
 type testMTSysReadPreimageTestCase struct {
@@ -352,80 +315,103 @@ type testMTSysReadPreimageTestCase struct {
 }
 
 func testMTSysReadPreimage(t *testing.T, preimageValue []byte, cases []testMTSysReadPreimageTestCase) {
-	llVariations := []struct {
-		name                   string
-		llReservationStatus    multithreaded.LLReservationStatus
-		matchThreadId          bool
-		effAddrOffset          Word
-		shouldClearReservation bool
-	}{
-		{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, shouldClearReservation: true},
-		{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
-		{name: "matching reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, shouldClearReservation: true},
-		{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
-		{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
-		{name: "no reservation, matching addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, shouldClearReservation: true},
-		{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
+	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, llTestCase string) string {
+		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, llTestCase)
+	}
+	MemoryReservationHandlingTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
+		effAddr := arch.AddressMask & testCase.addr
+		preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
+		oracle := testutil.StaticOracle(t, preimageValue)
+		goVm := vm.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
+		state := mtutil.GetMtState(t, goVm)
+		step := state.GetStep()
+
+		// Set up state
+		state.PreimageKey = preimageKey
+		state.PreimageOffset = testCase.preimageOffset
+		state.GetRegistersRef()[2] = arch.SysRead
+		state.GetRegistersRef()[4] = exec.FdPreimageRead
+		state.GetRegistersRef()[5] = testCase.addr
+		state.GetRegistersRef()[6] = testCase.count
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetMemory().SetWord(effAddr, testCase.prestateMem)
+		reservation.SetupState(state, effAddr)
+
+		// Setup expectations
+		expected := mtutil.NewExpectedState(t, state)
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = testCase.writeLen
+		expected.ActiveThread().Registers[7] = 0 // no error
+		expected.PreimageOffset += testCase.writeLen
+		expected.ExpectMemoryWordWrite(effAddr, testCase.postateMem)
+		reservation.SetExpectations(expected)
+
+		if testCase.shouldPanic {
+			require.Panics(t, func() { _, _ = goVm.Step(true) })
+			testutil.AssertPreimageOracleReverts(t, preimageKey, preimageValue, testCase.preimageOffset, vm.Contracts)
+		} else {
+			stepWitness, err := goVm.Step(true)
+			require.NoError(t, err)
+
+			// Check expectations
+			expected.Validate(t, state)
+			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
+		}
+	}, testNamer)
+}
+
+type MemoryReservationTestCase struct {
+	name                   string
+	llReservationStatus    multithreaded.LLReservationStatus
+	matchThreadId          bool
+	effAddrOffset          Word
+	shouldClearReservation bool
+}
+
+func (m MemoryReservationTestCase) SetupState(state *multithreaded.State, effAddr Word) {
+	llAddress := effAddr + m.effAddrOffset
+	llOwnerThread := state.GetCurrentThread().ThreadId
+	if !m.matchThreadId {
+		llOwnerThread += 1
 	}
 
+	state.LLReservationStatus = m.llReservationStatus
+	state.LLAddress = llAddress
+	state.LLOwnerThread = llOwnerThread
+}
+
+func (m MemoryReservationTestCase) SetExpectations(expected *mtutil.ExpectedState) {
+	if m.shouldClearReservation {
+		expected.LLReservationStatus = multithreaded.LLStatusNone
+		expected.LLAddress = 0
+		expected.LLOwnerThread = 0
+	}
+}
+
+var memoryReservationTestCases = []MemoryReservationTestCase{
+	{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, shouldClearReservation: true},
+	{name: "matching reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, shouldClearReservation: true},
+	{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "mismatched reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "no reservation, matching addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, shouldClearReservation: true},
+	{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
+}
+
+type MemoryHandlingTest[T any] = func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
+type MemoryTestNamer[T any] = func(testCase T, vmVersion string, llTestCase string) string
+
+func MemoryReservationHandlingTester[T any](t *testing.T, cases []T, testFn MemoryHandlingTest[T], testNamer MemoryTestNamer[T]) {
 	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
+	for _, vmVersion := range vmVersions {
 		for i, c := range cases {
-			for _, llVariation := range llVariations {
-				tName := fmt.Sprintf("%v (%v,%v)", c.name, ver.Name, llVariation.name)
+			for _, reservationTestCase := range memoryReservationTestCases {
+				tName := testNamer(c, vmVersion.Name, reservationTestCase.name)
 				t.Run(tName, func(t *testing.T) {
 					t.Parallel()
-					effAddr := arch.AddressMask & c.addr
-					preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
-					oracle := testutil.StaticOracle(t, preimageValue)
-					goVm := ver.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-					state := mtutil.GetMtState(t, goVm)
-					step := state.GetStep()
-
-					// Define LL-related params
-					llAddress := effAddr + llVariation.effAddrOffset
-					llOwnerThread := state.GetCurrentThread().ThreadId
-					if !llVariation.matchThreadId {
-						llOwnerThread += 1
-					}
-
-					// Set up state
-					state.PreimageKey = preimageKey
-					state.PreimageOffset = c.preimageOffset
-					state.GetRegistersRef()[2] = arch.SysRead
-					state.GetRegistersRef()[4] = exec.FdPreimageRead
-					state.GetRegistersRef()[5] = c.addr
-					state.GetRegistersRef()[6] = c.count
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-					state.LLReservationStatus = llVariation.llReservationStatus
-					state.LLAddress = llAddress
-					state.LLOwnerThread = llOwnerThread
-					state.GetMemory().SetWord(effAddr, c.prestateMem)
-
-					// Setup expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.ActiveThread().Registers[2] = c.writeLen
-					expected.ActiveThread().Registers[7] = 0 // no error
-					expected.PreimageOffset += c.writeLen
-					expected.ExpectMemoryWordWrite(effAddr, c.postateMem)
-					if llVariation.shouldClearReservation {
-						expected.LLReservationStatus = multithreaded.LLStatusNone
-						expected.LLAddress = 0
-						expected.LLOwnerThread = 0
-					}
-
-					if c.shouldPanic {
-						require.Panics(t, func() { _, _ = goVm.Step(true) })
-						testutil.AssertPreimageOracleReverts(t, preimageKey, preimageValue, c.preimageOffset, ver.Contracts)
-					} else {
-						stepWitness, err := goVm.Step(true)
-						require.NoError(t, err)
-
-						// Check expectations
-						expected.Validate(t, state)
-						testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-					}
+					testFn(t, vmVersion, reservationTestCase, c, i)
 				})
 			}
 		}

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -291,7 +291,7 @@ var memoryReservationTestCases = []MemoryReservationTestCase{
 }
 
 type MemoryHandlingTest[T any] = func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
-type MemoryTestNamer[T any] = func(testCase T, vmVersion string, llTestCase string) string
+type MemoryTestNamer[T any] = func(testCase T, vmVersion string, memoryTestCase string) string
 
 func MemoryReservationHandlingTester[T any](t *testing.T, cases []T, testFn MemoryHandlingTest[T], testNamer MemoryTestNamer[T]) {
 	vmVersions := GetMipsVersionTestCases(t)

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -32,8 +32,8 @@
     "sourceCodeHash": "0xb3e32b18c95d4940980333e1e99b4dcf42d8a8bfce78139db4dc3fb06e9349d0"
   },
   "src/L1/StandardValidator.sol:StandardValidator": {
-    "initCodeHash": "0x77b6a2becb96a5a77c71974d79d85492fc0d27f48cd11868a1a80ce393a2446a",
-    "sourceCodeHash": "0xe55ea4c8756d4a18f7fd3fd88a6bc7d6b17c6b3409cc94710bfb572d969807d6"
+    "initCodeHash": "0xf22fdf206ad25f64bb2611a787e8286a4f83df4b527110a00c4a412a356c32cd",
+    "sourceCodeHash": "0x5853dabe43131827ed157f99bf7581b34672da4616e1f14819b146e86f63ae3c"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x0ea921059d71fd19ac9c6e29c05b9724ad584eb27f74231de6df9551e9b13084",
@@ -137,7 +137,7 @@
   },
   "src/cannon/MIPS64.sol:MIPS64": {
     "initCodeHash": "0xbc7c3c50e8c3679576f87d79c2dae05dd1174e64bdaa4c1e0857314618e415a3",
-    "sourceCodeHash": "0xa94090f0da43d7d35f2bc23901669660a939d4b015729161de9adcb9e307cb75"
+    "sourceCodeHash": "0xf6e87bf46edca31c2b30c83fdf7b57a7851404743e16dd4f783be3a34c481d76"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x4c62ab095565b59be3e5dcb385c6a65b489e4d35daf060ae44c6add9b75a3681",
-    "sourceCodeHash": "0x476af3b1f1bd924e3bee8e896d2f4adbd2b24464d80519bc7d2b3284a6128c81"
+    "initCodeHash": "0xbc7c3c50e8c3679576f87d79c2dae05dd1174e64bdaa4c1e0857314618e415a3",
+    "sourceCodeHash": "0xa94090f0da43d7d35f2bc23901669660a939d4b015729161de9adcb9e307cb75"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/src/L1/StandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/StandardValidator.sol
@@ -35,8 +35,8 @@ import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 /// before and after an upgrade.
 contract StandardValidator is ISemver {
     /// @notice The semantic version of the StandardValidator contract.
-    /// @custom:semver 1.3.0
-    string public constant version = "1.3.0";
+    /// @custom:semver 1.4.0
+    string public constant version = "1.4.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -200,7 +200,7 @@ contract StandardValidator is ISemver {
 
     /// @notice Returns the expected MIPS version.
     function mipsVersion() public pure returns (string memory) {
-        return "1.7.0";
+        return "1.8.0";
     }
 
     /// @notice Returns the expected OptimismMintableERC20Factory version.

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -686,8 +686,8 @@ contract MIPS64 is ISemver {
         randDataMask <<= (arch.WORD_SIZE_BYTES - byteCount) * 8;
         randDataMask >>= targetByteIndex * 8;
         uint64 newMemVal = (memVal & ~randDataMask) | (randomWord & randDataMask);
-        memRoot_ = MIPS64Memory.writeMem(effAddr, memProofOffset, newMemVal);
 
+        memRoot_ = MIPS64Memory.writeMem(effAddr, memProofOffset, newMemVal);
         handleMemoryUpdate(_state, effAddr);
 
         v0_ = byteCount;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.7.0
-    string public constant version = "1.7.0";
+    /// @custom:semver 1.8.0
+    string public constant version = "1.8.0";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -687,6 +687,8 @@ contract MIPS64 is ISemver {
         randDataMask >>= targetByteIndex * 8;
         uint64 newMemVal = (memVal & ~randDataMask) | (randomWord & randDataMask);
         memRoot_ = MIPS64Memory.writeMem(effAddr, memProofOffset, newMemVal);
+
+        handleMemoryUpdate(_state, effAddr);
 
         v0_ = byteCount;
         v1_ = 0;


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Update the `getrandom` syscall logic to clear any existing memory reservations after updating memory. 

**Tests**

Update tests to check memory reservations are cleared as expected.  Create a generic helper to validate memory reservations are cleared as expected.  

Also, merge some helper functions in `testfuncs_test.go` into the methods where they are invoked.

**Metadata**

Part of: https://github.com/ethereum-optimism/optimism/issues/16483
