### PR TITLE
Up timeout for WaitForL2HeadToAdvanceTo from 1m to 5m

### DIFF
--- a/op-devstack/dsl/supervisor.go
+++ b/op-devstack/dsl/supervisor.go
@@ -155,7 +155,7 @@ func (s *Supervisor) WaitForL2HeadToAdvance(chainID eth.ChainID, delta uint64, l
 func (s *Supervisor) WaitForL2HeadToAdvanceTo(chainID eth.ChainID, lvl types.SafetyLevel, blockID eth.BlockID) {
 	ctx, cancel := context.WithCancelCause(s.ctx)
 	defer cancel(nil)
-	err := retry.Do0(ctx, 120, &retry.FixedStrategy{Dur: 500 * time.Millisecond}, func() error {
+	err := retry.Do0(ctx, 5*60, &retry.FixedStrategy{Dur: 1 * time.Second}, func() error {
 		chStatus := s.L2HeadBlockID(chainID, lvl)
 		s.log.Info("Supervisor view",
 			"chain", chainID, "label", lvl, "current", chStatus.Number, "target", blockID.Number)


### PR DESCRIPTION
Hopefully fixes flakes, for example: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/94103/workflows/0c37b3bc-3b0f-4779-9a08-0fb38828d071/jobs/3658856/tests