### PR TITLE
op-service/safemath: SaturatingSub and SafeSub

### DIFF
--- a/op-service/safemath/safemath.go
+++ b/op-service/safemath/safemath.go
@@ -2,13 +2,14 @@ package safemath
 
 import "golang.org/x/exp/constraints"
 
-// SaturatingAdd adds two unsigned integer values (of the same type), and caps the result at the max value of the type.
+// SaturatingAdd adds two unsigned integer values (of the same type),
+// and caps the result at the max value of the type.
 func SaturatingAdd[V constraints.Unsigned](a, b V) V {
-	sum, overflow := SafeAdd(a, b)
+	out, overflow := SafeAdd(a, b)
 	if overflow {
 		return ^V(0) // max value
 	}
-	return sum
+	return out
 }
 
 // SafeAdd adds two unsigned integer values (of the same type),
@@ -16,5 +17,23 @@ func SaturatingAdd[V constraints.Unsigned](a, b V) V {
 func SafeAdd[V constraints.Unsigned](a, b V) (out V, overflow bool) {
 	out = a + b
 	overflow = out < a
+	return
+}
+
+// SaturatingSub subtracts two unsigned integer values (of the same type),
+// and floors the result at zero.
+func SaturatingSub[V constraints.Unsigned](a, b V) V {
+	out, underflow := SafeSub(a, b)
+	if underflow {
+		return V(0) // min value
+	}
+	return out
+}
+
+// SafeSub subtracts two unsigned integer values (of the same type),
+// and allows integer underflows, and returns if it underflowed.
+func SafeSub[V constraints.Unsigned](a, b V) (out V, underflow bool) {
+	out = a - b
+	underflow = out > a
 	return
 }

--- a/op-service/safemath/safemath_test.go
+++ b/op-service/safemath/safemath_test.go
@@ -1,6 +1,7 @@
 package safemath
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-// TestAdd tests add / safe-add functions. Should be part of the Go std-lib, but is not.
+// TestAdd tests saturating-add / safe-add functions.
 func TestAdd(t *testing.T) {
 	t.Run("typed uint64", testAdd[hexutil.Uint64])
 	t.Run("uint64", testAdd[uint64])
@@ -49,6 +50,47 @@ func testAdd[V constraints.Unsigned](t *testing.T) {
 					require.Equal(t, expectedSum.Uint64(), uint64(got))
 				}
 			}
+		}
+	}
+}
+
+// TestSub tests saturating-sub / safe-sub functions.
+func TestSub(t *testing.T) {
+	t.Run("typed uint64", testSub[hexutil.Uint64])
+	t.Run("uint64", testSub[uint64])
+	t.Run("uint32", testSub[uint32])
+	t.Run("uint16", testSub[uint16])
+	t.Run("uint8", testSub[uint8])
+	t.Run("uint", testSub[uint])
+}
+
+func testSub[V constraints.Unsigned](t *testing.T) {
+	m := ^V(0)
+	require.Less(t, m+1, m, "sanity check min value does underflow")
+	vals := []V{
+		0, 1, 2, 3, m, m - 1, m - 2, m - 100, m / 2, (m / 2) - 1, (m / 2) + 1, (m / 2) + 2,
+	}
+	// Try every value with every other value. (so this checks (a, b) but also (b, a) calls)
+	for _, a := range vals {
+		for _, b := range vals {
+			t.Run(fmt.Sprintf("%d - %d", a, b), func(t *testing.T) {
+				// masked expected outcome to int size, since it may have underflowed
+				expectedOut := (uint64(a) - uint64(b)) & uint64(m)
+				expectedUnderflow := b > a
+				{
+					got, underflowed := SafeSub(a, b)
+					require.Equal(t, expectedUnderflow, underflowed)
+					require.Equal(t, expectedOut, uint64(got))
+				}
+				{
+					got := SaturatingSub(a, b)
+					if expectedUnderflow {
+						require.Equal(t, uint64(0), uint64(got))
+					} else {
+						require.Equal(t, expectedOut, uint64(got))
+					}
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
**Description**

While working on other things in the codebase I found these safemath functions useful to have. So I've split them out in their own PR for easy review.

**Tests**

Added unit tests.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
