### PR TITLE
op-node,op-supervisor: separate ctx from events

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -104,7 +104,7 @@ func (s *L2Sequencer) ActL2StartBlock(t Testing) {
 		t.InvalidAction("already started building L2 block")
 		return
 	}
-	s.synchronousEvents.Emit(sequencing.SequencerActionEvent{Ctx: event.WrapCtx(t.Ctx())})
+	s.synchronousEvents.Emit(t.Ctx(), sequencing.SequencerActionEvent{})
 	require.NoError(t, s.drainer.DrainUntil(event.Is[engine.BuildStartedEvent], false),
 		"failed to start block building")
 
@@ -119,14 +119,14 @@ func (s *L2Sequencer) ActL2EndBlock(t Testing) {
 	}
 	s.l2Building = false
 
-	s.synchronousEvents.Emit(sequencing.SequencerActionEvent{Ctx: event.WrapCtx(t.Ctx())})
+	s.synchronousEvents.Emit(t.Ctx(), sequencing.SequencerActionEvent{})
 	require.NoError(t, s.drainer.DrainUntil(event.Is[engine.PayloadSuccessEvent], false),
 		"failed to complete block building")
 
 	// After having built a L2 block, make sure to get an engine update processed.
 	// This will ensure the sync-status and such reflect the latest changes.
-	s.synchronousEvents.Emit(engine.TryUpdateEngineEvent{Ctx: event.WrapCtx(t.Ctx())})
-	s.synchronousEvents.Emit(engine.ForkchoiceRequestEvent{Ctx: event.WrapCtx(t.Ctx())})
+	s.synchronousEvents.Emit(t.Ctx(), engine.TryUpdateEngineEvent{})
+	s.synchronousEvents.Emit(t.Ctx(), engine.ForkchoiceRequestEvent{})
 	require.NoError(t, s.drainer.DrainUntil(func(ev event.Event) bool {
 		x, ok := ev.(engine.ForkchoiceUpdateEvent)
 		return ok && x.UnsafeL2Head == s.engine.UnsafeL2Head()

--- a/op-node/node/tracer/comms.go
+++ b/op-node/node/tracer/comms.go
@@ -20,7 +20,6 @@ type Tracer interface {
 
 type TracePublishBlockEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
-	event.Ctx
 }
 
 func (ev TracePublishBlockEvent) String() string {
@@ -46,7 +45,7 @@ func NewTracerDeriver(tracer Tracer) *TracerDeriver {
 	}
 }
 
-func (t *TracerDeriver) OnEvent(ev event.Event) bool {
+func (t *TracerDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case status.L1UnsafeEvent:
 		t.tracer.OnNewL1Head(t.ctx, x.L1Unsafe)

--- a/op-node/node/tracer/comms_test.go
+++ b/op-node/node/tracer/comms_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
@@ -40,7 +39,7 @@ func TestTracer(t *testing.T) {
 	rng := rand.New(rand.NewSource(123))
 
 	l1Head := testutils.RandomBlockRef(rng)
-	d.OnEvent(status.L1UnsafeEvent{L1Unsafe: l1Head})
+	d.OnEvent(context.Background(), status.L1UnsafeEvent{L1Unsafe: l1Head})
 	require.Equal(t, "L1Head: "+l1Head.ID().String()+"\n", tr.got)
 	tr.got = ""
 
@@ -49,11 +48,11 @@ func TestTracer(t *testing.T) {
 		ExecutionPayload: &eth.ExecutionPayload{
 			BlockHash: id.Hash, BlockNumber: eth.Uint64Quantity(id.Number)}}
 
-	d.OnEvent(p2p.ReceivedBlockEvent{From: "foo", Envelope: block, Ctx: event.WrapCtx(context.Background())})
+	d.OnEvent(context.Background(), p2p.ReceivedBlockEvent{From: "foo", Envelope: block})
 	require.Equal(t, "P2P in: from: foo id: "+id.String()+"\n", tr.got)
 	tr.got = ""
 
-	d.OnEvent(TracePublishBlockEvent{Envelope: block, Ctx: event.WrapCtx(context.Background())})
+	d.OnEvent(context.Background(), TracePublishBlockEvent{Envelope: block})
 	require.Equal(t, "P2P out: "+id.String()+"\n", tr.got)
 	tr.got = ""
 

--- a/op-node/p2p/event.go
+++ b/op-node/p2p/event.go
@@ -12,10 +12,8 @@ import (
 )
 
 type ReceivedBlockEvent struct {
-	ChainID  eth.ChainID
 	From     peer.ID
 	Envelope *eth.ExecutionPayloadEnvelope
-	event.Ctx
 }
 
 func (ev ReceivedBlockEvent) String() string {
@@ -49,6 +47,6 @@ func (g *BlockReceiver) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg
 		"id", msg.ExecutionPayload.ID(),
 		"peer", from, "txs", len(msg.ExecutionPayload.Transactions))
 	g.metrics.RecordReceivedUnsafePayload(msg)
-	g.emitter.Emit(ReceivedBlockEvent{From: from, Envelope: msg, Ctx: event.WrapCtx(ctx)})
+	g.emitter.Emit(ctx, ReceivedBlockEvent{From: from, Envelope: msg})
 	return nil
 }

--- a/op-node/rollup/clsync/clsync_test.go
+++ b/op-node/rollup/clsync/clsync_test.go
@@ -1,6 +1,7 @@
 package clsync
 
 import (
+	"context"
 	"errors"
 	"math/big"
 	"math/rand" // nosemgrep
@@ -132,10 +133,10 @@ func TestCLSync(t *testing.T) {
 		cl.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA2,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -154,10 +155,10 @@ func TestCLSync(t *testing.T) {
 		cl.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -177,10 +178,10 @@ func TestCLSync(t *testing.T) {
 		cl.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    altRefA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -198,10 +199,10 @@ func TestCLSync(t *testing.T) {
 		cl.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA2})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA2})
 		emitter.AssertExpectations(t)
 
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    altRefA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -222,7 +223,7 @@ func TestCLSync(t *testing.T) {
 		require.Nil(t, cl.unsafePayloads.Peek(), "no payloads yet")
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 
 		lowest := cl.LowestQueuedUnsafeBlock()
@@ -230,7 +231,7 @@ func TestCLSync(t *testing.T) {
 
 		// payload A1 should be possible to process on top of A0
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA1})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA0,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -238,7 +239,7 @@ func TestCLSync(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// now pretend the payload was processed: we can drop A1 now
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -247,14 +248,14 @@ func TestCLSync(t *testing.T) {
 
 		// repeat for A2
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA2})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA2})
 		emitter.AssertExpectations(t)
 
 		lowest = cl.LowestQueuedUnsafeBlock()
 		require.Equal(t, refA2, lowest, "expecting A2 next")
 
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA2})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -262,7 +263,7 @@ func TestCLSync(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// now pretend the payload was processed: we can drop A2 now
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA2,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -278,17 +279,17 @@ func TestCLSync(t *testing.T) {
 		cl.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA2})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA2})
 		emitter.AssertExpectations(t)
 
 		lowest := cl.LowestQueuedUnsafeBlock()
 		require.Equal(t, refA1, lowest, "expecting A1 next")
 
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA1})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA0,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -299,7 +300,7 @@ func TestCLSync(t *testing.T) {
 		// Now pretend the payload was processed: we can drop A1 now.
 		// The CL-sync will try to immediately continue with A2.
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA2})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -307,7 +308,7 @@ func TestCLSync(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// now pretend the payload was processed: we can drop A2 now
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA2,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -323,11 +324,11 @@ func TestCLSync(t *testing.T) {
 		cl.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA1})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA0,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -340,7 +341,7 @@ func TestCLSync(t *testing.T) {
 
 		// Pretend we are still stuck on the same forkchoice. The CL-sync will retry sending the payload.
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA1})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA0,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -349,7 +350,7 @@ func TestCLSync(t *testing.T) {
 		require.NotNil(t, cl.unsafePayloads.Peek(), "no pop because retry still unconfirmed")
 
 		// Now confirm we got the payload this time
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA1,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -365,12 +366,12 @@ func TestCLSync(t *testing.T) {
 
 		// CLSync gets payload and requests engine state, to later determine if payload should be forwarded
 		emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
-		cl.OnEvent(ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+		cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
 		emitter.AssertExpectations(t)
 
 		// Engine signals, CLSync sends the payload
 		emitter.ExpectOnce(engine.ProcessUnsafePayloadEvent{Envelope: payloadA1})
-		cl.OnEvent(engine.ForkchoiceUpdateEvent{
+		cl.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 			UnsafeL2Head:    refA0,
 			SafeL2Head:      refA0,
 			FinalizedL2Head: refA0,
@@ -378,7 +379,7 @@ func TestCLSync(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// Pretend the payload is bad. It should not be retried after this.
-		cl.OnEvent(engine.PayloadInvalidEvent{Envelope: payloadA1, Err: errors.New("test err")})
+		cl.OnEvent(context.Background(), engine.PayloadInvalidEvent{Envelope: payloadA1, Err: errors.New("test err")})
 		emitter.AssertExpectations(t)
 		require.Nil(t, cl.unsafePayloads.Peek(), "pop because invalid")
 	})

--- a/op-node/rollup/driver/steps.go
+++ b/op-node/rollup/driver/steps.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -10,7 +11,6 @@ import (
 )
 
 type ResetStepBackoffEvent struct {
-	event.Ctx
 }
 
 func (ev ResetStepBackoffEvent) String() string {
@@ -19,7 +19,6 @@ func (ev ResetStepBackoffEvent) String() string {
 
 type StepDelayedReqEvent struct {
 	Delay time.Duration
-	event.Ctx
 }
 
 func (ev StepDelayedReqEvent) String() string {
@@ -28,7 +27,6 @@ func (ev StepDelayedReqEvent) String() string {
 
 type StepReqEvent struct {
 	ResetBackoff bool
-	event.Ctx
 }
 
 func (ev StepReqEvent) String() string {
@@ -36,7 +34,6 @@ func (ev StepReqEvent) String() string {
 }
 
 type StepAttemptEvent struct {
-	event.Ctx
 }
 
 func (ev StepAttemptEvent) String() string {
@@ -44,7 +41,6 @@ func (ev StepAttemptEvent) String() string {
 }
 
 type StepEvent struct {
-	event.Ctx
 }
 
 func (ev StepEvent) String() string {
@@ -106,7 +102,7 @@ func (s *StepSchedulingDeriver) NextDelayedStep() <-chan time.Time {
 	return s.delayedStepReq
 }
 
-func (s *StepSchedulingDeriver) OnEvent(ev event.Event) bool {
+func (s *StepSchedulingDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	step := func() {
 		s.delayedStepReq = nil
 		select {
@@ -145,7 +141,7 @@ func (s *StepSchedulingDeriver) OnEvent(ev event.Event) bool {
 		}
 		// count as attempt by default. We reset to 0 if we are making healthy progress.
 		s.stepAttempts += 1
-		s.emitter.Emit(StepEvent(x))
+		s.emitter.Emit(ctx, StepEvent(x))
 	case ResetStepBackoffEvent:
 		s.stepAttempts = 0
 	default:

--- a/op-node/rollup/driver/steps_test.go
+++ b/op-node/rollup/driver/steps_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,41 +15,41 @@ import (
 func TestStepSchedulingDeriver(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)
 	var queued []event.Event
-	emitter := event.EmitterFunc(func(ev event.Event) {
+	emitter := event.EmitterFunc(func(ctx context.Context, ev event.Event) {
 		queued = append(queued, ev)
 	})
 	sched := NewStepSchedulingDeriver(logger)
 	sched.AttachEmitter(emitter)
 	require.Len(t, sched.NextStep(), 0, "start empty")
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.Len(t, sched.NextStep(), 1, "take request")
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.Len(t, sched.NextStep(), 1, "ignore duplicate request")
 	require.Empty(t, queued, "only scheduled so far, no step attempts yet")
 	<-sched.NextStep()
-	sched.OnEvent(StepAttemptEvent{})
+	sched.OnEvent(context.Background(), StepAttemptEvent{})
 	require.Equal(t, []event.Event{StepEvent{}}, queued, "got step event")
 	require.Nil(t, sched.NextDelayedStep(), "no delayed steps yet")
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.NotNil(t, sched.NextDelayedStep(), "2nd attempt before backoff reset causes delayed step to be scheduled")
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.NotNil(t, sched.NextDelayedStep(), "can continue to request attempts")
 
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.Len(t, sched.NextStep(), 0, "no step requests accepted without delay if backoff is counting")
 
-	sched.OnEvent(StepReqEvent{ResetBackoff: true})
+	sched.OnEvent(context.Background(), StepReqEvent{ResetBackoff: true})
 	require.Len(t, sched.NextStep(), 1, "request accepted if backoff is reset")
 	<-sched.NextStep()
 
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.Len(t, sched.NextStep(), 1, "no backoff, no attempt has been made yet")
 	<-sched.NextStep()
-	sched.OnEvent(StepAttemptEvent{})
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), StepAttemptEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.Len(t, sched.NextStep(), 0, "backoff again")
 
-	sched.OnEvent(ResetStepBackoffEvent{})
-	sched.OnEvent(StepReqEvent{})
+	sched.OnEvent(context.Background(), ResetStepBackoffEvent{})
+	sched.OnEvent(context.Background(), StepReqEvent{})
 	require.Len(t, sched.NextStep(), 1, "reset backoff accepted, was able to schedule non-delayed step")
 }

--- a/op-node/rollup/engine/api.go
+++ b/op-node/rollup/engine/api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 )
 
@@ -138,7 +137,7 @@ func (ec *EngineController) CommitBlock(ctx context.Context, signed *opsigner.Si
 	}
 
 	ec.SetUnsafeHead(ref)
-	ec.emitter.Emit(UnsafeUpdateEvent{Ref: ref, Ctx: event.WrapCtx(ctx)})
+	ec.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
 	if err := ec.TryUpdateEngine(ctx); err != nil {
 		return fmt.Errorf("failed to update engine forkchoice: %w", err)
 	}

--- a/op-node/rollup/engine/build_sealed.go
+++ b/op-node/rollup/engine/build_sealed.go
@@ -1,10 +1,10 @@
 package engine
 
 import (
+	"context"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
 // BuildSealedEvent is emitted by the engine when a payload finished building,
@@ -19,23 +19,21 @@ type BuildSealedEvent struct {
 	Info     eth.PayloadInfo
 	Envelope *eth.ExecutionPayloadEnvelope
 	Ref      eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev BuildSealedEvent) String() string {
 	return "build-sealed"
 }
 
-func (eq *EngDeriver) onBuildSealed(ev BuildSealedEvent) {
+func (eq *EngDeriver) onBuildSealed(ctx context.Context, ev BuildSealedEvent) {
 	// If a (pending) safe block, immediately process the block
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
-		eq.emitter.Emit(PayloadProcessEvent{
+		eq.emitter.Emit(ctx, PayloadProcessEvent{
 			Concluding:   ev.Concluding,
 			DerivedFrom:  ev.DerivedFrom,
 			Envelope:     ev.Envelope,
 			Ref:          ev.Ref,
 			BuildStarted: ev.BuildStarted,
-			Ctx:          ev.Ctx,
 		})
 	}
 }

--- a/op-node/rollup/engine/build_started.go
+++ b/op-node/rollup/engine/build_started.go
@@ -1,10 +1,10 @@
 package engine
 
 import (
+	"context"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
 type BuildStartedEvent struct {
@@ -18,22 +18,20 @@ type BuildStartedEvent struct {
 	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev BuildStartedEvent) String() string {
 	return "build-started"
 }
 
-func (eq *EngDeriver) onBuildStarted(ev BuildStartedEvent) {
+func (eq *EngDeriver) onBuildStarted(ctx context.Context, ev BuildStartedEvent) {
 	// If a (pending) safe block, immediately seal the block
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
-		eq.emitter.Emit(BuildSealEvent{
+		eq.emitter.Emit(ctx, BuildSealEvent{
 			Info:         ev.Info,
 			BuildStarted: ev.BuildStarted,
 			Concluding:   ev.Concluding,
 			DerivedFrom:  ev.DerivedFrom,
-			Ctx:          ev.Ctx,
 		})
 	}
 }

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -37,7 +37,6 @@ type Metrics interface {
 // This helps decouple derivers from the actual engine state,
 // while also not making the derivers wait for a forkchoice update at random.
 type ForkchoiceRequestEvent struct {
-	event.Ctx
 }
 
 func (ev ForkchoiceRequestEvent) String() string {
@@ -46,7 +45,6 @@ func (ev ForkchoiceRequestEvent) String() string {
 
 type ForkchoiceUpdateEvent struct {
 	UnsafeL2Head, SafeL2Head, FinalizedL2Head eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev ForkchoiceUpdateEvent) String() string {
@@ -60,7 +58,6 @@ func (ev ForkchoiceUpdateEvent) String() string {
 // See EngineController.InsertUnsafePayload.
 type PromoteUnsafeEvent struct {
 	Ref eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev PromoteUnsafeEvent) String() string {
@@ -71,7 +68,6 @@ func (ev PromoteUnsafeEvent) String() string {
 // This is pre-forkchoice update; the change may not be reflected yet in the EL.
 type UnsafeUpdateEvent struct {
 	Ref eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev UnsafeUpdateEvent) String() string {
@@ -81,7 +77,6 @@ func (ev UnsafeUpdateEvent) String() string {
 // PromoteCrossUnsafeEvent signals that the given block may be promoted to cross-unsafe.
 type PromoteCrossUnsafeEvent struct {
 	Ref eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev PromoteCrossUnsafeEvent) String() string {
@@ -92,7 +87,6 @@ func (ev PromoteCrossUnsafeEvent) String() string {
 type CrossUnsafeUpdateEvent struct {
 	CrossUnsafe eth.L2BlockRef
 	LocalUnsafe eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev CrossUnsafeUpdateEvent) String() string {
@@ -102,7 +96,6 @@ func (ev CrossUnsafeUpdateEvent) String() string {
 type PendingSafeUpdateEvent struct {
 	PendingSafe eth.L2BlockRef
 	Unsafe      eth.L2BlockRef // tip, added to the signal, to determine if there are existing blocks to consolidate
-	event.Ctx
 }
 
 func (ev PendingSafeUpdateEvent) String() string {
@@ -114,7 +107,6 @@ type PromotePendingSafeEvent struct {
 	Ref        eth.L2BlockRef
 	Concluding bool // Concludes the pending phase, so can be promoted to (local) safe
 	Source     eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev PromotePendingSafeEvent) String() string {
@@ -125,7 +117,6 @@ func (ev PromotePendingSafeEvent) String() string {
 type PromoteLocalSafeEvent struct {
 	Ref    eth.L2BlockRef
 	Source eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev PromoteLocalSafeEvent) String() string {
@@ -135,7 +126,6 @@ func (ev PromoteLocalSafeEvent) String() string {
 type CrossSafeUpdateEvent struct {
 	CrossSafe eth.L2BlockRef
 	LocalSafe eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev CrossSafeUpdateEvent) String() string {
@@ -146,7 +136,6 @@ func (ev CrossSafeUpdateEvent) String() string {
 type LocalSafeUpdateEvent struct {
 	Ref    eth.L2BlockRef
 	Source eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev LocalSafeUpdateEvent) String() string {
@@ -157,7 +146,6 @@ func (ev LocalSafeUpdateEvent) String() string {
 type PromoteSafeEvent struct {
 	Ref    eth.L2BlockRef
 	Source eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev PromoteSafeEvent) String() string {
@@ -169,7 +157,6 @@ func (ev PromoteSafeEvent) String() string {
 type SafeDerivedEvent struct {
 	Safe   eth.L2BlockRef
 	Source eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev SafeDerivedEvent) String() string {
@@ -177,7 +164,6 @@ func (ev SafeDerivedEvent) String() string {
 }
 
 type PendingSafeRequestEvent struct {
-	event.Ctx
 }
 
 func (ev PendingSafeRequestEvent) String() string {
@@ -186,7 +172,6 @@ func (ev PendingSafeRequestEvent) String() string {
 
 type ProcessUnsafePayloadEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
-	event.Ctx
 }
 
 func (ev ProcessUnsafePayloadEvent) String() string {
@@ -194,7 +179,6 @@ func (ev ProcessUnsafePayloadEvent) String() string {
 }
 
 type TryBackupUnsafeReorgEvent struct {
-	event.Ctx
 }
 
 func (ev TryBackupUnsafeReorgEvent) String() string {
@@ -207,7 +191,6 @@ type TryUpdateEngineEvent struct {
 	BuildStarted  time.Time
 	InsertStarted time.Time
 	Envelope      *eth.ExecutionPayloadEnvelope
-	event.Ctx
 }
 
 func (ev TryUpdateEngineEvent) String() string {
@@ -269,7 +252,6 @@ type EngineResetConfirmedEvent struct {
 	LocalSafe   eth.L2BlockRef
 	CrossSafe   eth.L2BlockRef
 	Finalized   eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev EngineResetConfirmedEvent) String() string {
@@ -279,7 +261,6 @@ func (ev EngineResetConfirmedEvent) String() string {
 // PromoteFinalizedEvent signals that a block can be marked as finalized.
 type PromoteFinalizedEvent struct {
 	Ref eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev PromoteFinalizedEvent) String() string {
@@ -289,7 +270,6 @@ func (ev PromoteFinalizedEvent) String() string {
 // FinalizedUpdateEvent signals that a block has been marked as finalized.
 type FinalizedUpdateEvent struct {
 	Ref eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev FinalizedUpdateEvent) String() string {
@@ -300,7 +280,6 @@ func (ev FinalizedUpdateEvent) String() string {
 type CrossUpdateRequestEvent struct {
 	CrossUnsafe bool
 	CrossSafe   bool
-	event.Ctx
 }
 
 func (ev CrossUpdateRequestEvent) String() string {
@@ -311,7 +290,6 @@ func (ev CrossUpdateRequestEvent) String() string {
 type InteropInvalidateBlockEvent struct {
 	Invalidated eth.BlockRef
 	Attributes  *derive.AttributesWithParent
-	event.Ctx
 }
 
 func (ev InteropInvalidateBlockEvent) String() string {
@@ -322,7 +300,6 @@ func (ev InteropInvalidateBlockEvent) String() string {
 type InteropReplacedBlockEvent struct {
 	Ref      eth.BlockRef
 	Envelope *eth.ExecutionPayloadEnvelope
-	event.Ctx
 }
 
 func (ev InteropReplacedBlockEvent) String() string {
@@ -357,7 +334,7 @@ func (d *EngDeriver) AttachEmitter(em event.Emitter) {
 	d.emitter = em
 }
 
-func (d *EngDeriver) OnEvent(ev event.Event) bool {
+func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	d.ec.mu.Lock()
 	defer d.ec.mu.Unlock()
 	switch x := ev.(type) {
@@ -375,13 +352,12 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 		if err != nil {
 			// If we needed to perform a network call, then we should yield even if we did not encounter an error.
 			if errors.Is(err, derive.ErrReset) {
-				d.emitter.Emit(rollup.ResetEvent{Err: err, Ctx: x.Ctx})
+				d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
 			} else if errors.Is(err, derive.ErrTemporary) {
-				d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err, Ctx: x.Ctx})
+				d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
 			} else {
-				d.emitter.Emit(rollup.CriticalErrorEvent{
+				d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
 					Err: fmt.Errorf("unexpected TryBackupUnsafeReorg error type: %w", err),
-					Ctx: x.Ctx,
 				})
 			}
 		}
@@ -390,13 +366,12 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 		// perform a network call, then we should yield even if we did not encounter an error.
 		if err := d.ec.TryUpdateEngine(d.ctx); err != nil && !errors.Is(err, ErrNoFCUNeeded) {
 			if errors.Is(err, derive.ErrReset) {
-				d.emitter.Emit(rollup.ResetEvent{Err: err, Ctx: x.Ctx})
+				d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
 			} else if errors.Is(err, derive.ErrTemporary) {
-				d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err, Ctx: x.Ctx})
+				d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
 			} else {
-				d.emitter.Emit(rollup.CriticalErrorEvent{
+				d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
 					Err: fmt.Errorf("unexpected TryUpdateEngine error type: %w", err),
-					Ctx: x.Ctx,
 				})
 			}
 		} else if x.triggeredByPayloadSuccess() {
@@ -423,30 +398,28 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			// unify the events handler with the engine-controller,
 			// remove a lot of code, and not do this error translation.
 			if errors.Is(err, derive.ErrReset) {
-				d.emitter.Emit(rollup.ResetEvent{Err: err, Ctx: x.Ctx})
+				d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
 			} else if errors.Is(err, derive.ErrTemporary) {
-				d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err, Ctx: x.Ctx})
+				d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
 			} else {
-				d.emitter.Emit(rollup.CriticalErrorEvent{
+				d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
 					Err: fmt.Errorf("unexpected InsertUnsafePayload error type: %w", err),
-					Ctx: x.Ctx,
 				})
 			}
 		} else {
 			d.log.Info("successfully processed payload", "ref", ref, "txs", len(x.Envelope.ExecutionPayload.Transactions))
 		}
 	case ForkchoiceRequestEvent:
-		d.emitter.Emit(ForkchoiceUpdateEvent{
+		d.emitter.Emit(ctx, ForkchoiceUpdateEvent{
 			UnsafeL2Head:    d.ec.UnsafeL2Head(),
 			SafeL2Head:      d.ec.SafeL2Head(),
 			FinalizedL2Head: d.ec.Finalized(),
-			Ctx:             x.Ctx,
 		})
 	case rollup.ForceResetEvent:
 		ForceEngineReset(d.ec, x)
 
 		// Time to apply the changes to the underlying engine
-		d.emitter.Emit(TryUpdateEngineEvent{Ctx: x.Ctx})
+		d.emitter.Emit(ctx, TryUpdateEngineEvent{})
 
 		v := EngineResetConfirmedEvent{
 			LocalUnsafe: d.ec.UnsafeL2Head(),
@@ -454,10 +427,9 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			LocalSafe:   d.ec.LocalSafeL2Head(),
 			CrossSafe:   d.ec.SafeL2Head(),
 			Finalized:   d.ec.Finalized(),
-			Ctx:         x.Ctx,
 		}
 		// We do not emit the original event values, since those might not be set (optional attributes).
-		d.emitter.Emit(v)
+		d.emitter.Emit(ctx, v)
 		d.log.Info("Reset of Engine is completed",
 			"local_unsafe", v.LocalUnsafe,
 			"cross_unsafe", v.CrossUnsafe,
@@ -471,26 +443,24 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			d.ec.SetBackupUnsafeL2Head(d.ec.unsafeHead, false)
 		}
 		d.ec.SetUnsafeHead(x.Ref)
-		d.emitter.Emit(UnsafeUpdateEvent(x))
+		d.emitter.Emit(ctx, UnsafeUpdateEvent(x))
 	case UnsafeUpdateEvent:
 		// pre-interop everything that is local-unsafe is also immediately cross-unsafe.
 		if !d.cfg.IsInterop(x.Ref.Time) {
-			d.emitter.Emit(PromoteCrossUnsafeEvent(x))
+			d.emitter.Emit(ctx, PromoteCrossUnsafeEvent(x))
 		}
 		// Try to apply the forkchoice changes
-		d.emitter.Emit(TryUpdateEngineEvent{Ctx: x.Ctx})
+		d.emitter.Emit(ctx, TryUpdateEngineEvent{})
 	case PromoteCrossUnsafeEvent:
 		d.ec.SetCrossUnsafeHead(x.Ref)
-		d.emitter.Emit(CrossUnsafeUpdateEvent{
+		d.emitter.Emit(ctx, CrossUnsafeUpdateEvent{
 			CrossUnsafe: x.Ref,
 			LocalUnsafe: d.ec.UnsafeL2Head(),
-			Ctx:         x.Ctx,
 		})
 	case PendingSafeRequestEvent:
-		d.emitter.Emit(PendingSafeUpdateEvent{
+		d.emitter.Emit(ctx, PendingSafeUpdateEvent{
 			PendingSafe: d.ec.PendingSafeL2Head(),
 			Unsafe:      d.ec.UnsafeL2Head(),
-			Ctx:         x.Ctx,
 		})
 	case PromotePendingSafeEvent:
 		// Only promote if not already stale.
@@ -498,49 +468,45 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 		if x.Ref.Number > d.ec.PendingSafeL2Head().Number {
 			d.log.Debug("Updating pending safe", "pending_safe", x.Ref, "local_safe", d.ec.LocalSafeL2Head(), "unsafe", d.ec.UnsafeL2Head(), "concluding", x.Concluding)
 			d.ec.SetPendingSafeL2Head(x.Ref)
-			d.emitter.Emit(PendingSafeUpdateEvent{
+			d.emitter.Emit(ctx, PendingSafeUpdateEvent{
 				PendingSafe: d.ec.PendingSafeL2Head(),
 				Unsafe:      d.ec.UnsafeL2Head(),
-				Ctx:         x.Ctx,
 			})
 		}
 		if x.Concluding && x.Ref.Number > d.ec.LocalSafeL2Head().Number {
-			d.emitter.Emit(PromoteLocalSafeEvent{
+			d.emitter.Emit(ctx, PromoteLocalSafeEvent{
 				Ref:    x.Ref,
 				Source: x.Source,
-				Ctx:    x.Ctx,
 			})
 		}
 	case PromoteLocalSafeEvent:
 		d.log.Debug("Updating local safe", "local_safe", x.Ref, "safe", d.ec.SafeL2Head(), "unsafe", d.ec.UnsafeL2Head())
 		d.ec.SetLocalSafeHead(x.Ref)
-		d.emitter.Emit(LocalSafeUpdateEvent(x))
+		d.emitter.Emit(ctx, LocalSafeUpdateEvent(x))
 	case LocalSafeUpdateEvent:
 		// pre-interop everything that is local-safe is also immediately cross-safe.
 		if !d.cfg.IsInterop(x.Ref.Time) {
-			d.emitter.Emit(PromoteSafeEvent(x))
+			d.emitter.Emit(ctx, PromoteSafeEvent(x))
 		}
 	case PromoteSafeEvent:
 		d.log.Debug("Updating safe", "safe", x.Ref, "unsafe", d.ec.UnsafeL2Head())
 		d.ec.SetSafeHead(x.Ref)
 		// Finalizer can pick up this safe cross-block now
-		d.emitter.Emit(SafeDerivedEvent{Safe: x.Ref, Source: x.Source, Ctx: x.Ctx})
-		d.emitter.Emit(CrossSafeUpdateEvent{
+		d.emitter.Emit(ctx, SafeDerivedEvent{Safe: x.Ref, Source: x.Source})
+		d.emitter.Emit(ctx, CrossSafeUpdateEvent{
 			CrossSafe: d.ec.SafeL2Head(),
 			LocalSafe: d.ec.LocalSafeL2Head(),
-			Ctx:       x.Ctx,
 		})
 		if x.Ref.Number > d.ec.crossUnsafeHead.Number {
 			d.log.Debug("Cross Unsafe Head is stale, updating to match cross safe", "cross_unsafe", d.ec.crossUnsafeHead, "cross_safe", x.Ref)
 			d.ec.SetCrossUnsafeHead(x.Ref)
-			d.emitter.Emit(CrossUnsafeUpdateEvent{
+			d.emitter.Emit(ctx, CrossUnsafeUpdateEvent{
 				CrossUnsafe: x.Ref,
 				LocalUnsafe: d.ec.UnsafeL2Head(),
-				Ctx:         x.Ctx,
 			})
 		}
 		// Try to apply the forkchoice changes
-		d.emitter.Emit(TryUpdateEngineEvent{Ctx: x.Ctx})
+		d.emitter.Emit(ctx, TryUpdateEngineEvent{})
 	case PromoteFinalizedEvent:
 		if x.Ref.Number < d.ec.Finalized().Number {
 			d.log.Error("Cannot rewind finality,", "ref", x.Ref, "finalized", d.ec.Finalized())
@@ -551,44 +517,42 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			return true
 		}
 		d.ec.SetFinalizedHead(x.Ref)
-		d.emitter.Emit(FinalizedUpdateEvent(x))
+		d.emitter.Emit(ctx, FinalizedUpdateEvent(x))
 		// Try to apply the forkchoice changes
-		d.emitter.Emit(TryUpdateEngineEvent{Ctx: x.Ctx})
+		d.emitter.Emit(ctx, TryUpdateEngineEvent{})
 	case CrossUpdateRequestEvent:
 		if x.CrossUnsafe {
-			d.emitter.Emit(CrossUnsafeUpdateEvent{
+			d.emitter.Emit(ctx, CrossUnsafeUpdateEvent{
 				CrossUnsafe: d.ec.CrossUnsafeL2Head(),
 				LocalUnsafe: d.ec.UnsafeL2Head(),
-				Ctx:         x.Ctx,
 			})
 		}
 		if x.CrossSafe {
-			d.emitter.Emit(CrossSafeUpdateEvent{
+			d.emitter.Emit(ctx, CrossSafeUpdateEvent{
 				CrossSafe: d.ec.SafeL2Head(),
 				LocalSafe: d.ec.LocalSafeL2Head(),
-				Ctx:       x.Ctx,
 			})
 		}
 	case InteropInvalidateBlockEvent:
-		d.emitter.Emit(BuildStartEvent{Attributes: x.Attributes, Ctx: x.Ctx})
+		d.emitter.Emit(ctx, BuildStartEvent{Attributes: x.Attributes})
 	case BuildStartEvent:
-		d.onBuildStart(x)
+		d.onBuildStart(ctx, x)
 	case BuildStartedEvent:
-		d.onBuildStarted(x)
+		d.onBuildStarted(ctx, x)
 	case BuildSealEvent:
-		d.onBuildSeal(x)
+		d.onBuildSeal(ctx, x)
 	case BuildSealedEvent:
-		d.onBuildSealed(x)
+		d.onBuildSealed(ctx, x)
 	case BuildInvalidEvent:
-		d.onBuildInvalid(x)
+		d.onBuildInvalid(ctx, x)
 	case BuildCancelEvent:
-		d.onBuildCancel(x)
+		d.onBuildCancel(ctx, x)
 	case PayloadProcessEvent:
-		d.onPayloadProcess(x)
+		d.onPayloadProcess(ctx, x)
 	case PayloadSuccessEvent:
-		d.onPayloadSuccess(x)
+		d.onPayloadSuccess(ctx, x)
 	case PayloadInvalidEvent:
-		d.onPayloadInvalid(x)
+		d.onPayloadInvalid(ctx, x)
 	default:
 		return false
 	}

--- a/op-node/rollup/engine/payload_invalid.go
+++ b/op-node/rollup/engine/payload_invalid.go
@@ -1,22 +1,21 @@
 package engine
 
 import (
+	"context"
+
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
 type PayloadInvalidEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
 	Err      error
-
-	event.Ctx
 }
 
 func (ev PayloadInvalidEvent) String() string {
 	return "payload-invalid"
 }
 
-func (eq *EngDeriver) onPayloadInvalid(ev PayloadInvalidEvent) {
+func (eq *EngDeriver) onPayloadInvalid(ctx context.Context, ev PayloadInvalidEvent) {
 	eq.log.Warn("Payload was invalid", "block", ev.Envelope.ExecutionPayload.ID(),
 		"err", ev.Err, "timestamp", uint64(ev.Envelope.ExecutionPayload.Timestamp))
 }

--- a/op-node/rollup/event.go
+++ b/op-node/rollup/event.go
@@ -8,7 +8,6 @@ import (
 // L1TemporaryErrorEvent identifies a temporary issue with the L1 data.
 type L1TemporaryErrorEvent struct {
 	Err error
-	event.Ctx
 }
 
 var _ event.Event = L1TemporaryErrorEvent{}
@@ -23,7 +22,6 @@ func (ev L1TemporaryErrorEvent) String() string {
 // See L1TemporaryErrorEvent for L1 related temporary errors.
 type EngineTemporaryErrorEvent struct {
 	Err error
-	event.Ctx
 }
 
 var _ event.Event = EngineTemporaryErrorEvent{}
@@ -34,7 +32,6 @@ func (ev EngineTemporaryErrorEvent) String() string {
 
 type ResetEvent struct {
 	Err error
-	event.Ctx
 }
 
 var _ event.Event = ResetEvent{}
@@ -49,7 +46,6 @@ func (ev ResetEvent) String() string {
 // Pre-interop both local and cross values should be set the same.
 type ForceResetEvent struct {
 	LocalUnsafe, CrossUnsafe, LocalSafe, CrossSafe, Finalized eth.L2BlockRef
-	event.Ctx
 }
 
 func (ev ForceResetEvent) String() string {

--- a/op-node/rollup/finality/altda.go
+++ b/op-node/rollup/finality/altda.go
@@ -37,7 +37,7 @@ func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config,
 	// Finality signal will come from the DA contract or L1 finality whichever is last.
 	// The AltDA module will then call the inner.Finalize function when applicable.
 	backend.OnFinalizedHeadSignal(func(ref eth.L1BlockRef) {
-		inner.OnEvent(FinalizeL1Event{FinalizedL1: ref, Ctx: event.WrapCtx(ctx)})
+		inner.OnEvent(ctx, FinalizeL1Event{FinalizedL1: ref})
 	})
 
 	return &AltDAFinalizer{
@@ -46,12 +46,12 @@ func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config,
 	}
 }
 
-func (fi *AltDAFinalizer) OnEvent(ev event.Event) bool {
+func (fi *AltDAFinalizer) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case FinalizeL1Event:
 		fi.backend.Finalize(x.FinalizedL1)
 		return true
 	default:
-		return fi.Finalizer.OnEvent(ev)
+		return fi.Finalizer.OnEvent(ctx, ev)
 	}
 }

--- a/op-node/rollup/sequencing/disabled.go
+++ b/op-node/rollup/sequencing/disabled.go
@@ -16,7 +16,7 @@ type DisabledSequencer struct{}
 
 var _ SequencerIface = DisabledSequencer{}
 
-func (ds DisabledSequencer) OnEvent(ev event.Event) bool {
+func (ds DisabledSequencer) OnEvent(ctx context.Context, ev event.Event) bool {
 	return false
 }
 

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -54,7 +54,7 @@ func (los *L1OriginSelector) SetRecoverMode(enabled bool) {
 	los.recoverMode.Store(enabled)
 }
 
-func (los *L1OriginSelector) OnEvent(ev event.Event) bool {
+func (los *L1OriginSelector) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case engine.ForkchoiceUpdateEvent:
 		los.onForkchoiceUpdate(x.UnsafeL2Head)

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -102,12 +102,12 @@ func TestOriginSelectorFetchNextError(t *testing.T) {
 
 	l1.ExpectL1BlockRefByNumber(b.Number, eth.L1BlockRef{}, ethereum.NotFound)
 
-	handled := s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+	handled := s.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
 	require.True(t, handled)
 
 	l1.ExpectL1BlockRefByNumber(b.Number, eth.L1BlockRef{}, errors.New("test error"))
 
-	handled = s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+	handled = s.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
 	require.True(t, handled)
 
 	// The next origin should still be `a` because the fetch failed.
@@ -177,7 +177,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 
 		// Trigger the background fetch via a forkchoice update.
 		// This should be a no-op because the next origin is already cached.
-		handled := s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+		handled := s.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
 		require.True(t, handled)
 
 		requireL1OriginAt(l2Head, b)
@@ -194,7 +194,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 
 		// Trigger the background fetch via a forkchoice update.
 		// This will actually fetch the next origin because the internal cache is empty.
-		handled = s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+		handled = s.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
 		require.True(t, handled)
 
 		// The next origin should be `c` now.
@@ -270,7 +270,7 @@ func TestOriginSelectorHandlesReset(t *testing.T) {
 	require.Equal(t, b, next)
 
 	// Trigger the pipeline reset
-	handled := s.OnEvent(rollup.ResetEvent{})
+	handled := s.OnEvent(context.Background(), rollup.ResetEvent{})
 	require.True(t, handled)
 
 	// The next origin should be `a` now, but we need to fetch it
@@ -331,7 +331,7 @@ func TestOriginSelectorFetchesNextOrigin(t *testing.T) {
 	require.Equal(t, a, next)
 
 	// Trigger the background fetch via a forkchoice update
-	handled := s.OnEvent(engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
+	handled := s.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: l2Head})
 	require.True(t, handled)
 
 	// The next origin should be `b` now.
@@ -730,6 +730,6 @@ func TestOriginSelectorMiscEvent(t *testing.T) {
 	s := NewL1OriginSelector(ctx, log, cfg, l1)
 
 	// This event is not handled
-	handled := s.OnEvent(rollup.L1TemporaryErrorEvent{})
+	handled := s.OnEvent(context.Background(), rollup.L1TemporaryErrorEvent{})
 	require.False(t, handled)
 }

--- a/op-node/rollup/status/l1_tracker.go
+++ b/op-node/rollup/status/l1_tracker.go
@@ -23,7 +23,7 @@ func NewL1Tracker(inner derive.L1Fetcher) *L1Tracker {
 	}
 }
 
-func (st *L1Tracker) OnEvent(ev event.Event) bool {
+func (st *L1Tracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case L1UnsafeEvent:
 		st.cache.Insert(x.L1Unsafe)

--- a/op-node/rollup/status/l1_tracker_test.go
+++ b/op-node/rollup/status/l1_tracker_test.go
@@ -15,7 +15,7 @@ func mockL1BlockRef(num uint64) eth.L1BlockRef {
 }
 
 func newL1HeadEvent(l1Tracker *L1Tracker, head eth.L1BlockRef) {
-	l1Tracker.OnEvent(L1UnsafeEvent{
+	l1Tracker.OnEvent(context.Background(), L1UnsafeEvent{
 		L1Unsafe: head,
 	})
 }

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
@@ -16,7 +17,6 @@ import (
 
 type L1UnsafeEvent struct {
 	L1Unsafe eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev L1UnsafeEvent) String() string {
@@ -25,7 +25,6 @@ func (ev L1UnsafeEvent) String() string {
 
 type L1SafeEvent struct {
 	L1Safe eth.L1BlockRef
-	event.Ctx
 }
 
 func (ev L1SafeEvent) String() string {
@@ -59,7 +58,7 @@ func NewStatusTracker(log log.Logger, metrics Metrics) *StatusTracker {
 	return st
 }
 
-func (st *StatusTracker) OnEvent(ev event.Event) bool {
+func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 

--- a/op-node/rollup/status/status_test.go
+++ b/op-node/rollup/status/status_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -23,7 +24,7 @@ func TestStatus(t *testing.T) {
 	status := tracker.SyncStatus()
 	require.Equal(t, eth.SyncStatus{}, *status)
 
-	tracker.OnEvent(engine.ForkchoiceUpdateEvent{
+	tracker.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
 		UnsafeL2Head:    eth.L2BlockRef{Number: 101},
 		SafeL2Head:      eth.L2BlockRef{Number: 102},
 		FinalizedL2Head: eth.L2BlockRef{Number: 99},
@@ -42,7 +43,7 @@ func TestStatus(t *testing.T) {
 	// which would cause a major issue:
 	require.NotZero(t, status.LocalSafeL2.Number)
 
-	tracker.OnEvent(rollup.ResetEvent{})
+	tracker.OnEvent(context.Background(), rollup.ResetEvent{})
 	status = tracker.SyncStatus()
 
 	require.Zero(t, status.LocalSafeL2.Number)

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -69,7 +69,7 @@ func NewDriver(logger log.Logger, cfg *rollup.Config, depSet derive.DependencySe
 	return d
 }
 
-func (d *Driver) Emit(ev event.Event) {
+func (d *Driver) Emit(ctx context.Context, ev event.Event) {
 	if d.end.Closing() {
 		return
 	}
@@ -78,7 +78,7 @@ func (d *Driver) Emit(ev event.Event) {
 
 func (d *Driver) RunComplete() (eth.L2BlockRef, error) {
 	// Initial reset
-	d.Emit(engine.ResetEngineRequestEvent{Ctx: event.WrapCtx(context.Background())})
+	d.Emit(context.Background(), engine.ResetEngineRequestEvent{})
 
 	for !d.end.Closing() {
 		if len(d.events) == 0 {
@@ -90,7 +90,7 @@ func (d *Driver) RunComplete() (eth.L2BlockRef, error) {
 		}
 		ev := d.events[0]
 		d.events = d.events[1:]
-		d.deriver.OnEvent(ev)
+		d.deriver.OnEvent(context.Background(), ev)
 	}
 	return d.end.Result()
 }

--- a/op-program/client/driver/driver_test.go
+++ b/op-program/client/driver/driver_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestDriver(t *testing.T) {
 			logger: logger,
 			end:    end,
 		}
-		d.deriver = event.DeriverFunc(func(ev event.Event) bool {
+		d.deriver = event.DeriverFunc(func(ctx context.Context, ev event.Event) bool {
 			onEvent(d, end, ev)
 			return true
 		})
@@ -68,7 +69,7 @@ func TestDriver(t *testing.T) {
 				return
 			}
 			count += 1
-			d.Emit(TestEvent{})
+			d.Emit(context.Background(), TestEvent{})
 		})
 		_, err := d.RunComplete()
 		require.NoError(t, err)
@@ -83,7 +84,7 @@ func TestDriver(t *testing.T) {
 				return
 			}
 			count += 1
-			d.Emit(TestEvent{})
+			d.Emit(context.Background(), TestEvent{})
 		})
 		_, err := d.RunComplete()
 		require.ErrorIs(t, mockErr, err)
@@ -93,7 +94,7 @@ func TestDriver(t *testing.T) {
 		count := 0
 		d := newTestDriver(t, func(d *Driver, end *fakeEnd, ev event.Event) {
 			if count < 3 { // stop generating events after a while, without changing end condition
-				d.Emit(TestEvent{})
+				d.Emit(context.Background(), TestEvent{})
 			}
 			count += 1
 		})
@@ -106,8 +107,8 @@ func TestDriver(t *testing.T) {
 		count := 0
 		d := newTestDriver(t, func(d *Driver, end *fakeEnd, ev event.Event) {
 			if count < 3 {
-				d.Emit(TestEvent{})
-				d.Emit(TestEvent{})
+				d.Emit(context.Background(), TestEvent{})
+				d.Emit(context.Background(), TestEvent{})
 			}
 			count += 1
 		})

--- a/op-service/event/events_test.go
+++ b/op-service/event/events_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -8,7 +9,6 @@ import (
 )
 
 type TestEvent struct {
-	Ctx
 }
 
 func (ev TestEvent) String() string {
@@ -17,39 +17,39 @@ func (ev TestEvent) String() string {
 
 func TestDeriverMux_OnEvent(t *testing.T) {
 	result := ""
-	a := DeriverFunc(func(ev Event) bool {
+	a := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		result += fmt.Sprintf("A:%s\n", ev)
 		return true
 	})
-	b := DeriverFunc(func(ev Event) bool {
+	b := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		result += fmt.Sprintf("B:%s\n", ev)
 		return true
 	})
-	c := DeriverFunc(func(ev Event) bool {
+	c := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		result += fmt.Sprintf("C:%s\n", ev)
 		return true
 	})
 
 	x := DeriverMux{}
-	x.OnEvent(TestEvent{})
+	x.OnEvent(context.Background(), TestEvent{})
 	require.Equal(t, "", result)
 
 	x = DeriverMux{a}
-	x.OnEvent(TestEvent{})
+	x.OnEvent(context.Background(), TestEvent{})
 	require.Equal(t, "A:X\n", result)
 
 	result = ""
 	x = DeriverMux{a, a}
-	x.OnEvent(TestEvent{})
+	x.OnEvent(context.Background(), TestEvent{})
 	require.Equal(t, "A:X\nA:X\n", result)
 
 	result = ""
 	x = DeriverMux{a, b}
-	x.OnEvent(TestEvent{})
+	x.OnEvent(context.Background(), TestEvent{})
 	require.Equal(t, "A:X\nB:X\n", result)
 
 	result = ""
 	x = DeriverMux{a, b, c}
-	x.OnEvent(TestEvent{})
+	x.OnEvent(context.Background(), TestEvent{})
 	require.Equal(t, "A:X\nB:X\nC:X\n", result)
 }

--- a/op-service/event/executor_global_test.go
+++ b/op-service/event/executor_global_test.go
@@ -63,7 +63,6 @@ func TestQueueSanityLimit(t *testing.T) {
 
 type CyclicEvent struct {
 	Count int
-	Ctx
 }
 
 func (ev CyclicEvent) String() string {

--- a/op-service/event/limiter.go
+++ b/op-service/event/limiter.go
@@ -28,14 +28,14 @@ func NewLimiter[E Emitter](ctx context.Context, em E, eventRate rate.Limit, even
 }
 
 // Emit is thread-safe, multiple parallel derivers can safely emit events to it.
-func (l *Limiter[E]) Emit(ev Event) {
+func (l *Limiter[E]) Emit(ctx context.Context, ev Event) {
 	if l.onLimited != nil && l.rl.Tokens() < 1.0 {
 		l.onLimited()
 	}
 	if err := l.rl.Wait(l.ctx); err != nil {
 		return // ctx error, safe to ignore.
 	}
-	l.emitter.Emit(ev)
+	l.emitter.Emit(ctx, ev)
 }
 
 // LimiterDrainer is a variant of Limiter that supports event draining.
@@ -45,8 +45,8 @@ func NewLimiterDrainer(ctx context.Context, em EmitterDrainer, eventRate rate.Li
 	return (*LimiterDrainer)(NewLimiter(ctx, em, eventRate, eventBurst, onLimited))
 }
 
-func (l *LimiterDrainer) Emit(ev Event) {
-	l.emitter.Emit(ev)
+func (l *LimiterDrainer) Emit(ctx context.Context, ev Event) {
+	l.emitter.Emit(ctx, ev)
 }
 
 func (l *LimiterDrainer) Drain() error {

--- a/op-service/event/limiter_test.go
+++ b/op-service/event/limiter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestLimiter(t *testing.T) {
 	count := uint64(0)
-	em := EmitterFunc(func(ev Event) {
+	em := EmitterFunc(func(ctx context.Context, ev Event) {
 		count += 1
 	})
 	hitRateLimitAt := uint64(0)
@@ -22,7 +22,7 @@ func TestLimiter(t *testing.T) {
 		hitRateLimitAt = count
 	})
 	for i := 0; i < 30; i++ {
-		lim.Emit(TestEvent{})
+		lim.Emit(context.Background(), TestEvent{})
 	}
 	require.LessOrEqual(t, uint64(10), hitRateLimitAt)
 }

--- a/op-service/event/system_test.go
+++ b/op-service/event/system_test.go
@@ -17,7 +17,7 @@ func TestSysTracing(t *testing.T) {
 	ex := NewGlobalSynchronous(context.Background())
 	sys := NewSystem(logger, ex)
 	count := 0
-	foo := DeriverFunc(func(ev Event) bool {
+	foo := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		switch ev.(type) {
 		case TestEvent:
 			count += 1
@@ -30,7 +30,7 @@ func TestSysTracing(t *testing.T) {
 	sys.AddTracer(logTracer)
 
 	em := sys.Register("foo", foo)
-	em.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	em.Emit(context.Background(), TestEvent{})
 	require.Equal(t, 0, count, "no event processing before synchronous executor explicitly drains")
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 1, count)
@@ -42,17 +42,17 @@ func TestSysTracing(t *testing.T) {
 		testlog.NewMessageContainsFilter("Processing event")))
 	require.NotNil(t, logs.FindLog(hasDebugLevel,
 		testlog.NewMessageContainsFilter("Processed event")))
-	em.Emit(FooEvent{Ctx: WrapCtx(context.Background())})
+	em.Emit(context.Background(), FooEvent{})
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 1, count, "foo does not count")
 
-	em.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	em.Emit(context.Background(), TestEvent{})
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 2, count)
 
 	logs.Clear()
 	sys.RemoveTracer(logTracer)
-	em.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	em.Emit(context.Background(), TestEvent{})
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 3, count)
 	require.Equal(t, 0, len(*logs.Logs), "no logs when tracer is not active anymore")
@@ -63,7 +63,7 @@ func TestSystemBroadcast(t *testing.T) {
 	ex := NewGlobalSynchronous(context.Background())
 	sys := NewSystem(logger, ex)
 	fooCount := 0
-	foo := DeriverFunc(func(ev Event) bool {
+	foo := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		switch ev.(type) {
 		case TestEvent:
 			fooCount += 1
@@ -75,7 +75,7 @@ func TestSystemBroadcast(t *testing.T) {
 		return true
 	})
 	barCount := 0
-	bar := DeriverFunc(func(ev Event) bool {
+	bar := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		switch ev.(type) {
 		case TestEvent:
 			barCount += 1
@@ -87,20 +87,20 @@ func TestSystemBroadcast(t *testing.T) {
 		return true
 	})
 	fooEm := sys.Register("foo", foo)
-	fooEm.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	fooEm.Emit(context.Background(), TestEvent{})
 	barEm := sys.Register("bar", bar)
-	barEm.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	barEm.Emit(context.Background(), TestEvent{})
 	// events are broadcast to every deriver, regardless who sends them
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 2, fooCount)
 	require.Equal(t, 2, barCount)
 	// emit from bar, process in foo
-	barEm.Emit(FooEvent{Ctx: WrapCtx(context.Background())})
+	barEm.Emit(context.Background(), FooEvent{})
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 3, fooCount)
 	require.Equal(t, 2, barCount)
 	// emit from foo, process in bar
-	fooEm.Emit(BarEvent{Ctx: WrapCtx(context.Background())})
+	fooEm.Emit(context.Background(), BarEvent{})
 	require.NoError(t, ex.Drain())
 	require.Equal(t, 3, fooCount)
 	require.Equal(t, 3, barCount)
@@ -110,7 +110,7 @@ func TestCriticalError(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)
 	count := 0
 	seenCrit := 0
-	deriverFn := DeriverFunc(func(ev Event) bool {
+	deriverFn := DeriverFunc(func(ctx context.Context, ev Event) bool {
 		switch ev.(type) {
 		case CriticalErrorEvent:
 			seenCrit += 1
@@ -125,15 +125,15 @@ func TestCriticalError(t *testing.T) {
 	emitterB := sys.Register("b", deriverFn)
 
 	require.NoError(t, exec.Drain(), "can drain, even if empty")
-	emitterA.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	emitterA.Emit(context.Background(), TestEvent{})
 	require.Equal(t, 0, count, "no processing yet, queued event")
 	require.NoError(t, exec.Drain())
 	require.Equal(t, 2, count, "both A and B processed the event")
 
-	emitterA.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
-	emitterB.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	emitterA.Emit(context.Background(), TestEvent{})
+	emitterB.Emit(context.Background(), TestEvent{})
 	testErr := errors.New("test crit error")
-	emitterB.Emit(CriticalErrorEvent{Err: testErr, Ctx: WrapCtx(context.Background())})
+	emitterB.Emit(context.Background(), CriticalErrorEvent{Err: testErr})
 	require.Equal(t, 2, count, "no processing yet, queued events")
 	require.Equal(t, 0, seenCrit, "critical error events are still scheduled like normal")
 	require.True(t, sys.abort.Load(), "we are aware of the crit")
@@ -144,7 +144,7 @@ func TestCriticalError(t *testing.T) {
 	// We are able to stop the processing now
 	sys.Stop()
 
-	emitterA.Emit(TestEvent{Ctx: WrapCtx(context.Background())})
+	emitterA.Emit(context.Background(), TestEvent{})
 	require.NoError(t, exec.Drain(), "system is closed, no further event processing")
 	require.Equal(t, 2, count)
 }

--- a/op-service/event/util_test.go
+++ b/op-service/event/util_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 type FooEvent struct {
-	Ctx
 }
 
 func (ev FooEvent) String() string {
@@ -15,7 +14,6 @@ func (ev FooEvent) String() string {
 }
 
 type BarEvent struct {
-	Ctx
 }
 
 func (ev BarEvent) String() string {

--- a/op-service/testutils/mock_emitter.go
+++ b/op-service/testutils/mock_emitter.go
@@ -1,6 +1,8 @@
 package testutils
 
 import (
+	"context"
+
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/stretchr/testify/mock"
 )
@@ -9,7 +11,7 @@ type MockEmitter struct {
 	mock.Mock
 }
 
-func (m *MockEmitter) Emit(ev event.Event) {
+func (m *MockEmitter) Emit(ctx context.Context, ev event.Event) {
 	m.Mock.MethodCalled("Emit", ev)
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -133,10 +133,9 @@ func TestBackendLifetime_InteropAtGenesis(t *testing.T) {
 	src.ExpectFetchReceipts(blockX.Hash, nil, nil)
 	src.ExpectBlockRefByNumber(2, blockY, nil)
 	src.ExpectFetchReceipts(blockY.Hash, nil, nil)
-	b.emitter.Emit(superevents.LocalUnsafeReceivedEvent{
+	b.emitter.Emit(context.Background(), superevents.LocalUnsafeReceivedEvent{
 		ChainID:        chainA,
 		NewLocalUnsafe: blockY,
-		Ctx:            event.WrapCtx(context.Background()),
 	})
 	require.NoError(t, ex.Drain())
 	src.AssertExpectations(t)
@@ -158,12 +157,11 @@ func TestBackendLifetime_InteropAtGenesis(t *testing.T) {
 
 	// Receive derived block X from node
 
-	b.emitter.Emit(superevents.LocalDerivedEvent{
+	b.emitter.Emit(context.Background(), superevents.LocalDerivedEvent{
 		ChainID: chainA,
 		Derived: types.DerivedBlockRefPair{
 			Derived: blockX,
 		},
-		Ctx: event.WrapCtx(context.Background()),
 	})
 	require.NoError(t, ex.Drain())
 	src.AssertExpectations(t)
@@ -259,10 +257,9 @@ func TestBackendLifetime_InteropPostGenesis(t *testing.T) {
 
 	// src.ExpectBlockRefByNumber(1, blockX, nil)
 	// src.ExpectFetchReceipts(blockX.Hash, nil, nil)
-	b.emitter.Emit(superevents.LocalUnsafeReceivedEvent{
+	b.emitter.Emit(context.Background(), superevents.LocalUnsafeReceivedEvent{
 		ChainID:        chainA,
 		NewLocalUnsafe: blockX,
-		Ctx:            event.WrapCtx(context.Background()),
 	})
 	require.NoError(t, ex.Drain())
 	src.AssertExpectations(t)
@@ -280,10 +277,9 @@ func TestBackendLifetime_InteropPostGenesis(t *testing.T) {
 
 	src.ExpectBlockRefByNumber(blockY.Number, blockY, nil)
 	src.ExpectFetchReceipts(blockY.Hash, nil, nil)
-	b.emitter.Emit(superevents.LocalUnsafeReceivedEvent{
+	b.emitter.Emit(context.Background(), superevents.LocalUnsafeReceivedEvent{
 		ChainID:        chainA,
 		NewLocalUnsafe: blockY,
-		Ctx:            event.WrapCtx(context.Background()),
 	})
 	require.NoError(t, ex.Drain())
 	src.AssertExpectations(t)
@@ -293,12 +289,11 @@ func TestBackendLifetime_InteropPostGenesis(t *testing.T) {
 
 	// Receive derived block X from node
 
-	b.emitter.Emit(superevents.LocalDerivedEvent{
+	b.emitter.Emit(context.Background(), superevents.LocalDerivedEvent{
 		ChainID: chainA,
 		Derived: types.DerivedBlockRefPair{
 			Derived: blockX,
 		},
-		Ctx: event.WrapCtx(context.Background()),
 	})
 	require.NoError(t, ex.Drain())
 	src.AssertExpectations(t)
@@ -313,12 +308,11 @@ func TestBackendLifetime_InteropPostGenesis(t *testing.T) {
 
 	// Receive derived block Y from node
 
-	b.emitter.Emit(superevents.LocalDerivedEvent{
+	b.emitter.Emit(context.Background(), superevents.LocalDerivedEvent{
 		ChainID: chainA,
 		Derived: types.DerivedBlockRefPair{
 			Derived: blockY,
 		},
-		Ctx: event.WrapCtx(context.Background()),
 	})
 	require.NoError(t, ex.Drain())
 	// cross-safe now at block Y
@@ -383,7 +377,7 @@ func TestBackendCallsMetrics(t *testing.T) {
 		Derived: block,
 	}
 	// update local unsafe/safe, cross unsafe/safe
-	b.chainDBs.OnEvent(superevents.SafeActivationBlockEvent{
+	b.chainDBs.OnEvent(context.Background(), superevents.SafeActivationBlockEvent{
 		Safe:    safe,
 		ChainID: chainA,
 	})

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -1,6 +1,7 @@
 package cross
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -143,7 +144,7 @@ type CrossSafeWorker struct {
 	linker  depset.LinkChecker
 }
 
-func (c *CrossSafeWorker) OnEvent(ev event.Event) bool {
+func (c *CrossSafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch ev.(type) {
 	case superevents.UpdateCrossSafeRequestEvent:
 		if err := CrossSafeUpdate(c.logger, c.chainID, c.d, c.linker); err != nil {

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -1,6 +1,7 @@
 package cross
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -87,7 +88,7 @@ type CrossUnsafeWorker struct {
 	linker  depset.LinkChecker
 }
 
-func (c *CrossUnsafeWorker) OnEvent(ev event.Event) bool {
+func (c *CrossUnsafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch ev.(type) {
 	case superevents.UpdateCrossUnsafeRequestEvent:
 		if err := CrossUnsafeUpdate(c.logger, c.chainID, c.d, c.linker); err != nil {

--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -174,7 +174,7 @@ func (db *ChainsDB) AttachEmitter(em event.Emitter) {
 	db.emitter = em
 }
 
-func (db *ChainsDB) OnEvent(ev event.Event) bool {
+func (db *ChainsDB) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case superevents.UnsafeActivationBlockEvent:
 		if !db.isInitialized(x.ChainID) {

--- a/op-supervisor/supervisor/backend/l1access/l1_accessor.go
+++ b/op-supervisor/supervisor/backend/l1access/l1_accessor.go
@@ -67,7 +67,7 @@ func (p *L1Accessor) AttachEmitter(em event.Emitter) {
 	p.emitter = em
 }
 
-func (p *L1Accessor) OnEvent(ev event.Event) bool {
+func (p *L1Accessor) OnEvent(ctx context.Context, ev event.Event) bool {
 	return false
 }
 
@@ -165,7 +165,7 @@ func (p *L1Accessor) PullLatest() error {
 }
 
 func (p *L1Accessor) onFinalized(ctx context.Context, ref eth.L1BlockRef) {
-	p.emitter.Emit(superevents.FinalizedL1RequestEvent{FinalizedL1: ref, Ctx: event.WrapCtx(ctx)})
+	p.emitter.Emit(ctx, superevents.FinalizedL1RequestEvent{FinalizedL1: ref})
 }
 
 func (p *L1Accessor) onLatest(ctx context.Context, ref eth.L1BlockRef) {
@@ -181,9 +181,8 @@ func (p *L1Accessor) onLatest(ctx context.Context, ref eth.L1BlockRef) {
 
 	// If the incoming block is not the child of the current tip, signal a potential reorg
 	if ref.ParentHash != p.tip.Hash {
-		p.emitter.Emit(superevents.RewindL1Event{
+		p.emitter.Emit(ctx, superevents.RewindL1Event{
 			IncomingBlock: ref.ID(),
-			Ctx:           event.WrapCtx(ctx),
 		})
 		p.log.Info("Reorg detected", "ref", ref)
 	}

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -107,7 +107,7 @@ func (s *ChainProcessor) nextNum() uint64 {
 	return headNum + 1
 }
 
-func (s *ChainProcessor) OnEvent(ev event.Event) bool {
+func (s *ChainProcessor) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case superevents.ChainProcessEvent:
 		if x.ChainID != s.chain {
@@ -174,9 +174,8 @@ func (s *ChainProcessor) index() {
 		if s.clientsTried < len(s.clients) {
 			s.log.Debug("Active client found no blocks, trying again with next client", "activeClient", s.activeClient)
 			s.nextActiveClient()
-			s.emitter.Emit(superevents.ChainIndexingContinueEvent{
+			s.emitter.Emit(s.systemContext, superevents.ChainIndexingContinueEvent{
 				ChainID: s.chain,
-				Ctx:     event.WrapCtx(s.systemContext),
 			})
 			return
 		} else {
@@ -194,9 +193,8 @@ func (s *ChainProcessor) index() {
 	// if the next block is within the target, we need to continue indexing
 	if next <= s.target {
 		s.log.Debug("More indexing needed, continuing", "target", target, "next", next)
-		s.emitter.Emit(superevents.ChainIndexingContinueEvent{
+		s.emitter.Emit(s.systemContext, superevents.ChainIndexingContinueEvent{
 			ChainID: s.chain,
-			Ctx:     event.WrapCtx(s.systemContext),
 		})
 		return
 	}

--- a/op-supervisor/supervisor/backend/processors/chain_processor_test.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor_test.go
@@ -52,7 +52,7 @@ func TestFailover(t *testing.T) {
 
 type mockEmitter struct{}
 
-func (m *mockEmitter) Emit(ev event.Event) {
+func (m *mockEmitter) Emit(ctx context.Context, ev event.Event) {
 }
 
 type mockSource struct {

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -66,7 +66,7 @@ func (r *Rewinder) AttachEmitter(em event.Emitter) {
 	r.emitter = em
 }
 
-func (r *Rewinder) OnEvent(ev event.Event) bool {
+func (r *Rewinder) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
 	case superevents.RewindL1Event:
 		r.handleRewindL1Event(x)
@@ -150,7 +150,7 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 	}
 
 	// Emit event to trigger node reset with new heads
-	r.emitter.Emit(superevents.ChainRewoundEvent{ChainID: ev.ChainID, Ctx: event.WrapCtx(r.rootCtx)})
+	r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{ChainID: ev.ChainID})
 }
 
 // rewindL1ChainIfReorged rewinds the L1 chain for the given chain ID if a reorg is detected
@@ -257,9 +257,8 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	}
 
 	// Emit rewound event for sync node
-	r.emitter.Emit(superevents.ChainRewoundEvent{
+	r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{
 		ChainID: chainID,
-		Ctx:     event.WrapCtx(r.rootCtx),
 	})
 	return nil
 }

--- a/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder_test.go
@@ -97,7 +97,7 @@ func TestRewindL1(t *testing.T) {
 	chain.l1Node.blocks[l1Block2B.Number] = l1Block2B
 
 	// Trigger L1 reorg
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block2B.ID(),
 	})
 
@@ -167,7 +167,7 @@ func TestRewindL2(t *testing.T) {
 	i.AttachEmitter(&mockEmitter{})
 
 	// Simulate receiving a LocalDerivedDoneEvent for block2B
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -236,7 +236,7 @@ func TestNoRewindNeeded(t *testing.T) {
 	}, true)
 
 	// Set genesis L1 block as finalized
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: eth.BlockRef{
 			Hash:   common.HexToHash("0xaaa0"),
 			Number: 0,
@@ -258,7 +258,7 @@ func TestNoRewindNeeded(t *testing.T) {
 	i.AttachEmitter(&mockEmitter{})
 
 	// Trigger L1 reorg check with same L1 block - should not rewind
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block2.ID(),
 	})
 
@@ -267,7 +267,7 @@ func TestNoRewindNeeded(t *testing.T) {
 	s.verifyCrossSafe(chainID, block2A.ID(), "block2A should still be cross-safe")
 
 	// Trigger LocalDerived check with same L2 block - should not rewind
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -341,7 +341,7 @@ func TestRewindLongChain(t *testing.T) {
 	s.makeBlockSafe(chainID, blocks[0], l1Blocks[0], true)
 
 	// Set genesis L1 block as finalized
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Blocks[0],
 	})
 
@@ -369,7 +369,7 @@ func TestRewindLongChain(t *testing.T) {
 	}
 
 	// Trigger LocalDerived event with block96B
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -432,7 +432,7 @@ func TestRewindMultiChain(t *testing.T) {
 	}
 
 	// Set genesis as finalized for all chains
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Genesis,
 	})
 
@@ -442,7 +442,7 @@ func TestRewindMultiChain(t *testing.T) {
 
 	// Trigger LocalDerived events for both chains
 	for chainID := range s.chains {
-		i.OnEvent(superevents.LocalSafeUpdateEvent{
+		i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 			ChainID: chainID,
 			NewLocalSafe: types.DerivedBlockSealPair{
 				Source: types.BlockSeal{
@@ -568,7 +568,7 @@ func TestRewindL2WalkBack(t *testing.T) {
 	s.makeBlockSafe(chainID, genesis, l1Genesis, true)
 
 	// Set genesis L1 block as finalized
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Genesis,
 	})
 
@@ -584,7 +584,7 @@ func TestRewindL2WalkBack(t *testing.T) {
 	i := New(s.logger, s.chainsDB, chain.l1Node)
 	i.AttachEmitter(&mockEmitter{})
 	// Trigger LocalDerived event with block4B
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -698,7 +698,7 @@ func TestRewindL1PastCrossSafe(t *testing.T) {
 	s.makeBlockSafe(chainID, genesis, l1Genesis, true)
 
 	// Set l1Genesis as finalized
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Genesis,
 	})
 
@@ -728,7 +728,7 @@ func TestRewindL1PastCrossSafe(t *testing.T) {
 	chain.l1Node.blocks[l1Block3B.Number] = l1Block3B
 
 	// Trigger L1 reorg
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block3B.ID(),
 	})
 
@@ -784,7 +784,7 @@ func TestRewindL1GenesisOnlyL2(t *testing.T) {
 	s.makeBlockSafe(chainID, genesis, l1Genesis, true)
 
 	// Set genesis L1 block as finalized
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Genesis,
 	})
 
@@ -794,14 +794,14 @@ func TestRewindL1GenesisOnlyL2(t *testing.T) {
 	chain.l1Node.blocks[l1GenesisB.Number] = l1GenesisB
 
 	// Trigger L1 reorg
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1GenesisB.ID(),
 	})
 
 	s.verifyHeads(chainID, genesis.ID(), "should still have genesis as head after L1 reorg attempt")
 
 	// Try LocalDerived event with same genesis block
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -903,7 +903,7 @@ func TestRewindL1NoL2Impact(t *testing.T) {
 	chain.l1Node.blocks[l1Block2B.Number] = l1Block2B
 
 	// Trigger L1 reorg
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block2B.ID(),
 	})
 
@@ -1016,7 +1016,7 @@ func TestRewindL1SingleBlockL2Impact(t *testing.T) {
 	chain.l1Node.blocks[l1Block2B.Number] = l1Block2B
 
 	// Trigger L1 reorg
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block2B.ID(),
 	})
 
@@ -1079,7 +1079,7 @@ func TestRewindL1DeepL2Impact(t *testing.T) {
 	s.makeBlockSafe(chainID, l2Blocks[0], l1Blocks[0], true)
 
 	// Set genesis L1 block as finalized
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Blocks[0],
 	})
 
@@ -1109,7 +1109,7 @@ func TestRewindL1DeepL2Impact(t *testing.T) {
 
 	// Trigger L1 reorg
 	chain.l1Node.reorg(t, l1Block20B)
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block20B.ID(),
 	})
 
@@ -1220,7 +1220,7 @@ func TestRewindL2LocalDerivationUnsafeMismatch(t *testing.T) {
 	s.verifyCrossSafe(chainID, block2.ID(), "block2 should be cross-safe")
 
 	// Simulate receiving a LocalDerivedEvent for block3B
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -1342,13 +1342,13 @@ func TestRewindL2LocalDerivationSafeMismatch(t *testing.T) {
 	s.makeBlockSafe(chainID, block3A, l1Block3A, true)
 
 	// Set L1 blocks as finalized up to l1Block3A
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Block0,
 	})
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Block1,
 	})
-	s.chainsDB.OnEvent(superevents.FinalizedL1RequestEvent{
+	s.chainsDB.OnEvent(context.Background(), superevents.FinalizedL1RequestEvent{
 		FinalizedL1: l1Block2,
 	})
 
@@ -1370,7 +1370,7 @@ func TestRewindL2LocalDerivationSafeMismatch(t *testing.T) {
 
 	// Trigger L1 reorg
 	chain.l1Node.reorg(t, l1Block3B)
-	i.OnEvent(superevents.RewindL1Event{
+	i.OnEvent(context.Background(), superevents.RewindL1Event{
 		IncomingBlock: l1Block3B.ID(),
 	})
 
@@ -1378,7 +1378,7 @@ func TestRewindL2LocalDerivationSafeMismatch(t *testing.T) {
 	s.verifyHeads(chainID, block2.ID(), "should have rewound to block2")
 
 	// Simulate receiving a LocalDerivedEvent for block3B
-	i.OnEvent(superevents.LocalSafeUpdateEvent{
+	i.OnEvent(context.Background(), superevents.LocalSafeUpdateEvent{
 		ChainID: chainID,
 		NewLocalSafe: types.DerivedBlockSealPair{
 			Source: types.BlockSeal{
@@ -1625,7 +1625,7 @@ type mockEmitter struct {
 	events []event.Event
 }
 
-func (m *mockEmitter) Emit(ev event.Event) {
+func (m *mockEmitter) Emit(_ context.Context, ev event.Event) {
 	m.events = append(m.events, ev)
 }
 

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -42,7 +43,7 @@ func NewStatusTracker(chains []eth.ChainID) *StatusTracker {
 	}
 }
 
-func (su *StatusTracker) OnEvent(ev event.Event) bool {
+func (su *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	su.mu.Lock()
 	defer su.mu.Unlock()
 

--- a/op-supervisor/supervisor/backend/status/status_test.go
+++ b/op-supervisor/supervisor/backend/status/status_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -23,11 +24,11 @@ func TestUpdateMinSyncedL1(t *testing.T) {
 	chains := []eth.ChainID{chain1, chain2}
 	tracker := NewStatusTracker(chains)
 	minL1 := eth.BlockRef{Number: 204, Hash: common.Hash{0xaa}}
-	tracker.OnEvent(superevents.LocalDerivedOriginUpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.LocalDerivedOriginUpdateEvent{
 		ChainID: chain1,
 		Origin:  minL1,
 	})
-	tracker.OnEvent(superevents.LocalDerivedOriginUpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.LocalDerivedOriginUpdateEvent{
 		ChainID: chain2,
 		Origin:  eth.BlockRef{Number: 228, Hash: common.Hash{0xbb}},
 	})
@@ -43,11 +44,11 @@ func TestUpdateLocalUnsafe(t *testing.T) {
 	tracker := NewStatusTracker(chains)
 	chain1Unsafe := eth.BlockRef{Number: 204, Hash: common.Hash{0xaa}}
 	chain2Unsafe := eth.BlockRef{Number: 228, Hash: common.Hash{0xbb}}
-	tracker.OnEvent(superevents.LocalUnsafeUpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.LocalUnsafeUpdateEvent{
 		ChainID:        chain1,
 		NewLocalUnsafe: chain1Unsafe,
 	})
-	tracker.OnEvent(superevents.LocalUnsafeUpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.LocalUnsafeUpdateEvent{
 		ChainID:        chain2,
 		NewLocalUnsafe: chain2Unsafe,
 	})
@@ -76,11 +77,11 @@ func TestUpdateCrossSafe(t *testing.T) {
 			Timestamp: 228000,
 		},
 	}
-	tracker.OnEvent(superevents.CrossSafeUpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.CrossSafeUpdateEvent{
 		ChainID:      chain1,
 		NewCrossSafe: chain1Safe,
 	})
-	tracker.OnEvent(superevents.CrossSafeUpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.CrossSafeUpdateEvent{
 		ChainID:      chain2,
 		NewCrossSafe: chain2Safe,
 	})
@@ -106,11 +107,11 @@ func TestUpdateFinalized(t *testing.T) {
 		Hash:      common.Hash{0xaa},
 		Timestamp: 228000,
 	}
-	tracker.OnEvent(superevents.FinalizedL2UpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.FinalizedL2UpdateEvent{
 		ChainID:     chain1,
 		FinalizedL2: chain1Finalized,
 	})
-	tracker.OnEvent(superevents.FinalizedL2UpdateEvent{
+	tracker.OnEvent(context.Background(), superevents.FinalizedL2UpdateEvent{
 		ChainID:     chain2,
 		FinalizedL2: chain2Finalized,
 	})

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -2,14 +2,12 @@ package superevents
 
 import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 type ChainProcessEvent struct {
 	ChainID eth.ChainID
 	Target  uint64
-	event.Ctx
 }
 
 func (ev ChainProcessEvent) String() string {
@@ -18,7 +16,6 @@ func (ev ChainProcessEvent) String() string {
 
 type UpdateCrossUnsafeRequestEvent struct {
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev UpdateCrossUnsafeRequestEvent) String() string {
@@ -27,7 +24,6 @@ func (ev UpdateCrossUnsafeRequestEvent) String() string {
 
 type UpdateCrossSafeRequestEvent struct {
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev UpdateCrossSafeRequestEvent) String() string {
@@ -37,7 +33,6 @@ func (ev UpdateCrossSafeRequestEvent) String() string {
 type LocalUnsafeUpdateEvent struct {
 	ChainID        eth.ChainID
 	NewLocalUnsafe eth.BlockRef
-	event.Ctx
 }
 
 func (ev LocalUnsafeUpdateEvent) String() string {
@@ -47,7 +42,6 @@ func (ev LocalUnsafeUpdateEvent) String() string {
 type LocalSafeUpdateEvent struct {
 	ChainID      eth.ChainID
 	NewLocalSafe types.DerivedBlockSealPair
-	event.Ctx
 }
 
 func (ev LocalSafeUpdateEvent) String() string {
@@ -57,7 +51,6 @@ func (ev LocalSafeUpdateEvent) String() string {
 type CrossUnsafeUpdateEvent struct {
 	ChainID        eth.ChainID
 	NewCrossUnsafe types.BlockSeal
-	event.Ctx
 }
 
 func (ev CrossUnsafeUpdateEvent) String() string {
@@ -67,7 +60,6 @@ func (ev CrossUnsafeUpdateEvent) String() string {
 type CrossSafeUpdateEvent struct {
 	ChainID      eth.ChainID
 	NewCrossSafe types.DerivedBlockSealPair
-	event.Ctx
 }
 
 func (ev CrossSafeUpdateEvent) String() string {
@@ -76,7 +68,6 @@ func (ev CrossSafeUpdateEvent) String() string {
 
 type FinalizedL1RequestEvent struct {
 	FinalizedL1 eth.BlockRef
-	event.Ctx
 }
 
 func (ev FinalizedL1RequestEvent) String() string {
@@ -85,7 +76,6 @@ func (ev FinalizedL1RequestEvent) String() string {
 
 type FinalizedL1UpdateEvent struct {
 	FinalizedL1 eth.BlockRef
-	event.Ctx
 }
 
 func (ev FinalizedL1UpdateEvent) String() string {
@@ -95,7 +85,6 @@ func (ev FinalizedL1UpdateEvent) String() string {
 type FinalizedL2UpdateEvent struct {
 	ChainID     eth.ChainID
 	FinalizedL2 types.BlockSeal
-	event.Ctx
 }
 
 func (ev FinalizedL2UpdateEvent) String() string {
@@ -105,7 +94,6 @@ func (ev FinalizedL2UpdateEvent) String() string {
 type LocalUnsafeReceivedEvent struct {
 	ChainID        eth.ChainID
 	NewLocalUnsafe eth.BlockRef
-	event.Ctx
 }
 
 func (ev LocalUnsafeReceivedEvent) String() string {
@@ -116,7 +104,6 @@ type LocalDerivedEvent struct {
 	ChainID eth.ChainID
 	Derived types.DerivedBlockRefPair
 	NodeID  string
-	event.Ctx
 }
 
 func (ev LocalDerivedEvent) String() string {
@@ -126,7 +113,6 @@ func (ev LocalDerivedEvent) String() string {
 type LocalDerivedOriginUpdateEvent struct {
 	ChainID eth.ChainID
 	Origin  eth.BlockRef
-	event.Ctx
 }
 
 func (ev LocalDerivedOriginUpdateEvent) String() string {
@@ -135,7 +121,6 @@ func (ev LocalDerivedOriginUpdateEvent) String() string {
 
 type ResetPreInteropRequestEvent struct {
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev ResetPreInteropRequestEvent) String() string {
@@ -145,7 +130,6 @@ func (ev ResetPreInteropRequestEvent) String() string {
 type UnsafeActivationBlockEvent struct {
 	Unsafe  eth.BlockRef
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev UnsafeActivationBlockEvent) String() string {
@@ -155,7 +139,6 @@ func (ev UnsafeActivationBlockEvent) String() string {
 type SafeActivationBlockEvent struct {
 	Safe    types.DerivedBlockRefPair
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev SafeActivationBlockEvent) String() string {
@@ -165,7 +148,6 @@ func (ev SafeActivationBlockEvent) String() string {
 type InvalidateLocalSafeEvent struct {
 	ChainID   eth.ChainID
 	Candidate types.DerivedBlockRefPair
-	event.Ctx
 }
 
 func (ev InvalidateLocalSafeEvent) String() string {
@@ -174,7 +156,6 @@ func (ev InvalidateLocalSafeEvent) String() string {
 
 type RewindL1Event struct {
 	IncomingBlock eth.BlockID
-	event.Ctx
 }
 
 func (ev RewindL1Event) String() string {
@@ -184,7 +165,6 @@ func (ev RewindL1Event) String() string {
 type ReplaceBlockEvent struct {
 	ChainID     eth.ChainID
 	Replacement types.BlockReplacement
-	event.Ctx
 }
 
 func (ev ReplaceBlockEvent) String() string {
@@ -193,7 +173,6 @@ func (ev ReplaceBlockEvent) String() string {
 
 type ChainRewoundEvent struct {
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev ChainRewoundEvent) String() string {
@@ -204,7 +183,6 @@ type UpdateLocalSafeFailedEvent struct {
 	ChainID eth.ChainID
 	Err     error
 	NodeID  string
-	event.Ctx
 }
 
 func (ev UpdateLocalSafeFailedEvent) String() string {
@@ -213,7 +191,6 @@ func (ev UpdateLocalSafeFailedEvent) String() string {
 
 type ChainIndexingContinueEvent struct {
 	ChainID eth.ChainID
-	event.Ctx
 }
 
 func (ev ChainIndexingContinueEvent) String() string {

--- a/op-supervisor/supervisor/backend/syncnode/controller.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller.go
@@ -1,6 +1,7 @@
 package syncnode
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 
@@ -47,7 +48,7 @@ func (snc *SyncNodesController) AttachEmitter(em event.Emitter) {
 	snc.emitter = em
 }
 
-func (snc *SyncNodesController) OnEvent(ev event.Event) bool {
+func (snc *SyncNodesController) OnEvent(ctx context.Context, ev event.Event) bool {
 	return false
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -214,7 +214,7 @@ type eventMonitor struct {
 	localDerivedOriginUpdate int
 }
 
-func (m *eventMonitor) OnEvent(ev event.Event) bool {
+func (m *eventMonitor) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch ev.(type) {
 	case superevents.LocalDerivedEvent:
 		m.localDerived += 1

--- a/op-supervisor/supervisor/backend/syncnode/node_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/node_test.go
@@ -63,11 +63,11 @@ func TestEventResponse(t *testing.T) {
 
 	// send events and continue to do so until at least one of each type has been received
 	require.Eventually(t, func() bool {
-		testCtx := event.WrapCtx(context.Background())
+		testCtx := context.Background()
 		// send in one event of each type
-		emitter.Emit(superevents.CrossUnsafeUpdateEvent{ChainID: chainID, Ctx: testCtx})
-		emitter.Emit(superevents.CrossSafeUpdateEvent{ChainID: chainID, Ctx: testCtx})
-		emitter.Emit(superevents.FinalizedL2UpdateEvent{ChainID: chainID, Ctx: testCtx})
+		emitter.Emit(testCtx, superevents.CrossUnsafeUpdateEvent{ChainID: chainID})
+		emitter.Emit(testCtx, superevents.CrossSafeUpdateEvent{ChainID: chainID})
+		emitter.Emit(testCtx, superevents.FinalizedL2UpdateEvent{ChainID: chainID})
 
 		syncCtrl.subscribeEvents.Send(&types.IndexingEvent{
 			UnsafeBlock: &eth.BlockRef{Number: 1}})

--- a/op-supervisor/supervisor/backend/syncnode/reset.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -48,8 +47,7 @@ func (m *ManagedNode) initiateReset(z eth.BlockID) {
 	start, err := m.backend.ActivationBlock(ctx, m.chainID)
 	if errors.Is(err, types.ErrFuture) {
 		m.log.Info("no activation block yet, initiating pre-Interop reset", "err", err)
-		m.emitter.Emit(superevents.ResetPreInteropRequestEvent{
-			ChainID: m.chainID, Ctx: event.WrapCtx(m.ctx)})
+		m.emitter.Emit(m.ctx, superevents.ResetPreInteropRequestEvent{ChainID: m.chainID})
 		return
 	} else if err != nil {
 		m.log.Error("failed to get activation block, cancelling reset", "err", err)
@@ -62,8 +60,7 @@ func (m *ManagedNode) initiateReset(z eth.BlockID) {
 		return
 	} else if target.PreInterop {
 		m.log.Info("bisection results in pre-Interop reset")
-		m.emitter.Emit(superevents.ResetPreInteropRequestEvent{
-			ChainID: m.chainID, Ctx: event.WrapCtx(m.ctx)})
+		m.emitter.Emit(m.ctx, superevents.ResetPreInteropRequestEvent{ChainID: m.chainID})
 		return
 	}
 	m.log.Info("bisection found reset target", "target", target.Target)


### PR DESCRIPTION
**Description**

Last week we added the `ctx`, but bundled it into the event object. See https://github.com/ethereum-optimism/optimism/pull/16472

After working with it for a while I learned bundling it into the event is not ideal.

Annotating contexts, and enhancing the context after the event is already created and generalized (i.e. no write-access to previous `ev.Ctx`) is helpful, and so separating out the ctx helps support that, while keeping the event itself immutable (events get broadcast, we don't want to modify the event, to avoid unpredictable copy behavior).


**Tests**

No change in behavior, just moving the ctx from one place to the other.
In a few files I've cleaned up the ctx usage a tiny bit, to use the longer-lived or shorter-lived context as needed, when given multiple choices.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
