### PR TITLE
op-supervisor: db support for reorging out the starting block

### DIFF
--- a/op-supervisor/supervisor/backend/db/db.go
+++ b/op-supervisor/supervisor/backend/db/db.go
@@ -94,7 +94,7 @@ type DerivationStorage interface {
 
 	// rewinding
 	RewindAndInvalidate(inv reads.Invalidator, invalidated types.DerivedBlockRefPair) error
-	RewindToScope(inv reads.Invalidator, scope eth.BlockID) error
+	RewindToSource(inv reads.Invalidator, scope eth.BlockID) error
 	RewindToFirstDerived(inv reads.Invalidator, v eth.BlockID, revision types.Revision) error
 }
 

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -151,6 +151,25 @@ func (db *DB) Rewind(inv reads.Invalidator, target types.DerivedBlockSealPair, i
 	return db.rewindLocked(inv, target, including)
 }
 
+// Clear clears the DB such that there is no data left.
+// An invalidator is required as argument, to force users to invalidate any current open reads.
+func (db *DB) Clear(inv reads.Invalidator) error {
+	// aggressively invalidate everything, since we are clearing the DB.
+	release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
+		reads.SourceInvalidation{Number: 0},
+		reads.DerivedInvalidation{Timestamp: 0},
+	})
+	if invalidateErr != nil {
+		return invalidateErr
+	}
+	defer release()
+	if truncateErr := db.store.Truncate(-1); truncateErr != nil {
+		return fmt.Errorf("failed to empty DB: %w", truncateErr)
+	}
+	db.m.RecordDBDerivedEntryCount(0)
+	return nil
+}
+
 // RewindToSource rewinds the DB to the last entry with
 // a source value matching the given scope (excluded from the rewind, included after in DB).
 // If the source is before the start of the DB, the DB will be emptied.
@@ -164,19 +183,9 @@ func (db *DB) RewindToSource(inv reads.Invalidator, source eth.BlockID) error {
 	if err != nil {
 		// If the rewind-point is before the first block in the DB, then drop all content of the DB.
 		if errors.Is(err, types.ErrSkipped) || errors.Is(err, types.ErrPreviousToFirst) {
-			// aggressively invalidate everything, since we are clearing the DB.
-			release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
-				reads.SourceInvalidation{Number: 0},
-				reads.DerivedInvalidation{Timestamp: 0},
-			})
-			if invalidateErr != nil {
-				return invalidateErr
+			if err := db.Clear(inv); err != nil {
+				return fmt.Errorf("failed to clear DA DB, upon rewinding to source block %s before first block: %w", source, err)
 			}
-			defer release()
-			if truncateErr := db.store.Truncate(-1); truncateErr != nil {
-				return fmt.Errorf("failed to empty DB, upon rewinding to source block %s before first block: %w", source, truncateErr)
-			}
-			db.m.RecordDBDerivedEntryCount(0)
 			return nil
 		}
 		return fmt.Errorf("failed to find last derived %d: %w", source.Number, err)

--- a/op-supervisor/supervisor/backend/db/fromda/update.go
+++ b/op-supervisor/supervisor/backend/db/fromda/update.go
@@ -1,6 +1,7 @@
 package fromda
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -150,21 +151,38 @@ func (db *DB) Rewind(inv reads.Invalidator, target types.DerivedBlockSealPair, i
 	return db.rewindLocked(inv, target, including)
 }
 
-// RewindToScope rewinds the DB to the last entry with
-// a source value matching the given scope (inclusive, scope is retained in DB).
+// RewindToSource rewinds the DB to the last entry with
+// a source value matching the given scope (excluded from the rewind, included after in DB).
+// If the source is before the start of the DB, the DB will be emptied.
 // Note that this drop L1 blocks that resulted in a previously invalidated local-safe block.
 // This returns ErrFuture if the block is newer than the last known block.
 // This returns ErrConflict if a different block at the given height is known.
-// TODO: rename this "RewindToSource" to match the idea of Source
-func (db *DB) RewindToScope(inv reads.Invalidator, scope eth.BlockID) error {
+func (db *DB) RewindToSource(inv reads.Invalidator, source eth.BlockID) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
-	_, link, err := db.sourceNumToLastDerived(scope.Number)
+	_, link, err := db.sourceNumToLastDerived(source.Number)
 	if err != nil {
-		return fmt.Errorf("failed to find last derived %d: %w", scope.Number, err)
+		// If the rewind-point is before the first block in the DB, then drop all content of the DB.
+		if errors.Is(err, types.ErrSkipped) || errors.Is(err, types.ErrPreviousToFirst) {
+			// aggressively invalidate everything, since we are clearing the DB.
+			release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
+				reads.SourceInvalidation{Number: 0},
+				reads.DerivedInvalidation{Timestamp: 0},
+			})
+			if invalidateErr != nil {
+				return invalidateErr
+			}
+			defer release()
+			if truncateErr := db.store.Truncate(-1); truncateErr != nil {
+				return fmt.Errorf("failed to empty DB, upon rewinding to source block %s before first block: %w", source, truncateErr)
+			}
+			db.m.RecordDBDerivedEntryCount(0)
+			return nil
+		}
+		return fmt.Errorf("failed to find last derived %d: %w", source.Number, err)
 	}
-	if link.source.ID() != scope {
-		return fmt.Errorf("found derived-from %s but expected %s: %w", link.source, scope, types.ErrConflict)
+	if link.source.ID() != source {
+		return fmt.Errorf("found derived-from %s but expected %s: %w", link.source, source, types.ErrConflict)
 	}
 	return db.rewindLocked(inv, types.DerivedBlockSealPair{
 		Source:  link.source,

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -587,6 +587,24 @@ func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32
 	return db.flush()
 }
 
+// Clear clears the DB such that there is no data left.
+// An invalidator is required as argument, to force users to invalidate any current open reads.
+func (db *DB) Clear(inv reads.Invalidator) error {
+	release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
+		reads.DerivedInvalidation{Timestamp: 0},
+	})
+	if invalidateErr != nil {
+		return invalidateErr
+	}
+	defer release()
+	defer db.updateEntryCountMetric()
+	if truncateErr := db.store.Truncate(-1); truncateErr != nil {
+		return fmt.Errorf("failed to empty DB: %w", truncateErr)
+	}
+	db.lastEntryContext = logContext{}
+	return nil
+}
+
 // Rewind the database to remove any blocks after newHead.
 // The block at newHead.Number itself is not removed.
 // If the newHead is before the start of the DB, then this empties the DB.
@@ -599,17 +617,9 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	iter, err := db.newIteratorAt(newHead.Number, 0)
 	if err != nil {
 		if errors.Is(err, types.ErrPreviousToFirst) || errors.Is(err, types.ErrSkipped) {
-			release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
-				reads.DerivedInvalidation{Timestamp: 0},
-			})
-			if invalidateErr != nil {
-				return invalidateErr
+			if err := db.Clear(inv); err != nil {
+				return fmt.Errorf("failed to clear logs DB, upon rewinding to log block %s before first block: %w", newHead, err)
 			}
-			defer release()
-			if truncateErr := db.store.Truncate(-1); truncateErr != nil {
-				return fmt.Errorf("failed to empty DB, upon rewinding to log block %s before first block: %w", newHead, truncateErr)
-			}
-			db.lastEntryContext = logContext{}
 			return nil
 		}
 		return err

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -587,15 +587,31 @@ func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32
 	return db.flush()
 }
 
-// Rewind the database to remove any blocks after headBlockNum
+// Rewind the database to remove any blocks after newHead.
 // The block at newHead.Number itself is not removed.
+// If the newHead is before the start of the DB, then this empties the DB.
 func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
+	defer db.updateEntryCountMetric()
 	// Even if the last fully-processed block matches headBlockNum,
 	// we might still have trailing log events to get rid of.
 	iter, err := db.newIteratorAt(newHead.Number, 0)
 	if err != nil {
+		if errors.Is(err, types.ErrPreviousToFirst) || errors.Is(err, types.ErrSkipped) {
+			release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
+				reads.DerivedInvalidation{Timestamp: 0},
+			})
+			if invalidateErr != nil {
+				return invalidateErr
+			}
+			defer release()
+			if truncateErr := db.store.Truncate(-1); truncateErr != nil {
+				return fmt.Errorf("failed to empty DB, upon rewinding to log block %s before first block: %w", newHead, truncateErr)
+			}
+			db.lastEntryContext = logContext{}
+			return nil
+		}
 		return err
 	}
 	if hash, num, ok := iter.SealedBlock(); !ok {

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -288,34 +288,34 @@ func (db *ChainsDB) InvalidateLocalSafe(chainID eth.ChainID, candidate types.Der
 	return nil
 }
 
-// RewindLocalSafe removes all local-safe blocks after the given new derived-from scope.
+// RewindLocalSafeSource removes all local-safe blocks after the given new derived-from source.
+// If the source is before the start of the DB, the DB will be emptied.
 // Note that this drop L1 blocks that resulted in a previously invalidated local-safe block.
 // This returns ErrFuture if the block is newer than the last known block.
 // This returns ErrConflict if a different block at the given height is known.
-func (db *ChainsDB) RewindLocalSafe(chainID eth.ChainID, scope eth.BlockID) error {
+func (db *ChainsDB) RewindLocalSafeSource(chainID eth.ChainID, source eth.BlockID) error {
 	localSafeDB, ok := db.localDBs.Get(chainID)
 	if !ok {
 		return fmt.Errorf("cannot find local-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
 	}
-	if err := localSafeDB.RewindToScope(db.readRegistry, scope); err != nil {
+	if err := localSafeDB.RewindToSource(db.readRegistry, source); err != nil {
 		return fmt.Errorf("failed to rewind local-safe: %w", err)
 	}
-
 	return nil
 }
 
-// RewindCrossSafe removes all cross-safe blocks after the given new derived-from scope.
+// RewindCrossSafeSource removes all cross-safe blocks after the given new derived-from source.
+// If the source is before the start of the DB, the DB will be emptied.
 // This returns ErrFuture if the block is newer than the last known block.
 // This returns ErrConflict if a different block at the given height is known.
-func (db *ChainsDB) RewindCrossSafe(chainID eth.ChainID, scope eth.BlockID) error {
+func (db *ChainsDB) RewindCrossSafeSource(chainID eth.ChainID, source eth.BlockID) error {
 	crossSafeDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
 		return fmt.Errorf("cannot find cross-safe DB of chain %s for invalidation: %w", chainID, types.ErrUnknownChain)
 	}
-	if err := crossSafeDB.RewindToScope(db.readRegistry, scope); err != nil {
+	if err := crossSafeDB.RewindToSource(db.readRegistry, source); err != nil {
 		return fmt.Errorf("failed to rewind cross-safe: %w", err)
 	}
-
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -29,8 +29,8 @@ type rewinderDB interface {
 	LocalSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
 	CrossSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
 
-	RewindLocalSafe(eth.ChainID, eth.BlockID) error
-	RewindCrossSafe(eth.ChainID, eth.BlockID) error
+	RewindLocalSafeSource(eth.ChainID, eth.BlockID) error
+	RewindCrossSafeSource(eth.ChainID, eth.BlockID) error
 	RewindLogs(chainID eth.ChainID, newHead types.BlockSeal) error
 
 	FindSealedBlock(eth.ChainID, uint64) (types.BlockSeal, error)
@@ -239,7 +239,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	}
 
 	// Rewind LocalSafe to not include data derived from the old L1 chain
-	if err := r.db.RewindLocalSafe(chainID, commonL1Ancestor); err != nil {
+	if err := r.db.RewindLocalSafeSource(chainID, commonL1Ancestor); err != nil {
 		if errors.Is(err, types.ErrFuture) {
 			r.log.Warn("Rewinding on L1 reorg, but local-safe DB does not have L1 block", "block", commonL1Ancestor, "err", err)
 		} else {
@@ -248,7 +248,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	}
 
 	// Rewind CrossSafe to not include data derived from the old L1 chain
-	if err := r.db.RewindCrossSafe(chainID, commonL1Ancestor); err != nil {
+	if err := r.db.RewindCrossSafeSource(chainID, commonL1Ancestor); err != nil {
 		if errors.Is(err, types.ErrFuture) {
 			r.log.Warn("Rewinding on L1 reorg, but cross-safe DB does not have L1 block", "block", commonL1Ancestor, "err", err)
 		} else {


### PR DESCRIPTION
**Description**

- Rename `RewindToScope` to `RewindToSource`
- Rename `RewindLocalSafe` and `RewindCrossSafe` to `RewindLocalSafeSource` and `RewindCrossSafeSource` to clarify it's the source block that is used as reference for the rewind.
- Clear the fromda DB (local-safe / cross-safe) if rewinding to a block before the first entry
- Clear the logs DB (local-unsafe) if rewinding to a block before the first entry.

**Tests**

Added unit-tests for the new rewind behavior.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Contributes to https://github.com/ethereum-optimism/optimism/issues/15774 with the DB changes, but no op-supervisor rewinder behavior change yet.
