### PR TITLE
txmgr and op-node p2p key management: enhance error check

### DIFF
--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -25,7 +25,7 @@ func LoadSignerSetup(ctx *cli.Context, logger log.Logger) (p2p.SignerSetup, erro
 		// Unencrypted keys from file are bad because they are easy to leak (and we are not checking file permissions).
 		priv, err := crypto.HexToECDSA(strings.TrimPrefix(key, "0x"))
 		if err != nil {
-			return nil, fmt.Errorf("failed to read batch submitter key: %w", err)
+			return nil, fmt.Errorf("failed to read sequencer p2p key: %w", err)
 		}
 
 		return &p2p.PreparedSigner{Signer: opsigner.NewLocalSigner(priv)}, nil

--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -17,6 +17,9 @@ import (
 func LoadSignerSetup(ctx *cli.Context, logger log.Logger) (p2p.SignerSetup, error) {
 	key := ctx.String(flags.SequencerP2PKeyName)
 	signerCfg := opsigner.ReadCLIConfig(ctx)
+	if key != "" && signerCfg.Enabled() {
+		return nil, fmt.Errorf("cannot specify both a private key and a remote signer for sequencer p2p")
+	}
 	if key != "" {
 		// Mnemonics are bad because they leak *all* keys when they leak.
 		// Unencrypted keys from file are bad because they are easy to leak (and we are not checking file permissions).

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -321,7 +321,7 @@ func (m CLIConfig) Check() error {
 	if err := m.SignerCLIConfig.Check(); err != nil {
 		return err
 	}
-	onlyOneIsSet := func(options ...bool) bool {
+	atMostOneIsSet := func(options ...bool) bool {
 		boolToInt := func(b bool) int {
 			if b {
 				return 1
@@ -333,9 +333,9 @@ func (m CLIConfig) Check() error {
 		for _, option := range options {
 			sum += boolToInt(option)
 		}
-		return sum == 1
+		return sum == 1 || sum == 0
 	}
-	if !onlyOneIsSet(m.PrivateKey != "", m.Mnemonic != "", m.SignerCLIConfig.Enabled()) {
+	if !atMostOneIsSet(m.PrivateKey != "", m.Mnemonic != "", m.SignerCLIConfig.Enabled()) {
 		return errors.New("must provide exactly one of: [private key, mnemonic, remote signer]")
 	}
 	return nil

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -336,7 +336,7 @@ func (m CLIConfig) Check() error {
 		return sum == 1 || sum == 0
 	}
 	if !atMostOneIsSet(m.PrivateKey != "", m.Mnemonic != "", m.SignerCLIConfig.Enabled()) {
-		return errors.New("must provide exactly one of: [private key, mnemonic, remote signer]")
+		return errors.New("can only provide at most one of: [private key, mnemonic, remote signer]")
 	}
 	return nil
 }

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -321,16 +321,22 @@ func (m CLIConfig) Check() error {
 	if err := m.SignerCLIConfig.Check(); err != nil {
 		return err
 	}
-	if m.PrivateKey != "" && m.Mnemonic != "" {
-		return errors.New("cannot specify both a private key and a mnemonic")
-	}
-	if m.SignerCLIConfig.Enabled() && (m.PrivateKey != "" || m.Mnemonic != "") {
-		return errors.New("must provide neither a mnemonic nor a private key when using a remote signer")
-	}
-	if !m.SignerCLIConfig.Enabled() {
-		if m.PrivateKey == "" && m.Mnemonic == "" {
-			return errors.New("must provide either a mnemonic or a private key when not using a remote signer")
+	onlyOneIsSet := func(options ...bool) bool {
+		boolToInt := func(b bool) int {
+			if b {
+				return 1
+			}
+			return 0
 		}
+
+		sum := 0
+		for _, option := range options {
+			sum += boolToInt(option)
+		}
+		return sum == 1
+	}
+	if !onlyOneIsSet(m.PrivateKey != "", m.Mnemonic != "", m.SignerCLIConfig.Enabled()) {
+		return errors.New("must provide exactly one of: [private key, mnemonic, remote signer]")
 	}
 	return nil
 }

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -325,11 +325,11 @@ func (m CLIConfig) Check() error {
 		return errors.New("cannot specify both a private key and a mnemonic")
 	}
 	if m.SignerCLIConfig.Enabled() && (m.PrivateKey != "" || m.Mnemonic != "") {
-		return errors.New("must provide neither a mnemonic nor a private key when using the opsigner CLIConfig")
+		return errors.New("must provide neither a mnemonic nor a private key when using a remote signer")
 	}
 	if !m.SignerCLIConfig.Enabled() {
 		if m.PrivateKey == "" && m.Mnemonic == "" {
-			return errors.New("must provide either a mnemonic or a private key when not using the opsigner CLIConfig")
+			return errors.New("must provide either a mnemonic or a private key when not using a remote signer")
 		}
 	}
 	return nil

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -321,6 +321,17 @@ func (m CLIConfig) Check() error {
 	if err := m.SignerCLIConfig.Check(); err != nil {
 		return err
 	}
+	if m.PrivateKey != "" && m.Mnemonic != "" {
+		return errors.New("cannot specify both a private key and a mnemonic")
+	}
+	if m.SignerCLIConfig.Enabled() && (m.PrivateKey != "" || m.Mnemonic != "") {
+		return errors.New("must provide neither a mnemonic nor a private key when using the opsigner CLIConfig")
+	}
+	if !m.SignerCLIConfig.Enabled() {
+		if m.PrivateKey == "" && m.Mnemonic == "" {
+			return errors.New("must provide either a mnemonic or a private key when not using the opsigner CLIConfig")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
`PrivateKey`/`Mnemonic`/`SignerCLIConfig` are mutually exclusive.