### PR TITLE
feat(op-acceptance-tests): support both op-devstack orchestrators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1173,7 +1173,12 @@ jobs:
   op-acceptance-tests:
     parameters:
       devnet:
-        description: The name of the devnet to run the acceptance tests against. The devnet must have a recipe defined in kurtosis-devnet/Justfile with the name <devnet>-devnet.
+        description: |
+          The name of the pre-defined kurtosis devnet to run the acceptance tests against
+          (e.g. 'simple', 'isthmus', 'interop'). Empty string uses
+          in-process testing (sysgo orchestrator). Named devnets use
+          external testing (sysext orchestrator) and must have a
+          recipe defined in kurtosis-devnet/Justfile.
         type: string
         default: ""
       gate:
@@ -1190,39 +1195,31 @@ jobs:
       - utils/checkout-with-mise
       - install-contracts-dependencies
       - run:
-          name: Setup Kurtosis
+          name: Setup Kurtosis (if needed)
           command: |
-            echo "Setting up Kurtosis..."
+            if [[ "<<parameters.devnet>>" != "" ]]; then
+              echo "Setting up Kurtosis for external devnet testing..."
 
-            # Print Kurtosis version
-            echo "Using Kurtosis from: $(which kurtosis || echo 'not found')"
-            kurtosis version
+              # Print Kurtosis version
+              echo "Using Kurtosis from: $(which kurtosis || echo 'not found')"
+              kurtosis version
 
-            # Start Kurtosis engine
-            echo "Starting Kurtosis engine..."
-            kurtosis engine start || true
+              # Start Kurtosis engine
+              echo "Starting Kurtosis engine..."
+              kurtosis engine start || true
 
-            # Clean old instances
-            echo "Cleaning old instances..."
-            kurtosis clean -a || true
+              # Clean old instances
+              echo "Cleaning old instances..."
+              kurtosis clean -a || true
 
-            # Check engine status
-            kurtosis engine status || true
+              # Check engine status
+              kurtosis engine status || true
 
-            echo "Kurtosis setup complete"
-      # Start our devnet
-      - run:
-          name: Start devnet (<<parameters.devnet>>)
-          working_directory: kurtosis-devnet
-          command: |
-            echo "Starting <<parameters.devnet>> devnet..."
-            just <<parameters.devnet>>-devnet
-
-            echo "<<parameters.devnet>> devnet started successfully"
-
-            # Print devnet info for debugging
-            kurtosis enclave inspect <<parameters.devnet>>-devnet || true
-      # Notify us of a devnet failure
+              echo "Kurtosis setup complete"
+            else
+              echo "Using in-process testing (sysgo orchestrator) - no Kurtosis setup needed"
+            fi
+      # Notify us of a setup failure
       - when:
           condition: on_fail
           steps:
@@ -1258,12 +1255,6 @@ jobs:
             GO111MODULE: "on"
             GOGC: "0"
           command: |
-            # Check if the devnet is running before attempting to run tests
-            if ! kurtosis enclave ls | grep -q "<<parameters.devnet>>-devnet"; then
-              echo "Devnet <<parameters.devnet>>-devnet is not running. Skipping tests."
-              exit 1
-            fi
-
             # Run the tests
             just acceptance-test "<<parameters.devnet>>" "<<parameters.gate>>"
       - run:
@@ -1308,22 +1299,25 @@ jobs:
           steps:
             - store_artifacts:
                 path: ./op-acceptance-tests/logs
-      # Before we have a more sturdy log dump solution, we'll simply use the kurtosis-specific dump command
-      # to store all service logs as job artifacts
+      # Dump kurtosis logs if external devnet was used
       - run:
-          name: Dump kurtosis logs
+          name: Dump kurtosis logs (if external devnet was used)
           when: on_fail
           command: |
-            # Dump logs & specs
-            kurtosis dump ./.kurtosis-dump
+            if [[ "<<parameters.devnet>>" != "" ]]; then
+              # Dump logs & specs
+              kurtosis dump ./.kurtosis-dump
 
-            # Remove spec.json files
-            rm -rf ./.kurtosis-dump/enclaves/**/*.json
+              # Remove spec.json files
+              rm -rf ./.kurtosis-dump/enclaves/**/*.json
 
-            # Remove all unnecessary logs
-            rm -rf ./.kurtosis-dump/enclaves/*/kurtosis-api--*
-            rm -rf ./.kurtosis-dump/enclaves/*/kurtosis-logs-collector--*
-            rm -rf ./.kurtosis-dump/enclaves/*/task-*
+              # Remove all unnecessary logs
+              rm -rf ./.kurtosis-dump/enclaves/*/kurtosis-api--*
+              rm -rf ./.kurtosis-dump/enclaves/*/kurtosis-logs-collector--*
+              rm -rf ./.kurtosis-dump/enclaves/*/task-*
+            else
+              echo "In-process testing was used - no kurtosis logs to dump"
+            fi
       - when:
           condition: always
           steps:

--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,7 @@ anvil = "1.1.0"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v0.4.1"
+op-acceptor = "op-acceptor/v1.0.0"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't

--- a/op-acceptance-tests/README.md
+++ b/op-acceptance-tests/README.md
@@ -17,55 +17,121 @@ Localnet → Alphanet → Betanet → Testnet
 
 This process helps maintain high-quality standards across all networks in the OP Stack ecosystem.
 
+## Architecture
+
+The acceptance testing system supports two orchestrator modes:
+
+### **sysgo (In-process)**
+- **Use case**: Fast, isolated testing without external dependencies
+- **Benefits**: Quick startup, no external infrastructure needed
+- **Dependencies**: None (pure Go services)
+
+### **sysext (External)**
+- **Use case**: Testing against Kurtosis-managed devnets or persistent networks
+- **Benefits**: Testing against realistic network conditions
+- **Dependencies**: Docker, Kurtosis (for Kurtosis devnets)
+
+The system automatically selects the appropriate orchestrator based on your usage pattern.
+
 ## Dependencies
 
-* Docker
-* Kurtosis
+### Basic Dependencies
 * Mise (install as instructed in CONTRIBUTING.md)
 
-Dependencies are managed using the repo-wide `mise` config. So ensure you've first run `mise install` at the repo root. If you need to manually modify the version of op-acceptor you wish to run you'll need to do it within the _mise.toml_ file at the repo root.
+### Additional Dependencies (for external devnet testing)
+* Docker
+* Kurtosis
 
-## CI Usage
+Dependencies are managed using the repo-wide `mise` config. Run `mise install` at the repo root to install `op-acceptor` and other tools.
 
-The tests can be run using the `just` command runner:
+## Usage
+
+### Quick Start
 
 ```bash
-# Run the default acceptance tests against a simple devnet
+# Run in-process tests (fast, no external dependencies)
+just acceptance-test "" base
+
+# Run against Kurtosis devnets (requires Docker + Kurtosis)
+just acceptance-test simple base
+just acceptance-test isthmus isthmus
+just acceptance-test interop interop
+```
+
+### Available Commands
+
+```bash
+# Default: Run tests against simple devnet with base gate
 just
 
-# Run the acceptance tests against a specific devnet and gate
+# Run specific devnet and gate combinations
 just acceptance-test <devnet> <gate>
 
-# Run the acceptance tests using a specific version of op-acceptor
-ACCEPTOR_IMAGE=op-acceptor:latest just acceptance-test
+# Use specific op-acceptor version
+ACCEPTOR_VERSION=v1.0.0 just acceptance-test simple base
+```
+
+### Direct CLI Usage
+
+You can also run the acceptance test wrapper directly:
+
+```bash
+cd op-acceptance-tests
+
+# In-process testing (sysgo orchestrator)
+go run cmd/main.go --orchestrator sysgo --gate base --testdir .. --validators ./acceptance-tests.yaml --acceptor op-acceptor
+
+# External devnet testing (sysext orchestrator)
+go run cmd/main.go --orchestrator sysext --devnet simple --gate base --testdir .. --validators ./acceptance-tests.yaml --kurtosis-dir ../kurtosis-devnet --acceptor op-acceptor
+
+# Remote network testing
+go run cmd/main.go --orchestrator sysext --devnet "kt://my-network" --gate base --testdir .. --validators ./acceptance-tests.yaml --acceptor op-acceptor
 ```
 
 ## Development Usage
 
-The above command works great for CI but less well for development because it pessimistically rebuilds kurtosis each time, regardless of whether anything has changed in the underlying Optimism services build.
-We will fix this in the future, but the workaround is to decouple your kurtosis deployment from test running by manually managing each.
+### Fast Development Loop (In-process)
 
-1. Deploy kurtosis
+For rapid test development, use in-process testing:
 
+```bash
+cd op-acceptance-tests
+just acceptance-test "" base  # Uses sysgo orchestrator - faster!
+```
+
+### Testing Against External Devnets
+
+For integration testing against realistic networks:
+
+1. **Automated approach** (rebuilds devnet each time):
+   ```bash
+   just acceptance-test isthmus isthmus
    ```
+
+2. **Manual approach** (once-off)
+   ```bash
+   cd op-acceptance-tests
+   # This spins up a devnet, then runs op-acceptor
+   go run cmd/main.go --orchestrator sysext --devnet "interop" --gate interop --testdir .. --validators ./acceptance-tests.yaml
+   ```
+
+3. **Manual approach** (faster for repeated testing):
+   ```bash
+   # Deploy devnet once
    cd kurtosis-devnet
-   just isthmus-devnet # or whatever devnet you intend to test
-   # will take ~3-4m to spin up
-   ```
+   just isthmus-devnet
 
-2. Run tests with devnet descriptor env var configuration (instant)
-
+   # Run tests multiple times against the same devnet
+   cd op-acceptance-tests
+   # This runs op-acceptor (devnet spin up is skipped due to `--reuse-devnet`)
+   go run cmd/main.go --orchestrator sysext --devnet "interop" --gate interop --testdir .. --validators ./acceptance-tests.yaml --reuse-devnet
    ```
-   cd ../op-acceptance-tests
-   DEVNET_ENV_URL=kt://isthmus-devnet/devnet-descriptor-0 go test -v ./tests/isthmus/...
-   ```
-
-This should allow you to tweak your test in a tight loop while the test subject remains the same.
 
 ### Configuration
 
 - `acceptance-tests.yaml`: Defines the validation gates and the suites and tests that should be run for each gate.
 - `justfile`: Contains the commands for running the acceptance tests.
+- `cmd/main.go`: Wrapper binary that handles orchestrator selection and devnet management.
 
 ### Logging Configuration
 

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v0.4.1")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v1.0.0")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 
@@ -19,7 +19,7 @@ interop:
 
 
 # Run acceptance tests with mise-managed binary
-acceptance-test devnet="simple" gate="holocene":
+acceptance-test devnet="" gate="holocene":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -37,14 +37,31 @@ acceptance-test devnet="simple" gate="holocene":
         # Print which binary is being used
         BINARY_PATH=$(mise which op-acceptor)
         echo "Using mise-managed binary: $BINARY_PATH"
-        go run cmd/main.go \
-            --devnet "{{devnet}}-devnet" \
-            --gate {{gate}} \
-            --testdir "{{REPO_ROOT}}" \
-            --validators ./acceptance-tests.yaml \
-            --log.level debug \
-            --kurtosis-dir "{{KURTOSIS_DIR}}" \
-            --acceptor "$BINARY_PATH"
+
+        # Build the command with conditional parameters
+        CMD_ARGS=(
+            "go" "run" "cmd/main.go"
+            "--gate" "{{gate}}"
+            "--testdir" "{{REPO_ROOT}}"
+            "--validators" "./acceptance-tests.yaml"
+            "--log.level" "debug"
+            "--acceptor" "$BINARY_PATH"
+        )
+
+        # Set orchestrator and devnet based on input
+        if [[ "{{devnet}}" == "" ]]; then
+            # In-process testing
+            CMD_ARGS+=("--orchestrator" "sysgo")
+        else
+            # External devnet testing
+            CMD_ARGS+=("--orchestrator" "sysext")
+            CMD_ARGS+=("--devnet" "{{devnet}}")
+            # Include kurtosis-dir for devnet deployment
+            CMD_ARGS+=("--kurtosis-dir" "{{KURTOSIS_DIR}}")
+        fi
+
+        # Execute the command
+        "${CMD_ARGS[@]}"
     else
         echo "Mise not installed, falling back to Docker..."
         just acceptance-test-docker {{devnet}} {{gate}}
@@ -72,6 +89,7 @@ acceptance-test-docker devnet="simple" gate="holocene":
         --gate {{gate}} \
         --validators /acceptance-tests.yaml \
         --log.level debug
+
 
 
 clean:


### PR DESCRIPTION
## Description
Added support for both in-memory (sysgo) and external/kurtosis (sysext) orchestrators and, thus, acceptance tests.
Note that this also paves the way for the justfile to be deprecated, should we want to do that.

A future PR will add some sysgo tests.

## Note
DO NOT MERGE until:
* https://github.com/ethereum-optimism/infra/pull/411 is merged
* op-acceptor v0.5.0 is released