### PR TITLE
feat(op-acceptance-tests): add sysgo support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1196,6 +1196,13 @@ jobs:
     steps:
       - utils/checkout-with-mise
       - install-contracts-dependencies
+      # Attach workspace for cannon dependencies if using sysgo orchestrator (empty devnet)
+      - when:
+          condition:
+            equal: ["", << parameters.devnet >>]
+          steps:
+            - attach_workspace:
+                at: "."
       - run:
           name: Setup Kurtosis (if needed)
           command: |
@@ -2336,6 +2343,25 @@ workflows:
           - equal: [true, <<pipeline.parameters.acceptance_tests_dispatch>>]
           - equal: ["api",<< pipeline.trigger_source >>]
     jobs:
+      - contracts-bedrock-build:  # needed for sysgo tests
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - cannon-prestate-quick:  # needed for sysgo tests
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      # IN-PROCESS (base)
+      - op-acceptance-tests:
+          # Acceptance Testing params
+          name: memory-base
+          gate: base
+          # CircleCI params
+          no_output_timeout: 10m
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
       # KURTOSIS (Simple)
       - op-acceptance-tests:
           # Acceptance Testing params
@@ -2382,6 +2408,25 @@ workflows:
       not:
         equal: [<< pipeline.git.branch >>, "develop"]
     jobs:
+      - contracts-bedrock-build:  # needed for sysgo tests
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - cannon-prestate-quick:  # needed for sysgo tests
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      # IN-PROCESS (base)
+      - op-acceptance-tests:
+          # Acceptance Testing params
+          name: memory-base
+          gate: base
+          # CircleCI params
+          no_output_timeout: 10m
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
       # KURTOSIS (Simple)
       - op-acceptance-tests:
           # Acceptance Testing params

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -23,49 +23,84 @@ acceptance-test devnet="" gate="holocene":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    echo -e "DEVNET: {{devnet}}, GATE: {{gate}}\n"
-
-    # Check if mise is installed
+     # Check if mise is installed
     if command -v mise >/dev/null; then
-        # Try to install op-acceptor using mise
-        if ! mise install op-acceptor; then
-            echo "WARNING: Failed to install op-acceptor with mise, falling back to Docker..."
-            just acceptance-test-docker {{devnet}} {{gate}}
-            exit 0
-        fi
-
-        # Print which binary is being used
-        BINARY_PATH=$(mise which op-acceptor)
-        echo "Using mise-managed binary: $BINARY_PATH"
-
-        # Build the command with conditional parameters
-        CMD_ARGS=(
-            "go" "run" "cmd/main.go"
-            "--gate" "{{gate}}"
-            "--testdir" "{{REPO_ROOT}}"
-            "--validators" "./acceptance-tests.yaml"
-            "--log.level" "debug"
-            "--acceptor" "$BINARY_PATH"
-        )
-
-        # Set orchestrator and devnet based on input
-        if [[ "{{devnet}}" == "" ]]; then
-            # In-process testing
-            CMD_ARGS+=("--orchestrator" "sysgo")
-        else
-            # External devnet testing
-            CMD_ARGS+=("--orchestrator" "sysext")
-            CMD_ARGS+=("--devnet" "{{devnet}}")
-            # Include kurtosis-dir for devnet deployment
-            CMD_ARGS+=("--kurtosis-dir" "{{KURTOSIS_DIR}}")
-        fi
-
-        # Execute the command
-        "${CMD_ARGS[@]}"
+        echo "mise is installed"
     else
         echo "Mise not installed, falling back to Docker..."
         just acceptance-test-docker {{devnet}} {{gate}}
     fi
+
+    if [[ "{{devnet}}" == "" ]]; then
+        echo -e "DEVNET: in-memory, GATE: {{gate}}\n"
+    else
+        echo -e "DEVNET: {{devnet}}, GATE: {{gate}}\n"
+    fi
+
+    # For sysgo orchestrator (in-process testing) ensure:
+    # - contracts are built
+    # - cannon dependencies are built
+    # Note: build contracts only if not in CI (CI jobs already take care of this)
+    if [[ "{{devnet}}" == "" && -z "${CIRCLECI:-}" ]]; then
+        echo "Building contracts (local build)..."
+        cd {{REPO_ROOT}}
+        echo " - Updating submodules..."
+        git submodule update --init --recursive
+        echo " - Installing mise..."
+        mise install
+        cd packages/contracts-bedrock
+        echo " - Installing contracts..."
+        just install
+        echo " - Cleaning forge..."
+        forge clean
+        just forge-build
+        cd {{REPO_ROOT}}
+
+        echo "Checking cannon dependencies..."
+        if [ ! -e {{REPO_ROOT}}/cannon/bin/cannon ] || [ ! -e {{REPO_ROOT}}/op-program/bin/prestate-mt64.bin.gz ]; then
+            echo "Building cannon dependencies..."
+            cd {{REPO_ROOT}}
+            make cannon-prestates
+        fi
+    fi
+
+    # Try to install op-acceptor using mise
+    if ! mise install op-acceptor; then
+        echo "WARNING: Failed to install op-acceptor with mise, falling back to Docker..."
+        just acceptance-test-docker {{devnet}} {{gate}}
+        exit 0
+    fi
+
+    # Print which binary is being used
+    BINARY_PATH=$(mise which op-acceptor)
+    echo "Using mise-managed binary: $BINARY_PATH"
+
+    # Build the command with conditional parameters
+    CMD_ARGS=(
+        "go" "run" "cmd/main.go"
+        "--gate" "{{gate}}"
+        "--testdir" "{{REPO_ROOT}}"
+        "--validators" "./acceptance-tests.yaml"
+        "--log.level" "debug"
+        "--acceptor" "$BINARY_PATH"
+    )
+
+    # Set orchestrator and devnet based on input
+    if [[ "{{devnet}}" == "" ]]; then
+        # In-process testing
+        CMD_ARGS+=("--orchestrator" "sysgo")
+    else
+        # External devnet testing
+        CMD_ARGS+=("--orchestrator" "sysext")
+        CMD_ARGS+=("--devnet" "{{devnet}}")
+        # Include kurtosis-dir for devnet deployment
+        CMD_ARGS+=("--kurtosis-dir" "{{KURTOSIS_DIR}}")
+    fi
+
+    # Execute the command
+    cd {{REPO_ROOT}}/op-acceptance-tests
+    "${CMD_ARGS[@]}"
+
 
 # Run acceptance tests against a devnet using Docker (fallback if needed)
 acceptance-test-docker devnet="simple" gate="holocene":


### PR DESCRIPTION
## Description
Adds in-memory (sysgo) tests to our CI and locally (via justfile)

<img width="1606" height="500" alt="Screenshot 2025-07-16 at 13 48 52" src="https://github.com/user-attachments/assets/ff54b503-0dd1-4901-8c8f-282e671b8796" />

## Note
Requires https://github.com/ethereum-optimism/optimism/pull/16594 which ports `TestChainFork` to op-devstack and thus allows it to run and pass.
(DO NOT MERGE UNTIL THAT ONE HAS AND THESE CHECKS THUS PASS)

## Metadata
- Relates to: https://github.com/ethereum-optimism/optimism/issues/16272
