### PR TITLE
op-acceptance-tests: Don't try to time travel in parallel, it gets messy

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSuperRootWithdrawal(gt *testing.T) {
-	t := devtest.ParallelT(gt)
+	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	sys.L1Network.WaitForOnline()
 


### PR DESCRIPTION
**Description**

Update proofs withdrawal test to be serial instead of parallel.  It's not safe to time travel when other tests are running.