### PR TITLE
op-e2e,op-devstack: Fix error msg for challenger prerequisites

### DIFF
--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -186,19 +186,19 @@ func applyCommonChallengerOpts(cfg *config.Config, options ...Option) error {
 	if cfg.Cannon.VmBin != "" {
 		_, err := os.Stat(cfg.Cannon.VmBin)
 		if err != nil {
-			return errors.New("cannon should be built. Make sure you've run make cannon-prestate")
+			return errors.New("cannon should be built. Make sure you've run make cannon-prestates")
 		}
 	}
 	if cfg.Cannon.Server != "" {
 		_, err := os.Stat(cfg.Cannon.Server)
 		if err != nil {
-			return errors.New("op-program should be built. Make sure you've run make cannon-prestate")
+			return errors.New("op-program should be built. Make sure you've run make cannon-prestates")
 		}
 	}
 	if cfg.CannonAbsolutePreState != "" {
 		_, err := os.Stat(cfg.CannonAbsolutePreState)
 		if err != nil {
-			return errors.New("cannon pre-state should be built. Make sure you've run make cannon-prestate")
+			return errors.New("cannon pre-state should be built. Make sure you've run make cannon-prestates")
 		}
 	}
 

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -202,15 +202,15 @@ func NewChallengerConfig(t *testing.T, sys EndpointProvider, l2NodeName string, 
 
 	if cfg.Cannon.VmBin != "" {
 		_, err := os.Stat(cfg.Cannon.VmBin)
-		require.NoError(t, err, "cannon should be built. Make sure you've run make cannon-prestate")
+		require.NoError(t, err, "cannon should be built. Make sure you've run make cannon-prestates")
 	}
 	if cfg.Cannon.Server != "" {
 		_, err := os.Stat(cfg.Cannon.Server)
-		require.NoError(t, err, "op-program should be built. Make sure you've run make cannon-prestate")
+		require.NoError(t, err, "op-program should be built. Make sure you've run make cannon-prestates")
 	}
 	if cfg.CannonAbsolutePreState != "" {
 		_, err := os.Stat(cfg.CannonAbsolutePreState)
-		require.NoError(t, err, "cannon pre-state should be built. Make sure you've run make cannon-prestate")
+		require.NoError(t, err, "cannon pre-state should be built. Make sure you've run make cannon-prestates")
 	}
 	if cfg.PollInterval == 0 {
 		cfg.PollInterval = time.Second


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We may build prerequisites for running challenger related tests via `make cannon-prestates` at the monorepo root. Matching the sanity check for updated makefile command.