### PR TITLE
op-service,op-supervisor: Correctly detect ethereum.NotFound in RPCs

### DIFF
--- a/op-service/eth/errors.go
+++ b/op-service/eth/errors.go
@@ -1,0 +1,27 @@
+package eth
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ethereum/go-ethereum"
+)
+
+// MaybeAsNotFoundErr checks if the error is an ethereum.NotFound error
+// or has an error string that heuristically indicates that it is this error.
+// If so, it returns ethereum.NotFound, otherwise it returns the original error.
+//
+// Note that correct implementations of the execution layer API must return an empty
+// result and no error if the block or header is not found. So using this translation
+// hardens against wrong implementations of the execution layer API only.
+func MaybeAsNotFoundErr(err error) error {
+	if errors.Is(err, ethereum.NotFound) || err == nil {
+		return err
+	}
+	if errStr := strings.ToLower(err.Error()); strings.Contains(errStr, "block not found") ||
+		strings.Contains(errStr, "header not found") ||
+		strings.Contains(errStr, "unknown block") {
+		return errors.Join(err, ethereum.NotFound)
+	}
+	return err
+}

--- a/op-service/eth/errors_test.go
+++ b/op-service/eth/errors_test.go
@@ -1,0 +1,101 @@
+package eth
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeAsNotFoundErr(t *testing.T) {
+	otherErr := errors.New("something else went wrong")
+
+	tests := []struct {
+		name               string
+		err                error
+		expectedIsNotFound bool
+		expectedSameErr    bool
+	}{
+		{
+			name:               "already ethereum.NotFound",
+			err:                ethereum.NotFound,
+			expectedIsNotFound: true,
+			expectedSameErr:    true,
+		},
+		{
+			name:               "block not found",
+			err:                errors.New("block not found"),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "header not found",
+			err:                errors.New("header not found"),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "Unknown block",
+			err:                errors.New("Unknown block"),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "unknown block",
+			err:                errors.New("unknown block"),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "BLOCK NOT FOUND",
+			err:                errors.New("BLOCK NOT FOUND"),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "block not found in the middle",
+			err:                fmt.Errorf("rpc error: %w for hash 0x123", errors.New("block not found")),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "header not found in context",
+			err:                fmt.Errorf("failed to get header: %w", errors.New("header not found")),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "Unknown block with context",
+			err:                fmt.Errorf("geth error: %w", errors.New("Unknown block")),
+			expectedIsNotFound: true,
+		},
+		{
+			name:               "unknown block with context",
+			err:                fmt.Errorf("chain query failed: %w", errors.New("unknown block")),
+			expectedIsNotFound: true,
+		},
+		{
+			name:            "different error",
+			err:             otherErr,
+			expectedSameErr: true,
+		},
+		{
+			name:            "similar but not matching text",
+			err:             errors.New("block is not available"),
+			expectedSameErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := MaybeAsNotFoundErr(tc.err)
+
+			if tc.expectedIsNotFound {
+				require.ErrorIs(t, result, ethereum.NotFound)
+				require.ErrorIs(t, result, tc.err, "original error should be preserved")
+			} else {
+				require.NotErrorIs(t, result, ethereum.NotFound)
+			}
+			if tc.expectedSameErr {
+				require.Equal(t, tc.err, result)
+			} else {
+				require.NotEqual(t, tc.err, result)
+			}
+		})
+	}
+}

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -216,7 +216,7 @@ func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID
 	var header *RPCHeader
 	err := s.client.CallContext(ctx, &header, method, id.Arg(), false) // headers are just blocks without txs
 	if err != nil {
-		return nil, err
+		return nil, eth.MaybeAsNotFoundErr(err)
 	}
 	if header == nil {
 		return nil, ethereum.NotFound
@@ -236,7 +236,7 @@ func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID)
 	var block *RPCBlock
 	err := s.client.CallContext(ctx, &block, method, id.Arg(), true)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, eth.MaybeAsNotFoundErr(err)
 	}
 	if block == nil {
 		return nil, nil, ethereum.NotFound
@@ -257,7 +257,7 @@ func (s *EthClient) payloadCall(ctx context.Context, method string, id rpcBlockI
 	var block *RPCBlock
 	err := s.client.CallContext(ctx, &block, method, id.Arg(), true)
 	if err != nil {
-		return nil, err
+		return nil, eth.MaybeAsNotFoundErr(err)
 	}
 	if block == nil {
 		return nil, ethereum.NotFound

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -61,13 +61,7 @@ func (rs *RPCSyncNode) BlockRefByNumber(ctx context.Context, number uint64) (eth
 	var out *eth.BlockRef
 	err := rs.cl.CallContext(ctx, &out, "interop_blockRefByNumber", number)
 	if err != nil {
-		var jsonErr gethrpc.Error
-		if errors.As(err, &jsonErr) {
-			if jsonErr.ErrorCode() == 0 { // TODO
-				return eth.BlockRef{}, ethereum.NotFound
-			}
-		}
-		return eth.BlockRef{}, err
+		return eth.BlockRef{}, eth.MaybeAsNotFoundErr(err)
 	}
 	return *out, nil
 }
@@ -76,13 +70,7 @@ func (rs *RPCSyncNode) FetchReceipts(ctx context.Context, blockHash common.Hash)
 	var out gethtypes.Receipts
 	err := rs.cl.CallContext(ctx, &out, "interop_fetchReceipts", blockHash)
 	if err != nil {
-		var jsonErr gethrpc.Error
-		if errors.As(err, &jsonErr) {
-			if jsonErr.ErrorCode() == 0 { // TODO
-				return nil, ethereum.NotFound
-			}
-		}
-		return nil, err
+		return nil, eth.MaybeAsNotFoundErr(err)
 	}
 	return out, nil
 }


### PR DESCRIPTION
**Description**

The `ethereum.NotFound` error can be lost across RPC boundaries. This PR fixes our L2 source and Interop RPC clients to heuristically detect this error and forward it internally accordingly. This is important because this error is often treated in a special way. The heuristic is isolated into a new function `eth.MaybeAsNotFoundErr(err)` for reuse.

**Tests**

Unit tests added for the new `MaybeAsNotFoundErr` function.

**Additional context**

Without this, Interop resets don't work because the bisection checks for this error but the RPC client didn't produce it correctly.
