### PR TITLE
op-supervisor: refactor rewinder; remove ChainRewoundEvent

### DIFF
--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -717,11 +717,7 @@ func (su *SupervisorBackend) IsLocalSafe(ctx context.Context, chainID eth.ChainI
 }
 
 func (su *SupervisorBackend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
-	v, err := su.chainDBs.CrossDerivedToSourceRef(chainID, derived)
-	if err != nil {
-		return eth.BlockRef{}, err
-	}
-	return v, nil
+	return su.chainDBs.CrossDerivedToSourceRef(chainID, derived)
 }
 
 func (su *SupervisorBackend) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -253,19 +253,11 @@ func (db *ChainsDB) Finalized(chainID eth.ChainID) (types.BlockSeal, error) {
 	}
 
 	// otherwise, use the finalized L1 block to determine the final L2 block that was derived from it
-	derived, err := db.CrossSourceToLastDerived(chainID, finalizedL1.ID())
+	derived, err := xDB.SourceToLastDerived(finalizedL1.ID())
 	if err != nil {
 		return types.BlockSeal{}, fmt.Errorf("could not find what was last derived in L2 chain %s from the finalized L1 block %s: %w", chainID, finalizedL1, err)
 	}
 	return derived, nil
-}
-
-func (db *ChainsDB) CrossSourceToLastDerived(chainID eth.ChainID, source eth.BlockID) (derived types.BlockSeal, err error) {
-	crossDB, ok := db.crossDBs.Get(chainID)
-	if !ok {
-		return types.BlockSeal{}, types.ErrUnknownChain
-	}
-	return crossDB.SourceToLastDerived(source)
 }
 
 // CrossDerivedToSourceRef returns the block that the given block was derived from, if it exists in the cross derived-from storage.

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -22,7 +22,6 @@ type l1Node interface {
 type rewinderDB interface {
 	DependencySet() depset.DependencySet
 
-	CrossSourceToLastDerived(chainID eth.ChainID, source eth.BlockID) (derived types.BlockSeal, err error)
 	PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource types.BlockSeal, err error)
 	CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error)
 

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -23,7 +23,7 @@ type rewinderDB interface {
 	DependencySet() depset.DependencySet
 
 	PreviousSource(chain eth.ChainID, source eth.BlockID) (prevSource types.BlockSeal, err error)
-	CrossDerivedToSourceRef(chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error)
+	CrossDerivedToSource(chainID eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
 
 	LocalSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
 	CrossSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
@@ -186,7 +186,7 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 			return fmt.Errorf("failed to get finalized block for chain %s: %w", chainID, err)
 		}
 	}
-	finalizedL1, err := r.db.CrossDerivedToSourceRef(chainID, finalized.ID())
+	finalizedL1, err := r.db.CrossDerivedToSource(chainID, finalized.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get finalized L1 block for chain %s: %w", chainID, err)
 	}

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -147,9 +147,6 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 		r.log.Error("failed to rewind logs DB", "chain", ev.ChainID, "err", err)
 		return
 	}
-
-	// Emit event to trigger node reset with new heads
-	//r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{ChainID: ev.ChainID})
 }
 
 // rewindL1ChainIfReorged rewinds the L1 chain for the given chain ID if a reorg is detected
@@ -254,9 +251,6 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 			return fmt.Errorf("failed to rewind cross-safe for chain %s: %w", chainID, err)
 		}
 	}
-
-	// Emit rewound event for sync node
-	//r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{ChainID: ev.ChainID})
 
 	return nil
 }

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -149,7 +149,7 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 	}
 
 	// Emit event to trigger node reset with new heads
-	r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{ChainID: ev.ChainID})
+	//r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{ChainID: ev.ChainID})
 }
 
 // rewindL1ChainIfReorged rewinds the L1 chain for the given chain ID if a reorg is detected
@@ -256,9 +256,8 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	}
 
 	// Emit rewound event for sync node
-	r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{
-		ChainID: chainID,
-	})
+	//r.emitter.Emit(r.rootCtx, superevents.ChainRewoundEvent{ChainID: ev.ChainID})
+
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -171,14 +171,6 @@ func (ev ReplaceBlockEvent) String() string {
 	return "replace-block-event"
 }
 
-type ChainRewoundEvent struct {
-	ChainID eth.ChainID
-}
-
-func (ev ChainRewoundEvent) String() string {
-	return "chain-rewound"
-}
-
 type UpdateLocalSafeFailedEvent struct {
 	ChainID eth.ChainID
 	Err     error

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -106,12 +106,6 @@ func (m *ManagedNode) AttachEmitter(em event.Emitter) {
 func (m *ManagedNode) OnEvent(ctx context.Context, ev event.Event) bool {
 	// if we're resetting, ignore all events
 	if m.resetCancel != nil {
-		// even if we are resetting, cancel the reset if the L1 rewinds
-		if _, ok := ev.(superevents.ChainRewoundEvent); ok {
-			m.log.Info("Canceling reset due to L1 rewind")
-			m.resetCancel()
-			return true
-		}
 		m.log.Debug("Ignoring event during ongoing reset", "event", ev)
 		return false
 	}
@@ -143,10 +137,6 @@ func (m *ManagedNode) OnEvent(ctx context.Context, ev event.Event) bool {
 			return false
 		}
 		m.onFinalizedL2(x.FinalizedL2)
-	case superevents.ChainRewoundEvent:
-		if x.ChainID != m.chainID {
-			return false
-		}
 	case superevents.ResetPreInteropRequestEvent:
 		if x.ChainID != m.chainID {
 			return false


### PR DESCRIPTION
**Description**

Fixes: https://github.com/ethereum-optimism/optimism/issues/16355

This PR:

1. Removes `CrossSourceToLastDerived` as it is used only at one internal place and is unnecessary indirection.
2. Updates `rewinderDB` interface to use `CrossDerivedToSource` and not `CrossDerivedToSourceRef`, as the `parent` field is not necessary/used.
3. Removes the `ChainRewoundEvent` event.