### PR TITLE
op-deployer: Add v0.4.0 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250620202749-6b65f330434d
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250608235258-6005dd53e1b5 h1:wczwl6+GChQaDe3no+h1TegOO8J1Cyb+L3BdFXDsMhk=
 github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250608235258-6005dd53e1b5/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250620202749-6b65f330434d h1:hAgJ89B40bIk7BNHt61Noe3kVQCs9niFli0CeSiJnEY=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250620202749-6b65f330434d/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -86,8 +86,8 @@ var taggedReleases = map[string]TaggedRelease{
 		ContentHash:   common.HexToHash("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb"),
 	},
 	ContractsV400Tag: {
-		ArtifactsHash: common.HexToHash("e9c20b45d7f6ad4c83ef9c0d5ba50f18d62493706aec2b556606151879e5b9f1"),
-		ContentHash:   common.HexToHash("8b4f4b0ff67d05dce382e7b7bc0d967cdb9a4d2c88d53d5640b618ac671fb7a0"),
+		ArtifactsHash: common.HexToHash("44f2b904c73df5d0e54ca6e51d081ada1e4d75ca5b136513b61ea1566459eaa5"),
+		ContentHash:   common.HexToHash("4783158242b1767b50a53fdf6cdefc25c136013f9e74ae58e990d5ec0a4d9807"),
 	},
 }
 

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,7 +42,7 @@ const (
 	ContractsV170Beta1L2Tag = "op-contracts/v1.7.0-beta.1+l2-contracts"
 	ContractsV200Tag        = "op-contracts/v2.0.0"
 	ContractsV300Tag        = "op-contracts/v3.0.0"
-	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
+	ContractsV400Tag        = "op-contracts/v4.0.0-rc.8"
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
@@ -86,8 +86,8 @@ var taggedReleases = map[string]TaggedRelease{
 		ContentHash:   common.HexToHash("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb"),
 	},
 	ContractsV400Tag: {
-		ArtifactsHash: common.HexToHash("da1d9ca1a4ebf80c4842ee3414ef1d13db7d1bb9e1fbbded5a21f28479d7cdf4"),
-		ContentHash:   common.HexToHash("67966a2cb9945e1d9ab40e9c61f499e73cdb31d21b8d29a5a5c909b2b13ecd70"),
+		ArtifactsHash: common.HexToHash("e9c20b45d7f6ad4c83ef9c0d5ba50f18d62493706aec2b556606151879e5b9f1"),
+		ContentHash:   common.HexToHash("8b4f4b0ff67d05dce382e7b7bc0d967cdb9a4d2c88d53d5640b618ac671fb7a0"),
 	},
 }
 

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -16,8 +16,8 @@ var addresses = map[uint64]map[string]common.Address{
 		standard.ContractsV200Tag: common.HexToAddress("0x12a9e38628e5a5b24d18b1956ed68a24fe4e3dc0"),
 		// Bootstrapped on 04/16/2025 using OP Deployer.
 		standard.ContractsV300Tag: common.HexToAddress("0xf989Df70FB46c581ba6157Ab335c0833bA60e1f0"),
-		// Bootstrapped on 06/03/2025 using OP Deployer.
-		standard.ContractsV400Tag: common.HexToAddress("0x3dfc5e44043DC5998928E0b8280136b7352d3F70"),
+		// Bootstrapped on 06/19/2025 using OP Deployer.
+		standard.ContractsV400Tag: common.HexToAddress("0xbb43313d206a9b02032c749ca0828a07c962b4b5"),
 	},
 	11155111: {
 		// Bootstrapped on 03/02/2025 using OP Deployer.
@@ -26,8 +26,8 @@ var addresses = map[uint64]map[string]common.Address{
 		standard.ContractsV200Tag: common.HexToAddress("0x37739a6b0a3f1e7429499a4ec4a0685439daff5c"),
 		// Bootstrapped on 04/03/2025 using OP Deployer.
 		standard.ContractsV300Tag: common.HexToAddress("0x2d56022cb84ce6b961c3b4288ca36386bcd9024c"),
-		// Bootstrapped on 06/03/2025 using OP Deployer.
-		standard.ContractsV400Tag: common.HexToAddress("0xA8a1529547306FEC7A32a001705160f2110451aE"),
+		// Bootstrapped on 06/19/2025 using OP Deployer.
+		standard.ContractsV400Tag: common.HexToAddress("0xaaabe70a4198ab9e99e1a22b1afa0a43cc7f2c79"),
 	},
 }
 


### PR DESCRIPTION
v0.4.0 was added directly to the backport branch and not develop. This brings develop in line with the backport branch.