### PR TITLE
feat(op-acceptance-tests): add interop-loadtest gate

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -49,14 +49,6 @@ gates:
         package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/preinterop
         timeout: 20m
 
-  - id: flashblocks
-    inherits:
-      - base
-    description: "Flashblocks network tests."
-    tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks
-        timeout: 5m
-
   - id: interop
     inherits:
       - base
@@ -68,3 +60,17 @@ gates:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/sync
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/smoke
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/contract
+
+  - id: interop-loadtest
+    description: "Interop network loadtests."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest
+        timeout: 10m
+
+  - id: flashblocks
+    inherits:
+      - base
+    description: "Flashblocks network tests."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks
+        timeout: 5m


### PR DESCRIPTION
Add a gate specifically to house the interop load tests, as we may not want to run them everytime.
