### PR TITLE
[DO NOT MERGE] op-acceptance-tests: interop invalid attribute exec msg tx mempool evict experiment

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -44,7 +44,7 @@ optimism_package:
             log_level: ""
             extra_env_vars: {}
             extra_labels: {}
-            extra_params: []
+            extra_params: ["--http.api admin,debug,eth,miner,net,txpool,web3"]
             tolerations: []
             volume_size: 0
             min_cpu: 0

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -655,4 +655,6 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 
 	// Check three ExecutingMessage triggered
 	require.Equal(3, len(receiptB.Logs))
+
+	// temp
 }

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -655,6 +655,4 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 
 	// Check three ExecutingMessage triggered
 	require.Equal(3, len(receiptB.Logs))
-
-	// temp
 }

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -554,7 +554,7 @@ func checkMempool(t devtest.T, sys *presets.SimpleInterop) {
 	require := sys.T.Require()
 	logger := t.Logger()
 	logger.Info("Check mempool")
-	res, err := sys.L2ELB.Escape().EthClient().TxPoolInspect(t.Ctx())
+	res, err := sys.L2ELB.Escape().EthClient().TxPoolContent(t.Ctx())
 	require.NoError(err)
 	b, err := json.Marshal(res)
 	require.NoError(err)

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -2,6 +2,7 @@ package msg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -549,6 +550,17 @@ func executeIndexedFault(
 	}
 }
 
+func checkMempool(t devtest.T, sys *presets.SimpleInterop) {
+	require := sys.T.Require()
+	logger := t.Logger()
+	logger.Info("Check mempool")
+	res, err := sys.L2ELB.Escape().EthClient().TxPoolInspect(t.Ctx())
+	require.NoError(err)
+	b, err := json.Marshal(res)
+	require.NoError(err)
+	logger.Info("Mempool", "content", string(b))
+}
+
 // TestExecMessageInvalidAttributes tests below scenario:
 // Execute message, but with one or more invalid attributes inside identifiers
 func TestExecMessageInvalidAttributes(gt *testing.T) {
@@ -558,12 +570,8 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 	logger := t.Logger()
 
 	rng := rand.New(rand.NewSource(1234))
-	// honest EOA which initiates messages
 	alice := sys.FunderA.NewFundedEOA(eth.OneTenthEther)
-	// honest EOA which executes messages
 	bob := sys.FunderB.NewFundedEOA(eth.OneTenthEther)
-	// malicious EOA which creates executing messages with invalid attributes
-	chuck := sys.FunderB.NewFundedEOA(eth.OneTenthEther)
 
 	eventLoggerAddress := alice.DeployEventLogger()
 
@@ -584,6 +592,8 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 	// Make sure supervisor syncs the chain A events
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
+	checkMempool(t, sys)
+
 	faultsLists := [][]invalidAttributeType{
 		// test each identifier attributes to be faulty for upper bound tests
 		{randomOrigin}, {randomBlockNumber}, {randomLogIndex}, {randomTimestamp}, {randomChainID},
@@ -593,28 +603,42 @@ func TestExecMessageInvalidAttributes(gt *testing.T) {
 		{mismatchedLogIndex}, {mismatchedTimestamp}, {msgNotPresent}, {logIndexGreaterOrEqualToEventCnt},
 	}
 
+	txHashes := []common.Hash{}
 	for _, faults := range faultsLists {
 		logger.Info("Attempt to validate message with invalid attribute", "faults", faults)
 		// Intent to validate message on chain B
-		txC := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](chuck.Plan())
-		txC.Content.DependOn(&txA.Result)
+		txB := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](bob.Plan())
+		txB.Content.DependOn(&txA.Result)
 
 		// Random select event index in tx for injecting faults
 		eventIdx := rng.Intn(len(initCalls))
-		txC.Content.Fn(executeIndexedFault(constants.CrossL2Inbox, &txA.Result, eventIdx, rng, faults, chuck.ChainID()))
+		txB.Content.Fn(executeIndexedFault(constants.CrossL2Inbox, &txA.Result, eventIdx, rng, faults, bob.ChainID()))
 
 		// make sure that the transaction is not reverted by CrossL2Inbox...
-		gas, err := txC.PlannedTx.Gas.Eval(t.Ctx())
+		gas, err := txB.PlannedTx.Gas.Eval(t.Ctx())
 		require.NoError(err)
 		require.Greater(gas, uint64(0))
+
+		signed, err := txB.PlannedTx.Signed.Eval(t.Ctx())
+		require.NoError(err)
+		txHash := signed.Hash()
+		logger.Info("Invalid exec msg tx hash", "hash", txHash)
+		txHashes = append(txHashes, txHash)
 
 		// but rather not included at chain B because of supervisor check
 		// chain B L2 EL will query supervisor to check whether given message is valid
 		// supervisor will throw ErrConflict(conflicting data), and L2 EL will drop tx
-		_, err = txC.PlannedTx.Included.Eval(t.Ctx())
+		_, err = txB.PlannedTx.Included.Eval(t.Ctx())
 		require.Error(err)
 		logger.Info("Validate message not included")
+
+		checkMempool(t, sys)
 	}
+
+	for idx, txHash := range txHashes {
+		logger.Info("Invalid exec msg tx hash", "idx", idx, "hash", txHash)
+	}
+	checkMempool(t, sys)
 
 	// we now attempt to execute msg correctly
 	// Intent to validate message on chain B

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -128,24 +129,45 @@ type EthMultiCaller interface {
 	NewMultiCaller(batchSize int) *batching.MultiCaller
 }
 
-// TxPoolInspect represents the response structure of txpool_inspect.
-type TxPoolInspect struct {
-	Pending map[common.Address]map[string]TxPoolEntry `json:"pending"`
-	Queued  map[common.Address]map[string]TxPoolEntry `json:"queued"`
-}
+type RPCTransaction struct {
+	BlockHash           *common.Hash                 `json:"blockHash"`
+	BlockNumber         *hexutil.Big                 `json:"blockNumber"`
+	From                common.Address               `json:"from"`
+	Gas                 hexutil.Uint64               `json:"gas"`
+	GasPrice            *hexutil.Big                 `json:"gasPrice"`
+	GasFeeCap           *hexutil.Big                 `json:"maxFeePerGas,omitempty"`
+	GasTipCap           *hexutil.Big                 `json:"maxPriorityFeePerGas,omitempty"`
+	MaxFeePerBlobGas    *hexutil.Big                 `json:"maxFeePerBlobGas,omitempty"`
+	Hash                common.Hash                  `json:"hash"`
+	Input               hexutil.Bytes                `json:"input"`
+	Nonce               hexutil.Uint64               `json:"nonce"`
+	To                  *common.Address              `json:"to"`
+	TransactionIndex    *hexutil.Uint64              `json:"transactionIndex"`
+	Value               *hexutil.Big                 `json:"value"`
+	Type                hexutil.Uint64               `json:"type"`
+	Accesses            *types.AccessList            `json:"accessList,omitempty"`
+	ChainID             *hexutil.Big                 `json:"chainId,omitempty"`
+	BlobVersionedHashes []common.Hash                `json:"blobVersionedHashes,omitempty"`
+	AuthorizationList   []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
+	V                   *hexutil.Big                 `json:"v"`
+	R                   *hexutil.Big                 `json:"r"`
+	S                   *hexutil.Big                 `json:"s"`
+	YParity             *hexutil.Uint64              `json:"yParity,omitempty"`
 
-// TxPoolEntry is a simplified view of a transaction in the pool.
-type TxPoolEntry struct {
-	Nonce    string `json:"nonce"`
-	To       string `json:"to"`
-	Value    string `json:"value"`
-	Gas      string `json:"gas"`
-	GasPrice string `json:"gasPrice"`
-	Input    string `json:"input"`
+	// deposit-tx only
+	SourceHash *common.Hash `json:"sourceHash,omitempty"`
+	Mint       *hexutil.Big `json:"mint,omitempty"`
+	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
+	// deposit-tx post-Canyon only
+	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
+}
+type TxPoolContent struct {
+	Pending map[string]map[string]*RPCTransaction `json:"pending"`
+	Queued  map[string]map[string]*RPCTransaction `json:"queued"`
 }
 
 type TxPool interface {
-	TxPoolInspect(ctx context.Context) (*TxPoolInspect, error)
+	TxPoolContent(ctx context.Context) (*TxPoolContent, error)
 }
 
 type EthClient interface {

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -128,6 +128,26 @@ type EthMultiCaller interface {
 	NewMultiCaller(batchSize int) *batching.MultiCaller
 }
 
+// TxPoolInspect represents the response structure of txpool_inspect.
+type TxPoolInspect struct {
+	Pending map[common.Address]map[string]TxPoolEntry `json:"pending"`
+	Queued  map[common.Address]map[string]TxPoolEntry `json:"queued"`
+}
+
+// TxPoolEntry is a simplified view of a transaction in the pool.
+type TxPoolEntry struct {
+	Nonce    string `json:"nonce"`
+	To       string `json:"to"`
+	Value    string `json:"value"`
+	Gas      string `json:"gas"`
+	GasPrice string `json:"gasPrice"`
+	Input    string `json:"input"`
+}
+
+type TxPool interface {
+	TxPoolInspect(ctx context.Context) (*TxPoolInspect, error)
+}
+
 type EthClient interface {
 	ChainID
 	EthBlockInfo
@@ -143,6 +163,7 @@ type EthClient interface {
 	EthBalance
 	EthCode
 	EthMultiCaller
+	TxPool
 }
 
 type EthExtendedClient interface {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -599,3 +599,10 @@ func (s *EthClient) CodeAtHash(ctx context.Context, account common.Address, bloc
 func (s *EthClient) NewMultiCaller(batchSize int) *batching.MultiCaller {
 	return batching.NewMultiCaller(s.client, batchSize)
 }
+
+// TxPoolInspect queries the txpool_inspect RPC method.
+func (s *EthClient) TxPoolInspect(ctx context.Context) (*apis.TxPoolInspect, error) {
+	var result apis.TxPoolInspect
+	err := s.client.CallContext(ctx, &result, "txpool_inspect")
+	return &result, err
+}

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -600,9 +600,8 @@ func (s *EthClient) NewMultiCaller(batchSize int) *batching.MultiCaller {
 	return batching.NewMultiCaller(s.client, batchSize)
 }
 
-// TxPoolInspect queries the txpool_inspect RPC method.
-func (s *EthClient) TxPoolInspect(ctx context.Context) (*apis.TxPoolInspect, error) {
-	var result apis.TxPoolInspect
-	err := s.client.CallContext(ctx, &result, "txpool_inspect")
+func (s *EthClient) TxPoolContent(ctx context.Context) (*apis.TxPoolContent, error) {
+	var result apis.TxPoolContent
+	err := s.client.CallContext(ctx, &result, "txpool_content")
 	return &result, err
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The [CI failure](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/94456/workflows/5e423a63-cea0-47cd-b777-51b7002daab6/jobs/3669140/steps) at commit https://github.com/ethereum-optimism/optimism/pull/16569/commits/e213ab76cd92ba0cf537b3bb9fd9c270b24f9900 shows that interop tx for invalid executing message persists in the mempool.

The test `TestExecMessageInvalidAttributes` does below steps
1. Initiate message at chain A
2. Intentionally injects faults to executing messages and attempts to included in chain B
3. check that the invalid exec msg txs are never included at chain B

Let inspect the [op-geth logs of chain B](https://output.circle-artifacts.com/output/job/60e6f41e-fc0d-4d0a-adf9-02b46f876dc4/artifacts/0/op-acceptance-tests/kurtosis-logs/interop-devnet--40a9ba48067a472ba89ce31665f12f60/op-el-2151909-node0-op-geth--9524084780e14d658dc03c7e54c1fa88/output.log), and also [the test logs for `TestExecMessageInvalidAttributes`](https://output.circle-artifacts.com/output/job/60e6f41e-fc0d-4d0a-adf9-02b46f876dc4/artifacts/0/op-acceptance-tests/logs/testrun-c79fd1f4-1d6c-444c-aafa-cb4991bb6b3d/passed/interop_message_TestExecMessageInvalidAttributes.log):

These are the tx hashes for invalid exec msgs
```
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=0 [32mhash[0m=adc199..52e4c5
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=1 [32mhash[0m=1f7952..331164
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=2 [32mhash[0m=4a7dd8..9f1d5e
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=3 [32mhash[0m=85600f..fccf3b
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=4 [32mhash[0m=3ad531..334e1c
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=5 [32mhash[0m=7a3941..02a5b5
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=6 [32mhash[0m=df7b17..b2dada
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=7 [32mhash[0m=4d3c5a..897305
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=8 [32mhash[0m=9031c6..b7b6a8
    interop_msg_test.go:639:    [32mINFO [0m[06-25|12:00:59.641] Invalid exec msg tx hash                 [32midx[0m=9 [32mhash[0m=42dc1f..4efec3
```
If we query the chain B's op-geth via `txpool_content` RPC,
```
    interop_msg_test.go:556:    [32mINFO [0m[06-25|12:00:59.641] Check mempool
    interop_msg_test.go:561:    [32mINFO [0m[06-25|12:00:59.642] Mempool                                  [32mcontent[0m="{\"pending\":{},\"queued\":{\"0xd27e50eb38f0e314e01138916dA960Df1efE792a\":{\"11\":{\"blockHash\":null,\"blockNumber\":null,\"from\":\"0xd27e50eb38f0e314e01138916da960df1efe792a\",\"gas\":\"0xa04d\",\"gasPrice\":\"0x4adb462f\",\"maxFeePerGas\":\"0x4adb462f\",\"maxPriorityFeePerGas\":\"0x3b9aca00\",\"hash\":\"0x3ad5319f3a6fc1a67f2163cb58d4737d187c3c129e3dd84250d9552463334e1c\",\"input\":\"0xab4d6f750000000000000000000000009272d07097bc63213bd516de3d401cc93e503b5e0000000000000000000000000000000000000000000000000000000000000133000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000685be458b3d9726859a55b528919e2e685b94f8f68100d54db45ed4700558059ab05d30870e869be4b324abadf3776cc5524ae2b153a7a555acd7f8cbe38dd8eba801c88\",\"nonce\":\"0xb\",\"to\":\"0x4200000000000000000000000000000000000022\",\"transactionIndex\":null,\"value\":\"0x0\",\"type\":\"0x2\",\"accessList\":[{\"address\":\"0x4200000000000000000000000000000000000022\",\"storageKeys\":[\"0x0100000000558059ab05d308000000000000013300000000685be45800000002\",\"0x0200000000000000b3d9726859a55b528919e2e685b94f8f68100d54db45ed47\",\"0x03c7a33ac63e958795fe772b56bdb3951169bab46fc1d584a6970a4bf55261d5\"]}],\"chainId\":\"0x20d5e5\",\"v\":\"0x1\",\"r\":\"0x8cf65139695f78a18e46dd36ebbea6fad2664440cbaf7a4702f88df8fd61cfa5\",\"s\":\"0x1d1894876d203bbd860a3e62414b18f32e67e53b662039ca98b66a370674ef7e\",\"yParity\":\"0x1\"}}}}"
```
we see that the invalid tx with hash `0x3ad5319f3a6fc1a67f2163cb58d4737d187c3c129e3dd84250d9552463334e1c` is persisting in the mempool, which is the fifth invalid exec msg tx sent to chain B.

We can also check the [supervisor logs](https://output.circle-artifacts.com/output/job/60e6f41e-fc0d-4d0a-adf9-02b46f876dc4/artifacts/0/op-acceptance-tests/kurtosis-logs/interop-devnet--40a9ba48067a472ba89ce31665f12f60/op-supervisor-supervisor-superchain--ad10f90078c84747bd6cab949f8ed075/output.log):
```
t=2025-06-25T11:58:26+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=22 duration=455.562µs err="conflicting data"
t=2025-06-25T11:58:40+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=23 duration=64.291µs err="conflicting data"
t=2025-06-25T11:58:56+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=24 duration=493.448µs err="conflicting data"
t=2025-06-25T11:59:12+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=25 duration=61.62µs err="conflicting data"
t=2025-06-25T11:59:42+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=26 duration=65.506µs err="conflicting data"
t=2025-06-25T11:59:58+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=27 duration=277.858µs err="conflicting data"
t=2025-06-25T12:00:14+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=28 duration=377.872µs err="conflicting data"
t=2025-06-25T12:00:30+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=29 duration=470.711µs err="conflicting data"
t=2025-06-25T12:00:46+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=30 duration=395.246µs err="conflicting data"
t=2025-06-25T12:01:00+0000 lvl=warn msg="Served supervisor_checkAccessList" conn=172.16.0.26:54280 reqid=32 duration=37.092µs err="conflicting data"
```
and check that op-geth properly requested access list check to the supervisor, and supervisor correctly responded with `conflicting data` error.

The expected behavior is that the invalid interop executing msg tx should have never got into the mempool.

**Additional context**

Inspection for https://github.com/ethereum-optimism/optimism/issues/16559 

