### PR TITLE
fix(kt-devnet): handle l1 chain properly

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -206,6 +206,10 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 	// Find L1 endpoint
 	finder := NewServiceFinder(
 		inspectResult.UserServices,
+		WithL1Chain(&spec.ChainSpec{
+			NetworkID: deployerData.L1ChainID,
+			Name:      "Ethereum",
+		}),
 		WithL2Chains(s.Chains),
 		WithDepSets(depsets),
 	)

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis_test.go
@@ -335,7 +335,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 						"0x123": common.HexToAddress("0x123"),
 					},
 				},
-				L1ChainID: "1234",
+				L1ChainID: "0",
 			},
 			jwt: testJWTs,
 			want: &KurtosisEnvironment{
@@ -343,7 +343,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					Name:            DefaultEnclave,
 					ReverseProxyURL: defaultKurtosisReverseProxyURL,
 					L1: &descriptors.Chain{
-						ID:       "1234",
+						ID:       "0",
 						Name:     "Ethereum",
 						Services: make(descriptors.RedundantServiceMap),
 						Nodes: []descriptors.Node{
@@ -416,7 +416,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 						"0x123": common.HexToAddress("0x123"),
 					},
 				},
-				L1ChainID: "1234",
+				L1ChainID: "0",
 			},
 			jwt: testJWTs,
 			want: &KurtosisEnvironment{
@@ -424,7 +424,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					Name:            DefaultEnclave,
 					ReverseProxyURL: defaultKurtosisReverseProxyURL,
 					L1: &descriptors.Chain{
-						ID:       "1234",
+						ID:       "0",
 						Name:     "Ethereum",
 						Services: make(descriptors.RedundantServiceMap),
 						Nodes: []descriptors.Node{
@@ -477,7 +477,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 						"0x123": common.HexToAddress("0x123"),
 					},
 				},
-				L1ChainID: "1234",
+				L1ChainID: "0",
 			},
 			jwt: testJWTs,
 			want: &KurtosisEnvironment{
@@ -485,7 +485,7 @@ func TestGetEnvironmentInfo(t *testing.T) {
 					Name:            DefaultEnclave,
 					ReverseProxyURL: defaultKurtosisReverseProxyURL,
 					L1: &descriptors.Chain{
-						ID:       "1234",
+						ID:       "0",
 						Name:     "Ethereum",
 						Services: make(descriptors.RedundantServiceMap),
 						Nodes: []descriptors.Node{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

New versions of optimism-package will provide us with real L1 chain ID
in services labels.
Cleanup the handling code to prepare for that

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

Tested ahead of time with optimism-package@011513f7a420befce41861dd046d64ebd685ac19

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
