### PR TITLE
fix: use abi.encodeCall for updatePrestate and addGameType + fix params

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -192,7 +192,6 @@ rules:
       - pattern-not: vm.expectRevert(abi.encodeWithSelector(...));
     paths:
       exclude:
-        - packages/contracts-bedrock/src/L1/OPContractsManager.sol
         - packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
 
   - id: sol-style-enforce-require-msg

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x11b35ee81f797b30ee834e2ffad52686d2100d7ee139db4299b7d854dba25550"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x92c81c14c86c0bbfdb26b6780ecc3ca402d762c20d423f66740825da679a44bc",
-    "sourceCodeHash": "0x69dce2bc136ec0dcb4ccafc98a9a9836478495e0ef08658493555dd78addaf71"
+    "initCodeHash": "0x508a478ed4f546f1ed50058f77d129d700457574cf9a634afdd2a0d5491ecbd9",
+    "sourceCodeHash": "0x41f6eb446cc562f58edd783e28d3602860a0bc347f34cfab713688beeccc21cb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x11b35ee81f797b30ee834e2ffad52686d2100d7ee139db4299b7d854dba25550"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x9e8736340e99bf972741ef0b90a371f2a18a8b46ea2ecaf00b61c1cda4663ab7",
-    "sourceCodeHash": "0x886ac1e919890e62dfeb0eade9d8f1d36fba9a43446903e91f5d9fc45b5fb16a"
+    "initCodeHash": "0x92c81c14c86c0bbfdb26b6780ecc3ca402d762c20d423f66740825da679a44bc",
+    "sourceCodeHash": "0x69dce2bc136ec0dcb4ccafc98a9a9836478495e0ef08658493555dd78addaf71"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1759,9 +1759,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 2.4.1
+    /// @custom:semver 2.4.2
     function version() public pure virtual returns (string memory) {
-        return "2.4.1";
+        return "2.4.2";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;
@@ -1903,8 +1903,7 @@ contract OPContractsManager is ISemver {
     function addGameType(AddGameInput[] memory _gameConfigs) public virtual returns (AddGameOutput[] memory) {
         if (address(this) == address(thisOPCM)) revert OnlyDelegatecall();
 
-        bytes memory data =
-            abi.encodeWithSelector(OPContractsManagerGameTypeAdder.addGameType.selector, _gameConfigs, superchainConfig);
+        bytes memory data = abi.encodeCall(OPContractsManagerGameTypeAdder.addGameType, (_gameConfigs));
 
         bytes memory returnData = _performDelegateCall(address(opcmGameTypeAdder), data);
         return abi.decode(returnData, (AddGameOutput[]));
@@ -1915,9 +1914,7 @@ contract OPContractsManager is ISemver {
     function updatePrestate(OpChainConfig[] memory _prestateUpdateInputs) public {
         if (address(this) == address(thisOPCM)) revert OnlyDelegatecall();
 
-        bytes memory data = abi.encodeWithSelector(
-            OPContractsManagerGameTypeAdder.updatePrestate.selector, _prestateUpdateInputs, superchainConfig
-        );
+        bytes memory data = abi.encodeCall(OPContractsManagerGameTypeAdder.updatePrestate, (_prestateUpdateInputs));
 
         _performDelegateCall(address(opcmGameTypeAdder), data);
     }

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1759,9 +1759,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 2.4.2
+    /// @custom:semver 2.5.0
     function version() public pure virtual returns (string memory) {
-        return "2.4.2";
+        return "2.5.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;


### PR DESCRIPTION
**Description**

  1. Changes from abi.encodeWithSelector to abi.encodeCall for better type safety
  2. Fixes parameter passing by removing the incorrect superchainConfig parameter
  3. Updates the contract version from 2.4.1 to 2.5.0

  Description

  This PR fixes parameter handling in the OPContractsManager contract's addGameType and updatePrestate
  functions. The changes address two issues:

  1. Type Safety: Replaces abi.encodeWithSelector with abi.encodeCall for compile-time type checking and
  better parameter validation
  2. Parameter Correction: Removes the incorrect superchainConfig parameter that was being passed to both
  addGameType and updatePrestate delegate calls, which was causing the functions to fail since the target
  functions don't expect this parameter

  The contract version is bumped from 2.4.1 to 2.5.0 to reflect this bug fix.
  
**Tests**


**Additional context**


**Metadata**


