### PR TITLE
op-supervisor: add API for Failsafe mode (part of AutoStop)

### DIFF
--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -20,8 +20,8 @@ type SupervisorAdminAPI interface {
 	Stop(ctx context.Context) error
 	AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error
 	Rewind(ctx context.Context, chain eth.ChainID, block eth.BlockID) error
-	SetAutoStop(ctx context.Context, enabled bool) error
-	GetAutoStop(ctx context.Context) (bool, error)
+	SetFailsafeEnabled(ctx context.Context, enabled bool) error
+	GetFailsafeEnabled(ctx context.Context) (bool, error)
 }
 
 type SupervisorQueryAPI interface {

--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -20,6 +20,8 @@ type SupervisorAdminAPI interface {
 	Stop(ctx context.Context) error
 	AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error
 	Rewind(ctx context.Context, chain eth.ChainID, block eth.BlockID) error
+	SetAutoStop(ctx context.Context, enabled bool) error
+	GetAutoStop(ctx context.Context) (bool, error)
 }
 
 type SupervisorQueryAPI interface {

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -56,19 +56,19 @@ func (cl *SupervisorClient) Rewind(ctx context.Context, chain eth.ChainID, block
 	return cl.client.CallContext(ctx, nil, "admin_rewind", chain, block)
 }
 
-func (cl *SupervisorClient) SetAutoStop(ctx context.Context, enabled bool) error {
-	err := cl.client.CallContext(ctx, nil, "admin_setAutoStop", enabled)
+func (cl *SupervisorClient) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
+	err := cl.client.CallContext(ctx, nil, "admin_setFailsafeEnabled", enabled)
 	if err != nil {
-		return fmt.Errorf("failed to set auto-stop for Supervisor: %w", err)
+		return fmt.Errorf("failed to set failsafe mode for Supervisor: %w", err)
 	}
 	return nil
 }
 
-func (cl *SupervisorClient) GetAutoStop(ctx context.Context) (bool, error) {
+func (cl *SupervisorClient) GetFailsafeEnabled(ctx context.Context) (bool, error) {
 	var enabled bool
-	err := cl.client.CallContext(ctx, &enabled, "admin_getAutoStop")
+	err := cl.client.CallContext(ctx, &enabled, "admin_getFailsafeEnabled")
 	if err != nil {
-		return false, fmt.Errorf("failed to get auto-stop for Supervisor: %w", err)
+		return false, fmt.Errorf("failed to get failsafe mode for Supervisor: %w", err)
 	}
 	return enabled, nil
 }

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -56,6 +56,23 @@ func (cl *SupervisorClient) Rewind(ctx context.Context, chain eth.ChainID, block
 	return cl.client.CallContext(ctx, nil, "admin_rewind", chain, block)
 }
 
+func (cl *SupervisorClient) SetAutoStop(ctx context.Context, enabled bool) error {
+	err := cl.client.CallContext(ctx, nil, "admin_setAutoStop", enabled)
+	if err != nil {
+		return fmt.Errorf("failed to set auto-stop for Supervisor: %w", err)
+	}
+	return nil
+}
+
+func (cl *SupervisorClient) GetAutoStop(ctx context.Context) (bool, error) {
+	var enabled bool
+	err := cl.client.CallContext(ctx, &enabled, "admin_getAutoStop")
+	if err != nil {
+		return false, fmt.Errorf("failed to get auto-stop for Supervisor: %w", err)
+	}
+	return enabled, nil
+}
+
 func (cl *SupervisorClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
 	return cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)

--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -44,6 +44,9 @@ type Config struct {
 
 	// RPCVerificationWarnings enables asynchronous RPC verification of DB checkAccess call in the CheckAccessList endpoint, indicating warnings as a metric
 	RPCVerificationWarnings bool
+
+	// AutoStop enables automatic rejection from the supervisor at start-up
+	AutoStop bool
 }
 
 func (c *Config) Check() error {

--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -45,8 +45,8 @@ type Config struct {
 	// RPCVerificationWarnings enables asynchronous RPC verification of DB checkAccess call in the CheckAccessList endpoint, indicating warnings as a metric
 	RPCVerificationWarnings bool
 
-	// AutoStop enables automatic rejection from the supervisor at start-up
-	AutoStop bool
+	// FailsafeEnabled enables failsafe mode for the supervisor
+	FailsafeEnabled bool
 }
 
 func (c *Config) Check() error {

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -95,10 +95,11 @@ var (
 		EnvVars: prefixEnvVars("RPC_VERIFICATION_WARNINGS"),
 		Value:   false,
 	}
-	AutoStopFlag = &cli.BoolFlag{
-		Name:    "auto-stop",
-		Usage:   "start the supervisor with auto-stop enabled",
-		EnvVars: prefixEnvVars("AUTO_STOP"),
+	FailsafeEnabledFlag = &cli.BoolFlag{
+		Name: "failsafe-enabled",
+		Usage: "Start the supervisor with failsafe enabled. In failsafe mode, the supervisor will reject all CheckAccessList requests. " +
+			"All other Indexing and Cross Validation actions will continue to operate normally.",
+		EnvVars: prefixEnvVars("FAILSAFE_ENABLED"),
 		Value:   false,
 	}
 )
@@ -118,7 +119,7 @@ var optionalFlags = []cli.Flag{
 	DependencySetFlag,
 	RollupConfigPathsFlag,
 	RollupConfigSetFlag,
-	AutoStopFlag,
+	FailsafeEnabledFlag,
 }
 
 func init() {
@@ -195,7 +196,7 @@ func ConfigFromCLI(ctx *cli.Context, version string) (*config.Config, error) {
 		RPC:                     oprpc.ReadCLIConfig(ctx),
 		MockRun:                 ctx.Bool(MockRunFlag.Name),
 		RPCVerificationWarnings: ctx.Bool(RPCVerificationWarningsFlag.Name),
-		AutoStop:                ctx.Bool(AutoStopFlag.Name),
+		FailsafeEnabled:         ctx.Bool(FailsafeEnabledFlag.Name),
 		L1RPC:                   ctx.String(L1RPCFlag.Name),
 		SyncSources:             syncSourceSetups(ctx),
 		Datadir:                 ctx.Path(DataDirFlag.Name),

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -95,6 +95,12 @@ var (
 		EnvVars: prefixEnvVars("RPC_VERIFICATION_WARNINGS"),
 		Value:   false,
 	}
+	AutoStopFlag = &cli.BoolFlag{
+		Name:    "auto-stop",
+		Usage:   "start the supervisor with auto-stop enabled",
+		EnvVars: prefixEnvVars("AUTO_STOP"),
+		Value:   false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -112,6 +118,7 @@ var optionalFlags = []cli.Flag{
 	DependencySetFlag,
 	RollupConfigPathsFlag,
 	RollupConfigSetFlag,
+	AutoStopFlag,
 }
 
 func init() {
@@ -188,6 +195,7 @@ func ConfigFromCLI(ctx *cli.Context, version string) (*config.Config, error) {
 		RPC:                     oprpc.ReadCLIConfig(ctx),
 		MockRun:                 ctx.Bool(MockRunFlag.Name),
 		RPCVerificationWarnings: ctx.Bool(RPCVerificationWarningsFlag.Name),
+		AutoStop:                ctx.Bool(AutoStopFlag.Name),
 		L1RPC:                   ctx.String(L1RPCFlag.Name),
 		SyncSources:             syncSourceSetups(ctx),
 		Datadir:                 ctx.Path(DataDirFlag.Name),

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -83,6 +83,9 @@ type SupervisorBackend struct {
 
 	// rpcVerificationWarnings enables asynchronous RPC verification of DB checkAccess call in the CheckAccessList endpoint, indicating warnings as a metric
 	rpcVerificationWarnings bool
+
+	// autoStop controls whether the supervisor should automatically stop
+	autoStop atomic.Bool
 }
 
 var (
@@ -550,6 +553,12 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 
 func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor) error {
+	// Check if auto-stop is enabled
+	if su.isAutoStop() {
+		su.logger.Debug("Auto-stop is enabled, rejecting access-list check")
+		return types.ErrAutoStop
+	}
+
 	switch minSafety {
 	case types.LocalUnsafe, types.CrossUnsafe, types.LocalSafe, types.CrossSafe, types.Finalized:
 		// valid safety level
@@ -820,4 +829,23 @@ func (su *SupervisorBackend) SetConfDepthL1(depth uint64) {
 // Rewind rolls back the state of the supervisor for the given chain.
 func (su *SupervisorBackend) Rewind(ctx context.Context, chain eth.ChainID, block eth.BlockID) error {
 	return su.chainDBs.Rewind(chain, block)
+}
+
+// SetAutoStop sets the auto-stop configuration for the supervisor.
+func (su *SupervisorBackend) SetAutoStop(ctx context.Context, enabled bool) error {
+	su.autoStop.Store(enabled)
+	return nil
+}
+
+// GetAutoStop gets the current auto-stop configuration for the supervisor.
+func (su *SupervisorBackend) GetAutoStop(ctx context.Context) (bool, error) {
+	return su.isAutoStop(), nil
+}
+
+// isAutoStop returns whether auto-stop is enabled.
+// If a more complex AutoStop functionality is needed,
+// this function can be extended to make those calls
+// For now, it just returns the current state of the autoStop flag.
+func (su *SupervisorBackend) isAutoStop() bool {
+	return su.autoStop.Load()
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -84,8 +84,8 @@ type SupervisorBackend struct {
 	// rpcVerificationWarnings enables asynchronous RPC verification of DB checkAccess call in the CheckAccessList endpoint, indicating warnings as a metric
 	rpcVerificationWarnings bool
 
-	// autoStop controls whether the supervisor should automatically stop
-	autoStop atomic.Bool
+	// failsafeEnabled controls whether the supervisor should enable failsafe mode
+	failsafeEnabled atomic.Bool
 }
 
 var (
@@ -164,7 +164,7 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 		rpcVerificationWarnings: cfg.RPCVerificationWarnings,
 	}
 	// Set auto-stop from config
-	super.SetAutoStop(ctx, cfg.AutoStop)
+	super.SetFailsafeEnabled(ctx, cfg.FailsafeEnabled)
 	eventSys.Register("backend", super)
 	eventSys.Register("rewinder", super.rewinder)
 
@@ -555,10 +555,10 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 
 func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor) error {
-	// Check if auto-stop is enabled
-	if su.isAutoStop() {
-		su.logger.Debug("Auto-stop is enabled, rejecting access-list check")
-		return types.ErrAutoStop
+	// Check if failsafe is enabled
+	if su.isFailsafeEnabled() {
+		su.logger.Debug("Failsafe is enabled, rejecting access-list check")
+		return types.ErrFailsafeEnabled
 	}
 
 	switch minSafety {
@@ -833,21 +833,19 @@ func (su *SupervisorBackend) Rewind(ctx context.Context, chain eth.ChainID, bloc
 	return su.chainDBs.Rewind(chain, block)
 }
 
-// SetAutoStop sets the auto-stop configuration for the supervisor.
-func (su *SupervisorBackend) SetAutoStop(ctx context.Context, enabled bool) error {
-	su.autoStop.Store(enabled)
+// SetFailsafeEnabled sets the failsafe mode configuration for the supervisor.
+func (su *SupervisorBackend) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
+	su.failsafeEnabled.Store(enabled)
 	return nil
 }
 
-// GetAutoStop gets the current auto-stop configuration for the supervisor.
-func (su *SupervisorBackend) GetAutoStop(ctx context.Context) (bool, error) {
-	return su.isAutoStop(), nil
+// GetFailsafeEnabled gets the current failsafe mode configuration for the supervisor.
+func (su *SupervisorBackend) GetFailsafeEnabled(ctx context.Context) (bool, error) {
+	return su.isFailsafeEnabled(), nil
 }
 
-// isAutoStop returns whether auto-stop is enabled.
-// If a more complex AutoStop functionality is needed,
-// this function can be extended to make those calls
-// For now, it just returns the current state of the autoStop flag.
-func (su *SupervisorBackend) isAutoStop() bool {
-	return su.autoStop.Load()
+// isFailsafeEnabled returns whether failsafe is enabled.
+func (su *SupervisorBackend) isFailsafeEnabled() bool {
+	// presently the failsafe bool is 1:1 with failsafe being enabled
+	return su.failsafeEnabled.Load()
 }

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -163,8 +163,8 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 
 		rpcVerificationWarnings: cfg.RPCVerificationWarnings,
 	}
-	// Set auto-stop from config
-	super.SetFailsafeEnabled(ctx, cfg.FailsafeEnabled)
+	// Set failsafe from config
+	super.setFailsafeEnabled(cfg.FailsafeEnabled)
 	eventSys.Register("backend", super)
 	eventSys.Register("rewinder", super.rewinder)
 
@@ -835,8 +835,14 @@ func (su *SupervisorBackend) Rewind(ctx context.Context, chain eth.ChainID, bloc
 
 // SetFailsafeEnabled sets the failsafe mode configuration for the supervisor.
 func (su *SupervisorBackend) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
-	su.failsafeEnabled.Store(enabled)
+	su.setFailsafeEnabled(enabled)
 	return nil
+}
+
+// setFailsafeEnabled sets the failsafe mode configuration for the supervisor.
+// it is an internal function because it does not need context, nor does it return an error.
+func (su *SupervisorBackend) setFailsafeEnabled(enabled bool) {
+	su.failsafeEnabled.Store(enabled)
 }
 
 // GetFailsafeEnabled gets the current failsafe mode configuration for the supervisor.

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -163,6 +163,8 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 
 		rpcVerificationWarnings: cfg.RPCVerificationWarnings,
 	}
+	// Set auto-stop from config
+	super.SetAutoStop(ctx, cfg.AutoStop)
 	eventSys.Register("backend", super)
 	eventSys.Register("rewinder", super.rewinder)
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -649,3 +649,49 @@ func TestAutoStop(t *testing.T) {
 	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
 	require.NoError(t, err, "CheckAccessList should work normally when auto-stop is disabled")
 }
+
+// TestAutoStopConfigInitialization confirms the configured auto-stop state is correctly initialized
+func TestAutoStopConfigInitialization(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	m := metrics.NoopMetrics
+	dataDir := t.TempDir()
+	fullCfgSet := fullConfigSet(t, 1)
+
+	testCases := []struct {
+		name          string
+		autoStop      bool
+		expectEnabled bool
+	}{
+		{
+			name:     "AutoStopEnabled",
+			autoStop: true,
+		},
+		{
+			name:     "AutoStopDisabled",
+			autoStop: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Version:               "test",
+				FullConfigSetSource:   fullCfgSet,
+				SynchronousProcessors: true,
+				MockRun:               false,
+				SyncSources:           &syncnode.CLISyncNodes{},
+				Datadir:               dataDir,
+				AutoStop:              tc.autoStop,
+			}
+
+			ex := event.NewGlobalSynchronous(context.Background())
+			b, err := NewSupervisorBackend(context.Background(), logger, m, cfg, ex)
+			require.NoError(t, err)
+
+			// Verify that auto-stop state matches config after initialization
+			enabled, err := b.GetAutoStop(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tc.autoStop, enabled, "auto-stop state should match config setting")
+		})
+	}
+}

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -602,7 +602,7 @@ func TestAsyncVerifyAccessWithRPC(t *testing.T) {
 	runScenario("NoErr_match", sealA, nil, idA)
 }
 
-func TestAutoStop(t *testing.T) {
+func TestFailsafeEnabled(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	m := metrics.NoopMetrics
 	dataDir := t.TempDir()
@@ -621,54 +621,56 @@ func TestAutoStop(t *testing.T) {
 	b, err := NewSupervisorBackend(context.Background(), logger, m, cfg, ex)
 	require.NoError(t, err)
 
-	// Test initial state - auto-stop should be disabled by default
-	enabled, err := b.GetAutoStop(context.Background())
+	// Test initial state - failsafe should be disabled by default
+	enabled, err := b.GetFailsafeEnabled(context.Background())
 	require.NoError(t, err)
-	require.False(t, enabled, "auto-stop should be disabled by default")
+	require.False(t, enabled, "failsafe should be disabled by default")
+
 	// Test that CheckAccessList works normally in initial state
 	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
-	require.NoError(t, err, "CheckAccessList should work normally when auto-stop is disabled")
+	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 
-	// Test setting auto-stop to true
-	err = b.SetAutoStop(context.Background(), true)
+	// Test setting failsafe to true
+	err = b.SetFailsafeEnabled(context.Background(), true)
 	require.NoError(t, err)
-	enabled, err = b.GetAutoStop(context.Background())
+	enabled, err = b.GetFailsafeEnabled(context.Background())
 	require.NoError(t, err)
-	require.True(t, enabled, "auto-stop should be enabled after setting to true")
-	// Test that CheckAccessList returns ErrAutoStop when auto-stop is enabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
-	require.ErrorIs(t, err, types.ErrAutoStop, "CheckAccessList should return ErrAutoStop when auto-stop is enabled")
+	require.True(t, enabled, "failsafe should be enabled after setting to true")
 
-	// Test setting auto-stop to false
-	err = b.SetAutoStop(context.Background(), false)
-	require.NoError(t, err)
-	enabled, err = b.GetAutoStop(context.Background())
-	require.NoError(t, err)
-	require.False(t, enabled, "auto-stop should be disabled after setting to false")
-	// Test that CheckAccessList works normally when auto-stop is disabled
+	// Test that CheckAccessList returns ErrFailsafeEnabled when failsafe is enabled
 	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
-	require.NoError(t, err, "CheckAccessList should work normally when auto-stop is disabled")
+	require.ErrorIs(t, err, types.ErrFailsafeEnabled, "CheckAccessList should return ErrFailsafeEnabled when failsafe is enabled")
+
+	// Test setting failsafe to false
+	err = b.SetFailsafeEnabled(context.Background(), false)
+	require.NoError(t, err)
+	enabled, err = b.GetFailsafeEnabled(context.Background())
+	require.NoError(t, err)
+	require.False(t, enabled, "failsafe should be disabled after setting to false")
+
+	// Test that CheckAccessList works normally when failsafe is disabled
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 }
 
-// TestAutoStopConfigInitialization confirms the configured auto-stop state is correctly initialized
-func TestAutoStopConfigInitialization(t *testing.T) {
+// TestFailsafeEnabledConfigInitialization confirms the configured failsafe state is correctly initialized
+func TestFailsafeEnabledConfigInitialization(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	m := metrics.NoopMetrics
 	dataDir := t.TempDir()
 	fullCfgSet := fullConfigSet(t, 1)
 
 	testCases := []struct {
-		name          string
-		autoStop      bool
-		expectEnabled bool
+		name            string
+		failsafeEnabled bool
 	}{
 		{
-			name:     "AutoStopEnabled",
-			autoStop: true,
+			name:            "FailsafeEnabled",
+			failsafeEnabled: true,
 		},
 		{
-			name:     "AutoStopDisabled",
-			autoStop: false,
+			name:            "FailsafeDisabled",
+			failsafeEnabled: false,
 		},
 	}
 
@@ -681,17 +683,17 @@ func TestAutoStopConfigInitialization(t *testing.T) {
 				MockRun:               false,
 				SyncSources:           &syncnode.CLISyncNodes{},
 				Datadir:               dataDir,
-				AutoStop:              tc.autoStop,
+				FailsafeEnabled:       tc.failsafeEnabled,
 			}
 
 			ex := event.NewGlobalSynchronous(context.Background())
 			b, err := NewSupervisorBackend(context.Background(), logger, m, cfg, ex)
 			require.NoError(t, err)
 
-			// Verify that auto-stop state matches config after initialization
-			enabled, err := b.GetAutoStop(context.Background())
+			// Verify that failsafe state matches config after initialization
+			enabled, err := b.GetFailsafeEnabled(context.Background())
 			require.NoError(t, err)
-			require.Equal(t, tc.autoStop, enabled, "auto-stop state should match config setting")
+			require.Equal(t, tc.failsafeEnabled, enabled, "failsafe state should match config setting")
 		})
 	}
 }

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -601,3 +601,51 @@ func TestAsyncVerifyAccessWithRPC(t *testing.T) {
 	// No error + match         => 0 failures
 	runScenario("NoErr_match", sealA, nil, idA)
 }
+
+func TestAutoStop(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	m := metrics.NoopMetrics
+	dataDir := t.TempDir()
+	fullCfgSet := fullConfigSet(t, 1)
+
+	cfg := &config.Config{
+		Version:               "test",
+		FullConfigSetSource:   fullCfgSet,
+		SynchronousProcessors: true,
+		MockRun:               false,
+		SyncSources:           &syncnode.CLISyncNodes{},
+		Datadir:               dataDir,
+	}
+
+	ex := event.NewGlobalSynchronous(context.Background())
+	b, err := NewSupervisorBackend(context.Background(), logger, m, cfg, ex)
+	require.NoError(t, err)
+
+	// Test initial state - auto-stop should be disabled by default
+	enabled, err := b.GetAutoStop(context.Background())
+	require.NoError(t, err)
+	require.False(t, enabled, "auto-stop should be disabled by default")
+	// Test that CheckAccessList works normally in initial state
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.NoError(t, err, "CheckAccessList should work normally when auto-stop is disabled")
+
+	// Test setting auto-stop to true
+	err = b.SetAutoStop(context.Background(), true)
+	require.NoError(t, err)
+	enabled, err = b.GetAutoStop(context.Background())
+	require.NoError(t, err)
+	require.True(t, enabled, "auto-stop should be enabled after setting to true")
+	// Test that CheckAccessList returns ErrAutoStop when auto-stop is enabled
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.ErrorIs(t, err, types.ErrAutoStop, "CheckAccessList should return ErrAutoStop when auto-stop is enabled")
+
+	// Test setting auto-stop to false
+	err = b.SetAutoStop(context.Background(), false)
+	require.NoError(t, err)
+	enabled, err = b.GetAutoStop(context.Background())
+	require.NoError(t, err)
+	require.False(t, enabled, "auto-stop should be disabled after setting to false")
+	// Test that CheckAccessList works normally when auto-stop is disabled
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	require.NoError(t, err, "CheckAccessList should work normally when auto-stop is disabled")
+}

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -87,6 +87,14 @@ func (m *MockBackend) Rewind(ctx context.Context, chain eth.ChainID, block eth.B
 	return nil
 }
 
+func (m *MockBackend) SetAutoStop(ctx context.Context, enabled bool) error {
+	return nil
+}
+
+func (m *MockBackend) GetAutoStop(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func (m *MockBackend) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -87,11 +87,11 @@ func (m *MockBackend) Rewind(ctx context.Context, chain eth.ChainID, block eth.B
 	return nil
 }
 
-func (m *MockBackend) SetAutoStop(ctx context.Context, enabled bool) error {
+func (m *MockBackend) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
 	return nil
 }
 
-func (m *MockBackend) GetAutoStop(ctx context.Context) (bool, error) {
+func (m *MockBackend) GetFailsafeEnabled(ctx context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -90,12 +90,12 @@ func (a *AdminFrontend) Rewind(ctx context.Context, chain eth.ChainID, block eth
 	return a.Supervisor.Rewind(ctx, chain, block)
 }
 
-// SetAutoStop sets the auto-stop configuration for the supervisor.
-func (a *AdminFrontend) SetAutoStop(ctx context.Context, enabled bool) error {
-	return a.Supervisor.SetAutoStop(ctx, enabled)
+// SetFailsafeEnabled sets the failsafe mode configuration for the supervisor.
+func (a *AdminFrontend) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
+	return a.Supervisor.SetFailsafeEnabled(ctx, enabled)
 }
 
-// GetAutoStop gets the current auto-stop configuration for the supervisor.
-func (a *AdminFrontend) GetAutoStop(ctx context.Context) (bool, error) {
-	return a.Supervisor.GetAutoStop(ctx)
+// GetFailsafeEnabled gets the current failsafe mode configuration for the supervisor.
+func (a *AdminFrontend) GetFailsafeEnabled(ctx context.Context) (bool, error) {
+	return a.Supervisor.GetFailsafeEnabled(ctx)
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -89,3 +89,13 @@ func (a *AdminFrontend) Rewind(ctx context.Context, chain eth.ChainID, block eth
 	// TODO(#15665) add logging here to track when rewinds are requested
 	return a.Supervisor.Rewind(ctx, chain, block)
 }
+
+// SetAutoStop sets the auto-stop configuration for the supervisor.
+func (a *AdminFrontend) SetAutoStop(ctx context.Context, enabled bool) error {
+	return a.Supervisor.SetAutoStop(ctx, enabled)
+}
+
+// GetAutoStop gets the current auto-stop configuration for the supervisor.
+func (a *AdminFrontend) GetAutoStop(ctx context.Context) (bool, error) {
+	return a.Supervisor.GetAutoStop(ctx)
+}

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -44,4 +44,6 @@ var (
 	ErrNoRPCSource = errors.New("no RPC client configured")
 	// ErrUninitialized happens when a chain database is not initialized yet
 	ErrUninitialized = errors.New("uninitialized chain database")
+	// ErrAutoStop is when auto-stop is enabled and the request is rejected
+	ErrAutoStop = errors.New("auto-stop is enabled")
 )

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -44,6 +44,6 @@ var (
 	ErrNoRPCSource = errors.New("no RPC client configured")
 	// ErrUninitialized happens when a chain database is not initialized yet
 	ErrUninitialized = errors.New("uninitialized chain database")
-	// ErrAutoStop is when auto-stop is enabled and the request is rejected
-	ErrAutoStop = errors.New("auto-stop is enabled")
+	// ErrFailsafeEnabled is when failsafe is enabled and the request is rejected
+	ErrFailsafeEnabled = errors.New("failsafe is enabled, rejecting all CheckAccessList requests")
 )


### PR DESCRIPTION
### What
Implements basic API for AutoStop:
- Get and Set Admin API
- Held as a simple `atomic.Bool`
- Whenever `CheckAccessList` is called, `isAutoStop` is checked and may short circuit the function to return `ErrAutoStop`
- Flags and Config included to set auto-stop as enabled on startup (for safety during operations which may include a reboot of the supervisor)

ProxyD and Geth may both call the `GetAutoStop` API to control their own rejection logic. Meanwhile, operators and metrics can use `SetAutoStop` to control the behavior.

Still to come (after this PR):
- Monitoring hooks for AutoStop
- AutoStop enablement when a Block Invalidation happens

### Testing
New unit tests confirming:
- Use of the config for initial values
- Functional Get/Set
- Blocking of `CheckAccessList` only when enabled