### PR TITLE
feat(op-acceptance-tests): flashblocks-websocket-proxy awareness to flashblocks gate

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -70,15 +70,73 @@ func TestFlashblocksStream(gt *testing.T) {
 					mode = FlashblocksStreamMode_Leader
 				}
 
-				testFlashblocksStream(tt, logger, flashblocksBuilderNode, mode, flashblocksStreamRateMs)
+				testFlashblocksStreamRbuilder(tt, logger, flashblocksBuilderNode, mode, flashblocksStreamRateMs)
+			}
+
+			for _, flashblocksWebsocketProxy := range sys.FlashblocksWebsocketProxies[l2Chain] {
+				testFlashblocksStreamFbWsProxy(tt, logger, flashblocksWebsocketProxy, flashblocksStreamRateMs)
 			}
 		})
 	}
 }
 
-// testFlashblocksStream tests the presence / absence of a flashblocks stream operating at a 250ms (configurable via env var FLASHBLOCKS_STREAM_RATE) rate
-func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNode *dsl.FlashblocksBuilderNode, mode FlashblocksStreamMode, expectedFlashblocksStreamRateMs int) {
-	t.Run(fmt.Sprintf("Flashblocks_Stream_%s", mode), func(t devtest.T) {
+func evaluateFlashblocksStream(t devtest.T, logger log.Logger, streamedMessages []string, failureTolerance int) int {
+	require.Greater(t, len(streamedMessages), 0, "should have received at least one message from WebSocket")
+	flashblocks := make([]Flashblock, len(streamedMessages))
+
+	failures := 0
+	for i, msg := range streamedMessages {
+		var flashblock Flashblock
+		if err := json.Unmarshal([]byte(msg), &flashblock); err != nil {
+			logger.Warn("Failed to unmarshal WebSocket message", "error", err)
+			failures++
+			if failures > failureTolerance {
+				logger.Error("failed to unmarshal streamed messages into flashblocks beyond the failure tolerance of %d", failureTolerance)
+				t.FailNow()
+			}
+			continue
+		}
+
+		flashblocks[i] = flashblock
+	}
+
+	totalFlashblocksProduced := 0
+
+	lastIndex := -1
+	lastBlockNumber := -1
+
+	for _, flashblock := range flashblocks {
+		currentIndex, currentBlockNumber := flashblock.Index, flashblock.Metadata.BlockNumber
+
+		if lastBlockNumber == -1 {
+			totalFlashblocksProduced += 1
+			lastIndex = currentIndex
+			lastBlockNumber = currentBlockNumber
+			continue
+		}
+
+		require.Greater(t, lastIndex, -1, "some bug: last index should be greater than -1 by now")
+		require.Greater(t, currentIndex, -1, "some bug: current index should be greater than -1 by now")
+
+		// same block number, just the flashblock incremented
+		if currentBlockNumber == lastBlockNumber {
+			require.Greater(t, currentIndex, lastIndex, "some bug: current index should be greater than last index from the stream")
+
+			totalFlashblocksProduced += (currentIndex - lastIndex)
+		} else if currentBlockNumber > lastBlockNumber { // new block number
+			totalFlashblocksProduced += (currentIndex + 1) // assuming it's a new block number whose flashblocks begin from 0th-index
+		}
+
+		lastIndex = currentIndex
+		lastBlockNumber = currentBlockNumber
+	}
+
+	return totalFlashblocksProduced
+}
+
+// testFlashblocksStreamRbuilder tests the presence / absence of a flashblocks stream operating at a 250ms (configurable via env var FLASHBLOCKS_STREAM_RATE) rate from an rbuilder node
+func testFlashblocksStreamRbuilder(t devtest.T, logger log.Logger, flashblocksBuilderNode *dsl.FlashblocksBuilderNode, mode FlashblocksStreamMode, expectedFlashblocksStreamRateMs int) {
+	t.Run(fmt.Sprintf("Flashblocks_Stream_Rbuilder_%s_%s", flashblocksBuilderNode.Escape().ID(), mode), func(t devtest.T) {
 		testDuration := time.Duration(int64(expectedFlashblocksStreamRateMs*maxExpectedFlashblocks)) * time.Millisecond
 		failureTolerance := int(0.15 * float64(maxExpectedFlashblocks))
 
@@ -110,58 +168,56 @@ func testFlashblocksStream(t devtest.T, logger log.Logger, flashblocksBuilderNod
 			return
 		}
 
-		require.Greater(t, len(streamedMessages), 0, "should have received at least one message from WebSocket")
-		flashblocks := make([]Flashblock, len(streamedMessages))
-
-		failures := 0
-		for i, msg := range streamedMessages {
-			var flashblock Flashblock
-			if err := json.Unmarshal([]byte(msg), &flashblock); err != nil {
-				logger.Warn("Failed to unmarshal WebSocket message", "error", err)
-				failures++
-				if failures > failureTolerance {
-					logger.Error("failed to unmarshal streamed messages into flashblocks beyond the failure tolerance of %d", failureTolerance)
-					t.FailNow()
-				}
-				continue
-			}
-
-			flashblocks[i] = flashblock
-		}
-
-		totalFlashblocksProduced := 0
-
-		lastIndex := -1
-		lastBlockNumber := -1
-
-		for _, flashblock := range flashblocks {
-			currentIndex, currentBlockNumber := flashblock.Index, flashblock.Metadata.BlockNumber
-
-			if lastBlockNumber == -1 {
-				totalFlashblocksProduced += 1
-				lastIndex = currentIndex
-				lastBlockNumber = currentBlockNumber
-				continue
-			}
-
-			require.Greater(t, lastIndex, -1, "some bug: last index should be greater than -1 by now")
-			require.Greater(t, currentIndex, -1, "some bug: current index should be greater than -1 by now")
-
-			// same block number, just the flashblock incremented
-			if currentBlockNumber == lastBlockNumber {
-				require.Greater(t, currentIndex, lastIndex, "some bug: current index should be greater than last index from the stream")
-
-				totalFlashblocksProduced += (currentIndex - lastIndex)
-			} else if currentBlockNumber > lastBlockNumber { // new block number
-				totalFlashblocksProduced += (currentIndex + 1) // assuming it's a new block number whose flashblocks begin from 0th-index
-			}
-
-			lastIndex = currentIndex
-			lastBlockNumber = currentBlockNumber
-		}
+		totalFlashblocksProduced := evaluateFlashblocksStream(t, logger, streamedMessages, failureTolerance)
 
 		minExpectedFlashblocks := maxExpectedFlashblocks - failureTolerance
+		require.Greater(t,
+			totalFlashblocksProduced, minExpectedFlashblocks,
+			fmt.Sprintf("total flashblocks produced should be greater than %d (%d over %s with a %dms rate with a failure tolerance of %d flashblocks)",
+				minExpectedFlashblocks,
+				maxExpectedFlashblocks,
+				testDuration,
+				expectedFlashblocksStreamRateMs,
+				failureTolerance,
+			),
+		)
 
+		logger.Info("Flashblocks stream validation completed", "total_flashblocks_produced", totalFlashblocksProduced)
+	})
+}
+
+// testFlashblocksStreamFbWsProxy tests the presence / absence of a flashblocks stream operating at a 250ms (configurable via env var FLASHBLOCKS_STREAM_RATE) rate from a flashblocks-websocket-proxy node
+func testFlashblocksStreamFbWsProxy(t devtest.T, logger log.Logger, flashblocksWebsocketProxy *dsl.FlashblocksWebsocketProxy, expectedFlashblocksStreamRateMs int) {
+	t.Run(fmt.Sprintf("Flashblocks_Stream_FbWsProxy_%s", flashblocksWebsocketProxy.Escape().ID()), func(t devtest.T) {
+		testDuration := time.Duration(int64(expectedFlashblocksStreamRateMs*maxExpectedFlashblocks)) * time.Millisecond
+		failureTolerance := int(0.15 * float64(maxExpectedFlashblocks))
+
+		logger.Debug("Test duration", "duration", testDuration, "failure tolerance (of flashblocks)", failureTolerance)
+
+		require.NotNil(t, flashblocksWebsocketProxy, "flashblocksWebsocketProxy should not be nil")
+
+		output := make(chan []byte, maxExpectedFlashblocks)
+		doneListening := make(chan struct{})
+		streamedMessages := make([]string, 0)
+		go flashblocksWebsocketProxy.ListenFor(logger, testDuration, output, doneListening) //nolint:errcheck
+
+		for {
+			select {
+			case <-doneListening:
+				goto done
+			case msg := <-output:
+				streamedMessages = append(streamedMessages, string(msg))
+			}
+		}
+	done:
+
+		defer close(output)
+
+		logger.Info("Completed WebSocket stream reading", "message_count", len(streamedMessages))
+
+		totalFlashblocksProduced := evaluateFlashblocksStream(t, logger, streamedMessages, failureTolerance)
+
+		minExpectedFlashblocks := maxExpectedFlashblocks - failureTolerance
 		require.Greater(t,
 			totalFlashblocksProduced, minExpectedFlashblocks,
 			fmt.Sprintf("total flashblocks produced should be greater than %d (%d over %s with a %dms rate with a failure tolerance of %d flashblocks)",

--- a/op-acceptance-tests/tests/flashblocks/init_test.go
+++ b/op-acceptance-tests/tests/flashblocks/init_test.go
@@ -9,5 +9,4 @@ import (
 // TestMain creates the test-setups against the shared backend
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleFlashblocks())
-
 }

--- a/op-devstack/dsl/fb_builder.go
+++ b/op-devstack/dsl/fb_builder.go
@@ -1,19 +1,16 @@
 package dsl
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/gorilla/websocket"
 )
 
 type FlashblocksBuilderSet []*FlashblocksBuilderNode
 
-func (f *FlashblocksBuilderSet) Leader() *FlashblocksBuilderNode {
-	for _, node := range *f {
+func (f FlashblocksBuilderSet) Leader() *FlashblocksBuilderNode {
+	for _, node := range f {
 		if node.Conductor().IsLeader() {
 			return node
 		}
@@ -54,43 +51,5 @@ func (c *FlashblocksBuilderNode) Conductor() *Conductor {
 }
 
 func (c *FlashblocksBuilderNode) ListenFor(logger log.Logger, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
-	defer close(done)
-	wsURL := c.Escape().FlashblocksWsUrl()
-	logger.Debug("Testing WebSocket connection to", "url", wsURL)
-
-	dialer := &websocket.Dialer{
-		HandshakeTimeout: 6 * time.Second,
-	}
-
-	conn, _, err := dialer.Dial(wsURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to connect to Flashblocks WebSocket endpoint %s: %w", wsURL, err)
-	}
-	defer conn.Close()
-
-	logger.Info("WebSocket connection established, reading stream for %s", duration)
-
-	timeout := time.After(duration)
-	for {
-		select {
-		case <-timeout:
-			return nil
-		default:
-			err = conn.SetReadDeadline(time.Now().Add(duration))
-			if err != nil {
-				return fmt.Errorf("failed to set read deadline: %w", err)
-			}
-			_, message, err := conn.ReadMessage()
-			if err != nil && !strings.Contains(err.Error(), "timeout") {
-				return fmt.Errorf("error reading WebSocket message: %w", err)
-			}
-			if err == nil {
-				select {
-				case output <- message:
-				case <-timeout: // to avoid indefinite hang
-					return nil
-				}
-			}
-		}
-	}
+	return websocketListenFor(logger, c.inner.FlashblocksWsUrl(), duration, output, done)
 }

--- a/op-devstack/dsl/fb_ws_proxy.go
+++ b/op-devstack/dsl/fb_ws_proxy.go
@@ -1,0 +1,86 @@
+package dsl
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/gorilla/websocket"
+)
+
+type FlashblocksWebsocketProxySet []*FlashblocksWebsocketProxy
+
+func NewFlashblocksWebsocketProxySet(inner []stack.FlashblocksWebsocketProxy) FlashblocksWebsocketProxySet {
+	flashblocksWebsocketProxies := make([]*FlashblocksWebsocketProxy, len(inner))
+	for i, c := range inner {
+		flashblocksWebsocketProxies[i] = NewFlashblocksWebsocketProxy(c)
+	}
+	return flashblocksWebsocketProxies
+}
+
+type FlashblocksWebsocketProxy struct {
+	commonImpl
+	inner stack.FlashblocksWebsocketProxy
+}
+
+func NewFlashblocksWebsocketProxy(inner stack.FlashblocksWebsocketProxy) *FlashblocksWebsocketProxy {
+	return &FlashblocksWebsocketProxy{
+		commonImpl: commonFromT(inner.T()),
+		inner:      inner,
+	}
+}
+
+func (c *FlashblocksWebsocketProxy) String() string {
+	return c.inner.ID().String()
+}
+
+func (c *FlashblocksWebsocketProxy) Escape() stack.FlashblocksWebsocketProxy {
+	return c.inner
+}
+
+func (c *FlashblocksWebsocketProxy) ListenFor(logger log.Logger, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
+	return websocketListenFor(logger, c.Escape().WsUrl(), duration, output, done)
+}
+
+func websocketListenFor(logger log.Logger, wsURL string, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
+	defer close(done)
+	logger.Debug("Testing WebSocket connection to", "url", wsURL)
+
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: 6 * time.Second,
+	}
+
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Flashblocks WebSocket endpoint %s: %w", wsURL, err)
+	}
+	defer conn.Close()
+
+	logger.Info("WebSocket connection established, reading stream for %s", duration)
+
+	timeout := time.After(duration)
+	for {
+		select {
+		case <-timeout:
+			return nil
+		default:
+			err = conn.SetReadDeadline(time.Now().Add(duration))
+			if err != nil {
+				return fmt.Errorf("failed to set read deadline: %w", err)
+			}
+			_, message, err := conn.ReadMessage()
+			if err != nil && !strings.Contains(err.Error(), "timeout") {
+				return fmt.Errorf("error reading WebSocket message: %w", err)
+			}
+			if err == nil {
+				select {
+				case output <- message:
+				case <-timeout: // to avoid indefinite hang
+					return nil
+				}
+			}
+		}
+	}
+}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -13,11 +13,13 @@ import (
 type SimpleFlashblocks struct {
 	*Minimal
 
-	ConductorSets          map[stack.L2NetworkID]dsl.ConductorSet
-	FlashblocksBuilderSets map[stack.L2NetworkID]dsl.FlashblocksBuilderSet
-	Faucets                map[stack.L2NetworkID]*dsl.Faucet
-	Funders                map[stack.L2NetworkID]*dsl.Funder
-	L2ELNodes              map[stack.L2NetworkID]*dsl.L2ELNode
+	ConductorSets               map[stack.L2NetworkID]dsl.ConductorSet
+	FlashblocksBuilderSets      map[stack.L2NetworkID]dsl.FlashblocksBuilderSet
+	FlashblocksWebsocketProxies map[stack.L2NetworkID]dsl.FlashblocksWebsocketProxySet
+
+	Faucets   map[stack.L2NetworkID]*dsl.Faucet
+	Funders   map[stack.L2NetworkID]*dsl.Funder
+	L2ELNodes map[stack.L2NetworkID]*dsl.L2ELNode
 }
 
 func WithSimpleFlashblocks() stack.CommonOption {
@@ -42,6 +44,7 @@ func NewSimpleFlashblocks(t devtest.T) *SimpleFlashblocks {
 	faucets := make(map[stack.L2NetworkID]*dsl.Faucet)
 	funders := make(map[stack.L2NetworkID]*dsl.Funder)
 	l2ELNodes := make(map[stack.L2NetworkID]*dsl.L2ELNode)
+	flashblocksWebsocketProxies := make(map[stack.L2NetworkID]dsl.FlashblocksWebsocketProxySet)
 
 	for _, chain := range chains {
 		chainMatcher := match.L2ChainById(chain.ID())
@@ -51,16 +54,19 @@ func NewSimpleFlashblocks(t devtest.T) *SimpleFlashblocks {
 
 		conductorSets[chain.ID()] = dsl.NewConductorSet(l2.Conductors())
 		flashblocksBuilderSets[chain.ID()] = dsl.NewFlashblocksBuilderSet(l2.FlashblocksBuilders())
+		flashblocksWebsocketProxies[chain.ID()] = dsl.NewFlashblocksWebsocketProxySet(l2.FlashblocksWebsocketProxies())
+
 		faucets[chain.ID()] = firstFaucet
 		funders[chain.ID()] = dsl.NewFunder(minimalPreset.Wallet, firstFaucet, firstELNode)
 		l2ELNodes[chain.ID()] = firstELNode
 	}
 	return &SimpleFlashblocks{
-		Minimal:                minimalPreset,
-		ConductorSets:          conductorSets,
-		FlashblocksBuilderSets: flashblocksBuilderSets,
-		Faucets:                faucets,
-		Funders:                funders,
-		L2ELNodes:              l2ELNodes,
+		Minimal:                     minimalPreset,
+		ConductorSets:               conductorSets,
+		FlashblocksBuilderSets:      flashblocksBuilderSets,
+		FlashblocksWebsocketProxies: flashblocksWebsocketProxies,
+		Faucets:                     faucets,
+		Funders:                     funders,
+		L2ELNodes:                   l2ELNodes,
 	}
 }

--- a/op-devstack/shim/fb_ws_proxy.go
+++ b/op-devstack/shim/fb_ws_proxy.go
@@ -1,0 +1,41 @@
+package shim
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type FlashblocksWebsocketProxyConfig struct {
+	CommonConfig
+	ID    stack.FlashblocksWebsocketProxyID
+	WsUrl string
+}
+
+type flashblocksWebsocketProxy struct {
+	commonImpl
+	id    stack.FlashblocksWebsocketProxyID
+	wsUrl string
+}
+
+var _ stack.FlashblocksWebsocketProxy = (*flashblocksWebsocketProxy)(nil)
+
+func NewFlashblocksWebsocketProxy(cfg FlashblocksWebsocketProxyConfig) stack.FlashblocksWebsocketProxy {
+	cfg.T = cfg.T.WithCtx(stack.ContextWithID(cfg.T.Ctx(), cfg.ID))
+	return &flashblocksWebsocketProxy{
+		commonImpl: newCommon(cfg.CommonConfig),
+		id:         cfg.ID,
+		wsUrl:      cfg.WsUrl,
+	}
+}
+
+func (r *flashblocksWebsocketProxy) ID() stack.FlashblocksWebsocketProxyID {
+	return r.id
+}
+
+func (r *flashblocksWebsocketProxy) ChainID() eth.ChainID {
+	return r.id.ChainID()
+}
+
+func (r *flashblocksWebsocketProxy) WsUrl() string {
+	return r.wsUrl
+}

--- a/op-devstack/shim/l2_network.go
+++ b/op-devstack/shim/l2_network.go
@@ -40,8 +40,9 @@ type presetL2Network struct {
 	els locks.RWMap[stack.L2ELNodeID, stack.L2ELNode]
 	cls locks.RWMap[stack.L2CLNodeID, stack.L2CLNode]
 
-	conductors locks.RWMap[stack.ConductorID, stack.Conductor]
-	fbBuilders locks.RWMap[stack.FlashblocksBuilderID, stack.FlashblocksBuilderNode]
+	conductors  locks.RWMap[stack.ConductorID, stack.Conductor]
+	fbBuilders  locks.RWMap[stack.FlashblocksBuilderID, stack.FlashblocksBuilderNode]
+	fbWsProxies locks.RWMap[stack.FlashblocksWebsocketProxyID, stack.FlashblocksWebsocketProxy]
 }
 
 var _ stack.L2Network = (*presetL2Network)(nil)
@@ -144,6 +145,12 @@ func (p *presetL2Network) AddL2Proposer(v stack.L2Proposer) {
 	p.require().True(p.proposers.SetIfMissing(id, v), "l2 proposer %s must not already exist", id)
 }
 
+func (p *presetL2Network) AddFlashblocksWebsocketProxy(v stack.FlashblocksWebsocketProxy) {
+	id := v.ID()
+	p.require().Equal(p.chainID, id.ChainID(), "flashblocks websocket proxy %s must be on chain %s", id, p.chainID)
+	p.require().True(p.fbWsProxies.SetIfMissing(id, v), "flashblocks websocket proxy %s must not already exist", id)
+}
+
 func (p *presetL2Network) L2Challenger(m stack.L2ChallengerMatcher) stack.L2Challenger {
 	v, ok := findMatch(m, p.challengers.Get, p.L2Challengers)
 	p.require().True(ok, "must find L2 challenger %s", m)
@@ -194,6 +201,14 @@ func (p *presetL2Network) L2ProposerIDs() []stack.L2ProposerID {
 
 func (p *presetL2Network) L2Proposers() []stack.L2Proposer {
 	return stack.SortL2Proposers(p.proposers.Values())
+}
+
+func (p *presetL2Network) FlashblocksWebsocketProxies() []stack.FlashblocksWebsocketProxy {
+	return stack.SortFlashblocksWebsocketProxies(p.fbWsProxies.Values())
+}
+
+func (p *presetL2Network) FlashblocksWebsocketProxyIDs() []stack.FlashblocksWebsocketProxyID {
+	return stack.SortFlashblocksWebsocketProxyIDs(p.fbWsProxies.Keys())
 }
 
 func (p *presetL2Network) L2ChallengerIDs() []stack.L2ChallengerID {

--- a/op-devstack/stack/fb_ws_proxy.go
+++ b/op-devstack/stack/fb_ws_proxy.go
@@ -1,0 +1,63 @@
+package stack
+
+import (
+	"log/slog"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type FlashblocksWebsocketProxy interface {
+	Common
+	ChainID() eth.ChainID
+	ID() FlashblocksWebsocketProxyID
+	WsUrl() string
+}
+
+type FlashblocksWebsocketProxyID idWithChain
+
+const FlashblocksWebsocketProxyKind Kind = "FlashblocksWebsocketProxy"
+
+func NewFlashblocksWebsocketProxyID(key string, chainID eth.ChainID) FlashblocksWebsocketProxyID {
+	return FlashblocksWebsocketProxyID{
+		key:     key,
+		chainID: chainID,
+	}
+}
+
+func (id FlashblocksWebsocketProxyID) String() string {
+	return idWithChain(id).string(FlashblocksWebsocketProxyKind)
+}
+
+func (id FlashblocksWebsocketProxyID) ChainID() eth.ChainID {
+	return idWithChain(id).chainID
+}
+
+func (id FlashblocksWebsocketProxyID) MarshalText() ([]byte, error) {
+	return idWithChain(id).marshalText(FlashblocksWebsocketProxyKind)
+}
+
+func (id FlashblocksWebsocketProxyID) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id *FlashblocksWebsocketProxyID) UnmarshalText(data []byte) error {
+	return (*idWithChain)(id).unmarshalText(FlashblocksWebsocketProxyKind, data)
+}
+
+func SortFlashblocksWebsocketProxyIDs(ids []FlashblocksWebsocketProxyID) []FlashblocksWebsocketProxyID {
+	return copyAndSort(ids, func(a, b FlashblocksWebsocketProxyID) bool {
+		return lessIDWithChain(idWithChain(a), idWithChain(b))
+	})
+}
+
+func SortFlashblocksWebsocketProxies(elems []FlashblocksWebsocketProxy) []FlashblocksWebsocketProxy {
+	return copyAndSort(elems, func(a, b FlashblocksWebsocketProxy) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ FlashblocksBuilderMatcher = FlashblocksBuilderID{}
+
+func (id FlashblocksWebsocketProxyID) Match(elems []FlashblocksWebsocketProxy) []FlashblocksWebsocketProxy {
+	return findByID(id, elems)
+}

--- a/op-devstack/stack/l2_network.go
+++ b/op-devstack/stack/l2_network.go
@@ -105,6 +105,8 @@ type L2Network interface {
 	Conductors() []Conductor
 	FlashblocksBuilders() []FlashblocksBuilderNode
 	AddFlashblocksBuilder(v FlashblocksBuilderNode)
+	FlashblocksWebsocketProxies() []FlashblocksWebsocketProxy
+	AddFlashblocksWebsocketProxy(v FlashblocksWebsocketProxy)
 }
 
 // ExtensibleL2Network is an optional extension interface for L2Network,

--- a/op-devstack/stack/match/labels.go
+++ b/op-devstack/stack/match/labels.go
@@ -20,9 +20,10 @@ const (
 type L2ELVendor string
 
 const (
-	OpReth L2ELVendor = "op-reth"
-	OpGeth L2ELVendor = "op-geth"
-	Proxyd L2ELVendor = "proxyd"
+	OpReth                    L2ELVendor = "op-reth"
+	OpGeth                    L2ELVendor = "op-geth"
+	Proxyd                    L2ELVendor = "proxyd"
+	FlashblocksWebsocketProxy L2ELVendor = "flashblocks-websocket-proxy"
 )
 
 func (v L2ELVendor) Match(elems []stack.L2ELNode) []stack.L2ELNode {

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -22,6 +22,7 @@ const (
 	HTTPProtocol                 = "http"
 	RPCProtocol                  = "rpc"
 	MetricsProtocol              = "metrics"
+	WssProtocol                  = "wss"
 	WebsocketFlashblocksProtocol = "ws-flashblocks"
 
 	FeatureInterop = "interop"


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

**Description**

This PR:
- Parses and hydrates the L2 network with flashblocks-websocket-proxy config (one or more) if it's available. This also includes shim, preset, stack and dsl for this new component.
- Runs flashblocks_stream_test against all the hydrated flashblocks-websocket-proxy's in addition to the rbuilders already.
- While running flashblocks_transfer_test, it tries to stream flashblocks from the flashblocks-websocket-proxy and if unavailable, it falls back to the leader rbuilder like it's done currently.

**Tests**

**When running the tests not containing a flashblocks-websocket-proxy**

Note the following logs (flashblocks transfer choosing builder to stream flashblocks):

```
Listening for flashblocks via flashblocks builder....TestFlashblocksTransfer
```

![image](https://github.com/user-attachments/assets/b8b61b34-f92e-466f-81bb-e0b696e014a3)

**When running the tests containing a flashblocks-websocket-proxy**

Note the following logs (flashblocks transfer choosing the websocket-proxy over builder and an additional stream test against that websocket-proxy)

```
Listening for flashblocks via websocket proxy....TestFlashblocksTransfer
```
```
PASS: TestFlashblocksStream/L2_Chain_L2Network-420110011/Flashblocks_Stream_FbWsProxy_FlashblocksWebsocketProxy-flashblocks-websocket-proxy-0-420110011
```

![image](https://github.com/user-attachments/assets/534e4137-8baf-4e32-a607-02680b8901f9)

