### PR TITLE
fix(kt-devnet): improve compatibility with devnet-sdk system tests

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -23,8 +23,9 @@ type EndpointMap map[string]*PortInfo
 
 // Service represents a chain service (e.g. batcher, proposer, challenger)
 type Service struct {
-	Name      string      `json:"name"`
-	Endpoints EndpointMap `json:"endpoints"`
+	Name      string            `json:"name"`
+	Endpoints EndpointMap       `json:"endpoints"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 // ServiceMap is a map of service names to services.
@@ -36,8 +37,9 @@ type RedundantServiceMap map[string][]*Service
 
 // Node represents a node for a chain
 type Node struct {
-	Name     string     `json:"name"`
-	Services ServiceMap `json:"services"`
+	Name     string            `json:"name"`
+	Services ServiceMap        `json:"services"`
+	Labels   map[string]string `json:"labels,omitempty"`
 }
 
 // AddressMap is a map of address names to their corresponding addresses

--- a/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/spec/spec_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -51,6 +52,9 @@ ethereum_package:
 	}
 
 	require.Len(t, result.Chains, len(expectedChains))
+	sort.Slice(result.Chains, func(i, j int) bool {
+		return result.Chains[i].Name < result.Chains[j].Name
+	})
 
 	for i, expected := range expectedChains {
 		actual := result.Chains[i]


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Unfortunately we've backed into devnet-sdk system tests unsafe
assumptions around the first node being a sequencer.
This change attempts to restore some compatibility with these
assumptions, until we finally deprecate the old framework.
Devstack on the other hand should not be affected at all.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
