### PR TITLE
fix(test): update test files to pass validation script

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -332,7 +332,6 @@ var excludedPaths = []string{
 	"test/cannon/MIPS64Memory.t.sol",      // Tests external MIPS implementation
 	"test/dispute/lib/LibClock.t.sol",     // Tests library utilities
 	"test/dispute/lib/LibGameId.t.sol",    // Tests library utilities
-	"test/libraries/DeployUtils.t.sol",    // Tests deployment utilities
 	"test/universal/BenchmarkTest.t.sol",  // Performance benchmarking tests
 	"test/universal/ExtendedPause.t.sol",  // Tests extended functionality
 	"test/vendor/Initializable.t.sol",     // Tests external vendor code
@@ -352,8 +351,6 @@ var excludedPaths = []string{
 	//
 	// These naming inconsistencies may indicate the presence of specialized test
 	// infrastructure beyond standard harnesses or different setup contracts patterns.
-	"test/dispute/DelayedWETH.t.sol",            // Contains contracts not matching DelayedWETH base name
-	"test/dispute/DisputeGameFactory.t.sol",     // Contains contracts not matching DisputeGameFactory base name
 	"test/dispute/FaultDisputeGame.t.sol",       // Contains contracts not matching FaultDisputeGame base name
 	"test/dispute/SuperFaultDisputeGame.t.sol",  // Contains contracts not matching SuperFaultDisputeGame base name
 	"test/L1/L1CrossDomainMessenger.t.sol",      // Contains contracts not matching L1CrossDomainMessenger base name

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -15,9 +15,9 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
-/// @title FallbackGasUser
+/// @title DelayedWETH_FallbackGasUser_Harness
 /// @notice Contract that burns gas in the fallback function.
-contract FallbackGasUser {
+contract DelayedWETH_FallbackGasUser_Harness {
     /// @notice Amount of gas to use in the fallback function.
     uint256 public gas;
 
@@ -37,9 +37,9 @@ contract FallbackGasUser {
     }
 }
 
-/// @title FallbackReverter
+/// @title DelayedWETH_FallbackReverter_Harness
 /// @notice Contract that reverts in the fallback function.
-contract FallbackReverter {
+contract DelayedWETH_FallbackReverter_Harness {
     /// @notice Revert on fallback.
     fallback() external payable {
         revert("FallbackReverter: revert");
@@ -247,13 +247,9 @@ contract DelayedWETH_Withdraw_Test is DelayedWETH_TestInit {
         vm.prank(alice);
         delayedWeth.withdraw(1 ether);
     }
-}
 
-/// @title DelayedWETH_WithdrawFrom_Test
-/// @notice Tests the `withdraw(address, uint256)` function of the `DelayedWETH` contract.
-contract DelayedWETH_WithdrawFrom_Test is DelayedWETH_TestInit {
     /// @notice Tests that withdrawing while unlocked and delay has passed is successful.
-    function test_withdraw_whileUnlocked_succeeds() public {
+    function test_withdraw_withdrawFromWhileUnlocked_succeeds() public {
         // Deposit some WETH.
         vm.prank(alice);
         delayedWeth.deposit{ value: 1 ether }();
@@ -275,7 +271,7 @@ contract DelayedWETH_WithdrawFrom_Test is DelayedWETH_TestInit {
     }
 
     /// @notice Tests that withdrawing when unlock was not called fails.
-    function test_withdraw_whileLocked_fails() public {
+    function test_withdraw_withdrawFromWhileLocked_fails() public {
         // Deposit some WETH.
         vm.prank(alice);
         delayedWeth.deposit{ value: 1 ether }();
@@ -289,7 +285,7 @@ contract DelayedWETH_WithdrawFrom_Test is DelayedWETH_TestInit {
     }
 
     /// @notice Tests that withdrawing while locked and delay has not passed fails.
-    function test_withdraw_whileLockedNotLongEnough_fails() public {
+    function test_withdraw_withdrawFromWhileLockedNotLongEnough_fails() public {
         // Deposit some WETH.
         vm.prank(alice);
         delayedWeth.deposit{ value: 1 ether }();
@@ -310,7 +306,7 @@ contract DelayedWETH_WithdrawFrom_Test is DelayedWETH_TestInit {
     }
 
     /// @notice Tests that withdrawing more than unlocked amount fails.
-    function test_withdraw_tooMuch_fails() public {
+    function test_withdraw_withdrawFromTooMuch_fails() public {
         // Deposit some WETH.
         vm.prank(alice);
         delayedWeth.deposit{ value: 1 ether }();
@@ -331,7 +327,7 @@ contract DelayedWETH_WithdrawFrom_Test is DelayedWETH_TestInit {
     }
 
     /// @notice Tests that withdrawing while paused fails.
-    function test_withdraw_whenPaused_fails() public {
+    function test_withdraw_withdrawFromWhenPaused_fails() public {
         // Deposit some WETH.
         vm.prank(alice);
         delayedWeth.deposit{ value: 1 ether }();
@@ -369,7 +365,7 @@ contract DelayedWETH_Recover_Test is DelayedWETH_TestInit {
         _fallbackGasUsage = bound(_fallbackGasUsage, 0, 20000000);
 
         // Set up the gas burner.
-        FallbackGasUser gasUser = new FallbackGasUser(_fallbackGasUsage);
+        DelayedWETH_FallbackGasUser_Harness gasUser = new DelayedWETH_FallbackGasUser_Harness(_fallbackGasUsage);
 
         // Mock owner to return the gas user.
         vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(address(gasUser)));
@@ -422,7 +418,7 @@ contract DelayedWETH_Recover_Test is DelayedWETH_TestInit {
     /// @notice Tests that recover reverts when recipient reverts.
     function test_recover_whenRecipientReverts_fails() public {
         // Set up the reverter.
-        FallbackReverter reverter = new FallbackReverter();
+        DelayedWETH_FallbackReverter_Harness reverter = new DelayedWETH_FallbackReverter_Harness();
 
         // Mock owner to return the reverter.
         vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(address(reverter)));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -25,7 +25,7 @@ import { ISuperPermissionedDisputeGame } from "interfaces/dispute/ISuperPermissi
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 
 /// @notice A fake clone used for testing the `DisputeGameFactory` contract's `create` function.
-contract FakeClone {
+contract DisputeGameFactory_FakeClone_Harness {
     function initialize() external payable {
         // noop
     }
@@ -46,7 +46,7 @@ contract FakeClone {
 /// @title DisputeGameFactory_TestInit
 /// @notice Reusable test initialization for `DisputeGameFactory` tests.
 contract DisputeGameFactory_TestInit is CommonTest {
-    FakeClone fakeClone;
+    DisputeGameFactory_FakeClone_Harness fakeClone;
 
     event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
     event ImplementationSet(address indexed impl, GameType indexed gameType);
@@ -54,7 +54,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
 
     function setUp() public virtual override {
         super.setUp();
-        fakeClone = new FakeClone();
+        fakeClone = new DisputeGameFactory_FakeClone_Harness();
 
         // Transfer ownership of the factory to the test contract.
         vm.prank(disputeGameFactory.owner());


### PR DESCRIPTION
This PR updates tests in the `/dispute` folder to bring them into compliance with the test validation script and reduce the exclusion list.

### Changes Summary

- **`DelayedWETH.t.sol`**
  - Renamed helper contracts to match naming conventions:
    - `FallbackGasUser` → `DelayedWETH_FallbackGasUser_Harness`
    - `FallbackReverter` → `DelayedWETH_FallbackReverter_Harness`
  - Consolidated `WithdrawFrom` tests into `Withdraw` test contract
  - Renamed test functions for clarity:
    - `test_withdraw_whileUnlocked_succeeds` → `test_withdraw_withdrawFromWhileUnlocked_succeeds`
    - `test_withdraw_whileLocked_fails` → `test_withdraw_withdrawFromWhileLocked_fails`
    - `test_withdraw_whileLockedNotLongEnough_fails` → `test_withdraw_withdrawFromWhileLockedNotLongEnough_fails`
    - `test_withdraw_tooMuch_fails` → `test_withdraw_withdrawFromTooMuch_fails`
    - `test_withdraw_whenPaused_fails` → `test_withdraw_withdrawFromWhenPaused_fails`
  - Updated all references to renamed harness contracts

- **`DisputeGameFactory.t.sol`**
  - Renamed `FakeClone` → `DisputeGameFactory_FakeClone_Harness`
  - Updated variable and constructor usage accordingly

- **`main.go` validation script**
  - Removed:
    - `test/dispute/DelayedWETH.t.sol`
    - `test/dispute/DisputeGameFactory.t.sol`
  - Cleaned up redundant `DeployUtils.t.sol` exclusion

All affected files now pass validation and have been removed from the exclusion list.