### PR TITLE
op-supervisor: Add Invalid Block Trigger to Failsafe Enablement

### DIFF
--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -47,6 +47,9 @@ type Config struct {
 
 	// FailsafeEnabled enables failsafe mode for the supervisor
 	FailsafeEnabled bool
+
+	// FailsafeOnInvalidation controls whether failsafe should activate when a block is invalidated
+	FailsafeOnInvalidation bool
 }
 
 func (c *Config) Check() error {

--- a/op-supervisor/config/config.go
+++ b/op-supervisor/config/config.go
@@ -75,14 +75,16 @@ func (c *Config) Check() error {
 // Required options with no suitable default are passed as parameters.
 func NewConfig(l1RPC string, syncSrcs syncnode.SyncNodeCollection, fullCfgSet depset.FullConfigSetSource, datadir string) *Config {
 	return &Config{
-		LogConfig:           oplog.DefaultCLIConfig(),
-		MetricsConfig:       opmetrics.DefaultCLIConfig(),
-		PprofConfig:         oppprof.DefaultCLIConfig(),
-		RPC:                 oprpc.DefaultCLIConfig(),
-		FullConfigSetSource: fullCfgSet,
-		MockRun:             false,
-		L1RPC:               l1RPC,
-		SyncSources:         syncSrcs,
-		Datadir:             datadir,
+		LogConfig:              oplog.DefaultCLIConfig(),
+		MetricsConfig:          opmetrics.DefaultCLIConfig(),
+		PprofConfig:            oppprof.DefaultCLIConfig(),
+		RPC:                    oprpc.DefaultCLIConfig(),
+		FullConfigSetSource:    fullCfgSet,
+		MockRun:                false,
+		L1RPC:                  l1RPC,
+		SyncSources:            syncSrcs,
+		Datadir:                datadir,
+		FailsafeEnabled:        false,
+		FailsafeOnInvalidation: true,
 	}
 }

--- a/op-supervisor/flags/flags.go
+++ b/op-supervisor/flags/flags.go
@@ -102,6 +102,13 @@ var (
 		EnvVars: prefixEnvVars("FAILSAFE_ENABLED"),
 		Value:   false,
 	}
+	FailsafeOnInvalidationFlag = &cli.BoolFlag{
+		Name: "failsafe-on-invalidation",
+		Usage: "Enable automatic failsafe activation when a block is invalidated. When enabled, the supervisor will automatically " +
+			"enter failsafe mode when a Safe Block is determined to be Invalid on any chain, causing all future CheckAccessList requests to be rejected.",
+		EnvVars: prefixEnvVars("FAILSAFE_ON_INVALIDATION"),
+		Value:   true,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -120,6 +127,7 @@ var optionalFlags = []cli.Flag{
 	RollupConfigPathsFlag,
 	RollupConfigSetFlag,
 	FailsafeEnabledFlag,
+	FailsafeOnInvalidationFlag,
 }
 
 func init() {
@@ -197,6 +205,7 @@ func ConfigFromCLI(ctx *cli.Context, version string) (*config.Config, error) {
 		MockRun:                 ctx.Bool(MockRunFlag.Name),
 		RPCVerificationWarnings: ctx.Bool(RPCVerificationWarningsFlag.Name),
 		FailsafeEnabled:         ctx.Bool(FailsafeEnabledFlag.Name),
+		FailsafeOnInvalidation:  ctx.Bool(FailsafeOnInvalidationFlag.Name),
 		L1RPC:                   ctx.String(L1RPCFlag.Name),
 		SyncSources:             syncSourceSetups(ctx),
 		Datadir:                 ctx.Path(DataDirFlag.Name),


### PR DESCRIPTION
- Backend now activates `FailsafeEnabled` in response to a `InvalidateLocalSafeEvent`
- New flags and config to support `FailsafeOnInvalidation`
  - Enabled By Default !
  - Controls whether a Block Invalidation triggers Failsafe Enablement.
- Tests showing that `InvalidateLocalSafeEvent` triggers Failsafe with respect to both possible config values