### PR TITLE
fix(test): validation compliance for /L1 tests

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -353,8 +353,6 @@ var excludedPaths = []string{
 	// infrastructure beyond standard harnesses or different setup contracts patterns.
 	"test/dispute/FaultDisputeGame.t.sol",       // Contains contracts not matching FaultDisputeGame base name
 	"test/dispute/SuperFaultDisputeGame.t.sol",  // Contains contracts not matching SuperFaultDisputeGame base name
-	"test/L1/L1CrossDomainMessenger.t.sol",      // Contains contracts not matching L1CrossDomainMessenger base name
-	"test/L1/L1ERC721Bridge.t.sol",              // Contains contracts not matching L1ERC721Bridge base name
 	"test/L1/ResourceMetering.t.sol",            // Contains contracts not matching ResourceMetering base name
 	"test/L1/StandardValidator.t.sol",           // Contains contracts not matching StandardValidator base name
 	"test/L2/CrossDomainOwnable.t.sol",          // Contains contracts not matching CrossDomainOwnable base name

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -20,7 +20,7 @@ import { IL2ERC721Bridge } from "interfaces/L2/IL2ERC721Bridge.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
 /// @notice Test ERC721 contract.
-contract TestERC721 is ERC721 {
+contract L1ERC721Bridge_TestERC721_Harness is ERC721 {
     constructor() ERC721("Test", "TST") { }
 
     function mint(address to, uint256 tokenId) public {
@@ -31,8 +31,8 @@ contract TestERC721 is ERC721 {
 /// @title L1ERC721Bridge_TestInit
 /// @notice Test contract for L1ERC721Bridge initialization and setup.
 contract L1ERC721Bridge_TestInit is CommonTest {
-    TestERC721 internal localToken;
-    TestERC721 internal remoteToken;
+    L1ERC721Bridge_TestERC721_Harness internal localToken;
+    L1ERC721Bridge_TestERC721_Harness internal remoteToken;
     uint256 internal constant tokenId = 1;
 
     event ERC721BridgeInitiated(
@@ -59,8 +59,8 @@ contract L1ERC721Bridge_TestInit is CommonTest {
     function setUp() public virtual override {
         super.setUp();
 
-        localToken = new TestERC721();
-        remoteToken = new TestERC721();
+        localToken = new L1ERC721Bridge_TestERC721_Harness();
+        remoteToken = new L1ERC721Bridge_TestERC721_Harness();
 
         // Mint alice a token.
         localToken.mint(alice, tokenId);
@@ -211,9 +211,9 @@ contract L1ERC721Bridge_Upgrade_Test is L1ERC721Bridge_TestInit {
     }
 }
 
-/// @title L1ERC721Bridge_Pause_Test
-/// @notice Test contract for L1ERC721Bridge `pause` functionality.
-contract L1ERC721Bridge_Pause_Test is L1ERC721Bridge_TestInit {
+/// @title L1ERC721Bridge_Paused_Test
+/// @notice Test contract for L1ERC721Bridge `paused` functionality.
+contract L1ERC721Bridge_Paused_Test is L1ERC721Bridge_TestInit {
     /// @dev Verifies that the `paused` accessor returns the same value as the `paused` function of
     ///      the `superchainConfig`.
     function test_paused_succeeds() external view {
@@ -348,10 +348,10 @@ contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_TestInit {
     }
 }
 
-/// @title L1ERC721Bridge_Test
-/// @notice Test contract for L1ERC721Bridge functionality with test for functions that are
-///         not specific to the L1ERC721Bridge.sol file
-contract L1ERC721Bridge_Test is L1ERC721Bridge_TestInit {
+/// @title L1ERC721Bridge_Uncategorized_Test
+/// @notice General tests that are not testing any function directly of the `L1ERC721Bridge`
+///         contract or are testing multiple functions at once.
+contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_TestInit {
     /// @notice Tests that the ERC721 can be bridged successfully.
     function test_bridgeERC721_fromEOA_succeeds() public {
         // Expect a call to the messenger.


### PR DESCRIPTION
This PR updates tests in the `/L1` folder to bring them into compliance with the test validation script and reduce the exclusion list.

### Changes Summary

- **`L1ERC721Bridge.t.sol`**
  - Renamed helper contract:  
    - `TestERC721` → `L1ERC721Bridge_TestERC721_Harness`
  - Updated variable names and constructor calls to reflect new name
  - Renamed test contracts for consistency:  
    - `L1ERC721Bridge_Pause_Test` → `L1ERC721Bridge_Paused_Test`  
    - `L1ERC721Bridge_Test` → `L1ERC721Bridge_Uncategorized_Test`

- **`L1CrossDomainMessenger.t.sol`**
  - Renamed `Encoding_Harness` → `L1CrossDomainMessenger_Encoding_Harness`
  - Merged `ReinitReentryTest` into `Uncategorized_Test`
  - Renamed `Unclassified_Test` → `Uncategorized_Test`
  - Renamed multiple variables to avoid shadowing
  - Moved helper method and test function into `Uncategorized_Test`
  - Preserved reentrancy documentation and improved formatting

- **`main.go` validation script**
  - Removed:
    - `test/L1/L1ERC721Bridge.t.sol`
    - `test/L1/L1CrossDomainMessenger.t.sol`

All affected files now pass validation and have been removed from the exclusion list.