### PR TITLE
op-acceptance-tests: remove prints from tests

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
@@ -244,8 +243,4 @@ func TestReorgInitExecMsg(gt *testing.T) {
 		return true, nil
 	})
 	require.NoError(t, err, "Expected to get same safe ref on both supervisor and sequencer eventually")
-
-	sys.L2ChainA.PrintChain()
-	sys.L2ChainB.PrintChain()
-	spew.Dump(sys.Supervisor.FetchSyncStatus())
 }

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/bindings"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
@@ -241,8 +240,4 @@ func testReorgInvalidExecMsg(gt *testing.T, txModifierFn func(msg *suptypes.Mess
 		return true, nil
 	})
 	require.NoError(t, err, "Expected to get same safe ref on both supervisor and sequencer eventually")
-
-	sys.L2ChainA.PrintChain()
-	sys.L2ChainB.PrintChain()
-	spew.Dump(sys.Supervisor.FetchSyncStatus())
 }

--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -51,8 +51,6 @@ func TestReorgUnsafeHead(gt *testing.T) {
 		divergenceBlockNumber_A = unsafeHeadRef.Number
 		originalRef_A = unsafeHeadRef
 
-		sys.L2ChainA.PrintChain()
-
 		parentOfUnsafeHead := unsafeHeadRef.ParentID()
 
 		l.Info("Sequencing a conflicting block", "unsafeHead", unsafeHeadRef, "parent", parentOfUnsafeHead)
@@ -110,8 +108,6 @@ func TestReorgUnsafeHead(gt *testing.T) {
 	reorgedRef_A, err := sys.L2ELA.Escape().EthClient().BlockRefByNumber(ctx, divergenceBlockNumber_A)
 	require.NoError(t, err, "Expected to be able to call BlockRefByNumber API, but got error")
 
-	sys.L2ChainA.PrintChain()
-
 	l.Info("Reorged chain A on divergence block number (prior the reorg)", "number", divergenceBlockNumber_A, "head", originalRef_A.Hash, "parent", originalRef_A.ParentID().Hash)
 	l.Info("Reorged chain A on divergence block number (after the reorg)", "number", divergenceBlockNumber_A, "head", reorgedRef_A.Hash, "parent", reorgedRef_A.ParentID().Hash)
 	require.NotEqual(t, originalRef_A.Hash, reorgedRef_A.Hash, "Expected to get different heads on divergence block number, but got the same hash, so no reorg happened on chain A")
@@ -134,5 +130,4 @@ func TestReorgUnsafeHead(gt *testing.T) {
 		return true, nil
 	})
 	require.NoError(t, err, "Expected to get same safe ref on both supervisor and sequencer eventually")
-	sys.L2ChainA.PrintChain()
 }


### PR DESCRIPTION
These print statements are useful for debugging, but we need to remove them in preparation for running these tests on live networks.