### PR TITLE
[backports] op-deployer/v0.2.0 support custom opcm

### DIFF
--- a/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
+++ b/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
@@ -1,0 +1,103 @@
+package opcm
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
+	"github.com/lmittmann/w3/module/eth"
+)
+
+type ReadSuperchainDeploymentInput struct {
+	OPCMAddress common.Address `abi:"opcmAddress"`
+}
+
+type ReadSuperchainDeploymentOutput struct {
+	ProtocolVersionsImpl  common.Address
+	ProtocolVersionsProxy common.Address
+	SuperchainConfigImpl  common.Address
+	SuperchainConfigProxy common.Address
+	SuperchainProxyAdmin  common.Address
+
+	Guardian                   common.Address
+	ProtocolVersionsOwner      common.Address
+	SuperchainProxyAdminOwner  common.Address
+	RecommendedProtocolVersion [32]byte
+	RequiredProtocolVersion    [32]byte
+}
+
+// Function signatures
+var (
+	// OPContractsManager functions
+	funcProtocolVersions     = w3.MustNewFunc("protocolVersions()", "address")
+	funcSuperchainConfig     = w3.MustNewFunc("superchainConfig()", "address")
+	funcSuperchainProxyAdmin = w3.MustNewFunc("superchainProxyAdmin()", "address")
+
+	// Proxy functions
+	funcImplementation = w3.MustNewFunc("implementation()", "address")
+
+	// Ownable functions
+	funcOwner = w3.MustNewFunc("owner()", "address")
+
+	// SuperchainConfig functions
+	funcGuardian = w3.MustNewFunc("guardian()", "address")
+
+	// ProtocolVersions functions
+	funcRecommended = w3.MustNewFunc("recommended()", "uint256")
+	funcRequired    = w3.MustNewFunc("required()", "uint256")
+)
+
+func ReadSuperchainDeployment(ctx context.Context, rpcClient *rpc.Client, input ReadSuperchainDeploymentInput) (*ReadSuperchainDeploymentOutput, error) {
+	if input.OPCMAddress == (common.Address{}) {
+		return nil, fmt.Errorf("ReadSuperchainDeployment: opcmAddress not set")
+	}
+
+	w3Client := w3.NewClient(rpcClient)
+	defer w3Client.Close()
+
+	output := &ReadSuperchainDeploymentOutput{}
+
+	// Step 1: Get proxy addresses from OPCM
+	if err := w3Client.Call(
+		eth.CallFunc(input.OPCMAddress, funcProtocolVersions).Returns(&output.ProtocolVersionsProxy),
+		eth.CallFunc(input.OPCMAddress, funcSuperchainConfig).Returns(&output.SuperchainConfigProxy),
+		eth.CallFunc(input.OPCMAddress, funcSuperchainProxyAdmin).Returns(&output.SuperchainProxyAdmin),
+	); err != nil {
+		return nil, fmt.Errorf("failed to get proxy addresses: %w", err)
+	}
+
+	// Step 2: Get implementation addresses from proxies
+	if err := w3Client.Call(
+		eth.CallFunc(output.ProtocolVersionsProxy, funcImplementation).Returns(&output.ProtocolVersionsImpl),
+		eth.CallFunc(output.SuperchainConfigProxy, funcImplementation).Returns(&output.SuperchainConfigImpl),
+	); err != nil {
+		return nil, fmt.Errorf("failed to get implementation addresses: %w", err)
+	}
+
+	// Step 3: Get owner/guardian information and protocol versions
+	var recommendedBig, requiredBig *big.Int
+	if err := w3Client.Call(
+		eth.CallFunc(output.SuperchainConfigProxy, funcGuardian).Returns(&output.Guardian),
+		eth.CallFunc(output.ProtocolVersionsProxy, funcOwner).Returns(&output.ProtocolVersionsOwner),
+		eth.CallFunc(output.SuperchainProxyAdmin, funcOwner).Returns(&output.SuperchainProxyAdminOwner),
+		eth.CallFunc(output.ProtocolVersionsProxy, funcRecommended).Returns(&recommendedBig),
+		eth.CallFunc(output.ProtocolVersionsProxy, funcRequired).Returns(&requiredBig),
+	); err != nil {
+		return nil, fmt.Errorf("failed to get owner/guardian info: %w", err)
+	}
+
+	// Convert big.Int to [32]byte
+	if recommendedBig != nil {
+		recommendedBytes := recommendedBig.Bytes()
+		copy(output.RecommendedProtocolVersion[32-len(recommendedBytes):], recommendedBytes)
+	}
+	if requiredBig != nil {
+		requiredBytes := requiredBig.Bytes()
+		copy(output.RequiredProtocolVersion[32-len(requiredBytes):], requiredBytes)
+	}
+
+	return output, nil
+}

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -57,7 +57,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 			SuperchainConfigProxy:           st.SuperchainDeployment.SuperchainConfigProxyAddress,
 			ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxyAddress,
 			SuperchainProxyAdmin:            st.SuperchainDeployment.ProxyAdminAddress,
-			UpgradeController:               intent.SuperchainRoles.ProxyAdminOwner,
+			UpgradeController:               st.SuperchainRoles.ProxyAdminOwner,
 			UseInterop:                      intent.UseInterop,
 		},
 	)

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -5,12 +5,14 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func IsSupportedStateVersion(version int) bool {
@@ -25,8 +27,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return err
 	}
 
-	opcmAddress, opcmAddrErr := standard.ManagerImplementationAddrFor(intent.L1ChainID, intent.L1ContractsLocator.Tag)
-	hasPredeployedOPCM := opcmAddrErr == nil
+	hasPredeployedOPCM := intent.OPCMAddress != nil
 	isL1Tag := intent.L1ContractsLocator.IsTag()
 	isL2Tag := intent.L2ContractsLocator.IsTag()
 
@@ -38,34 +39,23 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		return fmt.Errorf("unsupported L2 version: %s", intent.L2ContractsLocator.Tag)
 	}
 
-	isStandardIntent := intent.ConfigType == state.IntentTypeStandard ||
-		intent.ConfigType == state.IntentTypeStandardOverrides
-	if isL1Tag && hasPredeployedOPCM && isStandardIntent {
-		stdRoles, err := state.GetStandardSuperchainRoles(intent.L1ChainID)
-		if err != nil {
-			return fmt.Errorf("error getting superchain roles: %w", err)
+	if hasPredeployedOPCM {
+		if intent.SuperchainConfigProxy != nil {
+			return fmt.Errorf("cannot set superchain config proxy for predeployed OPCM")
 		}
 
-		if *intent.SuperchainRoles == *stdRoles {
-			superCfg, err := standard.SuperchainFor(intent.L1ChainID)
-			if err != nil {
-				return fmt.Errorf("error getting superchain config: %w", err)
-			}
+		if intent.SuperchainRoles != nil {
+			return fmt.Errorf("cannot set superchain roles for predeployed OPCM")
+		}
 
-			proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(intent.L1ChainID)
-			if err != nil {
-				return fmt.Errorf("error getting superchain proxy admin address: %w", err)
-			}
-
-			st.SuperchainDeployment = &state.SuperchainDeployment{
-				ProxyAdminAddress:            proxyAdmin,
-				ProtocolVersionsProxyAddress: superCfg.ProtocolVersionsAddr,
-				SuperchainConfigProxyAddress: superCfg.SuperchainConfigAddr,
-			}
-
-			st.ImplementationsDeployment = &state.ImplementationsDeployment{
-				OpcmAddress: opcmAddress,
-			}
+		superDeployment, superRoles, err := PopulateSuperchainState(env.L1Client.Client(), *intent.OPCMAddress)
+		if err != nil {
+			return fmt.Errorf("error populating superchain state: %w", err)
+		}
+		st.SuperchainDeployment = superDeployment
+		st.SuperchainRoles = superRoles
+		st.ImplementationsDeployment = &state.ImplementationsDeployment{
+			OpcmAddress: *intent.OPCMAddress,
 		}
 	}
 
@@ -142,4 +132,27 @@ func InitGenesisStrategy(env *Env, intent *state.Intent, st *state.State) error 
 
 func immutableErr(field string, was, is any) error {
 	return fmt.Errorf("%s is immutable: was %v, is %v", field, was, is)
+}
+
+func PopulateSuperchainState(rpcClient *rpc.Client, opcmAddr common.Address) (*state.SuperchainDeployment, *state.SuperchainRoles, error) {
+	out, err := opcm.ReadSuperchainDeployment(context.Background(), rpcClient, opcm.ReadSuperchainDeploymentInput{
+		OPCMAddress: opcmAddr,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading superchain deployment: %w", err)
+	}
+
+	deployment := &state.SuperchainDeployment{
+		ProxyAdminAddress:            out.SuperchainProxyAdmin,
+		SuperchainConfigProxyAddress: out.SuperchainConfigProxy,
+		SuperchainConfigImplAddress:  out.SuperchainConfigImpl,
+		ProtocolVersionsProxyAddress: out.ProtocolVersionsProxy,
+		ProtocolVersionsImplAddress:  out.ProtocolVersionsImpl,
+	}
+	roles := &state.SuperchainRoles{
+		Guardian:              out.Guardian,
+		ProtocolVersionsOwner: out.ProtocolVersionsOwner,
+		ProxyAdminOwner:       out.SuperchainProxyAdminOwner,
+	}
+	return deployment, roles, nil
 }

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
@@ -18,6 +24,8 @@ import (
 )
 
 func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
+	t.Parallel()
+
 	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
 	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
 
@@ -31,8 +39,9 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	client, err := ethclient.Dial(retryProxy.Endpoint())
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
 	require.NoError(t, err)
+	client := ethclient.NewClient(rpcClient)
 
 	l1ChainID := uint64(11155111)
 	t.Run("untagged L1 locator", func(t *testing.T) {
@@ -60,7 +69,21 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 
 	t.Run("tagged L1 locator with standard intent types and standard roles", func(t *testing.T) {
 		runTest := func(configType state.IntentType) {
+			_, afacts := testutil.LocalArtifacts(t)
+			host, err := env.DefaultForkedScriptHost(
+				ctx,
+				broadcaster.NoopBroadcaster(),
+				testlog.Logger(t, log.LevelInfo),
+				common.Address{'D'},
+				afacts,
+				rpcClient,
+			)
+			require.NoError(t, err)
+
 			stdSuperchainRoles, err := state.GetStandardSuperchainRoles(l1ChainID)
+			require.NoError(t, err)
+
+			opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, artifacts.DefaultL1ContractsLocator.Tag)
 			require.NoError(t, err)
 
 			intent := &state.Intent{
@@ -68,7 +91,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 				L1ChainID:          l1ChainID,
 				L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
 				L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-				SuperchainRoles:    stdSuperchainRoles,
+				OPCMAddress:        &opcmAddr,
 			}
 			st := &state.State{
 				Version: 1,
@@ -76,8 +99,9 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			require.NoError(t, InitLiveStrategy(
 				ctx,
 				&Env{
-					L1Client: client,
-					Logger:   lgr,
+					L1Client:     client,
+					Logger:       lgr,
+					L1ScriptHost: host,
 				},
 				intent,
 				st,
@@ -88,20 +112,22 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			require.NoError(t, err)
 			proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(l1ChainID)
 			require.NoError(t, err)
-			opcmAddr, err := standard.ManagerImplementationAddrFor(l1ChainID, intent.L1ContractsLocator.Tag)
-			require.NoError(t, err)
 
 			expDeployment := &state.SuperchainDeployment{
 				ProxyAdminAddress:            proxyAdmin,
 				ProtocolVersionsProxyAddress: superCfg.ProtocolVersionsAddr,
+				ProtocolVersionsImplAddress:  common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 				SuperchainConfigProxyAddress: superCfg.SuperchainConfigAddr,
+				SuperchainConfigImplAddress:  common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM
 			require.NotNil(t, st.SuperchainDeployment)
 			require.NotNil(t, st.ImplementationsDeployment)
+			require.NotNil(t, st.SuperchainRoles)
 			require.Equal(t, *expDeployment, *st.SuperchainDeployment)
 			require.Equal(t, opcmAddr, st.ImplementationsDeployment.OpcmAddress)
+			require.Equal(t, *stdSuperchainRoles, *st.SuperchainRoles)
 		}
 
 		runTest(state.IntentTypeStandard)
@@ -168,4 +194,45 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 		require.Nil(t, st.SuperchainDeployment)
 		require.Nil(t, st.ImplementationsDeployment)
 	})
+}
+
+// TestPopulateSuperchainState validates that the ReadSuperchainDeployment script successfully returns data about the
+// given Superchain. For testing purposes, we use a forked script host that points to a pinned block on Sepolia. Pinning
+// the block lets us use constant values in the test without worrying about changes on chain. We use values from the SR
+// whenever possible, however some (like the Superchain PAO) are not included in the SR and are therefore hardcoded.
+func TestPopulateSuperchainState(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
+	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
+
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
+	require.NoError(t, retryProxy.Start())
+	t.Cleanup(func() {
+		require.NoError(t, retryProxy.Stop())
+	})
+
+	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
+	require.NoError(t, err)
+
+	l1Versions, err := standard.L1VersionsFor(11155111)
+	require.NoError(t, err)
+	superchain, err := standard.SuperchainFor(11155111)
+	require.NoError(t, err)
+	opcmAddr := l1Versions["op-contracts/v2.0.0-rc.1"].OPContractsManager.Address
+	dep, roles, err := PopulateSuperchainState(rpcClient, common.Address(*opcmAddr))
+	require.NoError(t, err)
+	require.Equal(t, state.SuperchainDeployment{
+		ProxyAdminAddress:            common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"),
+		SuperchainConfigProxyAddress: superchain.SuperchainConfigAddr,
+		SuperchainConfigImplAddress:  common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
+		ProtocolVersionsProxyAddress: superchain.ProtocolVersionsAddr,
+		ProtocolVersionsImplAddress:  common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
+	}, *dep)
+	require.Equal(t, state.SuperchainRoles{
+		ProxyAdminOwner:       common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2"),
+		ProtocolVersionsOwner: common.HexToAddress("0xfd1D2e729aE8eEe2E146c033bf4400fE75284301"),
+		Guardian:              common.HexToAddress("0x7a50f00e8D05b95F98fE38d8BeE366a7324dCf7E"),
+	}, *roles)
 }

--- a/op-deployer/pkg/deployer/pipeline/superchain.go
+++ b/op-deployer/pkg/deployer/pipeline/superchain.go
@@ -41,6 +41,7 @@ func DeploySuperchain(env *Env, intent *state.Intent, st *state.State) error {
 		ProtocolVersionsProxyAddress: dso.ProtocolVersionsProxy,
 		ProtocolVersionsImplAddress:  dso.ProtocolVersionsImpl,
 	}
+	st.SuperchainRoles = intent.SuperchainRoles
 
 	return nil
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -133,16 +133,24 @@ func SuperchainFor(chainID uint64) (superchain.Superchain, error) {
 	}
 }
 
-func ManagerImplementationAddrFor(chainID uint64, tag string) (common.Address, error) {
+func OPCMImplAddressFor(chainID uint64, tag string) (common.Address, error) {
 	versionsData, err := L1VersionsFor(chainID)
 	if err != nil {
-		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+		return common.Address{}, fmt.Errorf("unsupported chainID: %d", chainID)
 	}
 	versionData, ok := versionsData[validation.Semver(tag)]
 	if !ok {
-		return common.Address{}, fmt.Errorf("unsupported tag for chain ID %d: %s", chainID, tag)
+		return common.Address{}, fmt.Errorf("unsupported tag for chainID %d: %s", chainID, tag)
 	}
-	return common.Address(*versionData.OPContractsManager.Address), nil
+	if versionData.OPContractsManager.Address != nil {
+		// op-contracts/v1.8.0 and earlier use proxied opcm
+		return common.Address(*versionData.OPContractsManager.Address), nil
+	}
+	if versionData.OPContractsManager.ImplementationAddress != nil {
+		// op-contracts/v2.0.0-rc.1 and later use non-proxied opcm
+		return common.Address(*versionData.OPContractsManager.ImplementationAddress), nil
+	}
+	return common.Address{}, fmt.Errorf("OPContractsManager address is nil for tag %s", tag)
 }
 
 // SuperchainProxyAdminAddrFor returns the address of the Superchain ProxyAdmin for the given chain ID.

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -85,3 +85,56 @@ func TestL2ProxyAdminOwner(t *testing.T) {
 		require.Equal(t, common.Address(test.expAddr), addr)
 	}
 }
+
+func TestManagerImplementationAddrFor(t *testing.T) {
+	testCases := []struct {
+		name          string
+		chainID       uint64
+		tag           string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "proxied opcm",
+			chainID:     1,
+			tag:         "op-contracts/v1.8.0",
+			expectError: false,
+		},
+		{
+			name:        "non-proxied opcm",
+			chainID:     1,
+			tag:         "op-contracts/v2.0.0-rc.1",
+			expectError: false,
+		},
+		{
+			name:          "unsupported chainID",
+			chainID:       999999,
+			tag:           "op-contracts/v1.8.0",
+			expectError:   true,
+			errorContains: "unsupported chainID",
+		},
+		{
+			name:          "unsupported tag",
+			chainID:       1,
+			tag:           "op-contracts/v999.999.999",
+			expectError:   true,
+			errorContains: "unsupported tag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, err := OPCMImplAddressFor(tc.chainID, tc.tag)
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorContains != "" {
+					require.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotEqual(t, common.Address{}, addr, "address should not be empty")
+			}
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -63,6 +63,7 @@ var ErrChainRoleZeroAddress = fmt.Errorf("ChainRole is set to zero address")
 var ErrFeeVaultZeroAddress = fmt.Errorf("chain has a fee vault set to zero address")
 var ErrNonStandardValue = fmt.Errorf("chain contains non-standard config value")
 var ErrEip1559ZeroValue = fmt.Errorf("eip1559 param is set to zero value")
+var ErrIncompatibleValue = fmt.Errorf("chain contains incompatible config value")
 
 func (c *ChainIntent) Check() error {
 	if c.ID == emptyHash {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -41,6 +41,8 @@ type SuperchainProofParams struct {
 type Intent struct {
 	ConfigType            IntentType         `json:"configType" toml:"configType"`
 	L1ChainID             uint64             `json:"l1ChainID" toml:"l1ChainID"`
+	OPCMAddress           *common.Address    `json:"opcmAddress" toml:"opcmAddress"`
+	SuperchainConfigProxy *common.Address    `json:"superchainConfigProxy" toml:"superchainConfigProxy"`
 	SuperchainRoles       *SuperchainRoles   `json:"superchainRoles" toml:"superchainRoles,omitempty"`
 	FundDevAccounts       bool               `json:"fundDevAccounts" toml:"fundDevAccounts"`
 	UseInterop            bool               `json:"useInterop" toml:"useInterop"`
@@ -85,16 +87,23 @@ func (c *Intent) validateCustomConfig() error {
 		(c.L1ContractsLocator.Tag == "" && c.L1ContractsLocator.URL == &url.URL{}) {
 		return ErrL1ContractsLocatorUndefined
 	}
+
 	if c.L2ContractsLocator == nil ||
 		(c.L2ContractsLocator.Tag == "" && c.L2ContractsLocator.URL == &url.URL{}) {
 		return ErrL2ContractsLocatorUndefined
 	}
 
-	if c.SuperchainRoles == nil {
-		return errors.New("SuperchainRoles is set to nil")
-	}
-	if err := c.SuperchainRoles.CheckNoZeroAddresses(); err != nil {
-		return err
+	if c.OPCMAddress == nil {
+		if c.SuperchainRoles == nil {
+			return fmt.Errorf("%w: must set superchain roles if OPCM address is nil", ErrIncompatibleValue)
+		}
+		if err := c.SuperchainRoles.CheckNoZeroAddresses(); err != nil {
+			return err
+		}
+	} else {
+		if c.SuperchainRoles != nil {
+			return fmt.Errorf("%w: must not set superchain roles if OPCM address is set", ErrIncompatibleValue)
+		}
 	}
 
 	if len(c.Chains) == 0 {
@@ -121,12 +130,20 @@ func (c *Intent) validateStandardValues() error {
 		return err
 	}
 
-	standardSuperchainRoles, err := GetStandardSuperchainRoles(c.L1ChainID)
-	if err != nil {
-		return fmt.Errorf("error getting standard superchain roles: %w", err)
+	if c.SuperchainConfigProxy != nil {
+		return ErrIncompatibleValue
 	}
-	if c.SuperchainRoles == nil || *c.SuperchainRoles != *standardSuperchainRoles {
-		return fmt.Errorf("SuperchainRoles does not match standard value")
+
+	if c.SuperchainRoles != nil {
+		return ErrIncompatibleValue
+	}
+
+	standardOPCM, err := standard.OPCMImplAddressFor(c.L1ChainID, c.L1ContractsLocator.Tag)
+	if err != nil {
+		return fmt.Errorf("error getting OPCM address: %w", err)
+	}
+	if c.OPCMAddress == nil || *c.OPCMAddress != standardOPCM {
+		return fmt.Errorf("%w: opcmAddress=%s", ErrNonStandardValue, standardOPCM)
 	}
 
 	for _, chain := range c.Chains {
@@ -235,6 +252,14 @@ func (c *Intent) checkL1Prod() error {
 		return fmt.Errorf("tag '%s' not found in standard versions", c.L1ContractsLocator.Tag)
 	}
 
+	opcmAddr, err := standard.OPCMImplAddressFor(c.L1ChainID, c.L1ContractsLocator.Tag)
+	if err != nil {
+		return fmt.Errorf("error getting OPCM address: %w", err)
+	}
+	if c.OPCMAddress == nil || *c.OPCMAddress != opcmAddr {
+		return fmt.Errorf("%w: opcmAddress=%s", ErrNonStandardValue, opcmAddr)
+	}
+
 	return nil
 }
 
@@ -279,18 +304,18 @@ func NewIntentCustom(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error)
 }
 
 func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error) {
+	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainId, artifacts.DefaultL1ContractsLocator.Tag)
+	if err != nil {
+		return Intent{}, fmt.Errorf("error getting OPCM impl address: %w", err)
+	}
+
 	intent := Intent{
 		ConfigType:         IntentTypeStandard,
 		L1ChainID:          l1ChainId,
 		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
 		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
+		OPCMAddress:        &opcmAddr,
 	}
-
-	superchainRoles, err := GetStandardSuperchainRoles(l1ChainId)
-	if err != nil {
-		return Intent{}, fmt.Errorf("error getting standard superchain roles: %w", err)
-	}
-	intent.SuperchainRoles = superchainRoles
 
 	challenger, err := standard.ChallengerAddressFor(l1ChainId)
 	if err != nil {

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -61,6 +61,31 @@ func TestValidateStandardValues(t *testing.T) {
 			},
 			ErrNonStandardValue,
 		},
+		{
+			"SuperchainConfigProxy",
+			func(intent *Intent) {
+				addr := common.HexToAddress("0x9999")
+				intent.SuperchainConfigProxy = &addr
+			},
+			ErrIncompatibleValue,
+		},
+		{
+			"OPCMAddress",
+			func(intent *Intent) {
+				addr := common.HexToAddress("0x9999")
+				intent.OPCMAddress = &addr
+			},
+			ErrNonStandardValue,
+		},
+		{
+			"SuperchainRoles",
+			func(intent *Intent) {
+				intent.SuperchainRoles = &SuperchainRoles{
+					Guardian: common.HexToAddress("0x9999"),
+				}
+			},
+			ErrIncompatibleValue,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,6 +129,50 @@ func TestValidateCustomValues(t *testing.T) {
 	setFeeAddresses(&intent)
 	err = intent.Check()
 	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		mutator func(intent *Intent)
+		err     error
+	}{
+		{
+			"both OPCM and SuperchainRoles defined",
+			func(intent *Intent) {
+				addr := common.HexToAddress("0x9999")
+				intent.SuperchainRoles = &SuperchainRoles{
+					Guardian: addr,
+				}
+				intent.OPCMAddress = &addr
+			},
+			ErrIncompatibleValue,
+		},
+		{
+			"neither OPCM or SuperchainRoles defined",
+			func(intent *Intent) {
+				intent.OPCMAddress = nil
+				intent.SuperchainRoles = nil
+			},
+			ErrIncompatibleValue,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			intent, err := NewIntentCustom(11155111, []common.Hash{common.HexToHash("0x336")})
+			require.NoError(t, err)
+
+			setSuperchainRoles(&intent)
+			setChainRoles(&intent)
+
+			setEip1559Params(&intent)
+			setFeeAddresses(&intent)
+
+			tt.mutator(&intent)
+
+			err = intent.Check()
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
 }
 
 func setSuperchainRoles(intent *Intent) {

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -33,6 +33,9 @@ type State struct {
 	// can be looked up on chain.
 	SuperchainDeployment *SuperchainDeployment `json:"superchainDeployment"`
 
+	// SuperchainRoles contains the addresses of the Superchain roles.
+	SuperchainRoles *SuperchainRoles `json:"superchainRoles"`
+
 	// ImplementationsDeployment contains the addresses of the common implementation
 	// contracts required for the Superchain to function.
 	ImplementationsDeployment *ImplementationsDeployment `json:"implementationsDeployment"`


### PR DESCRIPTION
This pr was created by the following command, with cherry-picks the same change from the `backports/op-deployer/v0.3.0` branch:
```
git cherry-pick fed79f58d4ea1840d6f2dd506d48c4872294bc17
```

# Tests
Manually tested deploying a new op chain using the following sequence:

1. bootstrap superchain
```
go run ./cmd/op-deployer bootstrap superchain \
  --l1-rpc-url=$SEPOLIA_RPC_URL \
  --private-key=$OP_DEPLOYER_PRIVATE_KEY \
  --artifacts-locator="tag://op-contracts/v2.0.0" \
  --outfile=./.deployer/bootstrap_superchain.json \
  --required-protocol-version="0xbbb0e51eCD7188d2F13769D7B4feE4390e970C7D000000000000000000000000" \
  --recommended-protocol-version="0xbbb0e51eCD7188d2F13769D7B4feE4390e970C7D000000000000000000000000" \
  --superchain-proxy-admin-owner="0x83D4eB702690413a0A1E5819ECc48b62160dFb42" \
  --protocol-versions-owner="0x83D4eB702690413a0A1E5819ECc48b62160dFb42" \
  --guardian="0x83D4eB702690413a0A1E5819ECc48b62160dFb42"
```
2. bootstrap implementations
```
go run ./cmd/op-deployer bootstrap implementations \
  --l1-rpc-url=$SEPOLIA_RPC_URL \
  --l1-contracts-release="dev" \
  --private-key=$OP_DEPLOYER_PRIVATE_KEY \
  --artifacts-locator="tag://op-contracts/v2.0.0" \
  --outfile=./.deployer/bootstrap_implementations.json \
  --superchain-config-proxy="0x2f924e93fc8c3a15d31fe7cefce5c73da2b3ea7b" \
  --protocol-versions-proxy="0x417a618d20c438b5f256b615cbe7435083e63720" \
  --superchain-proxy-admin="0x653c7efacc26f43311d1886feb8b3c210f16cdde" \
  --upgrade-controller="0x83D4eB702690413a0A1E5819ECc48b62160dFb42"
```
3. create intent/state
```
go run ./cmd/op-deployer init --l2-chain-ids=336 --workdir=.deployer
```
4. edit intent type to be custom, populate opcmAddress from [2]
5. deploy op-chain
```
go run ./cmd/op-deployer apply \
  --private-key=$OP_DEPLOYER_PRIVATE_KEY \
  --l1-rpc-url $SEPOLIA_RPC_URL \
  --workdir ./.deployer
```