### PR TITLE
fix(test): validation compliance for /L2 tests

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -358,10 +358,7 @@ var excludedPaths = []string{
 	"test/L2/CrossDomainOwnable.t.sol",          // Contains contracts not matching CrossDomainOwnable base name
 	"test/L2/CrossDomainOwnable2.t.sol",         // Contains contracts not matching CrossDomainOwnable2 base name
 	"test/L2/CrossDomainOwnable3.t.sol",         // Contains contracts not matching CrossDomainOwnable3 base name
-	"test/L2/CrossL2Inbox.t.sol",                // Contains contracts not matching CrossL2Inbox base name
 	"test/L2/GasPriceOracle.t.sol",              // Contains contracts not matching GasPriceOracle base name
-	"test/L2/L2ERC721Bridge.t.sol",              // Contains contracts not matching L2ERC721Bridge base name
-	"test/L2/L2ToL2CrossDomainMessenger.t.sol",  // Contains contracts not matching L2ToL2CrossDomainMessenger base name
 	"test/legacy/L1ChugSplashProxy.t.sol",       // Contains contracts not matching L1ChugSplashProxy base name
 	"test/legacy/ResolvedDelegateProxy.t.sol",   // Contains contracts not matching ResolvedDelegateProxy base name
 	"test/libraries/Blueprint.t.sol",            // Contains contracts not matching Blueprint base name

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -9,9 +9,9 @@ import { VmSafe } from "forge-std/Vm.sol";
 // Interfaces
 import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
 
-/// @title ValidateMessageRelayer
+/// @title CrossL2Inbox_ValidateMessageRelayer_Harness
 /// @notice For test contract used to validate multiple messages in a single tx.
-contract ValidateMessageRelayer is Test {
+contract CrossL2Inbox_ValidateMessageRelayer_Harness is Test {
     ICrossL2Inbox public immutable CROSS_L2_INBOX;
 
     constructor(address _crossL2Inbox) {
@@ -44,7 +44,7 @@ contract ValidateMessageRelayer is Test {
 contract CrossL2Inbox_TestInit is CommonTest {
     event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
 
-    ValidateMessageRelayer public validateMessageRelayer;
+    CrossL2Inbox_ValidateMessageRelayer_Harness public validateMessageRelayer;
 
     mapping(bytes32 => bool) public relayedMessages;
     mapping(bytes32 => bool) public warmedSlots;
@@ -52,7 +52,7 @@ contract CrossL2Inbox_TestInit is CommonTest {
     function setUp() public override {
         useInteropOverride = true;
         super.setUp();
-        validateMessageRelayer = new ValidateMessageRelayer(address(crossL2Inbox));
+        validateMessageRelayer = new CrossL2Inbox_ValidateMessageRelayer_Harness(address(crossL2Inbox));
     }
 }
 

--- a/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
@@ -14,7 +14,7 @@ import { IL2ERC721Bridge } from "interfaces/L2/IL2ERC721Bridge.sol";
 
 /// @title TestERC721
 /// @notice A test ERC721 token used for `L2ERC721Bridge` tests.
-contract TestERC721 is ERC721 {
+contract L2ERC721Bridge_TestERC721_Harness is ERC721 {
     constructor() ERC721("Test", "TST") { }
 
     function mint(address to, uint256 tokenId) public {
@@ -24,7 +24,7 @@ contract TestERC721 is ERC721 {
 
 /// @title TestMintableERC721
 /// @notice A test OptimismMintableERC721 token used for `L2ERC721Bridge` tests.
-contract TestMintableERC721 is OptimismMintableERC721 {
+contract L2ERC721Bridge_TestMintableERC721_Harness is OptimismMintableERC721 {
     constructor(
         address _bridge,
         address _remoteToken
@@ -41,7 +41,7 @@ contract TestMintableERC721 is OptimismMintableERC721 {
 /// @notice A non-compliant ERC721 token that does not implement the full ERC721 interface.
 ///         This is used to test that the bridge will revert if the token does not claim to
 ///         support the ERC721 interface.
-contract NonCompliantERC721 {
+contract L2ERC721Bridge_NonCompliantERC721_Harness {
     address internal immutable owner;
 
     constructor(address _owner) {
@@ -68,8 +68,8 @@ contract NonCompliantERC721 {
 /// @title L2ERC721Bridge_TestInit
 /// @notice Reusable test initialization for `L2ERC721Bridge` tests.
 contract L2ERC721Bridge_TestInit is CommonTest {
-    TestMintableERC721 internal localToken;
-    TestERC721 internal remoteToken;
+    L2ERC721Bridge_TestMintableERC721_Harness internal localToken;
+    L2ERC721Bridge_TestERC721_Harness internal remoteToken;
     uint256 internal constant tokenId = 1;
 
     event ERC721BridgeInitiated(
@@ -94,8 +94,8 @@ contract L2ERC721Bridge_TestInit is CommonTest {
     function setUp() public override {
         super.setUp();
 
-        remoteToken = new TestERC721();
-        localToken = new TestMintableERC721(address(l2ERC721Bridge), address(remoteToken));
+        remoteToken = new L2ERC721Bridge_TestERC721_Harness();
+        localToken = new L2ERC721Bridge_TestMintableERC721_Harness(address(l2ERC721Bridge), address(remoteToken));
 
         // Mint alice a token.
         localToken.mint(alice, tokenId);
@@ -108,7 +108,7 @@ contract L2ERC721Bridge_TestInit is CommonTest {
 
 /// @title L2ERC721Bridge_Test_Constructor
 /// @notice Tests the `constructor` of the `L2ERC721Bridge` contract.
-contract L2ERC721Bridge_Test_Constructor is L2ERC721Bridge_TestInit {
+contract L2ERC721Bridge_Constructor_Test is L2ERC721Bridge_TestInit {
     /// @notice Tests that the constructor sets the correct variables.
     function test_constructor_succeeds() public view {
         assertEq(address(l2ERC721Bridge.MESSENGER()), address(l2CrossDomainMessenger));
@@ -148,7 +148,8 @@ contract L2ERC721Bridge_FinalizeBridgeERC721_Test is L2ERC721Bridge_TestInit {
     ///         `IOptimismMintableERC721` interface.
     function test_finalizeBridgeERC721_interfaceNotCompliant_reverts() external {
         // Create a non-compliant token
-        NonCompliantERC721 nonCompliantToken = new NonCompliantERC721(alice);
+        L2ERC721Bridge_NonCompliantERC721_Harness nonCompliantToken =
+            new L2ERC721Bridge_NonCompliantERC721_Harness(alice);
 
         // Bridge the non-compliant token.
         vm.prank(alice, alice);
@@ -219,9 +220,10 @@ contract L2ERC721Bridge_FinalizeBridgeERC721_Test is L2ERC721Bridge_TestInit {
     }
 }
 
-/// @title L2ERC721Bridge_Unclassified_Test
-/// @notice General tests that are not testing any function directly of the `L2ERC721Bridge` contract.
-contract L2ERC721Bridge_Unclassified_Test is L2ERC721Bridge_TestInit {
+/// @title L2ERC721Bridge_Uncategorized_Test
+/// @notice General tests that are not testing any function directly of the `L2ERC721Bridge`
+///         contract or are testing multiple functions at once.
+contract L2ERC721Bridge_Uncategorized_Test is L2ERC721Bridge_TestInit {
     /// @notice Ensures that the L2ERC721Bridge is always not paused. The pausability happens on L1
     ///         and not L2.
     function test_paused_succeeds() external view {

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -26,10 +26,10 @@ import {
 // Interfaces
 import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
 
-/// @title L2ToL2CrossDomainMessengerWithModifiableTransientStorage
+/// @title L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness
 /// @notice L2ToL2CrossDomainMessenger contract with methods to modify the transient storage.
 ///         This is used to test the transient storage of L2ToL2CrossDomainMessenger.
-contract L2ToL2CrossDomainMessengerWithModifiableTransientStorage is L2ToL2CrossDomainMessenger {
+contract L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness is L2ToL2CrossDomainMessenger {
     /// @notice Returns the value of the entered slot in transient storage.
     /// @return Value of the entered slot.
     function entered() external view returns (bool) {
@@ -67,17 +67,18 @@ contract L2ToL2CrossDomainMessenger_TestInit is Test {
     address internal foundryVMAddress = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
 
     /// @notice L2ToL2CrossDomainMessenger contract instance with modifiable transient storage.
-    L2ToL2CrossDomainMessengerWithModifiableTransientStorage l2ToL2CrossDomainMessenger;
+    L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness l2ToL2CrossDomainMessenger;
 
     /// @notice Sets up the test suite.
     function setUp() public {
         // Deploy the L2ToL2CrossDomainMessenger contract
         vm.etch(
             Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER,
-            address(new L2ToL2CrossDomainMessengerWithModifiableTransientStorage()).code
+            address(new L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness()).code
         );
-        l2ToL2CrossDomainMessenger =
-            L2ToL2CrossDomainMessengerWithModifiableTransientStorage(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        l2ToL2CrossDomainMessenger = L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness(
+            Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
+        );
     }
 }
 


### PR DESCRIPTION
This PR updates tests in the `/L2` folder to bring them into compliance with the test validation script and remove them from the exclusion list.

### Changes Summary

- **`CrossL2Inbox.t.sol`**
  - Renamed helper contract:
    - `ValidateMessageRelayer` → `CrossL2Inbox_ValidateMessageRelayer_Harness`
  - Updated all references in `TestInit` and test functions to use new name

- **`L2ERC721Bridge.t.sol`**
  - Renamed helper contracts:
    - `TestERC721` → `L2ERC721Bridge_TestERC721_Harness`
    - `TestMintableERC721` → `L2ERC721Bridge_TestMintableERC721_Harness`
    - `NonCompliantERC721` → `L2ERC721Bridge_NonCompliantERC721_Harness`
  - Renamed test contracts:
    - `L2ERC721Bridge_Test_Constructor` → `L2ERC721Bridge_Constructor_Test`
    - `L2ERC721Bridge_Unclassified_Test` → `L2ERC721Bridge_Uncategorized_Test`
  - Updated all variable declarations, instantiations, and setup logic accordingly

- **`L2ToL2CrossDomainMessenger.t.sol`**
  - Renamed helper contract:
    - `L2ToL2CrossDomainMessengerWithModifiableTransientStorage` → `L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness`
  - Updated all references, types, and constructor calls to match new name
  - Existing test contract names already conform to spec

- **`main.go` validation script**
  - Removed the following from contract name validation exclusions:
    - `test/L2/CrossL2Inbox.t.sol`
    - `test/L2/L2ERC721Bridge.t.sol`
    - `test/L2/L2ToL2CrossDomainMessenger.t.sol`

All affected files now pass validation and have been removed from the exclusion list.