### PR TITLE
fix(test): validation compliance for /universal tests

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -351,23 +351,21 @@ var excludedPaths = []string{
 	//
 	// These naming inconsistencies may indicate the presence of specialized test
 	// infrastructure beyond standard harnesses or different setup contracts patterns.
-	"test/dispute/FaultDisputeGame.t.sol",       // Contains contracts not matching FaultDisputeGame base name
-	"test/dispute/SuperFaultDisputeGame.t.sol",  // Contains contracts not matching SuperFaultDisputeGame base name
-	"test/L1/ResourceMetering.t.sol",            // Contains contracts not matching ResourceMetering base name
-	"test/L1/StandardValidator.t.sol",           // Contains contracts not matching StandardValidator base name
-	"test/L2/CrossDomainOwnable.t.sol",          // Contains contracts not matching CrossDomainOwnable base name
-	"test/L2/CrossDomainOwnable2.t.sol",         // Contains contracts not matching CrossDomainOwnable2 base name
-	"test/L2/CrossDomainOwnable3.t.sol",         // Contains contracts not matching CrossDomainOwnable3 base name
-	"test/L2/GasPriceOracle.t.sol",              // Contains contracts not matching GasPriceOracle base name
-	"test/legacy/L1ChugSplashProxy.t.sol",       // Contains contracts not matching L1ChugSplashProxy base name
-	"test/legacy/ResolvedDelegateProxy.t.sol",   // Contains contracts not matching ResolvedDelegateProxy base name
-	"test/libraries/Blueprint.t.sol",            // Contains contracts not matching Blueprint base name
-	"test/libraries/SafeCall.t.sol",             // Contains contracts not matching SafeCall base name
-	"test/periphery/drippie/Drippie.t.sol",      // Contains contracts not matching Drippie base name
-	"test/safe/LivenessGuard.t.sol",             // Contains contracts not matching LivenessGuard base name
-	"test/universal/CrossDomainMessenger.t.sol", // Contains contracts not matching CrossDomainMessenger base name
-	"test/universal/Proxy.t.sol",                // Contains contracts not matching Proxy base name
-	"test/universal/StandardBridge.t.sol",       // Contains contracts not matching StandardBridge base name
+	"test/dispute/FaultDisputeGame.t.sol",      // Contains contracts not matching FaultDisputeGame base name
+	"test/dispute/SuperFaultDisputeGame.t.sol", // Contains contracts not matching SuperFaultDisputeGame base name
+	"test/L1/ResourceMetering.t.sol",           // Contains contracts not matching ResourceMetering base name
+	"test/L1/StandardValidator.t.sol",          // Contains contracts not matching StandardValidator base name
+	"test/L2/CrossDomainOwnable.t.sol",         // Contains contracts not matching CrossDomainOwnable base name
+	"test/L2/CrossDomainOwnable2.t.sol",        // Contains contracts not matching CrossDomainOwnable2 base name
+	"test/L2/CrossDomainOwnable3.t.sol",        // Contains contracts not matching CrossDomainOwnable3 base name
+	"test/L2/GasPriceOracle.t.sol",             // Contains contracts not matching GasPriceOracle base name
+	"test/legacy/L1ChugSplashProxy.t.sol",      // Contains contracts not matching L1ChugSplashProxy base name
+	"test/legacy/ResolvedDelegateProxy.t.sol",  // Contains contracts not matching ResolvedDelegateProxy base name
+	"test/libraries/Blueprint.t.sol",           // Contains contracts not matching Blueprint base name
+	"test/libraries/SafeCall.t.sol",            // Contains contracts not matching SafeCall base name
+	"test/periphery/drippie/Drippie.t.sol",     // Contains contracts not matching Drippie base name
+	"test/safe/LivenessGuard.t.sol",            // Contains contracts not matching LivenessGuard base name
+	"test/universal/StandardBridge.t.sol",      // Contains contracts not matching StandardBridge base name
 
 	// PATHS EXCLUDED FROM FUNCTION NAME VALIDATION:
 	// These paths are excluded because they don't pass the function name validation,

--- a/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
@@ -13,10 +13,10 @@ import { Encoding } from "src/libraries/Encoding.sol";
 
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 
-/// @title ExternalRelay
+/// @title CrossDomainMessenger_ExternalRelay_Harness
 /// @notice A mock external contract called via the SafeCall inside the CrossDomainMessenger's
 ///         `relayMessage` function.
-contract ExternalRelay is Test {
+contract CrossDomainMessenger_ExternalRelay_Harness is Test {
     address internal op;
     address internal fuzzedSender;
     IL1CrossDomainMessenger internal l1CrossDomainMessenger;
@@ -74,7 +74,7 @@ contract ExternalRelay is Test {
 
     /// @notice Helper function to get the callData for an `externalCallWithMinGas
     function getCallData() public pure returns (bytes memory) {
-        return abi.encodeCall(ExternalRelay.externalCallWithMinGas, ());
+        return abi.encodeCall(CrossDomainMessenger_ExternalRelay_Harness.externalCallWithMinGas, ());
     }
 
     /// @notice Helper function to set the fuzzed sender
@@ -89,11 +89,11 @@ contract CrossDomainMessenger_TestInit is CommonTest {
     // Storage slot of the l2Sender
     uint256 constant senderSlotIndex = 50;
 
-    ExternalRelay public er;
+    CrossDomainMessenger_ExternalRelay_Harness public er;
 
     function setUp() public override {
         super.setUp();
-        er = new ExternalRelay(l1CrossDomainMessenger, address(optimismPortal2));
+        er = new CrossDomainMessenger_ExternalRelay_Harness(l1CrossDomainMessenger, address(optimismPortal2));
     }
 }
 

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { Test } from "forge-std/Test.sol";
-import { SimpleStorage } from "test/universal/Proxy.t.sol";
+import { Proxy_SimpleStorage_Harness } from "test/universal/Proxy.t.sol";
 
 // Interfaces
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
@@ -27,7 +27,7 @@ contract ProxyAdmin_TestInit is Test {
 
     IProxyAdmin admin;
 
-    SimpleStorage implementation;
+    Proxy_SimpleStorage_Harness implementation;
 
     function setUp() external {
         // Deploy the proxy admin
@@ -87,7 +87,7 @@ contract ProxyAdmin_TestInit is Test {
         admin.setProxyType(address(resolved), IProxyAdmin.ProxyType.RESOLVED);
         vm.stopPrank();
 
-        implementation = new SimpleStorage();
+        implementation = new Proxy_SimpleStorage_Harness();
     }
 }
 
@@ -269,12 +269,12 @@ contract ProxyAdmin_Upgrade_Test is ProxyAdmin_TestInit {
 contract ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_TestInit {
     function upgradeAndCall(address payable _proxy) internal {
         vm.prank(alice);
-        admin.upgradeAndCall(_proxy, address(implementation), abi.encodeCall(SimpleStorage.set, (1, 1)));
+        admin.upgradeAndCall(_proxy, address(implementation), abi.encodeCall(Proxy_SimpleStorage_Harness.set, (1, 1)));
 
         address impl = admin.getProxyImplementation(_proxy);
         assertEq(impl, address(implementation));
 
-        uint256 got = SimpleStorage(address(_proxy)).get(1);
+        uint256 got = Proxy_SimpleStorage_Harness(address(_proxy)).get(1);
         assertEq(got, 1);
     }
 


### PR DESCRIPTION
This PR updates tests in the `/universal` folder to bring them into compliance with the test validation script and remove them from the exclusion list.

### Changes Summary

- **`CrossDomainMessenger.t.sol`**
  - Renamed helper contract:
    - `ExternalRelay` → `CrossDomainMessenger_ExternalRelay_Harness`
  - Updated constructor calls, variable declarations, and references throughout `TestInit` and helper functions

- **`Proxy.t.sol`**
  - Renamed helper contracts:
    - `SimpleStorage` → `Proxy_SimpleStorage_Harness`
    - `Clasher` → `Proxy_Clasher_Harness`
  - Updated all references to renamed helpers: variable types, instantiations, function calls, and type casts

- **`ProxyAdmin.t.sol`**
  - Updated imports and references to renamed helper contracts from `Proxy.t.sol`
  - No direct compliance changes; only required updates to match the new contract names

- **`main.go` validation script**
  - Removed the following test files from the contract name validation exclusions:
    - `test/universal/CrossDomainMessenger.t.sol`
    - `test/universal/Proxy.t.sol`

All affected files now pass validation and have been removed from the exclusion list.