### PR TITLE
cannon: Extend no_output_timeout for cannon e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2190,7 +2190,7 @@ workflows:
           name: op-e2e-cannon-tests
           notify: true
           mentions: "@proofs-team"
-          no_output_timeout: 60m
+          no_output_timeout: 90m
           test_timeout: 120m
           resource_class: ethereum-optimism/latitude-fps-1
           context:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Extend `no_output_timeout` for cannon e2e tests to mitigate test failures ([for example](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/94686/workflows/6678b0a8-e90d-4a50-830e-6d2af123b793/jobs/3676485)).
