### PR TITLE
fix(op-node): ensure peerStatsLock always unlocks

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -881,6 +881,7 @@ func (srv *ReqRespServer) handleSyncRequest(ctx context.Context, stream network.
 		// We'll disconnect ourselves only when failing to read/write,
 		// if the work is invalid (range validation), or when individual sub tasks timeout.
 		if err := ps.Requests.Wait(ctx); err != nil {
+			srv.peerStatsLock.Unlock()
 			return 0, fmt.Errorf("timed out waiting for global sync rate limit: %w", err)
 		}
 	}

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -866,25 +866,31 @@ func (srv *ReqRespServer) handleSyncRequest(ctx context.Context, stream network.
 	}
 
 	// find rate limiting data of peer, or add otherwise
-	srv.peerStatsLock.Lock()
-	ps, _ := srv.peerRateLimits.Get(peerId)
-	if ps == nil {
-		ps = &peerStat{
-			Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
-		}
-		srv.peerRateLimits.Add(peerId, ps)
-		ps.Requests.Reserve() // count the hit, but make it delay the next request rather than immediately waiting
-	} else {
-		// Only wait if it's an existing peer, otherwise the instant rate-limit Wait call always errors.
+	if err := func() error {
+		srv.peerStatsLock.Lock()
+		defer srv.peerStatsLock.Unlock()
 
-		// If the requester thinks we're taking too long, then it's their problem and they can disconnect.
-		// We'll disconnect ourselves only when failing to read/write,
-		// if the work is invalid (range validation), or when individual sub tasks timeout.
-		if err := ps.Requests.Wait(ctx); err != nil {
-			return 0, fmt.Errorf("timed out waiting for global sync rate limit: %w", err)
+		ps, _ := srv.peerRateLimits.Get(peerId)
+		if ps == nil {
+			ps = &peerStat{
+				Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
+			}
+			srv.peerRateLimits.Add(peerId, ps)
+			ps.Requests.Reserve() // count the hit, but make it delay the next request rather than immediately waiting
+		} else {
+			// Only wait if it's an existing peer, otherwise the instant rate-limit Wait call always errors.
+
+			// If the requester thinks we're taking too long, then it's their problem and they can disconnect.
+			// We'll disconnect ourselves only when failing to read/write,
+			// if the work is invalid (range validation), or when individual sub tasks timeout.
+			if err := ps.Requests.Wait(ctx); err != nil {
+				return fmt.Errorf("timed out waiting for peer sync rate limit: %w", err)
+			}
 		}
+		return nil
+	}(); err != nil {
+		return 0, err
 	}
-	srv.peerStatsLock.Unlock()
 
 	// Set read deadline, if available
 	_ = stream.SetReadDeadline(time.Now().Add(serverReadRequestTimeout))

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -866,31 +866,25 @@ func (srv *ReqRespServer) handleSyncRequest(ctx context.Context, stream network.
 	}
 
 	// find rate limiting data of peer, or add otherwise
-	if err := func() error {
-		srv.peerStatsLock.Lock()
-		defer srv.peerStatsLock.Unlock()
-
-		ps, _ := srv.peerRateLimits.Get(peerId)
-		if ps == nil {
-			ps = &peerStat{
-				Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
-			}
-			srv.peerRateLimits.Add(peerId, ps)
-			ps.Requests.Reserve() // count the hit, but make it delay the next request rather than immediately waiting
-		} else {
-			// Only wait if it's an existing peer, otherwise the instant rate-limit Wait call always errors.
-
-			// If the requester thinks we're taking too long, then it's their problem and they can disconnect.
-			// We'll disconnect ourselves only when failing to read/write,
-			// if the work is invalid (range validation), or when individual sub tasks timeout.
-			if err := ps.Requests.Wait(ctx); err != nil {
-				return fmt.Errorf("timed out waiting for peer sync rate limit: %w", err)
-			}
+	srv.peerStatsLock.Lock()
+	ps, _ := srv.peerRateLimits.Get(peerId)
+	if ps == nil {
+		ps = &peerStat{
+			Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
 		}
-		return nil
-	}(); err != nil {
-		return 0, err
+		srv.peerRateLimits.Add(peerId, ps)
+		ps.Requests.Reserve() // count the hit, but make it delay the next request rather than immediately waiting
+	} else {
+		// Only wait if it's an existing peer, otherwise the instant rate-limit Wait call always errors.
+
+		// If the requester thinks we're taking too long, then it's their problem and they can disconnect.
+		// We'll disconnect ourselves only when failing to read/write,
+		// if the work is invalid (range validation), or when individual sub tasks timeout.
+		if err := ps.Requests.Wait(ctx); err != nil {
+			return 0, fmt.Errorf("timed out waiting for global sync rate limit: %w", err)
+		}
 	}
+	srv.peerStatsLock.Unlock()
 
 	// Set read deadline, if available
 	_ = stream.SetReadDeadline(time.Now().Add(serverReadRequestTimeout))

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -465,4 +467,103 @@ func TestRequestResultErr_Error(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMutexUnlocksInBothSuccessAndErrorCases(t *testing.T) {
+	cfg, payloads := setupSyncTestData(10)
+
+	mockL2 := mockPayloadFn(func(n uint64) (*eth.ExecutionPayloadEnvelope, error) {
+		p, ok := payloads.getPayload(n)
+		if !ok {
+			return nil, ethereum.NotFound
+		}
+		return p, nil
+	})
+
+	srv := NewReqRespServer(cfg, mockL2, metrics.NoopMetrics)
+
+	t.Run("SuccessCase", func(t *testing.T) {
+		var wg sync.WaitGroup
+		successCount := int32(0)
+
+		testPeerID := peer.ID("test-peer")
+
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				func() {
+					srv.peerStatsLock.Lock()
+					defer srv.peerStatsLock.Unlock()
+
+					ps, _ := srv.peerRateLimits.Get(testPeerID)
+					if ps == nil {
+						ps = &peerStat{
+							Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
+						}
+						srv.peerRateLimits.Add(testPeerID, ps)
+					}
+					atomic.AddInt32(&successCount, 1)
+				}()
+			}()
+		}
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			require.Equal(t, int32(5), successCount, "All operations should have succeeded")
+			t.Logf("All goroutines completed successfully. Success count: %d", successCount)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Test timed out - likely due to mutex not being unlocked")
+		}
+	})
+
+	t.Run("ErrorCase", func(t *testing.T) {
+		var wg sync.WaitGroup
+		errorCount := int32(0)
+
+		testPeerID := peer.ID("test-peer-error")
+
+		for i := 0; i < 3; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				func() {
+					srv.peerStatsLock.Lock()
+					defer srv.peerStatsLock.Unlock()
+
+					ps, _ := srv.peerRateLimits.Get(testPeerID)
+					if ps == nil {
+						ps = &peerStat{
+							Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
+						}
+						srv.peerRateLimits.Add(testPeerID, ps)
+					}
+
+					atomic.AddInt32(&errorCount, 1)
+				}()
+			}()
+		}
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			require.Equal(t, int32(3), errorCount, "All operations should have completed")
+			t.Logf("All goroutines completed as expected. Error count: %d", errorCount)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Test timed out - likely due to mutex not being unlocked due to error")
+		}
+	})
 }

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -531,7 +531,8 @@ func TestMutexUnlocks(t *testing.T) {
 			stream2.Close()
 		}()
 
-		time.Sleep(10 * time.Millisecond)
+		// Wait for request to fail
+		time.Sleep(100 * time.Millisecond)
 
 		// Test if mutex is stuck - should not hang on lock(), even if error is returned
 		done := make(chan struct{})

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -2,11 +2,11 @@ package p2p
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -469,9 +469,8 @@ func TestRequestResultErr_Error(t *testing.T) {
 	}
 }
 
-func TestMutexUnlocksInBothSuccessAndErrorCases(t *testing.T) {
+func TestMutexUnlocks(t *testing.T) {
 	cfg, payloads := setupSyncTestData(10)
-
 	mockL2 := mockPayloadFn(func(n uint64) (*eth.ExecutionPayloadEnvelope, error) {
 		p, ok := payloads.getPayload(n)
 		if !ok {
@@ -479,91 +478,74 @@ func TestMutexUnlocksInBothSuccessAndErrorCases(t *testing.T) {
 		}
 		return p, nil
 	})
-
 	srv := NewReqRespServer(cfg, mockL2, metrics.NoopMetrics)
 
+	mnet, err := mocknet.FullMeshConnected(2)
+	require.NoError(t, err)
+	defer mnet.Close()
+	hosts := mnet.Hosts()
+	hostA, hostB := hosts[0], hosts[1]
+
+	ctx := context.Background()
+	log := testlog.Logger(t, log.LevelError)
+	payloadByNumber := MakeStreamHandler(ctx, log, srv.HandleSyncRequest)
+	hostA.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
+
 	t.Run("SuccessCase", func(t *testing.T) {
-		var wg sync.WaitGroup
-		successCount := int32(0)
+		stream, _ := hostB.NewStream(ctx, hostA.ID(), PayloadByNumberProtocolID(cfg.L2ChainID))
+		binary.Write(stream, binary.LittleEndian, uint64(1))
+		stream.CloseWrite()
+		var result [1]byte
+		stream.Read(result[:])
+		require.Equal(t, byte(0), result[0])
+		stream.Close()
 
-		testPeerID := peer.ID("test-peer")
-
-		for i := 0; i < 5; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				func() {
-					srv.peerStatsLock.Lock()
-					defer srv.peerStatsLock.Unlock()
-
-					ps, _ := srv.peerRateLimits.Get(testPeerID)
-					if ps == nil {
-						ps = &peerStat{
-							Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
-						}
-						srv.peerRateLimits.Add(testPeerID, ps)
-					}
-					atomic.AddInt32(&successCount, 1)
-				}()
-			}()
-		}
-
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-
-		select {
-		case <-done:
-			require.Equal(t, int32(5), successCount, "All operations should have succeeded")
-			t.Logf("All goroutines completed successfully. Success count: %d", successCount)
-		case <-time.After(5 * time.Second):
-			t.Fatal("Test timed out - likely due to mutex not being unlocked")
-		}
+		srv.peerStatsLock.Lock()
+		srv.peerStatsLock.Unlock()
 	})
 
 	t.Run("ErrorCase", func(t *testing.T) {
-		var wg sync.WaitGroup
-		errorCount := int32(0)
+		// First request: establish peer in rate limiter
+		stream, _ := hostB.NewStream(ctx, hostA.ID(), PayloadByNumberProtocolID(cfg.L2ChainID))
+		binary.Write(stream, binary.LittleEndian, uint64(1))
+		stream.CloseWrite()
+		var result [1]byte
+		stream.Read(result[:])
+		stream.Close()
 
-		testPeerID := peer.ID("test-peer-error")
+		// Make rate limiter fail on next request
+		peerId := hostB.ID()
+		srv.peerStatsLock.Lock()
+		ps, _ := srv.peerRateLimits.Get(peerId)
+		ps.Requests = rate.NewLimiter(0, 0)
+		ps.Requests.Reserve()
+		srv.peerStatsLock.Unlock()
 
-		for i := 0; i < 3; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+		// Second request with short timeout - return error but still unlock
+		shortCtx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+		defer cancel()
+		go func() {
+			stream2, _ := hostB.NewStream(shortCtx, hostA.ID(), PayloadByNumberProtocolID(cfg.L2ChainID))
+			binary.Write(stream2, binary.LittleEndian, uint64(2))
+			stream2.CloseWrite()
+			stream2.Close()
+		}()
 
-				func() {
-					srv.peerStatsLock.Lock()
-					defer srv.peerStatsLock.Unlock()
+		time.Sleep(10 * time.Millisecond)
 
-					ps, _ := srv.peerRateLimits.Get(testPeerID)
-					if ps == nil {
-						ps = &peerStat{
-							Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
-						}
-						srv.peerRateLimits.Add(testPeerID, ps)
-					}
-
-					atomic.AddInt32(&errorCount, 1)
-				}()
-			}()
-		}
-
+		// Test if mutex is stuck - should not hang on lock(), even if error is returned
 		done := make(chan struct{})
 		go func() {
-			wg.Wait()
+			srv.peerStatsLock.Lock()
+			srv.peerStatsLock.Unlock()
 			close(done)
 		}()
 
 		select {
 		case <-done:
-			require.Equal(t, int32(3), errorCount, "All operations should have completed")
-			t.Logf("All goroutines completed as expected. Error count: %d", errorCount)
-		case <-time.After(5 * time.Second):
-			t.Fatal("Test timed out - likely due to mutex not being unlocked due to error")
+			// Mutex unlocked
+		case <-time.After(1 * time.Second):
+			t.Fatal("Mutex deadlock detected - bug exists")
 		}
 	})
 }

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -493,24 +493,25 @@ func TestMutexUnlocks(t *testing.T) {
 
 	t.Run("SuccessCase", func(t *testing.T) {
 		stream, _ := hostB.NewStream(ctx, hostA.ID(), PayloadByNumberProtocolID(cfg.L2ChainID))
-		binary.Write(stream, binary.LittleEndian, uint64(1))
-		stream.CloseWrite()
+		_ = binary.Write(stream, binary.LittleEndian, uint64(1))
+		_ = stream.CloseWrite()
 		var result [1]byte
-		stream.Read(result[:])
+		_, _ = stream.Read(result[:])
 		require.Equal(t, byte(0), result[0])
 		stream.Close()
 
 		srv.peerStatsLock.Lock()
+		_ = srv.peerRateLimits.Len() // needed to satisfy linter
 		srv.peerStatsLock.Unlock()
 	})
 
 	t.Run("ErrorCase", func(t *testing.T) {
 		// First request: establish peer in rate limiter
 		stream, _ := hostB.NewStream(ctx, hostA.ID(), PayloadByNumberProtocolID(cfg.L2ChainID))
-		binary.Write(stream, binary.LittleEndian, uint64(1))
-		stream.CloseWrite()
+		_ = binary.Write(stream, binary.LittleEndian, uint64(1))
+		_ = stream.CloseWrite()
 		var result [1]byte
-		stream.Read(result[:])
+		_, _ = stream.Read(result[:])
 		stream.Close()
 
 		// Make rate limiter fail on next request
@@ -526,8 +527,8 @@ func TestMutexUnlocks(t *testing.T) {
 		defer cancel()
 		go func() {
 			stream2, _ := hostB.NewStream(shortCtx, hostA.ID(), PayloadByNumberProtocolID(cfg.L2ChainID))
-			binary.Write(stream2, binary.LittleEndian, uint64(2))
-			stream2.CloseWrite()
+			_ = binary.Write(stream2, binary.LittleEndian, uint64(2))
+			_ = stream2.CloseWrite()
 			stream2.Close()
 		}()
 
@@ -538,6 +539,7 @@ func TestMutexUnlocks(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			srv.peerStatsLock.Lock()
+			_ = srv.peerRateLimits.Len() // needed to satisfy linter
 			srv.peerStatsLock.Unlock()
 			close(done)
 		}()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

If we return early with error, peerStats mutex never unlocks.

Adding a one-liner to unlock on error, and additional testing to confirm fix works.

**Tests**

Simulates error case by exhausting rate limiter to force an error, and then checking to see that the mutex is still available after error is returned.
