### PR TITLE
op-service/tls: remove unused `ReadCLIConfig`

### DIFF
--- a/op-service/tls/cli.go
+++ b/op-service/tls/cli.go
@@ -99,17 +99,6 @@ func (c CLIConfig) TLSEnabled() bool {
 	return c.Enabled
 }
 
-// ReadCLIConfig reads tls cli configs
-// This should be used for server TLS configs, or when client and server tls configs are the same
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
-	return CLIConfig{
-		TLSCaCert: ctx.String(TLSCaCertFlagName),
-		TLSCert:   ctx.String(TLSCertFlagName),
-		TLSKey:    ctx.String(TLSKeyFlagName),
-		Enabled:   ctx.Bool(TLSEnabledFlagName),
-	}
-}
-
 // ReadCLIConfigWithPrefix reads tls cli configs with flag prefix
 // Should be used for client TLS configs when different from server on the same process
 func ReadCLIConfigWithPrefix(ctx *cli.Context, flagPrefix string) CLIConfig {


### PR DESCRIPTION
The `ReadCLIConfig` is not used and is the same as `ReadCLIConfigWithPrefix(ctx, "")`.