### PR TITLE
op-acceptance: Add test for safe head db when EL state is deleted

### DIFF
--- a/op-acceptance-tests/tests/base/rpc_connectivity_test.go
+++ b/op-acceptance-tests/tests/base/rpc_connectivity_test.go
@@ -39,8 +39,8 @@ func TestRPCConnectivity(gt *testing.T) {
 		t.Run(fmt.Sprintf("L2_Chain_%s", networkName), func(tt devtest.T) {
 			// Get the expected chain ID from the L2Chain
 			expectedChainID := l2Chain.ChainID().ToBig()
-			for _, node := range l2Chain.Escape().L2ELNodes() {
-				testL2ELNode(tt, ctx, logger, networkName, expectedChainID, dsl.NewL2ELNode(node))
+			for _, node := range l2Chain.L2ELNodes() {
+				testL2ELNode(tt, ctx, logger, networkName, expectedChainID, node)
 			}
 		})
 	}

--- a/op-acceptance-tests/tests/safeheaddb/init_test.go
+++ b/op-acceptance-tests/tests/safeheaddb/init_test.go
@@ -1,0 +1,17 @@
+package safeheaddb
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		presets.WithSafeDBEnabled(),
+		// Destructive test that requiring an in-memory only geth database
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/safeheaddb/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb/safeheaddb_test.go
@@ -1,0 +1,36 @@
+package safeheaddb
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestTruncateDatabaseOnResync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	t.Skip("Known issue: safe head db is not currently truncated when EL sync is used")
+	sys := presets.NewSingleChainMultiNode(t)
+
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+
+	sys.L2ELB.Stop()
+	sys.L2CLB.Stop()
+
+	sys.L2CL.Advanced(types.LocalSafe, 3, 30)
+
+	sys.L2ELB.Start()
+	sys.L2CLB.Start()
+	sys.L2ELB.PeerWith(sys.L2EL)
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+}

--- a/op-acceptance-tests/tests/safeheaddb/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb/safeheaddb_test.go
@@ -21,6 +21,9 @@ func TestTruncateDatabaseOnResync(gt *testing.T) {
 	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
+	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
+	// With the EL reset to genesis, when the CL restarts it will use EL sync to resync the chain rather than
+	// deriving it from L1.
 	sys.L2ELB.Stop()
 	sys.L2CLB.Stop()
 
@@ -31,6 +34,7 @@ func TestTruncateDatabaseOnResync(gt *testing.T) {
 	sys.L2ELB.PeerWith(sys.L2EL)
 
 	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -124,6 +124,16 @@ func (cl *L2CLNode) ChainID() eth.ChainID {
 	return cl.inner.ID().ChainID()
 }
 
+func (cl *L2CLNode) AwaitMinL1Processed(minL1 uint64) {
+	ctx, cancel := context.WithTimeout(cl.ctx, DefaultTimeout)
+	defer cancel()
+	// Wait for CurrentL1 to be at least one block _past_ minL1 since CurrentL1 may not yet be fully processed.
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		return cl.SyncStatus().CurrentL1.Number > minL1, nil
+	})
+	cl.require.NoErrorf(err, "CurrentL1 did not reach %v", minL1+1)
+}
+
 // AdvancedFn returns a lambda that checks the L2CL chain head with given safety level advanced more than delta block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) AdvancedFn(lvl types.SafetyLevel, delta uint64, attempts int) CheckFunc {
@@ -308,5 +318,8 @@ func (cl *L2CLNode) ConnectPeer(peer *L2CLNode) {
 
 func (cl *L2CLNode) VerifySafeHeadDatabaseMatches(sourceOfTruth *L2CLNode) {
 	l1Block := cl.SyncStatus().CurrentL1.Number
+	cl.log.Info("Verifying safe head database matches", "maxL1Block", l1Block)
+	cl.AwaitMinL1Processed(l1Block) // Ensure this block is fully processed before checking safe head db
+	sourceOfTruth.AwaitMinL1Processed(l1Block)
 	checkSafeHeadConsistent(cl.t, l1Block, cl, sourceOfTruth)
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -29,6 +30,10 @@ func NewL2CLNode(inner stack.L2CLNode, control stack.ControlPlane) *L2CLNode {
 		inner:      inner,
 		control:    control,
 	}
+}
+
+func (cl *L2CLNode) ID() stack.L2CLNodeID {
+	return cl.inner.ID()
 }
 
 func (cl *L2CLNode) String() string {
@@ -237,6 +242,15 @@ func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) 
 	return cl.HeadBlockRef(lvl).ID()
 }
 
+func (cl *L2CLNode) safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse {
+	resp, err := cl.inner.RollupAPI().SafeHeadAtL1Block(cl.ctx, l1BlockNum)
+	if errors.Is(err, safedb.ErrNotFound) {
+		return nil
+	}
+	cl.require.NoErrorf(err, "failed to get safe head at l1 block %v", l1BlockNum)
+	return resp
+}
+
 // LaggedFn returns a lambda that checks the L2CL chain head with given safety level is lagged with the reference chain sync status provider
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) LaggedFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int, allowMatch bool) CheckFunc {
@@ -290,4 +304,9 @@ func (cl *L2CLNode) ConnectPeer(peer *L2CLNode) {
 		return cl.inner.P2PAPI().ConnectPeer(cl.ctx, peerInfo.Addresses[0])
 	})
 	cl.require.NoError(err, "failed to connect peer")
+}
+
+func (cl *L2CLNode) VerifySafeHeadDatabaseMatches(sourceOfTruth *L2CLNode) {
+	l1Block := cl.SyncStatus().CurrentL1.Number
+	checkSafeHeadConsistent(cl.t, l1Block, cl, sourceOfTruth)
 }

--- a/op-devstack/dsl/safedb.go
+++ b/op-devstack/dsl/safedb.go
@@ -19,7 +19,7 @@ func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode
 		if actual == nil {
 			// No further safe head data available
 			// Stop iterating as long as we found _some_ data
-			require.True(matchedSomething, "no safe head data available")
+			require.Truef(matchedSomething, "no safe head data available at L1 block %v", l1BlockNum)
 			return
 		}
 

--- a/op-devstack/dsl/safedb.go
+++ b/op-devstack/dsl/safedb.go
@@ -1,0 +1,34 @@
+package dsl
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
+)
+
+type safeHeadDBProvider interface {
+	safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse
+}
+
+func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode, sourceOfTruth safeHeadDBProvider) {
+	require := testreq.New(t)
+	l1BlockNum := maxL1BlockNum
+	matchedSomething := false
+	for {
+
+		actual := checkNode.safeHeadAtL1Block(l1BlockNum)
+		if actual == nil {
+			// No further safe head data available
+			// Stop iterating as long as we found _some_ data
+			require.True(matchedSomething, "no safe head data available")
+			return
+		}
+
+		expected := sourceOfTruth.safeHeadAtL1Block(l1BlockNum)
+		require.Equalf(expected, actual, "Mismatched safe head data at l1 block %v", l1BlockNum)
+		if actual.L1Block.Number == 0 {
+			return // Reached L1 and L2 genesis.
+		}
+		l1BlockNum = actual.L1Block.Number - 1
+		matchedSomething = true
+	}
+}

--- a/op-devstack/presets/cl_config.go
+++ b/op-devstack/presets/cl_config.go
@@ -1,0 +1,27 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+)
+
+func WithExecutionLayerSyncOnVerifiers() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithL2CLOption(func(_ devtest.P, id stack.L2CLNodeID, cfg *config.Config) {
+			// Can't enable ELSync on the sequencer or it will never start sequencing because
+			// ELSync needs to receive gossip from the sequencer to drive the sync
+			if !cfg.Driver.SequencerEnabled {
+				cfg.Sync.SyncMode = sync.ELSync
+			}
+		}))
+}
+
+func WithSafeDBEnabled() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithL2CLOption(func(p devtest.P, _ stack.L2CLNodeID, cfg *config.Config) {
+			cfg.SafeDBPath = p.TempDir()
+		}))
+}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -49,7 +49,7 @@ func NewSimpleFlashblocks(t devtest.T) *SimpleFlashblocks {
 	for _, chain := range chains {
 		chainMatcher := match.L2ChainById(chain.ID())
 		l2 := system.L2Network(match.Assume(t, chainMatcher))
-		firstELNode := dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL))
+		firstELNode := dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL), orch.ControlPlane())
 		firstFaucet := dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet)))
 
 		conductorSets[chain.ID()] = dsl.NewConductorSet(l2.Conductors())

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -65,8 +65,8 @@ func NewSingleChainInterop(t devtest.T) *SingleChainInterop {
 		ControlPlane:  orch.ControlPlane(),
 		L1Network:     dsl.NewL1Network(l1Net),
 		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2ChainA:      dsl.NewL2Network(l2A),
-		L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2ChainA:      dsl.NewL2Network(l2A, orch.ControlPlane()),
+		L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL)), orch.ControlPlane()),
 		L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
 		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
 		FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
@@ -155,8 +155,8 @@ func NewSimpleInterop(t devtest.T) *SimpleInterop {
 	l2B := singleChain.system.L2Network(match.Assume(t, match.L2ChainB))
 	out := &SimpleInterop{
 		SingleChainInterop: *singleChain,
-		L2ChainB:           dsl.NewL2Network(l2B),
-		L2ELB:              dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.FirstL2EL))),
+		L2ChainB:           dsl.NewL2Network(l2B, orch.ControlPlane()),
+		L2ELB:              dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.FirstL2EL)), orch.ControlPlane()),
 		L2CLB:              dsl.NewL2CLNode(l2B.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
 		FaucetB:            dsl.NewFaucet(l2B.Faucet(match.Assume(t, match.FirstFaucet))),
 		L2BatcherB:         dsl.NewL2Batcher(l2B.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
@@ -245,9 +245,9 @@ func NewMultiSupervisorInterop(t devtest.T) *MultiSupervisorInterop {
 	out := &MultiSupervisorInterop{
 		SimpleInterop:       *simpleInterop,
 		SupervisorSecondary: dsl.NewSupervisor(simpleInterop.system.Supervisor(match.Assume(t, match.SecondSupervisor)), orch.ControlPlane()),
-		L2ELA2:              dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.SecondL2EL))),
+		L2ELA2:              dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.SecondL2EL)), orch.ControlPlane()),
 		L2CLA2:              dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.SecondL2CL)), orch.ControlPlane()),
-		L2ELB2:              dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.SecondL2EL))),
+		L2ELB2:              dsl.NewL2ELNode(l2B.L2ELNode(match.Assume(t, match.SecondL2EL)), orch.ControlPlane()),
 		L2CLB2:              dsl.NewL2CLNode(l2B.L2CLNode(match.Assume(t, match.SecondL2CL)), orch.ControlPlane()),
 	}
 	return out

--- a/op-devstack/presets/minimal.go
+++ b/op-devstack/presets/minimal.go
@@ -54,20 +54,26 @@ func NewMinimal(t devtest.T) *Minimal {
 	orch := Orchestrator()
 	orch.Hydrate(system)
 
+	return minimalFromSystem(t, system, orch)
+}
+
+func minimalFromSystem(t devtest.T, system stack.ExtensibleSystem, orch stack.Orchestrator) *Minimal {
 	t.Gate().Equal(len(system.TestSequencers()), 1, "expected exactly one test sequencer")
 
 	l1Net := system.L1Network(match.FirstL1Network)
 	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
+	sequencerCL := l2.L2CLNode(match.Assume(t, match.WithSequencerActive(t.Ctx())))
+	sequencerEL := l2.L2ELNode(match.Assume(t, match.EngineFor(sequencerCL)))
 	out := &Minimal{
 		Log:           t.Logger(),
 		T:             t,
 		ControlPlane:  orch.ControlPlane(),
 		L1Network:     dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
 		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2Chain:       dsl.NewL2Network(l2),
+		L2Chain:       dsl.NewL2Network(l2, orch.ControlPlane()),
 		L2Batcher:     dsl.NewL2Batcher(l2.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
-		L2EL:          dsl.NewL2ELNode(l2.L2ELNode(match.Assume(t, match.FirstL2EL))),
-		L2CL:          dsl.NewL2CLNode(l2.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		L2EL:          dsl.NewL2ELNode(sequencerEL, orch.ControlPlane()),
+		L2CL:          dsl.NewL2CLNode(sequencerCL, orch.ControlPlane()),
 		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
 		Wallet:        dsl.NewHDWallet(t, devkeys.TestMnemonic, 30),
 		FaucetL2:      dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),

--- a/op-devstack/presets/singlechain_multinode.go
+++ b/op-devstack/presets/singlechain_multinode.go
@@ -1,0 +1,43 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+type SingleChainMultiNode struct {
+	Minimal
+
+	L2ELB *dsl.L2ELNode
+	L2CLB *dsl.L2CLNode
+}
+
+func WithSingleChainMultiNode() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainMultiNodeSystem(&sysgo.DefaultSingleChainMultiNodeSystemIDs{}))
+}
+
+func NewSingleChainMultiNode(t devtest.T) *SingleChainMultiNode {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+	minimal := minimalFromSystem(t, system, orch)
+	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
+	verifierCL := l2.L2CLNode(match.Assume(t,
+		match.And(
+			match.Not(match.WithSequencerActive(t.Ctx())),
+			match.Not[stack.L2CLNodeID, stack.L2CLNode](minimal.L2CL.ID()),
+		)))
+	verifierEL := l2.L2ELNode(match.Assume(t,
+		match.And(
+			match.EngineFor(verifierCL),
+			match.Not[stack.L2ELNodeID, stack.L2ELNode](minimal.L2EL.ID()))))
+	return &SingleChainMultiNode{
+		Minimal: *minimal,
+		L2ELB:   dsl.NewL2ELNode(verifierEL, orch.ControlPlane()),
+		L2CLB:   dsl.NewL2CLNode(verifierCL, orch.ControlPlane()),
+	}
+}

--- a/op-devstack/stack/match/engine.go
+++ b/op-devstack/stack/match/engine.go
@@ -12,3 +12,14 @@ func WithEngine(engine stack.L2ELNodeID) stack.Matcher[stack.L2CLNodeID, stack.L
 		return false
 	})
 }
+
+func EngineFor(cl stack.L2CLNode) stack.Matcher[stack.L2ELNodeID, stack.L2ELNode] {
+	return MatchElemFn[stack.L2ELNodeID, stack.L2ELNode](func(elem stack.L2ELNode) bool {
+		for _, el := range cl.ELs() {
+			if el.ID() == elem.ID() {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/op-devstack/stack/match/sequencer.go
+++ b/op-devstack/stack/match/sequencer.go
@@ -1,0 +1,21 @@
+package match
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+)
+
+func WithSequencerActive(ctx context.Context) stack.Matcher[stack.L2CLNodeID, stack.L2CLNode] {
+	return MatchElemFn[stack.L2CLNodeID, stack.L2CLNode](func(elem stack.L2CLNode) bool {
+		sequencing, err := retry.Do(ctx, 10, retry.Exponential(), func() (bool, error) {
+			return elem.RollupAPI().SequencerActive(ctx)
+		})
+		if err != nil {
+			// Not available so can't be used by the test
+			return false
+		}
+		return sequencing
+	})
+}

--- a/op-devstack/stack/orchestrator.go
+++ b/op-devstack/stack/orchestrator.go
@@ -22,6 +22,7 @@ const (
 type ControlPlane interface {
 	SupervisorState(id SupervisorID, action ControlAction)
 	L2CLNodeState(id L2CLNodeID, action ControlAction)
+	L2ELNodeState(id L2ELNodeID, action ControlAction)
 	FakePoSState(id L1CLNodeID, action ControlAction)
 }
 

--- a/op-devstack/sysext/control_plane.go
+++ b/op-devstack/sysext/control_plane.go
@@ -34,6 +34,10 @@ func (c *ControlPlane) L2CLNodeState(id stack.L2CLNodeID, mode stack.ControlActi
 	c.setLifecycleState(id.Key(), mode)
 }
 
+func (c *ControlPlane) L2ELNodeState(id stack.L2ELNodeID, mode stack.ControlAction) {
+	c.setLifecycleState(id.Key(), mode)
+}
+
 func (c *ControlPlane) FakePoSState(id stack.L1CLNodeID, mode stack.ControlAction) {
 	panic("not implemented: plug in kurtosis wrapper, or gate for the test that uses this method to not run in kurtosis")
 }

--- a/op-devstack/sysgo/control_plane.go
+++ b/op-devstack/sysgo/control_plane.go
@@ -29,6 +29,12 @@ func (c *ControlPlane) L2CLNodeState(id stack.L2CLNodeID, mode stack.ControlActi
 	control(s, mode)
 }
 
+func (c *ControlPlane) L2ELNodeState(id stack.L2ELNodeID, mode stack.ControlAction) {
+	s, ok := c.o.l2ELs.Get(id)
+	c.o.P().Require().True(ok, "need l2el node to change state")
+	control(s, mode)
+}
+
 func (c *ControlPlane) FakePoSState(id stack.L1CLNodeID, mode stack.ControlAction) {
 	s, ok := c.o.l1CLs.Get(id)
 	c.o.P().Require().True(ok, "need l1cl node to change state of fakePoS module")

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -125,6 +125,14 @@ func (n *L2CLNode) Stop() {
 	n.opNode = nil
 }
 
+type L2CLOption func(p devtest.P, id stack.L2CLNodeID, cfg *config.Config)
+
+func WithL2CLOption(opt L2CLOption) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.l2CLOptions = append(o.l2CLOptions, opt)
+	})
+}
+
 func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
@@ -261,6 +269,9 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, 
 			AltDA:                           altda.CLIConfig{},
 			IgnoreMissingPectraBlobSchedule: false,
 			ExperimentalOPStackAPI:          true,
+		}
+		for _, opt := range orch.l2CLOptions {
+			opt(orch.P(), l2CLID, nodeCfg)
 		}
 		l2CLNode := &L2CLNode{
 			id:     l2CLID,

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -3,6 +3,7 @@ package sysgo
 import (
 	"context"
 	"net/url"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -16,7 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/testreq"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/log"
 	gn "github.com/ethereum/go-ethereum/node"
@@ -193,11 +193,17 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	err := wait.For(ctx, time.Second, func() (bool, error) {
-		var peerCount hexutil.Uint64
-		if err := initiator.CallContext(ctx, &peerCount, "net_peerCount"); err != nil {
+		var peers []peer
+		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
 			return false, err
 		}
-		return peerCount >= hexutil.Uint64(1), nil
+		return slices.ContainsFunc(peers, func(p peer) bool {
+			return p.ID == targetInfo.ID
+		}), nil
 	})
-	require.NoError(err, "wait for a peer to be connected")
+	require.NoError(err, "The peer was not connected")
+}
+
+type peer struct {
+	ID string `json:"id"`
 }

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -102,6 +102,8 @@ func rpcPort(require *testreq.Assertions, rpc string) int {
 }
 
 func (n *L2ELNode) Stop() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	if n.l2Geth == nil {
 		n.logger.Warn("op-geth already stopped")
 		return
@@ -134,9 +136,6 @@ func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID) stack.O
 		}
 
 		logger := p.Logger()
-
-		p.Cleanup(func() {
-		})
 
 		l2EL := &L2ELNode{
 			id:            id,

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -1,18 +1,39 @@
 package sysgo
 
 import (
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	gn "github.com/ethereum/go-ethereum/node"
+	"context"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
 
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
 )
 
 type L2ELNode struct {
-	id      stack.L2ELNodeID
+	mu sync.Mutex
+
+	p             devtest.P
+	logger        log.Logger
+	id            stack.L2ELNodeID
+	l2Net         *L2Network
+	jwtPath       string
+	supervisorRPC string
+	l2Geth        *geth.GethInstance
+
 	authRPC string
 	userRPC string
 }
@@ -35,6 +56,60 @@ func (n *L2ELNode) hydrate(system stack.ExtensibleSystem) {
 	})
 	sysL2EL.SetLabel(match.LabelVendor, string(match.OpGeth))
 	l2Net.(stack.ExtensibleL2Network).AddL2ELNode(sysL2EL)
+}
+
+func (n *L2ELNode) Start() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.l2Geth != nil {
+		n.logger.Warn("op-geth already started")
+		return
+	}
+
+	require := n.p.Require()
+	l2Geth, err := geth.InitL2(n.id.String(), n.l2Net.genesis, n.jwtPath,
+		func(ethCfg *ethconfig.Config, nodeCfg *gn.Config) error {
+			ethCfg.InteropMessageRPC = n.supervisorRPC
+			ethCfg.InteropMempoolFiltering = true
+			nodeCfg.P2P = p2p.Config{
+				NoDiscovery: true,
+				ListenAddr:  "127.0.0.1:0",
+				MaxPeers:    10,
+			}
+			if n.authRPC != "" {
+				// Preserve the existing auth rpc port
+				nodeCfg.AuthPort = rpcPort(require, n.authRPC)
+			}
+			if n.userRPC != "" {
+				// Preserve the existing websocket rpc port
+				nodeCfg.WSPort = rpcPort(require, n.userRPC)
+			}
+			return nil
+		})
+	require.NoError(err)
+	require.NoError(l2Geth.Node.Start())
+	n.l2Geth = l2Geth
+	n.authRPC = l2Geth.AuthRPC().RPC()
+	n.userRPC = l2Geth.UserRPC().RPC()
+}
+
+func rpcPort(require *testreq.Assertions, rpc string) int {
+	u, err := url.Parse(rpc)
+	require.NoError(err, "Failed to parse existing rpc url")
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(err, "Invalid rpc port")
+	return port
+}
+
+func (n *L2ELNode) Stop() {
+	if n.l2Geth == nil {
+		n.logger.Warn("op-geth already stopped")
+		return
+	}
+	n.logger.Info("Closing op-geth", "id", n.id)
+	closeErr := n.l2Geth.Close()
+	n.logger.Info("Closed op-geth", "id", n.id, "err", closeErr)
+	n.l2Geth = nil
 }
 
 func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID) stack.Option[*Orchestrator] {
@@ -60,26 +135,70 @@ func WithL2ELNode(id stack.L2ELNodeID, supervisorID *stack.SupervisorID) stack.O
 
 		logger := p.Logger()
 
-		l2Geth, err := geth.InitL2(id.String(), l2Net.genesis, jwtPath,
-			func(ethCfg *ethconfig.Config, nodeCfg *gn.Config) error {
-				ethCfg.InteropMessageRPC = supervisorRPC
-				ethCfg.InteropMempoolFiltering = true // TODO option
-				return nil
-			})
-		require.NoError(err)
-		require.NoError(l2Geth.Node.Start())
-
 		p.Cleanup(func() {
-			logger.Info("Closing op-geth", "id", id)
-			closeErr := l2Geth.Close()
-			logger.Info("Closed op-geth", "id", id, "err", closeErr)
 		})
 
 		l2EL := &L2ELNode{
-			id:      id,
-			authRPC: l2Geth.AuthRPC().RPC(),
-			userRPC: l2Geth.UserRPC().RPC(),
+			id:            id,
+			p:             orch.P(),
+			logger:        logger,
+			l2Net:         l2Net,
+			jwtPath:       jwtPath,
+			supervisorRPC: supervisorRPC,
 		}
+		l2EL.Start()
+		p.Cleanup(func() {
+			l2EL.Stop()
+		})
 		require.True(orch.l2ELs.SetIfMissing(id, l2EL), "must be unique L2 EL node")
 	})
+}
+
+func WithL2ELP2PConnection(l2EL1ID, l2EL2ID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
+
+		l2EL1, ok := orch.l2ELs.Get(l2EL1ID)
+		require.True(ok, "looking for L2 EL node 1 to connect p2p")
+		l2EL2, ok := orch.l2ELs.Get(l2EL2ID)
+		require.True(ok, "looking for L2 EL node 2 to connect p2p")
+		require.Equal(l2EL1.l2Net.rollupCfg.L2ChainID, l2EL2.l2Net.rollupCfg.L2ChainID, "must be same l2 chain")
+
+		ctx := orch.P().Ctx()
+		logger := orch.P().Logger()
+
+		rpc1, err := dial.DialRPCClientWithTimeout(ctx, 30*time.Second, logger, l2EL1.userRPC)
+		require.NoError(err, "failed to connect to el1 rpc")
+		defer rpc1.Close()
+		rpc2, err := dial.DialRPCClientWithTimeout(ctx, 30*time.Second, logger, l2EL2.userRPC)
+		require.NoError(err, "failed to connect to el2 rpc")
+		defer rpc2.Close()
+
+		ConnectP2P(orch.P().Ctx(), require, rpc1, rpc2)
+	})
+}
+
+type RpcCaller interface {
+	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+}
+
+// ConnectP2P creates a p2p peer connection between node1 and node2.
+func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller) {
+	var targetInfo p2p.NodeInfo
+	require.NoError(acceptor.CallContext(ctx, &targetInfo, "admin_nodeInfo"), "get node info")
+
+	var peerAdded bool
+	require.NoError(initiator.CallContext(ctx, &peerAdded, "admin_addPeer", targetInfo.Enode), "add peer")
+	require.True(peerAdded, "should have added peer successfully")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := wait.For(ctx, time.Second, func() (bool, error) {
+		var peerCount hexutil.Uint64
+		if err := initiator.CallContext(ctx, &peerCount, "net_peerCount"); err != nil {
+			return false, err
+		}
+		return peerCount >= hexutil.Uint64(1), nil
+	})
+	require.NoError(err, "wait for a peer to be connected")
 }

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -31,6 +31,7 @@ type Orchestrator struct {
 	// options
 	batcherOptions          []BatcherOption
 	proposerOptions         []ProposerOption
+	l2CLOptions             []L2CLOption
 	deployerPipelineOptions []DeployerPipelineOption
 
 	superchains    locks.RWMap[stack.SuperchainID, *Superchain]

--- a/op-devstack/sysgo/system_singlechain_multinode.go
+++ b/op-devstack/sysgo/system_singlechain_multinode.go
@@ -1,0 +1,43 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type DefaultSingleChainMultiNodeSystemIDs struct {
+	DefaultMinimalSystemIDs
+
+	L2CLB stack.L2CLNodeID
+	L2ELB stack.L2ELNodeID
+}
+
+func NewDefaultSingleChainMultiNodeSystemIDs(l1ID, l2ID eth.ChainID) DefaultSingleChainMultiNodeSystemIDs {
+	minimal := NewDefaultMinimalSystemIDs(l1ID, l2ID)
+	return DefaultSingleChainMultiNodeSystemIDs{
+		DefaultMinimalSystemIDs: minimal,
+		L2CLB:                   stack.NewL2CLNodeID("b", l2ID),
+		L2ELB:                   stack.NewL2ELNodeID("b", l2ID),
+	}
+}
+
+func DefaultSingleChainMultiNodeSystem(dest *DefaultSingleChainMultiNodeSystemIDs) stack.Option[*Orchestrator] {
+	l1ID := eth.ChainIDFromUInt64(900)
+	l2ID := eth.ChainIDFromUInt64(901)
+	ids := NewDefaultSingleChainMultiNodeSystemIDs(l1ID, l2ID)
+
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(DefaultMinimalSystem(&dest.DefaultMinimalSystemIDs))
+
+	opt.Add(WithL2ELNode(ids.L2ELB, nil))
+	opt.Add(WithL2CLNode(ids.L2CLB, false, false, ids.L1CL, ids.L1EL, ids.L2ELB))
+
+	// P2P connect L2CL nodes
+	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CLB))
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELB))
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+	return opt
+}

--- a/op-node/node/safedb/safedb.go
+++ b/op-node/node/safedb/safedb.go
@@ -115,6 +115,7 @@ func (d *SafeDB) SafeHeadUpdated(safeHead eth.L2BlockRef, l1Head eth.BlockID) er
 func (d *SafeDB) SafeHeadReset(safeHead eth.L2BlockRef) error {
 	d.m.Lock()
 	defer d.m.Unlock()
+	d.log.Info("Resetting safe head db", "l2", safeHead.ID())
 	iter, err := d.db.NewIter(safeByL1BlockNumKey.IterRange())
 	if err != nil {
 		return fmt.Errorf("reset failed to create iterator: %w", err)

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -128,6 +129,10 @@ type EthMultiCaller interface {
 	NewMultiCaller(batchSize int) *batching.MultiCaller
 }
 
+type RPCCaller interface {
+	RPC() client.RPC
+}
+
 type EthClient interface {
 	ChainID
 	EthBlockInfo
@@ -143,6 +148,7 @@ type EthClient interface {
 	EthBalance
 	EthCode
 	EthMultiCaller
+	RPCCaller
 }
 
 type EthExtendedClient interface {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -599,3 +599,7 @@ func (s *EthClient) CodeAtHash(ctx context.Context, account common.Address, bloc
 func (s *EthClient) NewMultiCaller(batchSize int) *batching.MultiCaller {
 	return batching.NewMultiCaller(s.client, batchSize)
 }
+
+func (s *EthClient) RPC() client.RPC {
+	return s.client
+}

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -3,7 +3,9 @@ package sources
 import (
 	"context"
 	"log/slog"
+	"strings"
 
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -33,6 +35,9 @@ func (r *RollupClient) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth
 func (r *RollupClient) SafeHeadAtL1Block(ctx context.Context, blockNum uint64) (*eth.SafeHeadResponse, error) {
 	var output *eth.SafeHeadResponse
 	err := r.rpc.CallContext(ctx, &output, "optimism_safeHeadAtL1Block", hexutil.Uint64(blockNum))
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil, safedb.ErrNotFound
+	}
 	return output, err
 }
 


### PR DESCRIPTION
**Description**

Add a test to reproduce the case where safe head db entries are skipped when the EL's database is wiped and EL sync is used.  The EL sync means the safe head advances via the EL without the CL ever deriving those blocks from L1, so it can't update the safe head db.

Introduces a lot of functionality to sysgo to support this including:
* stopping and starting EL nodes
* Enabling and interacting with the safe head db
* Peering L2 EL nodes
* A new preset with two nodes on a single chain
* Enabling execution layer sync

The test is currently skipped since a fix hasn't yet been implemented.


**Metadata**

https://github.com/ethereum-optimism/optimism-private/issues/378