### PR TITLE
op-acceptance: Reduce flakiness of proofs tests

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -3,6 +3,8 @@ package proofs
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -14,7 +16,10 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	// Setup
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
-	sys.L1Network.WaitForOnline()
+	dsl.CheckAll(t,
+		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
+	)
 
 	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
 	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(2))

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/init_test.go
@@ -1,4 +1,4 @@
-package proofs
+package withdrawal
 
 import (
 	"testing"
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSuperInterop())
+	presets.DoMain(m, presets.WithSuperInterop(), presets.WithTimeTravel())
 }

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -1,4 +1,4 @@
-package proofs
+package withdrawal
 
 import (
 	"testing"

--- a/op-devstack/dsl/supervisor.go
+++ b/op-devstack/dsl/supervisor.go
@@ -81,6 +81,15 @@ func (s *Supervisor) AwaitMinL1(minL1 uint64) {
 	s.require.NoError(err, "Expected sync status not found")
 }
 
+func (s *Supervisor) AwaitMinCrossSafeTimestamp(timestamp uint64) {
+	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		return s.FetchSyncStatus().SafeTimestamp >= timestamp, nil
+	})
+	s.require.NoError(err, "Expected sync status not found")
+}
+
 func (s *Supervisor) FetchSyncStatus() eth.SupervisorSyncStatus {
 	s.log.Debug("Fetching supervisor sync status")
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)


### PR DESCRIPTION
**Description**

Move the proofs withdrawal test to its own package. It time travels L1 a week into the future and the L2s take quite a while to catch up which impacts any tests that run after this one.  It's much more efficient to spin up a dedicated system that it torn down at the end of the test instead of waiting for the L2 to catch up.

Also tweaked the way super root proposals are made so they use the current cross safe timestamp rather than the L1 block timestamp. Otherwise it will always wind up waiting for the cross safe to advance since the latest L1 block timestamp is always after the safe timestamp.