### PR TITLE
Fix logic for updating oldestL1Origin in ChannelBuilder

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -193,7 +193,7 @@ func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, erro
 			Number: l1info.Number,
 		}
 	}
-	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.oldestL1Origin.Number {
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,


### PR DESCRIPTION
Previously, the logic for updating the oldestL1Origin field in the ChannelBuilder.AddBlock method compared the new L1 origin number (l1info.Number) to the current latestL1Origin.Number. This was incorrect, as oldestL1Origin is intended to track the minimum (oldest) L1 origin number among all blocks added to the channel.

By comparing to latestL1Origin.Number, the code could fail to update oldestL1Origin correctly if a block with an L1 origin number less than the current oldest but also less than the latest was added. This would result in oldestL1Origin not always reflecting the true oldest L1 origin in the channel.

This commit changes the comparison to use c.oldestL1Origin.Number instead. Now, oldestL1Origin is updated if the new block's L1 origin number is less than the current oldest, or if it is the first block being added. This makes the logic consistent with the intended behavior and with how oldestL2 is handled elsewhere in the code.

This fix ensures that oldestL1Origin always accurately represents the oldest L1 origin among all blocks in the channel, which is important for correct channel management and for any logic that depends on knowing the true oldest L1 origin. The change is also covered by existing tests, which expect this behavior.
