### PR TITLE
op-acceptance-tests: Pre-interop super proposer tests

### DIFF
--- a/op-acceptance-tests/tests/isthmus/preinterop/init_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/init_test.go
@@ -1,0 +1,11 @@
+package preinterop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithIsthmusSuper())
+}

--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go
@@ -1,4 +1,4 @@
-package base
+package preinterop
 
 import (
 	"bytes"

--- a/op-acceptance-tests/tests/isthmus/preinterop/proposer_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/proposer_test.go
@@ -1,0 +1,22 @@
+package preinterop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestProposer(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+
+	dgf := sys.DisputeGameFactory()
+
+	newGame := dgf.WaitForGame()
+	rootClaim := newGame.RootClaim().Value()
+	l2SequenceNumber := newGame.L2SequenceNumber()
+
+	superRoot := sys.Supervisor.FetchSuperRootAtTimestamp(l2SequenceNumber.Uint64())
+	t.Require().Equal(superRoot.SuperRoot[:], rootClaim[:])
+}

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -131,6 +131,10 @@ func WithSuperInterop() stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultInteropProofsSystem(&sysgo.DefaultInteropSystemIDs{}))
 }
 
+func WithIsthmusSuper() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultIsthmusSuperProofsSystem(&sysgo.DefaultInteropSystemIDs{}))
+}
+
 // WithUnscheduledInterop adds a test-gate to not run the test if the interop upgrade is scheduled.
 // If the backend is sysgo, it will disable the interop configuration
 func WithUnscheduledInterop() stack.CommonOption {

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -88,7 +88,7 @@ func WithSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, l2CLID stack
 			opcmAddr := o.wb.output.ImplementationsDeployment.OpcmImpl
 			contract := batching.NewBoundContract(opcmABI, opcmAddr)
 			migrateInput := bindings.OPContractsManagerInteropMigratorMigrateInput{
-				UsePermissionlessGame: false,
+				UsePermissionlessGame: true,
 				StartingAnchorRoot: bindings.Proposal{
 					Root:             common.Hash(superRoot),
 					L2SequenceNumber: big.NewInt(int64(header.Time)),

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -249,6 +249,64 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	return opt
 }
 
+func DefaultIsthmusSuperProofsSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestrator] {
+	l1ID := eth.ChainIDFromUInt64(900)
+	l2AID := eth.ChainIDFromUInt64(901)
+	l2BID := eth.ChainIDFromUInt64(902)
+	ids := NewDefaultInteropSystemIDs(l1ID, l2AID, l2BID)
+	opt := stack.Combine[*Orchestrator]()
+
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Logger().Info("Setting up")
+	}))
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithDeployer(),
+		WithDeployerOptions(
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2B.ChainID()),
+		),
+	)
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
+
+	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
+	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
+	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))
+
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
+
+	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
+	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
+
+	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
+	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+
+	opt.Add(WithSuperRoots(ids.L1.ChainID(), ids.L1EL, ids.L2ACL, ids.Supervisor, ids.L2A.ChainID()))
+
+	opt.Add(WithSuperProposer(ids.L2AProposer, ids.L1EL, &ids.Supervisor))
+
+	opt.Add(WithSuperL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, []stack.L2ELNodeID{
+		ids.L2BEL, ids.L2AEL,
+	}))
+
+	// Upon evaluation of the option, export the contents we created.
+	// Ids here are static, but other things may be exported too.
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}
+
 func DefaultInteropProofsSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2AID := eth.ChainIDFromUInt64(901)


### PR DESCRIPTION
Introduce proposer acceptance tests for the isthmus system that has migrated to super roots.

fixes #15950