### PR TITLE
op-node: experimental spike

### DIFF
--- a/op-e2e/actions/interop/opnodev2_test.go
+++ b/op-e2e/actions/interop/opnodev2_test.go
@@ -1,0 +1,176 @@
+package interop
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
+	cfgv2 "github.com/ethereum-optimism/optimism/op-node/opnv2/config"
+	opv2 "github.com/ethereum-optimism/optimism/op-node/opnv2/service"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+func TestOpnodeV2(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	is := dsl.SetupInterop(t)
+	actors := is.CreateActors()
+	logger := is.Log
+	ctx := t.Ctx()
+
+	// Wrap blob store with a beacon endpoint,
+	// in v2 we avoid the in-process RPC for simpler setup.
+	beaconNode := fakebeacon.NewBeacon(logger, actors.L1Miner.BlobStore(),
+		is.Out.L1.Genesis.Timestamp, 12)
+	require.NoError(t, beaconNode.Start("127.0.0.1:0"))
+	t.Cleanup(func() {
+		beaconNode.Close()
+	})
+
+	// Setup connections and configs
+	l1Cfg := cfgv2.DefaultL1EndpointConfig()
+	l1Cfg.L1NodeAddr = actors.L1Miner.HTTPEndpoint()
+
+	beaconCfg := cfgv2.DefaultBeaconEndpointConfig()
+	beaconCfg.BeaconAddr = beaconNode.BeaconAddr()
+
+	cfgSetV2 := depset.StaticRollupConfigSetV2{}
+	for _, chainID := range is.CfgSet.Chains() {
+		cfgSetV2[chainID] = is.Out.L2s[chainID.String()].RollupCfg
+	}
+	depSet := is.CfgSet.DependencySet.(*depset.StaticConfigDependencySet)
+
+	jwtPath := e2eutils.WriteDefaultJWT(t)
+	engA := helpers.NewL2Engine(t, logger.New("role", "EngA"),
+		is.Out.L2s[actors.ChainA.ChainID.String()].Genesis, jwtPath)
+	engB := helpers.NewL2Engine(t, logger.New("role", "EngB"),
+		is.Out.L2s[actors.ChainA.ChainID.String()].Genesis, jwtPath)
+
+	engineAddrs := []string{
+		engA.HTTPEndpoint(),
+		engB.HTTPEndpoint(),
+	}
+	jwtPaths := []string{jwtPath}
+
+	datadir := t.TempDir()
+
+	cfg := &cfgv2.Config{
+		Version:   "v0.0.0",
+		LogConfig: oplog.CLIConfig{},
+		MetricsConfig: opmetrics.CLIConfig{
+			Enabled: false,
+		},
+		PprofConfig: oppprof.CLIConfig{
+			ListenEnabled: false,
+		},
+		RPC: oprpc.CLIConfig{
+			ListenAddr:  "127.0.0.1",
+			ListenPort:  0,
+			EnableAdmin: true,
+		},
+		L1:          l1Cfg,
+		Beacon:      beaconCfg,
+		L1ConfDepth: 0,
+		L2: &cfgv2.L2ELsConfig{
+			L2EngineAddrs:      engineAddrs,
+			L2EngineJWTSecrets: jwtPaths,
+			L2EngineRpcTimeout: time.Second * 10,
+			L2ReadAddrs:        nil, // no read-only addrs yet
+		},
+		P2P:                   nil, // p2p disabled in action-tests
+		RollupConfigSetSource: cfgSetV2,
+		DependencySetSource:   depSet,
+		SynchronousProcessors: true,
+		Datadir:               datadir,
+		Cancel: func(cause error) {
+			t.Fatal("unexpected early exit", cause)
+		},
+	}
+
+	// Create the node
+	srv, err := opv2.FromConfig(ctx, cfg, logger.New("role", "opv2"))
+	require.NoError(t, err)
+
+	n := &OpnodeV2{
+		Node:    srv,
+		Backend: srv.Backend().(*backend.Backend),
+		Drain:   srv.Backend().(*backend.Backend).Executor().(event.Drainer),
+	}
+	// Hook up the action test actor to the event system of the service,
+	// so we can trigger/observe things.
+	n.Backend.EventSystem().Register("action-test", n)
+
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() {
+		err := srv.Stop(ctx)
+		if err != nil {
+			t.Log(err)
+		}
+	})
+
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainA.Sequencer.SyncSupervisor(t)
+	actors.Supervisor.ProcessFull(t)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+
+	// Create an L1 block, then an L2 block, and submit the L2 block
+	actors.L1Miner.ActEmptyBlock(t)
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+	actors.ChainA.Sequencer.ActL2EmptyBlock(t)
+	actors.ChainA.Batcher.ActSubmitAll(t)
+	actors.L1Miner.ActL1StartBlock(12)(t)
+	actors.L1Miner.ActL1IncludeTx(actors.ChainA.BatcherAddr)(t)
+	actors.L1Miner.ActL1EndBlock(t)
+
+	// Check if the op-node v2 can sync the block
+	n.SignalLatestL1(t)
+	n.ProcessEvents(t)
+	latest, err := n.Backend.LocalUnsafe(t.Ctx(), actors.ChainA.ChainID)
+	require.NoError(t, err)
+	require.Equal(t, latest.Number, uint64(1), "must have synced a L2 block via L1")
+}
+
+type OpnodeV2 struct {
+	Node    *opv2.Service
+	Backend *backend.Backend
+	Drain   event.Drainer
+	Emitter event.Emitter
+}
+
+func (n *OpnodeV2) OnEvent(ctx context.Context, ev event.Event) bool {
+	// anything interesting for testing we can intercept here
+	return false
+}
+
+func (n *OpnodeV2) AttachEmitter(em event.Emitter) {
+	n.Emitter = em
+}
+
+var _ event.AttachEmitter = (*OpnodeV2)(nil)
+var _ event.Deriver = (*OpnodeV2)(nil)
+
+// force the node to observe the latest L1 state
+func (n *OpnodeV2) SignalLatestL1(t helpers.Testing) {
+	require.NoError(t, n.Backend.PullLatestL1(t.Ctx()))
+}
+
+// force the node to observe the finalized L1 state
+func (n *OpnodeV2) SignalFinalizedL1(t helpers.Testing) {
+	require.NoError(t, n.Backend.PullFinalizedL1(t.Ctx()))
+}
+
+// make the node process the queue of events till it is empty
+func (n *OpnodeV2) ProcessEvents(t helpers.Testing) {
+	require.NoError(t, n.Drain.Drain())
+}

--- a/op-e2e/system/p2p/gossip_test.go
+++ b/op-e2e/system/p2p/gossip_test.go
@@ -63,7 +63,8 @@ func TestSystemMockP2P(t *testing.T) {
 
 	verifierPeerID := sys.RollupNodes["verifier"].P2P().Host().ID()
 	check := func() bool {
-		sequencerBlocksTopicPeers := sys.RollupNodes["sequencer"].P2P().GossipOut().AllBlockTopicsPeers()
+		blocksTopic := eth.BlockV4.BlocksTopic(eth.ChainIDFromBig(sys.RollupConfig.L2ChainID))
+		sequencerBlocksTopicPeers := sys.RollupNodes["sequencer"].P2P().GossipSub().ListPeers(blocksTopic)
 		return slices.Contains[[]peer.ID](sequencerBlocksTopicPeers, verifierPeerID)
 	}
 

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/node"
+	service2 "github.com/ethereum-optimism/optimism/op-node/opnv2/service"
 	"github.com/ethereum-optimism/optimism/op-node/version"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -35,6 +36,19 @@ var (
 var VersionWithMeta = opservice.FormatVersion(version.Version, GitCommit, GitDate, version.Meta)
 
 func main() {
+	if os.Getenv("OP_NODE_V2") == "true" {
+		ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
+		err := service2.RunCmd(ctx, os.Args, service2.VersionConfig{
+			Version:   version.Version,
+			GitCommit: GitCommit,
+			GitDate:   GitDate,
+		}, service2.LifecycleFromConfig)
+		if err != nil {
+			log.Crit("Application failed", "message", err)
+		}
+		return
+	}
+
 	// Set up logger with a default INFO level in case we fail to parse flags,
 	// otherwise the final critical log won't show what the parsing error was.
 	oplog.SetupDefaults()

--- a/op-node/config/l1_el_rpc.go
+++ b/op-node/config/l1_el_rpc.go
@@ -78,6 +78,7 @@ func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger, defaultC
 		client.WithHttpPollInterval(cfg.HttpPollInterval),
 		client.WithDialAttempts(10),
 		client.WithRPCRecorder(metrics.NewRecorder("l1")),
+		client.WithLazyDial(),
 	}
 	if cfg.RateLimit != 0 {
 		opts = append(opts, client.WithRateLimit(cfg.RateLimit, cfg.BatchSize))

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -39,7 +39,7 @@ type Metricer interface {
 	RecordEmittedEvent(eventName string, emitter string)
 	RecordProcessedEvent(eventName string, deriver string, duration time.Duration)
 	RecordEventsRateLimited()
-	RecordReceivedUnsafePayload(payload *eth.ExecutionPayloadEnvelope)
+	RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope)
 	RecordRef(layer string, name string, num uint64, timestamp uint64, h common.Hash)
 	RecordL1Ref(name string, ref eth.L1BlockRef)
 	RecordL2Ref(name string, ref eth.L2BlockRef)
@@ -460,7 +460,7 @@ func (m *Metrics) RecordDerivationError() {
 	m.DerivationErrors.Record()
 }
 
-func (m *Metrics) RecordReceivedUnsafePayload(payload *eth.ExecutionPayloadEnvelope) {
+func (m *Metrics) RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope) {
 	m.UnsafePayloads.Record()
 	m.RecordRef("l2", "received_payload", uint64(payload.ExecutionPayload.BlockNumber), uint64(payload.ExecutionPayload.Timestamp), payload.ExecutionPayload.BlockHash)
 }
@@ -662,7 +662,7 @@ func (n *noopMetricer) RecordPublishingError() {
 func (n *noopMetricer) RecordDerivationError() {
 }
 
-func (n *noopMetricer) RecordReceivedUnsafePayload(payload *eth.ExecutionPayloadEnvelope) {
+func (n *noopMetricer) RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope) {
 }
 
 func (n *noopMetricer) RecordRef(layer string, name string, num uint64, timestamp uint64, h common.Hash) {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -540,7 +540,8 @@ func (n *OpNode) initP2P(cfg *config.Config) (err error) {
 			return
 		}
 		if n.p2pNode.Dv5Udp() != nil {
-			go n.p2pNode.DiscoveryProcess(n.resourcesCtx, n.log, &cfg.Rollup, cfg.P2P.TargetPeers())
+			allowedNodes := &p2p.SingleChainFilter{AllowedChainID: eth.ChainIDFromBig(cfg.Rollup.L2ChainID)}
+			go n.p2pNode.DiscoveryProcess(n.resourcesCtx, n.log, allowedNodes, cfg.P2P.TargetPeers())
 		}
 	}
 	return nil
@@ -591,7 +592,8 @@ func (n *OpNode) PublishBlock(ctx context.Context, signedEnvelope *opsigner.Sign
 	n.apiEmitter.Emit(ctx, tracer.TracePublishBlockEvent{Envelope: signedEnvelope.Envelope})
 	if p2pNode := n.getP2PNodeIfEnabled(); p2pNode != nil {
 		n.log.Info("Publishing signed execution payload on p2p", "id", signedEnvelope.ID())
-		return p2pNode.GossipOut().PublishSignedL2Payload(ctx, signedEnvelope)
+		chainID := eth.ChainIDFromBig(n.cfg.Rollup.L2ChainID)
+		return p2pNode.GossipOut().PublishSignedL2Payload(ctx, chainID, signedEnvelope)
 	}
 	return errors.New("P2P not enabled")
 }
@@ -604,7 +606,8 @@ func (n *OpNode) SignAndPublishL2Payload(ctx context.Context, envelope *eth.Exec
 			return fmt.Errorf("node has no p2p signer, payload %s cannot be published", envelope.ID())
 		}
 		n.log.Info("Publishing signed execution payload on p2p", "id", envelope.ID())
-		return p2pNode.GossipOut().SignAndPublishL2Payload(ctx, envelope, n.p2pSigner)
+		chainID := eth.ChainIDFromBig(n.cfg.Rollup.L2ChainID)
+		return p2pNode.GossipOut().SignAndPublishL2Payload(ctx, chainID, envelope, n.p2pSigner)
 	}
 	// if p2p is not enabled then we just don't publish the payload
 	return nil

--- a/op-node/opnv2/cmd/main.go
+++ b/op-node/opnv2/cmd/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	service2 "github.com/ethereum-optimism/optimism/op-node/opnv2/service"
+	"github.com/ethereum-optimism/optimism/op-node/version"
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+)
+
+var (
+	GitCommit = ""
+	GitDate   = ""
+)
+
+func main() {
+	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
+	versionCfg := service2.VersionConfig{
+		Version:   version.Version,
+		GitCommit: GitCommit,
+		GitDate:   GitDate,
+	}
+	err := service2.RunCmd(ctx, os.Args, versionCfg, service2.LifecycleFromConfig)
+	if err != nil {
+		log.Crit("Application failed", "message", err)
+	}
+}

--- a/op-node/opnv2/config/chains.go
+++ b/op-node/opnv2/config/chains.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/superchain"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/flags"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+func ChainConfigsFromCLI(ctx *cli.Context) (depset.DependencySetSource, depset.RollupConfigSetSourceV2, error) {
+	if ctx.IsSet(flags.NetworkFlag.Name) {
+		return superchainSource(ctx)
+	} else if ctx.IsSet(flags.RollupConfigFlag.Name) {
+		return legacySource(ctx)
+	} else if ctx.IsSet(flags.RollupConfigPathsFlag.Name) && ctx.IsSet(flags.DependencySetFlag.Name) {
+		return dependencySetPathSource(ctx), rollupConfigPathsSource(ctx), nil
+	} else {
+		return nil, nil, fmt.Errorf("either %s, or %s, or a combination of %s and %s must be set",
+			flags.NetworkFlag.Name, flags.RollupConfigFlag.Name,
+			flags.DependencySetFlag.Name, flags.RollupConfigPathsFlag.Name)
+	}
+}
+
+func legacySource(ctx *cli.Context) (depset.DependencySetSource, depset.RollupConfigSetSourceV2, error) {
+	// Legacy flag from op-node v1.
+	// We used an implied dependency set of 1, and a single rollup config.
+	rollupCfg, err := depset.LoadRollupCfg(ctx.String(flags.RollupConfigFlag.Name))
+	if err != nil {
+		return nil, nil, err
+	}
+	chainID := eth.ChainIDFromBig(rollupCfg.L2ChainID)
+	cfgs := depset.StaticRollupConfigSetV2{
+		chainID: rollupCfg,
+	}
+	if rollupCfg.InteropTime == nil {
+		// dependency set is not required if interop is not scheduled, fall back to a default single-chain depset.
+		depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+			chainID: {},
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create implied dependency set: %w", err)
+		}
+		return depSet, cfgs, nil
+	}
+	if !ctx.IsSet(flags.DependencySetFlag.Name) {
+		return nil, nil, errors.New("interop fork is scheduled in legacy rollup config flag, must supply dependency-set path")
+	}
+	return dependencySetPathSource(ctx), cfgs, nil
+}
+
+func superchainSource(ctx *cli.Context) (depset.DependencySetSource, depset.RollupConfigSetSourceV2, error) {
+	network := ctx.String(flags.NetworkFlag.Name)
+	networkChainID, err := superchain.ChainIDByName(network)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Use the dependency set from the first chain.
+	// superchain-registry has checks to ensure consistency for all chains in the same set
+	depSet, err := depset.FromRegistry(eth.ChainIDFromUInt64(networkChainID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load dependency set for network %s: %w", network, err)
+	}
+	cfgs := make(depset.StaticRollupConfigSetV2)
+	for _, chainID := range depSet.Chains() {
+		chainIDU64, ok := chainID.Uint64()
+		if !ok {
+			return nil, nil, fmt.Errorf("unexpected non-uint64 chainID in registry: %s", chainID)
+		}
+		rollupCfg, err := rollup.LoadOPStackRollupConfig(chainIDU64)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load rollup config for network %s: %w", network, err)
+		}
+		cfgs[chainID] = rollupCfg
+	}
+	return depSet, cfgs, nil
+}
+
+func dependencySetPathSource(ctx *cli.Context) depset.DependencySetSource {
+	return &depset.JSONDependencySetLoader{
+		Path: ctx.Path(flags.DependencySetFlag.Name),
+	}
+}
+
+func rollupConfigPathsSource(ctx *cli.Context) depset.RollupConfigSetSourceV2 {
+	return &depset.JSONRollupConfigsLoaderV2{
+		PathPattern: ctx.String(flags.RollupConfigPathsFlag.Name),
+	}
+}

--- a/op-node/opnv2/config/config.go
+++ b/op-node/opnv2/config/config.go
@@ -1,0 +1,218 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/flags"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+var (
+	ErrMissingDependencySet   = errors.New("must specify a dependency set source")
+	ErrMissingRollupConfigSet = errors.New("must specify a rollup config set source")
+	ErrMissingDatadir         = errors.New("must specify datadir")
+)
+
+type Config struct {
+	Version string
+
+	LogConfig     oplog.CLIConfig
+	MetricsConfig opmetrics.CLIConfig
+	PprofConfig   oppprof.CLIConfig
+	RPC           oprpc.CLIConfig
+
+	L1     config.L1EndpointSetup
+	Beacon config.L1BeaconEndpointSetup
+
+	L1ConfDepth uint64
+
+	L2 L2ELsSetup
+
+	// TODO: sequencer config / state-persistence omitted for now
+	// TODO: conductor config omitted for now
+	// TODO: no p2p signer setup for now
+
+	P2P p2p.SetupP2P
+
+	RollupConfigSetSource depset.RollupConfigSetSourceV2
+	DependencySetSource   depset.DependencySetSource
+
+	// SynchronousProcessors disables background-workers,
+	// requiring manual triggers for the backend to process anything.
+	SynchronousProcessors bool
+
+	Datadir string
+
+	// Cancel to request a premature shutdown of the node itself, e.g. when halting. This may be nil.
+	Cancel context.CancelCauseFunc
+}
+
+func (c *Config) Check() error {
+	var result error
+	result = errors.Join(result, c.MetricsConfig.Check())
+	result = errors.Join(result, c.PprofConfig.Check())
+	result = errors.Join(result, c.RPC.Check())
+	if c.DependencySetSource == nil {
+		result = errors.Join(result, ErrMissingDependencySet)
+	}
+	if c.RollupConfigSetSource == nil {
+		result = errors.Join(result, ErrMissingRollupConfigSet)
+	}
+	if c.Datadir == "" {
+		result = errors.Join(result, ErrMissingDatadir)
+	}
+	if c.P2P != nil { // p2p is optional
+		if err := c.P2P.Check(); err != nil {
+			result = errors.Join(result, fmt.Errorf("p2p config error: %w", err))
+		}
+	}
+	if c.L1 == nil {
+		result = errors.New("missing L1 Eth RPC endpoint config")
+	} else if err := c.L1.Check(); err != nil {
+		result = errors.Join(result, fmt.Errorf("failed to validate L1 EL RPC config: %w", err))
+	}
+	if c.Beacon == nil { // used to not be required in op-node V1
+		result = errors.Join(result, errors.New("missing L1 beacon endpoint config"))
+	} else if err := c.Beacon.Check(); err != nil {
+		result = errors.Join(result, fmt.Errorf("misconfigured L1 Beacon API endpoint: %w", err))
+	}
+	if c.L2 == nil {
+		result = errors.New("missing L2 Execution Layer endpoints config")
+	} else if err := c.L2.Check(); err != nil {
+		result = errors.Join(result, fmt.Errorf("failed to validate L2 engine/read-EL RPC config: %w", err))
+	}
+	return result
+}
+
+func FromCLI(ctx *cli.Context, version string) (*Config, error) {
+	out := &Config{
+		Version:     version,
+		LogConfig:   oplog.ReadCLIConfig(ctx),
+		PprofConfig: oppprof.ReadCLIConfig(ctx),
+		// op-node does not use opmetrics.ReadCLIConfig, or oprpc.ReadCLIConfig,
+		// need to investigate if there are differences.
+		MetricsConfig: opmetrics.CLIConfig{
+			Enabled:    ctx.Bool(flags.MetricsEnabledFlag.Name),
+			ListenAddr: ctx.String(flags.MetricsAddrFlag.Name),
+			ListenPort: ctx.Int(flags.MetricsPortFlag.Name),
+		},
+		RPC: oprpc.CLIConfig{
+			ListenAddr:  ctx.String(flags.RPCListenAddr.Name),
+			ListenPort:  ctx.Int(flags.RPCListenPort.Name),
+			EnableAdmin: ctx.Bool(flags.RPCEnableAdmin.Name),
+		},
+		L1:          L1EndpointConfigFromCLI(ctx),
+		Beacon:      BeaconEndpointConfigFromCLI(ctx),
+		L1ConfDepth: ctx.Uint64(flags.L1VerifierConfs.Name),
+		L2:          L2EndpointsConfigFromCLI(ctx),
+
+		SynchronousProcessors: false,
+		Datadir:               ctx.Path(flags.DataDirFlag.Name),
+		Cancel:                nil,
+
+		// Loaded below
+		P2P: nil,
+	}
+
+	// TODO: make scoring params adapt per topic, so 2 second and 1 second chains can have adjusted scoring each
+	p2pConfig, err := p2pcli.NewConfig(ctx, 2)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load p2p config: %w", err)
+	}
+	out.P2P = p2pConfig
+
+	depSetSource, cfgSetSource, err := ChainConfigsFromCLI(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config set source: %w", err)
+	}
+	out.DependencySetSource = depSetSource
+	out.RollupConfigSetSource = cfgSetSource
+
+	return out, nil
+}
+
+func BeaconEndpointConfigFromCLI(ctx *cli.Context) config.L1BeaconEndpointSetup {
+	return &config.L1BeaconEndpointConfig{
+		BeaconAddr:             ctx.String(flags.BeaconAddr.Name),
+		BeaconHeader:           ctx.String(flags.BeaconHeader.Name),
+		BeaconFallbackAddrs:    ctx.StringSlice(flags.BeaconFallbackAddrs.Name),
+		BeaconCheckIgnore:      ctx.Bool(flags.BeaconCheckIgnore.Name),
+		BeaconFetchAllSidecars: ctx.Bool(flags.BeaconFetchAllSidecars.Name),
+	}
+}
+
+func DefaultBeaconEndpointConfig() *config.L1BeaconEndpointConfig {
+	return &config.L1BeaconEndpointConfig{
+		BeaconAddr:             flags.BeaconAddr.Value,
+		BeaconHeader:           flags.BeaconHeader.Value,
+		BeaconFallbackAddrs:    []string{},
+		BeaconCheckIgnore:      flags.BeaconCheckIgnore.Value,
+		BeaconFetchAllSidecars: flags.BeaconFetchAllSidecars.Value,
+	}
+}
+
+func L1EndpointConfigFromCLI(ctx *cli.Context) *config.L1EndpointConfig {
+	return &config.L1EndpointConfig{
+		L1NodeAddr:       ctx.String(flags.L1NodeAddr.Name),
+		L1TrustRPC:       ctx.Bool(flags.L1TrustRPC.Name),
+		L1RPCKind:        sources.RPCProviderKind(strings.ToLower(ctx.String(flags.L1RPCProviderKind.Name))),
+		RateLimit:        ctx.Float64(flags.L1RPCRateLimit.Name),
+		BatchSize:        ctx.Int(flags.L1RPCMaxBatchSize.Name),
+		HttpPollInterval: ctx.Duration(flags.L1HTTPPollInterval.Name),
+		MaxConcurrency:   ctx.Int(flags.L1RPCMaxConcurrency.Name),
+		CacheSize:        ctx.Uint(flags.L1CacheSize.Name),
+	}
+}
+
+func DefaultL1EndpointConfig() *config.L1EndpointConfig {
+	return &config.L1EndpointConfig{
+		L1NodeAddr:       flags.L1NodeAddr.Value,
+		L1TrustRPC:       flags.L1TrustRPC.Value,
+		L1RPCKind:        *flags.L1RPCProviderKind.Value.(*sources.RPCProviderKind),
+		RateLimit:        flags.L1RPCRateLimit.Value,
+		BatchSize:        flags.L1RPCMaxBatchSize.Value,
+		MaxConcurrency:   flags.L1RPCMaxConcurrency.Value,
+		HttpPollInterval: flags.L1HTTPPollInterval.Value,
+		CacheSize:        flags.L1CacheSize.Value,
+	}
+}
+
+// DefaultConfig creates a new config using default values whenever possible.
+// Required options with no suitable default are passed as parameters.
+func DefaultConfig() *Config {
+	depSet, err := depset.NewStaticConfigDependencySet(make(map[eth.ChainID]*depset.StaticConfigDependency))
+	if err != nil {
+		panic(err)
+	}
+	rollupConfigSet := depset.NewStaticRollupConfigSetV2(map[eth.ChainID]*rollup.Config{})
+	return &Config{
+		Version:               "dev",
+		LogConfig:             oplog.DefaultCLIConfig(),
+		MetricsConfig:         opmetrics.DefaultCLIConfig(),
+		PprofConfig:           oppprof.DefaultCLIConfig(),
+		RPC:                   oprpc.DefaultCLIConfig(),
+		L1:                    DefaultL1EndpointConfig(),
+		Beacon:                DefaultBeaconEndpointConfig(),
+		P2P:                   nil, // disabled
+		DependencySetSource:   depSet,
+		RollupConfigSetSource: rollupConfigSet,
+		SynchronousProcessors: false,
+		Datadir:               flags.DataDirFlag.Value,
+		Cancel:                func(cause error) {},
+	}
+}

--- a/op-node/opnv2/config/config_test.go
+++ b/op-node/opnv2/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	"github.com/ethereum-optimism/optimism/op-service/rpc"
+)
+
+func TestDefaultConfigIsValid(t *testing.T) {
+	cfg := validConfig()
+	require.NoError(t, cfg.Check())
+}
+
+func TestRequireDependencySet(t *testing.T) {
+	cfg := validConfig()
+	cfg.DependencySetSource = nil
+	require.ErrorIs(t, cfg.Check(), ErrMissingDependencySet)
+}
+
+func TestRequireDatadir(t *testing.T) {
+	cfg := validConfig()
+	cfg.Datadir = ""
+	require.ErrorIs(t, cfg.Check(), ErrMissingDatadir)
+}
+
+func TestValidateMetricsConfig(t *testing.T) {
+	cfg := validConfig()
+	cfg.MetricsConfig.Enabled = true
+	cfg.MetricsConfig.ListenPort = -1
+	require.ErrorIs(t, cfg.Check(), metrics.ErrInvalidPort)
+}
+
+func TestValidatePprofConfig(t *testing.T) {
+	cfg := validConfig()
+	cfg.PprofConfig.ListenEnabled = true
+	cfg.PprofConfig.ListenPort = -1
+	require.ErrorIs(t, cfg.Check(), oppprof.ErrInvalidPort)
+}
+
+func TestValidateRPCConfig(t *testing.T) {
+	cfg := validConfig()
+	cfg.RPC.ListenPort = -1
+	require.ErrorIs(t, cfg.Check(), rpc.ErrInvalidPort)
+}
+
+func validConfig() *Config {
+	// Should be valid using only the required arguments passed in via the constructor.
+	return DefaultConfig()
+}

--- a/op-node/opnv2/config/l2el.go
+++ b/op-node/opnv2/config/l2el.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/flags"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/closer"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type L2ELsSetup interface {
+	Check() error
+	Engines(ctx context.Context, logger log.Logger, m opmetrics.RPCMetricer) ([]client.RPC, error)
+	ReadELs(ctx context.Context, logger log.Logger, m opmetrics.RPCMetricer) ([]client.RPC, error)
+}
+
+type L2ELsConfig struct {
+	L2EngineAddrs      []string
+	L2EngineJWTSecrets []string
+	L2EngineRpcTimeout time.Duration
+	L2ReadAddrs        []string
+}
+
+var _ L2ELsSetup = (*L2ELsConfig)(nil)
+
+func (cfg *L2ELsConfig) Check() error {
+	if cfg.L2EngineRpcTimeout <= 0 {
+		return fmt.Errorf("timeout for L2 Engine RPC requests cannot be 0 or less, but got: %s", cfg.L2EngineRpcTimeout)
+	}
+	if len(cfg.L2EngineAddrs)+len(cfg.L2ReadAddrs) == 0 {
+		return errors.New("need at least one L2 engine RPC or read RPC address, but got none")
+	}
+	if len(cfg.L2EngineAddrs) > 0 &&
+		(len(cfg.L2EngineJWTSecrets) == 1 ||
+			len(cfg.L2EngineJWTSecrets) == len(cfg.L2EngineAddrs)) {
+		return fmt.Errorf("have %d execution engine RPCs, but %d engine JWT secrets, need matching number of secrets or shared secret",
+			len(cfg.L2EngineAddrs), len(cfg.L2EngineJWTSecrets))
+	}
+	return nil
+}
+
+func (cfg *L2ELsConfig) Engines(ctx context.Context, logger log.Logger, m opmetrics.RPCMetricer) ([]client.RPC, error) {
+	var out []client.RPC
+	// If one of the RPCs fails to be set up, then close everything we have open so far.
+	closeFn := closer.CloseFn(func() {
+		for _, cl := range out {
+			cl.Close()
+		}
+	})
+	cancel, closeEarly := closeFn.Maybe()
+	defer cancel()
+	for i, endpoint := range cfg.L2EngineAddrs {
+		rpcClient, err := client.NewRPC(ctx, logger, endpoint,
+			client.WithLazyDial(), // we lazy-dial, if we have fallbacks we don't want to block on an unavailable RPC.
+			client.WithCallTimeout(cfg.L2EngineRpcTimeout),
+			client.WithRPCRecorder(m.NewRecorder(fmt.Sprintf("l2-engine-api-%d", i))),
+		)
+		if err != nil {
+			closeEarly()
+			return nil, fmt.Errorf("failed to open L2 execution-engine RPC: %w", err)
+		}
+		out = append(out, rpcClient)
+	}
+	return out, nil
+}
+
+func (cfg *L2ELsConfig) ReadELs(ctx context.Context, logger log.Logger, m opmetrics.RPCMetricer) ([]client.RPC, error) {
+	var out []client.RPC
+	// If one of the RPCs fails to be set up, then close everything we have open so far.
+	closeFn := closer.CloseFn(func() {
+		for _, cl := range out {
+			cl.Close()
+		}
+	})
+	cancel, closeEarly := closeFn.Maybe()
+	defer cancel()
+	for i, endpoint := range cfg.L2ReadAddrs {
+		rpcClient, err := client.NewRPC(ctx, logger, endpoint,
+			client.WithLazyDial(), // we lazy-dial, if we have fallbacks we don't want to block on an unavailable RPC.
+			client.WithRPCRecorder(m.NewRecorder(fmt.Sprintf("l2-read-api-%d", i))),
+		)
+		if err != nil {
+			closeEarly()
+			return nil, fmt.Errorf("failed to open L2 read-only RPC: %w", err)
+		}
+		out = append(out, rpcClient)
+	}
+	return out, nil
+}
+
+func L2EndpointsConfigFromCLI(ctx *cli.Context) *L2ELsConfig {
+	return &L2ELsConfig{
+		L2EngineAddrs:      filterEmpty(ctx.StringSlice(flags.L2EngineAddrs.Name)),
+		L2EngineJWTSecrets: filterEmpty(ctx.StringSlice(flags.L2EngineJWTSecrets.Name)),
+		L2EngineRpcTimeout: ctx.Duration(flags.L2EngineRpcTimeout.Name),
+		L2ReadAddrs:        filterEmpty(ctx.StringSlice(flags.L2ReadAddrs.Name)),
+	}
+}
+
+// filterEmpty cleans empty entries from a string-slice flag,
+// which has the potential to have empty strings.
+func filterEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/op-node/opnv2/flags/deprecated.go
+++ b/op-node/opnv2/flags/deprecated.go
@@ -1,0 +1,168 @@
+package flags
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+// op-node legacy flags, ignored, here for compatibility with old CLI configurations.
+var (
+	L2EngineSyncEnabledFlag = &cli.BoolFlag{
+		Name:    "l2.engine-sync",
+		Usage:   "WARNING: Legacy flag. No longer in use.",
+		EnvVars: prefixEnvVars("L2_ENGINE_SYNC_ENABLED"),
+		Hidden:  true,
+	}
+	SkipSyncStartCheckFlag = &cli.BoolFlag{
+		Name:    "l2.skip-sync-start-check",
+		Usage:   "WARNING: Legacy flag. No longer in use.",
+		EnvVars: prefixEnvVars("L2_SKIP_SYNC_START_CHECK"),
+		Hidden:  true,
+	}
+	BetaExtraNetworksFlag = &cli.BoolFlag{
+		Name:    "beta.extra-networks",
+		Usage:   "WARNING: Legacy flag. No longer in use.", // networks are always available
+		EnvVars: prefixEnvVars("BETA_EXTRA_NETWORKS"),
+		Hidden:  true,
+	}
+	BackupL2UnsafeSyncRPCFlag = &cli.StringFlag{
+		Name:    "l2.backup-unsafe-sync-rpc",
+		Usage:   "WARNING: Legacy flag. No longer in use.",
+		EnvVars: prefixEnvVars("L2_BACKUP_UNSAFE_SYNC_RPC"),
+		Hidden:  true,
+	}
+	BackupL2UnsafeSyncRPCTrustRPCFlag = &cli.StringFlag{
+		Name:    "l2.backup-unsafe-sync-rpc.trustrpc",
+		Usage:   "WARNING: Legacy flag. No longer in use.",
+		EnvVars: prefixEnvVars("L2_BACKUP_UNSAFE_SYNC_RPC_TRUST_RPC"),
+		Hidden:  true,
+	}
+	SnapshotLogFlag = &cli.StringFlag{
+		Name:     "snapshotlog.file",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("SNAPSHOT_LOG"),
+		Category: OperationsCategory,
+		Hidden:   true, // non-critical function, removed, flag is no-op to avoid breaking setups.
+	}
+	HeartbeatEnabledFlag = &cli.BoolFlag{
+		Name:     "heartbeat.enabled",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("HEARTBEAT_ENABLED"),
+		Category: OperationsCategory,
+		Hidden:   true,
+	}
+	HeartbeatMonikerFlag = &cli.StringFlag{
+		Name:     "heartbeat.moniker",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("HEARTBEAT_MONIKER"),
+		Category: OperationsCategory,
+		Hidden:   true,
+	}
+	HeartbeatURLFlag = &cli.StringFlag{
+		Name:     "heartbeat.url",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("HEARTBEAT_URL"),
+		Category: OperationsCategory,
+		Hidden:   true,
+	}
+	PeerScoringNameFlag = &cli.StringFlag{
+		Name:     "p2p.scoring.peers", // Use p2p.scoring instead
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		Hidden:   true,
+		Category: P2PCategory,
+	}
+	PeerScoringBandsNameFlag = &cli.StringFlag{
+		Name:     "p2p.score.bands",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		Hidden:   true,
+		Category: P2PCategory,
+	}
+	TopicScoringNameFlag = &cli.StringFlag{
+		Name:     "p2p.scoring.topics",
+		Usage:    "WARNING: Legacy flag. No longer in use.", // Use p2p.scoring instead
+		Hidden:   true,
+		Category: P2PCategory,
+	}
+	SyncModeFlag = &cli.StringFlag{
+		Name:     "syncmode",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("SYNCMODE"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
+	L2EngineKindFlag = &cli.StringFlag{
+		Name: "l2.enginekind",
+		// used to inform syncmode differences
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("L2_ENGINE_KIND"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
+	RollupHaltFlag = &cli.StringFlag{
+		Name:     "rollup.halt",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("ROLLUP_HALT"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
+	RollupLoadProtocolVersionsFlag = &cli.BoolFlag{
+		Name:     "rollup.load-protocol-versions",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("ROLLUP_LOAD_PROTOCOL_VERSIONS"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
+	IgnoreMissingPectraBlobScheduleFlag = &cli.BoolFlag{
+		Name:     "ignore-missing-pectra-blob-schedule",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("IGNORE_MISSING_PECTRA_BLOB_SCHEDULE"),
+		Category: RollupCategory,
+		Hidden:   true,
+	}
+	SafeDBPathFlag = &cli.StringFlag{
+		Name:     "safedb.path",
+		Usage:    "WARNING: Legacy flag. No longer in use.",
+		EnvVars:  prefixEnvVars("SAFEDB_PATH"),
+		Category: OperationsCategory,
+		Hidden:   true,
+	}
+)
+
+// op-supervisor flags
+var (
+	L2ConsensusNodesFlag = &cli.StringSliceFlag{
+		Name:    "l2-consensus.nodes",
+		Usage:   "WARNING: Legacy flag. No longer in use.",
+		EnvVars: []string{"OP_SUPERVISOR_L2_CONSENSUS_NODES"},
+		Hidden:  true,
+	}
+	L2ConsensusJWTSecretFlag = &cli.StringSliceFlag{
+		Name:    "l2-consensus.jwt-secret",
+		Usage:   "WARNING: Legacy flag. No longer in use.",
+		EnvVars: []string{"OP_SUPERVISOR_L2_CONSENSUS_JWT_SECRET"},
+		Value:   cli.NewStringSlice(),
+		Hidden:  true,
+	}
+)
+
+var DeprecatedFlags = []cli.Flag{
+	L2EngineSyncEnabledFlag,
+	SkipSyncStartCheckFlag,
+	BetaExtraNetworksFlag,
+	BackupL2UnsafeSyncRPCFlag,
+	BackupL2UnsafeSyncRPCTrustRPCFlag,
+	SnapshotLogFlag,
+	HeartbeatEnabledFlag,
+	HeartbeatMonikerFlag,
+	HeartbeatURLFlag,
+	PeerScoringNameFlag,
+	PeerScoringBandsNameFlag,
+	TopicScoringNameFlag,
+	SyncModeFlag,
+	L2EngineKindFlag,
+	RollupHaltFlag,
+	RollupLoadProtocolVersionsFlag,
+	IgnoreMissingPectraBlobScheduleFlag,
+	SafeDBPathFlag,
+	L2ConsensusNodesFlag,
+	L2ConsensusJWTSecretFlag,
+}

--- a/op-node/opnv2/flags/flags.go
+++ b/op-node/opnv2/flags/flags.go
@@ -1,0 +1,41 @@
+package flags
+
+import (
+	"github.com/urfave/cli/v2"
+
+	opNodeFlags "github.com/ethereum-optimism/optimism/op-node/flags"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+)
+
+const (
+	RollupCategory     = "1. ROLLUP"
+	L1RPCCategory      = "2. L1 RPC"
+	L2RPCCategory      = "3. L2 RPC"
+	SequencerCategory  = "4. SEQUENCER"
+	OperationsCategory = "5. LOGGING, METRICS, DEBUGGING, AND API"
+	P2PCategory        = "6. PEER-TO-PEER"
+	AltDACategory      = "7. ALT-DA (EXPERIMENTAL)" // TODO: omitted from op-node v2 for now
+	MiscCategory       = "8. MISC"
+)
+
+const EnvVarPrefixOpnode = "OP_NODE"
+
+func prefixEnvVars(name string) (out []string) {
+	out = append(out, opservice.PrefixEnvVar(EnvVarPrefixOpnode, name)...)
+	return out
+}
+
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{}
+
+func init() {
+	Flags = append(Flags, RollupFlags...)
+	Flags = append(Flags, L1RPCFlags...)
+	Flags = append(Flags, L2RPCFlags...)
+	Flags = append(Flags, SequencerFlags...)
+	Flags = append(Flags, OperationsFlags...)
+	// For backwards compat, use the op-node namespace
+	Flags = append(Flags, opNodeFlags.P2PFlags("OP_NODE")...)
+	Flags = append(Flags, DeprecatedFlags...)
+	Flags = append(Flags, MiscFlags...)
+}

--- a/op-node/opnv2/flags/flags_test.go
+++ b/op-node/opnv2/flags/flags_test.go
@@ -1,0 +1,90 @@
+package flags
+
+import (
+	"strings"
+	"testing"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/stretchr/testify/require"
+)
+
+//
+//// TestOptionalFlagsDontSetRequired asserts that all flags deemed optional set
+//// the Required field to false.
+//func TestOptionalFlagsDontSetRequired(t *testing.T) {
+//	for _, flag := range optionalFlags {
+//		reqFlag, ok := flag.(cli.RequiredFlag)
+//		require.True(t, ok)
+//		require.False(t, reqFlag.IsRequired())
+//	}
+//}
+
+// TestUniqueFlags asserts that all flag names are unique, to avoid accidental conflicts between the many flags.
+func TestUniqueFlags(t *testing.T) {
+	seenCLI := make(map[string]struct{})
+	for _, flag := range Flags {
+		for _, name := range flag.Names() {
+			if _, ok := seenCLI[name]; ok {
+				t.Errorf("duplicate flag %s", name)
+				continue
+			}
+			seenCLI[name] = struct{}{}
+		}
+	}
+}
+
+// TestBetaFlags test that all flags starting with "beta." have "BETA_" in the env var, and vice versa.
+func TestBetaFlags(t *testing.T) {
+	for _, flag := range Flags {
+		envFlag, ok := flag.(interface {
+			GetEnvVars() []string
+		})
+		if !ok || len(envFlag.GetEnvVars()) == 0 { // skip flags without env-var support
+			continue
+		}
+		name := flag.Names()[0]
+		envName := envFlag.GetEnvVars()[0]
+		if strings.HasPrefix(name, "beta.") {
+			require.Contains(t, envName, "BETA_", "%q flag must contain BETA in env var to match \"beta.\" flag name", name)
+		}
+		if strings.Contains(envName, "BETA_") {
+			require.True(t, strings.HasPrefix(name, "beta."), "%q flag must start with \"beta.\" in flag name to match \"BETA_\" env var", name)
+		}
+	}
+}
+
+func TestHasEnvVar(t *testing.T) {
+	for _, flag := range Flags {
+		flag := flag
+		flagName := flag.Names()[0]
+
+		t.Run(flagName, func(t *testing.T) {
+			envFlagGetter, ok := flag.(interface {
+				GetEnvVars() []string
+			})
+			envFlags := envFlagGetter.GetEnvVars()
+			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
+			require.Equal(t, len(flag.Names()), len(envFlags), "flag should have same number of env vars as names")
+		})
+	}
+}
+
+func TestEnvVarFormat(t *testing.T) {
+	for _, flag := range Flags {
+		flag := flag
+		flagName := flag.Names()[0]
+
+		t.Run(flagName, func(t *testing.T) {
+			envFlagGetter, ok := flag.(interface {
+				GetEnvVars() []string
+			})
+			envFlags := envFlagGetter.GetEnvVars()
+			require.True(t, ok, "must be able to cast the flag to an EnvVar interface")
+			require.Equal(t, len(flag.Names()), len(envFlags), "flag should have same number of env vars as names")
+			for i, name := range flag.Names() {
+				expectedEnvVar := opservice.FlagNameToEnvVarName(name, "OP_SUPERVISOR")
+				require.Equal(t, expectedEnvVar, envFlags[i])
+			}
+		})
+	}
+}

--- a/op-node/opnv2/flags/l1rpc.go
+++ b/op-node/opnv2/flags/l1rpc.go
@@ -1,0 +1,158 @@
+package flags
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	openum "github.com/ethereum-optimism/optimism/op-service/enum"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+var (
+	L1NodeAddr = &cli.StringFlag{
+		Name:    "l1",
+		Usage:   "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
+		Value:   "http://127.0.0.1:8545",
+		EnvVars: prefixEnvVars("L1_ETH_RPC"),
+		// Note: originally in rollup-category, but non-breaking change.
+		Category: L1RPCCategory,
+	}
+	BeaconAddr = &cli.StringFlag{
+		Name:  "l1.beacon",
+		Usage: "Address of L1 Beacon-node HTTP endpoint to use.",
+		// Warning: op-node does not have a default, because of pre-ecotone logic.
+		Value:   "http://127.0.0.1:9000",
+		EnvVars: prefixEnvVars("L1_BEACON"),
+		// Note: originally in rollup-category, but non-breaking change.
+		Category: L1RPCCategory,
+	}
+	BeaconHeader = &cli.StringFlag{
+		Name:     "l1.beacon-header",
+		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
+		Required: false,
+		EnvVars:  prefixEnvVars("L1_BEACON_HEADER"),
+		Category: L1RPCCategory,
+	}
+	BeaconFallbackAddrs = &cli.StringSliceFlag{
+		Name:     "l1.beacon-fallbacks",
+		Aliases:  []string{"l1.beacon-archiver"},
+		Usage:    "Addresses of L1 Beacon-API compatible HTTP fallback endpoints. Used to fetch blob sidecars not available at the l1.beacon (e.g. expired blobs).",
+		EnvVars:  append(prefixEnvVars("L1_BEACON_FALLBACKS"), prefixEnvVars("L1_BEACON_ARCHIVER")...),
+		Category: L1RPCCategory,
+	}
+	BeaconCheckIgnore = &cli.BoolFlag{
+		Name:     "l1.beacon.ignore",
+		Usage:    "When false, halts op-node startup if the healthcheck to the Beacon-node endpoint fails.",
+		Required: false,
+		Value:    false,
+		EnvVars:  prefixEnvVars("L1_BEACON_IGNORE"),
+		Category: L1RPCCategory,
+	}
+	BeaconFetchAllSidecars = &cli.BoolFlag{
+		Name:     "l1.beacon.fetch-all-sidecars",
+		Usage:    "If true, all sidecars are fetched and filtered locally. Workaround for buggy Beacon nodes.",
+		Required: false,
+		Value:    false,
+		EnvVars:  prefixEnvVars("L1_BEACON_FETCH_ALL_SIDECARS"),
+		Category: L1RPCCategory,
+	}
+	L1TrustRPC = &cli.BoolFlag{
+		Name:     "l1.trustrpc",
+		Usage:    "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",
+		EnvVars:  prefixEnvVars("L1_TRUST_RPC"),
+		Category: L1RPCCategory,
+	}
+	L1RPCProviderKind = &cli.GenericFlag{
+		Name: "l1.rpckind",
+		Usage: "The kind of RPC provider, used to inform optimal transactions receipts fetching, and thus reduce costs. Valid options: " +
+			openum.EnumString(sources.RPCProviderKinds),
+		EnvVars: prefixEnvVars("L1_RPC_KIND"),
+		Value: func() *sources.RPCProviderKind {
+			out := sources.RPCKindStandard
+			return &out
+		}(),
+		Category: L1RPCCategory,
+	}
+	L1RPCMaxConcurrency = &cli.IntFlag{
+		Name:     "l1.max-concurrency",
+		Usage:    "Maximum number of concurrent RPC requests to make to the L1 RPC provider.",
+		EnvVars:  prefixEnvVars("L1_MAX_CONCURRENCY"),
+		Value:    10,
+		Category: L1RPCCategory,
+	}
+	L1RPCRateLimit = &cli.Float64Flag{
+		Name:     "l1.rpc-rate-limit",
+		Usage:    "Optional self-imposed global rate-limit on L1 RPC requests, specified in requests / second. Disabled if set to 0.",
+		EnvVars:  prefixEnvVars("L1_RPC_RATE_LIMIT"),
+		Value:    0,
+		Category: L1RPCCategory,
+	}
+	L1RPCMaxBatchSize = &cli.IntFlag{
+		Name:     "l1.rpc-max-batch-size",
+		Usage:    "Maximum number of RPC requests to bundle, e.g. during L1 blocks receipt fetching. The L1 RPC rate limit counts this as N items, but allows it to burst at once.",
+		EnvVars:  prefixEnvVars("L1_RPC_MAX_BATCH_SIZE"),
+		Value:    20,
+		Category: L1RPCCategory,
+	}
+	L1CacheSize = &cli.UintFlag{
+		Name: "l1.cache-size",
+		Usage: "Cache size for blocks, receipts and transactions. " +
+			"If this flag is set to 0, 2/3 of the sequencing window size is used (usually 2400). " +
+			"The default value of 900 (~3h of L1 blocks) is good for (high-throughput) networks that see frequent safe head increments. " +
+			"On (low-throughput) networks with infrequent safe head increments, it is recommended to set this value to 0, " +
+			"or a value that well covers the typical span between safe head increments. " +
+			"Note that higher values will cause significantly increased memory usage.",
+		EnvVars:  prefixEnvVars("L1_CACHE_SIZE"),
+		Value:    900, // ~3h of L1 blocks
+		Category: L1RPCCategory,
+	}
+	L1HTTPPollInterval = &cli.DurationFlag{
+		Name:     "l1.http-poll-interval",
+		Usage:    "Polling interval for latest-block subscription when using an HTTP RPC provider. Ignored for other types of RPC endpoints.",
+		EnvVars:  prefixEnvVars("L1_HTTP_POLL_INTERVAL"),
+		Value:    time.Second * 12,
+		Category: L1RPCCategory,
+	}
+	L1VerifierConfs = &cli.Uint64Flag{
+		Name:     "l1.verifier-confs",
+		Aliases:  []string{"verifier.l1-confs"}, // legacy op-node CLI flag name
+		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
+		EnvVars:  prefixEnvVars("VERIFIER_L1_CONFS"),
+		Value:    3, // Warning: this used to default to 0.
+		Category: L1RPCCategory,
+	}
+	L1EpochPollIntervalFlag = &cli.DurationFlag{
+		Name:     "l1.epoch-poll-interval",
+		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
+		EnvVars:  prefixEnvVars("L1_EPOCH_POLL_INTERVAL"),
+		Value:    time.Second * 12 * 32,
+		Category: L1RPCCategory,
+	}
+	RuntimeConfigReloadIntervalFlag = &cli.DurationFlag{
+		Name:     "l1.runtime-config-reload-interval",
+		Usage:    "Poll interval for reloading the runtime config, useful when config events are not being picked up. Disabled if 0 or negative.",
+		EnvVars:  prefixEnvVars("L1_RUNTIME_CONFIG_RELOAD_INTERVAL"),
+		Value:    time.Minute * 10,
+		Category: L1RPCCategory,
+	}
+)
+
+var L1RPCFlags = []cli.Flag{
+	L1NodeAddr,
+	BeaconAddr,
+	BeaconHeader,
+	BeaconFallbackAddrs,
+	BeaconCheckIgnore,
+	BeaconFetchAllSidecars,
+	L1TrustRPC,
+	L1RPCProviderKind,
+	L1RPCMaxConcurrency,
+	L1RPCRateLimit,
+	L1RPCMaxBatchSize,
+	L1CacheSize,
+	L1HTTPPollInterval,
+	L1VerifierConfs,
+	L1EpochPollIntervalFlag,
+	RuntimeConfigReloadIntervalFlag,
+}

--- a/op-node/opnv2/flags/l2rpc.go
+++ b/op-node/opnv2/flags/l2rpc.go
@@ -1,0 +1,53 @@
+package flags
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	L2EngineAddrs = &cli.StringSliceFlag{
+		Name:    "l2",
+		Usage:   "Addresses of L2 Engine JSON-RPC endpoints to use (engine and eth RPC namespaces are required)",
+		EnvVars: prefixEnvVars("L2_ENGINE_RPC"),
+		// Note: originally in rollup-category, but non-breaking change.
+		Category: L2RPCCategory,
+		// Note: originally a single-value, now a slice in v2.
+		// Now has a default in v2. Defaulting to a port different from the L1 default.
+		Value: cli.NewStringSlice("ws://127.0.0.1:8651"),
+	}
+	L2EngineJWTSecrets = &cli.StringSliceFlag{
+		Name: "l2.jwt-secret",
+		Usage: "Path(s) to JWT secret key(s). Keys are 32 bytes, hex encoded in a file. " +
+			"A new key will be generated if the file does not exist. " +
+			"If multiple paths are specified, secrets are assumed to match l2 engine endpoints order.",
+		EnvVars: prefixEnvVars("L2_ENGINE_AUTH"),
+		// Note: originally in rollup-category, but non-breaking change.
+		Category: L2RPCCategory,
+		// Note: originally a single-value, now a slice in v2.
+		Value: cli.NewStringSlice("jwt_secret.txt"), // now has a default in v2
+	}
+	L2EngineRpcTimeout = &cli.DurationFlag{
+		Name:    "l2.engine-rpc-timeout",
+		Usage:   "L2 engine client RPC request timeout.",
+		EnvVars: prefixEnvVars("L2_ENGINE_RPC_TIMEOUT"),
+		Value:   time.Second * 10,
+		// Note: originally in rollup-category, but non-breaking change.
+		Category: L2RPCCategory,
+	}
+	L2ReadAddrs = &cli.StringSliceFlag{
+		Name:     "l2.read-rpc",
+		Usage:    "Addresses of L2 read-only JSON-RPC endpoints to use as alternative to an execution engine.",
+		EnvVars:  prefixEnvVars("L2_READ_RPC"),
+		Category: L2RPCCategory,
+		// empty by default
+	}
+)
+
+var L2RPCFlags = []cli.Flag{
+	L2EngineAddrs,
+	L2EngineJWTSecrets,
+	L2EngineRpcTimeout,
+	L2ReadAddrs,
+}

--- a/op-node/opnv2/flags/misc.go
+++ b/op-node/opnv2/flags/misc.go
@@ -1,0 +1,22 @@
+package flags
+
+import "github.com/urfave/cli/v2"
+
+func init() {
+	cli.HelpFlag.(*cli.BoolFlag).Category = MiscCategory
+	cli.VersionFlag.(*cli.BoolFlag).Category = MiscCategory
+}
+
+var (
+	ExperimentalOPStackAPI = &cli.BoolFlag{
+		Name:     "experimental.sequencer-api",
+		Usage:    "Enables experimental test sequencer RPC functionality",
+		Required: false,
+		EnvVars:  prefixEnvVars("EXPERIMENTAL_SEQUENCER_API"),
+		Category: MiscCategory,
+	}
+)
+
+var MiscFlags = []cli.Flag{
+	ExperimentalOPStackAPI,
+}

--- a/op-node/opnv2/flags/operations.go
+++ b/op-node/opnv2/flags/operations.go
@@ -1,0 +1,80 @@
+package flags
+
+import (
+	"github.com/urfave/cli/v2"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+)
+
+var (
+	RPCListenAddr = &cli.StringFlag{
+		Name:     "rpc.addr",
+		Usage:    "RPC listening address",
+		EnvVars:  prefixEnvVars("RPC_ADDR"),
+		Value:    "127.0.0.1",
+		Category: OperationsCategory,
+	}
+	RPCListenPort = &cli.IntFlag{
+		Name:     "rpc.port",
+		Usage:    "RPC listening port",
+		EnvVars:  prefixEnvVars("RPC_PORT"),
+		Value:    9545, // Note: op-service/rpc/cli.go uses 8545 as the default.
+		Category: OperationsCategory,
+	}
+	RPCEnableAdmin = &cli.BoolFlag{
+		Name:     "rpc.enable-admin",
+		Usage:    "Enable the admin API (experimental)",
+		EnvVars:  prefixEnvVars("RPC_ENABLE_ADMIN"),
+		Category: OperationsCategory,
+	}
+	RPCAdminPersistence = &cli.StringFlag{
+		Name:     "rpc.admin-state",
+		Usage:    "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
+		EnvVars:  prefixEnvVars("RPC_ADMIN_STATE"),
+		Category: OperationsCategory,
+	}
+	MetricsEnabledFlag = &cli.BoolFlag{
+		Name:     "metrics.enabled",
+		Usage:    "Enable the metrics server",
+		EnvVars:  prefixEnvVars("METRICS_ENABLED"),
+		Category: OperationsCategory,
+	}
+	MetricsAddrFlag = &cli.StringFlag{
+		Name:     "metrics.addr",
+		Usage:    "Metrics listening address",
+		Value:    "127.0.0.1", // Warning: this used to default to 0.0.0.0
+		EnvVars:  prefixEnvVars("METRICS_ADDR"),
+		Category: OperationsCategory,
+	}
+	MetricsPortFlag = &cli.IntFlag{
+		Name:     "metrics.port",
+		Usage:    "Metrics listening port",
+		Value:    7300,
+		EnvVars:  prefixEnvVars("METRICS_PORT"),
+		Category: OperationsCategory,
+	}
+	FetchWithdrawalRootFromState = &cli.BoolFlag{
+		Name:     "fetch-withdrawal-root-from-state",
+		Usage:    "Read withdrawal_storage_root (aka message passer storage root) from state trie (via execution layer) instead of the block header. Restores pre-Isthmus behavior, requires an archive EL client.",
+		Required: false,
+		EnvVars:  prefixEnvVars("FETCH_WITHDRAWAL_ROOT_FROM_STATE"),
+		Category: OperationsCategory,
+	}
+)
+
+var OperationsFlags = append(append([]cli.Flag{
+	RPCListenAddr,
+	RPCListenPort,
+	RPCEnableAdmin,
+	RPCAdminPersistence,
+	MetricsEnabledFlag,
+	MetricsAddrFlag,
+	MetricsPortFlag,
+	FetchWithdrawalRootFromState,
+},
+	// TODO: why does op-node redeclare these flags? We can import from the package?
+	//oprpc.CLIFlags(EnvVarPrefix)...)
+	//opmetrics.CLIFlags(EnvVarPrefix)...)
+	oplog.CLIFlagsWithCategory(EnvVarPrefixOpnode, OperationsCategory)...),
+	oppprof.CLIFlagsWithCategory(EnvVarPrefixOpnode, OperationsCategory)...)

--- a/op-node/opnv2/flags/rollup.go
+++ b/op-node/opnv2/flags/rollup.go
@@ -1,0 +1,61 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
+)
+
+var (
+	DataDirFlag = &cli.PathFlag{
+		Name:     "datadir", // New in op-node v2
+		Usage:    "Directory to store derivation-safety and log-indexing data.",
+		EnvVars:  prefixEnvVars("DATADIR"),
+		Value:    "data",
+		Category: RollupCategory,
+	}
+	NetworkFlag = &cli.StringSliceFlag{
+		Name:     "networks",
+		Aliases:  []string{"network"},
+		Usage:    fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
+		EnvVars:  append(prefixEnvVars("NETWORKS"), prefixEnvVars("NETWORK")...),
+		Category: RollupCategory,
+	}
+	DependencySetFlag = &cli.PathFlag{
+		Name:    "dependency-set",
+		Aliases: []string{"interop.dependency-set"}, // alias from op-supervisor service
+		Usage: "Dependency-set configuration, point at JSON file. " +
+			"Does not have to be set if a predefined network is selected.",
+		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
+		TakesFile: true,
+		Category:  RollupCategory,
+	}
+	RollupConfigPathsFlag = &cli.StringFlag{
+		Name:    "rollup.config-paths",
+		Aliases: []string{"rollup-config-paths"},
+		Usage: "Path pattern to op-node rollup.json configs to load as a rollup config set. " +
+			"For an interop-set chain the pattern should use the Go filepath glob syntax, e.g. '/configs/rollup-*.json' ",
+		EnvVars:  prefixEnvVars("ROLLUP_CONFIG_PATHS"),
+		Category: RollupCategory,
+	}
+	// RollupConfigFlag is from op-node V1, originally part of the opflags package, but customized with more description.
+	RollupConfigFlag = &cli.StringFlag{
+		Name: "rollup.config",
+		Usage: "Rollup chain configuration parameters. Alternative to predefined network selection. " +
+			"Backward-compatible alternative to rollup.config-paths flag for single-chain post-interop configurations",
+		EnvVars:  prefixEnvVars("ROLLUP_CONFIG"),
+		Category: RollupCategory,
+	}
+)
+
+var RollupFlags = append([]cli.Flag{
+	DataDirFlag,
+	NetworkFlag,
+	DependencySetFlag,
+	RollupConfigPathsFlag,
+	RollupConfigFlag,
+}, opflags.OverrideCLIFlags(EnvVarPrefixOpnode, RollupCategory)...)

--- a/op-node/opnv2/flags/sequencer.go
+++ b/op-node/opnv2/flags/sequencer.go
@@ -1,0 +1,75 @@
+package flags
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	SequencerEnabledFlag = &cli.BoolFlag{
+		Name:     "sequencer.enabled",
+		Usage:    "Enable sequencing of new L2 blocks. A separate batch submitter has to be deployed to publish the data for verifiers.",
+		EnvVars:  prefixEnvVars("SEQUENCER_ENABLED"),
+		Category: SequencerCategory,
+	}
+	SequencerStoppedFlag = &cli.BoolFlag{
+		Name:     "sequencer.stopped",
+		Usage:    "Initialize the sequencer in a stopped state. The sequencer can be started using the admin_startSequencer RPC",
+		EnvVars:  prefixEnvVars("SEQUENCER_STOPPED"),
+		Category: SequencerCategory,
+	}
+	SequencerMaxSafeLagFlag = &cli.Uint64Flag{
+		Name:     "sequencer.max-safe-lag",
+		Usage:    "Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe. Disabled if 0.",
+		EnvVars:  prefixEnvVars("SEQUENCER_MAX_SAFE_LAG"),
+		Value:    0,
+		Category: SequencerCategory,
+	}
+	SequencerL1Confs = &cli.Uint64Flag{
+		Name:     "sequencer.l1-confs",
+		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
+		EnvVars:  prefixEnvVars("SEQUENCER_L1_CONFS"),
+		Value:    4,
+		Category: SequencerCategory,
+	}
+	SequencerRecoverMode = &cli.BoolFlag{
+		Name:     "sequencer.recover",
+		Usage:    "Forces the sequencer to strictly prepare the next L1 origin and create empty L2 blocks",
+		EnvVars:  prefixEnvVars("SEQUENCER_RECOVER"),
+		Value:    false,
+		Category: SequencerCategory,
+	}
+	ConductorEnabledFlag = &cli.BoolFlag{
+		Name:     "conductor.enabled",
+		Usage:    "Enable the conductor service",
+		EnvVars:  prefixEnvVars("CONDUCTOR_ENABLED"),
+		Value:    false,
+		Category: SequencerCategory,
+	}
+	ConductorRpcFlag = &cli.StringFlag{
+		Name:     "conductor.rpc",
+		Usage:    "Conductor service rpc endpoint",
+		EnvVars:  prefixEnvVars("CONDUCTOR_RPC"),
+		Value:    "http://127.0.0.1:8547",
+		Category: SequencerCategory,
+	}
+	ConductorRpcTimeoutFlag = &cli.DurationFlag{
+		Name:     "conductor.rpc-timeout",
+		Usage:    "Conductor service rpc timeout",
+		EnvVars:  prefixEnvVars("CONDUCTOR_RPC_TIMEOUT"),
+		Value:    time.Second * 1,
+		Category: SequencerCategory,
+	}
+)
+
+var SequencerFlags = []cli.Flag{
+	SequencerEnabledFlag,
+	SequencerStoppedFlag,
+	SequencerMaxSafeLagFlag,
+	SequencerL1Confs,
+	SequencerRecoverMode,
+	ConductorEnabledFlag,
+	ConductorRpcFlag,
+	ConductorRpcTimeoutFlag,
+}

--- a/op-node/opnv2/metrics/cache.go
+++ b/op-node/opnv2/metrics/cache.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type CacheMetricer interface {
+	CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool)
+	CacheGet(chainID eth.ChainID, label string, hit bool)
+}
+
+type CacheMetrics struct {
+
+	// From op-node (no longer used)
+	//L1SourceCache *metrics.CacheMetrics
+	//L2SourceCache *metrics.CacheMetrics
+
+	// From op-supervisor
+	CacheSizeVec *prometheus.GaugeVec
+	CacheGetVec  *prometheus.CounterVec
+	CacheAddVec  *prometheus.CounterVec
+}
+
+var _ CacheMetricer = (*CacheMetrics)(nil)
+
+func NewCacheMetrics(ns string, factory metrics.Factory) *CacheMetrics {
+	return &CacheMetrics{
+		//L1SourceCache: metrics.NewCacheMetrics(factory, ns, "l1_source_cache", "L1 Source cache"),
+		//L2SourceCache: metrics.NewCacheMetrics(factory, ns, "l2_source_cache", "L2 Source cache"),
+
+		CacheSizeVec: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "source_rpc_cache_size",
+			Help:      "Source rpc cache cache size",
+		}, []string{
+			"chain",
+			"type",
+		}),
+		CacheGetVec: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "source_rpc_cache_get",
+			Help:      "Source rpc cache lookups, hitting or not",
+		}, []string{
+			"chain",
+			"type",
+			"hit",
+		}),
+		CacheAddVec: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "source_rpc_cache_add",
+			Help:      "Source rpc cache additions, evicting previous values or not",
+		}, []string{
+			"chain",
+			"type",
+			"evicted",
+		}),
+	}
+}
+
+func (m *CacheMetrics) CacheAdd(chainID eth.ChainID, label string, cacheSize int, evicted bool) {
+	chain := chainIDLabel(chainID)
+	m.CacheSizeVec.WithLabelValues(chain, label).Set(float64(cacheSize))
+	if evicted {
+		m.CacheAddVec.WithLabelValues(chain, label, "true").Inc()
+	} else {
+		m.CacheAddVec.WithLabelValues(chain, label, "false").Inc()
+	}
+}
+
+func (m *CacheMetrics) CacheGet(chainID eth.ChainID, label string, hit bool) {
+	chain := chainIDLabel(chainID)
+	if hit {
+		m.CacheGetVec.WithLabelValues(chain, label, "true").Inc()
+	} else {
+		m.CacheGetVec.WithLabelValues(chain, label, "false").Inc()
+	}
+}
+
+type NoopCacheMetrics struct{}
+
+var _ CacheMetricer = NoopCacheMetrics{}
+
+func (NoopCacheMetrics) CacheAdd(_ eth.ChainID, _ string, _ int, _ bool) {}
+func (NoopCacheMetrics) CacheGet(_ eth.ChainID, _ string, _ bool)        {}

--- a/op-node/opnv2/metrics/chain.go
+++ b/op-node/opnv2/metrics/chain.go
@@ -1,0 +1,161 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type ChainLegacyRefMetrics interface {
+	RecordL1Ref(name string, ref eth.L1BlockRef)
+}
+
+type ChainRefMetricer interface {
+	RecordCrossUnsafe(seal types.BlockSeal)
+	RecordCrossSafe(seal types.BlockSeal)
+	RecordLocalSafe(seal types.BlockSeal)
+	RecordLocalUnsafe(seal types.BlockSeal)
+	RecordFinalized(seal types.BlockSeal)
+}
+
+type ChainDBMetrics interface {
+	RecordDBEntryCount(kind string, count int64)
+	RecordDBSearchEntriesRead(count int64)
+}
+
+type ChainSequencingMetrics interface {
+	CountSequencedTxsInBlock(txns int, deposits int)
+	RecordSequencerBuildingDiffTime(duration time.Duration)
+	RecordSequencerSealingTime(duration time.Duration)
+}
+
+// TODO: below derivation metrics are not yet attributed with chainID
+// (or unique derivation pipeline, if we run multiple per chain)
+
+type ChainDerivationMetrics interface {
+	SetDerivationIdle(status bool)
+	RecordPipelineReset()
+	RecordDerivationError()
+	RecordDerivedBatches(batchType string)
+	RecordChannelInputBytes(num int)
+	RecordHeadChannelOpened()
+	RecordChannelTimedOut()
+	RecordFrame()
+}
+
+type ChainMetricer interface {
+	ChainRefMetricer
+	caching.Metrics
+	ChainDBMetrics
+	ChainLegacyRefMetrics
+	ChainDerivationMetrics
+}
+
+// ChainMetrics is an adapter between the metrics API expected by clients that assume there's only a single chain
+// and the actual metrics implementation which requires a chain ID to identify the source chain.
+type ChainMetrics struct {
+	chainID  eth.ChainID
+	delegate Metricer
+
+	// TODO: it would be nice if we compose the chain-delegated metrics
+}
+
+var _ ChainMetricer = (*ChainMetrics)(nil)
+var _ caching.Metrics = (*ChainMetrics)(nil)
+var _ logs.Metrics = (*ChainMetrics)(nil)
+
+func NewChainMetrics(chainID eth.ChainID, delegate Metricer) *ChainMetrics {
+	return &ChainMetrics{
+		chainID:  chainID,
+		delegate: delegate,
+	}
+}
+
+func (c *ChainMetrics) RecordCrossUnsafe(seal types.BlockSeal) {
+	c.delegate.RecordCrossUnsafe(c.chainID, seal)
+}
+
+func (c *ChainMetrics) RecordCrossSafe(seal types.BlockSeal) {
+	c.delegate.RecordCrossSafe(c.chainID, seal)
+}
+
+func (c *ChainMetrics) RecordLocalSafe(seal types.BlockSeal) {
+	c.delegate.RecordLocalSafe(c.chainID, seal)
+}
+
+func (c *ChainMetrics) RecordLocalUnsafe(seal types.BlockSeal) {
+	c.delegate.RecordLocalUnsafe(c.chainID, seal)
+}
+
+func (c *ChainMetrics) RecordFinalized(seal types.BlockSeal) {
+	c.delegate.RecordFinalized(c.chainID, seal)
+}
+
+func (c *ChainMetrics) CacheAdd(label string, cacheSize int, evicted bool) {
+	c.delegate.CacheAdd(c.chainID, label, cacheSize, evicted)
+}
+
+func (c *ChainMetrics) CacheGet(label string, hit bool) {
+	c.delegate.CacheGet(c.chainID, label, hit)
+}
+
+func (c *ChainMetrics) RecordDBEntryCount(kind string, count int64) {
+	c.delegate.RecordDBEntryCount(c.chainID, kind, count)
+}
+
+func (c *ChainMetrics) RecordDBSearchEntriesRead(count int64) {
+	c.delegate.RecordDBSearchEntriesRead(c.chainID, count)
+}
+
+func (c *ChainMetrics) CountSequencedTxsInBlock(txns int, deposits int) {
+	c.delegate.CountSequencedTxsInBlock(c.chainID, txns, deposits)
+}
+
+func (c *ChainMetrics) RecordSequencerBuildingDiffTime(duration time.Duration) {
+	c.delegate.RecordSequencerBuildingDiffTime(c.chainID, duration)
+}
+
+func (c *ChainMetrics) RecordSequencerSealingTime(duration time.Duration) {
+	c.delegate.RecordSequencerSealingTime(c.chainID, duration)
+}
+
+func (c *ChainMetrics) RecordL1Ref(name string, ref eth.L1BlockRef) {
+	if name == "l1_derived" { // old derivation pipeline uses this
+		c.delegate.RecordL1Derived(c.chainID, types.BlockSealFromRef(ref))
+	}
+}
+
+func (c *ChainMetrics) SetDerivationIdle(status bool) {
+	c.delegate.SetDerivationIdle(status)
+}
+
+func (c *ChainMetrics) RecordPipelineReset() {
+	c.delegate.RecordPipelineReset()
+}
+
+func (c *ChainMetrics) RecordDerivationError() {
+	c.delegate.RecordDerivationError()
+}
+
+func (c *ChainMetrics) RecordDerivedBatches(batchType string) {
+	c.delegate.RecordDerivedBatches(batchType)
+}
+
+func (c *ChainMetrics) RecordChannelInputBytes(num int) {
+	c.delegate.RecordChannelInputBytes(num)
+}
+
+func (c *ChainMetrics) RecordHeadChannelOpened() {
+	c.delegate.RecordHeadChannelOpened()
+}
+
+func (c *ChainMetrics) RecordChannelTimedOut() {
+	c.delegate.RecordChannelTimedOut()
+}
+
+func (c *ChainMetrics) RecordFrame() {
+	c.delegate.RecordFrame()
+}

--- a/op-node/opnv2/metrics/db.go
+++ b/op-node/opnv2/metrics/db.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type DBMetricer interface {
+	RecordDBEntryCount(chainID eth.ChainID, kind string, count int64)
+	RecordDBSearchEntriesRead(chainID eth.ChainID, count int64)
+}
+
+type DBMetrics struct {
+	DBEntryCountVec        *prometheus.GaugeVec
+	DBSearchEntriesReadVec *prometheus.HistogramVec
+}
+
+var _ DBMetricer = (*DBMetrics)(nil)
+
+func NewDBMetrics(ns string, factory metrics.Factory) *DBMetrics {
+	return &DBMetrics{
+		DBEntryCountVec: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "logdb_entries_current",
+			Help:      "Current number of entries in the database of specified kind and chain ID",
+		}, []string{
+			"chain",
+			"kind",
+		}),
+		DBSearchEntriesReadVec: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "logdb_search_entries_read",
+			Help:      "Entries read per search of the log database",
+			Buckets:   []float64{1, 2, 5, 10, 100, 200, 256},
+		}, []string{
+			"chain",
+		}),
+	}
+}
+
+func (m *DBMetrics) RecordDBEntryCount(chainID eth.ChainID, kind string, count int64) {
+	m.DBEntryCountVec.WithLabelValues(chainIDLabel(chainID), kind).Set(float64(count))
+}
+
+func (m *DBMetrics) RecordDBSearchEntriesRead(chainID eth.ChainID, count int64) {
+	m.DBSearchEntriesReadVec.WithLabelValues(chainIDLabel(chainID)).Observe(float64(count))
+}
+
+type NoopDBMetrics struct{}
+
+var _ DBMetricer = NoopDBMetrics{}
+
+func (NoopDBMetrics) RecordDBEntryCount(_ eth.ChainID, _ string, _ int64) {}
+func (NoopDBMetrics) RecordDBSearchEntriesRead(_ eth.ChainID, _ int64)    {}

--- a/op-node/opnv2/metrics/deprecated.go
+++ b/op-node/opnv2/metrics/deprecated.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// DeprecatedMetrics is unused. It is here to document old metrics that used to exist.
+type DeprecatedMetrics struct {
+	// req-resp sync, no longer used
+	PayloadsQuarantineTotal prometheus.Gauge
+	P2PReqDurationSeconds   *prometheus.HistogramVec
+	P2PReqTotal             *prometheus.CounterVec
+	P2PPayloadByNumber      *prometheus.GaugeVec
+
+	// Protocol version reporting, no longer used
+	// Delta = params.ProtocolVersionComparison
+	ProtocolVersionDelta *prometheus.GaugeVec
+	// ProtocolVersions is pseudo-metric to report the exact protocol version info
+	ProtocolVersions *prometheus.GaugeVec
+}

--- a/op-node/opnv2/metrics/derivation.go
+++ b/op-node/opnv2/metrics/derivation.go
@@ -1,0 +1,111 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type DerivationMetricer interface {
+	SetDerivationIdle(status bool)
+	RecordPipelineReset()
+	RecordDerivationError()
+	RecordDerivedBatches(batchType string)
+	RecordChannelInputBytes(num int)
+	RecordHeadChannelOpened()
+	RecordChannelTimedOut()
+	RecordFrame()
+}
+
+type DerivationMetrics struct {
+	DerivationIdle    prometheus.Gauge
+	PipelineResets    *metrics.Event
+	DerivationErrors  *metrics.Event
+	DerivedBatches    metrics.EventVec
+	ChannelInputBytes prometheus.Counter
+
+	headChannelOpenedEvent *metrics.Event
+	channelTimedOutEvent   *metrics.Event
+	frameAddedEvent        *metrics.Event
+}
+
+var _ DerivationMetricer = (*DerivationMetrics)(nil)
+
+func NewDerivationMetrics(ns string, factory metrics.Factory) *DerivationMetrics {
+	return &DerivationMetrics{
+		DerivationIdle: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "derivation_idle",
+			Help:      "1 if the derivation pipeline is idle",
+		}),
+		PipelineResets:   metrics.NewEvent(factory, ns, "", "pipeline_resets", "derivation pipeline resets"),
+		DerivationErrors: metrics.NewEvent(factory, ns, "", "derivation_errors", "derivation errors"),
+		DerivedBatches:   metrics.NewEventVec(factory, ns, "", "derived_batches", "derived batches", []string{"type"}),
+
+		headChannelOpenedEvent: metrics.NewEvent(factory, ns, "", "head_channel", "New channel at the front of the channel bank"),
+		channelTimedOutEvent:   metrics.NewEvent(factory, ns, "", "channel_timeout", "Channel has timed out"),
+		frameAddedEvent:        metrics.NewEvent(factory, ns, "", "frame_added", "New frame ingested in the channel bank"),
+
+		ChannelInputBytes: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "channel_input_bytes",
+			Help:      "Number of compressed bytes added to the channel",
+		}),
+	}
+}
+
+func (m *DerivationMetrics) SetDerivationIdle(status bool) {
+	var val float64
+	if status {
+		val = 1
+	}
+	m.DerivationIdle.Set(val)
+}
+
+func (m *DerivationMetrics) RecordPipelineReset() {
+	m.PipelineResets.Record()
+}
+
+func (m *DerivationMetrics) RecordDerivationError() {
+	m.DerivationErrors.Record()
+}
+
+func (m *DerivationMetrics) RecordDerivedBatches(batchType string) {
+	m.DerivedBatches.Record(batchType)
+}
+
+func (m *DerivationMetrics) RecordChannelInputBytes(inputCompressedBytes int) {
+	m.ChannelInputBytes.Add(float64(inputCompressedBytes))
+}
+
+func (m *DerivationMetrics) RecordHeadChannelOpened() {
+	m.headChannelOpenedEvent.Record()
+}
+
+func (m *DerivationMetrics) RecordChannelTimedOut() {
+	m.channelTimedOutEvent.Record()
+}
+
+func (m *DerivationMetrics) RecordFrame() {
+	m.frameAddedEvent.Record()
+}
+
+type NoopDerivationMetrics struct{}
+
+var _ DerivationMetricer = NoopDerivationMetrics{}
+
+func (NoopDerivationMetrics) SetDerivationIdle(status bool) {}
+
+func (NoopDerivationMetrics) RecordPipelineReset() {}
+
+func (NoopDerivationMetrics) RecordDerivationError() {}
+
+func (NoopDerivationMetrics) RecordDerivedBatches(batchType string) {}
+
+func (NoopDerivationMetrics) RecordChannelInputBytes(int) {}
+
+func (NoopDerivationMetrics) RecordHeadChannelOpened() {}
+
+func (NoopDerivationMetrics) RecordChannelTimedOut() {}
+
+func (NoopDerivationMetrics) RecordFrame() {}

--- a/op-node/opnv2/metrics/l1.go
+++ b/op-node/opnv2/metrics/l1.go
@@ -1,0 +1,57 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type L1Metricer interface {
+	RecordL1ReorgDepth(d uint64)
+	RecordL1RequestTime(method string, duration time.Duration)
+}
+
+type L1Metrics struct {
+	// Historically from op-node
+	L1RequestDurationSeconds *prometheus.HistogramVec
+	L1ReorgDepth             prometheus.Histogram
+}
+
+var _ L1Metricer = (*L1Metrics)(nil)
+
+func NewL1Metrics(ns string, factory metrics.Factory) *L1Metrics {
+	return &L1Metrics{
+		L1ReorgDepth: factory.NewHistogram(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "l1_reorg_depth",
+			Buckets:   []float64{0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 20.5, 50.5, 100.5},
+			Help:      "Histogram of L1 Reorg Depths",
+		}),
+
+		L1RequestDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "l1_request_seconds",
+			Buckets: []float64{
+				.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help: "Histogram of L1 request time",
+		}, []string{"request"}),
+	}
+}
+
+func (m *L1Metrics) RecordL1ReorgDepth(d uint64) {
+	m.L1ReorgDepth.Observe(float64(d))
+}
+
+// RecordL1RequestTime tracks the amount of time the derivation pipeline spent waiting for L1 data requests.
+func (m *L1Metrics) RecordL1RequestTime(method string, duration time.Duration) {
+	m.L1RequestDurationSeconds.WithLabelValues(method).Observe(float64(duration) / float64(time.Second))
+}
+
+type NoopL1Metrics struct{}
+
+var _ L1Metricer = NoopL1Metrics{}
+
+func (NoopL1Metrics) RecordL1ReorgDepth(d uint64) {}
+
+func (NoopL1Metrics) RecordL1RequestTime(method string, duration time.Duration) {}

--- a/op-node/opnv2/metrics/metrics.go
+++ b/op-node/opnv2/metrics/metrics.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type Metricer interface {
+	Document() []opmetrics.DocumentedMetric
+
+	opmetrics.RPCMetricer
+	event.Metrics
+
+	CacheMetricer
+	DBMetricer
+	DerivationMetricer
+	L1Metricer
+	P2PMetricer
+	PayloadsMetricer
+	SuperRefMetricer
+	SequencerMetricer
+	ServiceMetricer
+	SuperMetricer
+}
+
+type Metrics struct {
+	registry *prometheus.Registry
+	factory  opmetrics.Factory
+
+	*event.EventMetricsTracker
+	opmetrics.RPCMetrics
+
+	*CacheMetrics
+	*DBMetrics
+	*DerivationMetrics
+	*L1Metrics
+	*P2PMetrics
+	*PayloadsMetrics
+	*SuperRefMetrics
+	*SequencerMetrics
+	*ServiceMetrics
+	*SuperMetrics
+}
+
+var _ Metricer = (*Metrics)(nil)
+
+// implements the Registry getter, for metrics HTTP server to hook into
+var _ = (*Metrics)(nil)
+
+func NewMetrics() *Metrics {
+	ns := "op_node_default"
+
+	registry := opmetrics.NewRegistry()
+	factory := opmetrics.With(registry)
+
+	return &Metrics{
+		registry: registry,
+		factory:  factory,
+
+		EventMetricsTracker: event.NewMetricsTracker(ns, factory),
+		RPCMetrics:          opmetrics.MakeRPCMetrics(ns, factory),
+
+		CacheMetrics:      NewCacheMetrics(ns, factory),
+		DBMetrics:         NewDBMetrics(ns, factory),
+		DerivationMetrics: NewDerivationMetrics(ns, factory),
+		L1Metrics:         NewL1Metrics(ns, factory),
+		P2PMetrics:        NewP2PMetrics(ns, factory),
+		PayloadsMetrics:   NewPayloadsMetrics(ns, factory),
+		SuperRefMetrics:   NewSuperRefMetrics(ns, factory),
+		SequencerMetrics:  NewSequencerMetrics(ns, factory),
+		ServiceMetrics:    NewServiceMetrics(ns, factory),
+		SuperMetrics:      NewSuperMetrics(ns, factory),
+	}
+}
+
+func (m *Metrics) Registry() *prometheus.Registry {
+	return m.registry
+}
+
+func (m *Metrics) Document() []opmetrics.DocumentedMetric {
+	return m.factory.Document()
+}
+
+func chainIDLabel(chainID eth.ChainID) string {
+	return chainID.String()
+}
+
+func (m *Metrics) RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope) {
+	m.SuperRefMetrics.RecordReceivedUnsafePayloadRef(chainID, payload.ExecutionPayload.BlockRef())
+	m.PayloadsMetrics.RecordReceivedUnsafePayload(chainID, payload)
+}
+
+func (m *Metrics) RecordUnsafePayloadsBuffer(chainID eth.ChainID, length uint64, memSize uint64, next eth.BlockRef) {
+	m.SuperRefMetrics.RecordUnsafePayloadsBufferRef(chainID, next)
+	m.PayloadsMetrics.RecordUnsafePayloadsBuffer(chainID, length, memSize, next)
+}
+
+type NoopMetrics struct {
+	opmetrics.NoopRPCMetrics
+	event.NoopMetrics
+
+	NoopCacheMetrics
+	NoopDBMetrics
+	NoopDerivationMetrics
+	NoopL1Metrics
+	NoopP2PMetrics
+	NoopPayloadsMetrics
+	NoopSuperRefMetrics
+	NoopSequencerMetrics
+	NoopServiceMetrics
+	NoopSuperMetrics
+}
+
+var _ Metricer = NoopMetrics{}
+
+func (NoopMetrics) Document() []opmetrics.DocumentedMetric { return nil }

--- a/op-node/opnv2/metrics/p2p.go
+++ b/op-node/opnv2/metrics/p2p.go
@@ -1,0 +1,208 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	libp2pmetrics "github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type P2PMetricer interface {
+	RecordGossipEvent(evType int32)
+	IncPeerCount()
+	DecPeerCount()
+	IncStreamCount()
+	DecStreamCount()
+	RecordBandwidth(ctx context.Context, bwc *libp2pmetrics.BandwidthCounter)
+	SetPeerScores(allScores []store.PeerScores)
+	RecordPeerUnban()
+	RecordIPUnban()
+	RecordDial(allow bool)
+	RecordAccept(allow bool)
+}
+
+type P2PMetrics struct {
+	PeerCount         prometheus.Gauge
+	StreamCount       prometheus.Gauge
+	GossipEventsTotal *prometheus.CounterVec
+	BandwidthTotal    *prometheus.GaugeVec
+	PeerUnbans        prometheus.Counter
+	IPUnbans          prometheus.Counter
+	Dials             *prometheus.CounterVec
+	Accepts           *prometheus.CounterVec
+	PeerScores        *prometheus.HistogramVec
+}
+
+var _ P2PMetricer = (*P2PMetrics)(nil)
+
+func NewP2PMetrics(ns string, factory metrics.Factory) *P2PMetrics {
+	return &P2PMetrics{
+		PeerCount: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "peer_count",
+			Help:      "Count of currently connected p2p peers",
+		}),
+		PeerScores: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "peer_scores",
+			Help:      "Histogram of currently connected peer scores",
+			Buckets:   []float64{-100, -40, -20, -10, -5, -2, -1, -0.5, -0.05, 0, 0.05, 0.5, 1, 2, 5, 10, 20, 40},
+		}, []string{"type"}),
+		StreamCount: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "stream_count",
+			Help:      "Count of currently connected p2p streams",
+		}),
+		GossipEventsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "gossip_events_total",
+			Help:      "Count of gossip events by type",
+		}, []string{
+			"type",
+		}),
+		BandwidthTotal: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "bandwidth_bytes_total",
+			Help:      "P2P bandwidth by direction",
+		}, []string{
+			"direction",
+		}),
+		PeerUnbans: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "peer_unbans",
+			Help:      "Count of peer unbans",
+		}),
+		IPUnbans: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "ip_unbans",
+			Help:      "Count of IP unbans",
+		}),
+		Dials: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "dials",
+			Help:      "Count of outgoing dial attempts, with label to filter to allowed attempts",
+		}, []string{"allow"}),
+		Accepts: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "p2p",
+			Name:      "accepts",
+			Help:      "Count of incoming dial attempts to accept, with label to filter to allowed attempts",
+		}, []string{"allow"}),
+	}
+}
+
+// SetPeerScores updates the peer score metrics.
+// Accepts a slice of peer scores in any order.
+func (m *P2PMetrics) SetPeerScores(allScores []store.PeerScores) {
+	for _, scores := range allScores {
+		m.PeerScores.WithLabelValues("total").Observe(scores.Gossip.Total)
+		m.PeerScores.WithLabelValues("ipColocation").Observe(scores.Gossip.IPColocationFactor)
+		m.PeerScores.WithLabelValues("behavioralPenalty").Observe(scores.Gossip.BehavioralPenalty)
+		m.PeerScores.WithLabelValues("blocksFirstMessage").Observe(scores.Gossip.Blocks.FirstMessageDeliveries)
+		m.PeerScores.WithLabelValues("blocksTimeInMesh").Observe(scores.Gossip.Blocks.TimeInMesh)
+		m.PeerScores.WithLabelValues("blocksMessageDeliveries").Observe(scores.Gossip.Blocks.MeshMessageDeliveries)
+		m.PeerScores.WithLabelValues("blocksInvalidMessageDeliveries").Observe(scores.Gossip.Blocks.InvalidMessageDeliveries)
+
+		m.PeerScores.WithLabelValues("reqRespValidResponses").Observe(scores.ReqResp.ValidResponses)
+		m.PeerScores.WithLabelValues("reqRespErrorResponses").Observe(scores.ReqResp.ErrorResponses)
+		m.PeerScores.WithLabelValues("reqRespRejectedPayloads").Observe(scores.ReqResp.RejectedPayloads)
+	}
+}
+
+func (m *P2PMetrics) RecordGossipEvent(evType int32) {
+	m.GossipEventsTotal.WithLabelValues(pb.TraceEvent_Type_name[evType]).Inc()
+}
+
+func (m *P2PMetrics) IncPeerCount() {
+	m.PeerCount.Inc()
+}
+
+func (m *P2PMetrics) DecPeerCount() {
+	m.PeerCount.Dec()
+}
+
+func (m *P2PMetrics) IncStreamCount() {
+	m.StreamCount.Inc()
+}
+
+func (m *P2PMetrics) DecStreamCount() {
+	m.StreamCount.Dec()
+}
+
+func (m *P2PMetrics) RecordBandwidth(ctx context.Context, bwc *libp2pmetrics.BandwidthCounter) {
+	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-tick.C:
+			bwTotals := bwc.GetBandwidthTotals()
+			m.BandwidthTotal.WithLabelValues("in").Set(float64(bwTotals.TotalIn))
+			m.BandwidthTotal.WithLabelValues("out").Set(float64(bwTotals.TotalOut))
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *P2PMetrics) RecordPeerUnban() {
+	m.PeerUnbans.Inc()
+}
+
+func (m *P2PMetrics) RecordIPUnban() {
+	m.IPUnbans.Inc()
+}
+
+func (m *P2PMetrics) RecordDial(allow bool) {
+	if allow {
+		m.Dials.WithLabelValues("true").Inc()
+	} else {
+		m.Dials.WithLabelValues("false").Inc()
+	}
+}
+
+func (m *P2PMetrics) RecordAccept(allow bool) {
+	if allow {
+		m.Accepts.WithLabelValues("true").Inc()
+	} else {
+		m.Accepts.WithLabelValues("false").Inc()
+	}
+}
+
+type NoopP2PMetrics struct{}
+
+var _ P2PMetricer = NoopP2PMetrics{}
+
+func (NoopP2PMetrics) RecordGossipEvent(evType int32) {}
+
+func (NoopP2PMetrics) SetPeerScores(allScores []store.PeerScores) {}
+
+func (NoopP2PMetrics) IncPeerCount() {}
+
+func (NoopP2PMetrics) DecPeerCount() {}
+
+func (NoopP2PMetrics) IncStreamCount() {}
+
+func (NoopP2PMetrics) DecStreamCount() {}
+
+func (NoopP2PMetrics) RecordBandwidth(ctx context.Context, bwc *libp2pmetrics.BandwidthCounter) {}
+
+func (NoopP2PMetrics) RecordPeerUnban() {}
+
+func (NoopP2PMetrics) RecordIPUnban() {}
+
+func (NoopP2PMetrics) RecordDial(allow bool) {}
+
+func (NoopP2PMetrics) RecordAccept(allow bool) {}

--- a/op-node/opnv2/metrics/payloads.go
+++ b/op-node/opnv2/metrics/payloads.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type PayloadsMetricer interface {
+	RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope)
+	RecordUnsafePayloadsBuffer(chainID eth.ChainID, length uint64, memSize uint64, next eth.BlockRef)
+}
+
+type PayloadsMetrics struct {
+	UnsafePayloads              *metrics.Event
+	UnsafePayloadsBufferLen     *prometheus.GaugeVec
+	UnsafePayloadsBufferMemSize *prometheus.GaugeVec
+}
+
+var _ PayloadsMetricer = (*PayloadsMetrics)(nil)
+
+func NewPayloadsMetrics(ns string, factory metrics.Factory) *PayloadsMetrics {
+	return &PayloadsMetrics{
+		// TODO: also per chain?
+		UnsafePayloads: metrics.NewEvent(factory, ns, "", "unsafe_payloads", "unsafe payloads"),
+
+		UnsafePayloadsBufferLen: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "unsafe_payloads_buffer_len",
+			Help:      "Number of buffered L2 unsafe payloads",
+		}, []string{"chain"}),
+		UnsafePayloadsBufferMemSize: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "unsafe_payloads_buffer_mem_size",
+			Help:      "Total estimated memory size of buffered L2 unsafe payloads",
+		}, []string{"chain"}),
+	}
+}
+
+func (m *PayloadsMetrics) RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope) {
+	m.UnsafePayloads.Record()
+}
+
+func (m *PayloadsMetrics) RecordUnsafePayloadsBuffer(chainID eth.ChainID, length uint64, memSize uint64, next eth.BlockRef) {
+	m.UnsafePayloadsBufferLen.WithLabelValues(chainIDLabel(chainID)).Set(float64(length))
+	m.UnsafePayloadsBufferMemSize.WithLabelValues(chainIDLabel(chainID)).Set(float64(memSize))
+}
+
+type NoopPayloadsMetrics struct{}
+
+var _ PayloadsMetricer = NoopPayloadsMetrics{}
+
+func (NoopPayloadsMetrics) RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope) {
+}
+
+func (NoopPayloadsMetrics) RecordUnsafePayloadsBuffer(chainID eth.ChainID, length uint64, memSize uint64, next eth.BlockRef) {
+}

--- a/op-node/opnv2/metrics/refs.go
+++ b/op-node/opnv2/metrics/refs.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type SuperRefMetricer interface {
+	// from supervisor
+	RecordCrossUnsafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordCrossSafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordLocalSafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordLocalUnsafe(chainID eth.ChainID, seal types.BlockSeal)
+	RecordFinalized(chainID eth.ChainID, seal types.BlockSeal)
+
+	RecordL1Derived(chainID eth.ChainID, seal types.BlockSeal)
+
+	RecordReceivedUnsafePayloadRef(chainID eth.ChainID, r eth.BlockRef)
+	RecordUnsafePayloadsBufferRef(chainID eth.ChainID, next eth.BlockRef)
+}
+
+type SuperRefMetrics struct {
+	refMetrics opmetrics.RefMetricsWithChainID
+}
+
+var _ SuperRefMetricer = (*SuperRefMetrics)(nil)
+
+func NewSuperRefMetrics(ns string, factory opmetrics.Factory) *SuperRefMetrics {
+	return &SuperRefMetrics{
+		refMetrics: opmetrics.MakeRefMetricsWithChainID(ns, factory),
+	}
+}
+
+// TODO: some of the metric names here need to be updated to reflect original op-node metrics, or alias them.
+
+func (m *SuperRefMetrics) RecordCrossUnsafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.refMetrics.RecordRef("l2", "cross_unsafe", seal.Number, seal.Timestamp, seal.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordCrossSafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.refMetrics.RecordRef("l2", "cross_safe", seal.Number, seal.Timestamp, seal.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordLocalUnsafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.refMetrics.RecordRef("l2", "local_unsafe", seal.Number, seal.Timestamp, seal.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordLocalSafe(chainID eth.ChainID, seal types.BlockSeal) {
+	m.refMetrics.RecordRef("l2", "local_safe", seal.Number, seal.Timestamp, seal.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordFinalized(chainID eth.ChainID, seal types.BlockSeal) {
+	m.refMetrics.RecordRef("l2", "finalized", seal.Number, seal.Timestamp, seal.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordL1Derived(chainID eth.ChainID, seal types.BlockSeal) {
+	m.refMetrics.RecordRef("l1", "l1_derived", seal.Number, seal.Timestamp, seal.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordReceivedUnsafePayloadRef(chainID eth.ChainID, ref eth.BlockRef) {
+	m.refMetrics.RecordRef("l2", "received_payload", ref.Number, ref.Time, ref.Hash, chainID)
+}
+
+func (m *SuperRefMetrics) RecordUnsafePayloadsBufferRef(chainID eth.ChainID, next eth.BlockRef) {
+	m.refMetrics.RecordRef("l2", "l2_buffer_unsafe", next.Number, next.Time, next.Hash, chainID)
+}
+
+type NoopSuperRefMetrics struct{}
+
+var _ SuperRefMetricer = NoopSuperRefMetrics{}
+
+func (NoopSuperRefMetrics) RecordCrossUnsafe(chainID eth.ChainID, seal types.BlockSeal)          {}
+func (NoopSuperRefMetrics) RecordCrossSafe(chainID eth.ChainID, seal types.BlockSeal)            {}
+func (NoopSuperRefMetrics) RecordLocalSafe(chainID eth.ChainID, seal types.BlockSeal)            {}
+func (NoopSuperRefMetrics) RecordLocalUnsafe(chainID eth.ChainID, seal types.BlockSeal)          {}
+func (NoopSuperRefMetrics) RecordFinalized(chainID eth.ChainID, seal types.BlockSeal)            {}
+func (NoopSuperRefMetrics) RecordL1Derived(chainID eth.ChainID, seal types.BlockSeal)            {}
+func (NoopSuperRefMetrics) RecordReceivedUnsafePayloadRef(chainID eth.ChainID, ref eth.BlockRef) {}
+func (NoopSuperRefMetrics) RecordUnsafePayloadsBufferRef(chainID eth.ChainID, next eth.BlockRef) {}

--- a/op-node/opnv2/metrics/sequencer.go
+++ b/op-node/opnv2/metrics/sequencer.go
@@ -1,0 +1,154 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type SequencerMetricer interface {
+	SetSequencerState(active bool)
+	RecordSequencingError()
+	RecordPublishingError()
+
+	RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.BlockID)
+	RecordSequencerReset()
+
+	CountSequencedTxsInBlock(chainID eth.ChainID, txns int, deposits int)
+	RecordSequencerBuildingDiffTime(chainID eth.ChainID, duration time.Duration)
+	RecordSequencerSealingTime(chainID eth.ChainID, duration time.Duration)
+}
+
+type SequencerMetrics struct {
+	SequencerInconsistentL1Origin *metrics.Event
+	SequencerResets               *metrics.Event
+
+	SequencerBuildingDiffDurationSeconds *prometheus.HistogramVec
+	SequencerBuildingDiffTotal           *prometheus.CounterVec
+
+	SequencerSealingDurationSeconds *prometheus.HistogramVec
+	SequencerSealingTotal           *prometheus.CounterVec
+
+	TransactionsSequencedTotal *prometheus.CounterVec
+
+	SequencingErrors *metrics.Event
+	PublishingErrors *metrics.Event
+
+	SequencerActive prometheus.Gauge
+}
+
+var _ SequencerMetricer = (*SequencerMetrics)(nil)
+
+func NewSequencerMetrics(ns string, factory metrics.Factory) *SequencerMetrics {
+	return &SequencerMetrics{
+		SequencingErrors: metrics.NewEvent(factory, ns, "", "sequencing_errors", "sequencing errors"),
+		PublishingErrors: metrics.NewEvent(factory, ns, "", "publishing_errors", "p2p publishing errors"),
+		SequencerActive: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "sequencer_active",
+			Help:      "1 if sequencer active, 0 otherwise",
+		}),
+
+		SequencerInconsistentL1Origin: metrics.NewEvent(factory, ns, "", "sequencer_inconsistent_l1_origin", "events when the sequencer selects an inconsistent L1 origin"),
+		SequencerResets:               metrics.NewEvent(factory, ns, "", "sequencer_resets", "sequencer resets"),
+
+		TransactionsSequencedTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "transactions_sequenced_total",
+			Help:      "Count of total transactions sequenced",
+		}, []string{"type", "chainID"}),
+
+		SequencerBuildingDiffDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "sequencer_building_diff_seconds",
+			Buckets: []float64{
+				-10, -5, -2.5, -1, -.5, -.25, -.1, -0.05, -0.025, -0.01, -0.005,
+				.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help: "Histogram of Sequencer building time, minus block time",
+		}, []string{"chainID"}),
+		SequencerBuildingDiffTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "sequencer_building_diff_total",
+			Help:      "Number of sequencer block building jobs",
+		}, []string{"chainID"}),
+		SequencerSealingDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "sequencer_sealing_seconds",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help:      "Histogram of Sequencer block sealing time",
+		}, []string{"chainID"}),
+		SequencerSealingTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "sequencer_sealing_total",
+			Help:      "Number of sequencer block sealing jobs",
+		}, []string{"chainID"}),
+	}
+}
+
+func (m *SequencerMetrics) SetSequencerState(active bool) {
+	var val float64
+	if active {
+		val = 1
+	}
+	m.SequencerActive.Set(val)
+}
+
+func (m *SequencerMetrics) RecordSequencingError() {
+	m.SequencingErrors.Record()
+}
+
+func (m *SequencerMetrics) RecordPublishingError() {
+	m.PublishingErrors.Record()
+}
+
+func (m *SequencerMetrics) CountSequencedTxsInBlock(chainID eth.ChainID, txns int, deposits int) {
+	m.TransactionsSequencedTotal.WithLabelValues("deposits", chainIDLabel(chainID)).Add(float64(deposits))
+	m.TransactionsSequencedTotal.WithLabelValues("txns", chainIDLabel(chainID)).Add(float64(txns - deposits))
+}
+
+func (m *SequencerMetrics) RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.BlockID) {
+	m.SequencerInconsistentL1Origin.Record()
+}
+
+func (m *SequencerMetrics) RecordSequencerReset() {
+	m.SequencerResets.Record()
+}
+
+// RecordSequencerBuildingDiffTime tracks the amount of time the sequencer was allowed between
+// start to finish, incl. sealing, minus the block time.
+// Ideally this is 0, realistically the sequencer scheduler may be busy with other jobs like syncing sometimes.
+func (m *SequencerMetrics) RecordSequencerBuildingDiffTime(chainID eth.ChainID, duration time.Duration) {
+	m.SequencerBuildingDiffTotal.WithLabelValues(chainIDLabel(chainID)).Inc()
+	m.SequencerBuildingDiffDurationSeconds.WithLabelValues(chainIDLabel(chainID)).Observe(float64(duration) / float64(time.Second))
+}
+
+// RecordSequencerSealingTime tracks the amount of time the sequencer took to finish sealing the block.
+// Ideally this is 0, realistically it may take some time.
+func (m *SequencerMetrics) RecordSequencerSealingTime(chainID eth.ChainID, duration time.Duration) {
+	m.SequencerSealingTotal.WithLabelValues(chainIDLabel(chainID)).Inc()
+	m.SequencerSealingDurationSeconds.WithLabelValues(chainIDLabel(chainID)).Observe(float64(duration) / float64(time.Second))
+}
+
+type NoopSequencerMetrics struct{}
+
+var _ SequencerMetricer = NoopSequencerMetrics{}
+
+func (NoopSequencerMetrics) SetSequencerState(active bool) {}
+
+func (NoopSequencerMetrics) RecordSequencingError() {}
+
+func (NoopSequencerMetrics) RecordPublishingError() {}
+
+func (NoopSequencerMetrics) CountSequencedTxsInBlock(chainID eth.ChainID, txns int, deposits int) {}
+
+func (NoopSequencerMetrics) RecordSequencerInconsistentL1Origin(from eth.BlockID, to eth.BlockID) {}
+
+func (NoopSequencerMetrics) RecordSequencerReset() {}
+
+func (NoopSequencerMetrics) RecordSequencerBuildingDiffTime(chainID eth.ChainID, duration time.Duration) {
+}
+
+func (NoopSequencerMetrics) RecordSequencerSealingTime(chainID eth.ChainID, duration time.Duration) {}

--- a/op-node/opnv2/metrics/service.go
+++ b/op-node/opnv2/metrics/service.go
@@ -1,0 +1,53 @@
+package metrics
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ServiceMetricer interface {
+	RecordInfo(version string)
+	RecordUp()
+}
+
+type ServiceMetrics struct {
+	info *prometheus.GaugeVec
+	up   prometheus.Gauge
+}
+
+var _ ServiceMetricer = (*ServiceMetrics)(nil)
+
+func NewServiceMetrics(ns string, factory metrics.Factory) *ServiceMetrics {
+	return &ServiceMetrics{
+		info: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "info",
+			Help:      "Pseudo-metric tracking version and config info",
+		}, []string{
+			"version",
+		}),
+		up: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "up",
+			Help:      "1 if the op-node has finished starting up",
+		}),
+	}
+}
+
+// RecordInfo sets a pseudo-metric that contains versioning and config info for the op-node-v2.
+func (m *ServiceMetrics) RecordInfo(version string) {
+	m.info.WithLabelValues(version).Set(1)
+}
+
+// RecordUp sets the up metric to 1.
+func (m *ServiceMetrics) RecordUp() {
+	m.up.Set(1)
+}
+
+type NoopServiceMetrics struct{}
+
+var _ ServiceMetricer = NoopServiceMetrics{}
+
+func (NoopServiceMetrics) RecordInfo(version string) {}
+
+func (NoopServiceMetrics) RecordUp() {}

--- a/op-node/opnv2/metrics/super.go
+++ b/op-node/opnv2/metrics/super.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+)
+
+type SuperMetricer interface {
+	RecordAccessListVerifyFailure(chainID eth.ChainID)
+}
+
+type SuperMetrics struct {
+	AccessListVerifyFailureVec *prometheus.CounterVec
+}
+
+var _ SuperMetricer = (*SuperMetrics)(nil)
+
+func NewSuperMetrics(ns string, factory metrics.Factory) *SuperMetrics {
+	return &SuperMetrics{
+		AccessListVerifyFailureVec: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "access_list_verify_failure",
+			Help:      "Number of access list verify failures",
+		}, []string{
+			"chain",
+		}),
+	}
+}
+
+func (m *SuperMetrics) RecordAccessListVerifyFailure(chainID eth.ChainID) {
+	m.AccessListVerifyFailureVec.WithLabelValues(chainIDLabel(chainID)).Inc()
+}
+
+type NoopSuperMetrics struct{}
+
+var _ SuperMetricer = NoopSuperMetrics{}
+
+func (NoopSuperMetrics) RecordAccessListVerifyFailure(_ eth.ChainID) {}

--- a/op-node/opnv2/service/backend/backend.go
+++ b/op-node/opnv2/service/backend/backend.go
@@ -1,0 +1,688 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	gosync "sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/config"
+	metrics2 "github.com/ethereum-optimism/optimism/op-node/opnv2/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/controller"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/derive2"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1access"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1rewind"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l2rewind"
+	sp2p "github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/payloads"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rel"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/runcfg2"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/cross"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/status"
+)
+
+type Backend struct {
+	started atomic.Bool
+	logger  log.Logger
+	m       metrics2.Metricer
+	dataDir string
+
+	eventSys  event.System
+	eventExec event.Executor // may implement event.Drainer if synchronous
+
+	// synchronousProcessors disables background-workers,
+	// requiring manual triggers for the backend to process l2 data.
+	synchronousProcessors bool
+
+	sysContext context.Context
+	sysCancel  context.CancelFunc
+
+	// cfgSet is the full config set that the backend uses to know about the chains it is indexing
+	cfgSet        depset.FullConfigSet
+	rollupConfigs depset.RollupConfigSetV2
+
+	l1ChainID eth.ChainID
+
+	// linker checks if the configuration constraints of a message (check chain ID + timestamp)
+	linker depset.LinkChecker
+
+	// chainDBs is the primary interface to the databases, including logs, derived-from information and L1 finalization
+	chainDBs *db.ChainsDB
+
+	l1RPC  *sources.L1Client
+	beacon *sources.L1BeaconClient
+	// l1Accessor provides access to the L1 chain for the L1 processor and subscribes to new block events
+	l1Accessor *l1access.L1Accessor
+
+	// L2 read-only RPC clients, mapped by their preserved ID.
+	// Until we have identified which chain they correspond to we do not recognize them as REL component.
+	// RPC connections persist here, and are closed on shutdown.
+	readEndpoints locks.RWMap[rel.ID, client.RPC]
+
+	// L2 execution-engine RPC clients, mapped by their preserved ID.
+	// Until we have identified which chain they correspond to we do not recognize them as RWEL component.
+	// RPC connections persist here, and are closed on shutdown.
+	engineEndpoints locks.RWMap[rwel.ID, client.RPC]
+
+	// rels are read-only execution-layer nodes, we use them as fallback for execution verification.
+	rels locks.RWMap[rel.ID, *rel.REL]
+	// rwel are read-write execution-layer nodes, we use them to sync execution layer nodes and verify execution fully.
+	rwels locks.RWMap[rwel.ID, *rwel.RWEL]
+
+	pipelines locks.RWMap[derive2.ID, *derive2.PipelineV2]
+
+	// TODO set these, once known
+	readL2Clients locks.RWMap[rel.ID, apis.L2EthExtendedClient]
+	rwL2Clients   locks.RWMap[rwel.ID, apis.L2EthExtendedClient]
+
+	// chainProcessors are notified of new unsafe blocks, and add the unsafe log events data into the events DB
+	chainProcessors locks.RWMap[eth.ChainID, *processors.ChainProcessor]
+	// L1 rewinders are notified of potential L1 divergence,
+	// and resolve inconsistency by rewinding local-safe/cross-safe DBs
+	l1Rewinders locks.RWMap[eth.ChainID, *l1rewind.L1Rewinder]
+	// L2 rewinders are notified of potential log-index divergence from the local-safe DB,
+	// and resolve inconsistency by rewinding the local-unsafe log index.
+	l2Rewinders locks.RWMap[eth.ChainID, *l2rewind.L2Rewinder]
+	// Cross-unsafe workers will check cross-unsafe safety and promote when possible
+	crossUnsafeWorkers locks.RWMap[eth.ChainID, *cross.CrossUnsafeWorker]
+	// Cross-safe workers will check cross-safety and promote when possible
+	crossSafeWorkers locks.RWMap[eth.ChainID, *cross.CrossSafeWorker]
+
+	payloads locks.RWMap[eth.ChainID, *payloads.Payloads]
+
+	// statusTracker tracks the sync status of the supervisor
+	statusTracker *status.StatusTracker
+
+	// controller makes all the syncing / state-change decisions but does none of the long-running computation.
+	controller *controller.Controller
+
+	// chainMetrics are used to track metrics for each chain
+	// they are reused for processors and databases of the same chain
+	chainMetrics locks.RWMap[eth.ChainID, *metrics2.ChainMetrics]
+
+	runCfg *runcfg2.RuntimeConfig
+
+	p2pNode *sp2p.NodeP2P // P2P node functionality
+	p2pMu   gosync.Mutex  // protects p2pNode
+}
+
+var _ apis.SupervisorQueryAPI = (*Backend)(nil)
+
+var (
+	errAlreadyStopped = errors.New("already stopped")
+	errAlreadyStarted = errors.New("already started")
+
+	ErrUnexpectedMinSafetyLevel = errors.New("unexpected min-safety level")
+)
+
+func NewBackend(ctx context.Context, logger log.Logger,
+	m metrics2.Metricer, cfg *config.Config,
+) (*Backend, error) {
+	// attempt to prepare the data directory
+	if err := db.PrepDataDir(cfg.Datadir); err != nil {
+		return nil, err
+	}
+
+	// In the future we may introduce other executors.
+	// For now, we just use a synchronous executor, and poll the drain function of it.
+	eventExec := event.NewGlobalSynchronous(ctx)
+	// TODO: loop to await next event, then execute
+
+	eventSys := event.NewSystem(logger, eventExec)
+	eventSys.AddTracer(event.NewMetricsTracer(m))
+
+	sysCtx, sysCancel := context.WithCancel(ctx)
+
+	super := &Backend{
+		logger:     logger,
+		m:          m,
+		dataDir:    cfg.Datadir,
+		eventSys:   eventSys,
+		eventExec:  eventExec,
+		sysCancel:  sysCancel,
+		sysContext: sysCtx,
+		// For testing we can avoid running the processors.
+		synchronousProcessors: cfg.SynchronousProcessors,
+	}
+
+	// Initialize the resources of the backend.
+	// Stop if any of the resources fails to be initialized.
+	if err := super.initResources(ctx, cfg); err != nil {
+		err = fmt.Errorf("failed to init resources: %w", err)
+		return nil, errors.Join(err, super.Stop(ctx))
+	}
+
+	return super, nil
+}
+
+// initResources initializes all the resources, such as DBs and processors for chains.
+// An error may returned, without closing the thus-far initialized resources.
+// Upon error the caller should call Stop() on the supervisor backend to clean up and release resources.
+func (b *Backend) initResources(ctx context.Context, cfg *config.Config) error {
+	// Load the chain configs
+	if err := b.initChainConfigs(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init chain config: %w", err)
+	}
+
+	chains := b.cfgSet.Chains()
+
+	b.controller = controller.NewController(b.sysContext, b.logger, b.rollupConfigs, b.DependencySet())
+	b.eventSys.Register("controller", b.controller)
+
+	// Create chains DB
+	b.chainDBs = db.NewChainsDB(b.logger, b.cfgSet, b.m)
+	b.eventSys.Register("chainsDBs", b.chainDBs)
+
+	// Setup metrics adapters for each chain
+	for _, chainID := range chains {
+		cm := metrics2.NewChainMetrics(chainID, b.m)
+		b.chainMetrics.Set(chainID, cm)
+	}
+
+	// TODO setup monitor
+
+	// create status tracker
+	b.statusTracker = status.NewStatusTracker(b.cfgSet.Chains())
+	b.eventSys.Register("status", b.statusTracker)
+
+	// for each chain known to the dependency set, create the necessary DB resources
+	for _, chainID := range chains {
+		if err := b.openChainDBs(chainID); err != nil {
+			return fmt.Errorf("failed to open chain %s: %w", chainID, err)
+		}
+	}
+
+	// setup L1 connections
+	if err := b.initL1(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to set up L1 connection: %w", err)
+	}
+
+	// Init the runtime config loading (depends on L1).
+	b.initRunCfg()
+
+	// setup L2 connections
+	if err := b.initL2ELs(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to setup L2 execution layer connections: %w", err)
+	}
+
+	// setup rewinders
+	for _, chainID := range chains {
+		l1Rewinder := l1rewind.NewL1Rewinder(b.logger, chainID, b.chainDBs, b.l1Accessor)
+		b.eventSys.Register(fmt.Sprintf("l1-rewinder-%s", chainID), l1Rewinder)
+		b.l1Rewinders.Set(chainID, l1Rewinder)
+		l2Rewinder := l2rewind.NewL2Rewinder(b.logger, chainID, b.chainDBs)
+		b.eventSys.Register(fmt.Sprintf("l2-rewinder-%s", chainID), l2Rewinder)
+		b.l2Rewinders.Set(chainID, l2Rewinder)
+	}
+
+	// initialize all cross-unsafe processors
+	for _, chainID := range chains {
+		worker := cross.NewCrossUnsafeWorker(b.logger, chainID, b.chainDBs, b.linker)
+		b.eventSys.Register(fmt.Sprintf("cross-unsafe-%s", chainID), worker)
+		b.crossUnsafeWorkers.Set(chainID, worker)
+	}
+	// initialize all cross-safe processors
+	for _, chainID := range chains {
+		worker := cross.NewCrossSafeWorker(b.logger, chainID, b.chainDBs, b.linker)
+		b.eventSys.Register(fmt.Sprintf("cross-safe-%s", chainID), worker)
+		b.crossSafeWorkers.Set(chainID, worker)
+	}
+	// For each chain initialize a chain processor service,
+	// after cross-unsafe workers are ready to receive updates
+	for _, chainID := range chains {
+		logProcessor := processors.NewLogProcessor(chainID, b.chainDBs)
+		chainProcessor := processors.NewChainProcessor(b.sysContext, b.logger, chainID, logProcessor, b.chainDBs)
+		b.eventSys.Register(fmt.Sprintf("events-%s", chainID), chainProcessor)
+		b.chainProcessors.Set(chainID, chainProcessor)
+	}
+
+	// For each chain initialize a buffer for incoming payloads
+	for _, chainID := range chains {
+		payloadsBuf := payloads.NewPayloads(b.sysContext, b.logger, chainID)
+		b.eventSys.Register(fmt.Sprintf("payloads-%s", chainID), payloadsBuf)
+		b.payloads.Set(chainID, payloadsBuf)
+	}
+
+	if err := b.initP2P(cfg); err != nil {
+		return fmt.Errorf("failed to init P2P stack: %w", err)
+	}
+
+	return nil
+}
+
+func (b *Backend) initChainConfigs(ctx context.Context, cfg *config.Config) error {
+	depSet, err := cfg.DependencySetSource.LoadDependencySet(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load dependency set: %w", err)
+	}
+	rollupCfgSet, err := cfg.RollupConfigSetSource.LoadRollupConfigSetV2(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load rollup config set: %w", err)
+	}
+	b.rollupConfigs = rollupCfgSet
+
+	cfgSet := depset.FullConfigSetMerged{
+		RollupConfigSet: rollupCfgSet,
+		DependencySet:   depSet,
+	}
+	if err := cfgSet.CheckChains(); err != nil {
+		return err
+	}
+	b.cfgSet = cfgSet
+
+	var l1ChainID eth.ChainID
+	// Sanity-check that all configured L2s share the same L1
+	for _, chainID := range rollupCfgSet.Chains() {
+		rollupCfg := rollupCfgSet.RollupConfig(chainID)
+		got := eth.ChainIDFromBig(rollupCfg.L1ChainID)
+		if l1ChainID == (eth.ChainID{}) {
+			l1ChainID = got
+		} else if l1ChainID != got {
+			return fmt.Errorf("rollup configs refer to different L1 (%s vs %s)", l1ChainID, got)
+		}
+	}
+	b.l1ChainID = l1ChainID
+
+	b.linker = depset.LinkerFromConfig(cfgSet)
+	return nil
+}
+
+// openChainDBs initializes all the DB resources of a specific chain.
+// It is a sub-task of initResources.
+func (b *Backend) openChainDBs(chainID eth.ChainID) error {
+	cm, ok := b.chainMetrics.Get(chainID)
+	if !ok {
+		return fmt.Errorf("missing chain metrics for %s", chainID)
+	}
+
+	logDB, err := db.OpenLogDB(b.logger, chainID, b.dataDir, cm)
+	if err != nil {
+		return fmt.Errorf("failed to open logDB of chain %s: %w", chainID, err)
+	}
+	b.chainDBs.AddLogDB(chainID, logDB)
+
+	localDB, err := db.OpenLocalDerivationDB(b.logger.New("db-kind", "local-db", "chainID", chainID), chainID, b.dataDir, cm)
+	if err != nil {
+		return fmt.Errorf("failed to open local derived-from DB of chain %s: %w", chainID, err)
+	}
+	b.chainDBs.AddLocalDerivationDB(chainID, localDB)
+
+	crossDB, err := db.OpenCrossDerivationDB(b.logger.New("db-kind", "cross-db", "chainID", chainID), chainID, b.dataDir, cm)
+	if err != nil {
+		return fmt.Errorf("failed to open cross derived-from DB of chain %s: %w", chainID, err)
+	}
+	b.chainDBs.AddCrossDerivationDB(chainID, crossDB)
+
+	b.chainDBs.AddCrossUnsafeTracker(chainID)
+
+	return nil
+}
+
+func (b *Backend) initL1(ctx context.Context, cfg *config.Config) error {
+	// Set the default L1 cache size to 40 minutes of L1 data.
+	// Unlike op-node v1, which sets the cache to 12 hours worth of L1 data
+	// (because of the sequencing window walk-back legacy constraint there).
+	defaultCacheSize := 40 * 60 * 60 / 12
+	l1RPC, l1RPCCfg, err := cfg.L1.Setup(ctx, b.logger, defaultCacheSize, b.m)
+	if err != nil {
+		return fmt.Errorf("failed to get L1 RPC client: %w", err)
+	}
+	// TODO: hook up L1 cache metrics
+	l1Source, err := sources.NewL1Client(l1RPC, b.logger, nil, l1RPCCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create L1 source: %w", err)
+	}
+	b.l1RPC = l1Source
+
+	b.logger.Info("Checking L1 chain ID")
+	// Retry, we don't want start-up to abort too eagerly
+	// on a L1 connection that's only just coming online at the same time.
+	l1ChainIDBig, err := retry.Do(ctx, 10, retry.Exponential(), func() (*big.Int, error) {
+		result, err := l1Source.ChainID(ctx)
+		if err != nil {
+			b.logger.Warn("Failed to check L1 chain ID", "err", err)
+		}
+		return result, err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check L1 chain ID: %w", err)
+	}
+	if got := eth.ChainIDFromBig(l1ChainIDBig); b.l1ChainID != got {
+		return fmt.Errorf("expected L1 RPC to be connected to chain %s, but got %s", b.l1ChainID, got)
+	}
+
+	// Now that we have a connected L1 RPC on the right chain, let's try fix the rollup configs where needed.
+	if err := b.fixRollupConfigs(ctx); err != nil {
+		return err
+	}
+
+	beaconClient, fallbacks, err := cfg.Beacon.Setup(ctx, b.logger)
+	if err != nil {
+		return fmt.Errorf("failed to setup L1 Beacon API client: %w", err)
+	}
+	beaconCfg := sources.L1BeaconClientConfig{
+		FetchAllSidecars: cfg.Beacon.ShouldFetchAllSidecars(),
+	}
+	b.beacon = sources.NewL1BeaconClient(beaconClient, beaconCfg, fallbacks...)
+
+	l1Cfg := &l1access.Config{
+		ConfDepth: cfg.L1ConfDepth,
+		Subscribe: cfg.SynchronousProcessors,
+	}
+	l1Accessor := l1access.NewL1Access(b.sysContext, b.logger, l1Source, l1Cfg)
+	b.eventSys.Register("l1Accessor", l1Accessor)
+	b.l1Accessor = l1Accessor
+
+	// If we are not operating synchronously (action tests),
+	// set up background subscribers to pick up on L1 data as things change externally.
+	if !b.synchronousProcessors {
+		b.l1Accessor.SubscribeLatestHandler()
+		b.l1Accessor.SubscribeFinalityHandler()
+	}
+	return nil
+}
+
+func (b *Backend) fixRollupConfigs(ctx context.Context) error {
+	for _, chainID := range b.rollupConfigs.Chains() {
+		rollupCfg := b.rollupConfigs.RollupConfig(chainID)
+		if rollupCfg.Genesis.L1Time == 0 {
+			b.logger.Error("The rollup-configuration is missing the new '.genesis.l1_time' attribute! "+
+				"Attempting to repair that now", "l2", rollupCfg.L2ChainID)
+			if err := retry.Do0(ctx, 10, retry.Exponential(), func() error {
+				anchor, err := b.l1RPC.L1BlockRefByHash(ctx, rollupCfg.Genesis.L1.Hash)
+				if err != nil {
+					b.logger.Error("Failed to retrieve L1 anchor block of L2 chain",
+						"blockID", rollupCfg.Genesis.L1, "err", err, "l2", rollupCfg.L2ChainID)
+					return err
+				}
+				rollupCfg.Genesis.L1Time = anchor.Time
+				return nil
+			}); err != nil {
+				return fmt.Errorf("failed to fix missing L1 timestamp config attribute with L1 RPC: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (b *Backend) initRunCfg() {
+	v := runcfg2.NewRuntimeConfig(b.logger, b.DependencySet(), b.rollupConfigs, b.l1RPC)
+	b.eventSys.Register("runcfg", v)
+	b.runCfg = v
+}
+
+func (b *Backend) initL2ELs(ctx context.Context, cfg *config.Config) error {
+	readELs, err := cfg.L2.ReadELs(ctx, b.logger, b.m)
+	if err != nil {
+		return err
+	}
+	for _, relClient := range readELs {
+		id := rel.NextID()
+		b.readEndpoints.Set(id, relClient)
+	}
+	engineELs, err := cfg.L2.Engines(ctx, b.logger, b.m)
+	if err != nil {
+		return err
+	}
+	for _, engineClient := range engineELs {
+		id := rwel.NextID()
+		b.engineEndpoints.Set(id, engineClient)
+	}
+	// Try to update all ELs once initially
+	b.updateL2ELs()
+
+	// TODO background service that re-tries to dial the endpoints for chainID,
+	// and do not block the setup. Once identified, then we can promote them to REL/RWEL.
+	return nil
+}
+
+func (b *Backend) initP2P(cfg *config.Config) (err error) {
+	b.p2pMu.Lock()
+	defer b.p2pMu.Unlock()
+	if b.p2pNode != nil {
+		panic("p2p node already initialized")
+	}
+	if cfg.P2P != nil && !cfg.P2P.Disabled() {
+		em := b.eventSys.Register("p2p-block-receiver", nil)
+		rec := p2p.NewBlockReceiver(b.logger, em, b.m)
+		// Instantiate customized P2P stack, to not include req-resp and handle multi-chain properly
+		b.p2pNode, err = sp2p.NewNodeP2P(b.sysContext, b.logger, cfg.P2P, rec, b.runCfg, b.m)
+		if err != nil {
+			return
+		}
+		if b.p2pNode.Dv5Udp() != nil {
+			allowedNodes := &sp2p.MultiChainFilter{
+				Allowed: b.DependencySet().Chains(),
+				Log:     b.logger,
+			}
+			go b.p2pNode.DiscoveryProcess(b.sysContext, b.logger, allowedNodes, cfg.P2P.TargetPeers())
+		}
+	}
+	return nil
+}
+
+func (b *Backend) updateL2ELs() {
+	for _, id := range b.readEndpoints.Keys() {
+		b.updateREL(id)
+	}
+	for _, id := range b.engineEndpoints.Keys() {
+		b.updateRWEL(id)
+	}
+}
+
+// updateREL checks the given read only endpoint, and adds it to the read-only nodes, once we identified the chain.
+func (b *Backend) updateREL(id rel.ID) {
+	if b.rels.Has(id) {
+		b.logger.Debug("Already have set up L2 read-only RPC", "id", id)
+		return
+	}
+	cl, ok := b.readEndpoints.Get(id)
+	if !ok {
+		b.logger.Error("Cannot update L2 read-only RPC, unknown id", "id", id)
+		return
+	}
+	ctx, cancel := context.WithTimeout(b.sysContext, time.Second*10)
+	defer cancel()
+	chainID, err := sources.ChainID(ctx, cl)
+	if err != nil {
+		b.logger.Error("Failed to identify chain L2 read-only EL RPC", "index", id, "err", err)
+		return
+	}
+	if !b.DependencySet().HasChain(chainID) {
+		b.logger.Error("Chain of L2 read-only EL RPC is not part of dependency set", "chainID", chainID)
+		return
+	}
+	rollupCfg := b.rollupConfigs.RollupConfig(chainID)
+	clCfg := sources.L2ClientDefaultConfig(rollupCfg, true)
+	cm, ok := b.chainMetrics.Get(chainID)
+	if !ok {
+		panic(fmt.Errorf("expected every chain in dependency set to have chain metrics, but %s has none", chainID))
+	}
+	l2CL, err := sources.NewL2Client(cl, b.logger.New("chainID", chainID, "id", id), cm, clCfg)
+	if err != nil {
+		b.logger.Error("Cannot create L2 read-only EL RPC", "err", err)
+		return
+	}
+	b.readL2Clients.Set(id, l2CL)
+	relNode := rel.NewREL(b.sysContext, id, l2CL, rollupCfg)
+	b.rels.Set(id, relNode)
+	b.eventSys.Register(id.String(), relNode)
+	b.logger.Info("Connected to L2 read-only RPC", "id", id, "chainID", chainID)
+}
+
+// updateRWEL checks the given engine endpoint, and adds it to the engine nodes, once we identified the chain.
+func (b *Backend) updateRWEL(id rwel.ID) {
+	if b.rwels.Has(id) {
+		b.logger.Debug("Already have set up L2 engine RPC", "id", id)
+		return
+	}
+	cl, ok := b.engineEndpoints.Get(id)
+	if !ok {
+		b.logger.Error("Cannot update L2 engine RPC, unknown id", "id", id)
+		return
+	}
+	ctx, cancel := context.WithTimeout(b.sysContext, time.Second*10)
+	defer cancel()
+	chainID, err := sources.ChainID(ctx, cl)
+	if err != nil {
+		b.logger.Error("Failed to identify chain L2 engine EL RPC", "index", id, "err", err)
+		return
+	}
+	if !b.DependencySet().HasChain(chainID) {
+		b.logger.Error("Chain of L2 engine EL RPC is not part of dependency set", "chainID", chainID)
+		return
+	}
+	cm, ok := b.chainMetrics.Get(chainID)
+	if !ok {
+		panic(fmt.Errorf("expected every chain in dependency set to have chain metrics, but %s has none", chainID))
+	}
+	rollupCfg := b.rollupConfigs.RollupConfig(chainID)
+	clCfg := sources.EngineClientDefaultConfig(rollupCfg)
+	logger := b.logger.New("chainID", chainID, "id", id)
+	l2CL, err := sources.NewEngineClient(cl, logger, cm, clCfg)
+	if err != nil {
+		b.logger.Error("Cannot create L2 engine EL RPC", "err", err)
+		return
+	}
+	b.rwL2Clients.Set(id, l2CL)
+	rwelNode := rwel.NewRWEL(b.sysContext, id, logger, l2CL, cm, rollupCfg)
+	b.rwels.Set(id, rwelNode)
+	b.eventSys.Register(id.String(), rwelNode)
+	b.logger.Info("Connected to L2 engine RPC", "id", id, "chainID", chainID)
+
+	if p, ok := b.chainProcessors.Get(chainID); ok {
+		p.AddSource(&IndexingAdapter{Source: l2CL})
+	}
+
+	pipeline := derive2.NewDerivationPipeline(
+		b.sysContext, b.logger, rollupCfg, b.DependencySet(),
+		b.l1RPC, b.beacon, nil, l2CL, cm)
+	b.pipelines.Set(pipeline.ID(), pipeline)
+	b.eventSys.Register("derivation-"+id.String(), pipeline)
+
+	// make the controller aware of the node and pipeline, so we can use it for syncing
+	b.controller.AddRWEL(id, chainID)
+	b.controller.AddPipeline(pipeline.ID(), chainID)
+}
+
+func (b *Backend) Start(ctx context.Context) error {
+	// ensure we only start once
+	if !b.started.CompareAndSwap(false, true) {
+		return errAlreadyStarted
+	}
+
+	// initiate "ResumeFromLastSealedBlock" on the chains db,
+	// which rewinds the database to the last block that is guaranteed to have been fully recorded
+	if err := b.chainDBs.ResumeFromLastSealedBlock(); err != nil {
+		return fmt.Errorf("failed to resume chains db: %w", err)
+	}
+
+	// TODO start controller background process, if not synchronous
+
+	return nil
+}
+
+func (b *Backend) Stop(ctx context.Context) error {
+	if !b.started.CompareAndSwap(true, false) {
+		return errAlreadyStopped
+	}
+	b.logger.Info("Closing supervisor backend")
+
+	b.sysCancel()
+	defer b.eventSys.Stop()
+
+	var result error
+
+	// TODO stop controller background service
+
+	b.p2pMu.Lock()
+	if b.p2pNode != nil {
+		if err := b.p2pNode.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close p2p node: %w", err))
+		}
+		// Prevent further use of p2p.
+		b.p2pNode = nil
+	}
+	b.p2pMu.Unlock()
+
+	for _, l2RPC := range b.readEndpoints.Values() {
+		l2RPC.Close()
+	}
+	for _, l2RPC := range b.engineEndpoints.Values() {
+		l2RPC.Close()
+	}
+
+	if b.l1Accessor != nil {
+		b.l1Accessor.UnsubscribeFinalityHandler()
+		b.l1Accessor.UnsubscribeLatestHandler()
+	}
+
+	if b.l1RPC != nil {
+		b.l1RPC.Close()
+	}
+
+	b.chainProcessors.Clear()
+	b.l1Rewinders.Clear()
+	b.l2Rewinders.Clear()
+	b.crossUnsafeWorkers.Clear()
+	b.crossSafeWorkers.Clear()
+	b.payloads.Clear()
+
+	// close the databases
+	result = errors.Join(result, b.chainDBs.Close())
+
+	return result
+}
+
+func (b *Backend) P2P() p2p.Node {
+	return b.p2pNode
+}
+
+func (b *Backend) DependencySet() depset.DependencySet {
+	return b.cfgSet
+}
+
+// PullLatestL1 makes the supervisor aware of the latest L1 block. Exposed for testing purposes.
+func (b *Backend) PullLatestL1(ctx context.Context) error {
+	return b.l1Accessor.PullLatest(ctx)
+}
+
+// PullFinalizedL1 makes the supervisor aware of the finalized L1 block. Exposed for testing purposes.
+func (b *Backend) PullFinalizedL1(ctx context.Context) error {
+	return b.l1Accessor.PullFinalized(ctx)
+}
+
+// SetConfDepthL1 changes the confirmation depth of the L1 chain that is accessible to the supervisor.
+func (b *Backend) SetConfDepthL1(depth uint64) {
+	b.l1Accessor.SetConfDepth(depth)
+}
+
+// Rewind rolls back the state of the supervisor for the given chain.
+func (b *Backend) Rewind(ctx context.Context, chain eth.ChainID, block eth.BlockID) error {
+	return b.chainDBs.Rewind(chain, block)
+}
+
+func (b *Backend) EventSystem() event.System {
+	return b.eventSys
+}
+
+func (b *Backend) Executor() event.Executor {
+	return b.eventExec
+}

--- a/op-node/opnv2/service/backend/controller/controller.go
+++ b/op-node/opnv2/service/backend/controller/controller.go
@@ -1,0 +1,305 @@
+package controller
+
+import (
+	"context"
+	"iter"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/derive2"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1access"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1rewind"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l2rewind"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/payloads"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rel"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// Controller keeps track of what is being offered by other modules,
+// and tracks a set of requests of them.
+// Whenever a new offer is made, the scheduler adapts its state, and schedules inspection.
+// Whenever inspection finds something to do, new requests are made.
+type Controller struct {
+	rootCtx context.Context
+	log     log.Logger
+
+	cfgSet depset.RollupConfigSetV2
+	depSet depset.DependencySet
+
+	relStates      map[rel.ID]*RELState
+	rwelStates     map[rwel.ID]*RWELState
+	pipelineStates map[derive2.ID]*PipelineState
+	chainDBStates  map[eth.ChainID]*ChainDBState
+	payloadsStates map[eth.ChainID]*PayloadsState
+	runCfgs        map[eth.ChainID]*RunCfgState
+
+	l1AccessState *L1AccessState
+
+	clock clock.Clock
+
+	mu sync.RWMutex
+
+	emitter event.Emitter
+}
+
+var _ State = (*Controller)(nil)
+
+var _ event.AttachEmitter = (*Controller)(nil)
+var _ event.Deriver = (*Controller)(nil)
+
+func NewController(
+	rootCtx context.Context,
+	logger log.Logger,
+	cfgSet depset.RollupConfigSetV2,
+	depSet depset.DependencySet) *Controller {
+	out := &Controller{
+		rootCtx:        rootCtx,
+		log:            logger,
+		cfgSet:         cfgSet,
+		depSet:         depSet,
+		relStates:      make(map[rel.ID]*RELState),
+		rwelStates:     make(map[rwel.ID]*RWELState),
+		pipelineStates: make(map[derive2.ID]*PipelineState),
+		chainDBStates:  make(map[eth.ChainID]*ChainDBState),
+		payloadsStates: make(map[eth.ChainID]*PayloadsState),
+		runCfgs:        make(map[eth.ChainID]*RunCfgState),
+		clock:          clock.SystemClock,
+	}
+	return out
+}
+
+func (c *Controller) AttachEmitter(em event.Emitter) {
+	c.emitter = em
+
+	for _, chainID := range c.depSet.Chains() {
+		c.chainDBStates[chainID] = NewChainDBState(c.rootCtx, c.emitter, chainID)
+		c.payloadsStates[chainID] = NewPayloadsState(c.rootCtx, c.emitter, chainID)
+		c.runCfgs[chainID] = NewRunCfgState(c.rootCtx, c.emitter, chainID)
+	}
+	c.l1AccessState = NewL1AccessState(c.rootCtx, c.emitter)
+}
+
+func (c *Controller) AddRWEL(id rwel.ID, chainID eth.ChainID) {
+	c.rwelStates[id] = NewRWELState(c.rootCtx, c.emitter, chainID, id)
+}
+
+func (c *Controller) AddPipeline(id derive2.ID, chainID eth.ChainID) {
+	c.pipelineStates[id] = NewPipelineState(c.rootCtx, c.emitter, chainID, id)
+}
+
+func (c *Controller) OnEvent(ctx context.Context, ev event.Event) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if id := rel.IDFromContext(ctx); id != rel.UnknownID {
+		if state, ok := c.relStates[id]; ok {
+			state.onUpdate(ev)
+		}
+	}
+
+	if id := rwel.IDFromContext(ctx); id != rwel.UnknownID {
+		if state, ok := c.rwelStates[id]; ok {
+			state.onUpdate(ev, c.clock.Now())
+		}
+	}
+
+	if id := derive2.IDFromContext(ctx); id != derive2.UnknownID {
+		if state, ok := c.pipelineStates[id]; ok {
+			state.onUpdate(ev, c.clock.Now())
+		}
+	}
+
+	switch x := ev.(type) {
+	// Incoming payloads
+	case payloads.PayloadsUpdateEvent:
+		state := c.payloadsStates[x.ChainID]
+		state.min = x.Min
+		state.max = x.Max
+		state.count = x.Count
+	// L1 updates
+	case l1access.LatestL1UpdateEvent:
+		if x.LatestL1 != c.l1AccessState.latestL1 &&
+			x.LatestL1.ParentID() != c.l1AccessState.latestL1.ID() {
+			// TODO reset polling state
+			_ = x
+		}
+		c.l1AccessState.latestL1 = x.LatestL1
+	case l1access.ConfirmedL1UpdateEvent:
+		c.l1AccessState.confirmedL1 = x.ConfirmedL1
+	case l1access.FinalizedL1UpdateEvent:
+		c.l1AccessState.finalizedL1 = x.FinalizedL1
+	// L2 rewinds
+	case l2rewind.L2RewindCheckCompletedEvent:
+		c.chainDBStates[x.ChainID].localUnsafe = x.LocalUnsafe
+		// TODO handle cross-unsafe
+	// L1 rewinds
+	case l1rewind.L1RewindCheckCompletedEvent:
+		c.chainDBStates[x.ChainID].localSafe = x.LocalSafe
+		c.chainDBStates[x.ChainID].crossSafe = x.CrossSafe
+	// block replacement
+	case rwel.BuildReplacementBlockEvent:
+		id := rwel.IDFromContext(ctx)
+		s, ok := c.rwelStates[id]
+		if ok {
+			dbState, ok := c.chainDBStates[s.chainID]
+			if ok && dbState.invalidated.Derived == x.Invalidated {
+				dbState.replacementAttributes = x.Attributes
+			}
+		}
+	// DB events
+	case superevents.LocalUnsafeUpdateEvent:
+		c.chainDBStates[x.ChainID].localUnsafe = types.BlockSealFromRef(x.NewLocalUnsafe)
+	case superevents.CrossUnsafeUpdateEvent:
+		c.chainDBStates[x.ChainID].crossUnsafe = x.NewCrossUnsafe
+		c.chainDBStates[x.ChainID].crossUnsafeWork.ResetBackoff()
+	case superevents.LocalSafeUpdateEvent:
+		state := c.chainDBStates[x.ChainID]
+		state.localSafe = x.NewLocalSafe
+		if state.replacementComplete != nil {
+			if state.replacementComplete.Replacement.Hash != x.NewLocalSafe.Derived.Hash {
+				c.log.Warn("Inconsistent local-safe update reset block-replacement work")
+			}
+		}
+		state.invalidated = types.DerivedBlockRefPair{}
+		state.replacementAttributes = nil
+		state.replacementComplete = nil
+	case superevents.CrossSafeUpdateEvent:
+		c.chainDBStates[x.ChainID].crossSafe = x.NewCrossSafe
+		c.chainDBStates[x.ChainID].crossSafeWork.ResetBackoff()
+	case superevents.FinalizedL2UpdateEvent:
+		c.chainDBStates[x.ChainID].finalized = x.FinalizedL2
+	case superevents.InvalidateLocalSafeEvent:
+		c.chainDBStates[x.ChainID].invalidated = x.Candidate
+		c.chainDBStates[x.ChainID].replacementAttributes = nil
+		c.chainDBStates[x.ChainID].replacementComplete = nil
+	case superevents.CrossSafeWorkErrEvent:
+		c.chainDBStates[x.ChainID].crossSafeWork.DoBackoff(x.Err, c.clock.Now())
+	case superevents.CrossUnsafeWorkErrEvent:
+		c.chainDBStates[x.ChainID].crossUnsafeWork.DoBackoff(x.Err, c.clock.Now())
+	default:
+		return false
+	}
+
+	// check if the event was the desired response to a request
+	if req := RequestFromContext(ctx); req != nil {
+		if req.cond != nil && req.cond(ev) {
+			// If this was the response we were awaiting, then mark the task as done
+			c.log.Debug("Received response event", "req", req, "event", ev)
+			req.cancel(context.Canceled)
+			req.cond = nil
+			return true
+		}
+	}
+
+	return true
+}
+
+// Update is a function to inspect states, prioritize what needs to be done, and make new requests
+func (c *Controller) Update() {
+	for _, s := range c.rwelStates {
+		s.maybePollLocalUnsafe()
+		s.maybePollCrossSafe()
+		s.maybePollFinalized()
+	}
+	for _, s := range c.rwelStates {
+		s.maybeSyncFromL1()
+	}
+	for _, s := range c.rwelStates {
+		s.maybeBackupSync()
+	}
+	for _, s := range c.pipelineStates {
+		s.maybeDerive()
+	}
+	for _, s := range c.pipelineStates {
+		s.maybeProcessAttributes()
+	}
+	for _, s := range c.pipelineStates {
+		s.maybePrepareNextL1()
+	}
+	for _, s := range c.chainDBStates {
+		s.maybeDBInit()
+	}
+	for _, s := range c.chainDBStates {
+		s.maybeReplaceBlock()
+	}
+	for _, s := range c.chainDBStates {
+		s.maybeCrossSafeUpdate()
+		s.maybeCrossUnsafeUpdate()
+	}
+	for _, s := range c.chainDBStates {
+		s.maybeDBFinalize()
+	}
+	for _, s := range c.chainDBStates {
+		s.maybeCheckL1Origin()
+	}
+	for _, s := range c.chainDBStates {
+		s.maybeCheckL1Source()
+	}
+	for _, s := range c.rwelStates {
+		s.maybePromoteCrossSafe()
+	}
+	for _, s := range c.rwelStates {
+		s.maybePromoteFinalized()
+	}
+	for _, s := range c.rwelStates {
+		s.maybeELSync()
+	}
+	for _, s := range c.rwelStates {
+		s.maybeIndex()
+	}
+	for _, s := range c.rwelStates {
+		s.maybeNewBlock()
+	}
+	for _, s := range c.runCfgs {
+		s.maybeUpdate()
+	}
+}
+
+// TODO: do we want to iterate in sorted order for deterministic behavior?
+
+func (c *Controller) Now() time.Time {
+	return c.clock.Now()
+}
+
+func (c *Controller) IterPipelines(predicates ...Predicate[*PipelineState]) iter.Seq[*PipelineState] {
+	return Filter(maps.Values(c.pipelineStates), predicates...)
+}
+
+func (c *Controller) IterDBs(predicates ...Predicate[*ChainDBState]) iter.Seq[*ChainDBState] {
+	return Filter(maps.Values(c.chainDBStates), predicates...)
+}
+
+func (c *Controller) IterRWELs(predicates ...Predicate[*RWELState]) iter.Seq[*RWELState] {
+	return Filter(maps.Values(c.rwelStates), predicates...)
+}
+
+func (c *Controller) IterRELs(predicates ...Predicate[*RELState]) iter.Seq[*RELState] {
+	return Filter(maps.Values(c.relStates), predicates...)
+}
+
+func (c *Controller) IterRunCfgs(predicates ...Predicate[*RunCfgState]) iter.Seq[*RunCfgState] {
+	return Filter(maps.Values(c.runCfgs), predicates...)
+}
+
+func (c *Controller) Payloads(chainID eth.ChainID) (state *PayloadsState, ok bool) {
+	state, ok = c.payloadsStates[chainID]
+	return
+}
+
+func (c *Controller) ChainDB(chainID eth.ChainID) (state *ChainDBState, ok bool) {
+	state, ok = c.chainDBStates[chainID]
+	return
+}
+
+func (c *Controller) L1State() *L1AccessState {
+	return c.l1AccessState
+}

--- a/op-node/opnv2/service/backend/controller/core.go
+++ b/op-node/opnv2/service/backend/controller/core.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+// TODO: consider automating events that run upon timeout/cancel of the context
+type TimeoutEvent struct {
+	Err
+}
+
+func (ev TimeoutEvent) String() string {
+	return "timeout"
+}
+
+// Err can be embedded into events,
+// to give it an error-field while implementing the error interface at the same time.
+// This allows for catch-all error handling in event type-switches.
+type Err error
+
+type EventHandler func(ctx context.Context, ev event.Event)
+
+type NextStep struct {
+	// TODO: may need to nil this after the handler calls the next Emit,
+	// or handle stale events somehow.
+	Handler *TaskStateV2
+}
+
+type eventNextKeyType struct{}
+
+var eventNextKey = eventNextKeyType{}
+
+func ContextWithNextStep(ctx context.Context, n *NextStep) context.Context {
+	return context.WithValue(ctx, eventNextKey, n)
+}
+
+func NextStepFromContext(ctx context.Context) *NextStep {
+	v := ctx.Value(eventNextKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*NextStep)
+}
+
+type TaskStateV2 struct {
+	task struct {
+		Inspect func()
+
+		Default     EventHandler
+		LastEmitCtx context.Context
+		LastEvent   event.Event
+		LastSeqNr   uint64
+
+		// Next thing to do with an event that we previously emitted.
+		Next EventHandler
+
+		Emitter event.Emitter
+	}
+}
+
+func (ts *TaskStateV2) Init(emitter event.Emitter, inspect func()) {
+	ts.task.Emitter = emitter
+	ts.task.Inspect = inspect
+}
+
+func (ts *TaskStateV2) Inspect() {
+	if ts.IsBusy() {
+		return
+	}
+	ts.task.Inspect()
+}
+
+func (ts *TaskStateV2) IsBusy() bool {
+	return ts.task.Next != nil
+}
+
+func (ts *TaskStateV2) AssertNotBusy() {
+	if ts.IsBusy() {
+		panic("task is active")
+	}
+}
+
+// TODO: the controller should be able to look at the event context,
+// pull out the task the event originated from, and then apply the event to the task,
+// on the thread of the Controller itself, so we have synchronous controller state access.
+func (ts *TaskStateV2) OnEvent(ctx context.Context, ev event.Event) {
+	if ts.task.Next != nil {
+		ts.task.Next(ctx, ev)
+	}
+	ts.task.Default(ctx, ev)
+}
+
+func (ts *TaskStateV2) Emit(ctx context.Context, ev event.Event, next EventHandler) {
+	ts.task.LastEvent = ev
+	ts.task.LastEmitCtx = ContextWithNextStep(ctx, &NextStep{Handler: ts})
+	ts.task.Next = next
+	ts.task.Emitter.Emit(ts.task.LastEmitCtx, ev)
+}
+
+func (ts *TaskStateV2) Reset() {
+	ts.task.Next = nil
+}

--- a/op-node/opnv2/service/backend/controller/mixin_backoff.go
+++ b/op-node/opnv2/service/backend/controller/mixin_backoff.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+)
+
+var defaultBackoff = &retry.ExponentialStrategy{
+	Min:       time.Second,
+	Max:       time.Second * 10,
+	MaxJitter: time.Second / 10,
+}
+
+type BackoffProvider interface {
+	ResetBackoff()
+	SetStrategy(strategy retry.Strategy)
+	DoBackoff(err error, now time.Time)
+	IsBackedOff(now time.Time) bool
+}
+
+type backoffState struct {
+	strategy retry.Strategy
+	attempt  int
+	lastErr  error
+	lastTime time.Time
+	nextTime time.Time
+}
+
+var _ BackoffProvider = (*backoffState)(nil)
+
+func (b *backoffState) ResetBackoff() {
+	b.attempt = 0
+	b.lastTime = time.Time{}
+	b.nextTime = time.Time{}
+	b.lastErr = nil
+}
+
+func (b *backoffState) SetStrategy(strategy retry.Strategy) {
+	b.strategy = strategy
+}
+
+func (b *backoffState) DoBackoff(err error, now time.Time) {
+	if b.strategy == nil {
+		b.strategy = defaultBackoff
+	}
+	b.lastErr = err
+	b.lastTime = now
+	wait := b.strategy.Duration(b.attempt)
+	b.nextTime = b.lastTime.Add(wait)
+	b.attempt += 1
+}
+
+func (b *backoffState) IsBackedOff(now time.Time) bool {
+	if b.attempt == 0 {
+		return false
+	}
+	return now.Before(b.nextTime)
+}
+
+func NotBackedOff[V BackoffProvider](now time.Time) Predicate[V] {
+	return func(v V) bool {
+		return v.IsBackedOff(now)
+	}
+}

--- a/op-node/opnv2/service/backend/controller/mixin_chain.go
+++ b/op-node/opnv2/service/backend/controller/mixin_chain.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type ChainIDProvider interface {
+	ChainID() eth.ChainID
+}
+
+type chainIDState struct {
+	chainID eth.ChainID
+}
+
+var _ ChainIDProvider = (*chainIDState)(nil)
+
+func (c *chainIDState) Init(id eth.ChainID) {
+	c.chainID = id
+}
+
+func (c *chainIDState) ChainID() eth.ChainID {
+	return c.chainID
+}
+
+func OfChain[V ChainIDProvider](chainID eth.ChainID) Predicate[V] {
+	return func(v V) bool {
+		return v.ChainID() == chainID
+	}
+}

--- a/op-node/opnv2/service/backend/controller/mixin_poll.go
+++ b/op-node/opnv2/service/backend/controller/mixin_poll.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"time"
+)
+
+type PollProvider interface {
+	NeedPoll(interval time.Duration, now time.Time) bool
+}
+
+type pollState struct {
+	forcePoll bool
+	lastPoll  time.Time
+}
+
+func (p *pollState) ForcePoll() {
+	p.forcePoll = true
+}
+
+func (p *pollState) RegisterPoll(now time.Time) {
+	p.lastPoll = now
+	p.forcePoll = false
+}
+
+func (p *pollState) NeedPoll(interval time.Duration, now time.Time) bool {
+	return p.forcePoll || p.lastPoll.Add(interval).Before(now)
+}
+
+var _ PollProvider = (*pollState)(nil)
+
+func NeedsPoll[V PollProvider](interval time.Duration, now time.Time) Predicate[V] {
+	return func(v V) bool {
+		return v.NeedPoll(interval, now)
+	}
+}

--- a/op-node/opnv2/service/backend/controller/request.go
+++ b/op-node/opnv2/service/backend/controller/request.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type requestContextKeyType struct{}
+
+var requestContextKey = requestContextKeyType{}
+
+func RequestFromContext(ctx context.Context) *Request {
+	v := ctx.Value(requestContextKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*Request)
+}
+
+func WithRequest(ctx context.Context, cond event.Matcher) (context.Context, *Request) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	req := &Request{
+		cond:   cond,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	return context.WithValue(ctx, requestContextKey, req), req
+}
+
+type Request struct {
+	// cond is the completion condition: when we have seen this event the request is done.
+	// The condition is only checked for events that have this request attached to them.
+	// All responses have the contexts (or wrappers of) the context of the request.
+	// This is set to nil when the condition is met.
+	cond event.Matcher
+
+	// ctx for the duration of the request
+	ctx context.Context
+
+	// cancel is called when the condition completes
+	cancel context.CancelCauseFunc
+}

--- a/op-node/opnv2/service/backend/controller/state.go
+++ b/op-node/opnv2/service/backend/controller/state.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"iter"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type ClockState interface {
+	Now() time.Time
+}
+
+type State interface {
+	ClockState
+
+	IterPipelines(predicates ...Predicate[*PipelineState]) iter.Seq[*PipelineState]
+
+	IterDBs(predicates ...Predicate[*ChainDBState]) iter.Seq[*ChainDBState]
+	ChainDB(chainID eth.ChainID) (state *ChainDBState, ok bool)
+
+	IterRWELs(predicates ...Predicate[*RWELState]) iter.Seq[*RWELState]
+
+	IterRELs(predicates ...Predicate[*RELState]) iter.Seq[*RELState]
+
+	IterRunCfgs(predicates ...Predicate[*RunCfgState]) iter.Seq[*RunCfgState]
+
+	Payloads(chainID eth.ChainID) (state *PayloadsState, ok bool)
+
+	L1State() *L1AccessState
+}

--- a/op-node/opnv2/service/backend/controller/state_db.go
+++ b/op-node/opnv2/service/backend/controller/state_db.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type ChainDBState struct {
+	state State
+
+	rootCtx context.Context
+
+	localUnsafe types.BlockSeal
+	crossUnsafe types.BlockSeal
+	localSafe   types.DerivedBlockSealPair
+	crossSafe   types.DerivedBlockSealPair
+	finalized   types.DerivedBlockSealPair
+
+	// non-zero whenever we have an invalidated local-safe block to replace
+	invalidated types.DerivedBlockRefPair
+	// non-nil whenever we have invalidated something,
+	// and are ready to build the replacement block.
+	replacementAttributes *derive.AttributesWithParent
+	// non-nil once done attributes are converted
+	replacementComplete *types.BlockReplacement
+
+	Replacement TaskStateV2
+
+	FinalizeWork TaskStateV2
+
+	crossUnsafeWork struct {
+		TaskStateV2
+		backoffState
+	}
+	crossSafeWork struct {
+		TaskStateV2
+		backoffState
+	}
+
+	chainIndexingWork struct {
+		TaskStateV2
+		backoffState
+		// old chain indexing code does not bounce back events with same context, so we can't model tasks
+	}
+
+	chainIDState
+}
+
+func NewChainDBState(rootCtx context.Context, emitter event.Emitter, chainID eth.ChainID) *ChainDBState {
+	out := new(ChainDBState)
+	// TODO
+	return out
+}

--- a/op-node/opnv2/service/backend/controller/state_l1access.go
+++ b/op-node/opnv2/service/backend/controller/state_l1access.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type L1AccessState struct {
+	state ClockState
+
+	rootCtx context.Context
+
+	// latestL1 is the latest L1 block, ignoring the conf-depth.
+	// This may be zero if not known yet.
+	latestL1 eth.BlockRef
+
+	// confirmedL1 is the latest L1 block that has passed the conf-depth, or is finalized.
+	// This may be zero if not known yet, or if temporarily failing to confirm.
+	confirmedL1 eth.BlockRef
+
+	// finalizedL1 is the finalized L1 block.
+	// This may be zero if not known yet.
+	finalizedL1 eth.BlockRef
+
+	pollL1FinalizedTask TaskStateV2
+	finalizedPoll       pollState
+
+	pollL1LatestTask TaskStateV2
+	pollL1LatestPoll pollState
+
+	// TODO backoff on last known err
+}
+
+func NewL1AccessState(rootCtx context.Context, emitter event.Emitter) *L1AccessState {
+	out := new(L1AccessState)
+	out.rootCtx = rootCtx
+	out.pollL1LatestTask.Init(emitter, out.maybePollL1Latest)
+	out.pollL1FinalizedTask.Init(emitter, out.maybePollFinalized)
+	return out
+}

--- a/op-node/opnv2/service/backend/controller/state_payloads.go
+++ b/op-node/opnv2/service/backend/controller/state_payloads.go
@@ -1,0 +1,22 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type PayloadsState struct {
+	min   eth.BlockID
+	max   eth.BlockID
+	count uint64
+
+	chainIDState
+}
+
+func NewPayloadsState(rootCtx context.Context, emitter event.Emitter, chainID eth.ChainID) *PayloadsState {
+	out := new(PayloadsState)
+	// TODO
+	return out
+}

--- a/op-node/opnv2/service/backend/controller/state_pipeline.go
+++ b/op-node/opnv2/service/backend/controller/state_pipeline.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/derive2"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1access"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type PipelineState struct {
+	state State
+
+	id derive2.ID
+
+	rootCtx context.Context
+
+	lastL1Source  eth.BlockRef // if this is zero, a reset is needed
+	lastLocalSafe eth.L2BlockRef
+
+	attributes *derive.AttributesWithParent
+	envelope   *eth.ExecutionPayloadEnvelope
+	confirming eth.L2BlockRef
+
+	// non-nil when attributes were confirmed, this will become the next local-safe
+	nextL1Source eth.BlockRef // may be zero if not set
+
+	more bool // true if we know there is more derivation processing left
+
+	l1Backoff  backoffState // when we encounter a L1 error
+	engBackoff backoffState // when we encounter an engine related error
+
+	deriveTask TaskStateV2
+	nextL1Task TaskStateV2
+
+	chainIDState
+}
+
+func NewPipelineState(rootCtx context.Context, emitter event.Emitter, chainID eth.ChainID, id derive2.ID) *PipelineState {
+	//rootCtx = derive2.WithID(rootCtx, id)
+	out := new(PipelineState)
+	// TODO
+	return out
+}
+
+func (s *PipelineState) ID() derive2.ID {
+	return s.id
+}
+
+func (s *PipelineState) onUpdate(ev event.Event, now time.Time) {
+	switch x := ev.(type) {
+	case derive.DeriverMoreEvent:
+		s.more = true
+	case derive.DerivedAttributesEvent:
+		s.lastLocalSafe = x.Attributes.Parent
+		s.lastL1Source = x.Attributes.DerivedFrom
+		s.more = true
+		s.attributes = x.Attributes
+		if s.nextL1Source.ParentHash != s.lastL1Source.Hash {
+			s.nextL1Source = eth.BlockRef{}
+		}
+	case derive.ExhaustedL1Event:
+		s.nextL1Source = eth.BlockRef{}
+		s.lastL1Source = x.L1Ref
+		s.lastLocalSafe = x.LastL2
+		s.more = false
+	case rollup.ResetEvent:
+		*s = PipelineState{more: true}
+		s.engBackoff.DoBackoff(x.Err, now)
+	case rollup.L1TemporaryErrorEvent:
+		s.more = true
+		s.l1Backoff.DoBackoff(x.Err, now)
+	case rollup.EngineTemporaryErrorEvent:
+		s.more = true
+		s.engBackoff.DoBackoff(x.Err, now)
+	case l1access.RetrievedL1BlockEvent:
+		s.nextL1Source = x.Ref
+	case l1access.TemporaryL1AccessErrorEvent:
+		s.l1Backoff.DoBackoff(x.Err, now)
+	}
+}

--- a/op-node/opnv2/service/backend/controller/state_rel.go
+++ b/op-node/opnv2/service/backend/controller/state_rel.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rel"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type RELIDProvider interface {
+	ID() rel.ID
+}
+
+type RELState struct {
+	id rel.ID
+
+	// local-safe and cross-unsafe are not
+	// available or applicable from read-only endpoints
+
+	localUnsafe eth.L2BlockRef
+	crossSafe   eth.L2BlockRef
+	finalized   eth.L2BlockRef
+
+	// TODO backoff on last known err
+
+	chainIDState
+	pollState
+}
+
+func (s *RELState) ID() rel.ID {
+	return s.id
+}
+
+func (s *RELState) onUpdate(ev event.Event) {
+	switch x := ev.(type) {
+	case rel.LocalUnsafeUpdateEvent:
+		s.localUnsafe = x.LocalUnsafe
+	case rel.CrossSafeUpdateEvent:
+		s.crossSafe = x.CrossSafe
+	case rel.FinalizedUpdateEvent:
+		s.finalized = x.Finalized
+	case rollup.EngineTemporaryErrorEvent:
+		// TODO backoff
+	}
+}

--- a/op-node/opnv2/service/backend/controller/state_runcfg.go
+++ b/op-node/opnv2/service/backend/controller/state_runcfg.go
@@ -1,0 +1,22 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type RunCfgState struct {
+	state   State
+	rootCtx context.Context
+	chainIDState
+	pollState
+	backoffState
+	TaskStateV2
+}
+
+func NewRunCfgState(rootCtx context.Context, emitter event.Emitter, chainID eth.ChainID) *RunCfgState {
+	out := new(RunCfgState)
+	return out
+}

--- a/op-node/opnv2/service/backend/controller/state_rwel.go
+++ b/op-node/opnv2/service/backend/controller/state_rwel.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/payloads"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type RWELIDProvider interface {
+	ID() rwel.ID
+}
+
+type RWELState struct {
+	state State
+
+	id rwel.ID
+
+	rootCtx context.Context
+
+	// cross-unsafe is not available or applicable on read-write engines.
+
+	localUnsafe eth.BlockRef
+	crossSafe   eth.BlockRef
+	finalized   eth.BlockRef
+
+	crossSafeBackoff backoffState
+	finalizedBackoff backoffState
+
+	syncing    bool
+	syncTarget eth.BlockID
+
+	// next payload to process
+	next        *eth.ExecutionPayloadEnvelope
+	nextBackoff backoffState
+
+	// global, for any engine error
+	backoffState
+
+	Forkchoice TaskStateV2
+	ELSync     TaskStateV2
+
+	PollLocalUnsafe TaskStateV2
+	PollCrossSafe   TaskStateV2
+	PollFinalized   TaskStateV2
+
+	IncomingBlock        TaskStateV2
+	AttributesProcessing TaskStateV2
+
+	L1Sync TaskStateV2
+
+	chainIDState
+
+	pollState
+}
+
+func NewRWELState(rootCtx context.Context, emitter event.Emitter, chainID eth.ChainID, id rwel.ID) *RWELState {
+	//rootCtx = rwel.WithID(rootCtx, id)
+	out := new(RWELState)
+	// TODO
+	return out
+}
+
+func (s *RWELState) ID() rwel.ID {
+	return s.id
+}
+
+func (s *RWELState) onUpdate(ev event.Event, now time.Time) {
+	switch x := ev.(type) {
+	case rwel.LocalUnsafeUpdateEvent:
+		s.localUnsafe = x.Ref
+	case rwel.CrossSafeUpdateEvent:
+		s.crossSafe = x.CrossSafe
+	case rwel.FinalizedUpdateEvent:
+		s.finalized = x.Ref
+	case rwel.ForkchoiceUpdateEvent:
+		s.localUnsafe = x.LocalUnsafe
+		s.crossSafe = x.CrossSafe
+		s.finalized = x.Finalized
+	case rwel.SyncingUpdateEvent:
+		s.syncing = true
+		s.syncTarget = x.SyncTarget
+	case rwel.NoSyncingEvent:
+		s.syncing = false
+		s.syncTarget = eth.BlockID{}
+	case rollup.EngineTemporaryErrorEvent:
+		s.crossSafeBackoff.DoBackoff(x.Err, now)
+		s.finalizedBackoff.DoBackoff(x.Err, now)
+
+	case rwel.InvalidPayloadAttributesEvent:
+		// TODO
+	case rwel.PayloadSealInvalidEvent:
+		// TODO
+	case rwel.PayloadInvalidEvent:
+		s.nextBackoff.DoBackoff(x.Err, now)
+		s.next = nil
+	case payloads.PayloadResponseEvent:
+		s.next = x.Envelope
+	}
+}
+
+func LatestAtLeast(num uint64) Predicate[*RWELState] {
+	return func(v *RWELState) bool {
+		return v.localUnsafe.Number > num
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_db_cross_update.go
+++ b/op-node/opnv2/service/backend/controller/task_db_cross_update.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+)
+
+func (v *ChainDBState) maybeCrossSafeUpdate() {
+	if v.crossSafeWork.IsBusy() {
+		return
+	}
+	now := v.state.Now()
+	if !v.crossSafeWork.IsBackedOff(now) {
+		v.crossSafeWork.Emit(v.rootCtx, superevents.UpdateCrossSafeRequestEvent{
+			ChainID: v.ChainID(),
+		}, v.awaitCrossSafeUpdate)
+	}
+}
+
+func (v *ChainDBState) awaitCrossSafeUpdate(ctx context.Context, ev event.Event) {
+	// TODO handle error/success case
+}
+
+func (v *ChainDBState) maybeCrossUnsafeUpdate() {
+	if v.crossUnsafeWork.IsBusy() {
+		return
+	}
+	now := v.state.Now()
+	if !v.crossUnsafeWork.IsBackedOff(now) {
+		v.crossUnsafeWork.Emit(v.rootCtx, superevents.UpdateCrossUnsafeRequestEvent{
+			ChainID: v.ChainID(),
+		}, v.awaitCrossUnsafeUpdate)
+	}
+}
+
+func (v *ChainDBState) awaitCrossUnsafeUpdate(ctx context.Context, ev event.Event) {
+	// TODO handle error/success case
+}

--- a/op-node/opnv2/service/backend/controller/task_db_finalize.go
+++ b/op-node/opnv2/service/backend/controller/task_db_finalize.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func (s *ChainDBState) maybeDBFinalize() {
+	if !s.FinalizeWork.IsBusy() {
+		return
+	}
+	l1State := s.state.L1State()
+	// if L1 finality changed, then apply to DB finalized heads
+	if l1State.finalizedL1 != (eth.BlockRef{}) {
+		// TODO track L1 finality changes so we don't repeat
+		return
+	}
+	if s.crossSafe == (types.DerivedBlockSealPair{}) {
+		return // nothing to finalize
+	}
+	// TODO check for error backoff
+
+	// If we have a cross-safe block that is derived
+	// from a L1 block that is finalized,
+	// then let's signal the finalized L1 again to the DB
+	if s.crossSafe.Source.Number >= l1State.finalizedL1.Number &&
+		s.finalized.Source.ID() != l1State.finalizedL1.ID() {
+		s.FinalizeWork.Emit(s.rootCtx, superevents.FinalizedL1RequestEvent{
+			FinalizedL1: l1State.finalizedL1}, s.awaitFinalized)
+	}
+}
+
+func (s *ChainDBState) awaitFinalized(ctx context.Context, ev event.Event) {
+	// TODO handle success/error
+}

--- a/op-node/opnv2/service/backend/controller/task_db_init.go
+++ b/op-node/opnv2/service/backend/controller/task_db_init.go
@@ -1,0 +1,23 @@
+package controller
+
+func (s *ChainDBState) maybeDBInit() {
+
+	// emit superevents.UnsafeActivationBlockEvent when we have an unsafe block that holds as exact activation block
+	// emit superevents.SafeActivationBlockEvent when we have a local-safe block that holds as exact activation block
+
+	// TODO: the controller should ideally not deal with chain configs
+
+	// TODO: somewhere we need to init the DB, if we are not bootstrapping from a different point than genesis
+	//genesis := b.cfgSet.Genesis(chainID)
+	//if b.cfgSet.IsInterop(chainID, genesis.L2.Timestamp) { // This genesis check is old
+	//	b.emitter.Emit(superevents.SafeActivationBlockEvent{
+	//		ChainID: chainID,
+	//		Safe: types.DerivedBlockRefPair{
+	//			// Initialization skips parent checks, so zero parents are ok.
+	//			Source:  genesis.L1.WithZeroParent(),
+	//			Derived: genesis.L2.WithZeroParent(),
+	//		},
+	//		Ctx: event.WrapCtx(b.sysContext),
+	//	})
+	//}
+}

--- a/op-node/opnv2/service/backend/controller/task_db_l1_origin.go
+++ b/op-node/opnv2/service/backend/controller/task_db_l1_origin.go
@@ -1,0 +1,11 @@
+package controller
+
+func (s *ChainDBState) maybeCheckL1Origin() {
+	// If L1 changed, then compare L1 accessor head to the DB | REL | RWEL L1Origin
+	//
+	// for any DB | REL | RWEL, if local-unsafe head does not have validated L1 origin in the last 60 seconds, then validate it.
+	//   if it does not match we need to reorg away, and not use the REL|RWEL until reorged, or until revalidated.
+	//   if it is the DB, then we need to rewind it
+
+	// TODO
+}

--- a/op-node/opnv2/service/backend/controller/task_db_l1_source.go
+++ b/op-node/opnv2/service/backend/controller/task_db_l1_source.go
@@ -1,0 +1,10 @@
+package controller
+
+// L1 source-block checks: ensure that the local-safe DBs and cross-safe DBs are following the canonical L1 chain.
+func (s *ChainDBState) maybeCheckL1Source() {
+	// TODO: compare L1access and DB source, to force a check, if needed immediately
+
+	// If L1 changed, then compare L1 accessor head to the local/cross-safe DB L1 source block
+
+	// TODO trigger l1rewind.L1RewindCheckEvent{}
+}

--- a/op-node/opnv2/service/backend/controller/task_db_replace_block.go
+++ b/op-node/opnv2/service/backend/controller/task_db_replace_block.go
@@ -1,0 +1,75 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func (v *ChainDBState) maybeReplaceBlock() {
+	if v.Replacement.IsBusy() {
+		return
+	}
+	if v.invalidated == (types.DerivedBlockRefPair{}) {
+		return
+	}
+
+	r, ok := First[*RWELState](v.state.IterRWELs(
+		LatestAtLeast(v.invalidated.Derived.Number)))
+	if !ok {
+		// TODO try consolidate invalidation with REL nodes instead
+		return
+	}
+
+	// TODO: some engines might already have replaced it.
+	// If they already have, we can send back an event to skip the re-processing.
+
+	ctx := rwel.WithID(v.rootCtx, r.ID())
+	v.Replacement.Emit(ctx,
+		rwel.InvalidateBlockRequestEvent{
+			Invalidated: types.BlockSealFromRef(v.invalidated.Derived),
+		}, v.awaitReplacementAttributes)
+}
+
+func (v *ChainDBState) awaitReplacementAttributes(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.BuildReplacementBlockEvent:
+		v.replacementComplete = &types.BlockReplacement{
+			Invalidated: x.Invalidated.Hash,
+		}
+		// find an RWEL to process the replacement for us
+		r, ok := First(v.state.IterRWELs(LatestAtLeast(
+			v.replacementAttributes.Parent.Number)))
+		if ok {
+			// TODO lock the RWEL also
+			ctx = rwel.WithID(ctx, r.ID())
+			v.Replacement.Emit(ctx, rwel.BuildStartEvent{
+				Attributes: v.replacementAttributes,
+			}, v.awaitReplacementBuilt)
+			return
+		}
+	}
+}
+
+func (v *ChainDBState) awaitReplacementBuilt(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.PayloadSuccessEvent:
+		v.replacementComplete.Replacement = x.Envelope.BlockRef()
+		v.Replacement.Emit(ctx, rwel.PromoteLocalUnsafeEvent{
+			Ref: x.Envelope.BlockRef(),
+		}, v.awaitReplacementCanonical)
+	}
+}
+
+func (v *ChainDBState) awaitReplacementCanonical(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.LocalUnsafeUpdateEvent:
+		_ = x
+		v.Replacement.Emit(ctx, superevents.ReplaceBlockEvent{
+			Replacement: *v.replacementComplete,
+		}, nil)
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_derive_attributes.go
+++ b/op-node/opnv2/service/backend/controller/task_derive_attributes.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/derive2"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+// If there is more data to turn into block attributes, do it
+func (c *PipelineState) maybeDerive() {
+	if c.deriveTask.IsBusy() {
+		return
+	}
+	if !c.more {
+		return
+	}
+	if c.attributes != nil {
+		return // need to not be processing attributes already
+	}
+	if c.lastLocalSafe == (eth.L2BlockRef{}) {
+		return // need a starting point for derivation work
+	}
+	c.deriveTask.Emit(c.rootCtx, derive2.StepRequestEvent{}, c.awaitDerivedAttributes)
+}
+
+func (c *PipelineState) awaitDerivedAttributes(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case derive.DeriverMoreEvent:
+		c.more = true
+	case derive.DerivedAttributesEvent:
+		c.attributes = x.Attributes
+		c.deriveTask.Reset()
+	case derive.ExhaustedL1Event:
+		// do not reset nextL1, we may already have prefetched it
+		c.more = false
+	case rollup.L1TemporaryErrorEvent:
+		// TODO L1 backoff
+	case rollup.EngineTemporaryErrorEvent:
+		// TODO L2 backoff
+	default:
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_derive_confirm.go
+++ b/op-node/opnv2/service/backend/controller/task_derive_confirm.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/derive2"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// Complete derivation of pipelines with attributes
+func (c *PipelineState) maybeProcessAttributes() {
+	if c.deriveTask.IsBusy() {
+		return
+	}
+	// check if it has ready attribs ready
+	if c.attributes == nil {
+		return
+	}
+
+	// Plan A: If there is a RWEL that can process the block, do that.
+	if r, ok := First[*RWELState](c.state.IterRWELs(func(el *RWELState) bool {
+		return c.attributes.Parent.Number == el.localUnsafe.Number
+	})); ok {
+		// process it
+		ctx := rwel.WithID(c.rootCtx, r.ID())
+		c.deriveTask.Emit(ctx, rwel.BuildStartEvent{
+			Attributes: c.attributes,
+		}, c.awaitBuildStarted)
+		return
+	}
+
+	// Plan B: If there is a RWEL that can consolidate the block, do that.
+	if r, ok := First[*RWELState](c.state.IterRWELs(func(el *RWELState) bool {
+		return c.attributes.Parent.Number < el.localUnsafe.Number
+	})); ok {
+		// try to consolidate it
+		// (if parent does not match, we'll get a temporary error back)
+		ctx := rwel.WithID(c.rootCtx, r.ID())
+		c.deriveTask.Emit(ctx, rwel.TryConsolidateAttributesEvent{
+			Attributes: c.attributes,
+		}, c.awaitConsolidate)
+	}
+
+	// Plan C: If there is a REL that consolidate the block, do that.
+	// TODO
+}
+
+func (c *PipelineState) awaitConsolidate(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.ConfirmConsolidateAttributesEvent:
+		c.confirming = x.Ref
+		c.deriveTask.Emit(ctx, derive2.ConfirmAttributesEvent{
+			Confirmed: x.Ref,
+		}, c.awaitConfirmed)
+	case rwel.FailConsolidateAttributesEvent:
+		// TODO
+	case rollup.EngineTemporaryErrorEvent:
+		// TODO
+	}
+}
+
+func (c *PipelineState) awaitBuildStarted(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.BuildStartedEvent:
+		c.deriveTask.Emit(ctx, rwel.BuildSealEvent{
+			Info:         x.Info,
+			BuildStarted: x.BuildStarted,
+			DerivedFrom:  x.DerivedFrom,
+		}, c.awaitBuildSealed)
+	case rwel.BuildInvalidEvent:
+
+	}
+}
+func (c *PipelineState) awaitBuildSealed(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.BuildSealedEvent:
+		c.confirming = x.Ref
+		c.deriveTask.Emit(ctx, rwel.PayloadProcessEvent{
+			DerivedFrom:  x.DerivedFrom,
+			BuildStarted: x.BuildStarted,
+			Envelope:     x.Envelope,
+		}, c.awaitProcessed)
+	case rwel.PayloadSealInvalidEvent:
+	}
+}
+
+func (c *PipelineState) awaitProcessed(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.PayloadSuccessEvent:
+		c.envelope = x.Envelope
+		// TODO: maybe also fork to publish a block
+		c.deriveTask.Emit(ctx, rwel.PromoteLocalUnsafeEvent{
+			Ref: x.Envelope.BlockRef(),
+		}, c.awaitCanonical)
+	case rwel.PayloadInvalidEvent:
+	}
+}
+
+func (c *PipelineState) awaitCanonical(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.LocalUnsafeUpdateEvent:
+		if c.confirming.Hash != x.Ref.Hash {
+			panic("unexpected block update")
+		}
+		c.deriveTask.Emit(ctx, derive2.ConfirmAttributesEvent{
+			Confirmed: c.confirming,
+		}, c.awaitConfirmed)
+	}
+}
+
+// If attribs were confirmed, then update the local-safe pre-state
+func (c *PipelineState) awaitConfirmed(ctx context.Context, ev event.Event) {
+	switch ev.(type) {
+	case derive.DeriverMoreEvent:
+		id := rwel.IDFromContext(ctx)
+		c.deriveTask.Emit(ctx, superevents.LocalDerivedEvent{
+			ChainID: c.chainID,
+			Derived: types.DerivedBlockRefPair{
+				Source:  c.lastL1Source,
+				Derived: c.confirming.BlockRef(),
+			},
+			NodeID: id.String(),
+		}, c.awaitStored)
+	}
+}
+
+func (c *PipelineState) awaitStored(ctx context.Context, ev event.Event) {
+	switch ev.(type) {
+	case Err:
+		// TODO: if DB does not match
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_derive_nextL1.go
+++ b/op-node/opnv2/service/backend/controller/task_derive_nextL1.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1access"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+// if next L1 source block is needed, then make l1access provide that next L1 block
+func (c *PipelineState) maybePrepareNextL1() {
+	if c.lastL1Source == (eth.BlockRef{}) {
+		return
+	}
+	if c.nextL1Source != (eth.BlockRef{}) {
+		return
+	}
+	c.nextL1Task.Emit(c.rootCtx, l1access.ByNumberL1RequestEvent{
+		Num: c.lastL1Source.Number + 1,
+	}, c.awaitNextL1)
+}
+
+func (c *PipelineState) awaitNextL1(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case l1access.RetrievedL1BlockEvent:
+		c.nextL1Source = x.Ref
+		c.nextL1Task.Reset()
+	case Err:
+
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_l1_poll_finalized.go
+++ b/op-node/opnv2/service/backend/controller/task_l1_poll_finalized.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1access"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+const l1FinalizedPollDuration = time.Second * 60
+
+func (c *L1AccessState) maybePollFinalized() {
+	c.pollL1FinalizedTask.AssertNotBusy()
+	now := c.state.Now()
+	if c.finalizedPoll.NeedPoll(l1FinalizedPollDuration, now) {
+		c.finalizedPoll.RegisterPoll(now)
+		c.pollL1FinalizedTask.Emit(c.rootCtx, l1access.FinalizedL1RequestEvent{}, c.awaitL1Finalized)
+	}
+}
+
+func (c *L1AccessState) awaitL1Finalized(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case l1access.FinalizedL1UpdateEvent:
+		c.finalizedL1 = x.FinalizedL1
+		c.pollL1FinalizedTask.Reset()
+	case Err:
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_l1_poll_latest.go
+++ b/op-node/opnv2/service/backend/controller/task_l1_poll_latest.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/l1access"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+const l1LatestPollDuration = time.Second * 12
+
+func (c *L1AccessState) maybePollL1Latest() {
+	c.pollL1LatestTask.AssertNotBusy()
+	now := c.state.Now()
+	if c.pollL1LatestPoll.NeedPoll(l1LatestPollDuration, now) {
+		c.pollL1LatestPoll.RegisterPoll(now)
+		c.pollL1LatestTask.Emit(c.rootCtx, l1access.LatestL1RequestEvent{}, c.awaitL1Latest)
+	}
+}
+
+func (c *L1AccessState) awaitL1Latest(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case l1access.LatestL1UpdateEvent:
+		c.latestL1 = x.LatestL1
+		c.pollL1LatestTask.Reset()
+	case Err:
+
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_runcfg_update.go
+++ b/op-node/opnv2/service/backend/controller/task_runcfg_update.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/runcfg2"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+const runConfigPollInterval = time.Second * 60
+
+func (s *RunCfgState) maybeUpdate() {
+	if s.IsBusy() {
+		return
+	}
+	now := s.state.Now()
+	if !s.NeedPoll(runConfigPollInterval, now) {
+		return
+	}
+	// TODO backoff
+	l1Block := s.state.L1State().confirmedL1.ID()
+	if l1Block == (eth.BlockID{}) {
+		return
+	}
+	// TODO register poll attempt
+
+	s.Emit(s.rootCtx, runcfg2.RunCfgUpdateRequestEvent{L1Block: l1Block}, nil)
+
+	// TODO: on the latest L1 blocks, the receipts cache is warm,
+	//  and we can parse the receipts to get the run-config updates,
+	//  without overwhelming the L1 with state-reads or only doing the less frequent polling.
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_backup_sync.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_backup_sync.go
@@ -1,0 +1,6 @@
+package controller
+
+func (s *RWELState) maybeBackupSync() {
+	// for any RWEL, if same-chain REL local-unsafe > RWEL local-unsafe, then try copy the block over
+	// TODO: nice-to-have, until we have REL support
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_el_sync.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_el_sync.go
@@ -1,0 +1,24 @@
+package controller
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+)
+
+func (s *RWELState) maybeELSync() {
+	if s.ELSync.IsBusy() {
+		return
+	}
+	db, ok := s.state.ChainDB(s.ChainID())
+	if !ok {
+		return
+	}
+	// for any RWEL, if DB local-unsafe head > RWEL, then trigger RWEL to try to sync
+	if db.localUnsafe.Number > s.localUnsafe.Number {
+		// If syncing, and the sync target is beyond the DB, then keep that target
+		if s.syncing && s.syncTarget.Number > db.localUnsafe.Number {
+			return
+		}
+		// If not syncing, or targeting something older/nothing, then update the target.
+		s.ELSync.Emit(s.rootCtx, rwel.TriggerSyncEvent{Target: db.localUnsafe.ID()}, nil)
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_index.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_index.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+)
+
+func (s *RWELState) maybeIndex() {
+	db, ok := s.state.ChainDB(s.ChainID())
+	if !ok {
+		return
+	}
+	if db.chainIndexingWork.IsBusy() {
+		return
+	}
+	if s.localUnsafe == (eth.BlockRef{}) {
+		return // nothing to index yet
+	}
+	if s.syncing {
+		return // should not pull data that is incomplete
+	}
+
+	// For any RWEL|REL, if DB local-unsafe head < RWEL|REL, then index it into DB.
+	// Don't try to index data from an EL node that is actively doing EL sync.
+
+	now := s.state.Now()
+	if db.localUnsafe.Number < s.localUnsafe.Number &&
+		!db.chainIndexingWork.IsBackedOff(now) {
+		// Let's make the chain processor run.
+		// No tasks possible because of old assumptions in chain indexer.
+		db.chainIndexingWork.DoBackoff(errors.New("legacy indexing"), now)
+		db.chainIndexingWork.Emit(s.rootCtx, superevents.ChainProcessEvent{
+			ChainID: db.chainID,
+		}, nil)
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_l1catchup.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_l1catchup.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// Make the engine sync from L1.
+// To sync, it will first need a reference point from the DB, to start syncing from.
+// The DB is the only source of truth of which L2 block is derived from which L1 block.
+// If the DB does not have this data anymore, then we prefer to fall back to other sync methods.
+// If the other sync methods don't work,
+// we can attempt to find a sync starting point using legacy methods ("find sync start and channel walk back").
+func (c *RWELState) maybeSyncFromL1() {
+	db, ok := c.state.ChainDB(c.ChainID())
+	if !ok {
+		return
+	}
+
+	// If we're at or past the DB local-safe point already,
+	// then we will sync new blocks naturally as part of the DB local-safe derivation progress.
+	if c.localUnsafe.Number >= db.localSafe.Derived.Number {
+		return
+	}
+
+	// Ask the DB for a sync starting point.
+	c.L1Sync.Emit(c.rootCtx, FindDerivationStartEvent{}, c.awaitFoundDerivationStart)
+
+	// Syncing RWEL directly from L1:
+	// for any RWEL, if RWEL local-unsafe == RWEL local-safe, and within L1-syncing-distance,
+	//   then we can derive attribs for it, to sync from L1.
+}
+
+func (c *RWELState) awaitFoundDerivationStart(ctx context.Context, ev event.Event) {
+	switch ev.(type) {
+	case FoundDerivationStartEvent:
+		break
+	case Err:
+		// abort
+		c.L1Sync.Reset()
+		return
+	}
+
+	// Find a pipeline that is not busy
+	p, ok := First[*PipelineState](c.state.IterPipelines(func(state *PipelineState) bool {
+		return !state.deriveTask.IsBusy()
+	}))
+	if !ok {
+		// TODO If no pipeline is available for syncing, then backoff.
+		c.L1Sync.Reset()
+		return
+	}
+
+	// TODO reset the pipeline to the engine starting point
+	_ = p
+}
+
+type FindDerivationStartEvent struct {
+	LastL2 eth.BlockID
+}
+
+func (ev FindDerivationStartEvent) String() string {
+	return "find-derivation-start"
+}
+
+type FoundDerivationStartEvent struct {
+	Start types.DerivedBlockSealPair
+}
+
+func (ev FoundDerivationStartEvent) String() string {
+	return "found-derivation-start"
+}
+
+// TODO: above events need to be hooked up to the local-safe DB,
+// to find a derived-from source of an L2 block.

--- a/op-node/opnv2/service/backend/controller/task_rwel_newblock.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_newblock.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/payloads"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+func (v *RWELState) maybeNewBlock() {
+	if v.IncomingBlock.IsBusy() {
+		return
+	}
+
+	// If not, then try get a payload
+	pa, ok := v.state.Payloads(v.ChainID())
+	if !ok {
+		return
+	}
+	if v.localUnsafe.Number < pa.max.Number {
+		nextNum := v.localUnsafe.Number + 1
+		if v.syncing {
+			// If we are syncing, then instead get the next payload after the sync-target.
+			nextNum = v.syncTarget.Number + 1
+		}
+		v.IncomingBlock.Emit(v.rootCtx, payloads.PayloadRequestEvent{
+			ChainID: v.ChainID(),
+			Num:     nextNum,
+		}, v.awaitReceiveBlock)
+	}
+}
+
+func (v *RWELState) awaitReceiveBlock(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case payloads.PayloadResponseEvent:
+		v.IncomingBlock.Emit(ctx, rwel.PayloadProcessEvent{
+			DerivedFrom:  eth.L1BlockRef{},
+			BuildStarted: v.state.Now(),
+			Envelope:     x.Envelope,
+		}, v.awaitProcessBlock)
+	case Err:
+		// TODO log, backoff
+	}
+}
+
+func (v *RWELState) awaitProcessBlock(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.PayloadSuccessEvent:
+		v.IncomingBlock.Emit(ctx, rwel.PromoteLocalUnsafeEvent{
+			Ref: x.Envelope.BlockRef(),
+		}, v.awaitPromotedBlock)
+	case rwel.PayloadInvalidEvent:
+		// TODO
+	}
+}
+
+func (v *RWELState) awaitPromotedBlock(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.LocalUnsafeUpdateEvent:
+		v.localUnsafe = x.Ref
+	default:
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_poll_finalized.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_poll_finalized.go
@@ -1,0 +1,17 @@
+package controller
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func (c *RWELState) maybePollFinalized() {
+	if c.PollFinalized.IsBusy() {
+		return
+	}
+	if c.finalized != (eth.BlockRef{}) && !c.pollState.NeedPoll(enginePollDuration, c.state.Now()) {
+		return
+	}
+	c.pollState.RegisterPoll(c.state.Now())
+	c.PollFinalized.Emit(c.rootCtx, rwel.PollFinalizedRequestEvent{}, nil)
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_poll_safe.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_poll_safe.go
@@ -1,0 +1,17 @@
+package controller
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func (c *RWELState) maybePollCrossSafe() {
+	if c.PollCrossSafe.IsBusy() {
+		return
+	}
+	if c.crossSafe != (eth.BlockRef{}) && !c.pollState.NeedPoll(enginePollDuration, c.state.Now()) {
+		return
+	}
+	c.pollState.RegisterPoll(c.state.Now())
+	c.PollCrossSafe.Emit(c.rootCtx, rwel.PollLocalUnsafeRequestEvent{}, nil)
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_poll_unsafe.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_poll_unsafe.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+const enginePollDuration = time.Second * 30
+
+func (c *RWELState) maybePollLocalUnsafe() {
+	c.PollLocalUnsafe.AssertNotBusy()
+	if c.localUnsafe != (eth.BlockRef{}) && !c.pollState.NeedPoll(enginePollDuration, c.state.Now()) {
+		return
+	}
+	c.pollState.RegisterPoll(c.state.Now())
+	c.PollLocalUnsafe.Emit(c.rootCtx, rwel.PollLocalUnsafeRequestEvent{}, c.awaitPollLocalUnsafe)
+}
+
+func (c *RWELState) awaitPollLocalUnsafe(ctx context.Context, ev event.Event) {
+	switch x := ev.(type) {
+	case rwel.LocalUnsafeUpdateEvent:
+		c.localUnsafe = x.Ref
+	case Err:
+	}
+	c.PollLocalUnsafe.Reset()
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_promote_finalized.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_promote_finalized.go
@@ -1,0 +1,23 @@
+package controller
+
+import "github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+
+func (s *RWELState) maybePromoteFinalized() {
+	if s.Forkchoice.IsBusy() {
+		return
+	}
+	db, ok := s.state.ChainDB(s.ChainID())
+	if !ok {
+		return
+	}
+	if s.finalizedBackoff.IsBackedOff(s.state.Now()) {
+		return
+	}
+	if db.finalized.Derived.Number > s.finalized.Number &&
+		db.crossSafe.Derived.Number <= s.crossSafe.Number {
+		// If EL is on a different chain then this will error, and backoff finality work
+		s.Forkchoice.Emit(s.rootCtx, rwel.PromoteFinalizedEvent{
+			ID: db.finalized.Derived.ID()}, nil)
+		// TODO handle error
+	}
+}

--- a/op-node/opnv2/service/backend/controller/task_rwel_promote_safe.go
+++ b/op-node/opnv2/service/backend/controller/task_rwel_promote_safe.go
@@ -1,0 +1,23 @@
+package controller
+
+import "github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+
+func (c *RWELState) maybePromoteCrossSafe() {
+	if c.Forkchoice.IsBusy() {
+		return
+	}
+	db, ok := c.state.ChainDB(c.ChainID())
+	if !ok {
+		return
+	}
+	if c.crossSafeBackoff.IsBackedOff(c.state.Now()) {
+		return
+	}
+	if db.crossSafe.Derived.Number > c.crossSafe.Number &&
+		db.crossSafe.Derived.Number <= c.localUnsafe.Number {
+		// If EL is on a different chain then this will error, and backoff cross-safe work
+		c.Forkchoice.Emit(c.rootCtx, rwel.PromoteCrossSafeEvent{
+			ID: db.crossSafe.Derived.ID()}, nil)
+		// TODO: handle errors, backoff as needed
+	}
+}

--- a/op-node/opnv2/service/backend/controller/util.go
+++ b/op-node/opnv2/service/backend/controller/util.go
@@ -1,0 +1,33 @@
+package controller
+
+import "iter"
+
+// Predicate is a function that returns true/false for a given value.
+type Predicate[V any] func(V) bool
+
+// Filter wraps the given sequence, and filters it with the given predicates.
+// The outer iterator will hide the inner iterated values that do not match the predicates.
+func Filter[V any](seq iter.Seq[V], predicates ...Predicate[V]) iter.Seq[V] {
+	return func(yield func(V) bool) {
+	mainLoop:
+		for v := range seq {
+			for _, predicate := range predicates {
+				if !predicate(v) {
+					continue mainLoop
+				}
+			}
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// First is like a single iter.Pull with close.
+// It returns the first entry of the sequence, if any.
+func First[V any](seq iter.Seq[V]) (v V, ok bool) {
+	for entry := range seq {
+		return entry, true
+	}
+	return
+}

--- a/op-node/opnv2/service/backend/derive2/id.go
+++ b/op-node/opnv2/service/backend/derive2/id.go
@@ -1,0 +1,37 @@
+package derive2
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+)
+
+const UnknownID ID = 0
+
+type ID uint64
+
+func (id ID) String() string {
+	return fmt.Sprintf("Pipeline-%d", uint64(id))
+}
+
+var idGen = new(atomic.Uint64)
+
+func NextID() ID {
+	return ID(idGen.Add(1))
+}
+
+type idContextKeyType struct{}
+
+var idContextKey = idContextKeyType{}
+
+func IDFromContext(ctx context.Context) ID {
+	v := ctx.Value(idContextKey)
+	if v == nil {
+		return UnknownID
+	}
+	return v.(ID)
+}
+
+func WithID(ctx context.Context, id ID) context.Context {
+	return context.WithValue(ctx, idContextKey, id)
+}

--- a/op-node/opnv2/service/backend/derive2/l1traversal.go
+++ b/op-node/opnv2/service/backend/derive2/l1traversal.go
@@ -1,0 +1,100 @@
+package derive2
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// L1Traversal implements the legacy L1 traversal derivation stage interface,
+// while cleaning up state.
+// It allows for the next L1 origin to be prepared at any point, so it can be prefetched later.
+type L1Traversal struct {
+	logger log.Logger
+	cfg    *rollup.Config
+
+	l1Fetcher derive.L1ReceiptsFetcher
+
+	// The L1 origin that the pipeline is already consuming.
+	// This is installed in every stage during reset.
+	// The data-retrieval stage will not ask for this anymore.
+	source eth.L1BlockRef
+	sysCfg eth.SystemConfig
+
+	// The next L1 origin after source. Not yet consumed.
+	// This is moved into source once the next block is requested.
+	// Or, if zero, the pipeline will temporarily stall, until the next L1 origin is made available.
+	next eth.L1BlockRef
+}
+
+var _ derive.NextBlockProvider = (*L1Traversal)(nil)
+var _ derive.ResettableStage = (*L1Traversal)(nil)
+
+func NewL1Traversal(logger log.Logger, cfg *rollup.Config, l1Fetcher derive.L1ReceiptsFetcher) *L1Traversal {
+	return &L1Traversal{logger: logger, cfg: cfg, l1Fetcher: l1Fetcher}
+}
+
+func (l *L1Traversal) Reset(ctx context.Context, base eth.L1BlockRef, baseCfg eth.SystemConfig) error {
+	l.source = base
+	l.sysCfg = baseCfg
+	l.next = eth.L1BlockRef{}
+	return nil
+}
+
+func (l *L1Traversal) NextL1Block(ctx context.Context) (eth.L1BlockRef, error) {
+	if l.next == (eth.L1BlockRef{}) {
+		// Next L1 block not found yet
+		return eth.L1BlockRef{}, io.EOF
+	}
+	// Parse L1 receipts of the given block and update the L1 system configuration
+	_, receipts, err := l.l1Fetcher.FetchReceipts(ctx, l.next.Hash)
+	if err != nil {
+		return eth.L1BlockRef{}, derive.NewTemporaryError(fmt.Errorf(
+			"failed to fetch receipts of L1 block %s (parent: %s) for L1 sysCfg update: %w",
+			l.next, l.next.ParentID(), err))
+	}
+	sysCfg := l.sysCfg
+	if err := derive.UpdateSystemConfigWithL1Receipts(&sysCfg, receipts, l.cfg, l.next.Time); err != nil {
+		// the sysCfg changes should always be formatted correctly.
+		return eth.L1BlockRef{}, derive.NewCriticalError(fmt.Errorf(
+			"failed to update L1 sysCfg with receipts from block %s: %w", l.next, err))
+	}
+	l.source = l.next
+	l.next = eth.L1BlockRef{}
+	return l.source, nil
+}
+
+func (l *L1Traversal) Origin() eth.L1BlockRef {
+	return l.source
+}
+
+func (l *L1Traversal) SystemConfig() eth.SystemConfig {
+	return l.sysCfg
+}
+
+func (l *L1Traversal) ProvideNext(l1Ref eth.L1BlockRef) {
+	if l.next != (eth.L1BlockRef{}) {
+		l.logger.Warn("Already have the next L1 origin", "have", l.next, "provided", l1Ref)
+		return
+	}
+	// Check parent hash.
+	// If it does not match, then the next derivation attempt can request the right thing to get instead.
+	if l.source.Hash != l.next.ParentHash {
+		l.logger.Warn("Unexpected next L1 block",
+			"current", l.source, "provided", l1Ref, "expected", l1Ref.ParentID())
+		return
+	}
+	l.next = l1Ref
+}
+
+// TraversalState identifies if the current and next block (could be zero if not prepared yet).
+// The caller should check if a reorg is needed to be able to provide a canonical next block.
+func (l *L1Traversal) TraversalState() (current, next eth.L1BlockRef) {
+	return l.source, l.next
+}

--- a/op-node/opnv2/service/backend/derive2/pipeline.go
+++ b/op-node/opnv2/service/backend/derive2/pipeline.go
@@ -1,0 +1,262 @@
+package derive2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type PipelineV2 struct {
+	log       log.Logger
+	rollupCfg *rollup.Config
+	l1Fetcher derive.L1Fetcher
+	l2        derive.L2Source
+
+	metrics derive.Metrics
+
+	attrib      *derive.AttributesQueue
+	l1Traversal *L1Traversal
+
+	// lastLocalSafe is the last confirmed local-safe block.
+	// This is always non-zero, unless a reset was started.
+	// This is a fully confirmed block; the attributes-stage
+	// may contain attributes that follow *just after* this block, or otherwise nil attributes.
+	lastLocalSafe eth.L2BlockRef
+
+	// Index of the stage that is currently being reset.
+	// >= len(stages) if no additional resetting is required
+	resetting int
+	stages    []derive.ResettableStage
+
+	// if resetL2Safe is zero, then the stages cannot be reset yet
+
+	// resetL2Safe is the parent L2 block to start building on top of
+	resetL2Safe eth.L2BlockRef
+	// resetL1Source is the source L1 block that the first relevant
+	// channel data may be retrieved from to create the next block
+	resetL1Source eth.L1BlockRef
+	// resetSysConfig is system-config info that may be used during the reset, based on the resetL2Safe
+	resetSysConfig eth.SystemConfig
+
+	id ID
+
+	// context for the lifetime of the pipeline, to anchor all requests onto
+	ctx context.Context
+
+	emitter event.Emitter
+}
+
+var _ event.AttachEmitter = (*PipelineV2)(nil)
+var _ event.Deriver = (*PipelineV2)(nil)
+
+// NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
+func NewDerivationPipeline(rootCtx context.Context, log log.Logger, rollupCfg *rollup.Config,
+	depSet derive.DependencySet, l1Fetcher derive.L1Fetcher, l1Blobs derive.L1BlobsFetcher,
+	altDA derive.AltDAInputFetcher, l2Source derive.L2Source, metrics derive.Metrics,
+) *PipelineV2 {
+	id := NextID()
+
+	spec := rollup.NewChainSpec(rollupCfg)
+	// Stages are strung together into a pipeline,
+	// results are pulled from the stage closed to the L2 engine, which pulls from the previous stage, and so on.
+	l1Traversal := NewL1Traversal(log, rollupCfg, l1Fetcher)
+	dataSrc := derive.NewDataSourceFactory(log, rollupCfg, l1Fetcher, l1Blobs, altDA) // auxiliary stage for L1Retrieval
+	l1Src := derive.NewL1Retrieval(log, dataSrc, l1Traversal)
+	frameQueue := derive.NewFrameQueue(log, rollupCfg, l1Src)
+	channelMux := derive.NewChannelAssembler(log, spec, frameQueue, metrics)
+	chInReader := derive.NewChannelInReader(rollupCfg, log, channelMux, metrics)
+	batchMux := derive.NewBatchStage(log, rollupCfg, chInReader, l2Source)
+	attrBuilder := derive.NewFetchingAttributesBuilder(rollupCfg, depSet, l1Fetcher, l2Source)
+	attributesQueue := derive.NewAttributesQueue(log, rollupCfg, attrBuilder, batchMux)
+
+	// Reset from ResetEngine then up from L1 Traversal. The stages do not talk to each other during
+	// the ResetEngine, but after the ResetEngine, this is the order in which the stages could talk to each other.
+	// Note: The ResetEngine is the only reset that can fail.
+	stages := []derive.ResettableStage{l1Traversal, l1Src, altDA, frameQueue, channelMux, chInReader, batchMux, attributesQueue}
+
+	return &PipelineV2{
+		log:         log,
+		rollupCfg:   rollupCfg,
+		l1Fetcher:   l1Fetcher,
+		resetting:   0,
+		stages:      stages,
+		metrics:     metrics,
+		l1Traversal: l1Traversal,
+		attrib:      attributesQueue,
+		l2:          l2Source,
+		id:          id,
+		ctx:         WithID(rootCtx, id),
+	}
+}
+
+func (dp *PipelineV2) ID() ID {
+	return dp.id
+}
+
+func (dp *PipelineV2) Reset() {
+	dp.resetting = 0
+	dp.resetSysConfig = eth.SystemConfig{}
+	dp.resetL2Safe = eth.L2BlockRef{}
+}
+
+// Step tries to progress the buffer.
+// An EOF is returned if the pipeline is blocked by waiting for new L1 data.
+// If ctx errors no error is returned, but the step may exit early in a state that can still be continued.
+// Any other error is critical and the derivation pipeline should be reset.
+// An error is expected when the underlying source closes.
+// When Step returns nil, it should be called again, to continue the derivation process.
+func (dp *PipelineV2) onStep(ctx context.Context, ev StepRequestEvent) {
+	dp.metrics.SetDerivationIdle(false)
+
+	// if any stages need to be reset, do that first.
+	if dp.resetting < len(dp.stages) {
+		// Different from legacy pipeline implementation:
+		// Wait for the outside to reset us accurately and set the dp.resetL2Safe.
+		// The step request may also just be stale.
+		if dp.resetL2Safe == (eth.L2BlockRef{}) {
+			dp.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: errors.New("not determined where to reset to yet"),
+			})
+			return
+		}
+
+		dp.log.Info("Rewinding derivation-pipeline L1 traversal to handle reset")
+
+		dp.metrics.RecordPipelineReset()
+
+		sysCfg, err := dp.l2.SystemConfigByL2Hash(dp.ctx, dp.resetL2Safe.Hash)
+		if err != nil {
+			dp.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("failed to fetch L1 config of L2 block %s: %w", dp.resetL2Safe.ID(), err),
+			})
+			return
+		}
+		dp.resetSysConfig = sysCfg
+
+		if err := dp.stages[dp.resetting].Reset(dp.ctx, dp.resetL1Source, dp.resetSysConfig); err == io.EOF {
+			dp.log.Debug("reset of stage completed", "stage", dp.resetting)
+			dp.resetting += 1
+			return // TODO step request
+		} else if err != nil {
+			if errors.Is(err, derive.ErrReset) {
+				dp.emitter.Emit(ctx, rollup.ResetEvent{
+					Err: fmt.Errorf("reset during resetting: %w", err),
+				})
+				return
+			} else {
+				dp.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+					Err: fmt.Errorf("stage %d failed resetting: %w", dp.resetting, err),
+				})
+			}
+		}
+		// resetting will need to complete (iteratively) before continuing with derivation
+		return
+	}
+
+	// Sanity-check we are post-Holocene.
+	// Pre-Holocene derivation rules are no longer supported
+	if !dp.rollupCfg.IsHolocene(dp.lastLocalSafe.Time) {
+		dp.emitter.Emit(ctx, rollup.ResetEvent{
+			Err: fmt.Errorf("last L2 block is pre-Holocene, cannot derive blocks: %s", dp.lastLocalSafe),
+		})
+		return
+	}
+
+	goIdle := true
+	if attrib, err := dp.attrib.NextAttributes(dp.ctx, dp.lastLocalSafe); err == nil {
+		dp.emitter.Emit(ctx, derive.DerivedAttributesEvent{Attributes: attrib})
+		dp.metrics.RecordL1Ref("l1_derived", attrib.DerivedFrom)
+		goIdle = false
+	} else if err == io.EOF {
+		// If every stage has returned io.EOF, try to advance the L1 Origin
+		dp.emitter.Emit(ctx, derive.ExhaustedL1Event{
+			L1Ref:  dp.attrib.Origin(),
+			LastL2: dp.lastLocalSafe,
+		})
+	} else if errors.Is(err, derive.EngineELSyncing) {
+		dp.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("engine is syncing %s: %w", dp.resetL2Safe.ID(), err),
+		})
+	} else if errors.Is(err, derive.ErrReset) {
+		dp.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
+	} else if errors.Is(err, derive.ErrTemporary) { // TODO would be nice to differentiate between L1/L2
+		dp.emitter.Emit(ctx, rollup.L1TemporaryErrorEvent{Err: err})
+	} else if errors.Is(err, derive.ErrCritical) {
+		dp.emitter.Emit(ctx, rollup.CriticalErrorEvent{Err: err})
+	} else if errors.Is(err, derive.NotEnoughData) {
+		// don't do a backoff for this error (bad error name)
+		goIdle = false
+	} else if err != nil {
+		dp.log.Error("Derivation process error", "err", err)
+		dp.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
+	}
+
+	if goIdle {
+		dp.metrics.SetDerivationIdle(true)
+	} else {
+		dp.emitter.Emit(ctx, derive.DeriverMoreEvent{})
+	}
+}
+
+func (d *PipelineV2) AttachEmitter(em event.Emitter) {
+	d.emitter = em
+}
+
+type StepRequestEvent struct {
+}
+
+func (StepRequestEvent) String() string {
+	return "step-request"
+}
+
+type ConfirmAttributesEvent struct {
+	Confirmed eth.L2BlockRef
+}
+
+func (ConfirmAttributesEvent) String() string {
+	return "confirm-attributes"
+}
+
+func (d *PipelineV2) OnEvent(ctx context.Context, ev event.Event) bool {
+	if IDFromContext(ctx) != d.id { // If the event is not for us, ignore it
+		return false
+	}
+
+	switch x := ev.(type) {
+	case ConfirmAttributesEvent:
+		if d.lastLocalSafe.Hash != x.Confirmed.ParentHash {
+			d.log.Error("Confirmed payload does not follow last derived block", "confirmed", x.Confirmed, "last", d.lastLocalSafe)
+			d.emitter.Emit(ctx, rollup.ResetEvent{
+				Err: fmt.Errorf("confirmed payload %s does not follow %s", x.Confirmed, d.lastLocalSafe),
+			})
+			return true
+		}
+		d.lastLocalSafe = x.Confirmed
+		d.emitter.Emit(ctx, derive.DeriverMoreEvent{})
+	case StepRequestEvent:
+		d.onStep(ctx, x)
+	case derive.DepositsOnlyPayloadAttributesRequestEvent:
+		d.log.Warn("Deriving deposits-only attributes", "origin", d.attrib.Origin())
+		attrib, err := d.attrib.DepositsOnlyAttributes(x.Parent, x.DerivedFrom)
+		if err != nil {
+			d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
+				Err: fmt.Errorf("deriving deposits-only attributes: %w", err),
+			})
+			return true
+		}
+		d.emitter.Emit(ctx, derive.DerivedAttributesEvent{Attributes: attrib})
+	case derive.ProvideL1Traversal:
+		d.l1Traversal.ProvideNext(x.NextL1)
+	default:
+		return false
+	}
+	return true
+}

--- a/op-node/opnv2/service/backend/l1access/events.go
+++ b/op-node/opnv2/service/backend/l1access/events.go
@@ -1,0 +1,78 @@
+package l1access
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type LatestL1RequestEvent struct {
+}
+
+func (ev LatestL1RequestEvent) String() string {
+	return "latest-l1-request"
+}
+
+type LatestL1UpdateEvent struct {
+	LatestL1 eth.BlockRef
+}
+
+func (ev LatestL1UpdateEvent) String() string {
+	return "latest-l1-update"
+}
+
+type ConfirmedL1RequestEvent struct {
+}
+
+func (ev ConfirmedL1RequestEvent) String() string {
+	return "confirmed-l1-request"
+}
+
+type ConfirmedL1UpdateEvent struct {
+	// ConfirmedL1 block. Empty if we failed to retrieve it.
+	ConfirmedL1 eth.BlockRef
+}
+
+func (ev ConfirmedL1UpdateEvent) String() string {
+	return "confirmed-l1-update"
+}
+
+type FinalizedL1RequestEvent struct {
+}
+
+func (ev FinalizedL1RequestEvent) String() string {
+	return "finalized-l1-request"
+}
+
+type FinalizedL1UpdateEvent struct {
+	FinalizedL1 eth.BlockRef
+}
+
+func (ev FinalizedL1UpdateEvent) String() string {
+	return "finalized-l1-update"
+}
+
+type TemporaryL1AccessErrorEvent struct {
+	LatestL1    eth.BlockRef
+	ConfirmedL1 eth.BlockRef
+	FinalizedL1 eth.BlockRef
+	Err         error
+}
+
+func (ev TemporaryL1AccessErrorEvent) String() string {
+	return "temporary-l1-access-error"
+}
+
+type ByNumberL1RequestEvent struct {
+	Num uint64
+}
+
+func (ev ByNumberL1RequestEvent) String() string {
+	return "by-number-l1-request"
+}
+
+type RetrievedL1BlockEvent struct {
+	Ref eth.BlockRef
+}
+
+func (ev RetrievedL1BlockEvent) String() string {
+	return "retrieved-l1-block"
+}

--- a/op-node/opnv2/service/backend/l1access/l1access.go
+++ b/op-node/opnv2/service/backend/l1access/l1access.go
@@ -1,0 +1,273 @@
+package l1access
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/safemath"
+)
+
+type L1Source interface {
+	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
+	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
+}
+
+const reqTimeout = time.Second * 10
+
+type Config struct {
+	ConfDepth uint64
+
+	Subscribe bool
+
+	// TODO poll interval (or via underlying RPC http polling?)
+}
+
+// L1Accessor is a read-only L1 accessor
+type L1Accessor struct {
+	ctx context.Context
+
+	emitter event.Emitter
+
+	log log.Logger
+
+	finalitySub ethereum.Subscription
+	latestSub   ethereum.Subscription
+
+	// tip is the L1 chain tip. Used to block access to requests more recent than
+	// the confirmation depth, and to detect reorgs.
+	// Or zero if no block was seen yet.
+	tip eth.BlockRef
+
+	// confirmed is the last seen L1 block, with tip.Number-ConfDepth == confirmed.Number.
+	// Or the finalized block, if finalizing recent blocks.
+	// Or zero if no block is currently confirmed.
+	confirmed eth.BlockRef
+
+	// finalized is the last seen finalized L1 signal.
+	// Or zero if no signal has been received yet.
+	finalized eth.BlockRef
+
+	cfg *Config
+
+	client L1Source
+}
+
+var _ event.AttachEmitter = (*L1Accessor)(nil)
+var _ event.Deriver = (*L1Accessor)(nil)
+
+func NewL1Access(rootCtx context.Context, logger log.Logger,
+	client L1Source, cfg *Config) *L1Accessor {
+	return &L1Accessor{
+		log:    logger,
+		ctx:    rootCtx,
+		client: client,
+		cfg:    cfg,
+	}
+}
+
+func (a *L1Accessor) OnEvent(ctx context.Context, ev event.Event) bool {
+	switch x := ev.(type) {
+	case LatestL1RequestEvent:
+		a.onLatestL1Request(ctx, x)
+	case ConfirmedL1RequestEvent:
+		a.onConfirmedL1Request(ctx, x)
+	case FinalizedL1RequestEvent:
+		a.onFinalizedL1Request(ctx, x)
+	case ByNumberL1RequestEvent:
+		a.onByNumberL1Request(ctx, x)
+	default:
+		return false
+	}
+	return true
+}
+
+func (a *L1Accessor) AttachEmitter(em event.Emitter) {
+	a.emitter = em
+}
+
+func (a *L1Accessor) SubscribeFinalityHandler() {
+	// TODO: tests run faster finality, L1 has slow finality (every 6.4 minute, but not guaranteed),
+	//  and "finalized" does not have an eth_subscribe.
+	//  So customized polling, at a time just after the expected finality, would be ideal.
+	// Note that gap-slots can make the finalized EL timestamp not align with expected finality interval.
+	a.finalitySub = eth.PollBlockChanges(
+		a.log,
+		a.client,
+		a.updateFinalized,
+		eth.Finalized,
+		3*time.Second,
+		reqTimeout)
+}
+
+func (a *L1Accessor) UnsubscribeFinalityHandler() {
+	if a.finalitySub != nil {
+		a.finalitySub.Unsubscribe()
+	}
+}
+
+func (a *L1Accessor) SubscribeLatestHandler() {
+	// TODO: current options are all sub-optimal:
+	//  - the (unapplied) PollingClient wrapper around the untyped RPC does not contribute to the L1 block-header cache.
+	//  - the WatchHeadChanges will exit on fail, and needs to be wrapped with a retry-subscriber, and also does not contribute to the cache.
+	//  - the PollBlockChanges does contribute to the cache, but is polling rather than subscribing.
+	// So for now we go with polling, but we should make a subscriber, attached to EthClient (for L1/L2 reuse, and caching).
+
+	a.latestSub = eth.PollBlockChanges(
+		a.log,
+		a.client,
+		a.updateLatest,
+		eth.Unsafe,
+		3*time.Second,
+		reqTimeout)
+}
+
+func (a *L1Accessor) UnsubscribeLatestHandler() {
+	if a.latestSub != nil {
+		a.latestSub.Unsubscribe()
+	}
+}
+
+func (a *L1Accessor) SetConfDepth(depth uint64) {
+	a.cfg.ConfDepth = depth
+}
+
+func (a *L1Accessor) onLatestL1Request(ctx context.Context, ev LatestL1RequestEvent) {
+	if err := a.PullLatest(ctx); err != nil {
+		a.emitTempErr(ctx, err)
+	}
+}
+
+func (a *L1Accessor) onConfirmedL1Request(ctx context.Context, ev ConfirmedL1RequestEvent) {
+	a.updateConfirmed(ctx)
+}
+
+func (a *L1Accessor) onFinalizedL1Request(ctx context.Context, ev FinalizedL1RequestEvent) {
+	if err := a.PullFinalized(ctx); err != nil {
+		a.emitTempErr(ctx, err)
+	}
+}
+
+func (a *L1Accessor) emitTempErr(ctx context.Context, err error) {
+	a.emitter.Emit(ctx, TemporaryL1AccessErrorEvent{
+		LatestL1:    a.tip,
+		ConfirmedL1: a.confirmed,
+		FinalizedL1: a.finalized,
+		Err:         err,
+	})
+}
+
+func (a *L1Accessor) PullFinalized(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, reqTimeout)
+	defer cancel()
+	ref, err := a.client.L1BlockRefByLabel(ctx, eth.Finalized)
+	if err != nil {
+		return fmt.Errorf("failed to pull finalized block ref: %w", err)
+	}
+	a.updateFinalized(ctx, ref)
+	return nil
+}
+
+func (a *L1Accessor) PullLatest(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, reqTimeout)
+	defer cancel()
+	ref, err := a.client.L1BlockRefByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		return fmt.Errorf("failed to pull latest block ref: %w", err)
+	}
+	a.updateLatest(ctx, ref)
+	return nil
+}
+
+func (a *L1Accessor) updateFinalized(ctx context.Context, ref eth.L1BlockRef) {
+	if ref.Number <= a.finalized.Number {
+		a.log.Debug("Ignoring stale L1 finality signal", "stale", ref, "current", a.finalized)
+		a.emitter.Emit(ctx, FinalizedL1UpdateEvent{FinalizedL1: a.finalized})
+		return
+	}
+	a.finalized = ref
+	if ref.Number > a.confirmed.Number {
+		a.confirmed = ref
+		a.emitter.Emit(ctx, ConfirmedL1UpdateEvent{ConfirmedL1: a.confirmed})
+	}
+	a.emitter.Emit(ctx, FinalizedL1UpdateEvent{FinalizedL1: ref})
+}
+
+func (a *L1Accessor) updateLatest(ctx context.Context, ref eth.L1BlockRef) {
+	// Stop if the block is the same or older than the tip
+	if ref.Hash == a.tip.Hash {
+		a.log.Debug("Latest L1 block signal is a repeat", "ref", ref)
+		a.emitter.Emit(ctx, LatestL1UpdateEvent{LatestL1: a.tip})
+		return
+	}
+	if ref.Number < a.tip.Number {
+		a.log.Warn("L1 block is older than the tip", "ref", ref, "tip", a.tip)
+		a.emitter.Emit(ctx, LatestL1UpdateEvent{LatestL1: a.tip})
+		return
+	}
+	if ref.Number == a.tip.Number && ref.Hash != a.tip.Hash {
+		if ref.ParentHash == a.tip.ParentHash {
+			a.log.Warn("Detected L1 reorg, single block reorg",
+				"ref", ref, "tip", a.tip, "parent", a.tip.ParentID())
+		} else {
+			a.log.Warn("Detected L1 reorg, block conflicts with existing chain", "ref", ref, "tip", a.tip)
+		}
+	}
+	if ref.Number+1 == a.tip.Number {
+		if ref.ParentHash != a.tip.Hash {
+			a.log.Warn("Detected L1 reorg, next block does not continue same chain", "ref", ref, "tip", a.tip, "parent", a.tip.ParentID())
+		}
+	}
+	if ref.Number > a.tip.Number+1 {
+		a.log.Warn("Missed a L1 block signal", "ref", ref, "tip", a.tip)
+	}
+	a.tip = ref
+	a.log.Info("Registered new L1 block", "tip", a.tip)
+	a.emitter.Emit(ctx, LatestL1UpdateEvent{LatestL1: a.tip})
+	a.updateConfirmed(ctx)
+}
+
+func (a *L1Accessor) updateConfirmed(ctx context.Context) {
+	confNum := safemath.SaturatingSub(a.tip.Number, a.cfg.ConfDepth)
+	ctx, cancel := context.WithTimeout(ctx, reqTimeout)
+	defer cancel()
+	v, err := a.client.L1BlockRefByNumber(ctx, confNum)
+	if err != nil {
+		v = eth.BlockRef{}
+		a.log.Error("Could not retrieve confirmed L1 block", "err", err, "num", confNum)
+	}
+	a.confirmed = v
+	a.emitter.Emit(ctx, ConfirmedL1UpdateEvent{ConfirmedL1: a.confirmed})
+}
+
+func (a *L1Accessor) onByNumberL1Request(ctx context.Context, ev ByNumberL1RequestEvent) {
+	// The controller may ask for some specific L1 block, e.g. for derivation traversal.
+	// We provide it, while enforcing conf-depth.
+	ref, err := a.L1BlockRefByNumber(ctx, ev.Num)
+	if err != nil {
+		a.emitTempErr(ctx, fmt.Errorf("failed to retrieve block by number %d: %w", ev.Num, err))
+		return
+	}
+	a.emitter.Emit(ctx, RetrievedL1BlockEvent{
+		Ref: ref,
+	})
+}
+
+func (a *L1Accessor) isWithinConfDepth(num uint64) bool {
+	return safemath.SaturatingAdd(num, a.cfg.ConfDepth) <= a.tip.Number
+}
+
+// L1BlockRefByNumber implements the L1 source interface, with confirmation-depth applied.
+// Blocks that are too recent for the confirmation depth will appear like blocks that are not available yet.
+func (a *L1Accessor) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+	// block access to requests more recent than the confirmation depth
+	if !a.isWithinConfDepth(number) {
+		return eth.L1BlockRef{}, ethereum.NotFound
+	}
+	return a.client.L1BlockRefByNumber(ctx, number)
+}

--- a/op-node/opnv2/service/backend/l1rewind/l1rewind.go
+++ b/op-node/opnv2/service/backend/l1rewind/l1rewind.go
@@ -1,0 +1,102 @@
+package l1rewind
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type L1Source interface {
+	L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error)
+}
+
+type DB interface {
+	Finalized(eth.ChainID) (types.DerivedBlockSealPair, error)
+
+	LocalSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
+	CrossSafe(eth.ChainID) (types.DerivedBlockSealPair, error)
+
+	LocalSafeDerivedAt(chainID eth.ChainID, source eth.BlockID) (types.BlockSeal, error)
+	CrossSourceToLastDerived(chainID eth.ChainID, source eth.BlockID) (derived types.BlockSeal, err error)
+
+	RewindLocalSafeSource(eth.ChainID, eth.BlockID) error
+	RewindCrossSafeSource(eth.ChainID, eth.BlockID) error
+}
+
+type L1Rewinder struct {
+	log log.Logger
+
+	// The L2 chain that this rewinder will apply to
+	chainID eth.ChainID
+
+	db DB
+	l1 L1Source
+
+	emitter event.Emitter
+}
+
+func NewL1Rewinder(logger log.Logger, chainID eth.ChainID, db DB, l1 L1Source) *L1Rewinder {
+	return &L1Rewinder{
+		log:     logger,
+		chainID: chainID,
+		db:      db,
+		l1:      l1,
+	}
+}
+
+func (r *L1Rewinder) AttachEmitter(em event.Emitter) {
+	r.emitter = em
+}
+
+func (r *L1Rewinder) OnEvent(ctx context.Context, ev event.Event) bool {
+	// TODO filter event context by ChainID
+
+	// TODO on L1 rewind check, run the rewind, and emit an event when done
+	return false
+}
+
+type L1RewindCheckEvent struct {
+	ChainID eth.ChainID
+}
+
+func (ev L1RewindCheckEvent) String() string {
+	return "l1-rewind-check"
+}
+
+type L1RewindCheckCompletedEvent struct {
+	ChainID eth.ChainID
+	// zero if we rewind to a point older than DB start
+	LocalSafe types.DerivedBlockSealPair
+	// zero if we rewind to a point older than DB start
+	CrossSafe types.DerivedBlockSealPair
+}
+
+func (ev L1RewindCheckCompletedEvent) String() string {
+	return "l1-rewind-check-completed"
+}
+
+// TODO: L1 rewinds.
+//
+// The old "rewinder" has the following problems:
+// - does both L1 and L2
+// - does no binary search (reasonable for small finalized-head range, but not always the case)
+// - considers first block as "finalized"
+// - does not rewind out the first block in the DB, even if needed.
+//
+// What it does right:
+// - consider finality, to reduce search range
+// - use finality based on the local DB, not the remote chain,
+//   since the local DB may be out of sync in terms of block-number, but on the wrong chain.
+//
+// We need a single binary-search that fixes this.
+//
+// This needs to happen for each L1 chain.
+// This needs to happen for local-safe and cross-safe.
+//
+// When rewinding, we need the controller state of the affected DBs to be clearly expressed as busy,
+// until the rewind succeeds/fails.
+// So the fan-out for each chain may be better to apply with multiple L1Rewinder instances, so it can run in parallel.

--- a/op-node/opnv2/service/backend/l2rewind/l2rewind.go
+++ b/op-node/opnv2/service/backend/l2rewind/l2rewind.go
@@ -1,0 +1,90 @@
+package l2rewind
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type DB interface {
+	LocalUnsafe(chainID eth.ChainID) (types.BlockSeal, error)
+	LocalSafe(chainID eth.ChainID) (types.DerivedBlockSealPair, error)
+
+	RewindLogs(chainID eth.ChainID, newHead types.BlockSeal) error
+
+	FindSealedBlock(chainID eth.ChainID, num uint64) (types.BlockSeal, error)
+	IsLocalSafe(chainID eth.ChainID, block eth.BlockID) error
+}
+
+type L2Rewinder struct {
+	log log.Logger
+
+	chainID eth.ChainID
+
+	db DB
+
+	emitter event.Emitter
+}
+
+func NewL2Rewinder(logger log.Logger, chainID eth.ChainID, db DB) *L2Rewinder {
+	return &L2Rewinder{
+		log:     logger,
+		chainID: chainID,
+		db:      db,
+	}
+}
+
+func (r *L2Rewinder) AttachEmitter(em event.Emitter) {
+	r.emitter = em
+}
+
+func (r *L2Rewinder) OnEvent(ctx context.Context, ev event.Event) bool {
+	// TODO filter event context by ChainID
+
+	// TODO on L2 rewind check, run the rewind, and emit an event when done
+	return false
+}
+
+type L2RewindCheckEvent struct {
+	ChainID eth.ChainID
+}
+
+func (ev L2RewindCheckEvent) String() string {
+	return "l2-rewind-check"
+}
+
+type L2RewindCheckCompletedEvent struct {
+	ChainID eth.ChainID
+
+	// zero if we rewind to a point older than DB start
+	LocalUnsafe types.BlockSeal
+}
+
+func (ev L2RewindCheckCompletedEvent) String() string {
+	return "l2-rewind-check-completed"
+}
+
+// TODO: L2 log db rewinds
+//
+// A Lot like the L1 rewinder, except we are comparing the log-db against the local-safe-db
+// (use the most canonical version of each block, in case of invalidations).
+//
+// The old "rewinder" has the following problems:
+// - does both L1 and L2
+// - does no binary search (reasonable for small finalized-head range, but not always the case)
+// - considers first block as "finalized"
+// - does not rewind out the first block in the DB, even if needed.
+//    (it will be unable to get first-1, and error, and not reorg)
+//
+// What it does right:
+// - consider finality, to reduce search range
+// - use finality based on the local DB, not the remote chain,
+//   since the local DB may be out of sync in terms of block-number, but on the wrong chain.
+//
+// We need a single binary-search that fixes this.
+//
+// We do this per L2, so the chains can rewind in parallel.

--- a/op-node/opnv2/service/backend/monitor/monitor.go
+++ b/op-node/opnv2/service/backend/monitor/monitor.go
@@ -1,0 +1,82 @@
+package monitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type Monitor struct {
+	log log.Logger
+}
+
+func NewMonitor(log log.Logger) *Monitor {
+	return &Monitor{
+		log: log,
+	}
+}
+
+func (m *Monitor) OnEvent(ctx context.Context, ev event.Event) bool {
+	// TODO watch for more events, and log the interesting things
+
+	switch x := ev.(type) {
+	case rwel.LocalUnsafeUpdateEvent:
+		age := time.Unix(int64(x.Ref.Time), 0)
+		m.log.Info("New L2 head", "l2_local_unsafe", x.Ref, "l2_time", x.Ref.Time, "age", time.Since(age))
+	case rwel.CrossSafeUpdateEvent:
+		age := time.Unix(int64(x.CrossSafe.Time), 0)
+		m.log.Info("New L2 cross-safe", "l2_cross_unsafe", x.CrossSafe, "age", time.Since(age))
+	case rwel.PayloadSuccessEvent:
+		logValues := getBlockProcessingMetrics(&x)
+		m.log.Info("Processed new L2 unsafe block", logValues...)
+	}
+	return false
+}
+
+// Returns key/value pairs that can be logged and are useful for plotting
+// block build/insert time as a way to measure performance.
+func getBlockProcessingMetrics(ev *rwel.PayloadSuccessEvent) []any {
+	fcuFinish := time.Now()
+	payload := ev.Envelope.ExecutionPayload
+
+	logValues := []any{
+		"hash", payload.BlockHash,
+		"number", uint64(payload.BlockNumber),
+		"state_root", payload.StateRoot,
+		"timestamp", uint64(payload.Timestamp),
+		"parent", payload.ParentHash,
+		"prev_randao", payload.PrevRandao,
+		"fee_recipient", payload.FeeRecipient,
+		"txs", len(payload.Transactions),
+	}
+
+	var totalTime time.Duration
+	var mgasps float64
+	if !ev.BuildStarted.IsZero() {
+		totalTime = fcuFinish.Sub(ev.BuildStarted)
+		logValues = append(logValues,
+			"build_time", common.PrettyDuration(ev.InsertStarted.Sub(ev.BuildStarted)),
+			"insert_time", common.PrettyDuration(fcuFinish.Sub(ev.InsertStarted)),
+		)
+	} else if !ev.InsertStarted.IsZero() {
+		totalTime = fcuFinish.Sub(ev.InsertStarted)
+	}
+
+	// Avoid divide-by-zero for mgasps
+	if totalTime > 0 {
+		mgasps = float64(payload.GasUsed) * 1000 / float64(totalTime)
+	}
+
+	logValues = append(logValues,
+		"total_time", common.PrettyDuration(totalTime),
+		"mgas", float64(payload.GasUsed)/1000000,
+		"mgasps", mgasps,
+	)
+
+	return logValues
+}

--- a/op-node/opnv2/service/backend/p2p/discovery.go
+++ b/op-node/opnv2/service/backend/p2p/discovery.go
@@ -1,0 +1,41 @@
+package p2p
+
+import (
+	"golang.org/x/exp/slices"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type MultiChainFilter struct {
+	Allowed []eth.ChainID
+	Log     log.Logger
+}
+
+var _ p2p.NodeFilter = (*MultiChainFilter)(nil)
+
+// Allow filters the node record. If it returns false then the node is not accepted.
+func (f *MultiChainFilter) Allow(node *enode.Node) bool {
+	var dat p2p.OpStackENRData
+	err := node.Load(&dat)
+	// if the entry does not exist, or if it is invalid, then ignore the node
+	if err != nil {
+		f.Log.Trace("discovered node record has no opstack info", "node", node.ID(), "err", err)
+		return false
+	}
+	chainID := eth.ChainIDFromUInt64(dat.ChainID)
+	// check chain ID is allowed
+	if !slices.Contains(f.Allowed, chainID) {
+		f.Log.Trace("discovered node record has no allowed chain ID", "node", node.ID(), "got", dat.ChainID)
+		return false
+	}
+	// check version matches
+	if dat.Version != 0 {
+		f.Log.Trace("discovered node record has no matching version", "node", node.ID(), "got", dat.Version, "expected", 0)
+		return false
+	}
+	return true
+}

--- a/op-node/opnv2/service/backend/p2p/node.go
+++ b/op-node/opnv2/service/backend/p2p/node.go
@@ -1,0 +1,282 @@
+package p2p
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/connmgr"
+	"github.com/libp2p/go-libp2p/core/host"
+	p2pmetrics "github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/peer"
+	manet "github.com/multiformats/go-multiaddr/net"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/p2p/gating"
+	"github.com/ethereum-optimism/optimism/op-node/p2p/monitor"
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type P2PMetricer interface {
+	p2p.HostMetrics
+	p2p.GossipMetricer
+	p2p.ScoreMetrics
+	p2p.NotificationsMetricer
+	RecordBandwidth(ctx context.Context, bwc *p2pmetrics.BandwidthCounter)
+}
+
+// NodeP2P is a p2p node, which can be used to gossip messages.
+type NodeP2P struct {
+	host        host.Host                      // p2p host (optional, may be nil)
+	gater       gating.BlockingConnectionGater // p2p gater, to ban/unban peers with, may be nil even with p2p enabled
+	scorer      p2p.Scorer                     // writes score-updates to the peerstore and keeps metrics of score changes
+	connMgr     connmgr.ConnManager            // p2p conn manager, to keep a reliable number of peers, may be nil even with p2p enabled
+	peerMonitor *monitor.PeerMonitor           // peer monitor to disconnect bad peers, may be nil even with p2p enabled
+	store       store.ExtendedPeerstore        // peerstore of host, with extra bindings for scoring and banning
+	appScorer   p2p.ApplicationScorer
+	log         log.Logger
+	// the below components are all optional, and may be nil. They require the host to not be nil.
+	dv5Local *enode.LocalNode // p2p discovery identity
+	dv5Udp   *discover.UDPv5  // p2p discovery service
+	gs       *pubsub.PubSub   // p2p gossip router
+	gsOut    p2p.GossipOut    // p2p gossip application interface for publishing
+}
+
+// NewNodeP2P creates a new p2p node, and returns a reference to it. If the p2p is disabled, it returns nil.
+// If metrics are configured, a bandwidth monitor will be spawned in a goroutine.
+func NewNodeP2P(
+	resourcesCtx context.Context,
+	log log.Logger,
+	setup p2p.SetupP2P,
+	gossipIn p2p.GossipIn,
+	chainCfg p2p.GossipChainConfig, // TODO need multichain cfg
+	metrics P2PMetricer,
+) (*NodeP2P, error) {
+	if setup == nil {
+		return nil, errors.New("p2p node cannot be created without setup")
+	}
+	if setup.Disabled() {
+		return nil, errors.New("SetupP2P.Disabled is true")
+	}
+	var n NodeP2P
+	if err := n.init(resourcesCtx, log, setup, gossipIn, chainCfg, metrics); err != nil {
+		closeErr := n.Close()
+		if closeErr != nil {
+			log.Error("failed to close p2p after starting with err", "closeErr", closeErr, "err", err)
+		}
+		return nil, err
+	}
+	if n.host == nil {
+		// See prior comment about n.host optionality:
+		// TODO: host is not optional, NodeP2P as a whole is.
+		panic("host is not optional if p2p is enabled")
+	}
+	return &n, nil
+}
+
+func (n *NodeP2P) init(
+	resourcesCtx context.Context,
+	log log.Logger,
+	setup p2p.SetupP2P,
+	gossipIn p2p.GossipIn,
+	chainCfg p2p.GossipChainConfig,
+	metrics P2PMetricer,
+) error {
+	bwc := p2pmetrics.NewBandwidthCounter()
+
+	n.log = log
+
+	var err error
+	// nil if disabled.
+	n.host, err = setup.Host(log, bwc, metrics)
+	if err != nil {
+		if n.dv5Udp != nil {
+			n.dv5Udp.Close()
+		}
+		return fmt.Errorf("failed to start p2p host: %w", err)
+	}
+
+	// Don't ingest blocks that we publish ourselves
+	gossipIn = p2p.NewFilterSelf(n.host.ID(), gossipIn)
+
+	// Enable extra features, if any. During testing we don't setup the most advanced host all the time.
+	if extra, ok := n.host.(p2p.ExtraHostFeatures); ok {
+		n.gater = extra.ConnectionGater()
+		n.connMgr = extra.ConnectionManager()
+	}
+	eps, ok := n.host.Peerstore().(store.ExtendedPeerstore)
+	if !ok {
+		return fmt.Errorf("cannot init without extended peerstore: %w", err)
+	}
+	n.store = eps
+	scoreParams := setup.PeerScoringParams()
+
+	if scoreParams != nil {
+		n.appScorer = p2p.NewPeerApplicationScorer(resourcesCtx, log, clock.SystemClock, &scoreParams.ApplicationScoring, eps, n.host.Network().Peers)
+	} else {
+		n.appScorer = &p2p.NoopApplicationScorer{}
+	}
+	n.scorer = p2p.NewScorer(eps, metrics, n.appScorer, log)
+	// notify of any new connections/streams/etc.
+	n.host.Network().Notify(p2p.NewNetworkNotifier(log, metrics))
+	// note: the IDDelta functionality was removed from libP2P, and no longer needs to be explicitly disabled.
+
+	n.gs, err = p2p.NewGossipSub(resourcesCtx, n.host, chainCfg, setup, n.scorer, metrics, log)
+	if err != nil {
+		return fmt.Errorf("failed to start gossipsub router: %w", err)
+	}
+
+	n.gsOut, err = p2p.JoinGossip(n.host.ID(), n.gs, log, chainCfg, gossipIn)
+	if err != nil {
+		return fmt.Errorf("failed to join blocks gossip topic: %w", err)
+	}
+	log.Info("started p2p host", "addrs", n.host.Addrs(), "peerID", n.host.ID().String())
+
+	tcpPort, err := p2p.FindActiveTCPPort(n.host)
+	if err != nil {
+		log.Warn("failed to find what TCP port p2p is binded to", "err", err)
+	}
+
+	// Advertise the first of any list of chainIDs to identify we are part of the dependency set.
+	// Later on we may want to transition to a new OpStackENRData version.
+	localNodeMods := func(localNode *enode.LocalNode) {
+		chainIDU64, _ := chainCfg.ChainIDs()[0].Uint64()
+		dat := p2p.OpStackENRData{
+			ChainID: chainIDU64,
+			Version: 0,
+		}
+		localNode.Set(&dat)
+	}
+
+	// All nil if disabled.
+	n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"), localNodeMods, tcpPort)
+	if err != nil {
+		return fmt.Errorf("failed to start discv5: %w", err)
+	}
+
+	if metrics != nil {
+		go metrics.RecordBandwidth(resourcesCtx, bwc)
+	}
+
+	if setup.BanPeers() {
+		n.peerMonitor = monitor.NewPeerMonitor(resourcesCtx, log, clock.SystemClock, n, setup.BanThreshold(), setup.BanDuration())
+		n.peerMonitor.Start()
+	}
+	n.appScorer.Start()
+	return nil
+}
+
+func (n *NodeP2P) AltSyncEnabled() bool {
+	return false
+}
+
+func (n *NodeP2P) RequestL2Range(ctx context.Context, start, end eth.L2BlockRef) error {
+	return errors.New("req-resp is not supported")
+}
+
+func (n *NodeP2P) Host() host.Host {
+	return n.host
+}
+
+func (n *NodeP2P) Dv5Local() *enode.LocalNode {
+	return n.dv5Local
+}
+
+func (n *NodeP2P) Dv5Udp() *discover.UDPv5 {
+	return n.dv5Udp
+}
+
+func (n *NodeP2P) GossipSub() *pubsub.PubSub {
+	return n.gs
+}
+
+func (n *NodeP2P) GossipOut() p2p.GossipOut {
+	return n.gsOut
+}
+
+func (n *NodeP2P) ConnectionGater() gating.BlockingConnectionGater {
+	return n.gater
+}
+
+func (n *NodeP2P) ConnectionManager() connmgr.ConnManager {
+	return n.connMgr
+}
+
+func (n *NodeP2P) Peers() []peer.ID {
+	return n.host.Network().Peers()
+}
+
+func (n *NodeP2P) GetPeerScore(id peer.ID) (float64, error) {
+	return n.store.GetPeerScore(id)
+}
+
+func (n *NodeP2P) IsStatic(id peer.ID) bool {
+	return n.connMgr != nil && n.connMgr.IsProtected(id, p2p.StaticPeerTag)
+}
+
+func (n *NodeP2P) BanPeer(id peer.ID, expiration time.Time) error {
+	if err := n.store.SetPeerBanExpiration(id, expiration); err != nil {
+		return fmt.Errorf("failed to set peer ban expiry: %w", err)
+	}
+	if err := n.host.Network().ClosePeer(id); err != nil {
+		return fmt.Errorf("failed to close peer connection: %w", err)
+	}
+	return nil
+}
+
+func (n *NodeP2P) BanIP(ip net.IP, expiration time.Time) error {
+	if err := n.store.SetIPBanExpiration(ip, expiration); err != nil {
+		return fmt.Errorf("failed to set IP ban expiry: %w", err)
+	}
+	// kick all peers that match this IP
+	for _, conn := range n.host.Network().Conns() {
+		addr := conn.RemoteMultiaddr()
+		remoteIP, err := manet.ToIP(addr)
+		if err != nil {
+			continue
+		}
+		if remoteIP.Equal(ip) {
+			if err := conn.Close(); err != nil {
+				n.log.Error("failed to close connection to peer with banned IP", "peer", conn.RemotePeer(), "ip", ip)
+			}
+		}
+	}
+	return nil
+}
+
+func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, nodeFilter p2p.NodeFilter, connectGoal uint) {
+	p2p.DiscoveryProcess(ctx, log, n, nodeFilter, connectGoal)
+}
+
+func (n *NodeP2P) Close() error {
+	var result error
+	if n.peerMonitor != nil {
+		n.peerMonitor.Stop()
+	}
+	if n.dv5Udp != nil {
+		n.dv5Udp.Close()
+	}
+	if n.gsOut != nil {
+		if err := n.gsOut.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close gossip cleanly: %w", err))
+		}
+	}
+	if n.host != nil {
+		if err := n.host.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close p2p host cleanly: %w", err))
+		}
+	}
+	if n.appScorer != nil {
+		n.appScorer.Stop()
+	}
+	return result
+}

--- a/op-node/opnv2/service/backend/payloads/payloads.go
+++ b/op-node/opnv2/service/backend/payloads/payloads.go
@@ -1,0 +1,122 @@
+package payloads
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/clsync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+// Max memory used for buffering unsafe payloads, per chain
+const maxUnsafePayloadsMemory = 100 * 1024 * 1024
+
+// Payloads acts as a cache, for a single chain, of the recently received P2P blocks.
+// The cache size is defined in approximate memory consumption.
+// The blocks with the highest block number are retained.
+type Payloads struct {
+	ctx     context.Context
+	chainID eth.ChainID
+
+	log log.Logger
+
+	queue *clsync.PayloadsQueue
+
+	emitter event.Emitter
+}
+
+var _ event.AttachEmitter = (*Payloads)(nil)
+var _ event.Deriver = (*Payloads)(nil)
+
+func NewPayloads(ctx context.Context, logger log.Logger, chainID eth.ChainID) *Payloads {
+	return &Payloads{
+		ctx:     ctx,
+		chainID: chainID,
+		log:     logger.New("chainID", chainID),
+		queue:   clsync.NewPayloadsQueue(logger, maxUnsafePayloadsMemory, clsync.PayloadMemSize),
+		emitter: nil,
+	}
+}
+
+func (p *Payloads) AttachEmitter(em event.Emitter) {
+	p.emitter = em
+}
+
+func (p *Payloads) ChainID() eth.ChainID {
+	return p.chainID
+}
+
+func (p *Payloads) OnEvent(ctx context.Context, ev event.Event) bool {
+	switch x := ev.(type) {
+	case PayloadRequestEvent:
+		if p.chainID != x.ChainID {
+			return false
+		}
+		// payload may be nil, if not found
+		payload := p.queue.ByNumber(x.Num)
+		p.emitter.Emit(ctx, PayloadResponseEvent{
+			ChainID:  p.chainID,
+			Num:      x.Num,
+			Envelope: payload,
+		})
+	case p2p.ReceivedBlockEvent:
+		if p.chainID != x.ChainID {
+			return false
+		}
+		// this will pop the oldest payloads until there is room
+		if err := p.queue.Push(x.Envelope); err != nil {
+			p.log.Warn("Could not buffer payload", "err", err)
+		} else {
+			// Queue is non-empty now, so these are not nil
+			first := p.queue.Peek()
+			last := p.queue.Last()
+			p.emitter.Emit(ctx, PayloadsUpdateEvent{
+				ChainID: p.chainID,
+				Min:     first.ID(),
+				Max:     last.ID(),
+				Count:   uint64(p.queue.Len()),
+			})
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+type PayloadsUpdateEvent struct {
+	ChainID eth.ChainID
+	// Lowest available number
+	Min eth.BlockID
+	// Highest available number (there may be gaps in-between Min and Max)
+	Max eth.BlockID
+	// Number of blocks we have buffered for this chain
+	Count uint64
+}
+
+func (ev PayloadsUpdateEvent) String() string {
+	return "payloads-update"
+}
+
+type PayloadRequestEvent struct {
+	ChainID eth.ChainID
+	Num     uint64
+}
+
+func (ev PayloadRequestEvent) String() string {
+	return "payload-request"
+}
+
+type PayloadResponseEvent struct {
+	ChainID eth.ChainID
+	Num     uint64
+
+	// nil if the payload is not known
+	Envelope *eth.ExecutionPayloadEnvelope
+}
+
+func (ev PayloadResponseEvent) String() string {
+	return "payload-response"
+}

--- a/op-node/opnv2/service/backend/query.go
+++ b/op-node/opnv2/service/backend/query.go
@@ -1,0 +1,379 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/safemath"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// If the initiating message exists, the block it is included in is returned.
+func (b *Backend) checkAccessWithDB(acc types.Access) (eth.BlockID, error) {
+	// Check if message exists
+	bl, err := b.chainDBs.Contains(acc.ChainID, types.ContainsQuery{
+		Timestamp: acc.Timestamp,
+		BlockNum:  acc.BlockNumber,
+		LogIdx:    acc.LogIndex,
+		Checksum:  acc.Checksum,
+	})
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+
+	return bl.ID(), nil
+}
+
+// checkSafety is a helper method to check if a block has the given safety level.
+// It is already assumed to exist in the canonical unsafe chain.
+func (b *Backend) checkSafety(chainID eth.ChainID, blockID eth.BlockID, safetyLevel types.SafetyLevel) error {
+	switch safetyLevel {
+	case types.LocalUnsafe:
+		return nil // msg exists, nothing more to check
+	case types.CrossUnsafe:
+		return b.chainDBs.IsCrossUnsafe(chainID, blockID)
+	case types.LocalSafe:
+		return b.chainDBs.IsLocalSafe(chainID, blockID)
+	case types.CrossSafe:
+		return b.chainDBs.IsCrossSafe(chainID, blockID)
+	case types.Finalized:
+		return b.chainDBs.IsFinalized(chainID, blockID)
+	default:
+		return types.ErrConflict
+	}
+}
+
+func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
+	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor) error {
+	switch minSafety {
+	case types.LocalUnsafe, types.CrossUnsafe, types.LocalSafe, types.CrossSafe, types.Finalized:
+		// valid safety level
+	default:
+		return ErrUnexpectedMinSafetyLevel
+	}
+
+	b.logger.Debug("Checking access-list", "minSafety", minSafety, "length", len(inboxEntries))
+
+	h := b.chainDBs.AcquireHandle()
+	defer h.Release()
+
+	entries := inboxEntries
+	for len(entries) > 0 {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("stopped access-list check early: %w", err)
+		}
+		remaining, acc, err := types.ParseAccess(entries)
+		if err != nil {
+			return fmt.Errorf("failed to read data: %w", err)
+		}
+		entries = remaining
+
+		// Register initiating side as a dependency
+		h.DependOnDerivedTime(acc.Timestamp)
+
+		// TODO(#16245): backwards compat: if user does not specify executing chain, then assume the initiating chain ID.
+		// This supports op-reth, op-rbuilder, proxyd while they are not updated to provide this chain ID.
+		execChainID := execDescr.ChainID
+		if execDescr.ChainID == (eth.ChainID{}) {
+			execChainID = acc.ChainID
+		}
+		// If not specified, assume the same chain as the initiating side.
+		if !b.linker.CanExecute(execChainID, execDescr.Timestamp, acc.ChainID, acc.Timestamp) {
+			b.logger.Debug("Access-list link check failed")
+			return types.ErrConflict
+		}
+		if execDescr.Timeout != 0 {
+			maxTimestamp := safemath.SaturatingAdd(execDescr.Timestamp, execDescr.Timeout)
+			if !b.linker.CanExecute(execChainID, maxTimestamp, acc.ChainID, acc.Timestamp) {
+				b.logger.Debug("Access-list link check at timeout time failed")
+				return types.ErrConflict
+			}
+		}
+
+		msgBlockFromDB, err := b.checkAccessWithDB(acc)
+		if err != nil {
+			b.logger.Debug("Access-list inclusion check failed", "err", err)
+			return types.ErrConflict
+		}
+
+		if err := b.checkSafety(acc.ChainID, msgBlockFromDB, minSafety); err != nil {
+			b.logger.Debug("Access-list safety check failed", "err", err)
+			return types.ErrConflict
+		}
+	}
+	return h.Err()
+}
+
+func (b *Backend) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
+	p, err := b.chainDBs.CrossSafe(chainID)
+	if err != nil {
+		return types.DerivedIDPair{}, err
+	}
+	return types.DerivedIDPair{
+		Source:  p.Source.ID(),
+		Derived: p.Derived.ID(),
+	}, nil
+}
+
+func (b *Backend) LocalSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
+	p, err := b.chainDBs.LocalSafe(chainID)
+	if err != nil {
+		return types.DerivedIDPair{}, err
+	}
+	return types.DerivedIDPair{
+		Source:  p.Source.ID(),
+		Derived: p.Derived.ID(),
+	}, nil
+}
+
+func (b *Backend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	v, err := b.chainDBs.LocalUnsafe(chainID)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return v.ID(), nil
+}
+
+func (b *Backend) CrossUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	v, err := b.chainDBs.CrossUnsafe(chainID)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return v.ID(), nil
+}
+
+func (b *Backend) LocalSafeDerivedAt(ctx context.Context, chainID eth.ChainID, source eth.BlockID) (eth.BlockID, error) {
+	v, err := b.chainDBs.LocalSafeDerivedAt(chainID, source)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return v.ID(), nil
+}
+
+func (b *Backend) FindSealedBlock(ctx context.Context, chainID eth.ChainID, number uint64) (eth.BlockID, error) {
+	seal, err := b.chainDBs.FindSealedBlock(chainID, number)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return seal.ID(), nil
+}
+
+// AllSafeDerivedAt returns the last derived block for each chain, from the given L1 block
+func (b *Backend) AllSafeDerivedAt(ctx context.Context, source eth.BlockID) (map[eth.ChainID]eth.BlockID, error) {
+	chains := b.cfgSet.Chains()
+	ret := map[eth.ChainID]eth.BlockID{}
+
+	// Note: no need to reorg/rewind lock: everything is derived from the same L1 block
+	for _, chainID := range chains {
+		derived, err := b.LocalSafeDerivedAt(ctx, chainID, source)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get last derived block for chain %v: %w", chainID, err)
+		}
+		ret[chainID] = derived
+	}
+	return ret, nil
+}
+
+func (b *Backend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	v, err := b.chainDBs.Finalized(chainID)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return v.Derived.ID(), nil
+}
+
+func (b *Backend) FinalizedL1(ctx context.Context) (eth.BlockRef, error) {
+	v := b.chainDBs.FinalizedL1()
+	if v == (eth.BlockRef{}) {
+		return eth.BlockRef{}, fmt.Errorf("finality of L1 is not initialized: %w", ethereum.NotFound)
+	}
+	return v, nil
+}
+
+func (b *Backend) ActivationBlock(ctx context.Context, chainID eth.ChainID) (types.DerivedBlockSealPair, error) {
+	return b.chainDBs.AnchorPoint(chainID)
+}
+
+func (b *Backend) IsLocalUnsafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error {
+	return b.chainDBs.IsLocalUnsafe(chainID, block)
+}
+
+func (b *Backend) IsCrossSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error {
+	return b.chainDBs.IsCrossSafe(chainID, block)
+}
+
+func (b *Backend) IsLocalSafe(ctx context.Context, chainID eth.ChainID, block eth.BlockID) error {
+	return b.chainDBs.IsLocalSafe(chainID, block)
+}
+
+func (b *Backend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (source eth.BlockRef, err error) {
+	v, err := b.chainDBs.CrossDerivedToSourceRef(chainID, derived)
+	if err != nil {
+		return eth.BlockRef{}, err
+	}
+	return v, nil
+}
+
+func (b *Backend) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+	return b.l1Accessor.L1BlockRefByNumber(ctx, number)
+}
+
+func (m *Backend) findL2(chainID eth.ChainID, num uint64) apis.L2EthExtendedClient {
+	// Find a REL or RWEL that is in sync enough to serve our queries.
+
+	// Check all read-write sources
+	for _, v := range m.rwels.Values() {
+		if v.ChainID() == chainID && v.IsSyncedTo(num) {
+			cl, ok := m.rwL2Clients.Get(v.ID())
+			if ok {
+				return cl
+			}
+		}
+	}
+
+	// Check all read-only sources
+	for _, v := range m.rels.Values() {
+		if v.ChainID() == chainID && v.IsSyncedTo(num) {
+			cl, ok := m.readL2Clients.Get(v.ID())
+			if ok {
+				return cl
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *Backend) L2BlockRefByTimestamp(ctx context.Context, chainID eth.ChainID, timestamp uint64) (eth.L2BlockRef, error) {
+	if !m.cfgSet.HasChain(chainID) {
+		return eth.L2BlockRef{}, types.ErrUnknownChain
+	}
+	rollupCfg := m.rollupConfigs.RollupConfig(chainID)
+	num, err := rollupCfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		return eth.L2BlockRef{}, err
+	}
+	l2Src := m.findL2(chainID, num)
+	if l2Src == nil {
+		return eth.L2BlockRef{}, fmt.Errorf("unavailable L2 EL for chain %s", chainID)
+	}
+	return l2Src.L2BlockRefByNumber(ctx, num)
+}
+
+func (m *Backend) OutputV0AtTimestamp(ctx context.Context, chainID eth.ChainID, timestamp uint64) (*eth.OutputV0, error) {
+	ref, err := m.L2BlockRefByTimestamp(ctx, chainID, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	l2Src := m.findL2(chainID, ref.Number)
+	if l2Src == nil {
+		return nil, fmt.Errorf("unavailable L2 EL for chain %s", chainID)
+	}
+	return l2Src.OutputV0AtBlock(ctx, ref.Hash)
+}
+
+func (m *Backend) PendingOutputV0AtTimestamp(ctx context.Context, chainID eth.ChainID, timestamp uint64) (*eth.OutputV0, error) {
+	ref, err := m.L2BlockRefByTimestamp(ctx, chainID, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	l2Src := m.findL2(chainID, ref.Number)
+	if l2Src == nil {
+		return nil, fmt.Errorf("unavailable L2 EL for chain %s", chainID)
+	}
+	if ref.Number == 0 {
+		// The genesis block cannot have been invalid
+		return l2Src.OutputV0AtBlock(ctx, ref.Hash)
+	}
+
+	payload, err := l2Src.PayloadByHash(ctx, ref.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch block (%v): %w", ref, err)
+	}
+	optimisticOutput, err := indexing.DecodeInvalidatedBlockTxFromReplacement(payload.ExecutionPayload.Transactions)
+	if errors.Is(err, indexing.ErrNotReplacementBlock) {
+		// This block was not replaced so use the canonical output root as pending
+		return l2Src.OutputV0AtBlock(ctx, ref.Hash)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed parse replacement block (%v): %w", ref, err)
+	}
+	return optimisticOutput, nil
+}
+
+func (b *Backend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
+	chains := b.cfgSet.Chains()
+	slices.SortFunc(chains, func(a, b eth.ChainID) int {
+		return a.Cmp(b)
+	})
+	chainInfos := make([]eth.ChainRootInfo, len(chains))
+	superRootChains := make([]eth.ChainIDAndOutput, len(chains))
+
+	h := b.chainDBs.AcquireHandle()
+	defer h.Release()
+	h.DependOnDerivedTime(uint64(timestamp))
+
+	var crossSafeSource eth.BlockID
+	for i, chainID := range chains {
+		output, err := b.OutputV0AtTimestamp(ctx, chainID, uint64(timestamp))
+		if err != nil {
+			return eth.SuperRootResponse{}, err
+		}
+		pending, err := b.PendingOutputV0AtTimestamp(ctx, chainID, uint64(timestamp))
+		if err != nil {
+			return eth.SuperRootResponse{}, err
+		}
+		canonicalRoot := eth.OutputRoot(output)
+		chainInfos[i] = eth.ChainRootInfo{
+			ChainID:   chainID,
+			Canonical: canonicalRoot,
+			Pending:   pending.Marshal(),
+		}
+		superRootChains[i] = eth.ChainIDAndOutput{ChainID: chainID, Output: canonicalRoot}
+
+		ref, err := b.L2BlockRefByTimestamp(ctx, chainID, uint64(timestamp))
+		if err != nil {
+			return eth.SuperRootResponse{}, err
+		}
+		source, err := b.chainDBs.CrossDerivedToSource(chainID, ref.ID())
+		if err != nil {
+			// Transform error to ethereum.NotFound at RPC boundary so that the challenger can detect this case
+			if errors.Is(err, types.ErrFuture) {
+				err = errors.Join(err, ethereum.NotFound)
+			}
+			return eth.SuperRootResponse{}, fmt.Errorf("cross-derived-to-source failed for chain %s: %w", chainID, err)
+		}
+		h.DependOnSourceBlock(source.Number)
+		if crossSafeSource.Number == 0 || crossSafeSource.Number < source.Number {
+			crossSafeSource = source.ID()
+		}
+	}
+
+	if !h.IsValid() {
+		return eth.SuperRootResponse{}, h.Err()
+	}
+	super := eth.SuperV1{
+		Timestamp: uint64(timestamp),
+		Chains:    superRootChains,
+	}
+	superRoot := eth.SuperRoot(&super)
+	return eth.SuperRootResponse{
+		CrossSafeDerivedFrom: crossSafeSource,
+		Timestamp:            uint64(timestamp),
+		SuperRoot:            superRoot,
+		Version:              super.Version(),
+		Chains:               chainInfos,
+	}, nil
+}
+
+func (b *Backend) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
+	return b.statusTracker.SyncStatus()
+}

--- a/op-node/opnv2/service/backend/rel/id.go
+++ b/op-node/opnv2/service/backend/rel/id.go
@@ -1,0 +1,37 @@
+package rel
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+)
+
+const UnknownID ID = 0
+
+type ID uint64
+
+func (id ID) String() string {
+	return fmt.Sprintf("REL-%d", uint64(id))
+}
+
+var idGen = new(atomic.Uint64)
+
+func NextID() ID {
+	return ID(idGen.Add(1))
+}
+
+type idContextKeyType struct{}
+
+var idContextKey = idContextKeyType{}
+
+func IDFromContext(ctx context.Context) ID {
+	v := ctx.Value(idContextKey)
+	if v == nil {
+		return UnknownID
+	}
+	return v.(ID)
+}
+
+func WithID(ctx context.Context, id ID) context.Context {
+	return context.WithValue(ctx, idContextKey, id)
+}

--- a/op-node/opnv2/service/backend/rel/rel.go
+++ b/op-node/opnv2/service/backend/rel/rel.go
@@ -1,0 +1,98 @@
+package rel
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type L2Source interface {
+	apis.L2EthClient
+}
+
+// REL is a Read-only Execution Layer node
+type REL struct {
+
+	// TODO latest L2 head
+	// TODO last seen status
+
+	chainID  eth.ChainID
+	l2Source L2Source
+	cfg      *rollup.Config
+
+	id  ID
+	ctx context.Context
+
+	emitter event.Emitter
+}
+
+var _ event.AttachEmitter = (*REL)(nil)
+var _ event.Deriver = (*REL)(nil)
+
+func NewREL(rootCtx context.Context, id ID, l2Source L2Source, cfg *rollup.Config) *REL {
+	return &REL{
+		chainID:  eth.ChainIDFromBig(cfg.L2ChainID),
+		l2Source: l2Source,
+		cfg:      cfg,
+		id:       id,
+		ctx:      WithID(rootCtx, id),
+	}
+}
+
+func (r *REL) AttachEmitter(em event.Emitter) {
+	r.emitter = em
+}
+
+func (r *REL) ID() ID {
+	return r.id
+}
+
+func (r *REL) ChainID() eth.ChainID {
+	return r.chainID
+}
+
+// IsSyncedTo answers if the REL can serve things before the given block number
+func (r *REL) IsSyncedTo(num uint64) bool {
+	return false
+}
+
+func (r *REL) OnEvent(ctx context.Context, ev event.Event) bool {
+	if IDFromContext(ctx) != r.id { // If the event is not for us, ignore it
+		return false
+	}
+
+	// TODO: retrieve context from ev, and filter if the event is directed at us.
+
+	// TODO: handle requests to consolidate attributes
+
+	// TODO: handle requests to poll for new L2 unsafe head
+
+	return false
+}
+
+type LocalUnsafeUpdateEvent struct {
+	LocalUnsafe eth.L2BlockRef
+}
+
+func (ev LocalUnsafeUpdateEvent) String() string {
+	return "REL-local-unsafe-update"
+}
+
+type CrossSafeUpdateEvent struct {
+	CrossSafe eth.L2BlockRef
+}
+
+func (ev CrossSafeUpdateEvent) String() string {
+	return "REL-cross-safe-update"
+}
+
+type FinalizedUpdateEvent struct {
+	Finalized eth.L2BlockRef
+}
+
+func (ev FinalizedUpdateEvent) String() string {
+	return "REL-finalized-update"
+}

--- a/op-node/opnv2/service/backend/runcfg2/runcfg.go
+++ b/op-node/opnv2/service/backend/runcfg2/runcfg.go
@@ -1,0 +1,131 @@
+// Package runcfg2 replaces the v1 runcfg,
+// offering runtime config for multiple chains,
+// and no longer watching the previously deprecated protocol-version contract.
+package runcfg2
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/node/runcfg"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type RunCfgUpdateRequestEvent struct {
+	L1Block eth.BlockID
+}
+
+func (ev RunCfgUpdateRequestEvent) String() string {
+	return "run-cfg-update-request"
+}
+
+type SequencerAuthEntry struct {
+	LastL1Update eth.BlockID
+	Address      common.Address
+}
+
+type RuntimeConfig struct {
+	log      log.Logger
+	depSet   depset.DependencySet
+	cfgs     depset.RollupConfigSetV2
+	l1Client runcfg.RuntimeCfgL1Source
+
+	sequencerAuth locks.RWMap[eth.ChainID, SequencerAuthEntry]
+
+	emitter event.Emitter
+}
+
+func (r *RuntimeConfig) AttachEmitter(em event.Emitter) {
+	r.emitter = em
+}
+
+var _ event.AttachEmitter = (*RuntimeConfig)(nil)
+var _ event.Deriver = (*RuntimeConfig)(nil)
+
+var _ p2p.GossipChainConfig = (*RuntimeConfig)(nil)
+
+func NewRuntimeConfig(
+	logger log.Logger,
+	depSet depset.DependencySet,
+	cfgs depset.RollupConfigSetV2,
+	l1Client runcfg.RuntimeCfgL1Source,
+) *RuntimeConfig {
+	out := &RuntimeConfig{
+		log:      logger,
+		depSet:   depSet,
+		cfgs:     cfgs,
+		l1Client: l1Client,
+	}
+	for _, chainID := range depSet.Chains() {
+		out.sequencerAuth.Set(chainID, SequencerAuthEntry{})
+	}
+	return out
+}
+
+func (r *RuntimeConfig) OnEvent(ctx context.Context, ev event.Event) bool {
+	switch x := ev.(type) {
+	case RunCfgUpdateRequestEvent:
+		r.Load(ctx, x.L1Block)
+		return true
+	}
+	return false
+}
+
+func (r *RuntimeConfig) Load(ctx context.Context, l1Block eth.BlockID) {
+	for _, chainID := range r.ChainIDs() {
+		rollupCfg := r.cfgs.RollupConfig(chainID)
+
+		// TODO: if we replace this with receipt-parsing,
+		// then we can read cached data, since we already do derivation.
+
+		p2pSignerVal, err := r.l1Client.ReadStorageAt(ctx, rollupCfg.L1SystemConfigAddress,
+			runcfg.UnsafeBlockSignerAddressSystemConfigStorageSlot, l1Block.Hash)
+		if err != nil {
+			r.log.Warn("Failed to load params from L1", "chainID", chainID, "err", err)
+			continue
+		}
+		r.sequencerAuth.Set(chainID, SequencerAuthEntry{
+			LastL1Update: l1Block,
+			Address:      common.BytesToAddress(p2pSignerVal[:]),
+		})
+	}
+}
+
+func (r *RuntimeConfig) ChainIDs() []eth.ChainID {
+	return r.depSet.Chains()
+}
+
+func (r *RuntimeConfig) P2PSequencerAddress(chainID eth.ChainID) (common.Address, error) {
+	entry, ok := r.sequencerAuth.Get(chainID)
+	if !ok {
+		return common.Address{}, types.ErrUnknownChain
+	}
+	if entry.Address == (common.Address{}) {
+		return common.Address{}, errors.New("not loaded")
+	}
+	return entry.Address, nil
+}
+
+func (r *RuntimeConfig) BlockVersion(chainID eth.ChainID, timestamp uint64) (eth.BlockVersion, error) {
+	if !r.depSet.HasChain(chainID) {
+		return 0, types.ErrUnknownChain
+	}
+	rollupCfg := r.cfgs.RollupConfig(chainID)
+	if rollupCfg.IsIsthmus(timestamp) {
+		return eth.BlockV4, nil
+	} else if rollupCfg.IsEcotone(timestamp) {
+		return eth.BlockV3, nil
+	} else if rollupCfg.IsCanyon(timestamp) {
+		return eth.BlockV2, nil
+	} else {
+		return eth.BlockV1, nil
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/build_cancel.go
+++ b/op-node/opnv2/service/backend/rwel/build_cancel.go
@@ -1,0 +1,39 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type BuildCancelEvent struct {
+	Info  eth.PayloadInfo
+	Force bool
+}
+
+func (ev BuildCancelEvent) String() string {
+	return "build-cancel"
+}
+
+func (eq *RWEL) onBuildCancel(ctx context.Context, ev BuildCancelEvent) {
+	rpcCtx, cancel := context.WithTimeout(eq.ctx, buildCancelTimeout)
+	defer cancel()
+	// the building job gets wrapped up as soon as the payload is retrieved, there's no explicit cancel in the Engine API
+	eq.log.Warn("cancelling old block building job", "info", ev.Info)
+	_, err := eq.engine.GetPayload(rpcCtx, ev.Info)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
+			eq.log.Warn("tried cancelling unknown block building job", "info", ev.Info, "err", err)
+			return // if unknown, then it did not need to be cancelled anymore.
+		}
+		eq.log.Error("failed to cancel block building job", "info", ev.Info, "err", err)
+		if !ev.Force {
+			eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
+		}
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/build_invalid.go
+++ b/op-node/opnv2/service/backend/rwel/build_invalid.go
@@ -1,0 +1,59 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+// BuildInvalidEvent is an internal engine event, to post-process upon invalid attributes.
+// Not for temporary processing problems.
+type BuildInvalidEvent struct {
+	Attributes *derive.AttributesWithParent
+	Err        error
+}
+
+func (ev BuildInvalidEvent) String() string {
+	return "build-invalid"
+}
+
+// InvalidPayloadAttributesEvent is a signal to external derivers that the attributes were invalid.
+type InvalidPayloadAttributesEvent struct {
+	Attributes *derive.AttributesWithParent
+	Err        error
+}
+
+func (ev InvalidPayloadAttributesEvent) String() string {
+	return "invalid-payload-attributes"
+}
+
+func (eq *RWEL) onBuildInvalid(ctx context.Context, ev BuildInvalidEvent) {
+	eq.log.Warn("could not process payload attributes", "err", ev.Err)
+
+	// Deposit transaction execution errors are suppressed in the execution engine, but if the
+	// block is somehow invalid, there is nothing we can do to recover & we should exit.
+	if ev.Attributes.Attributes.IsDepositsOnly() {
+		eq.log.Error("deposit only block was invalid", "parent", ev.Attributes.Parent, "err", ev.Err)
+		eq.emitter.Emit(ctx, rollup.CriticalErrorEvent{
+			Err: fmt.Errorf("failed to process block with only deposit transactions: %w", ev.Err),
+		})
+		return
+	}
+
+	if ev.Attributes.IsDerived() {
+		req := derive.DepositsOnlyPayloadAttributesRequestEvent{
+			Parent:      ev.Attributes.Parent.ID(),
+			DerivedFrom: ev.Attributes.DerivedFrom,
+		}
+		eq.log.Warn("Payload building was invalid, requesting deposits-only attributes",
+			"parent", req.Parent, "derived_from", req.DerivedFrom)
+		eq.emitter.Emit(ctx, req)
+		return
+	}
+	// drop the payload without inserting it into the engine
+
+	// Signal that we deemed the attributes as unfit
+	eq.emitter.Emit(ctx, InvalidPayloadAttributesEvent(ev))
+}

--- a/op-node/opnv2/service/backend/rwel/build_seal.go
+++ b/op-node/opnv2/service/backend/rwel/build_seal.go
@@ -1,0 +1,119 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// PayloadSealInvalidEvent identifies a permanent in-consensus problem with the payload sealing.
+type PayloadSealInvalidEvent struct {
+	Info eth.PayloadInfo
+	Err  error
+
+	DerivedFrom eth.L1BlockRef
+}
+
+func (ev PayloadSealInvalidEvent) String() string {
+	return "payload-seal-invalid"
+}
+
+// PayloadSealExpiredErrorEvent identifies a form of failed payload-sealing that is not coupled
+// to the attributes themselves, but rather the build-job process.
+// The user should re-attempt by starting a new build process. The payload-sealing job should not be re-attempted,
+// as it most likely expired, timed out, or referenced an otherwise invalidated block-building job identifier.
+type PayloadSealExpiredErrorEvent struct {
+	Info eth.PayloadInfo
+	Err  error
+
+	DerivedFrom eth.L1BlockRef
+}
+
+func (ev PayloadSealExpiredErrorEvent) String() string {
+	return "payload-seal-expired-error"
+}
+
+type BuildSealEvent struct {
+	Info         eth.PayloadInfo
+	BuildStarted time.Time
+	// payload is promoted to pending-safe if non-zero
+	DerivedFrom eth.L1BlockRef
+}
+
+func (ev BuildSealEvent) String() string {
+	return "build-seal"
+}
+
+func (eq *RWEL) onBuildSeal(ctx context.Context, ev BuildSealEvent) {
+	rpcCtx, cancel := context.WithTimeout(ctx, buildSealTimeout)
+	defer cancel()
+
+	sealingStart := time.Now()
+	envelope, err := eq.engine.GetPayload(rpcCtx, ev.Info)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) && eth.ErrorCode(rpcErr.ErrorCode()) == eth.UnknownPayload {
+			eq.log.Warn("Cannot seal block, payload ID is unknown",
+				"payloadID", ev.Info.ID, "payload_time", ev.Info.Timestamp,
+				"started_time", ev.BuildStarted)
+		}
+		// Although the engine will very likely not be able to continue from here with the same building job,
+		// we still call it "temporary", since the exact same payload-attributes have not been invalidated in-consensus.
+		// So the user (attributes-handler or sequencer) should be able to re-attempt the exact
+		// same attributes with a new block-building job from here to recover from this error.
+		// We name it "expired", as this generally identifies a timeout, unknown job, or otherwise invalidated work.
+		eq.emitter.Emit(ctx, PayloadSealExpiredErrorEvent{
+			Info:        ev.Info,
+			Err:         fmt.Errorf("failed to seal execution payload (ID: %s): %w", ev.Info.ID, err),
+			DerivedFrom: ev.DerivedFrom,
+		})
+		return
+	}
+
+	if err := sanityCheckPayload(envelope.ExecutionPayload); err != nil {
+		eq.emitter.Emit(ctx, PayloadSealInvalidEvent{
+			Info: ev.Info,
+			Err: fmt.Errorf("failed sanity-check of execution payload contents (ID: %s, blockhash: %s): %w",
+				ev.Info.ID, envelope.ExecutionPayload.BlockHash, err),
+			DerivedFrom: ev.DerivedFrom,
+		})
+		return
+	}
+
+	ref, err := derive.PayloadToBlockRef(eq.cfg, envelope.ExecutionPayload)
+	if err != nil {
+		eq.emitter.Emit(ctx, PayloadSealInvalidEvent{
+			Info:        ev.Info,
+			Err:         fmt.Errorf("failed to decode L2 block ref from payload: %w", err),
+			DerivedFrom: ev.DerivedFrom,
+		})
+		return
+	}
+
+	now := time.Now()
+	sealTime := now.Sub(sealingStart)
+	buildTime := now.Sub(ev.BuildStarted)
+	eq.metrics.RecordSequencerSealingTime(sealTime)
+	eq.metrics.RecordSequencerBuildingDiffTime(buildTime - time.Duration(eq.cfg.BlockTime)*time.Second)
+
+	txnCount := len(envelope.ExecutionPayload.Transactions)
+	depositCount, _ := lastDeposit(envelope.ExecutionPayload.Transactions)
+	eq.metrics.CountSequencedTxsInBlock(txnCount, depositCount)
+
+	eq.log.Debug("Built new L2 block", "l2_unsafe", ref, "l1_origin", ref.L1Origin,
+		"txs", txnCount, "deposits", depositCount, "time", ref.Time, "seal_time", sealTime, "build_time", buildTime)
+
+	eq.emitter.Emit(ctx, BuildSealedEvent{
+		DerivedFrom:  ev.DerivedFrom,
+		BuildStarted: ev.BuildStarted,
+		Info:         ev.Info,
+		Envelope:     envelope,
+		Ref:          ref,
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/build_sealed.go
+++ b/op-node/opnv2/service/backend/rwel/build_sealed.go
@@ -1,0 +1,35 @@
+package rwel
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// BuildSealedEvent is emitted by the engine when a payload finished building,
+// but is not locally inserted as canonical block yet
+type BuildSealedEvent struct {
+	// payload is promoted to pending-safe if non-zero
+	DerivedFrom  eth.L1BlockRef
+	BuildStarted time.Time
+
+	Info     eth.PayloadInfo
+	Envelope *eth.ExecutionPayloadEnvelope
+	Ref      eth.L2BlockRef
+}
+
+func (ev BuildSealedEvent) String() string {
+	return "build-sealed"
+}
+
+func (eq *RWEL) onBuildSealed(ctx context.Context, ev BuildSealedEvent) {
+	// If a (pending) safe block, immediately process the block
+	if ev.DerivedFrom != (eth.L1BlockRef{}) {
+		eq.emitter.Emit(ctx, PayloadProcessEvent{
+			DerivedFrom:  ev.DerivedFrom,
+			Envelope:     ev.Envelope,
+			BuildStarted: ev.BuildStarted,
+		})
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/build_start.go
+++ b/op-node/opnv2/service/backend/rwel/build_start.go
@@ -1,0 +1,131 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type BuildStartEvent struct {
+	Attributes *derive.AttributesWithParent
+}
+
+func (ev BuildStartEvent) String() string {
+	return "build-start"
+}
+
+func (eq *RWEL) onBuildStart(ctx context.Context, ev BuildStartEvent) {
+	rpcCtx, cancel := context.WithTimeout(eq.ctx, buildStartTimeout)
+	defer cancel()
+
+	fcEvent := ForkchoiceUpdateEvent{
+		LocalUnsafe: ev.Attributes.Parent.BlockRef(),
+		CrossSafe:   eq.state.CrossSafe(),
+		Finalized:   eq.state.Finalized(),
+	}
+	if fcEvent.LocalUnsafe.Number < fcEvent.Finalized.Number {
+		err := fmt.Errorf("invalid block-building pre-state, unsafe head %s is behind finalized head %s",
+			fcEvent.LocalUnsafe, fcEvent.Finalized)
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
+		return
+	}
+	fc := eth.ForkchoiceState{
+		HeadBlockHash:      fcEvent.LocalUnsafe.Hash,
+		SafeBlockHash:      fcEvent.CrossSafe.Hash,
+		FinalizedBlockHash: fcEvent.Finalized.Hash,
+	}
+	buildStartTime := time.Now()
+
+	fcRes, err := eq.engine.ForkchoiceUpdate(rpcCtx, &fc, ev.Attributes.Attributes)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
+			switch code := eth.ErrorCode(rpcErr.ErrorCode()); code {
+			case eth.InvalidForkchoiceState:
+				eq.emitter.Emit(ctx, rollup.ResetEvent{
+					Err: fmt.Errorf("need reset to resolve pre-state problem: %w", err),
+				})
+				return
+			case eth.InvalidPayloadAttributes:
+				eq.state.SetLocalUnsafe(ev.Attributes.Parent.BlockRef())
+				eq.emitter.Emit(ctx, fcEvent) // the forkchoice was valid, but the attributes were not
+				eq.emitter.Emit(ctx, BuildInvalidEvent{Attributes: ev.Attributes, Err: err})
+				return
+			default:
+				if code.IsEngineError() {
+					err = fmt.Errorf("unexpected engine error code in FCU build start response: %w", err)
+					eq.emitter.Emit(ctx, BuildInvalidEvent{Attributes: ev.Attributes, Err: err})
+					return
+				} else {
+					eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+						Err: fmt.Errorf("unexpected generic RPC on FCU build start: %w", err),
+					})
+				}
+			}
+		} else {
+			eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("temporary error: %w", err),
+			})
+			return
+		}
+	}
+
+	eq.state.SetIsSyncing(false)
+	eq.state.SetSyncTarget(eth.BlockID{})
+	switch fcRes.PayloadStatus.Status {
+	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
+		// Even if the building is invalid, the FCU applies, and may cause reorgs and such.
+		// Let's check if we're in sync, and try to repair if we mismatch.
+		if latest := fcRes.PayloadStatus.LatestValidHash; latest != nil && *latest != (common.Hash{}) && *latest != eq.state.LocalUnsafe().Hash {
+			eq.emitter.Emit(ctx, PollLocalUnsafeRequestEvent{})
+		}
+		err := eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)
+		eq.emitter.Emit(ctx, BuildInvalidEvent{Attributes: ev.Attributes, Err: err})
+		return
+	case eth.ExecutionValid:
+		id := fcRes.PayloadID
+		if id == nil {
+			eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("unexpected nil payload ID (does the engine support block building?): %w", err),
+			})
+			return
+		}
+		// engine-API spec says we will get the FCU head back, let's warn if we don't
+		if latest := fcRes.PayloadStatus.LatestValidHash; latest != nil && ev.Attributes.Parent.Hash != *latest {
+			eq.log.Warn("Returned latest hash does not match", "latest", *latest, "expected", ev.Attributes.Parent)
+		}
+		eq.state.SetLocalUnsafe(ev.Attributes.Parent.BlockRef())
+		eq.emitter.Emit(ctx, fcEvent)
+		eq.emitter.Emit(ctx, BuildStartedEvent{
+			Info:         eth.PayloadInfo{ID: *id, Timestamp: uint64(ev.Attributes.Attributes.Timestamp)},
+			BuildStarted: buildStartTime,
+			DerivedFrom:  ev.Attributes.DerivedFrom,
+			Parent:       ev.Attributes.Parent.BlockRef(),
+		})
+		eq.emitter.Emit(ctx, NoSyncingEvent{
+			LocalUnsafe: eq.state.LocalUnsafe(),
+		})
+	case eth.ExecutionSyncing:
+		eq.state.SetIsSyncing(true)
+		eq.state.SetSyncTarget(ev.Attributes.Parent.ID())
+		eq.emitter.Emit(ctx, SyncingUpdateEvent{
+			SyncTarget: eq.state.SyncTarget(),
+		})
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("node is busy syncing, cannot build block on top of %s", ev.Attributes.Parent),
+		})
+	default:
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: eth.ForkchoiceUpdateErr(fcRes.PayloadStatus),
+		})
+		return
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/build_started.go
+++ b/op-node/opnv2/service/backend/rwel/build_started.go
@@ -1,0 +1,34 @@
+package rwel
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type BuildStartedEvent struct {
+	Info eth.PayloadInfo
+
+	BuildStarted time.Time
+
+	Parent eth.BlockRef
+
+	// payload is promoted to pending-safe if non-zero
+	DerivedFrom eth.L1BlockRef
+}
+
+func (ev BuildStartedEvent) String() string {
+	return "build-started"
+}
+
+func (eq *RWEL) onBuildStarted(ctx context.Context, ev BuildStartedEvent) {
+	// If a (pending) safe block, immediately seal the block
+	if ev.DerivedFrom != (eth.L1BlockRef{}) {
+		eq.emitter.Emit(ctx, BuildSealEvent{
+			Info:         ev.Info,
+			BuildStarted: ev.BuildStarted,
+			DerivedFrom:  ev.DerivedFrom,
+		})
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/consolidate.go
+++ b/op-node/opnv2/service/backend/rwel/consolidate.go
@@ -1,0 +1,92 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/attributes"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type TryConsolidateAttributesEvent struct {
+	Attributes *derive.AttributesWithParent
+}
+
+func (ev TryConsolidateAttributesEvent) String() string {
+	return "try-consolidate-attributes"
+}
+
+type FailConsolidateAttributesEvent struct {
+	Attributes *derive.AttributesWithParent
+	Got        *eth.ExecutionPayloadEnvelope
+	Ref        eth.L2BlockRef
+}
+
+func (ev FailConsolidateAttributesEvent) String() string {
+	return "fail-consolidate-attributes"
+}
+
+type ConfirmConsolidateAttributesEvent struct {
+	Attributes *derive.AttributesWithParent
+	Got        *eth.ExecutionPayloadEnvelope
+	Ref        eth.L2BlockRef
+}
+
+func (ev ConfirmConsolidateAttributesEvent) String() string {
+	return "confirm-consolidate-attributes"
+}
+
+func (eq *RWEL) onTryConsolidateAttributes(ctx context.Context, ev TryConsolidateAttributesEvent) {
+	onto := ev.Attributes.Parent
+	attrib := ev.Attributes.Attributes
+
+	rpcCtx, cancel := context.WithTimeout(ctx, buildStartTimeout)
+	defer cancel()
+	envelope, err := eq.engine.PayloadByNumber(rpcCtx, onto.Number+1)
+	if err != nil {
+		eq.emitter.Emit(eq.ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to get existing unsafe payload to compare against derived attributes from L1: %w", err),
+		})
+		return
+	}
+
+	if envelope.ExecutionPayload.ParentHash != ev.Attributes.Parent.Hash {
+		eq.emitter.Emit(eq.ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("cannot consolidate block (t=%d) when parent-block (%s) does not match expected block (%s)",
+				ev.Attributes.Attributes.Timestamp, ev.Attributes.Parent, envelope.ExecutionPayload.ParentID()),
+		})
+		return
+	}
+
+	ref, err := derive.PayloadToBlockRef(eq.cfg, envelope.ExecutionPayload)
+	if err != nil {
+		eq.log.Error("Failed to compute block-ref from execution payload")
+		return
+	}
+
+	// TODO: inspect if the envelope is a replacement block
+	// If it is, then the engine may already have replaced, while the attributes may get invalidated later.
+	// We should emit an event to signal that, the controller can proceed.
+
+	if err := attributes.AttributesMatchBlock(eq.cfg, attrib, onto.Hash, envelope, eq.log); err != nil {
+		eq.log.Warn("L2 reorg: existing unsafe block does not match derived attributes from L1",
+			"err", err, "unsafe", envelope.ExecutionPayload.ID(), "pending_safe", onto)
+
+		// No need to immediately reorg. Just signal that we failed to consolidate.
+		eq.emitter.Emit(ctx, FailConsolidateAttributesEvent{
+			Attributes: ev.Attributes,
+			Got:        envelope,
+			Ref:        ref,
+		})
+
+		return
+	} else {
+		eq.emitter.Emit(ctx, ConfirmConsolidateAttributesEvent{
+			Attributes: ev.Attributes,
+			Got:        envelope,
+			Ref:        ref,
+		})
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/engstate/state.go
+++ b/op-node/opnv2/service/backend/rwel/engstate/state.go
@@ -1,0 +1,94 @@
+package engstate
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type Metrics interface {
+	metrics.ChainRefMetricer
+}
+
+type State struct {
+	// localUnsafe block is the block that the engine considers "latest".
+	// This will never be optimistically assumed from the engine.
+	// This is confirmed as "latestValidHash" in the FCU response.
+	localUnsafe eth.BlockRef
+
+	// crossSafe block is the block that the engine considers "safe".
+	// This will never be optimistically assumed from the engine.
+	crossSafe eth.BlockRef
+
+	// finalized block is the block that the engine considers "finalized",
+	// or should consider "finalized" after FCU.
+	finalized eth.BlockRef
+
+	// true if the last returned newPayload or FCU status was "syncing"
+	isSyncing bool
+
+	// syncTarget is the block we have last asked the engine to sync towards,
+	// before getting a "SYNCING" status response.
+	syncTarget eth.BlockID
+
+	log     log.Logger
+	metrics Metrics
+}
+
+func NewState(logger log.Logger, m Metrics) *State {
+	return &State{
+		isSyncing: false,
+		log:       logger,
+		metrics:   m,
+	}
+}
+
+func (st *State) IsSyncing() bool {
+	return st.isSyncing
+}
+
+func (st *State) SetIsSyncing(v bool) {
+	// TODO metric?
+	st.isSyncing = v
+}
+
+func (st *State) SyncTarget() eth.BlockID {
+	return st.syncTarget
+}
+
+func (st *State) SetSyncTarget(v eth.BlockID) {
+	st.log.Trace("Setting sync-target", "sync_target", v)
+	st.syncTarget = v
+}
+
+func (st *State) LocalUnsafe() eth.BlockRef {
+	return st.localUnsafe
+}
+
+func (st *State) SetLocalUnsafe(v eth.BlockRef) {
+	st.log.Trace("Setting local-unsafe", "local_unsafe", v)
+	st.metrics.RecordLocalUnsafe(types.BlockSealFromRef(v))
+	st.localUnsafe = v
+}
+
+func (st *State) CrossSafe() eth.BlockRef {
+	return st.crossSafe
+}
+
+func (st *State) SetCrossSafe(v eth.BlockRef) {
+	st.log.Trace("Setting cross-safe", "cross_safe", v)
+	st.metrics.RecordCrossSafe(types.BlockSealFromRef(v))
+	st.crossSafe = v
+}
+
+func (st *State) Finalized() eth.BlockRef {
+	return st.finalized
+}
+
+func (st *State) SetFinalized(v eth.BlockRef) {
+	st.log.Trace("Setting finalized", "finalized", v)
+	st.metrics.RecordFinalized(types.BlockSealFromRef(v))
+	st.finalized = v
+}

--- a/op-node/opnv2/service/backend/rwel/helpers.go
+++ b/op-node/opnv2/service/backend/rwel/helpers.go
@@ -1,0 +1,64 @@
+package rwel
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// isDepositTx checks an opaqueTx to determine if it is a Deposit Transaction
+// It has to return an error in the case the transaction is empty
+func isDepositTx(opaqueTx eth.Data) (bool, error) {
+	if len(opaqueTx) == 0 {
+		return false, errors.New("empty transaction")
+	}
+	return opaqueTx[0] == types.DepositTxType, nil
+}
+
+// lastDeposit finds the index of last deposit at the start of the transactions.
+// It walks the transactions from the start until it finds a non-deposit tx.
+// An error is returned if any looked at transaction cannot be decoded
+func lastDeposit(txns []eth.Data) (int, error) {
+	var lastDeposit int
+	for i, tx := range txns {
+		deposit, err := isDepositTx(tx)
+		if err != nil {
+			return 0, fmt.Errorf("invalid transaction at idx %d", i)
+		}
+		if deposit {
+			lastDeposit = i
+		} else {
+			break
+		}
+	}
+	return lastDeposit, nil
+}
+
+func sanityCheckPayload(payload *eth.ExecutionPayload) error {
+	// Sanity check payload before inserting it
+	if len(payload.Transactions) == 0 {
+		return errors.New("no transactions in returned payload")
+	}
+	if payload.Transactions[0][0] != types.DepositTxType {
+		return fmt.Errorf("first transaction was not deposit tx. Got %v", payload.Transactions[0][0])
+	}
+	// Ensure that the deposits are first
+	lastDeposit, err := lastDeposit(payload.Transactions)
+	if err != nil {
+		return fmt.Errorf("failed to find last deposit: %w", err)
+	}
+	// Ensure no deposits after last deposit
+	for i := lastDeposit + 1; i < len(payload.Transactions); i++ {
+		tx := payload.Transactions[i]
+		deposit, err := isDepositTx(tx)
+		if err != nil {
+			return fmt.Errorf("failed to decode transaction idx %d: %w", i, err)
+		}
+		if deposit {
+			return fmt.Errorf("deposit tx (%d) after other tx in l2 block with prev deposit at idx %d", i, lastDeposit)
+		}
+	}
+	return nil
+}

--- a/op-node/opnv2/service/backend/rwel/id.go
+++ b/op-node/opnv2/service/backend/rwel/id.go
@@ -1,0 +1,37 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+)
+
+const UnknownID ID = 0
+
+type ID uint64
+
+func (id ID) String() string {
+	return fmt.Sprintf("RWEL-%d", uint64(id))
+}
+
+var idGen = new(atomic.Uint64)
+
+func NextID() ID {
+	return ID(idGen.Add(1))
+}
+
+type idContextKeyType struct{}
+
+var idContextKey = idContextKeyType{}
+
+func IDFromContext(ctx context.Context) ID {
+	v := ctx.Value(idContextKey)
+	if v == nil {
+		return UnknownID
+	}
+	return v.(ID)
+}
+
+func WithID(ctx context.Context, id ID) context.Context {
+	return context.WithValue(ctx, idContextKey, id)
+}

--- a/op-node/opnv2/service/backend/rwel/no_building_fcu.go
+++ b/op-node/opnv2/service/backend/rwel/no_building_fcu.go
@@ -1,0 +1,108 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type ForkchoiceUpdateRequestEvent struct {
+	LocalUnsafe eth.BlockRef
+	CrossSafe   eth.BlockRef
+	Finalized   eth.BlockRef
+}
+
+func (ev ForkchoiceUpdateRequestEvent) String() string {
+	return "forkchoice-update-request"
+}
+
+func (e *RWEL) onForkchoiceUpdateRequest(ctx context.Context, ev ForkchoiceUpdateRequestEvent) {
+	if e.state.IsSyncing() {
+		e.log.Warn("Attempting to update forkchoice state while EL syncing")
+	}
+
+	if ev.LocalUnsafe.Number < ev.Finalized.Number {
+		err := fmt.Errorf("invalid forkchoice state, unsafe head %s is behind finalized head %s",
+			ev.LocalUnsafe, ev.Finalized)
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: err,
+		})
+		return
+	}
+
+	fc := eth.ForkchoiceState{
+		HeadBlockHash:      ev.LocalUnsafe.Hash,
+		SafeBlockHash:      ev.CrossSafe.Hash,
+		FinalizedBlockHash: ev.Finalized.Hash,
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, fcuTimeout)
+	defer cancel()
+	fcRes, err := e.engine.ForkchoiceUpdate(rpcCtx, &fc, nil)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
+			switch eth.ErrorCode(rpcErr.ErrorCode()) {
+			case eth.InvalidForkchoiceState:
+				// TODO improve error, recover
+				e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+					Err: fmt.Errorf("no-build forkchoice update was inconsistent with engine: %w", err),
+				})
+			default:
+				e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+					Err: fmt.Errorf("unexpected error code in non-build forkchoice-updated response: %w", err),
+				})
+			}
+		} else {
+			e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("failed to sync forkchoice with engine: %w", err),
+			})
+		}
+		return
+	}
+	e.state.SetIsSyncing(false)
+	e.state.SetSyncTarget(eth.BlockID{})
+	switch fcRes.PayloadStatus.Status {
+	case eth.ExecutionSyncing:
+		e.state.SetIsSyncing(true)
+		e.state.SetSyncTarget(ev.LocalUnsafe.ID())
+		e.emitter.Emit(ctx, SyncingUpdateEvent{
+			SyncTarget: e.state.SyncTarget(),
+		})
+	case eth.ExecutionValid:
+		if e.state.LocalUnsafe() != ev.LocalUnsafe {
+			e.state.SetLocalUnsafe(ev.LocalUnsafe)
+			e.emitter.Emit(ctx, LocalUnsafeUpdateEvent{
+				Ref: e.state.LocalUnsafe(),
+			})
+		}
+		if e.state.CrossSafe() != ev.CrossSafe {
+			e.state.SetCrossSafe(ev.CrossSafe)
+			e.emitter.Emit(ctx, CrossSafeUpdateEvent{
+				CrossSafe: e.state.CrossSafe(),
+			})
+		}
+		if e.state.Finalized() != ev.Finalized {
+			e.state.SetCrossSafe(ev.CrossSafe)
+			e.emitter.Emit(ctx, FinalizedUpdateEvent{
+				Ref: e.state.Finalized(),
+			})
+		}
+		e.emitter.Emit(ctx, ForkchoiceUpdateEvent{
+			LocalUnsafe: e.state.LocalUnsafe(),
+			CrossSafe:   e.state.CrossSafe(),
+			Finalized:   e.state.Finalized(),
+		})
+		e.emitter.Emit(ctx, NoSyncingEvent{
+			LocalUnsafe: e.state.LocalUnsafe(),
+		})
+	default:
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("unexpected engine status: %w", eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)),
+		})
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/params.go
+++ b/op-node/opnv2/service/backend/rwel/params.go
@@ -1,0 +1,11 @@
+package rwel
+
+import "time"
+
+const (
+	buildSealTimeout      = time.Second * 10
+	buildStartTimeout     = time.Second * 10
+	buildCancelTimeout    = time.Second * 10
+	payloadProcessTimeout = time.Second * 10
+	fcuTimeout            = time.Second * 10
+)

--- a/op-node/opnv2/service/backend/rwel/payload_invalid.go
+++ b/op-node/opnv2/service/backend/rwel/payload_invalid.go
@@ -1,0 +1,21 @@
+package rwel
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type PayloadInvalidEvent struct {
+	Envelope *eth.ExecutionPayloadEnvelope
+	Err      error
+}
+
+func (ev PayloadInvalidEvent) String() string {
+	return "payload-invalid"
+}
+
+func (eq *RWEL) onPayloadInvalid(ctx context.Context, ev PayloadInvalidEvent) {
+	eq.log.Warn("Payload was invalid", "block", ev.Envelope.ExecutionPayload.ID(),
+		"err", ev.Err, "timestamp", uint64(ev.Envelope.ExecutionPayload.Timestamp))
+}

--- a/op-node/opnv2/service/backend/rwel/payload_process.go
+++ b/op-node/opnv2/service/backend/rwel/payload_process.go
@@ -1,0 +1,100 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type PayloadProcessEvent struct {
+	// payload is promoted to pending-safe if non-zero
+	DerivedFrom  eth.L1BlockRef
+	BuildStarted time.Time
+
+	Envelope *eth.ExecutionPayloadEnvelope
+}
+
+func (ev PayloadProcessEvent) String() string {
+	return "payload-process"
+}
+
+func (eq *RWEL) onPayloadProcess(ctx context.Context, ev PayloadProcessEvent) {
+	rpcCtx, cancel := context.WithTimeout(ctx, payloadProcessTimeout)
+	defer cancel()
+
+	insertStart := time.Now()
+	status, err := eq.engine.NewPayload(rpcCtx,
+		ev.Envelope.ExecutionPayload, ev.Envelope.ParentBeaconBlockRoot)
+	if err != nil {
+		// Engine API enshrines status codes:
+		// -38005 invalid fork -> if wrong engine API method version was used
+		// -32602 invalid params -> if wrong engine API method content was used
+		// But we support the right methods, and if the assumption is
+		// broken it's best to stall on temporary errors until the discrepancy is identified.
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to insert execution payload: %w", err),
+		})
+		return
+	}
+	ref := ev.Envelope.BlockRef()
+	switch status.Status {
+	case eth.ExecutionInvalid, eth.ExecutionInvalidBlockHash:
+		// Depending on execution engine, not all block-validity checks run immediately on build-start
+		// at the time of the forkchoiceUpdated engine-API call, nor during getPayload.
+		if ev.DerivedFrom != (eth.L1BlockRef{}) {
+			req := derive.DepositsOnlyPayloadAttributesRequestEvent{
+				Parent:      ev.Envelope.BlockRef().ParentID(),
+				DerivedFrom: ev.DerivedFrom,
+			}
+			eq.log.Warn("Payload processing was invalid, requesting deposits-only attributes",
+				"parent", req.Parent, "derived_from", req.DerivedFrom)
+			eq.emitter.Emit(ctx, req)
+			return
+		}
+
+		eq.emitter.Emit(ctx, PayloadInvalidEvent{
+			Envelope: ev.Envelope,
+			Err:      eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+		})
+		return
+	case eth.ExecutionAccepted:
+		if eq.state.IsSyncing() {
+			eq.log.Info("Execution engine is syncing, and buffered the new block", "ref", ref)
+		} else {
+			eq.log.Warn("Execution engine accepted block but never signaled it is syncing", "ref", ref)
+		}
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("cannot validate payload yet, but tentatively accepted block %s", ref),
+		})
+	case eth.ExecutionSyncing:
+		eq.state.SetIsSyncing(true)
+		eq.emitter.Emit(ctx, SyncingUpdateEvent{
+			SyncTarget: eq.state.SyncTarget(),
+		})
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+		})
+	case eth.ExecutionValid:
+		eq.state.SetIsSyncing(false)
+		eq.state.SetSyncTarget(eth.BlockID{})
+		eq.emitter.Emit(ctx, PayloadSuccessEvent{
+			DerivedFrom:   ev.DerivedFrom,
+			BuildStarted:  ev.BuildStarted,
+			InsertStarted: insertStart,
+			Envelope:      ev.Envelope,
+		})
+		eq.emitter.Emit(ctx, NoSyncingEvent{
+			LocalUnsafe: eq.state.LocalUnsafe(),
+		})
+		return
+	default:
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+		})
+		return
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/payload_success.go
+++ b/op-node/opnv2/service/backend/rwel/payload_success.go
@@ -1,0 +1,28 @@
+package rwel
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type PayloadSuccessEvent struct {
+	// payload is promoted to pending-safe if non-zero
+	DerivedFrom eth.L1BlockRef
+
+	BuildStarted  time.Time
+	InsertStarted time.Time
+
+	Envelope *eth.ExecutionPayloadEnvelope
+}
+
+func (ev PayloadSuccessEvent) String() string {
+	return "payload-success"
+}
+
+func (eq *RWEL) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEvent) {
+	// TODO: on invalidate-block replacements we need to update cross-safe at the same time
+
+	eq.emitter.Emit(ctx, PromoteLocalUnsafeEvent{Ref: ev.Envelope.BlockRef()})
+}

--- a/op-node/opnv2/service/backend/rwel/poll_cross_safe.go
+++ b/op-node/opnv2/service/backend/rwel/poll_cross_safe.go
@@ -1,0 +1,43 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type PollCrossSafeRequestEvent struct {
+}
+
+func (ev PollCrossSafeRequestEvent) String() string {
+	return "poll-cross-safe-request"
+}
+
+func (eq *RWEL) onPollCrossSafeRequest(ctx context.Context, ev PollCrossSafeRequestEvent) {
+	crossSafe, err := eq.engine.BlockRefByLabel(ctx, eth.Safe)
+	// Fall back to finalized, if the engine has not marked anything as "safe" yet
+	if errors.Is(err, ethereum.NotFound) {
+		eq.log.Warn("Engine does not have a 'safe' block yet, attempting to fall back to finalized now", "err", err)
+		crossSafe = eq.state.Finalized()
+	}
+	if err != nil {
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to get cross-safe block: %w", err),
+		})
+		return
+	}
+	if eq.state.CrossSafe() != crossSafe {
+		// suggest we need to poll the finalized head too, since we observed an inconsistency
+		eq.emitter.Emit(ctx, PollFinalizedRequestEvent{})
+		eq.state.SetCrossSafe(crossSafe)
+	}
+	// Even if no change, just emit the update event, to show we are done polling.
+	eq.emitter.Emit(ctx, CrossSafeUpdateEvent{
+		CrossSafe: crossSafe,
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/poll_finalized.go
+++ b/op-node/opnv2/service/backend/rwel/poll_finalized.go
@@ -1,0 +1,47 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type PollFinalizedRequestEvent struct {
+}
+
+func (ev PollFinalizedRequestEvent) String() string {
+	return "poll-finalized-request"
+}
+
+func (eq *RWEL) onPollFinalizedRequest(ctx context.Context, ev PollFinalizedRequestEvent) {
+	finalized, err := eq.engine.BlockRefByLabel(ctx, eth.Finalized)
+	// Fall back to genesis, if the engine has not marked anything as "finalized" yet
+	if errors.Is(err, ethereum.NotFound) {
+		eq.log.Warn("Engine does not have a 'finalized' block yet, attempting to fall back to genesis now", "err", err)
+		finalized = eth.BlockRef{
+			Hash:       eq.cfg.Genesis.L2.Hash,
+			Number:     eq.cfg.Genesis.L2.Number,
+			ParentHash: common.Hash{},
+			Time:       eq.cfg.Genesis.L2Time,
+		}
+		err = nil
+	}
+	if err != nil {
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to get finalized block: %w", err),
+		})
+		return
+	}
+	if eq.state.Finalized() != finalized {
+		eq.state.SetFinalized(finalized)
+	}
+	// Even if no change, just emit the update event, to show we are done polling.
+	eq.emitter.Emit(ctx, FinalizedUpdateEvent{
+		Ref: finalized,
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/poll_local_unsafe.go
+++ b/op-node/opnv2/service/backend/rwel/poll_local_unsafe.go
@@ -1,0 +1,35 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type PollLocalUnsafeRequestEvent struct {
+}
+
+func (ev PollLocalUnsafeRequestEvent) String() string {
+	return "poll-local-unsafe-request"
+}
+
+func (eq *RWEL) onPollLocalUnsafeRequest(ctx context.Context, ev PollLocalUnsafeRequestEvent) {
+	latest, err := eq.engine.BlockRefByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		eq.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to get latest block: %w", err),
+		})
+		return
+	}
+	if eq.state.LocalUnsafe() != latest {
+		// suggest we need to poll the safe head too, since we observed an inconsistency
+		eq.emitter.Emit(ctx, PollCrossSafeRequestEvent{})
+		eq.state.SetLocalUnsafe(latest)
+	}
+	// Even if no change, just emit the update event, to show we are done polling.
+	eq.emitter.Emit(ctx, LocalUnsafeUpdateEvent{
+		Ref: eq.state.LocalUnsafe(),
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/promote_cross_safe.go
+++ b/op-node/opnv2/service/backend/rwel/promote_cross_safe.go
@@ -1,0 +1,32 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// PromoteCrossSafeEvent signals that a block can be promoted to cross-safe.
+type PromoteCrossSafeEvent struct {
+	ID eth.BlockID
+}
+
+func (ev PromoteCrossSafeEvent) String() string {
+	return "promote-cross-safe"
+}
+
+func (e *RWEL) onPromoteCrossSafe(ctx context.Context, ev PromoteCrossSafeEvent) {
+	ref, err := e.engine.BlockRefByHash(ctx, ev.ID.Hash)
+	if err != nil {
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("cannot promote cross-safe block, failed to retrieve it: %w", err)})
+		return
+	}
+	e.onForkchoiceUpdateRequest(ctx, ForkchoiceUpdateRequestEvent{
+		LocalUnsafe: e.state.LocalUnsafe(),
+		CrossSafe:   ref,
+		Finalized:   e.state.Finalized(),
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/promote_finalized.go
+++ b/op-node/opnv2/service/backend/rwel/promote_finalized.go
@@ -1,0 +1,42 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// PromoteFinalizedEvent signals that a block can be marked as finalized.
+type PromoteFinalizedEvent struct {
+	ID eth.BlockID
+}
+
+func (ev PromoteFinalizedEvent) String() string {
+	return "promote-finalized"
+}
+
+func (e *RWEL) onPromoteFinalized(ctx context.Context, ev PromoteFinalizedEvent) {
+	if ev.ID.Number < e.state.Finalized().Number {
+		e.log.Error("Cannot rewind finality,",
+			"attempted", ev.ID, "finalized", e.state.Finalized())
+		return
+	}
+	if ev.ID.Number > e.state.CrossSafe().Number {
+		e.log.Error("Block must be cross-safe before it can be finalized",
+			"attempted", ev.ID, "safe", e.state.CrossSafe())
+		return
+	}
+	ref, err := e.engine.BlockRefByHash(ctx, ev.ID.Hash)
+	if err != nil {
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("cannot promote finalized block, failed to retrieve it: %w", err)})
+		return
+	}
+	e.onForkchoiceUpdateRequest(ctx, ForkchoiceUpdateRequestEvent{
+		LocalUnsafe: e.state.LocalUnsafe(),
+		CrossSafe:   e.state.CrossSafe(),
+		Finalized:   ref,
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/promote_local_unsafe.go
+++ b/op-node/opnv2/service/backend/rwel/promote_local_unsafe.go
@@ -1,0 +1,24 @@
+package rwel
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// PromoteLocalUnsafeEvent signals that the given block may now become a canonical local-unsafe block.
+type PromoteLocalUnsafeEvent struct {
+	Ref eth.BlockRef
+}
+
+func (ev PromoteLocalUnsafeEvent) String() string {
+	return "promote-local-unsafe"
+}
+
+func (e *RWEL) onPromoteLocalUnsafe(ctx context.Context, ev PromoteLocalUnsafeEvent) {
+	e.onForkchoiceUpdateRequest(ctx, ForkchoiceUpdateRequestEvent{
+		LocalUnsafe: ev.Ref,
+		CrossSafe:   e.state.CrossSafe(),
+		Finalized:   e.state.Finalized(),
+	})
+}

--- a/op-node/opnv2/service/backend/rwel/replace.go
+++ b/op-node/opnv2/service/backend/rwel/replace.go
@@ -1,0 +1,65 @@
+package rwel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type InvalidateBlockRequestEvent struct {
+	Invalidated supervisortypes.BlockSeal
+}
+
+func (ev InvalidateBlockRequestEvent) String() string {
+	return "invalidate-block-request"
+}
+
+// BuildReplacementBlockEvent is emitted when a block needs to be invalidated, and a replacement is needed.
+type BuildReplacementBlockEvent struct {
+	Invalidated eth.BlockRef
+	Attributes  *derive.AttributesWithParent
+}
+
+func (ev BuildReplacementBlockEvent) String() string {
+	return "build-replacement-block"
+}
+
+func (m *RWEL) onInvalidateBlockRequest(ctx context.Context, ev InvalidateBlockRequestEvent) {
+	m.log.Info("Invalidating block", "block", ev.Invalidated)
+
+	// Fetch the block we invalidate, so we can re-use the attributes that stay.
+	block, err := m.engine.PayloadByHash(ctx, ev.Invalidated.Hash)
+	if err != nil { // cannot invalidate if it wasn't there.
+		m.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to get block: %w", err),
+		})
+		return
+	}
+
+	parentRef, err := m.engine.L2BlockRefByHash(ctx, block.ExecutionPayload.ParentHash)
+	if err != nil {
+		m.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to get parent of invalidated block: %w", err),
+		})
+		return
+	}
+
+	ref := block.ExecutionPayload.BlockRef()
+
+	// Create the attributes that we build the replacement block with.
+	attributes := indexing.AttributesToReplaceInvalidBlock(block)
+	annotated := &derive.AttributesWithParent{
+		Attributes:  attributes,
+		Parent:      parentRef,
+		DerivedFrom: engine.ReplaceBlockSource,
+	}
+
+	m.emitter.Emit(ctx, BuildReplacementBlockEvent{
+		Invalidated: ref, Attributes: annotated})
+}

--- a/op-node/opnv2/service/backend/rwel/rwel.go
+++ b/op-node/opnv2/service/backend/rwel/rwel.go
@@ -1,0 +1,145 @@
+package rwel
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend/rwel/engstate"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+)
+
+type ExecEngine interface {
+	GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
+	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
+	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
+	BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockRef, error)
+	BlockRefByHash(ctx context.Context, hash common.Hash) (eth.BlockRef, error)
+	L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error)
+	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
+	PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error)
+}
+
+type Metrics interface {
+	engstate.Metrics
+
+	metrics.ChainSequencingMetrics
+}
+
+var _ Metrics = (*metrics.ChainMetrics)(nil)
+
+type RWEL struct {
+	// - the last propagated forkchoice state
+	// - the health (last successful contact)
+	// - the syncing situation as reported by past engine API responses
+
+	engine ExecEngine
+
+	chainID eth.ChainID
+	cfg     *rollup.Config
+
+	metrics Metrics
+	log     log.Logger
+	emitter event.Emitter
+
+	state *engstate.State
+
+	mu sync.RWMutex
+
+	ctx context.Context
+
+	id ID
+}
+
+func NewRWEL(rootCtx context.Context, id ID, logger log.Logger, eng ExecEngine, m Metrics, cfg *rollup.Config) *RWEL {
+	return &RWEL{
+		chainID: eth.ChainIDFromBig(cfg.L2ChainID),
+		engine:  eng,
+		metrics: m,
+		cfg:     cfg,
+		log:     logger,
+		state:   engstate.NewState(logger, m),
+		ctx:     WithID(rootCtx, id),
+		id:      id,
+	}
+}
+
+func (r *RWEL) ChainID() eth.ChainID {
+	return r.chainID
+}
+
+// IsSyncedTo answers if the RWEL can serve things before the given block number
+func (r *RWEL) IsSyncedTo(num uint64) bool {
+	return false
+}
+
+func (r *RWEL) ID() ID {
+	return r.id
+}
+
+var _ event.AttachEmitter = (*RWEL)(nil)
+var _ event.Deriver = (*RWEL)(nil)
+
+func (d *RWEL) AttachEmitter(em event.Emitter) {
+	d.emitter = em
+}
+
+func (d *RWEL) OnEvent(ctx context.Context, ev event.Event) bool {
+	if IDFromContext(ctx) != d.id { // If the event is not for us, ignore it
+		return false
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	switch x := ev.(type) {
+	case rollup.ForceResetEvent:
+		panic("not used anymore")
+	case PromoteLocalUnsafeEvent:
+		d.onPromoteLocalUnsafe(ctx, x)
+	case PromoteCrossSafeEvent:
+		d.onPromoteCrossSafe(ctx, x)
+	case PromoteFinalizedEvent:
+		d.onPromoteFinalized(ctx, x)
+	case ForkchoiceUpdateRequestEvent:
+		d.onForkchoiceUpdateRequest(ctx, x)
+	case BuildStartEvent:
+		d.onBuildStart(ctx, x)
+	case BuildStartedEvent:
+		d.onBuildStarted(ctx, x)
+	case BuildSealEvent:
+		d.onBuildSeal(ctx, x)
+	case BuildSealedEvent:
+		d.onBuildSealed(ctx, x)
+	case BuildInvalidEvent:
+		d.onBuildInvalid(ctx, x)
+	case BuildCancelEvent:
+		d.onBuildCancel(ctx, x)
+	case PayloadProcessEvent:
+		d.onPayloadProcess(ctx, x)
+	case PayloadSuccessEvent:
+		d.onPayloadSuccess(ctx, x)
+	case PayloadInvalidEvent:
+		d.onPayloadInvalid(ctx, x)
+	case PollLocalUnsafeRequestEvent:
+		d.onPollLocalUnsafeRequest(ctx, x)
+	case PollCrossSafeRequestEvent:
+		d.onPollCrossSafeRequest(ctx, x)
+	case PollFinalizedRequestEvent:
+		d.onPollFinalizedRequest(ctx, x)
+	case InvalidateBlockRequestEvent:
+		d.onInvalidateBlockRequest(ctx, x)
+	case TriggerSyncEvent:
+		d.onTriggerSync(ctx, x)
+	case TryConsolidateAttributesEvent:
+		d.onTryConsolidateAttributes(ctx, x)
+	default:
+		return false
+	}
+	return true
+}

--- a/op-node/opnv2/service/backend/rwel/sync.go
+++ b/op-node/opnv2/service/backend/rwel/sync.go
@@ -1,0 +1,71 @@
+package rwel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type TriggerSyncEvent struct {
+	Target eth.BlockID
+}
+
+func (ev TriggerSyncEvent) String() string {
+	return "trigger-sync"
+}
+
+func (e *RWEL) onTriggerSync(ctx context.Context, ev TriggerSyncEvent) {
+	fc := eth.ForkchoiceState{
+		HeadBlockHash:      ev.Target.Hash,
+		SafeBlockHash:      e.state.CrossSafe().Hash,
+		FinalizedBlockHash: e.state.Finalized().Hash,
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, fcuTimeout)
+	defer cancel()
+	fcRes, err := e.engine.ForkchoiceUpdate(rpcCtx, &fc, nil)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
+			switch eth.ErrorCode(rpcErr.ErrorCode()) {
+			case eth.InvalidForkchoiceState:
+				// TODO improve error, recover
+				e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+					Err: fmt.Errorf("sync forkchoice update was inconsistent with engine: %w", err),
+				})
+			default:
+				e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+					Err: fmt.Errorf("unexpected error code in sync forkchoice-updated response: %w", err),
+				})
+			}
+		} else {
+			e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+				Err: fmt.Errorf("failed to sync forkchoice with engine: %w", err),
+			})
+		}
+		return
+	}
+	e.state.SetIsSyncing(false)
+	switch fcRes.PayloadStatus.Status {
+	case eth.ExecutionSyncing:
+		e.state.SetIsSyncing(true)
+		e.state.SetSyncTarget(ev.Target)
+		e.emitter.Emit(ctx, SyncingUpdateEvent{
+			SyncTarget: e.state.SyncTarget(),
+		})
+	case eth.ExecutionValid:
+		if latest := fcRes.PayloadStatus.LatestValidHash; latest != nil && ev.Target.Hash != *latest {
+			e.log.Warn("Engine already synced to different block", "latest", *latest, "expected", ev.Target)
+		}
+		e.state.SetSyncTarget(eth.BlockID{})
+		e.emitter.Emit(ctx, PollLocalUnsafeRequestEvent{})
+	default:
+		e.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("unexpected engine status: %w", eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)),
+		})
+	}
+}

--- a/op-node/opnv2/service/backend/rwel/updates.go
+++ b/op-node/opnv2/service/backend/rwel/updates.go
@@ -1,0 +1,63 @@
+package rwel
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// LocalUnsafeUpdateEvent signals that the given block is now considered local-unsafe.
+// This is a subset of the ForkchoiceUpdateEvent event, emitted only when local-unsafe changes.
+type LocalUnsafeUpdateEvent struct {
+	Ref eth.BlockRef
+}
+
+func (ev LocalUnsafeUpdateEvent) String() string {
+	return "local-unsafe-update"
+}
+
+// CrossSafeUpdateEvent signals that a block has been marked as cross-safe.
+// This is a subset of the ForkchoiceUpdateEvent event, emitted only when cross-safety changes.
+type CrossSafeUpdateEvent struct {
+	CrossSafe eth.BlockRef
+}
+
+func (ev CrossSafeUpdateEvent) String() string {
+	return "cross-safe-update"
+}
+
+// FinalizedUpdateEvent signals that a block has been marked as finalized.
+// This is a subset of the ForkchoiceUpdateEvent event, emitted only when finality changes.
+type FinalizedUpdateEvent struct {
+	Ref eth.BlockRef
+}
+
+func (ev FinalizedUpdateEvent) String() string {
+	return "finalized-update"
+}
+
+type ForkchoiceUpdateEvent struct {
+	LocalUnsafe eth.BlockRef
+	CrossSafe   eth.BlockRef
+	Finalized   eth.BlockRef
+}
+
+func (ev ForkchoiceUpdateEvent) String() string {
+	return "forkchoice-update"
+}
+
+// SyncingUpdateEvent is emitted whenever the engine says it is syncing.
+type SyncingUpdateEvent struct {
+	SyncTarget eth.BlockID
+}
+
+func (ev SyncingUpdateEvent) String() string {
+	return "sync-target-update"
+}
+
+// NoSyncingEvent is emitted whenever the engine signals success without syncing status.
+type NoSyncingEvent struct {
+	LocalUnsafe eth.BlockRef
+}
+
+func (ev NoSyncingEvent) String() string {
+	return "no-syncing"
+}

--- a/op-node/opnv2/service/backend/workaround.go
+++ b/op-node/opnv2/service/backend/workaround.go
@@ -1,0 +1,31 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
+)
+
+// IndexingAdapter is a workaround to make the supervisor chain indexer work with a regular L2 client binding
+type IndexingAdapter struct {
+	Source interface {
+		apis.ReceiptsFetcher
+		apis.EthBlockRef
+	}
+}
+
+var _ processors.Source = (*IndexingAdapter)(nil)
+
+func (a *IndexingAdapter) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {
+	return a.Source.BlockRefByNumber(ctx, number)
+}
+
+func (a *IndexingAdapter) FetchReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error) {
+	_, receipts, err := a.Source.FetchReceipts(ctx, blockHash)
+	return receipts, err
+}

--- a/op-node/opnv2/service/cmd.go
+++ b/op-node/opnv2/service/cmd.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/config"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/flags"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/metrics"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics/doc"
+)
+
+type VersionConfig struct {
+	Version   string
+	GitCommit string
+	GitDate   string
+}
+
+func RunCmd(ctx context.Context, args []string, versionCfg VersionConfig, fn MainFn) error {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Flags = cliapp.ProtectFlags(flags.Flags)
+	app.Version = opservice.FormatVersion(versionCfg.Version, versionCfg.GitCommit, versionCfg.GitDate, "opnv2")
+	app.Name = "op-node"
+	app.Usage = "op-node V2 OP-Stack consensus-layer node"
+	app.Description = "The op-node syncs and verifies OP-Stack chains."
+	app.Action = cliapp.LifecycleCmd(Main(app.Version, fn))
+	app.Commands = []*cli.Command{
+		{
+			Name:        "doc",
+			Subcommands: doc.NewSubcommands(metrics.NewMetrics()),
+		},
+	}
+	return app.RunContext(ctx, args)
+}
+
+func LifecycleFromConfig(ctx context.Context, cfg *config.Config, logger log.Logger) (cliapp.Lifecycle, error) {
+	logger.Info("Starting op-node V2!")
+	return FromConfig(ctx, cfg, logger)
+}

--- a/op-node/opnv2/service/entrypoint.go
+++ b/op-node/opnv2/service/entrypoint.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/config"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/flags"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+type MainFn func(ctx context.Context, cfg *config.Config, logger log.Logger) (cliapp.Lifecycle, error)
+
+// Main is the entrypoint into the op-node-v2.
+// This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed op-node-v2 with.
+func Main(version string, fn MainFn) cliapp.LifecycleAction {
+	return func(cliCtx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+		cfg, err := config.FromCLI(cliCtx, version)
+		if err != nil {
+			return nil, err
+		}
+		if err := cfg.Check(); err != nil {
+			return nil, fmt.Errorf("invalid CLI flags: %w", err)
+		}
+
+		l := oplog.NewLogger(oplog.AppOut(cliCtx), cfg.LogConfig)
+		oplog.SetGlobalLogHandler(l.Handler())
+
+		opservice.ValidateEnvVars("OP_NODE", flags.Flags, l)
+
+		l.Info("Initializing op-node V2")
+		return fn(cliCtx.Context, cfg, l)
+	}
+}

--- a/op-node/opnv2/service/frontend/errors.go
+++ b/op-node/opnv2/service/frontend/errors.go
@@ -1,0 +1,10 @@
+package frontend
+
+import "github.com/ethereum/go-ethereum/rpc"
+
+// ErrNotImplemented represents a standard error: (EIP-1474) Method is not implemented
+var ErrNotImplemented = &rpc.JsonError{
+	Code:    -32004,
+	Message: "Method not supported",
+	Data:    nil,
+}

--- a/op-node/opnv2/service/frontend/opnode.go
+++ b/op-node/opnv2/service/frontend/opnode.go
@@ -1,0 +1,67 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+type OptimismFrontend struct {
+}
+
+func (f *OptimismFrontend) OutputAtBlock(ctx context.Context, number hexutil.Uint64) (*eth.OutputResponse, error) {
+	return nil, ErrNotImplemented
+}
+func (f *OptimismFrontend) SafeHeadAtL1Block(ctx context.Context, number hexutil.Uint64) (*eth.SafeHeadResponse, error) {
+	return nil, ErrNotImplemented
+}
+func (f *OptimismFrontend) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	return nil, ErrNotImplemented
+}
+func (f *OptimismFrontend) RollupConfig(_ context.Context) (*rollup.Config, error) {
+	return nil, ErrNotImplemented
+}
+func (f *OptimismFrontend) DependencySet(_ context.Context) (depset.DependencySet, error) {
+	return nil, ErrNotImplemented
+}
+func (f *OptimismFrontend) Version(ctx context.Context) (string, error) {
+	return "", ErrNotImplemented
+}
+
+type OpnodeAdminFrontend struct {
+}
+
+func (f *OpnodeAdminFrontend) ResetDerivationPipeline(ctx context.Context) error {
+	return ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) StartSequencer(ctx context.Context, blockHash common.Hash) error {
+	return ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) StopSequencer(ctx context.Context) (common.Hash, error) {
+	return common.Hash{}, ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) SequencerActive(ctx context.Context) (bool, error) {
+	return false, ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) PostUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
+	return ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) OverrideLeader(ctx context.Context) error {
+	return ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) ConductorEnabled(ctx context.Context) (bool, error) {
+	return false, ErrNotImplemented
+}
+func (f *OpnodeAdminFrontend) SetRecoverMode(ctx context.Context, mode bool) error {
+	return ErrNotImplemented
+}
+
+type OpstackFrontend struct {
+}
+
+// TODO: p2p api from p2p package

--- a/op-node/opnv2/service/frontend/opsupervisor.go
+++ b/op-node/opnv2/service/frontend/opsupervisor.go
@@ -1,0 +1,84 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type SupervisorQueryFrontend struct {
+	Supervisor apis.SupervisorQueryAPI
+}
+
+var _ apis.SupervisorQueryAPI = (*SupervisorQueryFrontend)(nil)
+
+func (q *SupervisorQueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	return q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+}
+
+func (q *SupervisorQueryFrontend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	return q.Supervisor.LocalUnsafe(ctx, chainID)
+}
+
+func (q *SupervisorQueryFrontend) LocalSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
+	return q.Supervisor.LocalSafe(ctx, chainID)
+}
+
+func (q *SupervisorQueryFrontend) CrossSafe(ctx context.Context, chainID eth.ChainID) (types.DerivedIDPair, error) {
+	return q.Supervisor.CrossSafe(ctx, chainID)
+}
+
+func (q *SupervisorQueryFrontend) Finalized(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	return q.Supervisor.Finalized(ctx, chainID)
+}
+
+func (q *SupervisorQueryFrontend) FinalizedL1(ctx context.Context) (eth.BlockRef, error) {
+	return q.Supervisor.FinalizedL1(ctx)
+}
+
+func (q *SupervisorQueryFrontend) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {
+	return q.Supervisor.CrossDerivedToSource(ctx, chainID, derived)
+}
+
+func (q *SupervisorQueryFrontend) SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error) {
+	return q.Supervisor.SuperRootAtTimestamp(ctx, timestamp)
+}
+
+func (q *SupervisorQueryFrontend) AllSafeDerivedAt(ctx context.Context, derivedFrom eth.BlockID) (derived map[eth.ChainID]eth.BlockID, err error) {
+	return q.Supervisor.AllSafeDerivedAt(ctx, derivedFrom)
+}
+
+func (q *SupervisorQueryFrontend) SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error) {
+	return q.Supervisor.SyncStatus(ctx)
+}
+
+type SupervisorAdminFrontend struct {
+}
+
+var _ apis.SupervisorAdminAPI = (*SupervisorAdminFrontend)(nil)
+
+// Start starts the service, if it was previously stopped.
+func (a *SupervisorAdminFrontend) Start(ctx context.Context) error {
+	return ErrNotImplemented
+}
+
+// Stop stops the service, if it was previously started.
+func (a *SupervisorAdminFrontend) Stop(ctx context.Context) error {
+	return ErrNotImplemented
+}
+
+// AddL2RPC adds a new L2 chain to the supervisor backend
+func (a *SupervisorAdminFrontend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.Bytes32) error {
+	return ErrNotImplemented
+}
+
+// Rewind removes some L2 chain data from the supervisor backend, starting from the given block.
+func (a *SupervisorAdminFrontend) Rewind(ctx context.Context, chain eth.ChainID, block eth.BlockID) error {
+	return ErrNotImplemented
+}

--- a/op-node/opnv2/service/service.go
+++ b/op-node/opnv2/service/service.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/config"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/service/backend"
+	frontend2 "github.com/ethereum-optimism/optimism/op-node/opnv2/service/frontend"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+)
+
+var errInvalidMetricer = errors.New("invalid metricer")
+
+type Backend interface {
+	apis.SupervisorQueryAPI
+
+	DependencySet() depset.DependencySet
+	P2P() p2p.Node
+
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+}
+
+// Service implements the full-environment bells and whistles around the op-node-v2.
+// This includes the setup and teardown of metrics, pprof, admin RPC, regular RPC etc.
+type Service struct {
+	closing atomic.Bool
+
+	log log.Logger
+
+	metrics metrics.Metricer
+
+	backend Backend
+
+	pprofService *oppprof.Service
+	metricsSrv   *httputil.HTTPServer
+	rpcServer    *oprpc.Server
+}
+
+var _ cliapp.Lifecycle = (*Service)(nil)
+
+func FromConfig(ctx context.Context, cfg *config.Config, logger log.Logger) (*Service, error) {
+	su := &Service{log: logger}
+	if err := su.initFromCLIConfig(ctx, cfg); err != nil {
+		return nil, errors.Join(err, su.Stop(ctx)) // try to clean up our failed initialization attempt
+	}
+	return su, nil
+}
+
+func (su *Service) initFromCLIConfig(ctx context.Context, cfg *config.Config) error {
+	su.initMetrics(cfg)
+	if err := su.initPProf(cfg); err != nil {
+		return fmt.Errorf("failed to start PProf server: %w", err)
+	}
+	if err := su.initMetricsServer(cfg); err != nil {
+		return fmt.Errorf("failed to start Metrics server: %w", err)
+	}
+	if err := su.initBackend(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to start backend: %w", err)
+	}
+	if err := su.initRPCServer(cfg); err != nil {
+		return fmt.Errorf("failed to start RPC server: %w", err)
+	}
+	return nil
+}
+
+func (su *Service) initBackend(ctx context.Context, cfg *config.Config) error {
+	be, err := backend.NewBackend(ctx, su.log, su.metrics, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create op-node backend: %w", err)
+	}
+	su.backend = be
+	return nil
+}
+
+func (su *Service) initMetrics(cfg *config.Config) {
+	if cfg.MetricsConfig.Enabled {
+		su.metrics = metrics.NewMetrics()
+		su.metrics.RecordInfo(cfg.Version)
+	} else {
+		su.metrics = metrics.NoopMetrics{}
+	}
+}
+
+func (su *Service) initPProf(cfg *config.Config) error {
+	su.pprofService = oppprof.New(
+		cfg.PprofConfig.ListenEnabled,
+		cfg.PprofConfig.ListenAddr,
+		cfg.PprofConfig.ListenPort,
+		cfg.PprofConfig.ProfileType,
+		cfg.PprofConfig.ProfileDir,
+		cfg.PprofConfig.ProfileFilename,
+	)
+
+	if err := su.pprofService.Start(); err != nil {
+		return fmt.Errorf("failed to start pprof service: %w", err)
+	}
+
+	return nil
+}
+
+func (su *Service) initMetricsServer(cfg *config.Config) error {
+	if !cfg.MetricsConfig.Enabled {
+		su.log.Info("Metrics disabled")
+		return nil
+	}
+	m, ok := su.metrics.(opmetrics.RegistryMetricer)
+	if !ok {
+		return fmt.Errorf("metrics were enabled, but metricer %T does not expose registry for metrics-server: %w", su.metrics, errInvalidMetricer)
+	}
+	su.log.Debug("Starting metrics server", "addr", cfg.MetricsConfig.ListenAddr, "port", cfg.MetricsConfig.ListenPort)
+	metricsSrv, err := opmetrics.StartServer(m.Registry(), cfg.MetricsConfig.ListenAddr, cfg.MetricsConfig.ListenPort)
+	if err != nil {
+		return fmt.Errorf("failed to start metrics server: %w", err)
+	}
+	su.log.Info("Started metrics server", "addr", metricsSrv.Addr())
+	su.metricsSrv = metricsSrv
+	return nil
+}
+
+func (su *Service) initRPCServer(cfg *config.Config) error {
+	server := oprpc.NewServer(
+		cfg.RPC.ListenAddr,
+		cfg.RPC.ListenPort,
+		cfg.Version,
+		oprpc.WithLogger(su.log),
+		oprpc.WithRPCRecorder(su.metrics.NewRecorder("main")),
+	)
+	if err := RegisterRPCs(su.log, cfg, server.Handler, su.backend); err != nil {
+		return fmt.Errorf("failed to setup RPC routes: %w", err)
+	}
+	su.rpcServer = server
+	return nil
+}
+
+type RpcRouter interface {
+	AddAPI(api rpc.API) error
+	AddRPC(route string) error
+	AddAPIToRPC(route string, api rpc.API) error
+}
+
+func RegisterRPCs(logger log.Logger, cfg *config.Config, router RpcRouter, backend Backend) error {
+	depSet := backend.DependencySet()
+
+	// If there is a single chain dependency-set,
+	// then make those RPCs available at the root route.
+	// This is backwards compatible with op-node v1 RPC routes.
+	var err error
+	if len(depSet.Chains()) <= 1 {
+		if cfg.RPC.EnableAdmin {
+			err = errors.Join(err, router.AddAPI(rpc.API{
+				Namespace: "admin",
+				Service:   &frontend2.OpnodeAdminFrontend{},
+			}))
+		}
+		err = errors.Join(err, router.AddAPI(rpc.API{
+			Namespace: "optimism",
+			Service:   &frontend2.OptimismFrontend{},
+		}))
+	}
+
+	if cfg.P2P != nil && !cfg.P2P.Disabled() {
+		err = errors.Join(err, router.AddAPI(rpc.API{
+			Namespace: p2p.NamespaceRPC,
+			Service:   p2p.NewP2PAPIBackend(backend.P2P(), logger),
+		}))
+	}
+
+	err = errors.Join(err, router.AddRPC("/super"))
+	err = errors.Join(err, router.AddAPIToRPC("/super", rpc.API{
+		Namespace: "supervisor",
+		Service:   &frontend2.SupervisorQueryFrontend{Supervisor: backend},
+	}))
+	if cfg.RPC.EnableAdmin {
+		err = errors.Join(err, router.AddAPIToRPC("/super", rpc.API{
+			Namespace: "admin",
+			Service:   &frontend2.SupervisorAdminFrontend{},
+		}))
+	}
+
+	// For each chain, register RPC frontends
+	for _, chainID := range depSet.Chains() {
+		route := "/chain/" + chainID.String()
+		err = errors.Join(err, router.AddRPC(route))
+
+		if cfg.RPC.EnableAdmin {
+			err = errors.Join(err, router.AddAPIToRPC(route, rpc.API{
+				Namespace: "admin",
+				Service:   &frontend2.OpnodeAdminFrontend{},
+			}))
+		}
+		err = errors.Join(err, router.AddAPIToRPC(route, rpc.API{
+			Namespace: "optimism",
+			Service:   &frontend2.OptimismFrontend{},
+		}))
+	}
+
+	return err
+}
+
+func (su *Service) Start(ctx context.Context) error {
+	su.log.Info("Starting JSON-RPC server")
+	if err := su.rpcServer.Start(); err != nil {
+		return fmt.Errorf("unable to start RPC server: %w", err)
+	}
+
+	if err := su.backend.Start(ctx); err != nil {
+		return fmt.Errorf("unable to start backend: %w", err)
+	}
+
+	su.metrics.RecordUp()
+	su.log.Info("JSON-RPC Server started", "endpoint", su.rpcServer.Endpoint())
+	return nil
+}
+
+func (su *Service) Stop(ctx context.Context) error {
+	if !su.closing.CompareAndSwap(false, true) {
+		su.log.Warn("op-node is already closing")
+		return nil // already closing
+	}
+	su.log.Info("Stopping JSON-RPC server")
+	var result error
+	if su.rpcServer != nil {
+		if err := su.rpcServer.Stop(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop RPC server: %w", err))
+		}
+	}
+	su.log.Info("Stopped RPC Server")
+	if su.backend != nil {
+		if err := su.backend.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close op-node backend: %w", err))
+		}
+	}
+	su.log.Info("Stopped Backend")
+	if su.pprofService != nil {
+		if err := su.pprofService.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop PProf server: %w", err))
+		}
+	}
+	su.log.Info("Stopped PProf")
+	if su.metricsSrv != nil {
+		if err := su.metricsSrv.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop metrics server: %w", err))
+		}
+	}
+	su.log.Info("JSON-RPC server stopped")
+	return result
+}
+
+func (su *Service) Stopped() bool {
+	return su.closing.Load()
+}
+
+func (su *Service) HttpRPC() string {
+	// the RPC endpoint is assumed to be HTTP
+	return "http://" + su.rpcServer.Endpoint()
+}
+
+func (su *Service) Port() (int, error) {
+	return su.rpcServer.Port()
+}
+
+func (su *Service) Backend() Backend {
+	return su.backend
+}

--- a/op-node/opnv2/service/service_test.go
+++ b/op-node/opnv2/service/service_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-node/opnv2/config"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestV2Service(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.MetricsConfig.Enabled = true
+	cfg.PprofConfig.ListenEnabled = true
+	// pick a port automatically
+	cfg.MetricsConfig.ListenPort = 0
+	cfg.PprofConfig.ListenPort = 0
+	cfg.RPC.ListenPort = 0
+
+	cfg.Datadir = t.TempDir()
+
+	logger := testlog.Logger(t, log.LevelError)
+	opn, err := FromConfig(context.Background(), cfg, logger)
+	require.NoError(t, err)
+	require.NoError(t, opn.Start(context.Background()), "start service")
+	// run some RPC tests against the service with the mock backend
+	{
+		endpoint := "http://" + opn.rpcServer.Endpoint()
+		t.Logf("dialing %s", endpoint)
+		cl, err := dial.DialRPCClientWithTimeout(context.Background(), time.Second*5, logger, endpoint)
+		require.NoError(t, err)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		err = cl.CallContext(ctx, nil, "supervisor_checkAccessList",
+			[]common.Hash{}, types.CrossUnsafe, types.ExecutingDescriptor{
+				Timestamp: 1234568, ChainID: eth.ChainIDFromUInt64(123)})
+		cancel()
+		var errJson rpc.Error
+		require.ErrorAs(t, err, &errJson)
+		require.Equal(t, 123, errJson.ErrorCode()) // TODO error codes
+		cl.Close()
+	}
+	require.NoError(t, opn.Stop(context.Background()), "stop service")
+}

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -21,8 +21,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/metrics"
 	cmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 var DefaultBootnodes = []string{
@@ -58,7 +56,7 @@ type SetupP2P interface {
 	// Host creates a libp2p host service. Returns nil, nil if p2p is disabled.
 	Host(log log.Logger, reporter metrics.Reporter, metrics HostMetrics) (host.Host, error)
 	// Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
-	Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error)
+	Discovery(log log.Logger, localNodeMods LocalNodeModFn, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error)
 	TargetPeers() uint
 	BanPeers() bool
 	BanThreshold() float64

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	decredSecp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -29,6 +31,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // force to use the new chainhash module, and not the legacy chainhash package btcd module
@@ -51,7 +54,19 @@ const (
 	collectiveDialTimeout  = time.Second * 30
 )
 
-func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
+type LocalNodeModFn func(localNode *enode.LocalNode)
+
+func WithSingleChainOPStackENR(rollupCfg *rollup.Config) LocalNodeModFn {
+	return func(localNode *enode.LocalNode) {
+		dat := OpStackENRData{
+			ChainID: rollupCfg.L2ChainID.Uint64(),
+			Version: 0,
+		}
+		localNode.Set(&dat)
+	}
+}
+
+func (conf *Config) Discovery(log log.Logger, localNodeMods LocalNodeModFn, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
 	if conf.NoDiscovery {
 		return nil, nil, nil
 	}
@@ -76,11 +91,6 @@ func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort 
 	} else {
 		return nil, nil, fmt.Errorf("no TCP port to put in discovery record")
 	}
-	dat := OpStackENRData{
-		chainID: rollupCfg.L2ChainID.Uint64(),
-		version: 0,
-	}
-	localNode.Set(&dat)
 
 	udpAddr := &net.UDPAddr{
 		IP:   conf.ListenIP,
@@ -95,6 +105,8 @@ func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort 
 		localUDPAddr := conn.LocalAddr().(*net.UDPAddr)
 		localNode.SetFallbackUDP(localUDPAddr.Port)
 	}
+
+	localNodeMods(localNode)
 
 	cfg := discover.Config{
 		PrivateKey:   priv,
@@ -171,8 +183,8 @@ func enrToAddrInfo(r *enode.Node) (*peer.AddrInfo, *crypto.Secp256k1PublicKey, e
 // The discovery ENRs are just key-value lists, and we filter them by records tagged with the "opstack" key,
 // and then check the chain ID and version.
 type OpStackENRData struct {
-	chainID uint64
-	version uint64
+	ChainID uint64
+	Version uint64
 }
 
 func (o *OpStackENRData) ENRKey() string {
@@ -181,8 +193,8 @@ func (o *OpStackENRData) ENRKey() string {
 
 func (o *OpStackENRData) EncodeRLP(w io.Writer) error {
 	out := make([]byte, 2*binary.MaxVarintLen64)
-	offset := binary.PutUvarint(out, o.chainID)
-	offset += binary.PutUvarint(out[offset:], o.version)
+	offset := binary.PutUvarint(out, o.ChainID)
+	offset += binary.PutUvarint(out[offset:], o.Version)
 	out = out[:offset]
 	// encode as byte-string
 	return rlp.Encode(w, out)
@@ -204,51 +216,66 @@ func (o *OpStackENRData) DecodeRLP(s *rlp.Stream) error {
 	if err != nil {
 		return fmt.Errorf("failed to read version var int: %w", err)
 	}
-	o.chainID = chainID
-	o.version = version
+	o.ChainID = chainID
+	o.Version = version
 	return nil
 }
 
 var _ enr.Entry = (*OpStackENRData)(nil)
 
-func FilterEnodes(log log.Logger, cfg *rollup.Config) func(node *enode.Node) bool {
-	return func(node *enode.Node) bool {
-		var dat OpStackENRData
-		err := node.Load(&dat)
-		// if the entry does not exist, or if it is invalid, then ignore the node
-		if err != nil {
-			log.Trace("discovered node record has no opstack info", "node", node.ID(), "err", err)
-			return false
-		}
-		// check chain ID matches
-		if cfg.L2ChainID.Uint64() != dat.chainID {
-			log.Trace("discovered node record has no matching chain ID", "node", node.ID(), "got", dat.chainID, "expected", cfg.L2ChainID.Uint64())
-			return false
-		}
-		// check version matches
-		if dat.version != 0 {
-			log.Trace("discovered node record has no matching version", "node", node.ID(), "got", dat.version, "expected", 0)
-			return false
-		}
-		return true
+type NodeFilter interface {
+	Allow(node *enode.Node) bool
+}
+
+type SingleChainFilter struct {
+	Log            log.Logger
+	AllowedChainID eth.ChainID
+}
+
+// Allow filters the node record. If it returns false then the node is not accepted.
+func (f *SingleChainFilter) Allow(node *enode.Node) bool {
+	var dat OpStackENRData
+	err := node.Load(&dat)
+	// if the entry does not exist, or if it is invalid, then ignore the node
+	if err != nil {
+		f.Log.Trace("discovered node record has no opstack info", "node", node.ID(), "err", err)
+		return false
 	}
+	// check chain ID matches
+	if eth.ChainIDFromUInt64(dat.ChainID) != f.AllowedChainID {
+		f.Log.Trace("discovered node record has no matching chain ID", "node", node.ID(), "got", dat.ChainID)
+		return false
+	}
+	// check version matches
+	if dat.Version != 0 {
+		f.Log.Trace("discovered node record has no matching version", "node", node.ID(), "got", dat.Version, "expected", 0)
+		return false
+	}
+	return true
+}
+
+type NodeWithDiscovery interface {
+	Dv5Udp() *discover.UDPv5
+	Host() host.Host
+	ConnectionManager() connmgr.ConnManager
+	Dv5Local() *enode.LocalNode
 }
 
 // DiscoveryProcess runs a discovery process that randomly walks the DHT to fill the peerstore,
 // and connects to nodes in the peerstore that we are not already connected to.
 // Nodes from the peerstore will be shuffled, unsuccessful connection attempts will cause peers to be avoided,
 // and only nodes with addresses (under TTL) will be connected to.
-func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rollup.Config, connectGoal uint) {
-	if n.dv5Udp == nil {
+func DiscoveryProcess(ctx context.Context, log log.Logger, n NodeWithDiscovery, nodeFilter NodeFilter, connectGoal uint) {
+	dv5Udp := n.Dv5Udp()
+	if dv5Udp == nil {
 		log.Warn("peer discovery is disabled")
 		return
 	}
-	filter := FilterEnodes(log, cfg)
 	// We pull nodes from discv5 DHT in random order to find new peers.
 	// Eventually we'll find a peer record that matches our filter.
-	randomNodeIter := n.dv5Udp.RandomNodes()
+	randomNodeIter := dv5Udp.RandomNodes()
 
-	randomNodeIter = enode.Filter(randomNodeIter, filter)
+	randomNodeIter = enode.Filter(randomNodeIter, nodeFilter.Allow)
 	defer randomNodeIter.Close()
 
 	// We pull from the DHT in a slow/fast interval, depending on the need to find more peers
@@ -329,8 +356,8 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 		// At the start we might have trouble walking the DHT,
 		// but we do have a table with some nodes,
 		// so take the table and feed it into the discovery process
-		for _, rec := range n.dv5Udp.AllNodes() {
-			if filter(rec) {
+		for _, rec := range dv5Udp.AllNodes() {
+			if nodeFilter.Allow(rec) {
 				select {
 				case randomNodesCh <- rec:
 					continue
@@ -361,7 +388,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 			if eps, ok := pstore.(store.ExtendedPeerstore); ok {
 				_, err := eps.SetPeerMetadata(info.ID, store.PeerMetadata{
 					ENR:       found.String(),
-					OPStackID: dat.chainID,
+					OPStackID: dat.ChainID,
 				})
 				if err != nil {
 					log.Warn("failed to set peer metadata", "peer", info.ID, "err", err)
@@ -375,14 +402,15 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 			// Tag the peer, we'd rather have the connection manager prune away old peers,
 			// or peers on different chains, or anyone we have not seen via discovery.
 			// There is no tag score decay yet, so just set it to 42.
-			n.ConnectionManager().TagPeer(info.ID, fmt.Sprintf("opstack-%d-%d", dat.chainID, dat.version), 42)
+			n.ConnectionManager().TagPeer(info.ID, fmt.Sprintf("opstack-%d-%d", dat.ChainID, dat.Version), 42)
 			log.Debug("discovered peer", "peer", info.ID, "nodeID", found.ID(), "addr", info.Addrs[0])
 		case <-connectTicker.C:
 			connected := n.Host().Network().Peers()
+			dv5Local := n.Dv5Local()
 			log.Debug("peering tick", "connected", len(connected),
-				"advertised_udp", n.dv5Local.Node().UDP(),
-				"advertised_tcp", n.dv5Local.Node().TCP(),
-				"advertised_ip", n.dv5Local.Node().IP())
+				"advertised_udp", dv5Local.Node().UDP(),
+				"advertised_tcp", dv5Local.Node().TCP(),
+				"advertised_ip", dv5Local.Node().IP())
 			if uint(len(connected)) < connectGoal {
 				// Start looking for more peers more actively again
 				faster()

--- a/op-node/p2p/event.go
+++ b/op-node/p2p/event.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ReceivedBlockEvent struct {
+	ChainID  eth.ChainID
 	From     peer.ID
 	Envelope *eth.ExecutionPayloadEnvelope
 }
@@ -21,7 +22,7 @@ func (ev ReceivedBlockEvent) String() string {
 }
 
 type BlockReceiverMetrics interface {
-	RecordReceivedUnsafePayload(payload *eth.ExecutionPayloadEnvelope)
+	RecordReceivedUnsafePayload(chainID eth.ChainID, payload *eth.ExecutionPayloadEnvelope)
 }
 
 // BlockReceiver can be plugged into the P2P gossip stack,
@@ -42,11 +43,11 @@ func NewBlockReceiver(log log.Logger, em event.Emitter, metrics BlockReceiverMet
 	}
 }
 
-func (g *BlockReceiver) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+func (g *BlockReceiver) OnUnsafeL2Payload(ctx context.Context, chainID eth.ChainID, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
 	g.log.Debug("Received signed execution payload from p2p",
 		"id", msg.ExecutionPayload.ID(),
 		"peer", from, "txs", len(msg.ExecutionPayload.Transactions))
-	g.metrics.RecordReceivedUnsafePayload(msg)
-	g.emitter.Emit(ctx, ReceivedBlockEvent{From: from, Envelope: msg})
+	g.metrics.RecordReceivedUnsafePayload(chainID, msg)
+	g.emitter.Emit(ctx, ReceivedBlockEvent{ChainID: chainID, From: from, Envelope: msg})
 	return nil
 }

--- a/op-node/p2p/filter.go
+++ b/op-node/p2p/filter.go
@@ -20,9 +20,9 @@ func NewFilterSelf(self peer.ID, inner GossipIn) *FilterSelf {
 	return &FilterSelf{self: self, inner: inner}
 }
 
-func (f *FilterSelf) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+func (f *FilterSelf) OnUnsafeL2Payload(ctx context.Context, chainID eth.ChainID, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
 	if f.self == from {
 		return nil // ignore blocks that we published ourselves
 	}
-	return f.inner.OnUnsafeL2Payload(ctx, from, msg)
+	return f.inner.OnUnsafeL2Payload(ctx, chainID, from, msg)
 }

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,7 +55,7 @@ var MessageDomainValidSnappy = [4]byte{1, 0, 0, 0}
 type GossipSetupConfigurables interface {
 	PeerScoringParams() *ScoringParams
 	// ConfigureGossip creates configuration options to apply to the GossipSub setup
-	ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option
+	ConfigureGossip() []pubsub.Option
 }
 
 type GossipRuntimeConfig interface {
@@ -66,31 +67,72 @@ type GossipMetricer interface {
 	RecordGossipEvent(evType int32)
 }
 
-func blocksTopicV1(cfg *rollup.Config) string {
-	return fmt.Sprintf("/optimism/%s/0/blocks", cfg.L2ChainID.String())
+type BlockVersioning interface {
+	BlockVersion(chainID eth.ChainID, timestamp uint64) (eth.BlockVersion, error)
 }
 
-func blocksTopicV2(cfg *rollup.Config) string {
-	return fmt.Sprintf("/optimism/%s/1/blocks", cfg.L2ChainID.String())
+type BlockRuntimeAuth interface {
+	// The result may change over time.
+	P2PSequencerAddress(chainID eth.ChainID) (common.Address, error)
 }
 
-func blocksTopicV3(cfg *rollup.Config) string {
-	return fmt.Sprintf("/optimism/%s/2/blocks", cfg.L2ChainID.String())
+type GossipChainConfig interface {
+	// ChainIDs returns the lists of chains to subscribe to
+	ChainIDs() []eth.ChainID
+	BlockRuntimeAuth
+	BlockVersioning
 }
 
-func blocksTopicV4(cfg *rollup.Config) string {
-	return fmt.Sprintf("/optimism/%s/3/blocks", cfg.L2ChainID.String())
+type SingleChainGossip struct {
+	RollupCfg        *rollup.Config
+	P2PSequencerAuth GossipRuntimeConfig
 }
+
+func (s *SingleChainGossip) P2PSequencerAddress(chainID eth.ChainID) (common.Address, error) {
+	if eth.ChainIDFromBig(s.RollupCfg.L2ChainID) != chainID {
+		return common.Address{}, fmt.Errorf("unknown chain: %s", chainID)
+	}
+	return s.P2PSequencerAuth.P2PSequencerAddress(), nil
+}
+
+func (s *SingleChainGossip) ChainIDs() []eth.ChainID {
+	return []eth.ChainID{eth.ChainIDFromBig(s.RollupCfg.L2ChainID)}
+}
+
+func (s *SingleChainGossip) BlockTime(chainID eth.ChainID) time.Duration {
+	return time.Duration(s.RollupCfg.BlockTime) * time.Second
+}
+
+func (s *SingleChainGossip) BlockVersion(chainID eth.ChainID, timestamp uint64) (eth.BlockVersion, error) {
+	if eth.ChainIDFromBig(s.RollupCfg.L2ChainID) != chainID {
+		return 0, fmt.Errorf("unknown chain: %s", chainID)
+	}
+	if s.RollupCfg.IsIsthmus(timestamp) {
+		return eth.BlockV4, nil
+	} else if s.RollupCfg.IsEcotone(timestamp) {
+		return eth.BlockV3, nil
+	} else if s.RollupCfg.IsCanyon(timestamp) {
+		return eth.BlockV2, nil
+	} else {
+		return eth.BlockV1, nil
+	}
+}
+
+var _ GossipChainConfig = (*SingleChainGossip)(nil)
 
 // BuildSubscriptionFilter builds a simple subscription filter,
 // to help protect against peers spamming useless subscriptions.
-func BuildSubscriptionFilter(cfg *rollup.Config) pubsub.SubscriptionFilter {
-	return pubsub.NewAllowlistSubscriptionFilter(
-		blocksTopicV1(cfg),
-		blocksTopicV2(cfg),
-		blocksTopicV3(cfg),
-		blocksTopicV4(cfg), // add more topics here in the future, if any.
-	)
+func BuildSubscriptionFilter(chains []eth.ChainID) pubsub.SubscriptionFilter {
+	var topics []string
+	for _, chainID := range chains {
+		topics = append(topics,
+			eth.BlockV1.BlocksTopic(chainID),
+			eth.BlockV2.BlocksTopic(chainID),
+			eth.BlockV3.BlocksTopic(chainID),
+			eth.BlockV4.BlocksTopic(chainID))
+	}
+	// add more topics here in the future, if any.
+	return pubsub.NewAllowlistSubscriptionFilter(topics...)
 }
 
 var msgBufPool = sync.Pool{New: func() any {
@@ -101,7 +143,7 @@ var msgBufPool = sync.Pool{New: func() any {
 
 // BuildMsgIdFn builds a generic message ID function for gossipsub that can handle compressed payloads,
 // mirroring the eth2 p2p gossip spec.
-func BuildMsgIdFn(cfg *rollup.Config) pubsub.MsgIdFunction {
+func BuildMsgIdFn() pubsub.MsgIdFunction {
 	return func(pmsg *pb.Message) string {
 		valid := false
 		var data []byte
@@ -141,8 +183,8 @@ func BuildMsgIdFn(cfg *rollup.Config) pubsub.MsgIdFunction {
 	}
 }
 
-func (p *Config) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
-	params := BuildGlobalGossipParams(rollupCfg)
+func (p *Config) ConfigureGossip() []pubsub.Option {
+	params := BuildGlobalGossipParams()
 
 	// override with CLI changes
 	params.D = p.MeshD
@@ -157,7 +199,7 @@ func (p *Config) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
 	}
 }
 
-func BuildGlobalGossipParams(cfg *rollup.Config) pubsub.GossipSubParams {
+func BuildGlobalGossipParams() pubsub.GossipSubParams {
 	params := pubsub.DefaultGossipSubParams()
 	params.D = DefaultMeshD                    // topic stable mesh target count
 	params.Dlo = DefaultMeshDlo                // topic stable mesh low watermark
@@ -173,17 +215,18 @@ func BuildGlobalGossipParams(cfg *rollup.Config) pubsub.GossipSubParams {
 
 // NewGossipSub configures a new pubsub instance with the specified parameters.
 // PubSub uses a GossipSubRouter as it's router under the hood.
-func NewGossipSub(p2pCtx context.Context, h host.Host, cfg *rollup.Config, gossipConf GossipSetupConfigurables, scorer Scorer, m GossipMetricer, log log.Logger) (*pubsub.PubSub, error) {
+func NewGossipSub(p2pCtx context.Context, h host.Host, cfg GossipChainConfig,
+	gossipConf GossipSetupConfigurables, scorer Scorer, m GossipMetricer, log log.Logger) (*pubsub.PubSub, error) {
 	denyList, err := pubsub.NewTimeCachedBlacklist(30 * time.Second)
 	if err != nil {
 		return nil, err
 	}
 	gossipOpts := []pubsub.Option{
 		pubsub.WithMaxMessageSize(maxGossipSize),
-		pubsub.WithMessageIdFn(BuildMsgIdFn(cfg)),
+		pubsub.WithMessageIdFn(BuildMsgIdFn()),
 		pubsub.WithNoAuthor(),
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
-		pubsub.WithSubscriptionFilter(BuildSubscriptionFilter(cfg)),
+		pubsub.WithSubscriptionFilter(BuildSubscriptionFilter(cfg.ChainIDs())),
 		pubsub.WithValidateQueueSize(maxValidateQueue),
 		pubsub.WithPeerOutboundQueueSize(maxOutboundQueue),
 		pubsub.WithValidateThrottle(globalValidateThrottle),
@@ -193,7 +236,7 @@ func NewGossipSub(p2pCtx context.Context, h host.Host, cfg *rollup.Config, gossi
 		pubsub.WithEventTracer(&gossipTracer{m: m}),
 	}
 	gossipOpts = append(gossipOpts, ConfigurePeerScoring(gossipConf, scorer, log)...)
-	gossipOpts = append(gossipOpts, gossipConf.ConfigureGossip(cfg)...)
+	gossipOpts = append(gossipOpts, gossipConf.ConfigureGossip()...)
 	return pubsub.NewGossipSub(p2pCtx, h, gossipOpts...)
 }
 
@@ -259,8 +302,7 @@ func (sb *seenBlocks) markSeen(h common.Hash) {
 	sb.blockHashes = append(sb.blockHashes, h)
 }
 
-func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, blockVersion eth.BlockVersion) pubsub.ValidatorEx {
-
+func BuildBlocksValidator(log log.Logger, chainID eth.ChainID, runCfg BlockRuntimeAuth, blockVersion eth.BlockVersion) pubsub.ValidatorEx {
 	// Seen block hashes per block height
 	// uint64 -> *seenBlocks
 	blockHeightLRU, err := lru.New[uint64, *seenBlocks](1000)
@@ -301,7 +343,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		payloadBytes := data[65:]
 
 		// [REJECT] if the signature by the sequencer is not valid
-		result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
+		result := verifyBlockSignature(log, chainID, runCfg, id, signature, payloadBytes)
 		if result != pubsub.ValidationAccept {
 			return result
 		}
@@ -427,10 +469,15 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 	}
 }
 
-func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {
+func verifyBlockSignature(log log.Logger, chainID eth.ChainID, runCfg BlockRuntimeAuth, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {
+	seqAddress, err := runCfg.P2PSequencerAddress(chainID)
+	if err != nil {
+		log.Warn("Cannot determine P2P Sequencer address to auth against", "chainID", chainID, "err", err)
+		return pubsub.ValidationReject
+	}
 	authCtx := &opsigner.OPStackP2PBlockAuthV1{
-		Allowed: runCfg.P2PSequencerAddress(),
-		Chain:   eth.ChainIDFromBig(cfg.L2ChainID),
+		Allowed: seqAddress,
+		Chain:   chainID,
 	}
 	if authCtx.Allowed == (common.Address{}) {
 		log.Warn("no configured p2p sequencer address, ignoring gossiped block", "peer", id, "addr", authCtx.Allowed)
@@ -448,21 +495,12 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 }
 
 type GossipIn interface {
-	OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error
-}
-
-type GossipTopicInfo interface {
-	AllBlockTopicsPeers() []peer.ID
-	BlocksTopicV1Peers() []peer.ID
-	BlocksTopicV2Peers() []peer.ID
-	BlocksTopicV3Peers() []peer.ID
-	BlocksTopicV4Peers() []peer.ID
+	OnUnsafeL2Payload(ctx context.Context, chainID eth.ChainID, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error
 }
 
 type GossipOut interface {
-	GossipTopicInfo
-	SignAndPublishL2Payload(ctx context.Context, msg *eth.ExecutionPayloadEnvelope, signer Signer) error
-	PublishSignedL2Payload(ctx context.Context, signedEnvelope *opsigner.SignedExecutionPayloadEnvelope) error
+	SignAndPublishL2Payload(ctx context.Context, chainID eth.ChainID, msg *eth.ExecutionPayloadEnvelope, signer Signer) error
+	PublishSignedL2Payload(ctx context.Context, chainID eth.ChainID, signedEnvelope *opsigner.SignedExecutionPayloadEnvelope) error
 	Close() error
 }
 
@@ -481,66 +519,27 @@ func (bt *blockTopic) Close() error {
 	return bt.topic.Close()
 }
 
+type blockTopicKey struct {
+	eth.BlockVersion
+	eth.ChainID
+}
+
 type publisher struct {
 	log log.Logger
-	cfg *rollup.Config
+
+	blockVersioning BlockVersioning
 
 	// p2pCancel cancels the downstream gossip event-handling functions, independent of the sources.
 	// A closed gossip event source (event handler or subscription) does not stop any open event iteration,
 	// thus we have to stop it ourselves this way.
 	p2pCancel context.CancelFunc
 
-	blocksV1 *blockTopic
-	blocksV2 *blockTopic
-	blocksV3 *blockTopic
-	blocksV4 *blockTopic
-
-	runCfg GossipRuntimeConfig
+	blockTopics map[blockTopicKey]*blockTopic
 }
 
 var _ GossipOut = (*publisher)(nil)
 
-func combinePeers(allPeers ...[]peer.ID) []peer.ID {
-	var seen = make(map[peer.ID]bool)
-	var res []peer.ID
-	for _, peers := range allPeers {
-		for _, p := range peers {
-			if _, ok := seen[p]; ok {
-				continue
-			}
-			res = append(res, p)
-			seen[p] = true
-		}
-	}
-	return res
-}
-
-func (p *publisher) AllBlockTopicsPeers() []peer.ID {
-	return combinePeers(
-		p.BlocksTopicV1Peers(),
-		p.BlocksTopicV2Peers(),
-		p.BlocksTopicV3Peers(),
-		p.BlocksTopicV4Peers(),
-	)
-}
-
-func (p *publisher) BlocksTopicV1Peers() []peer.ID {
-	return p.blocksV1.topic.ListPeers()
-}
-
-func (p *publisher) BlocksTopicV2Peers() []peer.ID {
-	return p.blocksV2.topic.ListPeers()
-}
-
-func (p *publisher) BlocksTopicV3Peers() []peer.ID {
-	return p.blocksV3.topic.ListPeers()
-}
-
-func (p *publisher) BlocksTopicV4Peers() []peer.ID {
-	return p.blocksV4.topic.ListPeers()
-}
-
-func (p *publisher) PublishSignedL2Payload(ctx context.Context, signedEnvelope *opsigner.SignedExecutionPayloadEnvelope) error {
+func (p *publisher) PublishSignedL2Payload(ctx context.Context, chainID eth.ChainID, signedEnvelope *opsigner.SignedExecutionPayloadEnvelope) error {
 	res := msgBufPool.Get().(*[]byte)
 	buf := bytes.NewBuffer((*res)[:0])
 	defer func() {
@@ -562,10 +561,10 @@ func (p *publisher) PublishSignedL2Payload(ctx context.Context, signedEnvelope *
 
 	data := buf.Bytes()
 	timestamp := uint64(signedEnvelope.Envelope.ExecutionPayload.Timestamp)
-	return p.publishRawSignedPayload(ctx, timestamp, data)
+	return p.publishRawSignedPayload(ctx, chainID, timestamp, data)
 }
 
-func (p *publisher) SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, signer Signer) error {
+func (p *publisher) SignAndPublishL2Payload(ctx context.Context, chainID eth.ChainID, envelope *eth.ExecutionPayloadEnvelope, signer Signer) error {
 	res := msgBufPool.Get().(*[]byte)
 	buf := bytes.NewBuffer((*res)[:0])
 	defer func() {
@@ -587,86 +586,89 @@ func (p *publisher) SignAndPublishL2Payload(ctx context.Context, envelope *eth.E
 	data := buf.Bytes()
 	payloadData := data[65:]
 	payloadHash := opsigner.PayloadHash(payloadData)
-	chainID := eth.ChainIDFromBig(p.cfg.L2ChainID)
 	sig, err := signer.SignBlockV1(ctx, chainID, payloadHash)
 	if err != nil {
 		return fmt.Errorf("failed to sign execution payload with signer: %w", err)
 	}
 	copy(data[:65], sig[:])
-	return p.publishRawSignedPayload(ctx, uint64(envelope.ExecutionPayload.Timestamp), data)
+	return p.publishRawSignedPayload(ctx, chainID, uint64(envelope.ExecutionPayload.Timestamp), data)
 }
 
-func (p *publisher) publishRawSignedPayload(ctx context.Context, timestamp uint64, data []byte) error {
+func (p *publisher) publishRawSignedPayload(ctx context.Context, chainID eth.ChainID, timestamp uint64, data []byte) error {
 	// compress the full message
 	// This also copies the data, freeing up the original buffer to go back into the pool
 	out := snappy.Encode(nil, data)
 
-	if p.cfg.IsIsthmus(timestamp) {
-		return p.blocksV4.topic.Publish(ctx, out)
-	} else if p.cfg.IsEcotone(timestamp) {
-		return p.blocksV3.topic.Publish(ctx, out)
-	} else if p.cfg.IsCanyon(timestamp) {
-		return p.blocksV2.topic.Publish(ctx, out)
-	} else {
-		return p.blocksV1.topic.Publish(ctx, out)
+	blockVersion, err := p.blockVersioning.BlockVersion(chainID, timestamp)
+	if err != nil {
+		return fmt.Errorf("unable to determine block version to publish on (chain %s, timestamp %d): %w", chainID, timestamp, err)
 	}
+	k := blockTopicKey{
+		BlockVersion: blockVersion,
+		ChainID:      chainID,
+	}
+	top, ok := p.blockTopics[k]
+	if !ok {
+		return fmt.Errorf("cannot publish on unknown block version %s / chain ID %s", blockVersion, chainID)
+	}
+	return top.topic.Publish(ctx, out)
 }
 
 func (p *publisher) Close() error {
 	p.p2pCancel()
-	e1 := p.blocksV1.Close()
-	e2 := p.blocksV2.Close()
-	return errors.Join(e1, e2)
+	var out error
+	for key, v := range p.blockTopics {
+		if err := v.Close(); err != nil {
+			out = errors.Join(out, fmt.Errorf("failed to close topic blocks %s %s: %w", key.ChainID, key.BlockVersion, err))
+		}
+	}
+	return out
 }
 
-func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, gossipIn GossipIn) (GossipOut, error) {
+func setupBlockTopic(p2pCtx context.Context, ps *pubsub.PubSub, self peer.ID, chainID eth.ChainID, runCfg BlockRuntimeAuth, blockVersion eth.BlockVersion, logger log.Logger, gossipIn GossipIn) (*blockTopic, error) {
+	logger = logger.New("topic", "blocks"+strings.ToUpper(blockVersion.String()))
+	validator := BuildBlocksValidator(logger, chainID, runCfg, blockVersion)
+	topicName := blockVersion.BlocksTopic(chainID)
+	guardedValidator := guardGossipValidator(logger, logValidationResult(self, "validated "+blockVersion.String(), logger, validator))
+	blTopic, err := newBlockTopic(p2pCtx, chainID, topicName, ps, logger, gossipIn, guardedValidator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup blocks %s topic p2p: %w", blockVersion, err)
+	}
+	return blTopic, nil
+}
+
+func JoinGossip(self peer.ID, ps *pubsub.PubSub, logger log.Logger, cfg GossipChainConfig, gossipIn GossipIn) (GossipOut, error) {
 	p2pCtx, p2pCancel := context.WithCancel(context.Background())
 
-	v1Logger := log.New("topic", "blocksV1")
-	blocksV1Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv1", v1Logger, BuildBlocksValidator(v1Logger, cfg, runCfg, eth.BlockV1)))
-	blocksV1, err := newBlockTopic(p2pCtx, blocksTopicV1(cfg), ps, v1Logger, gossipIn, blocksV1Validator)
-	if err != nil {
-		p2pCancel()
-		return nil, fmt.Errorf("failed to setup blocks v1 p2p: %w", err)
-	}
+	versions := []eth.BlockVersion{eth.BlockV1, eth.BlockV2, eth.BlockV3, eth.BlockV4}
+	chainIDs := cfg.ChainIDs()
+	blockTopics := make(map[blockTopicKey]*blockTopic)
+	for _, blockVersion := range versions {
+		for _, chainID := range chainIDs {
+			// TODO: we can stop subscribing to old inactive topics
 
-	v2Logger := log.New("topic", "blocksV2")
-	blocksV2Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv2", v2Logger, BuildBlocksValidator(v2Logger, cfg, runCfg, eth.BlockV2)))
-	blocksV2, err := newBlockTopic(p2pCtx, blocksTopicV2(cfg), ps, v2Logger, gossipIn, blocksV2Validator)
-	if err != nil {
-		p2pCancel()
-		return nil, fmt.Errorf("failed to setup blocks v2 p2p: %w", err)
-	}
-
-	v3Logger := log.New("topic", "blocksV3")
-	blocksV3Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv3", v3Logger, BuildBlocksValidator(v3Logger, cfg, runCfg, eth.BlockV3)))
-	blocksV3, err := newBlockTopic(p2pCtx, blocksTopicV3(cfg), ps, v3Logger, gossipIn, blocksV3Validator)
-	if err != nil {
-		p2pCancel()
-		return nil, fmt.Errorf("failed to setup blocks v3 p2p: %w", err)
-	}
-
-	v4Logger := log.New("topic", "blocksV4")
-	blocksV4Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv4", v4Logger, BuildBlocksValidator(v4Logger, cfg, runCfg, eth.BlockV4)))
-	blocksV4, err := newBlockTopic(p2pCtx, blocksTopicV4(cfg), ps, v4Logger, gossipIn, blocksV4Validator)
-	if err != nil {
-		p2pCancel()
-		return nil, fmt.Errorf("failed to setup blocks v4 p2p: %w", err)
+			blTopic, err := setupBlockTopic(p2pCtx, ps, self, chainID, cfg, blockVersion, logger, gossipIn)
+			if err != nil {
+				p2pCancel()
+				return nil, err
+			}
+			key := blockTopicKey{
+				BlockVersion: blockVersion,
+				ChainID:      chainID,
+			}
+			blockTopics[key] = blTopic
+		}
 	}
 
 	return &publisher{
-		log:       log,
-		cfg:       cfg,
-		p2pCancel: p2pCancel,
-		blocksV1:  blocksV1,
-		blocksV2:  blocksV2,
-		blocksV3:  blocksV3,
-		blocksV4:  blocksV4,
-		runCfg:    runCfg,
+		log:             logger,
+		blockVersioning: cfg,
+		p2pCancel:       p2pCancel,
+		blockTopics:     blockTopics,
 	}, nil
 }
 
-func newBlockTopic(ctx context.Context, topicId string, ps *pubsub.PubSub, log log.Logger, gossipIn GossipIn, validator pubsub.ValidatorEx) (*blockTopic, error) {
+func newBlockTopic(ctx context.Context, chainID eth.ChainID, topicId string, ps *pubsub.PubSub, log log.Logger, gossipIn GossipIn, validator pubsub.ValidatorEx) (*blockTopic, error) {
 	err := ps.RegisterTopicValidator(topicId,
 		validator,
 		pubsub.WithValidatorTimeout(3*time.Second),
@@ -694,7 +696,7 @@ func newBlockTopic(ctx context.Context, topicId string, ps *pubsub.PubSub, log l
 		return nil, fmt.Errorf("failed to subscribe to blocks gossip topic: %w", err)
 	}
 
-	subscriber := MakeSubscriber(log, BlocksHandler(gossipIn.OnUnsafeL2Payload))
+	subscriber := MakeSubscriber(log, BlocksHandler(chainID, gossipIn.OnUnsafeL2Payload))
 	go subscriber(ctx, subscription)
 
 	return &blockTopic{
@@ -707,13 +709,13 @@ func newBlockTopic(ctx context.Context, topicId string, ps *pubsub.PubSub, log l
 type TopicSubscriber func(ctx context.Context, sub *pubsub.Subscription)
 type MessageHandler func(ctx context.Context, from peer.ID, msg any) error
 
-func BlocksHandler(onBlock func(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error) MessageHandler {
+func BlocksHandler(chainID eth.ChainID, onBlock func(ctx context.Context, chainID eth.ChainID, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error) MessageHandler {
 	return func(ctx context.Context, from peer.ID, msg any) error {
 		payload, ok := msg.(*eth.ExecutionPayloadEnvelope)
 		if !ok {
 			return fmt.Errorf("expected topic validator to parse and validate data into execution payload, but got %T", msg)
 		}
-		return onBlock(ctx, from, payload)
+		return onBlock(ctx, chainID, from, payload)
 	}
 }
 

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -50,11 +50,6 @@ func TestGuardGossipValidator(t *testing.T) {
 	require.Equal(t, pubsub.ValidationIgnore, val(context.Background(), "bob", nil))
 }
 
-func TestCombinePeers(t *testing.T) {
-	res := combinePeers([]peer.ID{"foo", "bar"}, []peer.ID{"bar", "baz"})
-	require.Equal(t, []peer.ID{"foo", "bar", "baz"}, res)
-}
-
 func TestVerifyBlockSignature(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelCrit)
 	cfg := &rollup.Config{
@@ -65,37 +60,43 @@ func TestVerifyBlockSignature(t *testing.T) {
 	require.NoError(t, err)
 	msg := []byte("any msg")
 
+	chainID := eth.ChainIDFromBig(cfg.L2ChainID)
+
 	t.Run("Valid", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.PublicKey)}
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
-		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
+		sig, err := signer.SignBlockV1(context.Background(), chainID, opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		gCfg := &SingleChainGossip{RollupCfg: cfg, P2PSequencerAuth: runCfg}
+		result := verifyBlockSignature(logger, chainID, gCfg, peerId, sig, msg)
 		require.Equal(t, pubsub.ValidationAccept, result)
 	})
 
 	t.Run("WrongSigner", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: common.HexToAddress("0x1234")}
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
-		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
+		sig, err := signer.SignBlockV1(context.Background(), chainID, opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		gCfg := &SingleChainGossip{RollupCfg: cfg, P2PSequencerAuth: runCfg}
+		result := verifyBlockSignature(logger, chainID, gCfg, peerId, sig, msg)
 		require.Equal(t, pubsub.ValidationReject, result)
 	})
 
 	t.Run("InvalidSignature", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.PublicKey)}
 		sig := eth.Bytes65{}
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		gCfg := &SingleChainGossip{RollupCfg: cfg, P2PSequencerAuth: runCfg}
+		result := verifyBlockSignature(logger, chainID, gCfg, peerId, sig, msg)
 		require.Equal(t, pubsub.ValidationReject, result)
 	})
 
 	t.Run("NoSequencer", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{}
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
-		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
+		sig, err := signer.SignBlockV1(context.Background(), chainID, opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		gCfg := &SingleChainGossip{RollupCfg: cfg, P2PSequencerAuth: runCfg}
+		result := verifyBlockSignature(logger, chainID, gCfg, peerId, sig, msg)
 		require.Equal(t, pubsub.ValidationIgnore, result)
 	})
 }
@@ -153,9 +154,11 @@ func TestBlockValidator(t *testing.T) {
 	// Params Set 2: Call the validation function
 	peerID := peer.ID("foo")
 
-	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2)
-	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3)
-	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV4)
+	chainID := eth.ChainIDFromBig(cfg.L2ChainID)
+	gCfg := &SingleChainGossip{RollupCfg: cfg, P2PSequencerAuth: runCfg}
+	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), chainID, gCfg, eth.BlockV2)
+	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), chainID, gCfg, eth.BlockV3)
+	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), chainID, gCfg, eth.BlockV4)
 
 	zero, one := uint64(0), uint64(1)
 	beaconHash, withdrawalsRoot := common.HexToHash("0x1234"), common.HexToHash("0x9876")

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	staticPeerTag = "static"
+	StaticPeerTag = "static"
 )
 
 type HostNewStream interface {
@@ -97,7 +97,7 @@ func (e *extraHost) initStaticPeers() {
 		e.Peerstore().AddAddrs(addr.ID, addr.Addrs, time.Hour*24*7)
 		// We protect the peer, so the connection manager doesn't decide to prune it.
 		// We tag it with "static" so other protects/unprotects with different tags don't affect this protection.
-		e.connMgr.Protect(addr.ID, staticPeerTag)
+		e.connMgr.Protect(addr.ID, StaticPeerTag)
 		// Try to dial the node in the background
 		go func(addr *peer.AddrInfo) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -73,12 +73,12 @@ func TestP2PSimple(t *testing.T) {
 }
 
 type mockGossipIn struct {
-	OnUnsafeL2PayloadFn func(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error
+	OnUnsafeL2PayloadFn func(ctx context.Context, chainID eth.ChainID, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error
 }
 
-func (m *mockGossipIn) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
+func (m *mockGossipIn) OnUnsafeL2Payload(ctx context.Context, chainID eth.ChainID, from peer.ID, msg *eth.ExecutionPayloadEnvelope) error {
 	if m.OnUnsafeL2PayloadFn != nil {
-		return m.OnUnsafeL2PayloadFn(ctx, from, msg)
+		return m.OnUnsafeL2PayloadFn(ctx, chainID, from, msg)
 	}
 	return nil
 }
@@ -321,11 +321,13 @@ func TestDiscovery(t *testing.T) {
 	resourcesCtx, resourcesCancel := context.WithCancel(context.Background())
 	defer resourcesCancel()
 
+	allowedNodes := &SingleChainFilter{AllowedChainID: eth.ChainIDFromBig(rollupCfg.L2ChainID)}
+
 	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, false)
 	require.NoError(t, err)
 	defer nodeA.Close()
 	hostA := nodeA.Host()
-	go nodeA.DiscoveryProcess(resourcesCtx, logA, rollupCfg, 10)
+	go nodeA.DiscoveryProcess(resourcesCtx, logA, allowedNodes, 10)
 
 	// Add A as bootnode to B
 	confB.Bootnodes = []*enode.Node{nodeA.Dv5Udp().Self()}
@@ -340,7 +342,7 @@ func TestDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
-	go nodeB.DiscoveryProcess(resourcesCtx, logB, rollupCfg, 10)
+	go nodeB.DiscoveryProcess(resourcesCtx, logB, allowedNodes, 10)
 
 	// Track connections to B
 	connsB := make(chan network.Conn, 2)
@@ -355,7 +357,7 @@ func TestDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	defer nodeC.Close()
 	hostC := nodeC.Host()
-	go nodeC.DiscoveryProcess(resourcesCtx, logC, rollupCfg, 10)
+	go nodeC.DiscoveryProcess(resourcesCtx, logC, allowedNodes, 10)
 
 	// B and C don't know each other yet, but both have A as a bootnode.
 	// It should only be a matter of time for them to connect, if they discover each other via A.

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -160,11 +160,17 @@ func (n *NodeP2P) init(
 	// notify of any new connections/streams/etc.
 	n.host.Network().Notify(NewNetworkNotifier(log, metrics))
 	// note: the IDDelta functionality was removed from libP2P, and no longer needs to be explicitly disabled.
-	n.gs, err = NewGossipSub(resourcesCtx, n.host, rollupCfg, setup, n.scorer, metrics, log)
+
+	gossipChainCfg := &SingleChainGossip{
+		RollupCfg:        rollupCfg,
+		P2PSequencerAuth: runCfg,
+	}
+	n.gs, err = NewGossipSub(resourcesCtx, n.host, gossipChainCfg, setup, n.scorer, metrics, log)
 	if err != nil {
 		return fmt.Errorf("failed to start gossipsub router: %w", err)
 	}
-	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, gossipIn)
+
+	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, gossipChainCfg, gossipIn)
 	if err != nil {
 		return fmt.Errorf("failed to join blocks gossip topic: %w", err)
 	}
@@ -176,7 +182,8 @@ func (n *NodeP2P) init(
 	}
 
 	// All nil if disabled.
-	n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"), rollupCfg, tcpPort)
+	n.dv5Local, n.dv5Udp, err = setup.Discovery(log.New("p2p", "discv5"),
+		WithSingleChainOPStackENR(rollupCfg), tcpPort)
 	if err != nil {
 		return fmt.Errorf("failed to start discv5: %w", err)
 	}
@@ -242,7 +249,7 @@ func (n *NodeP2P) GetPeerScore(id peer.ID) (float64, error) {
 }
 
 func (n *NodeP2P) IsStatic(id peer.ID) bool {
-	return n.connMgr != nil && n.connMgr.IsProtected(id, staticPeerTag)
+	return n.connMgr != nil && n.connMgr.IsProtected(id, StaticPeerTag)
 }
 
 func (n *NodeP2P) BanPeer(id peer.ID, expiration time.Time) error {
@@ -273,6 +280,10 @@ func (n *NodeP2P) BanIP(ip net.IP, expiration time.Time) error {
 		}
 	}
 	return nil
+}
+
+func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, nodeFilter NodeFilter, connectGoal uint) {
+	DiscoveryProcess(ctx, log, n, nodeFilter, connectGoal)
 }
 
 func (n *NodeP2P) Close() error {

--- a/op-node/p2p/notifications.go
+++ b/op-node/p2p/notifications.go
@@ -51,7 +51,7 @@ func (notif *notifications) ClosedStream(n network.Network, v network.Stream) {
 	notif.log.Trace("opened stream", "protocol", v.Protocol(), "peer", c.RemotePeer(), "addr", c.RemoteMultiaddr())
 }
 
-func NewNetworkNotifier(log log.Logger, m metrics.Metricer) network.Notifiee {
+func NewNetworkNotifier(log log.Logger, m NotificationsMetricer) network.Notifiee {
 	if m == nil {
 		m = metrics.NoopMetrics
 	}

--- a/op-node/p2p/peer_params_test.go
+++ b/op-node/p2p/peer_params_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // PeerParamsTestSuite tests peer parameterization.
@@ -68,7 +69,7 @@ func (testSuite *PeerParamsTestSuite) TestGetPeerScoreParams_Light() {
 	testSuite.NoError(err)
 	// Topics should not contain options for any block topic
 	testSuite.Len(peerParams.Topics, 0)
-	_, ok := peerParams.Topics[blocksTopicV1(cfg)]
+	_, ok := peerParams.Topics[eth.BlockV1.BlocksTopic(eth.ChainIDFromBig(cfg.L2ChainID))]
 	testSuite.False(ok, "should not have block topic params")
 
 	testSuite.Equal(peerParams.AppSpecificWeight, float64(1))

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -13,8 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 // Prepared provides a p2p host and discv5 service that is already set up.
@@ -49,23 +47,19 @@ func (p *Prepared) Host(log log.Logger, reporter metrics.Reporter, metrics HostM
 }
 
 // Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
-func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
+func (p *Prepared) Discovery(log log.Logger, localNodeMods LocalNodeModFn, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
 	if p.LocalNode != nil {
-		dat := OpStackENRData{
-			chainID: rollupCfg.L2ChainID.Uint64(),
-			version: 0,
-		}
-		p.LocalNode.Set(&dat)
 		if tcpPort != 0 {
 			p.LocalNode.Set(enr.TCP(tcpPort))
 		}
+		localNodeMods(p.LocalNode)
 	}
 	return p.LocalNode, p.UDPv5, nil
 }
 
-func (p *Prepared) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
+func (p *Prepared) ConfigureGossip() []pubsub.Option {
 	return []pubsub.Option{
-		pubsub.WithGossipSubParams(BuildGlobalGossipParams(rollupCfg)),
+		pubsub.WithGossipSubParams(BuildGlobalGossipParams()),
 	}
 }
 

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -176,7 +176,13 @@ func (s *APIBackend) Peers(ctx context.Context, connected bool) (*apis.PeerDump,
 			dump.TotalConnected += 1
 		}
 	}
-	for _, id := range s.node.GossipOut().AllBlockTopicsPeers() {
+	gossipPeers := make(map[peer.ID]struct{})
+	for _, topicName := range s.node.GossipSub().GetTopics() {
+		for _, peerID := range s.node.GossipSub().ListPeers(topicName) {
+			gossipPeers[peerID] = struct{}{}
+		}
+	}
+	for id := range gossipPeers {
 		if p, ok := dump.Peers[id.String()]; ok {
 			p.GossipBlocks = true
 		}
@@ -194,15 +200,17 @@ func (s *APIBackend) PeerStats(_ context.Context) (*apis.PeerStats, error) {
 	nw := h.Network()
 	pstore := h.Peerstore()
 
+	gossipPeersByTopic := make(map[string]uint)
+	for _, topicName := range s.node.GossipSub().GetTopics() {
+		peerIDs := s.node.GossipSub().ListPeers(topicName)
+		gossipPeersByTopic[topicName] = uint(len(peerIDs))
+	}
 	stats := &apis.PeerStats{
-		Connected:     uint(len(nw.Peers())),
-		Table:         0,
-		BlocksTopic:   uint(len(s.node.GossipOut().BlocksTopicV1Peers())),
-		BlocksTopicV2: uint(len(s.node.GossipOut().BlocksTopicV2Peers())),
-		BlocksTopicV3: uint(len(s.node.GossipOut().BlocksTopicV3Peers())),
-		BlocksTopicV4: uint(len(s.node.GossipOut().BlocksTopicV4Peers())),
-		Banned:        0,
-		Known:         uint(len(pstore.Peers())),
+		Connected:          uint(len(nw.Peers())),
+		Table:              0,
+		GossipPeersByTopic: gossipPeersByTopic,
+		Banned:             0,
+		Known:              uint(len(pstore.Peers())),
 	}
 	if gater := s.node.ConnectionGater(); gater != nil {
 		stats.Banned = uint(len(gater.ListBlockedPeers()))

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -96,7 +96,7 @@ func MakeStreamHandler(resourcesCtx context.Context, log log.Logger, fn requestH
 
 type newStreamFn func(ctx context.Context, peerId peer.ID, protocolId ...protocol.ID) (network.Stream, error)
 
-type receivePayloadFn func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error
+type receivePayloadFn func(ctx context.Context, chainID eth.ChainID, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error
 
 type rangeRequest struct {
 	start uint64
@@ -508,7 +508,8 @@ func (s *SyncClient) tryPromote(h common.Hash) {
 func (s *SyncClient) promote(ctx context.Context, res syncResult) {
 	s.log.Debug("promoting p2p sync result", "payload", res.payload.ExecutionPayload.ID(), "peer", res.peer)
 
-	if err := s.receivePayload(ctx, res.peer, res.payload); err != nil {
+	chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)
+	if err := s.receivePayload(ctx, chainID, res.peer, res.payload); err != nil {
 		s.log.Warn("failed to promote payload, receiver error", "err", err)
 		return
 	}

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -141,7 +141,7 @@ func TestSinglePeerSync(t *testing.T) {
 
 	// collect received payloads in a buffered channel, so we can verify we get everything
 	received := make(chan *eth.ExecutionPayloadEnvelope, 100)
-	receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
+	receivePayload := receivePayloadFn(func(ctx context.Context, chainID eth.ChainID, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
 		received <- payload
 		return nil
 	})
@@ -214,7 +214,7 @@ func TestMultiPeerSync(t *testing.T) {
 
 		// collect received payloads in a buffered channel, so we can verify we get everything
 		received := make(chan *eth.ExecutionPayloadEnvelope, 100)
-		receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
+		receivePayload := receivePayloadFn(func(ctx context.Context, chainID eth.ChainID, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
 			received <- payload
 			return nil
 		})
@@ -368,7 +368,7 @@ func TestNetworkNotifyAddPeerAndRemovePeer(t *testing.T) {
 	require.NoError(t, err, "failed to launch host B")
 	defer hostB.Close()
 
-	syncCl := NewSyncClient(log, cfg, hostA, func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
+	syncCl := NewSyncClient(log, cfg, hostA, func(ctx context.Context, chainID eth.ChainID, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
 		return nil
 	}, metrics.NoopMetrics, &NoopApplicationScorer{})
 

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -39,7 +39,7 @@ func NewCLSync(log log.Logger, cfg *rollup.Config, metrics Metrics) *CLSync {
 		log:            log,
 		cfg:            cfg,
 		metrics:        metrics,
-		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
+		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, PayloadMemSize),
 	}
 }
 

--- a/op-node/rollup/clsync/payloads_queue.go
+++ b/op-node/rollup/clsync/payloads_queue.go
@@ -57,7 +57,7 @@ const (
 	payloadTxMemOverhead uint64 = 24
 )
 
-func payloadMemSize(p *eth.ExecutionPayloadEnvelope) uint64 {
+func PayloadMemSize(p *eth.ExecutionPayloadEnvelope) uint64 {
 	out := payloadMemFixedCost
 	if p == nil {
 		return out
@@ -81,6 +81,8 @@ type PayloadsQueue struct {
 	currentSize uint64
 	MaxSize     uint64
 	blockHashes map[common.Hash]struct{}
+	firstByNum  map[uint64]*eth.ExecutionPayloadEnvelope
+	highest     *eth.ExecutionPayloadEnvelope
 	SizeFn      func(p *eth.ExecutionPayloadEnvelope) uint64
 	log         log.Logger
 }
@@ -91,6 +93,8 @@ func NewPayloadsQueue(log log.Logger, maxSize uint64, sizeFn func(p *eth.Executi
 		currentSize: 0,
 		MaxSize:     maxSize,
 		blockHashes: make(map[common.Hash]struct{}),
+		firstByNum:  make(map[uint64]*eth.ExecutionPayloadEnvelope),
+		highest:     nil,
 		SizeFn:      sizeFn,
 		log:         log,
 	}
@@ -131,6 +135,13 @@ func (upq *PayloadsQueue) Push(e *eth.ExecutionPayloadEnvelope) error {
 		env := upq.Pop()
 		upq.log.Info("Dropping payload from payload queue because the payload queue is too large", "id", env.ExecutionPayload.ID())
 	}
+	num := uint64(e.ExecutionPayload.BlockNumber)
+	if _, ok := upq.firstByNum[num]; !ok {
+		upq.firstByNum[num] = e
+	}
+	if upq.highest == nil || uint64(upq.highest.ExecutionPayload.BlockNumber) < num {
+		upq.highest = e
+	}
 	upq.blockHashes[e.ExecutionPayload.BlockHash] = struct{}{}
 	return nil
 }
@@ -145,6 +156,11 @@ func (upq *PayloadsQueue) Peek() *eth.ExecutionPayloadEnvelope {
 	return upq.pq[0].envelope
 }
 
+// Last retrieves the payload with the highest block number from the queue in O(1), or nil if the queue is empty.
+func (upq *PayloadsQueue) Last() *eth.ExecutionPayloadEnvelope {
+	return upq.highest
+}
+
 // Pop removes the payload with the lowest block number from the queue in O(log(N)),
 // and may return nil if the queue is empty.
 func (upq *PayloadsQueue) Pop() *eth.ExecutionPayloadEnvelope {
@@ -154,6 +170,29 @@ func (upq *PayloadsQueue) Pop() *eth.ExecutionPayloadEnvelope {
 	ps := heap.Pop(&upq.pq).(payloadAndSize) // nosemgrep
 	upq.currentSize -= ps.size
 	// remove the key from the block hashes map
-	delete(upq.blockHashes, ps.envelope.ExecutionPayload.BlockHash)
+	hash := ps.envelope.ExecutionPayload.BlockHash
+	delete(upq.blockHashes, hash)
+	num := uint64(ps.envelope.ExecutionPayload.BlockNumber)
+	// Once we pop the first-seen payload with this number, also unregister it from first-seen.
+	if prev, ok := upq.firstByNum[num]; ok && prev.ID() == ps.envelope.ID() {
+		delete(upq.firstByNum, num)
+	}
+	// if we removed the highest, then unset highest.
+	if upq.highest != nil && upq.highest.ID() == ps.envelope.ID() {
+		upq.highest = nil
+	}
+	// If we have another remaining payload with the same number, then register that as new block.
+	if first := upq.Peek(); first != nil {
+		if uint64(first.ExecutionPayload.BlockNumber) == num {
+			upq.firstByNum[num] = first
+		}
+		if upq.highest == nil { // possible when we have equivocating highest blocks
+			upq.highest = first
+		}
+	}
 	return ps.envelope
+}
+
+func (upq *PayloadsQueue) ByNumber(num uint64) *eth.ExecutionPayloadEnvelope {
+	return upq.firstByNum[num]
 }

--- a/op-node/rollup/clsync/payloads_queue_test.go
+++ b/op-node/rollup/clsync/payloads_queue_test.go
@@ -65,12 +65,12 @@ func TestPayloadsByNumber(t *testing.T) {
 }
 
 func TestPayloadMemSize(t *testing.T) {
-	require.Equal(t, payloadMemFixedCost, payloadMemSize(nil), "nil is same fixed cost")
-	require.Equal(t, payloadMemFixedCost, payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{}}), "empty payload fixed cost")
-	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{nil}}}), "nil tx counts")
-	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{make([]byte, 0)}}}), "empty tx counts")
+	require.Equal(t, payloadMemFixedCost, PayloadMemSize(nil), "nil is same fixed cost")
+	require.Equal(t, payloadMemFixedCost, PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{}}), "empty payload fixed cost")
+	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{nil}}}), "nil tx counts")
+	require.Equal(t, payloadMemFixedCost+payloadTxMemOverhead, PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{make([]byte, 0)}}}), "empty tx counts")
 	require.Equal(t, payloadMemFixedCost+4*payloadTxMemOverhead+42+1337+0+1,
-		payloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{
+		PayloadMemSize(&eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{Transactions: []eth.Data{
 			make([]byte, 42),
 			make([]byte, 1337),
 			make([]byte, 0),
@@ -83,7 +83,7 @@ func envelope(payload *eth.ExecutionPayload) *eth.ExecutionPayloadEnvelope {
 }
 
 func TestPayloadsQueue(t *testing.T) {
-	pq := NewPayloadsQueue(testlog.Logger(t, log.LvlInfo), payloadMemFixedCost*3, payloadMemSize)
+	pq := NewPayloadsQueue(testlog.Logger(t, log.LvlInfo), payloadMemFixedCost*3, PayloadMemSize)
 	require.Equal(t, 0, pq.Len())
 	require.Nil(t, pq.Peek())
 	require.Nil(t, pq.Pop())

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -17,7 +17,6 @@ var ErrEngineResetReq = errors.New("cannot continue derivation until Engine has 
 
 type Metrics interface {
 	RecordL1Ref(name string, ref eth.L1BlockRef)
-	RecordL2Ref(name string, ref eth.L2BlockRef)
 	RecordChannelInputBytes(inputCompressedBytes int)
 	RecordHeadChannelOpened()
 	RecordChannelTimedOut()

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -43,8 +43,13 @@ type Genesis struct {
 	L1 eth.BlockID `json:"l1"`
 	// The L2 block the rollup starts from (no transactions, pre-configured state)
 	L2 eth.BlockID `json:"l2"`
-	// Timestamp of L2 block
+	// Timestamp of the L2 block
 	L2Time uint64 `json:"l2_time"`
+	// Timestamp of the L1 block.
+	// WARNING: This is set to 0 for rollup configs pre-interop.
+	// This may also be 0 post-interop.
+	// If zero, the user is expected to load the timestamp from the L1 block to prepare the config.
+	L1Time uint64 `json:"l1_time,omitempty"`
 	// Initial system configuration values.
 	// The L2 genesis block may not include transactions, and thus cannot encode the config values,
 	// unlike later L2 blocks.

--- a/op-service/apis/l2.go
+++ b/op-service/apis/l2.go
@@ -37,6 +37,7 @@ type L2EthClient interface {
 }
 
 type L2EthExtendedClient interface {
+	L2EthClient
 	EthExtendedClient
 	SystemConfigFetcher
 	OutputRootFetcher

--- a/op-service/apis/p2p.go
+++ b/op-service/apis/p2p.go
@@ -61,12 +61,9 @@ type PeerInfo struct {
 }
 
 type PeerStats struct {
-	Connected     uint `json:"connected"`
-	Table         uint `json:"table"`
-	BlocksTopic   uint `json:"blocksTopic"`
-	BlocksTopicV2 uint `json:"blocksTopicV2"`
-	BlocksTopicV3 uint `json:"blocksTopicV3"`
-	BlocksTopicV4 uint `json:"blocksTopicV4"`
-	Banned        uint `json:"banned"`
-	Known         uint `json:"known"`
+	Connected          uint            `json:"connected"`
+	Table              uint            `json:"table"`
+	GossipPeersByTopic map[string]uint `json:"gossipPeersByTopic"`
+	Banned             uint            `json:"banned"`
+	Known              uint            `json:"known"`
 }

--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -14,12 +14,22 @@ import (
 
 type BlockVersion int
 
-const ( // iota is reset to 0
+// zero-indexed: V1 is index 0, etc. etc.
+const (
 	BlockV1 BlockVersion = iota
 	BlockV2
 	BlockV3
 	BlockV4
 )
+
+func (v BlockVersion) String() string {
+	return fmt.Sprintf("v%d", int(v)+1)
+}
+
+func (v BlockVersion) BlocksTopic(chainID ChainID) string {
+	// ChainID in decimal, followed by 0-indexed block version
+	return fmt.Sprintf("/optimism/%s/%d/blocks", chainID.String(), int(v))
+}
 
 // ExecutionPayload and ExecutionPayloadEnvelope are the only SSZ types we have to marshal/unmarshal,
 // so instead of importing a SSZ lib we implement the bare minimum.

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -235,6 +235,10 @@ type ExecutionPayloadEnvelope struct {
 	ExecutionPayload      *ExecutionPayload `json:"executionPayload"`
 }
 
+func (env *ExecutionPayloadEnvelope) BlockRef() BlockRef {
+	return env.ExecutionPayload.BlockRef()
+}
+
 func (env *ExecutionPayloadEnvelope) ID() BlockID {
 	return env.ExecutionPayload.ID()
 }

--- a/op-service/event/util.go
+++ b/op-service/event/util.go
@@ -1,13 +1,21 @@
 package event
 
+type Matcher func(ev Event) bool
+
+func IsNot[T Event](ev Event) bool {
+	_, ok := ev.(T)
+	return !ok
+}
+
 // Is as helper function is syntax-sugar to do an Event type check as a boolean function
 func Is[T Event](ev Event) bool {
 	_, ok := ev.(T)
 	return ok
 }
 
-// Any as helper function combines different event conditions into a single function
-func Any(fns ...func(ev Event) bool) func(ev Event) bool {
+// Any as helper function combines different event conditions into a single OR expression.
+// This returns false if none of the inputs match, or if there are no conditions to check.
+func Any(fns ...Matcher) Matcher {
 	return func(ev Event) bool {
 		for _, fn := range fns {
 			if fn(ev) {
@@ -15,5 +23,18 @@ func Any(fns ...func(ev Event) bool) func(ev Event) bool {
 			}
 		}
 		return false
+	}
+}
+
+// All as helper function combines different event conditions into a single AND expression.
+// This returns true if all functions match, or if there are no conditions to check.
+func All(fns ...Matcher) Matcher {
+	return func(ev Event) bool {
+		for _, fn := range fns {
+			if !fn(ev) {
+				return false
+			}
+		}
+		return true
 	}
 }

--- a/op-service/flags/flags.go
+++ b/op-service/flags/flags.go
@@ -24,7 +24,14 @@ const (
 	InteropOverrideFlagName            = "override.interop"
 )
 
-func CLIFlags(envPrefix string, category string) []cli.Flag {
+func CLIFlags(envPrefix string, category string) (out []cli.Flag) {
+	out = append(out, OverrideCLIFlags(envPrefix, category)...)
+	out = append(out, CLINetworkFlag(envPrefix, category))
+	out = append(out, CLIRollupConfigFlag(envPrefix, category))
+	return out
+}
+
+func OverrideCLIFlags(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.Uint64Flag{
 			Name:     CanyonOverrideFlagName,
@@ -89,8 +96,6 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 			Hidden:   false,
 			Category: category,
 		},
-		CLINetworkFlag(envPrefix, category),
-		CLIRollupConfigFlag(envPrefix, category),
 	}
 }
 

--- a/op-service/metrics/rpc_metrics.go
+++ b/op-service/metrics/rpc_metrics.go
@@ -214,7 +214,7 @@ func (rec *rpcRecorder) RecordIncoming(ctx context.Context, msg rpc.RecordedMsg)
 
 type NoopRPCMetrics struct{}
 
-func (n *NoopRPCMetrics) NewRecorder(name string) rpc.Recorder {
+func (NoopRPCMetrics) NewRecorder(name string) rpc.Recorder {
 	return &NoopRPCRecorder{}
 }
 

--- a/op-service/signer/cli.go
+++ b/op-service/signer/cli.go
@@ -33,9 +33,10 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 			Category: category,
 		},
 		&cli.StringSliceFlag{
-			Name:    HeadersFlagName,
-			Usage:   "Headers to pass to the remote signer. Format `key=value`. Value can contain any character allowed in a HTTP header. When using env vars, split with commas. When using flags one key value pair per flag.",
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "HEADER"),
+			Name:     HeadersFlagName,
+			Usage:    "Headers to pass to the remote signer. Format `key=value`. Value can contain any character allowed in a HTTP header. When using env vars, split with commas. When using flags one key value pair per flag.",
+			EnvVars:  opservice.PrefixEnvVar(envPrefix, "HEADER"),
+			Category: category,
 		},
 	}
 	flags = append(flags, optls.CLIFlagsWithFlagPrefix(envPrefix, "signer", category)...)

--- a/op-service/sources/chainid.go
+++ b/op-service/sources/chainid.go
@@ -1,0 +1,22 @@
+package sources
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// ChainID retrieves the ChainID of an eth RPC directly.
+// This helps identify the chain configuration to use for full typed bindings.
+func ChainID(ctx context.Context, cl client.RPC) (eth.ChainID, error) {
+	var id hexutil.Big
+	err := cl.CallContext(ctx, &id, "eth_chainId")
+	if err != nil {
+		return eth.ChainID{}, err
+	}
+	return eth.ChainIDFromBig((*big.Int)(&id)), nil
+}

--- a/op-service/tls/cli.go
+++ b/op-service/tls/cli.go
@@ -42,10 +42,11 @@ func CLIFlagsWithFlagPrefix(envPrefix string, flagPrefix string, category string
 	}
 	return []cli.Flag{
 		&cli.BoolFlag{
-			Name:    prefixFunc(TLSEnabledFlagName),
-			Usage:   "Enable or disable TLS client authentication for the signer",
-			Value:   defaultTLSEnabled,
-			EnvVars: prefixEnvVars("TLS_ENABLED"),
+			Name:     prefixFunc(TLSEnabledFlagName),
+			Usage:    "Enable or disable TLS client authentication for the signer",
+			Value:    defaultTLSEnabled,
+			EnvVars:  prefixEnvVars("TLS_ENABLED"),
+			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     prefixFunc(TLSCaCertFlagName),

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -689,7 +689,7 @@ func (su *SupervisorBackend) Finalized(ctx context.Context, chainID eth.ChainID)
 	if err != nil {
 		return eth.BlockID{}, err
 	}
-	return v.ID(), nil
+	return v.Derived.ID(), nil
 }
 
 func (su *SupervisorBackend) FinalizedL1(ctx context.Context) (eth.BlockRef, error) {

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -142,6 +142,13 @@ type CrossSafeWorker struct {
 	chainID eth.ChainID
 	d       CrossSafeDeps
 	linker  depset.LinkChecker
+	emitter event.Emitter
+}
+
+var _ event.AttachEmitter = (*CrossSafeWorker)(nil)
+
+func (c *CrossSafeWorker) AttachEmitter(em event.Emitter) {
+	c.emitter = em
 }
 
 func (c *CrossSafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
@@ -153,6 +160,7 @@ func (c *CrossSafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
 			} else {
 				c.logger.Warn("Failed to process work", "err", err)
 			}
+			c.emitter.Emit(ctx, superevents.CrossSafeWorkErrEvent{ChainID: c.chainID, Err: err})
 		}
 	default:
 		return false

--- a/op-supervisor/supervisor/backend/cross/unsafe_update.go
+++ b/op-supervisor/supervisor/backend/cross/unsafe_update.go
@@ -86,6 +86,13 @@ type CrossUnsafeWorker struct {
 	chainID eth.ChainID
 	d       CrossUnsafeDeps
 	linker  depset.LinkChecker
+	emitter event.Emitter
+}
+
+var _ event.AttachEmitter = (*CrossUnsafeWorker)(nil)
+
+func (c *CrossUnsafeWorker) AttachEmitter(em event.Emitter) {
+	c.emitter = em
 }
 
 func (c *CrossUnsafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
@@ -97,6 +104,7 @@ func (c *CrossUnsafeWorker) OnEvent(ctx context.Context, ev event.Event) bool {
 			} else {
 				c.logger.Warn("Failed to process work", "err", err)
 			}
+			c.emitter.Emit(ctx, superevents.CrossUnsafeWorkErrEvent{ChainID: c.chainID, Err: err})
 		}
 	default:
 		return false

--- a/op-supervisor/supervisor/backend/db/query.go
+++ b/op-supervisor/supervisor/backend/db/query.go
@@ -183,6 +183,10 @@ func (db *ChainsDB) CrossUnsafe(chainID eth.ChainID) (types.BlockSeal, error) {
 	return crossUnsafe, nil
 }
 
+// AcceptedBlock checks if a block may be indexed,
+// by checking if it's not conflicting with the local-safe DB.
+// Otherwise, we may end up in a loop of indexing logs of an unsafe chain
+// while rewinding it because of divergence with the higher level of safety.
 func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 	localDB, ok := db.localDBs.Get(chainID)
 	if !ok {
@@ -192,7 +196,7 @@ func (db *ChainsDB) AcceptedBlock(chainID eth.ChainID, id eth.BlockID) error {
 	if err != nil {
 		return fmt.Errorf("failed to get revision: %w", err)
 	}
-	db.logger.Info("Checking if accepted", "chain", chainID, "id", id, "revision", revision)
+	db.logger.Debug("Checking if accepted", "chain", chainID, "id", id, "revision", revision)
 	// If the block is not cross-safe, then the revision will be the latest
 	// (assuming the trailing local-safe data only has 1 revision;
 	//  the same or something net-new exactly starting after cross-safe).
@@ -226,20 +230,20 @@ func (db *ChainsDB) FinalizedL1() eth.BlockRef {
 	return db.finalizedL1.Get()
 }
 
-func (db *ChainsDB) Finalized(chainID eth.ChainID) (types.BlockSeal, error) {
+func (db *ChainsDB) Finalized(chainID eth.ChainID) (types.DerivedBlockSealPair, error) {
 	finalizedL1 := db.finalizedL1.Get()
 	if finalizedL1 == (eth.L1BlockRef{}) {
-		return types.BlockSeal{}, fmt.Errorf("no finalized L1 signal, cannot determine L2 finality of chain %s yet: %w", chainID, types.ErrFuture)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("no finalized L1 signal, cannot determine L2 finality of chain %s yet: %w", chainID, types.ErrFuture)
 	}
 
 	// compare the finalized L1 block with the last derived block in the cross DB
 	xDB, ok := db.crossDBs.Get(chainID)
 	if !ok {
-		return types.BlockSeal{}, types.ErrUnknownChain
+		return types.DerivedBlockSealPair{}, types.ErrUnknownChain
 	}
 	latest, err := xDB.Last()
 	if err != nil {
-		return types.BlockSeal{}, fmt.Errorf("could not get the latest derived pair for chain %s: %w", chainID, err)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("could not get the latest derived pair for chain %s: %w", chainID, err)
 	}
 	// if the finalized L1 block is newer than the latest L1 block used to derive L2 blocks,
 	// the finality signal automatically applies to all previous blocks, including the latest derived block
@@ -249,15 +253,18 @@ func (db *ChainsDB) Finalized(chainID eth.ChainID) (types.BlockSeal, error) {
 			"finalizedL1", finalizedL1.Number,
 			"latestSource", latest.Source,
 			"latestDerived", latest.Derived)
-		return latest.Derived, nil
+		return latest, nil
 	}
 
 	// otherwise, use the finalized L1 block to determine the final L2 block that was derived from it
 	derived, err := db.CrossSourceToLastDerived(chainID, finalizedL1.ID())
 	if err != nil {
-		return types.BlockSeal{}, fmt.Errorf("could not find what was last derived in L2 chain %s from the finalized L1 block %s: %w", chainID, finalizedL1, err)
+		return types.DerivedBlockSealPair{}, fmt.Errorf("could not find what was last derived in L2 chain %s from the finalized L1 block %s: %w", chainID, finalizedL1, err)
 	}
-	return derived, nil
+	return types.DerivedBlockSealPair{
+		Source:  types.BlockSealFromRef(finalizedL1),
+		Derived: derived,
+	}, nil
 }
 
 func (db *ChainsDB) CrossSourceToLastDerived(chainID eth.ChainID, source eth.BlockID) (derived types.BlockSeal, err error) {

--- a/op-supervisor/supervisor/backend/depset/depset.go
+++ b/op-supervisor/supervisor/backend/depset/depset.go
@@ -29,7 +29,7 @@ type DependencySet interface {
 
 // FromRegistry loads a dependency set from the superchain-registry.
 // Returns error of type superchain.ErrUnknownChain if the chain is not available in the superchain registry.
-func FromRegistry(chainID eth.ChainID) (DependencySet, error) {
+func FromRegistry(chainID eth.ChainID) (*StaticConfigDependencySet, error) {
 	id, ok := chainID.Uint64()
 	if !ok {
 		return nil, fmt.Errorf("%w: %v", superchain.ErrUnknownChain, chainID)

--- a/op-supervisor/supervisor/backend/depset/rollup_config_set_v2.go
+++ b/op-supervisor/supervisor/backend/depset/rollup_config_set_v2.go
@@ -1,0 +1,159 @@
+package depset
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type StaticRollupConfigSetV2 map[eth.ChainID]*rollup.Config
+
+func (c StaticRollupConfigSetV2) RollupConfig(chainID eth.ChainID) *rollup.Config {
+	return c[chainID]
+}
+
+func (c StaticRollupConfigSetV2) LoadRollupConfigSet(ctx context.Context) (RollupConfigSet, error) {
+	return c, nil
+}
+
+func (c StaticRollupConfigSetV2) LoadRollupConfigSetV2(ctx context.Context) (RollupConfigSetV2, error) {
+	return c, nil
+}
+
+var (
+	_ RollupConfigSetSource = (StaticRollupConfigSetV2)(nil)
+	_ RollupConfigSet       = (StaticRollupConfigSetV2)(nil)
+)
+
+func NewStaticRollupConfigSetV2(cfgs map[eth.ChainID]*rollup.Config) StaticRollupConfigSetV2 {
+	return cfgs
+}
+
+// HasChain returns true if the chain is part of the rollup config set.
+func (s StaticRollupConfigSetV2) HasChain(chainID eth.ChainID) bool {
+	_, ok := s[chainID]
+	return ok
+}
+
+// Chains returns the list of chains in the rollup config set.
+func (s StaticRollupConfigSetV2) Chains() []eth.ChainID {
+	ids := make([]eth.ChainID, 0, len(s))
+	for id := range s {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// Genesis returns the genesis configuration for the given chain.
+// Panics if the chain is not part of the rollup config set.
+func (s StaticRollupConfigSetV2) Genesis(chainID eth.ChainID) Genesis {
+	cfg, ok := s[chainID]
+	if !ok {
+		panic("chain not found in rollup config set")
+	}
+	if cfg.Genesis.L1Time == 0 {
+		panic(fmt.Errorf("rollup config of chain %s was not prepared with L1 anchor block timestamp", chainID))
+	}
+	return Genesis{
+		L1: types.BlockSeal{
+			Hash:      cfg.Genesis.L1.Hash,
+			Number:    cfg.Genesis.L1.Number,
+			Timestamp: cfg.Genesis.L1Time,
+		},
+		L2: types.BlockSeal{
+			Hash:      cfg.Genesis.L2.Hash,
+			Number:    cfg.Genesis.L2.Number,
+			Timestamp: cfg.Genesis.L2Time,
+		},
+	}
+}
+
+// IsInterop returns true if the Interop hardfork is active for the given chain at the given timestamp.
+// Panics if the chain is not part of the rollup config set.
+func (s StaticRollupConfigSetV2) IsInterop(chainID eth.ChainID, ts uint64) bool {
+	cfg, ok := s[chainID]
+	if !ok {
+		panic("chain not found in rollup config set")
+	}
+	return cfg.IsInterop(ts)
+}
+
+// IsInteropActivationBlock returns true if the given timestamp is the activation block for the Interop hardfork.
+// Panics if the chain is not part of the rollup config set.
+func (s StaticRollupConfigSetV2) IsInteropActivationBlock(chainID eth.ChainID, ts uint64) bool {
+	cfg, ok := s[chainID]
+	if !ok {
+		panic("chain not found in rollup config set")
+	}
+	return cfg.IsInteropActivationBlock(ts)
+}
+
+type RollupConfigSetSourceV2 interface {
+	RollupConfigSetSource
+	LoadRollupConfigSetV2(ctx context.Context) (RollupConfigSetV2, error)
+}
+
+type RollupConfigSetV2 interface {
+	RollupConfigSet
+
+	// RollupConfig the rollup-config of the given chain.
+	// The user may mutate it to fix the missing L1 anchor timestamp.
+	RollupConfig(chainID eth.ChainID) *rollup.Config
+}
+
+// JSONRollupConfigsLoaderV2 loads a set of op-node rollup.json configs into
+// a V2 rollup config set, for use by op-node and op-supervisor code.
+//
+// The [PathPattern] is a glob pattern that matches the rollup.json files, e.g.
+// "configs/rollup-*.json". See https://pkg.go.dev/path/filepath#Glob for more details.
+//
+// Unlike the V1 loader, this does not query L1 and does not patch the L1 timestamp.
+// Instead, the user should patch it manually.
+// Long-term we can make the L1 timestamp a part of the config, and not rely on dynamic fetching at all.
+type JSONRollupConfigsLoaderV2 struct {
+	PathPattern string
+}
+
+func (j *JSONRollupConfigsLoaderV2) LoadRollupConfigSet(ctx context.Context) (RollupConfigSet, error) {
+	return j.LoadRollupConfigSetV2(ctx)
+}
+
+func (j *JSONRollupConfigsLoaderV2) LoadRollupConfigSetV2(ctx context.Context) (RollupConfigSetV2, error) {
+	matches, err := filepath.Glob(j.PathPattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to glob files: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("cannot run with empty set of chains: %w", err)
+	}
+
+	configs := make(map[eth.ChainID]*rollup.Config)
+	for _, path := range matches {
+		cfg, err := LoadRollupCfg(path)
+		if err != nil {
+			return nil, err
+		}
+		chainID := eth.ChainIDFromBig(cfg.L2ChainID)
+		configs[chainID] = cfg
+	}
+	return StaticRollupConfigSetV2(configs), nil
+}
+
+func LoadRollupCfg(path string) (*rollup.Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open rollup config %s: %w", path, err)
+	}
+	defer file.Close()
+
+	var cfg rollup.Config
+	if err = cfg.ParseRollupConfig(file); err != nil {
+		return nil, fmt.Errorf("failed to parse rollup config %s: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -200,6 +200,9 @@ func (s *ChainProcessor) index() {
 	}
 	s.log.Debug("Idling indexing, reached latest block", "head", target)
 	s.running.Store(false)
+	s.emitter.Emit(s.systemContext, superevents.ChainIndexingIdleEvent{
+		ChainID: s.chain,
+	})
 }
 
 // nextActiveClient advances the client index and sets the active client.

--- a/op-supervisor/supervisor/backend/rewinder/rewinder.go
+++ b/op-supervisor/supervisor/backend/rewinder/rewinder.go
@@ -34,7 +34,7 @@ type rewinderDB interface {
 	RewindLogs(chainID eth.ChainID, newHead types.BlockSeal) error
 
 	FindSealedBlock(eth.ChainID, uint64) (types.BlockSeal, error)
-	Finalized(eth.ChainID) (types.BlockSeal, error)
+	Finalized(eth.ChainID) (types.DerivedBlockSealPair, error)
 
 	LocalDerivedToSource(chain eth.ChainID, derived eth.BlockID) (source types.BlockSeal, err error)
 }
@@ -110,7 +110,8 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 	// Try rewinding the logs DB to the parent of the new safe head
 	// If it fails with a data conflict walk back through the chain
 	// until we find a common ancestor or reach the finalized block
-	finalized, err := r.db.Finalized(ev.ChainID)
+	finalizedPair, err := r.db.Finalized(ev.ChainID)
+	var finalized types.BlockSeal
 	if err != nil {
 		if errors.Is(err, types.ErrFuture) {
 			finalized = types.BlockSeal{Number: 0}
@@ -118,6 +119,8 @@ func (r *Rewinder) handleLocalDerivedEvent(ev superevents.LocalSafeUpdateEvent) 
 			r.log.Error("failed to get finalized block", "chain", ev.ChainID, "err", err)
 			return
 		}
+	} else {
+		finalized = finalizedPair.Derived
 	}
 	var target types.BlockSeal
 	for height := int64(newSafeHead.Number - 1); height >= int64(finalized.Number); height-- {
@@ -175,7 +178,8 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 	}
 
 	// Get the finalized block as our lower bound
-	finalized, err := r.db.Finalized(chainID)
+	finalizedPair, err := r.db.Finalized(chainID)
+	var finalized types.BlockSeal
 	if err != nil {
 		// If we don't have a finalized block, use the genesis block
 		if errors.Is(err, types.ErrFuture) {
@@ -186,6 +190,8 @@ func (r *Rewinder) rewindL1ChainIfReorged(chainID eth.ChainID, newTip eth.BlockI
 		} else {
 			return fmt.Errorf("failed to get finalized block for chain %s: %w", chainID, err)
 		}
+	} else {
+		finalized = finalizedPair.Derived
 	}
 	finalizedL1, err := r.db.CrossDerivedToSourceRef(chainID, finalized.ID())
 	if err != nil {

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -73,7 +73,7 @@ func (su *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		status.CrossSafe = x.NewCrossSafe.Derived
 	case superevents.FinalizedL2UpdateEvent:
 		status := loadStatusRef(x.ChainID)
-		status.Finalized = x.FinalizedL2
+		status.Finalized = x.FinalizedL2.Derived
 	case superevents.FinalizedL1UpdateEvent:
 		log.Debug("Updated finalized L1", "finalizedL1", x.FinalizedL1)
 	default:

--- a/op-supervisor/supervisor/backend/status/status_test.go
+++ b/op-supervisor/supervisor/backend/status/status_test.go
@@ -97,6 +97,11 @@ func TestUpdateFinalized(t *testing.T) {
 	chain2 := eth.ChainIDFromUInt64(2)
 	chains := []eth.ChainID{chain1, chain2}
 	tracker := NewStatusTracker(chains)
+	srcFinalized := types.BlockSeal{
+		Number:    10000,
+		Hash:      common.Hash{0x11},
+		Timestamp: 1234256,
+	}
 	chain1Finalized := types.BlockSeal{
 		Number:    204,
 		Hash:      common.Hash{0xaa},
@@ -109,11 +114,11 @@ func TestUpdateFinalized(t *testing.T) {
 	}
 	tracker.OnEvent(context.Background(), superevents.FinalizedL2UpdateEvent{
 		ChainID:     chain1,
-		FinalizedL2: chain1Finalized,
+		FinalizedL2: types.DerivedBlockSealPair{Source: srcFinalized, Derived: chain1Finalized},
 	})
 	tracker.OnEvent(context.Background(), superevents.FinalizedL2UpdateEvent{
 		ChainID:     chain2,
-		FinalizedL2: chain2Finalized,
+		FinalizedL2: types.DerivedBlockSealPair{Source: srcFinalized, Derived: chain2Finalized},
 	})
 	status, err := tracker.SyncStatus()
 	require.NoError(t, err)

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -84,7 +84,7 @@ func (ev FinalizedL1UpdateEvent) String() string {
 
 type FinalizedL2UpdateEvent struct {
 	ChainID     eth.ChainID
-	FinalizedL2 types.BlockSeal
+	FinalizedL2 types.DerivedBlockSealPair
 }
 
 func (ev FinalizedL2UpdateEvent) String() string {
@@ -195,4 +195,33 @@ type ChainIndexingContinueEvent struct {
 
 func (ev ChainIndexingContinueEvent) String() string {
 	return "chain-indexing-continue"
+}
+
+// ChainIndexingIdleEvent is informational, used by op-node-v2 only
+type ChainIndexingIdleEvent struct {
+	ChainID eth.ChainID
+}
+
+func (ev ChainIndexingIdleEvent) String() string {
+	return "chain-indexing-idle"
+}
+
+// CrossSafeWorkErrEvent is informational, used by op-node-v2 only
+type CrossSafeWorkErrEvent struct {
+	ChainID eth.ChainID
+	Err     error
+}
+
+func (ev CrossSafeWorkErrEvent) String() string {
+	return "cross-safe-work-err"
+}
+
+// CrossUnsafeWorkErrEvent is informational, used by op-node-v2 only
+type CrossUnsafeWorkErrEvent struct {
+	ChainID eth.ChainID
+	Err     error
+}
+
+func (ev CrossUnsafeWorkErrEvent) String() string {
+	return "cross-unsafe-work-err"
 }

--- a/op-supervisor/supervisor/backend/syncnode/node.go
+++ b/op-supervisor/supervisor/backend/syncnode/node.go
@@ -142,7 +142,7 @@ func (m *ManagedNode) OnEvent(ctx context.Context, ev event.Event) bool {
 		if x.ChainID != m.chainID {
 			return false
 		}
-		m.onFinalizedL2(x.FinalizedL2)
+		m.onFinalizedL2(x.FinalizedL2.Derived)
 	case superevents.ChainRewoundEvent:
 		if x.ChainID != m.chainID {
 			return false


### PR DESCRIPTION
# Description

This code is explorers what a new op-node iteration could look like, that combines parts of op-supervisor, and revisits some sub-components to improve stability and scalability.

The main architectural change is to introduce a "controller", that interacts with a model of the state of the sub-components, managing tasks that need to happen, without doing long-running compute itself. This direction aims to organize sync behavior for increased stability and maintainability.

**This is a work in progress**

This op-node-v2 spike draft is not functional yet, although large parts are usable, the core controller code is actively changing and what makes this sync or not.

Reviewers beware: the spike diff is large, but about half of it is organizing the Metrics/CLI flags/Configs to support the new combined op-node / op-supervisor setup. All v2 changes are relatively well contained to new packages. See Scope.

## Scope

### Reused fully

- op-supervisor DB
- op-supervisor cross-verification
- op-supervisor block indexing
- dependency set configuration

### Minor adjustments

- op-node derivation (almost no diff in v1 code, v2 swaps out a few parts)
    - exclude the pre-Holocene stage variants
    - exclude the channel-walkback
    - simplify L1 traversal / attribute emission
- op-supervisor L1 access
- op-node P2P stack
- op-supervisor and op-node operations (CLI/metrics/RPC)

### Major adjustments

- op-node engine-API interactions:
    - no pre-Holocene pending-safe / fallback-unsafe complexity
    - no legacy synchronous p2p block processing
- op-node CL-sync / attributes-handler: improve block processing
- op-supervisor syncnode / reset behavior: unify with op-node, simplify
- op-supervisor <> op-node communication is internalized and simplified


## Scaling

This approach to a single-process consensus-layer node aims to provide better infra-compatibility with op-node v1, while also enabling a new approach to syncing multiple chains for better redundancy and lower costs.

![image](https://github.com/user-attachments/assets/6c5aedf6-c63f-44f5-b463-819e46169484)

## Compatibility

The op-node-v2 spike aims to be compatible with:

- All op-node CLI arguments
    - Pre-Holocene functionality is no-op
    - Syncmode / Req-resp choice is no longer supported (already being deprecated in op-node)
    - The L2 execution engine endpoint option will be a list instead of singular value.
- All op-node Metrics, All op-supervisor metrics.
    - With exceptions for the deprecated functions above.
- Full op-node P2P stack: shared p2p stack between chains:
    - Gossip blocks of multiple chains.
    - Discovery-layer advertises the lowest chain ID for now.
- Full op-node RPC: `http://localhost:9545/chain/<chainid>` to serve `admin`, `optimism`, `debug`, `opp2p` and `opstack` RPC namespace.
And make `http://localhost:9545/` continue to serve the RPC chain of a single chain.
- Full op-supervisor RPC: `http://localhost:9545/super` to serve the `supervisor` RPC namespace.
    - access-list verification RPC works the same
    - op-challenger can work with this without changes
- Reuse the op-supervisor `cross` and `db` packages fully (audited by RV)
- Later on, block processing with `op-program` (if `op-program` wishes to move away from `op-node`).
- Existing services continue to work with op-node:
    - op-batcher
    - op-proposer
    - op-challenger
- Not the op-node sub-commands (rarely used, but can be copied if really needed)
- Not any pre-Holocene computation
- No legacy SafeDB, superseded by op-supervisor DB instead.
- Sequencing is excluded from the spike, but can be included later if we continue.
