### PR TITLE
op-supervisor,op-node: remove `interop_blockRefByNumber` API

### DIFF
--- a/op-node/rollup/interop/indexing/api.go
+++ b/op-node/rollup/interop/indexing/api.go
@@ -56,10 +56,6 @@ func (ib *InteropAPI) FetchReceipts(ctx context.Context, blockHash common.Hash) 
 	return ib.backend.FetchReceipts(ctx, blockHash)
 }
 
-func (ib *InteropAPI) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
-	return ib.backend.BlockRefByNumber(ctx, num)
-}
-
 func (ib *InteropAPI) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
 	return ib.backend.L2BlockRefByNumber(ctx, num)
 }

--- a/op-node/rollup/interop/indexing/system.go
+++ b/op-node/rollup/interop/indexing/system.go
@@ -467,10 +467,6 @@ func (m *IndexingMode) FetchReceipts(ctx context.Context, blockHash common.Hash)
 	return receipts, err
 }
 
-func (m *IndexingMode) BlockRefByNumber(ctx context.Context, num uint64) (eth.BlockRef, error) {
-	return m.l2.BlockRefByNumber(ctx, num)
-}
-
 func (m *IndexingMode) ChainID(ctx context.Context) (eth.ChainID, error) {
 	return eth.ChainIDFromBig(m.cfg.L2ChainID), nil
 }

--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Source interface {
-	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
+	L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)
 }
 
@@ -262,12 +262,13 @@ func (s *ChainProcessor) rangeUpdate(target uint64) (int, error) {
 
 		// fetch the block ref
 		ctx, cancel := context.WithTimeout(s.systemContext, time.Second*10)
-		next, err := s.activeClient.BlockRefByNumber(ctx, num)
+		nextL2BlockRef, err := s.activeClient.L2BlockRefByNumber(ctx, num)
 		cancel()
 		if err != nil {
 			result.err = err
 			return
 		}
+		next := nextL2BlockRef.BlockRef()
 		if err := s.rewinder.AcceptedBlock(s.chain, next.ID()); err != nil {
 			s.log.Warn("Cannot accept next block into events DB", "next", next.ID(), "err", err)
 			result.err = err

--- a/op-supervisor/supervisor/backend/processors/chain_processor_test.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor_test.go
@@ -28,8 +28,8 @@ func TestFailover(t *testing.T) {
 	require.Equal(t, source, chainProc.activeClient)
 
 	badSource := &mockSource{}
-	badSource.blockRefFunc = func(ctx context.Context, number uint64) (eth.BlockRef, error) {
-		return eth.BlockRef{}, errors.New("bad source")
+	badSource.l2blockRefFunc = func(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
+		return eth.L2BlockRef{}, errors.New("bad source")
 	}
 	// after adding the second source, the activeClient hasn't changed
 	chainProc.AddSource(badSource)
@@ -56,14 +56,14 @@ func (m *mockEmitter) Emit(ctx context.Context, ev event.Event) {
 }
 
 type mockSource struct {
-	blockRefFunc func(ctx context.Context, number uint64) (eth.BlockRef, error)
+	l2blockRefFunc func(ctx context.Context, number uint64) (eth.L2BlockRef, error)
 }
 
-func (m *mockSource) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {
-	if m.blockRefFunc != nil {
-		return m.blockRefFunc(ctx, number)
+func (m *mockSource) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
+	if m.l2blockRefFunc != nil {
+		return m.l2blockRefFunc(ctx, number)
 	}
-	return eth.BlockRef{}, nil
+	return eth.L2BlockRef{}, nil
 }
 func (m *mockSource) FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error) {
 	return gethtypes.Receipts{}, nil

--- a/op-supervisor/supervisor/backend/syncnode/controller_test.go
+++ b/op-supervisor/supervisor/backend/syncnode/controller_test.go
@@ -27,7 +27,6 @@ type mockSyncControl struct {
 	updateCrossUnsafeFn func(ctx context.Context, derived eth.BlockID) error
 	updateFinalizedFn   func(ctx context.Context, id eth.BlockID) error
 	pullEventFn         func(ctx context.Context) (*types.IndexingEvent, error)
-	blockRefByNumFn     func(ctx context.Context, number uint64) (eth.BlockRef, error)
 	l2BlockRefByNumFn   func(ctx context.Context, number uint64) (eth.L2BlockRef, error)
 
 	subscribeEvents gethevent.FeedOf[*types.IndexingEvent]
@@ -95,13 +94,6 @@ func (m *mockSyncControl) UpdateFinalized(ctx context.Context, id eth.BlockID) e
 		return m.updateFinalizedFn(ctx, id)
 	}
 	return nil
-}
-
-func (m *mockSyncControl) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {
-	if m.blockRefByNumFn != nil {
-		return m.blockRefByNumFn(ctx, number)
-	}
-	return eth.BlockRef{}, nil
 }
 
 func (m *mockSyncControl) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {

--- a/op-supervisor/supervisor/backend/syncnode/iface.go
+++ b/op-supervisor/supervisor/backend/syncnode/iface.go
@@ -25,7 +25,7 @@ type SyncNodeSetup interface {
 
 type SyncSource interface {
 	Contains(ctx context.Context, query types.ContainsQuery) (includedIn types.BlockSeal, err error)
-	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
+	L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (gethtypes.Receipts, error)
 	ChainID(ctx context.Context) (eth.ChainID, error)
 	OutputV0AtTimestamp(ctx context.Context, timestamp uint64) (*eth.OutputV0, error)
@@ -38,7 +38,6 @@ type SyncSource interface {
 type SyncControl interface {
 	SubscribeEvents(ctx context.Context, c chan *types.IndexingEvent) (ethereum.Subscription, error)
 	PullEvent(ctx context.Context) (*types.IndexingEvent, error)
-	BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error)
 	L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error)
 
 	UpdateCrossUnsafe(ctx context.Context, id eth.BlockID) error

--- a/op-supervisor/supervisor/backend/syncnode/reset.go
+++ b/op-supervisor/supervisor/backend/syncnode/reset.go
@@ -20,7 +20,7 @@ type managedNodeResetBackend struct {
 var _ resetBackend = (*managedNodeResetBackend)(nil)
 
 func (m *managedNodeResetBackend) BlockIDByNumber(ctx context.Context, n uint64) (eth.BlockID, error) {
-	r, err := m.node.BlockRefByNumber(ctx, n)
+	r, err := m.node.L2BlockRefByNumber(ctx, n)
 	return r.ID(), err
 }
 

--- a/op-supervisor/supervisor/backend/syncnode/rpc.go
+++ b/op-supervisor/supervisor/backend/syncnode/rpc.go
@@ -57,15 +57,6 @@ func (rs *RPCSyncNode) ReconnectRPC(ctx context.Context) error {
 	return nil
 }
 
-func (rs *RPCSyncNode) BlockRefByNumber(ctx context.Context, number uint64) (eth.BlockRef, error) {
-	var out *eth.BlockRef
-	err := rs.cl.CallContext(ctx, &out, "interop_blockRefByNumber", number)
-	if err != nil {
-		return eth.BlockRef{}, eth.MaybeAsNotFoundErr(err)
-	}
-	return *out, nil
-}
-
 func (rs *RPCSyncNode) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
 	var out *eth.L2BlockRef
 	err := rs.cl.CallContext(ctx, &out, "interop_l2BlockRefByNumber", number)
@@ -185,10 +176,11 @@ func (rs *RPCSyncNode) Contains(ctx context.Context, query types.ContainsQuery) 
 		return types.BlockSeal{}, fmt.Errorf("failed to get chain ID for verifying access with RPC: %w", err)
 	}
 
-	blockRef, err := rs.BlockRefByNumber(ctx, query.BlockNum)
+	l2BlockRef, err := rs.L2BlockRefByNumber(ctx, query.BlockNum)
 	if err != nil {
 		return types.BlockSeal{}, types.ErrFuture
 	}
+	blockRef := l2BlockRef.BlockRef()
 
 	log, err := rs.getLogAtIndex(ctx, blockRef.Hash, query.LogIdx)
 	if err != nil {


### PR DESCRIPTION
**Description**

Consolidate `interop_blockRefByNumber` into `interop_L2BlockRefByNumber`. Spec change is already merged at https://github.com/ethereum-optimism/specs/pull/735.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16604