### PR TITLE
op-acceptance-tests: interop: loadtest: unify stopping conditions

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/doc.go
+++ b/op-acceptance-tests/tests/interop/loadtest/doc.go
@@ -1,34 +1,27 @@
 // Package loadtest contains interop load tests that run against sysgo and sysext networks
 // satisfying the SimpleInterop spec.
 //
-// Test names follow the convention Test<spammer><scheduler>. The spammer name identifies what
-// kinds of transactions will be spammed. The scheduler defines how often the spammer is executed
-// and when spamming will stop.
-//
-// There are two schedulers:
-//
-//   - Steady: spams until the NAT_STEADY_TIMEOUT (see below) before exiting successfully. It
-//     attempts to approach but not exceed gas target, simulating benign but heavy load. Budget
-//     overdraft is the only fatal error.
-//   - Burst: spams as fast as possible until the budget is depleted. All non-overdraft errors are
-//     ignored, although they may reduce the spammer's frequency. Burst is intended to simulate a
-//     DoS attack.
-//
-// Configure global test behavior with the following environment variables:
+// Configure test behavior with the following environment variables:
 //
 //   - NAT_INTEROP_LOADTEST_TARGET (default: 100): the initial number of messages that should be
 //     passed per L2 slot in each test.
 //   - NAT_INTEROP_LOADTEST_BUDGET (default: 1): the max amount of ETH to spend per L2 per test. It
 //     may be a float. The test will panic if it overflows a uint256. Funds may be used during test
 //     setup to, e.g., deploy contracts.
-//   - NAT_STEADY_TIMEOUT (default: min(3m, go test timeout)): the amount of time to run the
-//     spammer in each Steady test. Also see https://github.com/golang/go/issues/48157.
+//   - NAT_INTEROP_LOADTEST_TIMEOUT (default: min(3m, go test timeout)): the amount of time to run
+//     each test. Also see https://github.com/golang/go/issues/48157.
 //
-// All errors encountered during test setup are fatal, including go test timeout expiration.
+// Test names follow the convention Test<spammer><scheduler>. The spammer name identifies what
+// kinds of transactions will be spammed. The scheduler defines how often the spammer is executed.
+// There are two schedulers:
 //
-// Each test increases the message throughput until some threshold is reached (e.g., the gas
-// target). The throughput is decreased if the threshold is exceeded or if errors are encountered
-// (e.g., transaction inclusion failures).
+//   - Steady: spams up to the gas target, simulating benign but heavy load.
+//   - Burst: spams as much as possible, simulating a DoS attack.
+//
+// Both schedulers decrease throughput if errors are encountered. They exit successfully upon
+// timeout or budget depletion, whichever comes first.
+//
+// All errors encountered during test setup are fatal, including timeouts and budget depletion.
 //
 // Visualizations for client-side metrics are stored in an artifacts directory, categorized by
 // test name and timestamp: artifacts/<test-name>_<yyyymmdd-hhmmss>/<metric-name>.png.
@@ -36,5 +29,5 @@
 // Examples:
 //
 //	NAT_INTEROP_LOADTEST_BUDGET=1.2 go test -v -run TestRelayBurst
-//	NAT_STEADY_TIMEOUT=1m NAT_INTEROP_LOADTEST_TARGET=500 go test -v -run TestRelaySteady
+//	NAT_INTEROP_LOADTEST_TIMEOUT=1m NAT_INTEROP_LOADTEST_TARGET=500 go test -v -run TestRelaySteady
 package loadtest

--- a/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/interop_load_test.go
@@ -109,6 +109,16 @@ func setupLoadTest(gt *testing.T) (devtest.T, *L2, *L2) {
 		gt.Skip("skipping load test in short mode")
 	}
 	t := devtest.SerialT(gt)
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 3*time.Minute)
+	if timeoutStr, exists := os.LookupEnv("NAT_INTEROP_LOADTEST_TIMEOUT"); exists {
+		timeout, err := time.ParseDuration(timeoutStr)
+		t.Require().NoError(err)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	t = t.WithCtx(ctx)
+	t.Cleanup(cancel)
+
 	l2A, l2B := setupL2s(t)
 	collectMetrics(t, l2A.BlockTime)
 	return t, l2A, l2B

--- a/op-devstack/dsl/funder.go
+++ b/op-devstack/dsl/funder.go
@@ -68,8 +68,6 @@ func (f *Funder) FundAtLeast(wallet *EOA, amount eth.ETH) eth.ETH {
 	if currentBalance.Lt(amount) {
 		missing := amount.Sub(currentBalance)
 		f.faucet.Fund(wallet.Address(), missing)
-		currentBalance = currentBalance.Add(missing)
-		wallet.WaitForBalance(currentBalance)
 	}
 	return currentBalance
 }


### PR DESCRIPTION
Previously, the Burst and Steady schedules had different stopping conditions: budget depletion and timeout, respectively.

This was undesirable for two reasons:

1. It was challenging to tune the timeout and budget to ensure Steady tests succeeded.
2. Burst tests ignored `NAT_STEADY_TIMEOUT` but succeeded on go test timeout expiration.

Making both schedulers report success on budget depletion and timeouts significantly reduces the cognitive overhead when running load tests.

Thanks to @nonsense for pointing this out.