### PR TITLE
op-chain-ops: Prove withdrawals using super roots

### DIFF
--- a/op-chain-ops/cmd/withdrawal/README.md
+++ b/op-chain-ops/cmd/withdrawal/README.md
@@ -27,6 +27,15 @@ valid proposal is made for a L2 block at or after the initiating transaction was
 go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>
 ```
 
+When proving super roots, you'll need to provide additional flags:
+
+```
+shell
+go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>\
+  --supervisor <supervisor-rpc> --rollup.config <path-to-rollup-config> --depset <path-to-dependency-set-json>
+```
+
+
 ### finalize
 
 The `finalize` subcommand finalizes a withdrawal that has previously been proven. The dispute game must have resolved as

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	opnode_bindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
@@ -113,26 +112,29 @@ func ProveWithdrawal(ctx *cli.Context) error {
 		return fmt.Errorf("could not find a dispute game at or above l2 block number %v: %w", rcpt.BlockNumber, err)
 	}
 
-	respectedGameType, err := portal.RespectedGameType(&bind.CallOpts{Context: ctx.Context})
+	l1EthClient, err := createEthClient(ctx, L1Flag.Name)
 	if err != nil {
-		return fmt.Errorf("failed to fetch respected game type from portal: %w", err)
+		return fmt.Errorf("failed to create L1 eth client: %w", err)
+	}
+	boundPortal := bindings.NewBindings[bindings.OptimismPortal2](bindings.WithClient(l1EthClient), bindings.WithTo(portalAddr))
+	usesSuperRoots, err := contractio.Read(boundPortal.SuperRootsActive(), ctx.Context)
+	if err != nil {
+		return fmt.Errorf("failed to fetch uses super roots from portal: %w", err)
 	}
 
 	var txData []byte
-	if respectedGameType == uint32(faultTypes.CannonGameType) || respectedGameType == uint32(faultTypes.PermissionedGameType) {
-		logger.Info("Proving withdrawal using output root proof", "gameType", respectedGameType)
+	if !usesSuperRoots {
+		logger.Info("Proving withdrawal using output root proof")
 		txData, err = txDataForOutputRootProof(ctx.Context, proofClient, l2Client, txHash, factory, portal)
 		if err != nil {
 			return err
 		}
-	} else if respectedGameType == uint32(faultTypes.SuperCannonGameType) || respectedGameType == uint32(faultTypes.SuperPermissionedGameType) {
-		logger.Info("Proving withdrawal using super root proof", "gameType", respectedGameType)
-		txData, err = txDataForSuperRootProof(ctx, proofClient, l2Client, txHash, factory, portal)
+	} else {
+		logger.Info("Proving withdrawal using super root proof")
+		txData, err = txDataForSuperRootProof(ctx, l1EthClient, proofClient, l2Client, txHash, factory, portal)
 		if err != nil {
 			return err
 		}
-	} else {
-		return fmt.Errorf("unsupported game type %d", respectedGameType)
 	}
 
 	rcpt, err = txMgr.Send(ctx.Context, txmgr.TxCandidate{
@@ -176,7 +178,7 @@ func txDataForOutputRootProof(ctx context.Context, proofClient *gethclient.Clien
 	return txData, nil
 }
 
-func txDataForSuperRootProof(ctx *cli.Context, proofClient *gethclient.Client, l2Client *ethclient.Client, txHash common.Hash, factory *opnode_bindings.DisputeGameFactoryCaller, portal *bindingspreview.OptimismPortal2) ([]byte, error) {
+func txDataForSuperRootProof(ctx *cli.Context, l1EthClient apis.EthClient, proofClient *gethclient.Client, l2Client *ethclient.Client, txHash common.Hash, factory *opnode_bindings.DisputeGameFactoryCaller, portal *bindingspreview.OptimismPortal2) ([]byte, error) {
 	supervisorClient, err := createSupervisorClient(ctx, SupervisorFlag.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create supervisor client: %w", err)
@@ -190,16 +192,12 @@ func txDataForSuperRootProof(ctx *cli.Context, proofClient *gethclient.Client, l
 		return nil, err
 	}
 
-	l1EthClient, err := createEthClient(ctx, L1Flag.Name)
-	if err != nil {
-		return nil, err
-	}
-	portalChainID, err := chainIDForPortal(ctx.Context, l1EthClient, portal)
+	portalL2ChainID, err := l2ChainIDForPortal(ctx.Context, l1EthClient, portal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get portal chain ID: %w", err)
 	}
-	if portalChainID != rollupCfg.L2ChainID.Uint64() {
-		return nil, fmt.Errorf("portal chain ID %d does not match the provided rollup config chain ID %d", portalChainID, rollupCfg.L2ChainID.Uint64())
+	if portalL2ChainID != rollupCfg.L2ChainID.Uint64() {
+		return nil, fmt.Errorf("portal chain ID %d does not match the provided rollup config chain ID %d", portalL2ChainID, rollupCfg.L2ChainID.Uint64())
 	}
 
 	params, err := withdrawals.ProveWithdrawalParametersSuperRoots(
@@ -244,7 +242,7 @@ func txDataForSuperRootProof(ctx *cli.Context, proofClient *gethclient.Client, l
 	return txData, nil
 }
 
-func chainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
+func l2ChainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
 	systemConfigAddr, err := portal.SystemConfig(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get system config address from portal: %w", err)

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-node/bindings"
+	opnode_bindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -35,6 +40,23 @@ var (
 		Name:    "portal-address",
 		Usage:   "Address of the optimism portal contract.",
 		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "PORTAL_ADDRESS"),
+	}
+
+	// Prove using SuperRoots Flags
+	SupervisorFlag = &cli.StringFlag{
+		Name:    "supervisor",
+		Usage:   "HTTP provider URL for supervisor. Only required for proving using super roots.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "SUPERVISOR"),
+	}
+	DepSetFlag = &cli.StringFlag{
+		Name:    "depset",
+		Usage:   "Path to the dependency set file. Only required for proving using super roots.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "DEPSET"),
+	}
+	RollupConfigFlag = &cli.StringFlag{
+		Name:    "rollup.config",
+		Usage:   "Path to the rollup config of the target chain. Only required for proving using super roots.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "ROLLUP_CONFIG"),
 	}
 )
 
@@ -81,7 +103,7 @@ func ProveWithdrawal(ctx *cli.Context) error {
 		return fmt.Errorf("failed to fetch dispute game factory address from portal: %w", err)
 	}
 
-	factory, err := bindings.NewDisputeGameFactoryCaller(factoryAddr, l1Client)
+	factory, err := opnode_bindings.NewDisputeGameFactoryCaller(factoryAddr, l1Client)
 	if err != nil {
 		return fmt.Errorf("failed to bind dispute game factory: %w", err)
 	}
@@ -91,9 +113,44 @@ func ProveWithdrawal(ctx *cli.Context) error {
 		return fmt.Errorf("could not find a dispute game at or above l2 block number %v: %w", rcpt.BlockNumber, err)
 	}
 
-	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(ctx.Context, proofClient, l2Client, l2Client, txHash, factory, &portal.OptimismPortal2Caller)
+	respectedGameType, err := portal.RespectedGameType(&bind.CallOpts{Context: ctx.Context})
 	if err != nil {
-		return fmt.Errorf("could not create withdrawal proof parameters: %w", err)
+		return fmt.Errorf("failed to fetch respected game type from portal: %w", err)
+	}
+
+	var txData []byte
+	if respectedGameType == uint32(faultTypes.CannonGameType) || respectedGameType == uint32(faultTypes.PermissionedGameType) {
+		logger.Info("Proving withdrawal using output root proof", "gameType", respectedGameType)
+		txData, err = txDataForOutputRootProof(ctx.Context, proofClient, l2Client, txHash, factory, portal)
+		if err != nil {
+			return err
+		}
+	} else if respectedGameType == uint32(faultTypes.SuperCannonGameType) || respectedGameType == uint32(faultTypes.SuperPermissionedGameType) {
+		logger.Info("Proving withdrawal using super root proof", "gameType", respectedGameType)
+		txData, err = txDataForSuperRootProof(ctx, proofClient, l2Client, txHash, factory, portal)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("unsupported game type %d", respectedGameType)
+	}
+
+	rcpt, err = txMgr.Send(ctx.Context, txmgr.TxCandidate{
+		TxData: txData,
+		To:     &portalAddr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to prove withdrawal: %w", err)
+	}
+
+	logger.Info("Proved withdrawal", "tx", rcpt.TxHash.Hex())
+	return nil
+}
+
+func txDataForOutputRootProof(ctx context.Context, proofClient *gethclient.Client, l2Client *ethclient.Client, txHash common.Hash, factory *opnode_bindings.DisputeGameFactoryCaller, portal *bindingspreview.OptimismPortal2) ([]byte, error) {
+	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(ctx, proofClient, l2Client, l2Client, txHash, factory, &portal.OptimismPortal2Caller)
+	if err != nil {
+		return nil, fmt.Errorf("could not create withdrawal proof parameters: %w", err)
 	}
 
 	txData, err := w3.MustNewFunc("proveWithdrawalTransaction("+
@@ -114,19 +171,90 @@ func ProveWithdrawal(ctx *cli.Context) error {
 		params.WithdrawalProof,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to pack withdrawal transaction: %w", err)
+		return nil, fmt.Errorf("failed to pack output root prove withdrawal transaction: %w", err)
 	}
+	return txData, nil
+}
 
-	rcpt, err = txMgr.Send(ctx.Context, txmgr.TxCandidate{
-		TxData: txData,
-		To:     &portalAddr,
-	})
+func txDataForSuperRootProof(ctx *cli.Context, proofClient *gethclient.Client, l2Client *ethclient.Client, txHash common.Hash, factory *opnode_bindings.DisputeGameFactoryCaller, portal *bindingspreview.OptimismPortal2) ([]byte, error) {
+	supervisorClient, err := createSupervisorClient(ctx, SupervisorFlag.Name)
 	if err != nil {
-		return fmt.Errorf("failed to prove withdrawal: %w", err)
+		return nil, fmt.Errorf("failed to create supervisor client: %w", err)
+	}
+	rollupCfg, err := loadRollupConfig(ctx, RollupConfigFlag.Name)
+	if err != nil {
+		return nil, err
+	}
+	depSet, err := loadDepsetConfig(ctx, DepSetFlag.Name)
+	if err != nil {
+		return nil, err
 	}
 
-	logger.Info("Proved withdrawal", "tx", rcpt.TxHash.Hex())
-	return nil
+	l1EthClient, err := createEthClient(ctx, L1Flag.Name)
+	if err != nil {
+		return nil, err
+	}
+	portalChainID, err := chainIDForPortal(ctx.Context, l1EthClient, portal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get portal chain ID: %w", err)
+	}
+	if portalChainID != rollupCfg.L2ChainID.Uint64() {
+		return nil, fmt.Errorf("portal chain ID %d does not match the provided rollup config chain ID %d", portalChainID, rollupCfg.L2ChainID.Uint64())
+	}
+
+	params, err := withdrawals.ProveWithdrawalParametersSuperRoots(
+		ctx.Context,
+		rollupCfg,
+		depSet,
+		proofClient,
+		l2Client,
+		l2Client,
+		txHash,
+		supervisorClient,
+		factory,
+		&portal.OptimismPortal2Caller,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create withdrawal proof parameters: %w", err)
+	}
+	txData, err := w3.MustNewFunc("proveWithdrawalTransaction("+
+		"(uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data),"+
+		"address DisputeGameProxy,"+
+		"uint256 OutputRootIndex,"+
+		"(bytes1 Version, uint64 Timestamp, (uint256 ChainId,bytes32 Root)[] OutputRoots),"+
+		"(bytes32 Version, bytes32 StateRoot, bytes32 MessagePasserStorageRoot, bytes32 LatestBlockhash),"+
+		"bytes[])", "").EncodeArgs(
+		bindingspreview.TypesWithdrawalTransaction{
+			Nonce:    params.Nonce,
+			Sender:   params.Sender,
+			Target:   params.Target,
+			Value:    params.Value,
+			GasLimit: params.GasLimit,
+			Data:     params.Data,
+		},
+		params.DisputeGameProxy,
+		params.OutputRootIndex,
+		params.SuperRootProof,
+		params.OutputRootProof,
+		params.WithdrawalProof,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack super root prove withdrawal transaction: %w", err)
+	}
+	return txData, nil
+}
+
+func chainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
+	systemConfigAddr, err := portal.SystemConfig(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get system config address from portal: %w", err)
+	}
+	systemConfig := bindings.NewSystemConfig(bindings.WithClient(l1EthClient), bindings.WithTo(systemConfigAddr))
+	l2ChainID, err := contractio.Read(systemConfig.L2ChainID(), ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read L2 chain ID from system config: %w", err)
+	}
+	return l2ChainID.Uint64(), nil
 }
 
 func proveFlags() []cli.Flag {
@@ -135,6 +263,10 @@ func proveFlags() []cli.Flag {
 		L2Flag,
 		TxFlag,
 		PortalAddressFlag,
+		// Super Roots Flags
+		SupervisorFlag,
+		DepSetFlag,
+		RollupConfigFlag,
 	}
 	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
 	cliFlags = append(cliFlags, oplog.CLIFlags(EnvVarPrefix)...)

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -221,7 +221,7 @@ func txDataForSuperRootProof(ctx *cli.Context, proofClient *gethclient.Client, l
 		"(uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data),"+
 		"address DisputeGameProxy,"+
 		"uint256 OutputRootIndex,"+
-		"(bytes1 Version, uint64 Timestamp, (uint256 ChainId,bytes32 Root)[] OutputRoots),"+
+		"(bytes1 Version, uint64 Timestamp, (uint256 ChainID, bytes32 Root)[] OutputRoots),"+
 		"(bytes32 Version, bytes32 StateRoot, bytes32 MessagePasserStorageRoot, bytes32 LatestBlockhash),"+
 		"bytes[])", "").EncodeArgs(
 		bindingspreview.TypesWithdrawalTransaction{

--- a/op-chain-ops/cmd/withdrawal/util.go
+++ b/op-chain-ops/cmd/withdrawal/util.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 )
@@ -38,4 +45,48 @@ func createTxMgr(ctx *cli.Context, logger log.Logger, rpcUrlFlag string) (*txmgr
 		return nil, fmt.Errorf("failed to create the transaction manager: %w", err)
 	}
 	return txMgr, nil
+}
+
+func createEthClient(ctx *cli.Context, rpcUrlFlag string) (*sources.EthClient, error) {
+	url := ctx.String(rpcUrlFlag)
+	l1RPC, err := client.NewRPC(ctx.Context, log.Root(), url, client.WithDialAttempts(10))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RPC client: %w", err)
+	}
+	l1Client, err := sources.NewEthClient(l1RPC, log.Root(), nil, sources.DefaultEthClientConfig(10))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create L1 client: %w", err)
+	}
+	return l1Client, nil
+}
+
+func loadRollupConfig(ctx *cli.Context, rollupConfigFlag string) (*rollup.Config, error) {
+	file, err := os.Open(ctx.String(rollupConfigFlag))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open rollup config file: %w", err)
+	}
+	defer file.Close()
+	var rollupConfig rollup.Config
+	return &rollupConfig, rollupConfig.ParseRollupConfig(file)
+}
+
+func loadDepsetConfig(ctx *cli.Context, depSetFlag string) (depset.DependencySet, error) {
+	data, err := os.ReadFile(ctx.String(depSetFlag))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read depset config: %w", err)
+	}
+	var depsetConfig depset.StaticConfigDependencySet
+	err = json.Unmarshal(data, &depsetConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse depset config: %w", err)
+	}
+	return &depsetConfig, nil
+}
+
+func createSupervisorClient(ctx *cli.Context, supervisorFlag string) (*sources.SupervisorClient, error) {
+	rpcCl, err := dial.DialRPCClientWithTimeout(ctx.Context, 1*time.Minute, log.Root(), ctx.String(supervisorFlag))
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial rollup client: %w", err)
+	}
+	return sources.NewSupervisorClient(client.NewBaseRPCClient(rpcCl)), nil
 }

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -10,13 +10,17 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 )
 
 var MessagePassedTopic = crypto.Keccak256Hash([]byte("MessagePassed(uint256,address,address,uint256,uint256,bytes,bytes32)"))
@@ -33,6 +37,10 @@ type HeaderClient interface {
 	HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
 }
 
+type SupervisorClient interface {
+	SuperRootAtTimestamp(context.Context, hexutil.Uint64) (eth.SuperRootResponse, error)
+}
+
 // ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
 // and FinalizeWithdrawalTransaction functions
 type ProvenWithdrawalParameters struct {
@@ -45,6 +53,20 @@ type ProvenWithdrawalParameters struct {
 	Data            []byte
 	OutputRootProof bindings.TypesOutputRootProof
 	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
+}
+
+type ProvenWithdrawalParametersSuperRoots struct {
+	Nonce            *big.Int
+	Sender           common.Address
+	Target           common.Address
+	Value            *big.Int
+	GasLimit         *big.Int
+	Data             []byte
+	DisputeGameProxy common.Address
+	OutputRootIndex  *big.Int // index of the output root in the super root
+	SuperRootProof   []byte
+	OutputRootProof  bindings.TypesOutputRootProof
+	WithdrawalProof  [][]byte // List of trie nodes to prove L2 storage
 }
 
 // ProveWithdrawalParameters calls ProveWithdrawalParametersForBlock with the most recent L2 output after the given header.
@@ -73,6 +95,86 @@ func ProveWithdrawalParametersFaultProofs(ctx context.Context, proofCl ProofClie
 	return ProveWithdrawalParametersForBlock(ctx, proofCl, l2ReceiptCl, txHash, l2Header, l2OutputIndex)
 }
 
+func ProveWithdrawalParametersSuperRoots(
+	ctx context.Context,
+	rollupCfg *rollup.Config,
+	depSet depset.DependencySet,
+	proofCl ProofClient,
+	l2ReceiptCl ReceiptClient,
+	l2HeaderCl HeaderClient,
+	txHash common.Hash,
+	supervisorClient SupervisorClient,
+	disputeGameFactoryContract *bindings.DisputeGameFactoryCaller,
+	optimismPortal2Contract *bindingspreview.OptimismPortal2Caller,
+) (ProvenWithdrawalParametersSuperRoots, error) {
+	var outputRootIndex *big.Int
+	for i, chain := range depSet.Chains() {
+		if chain.Cmp(eth.ChainIDFromBig(rollupCfg.L2ChainID)) == 0 {
+			outputRootIndex = new(big.Int).SetUint64(uint64(i))
+			break
+		}
+	}
+	if outputRootIndex == nil {
+		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("could not find rollup chain ID in dependency set: %v", rollupCfg.L2ChainID)
+	}
+
+	latestGame, err := FindLatestGame(ctx, disputeGameFactoryContract, optimismPortal2Contract)
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to find latest game: %w", err)
+	}
+	disputeGame, err := disputeGameFactoryContract.GameAtIndex(&bind.CallOpts{}, latestGame.Index)
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get dispute game: %w", err)
+	}
+	l2SequenceNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
+
+	superRoot, err := supervisorClient.SuperRootAtTimestamp(ctx, hexutil.Uint64(l2SequenceNumber.Uint64()))
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get super root: %w", err)
+	}
+
+	l2BlockNumber, err := rollupCfg.TargetBlockNumber(l2SequenceNumber.Uint64())
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get target block number: %w", err)
+	}
+	l2Header, err := l2HeaderCl.HeaderByNumber(ctx, new(big.Int).SetUint64(l2BlockNumber))
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get l2Block: %w", err)
+	}
+
+	receipt, err := l2ReceiptCl.TransactionReceipt(ctx, txHash)
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, err
+	}
+	// Parse the receipt
+	ev, err := ParseMessagePassed(receipt)
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, err
+	}
+	withdrawalProof, storageRoot, err := GetWithdrawalProof(ctx, proofCl, ev, l2Header)
+	if err != nil {
+		return ProvenWithdrawalParametersSuperRoots{}, err
+	}
+	return ProvenWithdrawalParametersSuperRoots{
+		Nonce:            ev.Nonce,
+		Sender:           ev.Sender,
+		Target:           ev.Target,
+		Value:            ev.Value,
+		GasLimit:         ev.GasLimit,
+		Data:             ev.Data,
+		DisputeGameProxy: disputeGame.Proxy,
+		OutputRootIndex:  outputRootIndex,
+		SuperRootProof:   superRoot.SuperRoot[:],
+		OutputRootProof: bindings.TypesOutputRootProof{
+			Version:                  [32]byte{}, // Empty for version 1
+			StateRoot:                l2Header.Root,
+			MessagePasserStorageRoot: storageRoot,
+			LatestBlockhash:          l2Header.Hash(),
+		},
+		WithdrawalProof: withdrawalProof,
+	}, nil
+}
+
 // ProveWithdrawalParametersForBlock queries L1 & L2 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.
 // The l2Header provided is very important. It should be a block for which there is a submitted output in the L2 Output Oracle
 // contract. If not, the withdrawal will fail as it the storage proof cannot be verified if there is no submitted state root.
@@ -94,35 +196,10 @@ func ProveWithdrawalParametersForBlock(ctx context.Context, proofCl ProofClient,
 // The l2Header provided is very important. It should be a block for which there is a submitted output in the L2 Output Oracle
 // contract. If not, the withdrawal will fail as it the storage proof cannot be verified if there is no submitted state root.
 func ProveWithdrawalParametersForEvent(ctx context.Context, proofCl ProofClient, ev *bindings.L2ToL1MessagePasserMessagePassed, l2Header *types.Header, l2OutputIndex *big.Int) (ProvenWithdrawalParameters, error) {
-	// Generate then verify the withdrawal proof
-	withdrawalHash, err := WithdrawalHash(ev)
-	if !bytes.Equal(withdrawalHash[:], ev.WithdrawalHash[:]) {
-		return ProvenWithdrawalParameters{}, errors.New("Computed withdrawal hash incorrectly")
-	}
+	withdrawalProof, storageRoot, err := GetWithdrawalProof(ctx, proofCl, ev, l2Header)
 	if err != nil {
 		return ProvenWithdrawalParameters{}, err
 	}
-	slot := StorageSlotOfWithdrawalHash(withdrawalHash)
-
-	p, err := proofCl.GetProof(ctx, predeploys.L2ToL1MessagePasserAddr, []string{slot.String()}, l2Header.Number)
-	if err != nil {
-		return ProvenWithdrawalParameters{}, err
-	}
-	if len(p.StorageProof) != 1 {
-		return ProvenWithdrawalParameters{}, errors.New("invalid amount of storage proofs")
-	}
-
-	err = VerifyProof(l2Header.Root, p)
-	if err != nil {
-		return ProvenWithdrawalParameters{}, err
-	}
-
-	// Encode it as expected by the contract
-	trieNodes := make([][]byte, len(p.StorageProof[0].Proof))
-	for i, s := range p.StorageProof[0].Proof {
-		trieNodes[i] = common.FromHex(s)
-	}
-
 	return ProvenWithdrawalParameters{
 		Nonce:         ev.Nonce,
 		Sender:        ev.Sender,
@@ -134,10 +211,10 @@ func ProveWithdrawalParametersForEvent(ctx context.Context, proofCl ProofClient,
 		OutputRootProof: bindings.TypesOutputRootProof{
 			Version:                  [32]byte{}, // Empty for version 1
 			StateRoot:                l2Header.Root,
-			MessagePasserStorageRoot: p.StorageHash,
+			MessagePasserStorageRoot: storageRoot,
 			LatestBlockhash:          l2Header.Hash(),
 		},
-		WithdrawalProof: trieNodes,
+		WithdrawalProof: withdrawalProof,
 	}, nil
 }
 
@@ -246,4 +323,36 @@ func StorageSlotOfWithdrawalHash(hash common.Hash) common.Hash {
 	buf := make([]byte, 64)
 	copy(buf, hash[:])
 	return crypto.Keccak256Hash(buf)
+}
+
+func GetWithdrawalProof(ctx context.Context, proofCl ProofClient, ev *bindings.L2ToL1MessagePasserMessagePassed, l2Header *types.Header) ([][]byte, common.Hash, error) {
+	// Generate then verify the withdrawal proof
+	withdrawalHash, err := WithdrawalHash(ev)
+	if !bytes.Equal(withdrawalHash[:], ev.WithdrawalHash[:]) {
+		return nil, common.Hash{}, errors.New("Computed withdrawal hash incorrectly")
+	}
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
+	slot := StorageSlotOfWithdrawalHash(withdrawalHash)
+
+	p, err := proofCl.GetProof(ctx, predeploys.L2ToL1MessagePasserAddr, []string{slot.String()}, l2Header.Number)
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
+	if len(p.StorageProof) != 1 {
+		return nil, common.Hash{}, errors.New("invalid amount of storage proofs")
+	}
+
+	err = VerifyProof(l2Header.Root, p)
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
+
+	// Encode it as expected by the contract
+	trieNodes := make([][]byte, len(p.StorageProof[0].Proof))
+	for i, s := range p.StorageProof[0].Proof {
+		trieNodes[i] = common.FromHex(s)
+	}
+	return trieNodes, p.StorageHash, nil
 }

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -55,6 +55,17 @@ type ProvenWithdrawalParameters struct {
 	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
 }
 
+type SuperRootProofOutputRoot struct {
+	ChainID *big.Int
+	Root    common.Hash
+}
+
+type SuperRootProof struct {
+	Version     [1]byte
+	Timestamp   uint64
+	OutputRoots []SuperRootProofOutputRoot
+}
+
 type ProvenWithdrawalParametersSuperRoots struct {
 	Nonce            *big.Int
 	Sender           common.Address
@@ -64,7 +75,7 @@ type ProvenWithdrawalParametersSuperRoots struct {
 	Data             []byte
 	DisputeGameProxy common.Address
 	OutputRootIndex  *big.Int // index of the output root in the super root
-	SuperRootProof   []byte
+	SuperRootProof   SuperRootProof
 	OutputRootProof  bindings.TypesOutputRootProof
 	WithdrawalProof  [][]byte // List of trie nodes to prove L2 storage
 }
@@ -155,6 +166,14 @@ func ProveWithdrawalParametersSuperRoots(
 	if err != nil {
 		return ProvenWithdrawalParametersSuperRoots{}, err
 	}
+
+	outputRoots := make([]SuperRootProofOutputRoot, len(superRoot.Chains))
+	for i, chain := range superRoot.Chains {
+		outputRoots[i] = SuperRootProofOutputRoot{
+			ChainID: chain.ChainID.ToBig(),
+			Root:    common.Hash(chain.Canonical),
+		}
+	}
 	return ProvenWithdrawalParametersSuperRoots{
 		Nonce:            ev.Nonce,
 		Sender:           ev.Sender,
@@ -164,7 +183,11 @@ func ProveWithdrawalParametersSuperRoots(
 		Data:             ev.Data,
 		DisputeGameProxy: disputeGame.Proxy,
 		OutputRootIndex:  outputRootIndex,
-		SuperRootProof:   superRoot.SuperRoot[:],
+		SuperRootProof: SuperRootProof{
+			Version:     [1]byte{superRoot.Version},
+			Timestamp:   superRoot.Timestamp,
+			OutputRoots: outputRoots,
+		},
 		OutputRootProof: bindings.TypesOutputRootProof{
 			Version:                  [32]byte{}, // Empty for version 1
 			StateRoot:                l2Header.Root,

--- a/op-service/txintent/bindings/SystemConfig.go
+++ b/op-service/txintent/bindings/SystemConfig.go
@@ -1,0 +1,14 @@
+package bindings
+
+import (
+	"math/big"
+)
+
+type SystemConfig struct {
+	L2ChainID func() TypedCall[*big.Int] `sol:"l2ChainId"`
+}
+
+func NewSystemConfig(opts ...CallFactoryOption) *SystemConfig {
+	sys := NewBindings[SystemConfig](opts...)
+	return &sys
+}


### PR DESCRIPTION
Update the withdrawals op-chain-ops script to support super roots.

part of #16456

## Testing

Successfully proved a [withdrawal](0x0567ebeb32e4a031b8ae72319c4dd7b22049d51f6f03fce6e4e69e638005e75f) using super roots on rehearsal-net-1:
```
go run . prove \
  --l1 $L1--l2 $L2 --private-key $KEY\
  --portal-address 0x42790Ac902171B231EB94C8B74DC15b140e6E169\
  --tx 0x7ac951125451c45a39a036a3b4e3e86e545d870ae31a19fc185a60322cde1030\
  --supervisor $SUPER --rollup.config /tmp/rehearsal-1-bn-0-rollup.json\
  --depset /tmp/depset.json
```