### PR TITLE
op-supervisor: remove redundant RLock/RUnlock and fix deadlock

### DIFF
--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -82,7 +82,8 @@ func (su *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	return true
 }
 
-func (su *StatusTracker) HasInitializedStatuses() bool {
+// hasInitializedStatuses is not behind a lock, because it is used only internally
+func (su *StatusTracker) hasInitializedStatuses() bool {
 	for _, nodeStatus := range su.statuses {
 		if nodeStatus != nil && *nodeStatus != (NodeSyncStatus{}) {
 			return true
@@ -97,7 +98,7 @@ func (su *StatusTracker) SyncStatus() (eth.SupervisorSyncStatus, error) {
 
 	// after supervisor restarts, there is a timespan where all node's sync status is not fetched yet
 	// error immediately until at least single node sync status is available, which is not empty
-	if !su.HasInitializedStatuses() {
+	if !su.hasInitializedStatuses() {
 		return eth.SupervisorSyncStatus{}, ErrStatusTrackerNotReady
 	}
 

--- a/op-supervisor/supervisor/backend/status/status.go
+++ b/op-supervisor/supervisor/backend/status/status.go
@@ -83,9 +83,6 @@ func (su *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 }
 
 func (su *StatusTracker) HasInitializedStatuses() bool {
-	su.mu.RLock()
-	defer su.mu.RUnlock()
-
 	for _, nodeStatus := range su.statuses {
 		if nodeStatus != nil && *nodeStatus != (NodeSyncStatus{}) {
 			return true


### PR DESCRIPTION
**Description**

Fixes: https://github.com/ethereum-optimism/optimism/issues/16603
Fixes: https://github.com/ethereum-optimism/optimism/issues/16335

```
func (rw *RWMutex) RLock() {
...
// When a writer is pending, it blocks subsequent readers to ensure
// write access is not starved.
```

In our case, I believe the following is happening:

1. Goroutine A acquires RLock() in SyncStatus(). (`goroutine 927671` from logs)
2. Goroutine B tries to acquire Lock() in OnEvent() and waits. (`goroutine 206` from logs)
3. Goroutine A continues to HasInitializedStatuses() and tries to acquire another RLock() and deadlocks goroutines A and B. (`goroutine 927671` from logs)

```
goroutine 206 gp=0xc000609180 m=nil [sync.RWMutex.Lock, 58 minutes]
goroutine 927671 gp=0xc0008b9500 m=nil [sync.RWMutex.RLock, 58 minutes]
```

Logs at: https://optimistic.grafana.net/a/grafana-lokiexplore-app/explore/cluster/oplabs-dev-infra-primary/logs?patterns=%5B%5D&from=2025-07-08T15:57:28.000Z&to=2025-07-08T15:57:30.000Z&var-lineFormat=&var-ds=grafanacloud-logs&var-filters=cluster%7C%3D%7Coplabs-dev-infra-primary&var-filters=instance%7C%3D%7Cdev-infra-rehearsal-1-bn-op-supervisor-sequencer-2&var-fields=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=caseInsensitive,0%7C__gfp__%3D%7Cstatus.go&displayedFields=%5B%5D&urlColumns=%5B%22Time%22,%22Line%22%5D&visualizationType=%22logs%22&var-fieldBy=$__all&var-labelBy=&timezone=browser&var-all-fields=&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false

I can't think of another reason why a goroutine holding a RLock would block on the same nested RLock, other than a writer (Lock) waiting, which also explains the deadlocks we are seeing, considering that `StatusTracker` doesn't do any time-consuming work.