### PR TITLE
op-node: Delete safe head db when EL sync is triggered

### DIFF
--- a/op-acceptance-tests/tests/safeheaddb_clsync/init_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_clsync/init_test.go
@@ -1,0 +1,17 @@
+package safeheaddb_elsync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+		presets.WithConsensusLayerSync(),
+		presets.WithSafeDBEnabled(),
+		// Destructive test that requiring an in-memory only geth database
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
@@ -1,4 +1,4 @@
-package safeheaddb
+package safeheaddb_elsync
 
 import (
 	"testing"
@@ -9,11 +9,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-func TestTruncateDatabaseOnResync(gt *testing.T) {
+func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	t.Skip("Known issue: safe head db is not currently truncated when EL sync is used")
 	sys := presets.NewSingleChainMultiNode(t)
 
+	startSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
@@ -36,5 +36,6 @@ func TestTruncateDatabaseOnResync(gt *testing.T) {
 	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
 
-	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+	// Safe head db should not have been reset
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(startSafeBlock))
 }

--- a/op-acceptance-tests/tests/safeheaddb_elsync/init_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/init_test.go
@@ -1,4 +1,4 @@
-package safeheaddb
+package safeheaddb_elsync
 
 import (
 	"testing"

--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -1,0 +1,65 @@
+package safeheaddb_elsync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestTruncateDatabaseOnELResync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNode(t)
+
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+
+	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
+	// With the EL reset to genesis, when the CL restarts it will use EL sync to resync the chain rather than
+	// deriving it from L1.
+	sys.L2ELB.Stop()
+	sys.L2CLB.Stop()
+
+	sys.L2CL.Advanced(types.LocalSafe, 3, 30)
+
+	sys.L2ELB.Start()
+	sys.L2CLB.Start()
+	sys.L2ELB.PeerWith(sys.L2EL)
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
+
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+}
+
+func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNode(t)
+
+	startSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
+
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+
+	// Restart the verifier op-node, but not the EL so the existing chain data is not deleted.
+	sys.L2CLB.Stop()
+
+	sys.L2CL.Advanced(types.LocalSafe, 3, 30)
+
+	sys.L2CLB.Start()
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
+
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(startSafeBlock))
+}

--- a/op-devstack/dsl/safedb.go
+++ b/op-devstack/dsl/safedb.go
@@ -1,8 +1,7 @@
 package dsl
 
 import (
-	"fmt"
-
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
@@ -11,7 +10,7 @@ type safeHeadDBProvider interface {
 	safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse
 }
 
-func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode, sourceOfTruth safeHeadDBProvider, minRequiredL2Block *uint64) {
+func checkSafeHeadConsistent(t devtest.T, maxL1BlockNum uint64, checkNode, sourceOfTruth safeHeadDBProvider, minRequiredL2Block *uint64) {
 	require := testreq.New(t)
 	l1BlockNum := maxL1BlockNum
 	var minL2BlockRecorded *uint64
@@ -21,7 +20,6 @@ func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode
 			// No further safe head data available
 			// Stop iterating as long as we found _some_ data
 			require.NotNil(minL2BlockRecorded, "no safe head data available at L1 block %v", l1BlockNum)
-			fmt.Printf("Require min block %v and got back to %v\n", minRequiredL2Block, minL2BlockRecorded)
 			if minRequiredL2Block != nil {
 				// Ensure we had data back at least as far as minRequiredL2Block
 				require.LessOrEqual(*minL2BlockRecorded, *minRequiredL2Block, "safe head db did not go back far enough")

--- a/op-devstack/dsl/safedb.go
+++ b/op-devstack/dsl/safedb.go
@@ -1,6 +1,8 @@
 package dsl
 
 import (
+	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
@@ -9,17 +11,21 @@ type safeHeadDBProvider interface {
 	safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse
 }
 
-func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode, sourceOfTruth safeHeadDBProvider) {
+func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode, sourceOfTruth safeHeadDBProvider, minRequiredL2Block *uint64) {
 	require := testreq.New(t)
 	l1BlockNum := maxL1BlockNum
-	matchedSomething := false
+	var minL2BlockRecorded *uint64
 	for {
-
 		actual := checkNode.safeHeadAtL1Block(l1BlockNum)
 		if actual == nil {
 			// No further safe head data available
 			// Stop iterating as long as we found _some_ data
-			require.Truef(matchedSomething, "no safe head data available at L1 block %v", l1BlockNum)
+			require.NotNil(minL2BlockRecorded, "no safe head data available at L1 block %v", l1BlockNum)
+			fmt.Printf("Require min block %v and got back to %v\n", minRequiredL2Block, minL2BlockRecorded)
+			if minRequiredL2Block != nil {
+				// Ensure we had data back at least as far as minRequiredL2Block
+				require.LessOrEqual(*minL2BlockRecorded, *minRequiredL2Block, "safe head db did not go back far enough")
+			}
 			return
 		}
 
@@ -29,6 +35,6 @@ func checkSafeHeadConsistent(t testreq.TestingT, maxL1BlockNum uint64, checkNode
 			return // Reached L1 and L2 genesis.
 		}
 		l1BlockNum = actual.L1Block.Number - 1
-		matchedSomething = true
+		minL2BlockRecorded = &actual.SafeHead.Number
 	}
 }

--- a/op-devstack/presets/cl_config.go
+++ b/op-devstack/presets/cl_config.go
@@ -19,6 +19,13 @@ func WithExecutionLayerSyncOnVerifiers() stack.CommonOption {
 		}))
 }
 
+func WithConsensusLayerSync() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithL2CLOption(func(_ devtest.P, id stack.L2CLNodeID, cfg *config.Config) {
+			cfg.Sync.SyncMode = sync.CLSync
+		}))
+}
+
 func WithSafeDBEnabled() stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithL2CLOption(func(p devtest.P, _ stack.L2CLNodeID, cfg *config.Config) {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -384,6 +384,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 			e.syncStatus = syncStatusStartedEL
 			e.log.Info("Starting EL sync")
 			e.elStart = e.clock.Now()
+			e.emitter.Emit(ctx, ELSyncStartedEvent{})
 		} else if err == nil {
 			e.syncStatus = syncStatusFinishedEL
 			e.log.Info("Skipping EL sync and going straight to CL sync because there is a finalized block", "id", b.ID())

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -306,6 +306,12 @@ func (ev InteropReplacedBlockEvent) String() string {
 	return "interop-replaced-block"
 }
 
+type ELSyncStartedEvent struct{}
+
+func (ev ELSyncStartedEvent) String() string {
+	return "el-sync-started"
+}
+
 type EngDeriver struct {
 	metrics Metrics
 


### PR DESCRIPTION
**Description**

Delete safe head db when EL sync is triggered. A new event is added to signal the start of the EL sync since the driver state doesn't otherwise know about it (only when it starts inserting payloads).

The EL sync may progress the safe head without it being derived by the consensus layer, which makes the safe head database inaccurate. To avoid returning invalid data the existing database is removed and it will start building again from where the EL sync completes.

The whole database is wiped instead of attempting to record the missing period of data because:
1. The database currently just records each L1 block that the safe head updated so recording a gap in the data would require redesigning that database format
2. It's very hard to validate that a node is suitable to use with op-challenger/op-dispute-mon if it might have arbitrary gaps in safe head data. Currently if it can return data at block X you know it has data for all blocks > X.
3. op-challenger couldn't use the node if it has a gap in the data and any game was created during that gap anyway so the partial safe head db is pretty useless.
4. This only occurs when you wipe the EL database and op-challenger requires the historic world state so safe head data prior to the EL sync isn't useful because the EL can't support playing those games anyway.

**Tests**

Enabled existing test for the failure case. Added additional tests to ensure the database isn't deleted unnecessarily.

**Metadata**

fixes https://github.com/ethereum-optimism/optimism-private/issues/378