### PR TITLE
op-service: add logfmtms and jsonms

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -16,6 +16,7 @@
 -}}
 {{- $flags := dict
   "log_level" "--log.level=info"
+  "log_format" "--log.format=logfmtms"
 -}}
 ---
 optimism_package:
@@ -34,6 +35,7 @@ optimism_package:
       image: {{ $local_images.op_supervisor }}
       extra_params:
       - {{ $flags.log_level }}
+      - {{ $flags.log_format }}
   chains:
     op-kurtosis1:
       participants:
@@ -57,7 +59,8 @@ optimism_package:
             log_level: ""
             extra_env_vars: {}
             extra_labels: {}
-            extra_params: []
+            extra_params:
+              - {{ $flags.log_format }}
             tolerations: []
             volume_size: 0
             min_cpu: 0
@@ -82,10 +85,12 @@ optimism_package:
         image: {{ $local_images.op_batcher }}
         extra_params:
         - {{ $flags.log_level }}
+        - {{ $flags.log_format }}
       proposer_params:
         image: {{ $local_images.op_proposer }}
         extra_params:
         - {{ $flags.log_level }}
+        - {{ $flags.log_format }}
         game_type: 1
         proposal_interval: 10m
     op-kurtosis2:
@@ -104,10 +109,12 @@ optimism_package:
         image: {{ $local_images.op_batcher }}
         extra_params:
         - {{ $flags.log_level }}
+        - {{ $flags.log_format }}
       proposer_params:
         image: {{ $local_images.op_proposer }}
         extra_params:
         - {{ $flags.log_level }}
+        - {{ $flags.log_format }}
         game_type: 1
         proposal_interval: 10m
   challengers:
@@ -119,6 +126,7 @@ optimism_package:
       cannon_trace_types: ["super-cannon", "super-permissioned"]
       extra_params:
       - {{ $flags.log_level }}
+      - {{ $flags.log_format }}
   op_contract_deployer_params:
     image: {{ $local_images.op_deployer }}
     l1_artifacts_locator: {{ $urls.l1_artifacts }}

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -185,7 +185,7 @@ func NewFormatFlagValue(fmtType FormatType) *FormatFlagValue {
 
 func (fv *FormatFlagValue) Set(value string) error {
 	switch FormatType(value) {
-	case FormatText, FormatTerminal, FormatLogFmt, FormatJSON:
+	case FormatText, FormatTerminal, FormatLogFmt, FormatLogFmtMs, FormatJSON, FormatJSONMs:
 		*fv = FormatFlagValue(value)
 		return nil
 	default:

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -29,7 +29,7 @@ const (
 // These flag configurations are used during testing, where level is set to trace.
 var (
 	flLevel  = flag.String(LevelFlagName, "trace", "Lowest log level that will be output")
-	flFormat = flag.String(FormatFlagName, "text", "Log format: text|terminal|logfmt|json|json-pretty")
+	flFormat = flag.String(FormatFlagName, "text", "Log format: text|terminal|logfmt|logfmtms|json|jsonms|json-pretty")
 	flColor  = flag.Bool(ColorFlagName, false, "Color the log output if in terminal mode: true|false")
 	flPID    = flag.Bool(PidFlagName, false, "Show pid in the log")
 )
@@ -138,7 +138,9 @@ const (
 	FormatText     FormatType = "text"
 	FormatTerminal FormatType = "terminal"
 	FormatLogFmt   FormatType = "logfmt"
+	FormatLogFmtMs FormatType = "logfmtms"
 	FormatJSON     FormatType = "json"
+	FormatJSONMs   FormatType = "jsonms"
 )
 
 // FormatHandler returns the correct slog handler factory for the provided format.
@@ -147,9 +149,12 @@ func FormatHandler(ft FormatType, color bool) func(io.Writer) slog.Handler {
 		return log.NewTerminalHandler(w, color)
 	}
 	logfmtHandler := func(w io.Writer) slog.Handler { return log.LogfmtHandlerWithLevel(w, log.LevelTrace) }
+	logfmtMsHandler := func(w io.Writer) slog.Handler { return LogfmtMsHandlerWithLevel(w, log.LevelTrace) }
 	switch ft {
 	case FormatJSON:
 		return log.JSONHandler
+	case FormatJSONMs:
+		return JSONMsHandler
 	case FormatText:
 		if color {
 			return termColorHandler
@@ -160,6 +165,8 @@ func FormatHandler(ft FormatType, color bool) func(io.Writer) slog.Handler {
 		return termColorHandler
 	case FormatLogFmt:
 		return logfmtHandler
+	case FormatLogFmtMs:
+		return logfmtMsHandler
 	default:
 		panic(fmt.Errorf("failed to create slog.Handler factory for format-type=%q and color=%v", ft, color))
 	}
@@ -270,6 +277,7 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 // ReadTestCLIConfig reads the CLI config from flags and environment variables into a CLIConfig.
 // flag.Parse() must be called before calling this function.
 func ReadTestCLIConfig() CLIConfig {
+	*flFormat = "logfmtms" // override the default cli format of text
 	if v := os.Getenv("LOG_LEVEL"); v != "" {
 		*flLevel = v
 	}

--- a/op-service/log/handler.go
+++ b/op-service/log/handler.go
@@ -1,0 +1,102 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"math/big"
+	"reflect"
+	"time"
+
+	"github.com/holiman/uint256"
+
+	elog "github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	timeFormatMs                 = "2006-01-02T15:04:05.000-0700"
+	levelMaxVerbosity slog.Level = math.MinInt
+)
+
+type leveler struct{ minLevel slog.Level }
+
+func (l *leveler) Level() slog.Level {
+	return l.minLevel
+}
+
+func JSONMsHandler(wr io.Writer) slog.Handler {
+	return JSONMsHandlerWithLevel(wr, levelMaxVerbosity)
+}
+
+func JSONMsHandlerWithLevel(wr io.Writer, level slog.Level) slog.Handler {
+	return slog.NewJSONHandler(wr, &slog.HandlerOptions{
+		ReplaceAttr: builtinReplaceJSONMs,
+		Level:       &leveler{level},
+	})
+}
+
+func LogfmtMsHandler(wr io.Writer) slog.Handler {
+	return slog.NewTextHandler(wr, &slog.HandlerOptions{
+		ReplaceAttr: builtinReplaceLogfmtMs,
+	})
+}
+
+func LogfmtMsHandlerWithLevel(wr io.Writer, level slog.Level) slog.Handler {
+	return slog.NewTextHandler(wr, &slog.HandlerOptions{
+		ReplaceAttr: builtinReplaceLogfmtMs,
+		Level:       &leveler{level},
+	})
+}
+
+func builtinReplaceLogfmtMs(_ []string, attr slog.Attr) slog.Attr {
+	return builtinReplaceMs(nil, attr, true)
+}
+
+func builtinReplaceJSONMs(_ []string, attr slog.Attr) slog.Attr {
+	return builtinReplaceMs(nil, attr, false)
+}
+
+func builtinReplaceMs(_ []string, attr slog.Attr, logfmt bool) slog.Attr {
+	switch attr.Key {
+	case slog.TimeKey:
+		if attr.Value.Kind() == slog.KindTime {
+			if logfmt {
+				return slog.String("t", attr.Value.Time().Format(timeFormatMs))
+			} else {
+				return slog.Attr{Key: "t", Value: attr.Value}
+			}
+		}
+	case slog.LevelKey:
+		if l, ok := attr.Value.Any().(slog.Level); ok {
+			attr = slog.Any("lvl", elog.LevelString(l))
+			return attr
+		}
+	}
+
+	switch v := attr.Value.Any().(type) {
+	case time.Time:
+		if logfmt {
+			attr = slog.String(attr.Key, v.Format(timeFormatMs))
+		}
+	case *big.Int:
+		if v == nil {
+			attr.Value = slog.StringValue("<nil>")
+		} else {
+			attr.Value = slog.StringValue(v.String())
+		}
+	case *uint256.Int:
+		if v == nil {
+			attr.Value = slog.StringValue("<nil>")
+		} else {
+			attr.Value = slog.StringValue(v.Dec())
+		}
+	case fmt.Stringer:
+		if v == nil || (reflect.ValueOf(v).Kind() == reflect.Pointer && reflect.ValueOf(v).IsNil()) {
+			attr.Value = slog.StringValue("<nil>")
+		} else {
+			attr.Value = slog.StringValue(v.String())
+		}
+	}
+	return attr
+}


### PR DESCRIPTION
**Description**

This PR is adding two new log format: `logfmtms` and `jsonms`.

It is also overriding the test log format, which by default uses the production default value with `logfmtms`.

Supersedes: https://github.com/ethereum-optimism/op-geth/pull/639

---

* Confirmed that logs look good on kurtosis interop network (op-node, supervisor, proposer...)
* Confirmed that logs look good on integration tests

---

When approved and merged, I will work with Platforms team to configure services on our systems to include ms granularity for logs on future interop networks.