### PR TITLE
feat: map supervisor errors to relevant rpc error codes

### DIFF
--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -24,7 +25,14 @@ var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
-	return q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+	if err != nil {
+		return &rpc.JsonError{
+			Code:    types.GetErrorCode(err),
+			Message: err.Error(),
+		}
+	}
+	return nil
 }
 
 func (q *QueryFrontend) LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -50,41 +50,38 @@ var (
 
 var genericInvalidParamsErr = -32602
 
-// GetErrorCode returns the error code for the given error based on interop supervisor spec - https://github.com/ethereum-optimism/specs/blob/28a0fac2428b10f9ee29ee1bfbbe366181cc9ac4/specs/interop/supervisor.md#json-rpc-error-codes
+// errorCodeMap is based on the interop supervisor spec - https://github.com/ethereum-optimism/specs/blob/28a0fac2428b10f9ee29ee1bfbbe366181cc9ac4/specs/interop/supervisor.md#json-rpc-error-codes
+var errorCodeMap = map[error]int{
+	ErrOutOfOrder:            -320900,
+	ErrDataCorruption:        -321501,
+	ErrNotExact:              -321500,
+	ErrSkipped:               -320500,
+	ErrFuture:                -321401,
+	ErrIneffective:           -320601,
+	ErrConflict:              -320600,
+	ErrAwaitReplacementBlock: -320901,
+	ErrStop:                  -321000,
+	ErrOutOfScope:            -321100,
+	ErrPreviousToFirst:       -321200,
+	ErrUnknownChain:          -320501,
+	ErrUninitialized:         -320400,
+
+	ErrNoRPCSource:             genericInvalidParamsErr,
+	ErrFailsafeEnabled:         genericInvalidParamsErr,
+	ErrInvalidatedRead:         genericInvalidParamsErr,
+	ErrAlreadyInvalidatingRead: genericInvalidParamsErr,
+	ErrRewindFailed:            genericInvalidParamsErr,
+}
+
+// GetErrorCode returns the error code for the given error based on interop supervisor spec
 func GetErrorCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	switch err {
-	case ErrOutOfOrder:
-		return -320900
-	case ErrDataCorruption:
-		return -321501
-	case ErrNotExact:
-		return -321500
-	case ErrSkipped:
-		return -320500
-	case ErrFuture:
-		return -321401
-	case ErrIneffective:
-		return -320601
-	case ErrConflict:
-		return -320600
-	case ErrAwaitReplacementBlock:
-		return -320901
-	case ErrStop:
-		return -321000
-	case ErrOutOfScope:
-		return -321100
-	case ErrPreviousToFirst:
-		return -321200
-	case ErrUnknownChain:
-		return -320501
-	case ErrUninitialized:
-		return -320400
-	case ErrNoRPCSource, ErrFailsafeEnabled, ErrInvalidatedRead, ErrAlreadyInvalidatingRead, ErrRewindFailed:
-		return genericInvalidParamsErr
-	default:
-		return genericInvalidParamsErr
+	for knownErr, code := range errorCodeMap {
+		if errors.Is(err, knownErr) {
+			return code
+		}
 	}
+	return genericInvalidParamsErr
 }

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -47,3 +47,44 @@ var (
 	// ErrFailsafeEnabled is when failsafe is enabled and the request is rejected
 	ErrFailsafeEnabled = errors.New("failsafe is enabled, rejecting all CheckAccessList requests")
 )
+
+var genericInvalidParamsErr = -32602
+
+// GetErrorCode returns the error code for the given error based on interop supervisor spec - https://github.com/ethereum-optimism/specs/blob/28a0fac2428b10f9ee29ee1bfbbe366181cc9ac4/specs/interop/supervisor.md#json-rpc-error-codes
+func GetErrorCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	switch err {
+	case ErrOutOfOrder:
+		return -320900
+	case ErrDataCorruption:
+		return -321501
+	case ErrNotExact:
+		return -321500
+	case ErrSkipped:
+		return -320500
+	case ErrFuture:
+		return -321401
+	case ErrIneffective:
+		return -320601
+	case ErrConflict:
+		return -320600
+	case ErrAwaitReplacementBlock:
+		return -320901
+	case ErrStop:
+		return -321000
+	case ErrOutOfScope:
+		return -321100
+	case ErrPreviousToFirst:
+		return -321200
+	case ErrUnknownChain:
+		return -320501
+	case ErrUninitialized:
+		return -320400
+	case ErrNoRPCSource, ErrFailsafeEnabled, ErrInvalidatedRead, ErrAlreadyInvalidatingRead, ErrRewindFailed:
+		return genericInvalidParamsErr
+	default:
+		return genericInvalidParamsErr
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

**Description**

Makes supervisor's checkAccessList RPC to return errors with relevant error codes as defined [here](https://github.com/ethereum-optimism/specs/blob/28a0fac2428b10f9ee29ee1bfbbe366181cc9ac4/specs/interop/supervisor.md#json-rpc-error-codes)

Fixes #15771