### PR TITLE
Fix: propagate goroutine errors to main thread in listGames for accurate error handling

### DIFF
--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -112,7 +112,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			defer wg.Done()
 			metadata, err := gameContract.GetGameMetadata(ctx, rpcblock.ByHash(block))
 			if err != nil {
-				info.err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
+				infos[currIndex].err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
 				return
 			}
 			infos[currIndex].status = metadata.Status
@@ -120,7 +120,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			infos[currIndex].rootClaim = metadata.RootClaim
 			claimCount, err := gameContract.GetClaimCount(ctx)
 			if err != nil {
-				info.err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
+				infos[currIndex].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
 				return
 			}
 			infos[currIndex].claimCount = claimCount


### PR DESCRIPTION
**Description**

This pull request fixes a critical bug in the listGames command where errors encountered inside goroutines (while retrieving game metadata or claim count) were not properly propagated to the main thread. Previously, such errors were assigned to a local variable and silently ignored, potentially resulting in incomplete or misleading output without any indication of failure.

Now, errors are correctly assigned to the corresponding entry in the infos array, ensuring that any failure is surfaced to the user and the command exits with an appropriate error message.

**Tests**

No new automated tests were added, as this change affects error propagation and user-facing CLI output. The fix was manually verified by simulating error conditions (e.g., by providing an invalid RPC endpoint or contract address) and confirming that errors are now reported as expected, rather than being silently ignored.

**Additional context**

This change improves the reliability and transparency of the listGames command. If, in the future, partial results are preferred (i.e., displaying all games except those with errors), the error handling logic can be adjusted to log errors per game instead of returning early. For now, this approach prioritizes correctness and user awareness.

