### PR TITLE
feat: bump op-geth to include latest SCR changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250608235258-6005dd53e1b5
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250709185215-3c0b5b36bc96
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250709185215-3c0b5b36bc96
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250710181308-c6e05723600e
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250608235258-6005dd53e1b5 h1:wczwl6+GChQaDe3no+h1TegOO8J1Cyb+L3BdFXDsMhk=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250608235258-6005dd53e1b5/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250709185215-3c0b5b36bc96 h1:qI3ZP5xomTAttJpMa3D5oyY7MlIhsbzMib12m526jcM=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250709185215-3c0b5b36bc96/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250709185215-3c0b5b36bc96 h1:qI3ZP5xomTAttJpMa3D5oyY7MlIhsbzMib12m526jcM=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250709185215-3c0b5b36bc96/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250710181308-c6e05723600e h1:Ur5vjH2RmYqspDBIZH4RymNB6viHFheZkvvHt9W3spQ=
+github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250710181308-c6e05723600e/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -326,10 +326,10 @@ func TestInteropBlockBuilding(t *testing.T) {
 				_, err := s2.ValidateMessage(ctx, chainB, "Alice", identifier, invalidPayloadHash, gethCore.ErrTxFilteredOut)
 				require.ErrorContains(t, err, gethCore.ErrTxFilteredOut.Error())
 			} else {
-				// We expect the miner to be unable to include this tx, and confirmation to thus time out, if mempool filtering is disabled.
+				// The miner will include the tx in the block if mempool filtering is disabled, because interop checks don't happen during block building
+				// this includes invalid interop messages
 				_, err := s2.ValidateMessage(ctx, chainB, "Alice", identifier, invalidPayloadHash, nil)
-				require.ErrorIs(t, err, ctx.Err())
-				require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+				require.NoError(t, err)
 			}
 		}
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
* Bump op-geth module to include swell-mainnet holocene activation time

**Tests**

```
╰─❯ ./bin/op-node --network swell-mainnet ---l2 "http://127.0.0.1:8545" --l2.jwt-secret 5ffc5f6abefe9467e5982c6a66bce1453ed21909bebc987810748aa1ddb7f281
INFO [07-09|15:30:52.954] Not opted in to ProtocolVersions signal loading, disabling ProtocolVersions contract now.
INFO [07-09|15:30:52.983] Using default bootnodes, none provided.
INFO [07-09|15:30:53.231] Rollup Config                            l2_chain_id=1923 l2_network=swell l1_chain_id=1 l1_network=mainnet l2_start_time=1,732,696,703 l2_block_hash=0x92379973a1576876b7337a9ce89e2a7a9cb99887f55e6045ed2069d5d98d9319 l2_block_number=0 l1_block_hash=0xd904f8475cc7b74a9ef4749d0ee9aeca3b233aa3dc143667e8a20ffe43789a26 l1_block_number=21,277,945
regolith_time="@ genesis" 
canyon_time="@ genesis"
delta_time="@ genesis" 
ecotone_time="@ genesis" 
fjord_time="@ genesis" 
granite_time="@ genesis"
holocene_time="@ 1752732000 ~ Thu Jul 17 02:00:00 EDT 2025"
isthmus_time="(not configured)"
jovian_time="(not configured)"
interop_time="(not configured)"
```

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
