### PR TITLE
fix: handle invalidated blocks in CrossSafeUpdate

### DIFF
--- a/op-supervisor/supervisor/backend/cross/hazard_set.go
+++ b/op-supervisor/supervisor/backend/cross/hazard_set.go
@@ -129,6 +129,11 @@ func (h *HazardSet) build(deps HazardDeps, linker depset.LinkChecker, logger log
 			}
 			includedIn, err := deps.Contains(msg.ChainID, q)
 			if err != nil {
+				// If the block containing the message was invalidated, we need to signal that
+				// a replacement block is needed before cross-safe progress can be made
+				if errors.Is(err, types.ErrAwaitReplacementBlock) {
+					return fmt.Errorf("executing msg %s references invalidated block: %w", msg, err)
+				}
 				return fmt.Errorf("executing msg %s failed inclusion check: %w", msg, err)
 			}
 

--- a/op-supervisor/supervisor/backend/cross/safe_update.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update.go
@@ -49,7 +49,7 @@ func CrossSafeUpdate(logger log.Logger, chainID eth.ChainID, d CrossSafeDeps, li
 		return h.Err() // make sure the read-consistency is still translated into an error
 	}
 	if errors.Is(err, types.ErrAwaitReplacementBlock) {
-		logger.Info("Awaiting replacement block", "err", err)
+		logger.Info("Awaiting replacement block during hazard set construction", "err", err)
 		return err
 	}
 	if errors.Is(err, types.ErrConflict) {
@@ -117,6 +117,10 @@ func scopedCrossSafeUpdate(h reads.Handle, logger log.Logger, chainID eth.ChainI
 
 	hazards, err := CrossSafeHazards(d, linker, logger, chainID, candidate.Source.ID(), types.BlockSealFromRef(candidate.Derived))
 	if err != nil {
+		// If hazard set construction encounters an invalidated block, bubble up the error
+		if errors.Is(err, types.ErrAwaitReplacementBlock) {
+			return candidate, err
+		}
 		return candidate, fmt.Errorf("failed to determine dependencies of cross-safe candidate %s: %w", candidate.Derived, err)
 	}
 	if err := HazardSafeFrontierChecks(d, candidate.Source.ID(), hazards); err != nil {

--- a/op-supervisor/supervisor/backend/cross/safe_update_test.go
+++ b/op-supervisor/supervisor/backend/cross/safe_update_test.go
@@ -60,7 +60,7 @@ func TestCrossSafeUpdate(t *testing.T) {
 		err := CrossSafeUpdate(logger, chainID, csd, linkerAny{})
 		require.ErrorContains(t, err, "some error")
 	})
-	t.Run("scopedCrossSafeUpdate returns ErrAwaitReplacementBlock", func(t *testing.T) {
+	t.Run("scopedCrossSafeUpdate returns ErrAwaitReplacementBlock from hazard set", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(123)
 		csd := &mockCrossSafeDeps{}
@@ -72,12 +72,28 @@ func TestCrossSafeUpdate(t *testing.T) {
 				Derived: candidate,
 			}, nil
 		}
+		// Mock OpenBlock to return an executing message that will trigger Contains check
 		csd.openBlockFn = func(chainID eth.ChainID, blockNum uint64) (ref eth.BlockRef, logCount uint32, execMsgs map[uint32]*types.ExecutingMessage, err error) {
-			return eth.BlockRef{}, 0, nil, types.ErrAwaitReplacementBlock
+			return eth.BlockRef{Hash: candidate.Hash, Number: candidate.Number}, 1, map[uint32]*types.ExecutingMessage{
+				0: {
+					ChainID:   eth.ChainIDFromUInt64(456),
+					BlockNum:  10,
+					LogIdx:    0,
+					Timestamp: candidate.Time,
+					Checksum:  types.MessageChecksum{0x1, 0x2, 0x3},
+				},
+			}, nil
 		}
+		// Mock Contains to return ErrAwaitReplacementBlock (indicating an invalidated block)
+		csd.checkFn = func(chainID eth.ChainID, blockNum uint64, logIdx uint32, checksum types.MessageChecksum) (types.BlockSeal, error) {
+			return types.BlockSeal{}, types.ErrAwaitReplacementBlock
+		}
+		// when hazard set construction encounters an invalidated block,
+		// ErrAwaitReplacementBlock is returned
 		err := CrossSafeUpdate(logger, chainID, csd, linkerAny{})
 		require.ErrorIs(t, err, types.ErrAwaitReplacementBlock)
 	})
+
 	t.Run("scopedCrossSafeUpdate returns ErrConflict and triggers invalidate-local-safe", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelDebug)
 		chainID := eth.ChainIDFromUInt64(123)


### PR DESCRIPTION
- Removed impossible test for ErrAwaitReplacementBlock.
- Added handling for invalidated blocks in hazard set construction.
- Introduced test for invalidated block handling.

Fixes #16548