### PR TITLE
op-challenger: Assign errors correctly in list-games

### DIFF
--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -99,13 +99,13 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 	infos := make([]gameInfo, len(games))
 	var wg sync.WaitGroup
 	for idx, game := range games {
+		idx := idx
 		gameContract, err := contracts.NewFaultDisputeGameContract(ctx, metrics.NoopContractMetrics, game.Proxy, caller)
 		if err != nil {
 			return fmt.Errorf("failed to create dispute game contract: %w", err)
 		}
 		infos[idx] = gameInfo{GameMetadata: game}
 		gameProxy := game.Proxy
-		currIndex := idx
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -114,15 +114,15 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 				infos[idx].err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
 				return
 			}
-			infos[currIndex].status = metadata.Status
-			infos[currIndex].l2BlockNum = metadata.L2SequenceNum
-			infos[currIndex].rootClaim = metadata.RootClaim
+			infos[idx].status = metadata.Status
+			infos[idx].l2BlockNum = metadata.L2SequenceNum
+			infos[idx].rootClaim = metadata.RootClaim
 			claimCount, err := gameContract.GetClaimCount(ctx)
 			if err != nil {
 				infos[idx].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
 				return
 			}
-			infos[currIndex].claimCount = claimCount
+			infos[idx].claimCount = claimCount
 		}()
 	}
 	wg.Wait()

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -103,8 +103,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 		if err != nil {
 			return fmt.Errorf("failed to create dispute game contract: %w", err)
 		}
-		info := gameInfo{GameMetadata: game}
-		infos[idx] = info
+		infos[idx] = gameInfo{GameMetadata: game}
 		gameProxy := game.Proxy
 		currIndex := idx
 		wg.Add(1)
@@ -112,7 +111,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			defer wg.Done()
 			metadata, err := gameContract.GetGameMetadata(ctx, rpcblock.ByHash(block))
 			if err != nil {
-				info.err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
+				infos[idx].err = fmt.Errorf("failed to retrieve metadata for game %v: %w", gameProxy, err)
 				return
 			}
 			infos[currIndex].status = metadata.Status
@@ -120,7 +119,7 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			infos[currIndex].rootClaim = metadata.RootClaim
 			claimCount, err := gameContract.GetClaimCount(ctx)
 			if err != nil {
-				info.err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
+				infos[idx].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
 				return
 			}
 			infos[currIndex].claimCount = claimCount


### PR DESCRIPTION
**Description**

Simplifies list_games to remove some foot guns and correctly assign errors to the gameInfo struct that's actually used instead of the local copy of it.

Replaces #16654 which fixed the error assignment but left the code in a place where it was likely similar errors would be made again in the future. Also worth noting that despite the AI generated PR description, this is not a critical bug and errors were always correctly reported if you supplied an incorrectly game address or rpc URL because errors were encountered listing the games before this code is reached. You'd only hit this casein there were intermittent issues with the RPC endpoint and it is pretty obvious in the resulting output.
