### PR TITLE
interop: Change E2E Test Expectation when no Mempool Filter

### DIFF
--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -326,10 +326,10 @@ func TestInteropBlockBuilding(t *testing.T) {
 				_, err := s2.ValidateMessage(ctx, chainB, "Alice", identifier, invalidPayloadHash, gethCore.ErrTxFilteredOut)
 				require.ErrorContains(t, err, gethCore.ErrTxFilteredOut.Error())
 			} else {
-				// We expect the miner to be unable to include this tx, and confirmation to thus time out, if mempool filtering is disabled.
+				// The miner will include the tx in the block if mempool filtering is disabled, because interop checks don't happen during block building
+				// this includes invalid interop messages
 				_, err := s2.ValidateMessage(ctx, chainB, "Alice", identifier, invalidPayloadHash, nil)
-				require.ErrorIs(t, err, ctx.Err())
-				require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+				require.NoError(t, err)
 			}
 		}
 


### PR DESCRIPTION
Previously, `op-geth` would decline to mine invalid interop transactions *even if* mempool filtering was disabled, because it would make an RPC call to `CheckAccessList` for every Interop Tx during block building.

We have since removed the check during block building, and thus this E2E test expects the transaction not to be included when it is now included.

this PR changes that expectation to match geth behavior: if mempool filtering is disabled, invalid messages can enter during block building