### PR TITLE
fix: optimize HTTP regex pattern in RPC client

### DIFF
--- a/op-service/client/rpc.go
+++ b/op-service/client/rpc.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
-var httpRegex = regexp.MustCompile("^http(s)?://")
+var httpRegex = regexp.MustCompile("^https?://")
 
 type RPC interface {
 	Close()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Replace capturing group regex `^http(s)?://` with non-capturing `^https?://` for better performance. This eliminates unnecessary memory allocations while maintaining identical functionality.