### PR TITLE
fix edge case in unsed imports check script

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/unused-imports/main.go
+++ b/packages/contracts-bedrock/scripts/checks/unused-imports/main.go
@@ -94,6 +94,21 @@ func isImportUsed(imp, content string) bool {
 		}
 
 		if matched, _ := regexp.MatchString(wordPattern, line); matched {
+			// Check if all occurrences of imp are within quotes
+			allWithinQuotes := true
+			inQuotes := false
+			for i := 0; i < len(line); i++ {
+				if line[i] == '"' || line[i] == '\'' {
+					inQuotes = !inQuotes
+				} else if !inQuotes && i+len(imp) <= len(line) && line[i:i+len(imp)] == imp {
+					// Found imp outside quotes
+					allWithinQuotes = false
+					break
+				}
+			}
+			if allWithinQuotes {
+				continue
+			}
 			return true
 		}
 	}

--- a/packages/contracts-bedrock/scripts/checks/unused-imports/main.go
+++ b/packages/contracts-bedrock/scripts/checks/unused-imports/main.go
@@ -80,6 +80,10 @@ func isImportUsed(imp, content string) bool {
 		if strings.HasPrefix(strings.TrimSpace(line), "//") || strings.HasPrefix(strings.TrimSpace(line), "/*") || strings.HasPrefix(strings.TrimSpace(line), "*") || strings.HasPrefix(strings.TrimSpace(line), "*/") {
 			continue
 		}
+		// Split the line at any comment markers and only process the code part
+		line = strings.Split(line, "//")[0]
+		line = strings.Split(line, "/*")[0]
+
 		if importOpen {
 			if strings.Contains(line, "}") {
 				importOpen = false

--- a/packages/contracts-bedrock/scripts/checks/unused-imports/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/unused-imports/main_test.go
@@ -120,6 +120,37 @@ func Test_isImportUsed(t *testing.T) {
 			`,
 			expected: false,
 		},
+		{
+			name:         "import name used in string quotes",
+			importedName: "UsedContract",
+			content: `
+				contract Test {
+					string used = "a, b, c, UsedContract, d, e, f";
+				}
+			`,
+			expected: false,
+		},
+		{
+			name:         "import name used both in string quotes and outside of quote string",
+			importedName: "UsedContract",
+			content: `
+				contract Test {
+					string used = "a, b, c, UsedContract, d, e, f";
+					UsedContract used2;
+				}
+			`,
+			expected: true,
+		},
+		{
+			name:         "import name used both in string quotes and outside of quote string on the same line",
+			importedName: "UsedContract",
+			content: `
+				contract Test {
+					(UsedContract a, string used) = (aaa, "a, b, c, UsedContract, d, e, f");
+				}
+			`,
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/packages/contracts-bedrock/scripts/checks/unused-imports/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/unused-imports/main_test.go
@@ -151,6 +151,26 @@ func Test_isImportUsed(t *testing.T) {
 			`,
 			expected: true,
 		},
+		{
+			name:         "import name used in comment after code on the same line",
+			importedName: "UsedContract",
+			content: `
+				contract Test {
+					string used = "hi"; // UsedContract
+				}
+			`,
+			expected: false,
+		},
+		{
+			name:         "import name used in code and in comment after the code on the same line",
+			importedName: "UsedContract",
+			content: `
+				contract Test {
+					UsedContract used = "hi"; // UsedContract
+				}
+			`,
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -60,8 +60,8 @@
     "sourceCodeHash": "0x4351fe2ac1106c8c220b8cfe7839bc107c24d8084deb21259ac954f5a362725d"
   },
   "src/L2/L1Block.sol:L1Block": {
-    "initCodeHash": "0xa1f984b8ea199574261c19122b5a9c8c7dbd3633980b1e7aaf6b7af24af60478",
-    "sourceCodeHash": "0xd04d64355dcf55247ac937748518e7f9620ae3f9eabe80fae9a82c0115ed77bc"
+    "initCodeHash": "0xc35734387887a95f611888f3944546c6bcf82fd4c05dcdaa1e019779b628ad68",
+    "sourceCodeHash": "0x6e5349fd781d5f0127ff29ccea4d86a80240550cfa322364183a0f629abcb43e"
   },
   "src/L2/L1FeeVault.sol:L1FeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.15;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
-import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -62,9 +61,9 @@ contract L1Block is ISemver {
     /// @notice The scalar value applied to the operator fee.
     uint32 public operatorFeeScalar;
 
-    /// @custom:semver 1.6.0
+    /// @custom:semver 1.6.1
     function version() public pure virtual returns (string memory) {
-        return "1.6.0";
+        return "1.6.1";
     }
 
     /// @notice Returns the gas paying token, its decimals, name and symbol.

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.15;
 
 // Forge
 import { VmSafe } from "forge-std/Vm.sol";
-import { console2 as console } from "forge-std/console2.sol";
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismMintableERC721Factory.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.15;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { OptimismMintableERC721 } from "src/L2/OptimismMintableERC721.sol";
-import { OptimismMintableERC721Factory } from "src/L2/OptimismMintableERC721Factory.sol";
 
 /// @title OptimismMintableERC721Factory_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC721Factory` tests.

--- a/packages/contracts-bedrock/test/L2/WETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/WETH.t.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";
 
-// Target contract
-import { WETH } from "src/L2/WETH.sol";
-
 /// @title WETH_Name_Test
 /// @notice Tests the `name` function of the `WETH` contract.
 contract WETH_Name_Test is CommonTest {


### PR DESCRIPTION
This PR fixes the following edge cases in the unused-imports-check script 

- if the import name is used within the contract file but within string quotes, the import is wrongly marked as used

- if the import name is used after a comment indicator that came after some code has been written on the same line e.g
```sol
     a = 15 // importName ....
```