### PR TITLE
chore: Speed up docker builds for releases and acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1191,7 +1191,7 @@ jobs:
         default: 30m
     machine:
       image: ubuntu-2404:edge
-      docker_layer_caching: true # Since we are building docker images for components, we'll chache the layers for faster builds
+      docker_layer_caching: true # Since we are building docker images for components, we'll cache the layers for faster builds
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1189,7 +1189,9 @@ jobs:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
         default: 30m
-    machine: true
+    machine:
+      image: ubuntu-2404:edge
+      docker_layer_caching: true
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise
@@ -1645,7 +1647,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - gcp-cli/install
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /tmp/gcp_cred_config.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1191,7 +1191,7 @@ jobs:
         default: 30m
     machine:
       image: ubuntu-2404:edge
-      docker_layer_caching: true
+      docker_layer_caching: true # Since we are building docker images for components, we'll chache the layers for faster builds
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1190,7 +1190,7 @@ jobs:
         type: string
         default: 30m
     machine:
-      image: ubuntu-2404:edge
+      image: ubuntu-2404:current
       docker_layer_caching: true # Since we are building docker images for components, we'll cache the layers for faster builds
     resource_class: xlarge
     steps:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Add docker layer caching for acceptance tests
- Fix a deprecation warning about `machine: true` by replacing it with an explicit machine image

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
