### PR TITLE
cannon: Migrate memory-reservation tests

### DIFF
--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -146,8 +146,7 @@ func (d *DiffTester[T]) generateTestModifiers(t require.TestingT, testCase T, vm
 	return modifiers
 }
 
-// memReservationTestModifier updates tests that write to memory, to ensure any overlapping memory reservation
-// is cleared
+// memReservationTestModifier updates tests that write to memory, to ensure that memory reservations are handled correctly
 func (d *DiffTester[T]) memReservationTestModifier(cfg *TestConfig, randSeed int64, expect *mtutil.ExpectedState) []*testModifier {
 	var modifiers []*testModifier
 
@@ -157,24 +156,56 @@ func (d *DiffTester[T]) memReservationTestModifier(cfg *TestConfig, randSeed int
 		return modifiers
 	}
 
-	modifiers = append(modifiers, &testModifier{
-		name: " [mod:overlappingMemReservation]",
-		stateMod: func(state *multithreaded.State) {
-			// Set up a memory reservation that overlaps with the effective address of the target memory word
-			r := testutil.NewRandHelper(randSeed + 10000)
-			targetMemAddr := memTargets[r.Intn(len(memTargets))]
-			effAddr := targetMemAddr & arch.AddressMask
+	for i, testCase := range memReservationTestCases {
+		modifiers = append(modifiers, &testModifier{
+			name: fmt.Sprintf(" [mod:%v]", testCase.name),
+			stateMod: func(state *multithreaded.State) {
+				r := testutil.NewRandHelper(randSeed*int64(i) + 10000)
+				targetMemAddr := memTargets[r.Intn(len(memTargets))]
+				effAddr := targetMemAddr & arch.AddressMask
 
-			state.LLReservationStatus = multithreaded.LLReservationStatus(r.Intn(2) + 1)
-			state.LLAddress = effAddr + arch.Word(r.Intn(arch.WordSizeBytes))
-			state.LLOwnerThread = arch.Word(r.Intn(10))
-		},
-		expectMod: func(expect *mtutil.ExpectedState) {
-			expect.ExpectMemoryReservationCleared()
-		},
-	})
+				llAddress := effAddr + testCase.effAddrOffset
+				llOwnerThread := state.GetCurrentThread().ThreadId
+				if !testCase.matchThreadId {
+					llOwnerThread += 1
+				}
+
+				state.LLReservationStatus = testCase.llReservationStatus
+				state.LLAddress = llAddress
+				state.LLOwnerThread = llOwnerThread
+			},
+			expectMod: func(expect *mtutil.ExpectedState) {
+				if testCase.shouldClearReservation {
+					expect.ExpectMemoryReservationCleared()
+				}
+			},
+		})
+	}
 
 	return modifiers
+}
+
+type memReservationTestCase struct {
+	name                   string
+	llReservationStatus    multithreaded.LLReservationStatus
+	matchThreadId          bool
+	effAddrOffset          arch.Word
+	shouldClearReservation bool
+}
+
+var memReservationTestCases []memReservationTestCase = []memReservationTestCase{
+	{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, 64-bit, unaligned", llReservationStatus: multithreaded.LLStatusActive64bit, effAddrOffset: 5, matchThreadId: true, shouldClearReservation: true},
+	{name: "matching reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, shouldClearReservation: true},
+	{name: "matching reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, shouldClearReservation: true},
+	{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "mismatched reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "mismatched reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "mismatched reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
+	{name: "no reservation, matching addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, shouldClearReservation: true},
+	{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
 }
 
 func randomSeed(t require.TestingT, s string, extraData ...int) int64 {

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -280,7 +280,7 @@ type vmPanicResult struct {
 	evmError string
 }
 
-func ExpectPanic(goPanicMsg, evmRevertMsg string) ExpectedExecResult {
+func ExpectVmPanic(goPanicMsg, evmRevertMsg string) ExpectedExecResult {
 	return vmPanicResult{
 		panicMsg: goPanicMsg,
 		evmError: evmRevertMsg,

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -81,21 +81,7 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 					execExpectation := d.setExpectations(testCase, expect, vm)
 					mod.expectMod(expect)
 
-					if execExpectation.shouldPanic {
-						proofData := vm.ProofGenerator(t, state)
-						errMsg := testutil.CreateErrorStringMatcher(execExpectation.evmError)
-						testutil.AssertEVMReverts(t, state, vm.Contracts, nil, proofData, errMsg)
-						require.PanicsWithValue(t, execExpectation.panicMsg, func() { _, _ = goVm.Step(false) })
-					} else {
-						// Step the VM
-						step := state.GetStep()
-						stepWitness, err := goVm.Step(true)
-						require.NoError(t, err)
-
-						// Validate
-						expect.Validate(t, state)
-						testutil.ValidateEVM(t, stepWitness, step, goVm, vm.StateHashFn, vm.Contracts)
-					}
+					execExpectation.assertExpectedResult(t, goVm, vm, expect)
 				})
 			}
 		}
@@ -267,24 +253,67 @@ func newTestConfig(t require.TestingT, opts ...TestOption) *TestConfig {
 	return testConfig
 }
 
-type ExpectedExecResult struct {
-	shouldPanic bool
-	panicMsg    string
-	evmError    string
+type ExpectedExecResult interface {
+	assertExpectedResult(t testing.TB, vm mipsevm.FPVM, vmType VersionedVMTestCase, expect *mtutil.ExpectedState)
 }
 
+type normalExecResult struct{}
+
 func ExpectNormalExecution() ExpectedExecResult {
-	return ExpectedExecResult{
-		shouldPanic: false,
-	}
+	return normalExecResult{}
+}
+
+func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState) {
+	// Step the VM
+	state := goVm.GetState()
+	step := state.GetStep()
+	stepWitness, err := goVm.Step(true)
+	require.NoError(t, err)
+
+	// Validate
+	expect.Validate(t, state)
+	testutil.ValidateEVM(t, stepWitness, step, goVm, vmVersion.StateHashFn, vmVersion.Contracts)
+}
+
+type vmPanicResult struct {
+	panicMsg string
+	evmError string
 }
 
 func ExpectPanic(goPanicMsg, evmRevertMsg string) ExpectedExecResult {
-	return ExpectedExecResult{
-		shouldPanic: true,
-		panicMsg:    goPanicMsg,
-		evmError:    evmRevertMsg,
+	return vmPanicResult{
+		panicMsg: goPanicMsg,
+		evmError: evmRevertMsg,
 	}
+}
+
+func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState) {
+	state := goVm.GetState()
+	proofData := vmVersion.ProofGenerator(t, state)
+	errMsg := testutil.CreateErrorStringMatcher(e.evmError)
+	testutil.AssertEVMReverts(t, state, vmVersion.Contracts, nil, proofData, errMsg)
+	require.PanicsWithValue(t, e.panicMsg, func() { _, _ = goVm.Step(false) })
+}
+
+type preimageOracleRevertResult struct {
+	panicMsg       string
+	preimageKey    [32]byte
+	preimageValue  []byte
+	preimageOffset arch.Word
+}
+
+func ExpectPreimageOraclePanic(preimageKey [32]byte, preimageValue []byte, preimageOffset arch.Word, panicMsg string) ExpectedExecResult {
+	return preimageOracleRevertResult{
+		panicMsg:       panicMsg,
+		preimageKey:    preimageKey,
+		preimageValue:  preimageValue,
+		preimageOffset: preimageOffset,
+	}
+}
+
+func (e preimageOracleRevertResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState) {
+	require.PanicsWithValue(t, e.panicMsg, func() { _, _ = goVm.Step(true) })
+	testutil.AssertPreimageOracleReverts(t, e.preimageKey, e.preimageValue, e.preimageOffset, vmVersion.Contracts)
 }
 
 type testcaseT interface {

--- a/cannon/mipsevm/tests/difftester_test.go
+++ b/cannon/mipsevm/tests/difftester_test.go
@@ -110,7 +110,10 @@ func TestDiffTester_Run_WithMemModifications(t *testing.T) {
 			versions := GetMipsVersionTestCases(t)
 			var mods []string
 			if !skipAutomaticMemTests {
-				mods = append(mods, " [mod:overlappingMemReservation]")
+				for _, memTestCase := range memReservationTestCases {
+					modName := fmt.Sprintf(" [mod:%v]", memTestCase.name)
+					mods = append(mods, modName)
+				}
 			}
 			expectedTestCases := generateExpectedTestCases(testCases, versions, mods...)
 

--- a/cannon/mipsevm/tests/difftester_test.go
+++ b/cannon/mipsevm/tests/difftester_test.go
@@ -37,7 +37,7 @@ func TestDiffTester_Run_SimpleTest(t *testing.T) {
 				if useCorrectReturnExpectation {
 					return ExpectNormalExecution()
 				} else {
-					return ExpectPanic("oops", "oops")
+					return ExpectVmPanic("oops", "oops")
 				}
 			}
 
@@ -171,7 +171,7 @@ func TestDiffTester_Run_WithPanic(t *testing.T) {
 				expect.ExpectStep()
 
 				if useCorrectReturnExpectation {
-					return ExpectPanic("unrecognized syscall: 0", "unimplemented syscall")
+					return ExpectVmPanic("unrecognized syscall: 0", "unimplemented syscall")
 				} else {
 					return ExpectNormalExecution()
 				}

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -567,7 +567,7 @@ func TestEVM_SingleStep_DCloDClz64(t *testing.T) {
 			return ExpectNormalExecution()
 		} else {
 			expectedMsg := fmt.Sprintf("invalid instruction: %x", insnFn(tt))
-			return ExpectPanic(expectedMsg, "invalid instruction")
+			return ExpectVmPanic(expectedMsg, "invalid instruction")
 		}
 	}
 

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -641,23 +641,37 @@ func TestEVM_MMap(t *testing.T) {
 	}
 }
 
+func TestEVM_SysGetRandom_isImplemented(t *testing.T) {
+	t.Parallel()
+	// Assert we have at least one vm with the working getrandom syscall
+	foundVmWithSyscallEnabled := false
+	for _, vers := range GetMipsVersionTestCases(t) {
+		features := versions.FeaturesForVersion(vers.Version)
+		foundVmWithSyscallEnabled = foundVmWithSyscallEnabled || features.SupportWorkingSysGetRandom
+	}
+	require.True(t, foundVmWithSyscallEnabled)
+
+	// Assert that latest version has a working getrandom ssycall
+	latestFeatures := versions.FeaturesForVersion(versions.GetExperimentalVersion())
+	require.True(t, latestFeatures.SupportWorkingSysGetRandom)
+}
+
 func TestEVM_SysGetRandom(t *testing.T) {
-	startingMemory := arch.Word(0x1234_5678_8765_4321)
-	effAddr := arch.Word(0x1000_0000)
+	t.Parallel()
 
-	// Random data is generated using the incremented step as the random seed
-	// For validation of this random data see instrumented_test.go TestSplitmix64 unit tests
-	step := uint64(0x1a2b3c4d5e6f7531) - 1
-	randomData := arch.Word(0x4141302768c9e9d0)
-
-	type GetRandomTestCase struct {
+	type testCase struct {
 		name                 string
 		bufAddrOffset        arch.Word
 		bufLen               arch.Word
 		expectedRandDataMask arch.Word
 		expectedReturnValue  arch.Word
 	}
-	cases := []GetRandomTestCase{
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		// Test word-aligned buffer address
 		{name: "Word-aligned buffer, zero bytes requested", bufAddrOffset: 0, bufLen: 0, expectedRandDataMask: 0x0000_0000_0000_0000, expectedReturnValue: 0},
 		{name: "Word-aligned buffer, 1 byte requested", bufAddrOffset: 0, bufLen: 1, expectedRandDataMask: 0xFF00_0000_0000_0000, expectedReturnValue: 1},
@@ -681,38 +695,25 @@ func TestEVM_SysGetRandom(t *testing.T) {
 		{name: "Buffer offset by 6, 8 byte requested", bufAddrOffset: 6, bufLen: 8, expectedRandDataMask: 0x0000_0000_0000_FFFF, expectedReturnValue: 2},
 	}
 
-	// Assert we have at least one vm with the working getrandom syscall
-	foundVmWithSyscallEnabled := false
-	for _, vers := range GetMipsVersionTestCases(t) {
-		features := versions.FeaturesForVersion(vers.Version)
-		foundVmWithSyscallEnabled = foundVmWithSyscallEnabled || features.SupportWorkingSysGetRandom
-	}
-	require.True(t, foundVmWithSyscallEnabled)
+	startingMemory := arch.Word(0x1234_5678_8765_4321)
+	effAddr := arch.Word(0x1000_0000)
+	// Random data is generated using the incremented step as the random seed
+	// For validation of this random data see instrumented_test.go TestSplitmix64 unit tests
+	step := uint64(0x1a2b3c4d5e6f7531) - 1
+	randomData := arch.Word(0x4141302768c9e9d0)
 
-	// Assert that latest version has a working getrandom ssycall
-	latestFeatures := versions.FeaturesForVersion(versions.GetExperimentalVersion())
-	require.True(t, latestFeatures.SupportWorkingSysGetRandom)
-
-	// Run test cases with memory reservation variations
-	testNamer := func(testCase GetRandomTestCase, vmVersion string, reservationTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, reservationTestCase)
-	}
-	MemoryReservationTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase GetRandomTestCase, i int) {
-		isNoop := !versions.FeaturesForVersion(vm.Version).SupportWorkingSysGetRandom
-		expectedMemory := testCase.expectedRandDataMask&randomData | ^testCase.expectedRandDataMask&startingMemory
-
-		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithStep(step))
-		state := goVm.GetState()
-		step := state.GetStep()
-
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase) {
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		state.GetMemory().SetWord(effAddr, startingMemory)
 		state.GetRegistersRef()[register.RegV0] = arch.SysGetRandom
 		state.GetRegistersRef()[register.RegA0] = effAddr + testCase.bufAddrOffset
 		state.GetRegistersRef()[register.RegA1] = testCase.bufLen
-		reservation.SetupState(mtutil.ToMTState(t, state), effAddr)
+	}
 
-		expected := mtutil.NewExpectedState(t, state)
+	setExpectations := func(testCase testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		isNoop := !versions.FeaturesForVersion(vm.Version).SupportWorkingSysGetRandom
+		expectedMemory := testCase.expectedRandDataMask&randomData | ^testCase.expectedRandDataMask&startingMemory
+
 		expected.ExpectStep()
 		if isNoop {
 			expected.ActiveThread().Registers[register.RegSyscallRet1] = 0
@@ -721,16 +722,14 @@ func TestEVM_SysGetRandom(t *testing.T) {
 			expected.ActiveThread().Registers[register.RegSyscallRet1] = testCase.expectedReturnValue
 			expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
 			expected.ExpectMemoryWrite(effAddr, expectedMemory)
-			reservation.SetExpectations(expected)
 		}
+		return ExpectNormalExecution()
+	}
 
-		stepWitness, err := goVm.Step(true)
-		require.NoError(t, err)
-
-		// Check expectations
-		expected.Validate(t, state)
-		testutil.ValidateEVM(t, stepWitness, step, goVm, vm.StateHashFn, vm.Contracts)
-	}, testNamer)
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithStep(step)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysWriteHint(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -8,18 +8,14 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
-	preimage "github.com/ethereum-optimism/optimism/op-preimage"
-
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
-	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
-
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
+	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 )
@@ -382,7 +378,9 @@ func TestEVM_MT64_SCD(t *testing.T) {
 }
 
 func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
-	type testMTSysReadPreimageTestCase struct {
+	t.Parallel()
+
+	type testCase struct {
 		name           string
 		addr           Word
 		count          Word
@@ -393,11 +391,12 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 		shouldPanic    bool
 	}
 
-	preimageValue := make([]byte, 0, 8)
-	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x12_34_56_78)
-	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x98_76_54_32)
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
 	prestateMem := Word(0xEE_EE_EE_EE_FF_FF_FF_FF)
-	cases := []testMTSysReadPreimageTestCase{
+	cases := []testCase{
 		{name: "Aligned addr, write 1 byte", addr: 0x00_00_FF_00, count: 1, writeLen: 1, preimageOffset: 8, prestateMem: prestateMem, postateMem: 0x12_EE_EE_EE_FF_FF_FF_FF},
 		{name: "Aligned addr, write 2 byte", addr: 0x00_00_FF_00, count: 2, writeLen: 2, preimageOffset: 8, prestateMem: prestateMem, postateMem: 0x12_34_EE_EE_FF_FF_FF_FF},
 		{name: "Aligned addr, write 3 byte", addr: 0x00_00_FF_00, count: 3, writeLen: 3, preimageOffset: 8, prestateMem: prestateMem, postateMem: 0x12_34_56_EE_FF_FF_FF_FF},
@@ -433,49 +432,41 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 		{name: "Offset just out of bounds", addr: 0x00_00_FF_00, count: 4, writeLen: 0, preimageOffset: 16, prestateMem: prestateMem, postateMem: 0xEE_EE_EE_EE_FF_FF_FF_FF, shouldPanic: true},
 		{name: "Offset out of bounds", addr: 0x00_00_FF_00, count: 4, writeLen: 0, preimageOffset: 17, prestateMem: prestateMem, postateMem: 0xEE_EE_EE_EE_FF_FF_FF_FF, shouldPanic: true},
 	}
-	testNamer := func(testCase testMTSysReadPreimageTestCase, vmVersion string, memoryTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, memoryTestCase)
-	}
-	MemoryReservationTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTSysReadPreimageTestCase, i int) {
-		effAddr := arch.AddressMask & testCase.addr
-		preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
-		oracle := testutil.StaticOracle(t, preimageValue)
-		goVm := vm.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-		state := mtutil.GetMtState(t, goVm)
-		step := state.GetStep()
 
-		// Set up state
-		state.PreimageKey = preimageKey
+	preimageValue := make([]byte, 0, 8)
+	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x12_34_56_78)
+	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x98_76_54_32)
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		state.PreimageKey = testutil.Keccak256Preimage(preimageValue)
 		state.PreimageOffset = testCase.preimageOffset
 		state.GetRegistersRef()[2] = arch.SysRead
 		state.GetRegistersRef()[4] = exec.FdPreimageRead
 		state.GetRegistersRef()[5] = testCase.addr
 		state.GetRegistersRef()[6] = testCase.count
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-		state.GetMemory().SetWord(effAddr, testCase.prestateMem)
-		reservation.SetupState(state, effAddr)
+		state.GetMemory().SetWord(testutil.EffAddr(testCase.addr), testCase.prestateMem)
+	}
 
-		// Setup expectations
-		expected := mtutil.NewExpectedState(t, state)
+	setExpectations := func(testCase testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.ExpectStep()
 		expected.ActiveThread().Registers[2] = testCase.writeLen
 		expected.ActiveThread().Registers[7] = 0 // no error
 		expected.PreimageOffset += testCase.writeLen
-		expected.ExpectMemoryWrite(effAddr, testCase.postateMem)
-		reservation.SetExpectations(expected)
+		expected.ExpectMemoryWrite(testutil.EffAddr(testCase.addr), testCase.postateMem)
 
 		if testCase.shouldPanic {
-			require.Panics(t, func() { _, _ = goVm.Step(true) })
-			testutil.AssertPreimageOracleReverts(t, preimageKey, preimageValue, testCase.preimageOffset, vm.Contracts)
+			preimageKey := testutil.Keccak256Preimage(preimageValue)
+			return ExpectPreimageOraclePanic(preimageKey, preimageValue, testCase.preimageOffset, "Preimage offset out-of-bounds")
 		} else {
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-
-			// Check expectations
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
+			return ExpectNormalExecution()
 		}
-	}, testNamer)
+	}
+
+	po := func() mipsevm.PreimageOracle { return testutil.StaticOracle(t, preimageValue) }
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases, WithPreimageOracle(po))
 }
 
 func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
@@ -565,7 +556,9 @@ func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
 }
 
 func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
-	type testMTStoreOpsClearMemReservationTestCase struct {
+	t.Parallel()
+
+	type testCase struct {
 		// name is the test name
 		name string
 		// opcode is the instruction opcode
@@ -582,8 +575,11 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 		postMem Word
 	}
 
-	t.Parallel()
-	cases := []testMTStoreOpsClearMemReservationTestCase{
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "Store byte", opcode: 0b10_1000, base: 0xFF_00_00_00, offset: 0x10, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0x78_FF_FF_FF_FF_FF_FF_FF},
 		{name: "Store byte lower", opcode: 0b10_1000, base: 0xFF_00_00_00, offset: 0x14, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0xFF_FF_FF_FF_78_FF_FF_FF},
 		{name: "Store halfword", opcode: 0b10_1001, base: 0xFF_00_00_00, offset: 0x10, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0x56_78_FF_FF_FF_FF_FF_FF},
@@ -595,40 +591,31 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 		{name: "Store word right", opcode: 0b10_1110, base: 0xFF_00_00_00, offset: 0x10, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0x78_FF_FF_FF_FF_FF_FF_FF},
 		{name: "Store word right lower", opcode: 0b10_1110, base: 0xFF_00_00_00, offset: 0x14, effAddr: 0xFF_00_00_10, preMem: ^Word(0), postMem: 0xFF_FF_FF_FF_78_FF_FF_FF},
 	}
+
+	pc := Word(0x08)
 	rt := Word(0x12_34_56_78)
 	//rt := Word(0x12_34_56_78_12_34_56_78)
 	baseReg := uint32(5)
 	rtReg := uint32(6)
-
-	testNamer := func(testCase testMTStoreOpsClearMemReservationTestCase, vmVersion string, memoryTestCase string) string {
-		return fmt.Sprintf("%v (%v,%v)", testCase.name, vmVersion, memoryTestCase)
-	}
-	MemoryReservationTester(t, cases, func(t *testing.T, vm VersionedVMTestCase, reservation MemoryReservationTestCase, testCase testMTStoreOpsClearMemReservationTestCase, i int) {
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase) {
 		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))
-		goVm := vm.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x08))
-		state := mtutil.GetMtState(t, goVm)
-		step := state.GetStep()
 
-		// Setup state
 		state.GetRegistersRef()[rtReg] = rt
 		state.GetRegistersRef()[baseReg] = testCase.base
-		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
 		state.GetMemory().SetWord(testCase.effAddr, testCase.preMem)
-		reservation.SetupState(state, testCase.effAddr)
+	}
 
-		// Setup expectations
-		expected := mtutil.NewExpectedState(t, state)
+	setExpectations := func(testCase testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.ExpectStep()
 		expected.ExpectMemoryWrite(testCase.effAddr, testCase.postMem)
-		reservation.SetExpectations(expected)
+		return ExpectNormalExecution()
+	}
 
-		stepWitness, err := goVm.Step(true)
-		require.NoError(t, err)
-
-		// Check expectations
-		expected.Validate(t, state)
-		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), vm.Contracts)
-	}, testNamer)
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithPCAndNextPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 var NoopSyscalls64 = map[string]uint32{

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -238,65 +238,6 @@ func testBranch(t *testing.T, cases []branchTestCase) {
 	}
 }
 
-type MemoryReservationTestCase struct {
-	name                   string
-	llReservationStatus    multithreaded.LLReservationStatus
-	matchThreadId          bool
-	effAddrOffset          Word
-	shouldClearReservation bool
-}
-
-func (m MemoryReservationTestCase) SetupState(state *multithreaded.State, effAddr Word) {
-	llAddress := effAddr + m.effAddrOffset
-	llOwnerThread := state.GetCurrentThread().ThreadId
-	if !m.matchThreadId {
-		llOwnerThread += 1
-	}
-
-	state.LLReservationStatus = m.llReservationStatus
-	state.LLAddress = llAddress
-	state.LLOwnerThread = llOwnerThread
-}
-
-func (m MemoryReservationTestCase) SetExpectations(expected *mtutil.ExpectedState) {
-	if m.shouldClearReservation {
-		expected.ExpectMemoryReservationCleared()
-	}
-}
-
-var memoryReservationTestCases = []MemoryReservationTestCase{
-	{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, shouldClearReservation: true},
-	{name: "matching reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, shouldClearReservation: true},
-	{name: "matching reservation, unaligned", llReservationStatus: multithreaded.LLStatusActive32bit, effAddrOffset: 1, matchThreadId: true, shouldClearReservation: true},
-	{name: "matching reservation, 64-bit, unaligned", llReservationStatus: multithreaded.LLStatusActive64bit, effAddrOffset: 5, matchThreadId: true, shouldClearReservation: true},
-	{name: "matching reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, shouldClearReservation: true},
-	{name: "matching reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, shouldClearReservation: true},
-	{name: "mismatched reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
-	{name: "mismatched reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
-	{name: "mismatched reservation, diff thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
-	{name: "mismatched reservation, diff thread, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, effAddrOffset: 8, shouldClearReservation: false},
-	{name: "no reservation, matching addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, shouldClearReservation: true},
-	{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, effAddrOffset: 8, shouldClearReservation: false},
-}
-
-type MemoryReservationTest[T any] func(t *testing.T, vmVersion VersionedVMTestCase, llVariation MemoryReservationTestCase, testCase T, index int)
-type MemoryTestNamer[T any] func(testCase T, vmVersion string, memoryTestCase string) string
-
-func MemoryReservationTester[T any](t *testing.T, cases []T, testFn MemoryReservationTest[T], testNamer MemoryTestNamer[T]) {
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, vmVersion := range vmVersions {
-		for i, c := range cases {
-			for _, reservationTestCase := range memoryReservationTestCases {
-				tName := testNamer(c, vmVersion.Name, reservationTestCase.name)
-				t.Run(tName, func(t *testing.T) {
-					t.Parallel()
-					testFn(t, vmVersion, reservationTestCase, c, i)
-				})
-			}
-		}
-	}
-}
-
 func testNoopSyscall(t *testing.T, vm VersionedVMTestCase, syscalls map[string]uint32) {
 	type testCase struct {
 		name      string

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -125,7 +125,7 @@ func testMulDiv(t *testing.T, templateCases []mulDivTestCase, mips32Insn bool) {
 
 	setExpectations := func(tt mulDivTestCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		if tt.panicMsg != "" {
-			return ExpectPanic(tt.panicMsg, tt.revertMsg)
+			return ExpectVmPanic(tt.panicMsg, tt.revertMsg)
 		} else {
 			expected.ExpectStep()
 			if tt.expectRes != 0 {
@@ -354,7 +354,7 @@ func testUnsupportedSyscall(t *testing.T, vm VersionedVMTestCase, unsupportedSys
 
 	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		goErr := fmt.Sprintf("unrecognized syscall: %v", tt.sycallNum)
-		return ExpectPanic(goErr, "unimplemented syscall")
+		return ExpectVmPanic(goErr, "unimplemented syscall")
 	}
 
 	NewDiffTester(testNamer).

--- a/cannon/mipsevm/testutil/memory.go
+++ b/cannon/mipsevm/testutil/memory.go
@@ -37,3 +37,7 @@ func GetInstruction(mem *memory.Memory, pc arch.Word) uint32 {
 	}
 	return uint32(exec.LoadSubWord(mem, pc, 4, false, new(exec.NoopMemoryTracker)))
 }
+
+func EffAddr(addr arch.Word) arch.Word {
+	return addr & arch.AddressMask
+}

--- a/cannon/mipsevm/testutil/preimage.go
+++ b/cannon/mipsevm/testutil/preimage.go
@@ -1,0 +1,11 @@
+package testutil
+
+import (
+	"github.com/ethereum/go-ethereum/crypto"
+
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+)
+
+func Keccak256Preimage(data []byte) [32]byte {
+	return preimage.Keccak256Key(crypto.Keccak256Hash(data)).PreimageKey()
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrate memory reservation-related tests to use new DiffTester framework.   Builds on https://github.com/ethereum-optimism/optimism/pull/16608.

Incorporate memory-reservation test helper into difftester framework by default.  Update execution expectations to include a new case where the preimage oracle reverts / panics. 

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483
