### PR TITLE
feat[op-node]: p2p flag to configure maximum age of payload

### DIFF
--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -868,10 +868,6 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		}
 
 		if p, ok := p2pNodes[name]; ok {
-			// Set the gossip timestamp threshold from the node's P2P config if available
-			if p2pConfig, ok := c.P2P.(*p2p.Config); ok {
-				p.GossipTimestampThreshold = p2pConfig.GetGossipTimestampThreshold()
-			}
 			c.P2P = p
 
 			if c.Driver.SequencerEnabled && c.P2PSigner == nil {

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -868,6 +868,10 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		}
 
 		if p, ok := p2pNodes[name]; ok {
+			// Set the gossip timestamp threshold from the node's P2P config if available
+			if p2pConfig, ok := c.P2P.(*p2p.Config); ok {
+				p.GossipTimestampThreshold = p2pConfig.GetGossipTimestampThreshold()
+			}
 			c.P2P = p
 
 			if c.Driver.SequencerEnabled && c.P2PSigner == nil {

--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -15,47 +15,48 @@ func p2pEnv(envprefix, v string) []string {
 }
 
 var (
-	DisableP2PName          = "p2p.disable"
-	NoDiscoveryName         = "p2p.no-discovery"
-	ScoringName             = "p2p.scoring"
-	PeerScoringName         = "p2p.scoring.peers"
-	PeerScoreBandsName      = "p2p.score.bands"
-	BanningName             = "p2p.ban.peers"
-	BanningThresholdName    = "p2p.ban.threshold"
-	BanningDurationName     = "p2p.ban.duration"
-	TopicScoringName        = "p2p.scoring.topics"
-	P2PPrivPathName         = "p2p.priv.path"
-	P2PPrivRawName          = "p2p.priv.raw"
-	ListenIPName            = "p2p.listen.ip"
-	ListenTCPPortName       = "p2p.listen.tcp"
-	ListenUDPPortName       = "p2p.listen.udp"
-	AdvertiseIPName         = "p2p.advertise.ip"
-	AdvertiseTCPPortName    = "p2p.advertise.tcp"
-	AdvertiseUDPPortName    = "p2p.advertise.udp"
-	BootnodesName           = "p2p.bootnodes"
-	StaticPeersName         = "p2p.static"
-	NetRestrictName         = "p2p.netrestrict"
-	HostMuxName             = "p2p.mux"
-	HostSecurityName        = "p2p.security"
-	PeersLoName             = "p2p.peers.lo"
-	PeersHiName             = "p2p.peers.hi"
-	PeersGraceName          = "p2p.peers.grace"
-	NATName                 = "p2p.nat"
-	UserAgentName           = "p2p.useragent"
-	TimeoutNegotiationName  = "p2p.timeout.negotiation"
-	TimeoutAcceptName       = "p2p.timeout.accept"
-	TimeoutDialName         = "p2p.timeout.dial"
-	PeerstorePathName       = "p2p.peerstore.path"
-	DiscoveryPathName       = "p2p.discovery.path"
-	SequencerP2PKeyName     = "p2p.sequencer.key"
-	GossipMeshDName         = "p2p.gossip.mesh.d"
-	GossipMeshDloName       = "p2p.gossip.mesh.lo"
-	GossipMeshDhiName       = "p2p.gossip.mesh.dhi"
-	GossipMeshDlazyName     = "p2p.gossip.mesh.dlazy"
-	GossipFloodPublishName  = "p2p.gossip.mesh.floodpublish"
-	SyncReqRespName         = "p2p.sync.req-resp"
-	SyncOnlyReqToStaticName = "p2p.sync.onlyreqtostatic"
-	P2PPingName             = "p2p.ping"
+	DisableP2PName               = "p2p.disable"
+	NoDiscoveryName              = "p2p.no-discovery"
+	ScoringName                  = "p2p.scoring"
+	PeerScoringName              = "p2p.scoring.peers"
+	PeerScoreBandsName           = "p2p.score.bands"
+	BanningName                  = "p2p.ban.peers"
+	BanningThresholdName         = "p2p.ban.threshold"
+	BanningDurationName          = "p2p.ban.duration"
+	TopicScoringName             = "p2p.scoring.topics"
+	P2PPrivPathName              = "p2p.priv.path"
+	P2PPrivRawName               = "p2p.priv.raw"
+	ListenIPName                 = "p2p.listen.ip"
+	ListenTCPPortName            = "p2p.listen.tcp"
+	ListenUDPPortName            = "p2p.listen.udp"
+	AdvertiseIPName              = "p2p.advertise.ip"
+	AdvertiseTCPPortName         = "p2p.advertise.tcp"
+	AdvertiseUDPPortName         = "p2p.advertise.udp"
+	BootnodesName                = "p2p.bootnodes"
+	StaticPeersName              = "p2p.static"
+	NetRestrictName              = "p2p.netrestrict"
+	HostMuxName                  = "p2p.mux"
+	HostSecurityName             = "p2p.security"
+	PeersLoName                  = "p2p.peers.lo"
+	PeersHiName                  = "p2p.peers.hi"
+	PeersGraceName               = "p2p.peers.grace"
+	NATName                      = "p2p.nat"
+	UserAgentName                = "p2p.useragent"
+	TimeoutNegotiationName       = "p2p.timeout.negotiation"
+	TimeoutAcceptName            = "p2p.timeout.accept"
+	TimeoutDialName              = "p2p.timeout.dial"
+	PeerstorePathName            = "p2p.peerstore.path"
+	DiscoveryPathName            = "p2p.discovery.path"
+	SequencerP2PKeyName          = "p2p.sequencer.key"
+	GossipMeshDName              = "p2p.gossip.mesh.d"
+	GossipMeshDloName            = "p2p.gossip.mesh.lo"
+	GossipMeshDhiName            = "p2p.gossip.mesh.dhi"
+	GossipMeshDlazyName          = "p2p.gossip.mesh.dlazy"
+	GossipFloodPublishName       = "p2p.gossip.mesh.floodpublish"
+	GossipTimestampThresholdName = "p2p.gossip.timestamp.threshold"
+	SyncReqRespName              = "p2p.sync.req-resp"
+	SyncOnlyReqToStaticName      = "p2p.sync.onlyreqtostatic"
+	P2PPingName                  = "p2p.ping"
 )
 
 func deprecatedP2PFlags(envPrefix string) []cli.Flag {
@@ -384,6 +385,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Hidden:   true,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_FLOOD_PUBLISH"),
+			Category: P2PCategory,
+		},
+		&cli.DurationFlag{
+			Name:     GossipTimestampThresholdName,
+			Usage:    "Threshold for rejecting gossip messages with payload timestamps older than this duration. Default is 60 seconds.",
+			Required: false,
+			Value:    60 * time.Second,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_TIMESTAMP_THRESHOLD"),
 			Category: P2PCategory,
 		},
 		&cli.BoolFlag{

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -377,5 +377,6 @@ func loadGossipOptions(conf *p2p.Config, ctx *cli.Context) error {
 	conf.MeshDHi = ctx.Int(flags.GossipMeshDhiName)
 	conf.MeshDLazy = ctx.Int(flags.GossipMeshDlazyName)
 	conf.FloodPublish = ctx.Bool(flags.GossipFloodPublishName)
+	conf.GossipTimestampThreshold = ctx.Duration(flags.GossipTimestampThresholdName)
 	return nil
 }

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -120,6 +120,9 @@ type Config struct {
 	// FloodPublish publishes messages from ourselves to peers outside of the gossip topic mesh but supporting the same topic.
 	FloodPublish bool
 
+	// GossipTimestampThreshold is the threshold for rejecting gossip messages with payload timestamps older than this duration
+	GossipTimestampThreshold time.Duration
+
 	// If true a NAT manager will host a NAT port mapping that is updated with PMP and UPNP by libp2p/go-nat
 	NAT bool
 
@@ -176,6 +179,10 @@ func (conf *Config) BanDuration() time.Duration {
 
 func (conf *Config) ReqRespSyncEnabled() bool {
 	return conf.EnableReqRespSync
+}
+
+func (conf *Config) GetGossipTimestampThreshold() time.Duration {
+	return conf.GossipTimestampThreshold
 }
 
 const maxMeshParam = 1000

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -154,7 +154,7 @@ func TestBlockValidator(t *testing.T) {
 	peerID := peer.ID("foo")
 
 	// Create a mock gossip configuration for testing
-	mockGossipConf := &mockGossipSetupConfigurables{}
+	mockGossipConf := &mockGossipSetupConfigurablesWithThreshold{threshold: 60 * time.Second}
 	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockGossipConf)
 	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3, mockGossipConf)
 	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV4, mockGossipConf)
@@ -211,21 +211,6 @@ func TestBlockValidator(t *testing.T) {
 			require.Equal(t, res, test.result)
 		})
 	}
-}
-
-// mockGossipSetupConfigurables implements GossipSetupConfigurables for testing
-type mockGossipSetupConfigurables struct{}
-
-func (m *mockGossipSetupConfigurables) PeerScoringParams() *ScoringParams {
-	return nil
-}
-
-func (m *mockGossipSetupConfigurables) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
-	return nil
-}
-
-func (m *mockGossipSetupConfigurables) GetGossipTimestampThreshold() time.Duration {
-	return 60 * time.Second // Default value for testing
 }
 
 // TestGossipTimestampThreshold tests that the configurable timestamp threshold works correctly

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -273,7 +273,7 @@ func TestGossipTimestampThreshold(t *testing.T) {
 			message := &pubsub.Message{Message: &pubsub_pb.Message{Data: data}}
 
 			// Test validation
-			result := validator(context.TODO(), peerID, message)
+			result := validator(context.Background(), peerID, message)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -153,9 +153,11 @@ func TestBlockValidator(t *testing.T) {
 	// Params Set 2: Call the validation function
 	peerID := peer.ID("foo")
 
-	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2)
-	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3)
-	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV4)
+	// Create a mock gossip configuration for testing
+	mockGossipConf := &mockGossipSetupConfigurables{}
+	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockGossipConf)
+	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3, mockGossipConf)
+	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV4, mockGossipConf)
 
 	zero, one := uint64(0), uint64(1)
 	beaconHash, withdrawalsRoot := common.HexToHash("0x1234"), common.HexToHash("0x9876")
@@ -209,4 +211,102 @@ func TestBlockValidator(t *testing.T) {
 			require.Equal(t, res, test.result)
 		})
 	}
+}
+
+// mockGossipSetupConfigurables implements GossipSetupConfigurables for testing
+type mockGossipSetupConfigurables struct{}
+
+func (m *mockGossipSetupConfigurables) PeerScoringParams() *ScoringParams {
+	return nil
+}
+
+func (m *mockGossipSetupConfigurables) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
+	return nil
+}
+
+func (m *mockGossipSetupConfigurables) GetGossipTimestampThreshold() time.Duration {
+	return 60 * time.Second // Default value for testing
+}
+
+// TestGossipTimestampThreshold tests that the configurable timestamp threshold works correctly
+func TestGossipTimestampThreshold(t *testing.T) {
+	cfg := &rollup.Config{
+		L2ChainID: big.NewInt(100),
+	}
+	secrets, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.PublicKey)}
+	signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
+	peerID := peer.ID("foo")
+
+	// Test with different threshold values
+	testCases := []struct {
+		name           string
+		threshold      time.Duration
+		payloadTime    time.Time
+		expectedResult pubsub.ValidationResult
+	}{
+		{
+			name:           "AcceptWithinThreshold",
+			threshold:      30 * time.Second,
+			payloadTime:    time.Now().Add(-15 * time.Second), // 15 seconds ago
+			expectedResult: pubsub.ValidationAccept,
+		},
+		{
+			name:           "RejectOutsideThreshold",
+			threshold:      30 * time.Second,
+			payloadTime:    time.Now().Add(-45 * time.Second), // 45 seconds ago
+			expectedResult: pubsub.ValidationReject,
+		},
+		{
+			name:           "AcceptWithLongerThreshold",
+			threshold:      120 * time.Second,
+			payloadTime:    time.Now().Add(-90 * time.Second), // 90 seconds ago
+			expectedResult: pubsub.ValidationAccept,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a mock config with the specific threshold
+			mockConfig := &mockGossipSetupConfigurablesWithThreshold{threshold: tc.threshold}
+
+			// Create validator with the mock config
+			validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockConfig)
+
+			// Create payload with the specific timestamp
+			payload := createExecutionPayload(types.Withdrawals{}, nil, nil, nil)
+			payload.Timestamp = hexutil.Uint64(tc.payloadTime.Unix())
+			// Set block number to avoid duplicate block validation issues
+			payload.BlockNumber = hexutil.Uint64(time.Now().Unix())
+			// Set a valid block hash for the payload
+			payload.BlockHash, _ = (&eth.ExecutionPayloadEnvelope{ExecutionPayload: payload}).CheckBlockHash()
+
+			// Create signed message
+			data, err := createSignedP2Payload(payload, signer, cfg.L2ChainID)
+			require.NoError(t, err)
+			message := &pubsub.Message{Message: &pubsub_pb.Message{Data: data}}
+
+			// Test validation
+			result := validator(context.TODO(), peerID, message)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+// mockGossipSetupConfigurablesWithThreshold implements GossipSetupConfigurables with configurable threshold
+type mockGossipSetupConfigurablesWithThreshold struct {
+	threshold time.Duration
+}
+
+func (m *mockGossipSetupConfigurablesWithThreshold) PeerScoringParams() *ScoringParams {
+	return nil
+}
+
+func (m *mockGossipSetupConfigurablesWithThreshold) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
+	return nil
+}
+
+func (m *mockGossipSetupConfigurablesWithThreshold) GetGossipTimestampThreshold() time.Duration {
+	return m.threshold
 }

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -164,7 +164,7 @@ func (n *NodeP2P) init(
 	if err != nil {
 		return fmt.Errorf("failed to start gossipsub router: %w", err)
 	}
-	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, gossipIn)
+	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, gossipIn, setup)
 	if err != nil {
 		return fmt.Errorf("failed to join blocks gossip topic: %w", err)
 	}

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -25,9 +25,6 @@ type Prepared struct {
 	UDPv5     *discover.UDPv5
 
 	EnableReqRespSync bool
-
-	// GossipTimestampThreshold is the threshold for rejecting gossip messages with old timestamps
-	GossipTimestampThreshold time.Duration
 }
 
 var _ SetupP2P = (*Prepared)(nil)
@@ -97,8 +94,5 @@ func (p *Prepared) ReqRespSyncEnabled() bool {
 }
 
 func (p *Prepared) GetGossipTimestampThreshold() time.Duration {
-	if p.GossipTimestampThreshold == 0 {
-		return 60 * time.Second // Default fallback
-	}
-	return p.GossipTimestampThreshold
+	return 60 * time.Second
 }

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -92,3 +92,7 @@ func (p *Prepared) Disabled() bool {
 func (p *Prepared) ReqRespSyncEnabled() bool {
 	return p.EnableReqRespSync
 }
+
+func (p *Prepared) GetGossipTimestampThreshold() time.Duration {
+	return 60 * time.Second // Default value for prepared setup
+}

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -25,6 +25,9 @@ type Prepared struct {
 	UDPv5     *discover.UDPv5
 
 	EnableReqRespSync bool
+
+	// GossipTimestampThreshold is the threshold for rejecting gossip messages with old timestamps
+	GossipTimestampThreshold time.Duration
 }
 
 var _ SetupP2P = (*Prepared)(nil)
@@ -94,5 +97,8 @@ func (p *Prepared) ReqRespSyncEnabled() bool {
 }
 
 func (p *Prepared) GetGossipTimestampThreshold() time.Duration {
-	return 60 * time.Second // Default value for prepared setup
+	if p.GossipTimestampThreshold == 0 {
+		return 60 * time.Second // Default fallback
+	}
+	return p.GossipTimestampThreshold
 }


### PR DESCRIPTION
**Description**

This PR adds a configurable `GossipTimestampThreshold` flag to allow operators to customize the age threshold for rejecting gossip messages with old payload timestamps. Previously, this was hard-coded to 60 seconds.

**Tests**

`op-node/p2p/gossip_test.go`
- Added tests to confirm the configured threshold is respected
- Created mock implementations for testing different threshold values

`op-e2e/system/e2esys/setup.go`
- Updated e2e setup to pass configured threshold to `Prepared` struct

I also ran the kurtosis devnet locally with a custom value in the new flag to make sure it works.

**Additional context**

The gossip validation logic had a hard-coded 60-second threshold for rejecting messages with old timestamps. This means that when a node falls out of sync by over a minute, the node will not be able to catch up on blocks until the next batch submission triggers derivation. In a controlled environment this 60 second cutoff is too aggressive. For chain operators who have isolated clusters, for example, this threshold can be much looser.