### PR TITLE
dispute-mon: remove lazy dial option

### DIFF
--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -169,7 +169,7 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 		return nil
 	}
 	for _, rpc := range cfg.RollupRpc {
-		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc, rpcclient.WithLazyDial())
+		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client %s: %w", rpc, err)
 		}


### PR DESCRIPTION
This fixes a problem with https://github.com/ethereum-optimism/optimism/pull/16490: The lazy dial option was added to prevent op-dispute-mon from failing on startup if one of the nodes wasn't available, but actually it doesn't work with `DialRollupClientWithTimeout`. A future PR will implement a better solution.