### PR TITLE
Update the Sepolia SuperchainConfig Implementation

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -241,7 +241,7 @@ func TestPopulateSuperchainState(t *testing.T) {
 	require.Equal(t, addresses.SuperchainContracts{
 		SuperchainProxyAdminImpl: common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"),
 		SuperchainConfigProxy:    superchain.SuperchainConfigAddr,
-		SuperchainConfigImpl:     common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
+		SuperchainConfigImpl:     common.HexToAddress("0xCe28685EB204186b557133766eCA00334EB441E4"),
 		ProtocolVersionsProxy:    superchain.ProtocolVersionsAddr,
 		ProtocolVersionsImpl:     common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 	}, *dep)


### PR DESCRIPTION
This PR updates the Sepolia SuperchainConfig Implementation since some tests are failling with the previous implementation required. 
-  from`0x4da82a327773965b8d4D85Fa3dB8249b387458E7` to `0xCe28685EB204186b557133766eCA00334EB441E4`. 