### PR TITLE
cannon: Migrate custom mem reservation tests

### DIFF
--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -19,7 +19,7 @@ import (
 
 type TestNamer[T any] func(testCase T) string
 
-type InitializeStateFn[T any] func(testCase T, state *multithreaded.State, vm VersionedVMTestCase)
+type InitializeStateFn[T any] func(testCase T, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
 type SetExpectationsFn[T any] func(testCase T, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
 
 type DiffTester[T any] struct {
@@ -73,7 +73,8 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 					state := mtutil.GetMtState(t, goVm)
 
 					// Set up state
-					d.initState(testCase, state, vm)
+					r := testutil.NewRandHelper(randSeed * 2)
+					d.initState(testCase, state, vm, r)
 					mod.stateMod(state)
 
 					// Set up expectations

--- a/cannon/mipsevm/tests/difftester_test.go
+++ b/cannon/mipsevm/tests/difftester_test.go
@@ -24,7 +24,7 @@ func TestDiffTester_Run_SimpleTest(t *testing.T) {
 		testName := fmt.Sprintf("useCorrectReturnExpectation=%v", useCorrectReturnExpectation)
 		t.Run(testName, func(t *testing.T) {
 			initStateCalled := make(map[string]int)
-			initState := func(testCase simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+			initState := func(testCase simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 				initStateCalled[testCase.name] += 1
 				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), testCase.insn)
 			}
@@ -91,7 +91,7 @@ func TestDiffTester_Run_WithMemModifications(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 
 			initStateCalled := make(map[string]int)
-			initState := func(tt simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+			initState := func(tt simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 				initStateCalled[tt.name] += 1
 				testutil.StoreInstruction(state.GetMemory(), pc, tt.insn)
 				state.GetMemory().SetWord(effAddr, 0xAA_BB_CC_DD_A1_B1_C1_D1)
@@ -159,7 +159,7 @@ func TestDiffTester_Run_WithPanic(t *testing.T) {
 		testName := fmt.Sprintf("useCorrectReturnExpectation=%v", useCorrectReturnExpectation)
 		t.Run(testName, func(t *testing.T) {
 			initStateCalled := make(map[string]int)
-			initState := func(testCase simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+			initState := func(testCase simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 				initStateCalled[testCase.name] += 1
 				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), testCase.insn)
 				state.GetRegistersRef()[2] = syscallNum
@@ -220,7 +220,7 @@ func TestDiffTester_Run_WithVm(t *testing.T) {
 	}
 
 	initStateCalled := make(map[string]int)
-	initState := func(testCase simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(testCase simpleTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		initStateCalled[testCase.name] += 1
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), testCase.insn)
 	}

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -554,7 +554,7 @@ func TestEVM_SingleStep_DCloDClz64(t *testing.T) {
 		return features.SupportDclzDclo
 	}), "dclz/dclo feature not tested")
 
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insnFn(tt))
 		state.GetRegistersRef()[rsReg] = tt.rs
 	}

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -703,7 +703,7 @@ func TestEVM_SysGetRandom(t *testing.T) {
 	step := uint64(0x1a2b3c4d5e6f7531) - 1
 	randomData := arch.Word(0x4141302768c9e9d0)
 
-	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		state.GetMemory().SetWord(effAddr, startingMemory)
 		state.GetRegistersRef()[register.RegV0] = arch.SysGetRandom

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -96,13 +96,14 @@ func TestEVM_MT64_LL(t *testing.T) {
 }
 
 func TestEVM_MT64_SC(t *testing.T) {
-	llVariations := []struct {
+	type llVariation struct {
 		name                string
 		llReservationStatus multithreaded.LLReservationStatus
 		matchThreadId       bool
 		matchAddr           bool
 		shouldSucceed       bool
-	}{
+	}
+	llVariations := []llVariation{
 		{name: "should succeed", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: true, shouldSucceed: true},
 		{name: "mismatch addr", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
 		{name: "mismatched thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
@@ -111,7 +112,7 @@ func TestEVM_MT64_SC(t *testing.T) {
 		{name: "no active reservation", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchAddr: true, shouldSucceed: false},
 	}
 
-	cases := []struct {
+	type baseTest struct {
 		name           string
 		base           Word
 		offset         int
@@ -120,7 +121,8 @@ func TestEVM_MT64_SC(t *testing.T) {
 		expectedMemVal Word
 		rtReg          int
 		threadId       Word
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "8-byte-aligned addr", base: 0x01, offset: 0x0137, addr: 0x0138, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
 		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0138, addr: 0x0139, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
 		{name: "8-byte-aligned addr, signed extended", base: 0x01, offset: 0xFF37, addr: 0xFFFF_FFFF_FFFF_FF38, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 4},
@@ -132,70 +134,70 @@ func TestEVM_MT64_SC(t *testing.T) {
 		{name: "Return register set to 0", base: 0x01, offset: 0x0138, addr: 0x0139, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 0, threadId: 4},
 		{name: "Zero valued ll args", base: 0x0, offset: 0x0, value: 0xABCD, expectedMemVal: 0xABCD_0000_0000, rtReg: 5, threadId: 0},
 	}
-	versions := GetMipsVersionTestCases(t)
-	for _, ver := range versions {
-		for i, c := range cases {
-			for _, llVar := range llVariations {
-				tName := fmt.Sprintf("%v (%v, %v)", c.name, ver.Name, llVar.name)
-				t.Run(tName, func(t *testing.T) {
-					effAddr := arch.AddressMask & c.addr
 
-					// Setup
-					rtReg := c.rtReg
-					baseReg := 6
-					insn := uint32((0b11_1000 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-					state := mtutil.GetMtState(t, goVm)
-					mtutil.InitializeSingleThread(i*23456, state, i%2 == 1, mtutil.WithPCAndNextPC(0x40))
-					step := state.GetStep()
-
-					// Define LL-related params
-					var llAddress, llOwnerThread Word
-					if llVar.matchAddr {
-						llAddress = c.addr
-					} else {
-						llAddress = c.addr + 1
-					}
-					if llVar.matchThreadId {
-						llOwnerThread = c.threadId
-					} else {
-						llOwnerThread = c.threadId + 1
-					}
-
-					// Setup state
-					state.GetCurrentThread().ThreadId = c.threadId
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetRegistersRef()[baseReg] = c.base
-					state.GetRegistersRef()[rtReg] = c.value
-					state.LLReservationStatus = llVar.llReservationStatus
-					state.LLAddress = llAddress
-					state.LLOwnerThread = llOwnerThread
-
-					// Setup expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					var retVal Word
-					if llVar.shouldSucceed {
-						retVal = 1
-						expected.ExpectMemoryWrite(effAddr, c.expectedMemVal)
-						expected.ExpectMemoryReservationCleared()
-					} else {
-						retVal = 0
-					}
-					if rtReg != 0 {
-						expected.ActiveThread().Registers[rtReg] = retVal
-					}
-
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, llVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		llVar := tt.Variation
+
+		rtReg := c.rtReg
+		baseReg := 6
+		insn := uint32((0b11_1000 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
+
+		traverseRight := r.Intn(2) == 1
+		mtutil.InitializeSingleThread(r.Intn(10000), state, traverseRight, mtutil.WithPCAndNextPC(0x40))
+
+		// Define LL-related params
+		var llAddress, llOwnerThread Word
+		if llVar.matchAddr {
+			llAddress = c.addr
+		} else {
+			llAddress = c.addr + 1
+		}
+		if llVar.matchThreadId {
+			llOwnerThread = c.threadId
+		} else {
+			llOwnerThread = c.threadId + 1
+		}
+
+		// Setup state
+		state.GetCurrentThread().ThreadId = c.threadId
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetRegistersRef()[baseReg] = c.base
+		state.GetRegistersRef()[rtReg] = c.value
+		state.LLReservationStatus = llVar.llReservationStatus
+		state.LLAddress = llAddress
+		state.LLOwnerThread = llOwnerThread
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		c := tt.Base
+		llVar := tt.Variation
+
+		expected.ExpectStep()
+		var retVal Word
+		if llVar.shouldSucceed {
+			retVal = 1
+			expected.ExpectMemoryWrite(testutil.EffAddr(c.addr), c.expectedMemVal)
+			expected.ExpectMemoryReservationCleared()
+		} else {
+			retVal = 0
+		}
+		if c.rtReg != 0 {
+			expected.ActiveThread().Registers[c.rtReg] = retVal
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases, SkipAutomaticMemoryReservationTests())
 }
 
 func TestEVM_MT64_LLD(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -274,14 +274,14 @@ func TestEVM_MT64_LLD(t *testing.T) {
 }
 
 func TestEVM_MT64_SCD(t *testing.T) {
-	value := Word(0x11223344_55667788)
-	llVariations := []struct {
+	type llVariation struct {
 		name                string
 		llReservationStatus multithreaded.LLReservationStatus
 		matchThreadId       bool
 		matchAddr           bool
 		shouldSucceed       bool
-	}{
+	}
+	llVariations := []llVariation{
 		{name: "should succeed", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchAddr: true, shouldSucceed: true},
 		{name: "mismatch addr", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
 		{name: "mismatched thread", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
@@ -290,14 +290,15 @@ func TestEVM_MT64_SCD(t *testing.T) {
 		{name: "no active reservation", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchAddr: true, shouldSucceed: false},
 	}
 
-	cases := []struct {
+	type baseTest struct {
 		name     string
 		base     Word
 		offset   int
 		addr     Word
 		rtReg    int
 		threadId Word
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "Aligned addr", base: 0x01, offset: 0x0137, addr: 0x0138, rtReg: 5, threadId: 4},
 		{name: "Unaligned addr, offset=1", base: 0x01, offset: 0x0100, addr: 0x0101, rtReg: 5, threadId: 4},
 		{name: "Unaligned addr, offset=2", base: 0x02, offset: 0x0100, addr: 0x0102, rtReg: 5, threadId: 4},
@@ -311,70 +312,71 @@ func TestEVM_MT64_SCD(t *testing.T) {
 		{name: "Return register set to 0", base: 0x01, offset: 0x0138, addr: 0x0139, rtReg: 0, threadId: 4},
 		{name: "Zero valued ll args", base: 0x0, offset: 0x0, rtReg: 5, threadId: 0},
 	}
-	versions := GetMipsVersionTestCases(t)
-	for _, ver := range versions {
-		for i, c := range cases {
-			for _, llVar := range llVariations {
-				tName := fmt.Sprintf("%v (%v,%v)", c.name, ver.Name, llVar.name)
-				t.Run(tName, func(t *testing.T) {
-					effAddr := arch.AddressMask & c.addr
 
-					// Setup
-					rtReg := c.rtReg
-					baseReg := 6
-					insn := uint32((0b11_1100 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-					state := mtutil.GetMtState(t, goVm)
-					mtutil.InitializeSingleThread(i*23456, state, i%2 == 1, mtutil.WithPCAndNextPC(0x40))
-					step := state.GetStep()
-
-					// Define LL-related params
-					var llAddress, llOwnerThread Word
-					if llVar.matchAddr {
-						llAddress = c.addr
-					} else {
-						llAddress = c.addr + 1
-					}
-					if llVar.matchThreadId {
-						llOwnerThread = c.threadId
-					} else {
-						llOwnerThread = c.threadId + 1
-					}
-
-					// Setup state
-					state.GetCurrentThread().ThreadId = c.threadId
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetRegistersRef()[baseReg] = c.base
-					state.GetRegistersRef()[rtReg] = value
-					state.LLReservationStatus = llVar.llReservationStatus
-					state.LLAddress = llAddress
-					state.LLOwnerThread = llOwnerThread
-
-					// Setup expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					var retVal Word
-					if llVar.shouldSucceed {
-						retVal = 1
-						expected.ExpectMemoryWrite(effAddr, value)
-						expected.ExpectMemoryReservationCleared()
-					} else {
-						retVal = 0
-					}
-					if rtReg != 0 {
-						expected.ActiveThread().Registers[rtReg] = retVal
-					}
-
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, llVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+
+	value := Word(0x11223344_55667788)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		llVar := tt.Variation
+
+		traverseRight := r.Intn(2) == 1
+		mtutil.InitializeSingleThread(r.Intn(10000), state, traverseRight, mtutil.WithPCAndNextPC(0x40))
+
+		// Define LL-related params
+		var llAddress, llOwnerThread Word
+		if llVar.matchAddr {
+			llAddress = c.addr
+		} else {
+			llAddress = c.addr + 1
+		}
+		if llVar.matchThreadId {
+			llOwnerThread = c.threadId
+		} else {
+			llOwnerThread = c.threadId + 1
+		}
+
+		// Setup state
+		baseReg := 6
+		insn := uint32((0b11_1100 << 26) | (baseReg & 0x1F << 21) | (c.rtReg & 0x1F << 16) | (0xFFFF & c.offset))
+
+		state.GetCurrentThread().ThreadId = c.threadId
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetRegistersRef()[baseReg] = c.base
+		state.GetRegistersRef()[c.rtReg] = value
+		state.LLReservationStatus = llVar.llReservationStatus
+		state.LLAddress = llAddress
+		state.LLOwnerThread = llOwnerThread
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		c := tt.Base
+		llVar := tt.Variation
+
+		expected.ExpectStep()
+		var retVal Word
+		if llVar.shouldSucceed {
+			retVal = 1
+			expected.ExpectMemoryWrite(testutil.EffAddr(c.addr), value)
+			expected.ExpectMemoryReservationCleared()
+		} else {
+			retVal = 0
+		}
+		if c.rtReg != 0 {
+			expected.ActiveThread().Registers[c.rtReg] = retVal
+		}
+
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases, SkipAutomaticMemoryReservationTests())
 }
 
 func TestEVM_MT_SysRead_Preimage64(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -436,7 +436,7 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 	preimageValue := make([]byte, 0, 8)
 	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x12_34_56_78)
 	preimageValue = binary.BigEndian.AppendUint32(preimageValue, 0x98_76_54_32)
-	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		state.PreimageKey = testutil.Keccak256Preimage(preimageValue)
 		state.PreimageOffset = testCase.preimageOffset
 		state.GetRegistersRef()[2] = arch.SysRead
@@ -597,7 +597,7 @@ func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {
 	//rt := Word(0x12_34_56_78_12_34_56_78)
 	baseReg := uint32(5)
 	rtReg := uint32(6)
-	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := uint32((testCase.opcode << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & testCase.offset))
 
 		state.GetRegistersRef()[rtReg] = rt

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -139,7 +139,7 @@ func TestEVM_MT64_SC(t *testing.T) {
 	testNamer := func(tc testCase) string {
 		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
-	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+	cases := testutil.TestVariations(baseTests, llVariations)
 
 	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		c := tt.Base
@@ -319,7 +319,7 @@ func TestEVM_MT64_SCD(t *testing.T) {
 	testNamer := func(tc testCase) string {
 		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
-	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+	cases := testutil.TestVariations(baseTests, llVariations)
 
 	value := Word(0x11223344_55667788)
 	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -807,14 +807,15 @@ func TestEVM_SysClockGettimeRealtime(t *testing.T) {
 }
 
 func testEVM_SysClockGettime(t *testing.T, clkid Word) {
-	llVariations := []struct {
+	type llVariation struct {
 		name                   string
 		llReservationStatus    multithreaded.LLReservationStatus
 		matchThreadId          bool
 		matchEffAddr           bool
 		matchEffAddr2          bool
 		shouldClearReservation bool
-	}{
+	}
+	llVariations := []llVariation{
 		{name: "matching reservation", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchEffAddr: true, shouldClearReservation: true},
 		{name: "matching reservation, 64-bit", llReservationStatus: multithreaded.LLStatusActive64bit, matchThreadId: true, matchEffAddr: true, shouldClearReservation: true},
 		{name: "matching reservation, 2nd word", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchEffAddr2: true, shouldClearReservation: true},
@@ -828,77 +829,82 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 		{name: "no reservation, mismatched addr", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchEffAddr: false, shouldClearReservation: false},
 	}
 
-	cases := []struct {
+	type baseTest struct {
 		name         string
 		timespecAddr Word
-	}{
+	}
+	baseTests := []baseTest{
 		{"aligned timespec address", 0x1000},
 		{"unaligned timespec address", 0x1003},
 	}
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			for _, llVar := range llVariations {
-				tName := fmt.Sprintf("%v (%v,%v)", c.name, ver.Name, llVar.name)
-				t.Run(tName, func(t *testing.T) {
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(2101)))
-					state := mtutil.GetMtState(t, goVm)
-					mtutil.InitializeSingleThread(2101+i, state, i%2 == 1)
-					effAddr := c.timespecAddr & arch.AddressMask
-					effAddr2 := effAddr + arch.WordSizeBytes
-					step := state.Step
 
-					// Define LL-related params
-					var llAddress, llOwnerThread Word
-					if llVar.matchEffAddr {
-						llAddress = effAddr
-					} else if llVar.matchEffAddr2 {
-						llAddress = effAddr2
-					} else {
-						llAddress = effAddr2 + 8
-					}
-					if llVar.matchThreadId {
-						llOwnerThread = state.GetCurrentThread().ThreadId
-					} else {
-						llOwnerThread = state.GetCurrentThread().ThreadId + 1
-					}
-
-					testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-					state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
-					state.GetRegistersRef()[4] = clkid                // a0
-					state.GetRegistersRef()[5] = c.timespecAddr       // a1
-					state.LLReservationStatus = llVar.llReservationStatus
-					state.LLAddress = llAddress
-					state.LLOwnerThread = llOwnerThread
-
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.ActiveThread().Registers[2] = 0
-					expected.ActiveThread().Registers[7] = 0
-					next := state.Step + 1
-					var secs, nsecs Word
-					if clkid == exec.ClockGettimeMonotonicFlag {
-						secs = Word(next / exec.HZ)
-						nsecs = Word((next % exec.HZ) * (1_000_000_000 / exec.HZ))
-					}
-					expected.ExpectMemoryWrite(effAddr, secs)
-					expected.ExpectMemoryWrite(effAddr2, nsecs)
-					if llVar.shouldClearReservation {
-						expected.ExpectMemoryReservationCleared()
-					}
-
-					var err error
-					var stepWitness *mipsevm.StepWitness
-					stepWitness, err = goVm.Step(true)
-					require.NoError(t, err)
-
-					// Validate post-state
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, llVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		llVar := tt.Variation
+
+		traverseRight := r.Intn(2) == 1
+		mtutil.InitializeSingleThread(r.Intn(10000), state, traverseRight)
+		effAddr := c.timespecAddr & arch.AddressMask
+		effAddr2 := effAddr + arch.WordSizeBytes
+
+		// Define LL-related params
+		var llAddress, llOwnerThread Word
+		if llVar.matchEffAddr {
+			llAddress = effAddr
+		} else if llVar.matchEffAddr2 {
+			llAddress = effAddr2
+		} else {
+			llAddress = effAddr2 + 8
+		}
+		if llVar.matchThreadId {
+			llOwnerThread = state.GetCurrentThread().ThreadId
+		} else {
+			llOwnerThread = state.GetCurrentThread().ThreadId + 1
+		}
+
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
+		state.GetRegistersRef()[4] = clkid                // a0
+		state.GetRegistersRef()[5] = c.timespecAddr       // a1
+		state.LLReservationStatus = llVar.llReservationStatus
+		state.LLAddress = llAddress
+		state.LLOwnerThread = llOwnerThread
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		c := tt.Base
+		llVar := tt.Variation
+
+		effAddr := c.timespecAddr & arch.AddressMask
+		effAddr2 := effAddr + arch.WordSizeBytes
+
+		expected.ExpectStep()
+		incrementedStep := expected.Step
+		expected.ActiveThread().Registers[2] = 0
+		expected.ActiveThread().Registers[7] = 0
+		var secs, nsecs Word
+		if clkid == exec.ClockGettimeMonotonicFlag {
+			secs = Word(incrementedStep / exec.HZ)
+			nsecs = Word((incrementedStep % exec.HZ) * (1_000_000_000 / exec.HZ))
+		}
+		expected.ExpectMemoryWrite(effAddr, secs)
+		expected.ExpectMemoryWrite(effAddr2, nsecs)
+		if llVar.shouldClearReservation {
+			expected.ExpectMemoryReservationCleared()
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases, SkipAutomaticMemoryReservationTests())
 }
 
 func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -132,7 +132,7 @@ func TestEVM_MT_SC(t *testing.T) {
 	testNamer := func(tc testCase) string {
 		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
-	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+	cases := testutil.TestVariations(baseTests, llVariations)
 
 	// Set up some test values that will be reused
 	memValue := uint64(0x1122_3344_5566_7788)
@@ -842,7 +842,7 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 	testNamer := func(tc testCase) string {
 		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
-	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+	cases := testutil.TestVariations(baseTests, llVariations)
 
 	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		c := tt.Base

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -95,16 +95,14 @@ func TestEVM_MT_LL(t *testing.T) {
 }
 
 func TestEVM_MT_SC(t *testing.T) {
-	// Set up some test values that will be reused
-	memValue := uint64(0x1122_3344_5566_7788)
-
-	llVariations := []struct {
+	type llVariation struct {
 		name                string
 		llReservationStatus multithreaded.LLReservationStatus
 		matchThreadId       bool
 		matchAddr           bool
 		shouldSucceed       bool
-	}{
+	}
+	llVariations := []llVariation{
 		{name: "should succeed", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: true, shouldSucceed: true},
 		{name: "mismatch thread", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: false, matchAddr: true, shouldSucceed: false},
 		{name: "mismatched addr", llReservationStatus: multithreaded.LLStatusActive32bit, matchThreadId: true, matchAddr: false, shouldSucceed: false},
@@ -113,8 +111,7 @@ func TestEVM_MT_SC(t *testing.T) {
 		{name: "no active reservation", llReservationStatus: multithreaded.LLStatusNone, matchThreadId: true, matchAddr: true, shouldSucceed: false},
 	}
 
-	// Note: Some parameters are written as 64-bit values. For 32-bit architectures, these values are downcast to 32-bit
-	cases := []struct {
+	type baseTest struct {
 		name         string
 		base         Word
 		offset       int
@@ -122,75 +119,79 @@ func TestEVM_MT_SC(t *testing.T) {
 		storeValue   uint32
 		rtReg        int
 		threadId     Word
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "Aligned addr", base: 0x01, offset: 0x0133, expectedAddr: 0x0134, storeValue: 0xAABB_CCDD, rtReg: 5, threadId: 4},
 		{name: "Aligned addr, signed extended", base: 0x01, offset: 0xFF33, expectedAddr: 0xFFFF_FFFF_FFFF_FF34, storeValue: 0xAABB_CCDD, rtReg: 5, threadId: 4},
 		{name: "Unaligned addr", base: 0xFF12_0001, offset: 0x3404, expectedAddr: 0xFF12_3405, storeValue: 0xAABB_CCDD, rtReg: 5, threadId: 4},
 		{name: "Unaligned addr, sign extended w overflow", base: 0xFF12_0001, offset: 0x8404, expectedAddr: 0xFF_11_8405, storeValue: 0xAABB_CCDD, rtReg: 5, threadId: 4},
 		{name: "Return register set to 0", base: 0xFF12_0001, offset: 0x7403, expectedAddr: 0xFF12_7404, storeValue: 0xAABB_CCDD, rtReg: 0, threadId: 4},
 	}
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			for _, llVar := range llVariations {
-				tName := fmt.Sprintf("%v (%v,%v)", c.name, ver.Name, llVar.name)
-				t.Run(tName, func(t *testing.T) {
-					rtReg := c.rtReg
-					baseReg := 6
-					insn := uint32((0b11_1000 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-					state := mtutil.GetMtState(t, goVm)
-					mtutil.InitializeSingleThread(i*23456, state, i%2 == 1, mtutil.WithPCAndNextPC(0x40))
-					step := state.GetStep()
 
-					// Define LL-related params
-					var llAddress, llOwnerThread Word
-					if llVar.matchAddr {
-						llAddress = Word(c.expectedAddr)
-					} else {
-						llAddress = Word(c.expectedAddr) + 1
-					}
-					if llVar.matchThreadId {
-						llOwnerThread = c.threadId
-					} else {
-						llOwnerThread = c.threadId + 1
-					}
-
-					// Setup state
-					testutil.SetMemoryUint64(t, state.GetMemory(), Word(c.expectedAddr), memValue)
-					state.GetCurrentThread().ThreadId = c.threadId
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetRegistersRef()[baseReg] = c.base
-					state.GetRegistersRef()[rtReg] = Word(c.storeValue)
-					state.LLReservationStatus = llVar.llReservationStatus
-					state.LLAddress = llAddress
-					state.LLOwnerThread = llOwnerThread
-
-					// Setup expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					var retVal Word
-					if llVar.shouldSucceed {
-						retVal = 1
-						expected.ExpectMemoryWriteUint32(t, Word(c.expectedAddr), c.storeValue)
-						expected.ExpectMemoryReservationCleared()
-					} else {
-						retVal = 0
-					}
-					if rtReg != 0 {
-						expected.ActiveThread().Registers[rtReg] = retVal
-					}
-
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, llVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v_%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.ApplyTestVariations(baseTests, llVariations)
+
+	// Set up some test values that will be reused
+	memValue := uint64(0x1122_3344_5566_7788)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		llVar := tt.Variation
+
+		traverseRight := r.Intn(2) == 1
+		mtutil.InitializeSingleThread(r.Intn(10000), state, traverseRight, mtutil.WithPCAndNextPC(0x40))
+
+		// Define LL-related params
+		var llAddress, llOwnerThread Word
+		if llVar.matchAddr {
+			llAddress = Word(c.expectedAddr)
+		} else {
+			llAddress = Word(c.expectedAddr) + 1
+		}
+		if llVar.matchThreadId {
+			llOwnerThread = c.threadId
+		} else {
+			llOwnerThread = c.threadId + 1
+		}
+
+		// Setup state
+		baseReg := 6
+		insn := uint32((0b11_1000 << 26) | (baseReg & 0x1F << 21) | (c.rtReg & 0x1F << 16) | (0xFFFF & c.offset))
+		testutil.SetMemoryUint64(t, state.GetMemory(), Word(c.expectedAddr), memValue)
+		state.GetCurrentThread().ThreadId = c.threadId
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetRegistersRef()[baseReg] = c.base
+		state.GetRegistersRef()[c.rtReg] = Word(c.storeValue)
+		state.LLReservationStatus = llVar.llReservationStatus
+		state.LLAddress = llAddress
+		state.LLOwnerThread = llOwnerThread
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		c := tt.Base
+		llVar := tt.Variation
+
+		expected.ExpectStep()
+		var retVal Word
+		if llVar.shouldSucceed {
+			retVal = 1
+			expected.ExpectMemoryWriteUint32(t, Word(c.expectedAddr), c.storeValue)
+			expected.ExpectMemoryReservationCleared()
+		} else {
+			retVal = 0
+		}
+		if c.rtReg != 0 {
+			expected.ActiveThread().Registers[c.rtReg] = retVal
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases, SkipAutomaticMemoryReservationTests())
 }
 
 func TestEVM_SysClone_FlagHandling(t *testing.T) {

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -116,7 +116,7 @@ func testMulDiv(t *testing.T, templateCases []mulDivTestCase, mips32Insn bool) {
 	rtReg := uint32(0xa)
 	pc := arch.Word(0)
 
-	initState := func(tt mulDivTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt mulDivTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := tt.opcode<<26 | baseReg<<21 | rtReg<<16 | tt.rdReg<<11 | tt.funct
 		state.GetRegistersRef()[rtReg] = tt.rt
 		state.GetRegistersRef()[baseReg] = tt.rs
@@ -169,7 +169,7 @@ func testLoadStore(t *testing.T, cases []loadStoreTestCase) {
 	rtReg := uint32(8)
 	pc := arch.Word(0)
 
-	initState := func(tt loadStoreTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt loadStoreTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := tt.opcode<<26 | baseReg<<21 | rtReg<<16 | tt.imm
 
 		testutil.StoreInstruction(state.GetMemory(), pc, insn)
@@ -253,7 +253,7 @@ func testNoopSyscall(t *testing.T, vm VersionedVMTestCase, syscalls map[string]u
 		cases = append(cases, testCase{name: name, sycallNum: arch.Word(syscallNum)})
 	}
 
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = tt.sycallNum // Set syscall number
 	}
@@ -288,7 +288,7 @@ func testUnsupportedSyscall(t *testing.T, vm VersionedVMTestCase, unsupportedSys
 		cases = append(cases, testCase{name: name, sycallNum: arch.Word(syscallNum)})
 	}
 
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = tt.sycallNum // Set syscall number
 	}

--- a/cannon/mipsevm/testutil/helpers.go
+++ b/cannon/mipsevm/testutil/helpers.go
@@ -1,0 +1,16 @@
+package testutil
+
+type TestCaseVariation[C, V any] struct {
+	Base      C
+	Variation V
+}
+
+func ApplyTestVariations[C, V any](cases []C, variations []V) []TestCaseVariation[C, V] {
+	out := make([]TestCaseVariation[C, V], 0, len(cases)*len(variations))
+	for _, baseTestCase := range cases {
+		for _, variation := range variations {
+			out = append(out, TestCaseVariation[C, V]{Base: baseTestCase, Variation: variation})
+		}
+	}
+	return out
+}

--- a/cannon/mipsevm/testutil/helpers.go
+++ b/cannon/mipsevm/testutil/helpers.go
@@ -5,7 +5,7 @@ type TestCaseVariation[C, V any] struct {
 	Variation V
 }
 
-func ApplyTestVariations[C, V any](cases []C, variations []V) []TestCaseVariation[C, V] {
+func TestVariations[C, V any](cases []C, variations []V) []TestCaseVariation[C, V] {
 	out := make([]TestCaseVariation[C, V], 0, len(cases)*len(variations))
 	for _, baseTestCase := range cases {
 		for _, variation := range variations {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrate differential tests with custom memory reservation setup to use the new DiffTester framework (introduced [here](https://github.com/ethereum-optimism/optimism/pull/16608)).  

For these tests we use the `SkipAutomaticMemoryReservationTests()` test option since memory reservation testing is already covered explicitly.

Introduce a few new helpers and dependencies to support these tests:
- Add `TestVariations()` util to build test case set from base cases and variations
- Add `RandHelper` to `InitializeStateFn` signature

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483