### PR TITLE
op-acceptance-tests: Temporal test skip for op-geth bump

### DIFF
--- a/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
+++ b/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestRegularMessage checks that messages can be sent and relayed via L2ToL2CrossDomainMessenger
 func TestRegularMessage(gt *testing.T) {
+	gt.Skip() // TODO(#16731) Fix to handle the op-geth version bump to v1.101511.1
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -552,6 +552,7 @@ func executeIndexedFault(
 // TestExecMessageInvalidAttributes tests below scenario:
 // Execute message, but with one or more invalid attributes inside identifiers
 func TestExecMessageInvalidAttributes(gt *testing.T) {
+	gt.Skip() // TODO(#16731) Fix to handle the op-geth version bump to v1.101511.1
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

After op-geth release to `v1.101511.1`, we have consistent interop acceptance test failures. Temporally skip them, to reduce noise. 

**Additional context**

Tests will be back, tracked at https://github.com/ethereum-optimism/optimism/issues/16731