### PR TITLE
chore(acceptance-tests): Update optimism-package to 1.4.0

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,7 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@011513f7a420befce41861dd046d64ebd685ac19
+  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@d295369dc96a9abbe891b2bcd4bd8a6db6c54171
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Update the `optimism-package` (a.k.a. kurtosis) to v1.4.0 (using its commit hash). See release notes [here](https://github.com/ethpandaops/optimism-package/commit/d295369dc96a9abbe891b2bcd4bd8a6db6c54171)
