### PR TITLE
kurtosis: Add rollup.interopmempoolfiltering to ELs

### DIFF
--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -17,6 +17,7 @@
 {{- $flags := dict
   "log_level" "--log.level=info"
   "log_format" "--log.format=logfmtms"
+  "interop_mempool_filtering" "--rollup.interopmempoolfiltering"
 -}}
 ---
 optimism_package:
@@ -46,7 +47,9 @@ optimism_package:
             log_level: ""
             extra_env_vars: {}
             extra_labels: {}
-            extra_params: []
+            extra_params:
+            - "--http.api admin,debug,eth,miner,net,txpool,web3"
+            - {{ $flags.interop_mempool_filtering }}
             tolerations: []
             volume_size: 0
             min_cpu: 0

--- a/kurtosis-devnet/interop.yaml
+++ b/kurtosis-devnet/interop.yaml
@@ -48,7 +48,6 @@ optimism_package:
             extra_env_vars: {}
             extra_labels: {}
             extra_params:
-            - "--http.api admin,debug,eth,miner,net,txpool,web3"
             - {{ $flags.interop_mempool_filtering }}
             tolerations: []
             volume_size: 0

--- a/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
+++ b/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
@@ -16,7 +16,6 @@ import (
 
 // TestRegularMessage checks that messages can be sent and relayed via L2ToL2CrossDomainMessenger
 func TestRegularMessage(gt *testing.T) {
-	gt.Skip() // TODO(#16731) Fix to handle the op-geth version bump to v1.101511.1
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -552,7 +552,6 @@ func executeIndexedFault(
 // TestExecMessageInvalidAttributes tests below scenario:
 // Execute message, but with one or more invalid attributes inside identifiers
 func TestExecMessageInvalidAttributes(gt *testing.T) {
-	gt.Skip() // TODO(#16731) Fix to handle the op-geth version bump to v1.101511.1
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()


### PR DESCRIPTION
Our Acceptance Tests send transactions directly to the Sequencer for block building. While this is good for simple network testing, it does not match a production topology, where proxyd and other mempools would buffer the sequencer.

However, we *did* follow the guidance of interop topology, and never enabled Ingress Filtering for the sequencer. This meant that most transactions got filtered out at block building time.

Recently, we removed the check during block building, and two tests began failing because invalid transactions were causing unexpected reorgs on the chain.

To fix this, I enabled ingress filtering on all ELs in the interop devnet. This does not match the guidance that the sequencer should not need to filter, *however* the topology already does not match. If tests used proxyd, they would be more accurate to production and we would not need to do this.