### PR TITLE
opd: remove -rc tag from op-contracts in standard.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250620202749-6b65f330434d
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250725185431-12c490e5f1bf
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4 h1:dNSl6HTSLsjQH8644PzLijoeMK0vyeQVEMfYVUTxGf4=
 github.com/ethereum-optimism/op-geth v1.101511.1-0.20250602182422-2ba5f6b747a4/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250620202749-6b65f330434d h1:hAgJ89B40bIk7BNHt61Noe3kVQCs9niFli0CeSiJnEY=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250620202749-6b65f330434d/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250725185431-12c490e5f1bf h1:ZS3mS5yUqHSmHgoS7zzWsieyvdOZylupL1NWyR9Wsbg=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250725185431-12c490e5f1bf/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -1,12 +1,10 @@
 package pipeline
 
 import (
-	"context"
 	"log/slog"
 	"math/big"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
@@ -15,188 +13,12 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
-
-func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
-	t.Parallel()
-
-	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
-	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
-
-	lgr := testlog.Logger(t, slog.LevelInfo)
-	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
-	require.NoError(t, retryProxy.Start())
-	t.Cleanup(func() {
-		require.NoError(t, retryProxy.Stop())
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
-	require.NoError(t, err)
-	client := ethclient.NewClient(rpcClient)
-
-	l1ChainID := uint64(11155111)
-	t.Run("untagged L1 locator", func(t *testing.T) {
-		st := &state.State{
-			Version: 1,
-		}
-		require.NoError(t, InitLiveStrategy(
-			ctx,
-			&Env{
-				L1Client: client,
-				Logger:   lgr,
-			},
-			&state.Intent{
-				L1ChainID:          l1ChainID,
-				L1ContractsLocator: artifacts.MustNewLocatorFromURL("file:///not-a-path"),
-				L2ContractsLocator: artifacts.MustNewLocatorFromURL("file:///not-a-path"),
-			},
-			st,
-		))
-
-		// Defining a file locator will always deploy a new superchain and OPCM
-		require.Nil(t, st.SuperchainDeployment)
-		require.Nil(t, st.ImplementationsDeployment)
-	})
-
-	t.Run("tagged L1 locator with standard intent types and standard roles", func(t *testing.T) {
-		runTest := func(configType state.IntentType) {
-			_, afacts := testutil.LocalArtifacts(t)
-			host, err := env.DefaultForkedScriptHost(
-				ctx,
-				broadcaster.NoopBroadcaster(),
-				testlog.Logger(t, log.LevelInfo),
-				common.Address{'D'},
-				afacts,
-				rpcClient,
-			)
-			require.NoError(t, err)
-
-			stdSuperchainRoles, err := state.GetStandardSuperchainRoles(l1ChainID)
-			require.NoError(t, err)
-
-			opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, artifacts.DefaultL1ContractsLocator.Tag)
-			require.NoError(t, err)
-
-			intent := &state.Intent{
-				ConfigType:         configType,
-				L1ChainID:          l1ChainID,
-				L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
-				L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-				OPCMAddress:        &opcmAddr,
-			}
-			st := &state.State{
-				Version: 1,
-			}
-			require.NoError(t, InitLiveStrategy(
-				ctx,
-				&Env{
-					L1Client:     client,
-					Logger:       lgr,
-					L1ScriptHost: host,
-				},
-				intent,
-				st,
-			))
-
-			// Defining a file locator will always deploy a new superchain and OPCM
-			superCfg, err := standard.SuperchainFor(l1ChainID)
-			require.NoError(t, err)
-			proxyAdmin, err := standard.SuperchainProxyAdminAddrFor(l1ChainID)
-			require.NoError(t, err)
-
-			expDeployment := &addresses.SuperchainContracts{
-				SuperchainProxyAdminImpl: proxyAdmin,
-				ProtocolVersionsProxy:    superCfg.ProtocolVersionsAddr,
-				ProtocolVersionsImpl:     common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
-				SuperchainConfigProxy:    superCfg.SuperchainConfigAddr,
-				SuperchainConfigImpl:     common.HexToAddress("0x4da82a327773965b8d4D85Fa3dB8249b387458E7"),
-			}
-
-			// Tagged locator will reuse the existing superchain and OPCM
-			require.NotNil(t, st.SuperchainDeployment)
-			require.NotNil(t, st.ImplementationsDeployment)
-			require.NotNil(t, st.SuperchainRoles)
-			require.Equal(t, *expDeployment, *st.SuperchainDeployment)
-			require.Equal(t, opcmAddr, st.ImplementationsDeployment.OpcmImpl)
-			require.Equal(t, *stdSuperchainRoles, *st.SuperchainRoles)
-		}
-
-		runTest(state.IntentTypeStandard)
-		runTest(state.IntentTypeStandardOverrides)
-	})
-
-	t.Run("tagged L1 locator with standard intent types and modified roles", func(t *testing.T) {
-		runTest := func(configType state.IntentType) {
-			intent := &state.Intent{
-				ConfigType:         configType,
-				L1ChainID:          l1ChainID,
-				L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
-				L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-				SuperchainRoles: &addresses.SuperchainRoles{
-					SuperchainGuardian: common.Address{0: 99},
-				},
-			}
-			st := &state.State{
-				Version: 1,
-			}
-			require.NoError(t, InitLiveStrategy(
-				ctx,
-				&Env{
-					L1Client: client,
-					Logger:   lgr,
-				},
-				intent,
-				st,
-			))
-
-			// Modified roles will cause a new superchain and OPCM to be deployed
-			require.Nil(t, st.SuperchainDeployment)
-			require.Nil(t, st.ImplementationsDeployment)
-		}
-
-		runTest(state.IntentTypeStandard)
-		runTest(state.IntentTypeStandardOverrides)
-	})
-
-	t.Run("tagged locator with custom intent type", func(t *testing.T) {
-		intent := &state.Intent{
-			ConfigType:         state.IntentTypeCustom,
-			L1ChainID:          l1ChainID,
-			L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
-			L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-			SuperchainRoles: &addresses.SuperchainRoles{
-				SuperchainGuardian: common.Address{0: 99},
-			},
-		}
-		st := &state.State{
-			Version: 1,
-		}
-		require.NoError(t, InitLiveStrategy(
-			ctx,
-			&Env{
-				L1Client: client,
-				Logger:   lgr,
-			},
-			intent,
-			st,
-		))
-
-		// Custom intent types always deploy a new superchain and OPCM
-		require.Nil(t, st.SuperchainDeployment)
-		require.Nil(t, st.ImplementationsDeployment)
-	})
-}
 
 // TestPopulateSuperchainState validates that the ReadSuperchainDeployment script successfully returns data about the
 // given Superchain. For testing purposes, we use a forked script host that points to a pinned block on Sepolia. Pinning

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,7 +42,7 @@ const (
 	ContractsV170Beta1L2Tag = "op-contracts/v1.7.0-beta.1+l2-contracts"
 	ContractsV200Tag        = "op-contracts/v2.0.0"
 	ContractsV300Tag        = "op-contracts/v3.0.0"
-	ContractsV400Tag        = "op-contracts/v4.0.0-rc.8"
+	ContractsV400Tag        = "op-contracts/v4.0.0"
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")


### PR DESCRIPTION
No longer an -rc as U16 has passed governance.