### PR TITLE
gnosis: move code out of main pkg

### DIFF
--- a/op-chain-ops/cmd/gnosis/main.go
+++ b/op-chain-ops/cmd/gnosis/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/version"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/gnosis"
 	"github.com/urfave/cli/v2"
 )
 
@@ -23,13 +24,13 @@ func main() {
 	app.Version = VersionWithMeta
 	app.Name = "gnosis"
 	app.Usage = "tool to interact with pre-deployed gnosis safe contracts"
-	app.Flags = cliapp.ProtectFlags(GlobalFlags)
+	app.Flags = cliapp.ProtectFlags(gnosis.GlobalFlags)
 	app.Commands = []*cli.Command{
 		{
 			Name:   "send-tx",
 			Usage:  "send tx via Gnosis Safe using calldata",
-			Flags:  cliapp.ProtectFlags(SendGnosisTxFlags),
-			Action: SendGnosisTransactionCLI,
+			Flags:  cliapp.ProtectFlags(gnosis.SendGnosisTxFlags),
+			Action: gnosis.SendGnosisTransactionCLI,
 		},
 	}
 	app.Writer = os.Stdout

--- a/op-service/gnosis/cli.go
+++ b/op-service/gnosis/cli.go
@@ -1,4 +1,4 @@
-package main
+package gnosis
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
-	"github.com/ethereum-optimism/optimism/op-service/gnosis"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
@@ -61,8 +60,8 @@ func SendGnosisTransactionCLI(cliCtx *cli.Context) error {
 		return fmt.Errorf("invalid calldata: %s", calldataHex)
 	}
 
-	gnosisClient, err := gnosis.NewGnosisClient(lgr, rpcUrl, privateKeys, safeAddress,
-		gnosis.WithCustomTxMgr(func(cfg *txmgr.CLIConfig) { cfg.NumConfirmations = 1 }),
+	gnosisClient, err := NewGnosisClient(lgr, rpcUrl, privateKeys, safeAddress,
+		WithCustomTxMgr(func(cfg *txmgr.CLIConfig) { cfg.NumConfirmations = 1 }),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create gnosis client: %w", err)

--- a/op-service/gnosis/flags.go
+++ b/op-service/gnosis/flags.go
@@ -1,4 +1,4 @@
-package main
+package gnosis
 
 import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"


### PR DESCRIPTION
Moving some cli code back into op-service/gnosis package so that we can import it into `netchef`. Previously it was part of a `main` pkg, which meant it couldn't be imported.

The cli app itself remains in op-chain-ops, which then imports from op-service/gnosis