### PR TITLE
feat[op-batcher]: admin rpc to flush the batcher

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -116,6 +116,8 @@ type BatchSubmitter struct {
 	prevCurrentL1   eth.L1BlockRef // cached CurrentL1 from the last syncStatus
 
 	throttleController *throttler.ThrottleController
+
+	publishSignal chan struct{}
 }
 
 // NewBatchSubmitter initializes the BatchSubmitter driver from a preconfigured DriverSetup
@@ -171,7 +173,8 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	// Channels used to signal between the loops
 	pendingBytesUpdated := make(chan int64, 1)
-	publishSignal := make(chan struct{}, 1)
+	publishSignal := make(chan struct{})
+	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)
 	if l.Config.ThrottleParams.Threshold > 0 {
@@ -254,6 +257,52 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	l.cancelKillCtx()
 
 	l.Log.Info("Batch Submitter stopped")
+	return nil
+}
+
+// FlushBatchSubmitting forces the batcher to submit any pending data immediately.
+// This works by signaling the publishing loop to process any available data.
+func (l *BatchSubmitter) FlushBatchSubmitting(ctx context.Context) error {
+	l.Log.Info("Flushing Batch Submitter")
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if !l.running {
+		return ErrBatcherNotRunning
+	}
+
+	// Get current L1 head for channel processing
+	l1tip, _, err := l.l1Tip(ctx)
+	if err != nil {
+		l.Log.Error("Failed to query L1 tip", "err", err)
+		return err
+	}
+
+	// Process any pending blocks and output frames in a thread-safe way
+	l.channelMgrMutex.Lock()
+	_, err = l.channelMgr.getReadyChannel(l1tip.ID())
+	l.channelMgrMutex.Unlock()
+
+	// getReadyChannel returns io.EOF when there's no data to process, which is fine for flush
+	if err == io.EOF {
+		l.Log.Info("No transaction data available to flush")
+		return nil
+	} else if err != nil {
+		l.Log.Error("Unable to process blocks and generate frames", "err", err)
+		return err
+	}
+
+	// Signal the publishing loop to immediately process any available data
+	// This ensures the publishing loop picks up the newly processed frames
+	if l.publishSignal != nil {
+		trySignal(l.publishSignal)
+		l.Log.Info("Signaled publishing loop to process flushed data")
+	} else {
+		l.Log.Warn("Publishing signal channel is nil, flush will not trigger immediate processing")
+	}
+
+	l.Log.Info("Batch Submitter flush completed")
 	return nil
 }
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -173,7 +173,7 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	// Channels used to signal between the loops
 	pendingBytesUpdated := make(chan int64, 1)
-	publishSignal := make(chan struct{})
+	publishSignal := make(chan struct{}, 1)
 	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +50,21 @@ func (p *mockL2EndpointProvider) RollupClient(context.Context) (dial.RollupClien
 func (p *mockL2EndpointProvider) Close() {}
 
 const genesisL1Origin = uint64(123)
+
+// mockL1Client implements the L1Client interface for testing
+type mockL1Client struct{}
+
+func (m *mockL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	// Return a mock L1 header
+	return &types.Header{
+		Number: big.NewInt(1000),
+		Time:   1000000,
+	}, nil
+}
+
+func (m *mockL1Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
 
 func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 	ep := newEndpointProvider()
@@ -335,4 +353,42 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	t.Run("two normal endpoints", testThrottlingEndpoints(2, 0))
 	t.Run("two failing endpoints", testThrottlingEndpoints(0, 2))
 	t.Run("one normal endpoint, one failing endpoint", testThrottlingEndpoints(1, 1))
+}
+
+func TestBatchSubmitter_FlushBatchSubmitting(t *testing.T) {
+	bs, ep := setup(t)
+
+	// Test that flush fails when batcher is not running
+	err := bs.FlushBatchSubmitting(context.Background())
+	require.Error(t, err)
+	require.Equal(t, ErrBatcherNotRunning, err)
+
+	// Mock L1 tip response - set this up before starting the batcher
+	ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{
+		HeadL1: eth.L1BlockRef{
+			Number: 1000,
+			Hash:   [32]byte{0x01},
+		},
+	}, nil)
+
+	// Set the L1 client and batcher configuration
+	bs.L1Client = &mockL1Client{}
+	bs.Config = BatcherConfig{
+		PollInterval: 100 * time.Millisecond, // Use a reasonable poll interval for testing
+	}
+
+	// Start the batcher
+	err = bs.StartBatchSubmitting()
+	require.NoError(t, err)
+
+	// Verify that the publish signal channel was created
+	require.NotNil(t, bs.publishSignal)
+
+	// Test that flush succeeds when batcher is running
+	err = bs.FlushBatchSubmitting(context.Background())
+	require.NoError(t, err)
+
+	// Stop the batcher
+	err = bs.StopBatchSubmitting(context.Background())
+	require.NoError(t, err)
 }

--- a/op-batcher/rpc/api.go
+++ b/op-batcher/rpc/api.go
@@ -15,6 +15,7 @@ import (
 type BatcherDriver interface {
 	StartBatchSubmitting() error
 	StopBatchSubmitting(ctx context.Context) error
+	FlushBatchSubmitting(ctx context.Context) error
 	SetThrottleController(controllerType config.ThrottleControllerType, pidConfig *config.PIDConfig) error
 	GetThrottleControllerInfo() (config.ThrottleControllerInfo, error)
 	ResetThrottleController() error
@@ -86,4 +87,8 @@ func (a *adminAPI) GetThrottleController(_ context.Context) (config.ThrottleCont
 // ResetThrottleController resets the current throttle controller state
 func (a *adminAPI) ResetThrottleController(_ context.Context) error {
 	return a.b.ResetThrottleController()
+}
+
+func (a *adminAPI) FlushBatcher(ctx context.Context) error {
+	return a.b.FlushBatchSubmitting(ctx)
 }

--- a/op-service/apis/batcher.go
+++ b/op-service/apis/batcher.go
@@ -5,6 +5,7 @@ import "context"
 type BatcherActivity interface {
 	StartBatcher(ctx context.Context) error
 	StopBatcher(ctx context.Context) error
+	FlushBatcher(ctx context.Context) error
 }
 
 type BatcherAdminServer interface {

--- a/op-service/sources/batcher_admin_client.go
+++ b/op-service/sources/batcher_admin_client.go
@@ -26,3 +26,7 @@ func (cl *BatcherAdminClient) StartBatcher(ctx context.Context) error {
 func (cl *BatcherAdminClient) StopBatcher(ctx context.Context) error {
 	return cl.client.CallContext(ctx, nil, "admin_stopBatcher")
 }
+
+func (cl *BatcherAdminClient) FlushBatcher(ctx context.Context) error {
+	return cl.client.CallContext(ctx, nil, "admin_flushBatcher")
+}


### PR DESCRIPTION
**Description**

This PR adds a new `admin_flushBatcher` RPC method to the op-batcher service, allowing external systems to trigger immediate flushing of pending transactions in the batcher's channel.

**Tests**

[x] Unit tests pass - All existing and new tests pass
[x] Integration tested - Verified functionality in Kurtosis devnet environment

Added a test in `driver_test.go` which makes sure the `FlushBatchSubmitting` works. _However_ I found it way too hard to add actual data to the channel in order to test the case where we are flushing _actual_ data. That is why I put the effort into running the kurtosis devnet with the new op-batcher code. If you have a good way for me to add a unit test for that code path please let me know.

**Additional context**

There are certain incidents where an op-node can be too far out of sync with head to keep up with p2p gossip. In these cases the recovery path is to wait for an L1 batch submission, which triggers derivation and therefore gets the op-node close enough to head to receive p2p gossip once again. On a low volume network this could take over an hour (depending on the batcher's max-channel-duration). In order to speed up recovery time we find ourselves trying to force the batcher to submit data to the L1 to trigger derivation. Today, we accomplish this by restarting the batcher with a lower max-channel-duration. This has high operational overhead. This PR implements an RPC method to trigger the batcher to post to L1, which would be _much_ faster.

Most of the PR is just scaffolding to hook up the RPC method. There are two meaningful changes to review.

(1) We are now storing a reference to the `publishSignal` on the `BatchSubmitter` struct. This allows other methods to send a signal to publish a batch to the parent chain.

(2) The `FlushBatchSubmitting` method contains the logic for actually flushing the pending block bytes. I would like reviewers to spend some time in this function. I am not _super_ familiar with the op-batcher code, so a few things I'd like to get reviewer attention on:
- I am using the `mutex` and `channelMgrMutex` to ensure that the `running` state and `channel` state have no race conditions. Let me know if I have implemented enough thread safety here.
- I am re-using the `getReadyChannel` and `trySignal` methods, which seem appropriate. Let me know if I should use lower-level methods instead.
- Is `publishSignal` the correct layer for this RPC method to integrate with? I think using `publishSignal` is the safest way to do this, rather than calling the underlying Publish function.

Ran the new op-batcher image in the kurtosis devnet and ran the `admin_flushBatcher` command to test. Everything worked and the logs look good:

```
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:55+0000 lvl=info msg="Added L2 block to local state" block=0xdb3f051768df50e61662c6bcfd86f1eba14b96e9876430af5538a2462a1d2b58:333 tx_count=1 time=1752861775
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:56+0000 lvl=info msg="Flushing Batch Submitter"
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:56+0000 lvl=info msg="Created channel" id=e131d478419de319fe988f10c81ca1db l1Head=0xe54481d5bea51c9bf2e222823469f8accb205fafbbe9af5d0aec9b87f7972f0f:127 blocks_pending=1 l1OriginLastSubmittedChannel=0x2442feb1956614784d74c02b0e97d58f6acf7676e5c0ef383c011c56bc798dba:123 batch_type=0 compression_algo=zlib target_num_frames=1 max_frame_size=130043 use_blobs=true
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:56+0000 lvl=info msg="Channel closed" id=e131d478419de319fe988f10c81ca1db blocks_pending=0 num_frames=1 input_bytes=78 output_bytes=117 oldest_l1_origin=0x2442feb1956614784d74c02b0e97d58f6acf7676e5c0ef383c011c56bc798dba:123 l1_origin=0x2442feb1956614784d74c02b0e97d58f6acf7676e5c0ef383c011c56bc798dba:123 oldest_l2=0xdb3f051768df50e61662c6bcfd86f1eba14b96e9876430af5538a2462a1d2b58:333 latest_l2=0xdb3f051768df50e61662c6bcfd86f1eba14b96e9876430af5538a2462a1d2b58:333 full_reason="channel full: max channel duration reached" compr_ratio=1.5
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:56+0000 lvl=info msg="Signaled publishing loop to process flushed data"
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:56+0000 lvl=info msg="Batch Submitter flush completed"
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:57+0000 lvl=info msg="Added L2 block to local state" block=0x2f117ef59e4978cd05c3f9073e18d4047f70cb22f8ed923da0b11ca2b4e77e95:334 tx_count=1 time=1752861777
[op-batcher-2151908-op-kurtosis] t=2025-07-18T18:02:59+0000 lvl=info msg="Added L2 block to local state" block=0x6776de76ec2e2cba24aedf44a707b11f98ae246b8464cec5515ad81e924ff574:335 tx_count=1 time=1752861779
```