### PR TITLE
op-node: ensure proper line continuation with backslashes

### DIFF
--- a/op-node/README.md
+++ b/op-node/README.md
@@ -51,8 +51,8 @@ just op-node
   --l1=ws://localhost:8546 \
   --l1.beacon=http://localhost:4000 \
   --l2=ws://localhost:9001 \
-  --p2p.listen.tcp=9222
-  --p2p.listen.udp=9222
+  --p2p.listen.tcp=9222 \
+  --p2p.listen.udp=9222 \
   --rpc.port=7000 \
   --syncmode=execution-layer
 


### PR DESCRIPTION
Updated the command-line example to correctly use backslashes (\) for line continuation.
Previously, `--p2p.listen.tcp and ``--p2p.listen.udp` were not followed by backslashes, which could cause copy-paste issues or shell parsing errors.
This change improves readability and correctness of the example command.