### PR TITLE
fix: prevent leading slash in AddTestScope when prev scope is empty

### DIFF
--- a/op-devstack/devtest/common.go
+++ b/op-devstack/devtest/common.go
@@ -65,7 +65,12 @@ func TestScope(ctx context.Context) string {
 // and returns a context with the updated scope value.
 func AddTestScope(ctx context.Context, scope string) context.Context {
 	prev := TestScope(ctx)
-	newScope := testScopeValue(prev + "/" + scope)
+	var newScope testScopeValue
+	if prev == "" {
+		newScope = testScopeValue(scope)
+	} else {
+		newScope = testScopeValue(prev + "/" + scope)
+	}
 	ctx = logfilter.AddLogAttrToContext(ctx, "scope", newScope)
 	return context.WithValue(ctx, testScopeCtxKey, newScope)
 }


### PR DESCRIPTION
Fix logical error in AddTestScope function that caused unwanted leading slashes

Problem:
- When previous scope was empty, AddTestScope would concatenate "/" + scope
- This resulted in scope values like "/test" instead of "test"

Solution:
- Added conditional logic to check if prev scope is empty
- If prev is empty: use scope directly without concatenation
- If prev exists: concatenate with "/" separator as before

Changes:
- Modified AddTestScope function in op-devstack/devtest/common.go
- Added if/else logic to handle empty previous scope case

