### PR TITLE
feat(op-acceptance-tests): move all ATs to one workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,7 +1246,7 @@ jobs:
           command: go test -v -c -o /dev/null $(go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./tests/...)
       # Run the acceptance tests (if the devnet is running)
       - run:
-          name: Run acceptance tests
+          name: Run acceptance tests (devnet=<<parameters.devnet>>, gate=<<parameters.gate>>)
           working_directory: op-acceptance-tests
           no_output_timeout: 1h
           environment:

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,6 @@ TEST_PKGS := \
 	./packages/contracts-bedrock/scripts/checks/... \
 	./op-dripper/... \
 	./devnet-sdk/... \
-	./op-acceptance-tests/... \
 	./kurtosis-devnet/... \
 	./op-devstack/... \
 	./op-deployer/pkg/deployer/artifacts/... \
@@ -265,7 +264,7 @@ go-tests-short: $(TEST_DEPS) ## Runs comprehensive Go tests with -short flag
 go-tests-short-ci: ## Runs short Go tests with gotestsum for CI (assumes deps built by CI)
 	@echo "Setting up test directories..."
 	mkdir -p ./tmp/test-results ./tmp/testlogs
-	@echo "Running Go tests with gotestsum..."
+	@echo 'Running Go tests (short) with gotestsum...'
 	$(DEFAULT_TEST_ENV_VARS) && \
 	$(CI_ENV_VARS) && \
 	gotestsum --format=testname \


### PR DESCRIPTION
## Description
Stop running (sysgo/in-memory) acceptance tests as unit tests in other workflows

## Note
DO NOT MERGE until this is merged: https://github.com/ethereum-optimism/optimism/pull/16817

## Metadata
Fixes https://github.com/ethereum-optimism/optimism/issues/16272