### PR TITLE
cannon: Migrate fault tests

### DIFF
--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -119,11 +119,6 @@ func (s *State) GetCurrentThread() *ThreadState {
 	return activeStack[activeStackSize-1]
 }
 
-func (s *State) ActiveThreadCount() int {
-	activeStack := s.getActiveThreadStack()
-	return len(activeStack)
-}
-
 func (s *State) getActiveThreadStack() []*ThreadState {
 	var activeStack []*ThreadState
 	if s.TraverseRight {

--- a/cannon/mipsevm/multithreaded/state.go
+++ b/cannon/mipsevm/multithreaded/state.go
@@ -119,6 +119,11 @@ func (s *State) GetCurrentThread() *ThreadState {
 	return activeStack[activeStackSize-1]
 }
 
+func (s *State) ActiveThreadCount() int {
+	activeStack := s.getActiveThreadStack()
+	return len(activeStack)
+}
+
 func (s *State) getActiveThreadStack() []*ThreadState {
 	var activeStack []*ThreadState
 	if s.TraverseRight {

--- a/cannon/mipsevm/multithreaded/testutil/thread.go
+++ b/cannon/mipsevm/multithreaded/testutil/thread.go
@@ -168,3 +168,8 @@ func GetThreadStacks(state *multithreaded.State) (activeStack, inactiveStack []*
 	}
 	return activeStack, inactiveStack
 }
+
+func ActiveThreadCount(state *multithreaded.State) int {
+	activeStack, _ := GetThreadStacks(state)
+	return len(activeStack)
+}

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -308,14 +308,6 @@ func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature strin
 	}
 }
 
-func ExpectVmPanicWithSilentRevert(goPanicMsg interface{}, memoryProofAddresses ...arch.Word) ExpectedExecResult {
-	return vmPanicResult{
-		panicValue:           goPanicMsg,
-		evmErrorMatcher:      testutil.SilentRevertMatcher(),
-		memoryProofAddresses: memoryProofAddresses,
-	}
-}
-
 func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
 	state := goVm.GetState()
 	proofData := vmVersion.ProofGenerator(t, state, e.memoryProofAddresses...)

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -349,9 +349,9 @@ func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmV
 	if panicErr, ok := e.panicValue.(error); ok {
 		require.PanicsWithError(t, panicErr.Error(), func() { _, _ = goVm.Step(false) })
 	} else if panicStr, ok := e.panicValue.(string); ok {
-		require.PanicsWithValue(t, e.panicValue, func() { _, _ = goVm.Step(false) })
+		require.PanicsWithValue(t, panicStr, func() { _, _ = goVm.Step(false) })
 	} else {
-		t.Fatalf("Invalid panic value provided.  Go panic value must be a string or error.  Got: %v", panicStr)
+		t.Fatalf("Invalid panic value provided.  Go panic value must be a string or error.  Got: %v", e.panicValue)
 	}
 }
 

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -79,7 +79,7 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 					mod.stateMod(state)
 
 					// Set up expectations
-					expect := mtutil.NewExpectedState(t, state)
+					expect := d.expectedState(t, state)
 					execExpectation := d.setExpectations(testCase, expect, vm)
 					mod.expectMod(expect)
 
@@ -88,6 +88,15 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 			}
 		}
 	}
+}
+
+func (d *DiffTester[T]) expectedState(t require.TestingT, state *multithreaded.State) *mtutil.ExpectedState {
+	if state.ActiveThreadCount() == 0 {
+		// State is invalid, just return an empty expectation
+		// We expect some tests to set up invalid states
+		return &mtutil.ExpectedState{}
+	}
+	return mtutil.NewExpectedState(t, state)
 }
 
 func (d *DiffTester[T]) isConfigValid(t testRunner) bool {
@@ -290,14 +299,32 @@ type vmPanicResult struct {
 	panicValue           interface{}
 	evmErrorMatcher      testutil.ErrMatcher
 	memoryProofAddresses []arch.Word
+	proofData            []byte
 }
 
-func ExpectVmPanic(goPanicValue interface{}, evmRevertMsg string, memoryProofAddresses ...arch.Word) ExpectedExecResult {
-	return vmPanicResult{
-		panicValue:           goPanicValue,
-		evmErrorMatcher:      testutil.StringErrorMatcher(evmRevertMsg),
-		memoryProofAddresses: memoryProofAddresses,
+type VMPanicTestOption func(*vmPanicResult)
+
+func WithProofData(proofData []byte) VMPanicTestOption {
+	return func(vmPanicResult *vmPanicResult) {
+		vmPanicResult.proofData = proofData
 	}
+}
+
+func WithMemoryProofAddr(addr arch.Word) VMPanicTestOption {
+	return func(vmPanicResult *vmPanicResult) {
+		vmPanicResult.memoryProofAddresses = append(vmPanicResult.memoryProofAddresses, addr)
+	}
+}
+
+func ExpectVmPanic(goPanicValue interface{}, evmRevertMsg string, options ...VMPanicTestOption) ExpectedExecResult {
+	result := vmPanicResult{
+		panicValue:      goPanicValue,
+		evmErrorMatcher: testutil.StringErrorMatcher(evmRevertMsg),
+	}
+	for _, opt := range options {
+		opt(&result)
+	}
+	return result
 }
 
 func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature string, memoryProofAddresses ...arch.Word) ExpectedExecResult {
@@ -310,7 +337,10 @@ func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature strin
 
 func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
 	state := goVm.GetState()
-	proofData := vmVersion.ProofGenerator(t, state, e.memoryProofAddresses...)
+	proofData := e.proofData
+	if proofData == nil {
+		proofData = vmVersion.ProofGenerator(t, state, e.memoryProofAddresses...)
+	}
 	testutil.AssertEVMReverts(t, state, vmVersion.Contracts, cfg.tracingHooks, proofData, e.evmErrorMatcher)
 
 	if panicErr, ok := e.panicValue.(error); ok {

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -91,7 +91,7 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 }
 
 func (d *DiffTester[T]) expectedState(t require.TestingT, state *multithreaded.State) *mtutil.ExpectedState {
-	if state.ActiveThreadCount() == 0 {
+	if mtutil.ActiveThreadCount(state) == 0 {
 		// State is invalid, just return an empty expectation
 		// We expect some tests to set up invalid states
 		return &mtutil.ExpectedState{}

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -82,7 +83,7 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 					execExpectation := d.setExpectations(testCase, expect, vm)
 					mod.expectMod(expect)
 
-					execExpectation.assertExpectedResult(t, goVm, vm, expect)
+					execExpectation.assertExpectedResult(t, goVm, vm, expect, cfg)
 				})
 			}
 		}
@@ -215,6 +216,8 @@ type TestConfig struct {
 	stdOut func() io.Writer
 	stdErr func() io.Writer
 	logger log.Logger
+	// no-tracer by default, but see test_util.MarkdownTracer
+	tracingHooks *tracing.Hooks
 	// Allow consumer to control automated test generation
 	skipAutomaticMemoryReservationTests bool
 }
@@ -239,6 +242,13 @@ func WithVm(vm VersionedVMTestCase) TestOption {
 	}
 }
 
+// WithTracingHooks Sets tracing hooks - see: testutil.MarkdownTracer
+func WithTracingHooks(hooks *tracing.Hooks) TestOption {
+	return func(tc *TestConfig) {
+		tc.tracingHooks = hooks
+	}
+}
+
 func newTestConfig(t require.TestingT, opts ...TestOption) *TestConfig {
 	testConfig := &TestConfig{
 		vms:    GetMipsVersionTestCases(t),
@@ -255,7 +265,7 @@ func newTestConfig(t require.TestingT, opts ...TestOption) *TestConfig {
 }
 
 type ExpectedExecResult interface {
-	assertExpectedResult(t testing.TB, vm mipsevm.FPVM, vmType VersionedVMTestCase, expect *mtutil.ExpectedState)
+	assertExpectedResult(t testing.TB, vm mipsevm.FPVM, vmType VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig)
 }
 
 type normalExecResult struct{}
@@ -264,7 +274,7 @@ func ExpectNormalExecution() ExpectedExecResult {
 	return normalExecResult{}
 }
 
-func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState) {
+func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
 	// Step the VM
 	state := goVm.GetState()
 	step := state.GetStep()
@@ -277,23 +287,47 @@ func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, 
 }
 
 type vmPanicResult struct {
-	panicMsg string
-	evmError string
+	panicValue           interface{}
+	evmErrorMatcher      testutil.ErrMatcher
+	memoryProofAddresses []arch.Word
 }
 
-func ExpectVmPanic(goPanicMsg, evmRevertMsg string) ExpectedExecResult {
+func ExpectVmPanic(goPanicValue interface{}, evmRevertMsg string, memoryProofAddresses ...arch.Word) ExpectedExecResult {
 	return vmPanicResult{
-		panicMsg: goPanicMsg,
-		evmError: evmRevertMsg,
+		panicValue:           goPanicValue,
+		evmErrorMatcher:      testutil.StringErrorMatcher(evmRevertMsg),
+		memoryProofAddresses: memoryProofAddresses,
 	}
 }
 
-func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState) {
+func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature string, memoryProofAddresses ...arch.Word) ExpectedExecResult {
+	return vmPanicResult{
+		panicValue:           goPanicMsg,
+		evmErrorMatcher:      testutil.CustomErrorMatcher(customErrSignature),
+		memoryProofAddresses: memoryProofAddresses,
+	}
+}
+
+func ExpectVmPanicWithSilentRevert(goPanicMsg interface{}, memoryProofAddresses ...arch.Word) ExpectedExecResult {
+	return vmPanicResult{
+		panicValue:           goPanicMsg,
+		evmErrorMatcher:      testutil.SilentRevertMatcher(),
+		memoryProofAddresses: memoryProofAddresses,
+	}
+}
+
+func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
 	state := goVm.GetState()
-	proofData := vmVersion.ProofGenerator(t, state)
-	errMsg := testutil.CreateErrorStringMatcher(e.evmError)
-	testutil.AssertEVMReverts(t, state, vmVersion.Contracts, nil, proofData, errMsg)
-	require.PanicsWithValue(t, e.panicMsg, func() { _, _ = goVm.Step(false) })
+	proofData := vmVersion.ProofGenerator(t, state, e.memoryProofAddresses...)
+	testutil.AssertEVMReverts(t, state, vmVersion.Contracts, cfg.tracingHooks, proofData, e.evmErrorMatcher)
+
+	if panicErr, ok := e.panicValue.(error); ok {
+		require.PanicsWithError(t, panicErr.Error(), func() { _, _ = goVm.Step(false) })
+	} else if panicStr, ok := e.panicValue.(string); ok {
+		require.PanicsWithValue(t, e.panicValue, func() { _, _ = goVm.Step(false) })
+	} else {
+		t.Fatalf("Invalid panic value provided.  Go panic value must be a string or error.  Got: %v", panicStr)
+	}
 }
 
 type preimageOracleRevertResult struct {
@@ -312,7 +346,7 @@ func ExpectPreimageOraclePanic(preimageKey [32]byte, preimageValue []byte, preim
 	}
 }
 
-func (e preimageOracleRevertResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState) {
+func (e preimageOracleRevertResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
 	require.PanicsWithValue(t, e.panicMsg, func() { _, _ = goVm.Step(true) })
 	testutil.AssertPreimageOracleReverts(t, e.preimageKey, e.preimageValue, e.preimageOffset, vmVersion.Contracts)
 }

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -327,12 +327,15 @@ func ExpectVmPanic(goPanicValue interface{}, evmRevertMsg string, options ...VMP
 	return result
 }
 
-func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature string, memoryProofAddresses ...arch.Word) ExpectedExecResult {
-	return vmPanicResult{
-		panicValue:           goPanicMsg,
-		evmErrorMatcher:      testutil.CustomErrorMatcher(customErrSignature),
-		memoryProofAddresses: memoryProofAddresses,
+func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature string, options ...VMPanicTestOption) ExpectedExecResult {
+	result := vmPanicResult{
+		panicValue:      goPanicMsg,
+		evmErrorMatcher: testutil.CustomErrorMatcher(customErrSignature),
 	}
+	for _, opt := range options {
+		opt(&result)
+	}
+	return result
 }
 
 func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
@@ -534,7 +533,7 @@ func TestEVM_SingleStep_JrJalr(t *testing.T) {
 
 				if tt.errorMsg != "" {
 					proofData := v.ProofGenerator(t, goVm.GetState())
-					errorMatcher := testutil.CreateErrorStringMatcher(tt.errorMsg)
+					errorMatcher := testutil.StringErrorMatcher(tt.errorMsg)
 					require.Panics(t, func() { _, _ = goVm.Step(false) })
 					testutil.AssertEVMReverts(t, state, v.Contracts, nil, proofData, errorMatcher)
 				} else {
@@ -925,52 +924,51 @@ func TestEVM_SysWriteHint(t *testing.T) {
 }
 
 func TestEVM_Fault(t *testing.T) {
-	var tracer *tracing.Hooks // no-tracer by default, but see test_util.MarkdownTracer
-
-	versions := GetMipsVersionTestCases(t)
-
-	misAlignedInstructionErr := func() testutil.ErrMatcher {
-		if arch.IsMips32 {
-			// matches revert(0,0)
-			return testutil.CreateNoopErrorMatcher()
-		} else {
-			return testutil.CreateCustomErrorMatcher("InvalidPC()")
-		}
-	}
-
-	cases := []struct {
+	type testCase struct {
 		name                 string
 		pc                   arch.Word
 		nextPC               arch.Word
 		insn                 uint32
-		errMsg               testutil.ErrMatcher
+		goPanicValue         interface{}
+		evmErrStr            string
+		evmErrSig            string
 		memoryProofAddresses []Word
-	}{
-		{name: "illegal instruction", nextPC: 0, insn: 0b111110 << 26, errMsg: testutil.CreateErrorStringMatcher("invalid instruction"), memoryProofAddresses: []Word{0x0}}, // memoryProof for the zero address at register 0 (+ imm)
-		{name: "branch in delay-slot", nextPC: 8, insn: 0x11_02_00_03, errMsg: testutil.CreateErrorStringMatcher("branch in delay slot")},
-		{name: "jump in delay-slot", nextPC: 8, insn: 0x0c_00_00_0c, errMsg: testutil.CreateErrorStringMatcher("jump in delay slot")},
-		{name: "misaligned instruction", pc: 1, nextPC: 4, insn: 0b110111_00001_00001 << 16, errMsg: misAlignedInstructionErr()},
-		{name: "misaligned instruction", pc: 2, nextPC: 4, insn: 0b110111_00001_00001 << 16, errMsg: misAlignedInstructionErr()},
-		{name: "misaligned instruction", pc: 3, nextPC: 4, insn: 0b110111_00001_00001 << 16, errMsg: misAlignedInstructionErr()},
-		{name: "misaligned instruction", pc: 5, nextPC: 4, insn: 0b110111_00001_00001 << 16, errMsg: misAlignedInstructionErr()},
 	}
 
-	for _, v := range versions {
-		for _, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithPC(tt.pc), mtutil.WithNextPC(tt.nextPC))
-				state := goVm.GetState()
-				testutil.StoreInstruction(state.GetMemory(), 0, tt.insn)
-				// set the return address ($ra) to jump into when test completes
-				state.GetRegistersRef()[31] = testutil.EndAddr
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
 
-				proofData := v.ProofGenerator(t, goVm.GetState(), tt.memoryProofAddresses...)
-				require.Panics(t, func() { _, _ = goVm.Step(false) })
-				testutil.AssertEVMReverts(t, state, v.Contracts, tracer, proofData, tt.errMsg)
-			})
+	cases := []testCase{
+		{name: "illegal instruction", nextPC: 0, insn: 0b111110 << 26, evmErrStr: "invalid instruction", goPanicValue: "invalid instruction: f8000000", memoryProofAddresses: []Word{0x0}}, // memoryProof for the zero address at register 0 (+ imm)
+		{name: "branch in delay-slot", nextPC: 8, insn: 0x11_02_00_03, evmErrStr: "branch in delay slot", goPanicValue: "branch in delay slot"},
+		{name: "jump in delay-slot", nextPC: 8, insn: 0x0c_00_00_0c, evmErrStr: "jump in delay slot", goPanicValue: "jump in delay slot"},
+		{name: "misaligned instruction", pc: 1, nextPC: 4, insn: 0b110111_00001_00001 << 16, evmErrSig: "InvalidPC()", goPanicValue: fmt.Errorf("invalid pc: 1")},
+		{name: "misaligned instruction", pc: 2, nextPC: 4, insn: 0b110111_00001_00001 << 16, evmErrSig: "InvalidPC()", goPanicValue: fmt.Errorf("invalid pc: 2")},
+		{name: "misaligned instruction", pc: 3, nextPC: 4, insn: 0b110111_00001_00001 << 16, evmErrSig: "InvalidPC()", goPanicValue: fmt.Errorf("invalid pc: 3")},
+		{name: "misaligned instruction", pc: 5, nextPC: 4, insn: 0b110111_00001_00001 << 16, evmErrSig: "InvalidPC()", goPanicValue: fmt.Errorf("invalid pc: 5")},
+	}
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		testutil.StoreInstruction(state.GetMemory(), 0, tt.insn)
+		state.GetCurrentThread().Cpu.PC = tt.pc
+		state.GetCurrentThread().Cpu.NextPC = tt.nextPC
+		// set the return address ($ra) to jump into when test completes
+		state.GetRegistersRef()[31] = testutil.EndAddr
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		if tt.evmErrSig != "" {
+			return ExpectVmPanicWithCustomErr(tt.goPanicValue, tt.evmErrSig, tt.memoryProofAddresses...)
+		} else {
+			return ExpectVmPanic(tt.goPanicValue, tt.evmErrStr, tt.memoryProofAddresses...)
 		}
 	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_RandomProgram(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -925,14 +925,13 @@ func TestEVM_SysWriteHint(t *testing.T) {
 
 func TestEVM_Fault(t *testing.T) {
 	type testCase struct {
-		name                 string
-		pc                   arch.Word
-		nextPC               arch.Word
-		insn                 uint32
-		goPanicValue         interface{}
-		evmErrStr            string
-		evmErrSig            string
-		memoryProofAddresses []Word
+		name         string
+		pc           arch.Word
+		nextPC       arch.Word
+		insn         uint32
+		goPanicValue interface{}
+		evmErrStr    string
+		evmErrSig    string
 	}
 
 	testNamer := func(tc testCase) string {
@@ -940,7 +939,7 @@ func TestEVM_Fault(t *testing.T) {
 	}
 
 	cases := []testCase{
-		{name: "illegal instruction", nextPC: 0, insn: 0b111110 << 26, evmErrStr: "invalid instruction", goPanicValue: "invalid instruction: f8000000", memoryProofAddresses: []Word{0x0}}, // memoryProof for the zero address at register 0 (+ imm)
+		{name: "illegal instruction", nextPC: 0, insn: 0b111110 << 26, evmErrStr: "invalid instruction", goPanicValue: "invalid instruction: f8000000"},
 		{name: "branch in delay-slot", nextPC: 8, insn: 0x11_02_00_03, evmErrStr: "branch in delay slot", goPanicValue: "branch in delay slot"},
 		{name: "jump in delay-slot", nextPC: 8, insn: 0x0c_00_00_0c, evmErrStr: "jump in delay slot", goPanicValue: "jump in delay slot"},
 		{name: "misaligned instruction", pc: 1, nextPC: 4, insn: 0b110111_00001_00001 << 16, evmErrSig: "InvalidPC()", goPanicValue: fmt.Errorf("invalid pc: 1")},
@@ -958,10 +957,16 @@ func TestEVM_Fault(t *testing.T) {
 	}
 
 	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		// Memory is accessed when processing illegal instructions, so we need to make sure to append a memory proof
+		// See: https://github.com/ethereum-optimism/optimism/blob/a08b5b343a0005c6308566cd8afa810dd67e0e8f/cannon/mipsevm/exec/mips_instructions.go#L102-L105
+		rsReg := (tt.insn >> 21) & 0x1F
+		rs := expected.ActiveThread().Registers[rsReg]
+		memAddr := testutil.EffAddr(rs + exec.SignExtendImmediate(tt.insn))
+
 		if tt.evmErrSig != "" {
-			return ExpectVmPanicWithCustomErr(tt.goPanicValue, tt.evmErrSig, tt.memoryProofAddresses...)
+			return ExpectVmPanicWithCustomErr(tt.goPanicValue, tt.evmErrSig, memAddr)
 		} else {
-			return ExpectVmPanic(tt.goPanicValue, tt.evmErrStr, tt.memoryProofAddresses...)
+			return ExpectVmPanic(tt.goPanicValue, tt.evmErrStr, memAddr)
 		}
 	}
 

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -964,7 +964,7 @@ func TestEVM_Fault(t *testing.T) {
 		memAddr := testutil.EffAddr(rs + exec.SignExtendImmediate(tt.insn))
 
 		if tt.evmErrSig != "" {
-			return ExpectVmPanicWithCustomErr(tt.goPanicValue, tt.evmErrSig, memAddr)
+			return ExpectVmPanicWithCustomErr(tt.goPanicValue, tt.evmErrSig, WithMemoryProofAddr(memAddr))
 		} else {
 			return ExpectVmPanic(tt.goPanicValue, tt.evmErrStr, WithMemoryProofAddr(memAddr))
 		}

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -966,7 +966,7 @@ func TestEVM_Fault(t *testing.T) {
 		if tt.evmErrSig != "" {
 			return ExpectVmPanicWithCustomErr(tt.goPanicValue, tt.evmErrSig, memAddr)
 		} else {
-			return ExpectVmPanic(tt.goPanicValue, tt.evmErrStr, memAddr)
+			return ExpectVmPanic(tt.goPanicValue, tt.evmErrStr, WithMemoryProofAddr(memAddr))
 		}
 	}
 

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -728,7 +728,7 @@ func TestEVM_UndefinedSyscall(t *testing.T) {
 
 				require.Panics(t, func() { _, _ = goVm.Step(true) })
 				errorMessage := "unimplemented syscall"
-				testutil.AssertEVMReverts(t, state, contracts, nil, proofData, testutil.CreateErrorStringMatcher(errorMessage))
+				testutil.AssertEVMReverts(t, state, contracts, nil, proofData, testutil.StringErrorMatcher(errorMessage))
 			})
 		}
 	}

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -711,25 +711,34 @@ func TestEVM_UnsupportedSyscall64(t *testing.T) {
 
 // Asserts the undefined syscall handling on cannon64 triggers a VM panic
 func TestEVM_UndefinedSyscall(t *testing.T) {
-	// These syscalls all have the same value. We enumerate them here anyways for completeness.
-	undefinedSyscalls := map[string]uint64{
-		"SysFstat64": arch.SysFstat64,
-		"SysStat64":  arch.SysStat64,
-		"SysLlseek":  arch.SysLlseek,
+	type testCase struct {
+		name       string
+		syscallNum Word
 	}
-	for name, val := range undefinedSyscalls {
-		for _, version := range GetMipsVersionTestCases(t) {
-			t.Run(fmt.Sprintf("%v-%v", version.Name, name), func(t *testing.T) {
-				t.Parallel()
-				goVm, state, contracts := setupWithTestCase(t, version, int(val), nil)
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = Word(val) // Set syscall number
-				proofData := multiThreadedProofGenerator(t, state)
 
-				require.Panics(t, func() { _, _ = goVm.Step(true) })
-				errorMessage := "unimplemented syscall"
-				testutil.AssertEVMReverts(t, state, contracts, nil, proofData, testutil.StringErrorMatcher(errorMessage))
-			})
-		}
+	testNamer := func(tc testCase) string {
+		return tc.name
 	}
+
+	cases := []testCase{
+		{"SysFstat64", arch.SysFstat64},
+		{"SysStat64", arch.SysStat64},
+		{"SysLlseek", arch.SysLlseek},
+	}
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = Word(tt.syscallNum)
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		goPanic := fmt.Sprintf("unrecognized syscall: %d", tt.syscallNum)
+		evmErr := "unimplemented syscall"
+		return ExpectVmPanic(goPanic, evmErr)
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -1005,7 +1005,7 @@ func TestEVM_EmptyThreadStacks(t *testing.T) {
 					require.PanicsWithValue(t, "Active thread stack is empty", func() { _, _ = goVm.Step(false) })
 
 					errorMessage := "active thread stack is empty"
-					testutil.AssertEVMReverts(t, state, ver.Contracts, tracer, proofCase.Proof, testutil.CreateErrorStringMatcher(errorMessage))
+					testutil.AssertEVMReverts(t, state, ver.Contracts, tracer, proofCase.Proof, testutil.StringErrorMatcher(errorMessage))
 				})
 			}
 		}

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -977,39 +976,43 @@ var NoopSyscalls = map[string]uint32{
 
 func TestEVM_EmptyThreadStacks(t *testing.T) {
 	t.Parallel()
-	var tracer *tracing.Hooks
 
-	cases := []struct {
+	proofVariations := GenerateEmptyThreadProofVariations(t)
+
+	type baseTest struct {
 		name           string
 		otherStackSize int
 		traverseRight  bool
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "Traverse right with empty stacks", otherStackSize: 0, traverseRight: true},
 		{name: "Traverse left with empty stacks", otherStackSize: 0, traverseRight: false},
 		{name: "Traverse right with one non-empty stack on the other side", otherStackSize: 1, traverseRight: true},
 		{name: "Traverse left with one non-empty stack on the other side", otherStackSize: 1, traverseRight: false},
 	}
-	// Generate proof variations
-	proofVariations := GenerateEmptyThreadProofVariations(t)
 
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			for _, proofCase := range proofVariations {
-				testName := fmt.Sprintf("%v (vm=%v,proofCase=%v)", c.name, ver.Name, proofCase.Name)
-				t.Run(testName, func(t *testing.T) {
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*123)))
-					state := mtutil.GetMtState(t, goVm)
-					mtutil.SetupThreads(int64(i*123), state, c.traverseRight, 0, c.otherStackSize)
-
-					require.PanicsWithValue(t, "Active thread stack is empty", func() { _, _ = goVm.Step(false) })
-
-					errorMessage := "active thread stack is empty"
-					testutil.AssertEVMReverts(t, state, ver.Contracts, tracer, proofCase.Proof, testutil.StringErrorMatcher(errorMessage))
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, threadProofTestcase]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v-%v", tc.Base.name, tc.Variation.Name)
 	}
+
+	cases := testutil.TestVariations(baseTests, proofVariations)
+
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		b := c.Base
+		mtutil.SetupThreads(r.Int64(1000), state, b.traverseRight, 0, b.otherStackSize)
+	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		goPanic := "Active thread stack is empty"
+		evmErr := "active thread stack is empty"
+		return ExpectVmPanic(goPanic, evmErr, WithProofData(c.Variation.Proof))
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_NormalTraversal_Full(t *testing.T) {

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -116,10 +116,3 @@ func GenerateEmptyThreadProofVariations(t require.TestingT) []threadProofTestcas
 		{Name: "nil thread bytes proof", Proof: nilBytesThreadProof},
 	}
 }
-
-func setupWithTestCase(t require.TestingT, v VersionedVMTestCase, randomSeed int, preimageOracle mipsevm.PreimageOracle, opts ...mtutil.StateOption) (mipsevm.FPVM, *multithreaded.State, *testutil.ContractMetadata) {
-	allOpts := append([]mtutil.StateOption{mtutil.WithRandomization(int64(randomSeed))}, opts...)
-	vm := v.VMFactory(preimageOracle, os.Stdout, os.Stderr, testutil.CreateLogger(), allOpts...)
-	state := mtutil.GetMtState(t, vm)
-	return vm, state, v.Contracts
-}

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"io"
-	"os"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"

--- a/cannon/mipsevm/testutil/mips.go
+++ b/cannon/mipsevm/testutil/mips.go
@@ -231,13 +231,6 @@ func ValidateEVM(t testing.TB, stepWitness *mipsevm.StepWitness, step uint64, go
 
 type ErrMatcher func(require.TestingT, []byte)
 
-// SilentRevertMatcher matches a low-level empty revert: `revert(0,0)`
-func SilentRevertMatcher() ErrMatcher {
-	return func(t require.TestingT, ret []byte) {
-		require.Equal(t, 0, len(ret), "Expected silent revert via `revert(0,0)`")
-	}
-}
-
 // StringErrorMatcher matches a string message revert: `revert("some string value")`
 func StringErrorMatcher(expect string) ErrMatcher {
 	return func(t require.TestingT, ret []byte) {

--- a/cannon/mipsevm/testutil/mips.go
+++ b/cannon/mipsevm/testutil/mips.go
@@ -231,12 +231,15 @@ func ValidateEVM(t testing.TB, stepWitness *mipsevm.StepWitness, step uint64, go
 
 type ErrMatcher func(require.TestingT, []byte)
 
-func CreateNoopErrorMatcher() ErrMatcher {
-	return func(t require.TestingT, ret []byte) {}
+// SilentRevertMatcher matches a low-level empty revert: `revert(0,0)`
+func SilentRevertMatcher() ErrMatcher {
+	return func(t require.TestingT, ret []byte) {
+		require.Equal(t, 0, len(ret), "Expected silent revert via `revert(0,0)`")
+	}
 }
 
-// CreateErrorStringMatcher matches an Error(string)
-func CreateErrorStringMatcher(expect string) ErrMatcher {
+// StringErrorMatcher matches a string message revert: `revert("some string value")`
+func StringErrorMatcher(expect string) ErrMatcher {
 	return func(t require.TestingT, ret []byte) {
 		require.Greaterf(t, len(ret), 4, "Return data length should be greater than 4 bytes: %x", ret)
 		unpacked, decodeErr := abi.UnpackRevert(ret)
@@ -245,8 +248,8 @@ func CreateErrorStringMatcher(expect string) ErrMatcher {
 	}
 }
 
-// CreateCustomErrorMatcher matches a custom error given the error signature
-func CreateCustomErrorMatcher(sig string) ErrMatcher {
+// CustomErrorMatcher matches a custom error (`revert SomeError(someArg)`) given an error signature like “SomeError(uint256)"
+func CustomErrorMatcher(sig string) ErrMatcher {
 	return func(t require.TestingT, ret []byte) {
 		expect := crypto.Keccak256([]byte(sig))[:4]
 		require.EqualValuesf(t, expect, ret, "return value is %x", ret)

--- a/cannon/mipsevm/testutil/rand.go
+++ b/cannon/mipsevm/testutil/rand.go
@@ -38,6 +38,10 @@ func (h *RandHelper) Intn(n int) int {
 	return h.r.Intn(n)
 }
 
+func (h *RandHelper) Int64(n int) int64 {
+	return int64(h.r.Intn(n))
+}
+
 func (h *RandHelper) RandHash() common.Hash {
 	var bytes [32]byte
 	_, err := h.r.Read(bytes[:])


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrate some evm fault tests to use the new `DiffTester` framework introduced [here](https://github.com/ethereum-optimism/optimism/pull/16608).

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483
