### PR TITLE
fix(kurtosis-devnet): support non template network descriptions

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -62,11 +62,18 @@ devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE: _prerequisit
         fi
     fi
     export ENCL_NAME="$DEVNET_NAME"-devnet
-    go run cmd/main.go -kurtosis-package {{PACKAGE}} \
-        -environment "tests/$ENCL_NAME.json" \
-        -template "{{TEMPLATE_FILE}}" \
-        -data "{{DATA_FILE}}" \
-        -enclave "$ENCL_NAME" \
+    if [ -n "{{DATA_FILE}}" ]; then
+        go run cmd/main.go -kurtosis-package {{PACKAGE}} \
+            -environment "tests/$ENCL_NAME.json" \
+            -template "{{TEMPLATE_FILE}}" \
+            -data "{{DATA_FILE}}" \
+            -enclave "$ENCL_NAME"
+    else
+        go run cmd/main.go -kurtosis-package {{PACKAGE}} \
+            -environment "tests/$ENCL_NAME.json" \
+            -template "{{TEMPLATE_FILE}}" \
+            -enclave "$ENCL_NAME"
+    fi \
     && cat "tests/$ENCL_NAME.json"
 
 devnet-test DEVNET *TEST: _prerequisites

--- a/kurtosis-devnet/pkg/deploy/template.go
+++ b/kurtosis-devnet/pkg/deploy/template.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/build"
@@ -168,6 +169,18 @@ func (f *Templater) Render(ctx context.Context) (*bytes.Buffer, error) {
 	// Initialize the build jobs map if it's nil
 	if f.buildJobs == nil {
 		f.buildJobs = make(map[string]*dockerBuildJob)
+	}
+
+	// Check if the template file contains template syntax
+	content, err := os.ReadFile(f.templateFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading template file: %w", err)
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "{{") && !strings.Contains(contentStr, "}}") {
+		// This is a plain YAML file, return it as-is
+		return bytes.NewBuffer(content), nil
 	}
 
 	buildWg := &sync.WaitGroup{}

--- a/kurtosis-devnet/pkg/deploy/template.go
+++ b/kurtosis-devnet/pkg/deploy/template.go
@@ -171,10 +171,19 @@ func (f *Templater) Render(ctx context.Context) (*bytes.Buffer, error) {
 		f.buildJobs = make(map[string]*dockerBuildJob)
 	}
 
+	// Check if template file exists
+	if _, err := os.Stat(f.templateFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("template file does not exist: %s", f.templateFile)
+	}
+
 	// Check if the template file contains template syntax
 	content, err := os.ReadFile(f.templateFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading template file: %w", err)
+	}
+
+	if len(content) == 0 {
+		return nil, fmt.Errorf("template file is empty: %s", f.templateFile)
 	}
 
 	contentStr := string(content)

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -241,3 +241,145 @@ func TestLocalContractArtifactsOption(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "artifact://contracts", artifacts)
 }
+
+func TestRenderTemplate_PlainYamlFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "template-test-plain-yaml")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	plainYamlContent := `optimism_package:
+  faucet:
+    enabled: true
+  chains:
+    chain1:
+      participants:
+        node1:
+          el:
+            type: op-geth
+          cl:
+            type: op-node
+      network_params:
+        network: "kurtosis"
+        network_id: "2151908"
+        interop_time_offset: 100
+    chain2:
+      participants:
+        node1:
+          el:
+            type: op-geth
+          cl:
+            type: op-node
+      network_params:
+        network: "kurtosis"
+        network_id: "2151909"
+        interop_time_offset: 5000
+`
+
+	templatePath := filepath.Join(tmpDir, "plain.yaml")
+	err = os.WriteFile(templatePath, []byte(plainYamlContent), 0644)
+	require.NoError(t, err)
+
+	// Create a Templater instance WITHOUT a data file
+	templater := &Templater{
+		enclave:      "test-enclave",
+		dryRun:       true,
+		baseDir:      tmpDir,
+		templateFile: templatePath,
+		dataFile:     "", // No data file - this triggers our plain YAML detection
+		buildDir:     tmpDir,
+		urlBuilder: func(path ...string) string {
+			return "http://localhost:8080/" + strings.Join(path, "/")
+		},
+	}
+
+	buf, err := templater.Render(context.Background())
+	require.NoError(t, err)
+
+	// The output should be exactly the same as the input (no template processing)
+	assert.Equal(t, plainYamlContent, buf.String())
+
+	output := buf.String()
+	assert.Contains(t, output, "interop_time_offset: 100")
+	assert.Contains(t, output, "interop_time_offset: 5000")
+	assert.Contains(t, output, "network_id: \"2151908\"")
+	assert.Contains(t, output, "network_id: \"2151909\"")
+}
+
+func TestRenderTemplate_PlainYamlWithDataFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "template-test-plain-yaml-with-data")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	plainYamlContent := `optimism_package:
+  chains:
+    test-chain:
+      network_params:
+        network_id: "123456"
+`
+
+	templatePath := filepath.Join(tmpDir, "plain.yaml")
+	err = os.WriteFile(templatePath, []byte(plainYamlContent), 0644)
+	require.NoError(t, err)
+
+	// Create a data file (even though the template doesn't use it)
+	dataContent := `{"someData": "value"}`
+	dataPath := filepath.Join(tmpDir, "data.json")
+	err = os.WriteFile(dataPath, []byte(dataContent), 0644)
+	require.NoError(t, err)
+
+	templater := &Templater{
+		enclave:      "test-enclave",
+		dryRun:       true,
+		baseDir:      tmpDir,
+		templateFile: templatePath,
+		dataFile:     dataPath, // With data file - should still process through template engine
+		buildDir:     tmpDir,
+		urlBuilder: func(path ...string) string {
+			return "http://localhost:8080/" + strings.Join(path, "/")
+		},
+	}
+
+	buf, err := templater.Render(context.Background())
+	require.NoError(t, err)
+
+	// When there's a data file, it should go through template processing
+	// it won't be exactly the same but the content should be preserved
+	output := buf.String()
+	assert.Contains(t, output, "optimism_package:")
+	assert.Contains(t, output, "network_id: \"123456\"")
+}
+
+func TestRenderTemplate_TemplateWithoutDataFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "template-test-template-no-data")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a file that DOES contain template syntax
+	templateContent := `optimism_package:
+  chains:
+    {{.chainName}}:
+      network_params:
+        network_id: "{{.networkId}}"
+`
+
+	templatePath := filepath.Join(tmpDir, "template.yaml")
+	err = os.WriteFile(templatePath, []byte(templateContent), 0644)
+	require.NoError(t, err)
+
+	templater := &Templater{
+		enclave:      "test-enclave",
+		dryRun:       true,
+		baseDir:      tmpDir,
+		templateFile: templatePath,
+		dataFile:     "",
+		buildDir:     tmpDir,
+		urlBuilder: func(path ...string) string {
+			return "http://localhost:8080/" + strings.Join(path, "/")
+		},
+	}
+
+	// This should fail because the template has syntax but no data
+	_, err = templater.Render(context.Background())
+	assert.Error(t, err, "Should fail when template has syntax but no data is provided")
+	assert.Contains(t, err.Error(), "failed to execute template")
+}

--- a/kurtosis-devnet/pkg/deploy/template_test.go
+++ b/kurtosis-devnet/pkg/deploy/template_test.go
@@ -243,7 +243,7 @@ func TestLocalContractArtifactsOption(t *testing.T) {
 }
 
 func TestRenderTemplate_PlainYamlFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "template-test-plain-yaml")
+	tmpDir, err := os.MkdirTemp("", "template-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -279,13 +279,11 @@ func TestRenderTemplate_PlainYamlFile(t *testing.T) {
 	err = os.WriteFile(templatePath, []byte(plainYamlContent), 0644)
 	require.NoError(t, err)
 
-	// Create a Templater instance WITHOUT a data file
 	templater := &Templater{
 		enclave:      "test-enclave",
 		dryRun:       true,
 		baseDir:      tmpDir,
 		templateFile: templatePath,
-		dataFile:     "", // No data file - this triggers our plain YAML detection
 		buildDir:     tmpDir,
 		urlBuilder: func(path ...string) string {
 			return "http://localhost:8080/" + strings.Join(path, "/")
@@ -297,16 +295,10 @@ func TestRenderTemplate_PlainYamlFile(t *testing.T) {
 
 	// The output should be exactly the same as the input (no template processing)
 	assert.Equal(t, plainYamlContent, buf.String())
-
-	output := buf.String()
-	assert.Contains(t, output, "interop_time_offset: 100")
-	assert.Contains(t, output, "interop_time_offset: 5000")
-	assert.Contains(t, output, "network_id: \"2151908\"")
-	assert.Contains(t, output, "network_id: \"2151909\"")
 }
 
 func TestRenderTemplate_PlainYamlWithDataFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "template-test-plain-yaml-with-data")
+	tmpDir, err := os.MkdirTemp("", "template-test-with-data")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -332,7 +324,7 @@ func TestRenderTemplate_PlainYamlWithDataFile(t *testing.T) {
 		dryRun:       true,
 		baseDir:      tmpDir,
 		templateFile: templatePath,
-		dataFile:     dataPath, // With data file - should still process through template engine
+		dataFile:     dataPath, // Data file is irrelevant for plain YAML
 		buildDir:     tmpDir,
 		urlBuilder: func(path ...string) string {
 			return "http://localhost:8080/" + strings.Join(path, "/")
@@ -341,16 +333,11 @@ func TestRenderTemplate_PlainYamlWithDataFile(t *testing.T) {
 
 	buf, err := templater.Render(context.Background())
 	require.NoError(t, err)
-
-	// When there's a data file, it should go through template processing
-	// it won't be exactly the same but the content should be preserved
-	output := buf.String()
-	assert.Contains(t, output, "optimism_package:")
-	assert.Contains(t, output, "network_id: \"123456\"")
+	assert.Equal(t, plainYamlContent, buf.String())
 }
 
 func TestRenderTemplate_TemplateWithoutDataFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "template-test-template-no-data")
+	tmpDir, err := os.MkdirTemp("", "template-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -382,4 +369,49 @@ func TestRenderTemplate_TemplateWithoutDataFile(t *testing.T) {
 	_, err = templater.Render(context.Background())
 	assert.Error(t, err, "Should fail when template has syntax but no data is provided")
 	assert.Contains(t, err.Error(), "failed to execute template")
+}
+
+func TestRenderTemplate_EmptyFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "template-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create an empty file
+	templatePath := filepath.Join(tmpDir, "empty.yaml")
+	err = os.WriteFile(templatePath, []byte(""), 0644)
+	require.NoError(t, err)
+
+	templater := &Templater{
+		enclave:      "test",
+		dryRun:       true,
+		baseDir:      tmpDir,
+		templateFile: templatePath,
+		buildDir:     tmpDir,
+		urlBuilder:   func(...string) string { return "http://localhost" },
+	}
+
+	_, err = templater.Render(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "template file is empty")
+}
+
+func TestRenderTemplate_FileDoesNotExist(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "template-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	nonExistentPath := filepath.Join(tmpDir, "nonexistent.yaml")
+
+	templater := &Templater{
+		enclave:      "test",
+		dryRun:       true,
+		baseDir:      tmpDir,
+		templateFile: nonExistentPath,
+		buildDir:     tmpDir,
+		urlBuilder:   func(...string) string { return "http://localhost" },
+	}
+
+	_, err = templater.Render(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "template file does not exist")
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes an issue that made non-template yaml files not supported by kurtosis-devnet.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
