### PR TITLE
fix: typos in PreimageOracle.sol

### DIFF
--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -98,7 +98,7 @@ contract PreimageOracle is ISemver {
     mapping(address => mapping(uint256 => LPPMetaData)) public proposalMetadata;
     /// @notice Mapping of claimants to proposal UUIDs to bond amounts.
     mapping(address => mapping(uint256 => uint256)) public proposalBonds;
-    /// @notice Mapping of claimants to proposal UUIDs to the preimage part picked up during the absorbtion process.
+    /// @notice Mapping of claimants to proposal UUIDs to the preimage part picked up during the absorption process.
     mapping(address => mapping(uint256 => bytes32)) public proposalParts;
     /// @notice Mapping of claimants to proposal UUIDs to blocks which leaves were added to the merkle tree.
     mapping(address => mapping(uint256 => uint64[])) public proposalBlocks;
@@ -318,7 +318,7 @@ contract PreimageOracle is ISemver {
             // Compute the versioned hash. The SHA2 hash of the 48 byte commitment is masked with the version byte,
             // which is currently 1. https://eips.ethereum.org/EIPS/eip-4844#parameters
             // SAFETY: We're only reading 48 bytes from `_commitment` into scratch space, so we're not reading into the
-            //         free memory ptr region. Since the exact number of btyes that is copied into scratch space is
+            //         free memory ptr region. Since the exact number of bytes that is copied into scratch space is
             //         the same size as the hash input, there's no concern of dirty memory being read into the hash
             //         input.
             calldatacopy(0x00, _commitment.offset, 0x30)
@@ -379,7 +379,7 @@ contract PreimageOracle is ISemver {
             // since memory at end is guaranteed to be clean.
             part := mload(add(ptr, _partOffset))
 
-            // Compute the key: `keccak256(commitment ++ z)`. Since the exact number of btyes that is copied into
+            // Compute the key: `keccak256(commitment ++ z)`. Since the exact number of bytes that is copied into
             // scratch space is the same size as the hash input, there's no concern of dirty memory being read into
             // the hash input.
             calldatacopy(ptr, _commitment.offset, 0x30)
@@ -639,7 +639,7 @@ contract PreimageOracle is ISemver {
             if (metaData.bytesProcessed() != metaData.claimedSize()) revert InvalidInputSize();
         }
 
-        // Perist the latest branch to storage.
+        // Persist the latest branch to storage.
         proposalBranches[msg.sender][_uuid] = branch;
         // Persist the block number that these leaves were added in. This assists off-chain observers in reconstructing
         // the proposal merkle tree by querying block bodies.


### PR DESCRIPTION


**Description:**  
This pull request corrects several typographical errors in the comments of `PreimageOracle.sol`:
- "absorbtion" → "absorption"
- "btyes" → "bytes"
- "Perist" → "Persist"

