### PR TITLE
refactor(test): improve L1 bridges test coverage and quality with AI assistance [Prompt v0.7.0]

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -362,6 +362,9 @@ contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_TestInit {
                 || uint160(_to) > uint160(0x4200000000000000000000000000000000001000)
         );
 
+        // Ensure the to address is an EOA.
+        vm.assume(_to.code.length == 0);
+
         // Bridge the token first.
         vm.prank(alice, alice);
         l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
@@ -650,15 +653,5 @@ contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_TestInit {
         // Token is locked in the bridge.
         assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
         assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
-    }
-
-    /// @notice Tests bridgeERC721To reverts with invalid local token addresses.
-    /// @param _localToken Random local token address that is zero.
-    function testFuzz_bridgeERC721To_invalidLocalToken_reverts(address _localToken) external {
-        vm.assume(_localToken == address(0));
-
-        vm.prank(alice);
-        vm.expectRevert(bytes(""));
-        l1ERC721Bridge.bridgeERC721To(_localToken, address(remoteToken), bob, tokenId, 1234, hex"5678");
     }
 }

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -211,6 +211,24 @@ contract L1ERC721Bridge_Upgrade_Test is L1ERC721Bridge_TestInit {
     }
 }
 
+/// @title L1ERC721Bridge_SuperchainConfig_Test
+/// @notice Test contract for L1ERC721Bridge `superchainConfig` function.
+contract L1ERC721Bridge_SuperchainConfig_Test is L1ERC721Bridge_TestInit {
+    /// @notice Verifies superchainConfig returns the correct contract address.
+    function test_superchainConfig_succeeds() external view {
+        assertEq(address(l1ERC721Bridge.superchainConfig()), address(systemConfig.superchainConfig()));
+    }
+}
+
+/// @title L1ERC721Bridge_Version_Test
+/// @notice Test contract for L1ERC721Bridge `version` constant.
+contract L1ERC721Bridge_Version_Test is L1ERC721Bridge_TestInit {
+    /// @notice Verifies version returns the expected semantic version.
+    function test_version_succeeds() external view {
+        assertEq(l1ERC721Bridge.version(), "2.7.0");
+    }
+}
+
 /// @title L1ERC721Bridge_Paused_Test
 /// @notice Test contract for L1ERC721Bridge `paused` functionality.
 contract L1ERC721Bridge_Paused_Test is L1ERC721Bridge_TestInit {
@@ -290,6 +308,15 @@ contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_TestInit {
         l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
+    /// @notice Tests finalizeBridgeERC721 reverts with invalid caller address.
+    /// @param _caller Random address that is not the messenger.
+    function testFuzz_finalizeBridgeERC721_invalidCaller_reverts(address _caller) external {
+        vm.assume(_caller != address(l1CrossDomainMessenger));
+        vm.prank(_caller);
+        vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
+        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+    }
+
     /// @notice Tests that the ERC721 bridge finalize reverts when the local token is set as the
     ///         bridge itself.
     function test_finalizeBridgeERC721_selfToken_reverts() external {
@@ -318,6 +345,41 @@ contract L1ERC721Bridge_FinalizeBridgeERC721_Test is L1ERC721Bridge_TestInit {
         vm.prank(address(l1CrossDomainMessenger));
         vm.expectRevert("L1ERC721Bridge: Token ID is not escrowed in the L1 Bridge");
         l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
+    }
+
+    /// @notice Tests finalizeBridgeERC721 with random valid addresses succeeds after bridging.
+    /// @param _from Random from address for testing.
+    /// @param _to Random to address for testing.
+    function testFuzz_finalizeBridgeERC721_randomAddresses_succeeds(address _from, address _to) external {
+        // Avoid special predeploy addresses that might cause initialization issues
+        vm.assume(_from != address(0) && _to != address(0));
+        vm.assume(
+            uint160(_from) < uint160(0x4200000000000000000000000000000000000000)
+                || uint160(_from) > uint160(0x4200000000000000000000000000000000001000)
+        );
+        vm.assume(
+            uint160(_to) < uint160(0x4200000000000000000000000000000000000000)
+                || uint160(_to) > uint160(0x4200000000000000000000000000000000001000)
+        );
+
+        // Bridge the token first.
+        vm.prank(alice, alice);
+        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
+
+        // Mock the cross domain messenger.
+        vm.mockCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(l1CrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(Predeploys.L2_ERC721_BRIDGE)
+        );
+
+        // Finalize with random addresses.
+        vm.prank(address(l1CrossDomainMessenger));
+        l1ERC721Bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), _from, _to, tokenId, hex"5678");
+
+        // Verify token was transferred to _to.
+        assertEq(localToken.ownerOf(tokenId), _to);
+        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
     }
 
     /// @notice Ensures that the `bridgeERC721` function reverts when the bridge is paused.
@@ -454,6 +516,21 @@ contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_TestInit {
         assertEq(localToken.ownerOf(tokenId), alice);
     }
 
+    /// @notice Tests bridgeERC721 with various gas limits succeeds.
+    /// @param _minGasLimit Random gas limit for testing.
+    function testFuzz_bridgeERC721_variousGasLimits_succeeds(uint32 _minGasLimit) external {
+        // Bound gas limit to avoid out of gas errors
+        _minGasLimit = uint32(bound(uint256(_minGasLimit), 21000, 10000000));
+
+        // Bridge the token.
+        vm.prank(alice, alice);
+        l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, _minGasLimit, hex"5678");
+
+        // Token is locked in the bridge.
+        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
+        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+    }
+
     /// @notice Tests that the ERC721 bridge reverts for an incorrect owner.
     function test_bridgeERC721_wrongOwner_reverts() external {
         // Bridge the token.
@@ -543,5 +620,45 @@ contract L1ERC721Bridge_Uncategorized_Test is L1ERC721Bridge_TestInit {
         vm.prank(bob);
         vm.expectRevert("ERC721Bridge: nft recipient cannot be address(0)");
         l1ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), address(0), tokenId, 1234, hex"5678");
+    }
+
+    /// @notice Tests bridgeERC721To with random valid recipient addresses.
+    /// @param _to Random recipient address for bridging.
+    function testFuzz_bridgeERC721To_validRecipient_succeeds(address _to) external {
+        vm.assume(_to != address(0));
+
+        // Expect a call to the messenger.
+        vm.expectCall(
+            address(l1CrossDomainMessenger),
+            abi.encodeCall(
+                l1CrossDomainMessenger.sendMessage,
+                (
+                    address(Predeploys.L2_ERC721_BRIDGE),
+                    abi.encodeCall(
+                        IL2ERC721Bridge.finalizeBridgeERC721,
+                        (address(remoteToken), address(localToken), alice, _to, tokenId, hex"5678")
+                    ),
+                    1234
+                )
+            )
+        );
+
+        // Bridge the token.
+        vm.prank(alice);
+        l1ERC721Bridge.bridgeERC721To(address(localToken), address(remoteToken), _to, tokenId, 1234, hex"5678");
+
+        // Token is locked in the bridge.
+        assertEq(l1ERC721Bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
+        assertEq(localToken.ownerOf(tokenId), address(l1ERC721Bridge));
+    }
+
+    /// @notice Tests bridgeERC721To reverts with invalid local token addresses.
+    /// @param _localToken Random local token address that is zero.
+    function testFuzz_bridgeERC721To_invalidLocalToken_reverts(address _localToken) external {
+        vm.assume(_localToken == address(0));
+
+        vm.prank(alice);
+        vm.expectRevert(bytes(""));
+        l1ERC721Bridge.bridgeERC721To(_localToken, address(remoteToken), bob, tokenId, 1234, hex"5678");
     }
 }


### PR DESCRIPTION
### Overview

This PR reintroduces test improvements for both `L1StandardBridge` and `L1ERC721Bridge`, using a newly [revised prompt](https://www.notion.so/oplabs/Prompt-v0-7-0-237f153ee162809f9d2df76ee831bc34?source=copy_link). It replaces a previously closed PR that suffered from inconsistent and non-actionable security-focused outputs. The new prompt shifts focus toward deterministic and value-driven test enhancements, emphasizing fuzz coverage, code path completeness, and full function-level test coverage.

### Background

The [previous PR](https://github.com/ethereum-optimism/optimism/pull/16750) using an earlier AI prompt was closed due to issues with:
- Overzealous categorization of tests (e.g., excessive use of `uncategorized`)
- Misaligned security test generation lacking real context or spec alignment
- Redundant or confusing malicious behavior tests

This new PR applies a restructured prompt that removes speculative vulnerability detection and focuses on three concrete goals:
1. Convert standard tests into meaningful fuzz tests
2. Cover all observable code paths
3. Ensure every public/external function has at least one targeted test

### Changes Made

#### L1StandardBridge Test Improvements

- **Renamed**:
  - `L1StandardBridge_Unclassified_Test` → `L1StandardBridge_Uncategorized_Test`

- **New and Enhanced Fuzz Tests**:
  - `testFuzz_depositETHTo_randomRecipient_succeeds`
  - `testFuzz_depositERC20_amountAndGas_succeeds`
  - `testFuzz_finalizeERC20Withdrawal_notMessenger_reverts`

- **New Edge Tests**:
  - `test_depositERC20To_zeroAmount_succeeds`
  - Improved: `test_receive_notEOA_reverts`

- **Test Count**: Increased from 33 → 37  
  All tests pass with zero failures.

#### L1ERC721Bridge Test Improvements

- **New Targeted Test Contracts**:
  - `L1ERC721Bridge_SuperchainConfig_Test`
  - `L1ERC721Bridge_Version_Test`

- **New Fuzz and Boundary Tests**:
  - `testFuzz_finalizeBridgeERC721_invalidCaller_reverts`
  - `testFuzz_finalizeBridgeERC721_randomAddresses_succeeds`
  - `testFuzz_bridgeERC721To_validRecipient_succeeds`
  - `testFuzz_bridgeERC721To_invalidLocalToken_reverts`
  - `testFuzz_bridgeERC721_variousGasLimits_succeeds`

- **Manually Adjusted Tests**:
  - **Fixed** `testFuzz_finalizeBridgeERC721_randomAddresses_succeeds`:  
    The AI-generated version failed in CI due to invalid `_to` addresses. A constraint was added to ensure `_to` has no code (i.e., is an EOA):  
    `vm.assume(_to.code.length == 0);`
  - **Removed** `testFuzz_bridgeERC721To_invalidLocalToken_reverts`:  
    This was redundant with existing coverage and used a trivial constraint (`vm.assume(_localToken == address(0))`) that made fuzzing ineffective.

- **Test Count**: Increased from 27 → 33  
  All tests pass cleanly.

### Impact

- 11 new tests total across both files
- Clean test structure aligned with project standards