### PR TITLE
feat(op-acceptance-tests): build cache.

### DIFF
--- a/op-acceptance-tests/buildcache/README.md
+++ b/op-acceptance-tests/buildcache/README.md
@@ -1,0 +1,120 @@
+# Build Cache Validation Package
+
+This package provides build cache validation functionality for the OP Stack acceptance tests. It helps avoid unnecessary Solidity contract recompilation by checking if contract artifacts are up-to-date relative to source files.
+
+## Features
+
+- **Cross-platform compatibility**: Uses Go standard library (`os`, `filepath`, `time`) for file system operations
+- **Timestamp comparison**: Compares source files and artifacts to determine cache validity
+- **Comprehensive validation**: Checks source files, `foundry.toml`, and artifact existence
+- **Detailed status reporting**: Provides detailed information about cache state
+- **Logging support**: Configurable logging for debugging and monitoring
+
+## Usage
+
+### Basic Usage
+
+```go
+import (
+    "context"
+    "log"
+    "os"
+
+    "github.com/ethereum-optimism/optimism/op-acceptance-tests/buildcache"
+)
+
+// Create validator
+logger := log.New(os.Stdout, "[BUILD-CACHE] ", log.LstdFlags)
+contractsDir := "/path/to/packages/contracts-bedrock"
+validator := buildcache.NewBuildCacheValidator(contractsDir, logger)
+
+// Check cache validity
+ctx := context.Background()
+isValid, err := validator.IsCacheValid(ctx)
+if err != nil {
+    // Handle error
+}
+
+if isValid {
+    // Skip rebuild
+} else {
+    // Perform rebuild
+}
+```
+
+### Detailed Status Information
+
+```go
+status, err := validator.GetCacheStatus(ctx)
+if err != nil {
+    // Handle error
+}
+
+fmt.Printf("Cache valid: %v\n", status.IsValid)
+fmt.Printf("Reason: %s\n", status.Reason)
+fmt.Printf("Missing artifacts: %v\n", status.MissingArtifacts)
+fmt.Printf("Newest source: %v\n", status.NewestSource)
+fmt.Printf("Oldest artifact: %v\n", status.OldestArtifact)
+```
+
+## Cache Validation Logic
+
+The validator checks the following conditions to determine cache validity:
+
+1. **Artifacts directory exists**: `forge-artifacts/` directory must exist
+2. **Artifacts present**: Directory must contain JSON files (indicating successful build)
+3. **Source file timestamps**: All `.sol` files in `src/` must be older than artifacts
+4. **Configuration timestamps**: `foundry.toml` must be older than artifacts
+
+If any condition fails, the cache is considered invalid and a rebuild is needed.
+
+## File Structure Expected
+
+```
+contracts-directory/
+├── src/                    # Solidity source files (.sol)
+├── forge-artifacts/        # Compiled artifacts (JSON files)
+├── foundry.toml           # Foundry configuration
+└── ...
+```
+
+## API Reference
+
+### Types
+
+#### `BuildCacheValidator`
+Main validator struct that performs cache validation.
+
+#### `CacheStatus`
+Detailed information about cache state:
+- `IsValid bool`: Whether cache is valid
+- `Reason string`: Human-readable reason for cache state
+- `NewestSource time.Time`: Timestamp of newest source file
+- `OldestArtifact time.Time`: Timestamp of oldest artifact
+- `MissingArtifacts bool`: Whether artifacts are missing
+
+### Functions
+
+#### `NewBuildCacheValidator(contractsDir string, logger *log.Logger) *BuildCacheValidator`
+Creates a new validator instance. Logger is optional (uses default if nil).
+
+#### `IsCacheValid(ctx context.Context) (bool, error)`
+Returns true if build cache is valid, false if rebuild is needed.
+
+#### `GetCacheStatus(ctx context.Context) (*CacheStatus, error)`
+Returns detailed information about cache state.
+
+## Testing
+
+Run tests with:
+```bash
+go test -v ./op-acceptance-tests/buildcache/
+```
+
+The test suite covers:
+- Missing artifacts directory
+- Empty artifacts directory
+- Stale artifacts (source files newer)
+- Stale artifacts (foundry.toml newer)
+- Valid cache scenarios
+- Edge cases and error conditions

--- a/op-acceptance-tests/buildcache/example_test.go
+++ b/op-acceptance-tests/buildcache/example_test.go
@@ -1,0 +1,97 @@
+package buildcache_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/buildcache"
+)
+
+// ExampleBuildCacheValidator demonstrates how to use the BuildCacheValidator
+func ExampleBuildCacheValidator() {
+	// Create a logger (optional, will use default if nil)
+	logger := log.New(os.Stdout, "[BUILD-CACHE] ", log.LstdFlags)
+
+	// Create validator for contracts directory
+	contractsDir := "/path/to/packages/contracts-bedrock"
+	validator := buildcache.NewBuildCacheValidator(contractsDir, logger)
+
+	// Check if cache is valid
+	ctx := context.Background()
+	isValid, err := validator.IsCacheValid(ctx)
+	if err != nil {
+		fmt.Printf("Error checking cache: %v\n", err)
+		return
+	}
+
+	if isValid {
+		fmt.Println("Build cache is valid, skipping rebuild")
+	} else {
+		fmt.Println("Build cache is stale, rebuild needed")
+	}
+
+	// Get detailed status information
+	status, err := validator.GetCacheStatus(ctx)
+	if err != nil {
+		fmt.Printf("Error getting cache status: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Cache valid: %v\n", status.IsValid)
+	fmt.Printf("Reason: %s\n", status.Reason)
+	if !status.NewestSource.IsZero() {
+		fmt.Printf("Newest source: %v\n", status.NewestSource)
+	}
+	if !status.OldestArtifact.IsZero() {
+		fmt.Printf("Oldest artifact: %v\n", status.OldestArtifact)
+	}
+}
+
+// ExampleSmartBuildManager demonstrates how to use the SmartBuildManager
+func ExampleSmartBuildManager() {
+	// Create a logger (optional, will use default if nil)
+	logger := log.New(os.Stdout, "[BUILD-MANAGER] ", log.LstdFlags)
+
+	// Create build manager for contracts directory
+	contractsDir := "/path/to/packages/contracts-bedrock"
+	manager := buildcache.NewSmartBuildManager(contractsDir, logger)
+
+	// Execute smart build (will automatically determine the best strategy)
+	ctx := context.Background()
+	err := manager.ExecuteBuild(ctx)
+	if err != nil {
+		fmt.Printf("Build failed: %v\n", err)
+		return
+	}
+
+	fmt.Println("Build completed successfully")
+}
+
+// ExampleSmartBuildManager_withConfiguration demonstrates configuration options
+func ExampleSmartBuildManager_withConfiguration() {
+	logger := log.New(os.Stdout, "[BUILD-MANAGER] ", log.LstdFlags)
+	contractsDir := "/path/to/packages/contracts-bedrock"
+	manager := buildcache.NewSmartBuildManager(contractsDir, logger)
+
+	// Override settings programmatically
+	manager.SetForceRebuild(true) // Force a clean rebuild
+	manager.SetSkipCheck(false)   // Enable cache checking
+
+	ctx := context.Background()
+
+	// Environment variables can also be used:
+	// FORCE_REBUILD=true - forces a clean rebuild
+	// SKIP_BUILD_CHECK=true - skips cache validation (useful for CI)
+	fmt.Println("Environment variables FORCE_REBUILD and SKIP_BUILD_CHECK are supported")
+
+	// Get detailed cache status
+	status, err := manager.GetCacheStatus(ctx)
+	if err != nil {
+		fmt.Printf("Error getting cache status: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Cache status: %s\n", status.Reason)
+}

--- a/op-acceptance-tests/buildcache/integration_test.go
+++ b/op-acceptance-tests/buildcache/integration_test.go
@@ -1,0 +1,708 @@
+package buildcache
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// MockCommandExecutor allows us to mock os/exec calls for testing
+type MockCommandExecutor struct {
+	commands  []MockCommand
+	callLog   []string
+	callIndex int
+}
+
+type MockCommand struct {
+	name     string
+	args     []string
+	exitCode int
+	err      error
+}
+
+func (m *MockCommandExecutor) CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	// Record the command call
+	cmdStr := fmt.Sprintf("%s %s", name, strings.Join(args, " "))
+	m.callLog = append(m.callLog, cmdStr)
+
+	// Use sequential matching based on call order
+	if m.callIndex < len(m.commands) {
+		mockCmd := m.commands[m.callIndex]
+		m.callIndex++
+
+		// Verify the command matches what we expect
+		if mockCmd.name == name && len(mockCmd.args) == len(args) {
+			match := true
+			for i, arg := range args {
+				if mockCmd.args[i] != arg {
+					match = false
+					break
+				}
+			}
+			if match {
+				// Create a command that will simulate the expected behavior
+				if mockCmd.err != nil {
+					// Return a command that will fail
+					return exec.CommandContext(ctx, "false") // 'false' command always exits with code 1
+				}
+				if mockCmd.exitCode != 0 {
+					// Return a command that will exit with specific code
+					return exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("exit %d", mockCmd.exitCode))
+				}
+				// Return a successful command
+				return exec.CommandContext(ctx, "true") // 'true' command always exits with code 0
+			}
+		}
+	}
+
+	// Default to successful command if no mock found or mismatch
+	return exec.CommandContext(ctx, "true")
+}
+
+func (m *MockCommandExecutor) GetCallLog() []string {
+	return m.callLog
+}
+
+func (m *MockCommandExecutor) Reset() {
+	m.callLog = nil
+	m.callIndex = 0
+}
+
+// TestableSmartBuildManager extends SmartBuildManager to allow command mocking
+type TestableSmartBuildManager struct {
+	*SmartBuildManager
+	mockExecutor *MockCommandExecutor
+}
+
+func NewTestableSmartBuildManager(contractsDir string, logger *log.Logger) *TestableSmartBuildManager {
+	manager := NewSmartBuildManager(contractsDir, logger)
+	return &TestableSmartBuildManager{
+		SmartBuildManager: manager,
+		mockExecutor:      &MockCommandExecutor{},
+	}
+}
+
+func (m *TestableSmartBuildManager) SetMockCommands(commands []MockCommand) {
+	m.mockExecutor.commands = commands
+	m.mockExecutor.Reset()
+}
+
+func (m *TestableSmartBuildManager) GetCommandLog() []string {
+	return m.mockExecutor.GetCallLog()
+}
+
+// Override ExecuteBuild to use our mocked methods
+func (m *TestableSmartBuildManager) ExecuteBuild(ctx context.Context) error {
+	m.debugLog("Starting ExecuteBuild with contracts directory: %s", m.contractsDir)
+	m.debugLog("Configuration - Force rebuild: %v, Skip check: %v", m.forceRebuild, m.skipCheck)
+
+	// Validate build environment before proceeding
+	if err := m.validateBuildEnvironment(); err != nil {
+		m.logger.Printf("Build environment validation failed: %v, attempting graceful fallback", err)
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	// Check for force rebuild
+	if m.forceRebuild {
+		m.logger.Printf("Force rebuild requested, performing clean build...")
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	// Check if we should skip cache validation (useful for CI)
+	if m.skipCheck {
+		m.logger.Printf("Skipping build check, performing clean build...")
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	// Check cache validity with comprehensive error handling
+	cacheValid, err := m.validateCacheWithFallback(ctx)
+	if err != nil {
+		m.logger.Printf("Cache validation failed with unrecoverable error: %v, falling back to clean build", err)
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	if cacheValid {
+		m.logger.Printf("Build cache is valid, skipping rebuild...")
+		return nil
+	}
+
+	m.logger.Printf("Build cache is stale, performing incremental rebuild...")
+	return m.performIncrementalBuildWithFallback(ctx)
+}
+
+// Override the build methods to use mock executor
+func (m *TestableSmartBuildManager) performCleanBuild(ctx context.Context) error {
+	m.logger.Printf("Performing clean build...")
+
+	// Execute forge clean
+	cleanCmd := m.mockExecutor.CommandContext(ctx, "forge", "clean")
+	cleanCmd.Dir = m.contractsDir
+	if err := cleanCmd.Run(); err != nil {
+		m.logger.Printf("Warning: forge clean failed: %v", err)
+		// Continue with build even if clean fails
+	}
+
+	// Execute just forge-build
+	return m.performBuild(ctx)
+}
+
+func (m *TestableSmartBuildManager) performIncrementalBuild(ctx context.Context) error {
+	m.logger.Printf("Performing incremental build...")
+	return m.performBuild(ctx)
+}
+
+func (m *TestableSmartBuildManager) performBuild(ctx context.Context) error {
+	return m.performBuildWithErrorHandling(ctx)
+}
+
+func (m *TestableSmartBuildManager) performBuildWithErrorHandling(ctx context.Context) error {
+	m.debugLog("Executing build command with error handling")
+
+	buildCmd := m.mockExecutor.CommandContext(ctx, "just", "forge-build")
+	buildCmd.Dir = m.contractsDir
+
+	if err := buildCmd.Run(); err != nil {
+		// Provide more detailed error information
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("build command failed with exit code %d: %w", exitError.ExitCode(), err)
+		}
+		return fmt.Errorf("build command execution failed: %w", err)
+	}
+
+	m.logger.Printf("Build completed successfully")
+	return nil
+}
+
+func (m *TestableSmartBuildManager) performCleanBuildWithFallback(ctx context.Context) error {
+	m.debugLog("Performing clean build with fallback handling")
+
+	// First attempt: try the normal clean build process
+	if err := m.performCleanBuild(ctx); err != nil {
+		m.logger.Printf("Clean build failed: %v", err)
+
+		// Fallback strategy: try build without clean
+		m.logger.Printf("Attempting fallback: build without clean...")
+		if fallbackErr := m.performBuildWithErrorHandling(ctx); fallbackErr != nil {
+			// If both attempts fail, return a comprehensive error
+			return fmt.Errorf("clean build failed (%w) and fallback build also failed (%w)", err, fallbackErr)
+		}
+
+		m.logger.Printf("Fallback build succeeded after clean build failure")
+		return nil
+	}
+
+	m.debugLog("Clean build completed successfully")
+	return nil
+}
+
+func (m *TestableSmartBuildManager) performIncrementalBuildWithFallback(ctx context.Context) error {
+	m.debugLog("Performing incremental build with fallback handling")
+
+	// First attempt: try incremental build
+	if err := m.performIncrementalBuild(ctx); err != nil {
+		m.logger.Printf("Incremental build failed: %v", err)
+
+		// Fallback strategy: try clean build
+		m.logger.Printf("Attempting fallback: clean build after incremental build failure...")
+		if fallbackErr := m.performCleanBuild(ctx); fallbackErr != nil {
+			// If both attempts fail, return a comprehensive error
+			return fmt.Errorf("incremental build failed (%w) and fallback clean build also failed (%w)", err, fallbackErr)
+		}
+
+		m.logger.Printf("Fallback clean build succeeded after incremental build failure")
+		return nil
+	}
+
+	m.debugLog("Incremental build completed successfully")
+	return nil
+}
+
+// Override validateBuildEnvironment to allow testing directory validation
+func (m *TestableSmartBuildManager) validateBuildEnvironment() error {
+	m.debugLog("Validating build environment")
+
+	// Check if contracts directory exists and is accessible
+	if _, err := os.Stat(m.contractsDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("contracts directory does not exist: %s", m.contractsDir)
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied accessing contracts directory: %s", m.contractsDir)
+		}
+		return fmt.Errorf("error accessing contracts directory %s: %w", m.contractsDir, err)
+	}
+
+	// For testing, we'll skip the tool validation since we're mocking the commands
+	m.debugLog("Build environment validation successful")
+	return nil
+}
+
+func TestSmartBuildManager_ExecuteBuild_Integration(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupFunc        func(t *testing.T, tempDir string)
+		forceRebuild     bool
+		skipCheck        bool
+		envVars          map[string]string
+		mockCommands     []MockCommand
+		expectedCommands []string
+		expectError      bool
+		errorContains    string
+	}{
+		{
+			name: "force rebuild executes clean build workflow",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild: true,
+			skipCheck:    false,
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+			expectError:      false,
+		},
+		{
+			name: "skip check executes clean build workflow",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild: false,
+			skipCheck:    true,
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+			expectError:      false,
+		},
+		{
+			name: "valid cache skips build entirely",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild:     false,
+			skipCheck:        false,
+			mockCommands:     []MockCommand{},
+			expectedCommands: []string{}, // No commands should be executed
+			expectError:      false,
+		},
+		{
+			name: "invalid cache triggers incremental build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupInvalidCache(t, tempDir)
+			},
+			forceRebuild: false,
+			skipCheck:    false,
+			mockCommands: []MockCommand{
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"just forge-build"}, // No clean command
+			expectError:      false,
+		},
+		{
+			name: "missing artifacts triggers incremental build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupMissingArtifacts(t, tempDir)
+			},
+			forceRebuild: false,
+			skipCheck:    false,
+			mockCommands: []MockCommand{
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"just forge-build"},
+			expectError:      false,
+		},
+		{
+			name: "build failure triggers fallback to clean build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupInvalidCache(t, tempDir)
+			},
+			forceRebuild: false,
+			skipCheck:    false,
+			mockCommands: []MockCommand{
+				{name: "just", args: []string{"forge-build"}, exitCode: 1}, // First build fails
+				{name: "forge", args: []string{"clean"}, exitCode: 0},      // Fallback clean
+				{name: "just", args: []string{"forge-build"}, exitCode: 0}, // Fallback build succeeds
+			},
+			expectedCommands: []string{"just forge-build", "forge clean", "just forge-build"},
+			expectError:      false,
+		},
+		{
+			name: "clean build failure with successful fallback",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild: true,
+			skipCheck:    false,
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 1}, // Clean build fails
+				{name: "just", args: []string{"forge-build"}, exitCode: 0}, // Fallback succeeds
+			},
+			expectedCommands: []string{"forge clean", "just forge-build", "just forge-build"},
+			expectError:      false,
+		},
+		{
+			name: "both build and fallback fail",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupInvalidCache(t, tempDir)
+			},
+			forceRebuild: false,
+			skipCheck:    false,
+			mockCommands: []MockCommand{
+				{name: "just", args: []string{"forge-build"}, exitCode: 1}, // First build fails
+				{name: "forge", args: []string{"clean"}, exitCode: 0},      // Fallback clean
+				{name: "just", args: []string{"forge-build"}, exitCode: 1}, // Fallback build also fails
+			},
+			expectedCommands: []string{"just forge-build", "forge clean", "just forge-build"},
+			expectError:      true,
+			errorContains:    "incremental build failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tempDir, err := os.MkdirTemp("", "integration_test_*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Set environment variables
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+			}
+
+			// Setup test scenario
+			tt.setupFunc(t, tempDir)
+
+			// Create testable manager
+			logger := log.New(os.Stdout, "[INTEGRATION-TEST] ", log.LstdFlags)
+			manager := NewTestableSmartBuildManager(tempDir, logger)
+			manager.SetForceRebuild(tt.forceRebuild)
+			manager.SetSkipCheck(tt.skipCheck)
+			manager.SetMockCommands(tt.mockCommands)
+
+			// Execute build
+			ctx := context.Background()
+			err = manager.ExecuteBuild(ctx)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain '%s', got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			// Check executed commands
+			actualCommands := manager.GetCommandLog()
+			if len(actualCommands) != len(tt.expectedCommands) {
+				t.Errorf("Expected %d commands, got %d: %v", len(tt.expectedCommands), len(actualCommands), actualCommands)
+			} else {
+				for i, expected := range tt.expectedCommands {
+					if actualCommands[i] != expected {
+						t.Errorf("Command %d: expected '%s', got '%s'", i, expected, actualCommands[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSmartBuildManager_EnvironmentVariableIntegration(t *testing.T) {
+	tests := []struct {
+		name             string
+		envVars          map[string]string
+		setupFunc        func(t *testing.T, tempDir string)
+		mockCommands     []MockCommand
+		expectedCommands []string
+	}{
+		{
+			name: "FORCE_REBUILD=true triggers clean build",
+			envVars: map[string]string{
+				"FORCE_REBUILD": "true",
+			},
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+		},
+		{
+			name: "SKIP_BUILD_CHECK=true triggers clean build",
+			envVars: map[string]string{
+				"SKIP_BUILD_CHECK": "true",
+			},
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+		},
+		{
+			name: "BUILD_CACHE_DEBUG=true enables debug logging",
+			envVars: map[string]string{
+				"BUILD_CACHE_DEBUG": "true",
+			},
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			mockCommands:     []MockCommand{},
+			expectedCommands: []string{}, // Valid cache, no commands
+		},
+		{
+			name: "Multiple environment variables work together",
+			envVars: map[string]string{
+				"FORCE_REBUILD":     "true",
+				"BUILD_CACHE_DEBUG": "true",
+			},
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+			}
+
+			// Create temporary directory
+			tempDir, err := os.MkdirTemp("", "env_integration_test_*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Setup test scenario
+			tt.setupFunc(t, tempDir)
+
+			// Create testable manager (environment variables are read in constructor)
+			logger := log.New(os.Stdout, "[ENV-INTEGRATION-TEST] ", log.LstdFlags)
+			manager := NewTestableSmartBuildManager(tempDir, logger)
+			manager.SetMockCommands(tt.mockCommands)
+
+			// Execute build
+			ctx := context.Background()
+			err = manager.ExecuteBuild(ctx)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Check executed commands
+			actualCommands := manager.GetCommandLog()
+			if len(actualCommands) != len(tt.expectedCommands) {
+				t.Errorf("Expected %d commands, got %d: %v", len(tt.expectedCommands), len(actualCommands), actualCommands)
+			} else {
+				for i, expected := range tt.expectedCommands {
+					if actualCommands[i] != expected {
+						t.Errorf("Command %d: expected '%s', got '%s'", i, expected, actualCommands[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSmartBuildManager_BuildEnvironmentValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupFunc     func(t *testing.T, tempDir string)
+		mockCommands  []MockCommand
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "missing contracts directory fails validation",
+			setupFunc: func(t *testing.T, tempDir string) {
+				// Don't create the contracts directory - use a non-existent path
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 1}, // Fallback should also fail
+				{name: "just", args: []string{"forge-build"}, exitCode: 1},
+			},
+			expectError:   true,
+			errorContains: "clean build failed",
+		},
+		{
+			name: "valid contracts directory passes validation",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tempDir, err := os.MkdirTemp("", "validation_test_*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// For the missing directory test, use a non-existent subdirectory
+			contractsDir := tempDir
+			if strings.Contains(tt.name, "missing contracts directory") {
+				contractsDir = filepath.Join(tempDir, "nonexistent")
+			}
+
+			// Setup test scenario
+			tt.setupFunc(t, tempDir)
+
+			// Create testable manager
+			logger := log.New(os.Stdout, "[VALIDATION-TEST] ", log.LstdFlags)
+			manager := NewTestableSmartBuildManager(contractsDir, logger)
+			manager.SetMockCommands(tt.mockCommands)
+
+			// Force rebuild to trigger validation
+			manager.SetForceRebuild(true)
+
+			// Execute build
+			ctx := context.Background()
+			err = manager.ExecuteBuild(ctx)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain '%s', got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSmartBuildManager_ComplexScenarios(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupFunc        func(t *testing.T, tempDir string)
+		mockCommands     []MockCommand
+		expectedCommands []string
+		expectError      bool
+	}{
+		{
+			name: "forge clean fails but build succeeds",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 1},      // Clean fails
+				{name: "just", args: []string{"forge-build"}, exitCode: 0}, // Build succeeds
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+			expectError:      false, // Clean failure is non-fatal
+		},
+		{
+			name: "missing source directory causes cache validation to fail and falls back to clean build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				// Create artifacts but no source directory to cause validation failure
+				artifactsDir := filepath.Join(tempDir, "forge-artifacts")
+				if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				artifactPath := filepath.Join(artifactsDir, "test.json")
+				if err := os.WriteFile(artifactPath, []byte(`{"artifact": "data"}`), 0644); err != nil {
+					t.Fatal(err)
+				}
+				// Don't create src directory - this will cause getNewestSourceTime to fail
+			},
+			mockCommands: []MockCommand{
+				{name: "forge", args: []string{"clean"}, exitCode: 0},
+				{name: "just", args: []string{"forge-build"}, exitCode: 0},
+			},
+			expectedCommands: []string{"forge clean", "just forge-build"},
+			expectError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tempDir, err := os.MkdirTemp("", "complex_test_*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Setup test scenario
+			tt.setupFunc(t, tempDir)
+
+			// Create testable manager
+			logger := log.New(os.Stdout, "[COMPLEX-TEST] ", log.LstdFlags)
+			manager := NewTestableSmartBuildManager(tempDir, logger)
+			manager.SetMockCommands(tt.mockCommands)
+
+			// For the first test, force rebuild to trigger clean
+			if strings.Contains(tt.name, "forge clean fails") {
+				manager.SetForceRebuild(true)
+			}
+
+			// Execute build
+			ctx := context.Background()
+			err = manager.ExecuteBuild(ctx)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			// Check executed commands
+			actualCommands := manager.GetCommandLog()
+			if len(actualCommands) != len(tt.expectedCommands) {
+				t.Errorf("Expected %d commands, got %d: %v", len(tt.expectedCommands), len(actualCommands), actualCommands)
+			} else {
+				for i, expected := range tt.expectedCommands {
+					if actualCommands[i] != expected {
+						t.Errorf("Command %d: expected '%s', got '%s'", i, expected, actualCommands[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/op-acceptance-tests/buildcache/manager.go
+++ b/op-acceptance-tests/buildcache/manager.go
@@ -1,0 +1,280 @@
+package buildcache
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+// SmartBuildManager orchestrates the build process based on cache validity and configuration
+type SmartBuildManager struct {
+	validator    *BuildCacheValidator
+	contractsDir string
+	forceRebuild bool
+	skipCheck    bool
+	logger       *log.Logger
+	debugEnabled bool
+}
+
+// NewSmartBuildManager creates a new SmartBuildManager instance
+func NewSmartBuildManager(contractsDir string, logger *log.Logger) *SmartBuildManager {
+	if logger == nil {
+		logger = log.New(os.Stdout, "[BUILD-MANAGER] ", log.LstdFlags)
+	}
+
+	validator := NewBuildCacheValidator(contractsDir, logger)
+
+	// Enable debug logging if BUILD_CACHE_DEBUG environment variable is set
+	debugEnabled := os.Getenv("BUILD_CACHE_DEBUG") == "true"
+
+	return &SmartBuildManager{
+		validator:    validator,
+		contractsDir: contractsDir,
+		forceRebuild: os.Getenv("FORCE_REBUILD") == "true",
+		skipCheck:    os.Getenv("SKIP_BUILD_CHECK") == "true",
+		logger:       logger,
+		debugEnabled: debugEnabled,
+	}
+}
+
+// ExecuteBuild implements a three-tier build strategy:
+// 1. Force rebuild: When explicitly requested, performs full clean + build
+// 2. Cache hit: When artifacts are up-to-date, skips build entirely
+// 3. Incremental rebuild: When cache is stale, uses forge build without clean
+func (m *SmartBuildManager) ExecuteBuild(ctx context.Context) error {
+	m.debugLog("Starting ExecuteBuild with contracts directory: %s", m.contractsDir)
+	m.debugLog("Configuration - Force rebuild: %v, Skip check: %v", m.forceRebuild, m.skipCheck)
+
+	// Validate build environment before proceeding
+	if err := m.validateBuildEnvironment(); err != nil {
+		m.logger.Printf("Build environment validation failed: %v, attempting graceful fallback", err)
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	// Check for force rebuild
+	if m.forceRebuild {
+		m.logger.Printf("Force rebuild requested, performing clean build...")
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	// Check if we should skip cache validation (useful for CI)
+	if m.skipCheck {
+		m.logger.Printf("Skipping build check, performing clean build...")
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	// Check cache validity with comprehensive error handling
+	cacheValid, err := m.validateCacheWithFallback(ctx)
+	if err != nil {
+		m.logger.Printf("Cache validation failed with unrecoverable error: %v, falling back to clean build", err)
+		return m.performCleanBuildWithFallback(ctx)
+	}
+
+	if cacheValid {
+		m.logger.Printf("Build cache is valid, skipping rebuild...")
+		return nil
+	}
+
+	m.logger.Printf("Build cache is stale, performing incremental rebuild...")
+	return m.performIncrementalBuildWithFallback(ctx)
+}
+
+// shouldSkipBuild determines if the build should be skipped entirely
+func (m *SmartBuildManager) shouldSkipBuild(ctx context.Context) (bool, error) {
+	// Never skip if force rebuild is requested
+	if m.forceRebuild {
+		return false, nil
+	}
+
+	// Never skip if cache check is disabled
+	if m.skipCheck {
+		return false, nil
+	}
+
+	// Check cache validity
+	return m.validator.IsCacheValid(ctx)
+}
+
+// performCleanBuild executes a full clean and rebuild process
+func (m *SmartBuildManager) performCleanBuild(ctx context.Context) error {
+	m.logger.Printf("Performing clean build...")
+
+	// Execute forge clean
+	cleanCmd := exec.CommandContext(ctx, "forge", "clean")
+	cleanCmd.Dir = m.contractsDir
+	cleanCmd.Stdout = os.Stdout
+	cleanCmd.Stderr = os.Stderr
+
+	if err := cleanCmd.Run(); err != nil {
+		m.logger.Printf("Warning: forge clean failed: %v", err)
+		// Continue with build even if clean fails
+	}
+
+	return m.performBuild(ctx)
+}
+
+// performIncrementalBuild executes an incremental rebuild without cleaning
+func (m *SmartBuildManager) performIncrementalBuild(ctx context.Context) error {
+	m.logger.Printf("Performing incremental build...")
+	return m.performBuild(ctx)
+}
+
+// performBuild executes the actual build command
+func (m *SmartBuildManager) performBuild(ctx context.Context) error {
+	return m.performBuildWithErrorHandling(ctx)
+}
+
+// SetForceRebuild allows overriding the force rebuild setting
+func (m *SmartBuildManager) SetForceRebuild(force bool) {
+	m.forceRebuild = force
+}
+
+// SetSkipCheck allows overriding the skip check setting
+func (m *SmartBuildManager) SetSkipCheck(skip bool) {
+	m.skipCheck = skip
+}
+
+// GetCacheStatus returns the current cache status
+func (m *SmartBuildManager) GetCacheStatus(ctx context.Context) (*CacheStatus, error) {
+	return m.validator.GetCacheStatus(ctx)
+}
+
+// debugLog logs debug messages if debug logging is enabled
+func (m *SmartBuildManager) debugLog(format string, args ...interface{}) {
+	if m.debugEnabled {
+		m.logger.Printf("[DEBUG] "+format, args...)
+	}
+}
+
+// validateBuildEnvironment checks if required build tools are available
+func (m *SmartBuildManager) validateBuildEnvironment() error {
+	m.debugLog("Validating build environment")
+
+	// Check if contracts directory exists and is accessible
+	if _, err := os.Stat(m.contractsDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("contracts directory does not exist: %s", m.contractsDir)
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied accessing contracts directory: %s", m.contractsDir)
+		}
+		return fmt.Errorf("error accessing contracts directory %s: %w", m.contractsDir, err)
+	}
+
+	// Check if required build tools are available
+	if err := m.checkBuildTool("forge"); err != nil {
+		return fmt.Errorf("forge tool validation failed: %w", err)
+	}
+
+	if err := m.checkBuildTool("just"); err != nil {
+		return fmt.Errorf("just tool validation failed: %w", err)
+	}
+
+	m.debugLog("Build environment validation successful")
+	return nil
+}
+
+// checkBuildTool verifies that a required build tool is available
+func (m *SmartBuildManager) checkBuildTool(tool string) error {
+	m.debugLog("Checking availability of build tool: %s", tool)
+
+	_, err := exec.LookPath(tool)
+	if err != nil {
+		return fmt.Errorf("required build tool '%s' not found in PATH: %w", tool, err)
+	}
+
+	m.debugLog("Build tool %s is available", tool)
+	return nil
+}
+
+// validateCacheWithFallback performs cache validation with graceful error handling
+func (m *SmartBuildManager) validateCacheWithFallback(ctx context.Context) (bool, error) {
+	m.debugLog("Validating cache with fallback handling")
+
+	cacheValid, err := m.validator.IsCacheValid(ctx)
+	if err != nil {
+		m.logger.Printf("Cache validation encountered error: %v", err)
+
+		// Try to get more detailed status information for better error reporting
+		if status, statusErr := m.validator.GetCacheStatus(ctx); statusErr == nil {
+			m.debugLog("Cache status details - Valid: %v, Reason: %s, Missing artifacts: %v",
+				status.IsValid, status.Reason, status.MissingArtifacts)
+		}
+
+		// Return the original error - caller will decide on fallback strategy
+		return false, fmt.Errorf("cache validation failed: %w", err)
+	}
+
+	m.debugLog("Cache validation completed successfully, valid: %v", cacheValid)
+	return cacheValid, nil
+}
+
+// performCleanBuildWithFallback executes a clean build with comprehensive error handling
+func (m *SmartBuildManager) performCleanBuildWithFallback(ctx context.Context) error {
+	m.debugLog("Performing clean build with fallback handling")
+
+	// First attempt: try the normal clean build process
+	if err := m.performCleanBuild(ctx); err != nil {
+		m.logger.Printf("Clean build failed: %v", err)
+
+		// Fallback strategy: try build without clean
+		m.logger.Printf("Attempting fallback: build without clean...")
+		if fallbackErr := m.performBuildWithErrorHandling(ctx); fallbackErr != nil {
+			// If both attempts fail, return a comprehensive error
+			return fmt.Errorf("clean build failed (%w) and fallback build also failed (%w)", err, fallbackErr)
+		}
+
+		m.logger.Printf("Fallback build succeeded after clean build failure")
+		return nil
+	}
+
+	m.debugLog("Clean build completed successfully")
+	return nil
+}
+
+// performIncrementalBuildWithFallback executes an incremental build with comprehensive error handling
+func (m *SmartBuildManager) performIncrementalBuildWithFallback(ctx context.Context) error {
+	m.debugLog("Performing incremental build with fallback handling")
+
+	// First attempt: try incremental build
+	if err := m.performIncrementalBuild(ctx); err != nil {
+		m.logger.Printf("Incremental build failed: %v", err)
+
+		// Fallback strategy: try clean build
+		m.logger.Printf("Attempting fallback: clean build after incremental build failure...")
+		if fallbackErr := m.performCleanBuild(ctx); fallbackErr != nil {
+			// If both attempts fail, return a comprehensive error
+			return fmt.Errorf("incremental build failed (%w) and fallback clean build also failed (%w)", err, fallbackErr)
+		}
+
+		m.logger.Printf("Fallback clean build succeeded after incremental build failure")
+		return nil
+	}
+
+	m.debugLog("Incremental build completed successfully")
+	return nil
+}
+
+// performBuildWithErrorHandling executes the build command with comprehensive error handling
+// It runs "just forge-build"
+func (m *SmartBuildManager) performBuildWithErrorHandling(ctx context.Context) error {
+	m.debugLog("Executing build command with error handling")
+
+	buildCmd := exec.CommandContext(ctx, "just", "forge-build")
+	buildCmd.Dir = m.contractsDir
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+
+	if err := buildCmd.Run(); err != nil {
+		// Provide more detailed error information
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("build command failed with exit code %d: %w", exitError.ExitCode(), err)
+		}
+		return fmt.Errorf("build command execution failed: %w", err)
+	}
+
+	m.logger.Printf("Build completed successfully")
+	return nil
+}

--- a/op-acceptance-tests/buildcache/manager_test.go
+++ b/op-acceptance-tests/buildcache/manager_test.go
@@ -1,0 +1,293 @@
+package buildcache
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSmartBuildManager_ExecuteBuild(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupFunc      func(t *testing.T, tempDir string)
+		forceRebuild   bool
+		skipCheck      bool
+		expectedAction string // "skip", "incremental", "clean"
+	}{
+		{
+			name: "force rebuild ignores cache state",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild:   true,
+			skipCheck:      false,
+			expectedAction: "clean",
+		},
+		{
+			name: "skip check performs clean build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild:   false,
+			skipCheck:      true,
+			expectedAction: "clean",
+		},
+		{
+			name: "valid cache skips build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupValidCache(t, tempDir)
+			},
+			forceRebuild:   false,
+			skipCheck:      false,
+			expectedAction: "skip",
+		},
+		{
+			name: "invalid cache triggers incremental build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupInvalidCache(t, tempDir)
+			},
+			forceRebuild:   false,
+			skipCheck:      false,
+			expectedAction: "incremental",
+		},
+		{
+			name: "missing artifacts triggers incremental build",
+			setupFunc: func(t *testing.T, tempDir string) {
+				setupMissingArtifacts(t, tempDir)
+			},
+			forceRebuild:   false,
+			skipCheck:      false,
+			expectedAction: "incremental",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tempDir, err := os.MkdirTemp("", "buildmanager_test_*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Setup test scenario
+			tt.setupFunc(t, tempDir)
+
+			// Create manager
+			logger := log.New(os.Stdout, "[TEST] ", log.LstdFlags)
+			manager := NewSmartBuildManager(tempDir, logger)
+			manager.SetForceRebuild(tt.forceRebuild)
+			manager.SetSkipCheck(tt.skipCheck)
+
+			// Test shouldSkipBuild to verify logic
+			ctx := context.Background()
+			shouldSkip, err := manager.shouldSkipBuild(ctx)
+			if err != nil {
+				t.Fatalf("shouldSkipBuild() error = %v", err)
+			}
+
+			expectedSkip := tt.expectedAction == "skip"
+			if shouldSkip != expectedSkip {
+				t.Errorf("shouldSkipBuild() = %v, want %v", shouldSkip, expectedSkip)
+			}
+
+			// Note: We don't test ExecuteBuild() directly because it would try to run
+			// actual forge and just commands. In a real integration test environment,
+			// we would mock these commands or use a test environment with the tools installed.
+		})
+	}
+}
+
+func TestSmartBuildManager_EnvironmentVariables(t *testing.T) {
+	// Test FORCE_REBUILD environment variable
+	t.Run("FORCE_REBUILD=true", func(t *testing.T) {
+		os.Setenv("FORCE_REBUILD", "true")
+		defer os.Unsetenv("FORCE_REBUILD")
+
+		tempDir, err := os.MkdirTemp("", "buildmanager_test_*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		logger := log.New(os.Stdout, "[TEST] ", log.LstdFlags)
+		manager := NewSmartBuildManager(tempDir, logger)
+
+		if !manager.forceRebuild {
+			t.Error("Expected forceRebuild to be true when FORCE_REBUILD=true")
+		}
+	})
+
+	// Test SKIP_BUILD_CHECK environment variable
+	t.Run("SKIP_BUILD_CHECK=true", func(t *testing.T) {
+		os.Setenv("SKIP_BUILD_CHECK", "true")
+		defer os.Unsetenv("SKIP_BUILD_CHECK")
+
+		tempDir, err := os.MkdirTemp("", "buildmanager_test_*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		logger := log.New(os.Stdout, "[TEST] ", log.LstdFlags)
+		manager := NewSmartBuildManager(tempDir, logger)
+
+		if !manager.skipCheck {
+			t.Error("Expected skipCheck to be true when SKIP_BUILD_CHECK=true")
+		}
+	})
+
+	// Test default values when environment variables are not set
+	t.Run("default values", func(t *testing.T) {
+		os.Unsetenv("FORCE_REBUILD")
+		os.Unsetenv("SKIP_BUILD_CHECK")
+
+		tempDir, err := os.MkdirTemp("", "buildmanager_test_*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		logger := log.New(os.Stdout, "[TEST] ", log.LstdFlags)
+		manager := NewSmartBuildManager(tempDir, logger)
+
+		if manager.forceRebuild {
+			t.Error("Expected forceRebuild to be false by default")
+		}
+		if manager.skipCheck {
+			t.Error("Expected skipCheck to be false by default")
+		}
+	})
+}
+
+func TestSmartBuildManager_SettersAndGetters(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildmanager_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	logger := log.New(os.Stdout, "[TEST] ", log.LstdFlags)
+	manager := NewSmartBuildManager(tempDir, logger)
+
+	// Test SetForceRebuild
+	manager.SetForceRebuild(true)
+	if !manager.forceRebuild {
+		t.Error("SetForceRebuild(true) did not set forceRebuild to true")
+	}
+
+	manager.SetForceRebuild(false)
+	if manager.forceRebuild {
+		t.Error("SetForceRebuild(false) did not set forceRebuild to false")
+	}
+
+	// Test SetSkipCheck
+	manager.SetSkipCheck(true)
+	if !manager.skipCheck {
+		t.Error("SetSkipCheck(true) did not set skipCheck to true")
+	}
+
+	manager.SetSkipCheck(false)
+	if manager.skipCheck {
+		t.Error("SetSkipCheck(false) did not set skipCheck to false")
+	}
+}
+
+func TestSmartBuildManager_GetCacheStatus(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildmanager_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Setup valid cache
+	setupValidCache(t, tempDir)
+
+	logger := log.New(os.Stdout, "[TEST] ", log.LstdFlags)
+	manager := NewSmartBuildManager(tempDir, logger)
+
+	ctx := context.Background()
+	status, err := manager.GetCacheStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetCacheStatus() error = %v", err)
+	}
+
+	if !status.IsValid {
+		t.Error("Expected cache status to be valid")
+	}
+
+	if status.Reason != "all artifacts are up-to-date" {
+		t.Errorf("Expected reason to be 'all artifacts are up-to-date', got %s", status.Reason)
+	}
+}
+
+// Helper functions for test setup
+
+func setupValidCache(t *testing.T, tempDir string) {
+	// Create src directory with source file first
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "test.sol"), []byte("contract Test {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create foundry.toml
+	foundryPath := filepath.Join(tempDir, "foundry.toml")
+	if err := os.WriteFile(foundryPath, []byte("[profile.default]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sleep to ensure different timestamps
+	time.Sleep(10 * time.Millisecond)
+
+	// Create newer artifacts
+	artifactsDir := filepath.Join(tempDir, "forge-artifacts")
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	artifactPath := filepath.Join(artifactsDir, "test.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"artifact": "data"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupInvalidCache(t *testing.T, tempDir string) {
+	// Create artifacts first (older)
+	artifactsDir := filepath.Join(tempDir, "forge-artifacts")
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	artifactPath := filepath.Join(artifactsDir, "test.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"artifact": "data"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sleep to ensure different timestamps
+	time.Sleep(10 * time.Millisecond)
+
+	// Create src directory with newer source file
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "test.sol"), []byte("contract Test {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupMissingArtifacts(t *testing.T, tempDir string) {
+	// Create src directory with source file
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "test.sol"), []byte("contract Test {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Don't create forge-artifacts directory
+}

--- a/op-acceptance-tests/buildcache/validator.go
+++ b/op-acceptance-tests/buildcache/validator.go
@@ -1,0 +1,366 @@
+package buildcache
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// BuildCacheValidator determines if contract artifacts are up-to-date relative to source files
+type BuildCacheValidator struct {
+	contractsDir string
+	logger       *log.Logger
+	debugEnabled bool
+}
+
+// CacheStatus represents the current state of the build cache
+type CacheStatus struct {
+	IsValid          bool
+	Reason           string
+	NewestSource     time.Time
+	OldestArtifact   time.Time
+	MissingArtifacts bool
+}
+
+// NewBuildCacheValidator creates a new BuildCacheValidator instance
+func NewBuildCacheValidator(contractsDir string, logger *log.Logger) *BuildCacheValidator {
+	if logger == nil {
+		logger = log.New(os.Stdout, "[BUILD-CACHE] ", log.LstdFlags)
+	}
+
+	// Enable debug logging if BUILD_CACHE_DEBUG environment variable is set
+	debugEnabled := os.Getenv("BUILD_CACHE_DEBUG") == "true"
+
+	return &BuildCacheValidator{
+		contractsDir: contractsDir,
+		logger:       logger,
+		debugEnabled: debugEnabled,
+	}
+}
+
+// IsCacheValid determines if the build cache is valid by comparing source and artifact timestamps
+func (v *BuildCacheValidator) IsCacheValid(ctx context.Context) (bool, error) {
+	status, err := v.GetCacheStatus(ctx)
+	if err != nil {
+		return false, err
+	}
+	return status.IsValid, nil
+}
+
+// GetCacheStatus provides detailed information about the cache state
+func (v *BuildCacheValidator) GetCacheStatus(ctx context.Context) (*CacheStatus, error) {
+	v.debugLog("Starting cache validation for contracts directory: %s", v.contractsDir)
+	status := &CacheStatus{
+		IsValid: true, // Start with valid assumption, set to false if issues found
+		Reason:  "all artifacts are up-to-date",
+	}
+
+	// Validate contracts directory exists and is accessible
+	if err := v.validateContractsDirectory(); err != nil {
+		v.logger.Printf("Contracts directory validation failed: %v", err)
+		return nil, fmt.Errorf("contracts directory validation failed: %w", err)
+	}
+
+	// Check if artifacts directory exists
+	artifactsDir := filepath.Join(v.contractsDir, "forge-artifacts")
+	if err := v.validateArtifactsDirectory(artifactsDir, status); err != nil {
+		if !status.IsValid {
+			// This is an expected condition (missing artifacts), not an error
+			v.debugLog("Artifacts directory validation resulted in invalid cache: %s", status.Reason)
+			return status, nil
+		}
+		return nil, fmt.Errorf("artifacts directory validation failed: %w", err)
+	}
+
+	// If artifacts directory validation already marked cache as invalid, return early
+	if !status.IsValid {
+		return status, nil
+	}
+
+	// Check if artifacts directory has JSON files (indicating successful build)
+	hasArtifacts, err := v.hasArtifactFiles(artifactsDir)
+	if err != nil {
+		v.logger.Printf("Error checking artifact files: %v", err)
+		return nil, fmt.Errorf("failed to check artifact files: %w", err)
+	}
+	if !hasArtifacts {
+		v.logger.Printf("forge-artifacts directory is empty or has no JSON files")
+		status.IsValid = false
+		status.Reason = "forge-artifacts directory is empty or has no JSON files"
+		status.MissingArtifacts = true
+		return status, nil
+	}
+
+	// Compare source vs artifact timestamps with comprehensive error handling
+	newestSource, err := v.getNewestSourceTime()
+	if err != nil {
+		v.logger.Printf("Error getting newest source time: %v", err)
+		return nil, fmt.Errorf("failed to get newest source time: %w", err)
+	}
+	status.NewestSource = newestSource
+	v.debugLog("Newest source file timestamp: %v", newestSource.Format(time.RFC3339))
+
+	oldestArtifact, err := v.getOldestArtifactTime(artifactsDir)
+	if err != nil {
+		v.logger.Printf("Error getting oldest artifact time: %v", err)
+		return nil, fmt.Errorf("failed to get oldest artifact time: %w", err)
+	}
+	status.OldestArtifact = oldestArtifact
+	v.debugLog("Oldest artifact timestamp: %v", oldestArtifact.Format(time.RFC3339))
+
+	// If source files are newer than artifacts, cache is invalid
+	if newestSource.After(oldestArtifact) {
+		v.logger.Printf("Source files are newer than artifacts (source: %v, artifacts: %v)",
+			newestSource.Format(time.RFC3339), oldestArtifact.Format(time.RFC3339))
+		status.IsValid = false
+		status.Reason = "source files are newer than artifacts"
+		return status, nil
+	} else {
+		v.debugLog("Source files are not newer than artifacts (source: %v, artifacts: %v)",
+			newestSource.Format(time.RFC3339), oldestArtifact.Format(time.RFC3339))
+	}
+
+	// Check if foundry.toml is newer than artifacts with error handling
+	if err := v.validateFoundryConfig(status, oldestArtifact); err != nil {
+		v.logger.Printf("Error validating foundry config: %v", err)
+		return nil, fmt.Errorf("failed to validate foundry config: %w", err)
+	}
+
+	if !status.IsValid {
+		return status, nil
+	}
+
+	v.logger.Printf("Build cache is valid")
+	return status, nil
+}
+
+// hasArtifactFiles checks if the artifacts directory contains JSON files
+func (v *BuildCacheValidator) hasArtifactFiles(artifactsDir string) (bool, error) {
+	v.debugLog("Checking for artifact files in: %s", artifactsDir)
+
+	// Check if the directory exists first
+	if _, err := os.Stat(artifactsDir); err != nil {
+		if os.IsNotExist(err) {
+			v.debugLog("Artifacts directory does not exist: %s", artifactsDir)
+			return false, nil // This is expected, not an error
+		}
+		if os.IsPermission(err) {
+			v.logger.Printf("Warning: Permission denied accessing artifacts directory: %s", artifactsDir)
+			return false, nil // Treat as no artifacts available
+		}
+		return false, fmt.Errorf("error accessing artifacts directory %s: %w", artifactsDir, err)
+	}
+
+	var hasJSON bool
+	err := filepath.Walk(artifactsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			v.debugLog("Error walking artifacts path %s: %v", path, err)
+			if os.IsPermission(err) {
+				v.logger.Printf("Warning: Permission denied accessing %s, skipping", path)
+				return nil // Skip this file/directory but continue walking
+			}
+			return fmt.Errorf("error walking artifacts directory at %s: %w", path, err)
+		}
+		if !info.IsDir() && strings.HasSuffix(strings.ToLower(info.Name()), ".json") {
+			v.debugLog("Found artifact file: %s", path)
+			hasJSON = true
+			return filepath.SkipDir // We found at least one JSON file, no need to continue
+		}
+		return nil
+	})
+
+	v.debugLog("Artifact files check completed, has JSON files: %v", hasJSON)
+	return hasJSON, err
+}
+
+// getNewestSourceTime finds the newest modification time among all source files
+func (v *BuildCacheValidator) getNewestSourceTime() (time.Time, error) {
+	v.debugLog("Getting newest source file timestamp")
+
+	var newestTime time.Time
+	srcDir := filepath.Join(v.contractsDir, "src")
+
+	// Check if source directory exists first
+	if _, err := os.Stat(srcDir); err != nil {
+		if os.IsNotExist(err) {
+			return time.Time{}, fmt.Errorf("source directory does not exist: %s", srcDir)
+		}
+		if os.IsPermission(err) {
+			return time.Time{}, fmt.Errorf("permission denied accessing source directory: %s", srcDir)
+		}
+		return time.Time{}, fmt.Errorf("error accessing source directory %s: %w", srcDir, err)
+	}
+
+	var sourceFileCount int
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			v.debugLog("Error walking path %s: %v", path, err)
+			if os.IsPermission(err) {
+				v.logger.Printf("Warning: Permission denied accessing %s, skipping", path)
+				return nil // Skip this file/directory but continue walking
+			}
+			return fmt.Errorf("error walking source directory at %s: %w", path, err)
+		}
+
+		if !info.IsDir() && v.isSourceFile(info.Name()) {
+			sourceFileCount++
+			v.debugLog("Found source file: %s (modified: %v)", path, info.ModTime().Format(time.RFC3339))
+			if info.ModTime().After(newestTime) {
+				newestTime = info.ModTime()
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to walk source directory: %w", err)
+	}
+
+	if sourceFileCount == 0 {
+		return time.Time{}, fmt.Errorf("no source files found in %s", srcDir)
+	}
+
+	v.debugLog("Found %d source files, newest timestamp: %v", sourceFileCount, newestTime.Format(time.RFC3339))
+	return newestTime, nil
+}
+
+// getOldestArtifactTime finds the oldest modification time among all artifact files
+func (v *BuildCacheValidator) getOldestArtifactTime(artifactsDir string) (time.Time, error) {
+	v.debugLog("Getting oldest artifact timestamp")
+
+	var oldestTime time.Time
+	first := true
+	var artifactFileCount int
+
+	err := filepath.Walk(artifactsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			v.debugLog("Error walking artifacts path %s: %v", path, err)
+			if os.IsPermission(err) {
+				v.logger.Printf("Warning: Permission denied accessing %s, skipping", path)
+				return nil // Skip this file/directory but continue walking
+			}
+			return fmt.Errorf("error walking artifacts directory at %s: %w", path, err)
+		}
+
+		if !info.IsDir() && strings.HasSuffix(strings.ToLower(info.Name()), ".json") {
+			artifactFileCount++
+			v.debugLog("Found artifact file: %s (modified: %v)", path, info.ModTime().Format(time.RFC3339))
+			if first || info.ModTime().Before(oldestTime) {
+				oldestTime = info.ModTime()
+				first = false
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to walk artifacts directory: %w", err)
+	}
+
+	if artifactFileCount == 0 {
+		return time.Time{}, fmt.Errorf("no artifact files found in %s", artifactsDir)
+	}
+
+	v.debugLog("Found %d artifact files, oldest timestamp: %v", artifactFileCount, oldestTime.Format(time.RFC3339))
+	return oldestTime, nil
+}
+
+// isSourceFile determines if a file is a Solidity source file
+func (v *BuildCacheValidator) isSourceFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".sol"
+}
+
+// debugLog logs debug messages if debug logging is enabled
+func (v *BuildCacheValidator) debugLog(format string, args ...interface{}) {
+	if v.debugEnabled {
+		v.logger.Printf("[DEBUG] "+format, args...)
+	}
+}
+
+// validateContractsDirectory ensures the contracts directory exists and is accessible
+func (v *BuildCacheValidator) validateContractsDirectory() error {
+	v.debugLog("Validating contracts directory: %s", v.contractsDir)
+
+	info, err := os.Stat(v.contractsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("contracts directory does not exist: %s", v.contractsDir)
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied accessing contracts directory: %s", v.contractsDir)
+		}
+		return fmt.Errorf("error accessing contracts directory %s: %w", v.contractsDir, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("contracts path is not a directory: %s", v.contractsDir)
+	}
+
+	v.debugLog("Contracts directory validation successful")
+	return nil
+}
+
+// validateArtifactsDirectory checks if artifacts directory exists and is accessible
+func (v *BuildCacheValidator) validateArtifactsDirectory(artifactsDir string, status *CacheStatus) error {
+	v.debugLog("Validating artifacts directory: %s", artifactsDir)
+
+	info, err := os.Stat(artifactsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			v.logger.Printf("forge-artifacts directory does not exist: %s", artifactsDir)
+			status.IsValid = false
+			status.Reason = "forge-artifacts directory does not exist"
+			status.MissingArtifacts = true
+			return nil // This is expected, not an error
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied accessing artifacts directory: %s", artifactsDir)
+		}
+		return fmt.Errorf("error accessing artifacts directory %s: %w", artifactsDir, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("artifacts path is not a directory: %s", artifactsDir)
+	}
+
+	v.debugLog("Artifacts directory validation successful")
+	return nil
+}
+
+// validateFoundryConfig checks if foundry.toml is newer than artifacts
+func (v *BuildCacheValidator) validateFoundryConfig(status *CacheStatus, oldestArtifact time.Time) error {
+	foundryPath := filepath.Join(v.contractsDir, "foundry.toml")
+	v.debugLog("Checking foundry.toml at: %s", foundryPath)
+
+	foundryInfo, err := os.Stat(foundryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			v.debugLog("foundry.toml not found, skipping config validation")
+			return nil // foundry.toml is optional
+		}
+		if os.IsPermission(err) {
+			v.logger.Printf("Warning: Permission denied accessing foundry.toml: %s", foundryPath)
+			return nil // Treat as non-critical error
+		}
+		return fmt.Errorf("error accessing foundry.toml at %s: %w", foundryPath, err)
+	}
+
+	v.debugLog("foundry.toml timestamp: %v", foundryInfo.ModTime().Format(time.RFC3339))
+
+	if foundryInfo.ModTime().After(oldestArtifact) {
+		v.logger.Printf("foundry.toml is newer than artifacts (foundry: %v, artifacts: %v)",
+			foundryInfo.ModTime().Format(time.RFC3339), oldestArtifact.Format(time.RFC3339))
+		status.IsValid = false
+		status.Reason = "foundry.toml is newer than artifacts"
+	} else {
+		v.debugLog("foundry.toml is not newer than artifacts (foundry: %v, artifacts: %v)",
+			foundryInfo.ModTime().Format(time.RFC3339), oldestArtifact.Format(time.RFC3339))
+	}
+
+	return nil
+}

--- a/op-acceptance-tests/buildcache/validator_test.go
+++ b/op-acceptance-tests/buildcache/validator_test.go
@@ -1,0 +1,224 @@
+package buildcache
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildCacheValidator_IsCacheValid_MissingArtifacts(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildcache_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "test.sol"), []byte("contract Test {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := log.New(io.Discard, "[TEST] ", log.LstdFlags)
+	validator := NewBuildCacheValidator(tempDir, logger)
+
+	ctx := context.Background()
+	valid, err := validator.IsCacheValid(ctx)
+	if err != nil {
+		t.Fatalf("IsCacheValid() error = %v", err)
+	}
+
+	if valid {
+		t.Error("Expected cache to be invalid when artifacts directory is missing")
+	}
+}
+
+func TestBuildCacheValidator_IsCacheValid_StaleArtifacts(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildcache_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	artifactsDir := filepath.Join(tempDir, "forge-artifacts")
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	artifactPath := filepath.Join(artifactsDir, "test.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"artifact": "data"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "test.sol"), []byte("contract Test {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := log.New(io.Discard, "[TEST] ", log.LstdFlags)
+	validator := NewBuildCacheValidator(tempDir, logger)
+
+	ctx := context.Background()
+	valid, err := validator.IsCacheValid(ctx)
+	if err != nil {
+		t.Fatalf("IsCacheValid() error = %v", err)
+	}
+
+	if valid {
+		t.Error("Expected cache to be invalid when source files are newer than artifacts")
+	}
+}
+
+func TestBuildCacheValidator_NoSourceDirectory(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildcache_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	logger := log.New(io.Discard, "[TEST] ", log.LstdFlags)
+	validator := NewBuildCacheValidator(tempDir, logger)
+
+	_, err = validator.getNewestSourceTime()
+	if err == nil {
+		t.Error("getNewestSourceTime() should return error when src directory does not exist")
+	}
+
+	if !strings.Contains(err.Error(), "source directory does not exist") {
+		t.Errorf("Expected error about source directory not existing, got: %v", err)
+	}
+}
+
+func TestBuildCacheValidator_IsCacheValid_UpToDateArtifacts(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildcache_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "test.sol"), []byte("contract Test {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	artifactsDir := filepath.Join(tempDir, "forge-artifacts")
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	artifactPath := filepath.Join(artifactsDir, "test.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"artifact": "data"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := log.New(io.Discard, "[TEST] ", log.LstdFlags)
+	validator := NewBuildCacheValidator(tempDir, logger)
+
+	ctx := context.Background()
+	valid, err := validator.IsCacheValid(ctx)
+	if err != nil {
+		t.Fatalf("IsCacheValid() error = %v", err)
+	}
+
+	if !valid {
+		t.Error("Expected cache to be valid when artifacts are newer than source files")
+	}
+}
+
+func TestBuildCacheValidator_CrossPlatformTimestamps(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "buildcache_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	srcDir := filepath.Join(tempDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	artifactsDir := filepath.Join(tempDir, "forge-artifacts")
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	baseTime := time.Now().Truncate(time.Second)
+
+	tests := []struct {
+		name          string
+		sourceTime    time.Time
+		artifactTime  time.Time
+		expectedValid bool
+	}{
+		{
+			name:          "artifacts exactly 1 second newer",
+			sourceTime:    baseTime,
+			artifactTime:  baseTime.Add(1 * time.Second),
+			expectedValid: true,
+		},
+		{
+			name:          "source exactly 1 millisecond newer",
+			sourceTime:    baseTime.Add(1 * time.Millisecond),
+			artifactTime:  baseTime,
+			expectedValid: false,
+		},
+		{
+			name:          "same timestamp",
+			sourceTime:    baseTime,
+			artifactTime:  baseTime,
+			expectedValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceFile := filepath.Join(srcDir, "test.sol")
+			if err := os.WriteFile(sourceFile, []byte("contract Test {}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(sourceFile, tt.sourceTime, tt.sourceTime); err != nil {
+				t.Fatal(err)
+			}
+
+			artifactFile := filepath.Join(artifactsDir, "test.json")
+			if err := os.WriteFile(artifactFile, []byte(`{"artifact": "data"}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(artifactFile, tt.artifactTime, tt.artifactTime); err != nil {
+				t.Fatal(err)
+			}
+
+			logger := log.New(io.Discard, "[TEST] ", log.LstdFlags)
+			validator := NewBuildCacheValidator(tempDir, logger)
+
+			ctx := context.Background()
+			valid, err := validator.IsCacheValid(ctx)
+			if err != nil {
+				t.Fatalf("IsCacheValid() error = %v", err)
+			}
+
+			if valid != tt.expectedValid {
+				t.Errorf("IsCacheValid() = %v, want %v (source: %v, artifact: %v)",
+					valid, tt.expectedValid, tt.sourceTime, tt.artifactTime)
+			}
+
+			os.Remove(sourceFile)
+			os.Remove(artifactFile)
+		})
+	}
+}

--- a/op-acceptance-tests/cmd/main.go
+++ b/op-acceptance-tests/cmd/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/telemetry"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/buildcache"
 	"github.com/honeycombio/otel-config-go/otelconfig"
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel"
@@ -105,6 +107,72 @@ func main() {
 	}
 }
 
+// ensureContractsBuilt ensures that contract artifacts are built and up-to-date
+func ensureContractsBuilt(ctx context.Context, contractsDir string) error {
+	logger := log.New(os.Stdout, "[BUILD-CACHE] ", log.LstdFlags)
+
+	// Log the start of build optimization process
+	logger.Printf("Starting build optimization for contracts directory: %s", contractsDir)
+
+	// Validate contracts directory exists before proceeding
+	if err := validateContractsDirectory(contractsDir, logger); err != nil {
+		logger.Printf("Contracts directory validation failed: %v", err)
+		return fmt.Errorf("contracts directory validation failed: %w", err)
+	}
+
+	// Create build manager
+	buildManager := buildcache.NewSmartBuildManager(contractsDir, logger)
+
+	// Execute build with optimization
+	if err := buildManager.ExecuteBuild(ctx); err != nil {
+		logger.Printf("Build execution failed: %v", err)
+
+		// Attempt to provide more context about the failure
+		if status, statusErr := buildManager.GetCacheStatus(ctx); statusErr == nil {
+			logger.Printf("Cache status at failure - Valid: %v, Reason: %s, Missing artifacts: %v",
+				status.IsValid, status.Reason, status.MissingArtifacts)
+		}
+
+		return fmt.Errorf("failed to ensure contracts are built: %w", err)
+	}
+
+	logger.Printf("Build optimization completed successfully")
+	return nil
+}
+
+// validateContractsDirectory performs basic validation of the contracts directory
+func validateContractsDirectory(contractsDir string, logger *log.Logger) error {
+	// Check if contracts directory exists
+	info, err := os.Stat(contractsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("contracts directory does not exist: %s", contractsDir)
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied accessing contracts directory: %s", contractsDir)
+		}
+		return fmt.Errorf("error accessing contracts directory %s: %w", contractsDir, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("contracts path is not a directory: %s", contractsDir)
+	}
+
+	// Check for expected subdirectories
+	expectedDirs := []string{"src", "foundry.toml"}
+	for _, expectedPath := range expectedDirs {
+		fullPath := filepath.Join(contractsDir, expectedPath)
+		if _, err := os.Stat(fullPath); err != nil {
+			if os.IsNotExist(err) {
+				logger.Printf("Warning: Expected path not found: %s", fullPath)
+				// Don't fail here, just warn - some paths might be optional
+			}
+		}
+	}
+
+	return nil
+}
+
 func runAcceptanceTest(c *cli.Context) error {
 	// Get command line arguments
 	orchestrator := c.String(orchestratorFlag.Name)
@@ -172,6 +240,16 @@ func runAcceptanceTest(c *cli.Context) error {
 	defer span.End()
 
 	steps := []func(ctx context.Context) error{}
+
+	// Add build cache validation step for sysgo orchestrator
+	if orchestrator == "sysgo" {
+		steps = append(steps,
+			func(ctx context.Context) error {
+				contractsDir := filepath.Join(absTestDir, "packages", "contracts-bedrock")
+				return ensureContractsBuilt(ctx, contractsDir)
+			},
+		)
+	}
 
 	// Deploy devnet if needed (simple name devnets only, when not reusing)
 	if needsDeployment {

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,3 +1,12 @@
+# Build Optimization Environment Variables:
+# - FORCE_REBUILD: Set to "true" to force a full clean rebuild of contracts (default: false)
+# - SKIP_BUILD_CHECK: Set to "true" to skip build cache validation and always rebuild (default: false)
+# - BUILD_CACHE_DEBUG: Set to "true" to enable verbose build optimization logging (default: false)
+#
+# Example usage:
+#   FORCE_REBUILD=true just acceptance-test "" base
+#   BUILD_CACHE_DEBUG=true just acceptance-test "" holocene
+
 REPO_ROOT := `realpath ..`
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
 ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v1.0.0")
@@ -38,11 +47,11 @@ acceptance-test devnet="" gate="holocene":
     fi
 
     # For sysgo orchestrator (in-process testing) ensure:
-    # - contracts are built
+    # - contracts are built (handled by Go-based build optimization in main.go)
     # - cannon dependencies are built
-    # Note: build contracts only if not in CI (CI jobs already take care of this)
+    # Note: Contract building is now handled by the Go entry point with intelligent caching
     if [[ "{{devnet}}" == "" && -z "${CIRCLECI:-}" ]]; then
-        echo "Building contracts (local build)..."
+        echo "Preparing for local build..."
         cd {{REPO_ROOT}}
         echo " - Updating submodules..."
         git submodule update --init --recursive
@@ -51,9 +60,6 @@ acceptance-test devnet="" gate="holocene":
         cd packages/contracts-bedrock
         echo " - Installing contracts..."
         just install
-        echo " - Cleaning forge..."
-        forge clean
-        just forge-build
         cd {{REPO_ROOT}}
 
         echo "Checking cannon dependencies..."


### PR DESCRIPTION
## Description
Implemented an simple build cache system for acceptance tests that dramatically reduces development iteration time by skipping unnecessary contract rebuilds, which take about 6 minutes.

* Detects when contract source files haven't changed since last build
* Automatically skips rebuild when cache is valid
* Falls back to full rebuild when contracts are modified or when forced
* Backwards compatible; no change to workflow


## Tests

BASE GATE:
* First run (cold cache): 9.5 minutes
* Second run (hot cache): 2.7 minutes

SINGLE TEST:
* First run (cold cache): 6.5 minutes
* Second run (hot cache): 25 seconds
