### PR TITLE
chore(op-devstack): Don't fail if no conductors are present

### DIFF
--- a/op-devstack/shim/l2_network.go
+++ b/op-devstack/shim/l2_network.go
@@ -220,9 +220,7 @@ func (p *presetL2Network) L2Challengers() []stack.L2Challenger {
 }
 
 func (p *presetL2Network) Conductors() []stack.Conductor {
-	output := stack.SortConductors(p.conductors.Values())
-	p.require().NotEmpty(output, "l2 chain %s must have at least one conductor", p.ID())
-	return output
+	return stack.SortConductors(p.conductors.Values())
 }
 
 func (p *presetL2Network) FlashblocksBuilders() []stack.FlashblocksBuilderNode {


### PR DESCRIPTION
## Overview

Updates the behavior of `l2_network.go`'s `ExtensibleL2Network` implementation to not fail tests if there are no conductors present in the query to fetch the network's conductors. This function is useful for tests that want to gate on configurations that have conductors present. As-is, it's not possible to do so due to the test failing on query.
