### PR TITLE
op-supervisor: replace ChainProcessEvent with synchronous function call

### DIFF
--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -107,20 +107,15 @@ func (s *ChainProcessor) nextNum() uint64 {
 	return headNum + 1
 }
 
+func (s *ChainProcessor) ProcessChain(target uint64) {
+	s.UpdateTarget(target)
+	if s.running.CompareAndSwap(false, true) {
+		s.index()
+	}
+}
+
 func (s *ChainProcessor) OnEvent(ctx context.Context, ev event.Event) bool {
 	switch x := ev.(type) {
-	case superevents.ChainProcessEvent:
-		if x.ChainID != s.chain {
-			return false
-		}
-		// always update the target
-		s.UpdateTarget(x.Target)
-
-		// and if not already running, begin indexing
-		if s.running.CompareAndSwap(false, true) {
-			s.index()
-		}
-
 	case superevents.ChainIndexingContinueEvent:
 		if x.ChainID != s.chain {
 			return false

--- a/op-supervisor/supervisor/backend/superevents/events.go
+++ b/op-supervisor/supervisor/backend/superevents/events.go
@@ -5,15 +5,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-type ChainProcessEvent struct {
-	ChainID eth.ChainID
-	Target  uint64
-}
-
-func (ev ChainProcessEvent) String() string {
-	return "chain-process"
-}
-
 type UpdateCrossUnsafeRequestEvent struct {
 	ChainID eth.ChainID
 }


### PR DESCRIPTION
This PR is removing the `ChainProcessEvent` event, and replacing it with synchronous function call.