### PR TITLE
op-e2e: Support blob DA type for interop supersystem

### DIFF
--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -45,6 +45,15 @@ func TestSuperCannonGame(t *testing.T) {
 	})
 }
 
+func TestSuperCannonGame_WithBlobs(t *testing.T) {
+	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
+		ctx := context.Background()
+		sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType), WithBlobBatches())
+		game := disputeGameFactory.StartSuperCannonGame(ctx, common.Hash{0x01})
+		testCannonGame(t, ctx, createSuperGameArena(t, sys, game), &game.SplitGameHelper)
+	})
+}
+
 func TestSuperCannonGame_ChallengeAllZeroClaim(t *testing.T) {
 	RunTestAcrossVmTypes(t, func(t *testing.T, allocType config.AllocType) {
 		ctx := context.Background()

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -19,8 +19,9 @@ import (
 )
 
 type faultDisputeConfig struct {
-	sysOpts      []e2esys.SystemConfigOpt
-	cfgModifiers []func(cfg *e2esys.SystemConfig)
+	sysOpts          []e2esys.SystemConfigOpt
+	cfgModifiers     []func(cfg *e2esys.SystemConfig)
+	batcherUsesBlobs bool
 }
 
 type faultDisputeConfigOpts func(cfg *faultDisputeConfig)
@@ -35,6 +36,7 @@ func WithBatcherStopped() faultDisputeConfigOpts {
 
 func WithBlobBatches() faultDisputeConfigOpts {
 	return func(fdc *faultDisputeConfig) {
+		fdc.batcherUsesBlobs = true
 		fdc.cfgModifiers = append(fdc.cfgModifiers, func(cfg *e2esys.SystemConfig) {
 			cfg.DataAvailabilityType = batcherFlags.BlobsType
 

--- a/op-e2e/faultproofs/util_interop.go
+++ b/op-e2e/faultproofs/util_interop.go
@@ -41,6 +41,7 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 	}
 	superCfg := interop.SuperSystemConfig{
 		SupportTimeTravel: true,
+		BatcherUsesBlobs:  fdc.batcherUsesBlobs,
 	}
 
 	hdWallet, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -107,6 +107,7 @@ type SuperSystem interface {
 type SuperSystemConfig struct {
 	mempoolFiltering  bool
 	SupportTimeTravel bool
+	BatcherUsesBlobs  bool
 }
 
 // NewSuperSystem creates a new SuperSystem from a recipe. It creates an interopE2ESystem.

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -269,6 +269,10 @@ func (s *interopE2ESystem) newBatcherForL2(
 ) *bss.BatcherService {
 	batcherSecret := operatorKeys[devkeys.BatcherRole]
 	logger := s.logger.New("role", "batcher"+id)
+	daType := batcherFlags.CalldataType
+	if s.config.BatcherUsesBlobs {
+		daType = batcherFlags.BlobsType
+	}
 	batcherCLIConfig := &bss.CLIConfig{
 		L1EthRpc:                 s.l1.UserRPC().RPC(),
 		L2EthRpc:                 []string{l2Geth.UserRPC().RPC()},
@@ -289,7 +293,7 @@ func (s *interopE2ESystem) newBatcherForL2(
 		Stopped:               false,
 		BatchType:             derive.SpanBatchType,
 		MaxBlocksPerSpanBatch: 10,
-		DataAvailabilityType:  batcherFlags.CalldataType,
+		DataAvailabilityType:  daType,
 		CompressionAlgo:       derive.Brotli,
 	}
 	batcher, err := bss.BatcherServiceFromCLIConfig(


### PR DESCRIPTION
Allow the supersystem batcher to be configured to use blobs for DA.

fixes https://github.com/ethereum-optimism/optimism/issues/15406