### PR TITLE
op-e2e: Enable blobs DA in TestSuperCannonStepWithPreimage tests

### DIFF
--- a/op-e2e/e2eutils/disputegame/super_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/super_cannon_helper.go
@@ -194,3 +194,20 @@ func (g *SuperCannonGameHelper) createSuperTraceProvider(ctx context.Context) *s
 	require.NoError(g.T, err, "failed to create rollup configs")
 	return super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, rootProvider, l1Head, splitDepth, prestateTimestamp, poststateTimestamp)
 }
+
+// BisectUntilSplitDepth bisects the top game towards the specified trace index at split depth.
+// It returns the claim at the split depth.
+func (g *SuperCannonGameHelper) BisectUntilSplitDepth(ctx context.Context, claim *ClaimHelper, targetTraceIndexAtSplitDepth uint64) *ClaimHelper {
+	provider := g.createSuperTraceProvider(ctx)
+	for claim.IsOutputRoot(ctx) && !claim.IsOutputRootLeaf(ctx) {
+		g.LogGameData(ctx)
+		claim = claim.WaitForCounterClaim(ctx)
+		if !claim.IsOutputRoot(ctx) || claim.IsOutputRootLeaf(ctx) {
+			break
+		}
+		g.LogGameData(ctx)
+		claim = topGameTraceBisection(g.t, ctx, claim, g.splitGame.SplitDepth(ctx), targetTraceIndexAtSplitDepth, provider)
+	}
+	g.LogGameData(ctx)
+	return claim
+}

--- a/op-e2e/e2eutils/disputegame/super_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/super_cannon_helper.go
@@ -195,19 +195,28 @@ func (g *SuperCannonGameHelper) createSuperTraceProvider(ctx context.Context) *s
 	return super.NewSuperTraceProvider(logger, rollupCfgs, prestateProvider, rootProvider, l1Head, splitDepth, prestateTimestamp, poststateTimestamp)
 }
 
-// BisectUntilSplitDepth bisects the top game towards the specified trace index at split depth.
-// It returns the claim at the split depth.
-func (g *SuperCannonGameHelper) BisectUntilSplitDepth(ctx context.Context, claim *ClaimHelper, targetTraceIndexAtSplitDepth uint64) *ClaimHelper {
-	provider := g.createSuperTraceProvider(ctx)
-	for claim.IsOutputRoot(ctx) && !claim.IsOutputRootLeaf(ctx) {
-		g.LogGameData(ctx)
-		claim = claim.WaitForCounterClaim(ctx)
-		if !claim.IsOutputRoot(ctx) || claim.IsOutputRootLeaf(ctx) {
-			break
+// InitFirstDerivationGame builds a top-level game whose deepest node (at splitDepth) asserts the first
+// output-root derivation that follows the prestate (timestamp=1, step<=1).
+// Returns the claim positioned at splitDepth, which is the parent of the constructed execution subgame root.
+func (g *SuperCannonGameHelper) InitFirstDerivationGame(ctx context.Context, correctTrace *OutputHonestHelper) *ClaimHelper {
+	splitDepth := g.SplitDepth(ctx)
+	g.Require.EqualValues(splitDepth, 30, "this operation assumes a specific split depth")
+	claim := g.RootClaim(ctx)
+
+	// We identify the one required right bisection that ensures that an execution game is positioned to derive the first output root
+	// This occurs at splitDepth-log(StepsPerTimestamp).
+	for {
+		if claim.Depth() == splitDepth-8 {
+			claim = correctTrace.AttackClaim(ctx, claim) // invalid attack to ensure that the honest actor bisects right
+			claim = correctTrace.DefendClaim(ctx, claim)
+		} else {
+			claim = claim.Attack(ctx, common.Hash{0x01})
+			claim = correctTrace.AttackClaim(ctx, claim)
 		}
 		g.LogGameData(ctx)
-		claim = topGameTraceBisection(g.t, ctx, claim, g.splitGame.SplitDepth(ctx), targetTraceIndexAtSplitDepth, provider)
+		if claim.Depth() == splitDepth {
+			break
+		}
 	}
-	g.LogGameData(ctx)
 	return claim
 }

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -258,15 +258,12 @@ func testSuperPreimageStep(t *testing.T, preimageType utils.PreimageOpt, preload
 	l2Timestamp := status.SafeTimestamp + 40
 
 	game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, l2Timestamp)
-	prestate, _, err := game.Game.GetGameRange(ctx)
-	require.NoError(t, err)
-
-	adjustment := prestate % 2 // at 2-second block time boundary
-	indexAtDepth := super.StepsPerTimestamp * (20 + adjustment)
+	correctTrace := game.CreateHonestActor(ctx, disputegame.WithPrivKey(malloryKey(t)), func(c *disputegame.HonestActorConfig) {
+		c.ChallengerOpts = append(c.ChallengerOpts, challenger.WithDepset(t, sys.DependencySet()))
+	})
+	topGameLeaf := game.InitFirstDerivationGame(ctx, correctTrace)
 
 	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
-	openingMove := game.RootClaim(ctx).Attack(ctx, common.Hash{0x01})
-	topGameLeaf := game.BisectUntilSplitDepth(ctx, openingMove, indexAtDepth)
 
 	// This attack creates a bottom game such that we will be making the last move at the bottom. (see game depth parameters for the super DG)
 	// This presents an opportunity for the challenger to step on our dishonest claim at the bottom.

--- a/op-e2e/faultproofs/super_test.go
+++ b/op-e2e/faultproofs/super_test.go
@@ -238,9 +238,6 @@ func TestSuperCannonStepWithPreimage_nonExistingPreimage(t *testing.T) {
 	}
 
 	RunTestsAcrossVmTypes(t, preimageConditions, func(t *testing.T, allocType config.AllocType, preimageType string) {
-		if preimageType == "blob" || preimageType == "sha256" {
-			t.Skip("TODO(#15311): Add blob preimage test case. sha256 is also used for blobs")
-		}
 		testSuperPreimageStep(t, utils.FirstPreimageLoadOfType(preimageType), false, allocType)
 	}, WithNextVMOnly[string](), WithTestName(testName))
 }
@@ -254,22 +251,28 @@ func TestSuperCannonStepWithPreimage_existingPreimage(t *testing.T) {
 
 func testSuperPreimageStep(t *testing.T, preimageType utils.PreimageOpt, preloadPreimage bool, allocType config.AllocType) {
 	ctx := context.Background()
-	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithAllocType(allocType))
+	sys, disputeGameFactory, _ := StartInteropFaultDisputeSystem(t, WithBlobBatches(), WithAllocType(allocType))
 
 	status, err := sys.SupervisorClient().SyncStatus(ctx)
 	require.NoError(t, err)
-	l2Timestamp := status.SafeTimestamp
+	l2Timestamp := status.SafeTimestamp + 40
 
 	game := disputeGameFactory.StartSuperCannonGameWithCorrectRootAtTimestamp(ctx, l2Timestamp)
-	topGameLeaf := game.DisputeLastBlock(ctx)
-	game.LogGameData(ctx)
+	prestate, _, err := game.Game.GetGameRange(ctx)
+	require.NoError(t, err)
+
+	adjustment := prestate % 2 // at 2-second block time boundary
+	indexAtDepth := super.StepsPerTimestamp * (20 + adjustment)
 
 	game.StartChallenger(ctx, "Challenger", challenger.WithPrivKey(aliceKey(t)), challenger.WithDepset(t, sys.DependencySet()))
+	openingMove := game.RootClaim(ctx).Attack(ctx, common.Hash{0x01})
+	topGameLeaf := game.BisectUntilSplitDepth(ctx, openingMove, indexAtDepth)
 
 	// This attack creates a bottom game such that we will be making the last move at the bottom. (see game depth parameters for the super DG)
 	// This presents an opportunity for the challenger to step on our dishonest claim at the bottom.
 	// This assumes the execution game depth is even. But if it is odd, then this test should be set up more like the FDG counter part.
 	topGameLeaf = topGameLeaf.Attack(ctx, common.Hash{0x01})
+	game.LogGameData(ctx)
 
 	// Now the honest challenger is positioned as the defender of the execution game. We then move to challenge it to induce a preimage load
 	preimageLoadCheck := game.CreateStepPreimageLoadCheck(ctx)


### PR DESCRIPTION
The test required some fixes to ensure that disputes don't occur at trace extension. Otherwise, no preimage is loaded.

fixes https://github.com/ethereum-optimism/optimism/issues/15311