### PR TITLE
Supervisor Fuzzing

### DIFF
--- a/op-supervisor/supervisor/backend/chain_randomizer_test.go
+++ b/op-supervisor/supervisor/backend/chain_randomizer_test.go
@@ -1,0 +1,564 @@
+package backend
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	types2 "github.com/ethereum/go-ethereum/core/types"
+	params2 "github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-node/params"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func ExecMsgForLog(chain eth.ChainID, block eth.L2BlockRef, log *types2.Log) *types2.Log {
+	msg := types.Message{
+		Identifier: types.Identifier{
+			Origin:      log.Address,
+			BlockNumber: block.Number,
+			LogIndex:    uint32(log.Index),
+			Timestamp:   block.Time,
+			ChainID:     chain,
+		},
+		PayloadHash: processors.LogToPayloadHash(log),
+	}
+	topics, data := msg.EncodeEvent()
+	return &types2.Log{
+		Address: params2.InteropCrossL2InboxAddress,
+		Data:    data,
+		Topics:  topics,
+		Index:   log.Index,
+	}
+}
+
+type ChainBlock struct {
+	chain eth.ChainID
+	block *eth.L2BlockRef
+}
+
+type ChainHeads struct {
+	// These are block numbers on the chain
+	localSafe   uint64
+	localUnsafe uint64
+	crossSafe   uint64
+	crossUnsafe uint64
+}
+
+type RandomChainParams struct {
+	chainCount int
+
+	minLength int
+	maxLength int
+
+	sameTimestampFrequency int // Percentage [0-100]
+	dependencyChance       int // Percentage [0-100]
+}
+
+type L1Assignments struct {
+	L1Block  eth.BlockRef
+	L2Blocks []*ChainBlock
+}
+
+type RandomChain struct {
+	randomGenerator *rand.Rand
+	cutoffs         struct {
+		crossUnsafe int
+		crossSafe   int
+		localUnsafe int
+		localSafe   int
+	}
+	chainIDs      []eth.ChainID
+	allBlocks     []*ChainBlock
+	cbIndices     map[ChainBlock]int // Lookup for a ChainBlock's index in allBlocks
+	generatedLogs map[ChainBlock][]*types2.Log
+	dependencies  map[ChainBlock][]*ChainBlock
+	chainSources  map[eth.ChainID]*MockProcessorSource
+	chainBlocks   map[eth.ChainID][]*eth.L2BlockRef
+	chainHeads    map[eth.ChainID]*ChainHeads
+	l1SourceMap   map[ChainBlock]eth.BlockRef
+	l1Source      map[uint64]eth.BlockRef
+}
+
+func (rc *RandomChain) ChainInfo(chainid eth.ChainID) (blocks []*eth.L2BlockRef, heads ChainHeads) {
+	blocks = rc.chainBlocks[chainid]
+	heads = *rc.chainHeads[chainid]
+	return blocks, heads
+}
+
+func (p *RandomChainParams) MakeRandomChain(seed int64) (res RandomChain) {
+	r := rand.New(rand.NewSource(seed))
+
+	// Add two special blocks to be used when creating invalid dependencies
+	totalLength := randomInRange(r, p.minLength, p.maxLength) + 2
+	// First block has a timestamp far in the past, already expired (used in InsertDependencyToExpiredMessage)
+	expiredBlockIndex := 0
+	// Last block has a timestamp in the future (used in InsertFutureDependency)
+	futureBlockIndex := totalLength - 1
+
+	// Heads (and candidates) must be between the two special blocks
+	localUnsafe := futureBlockIndex - 1
+	localSafe := randomInRange(r, expiredBlockIndex+2, futureBlockIndex)
+	crossSafe := randomInRange(r, expiredBlockIndex+1, localSafe)
+	crossUnsafe := randomInRange(r, crossSafe, localUnsafe)
+	res = RandomChain{
+		randomGenerator: r,
+		cutoffs: struct {
+			crossUnsafe int
+			crossSafe   int
+			localUnsafe int
+			localSafe   int
+		}{
+			crossUnsafe: crossUnsafe,
+			crossSafe:   crossSafe,
+			localUnsafe: localUnsafe,
+			localSafe:   localSafe,
+		},
+		chainIDs:      make([]eth.ChainID, 0, p.chainCount),
+		allBlocks:     make([]*ChainBlock, 0, totalLength),
+		cbIndices:     make(map[ChainBlock]int),
+		generatedLogs: make(map[ChainBlock][]*types2.Log),
+		dependencies:  make(map[ChainBlock][]*ChainBlock),
+		chainSources:  make(map[eth.ChainID]*MockProcessorSource),
+		chainBlocks:   make(map[eth.ChainID][]*eth.L2BlockRef),
+		chainHeads:    make(map[eth.ChainID]*ChainHeads),
+		l1SourceMap:   make(map[ChainBlock]eth.BlockRef),
+		l1Source:      make(map[uint64]eth.BlockRef),
+	}
+
+	for i := range p.chainCount {
+		chain := eth.ChainIDFromUInt64(testChainIDOffset + uint64(i))
+		res.chainBlocks[chain] = make([]*eth.L2BlockRef, 0)
+		res.chainSources[chain] = &MockProcessorSource{}
+		res.chainHeads[chain] = &ChainHeads{}
+		res.chainIDs = append(res.chainIDs, chain)
+	}
+
+	//
+	// Create array of all blocks
+	//
+	chainUninit := eth.ChainIDFromUInt64(0)
+	timeStampCount := 1 // Can't be greater than p.chainCount
+	var newBlock *ChainBlock
+	for i := range totalLength {
+		allBlocks := res.allBlocks
+		if i == 0 {
+			// First block has a timestamp far in the past, already expired (used in InsertDependencyToExpiredMessage)
+			randomBlock := testutils.RandomL2BlockRef(r)
+			randomBlock.Time = 0
+			newBlock = &ChainBlock{chainUninit, &randomBlock}
+		} else if i == 1 {
+			// Set the initial timestamp so that the block at index 0 is already expired
+			randomBlock := testutils.NextRandomL2Ref(r, 100, *allBlocks[0].block, eth.BlockID{})
+			randomBlock.Time = params.MessageExpiryTimeSecondsInterop + 1
+			newBlock = &ChainBlock{chainUninit, &randomBlock}
+		} else {
+			// Use NextRandomRef for timestamp coherence.
+			randomBlock := testutils.NextRandomL2Ref(r, 100, *allBlocks[len(allBlocks)-1].block, eth.BlockID{})
+
+			// Repeat timestamps with some probability, with two caveats:
+			// - Can only have one block per chain with the same timestamp,
+			// - Last block must have a unique future timestamp, so it can be used in InsertFutureDependency.
+			if timeStampCount < p.chainCount && i < futureBlockIndex && r.Intn(100) < p.sameTimestampFrequency {
+				randomBlock.Time = allBlocks[len(allBlocks)-1].block.Time
+				timeStampCount++
+			} else {
+				randomBlock.Time += 1 // Increment because NextRandomRef could return a block with the same timestamp
+				timeStampCount = 1
+			}
+			newBlock = &ChainBlock{chainUninit, &randomBlock}
+		}
+		res.allBlocks = append(res.allBlocks, newBlock)
+	}
+
+	//
+	// Assign blocks to random L2 chains
+	//
+	chainSelections := make([]eth.ChainID, p.chainCount)
+	copy(chainSelections, res.chainIDs)
+	shuffleChains := func() {
+		r.Shuffle(len(chainSelections), func(i, j int) {
+			chainSelections[i], chainSelections[j] = chainSelections[j], chainSelections[i]
+		})
+	}
+
+	nextChain := 0
+	var prevBlock *eth.L2BlockRef
+	for i, cb := range res.allBlocks {
+		block := cb.block
+		if i == 0 || prevBlock.Time != block.Time {
+			shuffleChains()
+			nextChain = 0
+		}
+		chainid := chainSelections[nextChain]
+		cb.chain = chainid
+		nextChain++
+
+		if len(res.chainBlocks[chainid]) == 0 {
+			block.Number = 0
+			block.ParentHash = common.Hash{}
+		} else {
+			chainBlocks := res.chainBlocks[chainid]
+			lastblock := chainBlocks[len(chainBlocks)-1]
+			block.Number = lastblock.Number + 1
+			block.ParentHash = lastblock.Hash
+		}
+
+		// Assign the cross/local heads based on where the cutoffs are
+		if i <= res.cutoffs.localSafe {
+			res.chainHeads[chainid].localSafe = block.Number
+		}
+		if i <= res.cutoffs.localUnsafe {
+			res.chainHeads[chainid].localUnsafe = block.Number
+		}
+		if i <= res.cutoffs.crossSafe {
+			res.chainHeads[chainid].crossSafe = block.Number
+		}
+		if i <= res.cutoffs.crossUnsafe {
+			res.chainHeads[chainid].crossUnsafe = block.Number
+		}
+
+		res.cbIndices[*cb] = i
+		res.chainSources[chainid].ExpectL2BlockRefByNumber(block.Number, *block, nil)
+		res.chainBlocks[chainid] = append(res.chainBlocks[chainid], block)
+		prevBlock = block
+	}
+
+	//
+	// Create random dependencies between all blocks
+	//
+	for initIndex, initcb := range res.allBlocks {
+		// Add an unimportant message at index 0 that can be modified later by the InsertCycle function
+		addRandomInitiatingMessage(r, &res, initcb)
+
+		block := initcb.block
+		if block.Number == 0 {
+			continue
+		}
+
+		for r.Intn(100) < p.dependencyChance {
+			execIndex := randomInRange(r, initIndex, totalLength)
+			execcb := res.allBlocks[execIndex]
+			if block.Number == 0 {
+				continue
+			}
+			res.dependencies[*execcb] = append(res.dependencies[*execcb], initcb)
+		}
+	}
+
+	// Add dependencies for candidates
+	candidateDependencyChance := p.dependencyChance
+	crossUnsafeCandidate := GetCrossUnsafeCandidate(res)
+	crossSafeCandidate := GetCrossSafeCandidate(res)
+
+	addCandidateDeps := func(candidate *ChainBlock) {
+		if candidate != nil {
+			time := candidate.block.Time
+			candidateIndex := res.cbIndices[*candidate]
+			index := candidateIndex - 1
+			// Find earliest block with the same timestamp as the candidate
+			for res.allBlocks[index].block.Time == time {
+				index--
+			}
+			// Iterate over this range of blocks and add dependencies between them
+			for i := candidateIndex; index+1 < i; i-- {
+				for r.Intn(100) < candidateDependencyChance {
+					execcb := res.allBlocks[i]
+					dependencyIndex := randomInRange(r, index+1, i)
+					initcb := res.allBlocks[dependencyIndex]
+					if initcb.block.Number == 0 {
+						continue
+					}
+					res.dependencies[*execcb] = append(res.dependencies[*execcb], initcb)
+				}
+			}
+		}
+	}
+
+	addCandidateDeps(crossUnsafeCandidate)
+	addCandidateDeps(crossSafeCandidate)
+
+	// Construct the dependencies by creating initiating/executing message pairs
+	for _, execcb := range res.allBlocks {
+		for _, initcb := range res.dependencies[*execcb] {
+			initiatingLog := addRandomInitiatingMessage(r, &res, initcb)
+			addExecutingMessage(&res, execcb, initcb, initiatingLog)
+		}
+	}
+
+	//
+	// Make L1 derivation info
+	//
+	taken := 0
+	nextL1 := testutils.RandomBlockRef(r)
+	for taken < totalLength {
+		nextL1 = testutils.NextRandomRef(r, nextL1)
+		take := randomInRange(r, 1, 5) // Take 1-4 L2 blocks
+		take = min(totalLength-taken, take)
+		for _, l2Block := range res.allBlocks[taken : taken+take] {
+			res.l1SourceMap[*l2Block] = nextL1
+		}
+		res.l1Source[nextL1.Number] = nextL1
+		taken += take
+	}
+
+	return res
+}
+
+func addRandomInitiatingMessage(r *rand.Rand, res *RandomChain, initcb *ChainBlock) *types2.Log {
+	initiatingLog := testutils.RandomLog(r)
+	initiatingLog.Index = uint(len(res.generatedLogs[*initcb]))
+	res.generatedLogs[*initcb] = append(res.generatedLogs[*initcb], initiatingLog)
+	return initiatingLog
+}
+
+func addExecutingMessage(res *RandomChain, execcb *ChainBlock, initcb *ChainBlock, initiatingLog *types2.Log) {
+	execLog := ExecMsgForLog(initcb.chain, *initcb.block, initiatingLog)
+	execLog.Index = uint(len(res.generatedLogs[*execcb]))
+	res.generatedLogs[*execcb] = append(res.generatedLogs[*execcb], execLog)
+}
+
+func addExecutingMessageWithDependency(res *RandomChain, execcb *ChainBlock, initcb *ChainBlock, initiatingLog *types2.Log) {
+	addExecutingMessage(res, execcb, initcb, initiatingLog)
+	res.dependencies[*execcb] = append(res.dependencies[*execcb], initcb)
+}
+
+func addInvalidExecutingMessage(r *rand.Rand, res *RandomChain, execcb *ChainBlock, initcb *ChainBlock, initiatingLog *types2.Log) {
+	execLog := InvalidExecMsgForLog(r, res, initcb.chain, *initcb.block, initiatingLog)
+	execLog.Index = uint(len(res.generatedLogs[*execcb]))
+	res.generatedLogs[*execcb] = append(res.generatedLogs[*execcb], execLog)
+}
+
+func insertExecutingMessageAt(i uint, res *RandomChain, execcb *ChainBlock, initcb *ChainBlock, initiatingLog *types2.Log) {
+	execLog := ExecMsgForLog(initcb.chain, *initcb.block, initiatingLog)
+	execLog.Index = i
+	res.generatedLogs[*execcb][i] = execLog
+}
+
+func GenerateReceiptsFromLogs(res *RandomChain) {
+	for _, cb := range res.allBlocks {
+		chain, block := cb.chain, cb.block
+		logs := res.generatedLogs[*cb]
+		rcpt := types2.Receipt{
+			Logs: logs,
+		}
+		source := res.chainSources[chain]
+		source.ExpectFetchReceipts(block.Hash, types2.Receipts{&rcpt}, nil)
+	}
+}
+
+// Returns a random integer in the interval [lowerIncluding, upperExcluding)
+func randomInRange(r *rand.Rand, lowerIncluding int, upperExcluding int) int {
+	return r.Intn(upperExcluding-lowerIncluding) + lowerIncluding
+}
+
+func InvalidExecMsgForLog(r *rand.Rand, res *RandomChain, chain eth.ChainID, block eth.L2BlockRef, log *types2.Log) *types2.Log {
+	msg := types.Message{
+		Identifier: types.Identifier{
+			Origin:      log.Address,
+			BlockNumber: block.Number,
+			LogIndex:    uint32(log.Index),
+			Timestamp:   block.Time,
+			ChainID:     chain,
+		},
+		PayloadHash: processors.LogToPayloadHash(log),
+	}
+
+	switch r.Intn(5) {
+	case 0:
+		// Invalid origin
+		msg.Identifier.Origin = common.HexToAddress("0xffffffffffffffffffffffffffffffffffffffff")
+	case 1:
+		// Invalid block number
+		msg.Identifier.BlockNumber += uint64(randomInRange(r, 1, 10))
+	case 2:
+		// Invalid log index
+		msg.Identifier.LogIndex += uint32(randomInRange(r, 1, 5))
+	case 3:
+		// Invalid timestamp
+		msg.Identifier.Timestamp -= uint64(randomInRange(r, 1, 100))
+	case 4:
+		// Invalid chain ID
+		impossibleChainID := testChainIDOffset + len(res.chainIDs)
+		msg.Identifier.ChainID = eth.ChainIDFromUInt64(uint64(impossibleChainID))
+	}
+
+	topics, data := msg.EncodeEvent()
+	return &types2.Log{
+		Address: params2.InteropCrossL2InboxAddress,
+		Data:    data,
+		Topics:  topics,
+		Index:   log.Index,
+	}
+}
+
+func InsertMessageWithInvalidIdentifier(r *rand.Rand, res *RandomChain, candidateIndex int) {
+	candidateBlock := res.allBlocks[candidateIndex]
+	randomIndex := r.Intn(candidateIndex + 1)
+	randomBlock := res.allBlocks[randomIndex]
+	randomLogIndex := r.Intn(len(res.generatedLogs[*randomBlock]))
+	randomLog := res.generatedLogs[*randomBlock][randomLogIndex]
+
+	addInvalidExecutingMessage(r, res, candidateBlock, randomBlock, randomLog)
+}
+
+func InvalidateBlock(t *testing.T, res *RandomChain, candidate *ChainBlock) {
+	r := res.randomGenerator
+	switch r.Intn(5) {
+	case 0:
+		InsertCycle(t, r, res, candidate)
+	case 1:
+		InsertSelfDependency(r, res, candidate)
+	case 2:
+		InsertFutureDependency(t, r, res, res.cbIndices[*candidate])
+	case 3:
+		InsertDependencyToExpiredMessage(t, r, res, res.cbIndices[*candidate])
+	case 4:
+		InsertMessageWithInvalidIdentifier(r, res, res.cbIndices[*candidate])
+	default:
+	}
+}
+
+func InsertFutureDependency(t *testing.T, r *rand.Rand, res *RandomChain, candidateIndex int) {
+	candidateBlock := res.allBlocks[candidateIndex]
+	t.Logf("Inserting a future dependency in candidate (%s, %2d)'s hazard set", candidateBlock.chain, candidateBlock.block.Number)
+
+	// Find the next block with a timestamp in the future (guaranteed to exist since we added a special block at the end)
+	i := candidateIndex + 1
+	for res.allBlocks[i].block.Time <= candidateBlock.block.Time {
+		i++
+	}
+
+	// Randomly pick a future block and create an executing message to it
+	futureIndex := randomInRange(r, i, len(res.allBlocks))
+	futureBlock := res.allBlocks[futureIndex]
+	initiatingLog := addRandomInitiatingMessage(r, res, futureBlock)
+	addExecutingMessageWithDependency(res, candidateBlock, futureBlock, initiatingLog)
+}
+
+func InsertDependencyToExpiredMessage(t *testing.T, r *rand.Rand, res *RandomChain, candidateIndex int) {
+	candidate := res.allBlocks[candidateIndex]
+
+	// We set the timestamps so that this is true for every block that can be selected as candidate
+	require.Less(t, uint64(params.MessageExpiryTimeSecondsInterop), candidate.block.Time)
+
+	// Any timestamp below this is expired
+	expiryTimestamp := candidate.block.Time - params.MessageExpiryTimeSecondsInterop
+
+	// Iterate until we find the first unexpired block
+	i := 0
+	for res.allBlocks[i].block.Time < expiryTimestamp {
+		i++
+	}
+
+	// i is at least 1 since the block at index 0 is guaranteed to be expired
+	expiredIndex := r.Intn(i)
+	expiredBlock := res.allBlocks[expiredIndex]
+	initiatingLog := addRandomInitiatingMessage(r, res, expiredBlock)
+	addExecutingMessageWithDependency(res, candidate, expiredBlock, initiatingLog)
+}
+
+func InsertSelfDependency(r *rand.Rand, res *RandomChain, candidate *ChainBlock) {
+	// Create a random initiating message to be inserted at index N+1
+	initiatingLog := testutils.RandomLog(r)
+	initiatingLog.Index = uint(len(res.generatedLogs[*candidate]) + 1)
+
+	// Insert executing message at index N
+	addExecutingMessageWithDependency(res, candidate, candidate, initiatingLog)
+
+	// Insert initiating message at index N+1
+	res.generatedLogs[*candidate] = append(res.generatedLogs[*candidate], initiatingLog)
+}
+
+func listHazards(t *testing.T, res *RandomChain, candidate *ChainBlock) []*ChainBlock {
+	hazards := make([]*ChainBlock, 0)
+	includedHazards := make(map[eth.ChainID]*ChainBlock)
+
+	// Add the candidate itself as a hazard
+	stack := []*ChainBlock{candidate}
+
+	for len(stack) > 0 {
+		// Pop hazard from the stack
+		hazard := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		// Check if we already found a hazard from this chain
+		includedHazard, ok := includedHazards[hazard.chain]
+		if ok {
+			// Ensure that there are not two different hazards from the same chain
+			require.Equal(t, includedHazard.block.ID(), hazard.block.ID())
+		} else {
+			// If not already included, add hazard to the list
+			hazards = append(hazards, hazard)
+			includedHazards[hazard.chain] = hazard
+
+			// For each new hazard, add all dependencies with the same timestamp to the stack
+			for _, dependency := range res.dependencies[*hazard] {
+				if dependency.block.Time == candidate.block.Time {
+					stack = append(stack, dependency)
+				}
+			}
+		}
+	}
+
+	return hazards
+}
+
+func InsertCycle(t *testing.T, r *rand.Rand, res *RandomChain, candidate *ChainBlock) {
+	t.Logf("Inserting a cycle in candidate (%s, %2d)'s hazard set", candidate.chain, candidate.block.Number)
+
+	candidateHazards := listHazards(t, res, candidate)
+	t.Logf("Size of (%s, %2d)'s hazard set: %d", candidate.chain, candidate.block.Number, len(candidateHazards))
+	cycleStart := candidateHazards[r.Intn(len(candidateHazards))]
+	t.Logf("Picked random hazard set element to start the cycle: (%s, %2d)", cycleStart.chain, cycleStart.block.Number)
+
+	// If the random element is equal to the candidate, no need to compute the hazards again
+	var subHazards []*ChainBlock
+	if cycleStart.chain == candidate.chain {
+		require.Equal(t, cycleStart.block.Number, candidate.block.Number)
+		subHazards = candidateHazards
+	} else {
+		subHazards = listHazards(t, res, cycleStart)
+		t.Logf("Size of (%s, %2d)'s hazard set: %d", cycleStart.chain, cycleStart.block.Number, len(subHazards))
+	}
+
+	cycleEnd := subHazards[r.Intn(len(subHazards))]
+	t.Logf("Picked random hazard set element to end the cycle: (%s, %2d)", cycleEnd.chain, cycleEnd.block.Number)
+
+	// Add executing message from first log of cycleEnd to last log of cycleStart
+	lastIndex := len(res.generatedLogs[*cycleStart]) - 1
+	initiatingLog := res.generatedLogs[*cycleStart][lastIndex]
+	// Replace dummy message at index 0
+	insertExecutingMessageAt(0, res, cycleEnd, cycleStart, initiatingLog)
+	res.dependencies[*cycleEnd] = append(res.dependencies[*cycleEnd], cycleStart)
+	t.Logf("Added cyclic dependency: (%s, %2d) -> (%s, %2d)", cycleEnd.chain, cycleEnd.block.Number, cycleStart.chain, cycleStart.block.Number)
+}
+
+func GetCrossUnsafeCandidate(rc RandomChain) (block *ChainBlock) {
+	for _, chain := range rc.chainIDs {
+		if rc.chainHeads[chain].crossUnsafe < rc.chainHeads[chain].localUnsafe {
+			return &ChainBlock{
+				chain: chain,
+				block: rc.chainBlocks[chain][rc.chainHeads[chain].crossUnsafe+1],
+			}
+		}
+	}
+	return nil
+}
+
+func GetCrossSafeCandidate(rc RandomChain) (block *ChainBlock) {
+	for _, chain := range rc.chainIDs {
+		if rc.chainHeads[chain].crossSafe < rc.chainHeads[chain].localSafe {
+			return &ChainBlock{
+				chain: chain,
+				block: rc.chainBlocks[chain][rc.chainHeads[chain].crossSafe+1],
+			}
+		}
+	}
+	return nil
+}

--- a/op-supervisor/supervisor/backend/cross_update_fuzz_test.go
+++ b/op-supervisor/supervisor/backend/cross_update_fuzz_test.go
@@ -1,0 +1,1261 @@
+package backend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-supervisor/config"
+	"github.com/ethereum-optimism/optimism/op-supervisor/metrics"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/superevents"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// Missing:
+// 10 - AnchorEvent
+// 12 - RewindL1Event
+
+// Done:
+// 1 - UpdateCrossUnsafeRequestEvent
+// 2 - CrossUnsafeUpdateEvent
+// 3 - UpdateCrossSafeRequestEvent
+// 4 - LocalSafeUpdateEvent
+// 5 - CrossSafeUpdateEvent
+// 6 - LocalUnsafeUpdateEvent
+// 7 - ChainProcessEvent
+// 8 - LocalUnsafeReceivedEvent
+// 9 - FinalizedL1UpdateEvent
+// 10 - FinalizedL2UpdateEvent
+// 11 - InvalidateLocalSafeEvent
+// 12 - ChainRewoundEvent
+// 13 - UpdateLocalSafeFailedEvent
+// 14 - LocalDerivedEvent
+// 15 - LocalDerivedOriginUpdateEvent
+// 16 - ReplaceBlockEvent
+// 17 - FinalizedL1RequestEvent
+
+type SafetyHeads struct {
+	// These are block numbers on the chain
+	localSafe   types.DerivedIDPair
+	localUnsafe eth.BlockID
+	crossSafe   types.DerivedIDPair
+	crossUnsafe eth.BlockID
+}
+
+type State struct {
+	chainHeads map[eth.ChainID]*SafetyHeads
+}
+
+var chainParams = RandomChainParams{
+	chainCount: 3,
+	minLength:  10,
+	maxLength:  30,
+
+	sameTimestampFrequency: 80,
+	dependencyChance:       50,
+}
+
+func FuzzUpdateCrossUnsafeSucceeds(f *testing.F) {
+
+	f.Add(int64(-62))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		t.Logf("Seed %d", seed)
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+
+		t.Run("UpdateCrossUnsafeRequestEvent Success", func(t *testing.T) {
+			ChainsInit(t, b, ex, randomChain)
+
+			// Ensure the invariants hold in the intiial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			// Enqueue the UpdateCrossUnsafeRequestEvent
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.UpdateCrossUnsafeRequestEvent{},
+				EmitPriority: event.High,
+			})
+
+			// Drain the event until it is processed
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.UpdateCrossUnsafeRequestEvent{}
+				}, false))
+			t.Log("UpdateCrossUnsafeRequestEvent processed")
+
+			t.Logf("Final State with Seed %d", seed)
+			// Assert the invariants hold after handling the event - Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Check that the state has changed as expected - Liveness property
+			AssertCrossUnsafeHeadUpdate(t, randomChain, preState, posState, eth.ChainIDFromUInt64(0))
+		})
+
+		t.Run("Cross-unsafe reaches local-unsafe", func(t *testing.T) {
+			// Ensure the invariants hold in the intiial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			// Drain the event until it is processed
+			require.NoError(t, ex.Drain())
+			t.Log("All Events processed")
+
+			t.Logf("Final State with Seed %d", seed)
+			// Assert the invariants hold after handling the event - Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Check that all cross-unsafe heads got equal to respective local-unsafe heads - Liveness property
+			for _, chain := range randomChain.chainIDs {
+				preLocalUnsafe := preState.chainHeads[chain].localUnsafe
+				posCrossUnsafe := posState.chainHeads[chain].crossUnsafe
+
+				require.Equal(t, posCrossUnsafe, preLocalUnsafe, "Cross Unsafe head for chain %d did not reach local-unsafe", chain)
+			}
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+}
+
+func FuzzUpdateCrossUnsafeFails(f *testing.F) {
+
+	f.Add(int64(63))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+
+		t.Run("UpdateCrossUnsafeRequestEvent Fails", func(t *testing.T) {
+			// Invalidate a block
+			crossUnsafeCandidate := GetCrossUnsafeCandidate(randomChain)
+			if crossUnsafeCandidate == nil {
+				t.Skip()
+			}
+			InvalidateBlock(t, &randomChain, crossUnsafeCandidate)
+			ChainsInit(t, b, ex, randomChain)
+
+			// Ensure the invariants hold in the intiial state
+			t.Logf("Initial State with Seed %d", seed)
+			preState := AssertInvariants(t, b, randomChain)
+
+			// Enqueue the UpdateCrossUnsafeRequestEvent
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.UpdateCrossUnsafeRequestEvent{},
+				EmitPriority: event.High,
+			})
+
+			// Drain the event until it is processed
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.UpdateCrossUnsafeRequestEvent{}
+				}, false))
+			t.Log("UpdateCrossUnsafeRequestEvent processed")
+
+			t.Logf("Final State with Seed %d", seed)
+			// Assert the invariants hold after handling the event - Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Check that the state has changed as expected - Liveness property
+			AssertCrossUnsafeHeadUpdate(t, randomChain, preState, posState, crossUnsafeCandidate.chain)
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+
+}
+
+func FuzzUpdateCrossSafeSucceeds(f *testing.F) {
+
+	f.Add(int64(-832))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+
+		t.Run("UpdateCrossSafeRequestEvent Succeeds", func(t *testing.T) {
+			ChainsInit(t, b, ex, randomChain)
+
+			// Ensure the invariants hold in the intiial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.UpdateCrossSafeRequestEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.UpdateCrossSafeRequestEvent{}
+				}, false))
+
+			t.Log("UpdateCrossSafeRequestEvent processed")
+
+			t.Logf("Final State with Seed %d", seed)
+			// Assert the invariants hold after handling the event - Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Check that the state has changed as expected - Liveness property
+			AssertCrossSafeHeadUpdate(t, randomChain, preState, posState, eth.ChainIDFromUInt64(0))
+		})
+
+		t.Run("Cross-Safe reaches Local-Safe", func(t *testing.T) {
+			// Ensure the invariants hold in the intiial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			// Drain the event until it is processed
+			require.NoError(t, ex.Drain())
+			t.Log("All Events processed")
+
+			t.Logf("Final State with Seed %d", seed)
+			// Assert the invariants hold after handling the event - Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Check that all cross-unsafe heads got equal to respective local-unsafe heads - Liveness property
+			for _, chain := range randomChain.chainIDs {
+				preLocalSafe := preState.chainHeads[chain].localSafe
+				posCrossSafe := posState.chainHeads[chain].crossSafe
+
+				require.Equal(t, preLocalSafe, posCrossSafe, "Cross Safe head for chain %d did not reach Local Safe", chain)
+			}
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+}
+
+func FuzzUpdateCrossSafeFails(f *testing.F) {
+
+	f.Add(int64(1052))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+
+		t.Run("UpdateCrossSafeRequestEvent Fails", func(t *testing.T) {
+			crossSafeCandidate := GetCrossSafeCandidate(randomChain)
+			if crossSafeCandidate == nil {
+				t.Skip()
+			}
+			InvalidateBlock(t, &randomChain, crossSafeCandidate)
+			ChainsInit(t, b, ex, randomChain)
+
+			// Ensure the invariants hold in the intiial state
+			t.Logf("Initial State with seed %d", seed)
+			preState := AssertInvariants(t, b, randomChain)
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.UpdateCrossSafeRequestEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.UpdateCrossSafeRequestEvent{}
+				}, false))
+
+			t.Log("UpdateCrossSafeRequestEvent processed")
+
+			t.Log("Final State")
+			// Assert the invariants hold after handling the event - Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Check that the state has changed as expected - Liveness property
+			AssertCrossSafeHeadUpdate(t, randomChain, preState, posState, crossSafeCandidate.chain)
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+}
+
+func FuzzUpdateLocalSafeInvariants(f *testing.F) {
+
+	f.Add(int64(94)) // Add initial values for fuzzing
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+		ChainsInit(t, b, ex, randomChain)
+
+		t.Run("LocalSafeUpdateEvent Event - LocalSafe equal to unsafe chain", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			chainA := randomChain.chainIDs[0]
+			localSafeHead := preState.chainHeads[chainA].localSafe
+
+			newBlock := randomChain.chainBlocks[chainA][localSafeHead.Derived.Number]
+			newSource := types.BlockSealFromRef(randomChain.l1SourceMap[ChainBlock{chain: chainA, block: newBlock}])
+			newLocalSafe := types.DerivedBlockSealPair{
+				Derived: types.BlockSealFromRef(newBlock.BlockRef()),
+				Source:  newSource,
+			}
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.LocalSafeUpdateEvent{
+					ChainID:      chainA,
+					NewLocalSafe: newLocalSafe,
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalSafeUpdateEvent{
+						ChainID:      chainA,
+						NewLocalSafe: newLocalSafe,
+					}
+				}, false))
+			t.Log("LocalSafeUpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("LocalSafeUpdateEvent Event - LocalSafe not equal to unsafe chain", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Logf("Initial State with seed %d", seed)
+			preState := AssertInvariants(t, b, randomChain)
+
+			chainA := randomChain.chainIDs[0]
+			localSafeHead := preState.chainHeads[chainA].localSafe
+
+			// WARN: We assume the first block to be always equal to the unsafe-chain
+			if localSafeHead.Derived.Number == 0 {
+				t.Skip()
+			}
+
+			newBlock := randomChain.chainBlocks[chainA][localSafeHead.Derived.Number]
+			newSource := types.BlockSealFromRef(randomChain.l1SourceMap[ChainBlock{chain: chainA, block: newBlock}])
+			hashDerived := testutils.RandomHash(randomChain.randomGenerator)
+			// Ensure the hash is different from the unsafe chain
+			if hashDerived == newBlock.Hash {
+				t.Skip()
+			}
+			newBlock.Hash = hashDerived
+			newLocalSafe := types.DerivedBlockSealPair{
+				Derived: types.BlockSealFromRef(newBlock.BlockRef()),
+				Source:  newSource,
+			}
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.LocalSafeUpdateEvent{
+					ChainID:      chainA,
+					NewLocalSafe: newLocalSafe,
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalSafeUpdateEvent{
+						ChainID:      chainA,
+						NewLocalSafe: newLocalSafe,
+					}
+				}, false))
+			t.Log("LocalSafeUpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			// Liveness property
+			require.Equal(t, posState.chainHeads[chainA].localSafe.Derived.Number, posState.chainHeads[chainA].localUnsafe.Number+1, "Local safe head should be equal to local unsafe head + 1")
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+}
+
+func FuzzLocalDerivedEventInvariants(f *testing.F) {
+
+	f.Add(int64(-383))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+		ChainsInit(t, b, ex, randomChain)
+
+		t.Run("LocalDerivedEvent Event Succeeds", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			chainA := randomChain.chainIDs[0]
+			chainLength := len(randomChain.chainBlocks[chainA])
+			preLocalSafeHead := preState.chainHeads[chainA].localSafe
+			localSafetoUpdate := preLocalSafeHead.Derived.Number + 1
+
+			var derived types.DerivedBlockRefPair
+
+			if localSafetoUpdate < uint64(chainLength) {
+				nextSafeBlock := randomChain.chainBlocks[chainA][localSafetoUpdate]
+				nextSafeBlockSource := randomChain.l1SourceMap[ChainBlock{chain: chainA, block: nextSafeBlock}]
+				if preLocalSafeHead.Source.Number < nextSafeBlockSource.Number {
+					derived = types.DerivedBlockRefPair{
+						Derived: randomChain.chainBlocks[chainA][preLocalSafeHead.Derived.Number].BlockRef(),
+						Source:  randomChain.l1Source[preLocalSafeHead.Source.Number+1],
+					}
+				} else {
+					derived = types.DerivedBlockRefPair{
+						Derived: nextSafeBlock.BlockRef(),
+						Source:  nextSafeBlockSource,
+					}
+				}
+			} else {
+				r := randomChain.randomGenerator
+				hashDerived := testutils.RandomHash(r)
+				source := randomChain.l1Source[preLocalSafeHead.Source.Number]
+				derived = types.DerivedBlockRefPair{
+					Derived: eth.BlockRef{
+						Hash:       hashDerived,
+						Number:     localSafetoUpdate,
+						ParentHash: preLocalSafeHead.Derived.Hash,
+						Time:       uint64(time.Now().Unix()),
+					},
+					Source: source,
+				}
+			}
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.LocalDerivedEvent{
+					ChainID: chainA,
+					Derived: derived,
+					NodeID:  "test-node",
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalDerivedEvent{
+						ChainID: chainA,
+						Derived: derived,
+						NodeID:  "test-node",
+					}
+				}, false))
+			t.Log("LocalDerivedEvent processed")
+
+			t.Logf("Final State with seed %d", seed)
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+
+			// Liveness property
+			posLocalSafeHead := posState.chainHeads[chainA].localSafe
+			if preLocalSafeHead.Derived.Number < posLocalSafeHead.Derived.Number {
+				require.Equal(t, localSafetoUpdate, posLocalSafeHead.Derived.Number)
+			} else {
+				require.Equal(t, preLocalSafeHead.Derived.Number, posLocalSafeHead.Derived.Number)
+				require.Equal(t, posLocalSafeHead.Source.Number, preLocalSafeHead.Source.Number+1)
+			}
+		})
+
+		t.Run("LocalDerivedEvent Event Fails", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			chainA := randomChain.chainIDs[0]
+			chainLength := len(randomChain.chainBlocks[chainA])
+			preLocalSafeHead := preState.chainHeads[chainA].localSafe
+			nextLocalSafe := preLocalSafeHead.Derived.Number + 1
+
+			localSafeToUpdate := uint64(randomChain.randomGenerator.Int63n(int64(chainLength + 1)))
+			var derived types.DerivedBlockRefPair
+
+			if localSafeToUpdate < uint64(chainLength) {
+				nextSafeBlock := randomChain.chainBlocks[chainA][localSafeToUpdate]
+				nextSafeBlockSource := randomChain.l1SourceMap[ChainBlock{chain: chainA, block: nextSafeBlock}]
+				if localSafeToUpdate == nextLocalSafe && preLocalSafeHead.Source.Number == nextSafeBlockSource.Number {
+					t.Skip("Local safe to update is the same as next safe block, skipping")
+				}
+				derived = types.DerivedBlockRefPair{
+					Derived: nextSafeBlock.BlockRef(),
+					Source:  nextSafeBlockSource,
+				}
+			} else {
+				r := randomChain.randomGenerator
+				hashDerived := testutils.RandomHash(r)
+				source := randomChain.l1Source[preLocalSafeHead.Source.Number+1]
+				derived = types.DerivedBlockRefPair{
+					Derived: eth.BlockRef{
+						Hash:       hashDerived,
+						Number:     localSafeToUpdate,
+						ParentHash: preLocalSafeHead.Derived.Hash,
+						Time:       uint64(time.Now().Unix()),
+					},
+					Source: source,
+				}
+			}
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.LocalDerivedEvent{
+					ChainID: chainA,
+					Derived: derived,
+					NodeID:  "test-node",
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalDerivedEvent{
+						ChainID: chainA,
+						Derived: derived,
+						NodeID:  "test-node",
+					}
+				}, false))
+			t.Log("LocalDerivedEvent processed")
+
+			t.Logf("Final State with seed %d", seed)
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+}
+
+func FuzzReplaceBlockEventInvariants(f *testing.F) {
+
+	f.Add(int64(536))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+		ChainsInit(t, b, ex, randomChain)
+
+		t.Run("ReplaceBlockEvent Event", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+
+			chainA := randomChain.chainIDs[0]
+			localSafe := preState.chainHeads[chainA].localSafe.Derived.Number
+			crossSafe := preState.chainHeads[chainA].crossSafe
+			genesisSource := randomChain.l1SourceMap[ChainBlock{chain: chainA, block: randomChain.chainBlocks[chainA][0]}]
+			if crossSafe.Derived.Number == localSafe || crossSafe.Source.Number == genesisSource.Number {
+				t.Skip()
+			}
+			crossSafeHeadCandidate := crossSafe.Derived.Number + 1
+			block := randomChain.chainBlocks[chainA][crossSafeHeadCandidate]
+			source := randomChain.l1SourceMap[ChainBlock{chain: chainA, block: block}]
+
+			invalidated := types.DerivedBlockRefPair{
+				Derived: block.BlockRef(),
+				Source:  source,
+			}
+			b.chainDBs.InvalidateLocalSafe(chainA, invalidated)
+
+			t.Logf("State after Chain %d Block Number %d invalidation", chainA, crossSafeHeadCandidate)
+			AssertInvariants(t, b, randomChain)
+
+			_, err := b.LocalSafe(context.Background(), chainA)
+			require.Equal(t, err, types.ErrAwaitReplacementBlock)
+
+			newHash := testutils.RandomHash(randomChain.randomGenerator)
+			replacementBlock := eth.BlockRef{
+				Hash:       newHash,
+				Number:     invalidated.Derived.Number,
+				ParentHash: invalidated.Derived.ParentHash,
+				Time:       uint64(time.Now().Unix()),
+			}
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.ReplaceBlockEvent{
+					ChainID: chainA,
+					Replacement: types.BlockReplacement{
+						Replacement: replacementBlock,
+						Invalidated: block.Hash,
+					},
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.ReplaceBlockEvent{
+						ChainID: chainA,
+						Replacement: types.BlockReplacement{
+							Replacement: replacementBlock,
+							Invalidated: block.Hash,
+						},
+					}
+				}, false))
+
+			t.Log("ReplaceBlockEvent processed")
+
+			t.Logf("Final State with seed %d", seed)
+			AssertInvariants(t, b, randomChain)
+
+			newLocalSafe, _ := b.LocalSafe(context.Background(), chainA)
+			require.Equal(t, crossSafeHeadCandidate, newLocalSafe.Derived.Number)
+			require.Equal(t, newLocalSafe.Derived.Hash, newHash)
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+}
+
+func FuzzChainProcessEventInvariants(f *testing.F) {
+
+	f.Add(int64(28))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+		ChainsInit(t, b, ex, randomChain)
+
+		chainA := randomChain.chainIDs[0]
+		srcChainA := randomChain.chainSources[chainA]
+
+		t.Run("ChainProcessEvent Event Succeeds", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Log("Initial State")
+			preState := AssertInvariants(t, b, randomChain)
+			target := preState.chainHeads[chainA].localUnsafe.Number + 1
+
+			newHash := testutils.RandomHash(randomChain.randomGenerator)
+
+			// TODO: Add L1Origin and SequenceNumber fields?
+			newLocalUnsafe := eth.L2BlockRef{
+				Hash:       newHash,
+				Number:     target,
+				ParentHash: randomChain.chainBlocks[chainA][target-1].Hash,
+				Time:       uint64(time.Now().Unix()),
+			}
+
+			t.Logf("Chain A block %d: %s\t Timestamp:%d", target, newLocalUnsafe.Hash.Hex(), newLocalUnsafe.Time)
+
+			srcChainA.ExpectL2BlockRefByNumber(target, newLocalUnsafe, nil)
+			srcChainA.ExpectFetchReceipts(newLocalUnsafe.Hash, nil, nil)
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.ChainProcessEvent{
+					ChainID: chainA,
+					Target:  target,
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.ChainProcessEvent{
+						ChainID: chainA,
+						Target:  target,
+					}
+				}, false))
+			t.Log("ChainProcessEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			// Liveness property
+			require.Equal(t, posState.chainHeads[chainA].localUnsafe.Number, target)
+		})
+
+		t.Run("ChainProcessEvent Event Fails", func(t *testing.T) {
+			// Ensure the invariants hold in the initial state
+			t.Logf("Initial State with seed %d", seed)
+			preState := AssertInvariants(t, b, randomChain)
+			chainABlocks := randomChain.chainBlocks[chainA]
+			nextLocalUnsafe := preState.chainHeads[chainA].localUnsafe.Number + 1
+			target := uint64(randomChain.randomGenerator.Int63n(int64(len(chainABlocks))))
+
+			if target == nextLocalUnsafe {
+				//This would be the right target to update the localUnsafe
+				t.Skip()
+			}
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.ChainProcessEvent{
+					ChainID: chainA,
+					Target:  target,
+				},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.ChainProcessEvent{
+						ChainID: chainA,
+						Target:  target,
+					}
+				}, false))
+			t.Log("ChainProcessEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+
+}
+
+// FuzzEventsPreserveState tests that various events preserve the state of the backend
+func FuzzEventsPreserveState(f *testing.F) {
+
+	f.Add(int64(30))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+
+		randomChain := chainParams.MakeRandomChain(seed)
+		ex, b := ExecutorBackendInit(t, randomChain)
+		ChainsInit(t, b, ex, randomChain)
+
+		t.Log("Initial State")
+		preState := AssertInvariants(t, b, randomChain)
+
+		t.Run("LocalUnsafeUpdateEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.LocalUnsafeUpdateEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalUnsafeUpdateEvent{}
+				}, false))
+			t.Log("LocalUnsafeUpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("LocalUnsafeReceivedEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.LocalUnsafeReceivedEvent{ChainID: randomChain.chainIDs[0]},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalUnsafeReceivedEvent{ChainID: randomChain.chainIDs[0]}
+				}, false))
+			t.Log("LocalUnsafeReceivedEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+
+		})
+
+		t.Run("CrossUnsafeUpdateEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.CrossUnsafeUpdateEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.CrossUnsafeUpdateEvent{}
+				}, false))
+			t.Log("CrossUnsafeUpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("CrossSafeUpdateEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.CrossSafeUpdateEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.CrossSafeUpdateEvent{}
+				}, false))
+			t.Log("CrossSafeUpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("FinalizedL1UpdateEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.FinalizedL1UpdateEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.FinalizedL1UpdateEvent{}
+				}, false))
+			t.Log("FinalizedL1UpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("FinalizedL2UpdateEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.FinalizedL2UpdateEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.FinalizedL2UpdateEvent{}
+				}, false))
+			t.Log("FinalizedL2UpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("InvalidateLocalSafeEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.InvalidateLocalSafeEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.InvalidateLocalSafeEvent{}
+				}, false))
+			t.Log("InvalidateLocalSafeEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("UpdateLocalSafeFailedEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.UpdateLocalSafeFailedEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.UpdateLocalSafeFailedEvent{}
+				}, false))
+			t.Log("UpdateLocalSafeFailedEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("LocalDerivedOriginUpdateEvent", func(t *testing.T) {
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.LocalDerivedOriginUpdateEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.LocalDerivedOriginUpdateEvent{}
+				}, false))
+			t.Log("LocalDerivedOriginUpdateEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		t.Run("FinalizedL1RequestEvent", func(t *testing.T) {
+			// Handling this event changes the finalized database which is not part of the invariants
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx:          context.Background(),
+				Event:        superevents.FinalizedL1RequestEvent{},
+				EmitPriority: event.High,
+			})
+
+			require.NoError(t, ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.FinalizedL1RequestEvent{}
+				}, false))
+			t.Log("FinalizedL1RequestEvent processed")
+
+			t.Log("Final State")
+			// Safety properties
+			posState := AssertInvariants(t, b, randomChain)
+			AssertStateNotChange(t, randomChain, preState, posState)
+		})
+
+		err := b.Stop(context.Background())
+		require.NoError(t, err)
+		t.Log("stopped!")
+	})
+
+}
+
+func fuzzConfigSet(t *testing.T, randomChain RandomChain) depset.FullConfigSetMerged {
+	size := chainParams.chainCount
+	staticDepSet := make(map[eth.ChainID]*depset.StaticConfigDependency, size)
+	staticRollupCfgSet := make(map[eth.ChainID]*depset.StaticRollupConfig, size)
+	zero := uint64(0)
+	for _, chain := range randomChain.chainIDs {
+		staticDepSet[chain] = &depset.StaticConfigDependency{}
+		staticRollupCfgSet[chain] = &depset.StaticRollupConfig{
+			InteropTime: &zero,
+			BlockTime:   2,
+		}
+	}
+	depSet, err := depset.NewStaticConfigDependencySet(staticDepSet)
+	require.NoError(t, err)
+	rollupCfgSet := depset.NewStaticRollupConfigSet(staticRollupCfgSet)
+	fullCfgSet, err := depset.NewFullConfigSetMerged(rollupCfgSet, depSet)
+	require.NoError(t, err)
+	return fullCfgSet
+}
+
+func ExecutorBackendInit(t *testing.T, randomChain RandomChain) (ex *event.GlobalSyncExec, b *SupervisorBackend) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	m := metrics.NoopMetrics
+	dataDir := t.TempDir()
+	fullCfgSet := fuzzConfigSet(t, randomChain)
+	rollupCfgSet := fullCfgSet.RollupConfigSet.(depset.StaticRollupConfigSet)
+
+	for _, chain := range randomChain.chainIDs {
+		anchor := randomChain.chainBlocks[chain][0]
+		rollupCfgSet[chain].Genesis = depset.Genesis{
+			L1: types.BlockSealFromRef(randomChain.l1SourceMap[ChainBlock{chain: chain, block: anchor}]),
+			L2: types.BlockSealFromRef(anchor.BlockRef()),
+		}
+	}
+	cfg := &config.Config{
+		Version:               "test",
+		FullConfigSetSource:   fullCfgSet,
+		SynchronousProcessors: true,
+		MockRun:               false,
+		SyncSources:           &syncnode.CLISyncNodes{},
+		Datadir:               dataDir,
+	}
+
+	ex = event.NewGlobalSynchronous(context.Background())
+	b, err := NewSupervisorBackend(context.Background(), logger, m, cfg, ex)
+	require.NoError(t, err)
+	t.Log("initialized!")
+
+	l1Src := &testutils.MockL1Source{}
+	b.AttachL1Source(l1Src)
+
+	for _, chain := range randomChain.chainIDs {
+		srcChain := randomChain.chainSources[chain]
+		require.NoError(t, b.AttachProcessorSource(chain, srcChain))
+	}
+
+	err = b.Start(context.Background())
+	require.NoError(t, err)
+	t.Log("started!")
+
+	return ex, b
+}
+
+func ChainsInit(t *testing.T, b *SupervisorBackend, ex *event.GlobalSyncExec, randomChain RandomChain) {
+	GenerateReceiptsFromLogs(&randomChain)
+
+	for _, chain := range randomChain.chainIDs {
+		chainHeads := randomChain.chainHeads[chain]
+		localUnsafe := randomChain.chainBlocks[chain][len(randomChain.chainBlocks[chain])-1].Number
+		crossUnsafe := randomChain.chainBlocks[chain][chainHeads.crossUnsafe]
+		localSafe := randomChain.chainBlocks[chain][chainHeads.localSafe].Number
+		crossSafe := randomChain.chainBlocks[chain][chainHeads.crossSafe]
+
+		t.Logf("Chain %d LocalUnsafe: %d CrossUnsafe: %d LocalSafe: %d CrossSafe: %d", chain, localUnsafe, crossUnsafe.Number, localSafe, crossSafe.Number)
+
+		for i := 1; i <= int(crossSafe.Number); i++ {
+			previous := randomChain.chainBlocks[chain][i-1]
+			previousSource := randomChain.l1SourceMap[ChainBlock{chain: chain, block: previous}]
+			block := randomChain.chainBlocks[chain][i]
+			source := randomChain.l1SourceMap[ChainBlock{chain: chain, block: block}]
+
+			for j := previousSource.Number + 1; j <= source.Number; j++ {
+				crossSafe := superevents.LocalDerivedEvent{
+					ChainID: chain,
+					Derived: types.DerivedBlockRefPair{
+						Derived: previous.BlockRef(),
+						Source:  randomChain.l1Source[j],
+					},
+					NodeID: "test-node",
+				}
+				b.emitter.Emit(context.Background(), crossSafe)
+			}
+			crossSafe := superevents.LocalDerivedEvent{
+				ChainID: chain,
+				Derived: types.DerivedBlockRefPair{
+					Derived: block.BlockRef(),
+					Source:  source,
+				},
+				NodeID: "test-node",
+			}
+			b.emitter.Emit(context.Background(), crossSafe)
+		}
+	}
+	ex.Drain()
+
+	for _, chain := range randomChain.chainIDs {
+		chainHeads := randomChain.chainHeads[chain]
+		crossSafe := randomChain.chainBlocks[chain][chainHeads.crossSafe].Number
+		localSafe := randomChain.chainBlocks[chain][chainHeads.localSafe].Number
+
+		for i := int(crossSafe) + 1; i < len(randomChain.chainBlocks[chain]); i++ {
+			block := randomChain.chainBlocks[chain][i]
+
+			ex.Enqueue(event.AnnotatedEvent{
+				Ctx: context.Background(),
+				Event: superevents.ChainProcessEvent{
+					ChainID: chain,
+					Target:  block.Number,
+				},
+				EmitPriority: event.High,
+			})
+
+			ex.DrainUntil(
+				func(ev event.Event) bool {
+					return ev == superevents.ChainProcessEvent{
+						ChainID: chain,
+						Target:  block.Number}
+				}, false)
+
+			if block.Number <= localSafe {
+				previous := randomChain.chainBlocks[chain][i-1]
+				previousSource := randomChain.l1SourceMap[ChainBlock{chain: chain, block: previous}]
+				source := randomChain.l1SourceMap[ChainBlock{chain: chain, block: block}]
+
+				for j := previousSource.Number + 1; j <= source.Number; j++ {
+					localSafe := superevents.LocalDerivedEvent{
+						ChainID: chain,
+						Derived: types.DerivedBlockRefPair{
+							Derived: previous.BlockRef(),
+							Source:  randomChain.l1Source[j],
+						},
+						NodeID: "test-node",
+					}
+					ex.Enqueue(event.AnnotatedEvent{
+						Ctx:          context.Background(),
+						Event:        localSafe,
+						EmitPriority: event.High,
+					})
+					ex.DrainUntil(
+						func(ev event.Event) bool {
+							return ev == localSafe
+						}, false)
+				}
+				localSafe := superevents.LocalDerivedEvent{
+					ChainID: chain,
+					Derived: types.DerivedBlockRefPair{
+						Derived: block.BlockRef(),
+						Source:  randomChain.l1SourceMap[ChainBlock{chain: chain, block: block}],
+					},
+					NodeID: "test-node",
+				}
+				ex.Enqueue(event.AnnotatedEvent{
+					Ctx:          context.Background(),
+					Event:        localSafe,
+					EmitPriority: event.High,
+				})
+				ex.DrainUntil(
+					func(ev event.Event) bool {
+						return ev == localSafe
+					}, false)
+			}
+		}
+		localUnsafe, _ := b.chainDBs.LocalUnsafe(chain)
+		crossUnsafe := types.BlockSealFromRef(randomChain.chainBlocks[chain][chainHeads.crossUnsafe].BlockRef())
+		if crossUnsafe.Number > localUnsafe.Number {
+			crossUnsafe = localUnsafe
+		}
+		err := b.chainDBs.UpdateCrossUnsafe(chain, crossUnsafe)
+		require.NoError(t, err)
+	}
+}
+
+func CrossUnsafe_LE_LocalUnsafe(t *testing.T, b *SupervisorBackend, chain eth.ChainID, state State) {
+
+	localUnsafe, err := b.LocalUnsafe(context.Background(), chain)
+	require.NoError(t, err)
+	crossUnsafe, err := b.CrossUnsafe(context.Background(), chain)
+	require.NoError(t, err)
+
+	t.Logf("\t- Cross Unsafe head %d <= Local Unsafe head %d", crossUnsafe.Number, localUnsafe.Number)
+	state.chainHeads[chain].crossUnsafe = crossUnsafe
+	state.chainHeads[chain].localUnsafe = localUnsafe
+	require.LessOrEqual(t, crossUnsafe.Number, localUnsafe.Number, "Chain %d: Cross Unsafe head %d is not less or equal than Local Unsafe head %d", chain, crossUnsafe.Number, localUnsafe.Number)
+}
+
+func CrossSafe_LE_LocalSafe(t *testing.T, b *SupervisorBackend, chain eth.ChainID, state State) {
+
+	localSafe, err := b.LocalSafe(context.Background(), chain)
+	crossSafe, _ := b.CrossSafe(context.Background(), chain)
+
+	state.chainHeads[chain].crossSafe = crossSafe
+	state.chainHeads[chain].localSafe = localSafe
+
+	if err == types.ErrAwaitReplacementBlock {
+		t.Logf("\t- Cross Safe head %d <= Local Safe awaiting replacement block", crossSafe.Derived.Number)
+		return
+	}
+	t.Logf("\t- Cross Safe head %d <= Local Safe head %d", crossSafe.Derived.Number, localSafe.Derived.Number)
+	require.LessOrEqual(t, crossSafe.Derived.Number, localSafe.Derived.Number, "Chain %d: Cross Safe head %d is not less or equal than Local Safe head %d", chain, crossSafe.Derived.Number, localSafe.Derived.Number)
+}
+
+func AssertInvariants(t *testing.T, b *SupervisorBackend, rc RandomChain) (state State) {
+	state.chainHeads = make(map[eth.ChainID]*SafetyHeads)
+	for _, chain := range rc.chainIDs {
+		t.Logf("Chain %d:", chain)
+		state.chainHeads[chain] = &SafetyHeads{}
+
+		CrossUnsafe_LE_LocalUnsafe(t, b, chain, state)
+		CrossSafe_LE_LocalSafe(t, b, chain, state)
+	}
+	return state
+}
+
+func AssertCrossUnsafeHeadUpdate(t *testing.T, rc RandomChain, preState State, posState State, expectNoUpdate eth.ChainID) {
+	crossUnsafeUpdates := 0
+	chainsToUpdate := len(rc.chainIDs)
+	for _, chain := range rc.chainIDs {
+		preCrossUnsafe := preState.chainHeads[chain].crossUnsafe.Number
+		preLocalUnsafe := preState.chainHeads[chain].localUnsafe.Number
+		posCrossUnsafe := posState.chainHeads[chain].crossUnsafe.Number
+		if chain != expectNoUpdate {
+			if preCrossUnsafe < preLocalUnsafe {
+				// Ensure the cross unsafe head has been updated
+				if posCrossUnsafe == preCrossUnsafe+1 {
+					crossUnsafeUpdates++
+					t.Logf("Cross Unsafe head for chain %d has been updated from %d to %d", chain, preCrossUnsafe, posCrossUnsafe)
+				}
+			} else {
+				chainsToUpdate--
+				require.Equal(t, posCrossUnsafe, preCrossUnsafe)
+				t.Logf("Cross Unsafe head for chain %d was already equal to Local Unsafe", chain)
+			}
+		} else {
+			chainsToUpdate--
+			require.Equal(t, posCrossUnsafe, preCrossUnsafe, "Cross Unsafe head unexpectedly updated for chain %d", chain)
+			t.Logf("Cross Unsafe head for chain %d was not updated because the candidate was invalid", chain)
+		}
+	}
+
+	if chainsToUpdate > 0 && expectNoUpdate == eth.ChainIDFromUInt64(0) {
+		// At least one chain must be updated
+		require.Greater(t, crossUnsafeUpdates, 0)
+	}
+}
+
+func AssertCrossSafeHeadUpdate(t *testing.T, rc RandomChain, preState State, posState State, expectNoUpdate eth.ChainID) {
+	crossSafeUpdates := 0
+	chainsToUpdate := len(rc.chainIDs)
+	for _, chain := range rc.chainIDs {
+		preCrossSafeDerived := preState.chainHeads[chain].crossSafe.Derived.Number
+		preLocalSafeDerived := preState.chainHeads[chain].localSafe.Derived.Number
+		posCrossSafeDerived := posState.chainHeads[chain].crossSafe.Derived.Number
+		if chain != expectNoUpdate {
+			if preCrossSafeDerived < preLocalSafeDerived {
+				preCrossSafeSource := preState.chainHeads[chain].crossSafe.Source.Number
+				posCrossSafeSource := posState.chainHeads[chain].crossSafe.Source.Number
+				if preCrossSafeDerived < posCrossSafeDerived {
+					require.Equal(t, posCrossSafeDerived, preCrossSafeDerived+1,
+						"Cross Safe update must be incremental, instead got %d -> %d on chain %d", preCrossSafeDerived, posCrossSafeDerived, chain)
+					require.Equal(t, preCrossSafeSource, posCrossSafeSource,
+						"Cross Safe head unexpectedly updated for chain %d", chain)
+					crossSafeUpdates++
+					t.Logf("Cross Safe head for chain %d has been updated from %d to %d", chain, preCrossSafeDerived, posCrossSafeDerived)
+				} else if posCrossSafeDerived == preCrossSafeDerived {
+					if preCrossSafeSource < posCrossSafeSource {
+						require.Equal(t, posCrossSafeSource, preCrossSafeSource+1,
+							"Cross Safe scope bump should be incremental, instead got %d -> %d on chain %d", preCrossSafeSource, posCrossSafeSource, chain)
+						crossSafeUpdates++
+						t.Logf("Cross Safe head for chain %d has increased source from %d to %d", chain, preCrossSafeSource, posCrossSafeSource)
+					}
+				}
+			} else {
+				chainsToUpdate--
+				require.Equal(t, posCrossSafeDerived, preCrossSafeDerived)
+				t.Logf("Cross Safe head for chain %d was already equal to Local Safe", chain)
+			}
+		} else {
+			chainsToUpdate--
+			require.Equal(t, posCrossSafeDerived, preCrossSafeDerived, "Cross Safe head unexpectedly updated for chain %d", chain)
+			t.Logf("Cross Safe head for chain %d was not updated because the candidate was invalid", chain)
+		}
+	}
+	if chainsToUpdate > 0 && expectNoUpdate == eth.ChainIDFromUInt64(0) {
+		// At least one chain must be updated
+		require.Greater(t, crossSafeUpdates, 0)
+	}
+}
+
+func AssertStateNotChange(t *testing.T, rc RandomChain, preState State, posState State) {
+	for _, chain := range rc.chainIDs {
+		require.Equal(t, preState.chainHeads[chain].localUnsafe, posState.chainHeads[chain].localUnsafe, "Local Unsafe head for chain %d was expected not to change", chain)
+		require.Equal(t, preState.chainHeads[chain].crossUnsafe, posState.chainHeads[chain].crossUnsafe, "Cross Unsafe head for chain %d was expected not to change", chain)
+		require.Equal(t, preState.chainHeads[chain].localSafe, posState.chainHeads[chain].localSafe, "Local Safe head for chain %d was expected not to change", chain)
+		require.Equal(t, preState.chainHeads[chain].crossSafe, posState.chainHeads[chain].crossSafe, "Cross Safe head for chain %d was expected not to change", chain)
+	}
+}

--- a/op-supervisor/supervisor/backend/processors/log_processor.go
+++ b/op-supervisor/supervisor/backend/processors/log_processor.go
@@ -56,12 +56,16 @@ func (p *logProcessor) ProcessLogs(_ context.Context, block eth.BlockRef, rcpts 
 	return nil
 }
 
+func LogToPayloadHash(l *ethTypes.Log) common.Hash {
+	return crypto.Keccak256Hash(types.LogToMessagePayload(l))
+}
+
 // LogToLogHash transforms a log into a hash that represents the log.
 // it is the concatenation of the log's address and the hash of the log's payload,
 // which is then hashed again. This is the hash that is stored in the log storage.
 // The address is hashed into the payload hash to save space in the log storage,
 // and because they represent paired data.
 func LogToLogHash(l *ethTypes.Log) common.Hash {
-	payloadHash := crypto.Keccak256Hash(types.LogToMessagePayload(l))
+	payloadHash := LogToPayloadHash(l)
 	return types.PayloadHashToLogHash(payloadHash, l.Address)
 }

--- a/op-supervisor/supervisor/types/types.go
+++ b/op-supervisor/supervisor/types/types.go
@@ -114,6 +114,31 @@ func (m *Message) Access() Access {
 	return m.ToCheckSumArgs().Access()
 }
 
+func (m *Message) EncodeEvent() (topics []common.Hash, data []byte) {
+	topics = make([]common.Hash, 2)
+	topics[0] = ExecutingMessageEventTopic
+	topics[1] = m.PayloadHash
+
+	putZeroes := func(length uint) {
+		zeroes := make([]byte, length)
+		data = append(data, zeroes...)
+	}
+
+	data = make([]byte, 0, 32*5)
+	putZeroes(12)
+	data = append(data, m.Identifier.Origin.Bytes()...)
+	putZeroes(32 - 8)
+	data = binary.BigEndian.AppendUint64(data, m.Identifier.BlockNumber)
+	putZeroes(32 - 4)
+	data = binary.BigEndian.AppendUint32(data, m.Identifier.LogIndex)
+	putZeroes(32 - 8)
+	data = binary.BigEndian.AppendUint64(data, m.Identifier.Timestamp)
+	chainid := m.Identifier.ChainID.Bytes32()
+	data = append(data, chainid[:]...)
+
+	return topics, data
+}
+
 func (m *Message) DecodeEvent(topics []common.Hash, data []byte) error {
 	if len(topics) != 2 { // event hash, indexed payloadHash
 		return fmt.Errorf("unexpected number of event topics: %d", len(topics))

--- a/op-supervisor/supervisor/types/types_test.go
+++ b/op-supervisor/supervisor/types/types_test.go
@@ -279,6 +279,23 @@ func TestMessage(t *testing.T) {
 	})
 }
 
+func TestMessageRoundTrip(t *testing.T) {
+	msg := Message{
+		Identifier: Identifier{
+			Origin:      testOrigin,
+			BlockNumber: testBlockNumber,
+			LogIndex:    testLogIndex,
+			Timestamp:   testTimestamp,
+			ChainID:     testChainID,
+		},
+		PayloadHash: testMsgHash,
+	}
+	msg_topics, msg_data := msg.EncodeEvent()
+	var msg_again Message
+	msg_again.DecodeEvent(msg_topics, msg_data)
+	require.Equal(t, msg, msg_again)
+}
+
 func TestChecksumArgs(t *testing.T) {
 	args := ChecksumArgs{
 		BlockNumber: testBlockNumber,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This is a set of Fuzzing targets for the supervisor backend which test the cross validation across many different events and chain configurations.

**Tests**

There's a unit test for a new `EncodeEvent` utility for creating a byte array out of a `types.Message`. The fuzzing targets themselves are also new tests.

**Additional context**

The targets already should quickly find #16258 , for which we have an unmerged commit that fixes it [here](https://github.com/runtimeverification/_audits_Ethereum-optimism_pausability/commit/6b34f313462c92fc3e1fbe73c97c19efee8a6b50).

A rough breakdown of the main additions:

`chain_randomizer_test.go`:
- Utilities that create metadata for a random set of L2 chains with cross-chain messages between them.
- `RandomChainParams` struct for configuring the chain metadata
- `RandomChain` struct generated from `RandomChainParams`
- Utilities to invalidate a `RandomChain` (`InsertCycle`, `InsertFutureDependency`, ...)

`cross_update_fuzz_test.go`:
A file with all of the fuzzing targets, functions to setup the backend with a `RandomChain`, and predicate functions to assert invariants.