### PR TITLE
op-service/event: trace and log emitting of events

### DIFF
--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -97,14 +97,14 @@ type systemActor struct {
 }
 
 func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, level slog.Level, ev Event) context.Context {
-	_, path, line, _ := runtime.Caller(2)
+	_, path, line, _ := runtime.Caller(2) // find the location of the caller of Emit()
 	if strings.Contains(path, "limiter.go") {
-		_, path, line, _ = runtime.Caller(3)
+		_, path, line, _ = runtime.Caller(3) // go one level up the stack to get the correct location, if the caller is rate-limited
 	}
 
 	file := filepath.Base(path)
 	dir := filepath.Base(filepath.Dir(path))
-	loc := fmt.Sprintf("%s/%s:%d", dir, file, line)
+	location := fmt.Sprintf("%s/%s:%d", dir, file, line)
 
 	var euuid string
 	var estep int
@@ -115,7 +115,7 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, level slog.Le
 	} else {
 		etrace, ok := ctx.Value(ctxKeyEventTrace).(eventTrace)
 		if !ok {
-			r.sys.log.Error("Event trace is not a eventTrace type", "ev", ev, "loc", loc)
+			r.sys.log.Error("Event trace is not a eventTrace type", "ev", ev, "loc", location)
 			return ctx
 		}
 		euuid = etrace.UUID
@@ -123,7 +123,7 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, level slog.Le
 		ctx = context.WithValue(ctx, ctxKeyEventTrace, eventTrace{euuid, estep})
 	}
 
-	r.sys.log.Log(level, "Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev, "loc", loc)
+	r.sys.log.Log(level, "Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev, "loc", location)
 
 	return ctx
 }

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -3,13 +3,25 @@ package event
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/google/uuid"
+)
+
+type eventUuidKeyType struct{}
+type eventStepKeyType struct{}
+
+var (
+	ctxKeyEventUuid = eventUuidKeyType{}
+	ctxKeyEventStep = eventStepKeyType{}
 )
 
 type Registry interface {
@@ -80,6 +92,34 @@ type systemActor struct {
 	emitPriority Priority
 }
 
+func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, ev Event) context.Context {
+	_, path, line, _ := runtime.Caller(2)
+	if strings.Contains(path, "limiter.go") {
+		_, path, line, _ = runtime.Caller(3)
+	}
+
+	file := filepath.Base(path)
+	dir := filepath.Base(filepath.Dir(path))
+
+	var euuid string
+	var estep int
+	if ctx.Value(ctxKeyEventUuid) == nil {
+		euuid = uuid.New().String()[:6]
+		estep = 0
+		ctx = context.WithValue(ctx, ctxKeyEventUuid, euuid)
+		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
+	} else {
+		euuid = ctx.Value(ctxKeyEventUuid).(string)
+		estep = ctx.Value(ctxKeyEventStep).(int)
+		estep++
+		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
+	}
+
+	r.sys.log.Info("Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
+
+	return ctx
+}
+
 // Emit is called by the end-user
 func (r *systemActor) Emit(ctx context.Context, ev Event) {
 	if ctx == nil {
@@ -91,6 +131,9 @@ func (r *systemActor) Emit(ctx context.Context, ev Event) {
 			ctx = context.Background()
 		}
 	}
+
+	ctx = r.traceAndLogEventEmitted(ctx, ev)
+
 	if r.ctx.Err() != nil {
 		return
 	}

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -28,6 +28,10 @@ type eventTrace struct {
 	Step int
 }
 
+func (e eventTrace) String() string {
+	return fmt.Sprintf("%s:%d", e.UUID, e.Step)
+}
+
 type Registry interface {
 	// Register registers a named event-emitter, optionally processing events itself:
 	// deriver may be nil, not all registrants have to process events.
@@ -106,24 +110,25 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, level slog.Le
 	dir := filepath.Base(filepath.Dir(path))
 	location := fmt.Sprintf("%s/%s:%d", dir, file, line)
 
-	var euuid string
-	var estep int
+	var etrace eventTrace
 	if ctx.Value(ctxKeyEventTrace) == nil {
-		euuid = uuid.New().String()[:6]
-		estep = 0
-		ctx = context.WithValue(ctx, ctxKeyEventTrace, eventTrace{euuid, estep})
+		etrace = eventTrace{
+			UUID: uuid.New().String()[:6],
+			Step: 0,
+		}
+		ctx = context.WithValue(ctx, ctxKeyEventTrace, etrace)
 	} else {
-		etrace, ok := ctx.Value(ctxKeyEventTrace).(eventTrace)
+		var ok bool
+		etrace, ok = ctx.Value(ctxKeyEventTrace).(eventTrace)
 		if !ok {
 			r.sys.log.Error("Event trace is not a eventTrace type", "ev", ev, "loc", location)
 			return ctx
 		}
-		euuid = etrace.UUID
-		estep = etrace.Step + 1
-		ctx = context.WithValue(ctx, ctxKeyEventTrace, eventTrace{euuid, estep})
+		etrace.Step++
+		ctx = context.WithValue(ctx, ctxKeyEventTrace, etrace)
 	}
 
-	r.sys.log.Log(level, "Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev, "loc", location)
+	r.sys.log.Log(level, "Event emitted", "euid", etrace, "ev", ev, "loc", location)
 
 	return ctx
 }

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -115,7 +115,7 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, ev Event) con
 		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
 	}
 
-	r.sys.log.Debug("Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
+	r.sys.log.Trace("Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
 
 	return ctx
 }

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -115,7 +115,7 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, ev Event) con
 		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
 	}
 
-	r.sys.log.Info("Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
+	r.sys.log.Debug("Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
 
 	return ctx
 }

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -92,7 +93,7 @@ type systemActor struct {
 	emitPriority Priority
 }
 
-func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, ev Event) context.Context {
+func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, level slog.Level, ev Event) context.Context {
 	_, path, line, _ := runtime.Caller(2)
 	if strings.Contains(path, "limiter.go") {
 		_, path, line, _ = runtime.Caller(3)
@@ -115,7 +116,7 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, ev Event) con
 		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
 	}
 
-	r.sys.log.Trace("Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
+	r.sys.log.Log(level, "Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
 
 	return ctx
 }
@@ -132,7 +133,10 @@ func (r *systemActor) Emit(ctx context.Context, ev Event) {
 		}
 	}
 
-	ctx = r.traceAndLogEventEmitted(ctx, ev)
+	level := log.LevelTrace
+	if r.sys.log.Enabled(ctx, level) {
+		ctx = r.traceAndLogEventEmitted(ctx, level, ev)
+	}
 
 	if r.ctx.Err() != nil {
 		return

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -17,13 +17,16 @@ import (
 	"github.com/google/uuid"
 )
 
-type eventUuidKeyType struct{}
-type eventStepKeyType struct{}
+type eventTraceKeyType struct{}
 
 var (
-	ctxKeyEventUuid = eventUuidKeyType{}
-	ctxKeyEventStep = eventStepKeyType{}
+	ctxKeyEventTrace = eventTraceKeyType{}
 )
+
+type eventTrace struct {
+	UUID string
+	Step int
+}
 
 type Registry interface {
 	// Register registers a named event-emitter, optionally processing events itself:
@@ -101,22 +104,26 @@ func (r *systemActor) traceAndLogEventEmitted(ctx context.Context, level slog.Le
 
 	file := filepath.Base(path)
 	dir := filepath.Base(filepath.Dir(path))
+	loc := fmt.Sprintf("%s/%s:%d", dir, file, line)
 
 	var euuid string
 	var estep int
-	if ctx.Value(ctxKeyEventUuid) == nil {
+	if ctx.Value(ctxKeyEventTrace) == nil {
 		euuid = uuid.New().String()[:6]
 		estep = 0
-		ctx = context.WithValue(ctx, ctxKeyEventUuid, euuid)
-		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
+		ctx = context.WithValue(ctx, ctxKeyEventTrace, eventTrace{euuid, estep})
 	} else {
-		euuid = ctx.Value(ctxKeyEventUuid).(string)
-		estep = ctx.Value(ctxKeyEventStep).(int)
-		estep++
-		ctx = context.WithValue(ctx, ctxKeyEventStep, estep)
+		etrace, ok := ctx.Value(ctxKeyEventTrace).(eventTrace)
+		if !ok {
+			r.sys.log.Error("Event trace is not a eventTrace type", "ev", ev, "loc", loc)
+			return ctx
+		}
+		euuid = etrace.UUID
+		estep = etrace.Step + 1
+		ctx = context.WithValue(ctx, ctxKeyEventTrace, eventTrace{euuid, estep})
 	}
 
-	r.sys.log.Log(level, "Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev.String(), "loc", fmt.Sprintf("%s/%s:%d", dir, file, line))
+	r.sys.log.Log(level, "Event emitted", "euid", fmt.Sprintf("%s:%d", euuid, estep), "ev", ev, "loc", loc)
 
 	return ctx
 }


### PR DESCRIPTION
**Description**

This PR is adding an event uuid and event step to all events emitted with the `systemActor`, which is the majority/all events in our stack.

It also logs where the event was emitted in the codebase, as sometimes we emit the same events at multiple locations.

It helps track runtime execution, and could be potentially useful while refactoring the event system usage, for example:

```
t=2025-07-23T12:54:00.952+0300 lvl=info msg="Event emitted" euid=e93000:0 ev=payload-process loc=sequencing/sequencer.go:288 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:54:00.954+0300 lvl=info msg="Event emitted" euid=e93000:1 ev=payload-success loc=engine/payload_process.go:55 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:54:00.954+0300 lvl=info msg="Event emitted" euid=e93000:2 ev=promote-unsafe loc=engine/payload_success.go:50 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:54:00.954+0300 lvl=info msg="Event emitted" euid=e93000:2 ev=try-update-engine loc=engine/payload_success.go:61 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:54:00.955+0300 lvl=info msg="Event emitted" euid=e93000:3 ev=unsafe-update loc=engine/events.go:452 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:54:00.956+0300 lvl=info msg="Event emitted" euid=e93000:4 ev=try-update-engine loc=engine/events.go:459 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
```

or

```
t=2025-07-23T12:53:57.910+0300 lvl=info msg="Event emitted" euid=de9ede:0 ev=pending-safe-request loc=driver/state.go:394 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:53:57.910+0300 lvl=info msg="Event emitted" euid=de9ede:1 ev=pending-safe-update loc=engine/events.go:467 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:53:57.910+0300 lvl=info msg="Event emitted" euid=de9ede:2 ev=pipeline-step loc=attributes/attributes.go:125 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:53:57.910+0300 lvl=info msg="Event emitted" euid=de9ede:3 ev=derivation-idle loc=derive/deriver.go:148 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:53:57.910+0300 lvl=info msg="Event emitted" euid=de9ede:3 ev=exhausted-l1 loc=derive/deriver.go:149 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
t=2025-07-23T12:53:57.910+0300 lvl=info msg="Event emitted" euid=de9ede:4 ev=reset-step-backoff loc=driver/state.go:265 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-sequencer-901
```

At the moment this doesn't handle too well fan-out structures, but I think it is a good first step into bringing a bit more observability in the event system.

This functionality relies on events propagating and reusing `context.Context`, which is the case at least with some subset of our usage of the event system.