### PR TITLE
[SPIKE] op-node: Async Await Pattern + Procedural Control Flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/campoy/embedmd v1.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/chebyrash/promise v0.0.0-20230709133807-42ec49ba1459 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
@@ -218,6 +219,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/panjf2000/ants/v2 v2.8.1 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
@@ -257,6 +259,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.24.6 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/supranational/blst v0.3.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chebyrash/promise v0.0.0-20230709133807-42ec49ba1459 h1:s7UrE2T8jRoriLIddT8fW5+Wf2sXcOgfteXUKD74SaU=
+github.com/chebyrash/promise v0.0.0-20230709133807-42ec49ba1459/go.mod h1:CQthfPdCoGmlBJAG/sP9Km5nfK1/jGpDf1RiG/LUxXw=
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
 github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
@@ -690,6 +692,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+github.com/panjf2000/ants/v2 v2.8.1 h1:C+n/f++aiW8kHCExKlpX6X+okmxKXP7DWLutxuAPuwQ=
+github.com/panjf2000/ants/v2 v2.8.1/go.mod h1:KIBmYG9QQX5U2qzFP/yQJaq/nSb6rahS9iEHkrCMgM8=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
@@ -858,6 +862,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
+github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
+github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -878,6 +884,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/op-acceptance-tests/tests/spike/init_test.go
+++ b/op-acceptance-tests/tests/spike/init_test.go
@@ -1,0 +1,15 @@
+package safeheaddb_elsync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+		presets.WithConsensusLayerSync(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/spike/temp_test.go
+++ b/op-acceptance-tests/tests/spike/temp_test.go
@@ -1,0 +1,21 @@
+package safeheaddb_elsync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestTemp(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNode(t)
+
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, 3, 30),
+		sys.L2CLB.AdvancedFn(types.LocalUnsafe, 3, 30))
+
+	sys.L2CLB.Matched(sys.L2CL, types.LocalUnsafe, 30)
+}

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -451,7 +451,7 @@ func (s *L2Verifier) ActL2InsertUnsafePayload(payload *eth.ExecutionPayloadEnvel
 	return func(t Testing) {
 		ref, err := derive.PayloadToBlockRef(s.RollupCfg, payload.ExecutionPayload)
 		require.NoError(t, err)
-		err = s.engine.InsertUnsafePayload(t.Ctx(), payload, ref)
+		err = s.engine.InsertUnsafePayload(t.Ctx(), payload, ref, t.Ctx())
 		require.NoError(t, err)
 	}
 }

--- a/op-node/p2p/event.go
+++ b/op-node/p2p/event.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -14,6 +15,7 @@ import (
 type ReceivedBlockEvent struct {
 	From     peer.ID
 	Envelope *eth.ExecutionPayloadEnvelope
+	UUID     string
 }
 
 func (ev ReceivedBlockEvent) String() string {
@@ -47,6 +49,7 @@ func (g *BlockReceiver) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg
 		"id", msg.ExecutionPayload.ID(),
 		"peer", from, "txs", len(msg.ExecutionPayload.Transactions))
 	g.metrics.RecordReceivedUnsafePayload(msg)
-	g.emitter.Emit(ctx, ReceivedBlockEvent{From: from, Envelope: msg})
+	// ReceivedBlockEvent is only emitted here
+	g.emitter.Emit(ctx, ReceivedBlockEvent{From: from, Envelope: msg, UUID: uuid.New().String()})
 	return nil
 }

--- a/op-node/p2p/event.go
+++ b/op-node/p2p/event.go
@@ -2,8 +2,8 @@ package p2p
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -49,7 +49,7 @@ func (g *BlockReceiver) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg
 		"id", msg.ExecutionPayload.ID(),
 		"peer", from, "txs", len(msg.ExecutionPayload.Transactions))
 	g.metrics.RecordReceivedUnsafePayload(msg)
-	// ReceivedBlockEvent is only emitted here
-	g.emitter.Emit(ctx, ReceivedBlockEvent{From: from, Envelope: msg, UUID: uuid.New().String()})
+	fmt.Printf("l33t event casacade start\n")
+	g.emitter.Emit(ctx, ReceivedBlockEvent{From: from, Envelope: msg})
 	return nil
 }

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -2,6 +2,7 @@ package clsync
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -9,6 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 )
@@ -32,6 +35,10 @@ type CLSync struct {
 	mu sync.Mutex
 
 	unsafePayloads *PayloadsQueue // queue of unsafe payloads, ordered by ascending block number, may have gaps and duplicates
+
+	EngineDeriver *engine.EngDeriver
+	Finalizer     *finality.Finalizer
+	StatusTracker *status.StatusTracker
 }
 
 func NewCLSync(log log.Logger, cfg *rollup.Config, metrics Metrics) *CLSync {
@@ -184,4 +191,80 @@ func (eq *CLSync) onUnsafePayload(ctx context.Context, x ReceivedUnsafePayloadEv
 
 	// request forkchoice signal, so we can process the payload maybe
 	eq.emitter.Emit(ctx, engine.ForkchoiceRequestEvent{})
+}
+
+// AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1.
+func (eq *CLSync) OnUnsafePayloadSync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
+	fmt.Println("l33t OnUnsafePayloadSync")
+	if envelope == nil {
+		eq.log.Warn("cannot add nil unsafe payload")
+		return
+	}
+	eq.log.Debug("CL sync received payload", "payload", envelope.ExecutionPayload.ID())
+
+	if err := eq.unsafePayloads.Push(envelope); err != nil {
+		eq.log.Warn("Could not add unsafe payload", "id", envelope.ExecutionPayload.ID(), "timestamp", uint64(envelope.ExecutionPayload.Timestamp), "err", err)
+		return
+	}
+	p := eq.unsafePayloads.Peek()
+	eq.metrics.RecordUnsafePayloadsBuffer(uint64(eq.unsafePayloads.Len()), eq.unsafePayloads.MemSize(), p.ExecutionPayload.ID())
+	eq.log.Trace("Next unsafe payload to process", "next", p.ExecutionPayload.ID(), "timestamp", uint64(p.ExecutionPayload.Timestamp))
+
+	// request forkchoice signal, so we can process the payload maybe
+
+	// 1. EngDeriver receives and converts to ForkchoiceUpdateEvent
+	// case ForkchoiceRequestEvent:
+	// 	d.emitter.Emit(ctx, ForkchoiceUpdateEvent{
+	// 		UnsafeL2Head:    d.ec.UnsafeL2Head(),
+	// 		SafeL2Head:      d.ec.SafeL2Head(),
+	// 		FinalizedL2Head: d.ec.Finalized(),
+	// 	})
+	// 2. {clsync, finalizer, origin_selector, sequencer, status}.go receives it
+	// and do their work
+
+	// No event emit:
+	//  eq.emitter.Emit(ctx, engine.ForkchoiceRequestEvent{})
+
+	// bypass ForkchoiceRequestEvent and directly do ForkChoiceUpdate
+	// Temporal measure: Do not handle origin_selector, sequencer since it is sequencer code path
+	info := eq.EngineDeriver.GetForkChoiceUpdateInfo()
+	// Handle finalizer.go
+	eq.Finalizer.SetFinalizedHead(info.FinalizedL2Head)
+	// Handle status.go
+	eq.StatusTracker.ForkchoiceUpdate(info)
+	// Handle clsync.go (Most heavy one)
+	eq.OnForkchoiceUpdateSync(ctx, info)
+}
+
+var _ engine.CLSyncWrapper = (*CLSync)(nil)
+
+func (eq *CLSync) OnForkchoiceUpdateSync(ctx context.Context, x engine.ForkchoiceUpdateInfo) {
+	fmt.Println("l33t OnForkchoiceUpdateSync")
+	eq.log.Debug("CL sync received forkchoice update",
+		"unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
+
+	for {
+		// some type conversion
+		pop, abort := eq.fromQueue(engine.ForkchoiceUpdateEvent{
+			UnsafeL2Head:    x.UnsafeL2Head,
+			SafeL2Head:      x.SafeL2Head,
+			FinalizedL2Head: x.FinalizedL2Head,
+		})
+		if abort {
+			return
+		}
+		if pop {
+			eq.unsafePayloads.Pop()
+		} else {
+			break
+		}
+	}
+
+	firstEnvelope := eq.unsafePayloads.Peek()
+
+	// We don't pop from the queue. If there is a temporary error then we can retry.
+	// Upon next forkchoice update or invalid-payload event we can remove it from the queue.
+
+	// eq.emitter.Emit(ctx, engine.ProcessUnsafePayloadEvent{Envelope: firstEnvelope})
+	eq.EngineDeriver.OnProcessUnsafePayloadSync(ctx, firstEnvelope)
 }

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -62,6 +62,7 @@ func (eq *CLSync) LowestQueuedUnsafeBlock() eth.L2BlockRef {
 
 type ReceivedUnsafePayloadEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
+	UUID     string
 }
 
 func (ev ReceivedUnsafePayloadEvent) String() string {

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -2,9 +2,11 @@ package clsync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
+	"github.com/chebyrash/promise"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -236,6 +238,69 @@ func (eq *CLSync) OnUnsafePayloadSync(ctx context.Context, envelope *eth.Executi
 	eq.OnForkchoiceUpdateSync(ctx, info)
 }
 
+// AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1.
+func (eq *CLSync) OnUnsafePayloadAsync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) *promise.Promise[struct{}] {
+	return promise.New(func(resolve func(struct{}), reject func(error)) {
+		fmt.Println("l33t OnUnsafePayloadAsync")
+		if envelope == nil {
+			eq.log.Warn("cannot add nil unsafe payload")
+			resolve(struct{}{})
+		}
+		eq.log.Debug("CL sync received payload", "payload", envelope.ExecutionPayload.ID())
+
+		if err := eq.unsafePayloads.Push(envelope); err != nil {
+			eq.log.Warn("Could not add unsafe payload", "id", envelope.ExecutionPayload.ID(), "timestamp", uint64(envelope.ExecutionPayload.Timestamp), "err", err)
+			resolve(struct{}{})
+		}
+		p := eq.unsafePayloads.Peek()
+		eq.metrics.RecordUnsafePayloadsBuffer(uint64(eq.unsafePayloads.Len()), eq.unsafePayloads.MemSize(), p.ExecutionPayload.ID())
+		eq.log.Trace("Next unsafe payload to process", "next", p.ExecutionPayload.ID(), "timestamp", uint64(p.ExecutionPayload.Timestamp))
+
+		// request forkchoice signal, so we can process the payload maybe
+
+		// 1. EngDeriver receives and converts to ForkchoiceUpdateEvent
+		// case ForkchoiceRequestEvent:
+		// 	d.emitter.Emit(ctx, ForkchoiceUpdateEvent{
+		// 		UnsafeL2Head:    d.ec.UnsafeL2Head(),
+		// 		SafeL2Head:      d.ec.SafeL2Head(),
+		// 		FinalizedL2Head: d.ec.Finalized(),
+		// 	})
+		// 2. {clsync, finalizer, origin_selector, sequencer, status}.go receives it
+		// and do their work
+
+		// No event emit:
+		//  eq.emitter.Emit(ctx, engine.ForkchoiceRequestEvent{})
+
+		// bypass ForkchoiceRequestEvent and directly do ForkChoiceUpdate
+		// Temporal measure: Do not handle origin_selector, sequencer since it is sequencer code path
+		info := eq.EngineDeriver.GetForkChoiceUpdateInfo()
+		// // Handle finalizer.go
+		// eq.Finalizer.SetFinalizedHead(info.FinalizedL2Head)
+		// // Handle status.go
+		// eq.StatusTracker.ForkchoiceUpdate(info)
+		// // Handle clsync.go (Most heavy one)
+		// eq.OnForkchoiceUpdateSync(ctx, info)
+
+		// async functions return promise
+		finalizerPromise := eq.Finalizer.SetFinalizedHeadAsync(info.FinalizedL2Head)
+		statusPromise := eq.StatusTracker.ForkchoiceUpdateAsync(info)
+		clsyncPromise := eq.OnForkchoiceUpdateAsync(ctx, info)
+
+		// Await all promises
+		_, err1 := finalizerPromise.Await(ctx)
+		_, err2 := statusPromise.Await(ctx)
+		_, err3 := clsyncPromise.Await(ctx)
+
+		// Handle errors
+		if err1 != nil || err2 != nil || err3 != nil {
+			eq.log.Warn("forkchoice async update had errors", "finalizerErr", err1, "statusErr", err2, "clsyncErr", err3)
+			err := errors.Join(err1, err2, err3)
+			reject(err)
+		}
+		resolve(struct{}{})
+	})
+}
+
 var _ engine.CLSyncWrapper = (*CLSync)(nil)
 
 func (eq *CLSync) OnForkchoiceUpdateSync(ctx context.Context, x engine.ForkchoiceUpdateInfo) {
@@ -267,4 +332,11 @@ func (eq *CLSync) OnForkchoiceUpdateSync(ctx context.Context, x engine.Forkchoic
 
 	// eq.emitter.Emit(ctx, engine.ProcessUnsafePayloadEvent{Envelope: firstEnvelope})
 	eq.EngineDeriver.OnProcessUnsafePayloadSync(ctx, firstEnvelope)
+}
+
+func (eq *CLSync) OnForkchoiceUpdateAsync(ctx context.Context, x engine.ForkchoiceUpdateInfo) *promise.Promise[struct{}] {
+	return promise.New(func(resolve func(struct{}), reject func(error)) {
+		eq.OnForkchoiceUpdateSync(ctx, x)
+		resolve(struct{}{})
+	})
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -81,7 +81,7 @@ type EngineController interface {
 	engine.RollupAPI
 	engine.LocalEngineControl
 	IsEngineSyncing() bool
-	InsertUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error
+	InsertUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, eventCtx context.Context) error
 	TryUpdateEngine(ctx context.Context) error
 	TryBackupUnsafeReorg(ctx context.Context) (bool, error)
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -187,6 +187,7 @@ func NewDriver(
 	l1 = metered.NewMeteredL1Fetcher(l1Tracker, metrics)
 	verifConfDepth := confdepth.NewConfDepth(driverCfg.VerifierConfDepth, statusTracker.L1Head, l1)
 
+	// necessary actor for p2p unsafe head sync
 	ec := engine.NewEngineController(l2, log, metrics, cfg, syncCfg,
 		sys.Register("engine-controller", nil))
 
@@ -194,6 +195,7 @@ func NewDriver(
 		engine.NewEngineResetDeriver(driverCtx, log, cfg, l1, l2, syncCfg))
 
 	clSync := clsync.NewCLSync(log, cfg, metrics) // alt-sync still uses cl-sync state to determine what to sync to
+	// necessary actor for p2p unsafe head sync
 	sys.Register("cl-sync", clSync)
 
 	var finalizer Finalizer
@@ -225,9 +227,12 @@ func NewDriver(
 		Ctx:                 driverCtx,
 		ManagedBySupervisor: indexingMode,
 	}
+	// necessary actor for p2p unsafe head sync
 	sys.Register("sync", syncDeriver)
 
-	sys.Register("engine", engine.NewEngDeriver(log, driverCtx, cfg, metrics, ec))
+	// necessary actor for p2p unsafe head sync
+	engineDeriver := engine.NewEngDeriver(log, driverCtx, cfg, metrics, ec)
+	sys.Register("engine", engineDeriver)
 
 	schedDeriv := NewStepSchedulingDeriver(log)
 	sys.Register("step-scheduler", schedDeriv)
@@ -263,6 +268,17 @@ func NewDriver(
 		metrics:       metrics,
 		altSync:       altSync,
 	}
+
+	// gather and wire up actors
+	// syncDeriver already embeds clsync
+	syncDeriver.CLSyncWrapper = clSync
+	clSync.EngineDeriver = engineDeriver
+	clSync.Finalizer = finalizer.(*finality.Finalizer) // did not care about AltDA
+	clSync.StatusTracker = statusTracker
+	ec.EngDeriver = engineDeriver
+	ec.CLSyncWrapper = clSync
+	ec.FinalizerWrapper = finalizer.(*finality.Finalizer) // did not care about AltDA
+	engineDeriver.StatusTracker = statusTracker
 
 	return driver
 }

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -294,7 +294,7 @@ func (s *SyncDeriver) onIncomingP2PBlock(ctx context.Context, envelope *eth.Exec
 			return
 		}
 		s.Log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
-		if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref); err != nil {
+		if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref, ctx); err != nil {
 			s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
 		}
 	}

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -228,6 +228,8 @@ type SyncDeriver struct {
 	// When in interop, and managed by an op-supervisor,
 	// the node performs a reset based on the instructions of the op-supervisor.
 	ManagedBySupervisor bool
+
+	CLSyncWrapper engine.CLSyncWrapper
 }
 
 func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
@@ -244,7 +246,9 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		// On "finalized" L1 blocks: we may be able to mark more L2 data as finalized now.
 		s.Emitter.Emit(ctx, StepReqEvent{})
 	case p2p.ReceivedBlockEvent:
-		s.onIncomingP2PBlock(ctx, x.Envelope)
+		// s.onIncomingP2PBlock(ctx, x.Envelope)
+		// Start Here for the procedural synchronous function call
+		s.OnIncomingP2PBlockSync(ctx, x.Envelope)
 	case StepEvent:
 		s.SyncStep()
 	case rollup.ResetEvent:
@@ -294,6 +298,32 @@ func (s *SyncDeriver) onIncomingP2PBlock(ctx context.Context, envelope *eth.Exec
 			return
 		}
 		s.Log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
+		if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref, ctx); err != nil {
+			s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
+		}
+	}
+}
+
+func (s *SyncDeriver) OnIncomingP2PBlockSync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
+	fmt.Println("l33t OnIncomingP2PBlockSync")
+	// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
+	if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
+		s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
+		s.CLSyncWrapper.OnUnsafePayloadSync(ctx, envelope)
+		// s.Emitter.Emit(ctx, clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
+	} else if s.SyncCfg.SyncMode == sync.ELSync {
+		// pcw109550: track this control flow
+		// not yet migrated
+		ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
+		if err != nil {
+			s.Log.Info("Failed to turn execution payload into a block ref", "id", envelope.ExecutionPayload.ID(), "err", err)
+			return
+		}
+		if ref.Number <= s.Engine.UnsafeL2Head().Number {
+			return
+		}
+		s.Log.Info("Optimistically inserting unsafe L2 execution payload to drive EL sync", "id", envelope.ExecutionPayload.ID())
+		// potential for more events
 		if err := s.Engine.InsertUnsafePayload(s.Ctx, envelope, ref, ctx); err != nil {
 			s.Log.Warn("Failed to insert unsafe payload for EL sync", "id", envelope.ExecutionPayload.ID(), "err", err)
 		}

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -309,7 +309,22 @@ func (s *SyncDeriver) OnIncomingP2PBlockSync(ctx context.Context, envelope *eth.
 	// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
 	if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
 		s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
-		s.CLSyncWrapper.OnUnsafePayloadSync(ctx, envelope)
+
+		onSafePayloadAsyncPromise := s.CLSyncWrapper.OnUnsafePayloadAsync(ctx, envelope)
+		// blocking
+		// {
+		// fmt.Println("l33t blocking")
+		// 	_, err := onSafePayloadAsyncPromise.Await(ctx)
+		// 	if err != nil {
+		// 		log.Warn("CLSync OnUnsafePayloadAsync failed", "err", err)
+		// 	}
+		// }
+		// no blocking(fire and forget, like events)
+		{
+			fmt.Println("l33t unblocking")
+			_ = onSafePayloadAsyncPromise
+		}
+		// s.CLSyncWrapper.OnUnsafePayloadSync(ctx, envelope)
 		// s.Emitter.Emit(ctx, clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
 	} else if s.SyncCfg.SyncMode == sync.ELSync {
 		// pcw109550: track this control flow

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -375,7 +375,7 @@ func (e *EngineController) TryUpdateEngine(ctx context.Context) error {
 	return nil
 }
 
-func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error {
+func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, eventCtx context.Context) error {
 	// Check if there is a finalized head once when doing EL sync. If so, transition to CL sync
 	if e.syncStatus == syncStatusWillStartEL {
 		b, err := e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
@@ -384,7 +384,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 			e.syncStatus = syncStatusStartedEL
 			e.log.Info("Starting EL sync")
 			e.elStart = e.clock.Now()
-			e.emitter.Emit(ctx, ELSyncStartedEvent{})
+			e.emitter.Emit(eventCtx, ELSyncStartedEvent{})
 		} else if err == nil {
 			e.syncStatus = syncStatusFinishedEL
 			e.log.Info("Skipping EL sync and going straight to CL sync because there is a finalized block", "id", b.ID())
@@ -400,7 +400,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		return derive.NewTemporaryError(fmt.Errorf("failed to update insert payload: %w", err))
 	}
 	if status.Status == eth.ExecutionInvalid {
-		e.emitter.Emit(ctx, PayloadInvalidEvent{
+		e.emitter.Emit(eventCtx, PayloadInvalidEvent{
 			Envelope: envelope,
 			Err:      eth.NewPayloadErr(envelope.ExecutionPayload, status),
 		})
@@ -422,10 +422,10 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		fc.SafeBlockHash = envelope.ExecutionPayload.BlockHash
 		fc.FinalizedBlockHash = envelope.ExecutionPayload.BlockHash
 		e.SetUnsafeHead(ref) // ensure that the unsafe head stays ahead of safe/finalized labels.
-		e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
+		e.emitter.Emit(eventCtx, UnsafeUpdateEvent{Ref: ref})
 		e.SetLocalSafeHead(ref)
 		e.SetSafeHead(ref)
-		e.emitter.Emit(ctx, CrossSafeUpdateEvent{LocalSafe: ref, CrossSafe: ref})
+		e.emitter.Emit(eventCtx, CrossSafeUpdateEvent{LocalSafe: ref, CrossSafe: ref})
 		e.SetFinalizedHead(ref)
 	}
 	logFn := e.logSyncProgressMaybe()
@@ -453,7 +453,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	fcu2Finish := time.Now()
 	e.SetUnsafeHead(ref)
 	e.needFCUCall = false
-	e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
+	e.emitter.Emit(eventCtx, UnsafeUpdateEvent{Ref: ref})
 
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		e.log.Info("Finished EL sync", "sync_duration", e.clock.Since(e.elStart), "finalized_block", ref.ID().String())
@@ -461,7 +461,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	}
 
 	if fcRes.PayloadStatus.Status == eth.ExecutionValid {
-		e.emitter.Emit(ctx, ForkchoiceUpdateEvent{
+		e.emitter.Emit(eventCtx, ForkchoiceUpdateEvent{
 			UnsafeL2Head:    e.unsafeHead,
 			SafeL2Head:      e.safeHead,
 			FinalizedL2Head: e.finalizedHead,

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -50,6 +50,20 @@ type ECMetrics interface {
 	RecordL2Ref(name string, ref eth.L2BlockRef)
 }
 
+type StatusTrackerWrapper interface {
+	CrossUnsafeUpdate(x CrossUnsafeUpdateInfo)
+	ForkchoiceUpdate(x ForkchoiceUpdateInfo)
+}
+
+type CLSyncWrapper interface {
+	OnForkchoiceUpdateSync(ctx context.Context, x ForkchoiceUpdateInfo)
+	OnUnsafePayloadSync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope)
+}
+
+type FinalizerWrapper interface {
+	SetFinalizedHead(x eth.L2BlockRef)
+}
+
 type EngineController struct {
 	engine     ExecEngine // Underlying execution engine RPC
 	log        log.Logger
@@ -94,6 +108,10 @@ type EngineController struct {
 	// because engine may forgot backupUnsafeHead or backupUnsafeHead is not part
 	// of the chain.
 	needFCUCallForBackupUnsafeReorg bool
+
+	EngDeriver       *EngDeriver
+	CLSyncWrapper    CLSyncWrapper
+	FinalizerWrapper FinalizerWrapper
 }
 
 func NewEngineController(engine ExecEngine, log log.Logger, metrics ECMetrics,
@@ -466,6 +484,136 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 			SafeL2Head:      e.safeHead,
 			FinalizedL2Head: e.finalizedHead,
 		})
+	}
+
+	totalTime := fcu2Finish.Sub(newPayloadStart)
+	e.log.Info("Inserted new L2 unsafe block (synchronous)",
+		"hash", envelope.ExecutionPayload.BlockHash,
+		"number", uint64(envelope.ExecutionPayload.BlockNumber),
+		"newpayload_time", common.PrettyDuration(newPayloadFinish.Sub(newPayloadStart)),
+		"fcu2_time", common.PrettyDuration(fcu2Finish.Sub(fcu2Start)),
+		"total_time", common.PrettyDuration(totalTime),
+		"mgas", float64(envelope.ExecutionPayload.GasUsed)/1000000,
+		"mgasps", float64(envelope.ExecutionPayload.GasUsed)*1000/float64(totalTime))
+
+	return nil
+}
+
+func (e *EngineController) InsertUnsafePayloadSync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, eventCtx context.Context) error {
+	fmt.Println("l33t InsertUnsafePayloadSync")
+	// Check if there is a finalized head once when doing EL sync. If so, transition to CL sync
+	if e.syncStatus == syncStatusWillStartEL {
+		b, err := e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
+		rollupGenesisIsFinalized := b.Hash == e.rollupCfg.Genesis.L2.Hash
+		if errors.Is(err, ethereum.NotFound) || rollupGenesisIsFinalized || e.syncCfg.SupportsPostFinalizationELSync {
+			e.syncStatus = syncStatusStartedEL
+			e.log.Info("Starting EL sync")
+			e.elStart = e.clock.Now()
+			e.emitter.Emit(eventCtx, ELSyncStartedEvent{})
+		} else if err == nil {
+			e.syncStatus = syncStatusFinishedEL
+			e.log.Info("Skipping EL sync and going straight to CL sync because there is a finalized block", "id", b.ID())
+			return nil
+		} else {
+			return derive.NewTemporaryError(fmt.Errorf("failed to fetch finalized head: %w", err))
+		}
+	}
+	// Insert the payload & then call FCU
+	newPayloadStart := time.Now()
+	status, err := e.engine.NewPayload(ctx, envelope.ExecutionPayload, envelope.ParentBeaconBlockRoot)
+	if err != nil {
+		return derive.NewTemporaryError(fmt.Errorf("failed to update insert payload: %w", err))
+	}
+	if status.Status == eth.ExecutionInvalid {
+		e.emitter.Emit(eventCtx, PayloadInvalidEvent{
+			Envelope: envelope,
+			Err:      eth.NewPayloadErr(envelope.ExecutionPayload, status),
+		})
+	}
+	if !e.checkNewPayloadStatus(status.Status) {
+		payload := envelope.ExecutionPayload
+		return derive.NewTemporaryError(fmt.Errorf("cannot process unsafe payload: new - %v; parent: %v; err: %w",
+			payload.ID(), payload.ParentID(), eth.NewPayloadErr(payload, status)))
+	}
+	newPayloadFinish := time.Now()
+
+	// Mark the new payload as valid
+	fc := eth.ForkchoiceState{
+		HeadBlockHash:      envelope.ExecutionPayload.BlockHash,
+		SafeBlockHash:      e.safeHead.Hash,
+		FinalizedBlockHash: e.finalizedHead.Hash,
+	}
+	if e.syncStatus == syncStatusFinishedELButNotFinalized {
+		fc.SafeBlockHash = envelope.ExecutionPayload.BlockHash
+		fc.FinalizedBlockHash = envelope.ExecutionPayload.BlockHash
+		e.SetUnsafeHead(ref) // ensure that the unsafe head stays ahead of safe/finalized labels.
+		e.emitter.Emit(eventCtx, UnsafeUpdateEvent{Ref: ref})
+		e.SetLocalSafeHead(ref)
+		e.SetSafeHead(ref)
+		e.emitter.Emit(eventCtx, CrossSafeUpdateEvent{LocalSafe: ref, CrossSafe: ref})
+		e.SetFinalizedHead(ref)
+	}
+	logFn := e.logSyncProgressMaybe()
+	defer logFn()
+	fcu2Start := time.Now()
+	fcRes, err := e.engine.ForkchoiceUpdate(ctx, &fc, nil)
+	if err != nil {
+		var rpcErr rpc.Error
+		if errors.As(err, &rpcErr) {
+			switch eth.ErrorCode(rpcErr.ErrorCode()) {
+			case eth.InvalidForkchoiceState:
+				return derive.NewResetError(fmt.Errorf("pre-unsafe-block forkchoice update was inconsistent with engine, need reset to resolve: %w", err))
+			default:
+				return derive.NewTemporaryError(fmt.Errorf("unexpected error code in forkchoice-updated response: %w", err))
+			}
+		} else {
+			return derive.NewTemporaryError(fmt.Errorf("failed to update forkchoice to prepare for new unsafe payload: %w", err))
+		}
+	}
+	if !e.checkForkchoiceUpdatedStatus(fcRes.PayloadStatus.Status) {
+		payload := envelope.ExecutionPayload
+		return derive.NewTemporaryError(fmt.Errorf("cannot prepare unsafe chain for new payload: new - %v; parent: %v; err: %w",
+			payload.ID(), payload.ParentID(), eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)))
+	}
+	fcu2Finish := time.Now()
+	e.SetUnsafeHead(ref)
+	e.needFCUCall = false
+	// events.go
+	// e.emitter.Emit(eventCtx,UnsafeUpdateEvent{Ref: ref})
+	e.EngDeriver.OnUnsafeUpdateSync(ctx, ref)
+
+	if e.syncStatus == syncStatusFinishedELButNotFinalized {
+		e.log.Info("Finished EL sync", "sync_duration", e.clock.Since(e.elStart), "finalized_block", ref.ID().String())
+		e.syncStatus = syncStatusFinishedEL
+	}
+
+	if fcRes.PayloadStatus.Status == eth.ExecutionValid {
+		// e.emitter.Emit(eventCtx, ForkchoiceUpdateEvent{
+		// 	UnsafeL2Head:    e.unsafeHead,
+		// 	SafeL2Head:      e.safeHead,
+		// 	FinalizedL2Head: e.finalizedHead,
+		// })
+
+		// 1. case ForkchoiceRequestEvent:
+		// 	d.emitter.Emit(ctx, ForkchoiceUpdateEvent{
+		// 		UnsafeL2Head:    d.ec.UnsafeL2Head(),
+		// 		SafeL2Head:      d.ec.SafeL2Head(),
+		// 		FinalizedL2Head: d.ec.Finalized(),
+		// 	})
+		// 2. {clsync, finalizer, origin_selector, sequencer, status}.go receives it
+		// and do their work
+		// Temporal measure: Do not handle origin_selector, sequencer since it is sequencer code path
+		info := ForkchoiceUpdateInfo{
+			UnsafeL2Head:    e.unsafeHead,
+			SafeL2Head:      e.safeHead,
+			FinalizedL2Head: e.finalizedHead,
+		}
+		// Handle finalizer.go
+		e.FinalizerWrapper.SetFinalizedHead(info.FinalizedL2Head)
+		// Handle status.go
+		e.EngDeriver.StatusTracker.ForkchoiceUpdate(info)
+		// Handle clsync.go (Most heavy one)
+		e.CLSyncWrapper.OnForkchoiceUpdateSync(ctx, info)
 	}
 
 	totalTime := fcu2Finish.Sub(newPayloadStart)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -7,6 +7,7 @@ import (
 	gosync "sync"
 	"time"
 
+	"github.com/chebyrash/promise"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -58,6 +59,7 @@ type StatusTrackerWrapper interface {
 type CLSyncWrapper interface {
 	OnForkchoiceUpdateSync(ctx context.Context, x ForkchoiceUpdateInfo)
 	OnUnsafePayloadSync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope)
+	OnUnsafePayloadAsync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) *promise.Promise[struct{}]
 }
 
 type FinalizerWrapper interface {

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -100,6 +100,11 @@ type CrossUnsafeUpdateEvent struct {
 	UUID string
 }
 
+type CrossUnsafeUpdateInfo struct {
+	CrossUnsafe eth.L2BlockRef
+	LocalUnsafe eth.L2BlockRef
+}
+
 func (ev CrossUnsafeUpdateEvent) String() string {
 	return "cross-unsafe-update"
 }
@@ -335,6 +340,8 @@ type EngDeriver struct {
 	ec      *EngineController
 	ctx     context.Context
 	emitter event.Emitter
+
+	StatusTracker StatusTrackerWrapper
 }
 
 var _ event.Deriver = (*EngDeriver)(nil)
@@ -578,6 +585,99 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		return false
 	}
 	return true
+}
+
+type ForkchoiceUpdateInfo struct {
+	UnsafeL2Head, SafeL2Head, FinalizedL2Head eth.L2BlockRef
+}
+
+func (d *EngDeriver) GetForkChoiceUpdateInfo() ForkchoiceUpdateInfo {
+	return ForkchoiceUpdateInfo{
+		UnsafeL2Head:    d.ec.UnsafeL2Head(),
+		SafeL2Head:      d.ec.SafeL2Head(),
+		FinalizedL2Head: d.ec.Finalized(),
+	}
+}
+
+func (d *EngDeriver) OnProcessUnsafePayloadSync(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
+	fmt.Println("l33t OnProcessUnsafePayloadSync")
+	ref, err := derive.PayloadToBlockRef(d.cfg, envelope.ExecutionPayload)
+	if err != nil {
+		d.log.Error("failed to decode L2 block ref from payload", "err", err)
+		return
+	}
+	// Avoid re-processing the same unsafe payload if it has already been processed. Because a FCU event emits the ProcessUnsafePayloadEvent
+	// it is possible to have multiple queueed up ProcessUnsafePayloadEvent for the same L2 block. This becomes an issue when processing
+	// a large number of unsafe payloads at once (like when iterating through the payload queue after the safe head has advanced).
+	if ref.BlockRef().ID() == d.ec.UnsafeL2Head().BlockRef().ID() {
+		return
+	}
+	if err := d.ec.InsertUnsafePayloadSync(d.ctx, envelope, ref, ctx); err != nil {
+		d.log.Info("failed to insert payload", "ref", ref,
+			"txs", len(envelope.ExecutionPayload.Transactions), "err", err)
+		// yes, duplicate error-handling. After all derivers are interacting with the engine
+		// through events, we can drop the engine-controller interface:
+		// unify the events handler with the engine-controller,
+		// remove a lot of code, and not do this error translation.
+		if errors.Is(err, derive.ErrReset) {
+			d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
+		} else if errors.Is(err, derive.ErrTemporary) {
+			d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
+		} else {
+			d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
+				Err: fmt.Errorf("unexpected InsertUnsafePayload error type: %w", err),
+			})
+		}
+	} else {
+		d.log.Info("successfully processed payload", "ref", ref, "txs", len(envelope.ExecutionPayload.Transactions))
+	}
+}
+
+func (d *EngDeriver) OnUnsafeUpdateSync(ctx context.Context, ref eth.L2BlockRef) {
+	fmt.Println("l33t OnUnsafeUpdateSync")
+	// pre-interop everything that is local-unsafe is also immediately cross-unsafe.
+	if !d.cfg.IsInterop(ref.Time) {
+		// d.emitter.Emit(ctx, PromoteCrossUnsafeEvent{Ref: ref})
+		d.OnPromoteCrossUnsafeSync(ctx, ref)
+	}
+	// Try to apply the forkchoice changes
+	// d.emitter.Emit(ctx, TryUpdateEngineEvent{})
+	d.OnTryUpdateEngineSync(ctx, TryUpdateEngineEvent{})
+}
+
+func (d *EngDeriver) OnPromoteCrossUnsafeSync(ctx context.Context, ref eth.L2BlockRef) {
+	fmt.Println("l33t OnPromoteCrossUnsafeSync")
+	d.ec.SetCrossUnsafeHead(ref)
+
+	// d.emitter.Emit(ctx, CrossUnsafeUpdateEvent{
+	// 	CrossUnsafe: ref,
+	// 	LocalUnsafe: d.ec.UnsafeL2Head(),
+	// })
+	d.StatusTracker.CrossUnsafeUpdate(CrossUnsafeUpdateInfo{
+		CrossUnsafe: ref,
+		LocalUnsafe: d.ec.UnsafeL2Head(),
+	})
+
+}
+
+func (d *EngDeriver) OnTryUpdateEngineSync(ctx context.Context, x TryUpdateEngineEvent) {
+	fmt.Println("l33t OnTryUpdateEngineSync")
+	// If we don't need to call FCU, keep going b/c this was a no-op. If we needed to
+	// perform a network call, then we should yield even if we did not encounter an error.
+	if err := d.ec.TryUpdateEngine(d.ctx); err != nil && !errors.Is(err, ErrNoFCUNeeded) {
+		if errors.Is(err, derive.ErrReset) {
+			d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
+		} else if errors.Is(err, derive.ErrTemporary) {
+			d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
+		} else {
+			d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
+				Err: fmt.Errorf("unexpected TryUpdateEngine error type: %w", err),
+			})
+		}
+	} else if x.triggeredByPayloadSuccess() {
+		logValues := x.getBlockProcessingMetrics()
+		d.log.Info("Inserted new L2 unsafe block", logValues...)
+	}
 }
 
 type ResetEngineControl interface {

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -37,6 +37,7 @@ type Metrics interface {
 // This helps decouple derivers from the actual engine state,
 // while also not making the derivers wait for a forkchoice update at random.
 type ForkchoiceRequestEvent struct {
+	UUID string
 }
 
 func (ev ForkchoiceRequestEvent) String() string {
@@ -45,6 +46,8 @@ func (ev ForkchoiceRequestEvent) String() string {
 
 type ForkchoiceUpdateEvent struct {
 	UnsafeL2Head, SafeL2Head, FinalizedL2Head eth.L2BlockRef
+
+	UUID string
 }
 
 func (ev ForkchoiceUpdateEvent) String() string {
@@ -58,6 +61,8 @@ func (ev ForkchoiceUpdateEvent) String() string {
 // See EngineController.InsertUnsafePayload.
 type PromoteUnsafeEvent struct {
 	Ref eth.L2BlockRef
+
+	UUID string
 }
 
 func (ev PromoteUnsafeEvent) String() string {
@@ -68,6 +73,8 @@ func (ev PromoteUnsafeEvent) String() string {
 // This is pre-forkchoice update; the change may not be reflected yet in the EL.
 type UnsafeUpdateEvent struct {
 	Ref eth.L2BlockRef
+
+	UUID string
 }
 
 func (ev UnsafeUpdateEvent) String() string {
@@ -77,6 +84,8 @@ func (ev UnsafeUpdateEvent) String() string {
 // PromoteCrossUnsafeEvent signals that the given block may be promoted to cross-unsafe.
 type PromoteCrossUnsafeEvent struct {
 	Ref eth.L2BlockRef
+
+	UUID string
 }
 
 func (ev PromoteCrossUnsafeEvent) String() string {
@@ -87,6 +96,8 @@ func (ev PromoteCrossUnsafeEvent) String() string {
 type CrossUnsafeUpdateEvent struct {
 	CrossUnsafe eth.L2BlockRef
 	LocalUnsafe eth.L2BlockRef
+
+	UUID string
 }
 
 func (ev CrossUnsafeUpdateEvent) String() string {
@@ -172,6 +183,8 @@ func (ev PendingSafeRequestEvent) String() string {
 
 type ProcessUnsafePayloadEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
+
+	UUID string
 }
 
 func (ev ProcessUnsafePayloadEvent) String() string {
@@ -191,6 +204,8 @@ type TryUpdateEngineEvent struct {
 	BuildStarted  time.Time
 	InsertStarted time.Time
 	Envelope      *eth.ExecutionPayloadEnvelope
+
+	UUID string
 }
 
 func (ev TryUpdateEngineEvent) String() string {
@@ -396,7 +411,7 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		if ref.BlockRef().ID() == d.ec.UnsafeL2Head().BlockRef().ID() {
 			return true
 		}
-		if err := d.ec.InsertUnsafePayload(d.ctx, x.Envelope, ref); err != nil {
+		if err := d.ec.InsertUnsafePayload(d.ctx, x.Envelope, ref, ctx); err != nil {
 			d.log.Info("failed to insert payload", "ref", ref,
 				"txs", len(x.Envelope.ExecutionPayload.Transactions), "err", err)
 			// yes, duplicate error-handling. After all derivers are interacting with the engine

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -158,6 +158,12 @@ func (fi *Finalizer) OnEvent(ctx context.Context, ev event.Event) bool {
 	return true
 }
 
+func (fi *Finalizer) SetFinalizedHead(x eth.L2BlockRef) {
+	fi.lastFinalizedL2 = x
+}
+
+var _ engine.FinalizerWrapper = (*Finalizer)(nil)
+
 // onL1Finalized applies a L1 finality signal
 func (fi *Finalizer) onL1Finalized(l1Origin eth.L1BlockRef) {
 	fi.mu.Lock()

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chebyrash/promise"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -160,6 +161,13 @@ func (fi *Finalizer) OnEvent(ctx context.Context, ev event.Event) bool {
 
 func (fi *Finalizer) SetFinalizedHead(x eth.L2BlockRef) {
 	fi.lastFinalizedL2 = x
+}
+
+func (fi *Finalizer) SetFinalizedHeadAsync(x eth.L2BlockRef) *promise.Promise[struct{}] {
+	return promise.New(func(resolve func(struct{}), reject func(error)) {
+		fi.SetFinalizedHead(x)
+		resolve(struct{}{})
+	})
 }
 
 var _ engine.FinalizerWrapper = (*Finalizer)(nil)

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/chebyrash/promise"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -66,6 +67,13 @@ func (st *StatusTracker) ForkchoiceUpdate(x engine.ForkchoiceUpdateInfo) {
 		st.data.LocalSafeL2 = x.SafeL2Head
 	}
 	st.data.FinalizedL2 = x.FinalizedL2Head
+}
+
+func (st *StatusTracker) ForkchoiceUpdateAsync(x engine.ForkchoiceUpdateInfo) *promise.Promise[struct{}] {
+	return promise.New(func(resolve func(struct{}), reject func(error)) {
+		st.ForkchoiceUpdate(x)
+		resolve(struct{}{})
+	})
 }
 
 func (st *StatusTracker) CrossUnsafeUpdate(x engine.CrossUnsafeUpdateInfo) {

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -58,6 +58,24 @@ func NewStatusTracker(log log.Logger, metrics Metrics) *StatusTracker {
 	return st
 }
 
+func (st *StatusTracker) ForkchoiceUpdate(x engine.ForkchoiceUpdateInfo) {
+	st.log.Debug("Forkchoice update", "unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
+	st.data.UnsafeL2 = x.UnsafeL2Head
+	st.data.SafeL2 = x.SafeL2Head
+	if st.data.LocalSafeL2.Number < x.SafeL2Head.Number {
+		st.data.LocalSafeL2 = x.SafeL2Head
+	}
+	st.data.FinalizedL2 = x.FinalizedL2Head
+}
+
+func (st *StatusTracker) CrossUnsafeUpdate(x engine.CrossUnsafeUpdateInfo) {
+	st.log.Debug("Cross unsafe head updated", "cross_unsafe", x.CrossUnsafe, "local_unsafe", x.LocalUnsafe)
+	st.data.CrossUnsafeL2 = x.CrossUnsafe
+	st.data.UnsafeL2 = x.LocalUnsafe
+}
+
+var _ engine.StatusTrackerWrapper = (*StatusTracker)(nil)
+
 func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	st.mu.Lock()
 	defer st.mu.Unlock()

--- a/op-service/event/events.go
+++ b/op-service/event/events.go
@@ -2,6 +2,8 @@ package event
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -82,7 +84,62 @@ func (d NoopDeriver) OnEvent(ctx context.Context, ev Event) {}
 // This can be used for small in-place derivers, test helpers, etc.
 type DeriverFunc func(ctx context.Context, ev Event) bool
 
+func hasStringUUIDField(val interface{}) bool {
+	v := reflect.ValueOf(val)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	field := v.FieldByName("UUID")
+	if !field.IsValid() {
+		return false
+	}
+	return field.Kind() == reflect.String
+}
+
+type UUIDKey struct{}
+
+var CtxKeyUUID = UUIDKey{}
+
+func printUUIDIfPresent(val interface{}) string {
+	v := reflect.ValueOf(val)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return ""
+	}
+	field := v.FieldByName("UUID")
+	if !field.IsValid() || field.Kind() != reflect.String {
+		return ""
+	}
+	return field.String()
+}
+
+func setUUIDCopy(val interface{}, uuid string) (interface{}, error) {
+	v := reflect.ValueOf(val)
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct value")
+	}
+	vCopy := reflect.New(v.Type()).Elem()
+	vCopy.Set(v)
+
+	field := vCopy.FieldByName("UUID")
+	if !field.IsValid() || !field.CanSet() || field.Kind() != reflect.String {
+		return nil, fmt.Errorf("UUID field not settable or missing")
+	}
+
+	field.SetString(uuid)
+	return vCopy.Interface(), nil
+}
+
 func (fn DeriverFunc) OnEvent(ctx context.Context, ev Event) bool {
+	if hasStringUUIDField(ev) {
+		uuid := printUUIDIfPresent(ev)
+		fmt.Printf("l33t [OnEvent] [%s] %s %s\n", uuid, reflect.TypeOf(ev), ctx)
+	}
 	return fn(ctx, ev)
 }
 

--- a/op-service/event/events.go
+++ b/op-service/event/events.go
@@ -103,7 +103,7 @@ type UUIDKey struct{}
 
 var CtxKeyUUID = UUIDKey{}
 
-func printUUIDIfPresent(val interface{}) string {
+func getUUIDIfPresent(val interface{}) string {
 	v := reflect.ValueOf(val)
 	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
@@ -137,8 +137,8 @@ func setUUIDCopy(val interface{}, uuid string) (interface{}, error) {
 
 func (fn DeriverFunc) OnEvent(ctx context.Context, ev Event) bool {
 	if hasStringUUIDField(ev) {
-		uuid := printUUIDIfPresent(ev)
-		fmt.Printf("l33t [OnEvent] [%s] %s %s\n", uuid, reflect.TypeOf(ev), ctx)
+		// uuid := getUUIDIfPresent(ev)
+		// fmt.Printf("l33t [O] [%s] %s %s\n", uuid, reflect.TypeOf(ev), ctx)
 	}
 	return fn(ctx, ev)
 }

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -111,7 +111,7 @@ func (r *systemActor) Emit(ctx context.Context, ev Event) {
 		ev = modified.(Event)
 		parentUUID, _ := ctx.Value(CtxKeyUUID).(string)
 		// fmt.Printf("l33t [E] [%s]<-[%s] %s %s\n", uuid, parentUUID, reflect.TypeOf(ev), ctx)
-		fmt.Printf("l33t [E] [%s]<-[%s] %s\n", uuid, parentUUID, reflect.TypeOf(ev))
+		fmt.Printf("l33t [E] [%s]<-[%s] %s %s\n", uuid, parentUUID, reflect.TypeOf(ev), r.name)
 	}
 
 	r.sys.emit(r.name, r.currentEvent, ctx, ev, r.emitPriority)

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/google/uuid"
 )
 
 type Registry interface {
@@ -96,36 +97,23 @@ func (r *systemActor) Emit(ctx context.Context, ev Event) {
 		return
 	}
 
-	// debugging purpose to find out UUID not attached events
-	prev, ok := ctx.Value(CtxKeyUUID).(string)
-	if ok && !hasStringUUIDField(ev) {
-		fmt.Printf("l33t [ Emit  ] [%s] %s <debug>\n", prev, reflect.TypeOf(ev))
-	}
+	// we know the name of actor
+	// we know the type of event
+	// we assign uuid to event if possible and not assigned
 
+	// attach uuid field when emitted
 	if hasStringUUIDField(ev) {
-		uuid := printUUIDIfPresent(ev)
-		if uuid != "" {
-			if ctx.Value(CtxKeyUUID) == nil {
-				ctx = context.WithValue(ctx, CtxKeyUUID, uuid)
-			}
-		} else {
-			prev, ok := ctx.Value(CtxKeyUUID).(string)
-			uuid = prev
-			if ok {
-				// very hack since arg ev is value
-				modified, err := setUUIDCopy(ev, uuid)
-				if err != nil {
-					panic(fmt.Sprintf("unable to set uuid field [%s]: %v", uuid, err))
-				}
-				ev = modified.(Event)
-			} else {
-				// panic("uuid not set from parent")
-				// possible
-			}
-
+		uuid := uuid.New().String()
+		modified, err := setUUIDCopy(ev, uuid)
+		if err != nil {
+			panic(fmt.Sprintf("unable to set uuid field [%s]: %v", uuid, err))
 		}
-		fmt.Printf("l33t [ Emit  ] [%s] %s %s\n", uuid, reflect.TypeOf(ev), ctx)
+		ev = modified.(Event)
+		parentUUID, _ := ctx.Value(CtxKeyUUID).(string)
+		// fmt.Printf("l33t [E] [%s]<-[%s] %s %s\n", uuid, parentUUID, reflect.TypeOf(ev), ctx)
+		fmt.Printf("l33t [E] [%s]<-[%s] %s\n", uuid, parentUUID, reflect.TypeOf(ev))
 	}
+
 	r.sys.emit(r.name, r.currentEvent, ctx, ev, r.emitPriority)
 }
 
@@ -146,7 +134,17 @@ func (r *systemActor) RunEvent(ev AnnotatedEvent) {
 	prev := r.currentEvent
 	start := time.Now()
 	r.currentEvent = r.sys.recordDerivStart(r.name, ev, start)
+
+	// set uuid field when
+	if hasStringUUIDField(ev.Event) {
+		uuid := getUUIDIfPresent(ev.Event)
+		// attach parent event uuid to context
+		ev.Ctx = context.WithValue(ev.Ctx, CtxKeyUUID, uuid)
+		// fmt.Printf("l33t [O] [%s] %s\n", uuid, reflect.TypeOf(ev.Event))
+	}
+
 	effect := r.deriv.OnEvent(ev.Ctx, ev.Event)
+
 	elapsed := time.Since(start)
 	r.sys.recordDerivEnd(r.name, ev, r.currentEvent, start, elapsed, effect)
 	r.currentEvent = prev

--- a/op-service/event/system.go
+++ b/op-service/event/system.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -93,6 +94,37 @@ func (r *systemActor) Emit(ctx context.Context, ev Event) {
 	}
 	if r.ctx.Err() != nil {
 		return
+	}
+
+	// debugging purpose to find out UUID not attached events
+	prev, ok := ctx.Value(CtxKeyUUID).(string)
+	if ok && !hasStringUUIDField(ev) {
+		fmt.Printf("l33t [ Emit  ] [%s] %s <debug>\n", prev, reflect.TypeOf(ev))
+	}
+
+	if hasStringUUIDField(ev) {
+		uuid := printUUIDIfPresent(ev)
+		if uuid != "" {
+			if ctx.Value(CtxKeyUUID) == nil {
+				ctx = context.WithValue(ctx, CtxKeyUUID, uuid)
+			}
+		} else {
+			prev, ok := ctx.Value(CtxKeyUUID).(string)
+			uuid = prev
+			if ok {
+				// very hack since arg ev is value
+				modified, err := setUUIDCopy(ev, uuid)
+				if err != nil {
+					panic(fmt.Sprintf("unable to set uuid field [%s]: %v", uuid, err))
+				}
+				ev = modified.(Event)
+			} else {
+				// panic("uuid not set from parent")
+				// possible
+			}
+
+		}
+		fmt.Printf("l33t [ Emit  ] [%s] %s %s\n", uuid, reflect.TypeOf(ev), ctx)
 	}
 	r.sys.emit(r.name, r.currentEvent, ctx, ev, r.emitPriority)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Step by step approach for async await poc

1. Find all events
2. Make the function chunks as functions
3. Make procedural 
4. Wrap with async await chain <- we are here

To do this, we need a way to trace events, since static analysis is taking too long.
First step is to draw a hierarchy to make the flow planar.

Example test: Triggers p2p unsafe sync for the verifier
```sh
cd optimism/op-acceptance-tests/tests/spike
go test ./... -v -count=1  | grep l33t
```

Raw log
```
l33t [E] [c011ea7d-ff5b-4371-b533-b8aa115b7983]<-[] p2p.ReceivedBlockEvent p2p-block-receiver
l33t [E] [77dfca01-e011-4e93-9179-d0dc1308ef30]<-[c011ea7d-ff5b-4371-b533-b8aa115b7983] clsync.ReceivedUnsafePayloadEvent sync
l33t [E] [57672d80-de58-4db4-8d35-5c798d032c3a]<-[77dfca01-e011-4e93-9179-d0dc1308ef30] engine.ForkchoiceRequestEvent cl-sync
l33t [E] [a69e2198-b8be-404e-aa63-d1c0c50fed37]<-[57672d80-de58-4db4-8d35-5c798d032c3a] engine.ForkchoiceUpdateEvent engine
l33t [E] [f7b7bcff-acc7-4b0a-b5a0-7c232df2c627]<-[a69e2198-b8be-404e-aa63-d1c0c50fed37] engine.ProcessUnsafePayloadEvent cl-sync
l33t [E] [c447c82b-184c-4af3-b65d-06cb00185e02]<-[f7b7bcff-acc7-4b0a-b5a0-7c232df2c627] engine.UnsafeUpdateEvent engine-controller
l33t [E] [4d7ff38a-19f0-4335-8fa9-0002dc3ced01]<-[f7b7bcff-acc7-4b0a-b5a0-7c232df2c627] engine.ForkchoiceUpdateEvent engine-controller
l33t [E] [c49e20c7-c76e-47a0-8fb9-bd2ff876efea]<-[c447c82b-184c-4af3-b65d-06cb00185e02] engine.PromoteCrossUnsafeEvent engine
l33t [E] [311866aa-b1f4-4237-a06e-75b33e49468c]<-[c447c82b-184c-4af3-b65d-06cb00185e02] engine.TryUpdateEngineEvent engine
l33t [E] [32777e6d-53b8-485c-ab08-11228217d145]<-[c49e20c7-c76e-47a0-8fb9-bd2ff876efea] engine.CrossUnsafeUpdateEvent engine
```

Necessary Actors
```
p2p-block-receiver (implicit)
sync
cl-sync
engine
engine-controller
```

Call Graph(Generate this by plugging in the logs to the LLM. Event tree well defined)
```
p2p.ReceivedBlockEvent [09ab623c]
└── clsync.ReceivedUnsafePayloadEvent [9277ffe6]
    └── engine.ForkchoiceRequestEvent [aca04240]
        └── engine.ForkchoiceUpdateEvent [e024a814]
            └── engine.ProcessUnsafePayloadEvent [78c3546d]
                ├── engine.UnsafeUpdateEvent [c5a17e39]
                │   ├── engine.PromoteCrossUnsafeEvent [a67127ca]
                │   │   └── engine.CrossUnsafeUpdateEvent [0e2159d5]
                │   └── engine.TryUpdateEngineEvent [a40cff76]
                └── engine.ForkchoiceUpdateEvent [ba5224e4]
```

All this events start with single `ReceivedBlockEvent`, which is emitted when unsafe block via p2p is received.  

Assumption: context passed from OnEvent arg is tossed to Emit arg


After procedural flow:
```
l33t event casacade start
l33t [E] [7f2210b2-aca4-400d-9607-e49b4a6038a9]<-[] p2p.ReceivedBlockEvent p2p-block-receiver
l33t OnIncomingP2PBlockSync
l33t OnUnsafePayloadSync
l33t OnForkchoiceUpdateSync
l33t OnProcessUnsafePayloadSync
l33t InsertUnsafePayloadSync
l33t OnUnsafeUpdateSync
l33t OnPromoteCrossUnsafeSync
l33t OnTryUpdateEngineSync
l33t OnForkchoiceUpdateSync
```

very crude example 
```go
func (s *Syncer) OnUnsafeL2Payload(ctx context.Context, block *Block) Future[Result] {
	return s.loop.DispatchTask[Result](ctx, func(ctx context.Context) (Result, error) {
		// Task 1: ReceivedBlockEvent
		err := s.p2p.ReceivedBlockAsync(ctx, block).Await()
		if err != nil {
			return Result{}, err
		}
		return Result{Success: true}, nil
	})
}

func (p *P2P) ReceivedBlockAsync(ctx context.Context, block *Block) Future[error] {
	return p.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 2: ReceivedUnsafePayloadEvent
		return p.clsync.ReceivedUnsafePayloadAsync(ctx, block).Await()
	})
}

func (c *CLSync) ReceivedUnsafePayloadAsync(ctx context.Context, block *Block) Future[error] {
	return c.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 3: ForkchoiceRequestEvent
		return c.engine.ForkchoiceRequestAsync(ctx, nil).Await()
	})
}

func (e *Engine) ForkchoiceRequestAsync(ctx context.Context, payload *Payload) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 4: ForkchoiceUpdateEvent
		return e.ForkchoiceUpdateAsync(ctx, nil).Await()
	})
}

func (e *Engine) ForkchoiceUpdateAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 5: ProcessUnsafePayloadEvent
		return e.ProcessUnsafePayloadAsync(ctx, state).Await()
	})
}

func (e *Engine) ProcessUnsafePayloadAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 6-1: UnsafeUpdateEvent
		unsafe := e.UnsafeUpdateAsync(ctx, state)

		// Task 6-2: ForkchoiceUpdateEvent (secondary)
		secondFC := e.SecondaryForkchoiceUpdateAsync(ctx, state)

		if err := unsafe.Await(); err != nil {
			return err, nil
		}
		if err := secondFC.Await(); err != nil {
			return err, nil
		}
		return nil, nil
	})
}

func (e *Engine) UnsafeUpdateAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 7-1: PromoteCrossUnsafeEvent
		cross := e.PromoteCrossUnsafeAsync(ctx, state)

		// Task 7-2: TryUpdateEngineEvent
		tryUpdate := e.TryUpdateEngineAsync(ctx, state)

		if err := cross.Await(); err != nil {
			return err, nil
		}
		if err := tryUpdate.Await(); err != nil {
			return err, nil
		}
		return nil, nil
	})
}

func (e *Engine) PromoteCrossUnsafeAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 8: CrossUnsafeUpdateEvent
		return e.CrossUnsafeUpdateAsync(ctx, state).Await()
	})
}

func (e *Engine) CrossUnsafeUpdateAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 9: terminal leaf
		return nil, nil
	})
}

func (e *Engine) TryUpdateEngineAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 10: sibling leaf
		return nil, nil
	})
}

func (e *Engine) SecondaryForkchoiceUpdateAsync(ctx context.Context, state *ForkchoiceState) Future[error] {
	return e.loop.DispatchTask[error](ctx, func(ctx context.Context) (error, error) {
		// Task 11: sibling leaf
		return nil, nil
	})
}
```
