### PR TITLE
cannon: Migrate more tests

### DIFF
--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -154,7 +154,7 @@ func TestEVM_SingleStep_Shift64(t *testing.T) {
 
 	pc := Word(0x0)
 	rdReg := uint32(8)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		rtReg := uint32(18)
 		insn := rtReg<<16 | rdReg<<11 | tt.sa<<6 | tt.funct
 		state.GetRegistersRef()[rdReg] = tt.rd

--- a/cannon/mipsevm/tests/evm_common64_test.go
+++ b/cannon/mipsevm/tests/evm_common64_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"os"
 	"slices"
 	"testing"
 
@@ -100,14 +99,21 @@ func TestEVM_SingleStep_Bitwise64(t *testing.T) {
 }
 
 func TestEVM_SingleStep_Shift64(t *testing.T) {
-	cases := []struct {
+
+	type testCase struct {
 		name      string
 		rd        Word
 		rt        Word
 		sa        uint32
 		funct     uint32
 		expectRes Word
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "dsll", funct: 0x38, rd: Word(0xAA_BB_CC_DD_A1_B1_C1_D1), rt: Word(0x1), sa: 0, expectRes: Word(0x1)},                                              // dsll t8, s2, 0
 		{name: "dsll", funct: 0x38, rd: Word(0xAA_BB_CC_DD_A1_B1_C1_D1), rt: Word(0x1), sa: 1, expectRes: Word(0x2)},                                              // dsll t8, s2, 1
 		{name: "dsll", funct: 0x38, rd: Word(0xAA_BB_CC_DD_A1_B1_C1_D1), rt: Word(0x1), sa: 31, expectRes: Word(0x80_00_00_00)},                                   // dsll t8, s2, 31
@@ -146,39 +152,27 @@ func TestEVM_SingleStep_Shift64(t *testing.T) {
 		{name: "dsra32", funct: 0x3f, rd: Word(0xAA_BB_CC_DD_A1_B1_C1_D1), rt: Word(0x7F_FF_FF_FF_FF_FF_FF_FF), sa: 31, expectRes: Word(0x0)},                      // dsra32 t8, s2, 1
 	}
 
-	for i, tt := range cases {
-		for _, v := range GetMipsVersionTestCases(t) {
-			v := v
-			testName := fmt.Sprintf("%v %v", v.Name, tt.name)
-			t.Run(testName, func(t *testing.T) {
-				pc := Word(0x0)
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(pc))
-				state := goVm.GetState()
-				var insn uint32
-				var rtReg uint32
-				var rdReg uint32
-				rtReg = 18
-				rdReg = 8
-				insn = rtReg<<16 | rdReg<<11 | tt.sa<<6 | tt.funct
-				state.GetRegistersRef()[rdReg] = tt.rd
-				state.GetRegistersRef()[rtReg] = tt.rt
-				testutil.StoreInstruction(state.GetMemory(), pc, insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[rdReg] = tt.expectRes
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	pc := Word(0x0)
+	rdReg := uint32(8)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		rtReg := uint32(18)
+		insn := rtReg<<16 | rdReg<<11 | tt.sa<<6 | tt.funct
+		state.GetRegistersRef()[rdReg] = tt.rd
+		state.GetRegistersRef()[rtReg] = tt.rt
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[rdReg] = tt.expectRes
+
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithPCAndNextPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_LoadStore64(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -508,12 +508,12 @@ func TestEVM_SingleStep_JrJalr(t *testing.T) {
 		{name: "jalr, delay slot", funct: uint16(0x9), rsReg: 8, jumpTo: 0x34, rdReg: uint32(0x9), expectLink: true, pc: 0, nextPC: 100, errorMsg: "jump in delay slot"}, // jalr t1, t0
 	}
 
-	pc := Word(0)
 	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := tt.rsReg<<21 | tt.rdReg<<11 | uint32(tt.funct)
 		state.GetRegistersRef()[tt.rsReg] = tt.jumpTo
+		state.GetCurrentThread().Cpu.PC = tt.pc
 		state.GetCurrentThread().Cpu.NextPC = tt.nextPC
-		testutil.StoreInstruction(state.GetMemory(), pc, insn)
+		testutil.StoreInstruction(state.GetMemory(), tt.pc, insn)
 	}
 
 	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
@@ -523,14 +523,14 @@ func TestEVM_SingleStep_JrJalr(t *testing.T) {
 			expected.ExpectStep()
 			expected.ActiveThread().NextPC = tt.jumpTo
 			if tt.expectLink {
-				expected.ActiveThread().Registers[tt.rdReg] = pc + 8
+				expected.ActiveThread().Registers[tt.rdReg] = tt.pc + 8
 			}
 			return ExpectNormalExecution()
 		}
 	}
 
 	NewDiffTester(testNamer).
-		InitState(initState, mtutil.WithPC(pc)).
+		InitState(initState).
 		SetExpectations(setExpectations).
 		Run(t, cases)
 }

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -26,47 +26,45 @@ import (
 )
 
 func TestEVM_SingleStep_Jump(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name         string
 		pc           arch.Word
 		nextPC       arch.Word
 		insn         uint32
 		expectNextPC arch.Word
 		expectLink   bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "j MSB set target", pc: 0, nextPC: 4, insn: 0x0A_00_00_02, expectNextPC: 0x08_00_00_08},                                           // j 0x02_00_00_02
 		{name: "j non-zero PC region", pc: 0x10000000, nextPC: 0x10000004, insn: 0x08_00_00_02, expectNextPC: 0x10_00_00_08},                     // j 0x2
 		{name: "jal MSB set target", pc: 0, nextPC: 4, insn: 0x0E_00_00_02, expectNextPC: 0x08_00_00_08, expectLink: true},                       // jal 0x02_00_00_02
 		{name: "jal non-zero PC region", pc: 0x10000000, nextPC: 0x10000004, insn: 0x0C_00_00_02, expectNextPC: 0x10_00_00_08, expectLink: true}, // jal 0x2
 	}
 
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPC(tt.pc), mtutil.WithNextPC(tt.nextPC))
-				state := goVm.GetState()
-				testutil.StoreInstruction(state.GetMemory(), tt.pc, tt.insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().NextPC = tt.expectNextPC
-				if tt.expectLink {
-					expected.ActiveThread().Registers[31] = state.GetPC() + 8
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		state.GetCurrentThread().Cpu.PC = tt.pc
+		state.GetCurrentThread().Cpu.NextPC = tt.nextPC
+		testutil.StoreInstruction(state.GetMemory(), tt.pc, tt.insn)
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().NextPC = tt.expectNextPC
+		if tt.expectLink {
+			expected.ActiveThread().Registers[31] = tt.pc + 8
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_Operators(t *testing.T) {
@@ -139,54 +137,52 @@ func TestEVM_SingleStep_Bitwise(t *testing.T) {
 }
 
 func TestEVM_SingleStep_Lui(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-
-	cases := []struct {
+	type testCase struct {
 		name     string
 		rtReg    uint32
 		imm      uint32
 		expectRt Word
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "lui unsigned", rtReg: 5, imm: 0x1234, expectRt: 0x1234_0000},
 		{name: "lui signed", rtReg: 7, imm: 0x8765, expectRt: signExtend64(0x8765_0000)},
 	}
 
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-				state := goVm.GetState()
-				insn := 0b1111<<26 | uint32(tt.rtReg)<<16 | (tt.imm & 0xFFFF)
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[tt.rtReg] = tt.expectRt
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		insn := 0b1111<<26 | uint32(tt.rtReg)<<16 | (tt.imm & 0xFFFF)
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[tt.rtReg] = tt.expectRt
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_CloClz(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-
-	rsReg := uint32(5)
-	rdReg := uint32(6)
-	cases := []struct {
+	type testCase struct {
 		name           string
 		rs             Word
 		expectedResult Word
 		funct          uint32
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "clo", rs: 0xFFFF_FFFE, expectedResult: 31, funct: 0b10_0001},
 		{name: "clo", rs: 0xE000_0000, expectedResult: 3, funct: 0b10_0001},
 		{name: "clo", rs: 0x8000_0000, expectedResult: 1, funct: 0b10_0001},
@@ -198,41 +194,39 @@ func TestEVM_SingleStep_CloClz(t *testing.T) {
 		{name: "clz, sign-extended", rs: signExtend64(0x8000_0000), expectedResult: 0, funct: 0b10_0000},
 	}
 
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				// Set up state
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-				state := goVm.GetState()
-				insn := 0b01_1100<<26 | rsReg<<21 | rdReg<<11 | tt.funct
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-				state.GetRegistersRef()[rsReg] = tt.rs
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[rdReg] = tt.expectedResult
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	rsReg := uint32(5)
+	rdReg := uint32(6)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		insn := 0b01_1100<<26 | rsReg<<21 | rdReg<<11 | tt.funct
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetRegistersRef()[rsReg] = tt.rs
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[rdReg] = tt.expectedResult
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_MovzMovn(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name          string
 		funct         uint32
 		testValue     Word
 		shouldSucceed bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "movz, success", funct: uint32(0xa), testValue: 0, shouldSucceed: true},
 		{name: "movz, failure, testVal=1", funct: uint32(0xa), testValue: 1, shouldSucceed: false},
 		{name: "movz, failure, testVal=2", funct: uint32(0xa), testValue: 2, shouldSucceed: false},
@@ -240,75 +234,71 @@ func TestEVM_SingleStep_MovzMovn(t *testing.T) {
 		{name: "movn, success, testVal=2", funct: uint32(0xb), testValue: 2, shouldSucceed: true},
 		{name: "movn, failure", funct: uint32(0xb), testValue: 0, shouldSucceed: false},
 	}
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPC(0), mtutil.WithNextPC(4))
-				state := goVm.GetState()
-				rsReg := uint32(9)
-				rtReg := uint32(10)
-				rdReg := uint32(8)
-				insn := rsReg<<21 | rtReg<<16 | rdReg<<11 | tt.funct
 
-				state.GetRegistersRef()[rtReg] = tt.testValue
-				state.GetRegistersRef()[rsReg] = Word(0xb)
-				state.GetRegistersRef()[rdReg] = Word(0xa)
-				testutil.StoreInstruction(state.GetMemory(), 0, insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if tt.shouldSucceed {
-					expected.ActiveThread().Registers[rdReg] = state.GetRegistersRef()[rsReg]
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	pc := arch.Word(0)
+	rsReg := uint32(9)
+	rtReg := uint32(10)
+	rdReg := uint32(8)
+	val := Word(0xb)
+	otherVal := Word(0xa)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		insn := rsReg<<21 | rtReg<<16 | rdReg<<11 | tt.funct
+		state.GetRegistersRef()[rtReg] = tt.testValue
+		state.GetRegistersRef()[rsReg] = val
+		state.GetRegistersRef()[rdReg] = otherVal
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
 	}
 
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		if tt.shouldSucceed {
+			expected.ActiveThread().Registers[rdReg] = val
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithPCAndNextPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_MfhiMflo(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
-		name  string
-		funct uint32
-		hi    Word
-		lo    Word
-	}{
-		{name: "mflo", funct: uint32(0x12), lo: Word(0xdeadbeef), hi: Word(0x0)},
-		{name: "mfhi", funct: uint32(0x10), lo: Word(0x0), hi: Word(0xdeadbeef)},
+	type testCase struct {
+		name   string
+		funct  uint32
+		hi     Word
+		lo     Word
+		result Word
 	}
-	expect := Word(0xdeadbeef)
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithLO(tt.lo), mtutil.WithHI(tt.hi))
-				state := goVm.GetState()
-				rdReg := uint32(8)
-				insn := rdReg<<11 | tt.funct
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-				step := state.GetStep()
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[rdReg] = expect
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
 	}
+
+	cases := []testCase{
+		{name: "mflo", funct: uint32(0x12), lo: Word(0xdeadbeef), hi: Word(0x0), result: Word(0xdeadbeef)},
+		{name: "mfhi", funct: uint32(0x10), lo: Word(0x0), hi: Word(0xdeadbeef), result: Word(0xdeadbeef)},
+	}
+
+	rdReg := uint32(8)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		insn := rdReg<<11 | tt.funct
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetCurrentThread().Cpu.HI = tt.hi
+		state.GetCurrentThread().Cpu.LO = tt.lo
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[rdReg] = tt.result
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_MulDiv(t *testing.T) {
@@ -348,108 +338,109 @@ func TestEVM_SingleStep_MulDiv(t *testing.T) {
 }
 
 func TestEVM_SingleStep_MthiMtlo(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name  string
 		funct uint32
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "mtlo", funct: uint32(0x13)},
 		{name: "mthi", funct: uint32(0x11)},
 	}
-	val := Word(0xdeadbeef)
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
 
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-				state := goVm.GetState()
-				rsReg := uint32(8)
-				insn := rsReg<<21 | tt.funct
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-				state.GetRegistersRef()[rsReg] = val
-				step := state.GetStep()
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if tt.funct == 0x11 {
-					expected.ActiveThread().HI = state.GetRegistersRef()[rsReg]
-				} else {
-					expected.ActiveThread().LO = state.GetRegistersRef()[rsReg]
-				}
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	val := Word(0xdeadbeef)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		rsReg := uint32(8)
+		insn := rsReg<<21 | tt.funct
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetRegistersRef()[rsReg] = val
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		if tt.funct == 0x11 {
+			expected.ActiveThread().HI = val
+		} else {
+			expected.ActiveThread().LO = val
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_BeqBne(t *testing.T) {
-	initialPC := Word(800)
-	negative := func(value Word) uint16 {
-		flipped := testutil.FlipSign(value)
-		return uint16(flipped)
-	}
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name           string
 		imm            uint16
 		opcode         uint32
 		rs             Word
 		rt             Word
 		expectedNextPC Word
-	}{
-		// on success, expectedNextPC should be: (imm * 4) + pc + 4
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "bne, success", opcode: uint32(0x5), imm: 10, rs: Word(0x123), rt: Word(0x456), expectedNextPC: 844},                                  // bne $t0, $t1, 16
 		{name: "bne, success, signed-extended offset", opcode: uint32(0x5), imm: negative(3), rs: Word(0x123), rt: Word(0x456), expectedNextPC: 792}, // bne $t0, $t1, 16
 		{name: "bne, fail", opcode: uint32(0x5), imm: 10, rs: Word(0x123), rt: Word(0x123), expectedNextPC: 808},                                     // bne $t0, $t1, 16
 		{name: "beq, success", opcode: uint32(0x4), imm: 10, rs: Word(0x123), rt: Word(0x123), expectedNextPC: 844},                                  // beq $t0, $t1, 16
 		{name: "beq, success, sign-extended offset", opcode: uint32(0x4), imm: negative(25), rs: Word(0x123), rt: Word(0x123), expectedNextPC: 704},  // beq $t0, $t1, 16
-		{name: "beq, fail", opcode: uint32(0x4), imm: 10, rs: Word(0x123), rt: Word(0x456), expectedNextPC: 808},                                     // beq $t0, $t1, 16
-	}
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(initialPC))
-				state := goVm.GetState()
-				rsReg := uint32(9)
-				rtReg := uint32(8)
-				insn := tt.opcode<<26 | rsReg<<21 | rtReg<<16 | uint32(tt.imm)
-				state.GetRegistersRef()[rtReg] = tt.rt
-				state.GetRegistersRef()[rsReg] = tt.rs
-				testutil.StoreInstruction(state.GetMemory(), initialPC, insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().NextPC = tt.expectedNextPC
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+		{name: "beq, fail", opcode: uint32(0x4), imm: 10, rs: Word(0x123), rt: Word(0x456), expectedNextPC: 808},
 	}
 
+	pc := Word(800)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		rsReg := uint32(9)
+		rtReg := uint32(8)
+		insn := tt.opcode<<26 | rsReg<<21 | rtReg<<16 | uint32(tt.imm)
+		state.GetRegistersRef()[rtReg] = tt.rt
+		state.GetRegistersRef()[rsReg] = tt.rs
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().NextPC = tt.expectedNextPC
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithPCAndNextPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
+}
+
+func negative(value Word) uint16 {
+	flipped := testutil.FlipSign(value)
+	return uint16(flipped)
 }
 
 func TestEVM_SingleStep_SlSr(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name      string
 		rs        Word
 		rt        Word
 		rsReg     uint32
 		funct     uint16
 		expectVal Word
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "sll", funct: uint16(4) << 6, rt: Word(0x20), rsReg: uint32(0x0), expectVal: Word(0x200)}, // sll t0, t1, 3
 		{name: "sll with overflow", funct: uint16(1) << 6, rt: Word(0x8000_0000), rsReg: uint32(0x0), expectVal: 0x0},
 		{name: "sll with sign extension", funct: uint16(4) << 6, rt: Word(0x0800_0000), rsReg: uint32(0x0), expectVal: signExtend64(0x8000_0000)},
@@ -471,41 +462,30 @@ func TestEVM_SingleStep_SlSr(t *testing.T) {
 		{name: "srav with sign extension", funct: uint16(7), rt: Word(0xdeafbeef), rs: Word(12), rsReg: uint32(0xa), expectVal: signExtend64(Word(0xfffdeafb))}, // srav t0, t1, t2
 	}
 
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPC(0), mtutil.WithNextPC(4))
-				state := goVm.GetState()
-				var insn uint32
-				rtReg := uint32(0x9)
-				rdReg := uint32(0x8)
-				insn = tt.rsReg<<21 | rtReg<<16 | rdReg<<11 | uint32(tt.funct)
-				state.GetRegistersRef()[rtReg] = tt.rt
-				state.GetRegistersRef()[tt.rsReg] = tt.rs
-				testutil.StoreInstruction(state.GetMemory(), 0, insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-
-				expected.ActiveThread().Registers[rdReg] = tt.expectVal
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	pc := Word(0)
+	rdReg := uint32(0x8)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		rtReg := uint32(0x9)
+		insn := tt.rsReg<<21 | rtReg<<16 | rdReg<<11 | uint32(tt.funct)
+		state.GetRegistersRef()[rtReg] = tt.rt
+		state.GetRegistersRef()[tt.rsReg] = tt.rs
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[rdReg] = tt.expectVal
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithPCAndNextPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_JrJalr(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name       string
 		funct      uint16
 		rsReg      uint32
@@ -515,46 +495,44 @@ func TestEVM_SingleStep_JrJalr(t *testing.T) {
 		nextPC     Word
 		expectLink bool
 		errorMsg   string
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "jr", funct: uint16(0x8), rsReg: 8, jumpTo: 0x34, pc: 0, nextPC: 4},                                                                                       // jr t0
 		{name: "jr, delay slot", funct: uint16(0x8), rsReg: 8, jumpTo: 0x34, pc: 0, nextPC: 8, errorMsg: "jump in delay slot"},                                           // jr t0
 		{name: "jalr", funct: uint16(0x9), rsReg: 8, jumpTo: 0x34, rdReg: uint32(0x9), expectLink: true, pc: 0, nextPC: 4},                                               // jalr t1, t0
 		{name: "jalr, delay slot", funct: uint16(0x9), rsReg: 8, jumpTo: 0x34, rdReg: uint32(0x9), expectLink: true, pc: 0, nextPC: 100, errorMsg: "jump in delay slot"}, // jalr t1, t0
 	}
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPC(tt.pc), mtutil.WithNextPC(tt.nextPC))
-				state := goVm.GetState()
-				insn := tt.rsReg<<21 | tt.rdReg<<11 | uint32(tt.funct)
-				state.GetRegistersRef()[tt.rsReg] = tt.jumpTo
-				testutil.StoreInstruction(state.GetMemory(), 0, insn)
-				step := state.GetStep()
 
-				if tt.errorMsg != "" {
-					proofData := v.ProofGenerator(t, goVm.GetState())
-					errorMatcher := testutil.StringErrorMatcher(tt.errorMsg)
-					require.Panics(t, func() { _, _ = goVm.Step(false) })
-					testutil.AssertEVMReverts(t, state, v.Contracts, nil, proofData, errorMatcher)
-				} else {
-					// Setup expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.ActiveThread().NextPC = tt.jumpTo
-					if tt.expectLink {
-						expected.ActiveThread().Registers[tt.rdReg] = state.GetPC() + 8
-					}
+	pc := Word(0)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		insn := tt.rsReg<<21 | tt.rdReg<<11 | uint32(tt.funct)
+		state.GetRegistersRef()[tt.rsReg] = tt.jumpTo
+		state.GetCurrentThread().Cpu.NextPC = tt.nextPC
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
+	}
 
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-				}
-			})
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		if tt.errorMsg != "" {
+			return ExpectVmPanic(tt.errorMsg, tt.errorMsg)
+		} else {
+			expected.ExpectStep()
+			expected.ActiveThread().NextPC = tt.jumpTo
+			if tt.expectLink {
+				expected.ActiveThread().Registers[tt.rdReg] = pc + 8
+			}
+			return ExpectNormalExecution()
 		}
 	}
+
+	NewDiffTester(testNamer).
+		InitState(initState, mtutil.WithPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SingleStep_Sync(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -46,7 +46,7 @@ func TestEVM_SingleStep_Jump(t *testing.T) {
 		{name: "jal non-zero PC region", pc: 0x10000000, nextPC: 0x10000004, insn: 0x0C_00_00_02, expectNextPC: 0x10_00_00_08, expectLink: true}, // jal 0x2
 	}
 
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		state.GetCurrentThread().Cpu.PC = tt.pc
 		state.GetCurrentThread().Cpu.NextPC = tt.nextPC
 		testutil.StoreInstruction(state.GetMemory(), tt.pc, tt.insn)
@@ -153,7 +153,7 @@ func TestEVM_SingleStep_Lui(t *testing.T) {
 		{name: "lui signed", rtReg: 7, imm: 0x8765, expectRt: signExtend64(0x8765_0000)},
 	}
 
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := 0b1111<<26 | uint32(tt.rtReg)<<16 | (tt.imm & 0xFFFF)
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 	}
@@ -196,7 +196,7 @@ func TestEVM_SingleStep_CloClz(t *testing.T) {
 
 	rsReg := uint32(5)
 	rdReg := uint32(6)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := 0b01_1100<<26 | rsReg<<21 | rdReg<<11 | tt.funct
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 		state.GetRegistersRef()[rsReg] = tt.rs
@@ -241,7 +241,7 @@ func TestEVM_SingleStep_MovzMovn(t *testing.T) {
 	rdReg := uint32(8)
 	val := Word(0xb)
 	otherVal := Word(0xa)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := rsReg<<21 | rtReg<<16 | rdReg<<11 | tt.funct
 		state.GetRegistersRef()[rtReg] = tt.testValue
 		state.GetRegistersRef()[rsReg] = val
@@ -282,7 +282,7 @@ func TestEVM_SingleStep_MfhiMflo(t *testing.T) {
 	}
 
 	rdReg := uint32(8)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := rdReg<<11 | tt.funct
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
 		state.GetCurrentThread().Cpu.HI = tt.hi
@@ -353,7 +353,7 @@ func TestEVM_SingleStep_MthiMtlo(t *testing.T) {
 	}
 
 	val := Word(0xdeadbeef)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		rsReg := uint32(8)
 		insn := rsReg<<21 | tt.funct
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
@@ -400,7 +400,7 @@ func TestEVM_SingleStep_BeqBne(t *testing.T) {
 	}
 
 	pc := Word(800)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		rsReg := uint32(9)
 		rtReg := uint32(8)
 		insn := tt.opcode<<26 | rsReg<<21 | rtReg<<16 | uint32(tt.imm)
@@ -464,7 +464,7 @@ func TestEVM_SingleStep_SlSr(t *testing.T) {
 
 	pc := Word(0)
 	rdReg := uint32(0x8)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		rtReg := uint32(0x9)
 		insn := tt.rsReg<<21 | rtReg<<16 | rdReg<<11 | uint32(tt.funct)
 		state.GetRegistersRef()[rtReg] = tt.rt
@@ -509,7 +509,7 @@ func TestEVM_SingleStep_JrJalr(t *testing.T) {
 	}
 
 	pc := Word(0)
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		insn := tt.rsReg<<21 | tt.rdReg<<11 | uint32(tt.funct)
 		state.GetRegistersRef()[tt.rsReg] = tt.jumpTo
 		state.GetCurrentThread().Cpu.NextPC = tt.nextPC
@@ -548,7 +548,7 @@ func TestEVM_SingleStep_Sync(t *testing.T) {
 		{name: "simple"},
 	}
 
-	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		syncInsn := uint32(0x0000_000F)
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syncInsn)
 	}
@@ -590,7 +590,7 @@ func TestEVM_MMap(t *testing.T) {
 		{name: "Request specific address", heap: program.HEAP_START, address: 0x50_00_00_00, size: 0, shouldFail: false, expectedHeap: program.HEAP_START},
 	}
 
-	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = arch.SysMmap
 		state.GetRegistersRef()[4] = c.address

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -536,39 +536,49 @@ func TestEVM_SingleStep_JrJalr(t *testing.T) {
 }
 
 func TestEVM_SingleStep_Sync(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	syncInsn := uint32(0x0000_000F)
-	for _, v := range versions {
-		testName := fmt.Sprintf("Sync (%v)", v.Name)
-		t.Run(testName, func(t *testing.T) {
-			goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(248)))
-			state := goVm.GetState()
-			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syncInsn)
-			step := state.GetStep()
-
-			// Setup expectations
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-			// Check expectations
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-		})
+	type testCase struct {
+		name string
 	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
+		{name: "simple"},
+	}
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		syncInsn := uint32(0x0000_000F)
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syncInsn)
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_MMap(t *testing.T) {
-	versions := GetMipsVersionTestCases(t)
-	cases := []struct {
+	type testCase struct {
 		name         string
 		heap         arch.Word
 		address      arch.Word
 		size         arch.Word
 		shouldFail   bool
 		expectedHeap arch.Word
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "Increment heap by max value", heap: program.HEAP_START, address: 0, size: ^arch.Word(0), shouldFail: true},
 		{name: "Increment heap to 0", heap: program.HEAP_START, address: 0, size: ^arch.Word(0) - program.HEAP_START + 1, shouldFail: true},
 		{name: "Increment heap to previous page", heap: program.HEAP_START, address: 0, size: ^arch.Word(0) - program.HEAP_START - memory.PageSize + 1, shouldFail: true},
@@ -580,44 +590,36 @@ func TestEVM_MMap(t *testing.T) {
 		{name: "Request specific address", heap: program.HEAP_START, address: 0x50_00_00_00, size: 0, shouldFail: false, expectedHeap: program.HEAP_START},
 	}
 
-	for _, v := range versions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithHeap(c.heap))
-				state := goVm.GetState()
-
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysMmap
-				state.GetRegistersRef()[4] = c.address
-				state.GetRegistersRef()[5] = c.size
-				step := state.GetStep()
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if c.shouldFail {
-					expected.ActiveThread().Registers[2] = exec.MipsEINVAL
-					expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-				} else {
-					expected.Heap = c.expectedHeap
-					if c.address == 0 {
-						expected.ActiveThread().Registers[2] = state.GetHeap()
-						expected.ActiveThread().Registers[7] = 0
-					} else {
-						expected.ActiveThread().Registers[2] = c.address
-						expected.ActiveThread().Registers[7] = 0
-					}
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysMmap
+		state.GetRegistersRef()[4] = c.address
+		state.GetRegistersRef()[5] = c.size
+		state.Heap = c.heap
 	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		if c.shouldFail {
+			expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+		} else {
+			expected.Heap = c.expectedHeap
+			if c.address == 0 {
+				expected.ActiveThread().Registers[2] = c.heap
+				expected.ActiveThread().Registers[7] = 0
+			} else {
+				expected.ActiveThread().Registers[2] = c.address
+				expected.ActiveThread().Registers[7] = 0
+			}
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysGetRandom_isImplemented(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -94,7 +94,7 @@ func TestEVM_MT64_LL(t *testing.T) {
 	}
 
 	NewDiffTester(testNamer).
-		InitState(initState).
+		InitState(initState, mtutil.WithPCAndNextPC(0x40)).
 		SetExpectations(setExpectations).
 		Run(t, cases)
 }
@@ -278,7 +278,7 @@ func TestEVM_MT64_LLD(t *testing.T) {
 	}
 
 	NewDiffTester(testNamer).
-		InitState(initState).
+		InitState(initState, mtutil.WithPCAndNextPC(0x40)).
 		SetExpectations(setExpectations).
 		Run(t, cases)
 }

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -4,11 +4,9 @@ package tests
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
 	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -483,90 +481,42 @@ func TestEVM_MT_SysRead_Preimage64(t *testing.T) {
 		Run(t, cases, WithPreimageOracle(po))
 }
 
-func TestEVM_MT_SysRead_FromEventFd(t *testing.T) {
+func TestEVM_MT_SysReadWrite_WithEventFd(t *testing.T) {
 	t.Parallel()
-	vmVersions := GetMipsVersionTestCases(t)
-	for i, ver := range vmVersions {
-		t.Run(ver.Name, func(t *testing.T) {
-			t.Parallel()
-			addr := Word(0x00_00_FF_00)
-			effAddr := arch.AddressMask & addr
-			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-			state := mtutil.GetMtState(t, goVm)
-			step := state.GetStep()
 
-			// Define LL-related params
-			llAddress := effAddr
-			llOwnerThread := state.GetCurrentThread().ThreadId
-
-			// Set up state
-			state.GetRegistersRef()[2] = arch.SysRead
-			state.GetRegistersRef()[4] = exec.FdEventFd
-			state.GetRegistersRef()[5] = addr
-			state.GetRegistersRef()[6] = 1
-			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-			state.LLReservationStatus = multithreaded.LLStatusNone
-			state.LLAddress = llAddress
-			state.LLOwnerThread = llOwnerThread
-			state.GetMemory().SetWord(effAddr, Word(0x12_EE_EE_EE_FF_FF_FF_FF))
-
-			// Setup expectations
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-
-			// Check expectations
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-		})
+	type testCase struct {
+		name       string
+		syscallNum Word
 	}
-}
 
-func TestEVM_MT_SysWrite_ToEventFd(t *testing.T) {
-	t.Parallel()
-	vmVersions := GetMipsVersionTestCases(t)
-	for i, ver := range vmVersions {
-		t.Run(ver.Name, func(t *testing.T) {
-			t.Parallel()
-			addr := Word(0x00_00_FF_00)
-			effAddr := arch.AddressMask & addr
-			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)))
-			state := mtutil.GetMtState(t, goVm)
-			step := state.GetStep()
-
-			// Define LL-related params
-			llAddress := effAddr
-			llOwnerThread := state.GetCurrentThread().ThreadId
-
-			// Set up state
-			state.GetRegistersRef()[2] = arch.SysWrite
-			state.GetRegistersRef()[4] = exec.FdEventFd
-			state.GetRegistersRef()[5] = addr
-			state.GetRegistersRef()[6] = 1
-			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-			state.LLReservationStatus = multithreaded.LLStatusNone
-			state.LLAddress = llAddress
-			state.LLOwnerThread = llOwnerThread
-			state.GetMemory().SetWord(effAddr, Word(0x12_EE_EE_EE_FF_FF_FF_FF))
-
-			// Setup expectations
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-
-			// Check expectations
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-		})
+	testNamer := func(tc testCase) string {
+		return tc.name
 	}
+
+	cases := []testCase{
+		{name: "SysRead", syscallNum: arch.SysRead},
+		{name: "SysWrite", syscallNum: arch.SysWrite},
+	}
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.GetRegistersRef()[2] = tt.syscallNum
+		state.GetRegistersRef()[4] = exec.FdEventFd
+		state.GetRegistersRef()[5] = 0x00_00_FF_00
+		state.GetRegistersRef()[6] = 1
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
+		expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_MT_StoreOpsClearMemReservation64(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -499,11 +499,14 @@ func TestEVM_MT_SysReadWrite_WithEventFd(t *testing.T) {
 	}
 
 	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		addr := Word(0x00_00_FF_00)
 		state.GetRegistersRef()[2] = tt.syscallNum
 		state.GetRegistersRef()[4] = exec.FdEventFd
-		state.GetRegistersRef()[5] = 0x00_00_FF_00
+		state.GetRegistersRef()[5] = addr
 		state.GetRegistersRef()[6] = 1
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		// Set a memory value to ensure that memory at the target address is not modified
+		state.GetMemory().SetWord(addr, Word(0x12_EE_EE_EE_FF_FF_FF_FF))
 	}
 
 	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -21,9 +21,16 @@ import (
 )
 
 func TestEVM_MT64_LL(t *testing.T) {
-	memVal := Word(0x11223344_55667788)
-	memValNeg := Word(0xF1223344_F5667788)
-	cases := []struct {
+	type llVariation struct {
+		name                    string
+		withExistingReservation bool
+	}
+	llVariations := []llVariation{
+		{"with existing reservation", true},
+		{"without existing reservation", false},
+	}
+
+	type baseTest struct {
 		name   string
 		base   Word
 		offset int
@@ -31,7 +38,11 @@ func TestEVM_MT64_LL(t *testing.T) {
 		memVal Word
 		retReg int
 		retVal Word
-	}{
+	}
+
+	memVal := Word(0x11223344_55667788)
+	memValNeg := Word(0xF1223344_F5667788)
+	baseTests := []baseTest{
 		{name: "8-byte-aligned addr", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 5},
 		{name: "8-byte-aligned addr, neg value", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memValNeg, retVal: 0xFFFFFFFF_F1223344, retReg: 5},
 		{name: "8-byte-aligned addr, extra bits", base: 0x01, offset: 0x0109, addr: 0x010A, memVal: memVal, retVal: 0x11223344, retReg: 5},
@@ -44,55 +55,50 @@ func TestEVM_MT64_LL(t *testing.T) {
 		{name: "4-byte-aligned addr, addr signed extended w overflow", base: 0x1000_0001, offset: 0xFF03, addr: 0x0000_0000_0FFF_FF04, memVal: memVal, retVal: 0x55667788, retReg: 5},
 		{name: "Return register set to 0", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retVal: 0x11223344, retReg: 0},
 	}
-	versions := GetMipsVersionTestCases(t)
-	for _, v := range versions {
-		for i, c := range cases {
-			for _, withExistingReservation := range []bool{true, false} {
-				tName := fmt.Sprintf("%v (vm = %v, withExistingReservation = %v)", c.name, v.Name, withExistingReservation)
-				t.Run(tName, func(t *testing.T) {
-					effAddr := arch.AddressMask & c.addr
 
-					retReg := c.retReg
-					baseReg := 6
-					insn := uint32((0b11_0000 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x40))
-					state := mtutil.GetMtState(t, goVm)
-					step := state.GetStep()
+	type testCase = testutil.TestCaseVariation[baseTest, llVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v-%v", tc.Base.name, tc.Variation.name)
+	}
+	cases := testutil.TestVariations(baseTests, llVariations)
 
-					// Set up state
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetMemory().SetWord(effAddr, c.memVal)
-					state.GetRegistersRef()[baseReg] = c.base
-					if withExistingReservation {
-						state.LLReservationStatus = multithreaded.LLStatusActive32bit
-						state.LLAddress = c.addr + 1
-						state.LLOwnerThread = 123
-					} else {
-						state.LLReservationStatus = multithreaded.LLStatusNone
-						state.LLAddress = 0
-						state.LLOwnerThread = 0
-					}
+	initState := func(testCase testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := testCase.Base
+		retReg := c.retReg
+		baseReg := 6
+		insn := uint32((0b11_0000 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
 
-					// Set up expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.LLReservationStatus = multithreaded.LLStatusActive32bit
-					expected.LLAddress = c.addr
-					expected.LLOwnerThread = state.GetCurrentThread().ThreadId
-					if retReg != 0 {
-						expected.ActiveThread().Registers[retReg] = c.retVal
-					}
-
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
-				})
-			}
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetMemory().SetWord(testutil.EffAddr(c.addr), c.memVal)
+		state.GetRegistersRef()[baseReg] = c.base
+		if testCase.Variation.withExistingReservation {
+			state.LLReservationStatus = multithreaded.LLStatusActive32bit
+			state.LLAddress = c.addr + 1
+			state.LLOwnerThread = 123
+		} else {
+			state.LLReservationStatus = multithreaded.LLStatusNone
+			state.LLAddress = 0
+			state.LLOwnerThread = 0
 		}
 	}
+
+	setExpectations := func(testCase testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.LLReservationStatus = multithreaded.LLStatusActive32bit
+		expected.LLAddress = testCase.Base.addr
+		expected.LLOwnerThread = expected.ActiveThreadId
+
+		retReg := testCase.Base.retReg
+		if retReg != 0 {
+			expected.ActiveThread().Registers[retReg] = testCase.Base.retVal
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_MT64_SC(t *testing.T) {
@@ -201,16 +207,26 @@ func TestEVM_MT64_SC(t *testing.T) {
 }
 
 func TestEVM_MT64_LLD(t *testing.T) {
+	type llVariation struct {
+		name                    string
+		withExistingReservation bool
+	}
+	llVariations := []llVariation{
+		{"with existing reservation", true},
+		{"without existing reservation", false},
+	}
+
 	memVal := Word(0x11223344_55667788)
 	memValNeg := Word(0xF1223344_F5667788)
-	cases := []struct {
+	type baseTest struct {
 		name   string
 		base   Word
 		offset int
 		addr   Word
 		memVal Word
 		retReg int
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "Aligned addr", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retReg: 5},
 		{name: "Aligned addr, neg value", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memValNeg, retReg: 5},
 		{name: "Unaligned addr, offset=1", base: 0x01, offset: 0x0100, addr: 0x0101, memVal: memVal, retReg: 5},
@@ -224,55 +240,49 @@ func TestEVM_MT64_LLD(t *testing.T) {
 		{name: "Aligned addr, signed extended w overflow", base: 0x1000_0001, offset: 0xFF07, addr: 0x0000_0000_0FFF_FF08, memVal: memVal, retReg: 5},
 		{name: "Return register set to 0", base: 0x01, offset: 0x0107, addr: 0x0108, memVal: memVal, retReg: 0},
 	}
-	versions := GetMipsVersionTestCases(t)
-	for _, v := range versions {
-		for i, c := range cases {
-			for _, withExistingReservation := range []bool{true, false} {
-				tName := fmt.Sprintf("%v (vm = %v, withExistingReservation = %v)", c.name, v.Name, withExistingReservation)
-				t.Run(tName, func(t *testing.T) {
-					effAddr := arch.AddressMask & c.addr
 
-					retReg := c.retReg
-					baseReg := 6
-					insn := uint32((0b11_0100 << 26) | (baseReg & 0x1F << 21) | (retReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x40))
-					state := mtutil.GetMtState(t, goVm)
-					step := state.GetStep()
-
-					// Set up state
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetMemory().SetWord(effAddr, c.memVal)
-					state.GetRegistersRef()[baseReg] = c.base
-					if withExistingReservation {
-						state.LLReservationStatus = multithreaded.LLStatusActive64bit
-						state.LLAddress = c.addr + 1
-						state.LLOwnerThread = 123
-					} else {
-						state.LLReservationStatus = multithreaded.LLStatusNone
-						state.LLAddress = 0
-						state.LLOwnerThread = 0
-					}
-
-					// Set up expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.LLReservationStatus = multithreaded.LLStatusActive64bit
-					expected.LLAddress = c.addr
-					expected.LLOwnerThread = state.GetCurrentThread().ThreadId
-					if retReg != 0 {
-						expected.ActiveThread().Registers[retReg] = c.memVal
-					}
-
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
-
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, llVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v-%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.TestVariations(baseTests, llVariations)
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		baseReg := 6
+		insn := uint32((0b11_0100 << 26) | (baseReg & 0x1F << 21) | (c.retReg & 0x1F << 16) | (0xFFFF & c.offset))
+
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetMemory().SetWord(testutil.EffAddr(c.addr), c.memVal)
+		state.GetRegistersRef()[baseReg] = c.base
+		if tt.Variation.withExistingReservation {
+			state.LLReservationStatus = multithreaded.LLStatusActive64bit
+			state.LLAddress = c.addr + 1
+			state.LLOwnerThread = 123
+		} else {
+			state.LLReservationStatus = multithreaded.LLStatusNone
+			state.LLAddress = 0
+			state.LLOwnerThread = 0
+		}
+
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		c := tt.Base
+		expected.ExpectStep()
+		expected.LLReservationStatus = multithreaded.LLStatusActive64bit
+		expected.LLAddress = c.addr
+		expected.LLOwnerThread = expected.ActiveThreadId
+		if c.retReg != 0 {
+			expected.ActiveThread().Registers[c.retReg] = c.memVal
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_MT64_SCD(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -94,7 +94,7 @@ func TestEVM_MT_LL(t *testing.T) {
 	}
 
 	NewDiffTester(testNamer).
-		InitState(initState).
+		InitState(initState, mtutil.WithPCAndNextPC(0x40)).
 		SetExpectations(setExpectations).
 		Run(t, cases)
 }

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -21,14 +21,22 @@ import (
 type Word = arch.Word
 
 func TestEVM_MT_LL(t *testing.T) {
+	type testVariation struct {
+		name                    string
+		withExistingReservation bool
+	}
+	testVariations := []testVariation{
+		{"with existing reservation", true},
+		{"without existing reservation", false},
+	}
+
 	// Set up some test values that will be reused
 	posValue := uint64(0xAAAA_BBBB_1122_3344)
 	posValueRet := uint64(0x1122_3344)
 	negValue := uint64(0x1111_1111_8877_6655)
 	negRetValue := uint64(0xFFFF_FFFF_8877_6655) // Sign extended version of negValue
 
-	// Note: parameters are written as 64-bit values. For 32-bit architectures, these values are downcast to 32-bit
-	cases := []struct {
+	type baseTest struct {
 		name         string
 		base         uint64
 		offset       int
@@ -36,7 +44,8 @@ func TestEVM_MT_LL(t *testing.T) {
 		memValue     uint64
 		retVal       uint64
 		rtReg        int
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "Aligned addr", base: 0x01, offset: 0x0133, expectedAddr: 0x0134, memValue: posValue, retVal: posValueRet, rtReg: 5},
 		{name: "Aligned addr, negative value", base: 0x01, offset: 0x0133, expectedAddr: 0x0134, memValue: negValue, retVal: negRetValue, rtReg: 5},
 		{name: "Aligned addr, addr signed extended", base: 0x01, offset: 0xFF33, expectedAddr: 0xFFFF_FFFF_FFFF_FF34, memValue: posValue, retVal: posValueRet, rtReg: 5},
@@ -44,53 +53,50 @@ func TestEVM_MT_LL(t *testing.T) {
 		{name: "Unaligned addr, addr sign extended w overflow", base: 0xFF12_0001, offset: 0x8405, expectedAddr: 0xFF11_8406, memValue: posValue, retVal: posValueRet, rtReg: 5},
 		{name: "Return register set to 0", base: 0xFF12_0001, offset: 0x7404, expectedAddr: 0xFF12_7405, memValue: posValue, retVal: 0, rtReg: 0},
 	}
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			for _, withExistingReservation := range []bool{true, false} {
-				tName := fmt.Sprintf("%v (vm = %v, withExistingReservation = %v)", c.name, ver.Name, withExistingReservation)
-				t.Run(tName, func(t *testing.T) {
-					rtReg := c.rtReg
-					baseReg := 6
-					insn := uint32((0b11_0000 << 26) | (baseReg & 0x1F << 21) | (rtReg & 0x1F << 16) | (0xFFFF & c.offset))
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(0x40))
-					state := mtutil.GetMtState(t, goVm)
-					step := state.GetStep()
 
-					// Set up state
-					testutil.SetMemoryUint64(t, state.GetMemory(), Word(c.expectedAddr), c.memValue)
-					testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
-					state.GetRegistersRef()[baseReg] = Word(c.base)
-					if withExistingReservation {
-						state.LLReservationStatus = multithreaded.LLStatusActive32bit
-						state.LLAddress = Word(c.expectedAddr + 1)
-						state.LLOwnerThread = 123
-					} else {
-						state.LLReservationStatus = multithreaded.LLStatusNone
-						state.LLAddress = 0
-						state.LLOwnerThread = 0
-					}
+	type testCase = testutil.TestCaseVariation[baseTest, testVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v-%v", tc.Base.name, tc.Variation.name)
+	}
+	cases := testutil.TestVariations(baseTests, testVariations)
 
-					// Set up expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.LLReservationStatus = multithreaded.LLStatusActive32bit
-					expected.LLAddress = Word(c.expectedAddr)
-					expected.LLOwnerThread = state.GetCurrentThread().ThreadId
-					if rtReg != 0 {
-						expected.ActiveThread().Registers[rtReg] = Word(c.retVal)
-					}
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
 
-					stepWitness, err := goVm.Step(true)
-					require.NoError(t, err)
+		baseReg := 6
+		insn := uint32((0b11_0000 << 26) | (baseReg & 0x1F << 21) | (c.rtReg & 0x1F << 16) | (0xFFFF & c.offset))
 
-					// Check expectations
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
+		// Set up state
+		testutil.SetMemoryUint64(t, state.GetMemory(), Word(c.expectedAddr), c.memValue)
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), insn)
+		state.GetRegistersRef()[baseReg] = Word(c.base)
+		if tt.Variation.withExistingReservation {
+			state.LLReservationStatus = multithreaded.LLStatusActive32bit
+			state.LLAddress = Word(c.expectedAddr + 1)
+			state.LLOwnerThread = 123
+		} else {
+			state.LLReservationStatus = multithreaded.LLStatusNone
+			state.LLAddress = 0
+			state.LLOwnerThread = 0
 		}
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		c := tt.Base
+		expected.ExpectStep()
+		expected.LLReservationStatus = multithreaded.LLStatusActive32bit
+		expected.LLAddress = Word(c.expectedAddr)
+		expected.LLOwnerThread = expected.ActiveThreadId
+		if c.rtReg != 0 {
+			expected.ActiveThread().Registers[c.rtReg] = Word(c.retVal)
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_MT_SC(t *testing.T) {
@@ -310,99 +316,93 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 }
 
 func TestEVM_SysGetTID(t *testing.T) {
-	cases := []struct {
+	type testCase struct {
 		name     string
 		threadId Word
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{"zero", 0},
 		{"non-zero", 11},
 	}
 
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*789)))
-				state := mtutil.GetMtState(t, goVm)
-				mtutil.InitializeSingleThread(i*789, state, false)
-
-				state.GetCurrentThread().ThreadId = c.threadId
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
-				step := state.Step
-
-				// Set up post-state expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[2] = c.threadId
-				expected.ActiveThread().Registers[7] = 0
-
-				// State transition
-				var err error
-				var stepWitness *mipsevm.StepWitness
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		mtutil.InitializeSingleThread(r.Intn(10000), state, false)
+		state.GetCurrentThread().ThreadId = c.threadId
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
 	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = c.threadId
+		expected.ActiveThread().Registers[7] = 0
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysExit(t *testing.T) {
-	cases := []struct {
+	type testVariation struct {
+		name          string
+		traverseRight bool
+	}
+	testVariations := []testVariation{
+		{name: "traverse right", traverseRight: true},
+		{name: "traverse left", traverseRight: false},
+	}
+
+	type baseTest struct {
 		name               string
 		threadCount        int
 		shouldExitGlobally bool
-	}{
+	}
+	baseTests := []baseTest{
 		// If we exit the last thread, the whole process should exit
 		{name: "one thread", threadCount: 1, shouldExitGlobally: true},
 		{name: "two threads ", threadCount: 2},
 		{name: "three threads ", threadCount: 3},
 	}
 
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				exitCode := uint8(3)
-
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*133)))
-				state := mtutil.GetMtState(t, goVm)
-				mtutil.SetupThreads(int64(i*1111), state, i%2 == 0, c.threadCount, 0)
-
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysExit   // Set syscall number
-				state.GetRegistersRef()[4] = Word(exitCode) // The first argument (exit code)
-				step := state.Step
-
-				// Set up expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.Step += 1
-				expected.StepsSinceLastContextSwitch += 1
-				expected.ActiveThread().Exited = true
-				expected.ActiveThread().ExitCode = exitCode
-				if c.shouldExitGlobally {
-					expected.Exited = true
-					expected.ExitCode = exitCode
-				}
-
-				// State transition
-				var err error
-				var stepWitness *mipsevm.StepWitness
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, testVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v-%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.TestVariations(baseTests, testVariations)
+
+	exitCode := uint8(3)
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		mtutil.SetupThreads(r.Int64(10000), state, tt.Variation.traverseRight, c.threadCount, 0)
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysExit   // Set syscall number
+		state.GetRegistersRef()[4] = Word(exitCode) // The first argument (exit code)
+	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.Step += 1
+		expected.StepsSinceLastContextSwitch += 1
+		expected.ActiveThread().Exited = true
+		expected.ActiveThread().ExitCode = exitCode
+		if c.Base.shouldExitGlobally {
+			expected.Exited = true
+			expected.ExitCode = exitCode
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_PopExitedThread(t *testing.T) {
@@ -609,68 +609,60 @@ func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {
 	const FUTEX_CMP_REQUEUE_PI = 12
 	const FUTEX_LOCK_PI2 = 13
 
-	unsupportedFutexOps := map[string]Word{
-		"FUTEX_WAIT":                    FUTEX_WAIT,
-		"FUTEX_WAKE":                    FUTEX_WAKE,
-		"FUTEX_FD":                      FUTEX_FD,
-		"FUTEX_REQUEUE":                 FUTEX_REQUEUE,
-		"FUTEX_CMP_REQUEUE":             FUTEX_CMP_REQUEUE,
-		"FUTEX_WAKE_OP":                 FUTEX_WAKE_OP,
-		"FUTEX_LOCK_PI":                 FUTEX_LOCK_PI,
-		"FUTEX_UNLOCK_PI":               FUTEX_UNLOCK_PI,
-		"FUTEX_TRYLOCK_PI":              FUTEX_TRYLOCK_PI,
-		"FUTEX_WAIT_BITSET":             FUTEX_WAIT_BITSET,
-		"FUTEX_WAKE_BITSET":             FUTEX_WAKE_BITSET,
-		"FUTEX_WAIT_REQUEUE_PI":         FUTEX_WAIT_REQUEUE_PI,
-		"FUTEX_CMP_REQUEUE_PI":          FUTEX_CMP_REQUEUE_PI,
-		"FUTEX_LOCK_PI2":                FUTEX_LOCK_PI2,
-		"FUTEX_REQUEUE_PRIVATE":         (FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG),
-		"FUTEX_CMP_REQUEUE_PRIVATE":     (FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG),
-		"FUTEX_WAKE_OP_PRIVATE":         (FUTEX_WAKE_OP | FUTEX_PRIVATE_FLAG),
-		"FUTEX_LOCK_PI_PRIVATE":         (FUTEX_LOCK_PI | FUTEX_PRIVATE_FLAG),
-		"FUTEX_LOCK_PI2_PRIVATE":        (FUTEX_LOCK_PI2 | FUTEX_PRIVATE_FLAG),
-		"FUTEX_UNLOCK_PI_PRIVATE":       (FUTEX_UNLOCK_PI | FUTEX_PRIVATE_FLAG),
-		"FUTEX_TRYLOCK_PI_PRIVATE":      (FUTEX_TRYLOCK_PI | FUTEX_PRIVATE_FLAG),
-		"FUTEX_WAIT_BITSET_PRIVATE":     (FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG),
-		"FUTEX_WAKE_BITSET_PRIVATE":     (FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG),
-		"FUTEX_WAIT_REQUEUE_PI_PRIVATE": (FUTEX_WAIT_REQUEUE_PI | FUTEX_PRIVATE_FLAG),
-		"FUTEX_CMP_REQUEUE_PI_PRIVATE":  (FUTEX_CMP_REQUEUE_PI | FUTEX_PRIVATE_FLAG),
+	type testCase struct {
+		name string
+		op   Word
 	}
 
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for name, op := range unsupportedFutexOps {
-			testName := fmt.Sprintf("%v (%v)", name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(op)))
-				state := mtutil.GetMtState(t, goVm)
-				step := state.GetStep()
-
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
-				state.GetRegistersRef()[5] = op
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.Step += 1
-				expected.StepsSinceLastContextSwitch += 1
-				expected.ActiveThread().PC = state.GetCpu().NextPC
-				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
-				expected.ActiveThread().Registers[2] = exec.MipsEINVAL
-				expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-
-				// State transition
-				var err error
-				var stepWitness *mipsevm.StepWitness
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	testNamer := func(tc testCase) string {
+		return tc.name
 	}
+
+	cases := []testCase{
+		{"FUTEX_WAIT", FUTEX_WAIT},
+		{"FUTEX_WAKE", FUTEX_WAKE},
+		{"FUTEX_FD", FUTEX_FD},
+		{"FUTEX_REQUEUE", FUTEX_REQUEUE},
+		{"FUTEX_CMP_REQUEUE", FUTEX_CMP_REQUEUE},
+		{"FUTEX_WAKE_OP", FUTEX_WAKE_OP},
+		{"FUTEX_LOCK_PI", FUTEX_LOCK_PI},
+		{"FUTEX_UNLOCK_PI", FUTEX_UNLOCK_PI},
+		{"FUTEX_TRYLOCK_PI", FUTEX_TRYLOCK_PI},
+		{"FUTEX_WAIT_BITSET", FUTEX_WAIT_BITSET},
+		{"FUTEX_WAKE_BITSET", FUTEX_WAKE_BITSET},
+		{"FUTEX_WAIT_REQUEUE_PI", FUTEX_WAIT_REQUEUE_PI},
+		{"FUTEX_CMP_REQUEUE_PI", FUTEX_CMP_REQUEUE_PI},
+		{"FUTEX_LOCK_PI2", FUTEX_LOCK_PI2},
+		{"FUTEX_REQUEUE_PRIVATE", (FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_CMP_REQUEUE_PRIVATE", (FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_WAKE_OP_PRIVATE", (FUTEX_WAKE_OP | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_LOCK_PI_PRIVATE", (FUTEX_LOCK_PI | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_LOCK_PI2_PRIVATE", (FUTEX_LOCK_PI2 | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_UNLOCK_PI_PRIVATE", (FUTEX_UNLOCK_PI | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_TRYLOCK_PI_PRIVATE", (FUTEX_TRYLOCK_PI | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_WAIT_BITSET_PRIVATE", (FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_WAKE_BITSET_PRIVATE", (FUTEX_WAKE_BITSET | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_WAIT_REQUEUE_PI_PRIVATE", (FUTEX_WAIT_REQUEUE_PI | FUTEX_PRIVATE_FLAG)},
+		{"FUTEX_CMP_REQUEUE_PI_PRIVATE", (FUTEX_CMP_REQUEUE_PI | FUTEX_PRIVATE_FLAG)},
+	}
+
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
+		state.GetRegistersRef()[5] = c.op
+	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+		expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysYield(t *testing.T) {
@@ -731,64 +723,57 @@ func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
 }
 
 func TestEVM_SysOpen(t *testing.T) {
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		t.Run(ver.Name, func(t *testing.T) {
-			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(5512)))
-			state := mtutil.GetMtState(t, goVm)
+	type testCase struct {
+		name string
+	}
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+	cases := []testCase{{"Base Case"}}
 
-			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = arch.SysOpen // Set syscall number
-			step := state.Step
-
-			// Set up post-state expectations
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.MipsEBADF
-			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-
-			// State transition
-			var err error
-			var stepWitness *mipsevm.StepWitness
-			stepWitness, err = goVm.Step(true)
-			require.NoError(t, err)
-
-			// Validate post-state
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-		})
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysOpen // Set syscall number
 	}
 
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = exec.MipsEBADF
+		expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysGetPID(t *testing.T) {
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		t.Run(ver.Name, func(t *testing.T) {
-			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(1929)))
-			state := mtutil.GetMtState(t, goVm)
-
-			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = arch.SysGetpid // Set syscall number
-			step := state.Step
-
-			// Set up post-state expectations
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = 0
-			expected.ActiveThread().Registers[7] = 0
-
-			// State transition
-			var err error
-			var stepWitness *mipsevm.StepWitness
-			stepWitness, err = goVm.Step(true)
-			require.NoError(t, err)
-
-			// Validate post-state
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-		})
+	type testCase struct {
+		name string
 	}
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+	cases := []testCase{{"Base Case"}}
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysGetpid // Set syscall number
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = 0
+		expected.ActiveThread().Registers[7] = 0
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysClockGettimeMonotonic(t *testing.T) {
@@ -901,71 +886,33 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 }
 
 func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		t.Run(ver.Name, func(t *testing.T) {
-			goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(2101)))
-			state := mtutil.GetMtState(t, goVm)
-
-			timespecAddr := Word(0x1000)
-			testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-			state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
-			state.GetRegistersRef()[4] = 0xDEAD               // a0 - invalid clockid
-			state.GetRegistersRef()[5] = timespecAddr         // a1
-			step := state.Step
-
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = exec.MipsEINVAL
-			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-
-			var err error
-			var stepWitness *mipsevm.StepWitness
-			stepWitness, err = goVm.Step(true)
-			require.NoError(t, err)
-
-			// Validate post-state
-			expected.Validate(t, state)
-			testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-		})
+	type testCase struct {
+		name string
 	}
-}
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+	cases := []testCase{{"Base Case"}}
 
-var NoopSyscalls = map[string]uint32{
-	"SysGetAffinity":   4240,
-	"SysMadvise":       4218,
-	"SysRtSigprocmask": 4195,
-	"SysSigaltstack":   4206,
-	"SysRtSigaction":   4194,
-	"SysPrlimit64":     4338,
-	"SysClose":         4006,
-	"SysPread64":       4200,
-	"SysStat":          4106,
-	"SysFstat":         4108,
-	"SysFstat64":       4215,
-	"SysOpenAt":        4288,
-	"SysReadlink":      4085,
-	"SysReadlinkAt":    4298,
-	"SysIoctl":         4054,
-	"SysEpollCreate1":  4326,
-	"SysPipe2":         4328,
-	"SysEpollCtl":      4249,
-	"SysEpollPwait":    4313,
-	"SysGetRandom":     4353,
-	"SysUname":         4122,
-	"SysStat64":        4213,
-	"SysGetuid":        4024,
-	"SysGetgid":        4047,
-	"SysLlseek":        4140,
-	"SysMinCore":       4217,
-	"SysTgkill":        4266,
-	"SysGetRLimit":     4076,
-	"SysLseek":         4019,
-	"SysMunmap":        4091,
-	"SysSetITimer":     4104,
-	"SysTimerCreate":   4257,
-	"SysTimerSetTime":  4258,
-	"SysTimerDelete":   4261,
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		timespecAddr := Word(0x1000)
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
+		state.GetRegistersRef()[4] = 0xDEAD               // a0 - invalid clockid
+		state.GetRegistersRef()[5] = timespecAddr         // a1
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+		expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_EmptyThreadStacks(t *testing.T) {

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -41,7 +41,7 @@ func testOperators(t *testing.T, testCases []operatorTestCase, mips32Insn bool) 
 	rtReg := uint32(8)
 	rdReg := uint32(18)
 
-	initState := func(tt operatorTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt operatorTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		var insn uint32
 		var baseReg uint32 = 17
 		if tt.isImm {
@@ -202,7 +202,7 @@ func (t branchTestCase) Name() string {
 }
 
 func testBranch(t *testing.T, cases []branchTestCase) {
-	initState := func(tt branchTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+	initState := func(tt branchTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		const rsReg = 8 // t0
 		insn := tt.opcode<<26 | rsReg<<21 | tt.regimm<<16 | uint32(tt.offset)
 

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"

--- a/cannon/mipsevm/tests/testfuncs_test.go
+++ b/cannon/mipsevm/tests/testfuncs_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,59 +24,54 @@ type operatorTestCase struct {
 	expectRes Word
 }
 
-func testOperators(t *testing.T, cases []operatorTestCase, mips32Insn bool) {
-	versions := GetMipsVersionTestCases(t)
-	for _, v := range versions {
-		for i, tt := range cases {
-			// sign extend inputs for 64-bit compatibility
-			if mips32Insn {
-				tt.rs = randomizeUpperWord(signExtend64(tt.rs))
-				tt.rt = randomizeUpperWord(signExtend64(tt.rt))
-				tt.expectRes = signExtend64(tt.expectRes)
-			}
+func (c operatorTestCase) Name() string {
+	return c.name
+}
 
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				validator := testutil.NewEvmValidator(t, v.StateHashFn, v.Contracts)
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPC(0), mtutil.WithNextPC(4))
-				state := goVm.GetState()
-				var insn uint32
-				var baseReg uint32 = 17
-				var rtReg uint32
-				var rdReg uint32
-				if tt.isImm {
-					rtReg = 8
-					insn = tt.opcode<<26 | baseReg<<21 | rtReg<<16 | uint32(tt.imm)
-					state.GetRegistersRef()[rtReg] = tt.rt
-					state.GetRegistersRef()[baseReg] = tt.rs
-				} else {
-					rtReg = 18
-					rdReg = 8
-					insn = baseReg<<21 | rtReg<<16 | rdReg<<11 | tt.funct
-					state.GetRegistersRef()[baseReg] = tt.rs
-					state.GetRegistersRef()[rtReg] = tt.rt
-				}
-				testutil.StoreInstruction(state.GetMemory(), 0, insn)
-				step := state.GetStep()
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if tt.isImm {
-					expected.ActiveThread().Registers[rtReg] = tt.expectRes
-				} else {
-					expected.ActiveThread().Registers[rdReg] = tt.expectRes
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				validator.ValidateEVM(t, stepWitness, step, goVm)
-			})
+func testOperators(t *testing.T, testCases []operatorTestCase, mips32Insn bool) {
+	var cases []operatorTestCase
+	for _, tt := range testCases {
+		if mips32Insn {
+			tt.rs = randomizeUpperWord(signExtend64(tt.rs))
+			tt.rt = randomizeUpperWord(signExtend64(tt.rt))
+			tt.expectRes = signExtend64(tt.expectRes)
 		}
+		cases = append(cases, tt)
 	}
+
+	pc := arch.Word(0)
+	rtReg := uint32(8)
+	rdReg := uint32(18)
+
+	initState := func(tt operatorTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		var insn uint32
+		var baseReg uint32 = 17
+		if tt.isImm {
+			insn = tt.opcode<<26 | baseReg<<21 | rtReg<<16 | uint32(tt.imm)
+			state.GetRegistersRef()[rtReg] = tt.rt
+			state.GetRegistersRef()[baseReg] = tt.rs
+		} else {
+			insn = baseReg<<21 | rtReg<<16 | rdReg<<11 | tt.funct
+			state.GetRegistersRef()[baseReg] = tt.rs
+			state.GetRegistersRef()[rtReg] = tt.rt
+		}
+		testutil.StoreInstruction(state.GetMemory(), pc, insn)
+	}
+
+	setExpectations := func(tt operatorTestCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		if tt.isImm {
+			expected.ActiveThread().Registers[rtReg] = tt.expectRes
+		} else {
+			expected.ActiveThread().Registers[rdReg] = tt.expectRes
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester((operatorTestCase).Name).
+		InitState(initState, mtutil.WithPCAndNextPC(pc)).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 type mulDivTestCase struct {
@@ -205,37 +199,35 @@ type branchTestCase struct {
 	offset       uint16
 }
 
+func (t branchTestCase) Name() string {
+	return t.name
+}
+
 func testBranch(t *testing.T, cases []branchTestCase) {
-	versions := GetMipsVersionTestCases(t)
-	for _, v := range versions {
-		for i, tt := range cases {
-			testName := fmt.Sprintf("%v (%v)", tt.name, v.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i)), mtutil.WithPCAndNextPC(tt.pc))
-				state := goVm.GetState()
-				const rsReg = 8 // t0
-				insn := tt.opcode<<26 | rsReg<<21 | tt.regimm<<16 | uint32(tt.offset)
-				testutil.StoreInstruction(state.GetMemory(), tt.pc, insn)
-				state.GetRegistersRef()[rsReg] = Word(tt.rs)
-				step := state.GetStep()
+	initState := func(tt branchTestCase, state *multithreaded.State, vm VersionedVMTestCase) {
+		const rsReg = 8 // t0
+		insn := tt.opcode<<26 | rsReg<<21 | tt.regimm<<16 | uint32(tt.offset)
 
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().NextPC = tt.expectNextPC
-				if tt.expectLink {
-					expected.ActiveThread().Registers[31] = state.GetPC() + 8
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Check expectations
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+		state.GetCurrentThread().Cpu.PC = tt.pc
+		state.GetCurrentThread().Cpu.NextPC = tt.pc + 4
+		testutil.StoreInstruction(state.GetMemory(), tt.pc, insn)
+		state.GetRegistersRef()[rsReg] = Word(tt.rs)
 	}
+
+	setExpectations := func(tt branchTestCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().NextPC = tt.expectNextPC
+		if tt.expectLink {
+			expected.ActiveThread().Registers[31] = tt.pc + 8
+		}
+
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester((branchTestCase).Name).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func testNoopSyscall(t *testing.T, vm VersionedVMTestCase, syscalls map[string]uint32) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrate more tests to use the `DiffTester` framework introduced [here](https://github.com/ethereum-optimism/optimism/pull/16608). 

This PR doesn't make any changes to the framework or other adjustments - it's just a straight migration of tests.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483
