### PR TITLE
refactor(test): improve L1 files L1CrossDomainMessenger and OptimismPortal2 test coverage and quality with AI assistance [Prompt v0.7.1]

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -289,7 +289,7 @@ contract L1CrossDomainMessenger_Paused_Test is L1CrossDomainMessenger_TestInit {
         l1CrossDomainMessenger.initialize(ISystemConfig(address(0)), optimismPortal2);
 
         // Calling paused() should revert when systemConfig is zero
-        vm.expectRevert();
+        vm.expectRevert(bytes(""));
         l1CrossDomainMessenger.paused();
     }
 }

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -239,23 +239,6 @@ contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit 
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
         l1CrossDomainMessenger.upgrade(newSystemConfig);
     }
-
-    /// @notice Fuzz test for upgrade with any system config address.
-    /// @param _systemConfig The system config address to test.
-    function testFuzz_upgrade_anySystemConfig_succeeds(address _systemConfig) external {
-        // Get the slot for _initialized.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-
-        // Set the initialized slot to 0.
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
-
-        // Trigger upgrade with the fuzzed address.
-        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
-        l1CrossDomainMessenger.upgrade(ISystemConfig(_systemConfig));
-
-        // Verify that the systemConfig was updated correctly.
-        assertEq(address(l1CrossDomainMessenger.systemConfig()), _systemConfig);
-    }
 }
 
 /// @title L1CrossDomainMessenger_Paused_Test

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -129,38 +129,40 @@ contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestIn
         l1CrossDomainMessenger.initialize(systemConfig, optimismPortal2);
     }
 
-    /// @notice Tests that initialize handles zero addresses correctly.
-    function test_initialize_zeroSystemConfig_succeeds() external {
+    /// @notice Fuzz test for initialize with any system config address.
+    /// @param _systemConfig The system config address to test.
+    function testFuzz_initialize_anySystemConfig_succeeds(address _systemConfig) external {
         // Get the slot for _initialized.
         StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
 
         // Set the initialized slot to 0.
         vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
 
-        // Initialize with zero system config
+        // Initialize with the fuzzed system config address
         vm.prank(address(proxyAdmin));
-        l1CrossDomainMessenger.initialize(ISystemConfig(address(0)), optimismPortal2);
+        l1CrossDomainMessenger.initialize(ISystemConfig(_systemConfig), optimismPortal2);
 
-        // Verify zero address was set
-        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(0));
+        // Verify the address was set correctly
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), _systemConfig);
         assertEq(address(l1CrossDomainMessenger.portal()), address(optimismPortal2));
     }
 
-    /// @notice Tests that initialize handles zero portal address correctly.
-    function test_initialize_zeroPortal_succeeds() external {
+    /// @notice Fuzz test for initialize with any portal address.
+    /// @param _portal The portal address to test.
+    function testFuzz_initialize_anyPortal_succeeds(address _portal) external {
         // Get the slot for _initialized.
         StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
 
         // Set the initialized slot to 0.
         vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
 
-        // Initialize with zero portal
+        // Initialize with the fuzzed portal address
         vm.prank(address(proxyAdmin));
-        l1CrossDomainMessenger.initialize(systemConfig, IOptimismPortal2(payable(address(0))));
+        l1CrossDomainMessenger.initialize(systemConfig, IOptimismPortal2(payable(_portal)));
 
-        // Verify zero address was set
+        // Verify the address was set correctly
         assertEq(address(l1CrossDomainMessenger.systemConfig()), address(systemConfig));
-        assertEq(address(l1CrossDomainMessenger.portal()), address(0));
+        assertEq(address(l1CrossDomainMessenger.portal()), _portal);
     }
 }
 
@@ -238,20 +240,21 @@ contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit 
         l1CrossDomainMessenger.upgrade(newSystemConfig);
     }
 
-    /// @notice Tests that upgrade handles zero address for system config.
-    function test_upgrade_zeroSystemConfig_succeeds() external {
+    /// @notice Fuzz test for upgrade with any system config address.
+    /// @param _systemConfig The system config address to test.
+    function testFuzz_upgrade_anySystemConfig_succeeds(address _systemConfig) external {
         // Get the slot for _initialized.
         StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
 
         // Set the initialized slot to 0.
         vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
 
-        // Trigger upgrade with zero address.
+        // Trigger upgrade with the fuzzed address.
         vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
-        l1CrossDomainMessenger.upgrade(ISystemConfig(address(0)));
+        l1CrossDomainMessenger.upgrade(ISystemConfig(_systemConfig));
 
-        // Verify that the systemConfig was updated to zero.
-        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(0));
+        // Verify that the systemConfig was updated correctly.
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), _systemConfig);
     }
 }
 
@@ -277,20 +280,6 @@ contract L1CrossDomainMessenger_Paused_Test is L1CrossDomainMessenger_TestInit {
 
         assertTrue(l1CrossDomainMessenger.paused());
         assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused(address(0)));
-    }
-
-    /// @notice Tests paused state when systemConfig is zero address.
-    function test_pause_zeroSystemConfig_reverts() external {
-        // Get initialized slot and reinitialize with zero system config
-        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
-        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
-
-        vm.prank(address(proxyAdmin));
-        l1CrossDomainMessenger.initialize(ISystemConfig(address(0)), optimismPortal2);
-
-        // Calling paused() should revert when systemConfig is zero
-        vm.expectRevert(bytes(""));
-        l1CrossDomainMessenger.paused();
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -128,6 +128,40 @@ contract L1CrossDomainMessenger_Initialize_Test is L1CrossDomainMessenger_TestIn
         vm.prank(_sender);
         l1CrossDomainMessenger.initialize(systemConfig, optimismPortal2);
     }
+
+    /// @notice Tests that initialize handles zero addresses correctly.
+    function test_initialize_zeroSystemConfig_succeeds() external {
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        // Initialize with zero system config
+        vm.prank(address(proxyAdmin));
+        l1CrossDomainMessenger.initialize(ISystemConfig(address(0)), optimismPortal2);
+
+        // Verify zero address was set
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(0));
+        assertEq(address(l1CrossDomainMessenger.portal()), address(optimismPortal2));
+    }
+
+    /// @notice Tests that initialize handles zero portal address correctly.
+    function test_initialize_zeroPortal_succeeds() external {
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        // Initialize with zero portal
+        vm.prank(address(proxyAdmin));
+        l1CrossDomainMessenger.initialize(systemConfig, IOptimismPortal2(payable(address(0))));
+
+        // Verify zero address was set
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(systemConfig));
+        assertEq(address(l1CrossDomainMessenger.portal()), address(0));
+    }
 }
 
 /// @title L1CrossDomainMessenger_Upgrade_Test
@@ -203,6 +237,22 @@ contract L1CrossDomainMessenger_Upgrade_Test is L1CrossDomainMessenger_TestInit 
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
         l1CrossDomainMessenger.upgrade(newSystemConfig);
     }
+
+    /// @notice Tests that upgrade handles zero address for system config.
+    function test_upgrade_zeroSystemConfig_succeeds() external {
+        // Get the slot for _initialized.
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+
+        // Set the initialized slot to 0.
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        // Trigger upgrade with zero address.
+        vm.prank(address(l1CrossDomainMessenger.proxyAdmin()));
+        l1CrossDomainMessenger.upgrade(ISystemConfig(address(0)));
+
+        // Verify that the systemConfig was updated to zero.
+        assertEq(address(l1CrossDomainMessenger.systemConfig()), address(0));
+    }
 }
 
 /// @title L1CrossDomainMessenger_Paused_Test
@@ -228,6 +278,20 @@ contract L1CrossDomainMessenger_Paused_Test is L1CrossDomainMessenger_TestInit {
         assertTrue(l1CrossDomainMessenger.paused());
         assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused(address(0)));
     }
+
+    /// @notice Tests paused state when systemConfig is zero address.
+    function test_pause_zeroSystemConfig_reverts() external {
+        // Get initialized slot and reinitialize with zero system config
+        StorageSlot memory slot = ForgeArtifacts.getSlot("L1CrossDomainMessenger", "_initialized");
+        vm.store(address(l1CrossDomainMessenger), bytes32(slot.slot), bytes32(0));
+
+        vm.prank(address(proxyAdmin));
+        l1CrossDomainMessenger.initialize(ISystemConfig(address(0)), optimismPortal2);
+
+        // Calling paused() should revert when systemConfig is zero
+        vm.expectRevert();
+        l1CrossDomainMessenger.paused();
+    }
 }
 
 /// @title L1CrossDomainMessenger_SuperchainConfig_Test
@@ -236,6 +300,16 @@ contract L1CrossDomainMessenger_SuperchainConfig_Test is L1CrossDomainMessenger_
     /// @notice Tests that `superchainConfig` returns the correct address.
     function test_superchainConfig_succeeds() external view {
         assertEq(address(l1CrossDomainMessenger.superchainConfig()), address(superchainConfig));
+    }
+}
+
+/// @title L1CrossDomainMessenger_portal_Test
+/// @notice Tests for the `PORTAL` legacy getter function of the L1CrossDomainMessenger.
+contract L1CrossDomainMessenger_portal_Test is L1CrossDomainMessenger_TestInit {
+    /// @notice Tests that `PORTAL` returns the correct portal address.
+    function test_portal_succeeds() external view {
+        assertEq(address(l1CrossDomainMessenger.PORTAL()), address(optimismPortal2));
+        assertEq(address(l1CrossDomainMessenger.PORTAL()), address(l1CrossDomainMessenger.portal()));
     }
 }
 
@@ -291,6 +365,32 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
         l1CrossDomainMessenger.sendMessage(recipient, hex"ff", uint32(100));
     }
 
+    /// @notice Fuzz test for sendMessage with various gas limits and message data.
+    /// @param _gasLimit Gas limit for the message (bounded to reasonable range).
+    /// @param _message Message data to send.
+    /// @param _sender Address sending the message.
+    function testFuzz_sendMessage_varyingInputs_succeeds(
+        uint32 _gasLimit,
+        bytes calldata _message,
+        address _sender
+    )
+        external
+    {
+        // Bound gas limit to reasonable range to avoid OutOfGas errors
+        _gasLimit = uint32(bound(uint256(_gasLimit), 21000, 1_000_000));
+        // Bound message length to avoid excessive gas costs
+        vm.assume(_message.length <= 1000);
+        vm.assume(_sender != address(0));
+
+        uint256 nonceBefore = l1CrossDomainMessenger.messageNonce();
+
+        vm.prank(_sender);
+        l1CrossDomainMessenger.sendMessage(recipient, _message, _gasLimit);
+
+        // Verify nonce incremented
+        assertEq(l1CrossDomainMessenger.messageNonce(), nonceBefore + 1);
+    }
+
     /// @notice Tests that the sendMessage function is able to send the same message twice.
     function test_sendMessage_twice_succeeds() external {
         uint256 nonce = l1CrossDomainMessenger.messageNonce();
@@ -298,6 +398,31 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
         l1CrossDomainMessenger.sendMessage(recipient, hex"aa", uint32(500_000));
         // the nonce increments for each message sent
         assertEq(nonce + 2, l1CrossDomainMessenger.messageNonce());
+    }
+
+    /// @notice Tests sendMessage with zero gas limit.
+    function test_sendMessage_zeroGasLimit_succeeds() external {
+        uint256 nonce = l1CrossDomainMessenger.messageNonce();
+
+        // Even with zero gas limit, message should send
+        vm.expectEmit(address(l1CrossDomainMessenger));
+        emit SentMessage(recipient, alice, hex"1234", nonce, 0);
+
+        vm.prank(alice);
+        l1CrossDomainMessenger.sendMessage(recipient, hex"1234", 0);
+
+        // Verify nonce incremented
+        assertEq(l1CrossDomainMessenger.messageNonce(), nonce + 1);
+    }
+
+    /// @notice Tests sendMessage with high gas limit that causes OutOfGas.
+    function test_sendMessage_highGasLimit_reverts() external {
+        // Very high gas limit causes OutOfGas error in portal deposit
+        uint32 highGasLimit = 30_000_000;
+
+        vm.prank(alice);
+        vm.expectRevert("OutOfGas()");
+        l1CrossDomainMessenger.sendMessage(recipient, hex"5678", highGasLimit);
     }
 }
 
@@ -427,6 +552,44 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
         assert(l1CrossDomainMessenger.successfulMessages(hash));
         // it is not in the received messages mapping
         assertEq(l1CrossDomainMessenger.failedMessages(hash), false);
+    }
+
+    /// @notice Fuzz test for relaying messages with various parameters.
+    /// @param _target Target address for the message.
+    /// @param _minGasLimit Minimum gas limit for message execution.
+    /// @param _message Message data to relay.
+    function testFuzz_relayMessage_varyingInputs_succeeds(
+        address _target,
+        uint32 _minGasLimit,
+        bytes calldata _message
+    )
+        external
+    {
+        // Ensure target is not a blocked address
+        vm.assume(_target != address(l1CrossDomainMessenger));
+        vm.assume(_target != address(optimismPortal2));
+        vm.assume(_target != address(0));
+
+        // Bound gas limit and message size to avoid OutOfGas errors
+        _minGasLimit = uint32(bound(uint256(_minGasLimit), 0, 100_000));
+        vm.assume(_message.length <= 100);
+
+        address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
+
+        // set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
+        vm.store(address(optimismPortal2), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+
+        bytes32 hash = Hashing.hashCrossDomainMessage(
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, _target, 0, _minGasLimit, _message
+        );
+
+        vm.prank(address(optimismPortal2));
+        l1CrossDomainMessenger.relayMessage(
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, _target, 0, _minGasLimit, _message
+        );
+
+        // Verify message was relayed (either successfully or failed)
+        assertTrue(l1CrossDomainMessenger.successfulMessages(hash) || l1CrossDomainMessenger.failedMessages(hash));
     }
 
     /// @notice Tests that `relayMessage` reverts if the caller is optimismPortal2 and the value
@@ -695,6 +858,13 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
             Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), address(0), address(0), 0, 0, hex""
         );
 
+        vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
+        l1CrossDomainMessenger.xDomainMessageSender();
+    }
+
+    /// @notice Tests that xDomainMessageSender is never set during sendMessage.
+    function test_xDomainMessageSender_duringSend_reverts() external {
+        // XDomainMessageSender is only set during relayMessage, not sendMessage
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         l1CrossDomainMessenger.xDomainMessageSender();
     }


### PR DESCRIPTION
## Overview

This PR introduces AI-guided test improvements for both `L1CrossDomainMessenger` and `OptimismPortal2`, using the newly revised [Prompt v0.7.1](https://www.notion.so/oplabs/Prompt-v0-7-1-239f153ee16280c294a2e483de38e91d?source=copy_link). It replaces [Prompt v0.7.0](https://www.notion.so/oplabs/Prompt-v0-7-0-237f153ee162809f9d2df76ee831bc34?source=copy_link), which generated inconsistent and non-actionable outputs in previous test generation efforts.

Prompt v0.7.1 introduces critical upgrades to AI-generated test reliability, including:

- Strict constraints enforcement (e.g., no redundant `vm.assume`)
- Accurate alignment with contract behavior and function requirements
- Mandatory heavy fuzz validation
- Output standardization and explicit coverage expectations

Check the [prompt changelog](https://www.notion.so/oplabs/Prompt-changelog-225f153ee1628010990ef3dc24cb0b83?source=copy_link) for more information.

This version ensures deterministic, spec-aligned test generation that emphasizes:

1. Converting standard tests into meaningful fuzz tests
2. Covering all observable code paths
3. Ensuring every public/external function has at least one targeted test

All tests in this PR were generated automatically via Prompt v0.7.1, without manual editing or validation intervention.

## L1CrossDomainMessenger Test Improvements

### New and Enhanced Tests

- `test_portal_succeeds`: Validates that the legacy `PORTAL()` getter correctly returns the assigned portal address.
- `testFuzz_initialize_anySystemConfig_succeeds`: Fuzz test that verifies `initialize()` correctly handles arbitrary system config addresses.
- `testFuzz_initialize_anyPortal_succeeds`: Fuzz test that checks `initialize()` accepts arbitrary portal addresses and sets them properly.
- `testFuzz_upgrade_anySystemConfig_succeeds`: Fuzz test validating that `upgrade()` can be called with any valid system config address and that the internal state is updated accordingly.
- `testFuzz_sendMessage_varyingInputs_succeeds`: Fuzzes `sendMessage()` with randomized inputs for gas limit, message payload, and sender.
- `test_sendMessage_zeroGasLimit_succeeds`: Confirms that `sendMessage()` behaves correctly when passed a zero gas limit (i.e., does not revert unexpectedly).
- `test_sendMessage_highGasLimit_reverts`: Verifies that `sendMessage()` reverts gracefully when passed an unreasonably high gas limit that would exhaust available gas.

### Modified Tests

- `testFuzz_relayMessage_varyingInputs_succeeds`: Converted from a regular test to a fuzz test covering target, gas, and payload.
- `test_xDomainMessageSender_duringSend_reverts`: Refactored and simplified; no longer marked as fuzz test.

### New Targeted Test Contracts

- `L1CrossDomainMessenger_Portal_Test`: Isolated test contract for legacy getter `PORTAL()`.

### Test Count

- Increased from 35 → 42
  All tests pass cleanly.

## OptimismPortal2 Test Improvements

### New Tests

- Getter tests:
  - `test_paused_succeeds`
  - `test_proofMaturityDelaySeconds_succeeds`
  - `test_disputeGameFactory_succeeds`
  - `test_superchainConfig_succeeds`
  - `test_guardian_succeeds`
  - `test_disputeGameFinalityDelaySeconds_succeeds`
  - `test_respectedGameType_succeeds`
  - `test_respectedGameTypeUpdatedAt_succeeds`

- Dispute-related tests:
  - `test_disputeGameBlacklist_nonBlacklisted_succeeds`
  - `testFuzz_disputeGameBlacklist_succeeds`

- Proof submitter tracking:
  - `test_numProofSubmitters_unprovenWithdrawal_succeeds`
  - `test_numProofSubmitters_provenWithdrawal_succeeds`
  - `testFuzz_numProofSubmitters_multipleProofs_succeeds`

### Converted and Split Tests

- `test_minimumGasLimit_succeeds` was split into:
  - `testFuzz_minimumGasLimit_increasesLinearly_succeeds`: A fuzz test with bounded linear constraints
  - `test_minimumGasLimit_zeroCalldata_succeeds`: Covers edge case with zero calldata

### Structural Enhancements

- Improved `MinimumGasLimit_Test` contract structure
- Refined naming and separation between fuzz and non-fuzz logic

### Test Count

- Increased from 78 → 91  
  All tests pass with full CI and heavy fuzz test success.

---

## Impact

- 20 new tests added across both files
- 3 existing tests converted into fuzz tests
- Getter, edge case, and behavioral coverage expanded significantly
- Generated using Prompt v0.7.1 with no manual adjustments
- All tests pass and meet project and prompt-defined validation standards

---

## Manual Changes

While the majority of this PR was generated via Prompt v0.7.1, a few targeted manual changes were made based on post-generation review. These will be incorporated into future prompt improvements to eliminate the need for manual intervention.

### Converted Tests

Several tests that previously focused on zero address edge cases were converted into fuzz tests to ensure broader behavioral coverage:

- `test_initialize_zeroSystemConfig_succeeds`  
  → replaced with `testFuzz_initialize_anySystemConfig_succeeds`

- `test_initialize_zeroPortal_succeeds`  
  → replaced with `testFuzz_initialize_anyPortal_succeeds`

- `test_upgrade_zeroSystemConfig_succeeds`  
  → replaced with `testFuzz_upgrade_anySystemConfig_succeeds`

These changes improve test quality by demonstrating that these functions accept any address, not just a specific edge case. They also align with the prompt's goal of exercising realistic inputs without artificially constraining the test logic.

### Removed Test

- `test_pause_zeroSystemConfig_reverts` was removed

This test exercised an invalid contract setup (zero `systemConfig` address) that does not reflect supported or expected behavior. Since the scenario falls outside meaningful improvement, the test was removed.

### Prompt Update Note

The need for these changes reflects areas that will be addressed in the next prompt version. Specifically:
- Fuzz test generation will default to broad input coverage instead of fixed-value edge cases
- Tests for invalid or unsupported setup states will be filtered out to avoid speculative behavior