### PR TITLE
feat(kurtosis-devnet): output op-conductor-ops configs from enclaves

### DIFF
--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -62,19 +62,14 @@ devnet TEMPLATE_FILE DATA_FILE="" NAME="" PACKAGE=KURTOSIS_PACKAGE: _prerequisit
         fi
     fi
     export ENCL_NAME="$DEVNET_NAME"-devnet
-    if [ -n "{{DATA_FILE}}" ]; then
-        go run cmd/main.go -kurtosis-package {{PACKAGE}} \
-            -environment "tests/$ENCL_NAME.json" \
-            -template "{{TEMPLATE_FILE}}" \
-            -data "{{DATA_FILE}}" \
-            -enclave "$ENCL_NAME"
-    else
-        go run cmd/main.go -kurtosis-package {{PACKAGE}} \
-            -environment "tests/$ENCL_NAME.json" \
-            -template "{{TEMPLATE_FILE}}" \
-            -enclave "$ENCL_NAME"
-    fi \
-    && cat "tests/$ENCL_NAME.json"
+    export CONDUCTOR_CONFIG="tests/op-conductor-ops-$ENCL_NAME.toml"
+    go run cmd/main.go -kurtosis-package {{PACKAGE}} \
+        -environment "tests/$ENCL_NAME.json" \
+        -conductor-config "$CONDUCTOR_CONFIG" \
+        -template "{{TEMPLATE_FILE}}" \
+        -data "{{DATA_FILE}}" \
+        -enclave "$ENCL_NAME" \
+    && cat "tests/$ENCL_NAME.json" && if [ -f "$CONDUCTOR_CONFIG" ]; then cat "$CONDUCTOR_CONFIG"; fi
 
 devnet-test DEVNET *TEST: _prerequisites
     #!/usr/bin/env bash

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/README.md
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/README.md
@@ -1,0 +1,351 @@
+# Kurtosis Inspect Tool
+
+A command-line tool for inspecting Kurtosis enclaves and extracting conductor configurations and environment data from running Optimism devnets.
+
+## Overview
+
+The Kurtosis Inspect Tool provides a clean interface to:
+
+- 🔍 **Inspect running Kurtosis enclaves** - Extract service information and file artifacts
+- 🎛️ **Generate conductor configurations** - Create TOML configs for `op-conductor-ops`
+- 📊 **Export environment data** - Save complete devnet information as JSON
+- 🔧 **Fix Traefik issues** - Repair missing network labels on containers
+
+## Installation
+
+### Build from Source
+
+```bash
+cd optimism/kurtosis-devnet
+go build -o kurtosis-inspect pkg/kurtosis/sources/inspect/cmd/main.go
+```
+
+### Run Directly
+
+```bash
+go run pkg/kurtosis/sources/inspect/cmd/main.go [options] <enclave-id>
+```
+
+## Usage
+
+### Basic Inspection
+
+Inspect a running enclave and display results:
+
+```bash
+./kurtosis-inspect my-devnet-enclave
+```
+
+### Extract Conductor Configuration
+
+Generate a conductor configuration file for use with `op-conductor-ops`:
+
+```bash
+./kurtosis-inspect --conductor-config conductor.toml my-devnet-enclave
+```
+
+### Export Complete Environment
+
+Save the complete environment data as JSON:
+
+```bash
+./kurtosis-inspect --environment environment.json my-devnet-enclave
+```
+
+### Combined Export
+
+Extract both conductor config and environment data:
+
+```bash
+./kurtosis-inspect \
+  --conductor-config conductor.toml \
+  --environment environment.json \
+  my-devnet-enclave
+```
+
+### Fix Traefik Network Issues
+
+Repair missing Traefik labels on containers:
+
+```bash
+./kurtosis-inspect --fix-traefik my-devnet-enclave
+```
+
+## Configuration Options
+
+### CLI Flags
+
+| Flag | Environment Variable | Description |
+|------|---------------------|-------------|
+| `--conductor-config` | `KURTOSIS_INSPECT_CONDUCTOR_CONFIG` | Path to write conductor configuration TOML file |
+| `--environment` | `KURTOSIS_INSPECT_ENVIRONMENT` | Path to write environment JSON file |
+| `--fix-traefik` | `KURTOSIS_INSPECT_FIX_TRAEFIK` | Fix missing Traefik labels on containers |
+| `--log.level` | `KURTOSIS_INSPECT_LOG_LEVEL` | Logging level (DEBUG, INFO, WARN, ERROR) |
+| `--log.format` | `KURTOSIS_INSPECT_LOG_FORMAT` | Log format (text, json, logfmt) |
+
+### Environment Variables
+
+All flags can be set via environment variables with the `KURTOSIS_INSPECT_` prefix:
+
+```bash
+export KURTOSIS_INSPECT_CONDUCTOR_CONFIG="/tmp/conductor.toml"
+export KURTOSIS_INSPECT_ENVIRONMENT="/tmp/environment.json"
+export KURTOSIS_INSPECT_LOG_LEVEL="DEBUG"
+
+./kurtosis-inspect my-devnet-enclave
+```
+
+## Output Formats
+
+### Conductor Configuration (TOML)
+
+The conductor configuration file is compatible with `op-conductor-ops`:
+
+```toml
+[networks]
+  [networks.2151908-chain0-kona]
+    sequencers = ["op-conductor-2151908-chain0-kona-sequencer"]
+  [networks.2151908-chain0-optimism]
+    sequencers = ["op-conductor-2151908-chain0-optimism-sequencer"]
+
+[sequencers]
+  [sequencers.op-conductor-2151908-chain0-kona-sequencer]
+    raft_addr = "127.0.0.1:60135"
+    conductor_rpc_url = "http://127.0.0.1:60134"
+    node_rpc_url = "http://127.0.0.1:60048"
+    voting = true
+  [sequencers.op-conductor-2151908-chain0-optimism-sequencer]
+    raft_addr = "127.0.0.1:60176"
+    conductor_rpc_url = "http://127.0.0.1:60177"
+    node_rpc_url = "http://127.0.0.1:60062"
+    voting = true
+```
+
+### Environment Data (JSON)
+
+Complete environment data including services and file artifacts:
+
+```json
+{
+  "FileArtifacts": [
+    "genesis-l1.json",
+    "genesis-l2-chain0.json",
+    "jwt.txt",
+    "rollup-l2-chain0.json"
+  ],
+  "UserServices": {
+    "op-node-chain0-sequencer": {
+      "Labels": {
+        "app": "op-node",
+        "chain": "chain0",
+        "role": "sequencer"
+      },
+      "Ports": {
+        "rpc": {
+          "Host": "127.0.0.1",
+          "Port": 9545
+        },
+        "p2p": {
+          "Host": "127.0.0.1",
+          "Port": 9222
+        }
+      }
+    }
+  }
+}
+```
+
+## Integration with op-conductor-ops
+
+### 1. Generate Conductor Configuration
+
+```bash
+# Extract conductor config from running devnet
+./kurtosis-inspect --conductor-config conductor.toml my-devnet
+
+# Use with op-conductor-ops
+cd infra/op-conductor-ops
+python op-conductor-ops.py --config ../../kurtosis-devnet/conductor.toml status
+```
+
+### 2. Leadership Transfer Example
+
+```bash
+# Generate config and perform leadership transfer
+./kurtosis-inspect --conductor-config conductor.toml my-devnet
+cd infra/op-conductor-ops
+python op-conductor-ops.py --config ../../kurtosis-devnet/conductor.toml \
+  transfer-leadership \
+  --target-sequencer "op-conductor-2151908-chain0-optimism-sequencer"
+```
+
+## Examples
+
+### Simple Devnet
+
+```bash
+# Deploy simple devnet
+cd kurtosis-devnet
+just devnet simple
+
+# Inspect and extract configs
+./kurtosis-inspect --conductor-config tests/simple-conductor.toml simple-devnet
+
+# Check conductor status
+cd ../infra/op-conductor-ops
+python op-conductor-ops.py --config ../../kurtosis-devnet/tests/simple-conductor.toml status
+```
+
+### Multi-Chain Interop
+
+```bash
+# Deploy interop devnet
+just devnet interop
+
+# Extract complex conductor configuration
+./kurtosis-inspect \
+  --conductor-config tests/interop-conductor.toml \
+  --environment tests/interop-environment.json \
+  interop-devnet
+
+# View conductor cluster status
+cd ../infra/op-conductor-ops
+python op-conductor-ops.py --config ../../kurtosis-devnet/tests/interop-conductor.toml status
+```
+
+### Debugging Network Issues
+
+```bash
+# Fix Traefik network issues
+./kurtosis-inspect --fix-traefik my-devnet
+
+# Inspect with debug logging
+./kurtosis-inspect --log.level DEBUG --log.format json my-devnet
+```
+
+## Architecture
+
+The tool follows a clean architecture pattern with clear separation of concerns:
+
+```
+pkg/kurtosis/sources/inspect/
+├── cmd/main.go              # CLI setup and entry point
+├── config.go                # Configuration parsing and validation
+├── service.go               # Business logic and service layer
+├── conductor.go             # Conductor configuration extraction
+├── inspect.go               # Core inspection functionality
+├── flags/
+│   ├── flags.go            # CLI flag definitions
+│   └── flags_test.go       # Flag testing
+└── *_test.go               # Comprehensive test suite
+```
+
+### Key Components
+
+- **Config**: Handles CLI argument parsing and validation
+- **InspectService**: Main business logic for inspection operations
+- **ConductorConfig**: Data structures for conductor configuration
+- **Inspector**: Core enclave inspection functionality
+
+## Testing
+
+### Run All Tests
+
+```bash
+go test ./pkg/kurtosis/sources/inspect/... -v
+```
+
+### Test Coverage
+
+```bash
+go test ./pkg/kurtosis/sources/inspect/... -cover
+```
+
+### Test Categories
+
+- **Unit Tests**: Individual component functionality
+- **Integration Tests**: File I/O and configuration parsing
+- **Real-World Tests**: Based on actual devnet configurations
+- **Error Tests**: Permission and validation error handling
+
+## Troubleshooting
+
+### Common Issues
+
+#### Kurtosis Engine Not Running
+
+```
+Error: failed to create Kurtosis context: The Kurtosis Engine Server is unavailable
+```
+
+**Solution:**
+```bash
+kurtosis engine start
+```
+
+#### Enclave Not Found
+
+```
+Error: failed to get enclave: enclave with identifier 'my-devnet' not found
+```
+
+**Solution:**
+```bash
+# List available enclaves
+kurtosis enclave ls
+
+# Use correct enclave name
+./kurtosis-inspect <correct-enclave-name>
+```
+
+#### Permission Denied
+
+```
+Error: error creating conductor config file: permission denied
+```
+
+**Solution:**
+```bash
+# Ensure write permissions to output directory
+chmod 755 /output/directory
+```
+
+### Debug Mode
+
+Enable debug logging for detailed troubleshooting:
+
+```bash
+./kurtosis-inspect --log.level DEBUG --log.format json my-devnet
+```
+
+## Contributing
+
+### Development Setup
+
+```bash
+# Install dependencies
+go mod download
+
+# Run tests
+go test ./pkg/kurtosis/sources/inspect/... -v
+
+# Build
+go build -o kurtosis-inspect pkg/kurtosis/sources/inspect/cmd/main.go
+```
+
+### Adding New Features
+
+1. Add functionality to appropriate service layer
+2. Create comprehensive tests with real data
+3. Update CLI flags if needed
+4. Update this README with examples
+
+## Related Tools
+
+- **[op-conductor-ops](../../infra/op-conductor-ops/)**: Python CLI for managing conductor clusters
+- **[Kurtosis](https://kurtosis.com/)**: Orchestration platform for development environments
+- **[Optimism Devnet](../)**: Kurtosis package for Optimism development networks
+
+## License
+
+This tool is part of the Optimism monorepo and follows the same licensing terms. 

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go
@@ -5,81 +5,61 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect"
-	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/util"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+var (
+	Version   = "v0.1.0"
+	GitCommit = ""
+	GitDate   = ""
 )
 
 func main() {
+	app := cli.NewApp()
+	app.Version = opservice.FormatVersion(Version, GitCommit, GitDate, "")
+	app.Name = "kurtosis-inspect"
+	app.Usage = "Inspect Kurtosis enclaves and extract configurations"
+	app.Description = "Tool to inspect running Kurtosis enclaves and extract conductor configurations and environment data"
+	app.Flags = cliapp.ProtectFlags(flags.Flags)
+	app.Action = cliapp.LifecycleCmd(run)
+	app.ArgsUsage = "<enclave-id>"
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(cliCtx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	// Parse configuration
+	cfg, err := inspect.NewConfig(cliCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup logging
+	log := oplog.NewLogger(oplog.AppOut(cliCtx), oplog.ReadCLIConfig(cliCtx))
+	oplog.SetGlobalLogHandler(log.Handler())
+
+	// Create service
+	service := inspect.NewInspectService(cfg, log)
+
+	// Create background context for operations
 	ctx := context.Background()
 
-	var fixTraefik bool
-	flag.BoolVar(&fixTraefik, "fix-traefik", false, "Fix missing Traefik labels on containers")
-
-	flag.Parse()
-	if flag.NArg() != 1 {
-		fmt.Fprintf(os.Stderr, "Usage: %s [--fix-traefik] <enclave-id>\n", os.Args[0])
-		os.Exit(1)
+	// Run the service
+	if err := service.Run(ctx); err != nil {
+		return nil, err
 	}
 
-	enclaveID := flag.Arg(0)
-
-	// If fix-traefik flag is provided, run the fix
-	if fixTraefik {
-		fmt.Println("🔧 Fixing Traefik network configuration...")
-		if err := util.SetReverseProxyConfig(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error fixing Traefik network: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Println("✅ Traefik network configuration fixed!")
-		return
-	}
-
-	inspector := inspect.NewInspector(enclaveID)
-
-	data, err := inspector.ExtractData(ctx)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error inspecting enclave: %v\n", err)
-		os.Exit(1)
-	}
-
-	conductorConfig, err := inspect.ExtractConductorConfig(ctx, enclaveID)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error extracting conductor configuration: %v\n", err)
-	}
-
-	fmt.Println("File Artifacts:")
-	for _, artifact := range data.FileArtifacts {
-		fmt.Printf("  %s\n", artifact)
-	}
-
-	fmt.Println("\nServices:")
-	for name, svc := range data.UserServices {
-		fmt.Printf("  %s:\n", name)
-		for portName, portInfo := range svc.Ports {
-			host := portInfo.Host
-			if host == "" {
-				host = "localhost"
-			}
-			fmt.Printf("    %s: %s:%d\n", portName, host, portInfo.Port)
-		}
-	}
-
-	// Print conductor configuration if available
-	if conductorConfig != nil {
-		fmt.Println("\nConductor Configuration:")
-		fmt.Println("========================")
-
-		yamlData, err := yaml.Marshal(conductorConfig)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error marshaling conductor config to YAML: %v\n", err)
-		} else {
-			fmt.Printf("%s", yamlData)
-		}
-	}
+	return nil, nil
 }

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect"
 	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/util"
 )
@@ -46,6 +48,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	conductorConfig, err := inspect.ExtractConductorConfig(ctx, enclaveID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error extracting conductor configuration: %v\n", err)
+	}
+
 	fmt.Println("File Artifacts:")
 	for _, artifact := range data.FileArtifacts {
 		fmt.Printf("  %s\n", artifact)
@@ -60,6 +67,19 @@ func main() {
 				host = "localhost"
 			}
 			fmt.Printf("    %s: %s:%d\n", portName, host, portInfo.Port)
+		}
+	}
+
+	// Print conductor configuration if available
+	if conductorConfig != nil {
+		fmt.Println("\nConductor Configuration:")
+		fmt.Println("========================")
+
+		yamlData, err := yaml.Marshal(conductorConfig)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error marshaling conductor config to YAML: %v\n", err)
+		} else {
+			fmt.Printf("%s", yamlData)
 		}
 	}
 }

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/conductor.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/conductor.go
@@ -10,19 +10,19 @@ import (
 )
 
 type ConductorSequencer struct {
-	RaftAddr        string `json:"raft_addr" toml:"raft_addr" yaml:"raft_addr"`
-	ConductorRPCURL string `json:"conductor_rpc_url" toml:"conductor_rpc_url" yaml:"conductor_rpc_url"`
-	NodeRPCURL      string `json:"node_rpc_url" toml:"node_rpc_url" yaml:"node_rpc_url"`
-	Voting          bool   `json:"voting" toml:"voting" yaml:"voting"`
+	RaftAddr        string `json:"raft_addr" toml:"raft_addr"`
+	ConductorRPCURL string `json:"conductor_rpc_url" toml:"conductor_rpc_url"`
+	NodeRPCURL      string `json:"node_rpc_url" toml:"node_rpc_url"`
+	Voting          bool   `json:"voting" toml:"voting"`
 }
 
 type ConductorNetwork struct {
-	Sequencers []string `json:"sequencers" toml:"sequencers" yaml:"sequencers"`
+	Sequencers []string `json:"sequencers" toml:"sequencers"`
 }
 
 type ConductorConfig struct {
-	Networks   map[string]*ConductorNetwork   `json:"networks" toml:"networks" yaml:"networks"`
-	Sequencers map[string]*ConductorSequencer `json:"sequencers" toml:"sequencers" yaml:"sequencers"`
+	Networks   map[string]*ConductorNetwork   `json:"networks" toml:"networks"`
+	Sequencers map[string]*ConductorSequencer `json:"sequencers" toml:"sequencers"`
 }
 
 func ExtractConductorConfig(ctx context.Context, enclaveID string) (*ConductorConfig, error) {

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/conductor.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/conductor.go
@@ -1,0 +1,155 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/kurtosis/api/wrappers"
+)
+
+type ConductorSequencer struct {
+	RaftAddr        string `json:"raft_addr" toml:"raft_addr" yaml:"raft_addr"`
+	ConductorRPCURL string `json:"conductor_rpc_url" toml:"conductor_rpc_url" yaml:"conductor_rpc_url"`
+	NodeRPCURL      string `json:"node_rpc_url" toml:"node_rpc_url" yaml:"node_rpc_url"`
+	Voting          bool   `json:"voting" toml:"voting" yaml:"voting"`
+}
+
+type ConductorNetwork struct {
+	Sequencers []string `json:"sequencers" toml:"sequencers" yaml:"sequencers"`
+}
+
+type ConductorConfig struct {
+	Networks   map[string]*ConductorNetwork   `json:"networks" toml:"networks" yaml:"networks"`
+	Sequencers map[string]*ConductorSequencer `json:"sequencers" toml:"sequencers" yaml:"sequencers"`
+}
+
+func ExtractConductorConfig(ctx context.Context, enclaveID string) (*ConductorConfig, error) {
+	kurtosisCtx, err := wrappers.GetDefaultKurtosisContext()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Kurtosis context: %w", err)
+	}
+
+	enclaveCtx, err := kurtosisCtx.GetEnclave(ctx, enclaveID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get enclave: %w", err)
+	}
+
+	services, err := enclaveCtx.GetServices()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+
+	conductorServices := make(map[string]map[string]interface{})
+	opNodeServices := make(map[string]map[string]interface{})
+
+	for svcName := range services {
+		svcNameStr := string(svcName)
+
+		svcCtx, err := enclaveCtx.GetService(svcNameStr)
+		if err != nil {
+			continue
+		}
+
+		labels := svcCtx.GetLabels()
+		ports := make(map[string]*descriptors.PortInfo)
+
+		for portName, portSpec := range svcCtx.GetPublicPorts() {
+			ports[portName] = &descriptors.PortInfo{
+				Host: svcCtx.GetMaybePublicIPAddress(),
+				Port: int(portSpec.GetNumber()),
+			}
+		}
+
+		if labels["op.kind"] == "conductor" {
+			conductorServices[svcNameStr] = map[string]interface{}{
+				"labels": labels,
+				"ports":  ports,
+			}
+		}
+
+		if labels["op.kind"] == "cl" && labels["op.cl.type"] == "op-node" {
+			opNodeServices[svcNameStr] = map[string]interface{}{
+				"labels": labels,
+				"ports":  ports,
+			}
+		}
+	}
+
+	if len(conductorServices) == 0 {
+		return nil, nil
+	}
+
+	networks := make(map[string]*ConductorNetwork)
+	sequencers := make(map[string]*ConductorSequencer)
+
+	networkSequencers := make(map[string][]string)
+
+	for conductorSvcName, conductorData := range conductorServices {
+		labels := conductorData["labels"].(map[string]string)
+		ports := conductorData["ports"].(map[string]*descriptors.PortInfo)
+
+		networkID := labels["op.network.id"]
+		if networkID == "" {
+			continue
+		}
+
+		// Find the network name from service name (e.g., "op-conductor-2151908-op-kurtosis-node0")
+		parts := strings.Split(conductorSvcName, "-")
+		var networkName string
+		if len(parts) >= 4 {
+			networkName = strings.Join(parts[2:len(parts)-1], "-")
+		}
+		if networkName == "" {
+			networkName = "unknown"
+		}
+
+		networkSequencers[networkName] = append(networkSequencers[networkName], conductorSvcName)
+
+		participantName := labels["op.network.participant.name"]
+		var nodeRPCURL string
+
+		// Look for matching op-node service
+		for _, nodeData := range opNodeServices {
+			nodeLabels := nodeData["labels"].(map[string]string)
+			nodePorts := nodeData["ports"].(map[string]*descriptors.PortInfo)
+
+			if nodeLabels["op.network.participant.name"] == participantName &&
+				nodeLabels["op.network.id"] == networkID {
+				if rpcPort, ok := nodePorts["rpc"]; ok {
+					nodeRPCURL = fmt.Sprintf("http://127.0.0.1:%d", rpcPort.Port)
+				}
+				break
+			}
+		}
+
+		var raftAddr, conductorRPCURL string
+
+		if consensusPort, ok := ports["consensus"]; ok {
+			raftAddr = fmt.Sprintf("127.0.0.1:%d", consensusPort.Port)
+		}
+
+		if rpcPort, ok := ports["rpc"]; ok {
+			conductorRPCURL = fmt.Sprintf("http://127.0.0.1:%d", rpcPort.Port)
+		}
+
+		sequencers[conductorSvcName] = &ConductorSequencer{
+			RaftAddr:        raftAddr,
+			ConductorRPCURL: conductorRPCURL,
+			NodeRPCURL:      nodeRPCURL,
+			Voting:          true,
+		}
+	}
+
+	for networkName, sequencerNames := range networkSequencers {
+		networks[networkName] = &ConductorNetwork{
+			Sequencers: sequencerNames,
+		}
+	}
+
+	return &ConductorConfig{
+		Networks:   networks,
+		Sequencers: sequencers,
+	}, nil
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/conductor_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/conductor_test.go
@@ -1,0 +1,86 @@
+package inspect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConductorConfig(t *testing.T) {
+	config := &ConductorConfig{
+		Networks: map[string]*ConductorNetwork{
+			"chain0": {Sequencers: []string{"seq0"}},
+			"chain1": {Sequencers: []string{"seq1"}},
+		},
+		Sequencers: map[string]*ConductorSequencer{
+			"seq0": {
+				RaftAddr:        "127.0.0.1:8001",
+				ConductorRPCURL: "http://127.0.0.1:8002",
+				NodeRPCURL:      "http://127.0.0.1:8003",
+				Voting:          true,
+			},
+			"seq1": {
+				RaftAddr:        "127.0.0.1:8011",
+				ConductorRPCURL: "http://127.0.0.1:8012",
+				NodeRPCURL:      "http://127.0.0.1:8013",
+				Voting:          false,
+			},
+		},
+	}
+
+	var buf strings.Builder
+	err := toml.NewEncoder(&buf).Encode(config)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "[networks]")
+	assert.Contains(t, output, "[sequencers]")
+	assert.Contains(t, output, "voting = true")
+	assert.Contains(t, output, "voting = false")
+
+	var decoded ConductorConfig
+	err = toml.Unmarshal([]byte(output), &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, config.Networks, decoded.Networks)
+	assert.Equal(t, config.Sequencers, decoded.Sequencers)
+}
+
+func TestConductorSequencer(t *testing.T) {
+	seq := &ConductorSequencer{
+		RaftAddr:        "localhost:8080",
+		ConductorRPCURL: "http://localhost:9090",
+		NodeRPCURL:      "http://localhost:7070",
+		Voting:          true,
+	}
+
+	assert.Equal(t, "localhost:8080", seq.RaftAddr)
+	assert.Equal(t, "http://localhost:9090", seq.ConductorRPCURL)
+	assert.True(t, seq.Voting)
+}
+
+func TestMultiChainConfig(t *testing.T) {
+	config := &ConductorConfig{
+		Networks: map[string]*ConductorNetwork{
+			"chain0": {Sequencers: []string{"seq0", "backup0"}},
+			"chain1": {Sequencers: []string{"seq1", "observer1"}},
+		},
+		Sequencers: map[string]*ConductorSequencer{
+			"seq0":      {RaftAddr: "127.0.0.1:8001", ConductorRPCURL: "http://127.0.0.1:8002", NodeRPCURL: "http://127.0.0.1:8003", Voting: true},
+			"backup0":   {RaftAddr: "127.0.0.1:8011", ConductorRPCURL: "http://127.0.0.1:8012", NodeRPCURL: "http://127.0.0.1:8013", Voting: true},
+			"seq1":      {RaftAddr: "127.0.0.1:8021", ConductorRPCURL: "http://127.0.0.1:8022", NodeRPCURL: "http://127.0.0.1:8023", Voting: true},
+			"observer1": {RaftAddr: "127.0.0.1:8031", ConductorRPCURL: "http://127.0.0.1:8032", NodeRPCURL: "http://127.0.0.1:8033", Voting: false},
+		},
+	}
+
+	assert.Len(t, config.Networks, 2)
+	assert.Len(t, config.Sequencers, 4)
+	assert.False(t, config.Sequencers["observer1"].Voting)
+
+	var buf strings.Builder
+	err := toml.NewEncoder(&buf).Encode(config)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "voting = false")
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/config.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/config.go
@@ -22,8 +22,8 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	cfg := &Config{
 		EnclaveID:           ctx.Args().Get(0),
 		FixTraefik:          ctx.Bool("fix-traefik"),
-		ConductorConfigPath: ctx.String("conductor-config"),
-		EnvironmentPath:     ctx.String("environment"),
+		ConductorConfigPath: ctx.String("conductor-config-path"),
+		EnvironmentPath:     ctx.String("environment-path"),
 	}
 
 	if cfg.EnclaveID == "" {

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/config.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/config.go
@@ -1,0 +1,34 @@
+package inspect
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+// Config holds the configuration for the inspect service
+type Config struct {
+	EnclaveID           string
+	FixTraefik          bool
+	ConductorConfigPath string
+	EnvironmentPath     string
+}
+
+func NewConfig(ctx *cli.Context) (*Config, error) {
+	if ctx.NArg() != 1 {
+		return nil, fmt.Errorf("expected exactly one argument (enclave-id), got %d", ctx.NArg())
+	}
+
+	cfg := &Config{
+		EnclaveID:           ctx.Args().Get(0),
+		FixTraefik:          ctx.Bool("fix-traefik"),
+		ConductorConfigPath: ctx.String("conductor-config"),
+		EnvironmentPath:     ctx.String("environment"),
+	}
+
+	if cfg.EnclaveID == "" {
+		return nil, fmt.Errorf("enclave-id is required")
+	}
+
+	return cfg, nil
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/config_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/config_test.go
@@ -1,0 +1,91 @@
+package inspect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestNewConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected *Config
+		wantErr  bool
+	}{
+		{
+			name: "valid config",
+			args: []string{"inspect", "test-enclave"},
+			expected: &Config{
+				EnclaveID:           "test-enclave",
+				FixTraefik:          false,
+				ConductorConfigPath: "",
+				EnvironmentPath:     "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with flags",
+			args: []string{
+				"inspect",
+				"--fix-traefik",
+				"--conductor-config", "/tmp/conductor.toml",
+				"--environment", "/tmp/env.json",
+				"my-enclave",
+			},
+			expected: &Config{
+				EnclaveID:           "my-enclave",
+				FixTraefik:          true,
+				ConductorConfigPath: "/tmp/conductor.toml",
+				EnvironmentPath:     "/tmp/env.json",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "no arguments",
+			args:     []string{"inspect"},
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "too many arguments",
+			args:     []string{"inspect", "enclave1", "enclave2"},
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &cli.App{
+				Name: "inspect",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "fix-traefik"},
+					&cli.StringFlag{Name: "conductor-config"},
+					&cli.StringFlag{Name: "environment"},
+				},
+				Action: func(ctx *cli.Context) error {
+					cfg, err := NewConfig(ctx)
+
+					if tt.wantErr {
+						assert.Error(t, err)
+						assert.Nil(t, cfg)
+					} else {
+						require.NoError(t, err)
+						require.NotNil(t, cfg)
+						assert.Equal(t, tt.expected.EnclaveID, cfg.EnclaveID)
+						assert.Equal(t, tt.expected.FixTraefik, cfg.FixTraefik)
+						assert.Equal(t, tt.expected.ConductorConfigPath, cfg.ConductorConfigPath)
+						assert.Equal(t, tt.expected.EnvironmentPath, cfg.EnvironmentPath)
+					}
+					return nil
+				},
+			}
+
+			err := app.Run(tt.args)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/config_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/config_test.go
@@ -31,8 +31,8 @@ func TestNewConfig(t *testing.T) {
 			args: []string{
 				"inspect",
 				"--fix-traefik",
-				"--conductor-config", "/tmp/conductor.toml",
-				"--environment", "/tmp/env.json",
+				"--conductor-config-path", "/tmp/conductor.toml",
+				"--environment-path", "/tmp/env.json",
 				"my-enclave",
 			},
 			expected: &Config{
@@ -63,8 +63,8 @@ func TestNewConfig(t *testing.T) {
 				Name: "inspect",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{Name: "fix-traefik"},
-					&cli.StringFlag{Name: "conductor-config"},
-					&cli.StringFlag{Name: "environment"},
+					&cli.StringFlag{Name: "conductor-config-path"},
+					&cli.StringFlag{Name: "environment-path"},
 				},
 				Action: func(ctx *cli.Context) error {
 					cfg, err := NewConfig(ctx)

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags.go
@@ -17,16 +17,16 @@ var (
 		Usage:   "Fix missing Traefik labels on containers",
 	}
 	ConductorConfig = &cli.StringFlag{
-		Name:    "conductor-config",
+		Name:    "conductor-config-path",
 		Value:   "",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "CONDUCTOR_CONFIG"),
-		Usage:   "Path to write conductor configuration TOML file",
+		Usage:   "Path where conductor configuration TOML file will be written (overwrites existing file)",
 	}
 	Environment = &cli.StringFlag{
-		Name:    "environment",
+		Name:    "environment-path",
 		Value:   "",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "ENVIRONMENT"),
-		Usage:   "Path to write environment JSON file",
+		Usage:   "Path where environment JSON file will be written (overwrites existing file)",
 	}
 )
 

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags.go
@@ -1,0 +1,50 @@
+package flags
+
+import (
+	"github.com/urfave/cli/v2"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+const EnvVarPrefix = "KURTOSIS_INSPECT"
+
+var (
+	FixTraefik = &cli.BoolFlag{
+		Name:    "fix-traefik",
+		Value:   false,
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "FIX_TRAEFIK"),
+		Usage:   "Fix missing Traefik labels on containers",
+	}
+	ConductorConfig = &cli.StringFlag{
+		Name:    "conductor-config",
+		Value:   "",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "CONDUCTOR_CONFIG"),
+		Usage:   "Path to write conductor configuration TOML file",
+	}
+	Environment = &cli.StringFlag{
+		Name:    "environment",
+		Value:   "",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "ENVIRONMENT"),
+		Usage:   "Path to write environment JSON file",
+	}
+)
+
+var requiredFlags = []cli.Flag{
+	// No required flags
+}
+
+var optionalFlags = []cli.Flag{
+	FixTraefik,
+	ConductorConfig,
+	Environment,
+}
+
+var Flags []cli.Flag
+
+func init() {
+	// Add common op-service flags
+	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
+
+	Flags = append(requiredFlags, optionalFlags...)
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags_test.go
@@ -1,0 +1,124 @@
+package flags
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		envVars  map[string]string
+		expected struct {
+			fixTraefik      bool
+			conductorConfig string
+			environment     string
+		}
+	}{
+		{
+			name: "default values",
+			args: []string{"inspect", "test-enclave"},
+			expected: struct {
+				fixTraefik      bool
+				conductorConfig string
+				environment     string
+			}{
+				fixTraefik:      false,
+				conductorConfig: "",
+				environment:     "",
+			},
+		},
+		{
+			name: "cli flags set",
+			args: []string{
+				"inspect",
+				"--fix-traefik",
+				"--conductor-config", "/tmp/conductor.toml",
+				"--environment", "/tmp/env.json",
+				"test-enclave",
+			},
+			expected: struct {
+				fixTraefik      bool
+				conductorConfig string
+				environment     string
+			}{
+				fixTraefik:      true,
+				conductorConfig: "/tmp/conductor.toml",
+				environment:     "/tmp/env.json",
+			},
+		},
+		{
+			name: "environment variables",
+			args: []string{"inspect", "test-enclave"},
+			envVars: map[string]string{
+				"KURTOSIS_INSPECT_FIX_TRAEFIK":      "true",
+				"KURTOSIS_INSPECT_CONDUCTOR_CONFIG": "/env/conductor.toml",
+				"KURTOSIS_INSPECT_ENVIRONMENT":      "/env/env.json",
+			},
+			expected: struct {
+				fixTraefik      bool
+				conductorConfig string
+				environment     string
+			}{
+				fixTraefik:      true,
+				conductorConfig: "/env/conductor.toml",
+				environment:     "/env/env.json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+				defer os.Unsetenv(key)
+			}
+
+			app := &cli.App{
+				Name:  "inspect",
+				Flags: Flags,
+				Action: func(ctx *cli.Context) error {
+					assert.Equal(t, tt.expected.fixTraefik, ctx.Bool("fix-traefik"))
+					assert.Equal(t, tt.expected.conductorConfig, ctx.String("conductor-config"))
+					assert.Equal(t, tt.expected.environment, ctx.String("environment"))
+					return nil
+				},
+			}
+
+			err := app.Run(tt.args)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFlagDefinitions(t *testing.T) {
+	flagNames := make(map[string]bool)
+	for _, flag := range Flags {
+		for _, name := range flag.Names() {
+			flagNames[name] = true
+		}
+	}
+
+	assert.True(t, flagNames["fix-traefik"])
+	assert.True(t, flagNames["conductor-config"])
+	assert.True(t, flagNames["environment"])
+	assert.True(t, flagNames["log.level"])
+}
+
+func TestEnvVarPrefix(t *testing.T) {
+	assert.Equal(t, "KURTOSIS_INSPECT", EnvVarPrefix)
+}
+
+func TestFlagStructure(t *testing.T) {
+	assert.NotEmpty(t, Flags)
+	assert.Contains(t, optionalFlags, FixTraefik)
+	assert.Contains(t, optionalFlags, ConductorConfig)
+	assert.Contains(t, optionalFlags, Environment)
+	assert.Empty(t, requiredFlags)
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/flags/flags_test.go
@@ -38,8 +38,8 @@ func TestFlags(t *testing.T) {
 			args: []string{
 				"inspect",
 				"--fix-traefik",
-				"--conductor-config", "/tmp/conductor.toml",
-				"--environment", "/tmp/env.json",
+				"--conductor-config-path", "/tmp/conductor.toml",
+				"--environment-path", "/tmp/env.json",
 				"test-enclave",
 			},
 			expected: struct {
@@ -85,8 +85,8 @@ func TestFlags(t *testing.T) {
 				Flags: Flags,
 				Action: func(ctx *cli.Context) error {
 					assert.Equal(t, tt.expected.fixTraefik, ctx.Bool("fix-traefik"))
-					assert.Equal(t, tt.expected.conductorConfig, ctx.String("conductor-config"))
-					assert.Equal(t, tt.expected.environment, ctx.String("environment"))
+					assert.Equal(t, tt.expected.conductorConfig, ctx.String("conductor-config-path"))
+					assert.Equal(t, tt.expected.environment, ctx.String("environment-path"))
 					return nil
 				},
 			}
@@ -106,8 +106,8 @@ func TestFlagDefinitions(t *testing.T) {
 	}
 
 	assert.True(t, flagNames["fix-traefik"])
-	assert.True(t, flagNames["conductor-config"])
-	assert.True(t, flagNames["environment"])
+	assert.True(t, flagNames["conductor-config-path"])
+	assert.True(t, flagNames["environment-path"])
 	assert.True(t, flagNames["log.level"])
 }
 

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/inspect_test.go
@@ -1,0 +1,76 @@
+package inspect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+)
+
+func TestNewInspector(t *testing.T) {
+	inspector := NewInspector("test-enclave")
+	assert.NotNil(t, inspector)
+	assert.Equal(t, "test-enclave", inspector.enclaveID)
+}
+
+func TestShortenedUUIDString(t *testing.T) {
+	assert.Equal(t, "f47ac10b-58c", ShortenedUUIDString("f47ac10b-58cc-4372-a567-0e02b2c3d479"))
+	assert.Equal(t, "abc", ShortenedUUIDString("abc"))
+	assert.Equal(t, "", ShortenedUUIDString(""))
+	assert.Equal(t, "123456789012", ShortenedUUIDString("123456789012"))
+	assert.Equal(t, "test2-devnet", ShortenedUUIDString("test2-devnet-2151908"))
+}
+
+func TestInspectData(t *testing.T) {
+	data := &InspectData{
+		FileArtifacts: []string{"genesis.json", "jwt.txt"},
+		UserServices: ServiceMap{
+			"op-node": &Service{
+				Labels: map[string]string{"app": "op-node", "role": "sequencer"},
+				Ports: PortMap{
+					"rpc": &descriptors.PortInfo{Host: "127.0.0.1", Port: 8545},
+					"p2p": &descriptors.PortInfo{Host: "127.0.0.1", Port: 9222},
+				},
+			},
+		},
+	}
+
+	assert.Len(t, data.FileArtifacts, 2)
+	assert.Len(t, data.UserServices, 1)
+	assert.Contains(t, data.FileArtifacts, "genesis.json")
+
+	service := data.UserServices["op-node"]
+	assert.Equal(t, "op-node", service.Labels["app"])
+	assert.Equal(t, "sequencer", service.Labels["role"])
+
+	rpcPort, exists := service.Ports["rpc"]
+	require.True(t, exists)
+	assert.Equal(t, 8545, rpcPort.Port)
+
+	_, exists = service.Ports["nonexistent"]
+	assert.False(t, exists)
+}
+
+func TestServiceMap(t *testing.T) {
+	services := ServiceMap{
+		"seq0":      &Service{Labels: map[string]string{"role": "sequencer"}, Ports: PortMap{"rpc": &descriptors.PortInfo{Port: 8545}}},
+		"seq1":      &Service{Labels: map[string]string{"role": "sequencer"}, Ports: PortMap{"rpc": &descriptors.PortInfo{Port: 8645}}},
+		"conductor": &Service{Labels: map[string]string{"app": "conductor"}, Ports: PortMap{"rpc": &descriptors.PortInfo{Port: 8547}}},
+	}
+
+	assert.Len(t, services, 3)
+
+	seq0, exists := services["seq0"]
+	require.True(t, exists)
+	assert.Equal(t, "sequencer", seq0.Labels["role"])
+
+	sequencerCount := 0
+	for _, svc := range services {
+		if svc.Labels["role"] == "sequencer" {
+			sequencerCount++
+		}
+	}
+	assert.Equal(t, 2, sequencerCount)
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/service.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/service.go
@@ -1,0 +1,150 @@
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/kurtosis-devnet/pkg/util"
+)
+
+// InspectService handles the core inspection functionality
+type InspectService struct {
+	cfg *Config
+	log log.Logger
+}
+
+func NewInspectService(cfg *Config, log log.Logger) *InspectService {
+	return &InspectService{
+		cfg: cfg,
+		log: log,
+	}
+}
+
+func (s *InspectService) Run(ctx context.Context) error {
+	if s.cfg.FixTraefik {
+		return s.fixTraefik(ctx)
+	}
+
+	return s.inspect(ctx)
+}
+
+func (s *InspectService) fixTraefik(ctx context.Context) error {
+	s.log.Info("Fixing Traefik network configuration...")
+	fmt.Println("🔧 Fixing Traefik network configuration...")
+
+	if err := util.SetReverseProxyConfig(ctx); err != nil {
+		return fmt.Errorf("error setting reverse proxy config: %w", err)
+	}
+
+	s.log.Info("Traefik network configuration fixed")
+	fmt.Println("✅ Traefik network configuration fixed!")
+	return nil
+}
+
+func (s *InspectService) inspect(ctx context.Context) error {
+	inspector := NewInspector(s.cfg.EnclaveID)
+
+	data, err := inspector.ExtractData(ctx)
+	if err != nil {
+		return fmt.Errorf("error inspecting enclave: %w", err)
+	}
+
+	conductorConfig, err := ExtractConductorConfig(ctx, s.cfg.EnclaveID)
+	if err != nil {
+		s.log.Warn("Error extracting conductor configuration", "error", err)
+	}
+
+	s.displayResults(data, conductorConfig)
+
+	if err := s.writeFiles(data, conductorConfig); err != nil {
+		return fmt.Errorf("error writing output files: %w", err)
+	}
+
+	return nil
+}
+
+func (s *InspectService) displayResults(data *InspectData, conductorConfig *ConductorConfig) {
+	fmt.Println("File Artifacts:")
+	for _, artifact := range data.FileArtifacts {
+		fmt.Printf("  %s\n", artifact)
+	}
+
+	fmt.Println("\nServices:")
+	for name, svc := range data.UserServices {
+		fmt.Printf("  %s:\n", name)
+		for portName, portInfo := range svc.Ports {
+			host := portInfo.Host
+			if host == "" {
+				host = "localhost"
+			}
+			fmt.Printf("    %s: %s:%d\n", portName, host, portInfo.Port)
+		}
+	}
+
+	if conductorConfig != nil {
+		fmt.Println("\nConductor Configuration:")
+		fmt.Println("========================")
+
+		if err := toml.NewEncoder(os.Stdout).Encode(conductorConfig); err != nil {
+			s.log.Error("Error marshaling conductor config to TOML", "error", err)
+		}
+	}
+}
+
+func (s *InspectService) writeFiles(data *InspectData, conductorConfig *ConductorConfig) error {
+	if s.cfg.ConductorConfigPath != "" {
+		if conductorConfig == nil {
+			s.log.Info("No conductor services found, skipping conductor config generation")
+		} else {
+			if err := s.writeConductorConfig(s.cfg.ConductorConfigPath, conductorConfig); err != nil {
+				return fmt.Errorf("error writing conductor config file: %w", err)
+			}
+			fmt.Printf("Conductor configuration saved to: %s\n", s.cfg.ConductorConfigPath)
+		}
+	}
+
+	if s.cfg.EnvironmentPath != "" {
+		if err := s.writeEnvironment(s.cfg.EnvironmentPath, data); err != nil {
+			return fmt.Errorf("error writing environment file: %w", err)
+		}
+		fmt.Printf("Environment data saved to: %s\n", s.cfg.EnvironmentPath)
+	}
+
+	return nil
+}
+
+func (s *InspectService) writeConductorConfig(path string, config *ConductorConfig) error {
+	out, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("error creating conductor config file: %w", err)
+	}
+	defer out.Close()
+
+	encoder := toml.NewEncoder(out)
+	if err := encoder.Encode(config); err != nil {
+		return fmt.Errorf("error encoding conductor config as TOML: %w", err)
+	}
+
+	return nil
+}
+
+func (s *InspectService) writeEnvironment(path string, data *InspectData) error {
+	out, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("error creating environment file: %w", err)
+	}
+	defer out.Close()
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		return fmt.Errorf("error encoding environment: %w", err)
+	}
+
+	return nil
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/service_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/service_test.go
@@ -1,0 +1,66 @@
+package inspect
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
+)
+
+func TestInspectService(t *testing.T) {
+	cfg := &Config{EnclaveID: "test-enclave"}
+	service := NewInspectService(cfg, log.New())
+
+	assert.NotNil(t, service)
+	assert.Equal(t, cfg, service.cfg)
+}
+
+func TestFileWriting(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test-files")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	cfg := &Config{
+		EnclaveID:           "test-enclave",
+		ConductorConfigPath: filepath.Join(tempDir, "conductor.toml"),
+		EnvironmentPath:     filepath.Join(tempDir, "environment.json"),
+	}
+	service := NewInspectService(cfg, log.New())
+
+	conductorConfig := &ConductorConfig{
+		Networks:   map[string]*ConductorNetwork{"chain": {Sequencers: []string{"seq"}}},
+		Sequencers: map[string]*ConductorSequencer{"seq": {RaftAddr: "127.0.0.1:8001", ConductorRPCURL: "http://127.0.0.1:8002", NodeRPCURL: "http://127.0.0.1:8003", Voting: true}},
+	}
+
+	inspectData := &InspectData{
+		FileArtifacts: []string{"genesis.json", "jwt.txt"},
+		UserServices: ServiceMap{
+			"op-node": &Service{
+				Labels: map[string]string{"app": "op-node"},
+				Ports:  PortMap{"rpc": &descriptors.PortInfo{Host: "127.0.0.1", Port: 8545}},
+			},
+		},
+	}
+
+	err = service.writeFiles(inspectData, conductorConfig)
+	require.NoError(t, err)
+
+	assert.FileExists(t, cfg.ConductorConfigPath)
+	assert.FileExists(t, cfg.EnvironmentPath)
+
+	content, err := ioutil.ReadFile(cfg.ConductorConfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "[networks]")
+	assert.Contains(t, string(content), "[sequencers]")
+
+	envContent, err := ioutil.ReadFile(cfg.EnvironmentPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(envContent), "genesis.json")
+	assert.Contains(t, string(envContent), "op-node")
+}

--- a/kurtosis-devnet/pkg/kurtosis/sources/inspect/service_test.go
+++ b/kurtosis-devnet/pkg/kurtosis/sources/inspect/service_test.go
@@ -1,7 +1,6 @@
 package inspect
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,9 +21,7 @@ func TestInspectService(t *testing.T) {
 }
 
 func TestFileWriting(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test-files")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	cfg := &Config{
 		EnclaveID:           "test-enclave",
@@ -48,18 +45,18 @@ func TestFileWriting(t *testing.T) {
 		},
 	}
 
-	err = service.writeFiles(inspectData, conductorConfig)
+	err := service.writeFiles(inspectData, conductorConfig)
 	require.NoError(t, err)
 
 	assert.FileExists(t, cfg.ConductorConfigPath)
 	assert.FileExists(t, cfg.EnvironmentPath)
 
-	content, err := ioutil.ReadFile(cfg.ConductorConfigPath)
+	content, err := os.ReadFile(cfg.ConductorConfigPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "[networks]")
 	assert.Contains(t, string(content), "[sequencers]")
 
-	envContent, err := ioutil.ReadFile(cfg.EnvironmentPath)
+	envContent, err := os.ReadFile(cfg.EnvironmentPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(envContent), "genesis.json")
 	assert.Contains(t, string(envContent), "op-node")

--- a/kurtosis-devnet/tests/.gitignore
+++ b/kurtosis-devnet/tests/.gitignore
@@ -1,1 +1,2 @@
 *.json
+*.toml


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR adds support to kurtosis-devnet (and the kurtosis inspect tool) to create op-conductor-ops configurations so that they can be quickly leveraged. These configurations will be created by default under `kurtosis-devnet/tests/op-conductor-ops-<enclave>.toml`

One can also directly leverage the inspect tool to get the yaml configuration.
`go run optimism/kurtosis-devnet/pkg/kurtosis/sources/inspect/cmd/main.go <enclave name>`

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
