### PR TITLE
feat(op-acceptance-tests): op-acceptor v2.0.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,7 @@ anvil = "1.1.0"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v1.1.1"
+op-acceptor = "op-acceptor/v2.0.0"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't


### PR DESCRIPTION
Upgrades op-acceptor to [v2.0.0](https://github.com/ethereum-optimism/infra/releases/tag/op-acceptor%2Fv2.0.0)
