### PR TITLE
op-batcher: more consistent use of throttle multiplier and max threshold in logging 

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -660,7 +660,7 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 	l.Log.Info("Starting DA throttling loop",
 		"controller_type", l.throttleController.GetType(),
 		"threshold", l.Config.ThrottleParams.Threshold,
-		"max_threshold", float64(l.Config.ThrottleParams.Threshold)*l.Config.ThrottleParams.ThresholdMultiplier,
+		"max_threshold", l.Config.ThrottleParams.MaxThreshold(),
 	)
 	updateChans := make([]chan struct{}, len(l.Config.ThrottleParams.Endpoints))
 
@@ -1111,11 +1111,7 @@ func (l *BatchSubmitter) SetThrottleController(newType config.ThrottleController
 
 	newController, err := factory.CreateController(
 		newType,
-		l.Config.ThrottleParams.Threshold,
-		l.Config.ThrottleParams.TxSize,
-		l.Config.ThrottleParams.BlockSize,
-		l.Config.ThrottleParams.AlwaysBlockSize,
-		l.Config.ThrottleParams.ThresholdMultiplier,
+		l.Config.ThrottleParams,
 		pidControllerConfig,
 	)
 	if err != nil {
@@ -1160,7 +1156,7 @@ func (l *BatchSubmitter) GetThrottleControllerInfo() (config.ThrottleControllerI
 	info := config.ThrottleControllerInfo{
 		Type:         string(controllerType),
 		Threshold:    l.Config.ThrottleParams.Threshold,
-		MaxThreshold: float64(l.Config.ThrottleParams.Threshold) * l.Config.ThrottleParams.ThresholdMultiplier,
+		MaxThreshold: l.Config.ThrottleParams.MaxThreshold(),
 		CurrentLoad:  currentLoad,
 		Intensity:    params.Intensity,
 		MaxTxSize:    params.MaxTxSize,

--- a/op-batcher/batcher/throttler/controller_test.go
+++ b/op-batcher/batcher/throttler/controller_test.go
@@ -89,10 +89,10 @@ var (
 		return NewStepStrategy(TestThresholdBytes)
 	}
 	testLinearStrategy = func(t *testing.T) *LinearStrategy {
-		return NewLinearStrategy(TestThresholdBytes, TestThresholdMultiplier, newTestLogger(t))
+		return NewLinearStrategy(TestThresholdBytes, TestThresholdMultiplier*TestThresholdBytes, newTestLogger(t))
 	}
 	testQuadraticStrategy = func(t *testing.T) *QuadraticStrategy {
-		return NewQuadraticStrategy(TestThresholdBytes, TestThresholdMultiplier, newTestLogger(t))
+		return NewQuadraticStrategy(TestThresholdBytes, TestThresholdMultiplier*TestThresholdBytes, newTestLogger(t))
 	}
 	testPIDStrategy = func(t *testing.T) *PIDStrategy {
 		return NewPIDStrategy(TestThresholdBytes, TestPIDConfig)

--- a/op-batcher/batcher/throttler/controller_test.go
+++ b/op-batcher/batcher/throttler/controller_test.go
@@ -177,7 +177,13 @@ func TestControllerFactory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller, err := factory.CreateController(
-				tt.controllerType, TestThresholdBytes, TestThrottleTxSize, TestThrottleBlockSize, TestAlwaysBlockSize, TestThresholdMultiplier, tt.pidConfig)
+				tt.controllerType, config.ThrottleParams{
+					Threshold:           TestThresholdBytes,
+					TxSize:              TestThrottleTxSize,
+					BlockSize:           TestThrottleBlockSize,
+					AlwaysBlockSize:     TestAlwaysBlockSize,
+					ThresholdMultiplier: TestThresholdMultiplier,
+				}, tt.pidConfig)
 
 			if tt.expectError {
 				if err == nil {
@@ -310,7 +316,13 @@ func TestControllerTypeConsistency(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(string(tc.controllerType), func(t *testing.T) {
 			controller, err := factory.CreateController(
-				tc.controllerType, TestThresholdBytes, TestThrottleTxSize, TestThrottleBlockSize, TestAlwaysBlockSize, TestThresholdMultiplier, tc.pidConfig)
+				tc.controllerType, config.ThrottleParams{
+					Threshold:           TestThresholdBytes,
+					TxSize:              TestThrottleTxSize,
+					BlockSize:           TestThrottleBlockSize,
+					AlwaysBlockSize:     TestAlwaysBlockSize,
+					ThresholdMultiplier: TestThresholdMultiplier,
+				}, tc.pidConfig)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/op-batcher/batcher/throttler/linear_strategy.go
+++ b/op-batcher/batcher/throttler/linear_strategy.go
@@ -16,13 +16,11 @@ type LinearStrategy struct {
 	currentIntensity float64
 }
 
-func NewLinearStrategy(threshold uint64, multiplier float64, log log.Logger) *LinearStrategy {
-	maxThreshold := uint64(float64(threshold) * multiplier)
-	// Ensure maxThreshold is always greater than threshold to prevent division by zero
+func NewLinearStrategy(threshold uint64, maxThreshold uint64, log log.Logger) *LinearStrategy {
 	if maxThreshold <= threshold {
-		maxThreshold = threshold + 1
-		log.Warn("maxThreshold is less than or equal to threshold, setting maxThreshold to threshold + 1", "threshold", threshold, "multiplier", multiplier, "maxThreshold", maxThreshold)
+		panic("maxThreshold must be greater than threshold")
 	}
+
 	return &LinearStrategy{
 		threshold:        threshold,
 		maxThreshold:     maxThreshold,

--- a/op-batcher/batcher/throttler/linear_strategy_test.go
+++ b/op-batcher/batcher/throttler/linear_strategy_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestLinearStrategy_NewLinearStrategy(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	if strategy.threshold != TestLinearThreshold {
 		t.Errorf("expected threshold %d, got %d", TestLinearThreshold, strategy.threshold)
@@ -41,7 +41,7 @@ func TestLinearStrategy_NewLinearStrategy(t *testing.T) {
 }
 
 func TestLinearStrategy_Update(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	tests := []struct {
 		name              string
@@ -117,7 +117,7 @@ func TestLinearStrategy_Update(t *testing.T) {
 }
 
 func TestLinearStrategy_LinearScaling(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	// Test that intensity scales linearly between threshold and maxThreshold
 	testPoints := []struct {
@@ -145,7 +145,7 @@ func TestLinearStrategy_LinearScaling(t *testing.T) {
 }
 
 func TestLinearStrategy_GetType(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	if strategy.GetType() != config.LinearControllerType {
 		t.Errorf("expected GetType() to return %s, got %s", config.LinearControllerType, strategy.GetType())
@@ -153,7 +153,7 @@ func TestLinearStrategy_GetType(t *testing.T) {
 }
 
 func TestLinearStrategy_Reset(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	// Update to build some state
 	strategy.Update(TestLinearMaxThreshold)
@@ -195,7 +195,7 @@ func TestLinearStrategy_EdgeCases(t *testing.T) {
 }
 
 func TestLinearStrategy_Load(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	// Test load consistency after update
 	updateIntensity := strategy.Update(TestLinearThreshold + TestLinearThreshold/2)
@@ -211,7 +211,7 @@ func TestLinearStrategy_Load(t *testing.T) {
 }
 
 func TestLinearStrategy_IntensityProgression(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMaxThreshold, newTestLogger(t))
 
 	// Test that intensity increases properly as load increases
 	loads := []uint64{

--- a/op-batcher/batcher/throttler/linear_strategy_test.go
+++ b/op-batcher/batcher/throttler/linear_strategy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/config"
+	"github.com/stretchr/testify/require"
 )
 
 // Test constants specific to linear strategy
@@ -171,30 +172,17 @@ func TestLinearStrategy_Reset(t *testing.T) {
 }
 
 func TestLinearStrategy_EdgeCases(t *testing.T) {
-	t.Run("multiplier less than 1", func(t *testing.T) {
-		// Test when multiplier results in maxThreshold <= threshold
-		strategy := NewLinearStrategy(TestLinearThreshold, 0.5, newTestLogger(t))
+	t.Run("max threshold less than threshold", func(t *testing.T) {
 
-		// Should handle this gracefully without division by zero
-		intensity := strategy.Update(TestLinearThreshold * 2)
+		require.Panics(t, func() {
+			// Test when multiplier results in maxThreshold <= threshold
+			NewLinearStrategy(TestLinearThreshold, 0, newTestLogger(t))
+		})
 
-		if intensity < TestIntensityMin || intensity > TestIntensityMax {
-			t.Errorf("expected valid intensity [%f,%f], got %f", TestIntensityMin, TestIntensityMax, intensity)
-		}
-	})
-
-	t.Run("zero threshold", func(t *testing.T) {
-		strategy := NewLinearStrategy(0, TestLinearMultiplier, newTestLogger(t))
-
-		intensity := strategy.Update(1)
-
-		if intensity != TestIntensityMax {
-			t.Errorf("expected maximum intensity with zero threshold, got %f", intensity)
-		}
 	})
 
 	t.Run("very large multiplier", func(t *testing.T) {
-		strategy := NewLinearStrategy(TestLinearThreshold, 100.0, newTestLogger(t))
+		strategy := NewLinearStrategy(TestLinearThreshold, TestLinearThreshold*2000, newTestLogger(t))
 
 		// Even with very large multiplier, should work correctly
 		intensity := strategy.Update(TestLinearThreshold * 2)

--- a/op-batcher/batcher/throttler/linear_strategy_test.go
+++ b/op-batcher/batcher/throttler/linear_strategy_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestLinearStrategy_NewLinearStrategy(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	if strategy.threshold != TestLinearThreshold {
 		t.Errorf("expected threshold %d, got %d", TestLinearThreshold, strategy.threshold)
@@ -41,7 +41,7 @@ func TestLinearStrategy_NewLinearStrategy(t *testing.T) {
 }
 
 func TestLinearStrategy_Update(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	tests := []struct {
 		name              string
@@ -117,7 +117,7 @@ func TestLinearStrategy_Update(t *testing.T) {
 }
 
 func TestLinearStrategy_LinearScaling(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	// Test that intensity scales linearly between threshold and maxThreshold
 	testPoints := []struct {
@@ -145,7 +145,7 @@ func TestLinearStrategy_LinearScaling(t *testing.T) {
 }
 
 func TestLinearStrategy_GetType(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	if strategy.GetType() != config.LinearControllerType {
 		t.Errorf("expected GetType() to return %s, got %s", config.LinearControllerType, strategy.GetType())
@@ -153,7 +153,7 @@ func TestLinearStrategy_GetType(t *testing.T) {
 }
 
 func TestLinearStrategy_Reset(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	// Update to build some state
 	strategy.Update(TestLinearMaxThreshold)
@@ -195,7 +195,7 @@ func TestLinearStrategy_EdgeCases(t *testing.T) {
 }
 
 func TestLinearStrategy_Load(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	// Test load consistency after update
 	updateIntensity := strategy.Update(TestLinearThreshold + TestLinearThreshold/2)
@@ -211,7 +211,7 @@ func TestLinearStrategy_Load(t *testing.T) {
 }
 
 func TestLinearStrategy_IntensityProgression(t *testing.T) {
-	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier, newTestLogger(t))
+	strategy := NewLinearStrategy(TestLinearThreshold, TestLinearMultiplier*TestLinearThreshold, newTestLogger(t))
 
 	// Test that intensity increases properly as load increases
 	loads := []uint64{

--- a/op-batcher/batcher/throttler/quadratic_strategy.go
+++ b/op-batcher/batcher/throttler/quadratic_strategy.go
@@ -16,12 +16,9 @@ type QuadraticStrategy struct {
 	currentIntensity float64
 }
 
-func NewQuadraticStrategy(threshold uint64, multiplier float64, log log.Logger) *QuadraticStrategy {
-	maxThreshold := uint64(float64(threshold) * multiplier)
-	// Ensure maxThreshold is always greater than threshold to prevent division by zero
+func NewQuadraticStrategy(threshold uint64, maxThreshold uint64, log log.Logger) *QuadraticStrategy {
 	if maxThreshold <= threshold {
-		maxThreshold = threshold + 1
-		log.Warn("maxThreshold is less than or equal to threshold, setting maxThreshold to threshold + 1", "threshold", threshold, "multiplier", multiplier, "maxThreshold", maxThreshold)
+		panic("maxThreshold must be greater than threshold")
 	}
 	return &QuadraticStrategy{
 		threshold:        threshold,

--- a/op-batcher/batcher/throttler/quadratic_strategy_test.go
+++ b/op-batcher/batcher/throttler/quadratic_strategy_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestQuadraticStrategy_NewQuadraticStrategy(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	if strategy.threshold != TestQuadraticThreshold {
 		t.Errorf("expected threshold %d, got %d", TestQuadraticThreshold, strategy.threshold)
@@ -41,7 +41,7 @@ func TestQuadraticStrategy_NewQuadraticStrategy(t *testing.T) {
 }
 
 func TestQuadraticStrategy_Update(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	tests := []struct {
 		name              string
@@ -117,7 +117,7 @@ func TestQuadraticStrategy_Update(t *testing.T) {
 }
 
 func TestQuadraticStrategy_QuadraticScaling(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	// Test that intensity scales quadratically between threshold and maxThreshold
 	testPoints := []struct {
@@ -145,7 +145,7 @@ func TestQuadraticStrategy_QuadraticScaling(t *testing.T) {
 }
 
 func TestQuadraticStrategy_GetType(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	if strategy.GetType() != config.QuadraticControllerType {
 		t.Errorf("expected GetType() to return %s, got %s", config.QuadraticControllerType, strategy.GetType())
@@ -153,7 +153,7 @@ func TestQuadraticStrategy_GetType(t *testing.T) {
 }
 
 func TestQuadraticStrategy_Reset(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	// Update to build some state
 	strategy.Update(TestQuadraticMaxThreshold)
@@ -193,7 +193,7 @@ func TestQuadraticStrategy_EdgeCases(t *testing.T) {
 }
 
 func TestQuadraticStrategy_Load(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	// Test load consistency after update
 	updateIntensity := strategy.Update(TestQuadraticThreshold + TestQuadraticThreshold/2)
@@ -209,7 +209,7 @@ func TestQuadraticStrategy_Load(t *testing.T) {
 }
 
 func TestQuadraticStrategy_IntensityProgression(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
 
 	// Test that intensity increases properly as load increases
 	loads := []uint64{

--- a/op-batcher/batcher/throttler/quadratic_strategy_test.go
+++ b/op-batcher/batcher/throttler/quadratic_strategy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/config"
+	"github.com/stretchr/testify/require"
 )
 
 // Test constants specific to quadratic strategy
@@ -171,35 +172,20 @@ func TestQuadraticStrategy_Reset(t *testing.T) {
 }
 
 func TestQuadraticStrategy_EdgeCases(t *testing.T) {
-	t.Run("multiplier less than 1", func(t *testing.T) {
-		// Test when multiplier results in maxThreshold <= threshold
-		strategy := NewQuadraticStrategy(TestQuadraticThreshold, 0.5, newTestLogger(t))
-
-		// Should handle this gracefully without division by zero
-		intensity := strategy.Update(TestQuadraticThreshold * 2)
-
-		if intensity < TestIntensityMin || intensity > TestIntensityMax {
-			t.Errorf("expected valid intensity [%f,%f], got %f", TestIntensityMin, TestIntensityMax, intensity)
-		}
-	})
-
-	t.Run("zero threshold", func(t *testing.T) {
-		strategy := NewQuadraticStrategy(0, TestQuadraticMultiplier, newTestLogger(t))
-
-		intensity := strategy.Update(1)
-
-		if intensity != TestIntensityMax {
-			t.Errorf("expected maximum intensity with zero threshold, got %f", intensity)
-		}
+	t.Run("max threshold less than threshold", func(t *testing.T) {
+		require.Panics(t, func() {
+			// Test when multiplier results in maxThreshold <= threshold
+			NewQuadraticStrategy(TestQuadraticThreshold, 0, newTestLogger(t))
+		})
 	})
 
 	t.Run("very large multiplier", func(t *testing.T) {
-		strategy := NewQuadraticStrategy(TestQuadraticThreshold, 100.0, newTestLogger(t))
+		strategy := NewQuadraticStrategy(TestLinearThreshold, TestLinearThreshold*2000, newTestLogger(t))
 
 		// Even with very large multiplier, should work correctly
-		intensity := strategy.Update(TestQuadraticThreshold * 2)
+		intensity := strategy.Update(TestLinearThreshold * 2)
 
-		// Should be very low intensity due to large range and quadratic scaling
+		// Should be very low intensity due to large range and linear scaling
 		if intensity > 0.05 {
 			t.Errorf("expected very low intensity with large multiplier, got %f", intensity)
 		}

--- a/op-batcher/batcher/throttler/quadratic_strategy_test.go
+++ b/op-batcher/batcher/throttler/quadratic_strategy_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestQuadraticStrategy_NewQuadraticStrategy(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	if strategy.threshold != TestQuadraticThreshold {
 		t.Errorf("expected threshold %d, got %d", TestQuadraticThreshold, strategy.threshold)
@@ -41,7 +41,7 @@ func TestQuadraticStrategy_NewQuadraticStrategy(t *testing.T) {
 }
 
 func TestQuadraticStrategy_Update(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	tests := []struct {
 		name              string
@@ -117,7 +117,7 @@ func TestQuadraticStrategy_Update(t *testing.T) {
 }
 
 func TestQuadraticStrategy_QuadraticScaling(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	// Test that intensity scales quadratically between threshold and maxThreshold
 	testPoints := []struct {
@@ -145,7 +145,7 @@ func TestQuadraticStrategy_QuadraticScaling(t *testing.T) {
 }
 
 func TestQuadraticStrategy_GetType(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	if strategy.GetType() != config.QuadraticControllerType {
 		t.Errorf("expected GetType() to return %s, got %s", config.QuadraticControllerType, strategy.GetType())
@@ -153,7 +153,7 @@ func TestQuadraticStrategy_GetType(t *testing.T) {
 }
 
 func TestQuadraticStrategy_Reset(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	// Update to build some state
 	strategy.Update(TestQuadraticMaxThreshold)
@@ -193,7 +193,7 @@ func TestQuadraticStrategy_EdgeCases(t *testing.T) {
 }
 
 func TestQuadraticStrategy_Load(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	// Test load consistency after update
 	updateIntensity := strategy.Update(TestQuadraticThreshold + TestQuadraticThreshold/2)
@@ -209,7 +209,7 @@ func TestQuadraticStrategy_Load(t *testing.T) {
 }
 
 func TestQuadraticStrategy_IntensityProgression(t *testing.T) {
-	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMultiplier*TestQuadraticThreshold, newTestLogger(t))
+	strategy := NewQuadraticStrategy(TestQuadraticThreshold, TestQuadraticMaxThreshold, newTestLogger(t))
 
 	// Test that intensity increases properly as load increases
 	loads := []uint64{

--- a/op-batcher/config/types.go
+++ b/op-batcher/config/types.go
@@ -36,7 +36,7 @@ func (t ThrottleControllerType) String() string {
 type ThrottleControllerInfo struct {
 	Type         string  `json:"type"`
 	Threshold    uint64  `json:"threshold"`
-	MaxThreshold float64 `json:"max_threshold"`
+	MaxThreshold uint64  `json:"max_threshold"`
 	CurrentLoad  uint64  `json:"current_load"`
 	Intensity    float64 `json:"intensity"`
 	MaxTxSize    uint64  `json:"max_tx_size"`
@@ -96,4 +96,8 @@ type ThrottleParams struct {
 	PIDConfig           *PIDConfig
 	ControllerType      ThrottleControllerType
 	Endpoints           []string
+}
+
+func (t *ThrottleParams) MaxThreshold() uint64 {
+	return uint64(float64(t.Threshold) * t.ThresholdMultiplier)
 }


### PR DESCRIPTION
Follow up to #16804, avoids making the same computation by hand in multiple places.

Also firms up how we handle multipliers less than one. In unit tests and other invocations of the throttling code as a library, we will just panic if we have such a case. In production, the CLI config will throw a descriptive error if an invalid multiplier is passed in. 