### PR TITLE
op-devstack: integrate op-sync-tester service

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -1,0 +1,14 @@
+package sync_tester
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithMinimalWithSyncTester(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_test.go
@@ -1,0 +1,25 @@
+package sync_tester
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestSyncTester(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimalWithSyncTester(t)
+	require := t.Require()
+
+	dsl.CheckAll(t, sys.L2CL.AdvancedFn(types.LocalUnsafe, 5, 30))
+
+	syncTester := sys.SyncTester.Escape()
+
+	chainID, err := syncTester.API().ChainID(t.Ctx())
+	require.NoError(err)
+
+	require.Equal(chainID, sys.L2EL.ChainID())
+}

--- a/op-devstack/dsl/sync_tester.go
+++ b/op-devstack/dsl/sync_tester.go
@@ -1,0 +1,22 @@
+package dsl
+
+import "github.com/ethereum-optimism/optimism/op-devstack/stack"
+
+// SyncTester wraps a stack.SyncTester interface for DSL operations
+type SyncTester struct {
+	commonImpl
+	inner stack.SyncTester
+}
+
+// NewSyncTester creates a new Sync Tester DSL wrapper
+func NewSyncTester(inner stack.SyncTester) *SyncTester {
+	return &SyncTester{
+		commonImpl: commonFromT(inner.T()),
+		inner:      inner,
+	}
+}
+
+// Escape returns the underlying stack.SyncTester
+func (s *SyncTester) Escape() stack.SyncTester {
+	return s.inner
+}

--- a/op-devstack/presets/minimal_with_synctester.go
+++ b/op-devstack/presets/minimal_with_synctester.go
@@ -1,0 +1,33 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+type MinimalWithSyncTester struct {
+	Minimal
+
+	SyncTester *dsl.SyncTester
+}
+
+func WithMinimalWithSyncTester() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}))
+}
+
+func NewMinimalWithSyncTester(t devtest.T) *MinimalWithSyncTester {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+	minimal := minimalFromSystem(t, system, orch)
+	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
+	syncTester := l2.SyncTester(match.Assume(t, match.FirstSyncTester))
+	return &MinimalWithSyncTester{
+		Minimal:    *minimal,
+		SyncTester: dsl.NewSyncTester(syncTester),
+	}
+}

--- a/op-devstack/shim/sync_tester.go
+++ b/op-devstack/shim/sync_tester.go
@@ -1,0 +1,40 @@
+package shim
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+type SyncTesterConfig struct {
+	CommonConfig
+	ID     stack.SyncTesterID
+	Client client.RPC
+}
+
+// presetSyncTester wraps around a syncTester-service,
+type presetSyncTester struct {
+	commonImpl
+	id               stack.SyncTesterID
+	syncTesterClient *sources.SyncTesterClient
+}
+
+var _ stack.SyncTester = (*presetSyncTester)(nil)
+
+func NewSyncTester(cfg SyncTesterConfig) stack.SyncTester {
+	cfg.T = cfg.T.WithCtx(stack.ContextWithID(cfg.T.Ctx(), cfg.ID))
+	return &presetSyncTester{
+		id:               cfg.ID,
+		commonImpl:       newCommon(cfg.CommonConfig),
+		syncTesterClient: sources.NewSyncTesterClient(cfg.Client),
+	}
+}
+
+func (p *presetSyncTester) ID() stack.SyncTesterID {
+	return p.id
+}
+
+func (p *presetSyncTester) API() apis.SyncTester {
+	return p.syncTesterClient
+}

--- a/op-devstack/shim/system.go
+++ b/op-devstack/shim/system.go
@@ -34,6 +34,7 @@ type presetSystem struct {
 
 	supervisors locks.RWMap[stack.SupervisorID, stack.Supervisor]
 	sequencers  locks.RWMap[stack.TestSequencerID, stack.TestSequencer]
+	syncTesters locks.RWMap[stack.SyncTesterID, stack.SyncTester]
 }
 
 var _ stack.ExtensibleSystem = (*presetSystem)(nil)
@@ -118,6 +119,10 @@ func (p *presetSystem) TestSequencer(m stack.TestSequencerMatcher) stack.TestSeq
 
 func (p *presetSystem) AddTestSequencer(v stack.TestSequencer) {
 	p.require().True(p.sequencers.SetIfMissing(v.ID(), v), "sequencer %s must not already exist", v.ID())
+}
+
+func (p *presetSystem) AddSyncTester(v stack.SyncTester) {
+	p.require().True(p.syncTesters.SetIfMissing(v.ID(), v), "sync tester %s must not already exist", v.ID())
 }
 
 func (p *presetSystem) SuperchainIDs() []stack.SuperchainID {

--- a/op-devstack/stack/match/first.go
+++ b/op-devstack/stack/match/first.go
@@ -20,3 +20,4 @@ var FirstSuperchain = First[stack.SuperchainID, stack.Superchain]()
 var FirstCluster = First[stack.ClusterID, stack.Cluster]()
 
 var FirstFaucet = First[stack.FaucetID, stack.Faucet]()
+var FirstSyncTester = First[stack.SyncTesterID, stack.SyncTester]()

--- a/op-devstack/stack/matcher.go
+++ b/op-devstack/stack/matcher.go
@@ -60,3 +60,5 @@ type FlashblocksBuilderMatcher = Matcher[FlashblocksBuilderID, FlashblocksBuilde
 type L2ELMatcher = Matcher[L2ELNodeID, L2ELNode]
 
 type FaucetMatcher = Matcher[FaucetID, Faucet]
+
+type SyncTesterMatcher = Matcher[SyncTesterID, SyncTester]

--- a/op-devstack/stack/network.go
+++ b/op-devstack/stack/network.go
@@ -19,10 +19,15 @@ type Network interface {
 	Faucet(m FaucetMatcher) Faucet
 	Faucets() []Faucet
 	FaucetIDs() []FaucetID
+
+	SyncTester(m SyncTesterMatcher) SyncTester
+	SyncTesters() []SyncTester
+	SyncTesterIDs() []SyncTesterID
 }
 
 type ExtensibleNetwork interface {
 	Network
 
 	AddFaucet(f Faucet)
+	AddSyncTester(st SyncTester)
 }

--- a/op-devstack/stack/sync_tester.go
+++ b/op-devstack/stack/sync_tester.go
@@ -1,0 +1,74 @@
+package stack
+
+import (
+	"log/slog"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// SyncTesterID identifies a syncTester by name and chainID, is type-safe, and can be value-copied and used as map key.
+type SyncTesterID idWithChain
+
+var _ IDWithChain = (*SyncTesterID)(nil)
+
+const SyncTesterKind Kind = "SyncTester"
+
+func NewSyncTesterID(key string, chainID eth.ChainID) SyncTesterID {
+	return SyncTesterID{
+		key:     key,
+		chainID: chainID,
+	}
+}
+
+func (id SyncTesterID) String() string {
+	return idWithChain(id).string(SyncTesterKind)
+}
+
+func (id SyncTesterID) ChainID() eth.ChainID {
+	return idWithChain(id).chainID
+}
+
+func (id SyncTesterID) Kind() Kind {
+	return SyncTesterKind
+}
+
+func (id SyncTesterID) Key() string {
+	return id.key
+}
+
+func (id SyncTesterID) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id SyncTesterID) MarshalText() ([]byte, error) {
+	return idWithChain(id).marshalText(SyncTesterKind)
+}
+
+func (id *SyncTesterID) UnmarshalText(data []byte) error {
+	return (*idWithChain)(id).unmarshalText(SyncTesterKind, data)
+}
+
+func SortSyncTesterIDs(ids []SyncTesterID) []SyncTesterID {
+	return copyAndSort(ids, func(a, b SyncTesterID) bool {
+		return lessIDWithChain(idWithChain(a), idWithChain(b))
+	})
+}
+
+func SortSyncTesters(elems []SyncTester) []SyncTester {
+	return copyAndSort(elems, func(a, b SyncTester) bool {
+		return lessIDWithChain(idWithChain(a.ID()), idWithChain(b.ID()))
+	})
+}
+
+var _ SyncTesterMatcher = SyncTesterID{}
+
+func (id SyncTesterID) Match(elems []SyncTester) []SyncTester {
+	return findByID(id, elems)
+}
+
+type SyncTester interface {
+	Common
+	ID() SyncTesterID
+	API() apis.SyncTester
+}

--- a/op-devstack/stack/system.go
+++ b/op-devstack/stack/system.go
@@ -45,6 +45,7 @@ type ExtensibleSystem interface {
 	AddL2Network(v L2Network)
 	AddSupervisor(v Supervisor)
 	AddTestSequencer(v TestSequencer)
+	AddSyncTester(v SyncTester)
 }
 
 type TimeTravelClock interface {

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -48,7 +48,8 @@ type Orchestrator struct {
 	challengers    locks.RWMap[stack.L2ChallengerID, *L2Challenger]
 	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
 
-	faucet *FaucetService
+	syncTester *SyncTesterService
+	faucet     *FaucetService
 
 	controlPlane *ControlPlane
 
@@ -129,6 +130,9 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.challengers.Range(rangeHydrateFn[stack.L2ChallengerID, *L2Challenger](sys))
 	o.proposers.Range(rangeHydrateFn[stack.L2ProposerID, *L2Proposer](sys))
 	o.faucet.hydrate(sys)
+	if o.syncTester != nil {
+		o.syncTester.hydrate(sys)
+	}
 	o.sysHook.PostHydrate(sys)
 }
 

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -1,0 +1,88 @@
+package sysgo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/config"
+
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester"
+
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+)
+
+type SyncTesterService struct {
+	service *synctester.Service
+}
+
+func (n *SyncTesterService) hydrate(system stack.ExtensibleSystem) {
+	require := system.T().Require()
+
+	for syncTesterID, chainID := range n.service.SyncTesters() {
+		syncTesterRPC := n.service.SyncTesterEndpoint(chainID)
+		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
+		require.NoError(err)
+		system.T().Cleanup(rpcCl.Close)
+		id := stack.NewSyncTesterID(syncTesterID.String(), chainID)
+		front := shim.NewSyncTester(shim.SyncTesterConfig{
+			CommonConfig: shim.NewCommonConfig(system.T()),
+			ID:           id,
+			Client:       rpcCl,
+		})
+		net := system.Network(chainID).(stack.ExtensibleNetwork)
+		net.AddSyncTester(front)
+	}
+}
+
+func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
+		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))
+
+		require := p.Require()
+
+		require.Nil(orch.syncTester, "can only support a single sync-tester-service in sysgo")
+
+		syncTesters := make(map[sttypes.SyncTesterID]*stconf.SyncTesterEntry)
+
+		for _, elID := range l2ELs {
+			id := sttypes.SyncTesterID(fmt.Sprintf("dev-sync-tester-%s", elID.ChainID()))
+			require.NotContains(syncTesters, id, "one sync tester per chain only")
+
+			el, ok := orch.l2ELs.Get(elID)
+			require.True(ok, "need L2 EL for sync tester", elID)
+
+			syncTesters[id] = &stconf.SyncTesterEntry{
+				ELRPC: endpoint.MustRPC{Value: endpoint.URL(el.userRPC)},
+				// EngineRPC: endpoint.MustRPC{Value: endpoint.URL(el.authRPC)},
+				// JwtPath:   el.jwtPath,
+				ChainID: elID.ChainID(),
+			}
+		}
+
+		cfg := &config.Config{
+			RPC: oprpc.CLIConfig{},
+			SyncTesters: &stconf.Config{
+				SyncTesters: syncTesters,
+			},
+		}
+		logger := p.Logger()
+		srv, err := synctester.FromConfig(p.Ctx(), cfg, logger)
+		require.NoError(err, "must setup sync tester service")
+		require.NoError(srv.Start(p.Ctx()))
+		p.Cleanup(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // force-quit
+			logger.Info("Closing sync tester")
+			_ = srv.Stop(ctx)
+			logger.Info("Closed sync tester")
+		})
+		orch.syncTester = &SyncTesterService{service: srv}
+	})
+}

--- a/op-service/apis/sync_tester.go
+++ b/op-service/apis/sync_tester.go
@@ -1,0 +1,11 @@
+package apis
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type SyncTester interface {
+	ChainID(ctx context.Context) (eth.ChainID, error)
+}

--- a/op-service/sources/sync_tester_client.go
+++ b/op-service/sources/sync_tester_client.go
@@ -1,0 +1,27 @@
+package sources
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type SyncTesterClient struct {
+	client client.RPC
+}
+
+var _ apis.SyncTester = (*SyncTesterClient)(nil)
+
+func NewSyncTesterClient(client client.RPC) *SyncTesterClient {
+	return &SyncTesterClient{
+		client: client,
+	}
+}
+
+func (cl *SyncTesterClient) ChainID(ctx context.Context) (eth.ChainID, error) {
+	var result eth.ChainID
+	err := cl.client.CallContext(ctx, &result, "eth_chainId")
+	return result, err
+}

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
@@ -49,6 +51,14 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial EL client: %w", err)
 	}
+	// chainId, err := elClient.ChainID(context.Background())
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to get chain ID: %w", err)
+	// }
+	// if eth.ChainIDFromBig(chainId) != stCfg.ChainID {
+	// 	return nil, fmt.Errorf("chain ID mismatch with rpc server: %d != %s", chainId.Uint64(), stCfg.ChainID)
+	// }
+
 	return &SyncTester{
 		log:      logger,
 		m:        m,
@@ -76,7 +86,6 @@ func (s *SyncTester) fetchSession(ctx context.Context) (*Session, error) {
 }
 
 func (s *SyncTester) GetSession(ctx context.Context) error {
-	// example session logic
 	_, err := s.fetchSession(ctx)
 	if err != nil {
 		return ErrNoSession
@@ -85,26 +94,77 @@ func (s *SyncTester) GetSession(ctx context.Context) error {
 }
 
 func (s *SyncTester) DeleteSession(ctx context.Context) error {
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return ErrNoSession
+	}
+	delete(s.sessions, session.SessionID)
 	return nil
 }
 
 func (s *SyncTester) ListSessions(ctx context.Context) ([]string, error) {
-	return []string{}, nil
+	panic("not implemented")
 }
 
 func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	receipts, err := s.elClient.BlockReceipts(ctx, blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(receipts) == 0 {
+		return nil, ErrNoReceipts
+	}
+
+	if receipts[0].BlockNumber.Uint64() > session.Latest {
+		return nil, ethereum.NotFound
+	}
+
+	return receipts, nil
 }
 
-func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
-	return nil, nil
+func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := s.elClient.BlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	if block.NumberU64() > session.Latest {
+		return nil, ethereum.NotFound
+	}
+
+	return block, nil
 }
 
-func (s *SyncTester) GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
-	return nil, nil
+func (s *SyncTester) GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if number.Uint64() > session.Latest {
+		return nil, ethereum.NotFound
+	}
+
+	return s.elClient.BlockByNumber(ctx, number)
 }
 
 func (s *SyncTester) ChainId(ctx context.Context) (eth.ChainID, error) {
+	_, err := s.fetchSession(ctx)
+	if err != nil {
+		return eth.ChainID(uint256.Int{}), err
+	}
+
 	return s.chainID, nil
 }
 

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -51,14 +51,6 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial EL client: %w", err)
 	}
-	// chainId, err := elClient.ChainID(context.Background())
-	// if err != nil {
-	// 	return nil, fmt.Errorf("failed to get chain ID: %w", err)
-	// }
-	// if eth.ChainIDFromBig(chainId) != stCfg.ChainID {
-	// 	return nil, fmt.Errorf("chain ID mismatch with rpc server: %d != %s", chainId.Uint64(), stCfg.ChainID)
-	// }
-
 	return &SyncTester{
 		log:      logger,
 		m:        m,

--- a/op-sync-tester/synctester/frontend/eth.go
+++ b/op-sync-tester/synctester/frontend/eth.go
@@ -11,8 +11,8 @@ import (
 )
 
 type EthBackend interface {
-	GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
-	GetBlockByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	GetBlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 	GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error)
 	ChainId(ctx context.Context) (eth.ChainID, error)
 }
@@ -25,11 +25,11 @@ func NewEthFrontend(b EthBackend) *EthFrontend {
 	return &EthFrontend{b: b}
 }
 
-func (e *EthFrontend) GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+func (e *EthFrontend) GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
 	return e.b.GetBlockByNumber(ctx, number)
 }
 
-func (e *EthFrontend) GetBlockByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+func (e *EthFrontend) GetBlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
 	return e.b.GetBlockByHash(ctx, hash)
 }
 


### PR DESCRIPTION
**Description**

This PR is integrating the Sync Tester into the `op-devstack`. Mostly extracted from the original PoC at https://github.com/ethereum-optimism/optimism/pull/16637 with small fixes.

Fixes: https://github.com/ethereum-optimism/optimism/issues/16700