### PR TITLE
op-proposer: if proposedRecently is false, the other return values are meaningless

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -266,7 +266,7 @@ func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal
 		return source.Proposal{}, false, fmt.Errorf("could not check for recent proposal: %w", err)
 	}
 
-	if proposedRecently {
+	if !proposedRecently {
 		l.Log.Debug("Duration since last game not past proposal interval", "duration", time.Since(proposalTime))
 		return source.Proposal{}, false, nil
 	}


### PR DESCRIPTION
If `proposedRecently` is false, the other return values are meaningless, so [here](https://github.com/ethereum-optimism/optimism/blob/e8e4ab97228d73df74f8c897bf92feed7a408b7e/op-proposer/proposer/driver.go#L269) should return immediately.