### PR TITLE
remove DeputyGuardianModule

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -334,7 +334,6 @@ rules:
         - packages/contracts-bedrock/src/periphery/TransferOnion.sol
         - packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
         - packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
-        - packages/contracts-bedrock/src/safe/DeputyGuardianModule.sol
         - packages/contracts-bedrock/src/safe/DeputyPauseModule.sol
         - packages/contracts-bedrock/src/safe/LivenessGuard.sol
         - packages/contracts-bedrock/src/safe/LivenessModule.sol

--- a/packages/contracts-bedrock/scripts/checks/check-frozen-files.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-frozen-files.sh
@@ -93,7 +93,6 @@ ALLOWED_FILES=(
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist"
   "src/legacy/L1BlockNumber.sol:L1BlockNumber"
   "src/legacy/LegacyMessagePasser.sol:LegacyMessagePasser"
-  "src/safe/DeputyGuardianModule.sol:DeputyGuardianModule"
   "src/safe/DeputyPauseModule.sol:DeputyPauseModule"
   "src/safe/LivenessGuard.sol:LivenessGuard"
   "src/safe/LivenessModule.sol:LivenessModule"

--- a/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOwnership.s.sol
@@ -38,16 +38,10 @@ struct SecurityCouncilConfig {
     LivenessModuleConfig livenessModuleConfig;
 }
 
-/// @notice Configuration for the Deputy Guardian Module
-struct DeputyGuardianModuleConfig {
-    address deputyGuardian;
-    ISuperchainConfig superchainConfig;
-}
 
 /// @notice Configuration for the Guardian Safe.
 struct GuardianConfig {
     SafeConfig safeConfig;
-    DeputyGuardianModuleConfig deputyGuardianModuleConfig;
 }
 
 /// @title DeployOwnership
@@ -85,11 +79,7 @@ contract DeployOwnership is Deploy {
         address[] memory exampleGuardianOwners = new address[](1);
         exampleGuardianOwners[0] = artifacts.mustGetAddress("SecurityCouncilSafe");
         guardianConfig_ = GuardianConfig({
-            safeConfig: SafeConfig({ threshold: 1, owners: exampleGuardianOwners }),
-            deputyGuardianModuleConfig: DeputyGuardianModuleConfig({
-                deputyGuardian: artifacts.mustGetAddress("FoundationOperationsSafe"),
-                superchainConfig: ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigImpl"))
-            })
+            safeConfig: SafeConfig({ threshold: 1, owners: exampleGuardianOwners })
         });
     }
 


### PR DESCRIPTION
Now that the `DeputyGuardianModule.sol` is gone, this pr removes all references of `DeputyGuardianModule`.