### PR TITLE
 feat(op-batcher): add admin rpc to flush the batcher

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -276,20 +276,19 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forc
 // If forcePublish is true, it will force close channels and
 // generate frames for them.
 func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) (*channel, error) {
-	var firstWithTxData *channel
-	for _, ch := range s.channelQueue {
-		if forcePublish {
-			s.log.Info("Force closing channel", "channel_id", ch.ID())
-			// Force close the channel
-			// (this has the same effect as if the channel was full)
-			ch.Close()
-			if ch.TotalFrames() == 0 {
-				// Generate frames now if we haven't already
-				if err := ch.OutputFrames(); err != nil {
-					return nil, err
-				}
+
+	if forcePublish {
+		s.log.Info("Force-publishing channel", "channel_id", s.currentChannel.ID())
+		s.currentChannel.Close()
+		if s.currentChannel.TotalFrames() == 0 {
+			if err := s.currentChannel.OutputFrames(); err != nil {
+				return nil, err
 			}
 		}
+	}
+
+	var firstWithTxData *channel
+	for _, ch := range s.channelQueue {
 		if ch.HasTxData() {
 			firstWithTxData = ch
 			break

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -225,8 +225,8 @@ func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 // It will decide whether to switch DA type automatically.
 // When switching DA type, the channelManager state will be rebuilt
 // with a new ChannelConfig.
-func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling bool) (txData, error) {
-	channel, err := s.getReadyChannel(l1Head)
+func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forcePublish bool) (txData, error) {
+	channel, err := s.getReadyChannel(l1Head, forcePublish)
 	if err != nil {
 		return emptyTxData, err
 	}
@@ -260,7 +260,7 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling bool)
 	s.defaultCfg = newCfg
 
 	// Try again to get data to send on chain.
-	channel, err = s.getReadyChannel(l1Head)
+	channel, err = s.getReadyChannel(l1Head, forcePublish)
 	if err != nil {
 		return emptyTxData, err
 	}
@@ -273,9 +273,14 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling bool)
 // to the current channel and generates frames for it.
 // Always returns nil and the io.EOF sentinel error when
 // there is no channel with txData
-func (s *channelManager) getReadyChannel(l1Head eth.BlockID) (*channel, error) {
+func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) (*channel, error) {
 	var firstWithTxData *channel
 	for _, ch := range s.channelQueue {
+		if forcePublish && ch.NoneSubmitted() {
+			s.log.Info("Force closing channel", "channel_id", ch.ID())
+			ch.Close()
+			ch.OutputFrames()
+		}
 		if ch.HasTxData() {
 			firstWithTxData = ch
 			break

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -273,16 +273,21 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forc
 // to the current channel and generates frames for it.
 // Always returns nil and the io.EOF sentinel error when
 // there is no channel with txData
+// If forcePublish is true, it will force close channels and
+// generate frames for them.
 func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) (*channel, error) {
 	var firstWithTxData *channel
 	for _, ch := range s.channelQueue {
-		if forcePublish && !ch.HasTxData() {
+		if forcePublish {
 			s.log.Info("Force closing channel", "channel_id", ch.ID())
-			// Force close the channel and output frames
+			// Force close the channel
 			// (this has the same effect as if the channel was full)
 			ch.Close()
-			if err := ch.OutputFrames(); err != nil {
-				return nil, err
+			if ch.TotalFrames() == 0 {
+				// Generate frames now if we haven't already
+				if err := ch.OutputFrames(); err != nil {
+					return nil, err
+				}
 			}
 		}
 		if ch.HasTxData() {

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -276,11 +276,12 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forc
 func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) (*channel, error) {
 	var firstWithTxData *channel
 	for _, ch := range s.channelQueue {
-		if forcePublish && ch.NoneSubmitted() {
+		if forcePublish && !ch.HasTxData() {
 			s.log.Info("Force closing channel", "channel_id", ch.ID())
+			// Force close the channel and output frames
+			// (this has the same effect as if the channel was full)
 			ch.Close()
-			err := ch.OutputFrames()
-			if err != nil {
+			if err := ch.OutputFrames(); err != nil {
 				return nil, err
 			}
 		}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -277,13 +277,11 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forc
 // generate frames for them.
 func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) (*channel, error) {
 
-	if forcePublish {
-		s.log.Info("Force-publishing channel", "channel_id", s.currentChannel.ID())
+	if forcePublish && s.currentChannel.TotalFrames() == 0 {
+		s.log.Info("Force-closing channel and creating frames", "channel_id", s.currentChannel.ID())
 		s.currentChannel.Close()
-		if s.currentChannel.TotalFrames() == 0 {
-			if err := s.currentChannel.OutputFrames(); err != nil {
-				return nil, err
-			}
+		if err := s.currentChannel.OutputFrames(); err != nil {
+			return nil, err
 		}
 	}
 

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -279,7 +279,10 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) 
 		if forcePublish && ch.NoneSubmitted() {
 			s.log.Info("Force closing channel", "channel_id", ch.ID())
 			ch.Close()
-			ch.OutputFrames()
+			err := ch.OutputFrames()
+			if err != nil {
+				return nil, err
+			}
 		}
 		if ch.HasTxData() {
 			firstWithTxData = ch

--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -124,7 +124,7 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 			require.NoError(t, m.processBlocks())
 
 			// Try to get transaction data to fill channels
-			_, err := m.TxData(eth.BlockID{}, false, false)
+			_, err := m.TxData(eth.BlockID{}, false, false, false)
 			// It's okay if there's no data ready (io.EOF)
 			if err != nil && err.Error() != "EOF" {
 				require.NoError(t, err)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -101,9 +101,9 @@ func ChannelManagerReturnsErrReorgWhenDrained(t *testing.T, batchType uint) {
 
 	require.NoError(t, m.AddL2Block(a))
 
-	_, err := m.TxData(eth.BlockID{}, false, false)
+	_, err := m.TxData(eth.BlockID{}, false, false, false)
 	require.NoError(t, err)
-	_, err = m.TxData(eth.BlockID{}, false, false)
+	_, err = m.TxData(eth.BlockID{}, false, false, false)
 	require.ErrorIs(t, err, io.EOF)
 
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
@@ -204,7 +204,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 
 	require.NoError(m.AddL2Block(a))
 
-	txdata0, err := m.TxData(eth.BlockID{}, false, false)
+	txdata0, err := m.TxData(eth.BlockID{}, false, false, false)
 	require.NoError(err)
 	txdata0bytes := txdata0.CallData()
 	data0 := make([]byte, len(txdata0bytes))
@@ -212,13 +212,13 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 	copy(data0, txdata0bytes)
 
 	// ensure channel is drained
-	_, err = m.TxData(eth.BlockID{}, false, false)
+	_, err = m.TxData(eth.BlockID{}, false, false, false)
 	require.ErrorIs(err, io.EOF)
 
 	// requeue frame
 	m.TxFailed(txdata0.ID())
 
-	txdata1, err := m.TxData(eth.BlockID{}, false, false)
+	txdata1, err := m.TxData(eth.BlockID{}, false, false, false)
 	require.NoError(err)
 
 	data1 := txdata1.CallData()
@@ -361,7 +361,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			m.blocks = []*types.Block{blockA}
 
 			// Call TxData a first time to trigger blocks->channels pipeline
-			_, err := m.TxData(eth.BlockID{}, false, false)
+			_, err := m.TxData(eth.BlockID{}, false, false, false)
 			require.ErrorIs(t, err, io.EOF)
 
 			// The test requires us to have something in the channel queue
@@ -380,7 +380,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			var data txData
 			for {
 				m.blocks = append(m.blocks, blockA)
-				data, err = m.TxData(eth.BlockID{}, false, false)
+				data, err = m.TxData(eth.BlockID{}, false, false, false)
 				if err == nil && data.Len() > 0 {
 					break
 				}
@@ -669,4 +669,40 @@ func TestChannelManager_ChannelOutFactory(t *testing.T) {
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 
 	require.IsType(t, &ChannelOutWrapper{}, m.currentChannel.channelBuilder.co)
+}
+
+// TestChannelManager_TxData seeds the channel manager with blocks and triggers the
+// blocks->channels pipeline once without force publish disabled, and once with force publish enabled.
+func TestChannelManager_TxData_ForcePublish(t *testing.T) {
+
+	l := testlog.Logger(t, log.LevelCrit)
+	cfg := newFakeDynamicEthChannelConfig(l, 1000)
+	m := NewChannelManager(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
+
+	// Seed channel manager with a block
+	rng := rand.New(rand.NewSource(99))
+	blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
+	m.blocks = []*types.Block{blockA}
+
+	// Call TxData a first time to trigger blocks->channels pipeline
+	txData, err := m.TxData(eth.BlockID{}, false, false, false)
+	require.ErrorIs(t, err, io.EOF)
+	require.Zero(t, txData.Len(), 0)
+
+	// The test requires us to have something in the channel queue
+	// at this point, but not yet ready to send and not full
+	require.NotEmpty(t, m.channelQueue)
+	require.False(t, m.channelQueue[0].IsFull())
+
+	// Call TxData with force publish enabled
+	txData, err = m.TxData(eth.BlockID{}, false, false, true)
+
+	// Despite no additional blocks being added, we should have tx data:
+	require.NoError(t, err)
+	require.True(t, txData.Len() > 0)
+
+	// The channel should be full and ready to send
+	require.Len(t, m.channelQueue, 1)
+	require.True(t, m.channelQueue[0].IsFull())
+
 }

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -699,7 +699,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 
 	// Despite no additional blocks being added, we should have tx data:
 	require.NoError(t, err)
-	require.True(t, txData.Len() > 0)
+	require.NotZero(t, txData.Len(), "txData should not be empty")
 
 	// The channel should be full and ready to send
 	require.Len(t, m.channelQueue, 1)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -260,9 +260,9 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	return nil
 }
 
-// FlushBatchSubmitting forces the batcher to submit any pending data immediately.
+// Flush forces the batcher to submit any pending data immediately.
 // This works by signaling the publishing loop to process any available data.
-func (l *BatchSubmitter) FlushBatchSubmitting(ctx context.Context) error {
+func (l *BatchSubmitter) Flush(ctx context.Context) error {
 	if !l.running {
 		return ErrBatcherNotRunning
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -116,6 +116,8 @@ type BatchSubmitter struct {
 	prevCurrentL1   eth.L1BlockRef // cached CurrentL1 from the last syncStatus
 
 	throttleController *throttler.ThrottleController
+
+	publishSignal chan struct{}
 }
 
 // NewBatchSubmitter initializes the BatchSubmitter driver from a preconfigured DriverSetup
@@ -171,7 +173,8 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	// Channels used to signal between the loops
 	pendingBytesUpdated := make(chan int64, 1)
-	publishSignal := make(chan struct{}, 1)
+	publishSignal := make(chan struct{})
+	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)
 	if l.Config.ThrottleParams.Threshold > 0 {
@@ -254,6 +257,52 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 	l.cancelKillCtx()
 
 	l.Log.Info("Batch Submitter stopped")
+	return nil
+}
+
+// FlushBatchSubmitting forces the batcher to submit any pending data immediately.
+// This works by signaling the publishing loop to process any available data.
+func (l *BatchSubmitter) FlushBatchSubmitting(ctx context.Context) error {
+	l.Log.Info("Flushing Batch Submitter")
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if !l.running {
+		return ErrBatcherNotRunning
+	}
+
+	// Get current L1 head for channel processing
+	l1tip, _, err := l.l1Tip(ctx)
+	if err != nil {
+		l.Log.Error("Failed to query L1 tip", "err", err)
+		return err
+	}
+
+	// Process any pending blocks and output frames in a thread-safe way
+	l.channelMgrMutex.Lock()
+	_, err = l.channelMgr.getReadyChannel(l1tip.ID())
+	l.channelMgrMutex.Unlock()
+
+	// getReadyChannel returns io.EOF when there's no data to process, which is fine for flush
+	if err == io.EOF {
+		l.Log.Info("No transaction data available to flush")
+		return nil
+	} else if err != nil {
+		l.Log.Error("Unable to process blocks and generate frames", "err", err)
+		return err
+	}
+
+	// Signal the publishing loop to immediately process any available data
+	// This ensures the publishing loop picks up the newly processed frames
+	if l.publishSignal != nil {
+		trySignal(l.publishSignal)
+		l.Log.Info("Signaled publishing loop to process flushed data")
+	} else {
+		l.Log.Warn("Publishing signal channel is nil, flush will not trigger immediate processing")
+	}
+
+	l.Log.Info("Batch Submitter flush completed")
 	return nil
 }
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -173,7 +173,7 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	// Channels used to signal between the loops
 	pendingBytesUpdated := make(chan int64, 1)
-	publishSignal := make(chan struct{})
+	publishSignal := make(chan struct{}, 1)
 	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -117,7 +117,7 @@ type BatchSubmitter struct {
 
 	throttleController *throttler.ThrottleController
 
-	publishSignal chan struct{}
+	publishSignal chan bool // true if we should force a tx to be published now, false if we should check the usual conditions (timeouts)
 }
 
 // NewBatchSubmitter initializes the BatchSubmitter driver from a preconfigured DriverSetup
@@ -173,7 +173,7 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	// Channels used to signal between the loops
 	pendingBytesUpdated := make(chan int64, 1)
-	publishSignal := make(chan struct{}, 1)
+	publishSignal := make(chan bool, 1)
 	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)
@@ -263,52 +263,18 @@ func (l *BatchSubmitter) StopBatchSubmitting(ctx context.Context) error {
 // FlushBatchSubmitting forces the batcher to submit any pending data immediately.
 // This works by signaling the publishing loop to process any available data.
 func (l *BatchSubmitter) FlushBatchSubmitting(ctx context.Context) error {
-	l.Log.Info("Flushing Batch Submitter")
-
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-
 	if !l.running {
 		return ErrBatcherNotRunning
 	}
 
-	// Get current L1 head for channel processing
-	l1tip, _, err := l.l1Tip(ctx)
-	if err != nil {
-		l.Log.Error("Failed to query L1 tip", "err", err)
-		return err
-	}
-
-	// Process any pending blocks and output frames in a thread-safe way
-	l.channelMgrMutex.Lock()
-	_, err = l.channelMgr.getReadyChannel(l1tip.ID())
-	l.channelMgrMutex.Unlock()
-
-	// getReadyChannel returns io.EOF when there's no data to process, which is fine for flush
-	if err == io.EOF {
-		l.Log.Info("No transaction data available to flush")
-		return nil
-	} else if err != nil {
-		l.Log.Error("Unable to process blocks and generate frames", "err", err)
-		return err
-	}
-
-	// Signal the publishing loop to immediately process any available data
-	// This ensures the publishing loop picks up the newly processed frames
-	if l.publishSignal != nil {
-		trySignal(l.publishSignal)
-		l.Log.Info("Signaled publishing loop to process flushed data")
-	} else {
-		l.Log.Warn("Publishing signal channel is nil, flush will not trigger immediate processing")
-	}
-
-	l.Log.Info("Batch Submitter flush completed")
+	l.Log.Info("Flushing Batch Submitter")
+	trySignal(l.publishSignal, true)
 	return nil
 }
 
 // loadBlocksIntoState loads the blocks between start and end (inclusive).
 // If there is a reorg, it will return an error.
-func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uint64, publishSignal chan struct{}, pendingBytesUpdated chan int64) error {
+func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uint64, publishSignal chan bool, pendingBytesUpdated chan int64) error {
 	if end < start {
 		return fmt.Errorf("start number is > end number %d,%d", start, end)
 	}
@@ -335,7 +301,7 @@ func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uin
 			// Every 100 blocks, signal the publishing loop to publish.
 			// This allows the batcher to start publishing sooner in the
 			// case of a large backlog of blocks to load.
-			trySignal(publishSignal)
+			trySignal(publishSignal, false)
 			l.sendToThrottlingLoop(pendingBytesUpdated)
 		}
 
@@ -471,9 +437,9 @@ func (l *BatchSubmitter) sendToThrottlingLoop(pendingBytesUpdated chan int64) {
 
 // trySignal tries to send an empty struct on the provided channel.
 // It is not blocking, no signal will be sent if the channel is full.
-func trySignal(c chan struct{}) {
+func trySignal(c chan bool, value bool) {
 	select {
-	case c <- struct{}{}:
+	case c <- value:
 	default:
 	}
 }
@@ -519,7 +485,7 @@ func (l *BatchSubmitter) syncAndPrune(syncStatus *eth.SyncStatus) *inclusiveBloc
 // -  waits for a signal that blocks have been loaded
 // -  drives the creation of channels and frames
 // -  sends transactions to the DA layer
-func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup, receiptsCh chan txmgr.TxReceipt[txRef], publishSignal chan struct{}) {
+func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup, receiptsCh chan txmgr.TxReceipt[txRef], publishSignal chan bool) {
 	defer close(receiptsCh)
 	defer wg.Done()
 
@@ -531,9 +497,9 @@ func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup,
 	}
 	txQueue := txmgr.NewQueue[txRef](ctx, l.Txmgr, l.Config.MaxPendingTransactions)
 
-	for range publishSignal {
-		l.Log.Debug("publishing loop received signal")
-		l.publishStateToL1(ctx, txQueue, receiptsCh, daGroup)
+	for forcePublish := range publishSignal {
+		l.Log.Debug("publishing loop received signal", "force_publish", forcePublish)
+		l.publishStateToL1(ctx, txQueue, receiptsCh, daGroup, forcePublish)
 	}
 
 	// First wait for all DA requests to finish to prevent new transactions being queued
@@ -556,7 +522,7 @@ func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup,
 // -  polls the sequencer,
 // -  prunes the channel manager state (i.e. safe blocks)
 // -  loads unsafe blocks from the sequencer
-func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGroup, pendingBytesUpdated chan int64, publishSignal chan struct{}) {
+func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGroup, pendingBytesUpdated chan int64, publishSignal chan bool) {
 	ticker := time.NewTicker(l.Config.PollInterval)
 	defer ticker.Stop()
 	defer close(pendingBytesUpdated)
@@ -588,7 +554,7 @@ func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGrou
 					l.sendToThrottlingLoop(pendingBytesUpdated) // we have increased the pending data. Signal the throttling loop to check if it should throttle.
 				}
 			}
-			trySignal(publishSignal) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
+			trySignal(publishSignal, false) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
 		case <-ctx.Done():
 			l.Log.Info("blockLoadingLoop returning")
 			return
@@ -802,7 +768,7 @@ func (l *BatchSubmitter) waitNodeSync() error {
 
 // publishStateToL1 queues up all pending TxData to be published to the L1, returning when there is no more data to
 // queue for publishing or if there was an error queuing the data.
-func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group) {
+func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group, forcePublish bool) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -819,7 +785,7 @@ func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queu
 			return
 		}
 
-		err := l.publishTxToL1(ctx, queue, receiptsCh, daGroup)
+		err := l.publishTxToL1(ctx, queue, receiptsCh, daGroup, forcePublish)
 		if err != nil {
 			if err != io.EOF {
 				l.Log.Error("Error publishing tx to l1", "err", err)
@@ -873,7 +839,7 @@ func (l *BatchSubmitter) clearState(ctx context.Context) {
 }
 
 // publishTxToL1 submits a single state tx to the L1
-func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group) error {
+func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group, forcePublish bool) error {
 	// send all available transactions
 	l1tip, isPectra, err := l.l1Tip(ctx)
 	if err != nil {
@@ -886,7 +852,7 @@ func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[t
 	// Collect next transaction data. This pulls data out of the channel, so we need to make sure
 	// to put it back if ever da or txmgr requests fail, by calling l.recordFailedDARequest/recordFailedTx.
 	l.channelMgrMutex.Lock()
-	txdata, err := l.channelMgr.TxData(l1tip.ID(), isPectra, params.IsThrottling())
+	txdata, err := l.channelMgr.TxData(l1tip.ID(), isPectra, params.IsThrottling(), forcePublish)
 	l.channelMgrMutex.Unlock()
 
 	if err == io.EOF {

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -19,8 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -51,21 +48,6 @@ func (p *mockL2EndpointProvider) Close() {}
 
 const genesisL1Origin = uint64(123)
 
-// mockL1Client implements the L1Client interface for testing
-type mockL1Client struct{}
-
-func (m *mockL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
-	// Return a mock L1 header
-	return &types.Header{
-		Number: big.NewInt(1000),
-		Time:   1000000,
-	}, nil
-}
-
-func (m *mockL1Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
-	return 0, nil
-}
-
 func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 	ep := newEndpointProvider()
 
@@ -83,7 +65,6 @@ func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 		},
 		ChannelConfig:    defaultTestChannelConfig(),
 		EndpointProvider: ep,
-		Txmgr:            nil, // this is unused so far in the tests, but could cause a panic as we add more tests
 	}), ep
 }
 
@@ -354,13 +335,4 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	t.Run("two normal endpoints", testThrottlingEndpoints(2, 0))
 	t.Run("two failing endpoints", testThrottlingEndpoints(0, 2))
 	t.Run("one normal endpoint, one failing endpoint", testThrottlingEndpoints(1, 1))
-}
-
-func TestBatchSubmitter_FlushBatchSubmitting(t *testing.T) {
-	bs, _ := setup(t)
-
-	// Test that flush fails when batcher is not running
-	err := bs.Flush(context.Background())
-	require.Error(t, err)
-	require.Equal(t, ErrBatcherNotRunning, err)
 }

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +50,21 @@ func (p *mockL2EndpointProvider) RollupClient(context.Context) (dial.RollupClien
 func (p *mockL2EndpointProvider) Close() {}
 
 const genesisL1Origin = uint64(123)
+
+// mockL1Client implements the L1Client interface for testing
+type mockL1Client struct{}
+
+func (m *mockL1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	// Return a mock L1 header
+	return &types.Header{
+		Number: big.NewInt(1000),
+		Time:   1000000,
+	}, nil
+}
+
+func (m *mockL1Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return 0, nil
+}
 
 func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 	ep := newEndpointProvider()
@@ -335,4 +353,42 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	t.Run("two normal endpoints", testThrottlingEndpoints(2, 0))
 	t.Run("two failing endpoints", testThrottlingEndpoints(0, 2))
 	t.Run("one normal endpoint, one failing endpoint", testThrottlingEndpoints(1, 1))
+}
+
+func TestBatchSubmitter_FlushBatchSubmitting(t *testing.T) {
+	bs, ep := setup(t)
+
+	// Test that flush fails when batcher is not running
+	err := bs.FlushBatchSubmitting(context.Background())
+	require.Error(t, err)
+	require.Equal(t, ErrBatcherNotRunning, err)
+
+	// Mock L1 tip response - set this up before starting the batcher
+	ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{
+		HeadL1: eth.L1BlockRef{
+			Number: 1000,
+			Hash:   [32]byte{0x01},
+		},
+	}, nil)
+
+	// Set the L1 client and batcher configuration
+	bs.L1Client = &mockL1Client{}
+	bs.Config = BatcherConfig{
+		PollInterval: 100 * time.Millisecond, // Use a reasonable poll interval for testing
+	}
+
+	// Start the batcher
+	err = bs.StartBatchSubmitting()
+	require.NoError(t, err)
+
+	// Verify that the publish signal channel was created
+	require.NotNil(t, bs.publishSignal)
+
+	// Test that flush succeeds when batcher is running
+	err = bs.FlushBatchSubmitting(context.Background())
+	require.NoError(t, err)
+
+	// Stop the batcher
+	err = bs.StopBatchSubmitting(context.Background())
+	require.NoError(t, err)
 }

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -360,7 +360,7 @@ func TestBatchSubmitter_FlushBatchSubmitting(t *testing.T) {
 	bs, _ := setup(t)
 
 	// Test that flush fails when batcher is not running
-	err := bs.FlushBatchSubmitting(context.Background())
+	err := bs.Flush(context.Background())
 	require.Error(t, err)
 	require.Equal(t, ErrBatcherNotRunning, err)
 }

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -83,6 +83,7 @@ func setup(t *testing.T) (*BatchSubmitter, *mockL2EndpointProvider) {
 		},
 		ChannelConfig:    defaultTestChannelConfig(),
 		EndpointProvider: ep,
+		Txmgr:            nil, // this is unused so far in the tests, but could cause a panic as we add more tests
 	}), ep
 }
 
@@ -356,39 +357,10 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 }
 
 func TestBatchSubmitter_FlushBatchSubmitting(t *testing.T) {
-	bs, ep := setup(t)
+	bs, _ := setup(t)
 
 	// Test that flush fails when batcher is not running
 	err := bs.FlushBatchSubmitting(context.Background())
 	require.Error(t, err)
 	require.Equal(t, ErrBatcherNotRunning, err)
-
-	// Mock L1 tip response - set this up before starting the batcher
-	ep.rollupClient.ExpectSyncStatus(&eth.SyncStatus{
-		HeadL1: eth.L1BlockRef{
-			Number: 1000,
-			Hash:   [32]byte{0x01},
-		},
-	}, nil)
-
-	// Set the L1 client and batcher configuration
-	bs.L1Client = &mockL1Client{}
-	bs.Config = BatcherConfig{
-		PollInterval: 100 * time.Millisecond, // Use a reasonable poll interval for testing
-	}
-
-	// Start the batcher
-	err = bs.StartBatchSubmitting()
-	require.NoError(t, err)
-
-	// Verify that the publish signal channel was created
-	require.NotNil(t, bs.publishSignal)
-
-	// Test that flush succeeds when batcher is running
-	err = bs.FlushBatchSubmitting(context.Background())
-	require.NoError(t, err)
-
-	// Stop the batcher
-	err = bs.StopBatchSubmitting(context.Background())
-	require.NoError(t, err)
 }

--- a/op-batcher/rpc/api.go
+++ b/op-batcher/rpc/api.go
@@ -15,7 +15,7 @@ import (
 type BatcherDriver interface {
 	StartBatchSubmitting() error
 	StopBatchSubmitting(ctx context.Context) error
-	FlushBatchSubmitting(ctx context.Context) error
+	Flush(ctx context.Context) error
 	SetThrottleController(controllerType config.ThrottleControllerType, pidConfig *config.PIDConfig) error
 	GetThrottleControllerInfo() (config.ThrottleControllerInfo, error)
 	ResetThrottleController() error
@@ -90,5 +90,5 @@ func (a *adminAPI) ResetThrottleController(_ context.Context) error {
 }
 
 func (a *adminAPI) FlushBatcher(ctx context.Context) error {
-	return a.b.FlushBatchSubmitting(ctx)
+	return a.b.Flush(ctx)
 }

--- a/op-batcher/rpc/api.go
+++ b/op-batcher/rpc/api.go
@@ -15,6 +15,7 @@ import (
 type BatcherDriver interface {
 	StartBatchSubmitting() error
 	StopBatchSubmitting(ctx context.Context) error
+	FlushBatchSubmitting(ctx context.Context) error
 	SetThrottleController(controllerType config.ThrottleControllerType, pidConfig *config.PIDConfig) error
 	GetThrottleControllerInfo() (config.ThrottleControllerInfo, error)
 	ResetThrottleController() error
@@ -86,4 +87,8 @@ func (a *adminAPI) GetThrottleController(_ context.Context) (config.ThrottleCont
 // ResetThrottleController resets the current throttle controller state
 func (a *adminAPI) ResetThrottleController(_ context.Context) error {
 	return a.b.ResetThrottleController()
+}
+
+func (a *adminAPI) FlushBatcher(ctx context.Context) error {
+	return a.b.FlushBatchSubmitting(ctx)
 }

--- a/op-service/apis/batcher.go
+++ b/op-service/apis/batcher.go
@@ -5,6 +5,7 @@ import "context"
 type BatcherActivity interface {
 	StartBatcher(ctx context.Context) error
 	StopBatcher(ctx context.Context) error
+	FlushBatcher(ctx context.Context) error
 }
 
 type BatcherAdminServer interface {

--- a/op-service/sources/batcher_admin_client.go
+++ b/op-service/sources/batcher_admin_client.go
@@ -26,3 +26,7 @@ func (cl *BatcherAdminClient) StartBatcher(ctx context.Context) error {
 func (cl *BatcherAdminClient) StopBatcher(ctx context.Context) error {
 	return cl.client.CallContext(ctx, nil, "admin_stopBatcher")
 }
+
+func (cl *BatcherAdminClient) FlushBatcher(ctx context.Context) error {
+	return cl.client.CallContext(ctx, nil, "admin_flushBatcher")
+}


### PR DESCRIPTION
Alternative implementation of #16748 

This will cause the current channel being built by the batcher to be closed and frames / transactions generated from it and added to the tx queue (even if the channel wouldn't otherwise be ready to submit because it wasn't full or the channel duration wasn't reached). 

Tested using `just simple-devnet` (in kurtosis-devnet) with a long max channel duration, as well as a newly added unit test. 