### PR TITLE
cannon: Migrate thread-related tests

### DIFF
--- a/cannon/mipsevm/multithreaded/testutil/expectations.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations.go
@@ -29,18 +29,8 @@ type ExpectedState struct {
 	Step                uint64
 	LastHint            hexutil.Bytes
 	MemoryRoot          common.Hash
+	threadExpectations  *threadExpectations
 	expectedMemory      *memory.Memory
-	// Threading-related expectations
-	StepsSinceLastContextSwitch uint64
-	TraverseRight               bool
-	NextThreadId                arch.Word
-	ThreadCount                 int
-	RightStackSize              int
-	LeftStackSize               int
-	prestateActiveThreadId      arch.Word
-	prestateActiveThreadOrig    ExpectedThreadState // Cached for internal use
-	ActiveThreadId              arch.Word
-	threadExpectations          map[arch.Word]*ExpectedThreadState
 	// Remember some actions so we can analyze expectations
 	memoryWrites []arch.Word
 }
@@ -60,13 +50,6 @@ type ExpectedThreadState struct {
 func NewExpectedState(t require.TestingT, state mipsevm.FPVMState) *ExpectedState {
 	fromState := ToMTState(t, state)
 
-	currentThread := fromState.GetCurrentThread()
-
-	expectedThreads := make(map[arch.Word]*ExpectedThreadState)
-	for _, t := range GetAllThreads(fromState) {
-		expectedThreads[t.ThreadId] = newExpectedThreadState(t)
-	}
-
 	return &ExpectedState{
 		// General Fields
 		PreimageKey:         fromState.GetPreimageKey(),
@@ -80,19 +63,8 @@ func NewExpectedState(t require.TestingT, state mipsevm.FPVMState) *ExpectedStat
 		Step:                fromState.GetStep(),
 		LastHint:            fromState.GetLastHint(),
 		MemoryRoot:          fromState.GetMemory().MerkleRoot(),
-		// Thread-related global fields
-		StepsSinceLastContextSwitch: fromState.StepsSinceLastContextSwitch,
-		TraverseRight:               fromState.TraverseRight,
-		NextThreadId:                fromState.NextThreadId,
-		ThreadCount:                 fromState.ThreadCount(),
-		RightStackSize:              len(fromState.RightThreadStack),
-		LeftStackSize:               len(fromState.LeftThreadStack),
-		// ThreadState expectations
-		prestateActiveThreadId:   currentThread.ThreadId,
-		prestateActiveThreadOrig: *newExpectedThreadState(currentThread), // Cache prestate thread for internal use
-		ActiveThreadId:           currentThread.ThreadId,
-		threadExpectations:       expectedThreads,
-		expectedMemory:           fromState.Memory.Copy(),
+		threadExpectations:  newThreadExpectations(fromState),
+		expectedMemory:      fromState.Memory.Copy(),
 	}
 }
 
@@ -119,7 +91,7 @@ func (e *ExpectedState) ExpectStep() {
 	e.Step += 1
 	e.PrestateActiveThread().PC += 4
 	e.PrestateActiveThread().NextPC += 4
-	e.StepsSinceLastContextSwitch += 1
+	e.threadExpectations.StepsSinceLastContextSwitch += 1
 }
 
 func (e *ExpectedState) ExpectMemoryReservationCleared() {
@@ -151,45 +123,52 @@ func (e *ExpectedState) ExpectMemoryWrite(addr arch.Word, val arch.Word) {
 	e.MemoryRoot = e.expectedMemory.MerkleRoot()
 }
 
-func (e *ExpectedState) ExpectPreemption(preState *multithreaded.State) {
-	e.ActiveThreadId = FindNextThread(preState).ThreadId
-	e.StepsSinceLastContextSwitch = 0
-	if preState.TraverseRight {
-		e.TraverseRight = e.RightStackSize > 1
-		e.RightStackSize -= 1
-		e.LeftStackSize += 1
-	} else {
-		e.TraverseRight = e.LeftStackSize == 1
-		e.LeftStackSize -= 1
-		e.RightStackSize += 1
-	}
+func (e *ExpectedState) ExpectPreemption() {
+	e.threadExpectations.ExpectPreemption()
 }
 
 func (e *ExpectedState) ExpectNewThread() *ExpectedThreadState {
-	newThreadId := e.NextThreadId
-	e.NextThreadId += 1
-	e.ThreadCount += 1
+	return e.threadExpectations.ExpectNewThread()
+}
 
-	// Clone expectations from prestate active thread's original state (bf changing any expectations)
-	newThread := &ExpectedThreadState{}
-	*newThread = e.prestateActiveThreadOrig
+func (e *ExpectedState) ExpectPoppedThread() {
+	e.threadExpectations.ExpectPop()
+}
 
-	newThread.ThreadId = newThreadId
-	e.threadExpectations[newThreadId] = newThread
+func (e *ExpectedState) ExpectTraverseRight(traverseRight bool) {
+	e.threadExpectations.ExpectTraverseRight(traverseRight)
+}
 
-	return newThread
+func (e *ExpectedState) ExpectNoContextSwitch() {
+	e.threadExpectations.StepsSinceLastContextSwitch += 1
+}
+
+func (e *ExpectedState) ExpectContextSwitch() {
+	e.threadExpectations.StepsSinceLastContextSwitch = 0
 }
 
 func (e *ExpectedState) ActiveThread() *ExpectedThreadState {
-	return e.threadExpectations[e.ActiveThreadId]
+	return e.threadExpectations.activeThread()
+}
+
+func (e *ExpectedState) ActiveThreadId() arch.Word {
+	return e.threadExpectations.ActiveThreadId
+}
+
+func (e *ExpectedState) ExpectActiveThreadId(expected arch.Word) {
+	e.threadExpectations.ActiveThreadId = expected
+}
+
+func (e *ExpectedState) ExpectNextThreadId(expected arch.Word) {
+	e.threadExpectations.NextThreadId = expected
 }
 
 func (e *ExpectedState) PrestateActiveThread() *ExpectedThreadState {
-	return e.threadExpectations[e.prestateActiveThreadId]
+	return e.threadExpectations.PrestateActiveThread()
 }
 
 func (e *ExpectedState) Thread(threadId arch.Word) *ExpectedThreadState {
-	return e.threadExpectations[threadId]
+	return e.threadExpectations.ThreadById(threadId)
 }
 
 func (e *ExpectedState) Validate(t require.TestingT, state mipsevm.FPVMState) {
@@ -207,40 +186,208 @@ func (e *ExpectedState) Validate(t require.TestingT, state mipsevm.FPVMState) {
 	require.Equalf(t, e.LastHint, actualState.GetLastHint(), "Expect lastHint = %v", e.LastHint)
 	require.Equalf(t, e.MemoryRoot, common.Hash(actualState.GetMemory().MerkleRoot()), "Expect memory root = %v", e.MemoryRoot)
 	// Thread-related global fields
-	require.Equalf(t, e.StepsSinceLastContextSwitch, actualState.StepsSinceLastContextSwitch, "Expect StepsSinceLastContextSwitch = %v", e.StepsSinceLastContextSwitch)
-	require.Equalf(t, e.TraverseRight, actualState.TraverseRight, "Expect TraverseRight = %v", e.TraverseRight)
-	require.Equalf(t, e.NextThreadId, actualState.NextThreadId, "Expect NextThreadId = %v", e.NextThreadId)
-	require.Equalf(t, e.ThreadCount, actualState.ThreadCount(), "Expect thread count = %v", e.ThreadCount)
-	require.Equalf(t, e.RightStackSize, len(actualState.RightThreadStack), "Expect right stack size = %v", e.RightStackSize)
-	require.Equalf(t, e.LeftStackSize, len(actualState.LeftThreadStack), "Expect right stack size = %v", e.LeftStackSize)
-
-	// Check active thread
-	activeThread := actualState.GetCurrentThread()
-	require.Equal(t, e.ActiveThreadId, activeThread.ThreadId)
-	// Check all threads
-	expectedThreadCount := 0
-	for tid, exp := range e.threadExpectations {
-		actualThread := FindThread(actualState, tid)
-		isActive := tid == activeThread.ThreadId
-		if exp.Dropped {
-			require.Nil(t, actualThread, "Thread %v should have been dropped", tid)
-		} else {
-			require.NotNil(t, actualThread, "Could not find thread matching expected thread with id %v", tid)
-			e.validateThread(t, exp, actualThread, isActive)
-			expectedThreadCount++
-		}
-	}
-	require.Equal(t, expectedThreadCount, actualState.ThreadCount(), "Thread expectations do not match thread count")
+	e.threadExpectations.Validate(t, actualState)
 }
 
-func (e *ExpectedState) validateThread(t require.TestingT, et *ExpectedThreadState, actual *multithreaded.ThreadState, isActive bool) {
-	threadInfo := fmt.Sprintf("tid = %v, active = %v", actual.ThreadId, isActive)
-	require.Equalf(t, et.ThreadId, actual.ThreadId, "Expect ThreadId = 0x%x (%v)", et.ThreadId, threadInfo)
-	require.Equalf(t, et.PC, actual.Cpu.PC, "Expect PC = 0x%x (%v)", et.PC, threadInfo)
-	require.Equalf(t, et.NextPC, actual.Cpu.NextPC, "Expect nextPC = 0x%x (%v)", et.NextPC, threadInfo)
-	require.Equalf(t, et.HI, actual.Cpu.HI, "Expect HI = 0x%x (%v)", et.HI, threadInfo)
-	require.Equalf(t, et.LO, actual.Cpu.LO, "Expect LO = 0x%x (%v)", et.LO, threadInfo)
-	require.Equalf(t, et.Registers, actual.Registers, "Expect registers to match (%v)", threadInfo)
-	require.Equalf(t, et.ExitCode, actual.ExitCode, "Expect exitCode = %v (%v)", et.ExitCode, threadInfo)
-	require.Equalf(t, et.Exited, actual.Exited, "Expect exited = %v (%v)", et.Exited, threadInfo)
+type threadExpectations struct {
+	ActiveThreadId              arch.Word
+	StepsSinceLastContextSwitch uint64
+	NextThreadId                arch.Word
+	prestateActiveThread        *ExpectedThreadState
+	traverseRight               bool
+	left                        []*ExpectedThreadState
+	right                       []*ExpectedThreadState
+	popped                      []*ExpectedThreadState
+}
+
+func newThreadExpectations(state *multithreaded.State) *threadExpectations {
+	left := expectedThreadStack(state.LeftThreadStack)
+	right := expectedThreadStack(state.RightThreadStack)
+	var prestateActiveThread *ExpectedThreadState
+	if state.TraverseRight {
+		prestateActiveThread = right[len(right)-1]
+	} else {
+		prestateActiveThread = left[len(left)-1]
+	}
+
+	return &threadExpectations{
+		ActiveThreadId:              prestateActiveThread.ThreadId,
+		StepsSinceLastContextSwitch: state.StepsSinceLastContextSwitch,
+		NextThreadId:                state.NextThreadId,
+		prestateActiveThread:        prestateActiveThread,
+		traverseRight:               state.TraverseRight,
+		left:                        left,
+		right:                       right,
+		popped:                      make([]*ExpectedThreadState, 0),
+	}
+}
+
+func (e *threadExpectations) Validate(t require.TestingT, state *multithreaded.State) {
+	actualState := ToMTState(t, state)
+
+	require.Equalf(t, e.StepsSinceLastContextSwitch, actualState.StepsSinceLastContextSwitch, "Expect StepsSinceLastContextSwitch = %v", e.StepsSinceLastContextSwitch)
+	require.Equalf(t, e.traverseRight, actualState.TraverseRight, "Expect TraverseRight = %v", e.traverseRight)
+	require.Equalf(t, e.NextThreadId, actualState.NextThreadId, "Expect NextThreadId = %v", e.NextThreadId)
+	require.Equalf(t, e.threadCount(), actualState.ThreadCount(), "Expect thread count = %v", e.threadCount())
+
+	// Check active thread
+	activeThreadId := actualState.GetCurrentThread().ThreadId
+	require.Equal(t, e.ActiveThreadId, activeThreadId)
+
+	// Check stacks
+	e.assertStackMatchesExpectations(t, e.left, actualState.LeftThreadStack, "left", activeThreadId)
+	e.assertStackMatchesExpectations(t, e.right, actualState.RightThreadStack, "right", activeThreadId)
+}
+
+func (e *threadExpectations) assertStackMatchesExpectations(t require.TestingT, expectedStack []*ExpectedThreadState, actualStack []*multithreaded.ThreadState, label string, activeThreadId arch.Word) {
+	require.Equalf(t, len(expectedStack), len(actualStack), "Expect %v stack size = %v", label, len(expectedStack))
+	for i, expectedThread := range expectedStack {
+		if i >= len(actualStack) {
+			// Break to avoid unit test panics - should be unreachable for actual tests
+			require.FailNow(t, "Missing thread")
+			break
+		}
+		actualThread := actualStack[i]
+		e.validateThread(t, expectedThread, actualThread, activeThreadId)
+	}
+}
+
+func (e *threadExpectations) validateThread(t require.TestingT, expected *ExpectedThreadState, actual *multithreaded.ThreadState, activeThreadId arch.Word) {
+	threadInfo := fmt.Sprintf("tid = %v, active = %v", actual.ThreadId, actual.ThreadId == activeThreadId)
+	require.Equalf(t, expected.ThreadId, actual.ThreadId, "Expect ThreadId = 0x%x (%v)", expected.ThreadId, threadInfo)
+	require.Equalf(t, expected.PC, actual.Cpu.PC, "Expect PC = 0x%x (%v)", expected.PC, threadInfo)
+	require.Equalf(t, expected.NextPC, actual.Cpu.NextPC, "Expect nextPC = 0x%x (%v)", expected.NextPC, threadInfo)
+	require.Equalf(t, expected.HI, actual.Cpu.HI, "Expect HI = 0x%x (%v)", expected.HI, threadInfo)
+	require.Equalf(t, expected.LO, actual.Cpu.LO, "Expect LO = 0x%x (%v)", expected.LO, threadInfo)
+	require.Equalf(t, expected.Registers, actual.Registers, "Expect registers to match (%v)", threadInfo)
+	require.Equalf(t, expected.ExitCode, actual.ExitCode, "Expect exitCode = %v (%v)", expected.ExitCode, threadInfo)
+	require.Equalf(t, expected.Exited, actual.Exited, "Expect exited = %v (%v)", expected.Exited, threadInfo)
+	require.Equalf(t, expected.Dropped, false, "Thread should not be dropped")
+}
+
+func (e *threadExpectations) ExpectPreemption() {
+	e.StepsSinceLastContextSwitch = 0
+	if e.traverseRight {
+		lastEl := len(e.right) - 1
+		preempted := e.right[lastEl]
+		e.right = e.right[:lastEl]
+		e.left = append(e.left, preempted)
+		e.traverseRight = len(e.right) > 0
+	} else {
+		lastEl := len(e.left) - 1
+		preempted := e.left[lastEl]
+		e.left = e.left[:lastEl]
+		e.right = append(e.right, preempted)
+		e.traverseRight = len(e.left) == 0
+	}
+	e.updateActiveThreadId()
+}
+
+func (e *threadExpectations) ExpectNewThread() *ExpectedThreadState {
+	e.StepsSinceLastContextSwitch = 0
+	newThreadId := e.NextThreadId
+	e.NextThreadId += 1
+
+	// Copy expectations from prestate active thread's original state (bf changing any expectations)
+	newThread := &ExpectedThreadState{}
+	*newThread = *e.prestateActiveThread
+
+	newThread.ThreadId = newThreadId
+	if e.traverseRight {
+		e.right = append(e.right, newThread)
+	} else {
+		e.left = append(e.left, newThread)
+	}
+
+	e.ActiveThreadId = newThreadId
+	return newThread
+}
+
+func (e *threadExpectations) ExpectPop() {
+	e.StepsSinceLastContextSwitch = 0
+	var popped *ExpectedThreadState
+	if e.traverseRight {
+		lastEl := len(e.right) - 1
+		popped = e.right[lastEl]
+		popped.Dropped = true
+		e.right = e.right[:lastEl]
+		e.traverseRight = len(e.right) > 0
+	} else {
+		lastEl := len(e.left) - 1
+		popped = e.left[lastEl]
+		popped.Dropped = true
+		e.left = e.left[:lastEl]
+		e.traverseRight = len(e.left) == 0
+	}
+	e.popped = append(e.popped, popped)
+
+	e.updateActiveThreadId()
+}
+
+func (e *threadExpectations) ExpectTraverseRight(traverseRight bool) {
+	e.traverseRight = traverseRight
+}
+
+func (e *threadExpectations) PrestateActiveThread() *ExpectedThreadState {
+	return e.prestateActiveThread
+}
+
+func (e *threadExpectations) ThreadById(threadId arch.Word) *ExpectedThreadState {
+	for _, thread := range e.allThreads() {
+		if thread.ThreadId == threadId {
+			return thread
+		}
+	}
+	return nil
+}
+
+func (e *threadExpectations) allThreads() []*ExpectedThreadState {
+	var allThreads []*ExpectedThreadState
+	allThreads = append(allThreads, e.right...)
+	allThreads = append(allThreads, e.left...)
+	allThreads = append(allThreads, e.popped...)
+
+	return allThreads
+}
+
+func (e *threadExpectations) updateActiveThreadId() {
+	activeStack := e.activeStack()
+	e.ActiveThreadId = activeStack[len(activeStack)-1].ThreadId
+}
+
+func (e *threadExpectations) threadCount() int {
+	return e.leftStackSize() + e.rightStackSize()
+}
+
+func (e *threadExpectations) rightStackSize() int {
+	return len(e.right)
+}
+
+func (e *threadExpectations) leftStackSize() int {
+	return len(e.left)
+}
+
+func (e *threadExpectations) activeStack() []*ExpectedThreadState {
+	if e.traverseRight {
+		return e.right
+	} else {
+		return e.left
+	}
+}
+
+func (e *threadExpectations) activeThread() *ExpectedThreadState {
+	lastEl := len(e.activeStack()) - 1
+	if lastEl < 0 {
+		return nil
+	}
+	return e.activeStack()[lastEl]
+}
+
+func expectedThreadStack(threadStack []*multithreaded.ThreadState) []*ExpectedThreadState {
+	expectedThreads := make([]*ExpectedThreadState, 0, len(threadStack))
+	for _, threadState := range threadStack {
+		expectedThreads = append(expectedThreads, newExpectedThreadState(threadState))
+	}
+
+	return expectedThreads
 }

--- a/cannon/mipsevm/multithreaded/testutil/expectations.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations.go
@@ -194,10 +194,12 @@ type threadExpectations struct {
 	StepsSinceLastContextSwitch uint64
 	NextThreadId                arch.Word
 	prestateActiveThread        *ExpectedThreadState
-	traverseRight               bool
-	left                        []*ExpectedThreadState
-	right                       []*ExpectedThreadState
-	popped                      []*ExpectedThreadState
+	// Cache the original value of the prestate active thread, so we can keep the original values before any updates
+	prestateActiveThreadValue ExpectedThreadState
+	traverseRight             bool
+	left                      []*ExpectedThreadState
+	right                     []*ExpectedThreadState
+	popped                    []*ExpectedThreadState
 }
 
 func newThreadExpectations(state *multithreaded.State) *threadExpectations {
@@ -215,6 +217,7 @@ func newThreadExpectations(state *multithreaded.State) *threadExpectations {
 		StepsSinceLastContextSwitch: state.StepsSinceLastContextSwitch,
 		NextThreadId:                state.NextThreadId,
 		prestateActiveThread:        prestateActiveThread,
+		prestateActiveThreadValue:   *prestateActiveThread,
 		traverseRight:               state.TraverseRight,
 		left:                        left,
 		right:                       right,
@@ -288,9 +291,9 @@ func (e *threadExpectations) ExpectNewThread() *ExpectedThreadState {
 	newThreadId := e.NextThreadId
 	e.NextThreadId += 1
 
-	// Copy expectations from prestate active thread's original state (bf changing any expectations)
+	// Copy expectations from prestate active thread's original value (before changing any expectations)
 	newThread := &ExpectedThreadState{}
-	*newThread = *e.prestateActiveThread
+	*newThread = e.prestateActiveThreadValue
 
 	newThread.ThreadId = newThreadId
 	if e.traverseRight {

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -152,6 +152,21 @@ func TestValidate_shouldPassUnchangedExpectations(t *testing.T) {
 	}
 }
 
+func TestExpectNewThread_DoesNotInheritChangedExpectations(t *testing.T) {
+	state := RandomState(123)
+	expected := NewExpectedState(t, state)
+
+	// Make some changes to the active thread
+	origHI := expected.ActiveThread().HI
+	expected.ActiveThread().HI = 123
+
+	// Create a new thread
+	newThread := expected.ExpectNewThread()
+
+	// New thread should not carry over changes to the original thread
+	require.Equal(t, origHI, newThread.HI)
+}
+
 type MockTestingT struct {
 	errCount int
 }

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 )
 
-type ExpectationMutator func(e *ExpectedState, st *multithreaded.State)
+type ExpectationMutator func(t *testing.T, e *ExpectedState, st *multithreaded.State)
 
 func TestValidate_shouldCatchMutations(t *testing.T) {
 	states := []*multithreaded.State{
@@ -24,90 +24,96 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 		name string
 		mut  ExpectationMutator
 	}{
-		{name: "PreimageKey", mut: func(e *ExpectedState, st *multithreaded.State) { e.PreimageKey = emptyHash }},
-		{name: "PreimageOffset", mut: func(e *ExpectedState, st *multithreaded.State) { e.PreimageOffset += 1 }},
-		{name: "Heap", mut: func(e *ExpectedState, st *multithreaded.State) { e.Heap += 1 }},
-		{name: "LLReservationStatus", mut: func(e *ExpectedState, st *multithreaded.State) { e.LLReservationStatus = e.LLReservationStatus + 1 }},
-		{name: "LLAddress", mut: func(e *ExpectedState, st *multithreaded.State) { e.LLAddress += 1 }},
-		{name: "LLOwnerThread", mut: func(e *ExpectedState, st *multithreaded.State) { e.LLOwnerThread += 1 }},
-		{name: "ExitCode", mut: func(e *ExpectedState, st *multithreaded.State) { e.ExitCode += 1 }},
-		{name: "Exited", mut: func(e *ExpectedState, st *multithreaded.State) { e.Exited = !e.Exited }},
-		{name: "Step", mut: func(e *ExpectedState, st *multithreaded.State) { e.Step += 1 }},
-		{name: "LastHint", mut: func(e *ExpectedState, st *multithreaded.State) { e.LastHint = []byte{7, 8, 9, 10} }},
-		{name: "MemoryRoot", mut: func(e *ExpectedState, st *multithreaded.State) { e.MemoryRoot = emptyHash }},
-		{name: "StepsSinceLastContextSwitch", mut: func(e *ExpectedState, st *multithreaded.State) { e.threadExpectations.StepsSinceLastContextSwitch += 1 }},
-		{name: "TraverseRight", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "PreimageKey", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.PreimageKey = emptyHash }},
+		{name: "PreimageOffset", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.PreimageOffset += 1 }},
+		{name: "Heap", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.Heap += 1 }},
+		{name: "LLReservationStatus", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			e.LLReservationStatus = e.LLReservationStatus + 1
+		}},
+		{name: "LLAddress", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.LLAddress += 1 }},
+		{name: "LLOwnerThread", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.LLOwnerThread += 1 }},
+		{name: "ExitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.ExitCode += 1 }},
+		{name: "Exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.Exited = !e.Exited }},
+		{name: "Step", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.Step += 1 }},
+		{name: "LastHint", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.LastHint = []byte{7, 8, 9, 10} }},
+		{name: "MemoryRoot", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.MemoryRoot = emptyHash }},
+		{name: "StepsSinceLastContextSwitch", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			e.threadExpectations.StepsSinceLastContextSwitch += 1
+		}},
+		{name: "TraverseRight", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.traverseRight = !e.threadExpectations.traverseRight
 		}},
-		{name: "NextThreadId", mut: func(e *ExpectedState, st *multithreaded.State) { e.threadExpectations.NextThreadId += 1 }},
-		{name: "ActiveThreadId", mut: func(e *ExpectedState, st *multithreaded.State) { e.threadExpectations.ActiveThreadId += 1 }},
-		{name: "Empty thread expectations", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "NextThreadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.threadExpectations.NextThreadId += 1 }},
+		{name: "ActiveThreadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			e.threadExpectations.ActiveThreadId += 1
+		}},
+		{name: "Empty thread expectations", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.left = []*ExpectedThreadState{}
 			e.threadExpectations.right = []*ExpectedThreadState{}
 		}},
-		{name: "Missing single thread expectation", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Missing single thread expectation", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			if len(e.threadExpectations.left) > 0 {
 				e.threadExpectations.left = e.threadExpectations.left[:len(e.threadExpectations.left)-1]
 			} else {
 				e.threadExpectations.right = e.threadExpectations.right[:len(e.threadExpectations.right)-1]
 			}
 		}},
-		{name: "Extra thread expectation", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Extra thread expectation", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.left = append(e.threadExpectations.left, newExpectedThreadState(someThread))
 		}},
-		{name: "Active threadId", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active threadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.ThreadId += 1
 		}},
-		{name: "Active thread exitCode", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread exitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.ExitCode += 1
 		}},
-		{name: "Active thread exited", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.Exited = !st.GetCurrentThread().Exited
 		}},
-		{name: "Active thread PC", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread PC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.PC += 1
 		}},
-		{name: "Active thread NextPC", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread NextPC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.NextPC += 1
 		}},
-		{name: "Active thread HI", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread HI", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.HI += 1
 		}},
-		{name: "Active thread LO", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread LO", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.LO += 1
 		}},
-		{name: "Active thread Registers", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread Registers", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.Registers[0] += 1
 		}},
-		{name: "Active thread dropped", mut: func(e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread dropped", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			e.threadExpectations.prestateActiveThread.Dropped = true
 		}},
-		{name: "Inactive threadId", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).ThreadId += 1
+		{name: "Inactive threadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).ThreadId += 1
 		}},
-		{name: "Inactive thread exitCode", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).ExitCode += 1
+		{name: "Inactive thread exitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).ExitCode += 1
 		}},
-		{name: "Inactive thread exited", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).Exited = !FindNextThread(st).Exited
+		{name: "Inactive thread exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).Exited = !FindNextThread(st).Exited
 		}},
-		{name: "Inactive thread PC", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).PC += 1
+		{name: "Inactive thread PC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).PC += 1
 		}},
-		{name: "Inactive thread NextPC", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).NextPC += 1
+		{name: "Inactive thread NextPC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).NextPC += 1
 		}},
-		{name: "Inactive thread HI", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).HI += 1
+		{name: "Inactive thread HI", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).HI += 1
 		}},
-		{name: "Inactive thread LO", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).LO += 1
+		{name: "Inactive thread LO", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).LO += 1
 		}},
-		{name: "Inactive thread Registers", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).Registers[0] += 1
+		{name: "Inactive thread Registers", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).Registers[0] += 1
 		}},
-		{name: "Inactive thread dropped", mut: func(e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(e).Dropped = true
+		{name: "Inactive thread dropped", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+			findInactiveThread(t, e).Dropped = true
 		}},
 	}
 	for _, c := range cases {
@@ -115,7 +121,7 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 			testName := fmt.Sprintf("%v (state #%v)", c.name, i)
 			t.Run(testName, func(t *testing.T) {
 				expected := NewExpectedState(t, state)
-				c.mut(expected, state)
+				c.mut(t, expected, state)
 
 				// We should detect the change and fail
 				mockT := &MockTestingT{}
@@ -125,12 +131,6 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 		}
 
 	}
-}
-
-func findInactiveThread(e *ExpectedState) *ExpectedThreadState {
-	threads := e.threadExpectations.allThreads()
-	idx := int(len(threads) / 2)
-	return threads[idx]
 }
 
 func TestValidate_shouldPassUnchangedExpectations(t *testing.T) {
@@ -165,6 +165,19 @@ func TestExpectNewThread_DoesNotInheritChangedExpectations(t *testing.T) {
 
 	// New thread should not carry over changes to the original thread
 	require.Equal(t, origHI, newThread.HI)
+}
+
+func findInactiveThread(t *testing.T, e *ExpectedState) *ExpectedThreadState {
+	threads := e.threadExpectations.allThreads()
+	activeThread := e.threadExpectations.prestateActiveThread
+	for _, thread := range threads {
+		if thread.ThreadId != activeThread.ThreadId {
+			return thread
+		}
+	}
+	t.Error("No inactive thread found")
+	t.FailNow()
+	return nil
 }
 
 func randomStateWithMultipleThreads(seed int64) *multithreaded.State {

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 )
 
@@ -36,72 +35,79 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 		{name: "Step", mut: func(e *ExpectedState, st *multithreaded.State) { e.Step += 1 }},
 		{name: "LastHint", mut: func(e *ExpectedState, st *multithreaded.State) { e.LastHint = []byte{7, 8, 9, 10} }},
 		{name: "MemoryRoot", mut: func(e *ExpectedState, st *multithreaded.State) { e.MemoryRoot = emptyHash }},
-		{name: "StepsSinceLastContextSwitch", mut: func(e *ExpectedState, st *multithreaded.State) { e.StepsSinceLastContextSwitch += 1 }},
-		{name: "TraverseRight", mut: func(e *ExpectedState, st *multithreaded.State) { e.TraverseRight = !e.TraverseRight }},
-		{name: "NextThreadId", mut: func(e *ExpectedState, st *multithreaded.State) { e.NextThreadId += 1 }},
-		{name: "ThreadCount", mut: func(e *ExpectedState, st *multithreaded.State) { e.ThreadCount += 1 }},
-		{name: "RightStackSize", mut: func(e *ExpectedState, st *multithreaded.State) { e.RightStackSize += 1 }},
-		{name: "LeftStackSize", mut: func(e *ExpectedState, st *multithreaded.State) { e.LeftStackSize += 1 }},
-		{name: "ActiveThreadId", mut: func(e *ExpectedState, st *multithreaded.State) { e.ActiveThreadId += 1 }},
-		{name: "Empty thread expectations", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations = map[arch.Word]*ExpectedThreadState{}
+		{name: "StepsSinceLastContextSwitch", mut: func(e *ExpectedState, st *multithreaded.State) { e.threadExpectations.StepsSinceLastContextSwitch += 1 }},
+		{name: "TraverseRight", mut: func(e *ExpectedState, st *multithreaded.State) {
+			e.threadExpectations.traverseRight = !e.threadExpectations.traverseRight
 		}},
-		{name: "Mismatched thread expectations", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations = map[arch.Word]*ExpectedThreadState{someThread.ThreadId: newExpectedThreadState(someThread)}
+		{name: "NextThreadId", mut: func(e *ExpectedState, st *multithreaded.State) { e.threadExpectations.NextThreadId += 1 }},
+		{name: "ActiveThreadId", mut: func(e *ExpectedState, st *multithreaded.State) { e.threadExpectations.ActiveThreadId += 1 }},
+		{name: "Empty thread expectations", mut: func(e *ExpectedState, st *multithreaded.State) {
+			e.threadExpectations.left = []*ExpectedThreadState{}
+			e.threadExpectations.right = []*ExpectedThreadState{}
+		}},
+		{name: "Missing single thread expectation", mut: func(e *ExpectedState, st *multithreaded.State) {
+			if len(e.threadExpectations.left) > 0 {
+				e.threadExpectations.left = e.threadExpectations.left[:len(e.threadExpectations.left)-1]
+			} else {
+				e.threadExpectations.right = e.threadExpectations.right[:len(e.threadExpectations.right)-1]
+			}
+		}},
+		{name: "Extra thread expectation", mut: func(e *ExpectedState, st *multithreaded.State) {
+			e.threadExpectations.left = append(e.threadExpectations.left, newExpectedThreadState(someThread))
 		}},
 		{name: "Active threadId", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].ThreadId += 1
+			e.threadExpectations.prestateActiveThread.ThreadId += 1
 		}},
 		{name: "Active thread exitCode", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].ExitCode += 1
+			e.threadExpectations.prestateActiveThread.ExitCode += 1
 		}},
 		{name: "Active thread exited", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].Exited = !st.GetCurrentThread().Exited
+			e.threadExpectations.prestateActiveThread.Exited = !st.GetCurrentThread().Exited
 		}},
 		{name: "Active thread PC", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].PC += 1
+			e.threadExpectations.prestateActiveThread.PC += 1
 		}},
 		{name: "Active thread NextPC", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].NextPC += 1
+			e.threadExpectations.prestateActiveThread.NextPC += 1
 		}},
 		{name: "Active thread HI", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].HI += 1
+			e.threadExpectations.prestateActiveThread.HI += 1
 		}},
 		{name: "Active thread LO", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].LO += 1
+			e.threadExpectations.prestateActiveThread.LO += 1
 		}},
 		{name: "Active thread Registers", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].Registers[0] += 1
+			e.threadExpectations.prestateActiveThread.Registers[0] += 1
 		}},
 		{name: "Active thread dropped", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[st.GetCurrentThread().ThreadId].Dropped = true
+			e.threadExpectations.prestateActiveThread.Dropped = true
 		}},
 		{name: "Inactive threadId", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].ThreadId += 1
+			findInactiveThread(e).ThreadId += 1
 		}},
 		{name: "Inactive thread exitCode", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].ExitCode += 1
+			findInactiveThread(e).ExitCode += 1
 		}},
 		{name: "Inactive thread exited", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].Exited = !FindNextThread(st).Exited
+			findInactiveThread(e).Exited = !FindNextThread(st).Exited
 		}},
 		{name: "Inactive thread PC", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].PC += 1
+			findInactiveThread(e).PC += 1
 		}},
 		{name: "Inactive thread NextPC", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].NextPC += 1
+			findInactiveThread(e).NextPC += 1
 		}},
 		{name: "Inactive thread HI", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].HI += 1
+			findInactiveThread(e).HI += 1
 		}},
 		{name: "Inactive thread LO", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].LO += 1
+			findInactiveThread(e).LO += 1
 		}},
 		{name: "Inactive thread Registers", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].Registers[0] += 1
+			findInactiveThread(e).Registers[0] += 1
 		}},
 		{name: "Inactive thread dropped", mut: func(e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations[FindNextThread(st).ThreadId].Dropped = true
+			findInactiveThread(e).Dropped = true
 		}},
 	}
 	for _, c := range cases {
@@ -119,6 +125,12 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 		}
 
 	}
+}
+
+func findInactiveThread(e *ExpectedState) *ExpectedThreadState {
+	threads := e.threadExpectations.allThreads()
+	idx := int(len(threads) / 2)
+	return threads[idx]
 }
 
 func TestValidate_shouldPassUnchangedExpectations(t *testing.T) {

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -135,9 +135,9 @@ func findInactiveThread(e *ExpectedState) *ExpectedThreadState {
 
 func TestValidate_shouldPassUnchangedExpectations(t *testing.T) {
 	states := []*multithreaded.State{
-		RandomState(0),
-		RandomState(1),
-		RandomState(2),
+		RandomState(10),
+		RandomState(11),
+		RandomState(12),
 	}
 
 	for i, state := range states {

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 )
 
-type ExpectationMutator func(t *testing.T, e *ExpectedState, st *multithreaded.State)
+type ExpectationMutator func(t *testing.T, e *ExpectedState)
 
 func TestValidate_shouldCatchMutations(t *testing.T) {
 	states := []*multithreaded.State{
@@ -24,95 +24,96 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 		name string
 		mut  ExpectationMutator
 	}{
-		{name: "PreimageKey", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.PreimageKey = emptyHash }},
-		{name: "PreimageOffset", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.PreimageOffset += 1 }},
-		{name: "Heap", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.Heap += 1 }},
-		{name: "LLReservationStatus", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "PreimageKey", mut: func(t *testing.T, e *ExpectedState) { e.PreimageKey = emptyHash }},
+		{name: "PreimageOffset", mut: func(t *testing.T, e *ExpectedState) { e.PreimageOffset += 1 }},
+		{name: "Heap", mut: func(t *testing.T, e *ExpectedState) { e.Heap += 1 }},
+		{name: "LLReservationStatus", mut: func(t *testing.T, e *ExpectedState) {
 			e.LLReservationStatus = e.LLReservationStatus + 1
 		}},
-		{name: "LLAddress", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.LLAddress += 1 }},
-		{name: "LLOwnerThread", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.LLOwnerThread += 1 }},
-		{name: "ExitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.ExitCode += 1 }},
-		{name: "Exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.Exited = !e.Exited }},
-		{name: "Step", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.Step += 1 }},
-		{name: "LastHint", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.LastHint = []byte{7, 8, 9, 10} }},
-		{name: "MemoryRoot", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.MemoryRoot = emptyHash }},
-		{name: "StepsSinceLastContextSwitch", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "LLAddress", mut: func(t *testing.T, e *ExpectedState) { e.LLAddress += 1 }},
+		{name: "LLOwnerThread", mut: func(t *testing.T, e *ExpectedState) { e.LLOwnerThread += 1 }},
+		{name: "ExitCode", mut: func(t *testing.T, e *ExpectedState) { e.ExitCode += 1 }},
+		{name: "Exited", mut: func(t *testing.T, e *ExpectedState) { e.Exited = !e.Exited }},
+		{name: "Step", mut: func(t *testing.T, e *ExpectedState) { e.Step += 1 }},
+		{name: "LastHint", mut: func(t *testing.T, e *ExpectedState) { e.LastHint = []byte{7, 8, 9, 10} }},
+		{name: "MemoryRoot", mut: func(t *testing.T, e *ExpectedState) { e.MemoryRoot = emptyHash }},
+		{name: "StepsSinceLastContextSwitch", mut: func(t *testing.T, e *ExpectedState) {
 			e.threadExpectations.StepsSinceLastContextSwitch += 1
 		}},
-		{name: "TraverseRight", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "TraverseRight", mut: func(t *testing.T, e *ExpectedState) {
 			e.threadExpectations.traverseRight = !e.threadExpectations.traverseRight
 		}},
-		{name: "NextThreadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) { e.threadExpectations.NextThreadId += 1 }},
-		{name: "ActiveThreadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "NextThreadId", mut: func(t *testing.T, e *ExpectedState) { e.threadExpectations.NextThreadId += 1 }},
+		{name: "ActiveThreadId", mut: func(t *testing.T, e *ExpectedState) {
 			e.threadExpectations.ActiveThreadId += 1
 		}},
-		{name: "Empty thread expectations", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Empty thread expectations", mut: func(t *testing.T, e *ExpectedState) {
 			e.threadExpectations.left = []*ExpectedThreadState{}
 			e.threadExpectations.right = []*ExpectedThreadState{}
 		}},
-		{name: "Missing single thread expectation", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Missing single thread expectation", mut: func(t *testing.T, e *ExpectedState) {
 			if len(e.threadExpectations.left) > 0 {
 				e.threadExpectations.left = e.threadExpectations.left[:len(e.threadExpectations.left)-1]
 			} else {
 				e.threadExpectations.right = e.threadExpectations.right[:len(e.threadExpectations.right)-1]
 			}
 		}},
-		{name: "Extra thread expectation", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Extra thread expectation", mut: func(t *testing.T, e *ExpectedState) {
 			e.threadExpectations.left = append(e.threadExpectations.left, newExpectedThreadState(someThread))
 		}},
-		{name: "Active threadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active threadId", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().ThreadId += 1
 		}},
-		{name: "Active thread exitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread exitCode", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().ExitCode += 1
 		}},
-		{name: "Active thread exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.ActiveThread().Exited = !st.GetCurrentThread().Exited
+		{name: "Active thread exited", mut: func(t *testing.T, e *ExpectedState) {
+			e.ActiveThread().Exited = !e.ActiveThread().Exited
 		}},
-		{name: "Active thread PC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread PC", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().PC += 1
 		}},
-		{name: "Active thread NextPC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread NextPC", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().NextPC += 1
 		}},
-		{name: "Active thread HI", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread HI", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().HI += 1
 		}},
-		{name: "Active thread LO", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread LO", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().LO += 1
 		}},
-		{name: "Active thread Registers", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread Registers", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().Registers[0] += 1
 		}},
-		{name: "Active thread dropped", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Active thread dropped", mut: func(t *testing.T, e *ExpectedState) {
 			e.ActiveThread().Dropped = true
 		}},
-		{name: "Inactive threadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive threadId", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).ThreadId += 1
 		}},
-		{name: "Inactive thread exitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread exitCode", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).ExitCode += 1
 		}},
-		{name: "Inactive thread exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			findInactiveThread(t, e).Exited = !FindNextThread(st).Exited
+		{name: "Inactive thread exited", mut: func(t *testing.T, e *ExpectedState) {
+			thread := findInactiveThread(t, e)
+			thread.Exited = !thread.Exited
 		}},
-		{name: "Inactive thread PC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread PC", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).PC += 1
 		}},
-		{name: "Inactive thread NextPC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread NextPC", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).NextPC += 1
 		}},
-		{name: "Inactive thread HI", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread HI", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).HI += 1
 		}},
-		{name: "Inactive thread LO", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread LO", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).LO += 1
 		}},
-		{name: "Inactive thread Registers", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread Registers", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).Registers[0] += 1
 		}},
-		{name: "Inactive thread dropped", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
+		{name: "Inactive thread dropped", mut: func(t *testing.T, e *ExpectedState) {
 			findInactiveThread(t, e).Dropped = true
 		}},
 	}
@@ -121,7 +122,7 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 			testName := fmt.Sprintf("%v (state #%v)", c.name, i)
 			t.Run(testName, func(t *testing.T) {
 				expected := NewExpectedState(t, state)
-				c.mut(t, expected, state)
+				c.mut(t, expected)
 
 				// We should detect the change and fail
 				mockT := &MockTestingT{}

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -13,9 +13,9 @@ type ExpectationMutator func(e *ExpectedState, st *multithreaded.State)
 
 func TestValidate_shouldCatchMutations(t *testing.T) {
 	states := []*multithreaded.State{
-		RandomState(0),
-		RandomState(1),
-		RandomState(2),
+		randomStateWithMultipleThreads(0),
+		randomStateWithMultipleThreads(1),
+		randomStateWithMultipleThreads(2),
 	}
 	var emptyHash [32]byte
 	someThread := RandomThread(123)
@@ -165,6 +165,15 @@ func TestExpectNewThread_DoesNotInheritChangedExpectations(t *testing.T) {
 
 	// New thread should not carry over changes to the original thread
 	require.Equal(t, origHI, newThread.HI)
+}
+
+func randomStateWithMultipleThreads(seed int64) *multithreaded.State {
+	state := RandomState(int(seed))
+	if state.ThreadCount() == 1 {
+		// Make sure we have at least 2 threads
+		SetupThreads(seed+100, state, state.TraverseRight, 1, 1)
+	}
+	return state
 }
 
 type MockTestingT struct {

--- a/cannon/mipsevm/multithreaded/testutil/expectations_test.go
+++ b/cannon/mipsevm/multithreaded/testutil/expectations_test.go
@@ -62,31 +62,31 @@ func TestValidate_shouldCatchMutations(t *testing.T) {
 			e.threadExpectations.left = append(e.threadExpectations.left, newExpectedThreadState(someThread))
 		}},
 		{name: "Active threadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.ThreadId += 1
+			e.ActiveThread().ThreadId += 1
 		}},
 		{name: "Active thread exitCode", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.ExitCode += 1
+			e.ActiveThread().ExitCode += 1
 		}},
 		{name: "Active thread exited", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.Exited = !st.GetCurrentThread().Exited
+			e.ActiveThread().Exited = !st.GetCurrentThread().Exited
 		}},
 		{name: "Active thread PC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.PC += 1
+			e.ActiveThread().PC += 1
 		}},
 		{name: "Active thread NextPC", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.NextPC += 1
+			e.ActiveThread().NextPC += 1
 		}},
 		{name: "Active thread HI", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.HI += 1
+			e.ActiveThread().HI += 1
 		}},
 		{name: "Active thread LO", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.LO += 1
+			e.ActiveThread().LO += 1
 		}},
 		{name: "Active thread Registers", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.Registers[0] += 1
+			e.ActiveThread().Registers[0] += 1
 		}},
 		{name: "Active thread dropped", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
-			e.threadExpectations.prestateActiveThread.Dropped = true
+			e.ActiveThread().Dropped = true
 		}},
 		{name: "Inactive threadId", mut: func(t *testing.T, e *ExpectedState, st *multithreaded.State) {
 			findInactiveThread(t, e).ThreadId += 1
@@ -169,7 +169,7 @@ func TestExpectNewThread_DoesNotInheritChangedExpectations(t *testing.T) {
 
 func findInactiveThread(t *testing.T, e *ExpectedState) *ExpectedThreadState {
 	threads := e.threadExpectations.allThreads()
-	activeThread := e.threadExpectations.prestateActiveThread
+	activeThread := e.ActiveThread()
 	for _, thread := range threads {
 		if thread.ThreadId != activeThread.ThreadId {
 			return thread

--- a/cannon/mipsevm/tests/difftester_test.go
+++ b/cannon/mipsevm/tests/difftester_test.go
@@ -132,7 +132,7 @@ func TestDiffTester_Run_WithMemModifications(t *testing.T) {
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
 				// Difftester runs extra calls in order to analyze the tests
-				expectedCalls := len(versions)*(len(mods)+1) + +len(versions)
+				expectedCalls := len(versions) * (len(mods) + 2)
 				require.Equal(t, expectedCalls, initStateCalled[c.name])
 				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}

--- a/cannon/mipsevm/tests/difftester_test.go
+++ b/cannon/mipsevm/tests/difftester_test.go
@@ -53,10 +53,10 @@ func TestDiffTester_Run_SimpleTest(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
-				testsPerCase := len(versions)
-				require.Equal(t, testsPerCase, initStateCalled[c.name])
-				// Difftester runs extra calls on the expectations fn in order to analyze the tests
-				require.Equal(t, testsPerCase+len(versions), expectationsCalled[c.name])
+				// Difftester runs extra calls in order to analyze the tests
+				expectedCalls := 2 * len(versions)
+				require.Equal(t, expectedCalls, initStateCalled[c.name])
+				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}
 
 			// Validate that tests ran and passed as expected
@@ -131,10 +131,10 @@ func TestDiffTester_Run_WithMemModifications(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
-				testsPerCase := len(versions) * (len(mods) + 1)
-				require.Equal(t, testsPerCase, initStateCalled[c.name])
-				// Difftester runs extra calls on the expectations fn in order to analyze the tests
-				require.Equal(t, testsPerCase+len(versions), expectationsCalled[c.name])
+				// Difftester runs extra calls in order to analyze the tests
+				expectedCalls := len(versions)*(len(mods)+1) + +len(versions)
+				require.Equal(t, expectedCalls, initStateCalled[c.name])
+				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}
 
 			// Validate that tests ran and passed
@@ -189,10 +189,10 @@ func TestDiffTester_Run_WithPanic(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
-				testsPerCase := len(versions)
-				require.Equal(t, testsPerCase, initStateCalled[c.name])
-				// Difftester runs extra calls on the expectations fn in order to analyze the tests
-				require.Equal(t, testsPerCase+len(versions), expectationsCalled[c.name])
+				// Difftester runs extra calls in order to analyze the tests
+				expectedCalls := 2 * len(versions)
+				require.Equal(t, expectedCalls, initStateCalled[c.name])
+				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}
 
 			// Validate that tests ran and passed as expected
@@ -246,8 +246,8 @@ func TestDiffTester_Run_WithVm(t *testing.T) {
 
 	// Validate that we invoked initState and setExpectations as expected
 	for _, c := range testCases {
-		require.Equal(t, 1, initStateCalled[c.name])
-		// Difftester runs extra calls on the expectations fn in order to analyze the tests
+		// Difftester runs extra calls in order to analyze the tests
+		require.Equal(t, 2, initStateCalled[c.name])
 		require.Equal(t, 2, expectationsCalled[c.name])
 	}
 

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -84,7 +84,7 @@ func TestEVM_MT64_LL(t *testing.T) {
 		expected.ExpectStep()
 		expected.LLReservationStatus = multithreaded.LLStatusActive32bit
 		expected.LLAddress = testCase.Base.addr
-		expected.LLOwnerThread = expected.ActiveThreadId
+		expected.LLOwnerThread = expected.ActiveThreadId()
 
 		retReg := testCase.Base.retReg
 		if retReg != 0 {
@@ -270,7 +270,7 @@ func TestEVM_MT64_LLD(t *testing.T) {
 		expected.ExpectStep()
 		expected.LLReservationStatus = multithreaded.LLStatusActive64bit
 		expected.LLAddress = c.addr
-		expected.LLOwnerThread = expected.ActiveThreadId
+		expected.LLOwnerThread = expected.ActiveThreadId()
 		if c.retReg != 0 {
 			expected.ActiveThread().Registers[c.retReg] = c.memVal
 		}

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -976,51 +976,44 @@ func TestEVM_NormalTraversal_Full(t *testing.T) {
 }
 
 func TestEVM_SchedQuantumThreshold(t *testing.T) {
-	cases := []struct {
+	type testCase struct {
 		name                        string
 		stepsSinceLastContextSwitch uint64
 		shouldPreempt               bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "just under threshold", stepsSinceLastContextSwitch: exec.SchedQuantum - 1},
 		{name: "at threshold", stepsSinceLastContextSwitch: exec.SchedQuantum, shouldPreempt: true},
 		{name: "beyond threshold", stepsSinceLastContextSwitch: exec.SchedQuantum + 1, shouldPreempt: true},
 	}
 
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*789)))
-				state := mtutil.GetMtState(t, goVm)
-				// Setup basic getThreadId syscall instruction
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
-				state.StepsSinceLastContextSwitch = c.stepsSinceLastContextSwitch
-				step := state.Step
-
-				// Set up post-state expectations
-				expected := mtutil.NewExpectedState(t, state)
-				if c.shouldPreempt {
-					expected.Step += 1
-					expected.ExpectPreemption()
-				} else {
-					// Otherwise just expect a normal step
-					expected.ExpectStep()
-					expected.ActiveThread().Registers[2] = state.GetCurrentThread().ThreadId
-					expected.ActiveThread().Registers[7] = 0
-				}
-
-				// State transition
-				var err error
-				var stepWitness *mipsevm.StepWitness
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		// Setup basic getThreadId syscall instruction
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysGetTID // Set syscall number
+		state.StepsSinceLastContextSwitch = c.stepsSinceLastContextSwitch
 	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		if c.shouldPreempt {
+			expected.Step += 1
+			expected.ExpectPreemption()
+		} else {
+			// Otherwise just expect a normal step
+			expected.ExpectStep()
+			expected.ActiveThread().Registers[2] = expected.ActiveThreadId()
+			expected.ActiveThread().Registers[7] = 0
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -649,52 +649,53 @@ func TestEVM_SysNanosleep(t *testing.T) {
 }
 
 func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
-	cases := []struct {
+	type testVariation struct {
+		name          string
+		traverseRight bool
+	}
+	testVariations := []testVariation{
+		{"Traverse right", true},
+		{"Traverse left", false},
+	}
+
+	type baseTest struct {
 		name            string
 		traverseRight   bool
 		activeThreads   int
 		inactiveThreads int
-	}{
+	}
+	baseTests := []baseTest{
 		{name: "Last active thread", activeThreads: 1, inactiveThreads: 2},
 		{name: "Only thread", activeThreads: 1, inactiveThreads: 0},
 		{name: "Do not change directions", activeThreads: 2, inactiveThreads: 2},
 		{name: "Do not change directions", activeThreads: 3, inactiveThreads: 0},
 	}
 
-	versions := GetMipsVersionTestCases(t)
-	for _, ver := range versions {
-		for i, c := range cases {
-			for _, traverseRight := range []bool{true, false} {
-				testName := fmt.Sprintf("%v: %v (vm = %v, traverseRight = %v)", syscallName, c.name, ver.Name, traverseRight)
-				t.Run(testName, func(t *testing.T) {
-					goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*789)))
-					state := mtutil.GetMtState(t, goVm)
-					mtutil.SetupThreads(int64(i*3259), state, traverseRight, c.activeThreads, c.inactiveThreads)
-
-					testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-					state.GetRegistersRef()[2] = Word(syscallNum) // Set syscall number
-					step := state.Step
-
-					// Set up post-state expectations
-					expected := mtutil.NewExpectedState(t, state)
-					expected.ExpectStep()
-					expected.ExpectPreemption()
-					expected.PrestateActiveThread().Registers[2] = 0
-					expected.PrestateActiveThread().Registers[7] = 0
-
-					// State transition
-					var err error
-					var stepWitness *mipsevm.StepWitness
-					stepWitness, err = goVm.Step(true)
-					require.NoError(t, err)
-
-					// Validate post-state
-					expected.Validate(t, state)
-					testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-				})
-			}
-		}
+	type testCase = testutil.TestCaseVariation[baseTest, testVariation]
+	testNamer := func(tc testCase) string {
+		return fmt.Sprintf("%v-%v", tc.Base.name, tc.Variation.name)
 	}
+	cases := testutil.TestVariations(baseTests, testVariations)
+
+	initState := func(tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		c := tt.Base
+		mtutil.SetupThreads(r.Int64(1000), state, tt.Variation.traverseRight, c.activeThreads, c.inactiveThreads)
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = Word(syscallNum) // Set syscall number
+	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ExpectPreemption()
+		expected.PrestateActiveThread().Registers[2] = 0
+		expected.PrestateActiveThread().Registers[7] = 0
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysOpen(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -652,7 +652,6 @@ func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
 
 	type baseTest struct {
 		name            string
-		traverseRight   bool
 		activeThreads   int
 		inactiveThreads int
 	}

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -401,52 +401,43 @@ func TestEVM_SysExit(t *testing.T) {
 }
 
 func TestEVM_PopExitedThread(t *testing.T) {
-	cases := []struct {
+	type testCase struct {
 		name                         string
 		traverseRight                bool
 		activeStackThreadCount       int
 		expectTraverseRightPostState bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "traverse right", traverseRight: true, activeStackThreadCount: 2, expectTraverseRightPostState: true},
 		{name: "traverse right, switch directions", traverseRight: true, activeStackThreadCount: 1, expectTraverseRightPostState: false},
 		{name: "traverse left", traverseRight: false, activeStackThreadCount: 2, expectTraverseRightPostState: false},
 		{name: "traverse left, switch directions", traverseRight: false, activeStackThreadCount: 1, expectTraverseRightPostState: true},
 	}
 
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*133)))
-				state := mtutil.GetMtState(t, goVm)
-				mtutil.SetupThreads(int64(i*222), state, c.traverseRight, c.activeStackThreadCount, 1)
-				step := state.Step
-
-				// Setup thread to be dropped
-				threadToPop := state.GetCurrentThread()
-				threadToPop.Exited = true
-				threadToPop.ExitCode = 1
-
-				// Set up expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.Step += 1
-				expected.ExpectPoppedThread()
-				expected.ExpectContextSwitch()
-				expected.ExpectTraverseRight(c.expectTraverseRightPostState)
-
-				// State transition
-				var err error
-				var stepWitness *mipsevm.StepWitness
-				stepWitness, err = goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		mtutil.SetupThreads(r.Int64(1000), state, c.traverseRight, c.activeStackThreadCount, 1)
+		threadToPop := state.GetCurrentThread()
+		threadToPop.Exited = true
+		threadToPop.ExitCode = 1
 	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.Step += 1
+		expected.ExpectPoppedThread()
+		expected.ExpectContextSwitch()
+		expected.ExpectTraverseRight(c.expectTraverseRightPostState)
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysFutex_WaitPrivate(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -15,7 +15,6 @@ import (
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 )
 
 type Word = arch.Word
@@ -200,12 +199,17 @@ func TestEVM_MT_SC(t *testing.T) {
 }
 
 func TestEVM_SysClone_FlagHandling(t *testing.T) {
-
-	cases := []struct {
+	type testCase struct {
 		name  string
 		flags Word
 		valid bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{"the supported flags bitmask", exec.ValidCloneFlags, true},
 		{"no flags", 0, false},
 		{"all flags", ^Word(0), false},
@@ -217,41 +221,33 @@ func TestEVM_SysClone_FlagHandling(t *testing.T) {
 		{"multiple unsupported flags", exec.CloneUntraced | exec.CloneParentSettid, false},
 	}
 
-	for _, c := range cases {
-		c := c
-		for _, version := range GetMipsVersionTestCases(t) {
-			version := version
-			t.Run(fmt.Sprintf("%v-%v", version.Name, c.name), func(t *testing.T) {
-				state := multithreaded.CreateEmptyState()
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
-				state.GetRegistersRef()[4] = c.flags       // Set first argument
-				curStep := state.Step
-
-				var err error
-				var stepWitness *mipsevm.StepWitness
-				goVm := multithreaded.NewInstrumentedState(state, nil, os.Stdout, os.Stderr, nil, nil, versions.FeaturesForVersion(version.Version))
-				if !c.valid {
-					// The VM should exit
-					stepWitness, err = goVm.Step(true)
-					require.NoError(t, err)
-					require.Equal(t, curStep+1, state.GetStep())
-					require.Equal(t, true, goVm.GetState().GetExited())
-					require.Equal(t, uint8(mipsevm.VMStatusPanic), goVm.GetState().GetExitCode())
-					require.Equal(t, 1, state.ThreadCount())
-				} else {
-					stepWitness, err = goVm.Step(true)
-					require.NoError(t, err)
-					require.Equal(t, curStep+1, state.GetStep())
-					require.Equal(t, false, goVm.GetState().GetExited())
-					require.Equal(t, uint8(0), goVm.GetState().GetExitCode())
-					require.Equal(t, 2, state.ThreadCount())
-				}
-
-				testutil.ValidateEVM(t, stepWitness, curStep, goVm, multithreaded.GetStateHashFn(), version.Contracts)
-			})
-		}
+	stackPtr := Word(204)
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		mtutil.InitializeSingleThread(r.Intn(10000), state, true)
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysClone // Set syscall number
+		state.GetRegistersRef()[4] = c.flags       // Set first argument
+		state.GetRegistersRef()[5] = stackPtr      // a1 - the stack pointer
 	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		if !c.valid {
+			// The VM should exit
+			expected.Step += 1
+			expected.ExpectNoContextSwitch()
+			expected.Exited = true
+			expected.ExitCode = uint8(mipsevm.VMStatusPanic)
+		} else {
+			// Otherwise, we should clone the thread as normal
+			setCloneExpectations(expected, stackPtr)
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysClone_Successful(t *testing.T) {
@@ -282,32 +278,37 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 	}
 
 	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
-		expected.Step += 1
-		expectedNewThread := expected.ExpectNewThread()
-		expected.ExpectActiveThreadId(expectedNewThread.ThreadId)
-		expected.ExpectContextSwitch()
-
-		// Original thread expectations
-		prestateNextPC := expected.PrestateActiveThread().NextPC
-		expected.PrestateActiveThread().PC = prestateNextPC
-		expected.PrestateActiveThread().NextPC = prestateNextPC + 4
-		expected.PrestateActiveThread().Registers[2] = 1
-		expected.PrestateActiveThread().Registers[7] = 0
-		// New thread expectations
-		expectedNewThread.PC = prestateNextPC
-		expectedNewThread.NextPC = prestateNextPC + 4
-		expectedNewThread.ThreadId = 1
-		expectedNewThread.Registers[register.RegSyscallRet1] = 0
-		expectedNewThread.Registers[register.RegSyscallErrno] = 0
-		expectedNewThread.Registers[register.RegSP] = stackPtr
-
-		return ExpectNormalExecution()
+		return setCloneExpectations(expected, stackPtr)
 	}
 
 	NewDiffTester(testNamer).
 		InitState(initState).
 		SetExpectations(setExpectations).
 		Run(t, cases)
+}
+
+// setCloneExpectations sets state expectations assuming we start with 1 thread
+func setCloneExpectations(expected *mtutil.ExpectedState, stackPointer Word) ExpectedExecResult {
+	expected.Step += 1
+	expectedNewThread := expected.ExpectNewThread()
+	expected.ExpectActiveThreadId(expectedNewThread.ThreadId)
+	expected.ExpectContextSwitch()
+
+	// Original thread expectations
+	prestateNextPC := expected.PrestateActiveThread().NextPC
+	expected.PrestateActiveThread().PC = prestateNextPC
+	expected.PrestateActiveThread().NextPC = prestateNextPC + 4
+	expected.PrestateActiveThread().Registers[2] = 1
+	expected.PrestateActiveThread().Registers[7] = 0
+	// New thread expectations
+	expectedNewThread.PC = prestateNextPC
+	expectedNewThread.NextPC = prestateNextPC + 4
+	expectedNewThread.ThreadId = 1
+	expectedNewThread.Registers[register.RegSyscallRet1] = 0
+	expectedNewThread.Registers[register.RegSyscallErrno] = 0
+	expectedNewThread.Registers[register.RegSP] = stackPointer
+
+	return ExpectNormalExecution()
 }
 
 func TestEVM_SysGetTID(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -450,8 +450,7 @@ func TestEVM_PopExitedThread(t *testing.T) {
 }
 
 func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
-	// Note: parameters are written as 64-bit values. For 32-bit architectures, these values are downcast to 32-bit
-	cases := []struct {
+	type testCase struct {
 		name         string
 		addressParam uint64
 		effAddr      uint64
@@ -459,7 +458,13 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 		actualValue  uint32
 		timeout      uint64
 		shouldFail   bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "successful wait, no timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_38, effAddr: 0xFF_FF_FF_FF_FF_FF_12_38, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_01},
 		{name: "successful wait, no timeout, unaligned addr #1", addressParam: 0xFF_FF_FF_FF_FF_FF_12_33, effAddr: 0xFF_FF_FF_FF_FF_FF_12_30, targetValue: 0x01, actualValue: 0x01},
 		{name: "successful wait, no timeout, unaligned addr #2", addressParam: 0xFF_FF_FF_FF_FF_FF_12_37, effAddr: 0xFF_FF_FF_FF_FF_FF_12_34, targetValue: 0x01, actualValue: 0x01},
@@ -472,51 +477,39 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 		{name: "memory mismatch w timeout", addressParam: 0xFF_FF_FF_FF_FF_FF_12_00, effAddr: 0xFF_FF_FF_FF_FF_FF_12_00, targetValue: 0xFF_FF_FF_F8, actualValue: 0xF8, timeout: 2000000, shouldFail: true},
 		{name: "memory mismatch w timeout, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_12_0F, effAddr: 0xFF_FF_FF_FF_FF_FF_12_0C, targetValue: 0xFF_FF_FF_01, actualValue: 0xFF_FF_FF_02, timeout: 2000000, shouldFail: true},
 	}
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				rand := testutil.NewRandHelper(int64(i * 33))
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*1234)), mtutil.WithPCAndNextPC(0x04))
-				state := mtutil.GetMtState(t, goVm)
-				step := state.GetStep()
 
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				testutil.RandomizeWordAndSetUint32(state.GetMemory(), Word(c.effAddr), c.actualValue, int64(i+22))
-				state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
-				state.GetRegistersRef()[4] = Word(c.addressParam)
-				state.GetRegistersRef()[5] = exec.FutexWaitPrivate
-				// Randomize upper bytes of futex target
-				state.GetRegistersRef()[6] = (rand.Word() & ^Word(0xFF_FF_FF_FF)) | Word(c.targetValue)
-				state.GetRegistersRef()[7] = Word(c.timeout)
-
-				// Setup expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.Step += 1
-				expected.ActiveThread().PC = state.GetCpu().NextPC
-				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
-				if c.shouldFail {
-					expected.ExpectNoContextSwitch()
-					expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
-					expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-				} else {
-					// Return empty result and preempt thread
-					expected.ActiveThread().Registers[2] = 0
-					expected.ActiveThread().Registers[7] = 0
-					expected.ExpectPreemption()
-				}
-
-				// State transition
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		testutil.RandomizeWordAndSetUint32(state.GetMemory(), Word(c.effAddr), c.actualValue, r.Int64(1000))
+		state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
+		state.GetRegistersRef()[4] = Word(c.addressParam)
+		state.GetRegistersRef()[5] = exec.FutexWaitPrivate
+		// Randomize upper bytes of futex target
+		state.GetRegistersRef()[6] = (rand.Word() & ^Word(0xFF_FF_FF_FF)) | Word(c.targetValue)
+		state.GetRegistersRef()[7] = Word(c.timeout)
 	}
+
+	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.Step += 1
+		expected.ActiveThread().PC = expected.ActiveThread().NextPC
+		expected.ActiveThread().NextPC = expected.ActiveThread().NextPC + 4
+		if c.shouldFail {
+			expected.ExpectNoContextSwitch()
+			expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+		} else {
+			// Return empty result and preempt thread
+			expected.ActiveThread().Registers[2] = 0
+			expected.ActiveThread().Registers[7] = 0
+			expected.ExpectPreemption()
+		}
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysFutex_WakePrivate(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -513,15 +513,20 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 }
 
 func TestEVM_SysFutex_WakePrivate(t *testing.T) {
-	// Note: parameters are written as 64-bit values. For 32-bit architectures, these values are downcast to 32-bit
-	cases := []struct {
+	type testCase struct {
 		name                string
 		addressParam        uint64
 		effAddr             uint64
 		activeThreadCount   int
 		inactiveThreadCount int
 		traverseRight       bool
-	}{
+	}
+
+	testNamer := func(tc testCase) string {
+		return tc.name
+	}
+
+	cases := []testCase{
 		{name: "Traverse right", addressParam: 0xFF_FF_FF_FF_FF_FF_67_00, effAddr: 0xFF_FF_FF_FF_FF_FF_67_00, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
 		{name: "Traverse right, unaligned addr #1", addressParam: 0xFF_FF_FF_FF_FF_FF_67_83, effAddr: 0xFF_FF_FF_FF_FF_FF_67_80, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
 		{name: "Traverse right, unaligned addr #2", addressParam: 0xFF_FF_FF_FF_FF_FF_67_87, effAddr: 0xFF_FF_FF_FF_FF_FF_67_84, activeThreadCount: 2, inactiveThreadCount: 1, traverseRight: true},
@@ -538,38 +543,27 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 		{name: "Traverse left, single thread", addressParam: 0xFF_FF_FF_FF_FF_FF_67_88, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 0, traverseRight: false},
 		{name: "Traverse left, single thread, unaligned", addressParam: 0xFF_FF_FF_FF_FF_FF_67_89, effAddr: 0xFF_FF_FF_FF_FF_FF_67_88, activeThreadCount: 1, inactiveThreadCount: 0, traverseRight: false},
 	}
-	vmVersions := GetMipsVersionTestCases(t)
-	for _, ver := range vmVersions {
-		for i, c := range cases {
-			testName := fmt.Sprintf("%v (%v)", c.name, ver.Name)
-			t.Run(testName, func(t *testing.T) {
-				goVm := ver.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(int64(i*1122)))
-				state := mtutil.GetMtState(t, goVm)
-				mtutil.SetupThreads(int64(i*2244), state, c.traverseRight, c.activeThreadCount, c.inactiveThreadCount)
-				step := state.Step
 
-				testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
-				state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
-				state.GetRegistersRef()[4] = Word(c.addressParam)
-				state.GetRegistersRef()[5] = exec.FutexWakePrivate
-
-				// Set up post-state expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[2] = 0
-				expected.ActiveThread().Registers[7] = 0
-				expected.ExpectPreemption()
-
-				// State transition
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-
-				// Validate post-state
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), ver.Contracts)
-			})
-		}
+	initState := func(c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		mtutil.SetupThreads(r.Int64(1000), state, c.traverseRight, c.activeThreadCount, c.inactiveThreadCount)
+		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
+		state.GetRegistersRef()[2] = arch.SysFutex // Set syscall number
+		state.GetRegistersRef()[4] = Word(c.addressParam)
+		state.GetRegistersRef()[5] = exec.FutexWakePrivate
 	}
+
+	setExpectations := func(tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = 0
+		expected.ActiveThread().Registers[7] = 0
+		expected.ExpectPreemption()
+		return ExpectNormalExecution()
+	}
+
+	NewDiffTester(testNamer).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		Run(t, cases)
 }
 
 func TestEVM_SysFutex_UnsupportedOp(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -86,7 +86,7 @@ func TestEVM_MT_LL(t *testing.T) {
 		expected.ExpectStep()
 		expected.LLReservationStatus = multithreaded.LLStatusActive32bit
 		expected.LLAddress = Word(c.expectedAddr)
-		expected.LLOwnerThread = expected.ActiveThreadId
+		expected.LLOwnerThread = expected.ActiveThreadId()
 		if c.rtReg != 0 {
 			expected.ActiveThread().Registers[c.rtReg] = Word(c.retVal)
 		}
@@ -284,16 +284,11 @@ func TestEVM_SysClone_Successful(t *testing.T) {
 	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.Step += 1
 		expectedNewThread := expected.ExpectNewThread()
-		expected.ActiveThreadId = expectedNewThread.ThreadId
-		expected.StepsSinceLastContextSwitch = 0
-		if c.traverseRight {
-			expected.RightStackSize += 1
-		} else {
-			expected.LeftStackSize += 1
-		}
+		expected.ExpectActiveThreadId(expectedNewThread.ThreadId)
+		expected.ExpectContextSwitch()
 
 		// Original thread expectations
-		prestateNextPC := expected.ActiveThread().NextPC
+		prestateNextPC := expected.PrestateActiveThread().NextPC
 		expected.PrestateActiveThread().PC = prestateNextPC
 		expected.PrestateActiveThread().NextPC = prestateNextPC + 4
 		expected.PrestateActiveThread().Registers[2] = 1
@@ -389,7 +384,7 @@ func TestEVM_SysExit(t *testing.T) {
 
 	setExpectations := func(c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.Step += 1
-		expected.StepsSinceLastContextSwitch += 1
+		expected.ExpectNoContextSwitch()
 		expected.ActiveThread().Exited = true
 		expected.ActiveThread().ExitCode = exitCode
 		if c.Base.shouldExitGlobally {
@@ -436,16 +431,9 @@ func TestEVM_PopExitedThread(t *testing.T) {
 				// Set up expectations
 				expected := mtutil.NewExpectedState(t, state)
 				expected.Step += 1
-				expected.ActiveThreadId = mtutil.FindNextThreadExcluding(state, threadToPop.ThreadId).ThreadId
-				expected.StepsSinceLastContextSwitch = 0
-				expected.ThreadCount -= 1
-				expected.TraverseRight = c.expectTraverseRightPostState
-				expected.Thread(threadToPop.ThreadId).Dropped = true
-				if c.traverseRight {
-					expected.RightStackSize -= 1
-				} else {
-					expected.LeftStackSize -= 1
-				}
+				expected.ExpectPoppedThread()
+				expected.ExpectContextSwitch()
+				expected.ExpectTraverseRight(c.expectTraverseRightPostState)
 
 				// State transition
 				var err error
@@ -509,14 +497,14 @@ func TestEVM_SysFutex_WaitPrivate(t *testing.T) {
 				expected.ActiveThread().PC = state.GetCpu().NextPC
 				expected.ActiveThread().NextPC = state.GetCpu().NextPC + 4
 				if c.shouldFail {
-					expected.StepsSinceLastContextSwitch += 1
+					expected.ExpectNoContextSwitch()
 					expected.ActiveThread().Registers[2] = exec.MipsEAGAIN
 					expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 				} else {
 					// Return empty result and preempt thread
 					expected.ActiveThread().Registers[2] = 0
 					expected.ActiveThread().Registers[7] = 0
-					expected.ExpectPreemption(state)
+					expected.ExpectPreemption()
 				}
 
 				// State transition
@@ -577,7 +565,7 @@ func TestEVM_SysFutex_WakePrivate(t *testing.T) {
 				expected.ExpectStep()
 				expected.ActiveThread().Registers[2] = 0
 				expected.ActiveThread().Registers[7] = 0
-				expected.ExpectPreemption(state)
+				expected.ExpectPreemption()
 
 				// State transition
 				stepWitness, err := goVm.Step(true)
@@ -703,7 +691,7 @@ func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
 					// Set up post-state expectations
 					expected := mtutil.NewExpectedState(t, state)
 					expected.ExpectStep()
-					expected.ExpectPreemption(state)
+					expected.ExpectPreemption()
 					expected.PrestateActiveThread().Registers[2] = 0
 					expected.PrestateActiveThread().Registers[7] = 0
 
@@ -990,7 +978,7 @@ func TestEVM_NormalTraversal_Full(t *testing.T) {
 						expected.ActiveThread().Registers[2] = 0
 						expected.ActiveThread().Registers[7] = 0
 						expected.ExpectStep()
-						expected.ExpectPreemption(state)
+						expected.ExpectPreemption()
 
 						// State transition
 						var err error
@@ -1036,7 +1024,7 @@ func TestEVM_SchedQuantumThreshold(t *testing.T) {
 				expected := mtutil.NewExpectedState(t, state)
 				if c.shouldPreempt {
 					expected.Step += 1
-					expected.ExpectPreemption(state)
+					expected.ExpectPreemption()
 				} else {
 					// Otherwise just expect a normal step
 					expected.ExpectStep()

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -115,7 +115,7 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 
 				expected := mtutil.NewExpectedState(t, state)
 				expected.Step += 1
-				expected.StepsSinceLastContextSwitch += 1
+				expected.ExpectNoContextSwitch()
 				expected.Exited = true
 				expected.ExitCode = exitCode
 

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -45,20 +45,15 @@ func FuzzStateSyscallCloneMT(f *testing.F) {
 		expected.PrestateActiveThread().Registers[2] = nextThreadId
 		expected.PrestateActiveThread().Registers[7] = 0
 		// Set expectations for new, cloned thread
-		expected.ActiveThreadId = nextThreadId
 		expectedNewThread := expected.ExpectNewThread()
 		expectedNewThread.PC = state.GetCpu().NextPC
 		expectedNewThread.NextPC = state.GetCpu().NextPC + 4
 		expectedNewThread.Registers[register.RegSyscallNum] = 0
 		expectedNewThread.Registers[register.RegSyscallErrno] = 0
 		expectedNewThread.Registers[register.RegSP] = stackPtr
-		expected.NextThreadId = nextThreadId + 1
-		expected.StepsSinceLastContextSwitch = 0
-		if state.TraverseRight {
-			expected.RightStackSize += 1
-		} else {
-			expected.LeftStackSize += 1
-		}
+		expected.ExpectActiveThreadId(nextThreadId)
+		expected.ExpectNextThreadId(nextThreadId + 1)
+		expected.ExpectContextSwitch()
 
 		stepWitness, err := goVm.Step(true)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrate thread-related tests to use the `DiffTester` framework introduced [here](https://github.com/ethereum-optimism/optimism/pull/16608). 

This migration requires a few modifications to existing test utilities:
- `ExpectedState` is modified to fully internalize logic required to make assertions related to thread preemption and thread popping.  Thread-related assertions are now encapsulated in a new `threadExpectations` struct.
- `DiffTester` is updated to fully construct the prestate using the `InitializeStateFn` when calling `generateTestModifiers`.  This ensures the `SetExpectationsFn` function can be executed without any errors (for example when asserting on a thread that may not exist in an empty prestate).  

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483
