### PR TITLE
cannon: Add singleton DiffTester helper

### DIFF
--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -20,29 +20,29 @@ import (
 
 type TestNamer[T any] func(testCase T) string
 
-type SingletonInitializeStateFn func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
-type SingletonSetExpectationsFn func(t require.TestingT, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
-type SingletonPostStepCheckFn func(t require.TestingT, vm VersionedVMTestCase, deps *TestDependencies)
+type SimpleInitializeStateFn func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
+type SimpleSetExpectationsFn func(t require.TestingT, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
+type SimplePostStepCheckFn func(t require.TestingT, vm VersionedVMTestCase, deps *TestDependencies)
 
-type singletonTestCase struct {
+type soloTestCase struct {
 	name string
 }
 
-type SingletonDiffTester struct {
-	diffTester DiffTester[singletonTestCase]
+type SimpleDiffTester struct {
+	diffTester DiffTester[soloTestCase]
 }
 
-// NewSingletonDiffTester returns a DiffTester designed to run only a single default test case
-func NewSingletonDiffTester() *SingletonDiffTester {
-	return &SingletonDiffTester{
-		diffTester: *NewDiffTester(func(t singletonTestCase) string {
+// NewSimpleDiffTester returns a DiffTester designed to run only a single default test case
+func NewSimpleDiffTester() *SimpleDiffTester {
+	return &SimpleDiffTester{
+		diffTester: *NewDiffTester(func(t soloTestCase) string {
 			return t.name
 		}),
 	}
 }
 
-func (d *SingletonDiffTester) InitState(initStateFn SingletonInitializeStateFn, opts ...mtutil.StateOption) *SingletonDiffTester {
-	wrappedFn := func(t require.TestingT, testCase singletonTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+func (d *SimpleDiffTester) InitState(initStateFn SimpleInitializeStateFn, opts ...mtutil.StateOption) *SimpleDiffTester {
+	wrappedFn := func(t require.TestingT, testCase soloTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		initStateFn(t, state, vm, r)
 	}
 	d.diffTester.InitState(wrappedFn, opts...)
@@ -50,8 +50,8 @@ func (d *SingletonDiffTester) InitState(initStateFn SingletonInitializeStateFn, 
 	return d
 }
 
-func (d *SingletonDiffTester) SetExpectations(setExpectationsFn SingletonSetExpectationsFn) *SingletonDiffTester {
-	wrappedFn := func(t require.TestingT, testCase singletonTestCase, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+func (d *SimpleDiffTester) SetExpectations(setExpectationsFn SimpleSetExpectationsFn) *SimpleDiffTester {
+	wrappedFn := func(t require.TestingT, testCase soloTestCase, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		return setExpectationsFn(t, expect, vm)
 	}
 	d.diffTester.SetExpectations(wrappedFn)
@@ -59,8 +59,8 @@ func (d *SingletonDiffTester) SetExpectations(setExpectationsFn SingletonSetExpe
 	return d
 }
 
-func (d *SingletonDiffTester) PostCheck(postStepCheckFn SingletonPostStepCheckFn) *SingletonDiffTester {
-	wrappedFn := func(t require.TestingT, testCase singletonTestCase, vm VersionedVMTestCase, deps *TestDependencies) {
+func (d *SimpleDiffTester) PostCheck(postStepCheckFn SimplePostStepCheckFn) *SimpleDiffTester {
+	wrappedFn := func(t require.TestingT, testCase soloTestCase, vm VersionedVMTestCase, deps *TestDependencies) {
 		postStepCheckFn(t, vm, deps)
 	}
 	d.diffTester.PostCheck(wrappedFn)
@@ -68,12 +68,11 @@ func (d *SingletonDiffTester) PostCheck(postStepCheckFn SingletonPostStepCheckFn
 	return d
 }
 
-func (d *SingletonDiffTester) Run(t *testing.T, opts ...TestOption) {
-	// Encapsulate core logic in run() for easier unit testing with the testRunner interface
-	singletonTestCases := []singletonTestCase{
-		{name: "singleton"},
+func (d *SimpleDiffTester) Run(t *testing.T, opts ...TestOption) {
+	singleTestCase := []soloTestCase{
+		{name: "solo test case"},
 	}
-	d.diffTester.run(wrapT(t), singletonTestCases, opts...)
+	d.diffTester.run(wrapT(t), singleTestCase, opts...)
 }
 
 type InitializeStateFn[T any] func(t require.TestingT, testCase T, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -20,6 +20,62 @@ import (
 
 type TestNamer[T any] func(testCase T) string
 
+type SingletonInitializeStateFn func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
+type SingletonSetExpectationsFn func(t require.TestingT, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
+type SingletonPostStepCheckFn func(t require.TestingT, vm VersionedVMTestCase, deps *TestDependencies)
+
+type singletonTestCase struct {
+	name string
+}
+
+type SingletonDiffTester struct {
+	diffTester DiffTester[singletonTestCase]
+}
+
+// NewSingletonDiffTester returns a DiffTester designed to run only a single default test case
+func NewSingletonDiffTester() *SingletonDiffTester {
+	return &SingletonDiffTester{
+		diffTester: *NewDiffTester(func(t singletonTestCase) string {
+			return t.name
+		}),
+	}
+}
+
+func (d *SingletonDiffTester) InitState(initStateFn SingletonInitializeStateFn, opts ...mtutil.StateOption) *SingletonDiffTester {
+	wrappedFn := func(t require.TestingT, testCase singletonTestCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		initStateFn(t, state, vm, r)
+	}
+	d.diffTester.InitState(wrappedFn, opts...)
+
+	return d
+}
+
+func (d *SingletonDiffTester) SetExpectations(setExpectationsFn SingletonSetExpectationsFn) *SingletonDiffTester {
+	wrappedFn := func(t require.TestingT, testCase singletonTestCase, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		return setExpectationsFn(t, expect, vm)
+	}
+	d.diffTester.SetExpectations(wrappedFn)
+
+	return d
+}
+
+func (d *SingletonDiffTester) PostCheck(postStepCheckFn SingletonPostStepCheckFn) *SingletonDiffTester {
+	wrappedFn := func(t require.TestingT, testCase singletonTestCase, vm VersionedVMTestCase, deps *TestDependencies) {
+		postStepCheckFn(t, vm, deps)
+	}
+	d.diffTester.PostCheck(wrappedFn)
+
+	return d
+}
+
+func (d *SingletonDiffTester) Run(t *testing.T, opts ...TestOption) {
+	// Encapsulate core logic in run() for easier unit testing with the testRunner interface
+	singletonTestCases := []singletonTestCase{
+		{name: "singleton"},
+	}
+	d.diffTester.run(wrapT(t), singletonTestCases, opts...)
+}
+
 type InitializeStateFn[T any] func(t require.TestingT, testCase T, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
 type SetExpectationsFn[T any] func(t require.TestingT, testCase T, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
 type PostStepCheckFn[T any] func(t require.TestingT, testCase T, vm VersionedVMTestCase, deps *TestDependencies)

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -689,57 +689,41 @@ func runPreemptSyscall(t *testing.T, syscallName string, syscallNum uint32) {
 }
 
 func TestEVM_SysOpen(t *testing.T) {
-	type testCase struct {
-		name string
-	}
-	testNamer := func(tc testCase) string {
-		return tc.name
-	}
-	cases := []testCase{{"Base Case"}}
-
-	initState := func(t require.TestingT, tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+	initState := func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = arch.SysOpen // Set syscall number
 	}
 
-	setExpectations := func(t require.TestingT, tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+	setExpectations := func(t require.TestingT, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.ExpectStep()
 		expected.ActiveThread().Registers[2] = exec.MipsEBADF
 		expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 		return ExpectNormalExecution()
 	}
 
-	NewDiffTester(testNamer).
+	NewSingletonDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations).
-		Run(t, cases)
+		Run(t)
 }
 
 func TestEVM_SysGetPID(t *testing.T) {
-	type testCase struct {
-		name string
-	}
-	testNamer := func(tc testCase) string {
-		return tc.name
-	}
-	cases := []testCase{{"Base Case"}}
-
-	initState := func(t require.TestingT, tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+	initState := func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = arch.SysGetpid // Set syscall number
 	}
 
-	setExpectations := func(t require.TestingT, tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+	setExpectations := func(t require.TestingT, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.ExpectStep()
 		expected.ActiveThread().Registers[2] = 0
 		expected.ActiveThread().Registers[7] = 0
 		return ExpectNormalExecution()
 	}
 
-	NewDiffTester(testNamer).
+	NewSingletonDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations).
-		Run(t, cases)
+		Run(t)
 }
 
 func TestEVM_SysClockGettimeMonotonic(t *testing.T) {
@@ -852,15 +836,7 @@ func testEVM_SysClockGettime(t *testing.T, clkid Word) {
 }
 
 func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
-	type testCase struct {
-		name string
-	}
-	testNamer := func(tc testCase) string {
-		return tc.name
-	}
-	cases := []testCase{{"Base Case"}}
-
-	initState := func(t require.TestingT, tt testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+	initState := func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		timespecAddr := Word(0x1000)
 		testutil.StoreInstruction(state.Memory, state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = arch.SysClockGetTime // Set syscall number
@@ -868,17 +844,17 @@ func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
 		state.GetRegistersRef()[5] = timespecAddr         // a1
 	}
 
-	setExpectations := func(t require.TestingT, tt testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+	setExpectations := func(t require.TestingT, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.ExpectStep()
 		expected.ActiveThread().Registers[2] = exec.MipsEINVAL
 		expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 		return ExpectNormalExecution()
 	}
 
-	NewDiffTester(testNamer).
+	NewSingletonDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations).
-		Run(t, cases)
+		Run(t)
 }
 
 func TestEVM_EmptyThreadStacks(t *testing.T) {

--- a/cannon/mipsevm/tests/evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded_test.go
@@ -701,7 +701,7 @@ func TestEVM_SysOpen(t *testing.T) {
 		return ExpectNormalExecution()
 	}
 
-	NewSingletonDiffTester().
+	NewSimpleDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations).
 		Run(t)
@@ -720,7 +720,7 @@ func TestEVM_SysGetPID(t *testing.T) {
 		return ExpectNormalExecution()
 	}
 
-	NewSingletonDiffTester().
+	NewSimpleDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations).
 		Run(t)
@@ -851,7 +851,7 @@ func TestEVM_SysClockGettimeNonMonotonic(t *testing.T) {
 		return ExpectNormalExecution()
 	}
 
-	NewSingletonDiffTester().
+	NewSimpleDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations).
 		Run(t)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add a `SingletonDiffTester` that extends the `DiffTester` framework introduced [here](https://github.com/ethereum-optimism/optimism/pull/16608). This utility just makes it simpler to write differential tests when there is only a single test case.  Builds on https://github.com/ethereum-optimism/optimism/pull/16847

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483
