### PR TITLE
cannon: Migrate fuzz tests

### DIFF
--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -91,9 +91,9 @@ cannon-stf-verify:
 
 fuzz:
 	printf "%s\n" \
-		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzStateConsistencyMulOp ./mipsevm/tests" \
-		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzStateConsistencyMultOp ./mipsevm/tests" \
-		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzStateConsistencyMultuOp ./mipsevm/tests" \
+		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzMulOp ./mipsevm/tests" \
+		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzMultOp ./mipsevm/tests" \
+		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzMultuOp ./mipsevm/tests" \
 		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzStateSyscallBrk ./mipsevm/tests" \
 		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzStateSyscallMmap ./mipsevm/tests" \
 		"go test $(FUZZLDFLAGS) -run NOTAREALTEST -v -fuzztime $(CANNON64_FUZZTIME) -fuzz=FuzzStateSyscallExitGroup ./mipsevm/tests" \

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -20,6 +20,10 @@ import (
 
 type TestNamer[T any] func(testCase T) string
 
+func NoopTestNamer[T any](c T) string {
+	return ""
+}
+
 type SimpleInitializeStateFn func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
 type SimpleSetExpectationsFn func(t require.TestingT, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
 type SimplePostStepCheckFn func(t require.TestingT, vm VersionedVMTestCase, deps *TestDependencies)

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -139,34 +139,59 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 				t.Run(testName, func(t testcaseT) {
 					t.Parallel()
 
-					testDeps := cfg.testDependencies()
-					stateOpts := []mtutil.StateOption{mtutil.WithRandomization(randSeed)}
-					stateOpts = append(stateOpts, d.stateOpts...)
-					goVm := vm.VMFactory(testDeps.po, testDeps.stdOut, testDeps.stdErr, testDeps.logger, stateOpts...)
-					state := mtutil.GetMtState(t, goVm)
+					setup := mod.cachedSetup
+					if setup == nil {
+						setup = d.newTestSetup(t, testCase, vm, cfg, randSeed, mod)
+					}
 
-					// Set up state
-					r := testutil.NewRandHelper(randSeed * 2)
-					d.initState(t, testCase, state, vm, r)
-					mod.stateMod(state)
-
+					expect := setup.expect
+					execExpectation := setup.expectedResult
 					var witness *mipsevm.StepWitness
 					for i := 0; i < cfg.steps; i++ {
-						// Set up expectations
-						expect := d.expectedState(t, state)
-						execExpectation := d.setExpectations(t, testCase, expect, vm)
-						mod.expectMod(expect)
+						if i > 0 {
+							// After the initial step, we need to set up our expectations again
+							expect = d.expectedState(t, setup.state)
+							execExpectation = d.setExpectations(t, testCase, expect, vm)
+						}
 
-						witness = execExpectation.assertExpectedResult(t, goVm, vm, expect, cfg)
+						witness = execExpectation.assertExpectedResult(t, setup.goVm, vm, expect, cfg)
 					}
 
 					// Run post-step checks
 					if d.postStepCheck != nil {
-						d.postStepCheck(t, testCase, vm, testDeps, witness)
+						d.postStepCheck(t, testCase, vm, setup.deps, witness)
 					}
 				})
 			}
 		}
+	}
+}
+
+func (d *DiffTester[T]) newTestSetup(t require.TestingT, testCase T, vm VersionedVMTestCase, cfg *TestConfig, randSeed int64, mod *testModifier) *testSetup {
+	testDeps := cfg.testDependencies()
+
+	stateOpts := []mtutil.StateOption{mtutil.WithRandomization(randSeed)}
+	stateOpts = append(stateOpts, d.stateOpts...)
+	goVm := vm.VMFactory(testDeps.po, testDeps.stdOut, testDeps.stdErr, testDeps.logger, stateOpts...)
+
+	state := mtutil.GetMtState(t, goVm)
+	d.initState(t, testCase, state, vm, testutil.NewRandHelper(randSeed*2))
+	if mod != nil {
+		mod.stateMod(state)
+	}
+
+	expect := d.expectedState(t, state)
+	if mod != nil {
+		mod.expectMod(expect)
+	}
+	expectedResult := d.setExpectations(t, testCase, expect, vm)
+
+	return &testSetup{
+		deps:           testDeps,
+		goVm:           goVm,
+		state:          state,
+		expect:         expect,
+		expectedResult: expectedResult,
 	}
 }
 
@@ -193,35 +218,32 @@ func (d *DiffTester[T]) isConfigValid(t testRunner) bool {
 }
 
 type testModifier struct {
-	name      string
-	stateMod  func(state *multithreaded.State)
-	expectMod func(expect *mtutil.ExpectedState)
+	name        string
+	stateMod    func(state *multithreaded.State)
+	expectMod   func(expect *mtutil.ExpectedState)
+	cachedSetup *testSetup
 }
 
-func newTestModifier(name string) *testModifier {
+func newTestModifier(name string, cachedSetup *testSetup) *testModifier {
 	return &testModifier{
-		name:      name,
-		stateMod:  func(state *multithreaded.State) {},
-		expectMod: func(expect *mtutil.ExpectedState) {},
+		name:        name,
+		stateMod:    func(state *multithreaded.State) {},
+		expectMod:   func(expect *mtutil.ExpectedState) {},
+		cachedSetup: cachedSetup,
 	}
 }
 
 func (d *DiffTester[T]) generateTestModifiers(t require.TestingT, testCase T, vm VersionedVMTestCase, cfg *TestConfig, randSeed int64) []*testModifier {
+	// Set up state
+	setup := d.newTestSetup(t, testCase, vm, cfg, randSeed, nil)
+
+	// Build modifiers array, start with the original case (noop modification)
 	modifiers := []*testModifier{
-		newTestModifier(""), // Always return a noop
+		newTestModifier("", setup), // Always return a noop
 	}
 
-	// Set up state
-	testDeps := cfg.testDependencies()
-	goVm := vm.VMFactory(testDeps.po, testDeps.stdOut, testDeps.stdErr, testDeps.logger, d.stateOpts...)
-	state := mtutil.GetMtState(t, goVm)
-	d.initState(t, testCase, state, vm, testutil.NewRandHelper(randSeed))
-	// Process expectations
-	expect := d.expectedState(t, state)
-	d.setExpectations(t, testCase, expect, vm)
-
 	// Generate test modifiers based on expectations
-	modifiers = append(modifiers, d.memReservationTestModifier(cfg, randSeed, expect)...)
+	modifiers = append(modifiers, d.memReservationTestModifier(cfg, randSeed, setup.expect)...)
 
 	return modifiers
 }
@@ -300,6 +322,14 @@ func randomSeed(t require.TestingT, s string, extraData ...int) int64 {
 	}
 
 	return int64(h.Sum64())
+}
+
+type testSetup struct {
+	deps           *TestDependencies
+	goVm           mipsevm.FPVM
+	state          *multithreaded.State
+	expect         *mtutil.ExpectedState
+	expectedResult ExpectedExecResult
 }
 
 type TestDependencies struct {

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -125,7 +125,10 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 	cfg := newTestConfig(t, opts...)
 	for _, vm := range cfg.vms {
 		for i, testCase := range testCases {
-			randSeed := randomSeed(t, d.testNamer(testCase), i)
+			randSeed := cfg.randomSeed
+			if randSeed == 0 {
+				randSeed = randomSeed(t, d.testNamer(testCase), i)
+			}
 			mods := d.generateTestModifiers(t, testCase, vm, cfg, randSeed)
 			for _, mod := range mods {
 				testName := fmt.Sprintf("%v%v (%v)", d.testNamer(testCase), mod.name, vm.Name)
@@ -313,6 +316,8 @@ type TestConfig struct {
 	tracingHooks *tracing.Hooks
 	// Allow consumer to control automated test generation
 	skipAutomaticMemoryReservationTests bool
+	// Allow consumer to configure a random seed, if not configured (equal to 0) one will be generated
+	randomSeed int64
 }
 
 func (c *TestConfig) testDependencies() *TestDependencies {
@@ -344,6 +349,18 @@ func WithVm(vm VersionedVMTestCase) TestOption {
 	}
 }
 
+func WithVms(vms []VersionedVMTestCase) TestOption {
+	return func(tc *TestConfig) {
+		tc.vms = vms
+	}
+}
+
+func WithRandomSeed(seed int64) TestOption {
+	return func(tc *TestConfig) {
+		tc.randomSeed = seed
+	}
+}
+
 // WithTracingHooks Sets tracing hooks - see: testutil.MarkdownTracer
 func WithTracingHooks(hooks *tracing.Hooks) TestOption {
 	return func(tc *TestConfig) {
@@ -362,7 +379,6 @@ func WithSteps(steps int) TestOption {
 
 func newTestConfig(t require.TestingT, opts ...TestOption) *TestConfig {
 	testConfig := &TestConfig{
-		vms:    GetMipsVersionTestCases(t),
 		po:     func() mipsevm.PreimageOracle { return nil },
 		stdOut: func() io.Writer { return os.Stdout },
 		stdErr: func() io.Writer { return os.Stderr },
@@ -373,6 +389,12 @@ func newTestConfig(t require.TestingT, opts ...TestOption) *TestConfig {
 	for _, opt := range opts {
 		opt(testConfig)
 	}
+
+	// Generating vm versions is expensive, only do it if necessary
+	if testConfig.vms == nil {
+		testConfig.vms = GetMipsVersionTestCases(t)
+	}
+
 	return testConfig
 }
 

--- a/cannon/mipsevm/tests/difftester.go
+++ b/cannon/mipsevm/tests/difftester.go
@@ -26,7 +26,7 @@ func NoopTestNamer[T any](c T) string {
 
 type SimpleInitializeStateFn func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
 type SimpleSetExpectationsFn func(t require.TestingT, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
-type SimplePostStepCheckFn func(t require.TestingT, vm VersionedVMTestCase, deps *TestDependencies)
+type SimplePostStepCheckFn func(t require.TestingT, vm VersionedVMTestCase, deps *TestDependencies, witness *mipsevm.StepWitness)
 
 type soloTestCase struct {
 	name string
@@ -64,8 +64,8 @@ func (d *SimpleDiffTester) SetExpectations(setExpectationsFn SimpleSetExpectatio
 }
 
 func (d *SimpleDiffTester) PostCheck(postStepCheckFn SimplePostStepCheckFn) *SimpleDiffTester {
-	wrappedFn := func(t require.TestingT, testCase soloTestCase, vm VersionedVMTestCase, deps *TestDependencies) {
-		postStepCheckFn(t, vm, deps)
+	wrappedFn := func(t require.TestingT, testCase soloTestCase, vm VersionedVMTestCase, deps *TestDependencies, wit *mipsevm.StepWitness) {
+		postStepCheckFn(t, vm, deps, wit)
 	}
 	d.diffTester.PostCheck(wrappedFn)
 
@@ -81,7 +81,7 @@ func (d *SimpleDiffTester) Run(t *testing.T, opts ...TestOption) {
 
 type InitializeStateFn[T any] func(t require.TestingT, testCase T, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper)
 type SetExpectationsFn[T any] func(t require.TestingT, testCase T, expect *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult
-type PostStepCheckFn[T any] func(t require.TestingT, testCase T, vm VersionedVMTestCase, deps *TestDependencies)
+type PostStepCheckFn[T any] func(t require.TestingT, testCase T, vm VersionedVMTestCase, deps *TestDependencies, witness *mipsevm.StepWitness)
 
 type DiffTester[T any] struct {
 	testNamer       TestNamer[T]
@@ -150,18 +150,19 @@ func (d *DiffTester[T]) run(t testRunner, testCases []T, opts ...TestOption) {
 					d.initState(t, testCase, state, vm, r)
 					mod.stateMod(state)
 
+					var witness *mipsevm.StepWitness
 					for i := 0; i < cfg.steps; i++ {
 						// Set up expectations
 						expect := d.expectedState(t, state)
 						execExpectation := d.setExpectations(t, testCase, expect, vm)
 						mod.expectMod(expect)
 
-						execExpectation.assertExpectedResult(t, goVm, vm, expect, cfg)
+						witness = execExpectation.assertExpectedResult(t, goVm, vm, expect, cfg)
 					}
 
 					// Run post-step checks
 					if d.postStepCheck != nil {
-						d.postStepCheck(t, testCase, vm, testDeps)
+						d.postStepCheck(t, testCase, vm, testDeps, witness)
 					}
 				})
 			}
@@ -403,7 +404,7 @@ func newTestConfig(t require.TestingT, opts ...TestOption) *TestConfig {
 }
 
 type ExpectedExecResult interface {
-	assertExpectedResult(t testing.TB, vm mipsevm.FPVM, vmType VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig)
+	assertExpectedResult(t testing.TB, vm mipsevm.FPVM, vmType VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) *mipsevm.StepWitness
 }
 
 type normalExecResult struct{}
@@ -412,7 +413,7 @@ func ExpectNormalExecution() ExpectedExecResult {
 	return normalExecResult{}
 }
 
-func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
+func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) *mipsevm.StepWitness {
 	// Step the VM
 	state := goVm.GetState()
 	step := state.GetStep()
@@ -422,6 +423,8 @@ func (e normalExecResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, 
 	// Validate
 	expect.Validate(t, state)
 	testutil.ValidateEVM(t, stepWitness, step, goVm, vmVersion.StateHashFn, vmVersion.Contracts)
+
+	return stepWitness
 }
 
 type vmPanicResult struct {
@@ -467,7 +470,7 @@ func ExpectVmPanicWithCustomErr(goPanicMsg interface{}, customErrSignature strin
 	return result
 }
 
-func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
+func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) *mipsevm.StepWitness {
 	state := goVm.GetState()
 	proofData := e.proofData
 	if proofData == nil {
@@ -482,6 +485,8 @@ func (e vmPanicResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmV
 	} else {
 		t.Fatalf("Invalid panic value provided.  Go panic value must be a string or error.  Got: %v", e.panicValue)
 	}
+
+	return nil
 }
 
 type preimageOracleRevertResult struct {
@@ -500,9 +505,10 @@ func ExpectPreimageOraclePanic(preimageKey [32]byte, preimageValue []byte, preim
 	}
 }
 
-func (e preimageOracleRevertResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) {
+func (e preimageOracleRevertResult) assertExpectedResult(t testing.TB, goVm mipsevm.FPVM, vmVersion VersionedVMTestCase, expect *mtutil.ExpectedState, cfg *TestConfig) *mipsevm.StepWitness {
 	require.PanicsWithValue(t, e.panicMsg, func() { _, _ = goVm.Step(true) })
 	testutil.AssertPreimageOracleReverts(t, e.preimageKey, e.preimageValue, e.preimageOffset, vmVersion.Contracts)
+	return nil
 }
 
 type testcaseT interface {

--- a/cannon/mipsevm/tests/difftester_test.go
+++ b/cannon/mipsevm/tests/difftester_test.go
@@ -53,8 +53,7 @@ func TestDiffTester_Run_SimpleTest(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
-				// Difftester runs extra calls in order to analyze the tests
-				expectedCalls := 2 * len(versions)
+				expectedCalls := len(versions)
 				require.Equal(t, expectedCalls, initStateCalled[c.name])
 				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}
@@ -115,9 +114,8 @@ func TestDiffTester_Run_WithSteps(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range cases {
-				// Difftester runs extra calls in order to analyze the tests
-				initCalls := 2 * len(versions)
-				expectCalls := oc.expectedSteps*len(versions) + len(versions)
+				initCalls := len(versions)
+				expectCalls := oc.expectedSteps * len(versions)
 				require.Equal(t, initCalls, initStateCalled[c.name])
 				require.Equal(t, expectCalls, expectationsCalled[c.name])
 			}
@@ -194,8 +192,7 @@ func TestDiffTester_Run_WithMemModifications(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
-				// Difftester runs extra calls in order to analyze the tests
-				expectedCalls := len(versions) * (len(mods) + 2)
+				expectedCalls := len(versions) * (len(mods) + 1)
 				require.Equal(t, expectedCalls, initStateCalled[c.name])
 				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}
@@ -252,8 +249,7 @@ func TestDiffTester_Run_WithPanic(t *testing.T) {
 
 			// Validate that we invoked initState and setExpectations as expected
 			for _, c := range testCases {
-				// Difftester runs extra calls in order to analyze the tests
-				expectedCalls := 2 * len(versions)
+				expectedCalls := len(versions)
 				require.Equal(t, expectedCalls, initStateCalled[c.name])
 				require.Equal(t, expectedCalls, expectationsCalled[c.name])
 			}
@@ -309,9 +305,8 @@ func TestDiffTester_Run_WithVm(t *testing.T) {
 
 	// Validate that we invoked initState and setExpectations as expected
 	for _, c := range testCases {
-		// Difftester runs extra calls in order to analyze the tests
-		require.Equal(t, 2, initStateCalled[c.name])
-		require.Equal(t, 2, expectationsCalled[c.name])
+		require.Equal(t, 1, initStateCalled[c.name])
+		require.Equal(t, 1, expectationsCalled[c.name])
 	}
 
 	// Validate that we ran the expected tests

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -891,7 +891,7 @@ func TestEVM_SysWriteHint(t *testing.T) {
 		return ExpectNormalExecution()
 	}
 
-	postCheck := func(t require.TestingT, tt testCase, vm VersionedVMTestCase, deps *TestDependencies) {
+	postCheck := func(t require.TestingT, tt testCase, vm VersionedVMTestCase, deps *TestDependencies, wit *mipsevm.StepWitness) {
 		trackingOracle, ok := deps.po.(*testutil.HintTrackingOracle)
 		require.True(t, ok)
 		require.Equal(t, tt.expectedHints, trackingOracle.Hints())

--- a/cannon/mipsevm/tests/fuzz_evm_common64_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common64_test.go
@@ -1,133 +1,98 @@
 package tests
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
 )
 
-func FuzzStateConsistencyMulOp(f *testing.F) {
-	f.Add(int64(0x80_00_00_00), int64(0x80_00_00_00), int64(1))
-	f.Add(
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_11_22_33_44)),
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_11_22_33_44)),
-		int64(1),
-	)
-	f.Add(
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_80_00_00_00)),
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_80_00_00_00)),
-		int64(1),
-	)
-	f.Add(
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_FF_FF_FF_FF)),
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_FF_FF_FF_FF)),
-		int64(1),
-	)
-
+func FuzzMulOp(f *testing.F) {
 	const opcode uint32 = 28
 	const mulFunct uint32 = 0x2
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, rs int64, rt int64, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				mulOpConsistencyCheck(t, versions, opcode, true, mulFunct, Word(rs), Word(rt), seed)
-			})
-		}
-	})
+	multiplier := func(rs, rt Word) uint64 {
+		return uint64(int64(int32(rs)) * int64(int32(rt)))
+	}
+	mulOpCheck(f, multiplier, opcode, true, mulFunct)
 }
 
-func FuzzStateConsistencyMultOp(f *testing.F) {
+func FuzzMultOp(f *testing.F) {
+	const multFunct uint32 = 0x18
+	multiplier := func(rs, rt Word) uint64 {
+		return uint64(int64(int32(rs)) * int64(int32(rt)))
+	}
+	mulOpCheck(f, multiplier, 0, false, multFunct)
+}
+
+func FuzzMultuOp(f *testing.F) {
+	const multuFunct uint32 = 0x19
+	multiplier := func(rs, rt Word) uint64 {
+		return uint64(uint32(rs)) * uint64(uint32(rt))
+	}
+	mulOpCheck(f, multiplier, 0, false, multuFunct)
+}
+
+type multiplierFn func(rs, rt Word) uint64
+
+func mulOpCheck(f *testing.F, multiplier multiplierFn, opcode uint32, expectRdReg bool, funct uint32) {
 	f.Add(int64(0x80_00_00_00), int64(0x80_00_00_00), int64(1))
 	f.Add(
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_11_22_33_44)),
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_11_22_33_44)),
+		testutil.ToSignedInteger(0xFF_FF_FF_FF_11_22_33_44),
+		testutil.ToSignedInteger(0xFF_FF_FF_FF_11_22_33_44),
 		int64(1),
 	)
 	f.Add(
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_80_00_00_00)),
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_80_00_00_00)),
+		testutil.ToSignedInteger(0xFF_FF_FF_FF_80_00_00_00),
+		testutil.ToSignedInteger(0xFF_FF_FF_FF_80_00_00_00),
 		int64(1),
 	)
 	f.Add(
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_FF_FF_FF_FF)),
-		testutil.ToSignedInteger(uint64(0xFF_FF_FF_FF_FF_FF_FF_FF)),
+		testutil.ToSignedInteger(0xFF_FF_FF_FF_FF_FF_FF_FF),
+		testutil.ToSignedInteger(0xFF_FF_FF_FF_FF_FF_FF_FF),
 		int64(1),
 	)
 
-	const multFunct uint32 = 0x18
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, rs int64, rt int64, seed int64) {
-		mulOpConsistencyCheck(t, versions, 0, false, multFunct, Word(rs), Word(rt), seed)
-	})
-}
-
-func FuzzStateConsistencyMultuOp(f *testing.F) {
-	f.Add(uint64(0x80_00_00_00), uint64(0x80_00_00_00), int64(1))
-	f.Add(
-		uint64(0xFF_FF_FF_FF_11_22_33_44),
-		uint64(0xFF_FF_FF_FF_11_22_33_44),
-		int64(1),
-	)
-	f.Add(
-		uint64(0xFF_FF_FF_FF_80_00_00_00),
-		uint64(0xFF_FF_FF_FF_80_00_00_00),
-		int64(1),
-	)
-	f.Add(
-		uint64(0xFF_FF_FF_FF_FF_FF_FF_FF),
-		uint64(0xFF_FF_FF_FF_FF_FF_FF_FF),
-		int64(1),
-	)
-
-	const multuFunct uint32 = 0x19
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, rs uint64, rt uint64, seed int64) {
-		mulOpConsistencyCheck(t, versions, 0, false, multuFunct, rs, rt, seed)
-	})
-}
-
-func mulOpConsistencyCheck(
-	t *testing.T, versions []VersionedVMTestCase,
-	opcode uint32, expectRdReg bool, funct uint32,
-	rs Word, rt Word, seed int64) {
-	for _, v := range versions {
-		t.Run(v.Name, func(t *testing.T) {
-			rsReg := uint32(17)
-			rtReg := uint32(18)
-			rdReg := uint32(0)
-			if expectRdReg {
-				rdReg = 19
-			}
-
-			insn := opcode<<26 | rsReg<<21 | rtReg<<16 | rdReg<<11 | funct
-			goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(seed), mtutil.WithPCAndNextPC(0))
-			state := goVm.GetState()
-			state.GetRegistersRef()[rsReg] = rs
-			state.GetRegistersRef()[rtReg] = rt
-			testutil.StoreInstruction(state.GetMemory(), 0, insn)
-			step := state.GetStep()
-
-			// mere sanity checks
-			expected := mtutil.NewExpectedState(t, state)
-			expected.ExpectStep()
-
-			stepWitness, err := goVm.Step(true)
-			require.NoError(t, err)
-
-			// use the post-state rdReg or LO and HI just so we can run sanity checks
-			if expectRdReg {
-				expected.ActiveThread().Registers[rdReg] = state.GetRegistersRef()[rdReg]
-			} else {
-				expected.ActiveThread().LO = state.GetCpu().LO
-				expected.ActiveThread().HI = state.GetCpu().HI
-			}
-			expected.Validate(t, state)
-
-			testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-		})
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		rs Word
+		rt Word
 	}
+
+	rsReg := uint32(17)
+	rtReg := uint32(18)
+	rdReg := uint32(0)
+	if expectRdReg {
+		rdReg = 19
+	}
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		insn := opcode<<26 | rsReg<<21 | rtReg<<16 | rdReg<<11 | funct
+		testutil.StoreInstruction(state.GetMemory(), 0, insn)
+		state.GetRegistersRef()[rsReg] = c.rs
+		state.GetRegistersRef()[rtReg] = c.rt
+	}
+
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		result := multiplier(c.rs, c.rt)
+		if expectRdReg {
+			expected.ActiveThread().Registers[rdReg] = exec.SignExtend(result, 32)
+		} else {
+			expected.ActiveThread().LO = exec.SignExtend(result, 32)
+			expected.ActiveThread().HI = exec.SignExtend(result>>32, 32)
+		}
+		return ExpectNormalExecution()
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState, mtutil.WithPCAndNextPC(0)).
+		SetExpectations(setExpectations)
+
+	f.Fuzz(func(t *testing.T, rs, rt, seed int64) {
+		tests := []testCase{{rs: Word(rs), rt: Word(rt)}}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed)...)
+	})
 }

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -52,49 +52,51 @@ func FuzzStateSyscallMmap(f *testing.F) {
 	// Check edge case - just within bounds
 	f.Add(Word(0), Word(0x1000), Word(program.HEAP_END-4096), int64(3))
 
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr Word, siz Word, heap Word, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(seed), mtutil.WithHeap(heap))
-				state := goVm.GetState()
-				step := state.GetStep()
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		addr Word
+		siz  Word
+		heap Word
+	}
 
-				state.GetRegistersRef()[2] = arch.SysMmap
-				state.GetRegistersRef()[4] = addr
-				state.GetRegistersRef()[5] = siz
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.Heap = c.heap
+		state.GetRegistersRef()[2] = arch.SysMmap
+		state.GetRegistersRef()[4] = c.addr
+		state.GetRegistersRef()[5] = c.siz
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	}
 
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if addr == 0 {
-					sizAlign := siz
-					if sizAlign&memory.PageAddrMask != 0 { // adjust size to align with page size
-						sizAlign = siz + memory.PageSize - (siz & memory.PageAddrMask)
-					}
-					newHeap := heap + sizAlign
-					if newHeap > program.HEAP_END || newHeap < heap || sizAlign < siz {
-						expected.ActiveThread().Registers[2] = exec.MipsEINVAL
-						expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-					} else {
-						expected.Heap = heap + sizAlign
-						expected.ActiveThread().Registers[2] = heap
-						expected.ActiveThread().Registers[7] = 0 // no error
-					}
-				} else {
-					expected.ActiveThread().Registers[2] = addr
-					expected.ActiveThread().Registers[7] = 0 // no error
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		if c.addr == 0 {
+			sizAlign := c.siz
+			if sizAlign&memory.PageAddrMask != 0 { // adjust size to align with page size
+				sizAlign = c.siz + memory.PageSize - (c.siz & memory.PageAddrMask)
+			}
+			newHeap := c.heap + sizAlign
+			if newHeap > program.HEAP_END || newHeap < c.heap || sizAlign < c.siz {
+				expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+				expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+			} else {
+				expected.Heap = c.heap + sizAlign
+				expected.ActiveThread().Registers[2] = c.heap
+				expected.ActiveThread().Registers[7] = 0 // no error
+			}
+		} else {
+			expected.ActiveThread().Registers[2] = c.addr
+			expected.ActiveThread().Registers[7] = 0 // no error
 		}
+		return ExpectNormalExecution()
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations)
+
+	f.Fuzz(func(t *testing.T, addr Word, siz Word, heap Word, seed int64) {
+		tests := []testCase{{addr, siz, heap}}
+		diffTester.Run(t, tests, WithVms(vms), WithRandomSeed(seed))
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -101,32 +101,32 @@ func FuzzStateSyscallMmap(f *testing.F) {
 }
 
 func FuzzStateSyscallExitGroup(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		exitCode uint8
+	}
+
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.GetRegistersRef()[2] = arch.SysExitGroup
+		state.GetRegistersRef()[4] = Word(c.exitCode)
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	}
+
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.Step += 1
+		expected.ExpectNoContextSwitch()
+		expected.Exited = true
+		expected.ExitCode = c.exitCode
+		return ExpectNormalExecution()
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations)
+
 	f.Fuzz(func(t *testing.T, exitCode uint8, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(seed))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysExitGroup
-				state.GetRegistersRef()[4] = Word(exitCode)
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				step := state.GetStep()
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.Step += 1
-				expected.ExpectNoContextSwitch()
-				expected.Exited = true
-				expected.ExitCode = exitCode
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
-		}
+		tests := []testCase{{exitCode}}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed)...)
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -23,29 +23,25 @@ const syscallInsn = uint32(0x00_00_00_0c)
 
 func FuzzStateSyscallBrk(f *testing.F) {
 	vms := GetMipsVersionTestCases(f)
-	type testCase struct {
-		seed int64
-	}
 
-	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+	initState := func(t require.TestingT, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		state.GetRegistersRef()[2] = arch.SysBrk
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 	}
 
-	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+	setExpectations := func(t require.TestingT, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.ExpectStep()
 		expected.ActiveThread().Registers[2] = program.PROGRAM_BREAK // Return fixed BRK value
 		expected.ActiveThread().Registers[7] = 0                     // No error
 		return ExpectNormalExecution()
 	}
 
-	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+	diffTester := NewSimpleDiffTester().
 		InitState(initState).
 		SetExpectations(setExpectations)
 
 	f.Fuzz(func(t *testing.T, seed int64) {
-		tests := []testCase{{seed}}
-		diffTester.Run(t, tests, WithVms(vms), WithRandomSeed(seed))
+		diffTester.Run(t, WithVms(vms), WithRandomSeed(seed))
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
@@ -21,29 +22,25 @@ import (
 const syscallInsn = uint32(0x00_00_00_0c)
 
 func FuzzStateSyscallBrk(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
+	vms := GetMipsVersionTestCases(f)
+
 	f.Fuzz(func(t *testing.T, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(seed))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysBrk
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				step := state.GetStep()
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[2] = program.PROGRAM_BREAK // Return fixed BRK value
-				expected.ActiveThread().Registers[7] = 0                     // No error
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+		initState := func(state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+			state.GetRegistersRef()[2] = arch.SysBrk
+			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		}
+
+		setExpectations := func(expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+			expected.ExpectStep()
+			expected.ActiveThread().Registers[2] = program.PROGRAM_BREAK // Return fixed BRK value
+			expected.ActiveThread().Registers[7] = 0                     // No error
+			return ExpectNormalExecution()
+		}
+
+		NewSingletonDiffTester().
+			InitState(initState).
+			SetExpectations(setExpectations).
+			Run(t, WithVms(vms), WithRandomSeed(seed))
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/exec"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/memory"
@@ -186,37 +187,46 @@ func FuzzStateSyscallFcntl(f *testing.F) {
 }
 
 func FuzzStateHintRead(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		addr  Word
+		count Word
+	}
+
+	preimageData := []byte("hello world")
+	preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.PreimageKey = preimageKey
+		state.GetRegistersRef()[2] = arch.SysRead
+		state.GetRegistersRef()[4] = exec.FdHintRead
+		state.GetRegistersRef()[5] = c.addr
+		state.GetRegistersRef()[6] = c.count
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	}
+
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = c.count
+		expected.ActiveThread().Registers[7] = 0 // no error
+		return ExpectNormalExecution()
+	}
+
+	postCheck := func(t require.TestingT, c testCase, vm VersionedVMTestCase, deps *TestDependencies, stepWitness *mipsevm.StepWitness) {
+		require.False(t, stepWitness.HasPreimage())
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		PostCheck(postCheck)
+
 	f.Fuzz(func(t *testing.T, addr Word, count Word, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				preimageData := []byte("hello world")
-				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
-				oracle := testutil.StaticOracle(t, preimageData) // only used for hinting
-
-				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(seed), mtutil.WithPreimageKey(preimageKey))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysRead
-				state.GetRegistersRef()[4] = exec.FdHintRead
-				state.GetRegistersRef()[5] = addr
-				state.GetRegistersRef()[6] = count
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				step := state.GetStep()
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[2] = count
-				expected.ActiveThread().Registers[7] = 0 // no error
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+		tests := []testCase{{addr, count}}
+		po := func() mipsevm.PreimageOracle {
+			return testutil.StaticOracle(t, preimageData)
 		}
+
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed, WithPreimageOracle(po))...)
 	})
 }
 
@@ -420,10 +430,12 @@ func FuzzStatePreimageWrite(f *testing.F) {
 	})
 }
 
-func fuzzTestOptions(vms []VersionedVMTestCase, seed int64) []TestOption {
-	return []TestOption{
+func fuzzTestOptions(vms []VersionedVMTestCase, seed int64, opts ...TestOption) []TestOption {
+	testOpts := []TestOption{
 		WithVms(vms),
 		WithRandomSeed(seed),
 		SkipAutomaticMemoryReservationTests(),
 	}
+	testOpts = append(testOpts, opts...)
+	return testOpts
 }

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -307,15 +307,62 @@ func FuzzStatePreimageRead(f *testing.F) {
 func FuzzStateHintWrite(f *testing.F) {
 	vms := GetMipsVersionTestCases(f)
 	type testCase struct {
-		addr             Word
-		count            Word
+		// Fuzz inputs
+		addr  Word
+		count Word
+		hint1 []byte
+		hint2 []byte
+		hint3 []byte
+		// Cached calculations
 		hintData         []byte
 		lastHint         []byte
 		expectedHints    [][]byte
 		expectedLastHint []byte
 	}
 
-	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+	cacheHintCalculations := func(t require.TestingT, c *testCase) {
+		if c.hintData != nil {
+			// Already cached
+			return
+		}
+
+		// Set up hint data
+		r := testutil.NewRandHelper(seed)
+		hints := [][]byte{c.hint1, c.hint2, c.hint3}
+		c.hintData = make([]byte, 0)
+		for _, hint := range hints {
+			prefixedHint := mtutil.AddHintLengthPrefix(hint)
+			c.hintData = append(c.hintData, prefixedHint...)
+		}
+		lastHintLen := math.Round(r.Fraction() * float64(len(c.hintData)))
+		c.lastHint = c.hintData[:int(lastHintLen)]
+		expectedBytesToProcess := int(c.count) + int(lastHintLen)
+		if expectedBytesToProcess > len(c.hintData) {
+			// Add an extra hint to span the rest of the hint data
+			randomHint := r.RandomBytes(t, expectedBytesToProcess)
+			prefixedHint := mtutil.AddHintLengthPrefix(randomHint)
+			c.hintData = append(c.hintData, prefixedHint...)
+			hints = append(hints, randomHint)
+		}
+
+		// Figure out hint expectations
+		c.expectedLastHint = make([]byte, 0)
+		byteIndex := 0
+		for _, hint := range hints {
+			hintDataLength := len(hint) + 4 // Hint data + prefix
+			hintLastByteIndex := hintDataLength + byteIndex - 1
+			if hintLastByteIndex < expectedBytesToProcess {
+				c.expectedHints = append(c.expectedHints, hint)
+			} else {
+				c.expectedLastHint = c.hintData[byteIndex:expectedBytesToProcess]
+				break
+			}
+			byteIndex += hintDataLength
+		}
+	}
+
+	initState := func(t require.TestingT, c *testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		cacheHintCalculations(t, c)
 		state.LastHint = c.lastHint
 		state.GetRegistersRef()[2] = arch.SysWrite
 		state.GetRegistersRef()[4] = exec.FdHintWrite
@@ -326,7 +373,8 @@ func FuzzStateHintWrite(f *testing.F) {
 		require.NoError(t, err)
 	}
 
-	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+	setExpectations := func(t require.TestingT, c *testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		cacheHintCalculations(t, c)
 		expected.ExpectStep()
 		expected.ActiveThread().Registers[2] = c.count
 		expected.ActiveThread().Registers[7] = 0 // no error
@@ -334,13 +382,13 @@ func FuzzStateHintWrite(f *testing.F) {
 		return ExpectNormalExecution()
 	}
 
-	postCheck := func(t require.TestingT, c testCase, vm VersionedVMTestCase, deps *TestDependencies, stepWitness *mipsevm.StepWitness) {
+	postCheck := func(t require.TestingT, c *testCase, vm VersionedVMTestCase, deps *TestDependencies, stepWitness *mipsevm.StepWitness) {
 		oracle, ok := deps.po.(*testutil.HintTrackingOracle)
 		require.True(t, ok)
 		require.Equal(t, c.expectedHints, oracle.Hints())
 	}
 
-	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+	diffTester := NewDiffTester(NoopTestNamer[*testCase]).
 		InitState(initState, mtutil.WithPCAndNextPC(0)).
 		SetExpectations(setExpectations).
 		PostCheck(postCheck)
@@ -350,52 +398,18 @@ func FuzzStateHintWrite(f *testing.F) {
 		if addr <= 8 {
 			addr += 8
 		}
-		// Set up hint data
-		r := testutil.NewRandHelper(seed)
-		hints := [][]byte{hint1, hint2, hint3}
-		hintData := make([]byte, 0)
-		for _, hint := range hints {
-			prefixedHint := mtutil.AddHintLengthPrefix(hint)
-			hintData = append(hintData, prefixedHint...)
-		}
-		lastHintLen := math.Round(r.Fraction() * float64(len(hintData)))
-		lastHint := hintData[:int(lastHintLen)]
-		expectedBytesToProcess := int(count) + int(lastHintLen)
-		if expectedBytesToProcess > len(hintData) {
-			// Add an extra hint to span the rest of the hint data
-			randomHint := r.RandomBytes(t, expectedBytesToProcess)
-			prefixedHint := mtutil.AddHintLengthPrefix(randomHint)
-			hintData = append(hintData, prefixedHint...)
-			hints = append(hints, randomHint)
-		}
-		// Figure out hint expectations
-		var expectedHints [][]byte
-		expectedLastHint := make([]byte, 0)
-		byteIndex := 0
-		for _, hint := range hints {
-			hintDataLength := len(hint) + 4 // Hint data + prefix
-			hintLastByteIndex := hintDataLength + byteIndex - 1
-			if hintLastByteIndex < expectedBytesToProcess {
-				expectedHints = append(expectedHints, hint)
-			} else {
-				expectedLastHint = hintData[byteIndex:expectedBytesToProcess]
-				break
-			}
-			byteIndex += hintDataLength
-		}
 
 		po := func() mipsevm.PreimageOracle {
 			return &testutil.HintTrackingOracle{}
 		}
 
-		tests := []testCase{
+		tests := []*testCase{
 			{
-				addr:             addr,
-				count:            count,
-				hintData:         hintData,
-				lastHint:         lastHint,
-				expectedHints:    expectedHints,
-				expectedLastHint: expectedLastHint,
+				addr:  addr,
+				count: count,
+				hint1: hint1,
+				hint2: hint2,
+				hint3: hint3,
 			},
 		}
 		diffTester.Run(t, tests, fuzzTestOptions(vms, seed, WithPreimageOracle(po))...)

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -306,82 +306,100 @@ func FuzzStatePreimageRead(f *testing.F) {
 }
 
 func FuzzStateHintWrite(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr Word, count Word, hint1, hint2, hint3 []byte, randSeed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				// Make sure pc does not overlap with hint data in memory
-				pc := Word(0)
-				if addr <= 8 {
-					addr += 8
-				}
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		addr             Word
+		count            Word
+		hintData         []byte
+		lastHint         []byte
+		expectedHints    [][]byte
+		expectedLastHint []byte
+	}
 
-				// Set up hint data
-				r := testutil.NewRandHelper(randSeed)
-				hints := [][]byte{hint1, hint2, hint3}
-				hintData := make([]byte, 0)
-				for _, hint := range hints {
-					prefixedHint := mtutil.AddHintLengthPrefix(hint)
-					hintData = append(hintData, prefixedHint...)
-				}
-				lastHintLen := math.Round(r.Fraction() * float64(len(hintData)))
-				lastHint := hintData[:int(lastHintLen)]
-				expectedBytesToProcess := int(count) + int(lastHintLen)
-				if expectedBytesToProcess > len(hintData) {
-					// Add an extra hint to span the rest of the hint data
-					randomHint := r.RandomBytes(t, expectedBytesToProcess)
-					prefixedHint := mtutil.AddHintLengthPrefix(randomHint)
-					hintData = append(hintData, prefixedHint...)
-					hints = append(hints, randomHint)
-				}
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.LastHint = c.lastHint
+		state.GetRegistersRef()[2] = arch.SysWrite
+		state.GetRegistersRef()[4] = exec.FdHintWrite
+		state.GetRegistersRef()[5] = c.addr
+		state.GetRegistersRef()[6] = c.count
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		err := state.GetMemory().SetMemoryRange(c.addr, bytes.NewReader(c.hintData[int(len(c.lastHint)):]))
+		require.NoError(t, err)
+	}
 
-				// Set up state
-				oracle := &testutil.HintTrackingOracle{}
-				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(randSeed), mtutil.WithLastHint(lastHint), mtutil.WithPCAndNextPC(pc))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysWrite
-				state.GetRegistersRef()[4] = exec.FdHintWrite
-				state.GetRegistersRef()[5] = addr
-				state.GetRegistersRef()[6] = count
-				step := state.GetStep()
-				err := state.GetMemory().SetMemoryRange(addr, bytes.NewReader(hintData[int(lastHintLen):]))
-				require.NoError(t, err)
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = c.count
+		expected.ActiveThread().Registers[7] = 0 // no error
+		expected.LastHint = c.expectedLastHint
+		return ExpectNormalExecution()
+	}
 
-				// Set up expectations
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[2] = count
-				expected.ActiveThread().Registers[7] = 0 // no error
-				// Figure out hint expectations
-				var expectedHints [][]byte
-				expectedLastHint := make([]byte, 0)
-				byteIndex := 0
-				for _, hint := range hints {
-					hintDataLength := len(hint) + 4 // Hint data + prefix
-					hintLastByteIndex := hintDataLength + byteIndex - 1
-					if hintLastByteIndex < expectedBytesToProcess {
-						expectedHints = append(expectedHints, hint)
-					} else {
-						expectedLastHint = hintData[byteIndex:expectedBytesToProcess]
-						break
-					}
-					byteIndex += hintDataLength
-				}
-				expected.LastHint = expectedLastHint
+	postCheck := func(t require.TestingT, c testCase, vm VersionedVMTestCase, deps *TestDependencies, stepWitness *mipsevm.StepWitness) {
+		oracle, ok := deps.po.(*testutil.HintTrackingOracle)
+		require.True(t, ok)
+		require.Equal(t, c.expectedHints, oracle.Hints())
+	}
 
-				// Run state transition
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState, mtutil.WithPCAndNextPC(0)).
+		SetExpectations(setExpectations).
+		PostCheck(postCheck)
 
-				// Validate
-				require.Equal(t, expectedHints, oracle.Hints())
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+	f.Fuzz(func(t *testing.T, addr Word, count Word, hint1, hint2, hint3 []byte, seed int64) {
+		// Make sure pc does not overlap with hint data in memory
+		if addr <= 8 {
+			addr += 8
 		}
+		// Set up hint data
+		r := testutil.NewRandHelper(seed)
+		hints := [][]byte{hint1, hint2, hint3}
+		hintData := make([]byte, 0)
+		for _, hint := range hints {
+			prefixedHint := mtutil.AddHintLengthPrefix(hint)
+			hintData = append(hintData, prefixedHint...)
+		}
+		lastHintLen := math.Round(r.Fraction() * float64(len(hintData)))
+		lastHint := hintData[:int(lastHintLen)]
+		expectedBytesToProcess := int(count) + int(lastHintLen)
+		if expectedBytesToProcess > len(hintData) {
+			// Add an extra hint to span the rest of the hint data
+			randomHint := r.RandomBytes(t, expectedBytesToProcess)
+			prefixedHint := mtutil.AddHintLengthPrefix(randomHint)
+			hintData = append(hintData, prefixedHint...)
+			hints = append(hints, randomHint)
+		}
+		// Figure out hint expectations
+		var expectedHints [][]byte
+		expectedLastHint := make([]byte, 0)
+		byteIndex := 0
+		for _, hint := range hints {
+			hintDataLength := len(hint) + 4 // Hint data + prefix
+			hintLastByteIndex := hintDataLength + byteIndex - 1
+			if hintLastByteIndex < expectedBytesToProcess {
+				expectedHints = append(expectedHints, hint)
+			} else {
+				expectedLastHint = hintData[byteIndex:expectedBytesToProcess]
+				break
+			}
+			byteIndex += hintDataLength
+		}
+
+		po := func() mipsevm.PreimageOracle {
+			return &testutil.HintTrackingOracle{}
+		}
+
+		tests := []testCase{
+			{
+				addr:             addr,
+				count:            count,
+				hintData:         hintData,
+				lastHint:         lastHint,
+				expectedHints:    expectedHints,
+				expectedLastHint: expectedLastHint,
+			},
+		}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed, WithPreimageOracle(po))...)
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -41,7 +41,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 		SetExpectations(setExpectations)
 
 	f.Fuzz(func(t *testing.T, seed int64) {
-		diffTester.Run(t, WithVms(vms), WithRandomSeed(seed))
+		diffTester.Run(t, fuzzTestOptions(vms, seed)...)
 	})
 }
 
@@ -96,7 +96,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, addr Word, siz Word, heap Word, seed int64) {
 		tests := []testCase{{addr, siz, heap}}
-		diffTester.Run(t, tests, WithVms(vms), WithRandomSeed(seed))
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed)...)
 	})
 }
 
@@ -417,4 +417,12 @@ func FuzzStatePreimageWrite(f *testing.F) {
 			})
 		}
 	})
+}
+
+func fuzzTestOptions(vms []VersionedVMTestCase, seed int64) []TestOption {
+	return []TestOption{
+		WithVms(vms),
+		WithRandomSeed(seed),
+		SkipAutomaticMemoryReservationTests(),
+	}
 }

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"bytes"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -404,60 +403,66 @@ func FuzzStateHintWrite(f *testing.F) {
 }
 
 func FuzzStatePreimageWrite(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr arch.Word, count arch.Word, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				// Make sure pc does not overlap with preimage data in memory
-				pc := Word(0)
-				if addr <= 8 {
-					addr += 8
-				}
-				effAddr := addr & arch.AddressMask
-				preexistingMemoryVal := [8]byte{0x12, 0x34, 0x56, 0x78, 0x87, 0x65, 0x43, 0x21}
-				preimageData := []byte("hello world")
-				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
-				oracle := testutil.StaticOracle(t, preimageData)
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		addr  arch.Word
+		count arch.Word
+	}
 
-				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(seed), mtutil.WithPreimageKey(preimageKey), mtutil.WithPreimageOffset(128), mtutil.WithPCAndNextPC(pc))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysWrite
-				state.GetRegistersRef()[4] = exec.FdPreimageWrite
-				state.GetRegistersRef()[5] = addr
-				state.GetRegistersRef()[6] = count
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				state.GetMemory().SetWord(effAddr, arch.ByteOrderWord.Word(preexistingMemoryVal[:]))
-				step := state.GetStep()
+	preexistingMemoryVal := [8]byte{0x12, 0x34, 0x56, 0x78, 0x87, 0x65, 0x43, 0x21}
+	preimageData := []byte("hello world")
+	preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageData)).PreimageKey()
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.GetRegistersRef()[2] = arch.SysWrite
+		state.GetRegistersRef()[4] = exec.FdPreimageWrite
+		state.GetRegistersRef()[5] = c.addr
+		state.GetRegistersRef()[6] = c.count
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetMemory().SetWord(testutil.EffAddr(c.addr), arch.ByteOrderWord.Word(preexistingMemoryVal[:]))
+	}
 
-				expectBytesWritten := count
-				alignment := addr & arch.ExtMask
-				sz := arch.WordSizeBytes - alignment
-				if sz < expectBytesWritten {
-					expectBytesWritten = sz
-				}
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.PreimageOffset = 0
-				expected.ActiveThread().Registers[2] = expectBytesWritten
-				expected.ActiveThread().Registers[7] = 0 // No error
-				expected.PreimageKey = preimageKey
-				if expectBytesWritten > 0 {
-					// Copy original preimage key, but shift it left by expectBytesWritten
-					copy(expected.PreimageKey[:], preimageKey[expectBytesWritten:])
-					// Copy memory data to rightmost expectedBytesWritten
-					copy(expected.PreimageKey[32-expectBytesWritten:], preexistingMemoryVal[alignment:])
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expectBytesWritten := c.count
+		alignment := c.addr & arch.ExtMask
+		sz := arch.WordSizeBytes - alignment
+		if sz < expectBytesWritten {
+			expectBytesWritten = sz
 		}
+
+		expected.ExpectStep()
+		expected.PreimageOffset = 0
+		expected.ActiveThread().Registers[2] = expectBytesWritten
+		expected.ActiveThread().Registers[7] = 0 // No error
+		expected.PreimageKey = preimageKey
+		if expectBytesWritten > 0 {
+			// Copy original preimage key, but shift it left by expectBytesWritten
+			copy(expected.PreimageKey[:], preimageKey[expectBytesWritten:])
+			// Copy memory data to rightmost expectedBytesWritten
+			copy(expected.PreimageKey[32-expectBytesWritten:], preexistingMemoryVal[alignment:])
+		}
+		return ExpectNormalExecution()
+	}
+
+	postCheck := func(t require.TestingT, c testCase, vm VersionedVMTestCase, deps *TestDependencies, stepWitness *mipsevm.StepWitness) {
+		require.False(t, stepWitness.HasPreimage())
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState, mtutil.WithPCAndNextPC(0), mtutil.WithPreimageKey(preimageKey), mtutil.WithPreimageOffset(128)).
+		SetExpectations(setExpectations).
+		PostCheck(postCheck)
+
+	f.Fuzz(func(t *testing.T, addr arch.Word, count arch.Word, seed int64) {
+		if addr <= 8 {
+			addr += 8
+		}
+
+		po := func() mipsevm.PreimageOracle {
+			return testutil.StaticOracle(t, preimageData)
+		}
+
+		tests := []testCase{{addr, count}}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed, WithPreimageOracle(po))...)
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -131,56 +131,57 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 }
 
 func FuzzStateSyscallFcntl(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, fd Word, cmd Word, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(seed))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysFcntl
-				state.GetRegistersRef()[4] = fd
-				state.GetRegistersRef()[5] = cmd
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				step := state.GetStep()
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		fd  Word
+		cmd Word
+	}
 
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				if cmd == 1 {
-					switch fd {
-					case exec.FdStdin, exec.FdStdout, exec.FdStderr,
-						exec.FdPreimageRead, exec.FdHintRead, exec.FdPreimageWrite, exec.FdHintWrite:
-						expected.ActiveThread().Registers[2] = 0
-						expected.ActiveThread().Registers[7] = 0
-					default:
-						expected.ActiveThread().Registers[2] = exec.MipsEBADF
-						expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-					}
-				} else if cmd == 3 {
-					switch fd {
-					case exec.FdStdin, exec.FdPreimageRead, exec.FdHintRead:
-						expected.ActiveThread().Registers[2] = 0
-						expected.ActiveThread().Registers[7] = 0
-					case exec.FdStdout, exec.FdStderr, exec.FdPreimageWrite, exec.FdHintWrite:
-						expected.ActiveThread().Registers[2] = 1
-						expected.ActiveThread().Registers[7] = 0
-					default:
-						expected.ActiveThread().Registers[2] = exec.MipsEBADF
-						expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-					}
-				} else {
-					expected.ActiveThread().Registers[2] = exec.MipsEINVAL
-					expected.ActiveThread().Registers[7] = exec.SysErrorSignal
-				}
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.GetRegistersRef()[2] = arch.SysFcntl
+		state.GetRegistersRef()[4] = c.fd
+		state.GetRegistersRef()[5] = c.cmd
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	}
 
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.False(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		if c.cmd == 1 {
+			switch c.fd {
+			case exec.FdStdin, exec.FdStdout, exec.FdStderr,
+				exec.FdPreimageRead, exec.FdHintRead, exec.FdPreimageWrite, exec.FdHintWrite:
+				expected.ActiveThread().Registers[2] = 0
+				expected.ActiveThread().Registers[7] = 0
+			default:
+				expected.ActiveThread().Registers[2] = exec.MipsEBADF
+				expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+			}
+		} else if c.cmd == 3 {
+			switch c.fd {
+			case exec.FdStdin, exec.FdPreimageRead, exec.FdHintRead:
+				expected.ActiveThread().Registers[2] = 0
+				expected.ActiveThread().Registers[7] = 0
+			case exec.FdStdout, exec.FdStderr, exec.FdPreimageWrite, exec.FdHintWrite:
+				expected.ActiveThread().Registers[2] = 1
+				expected.ActiveThread().Registers[7] = 0
+			default:
+				expected.ActiveThread().Registers[2] = exec.MipsEBADF
+				expected.ActiveThread().Registers[7] = exec.SysErrorSignal
+			}
+		} else {
+			expected.ActiveThread().Registers[2] = exec.MipsEINVAL
+			expected.ActiveThread().Registers[7] = exec.SysErrorSignal
 		}
+		return ExpectNormalExecution()
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations)
+
+	f.Fuzz(func(t *testing.T, fd Word, cmd Word, seed int64) {
+		tests := []testCase{{fd, cmd}}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed)...)
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -23,24 +23,29 @@ const syscallInsn = uint32(0x00_00_00_0c)
 
 func FuzzStateSyscallBrk(f *testing.F) {
 	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		seed int64
+	}
+
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.GetRegistersRef()[2] = arch.SysBrk
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+	}
+
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = program.PROGRAM_BREAK // Return fixed BRK value
+		expected.ActiveThread().Registers[7] = 0                     // No error
+		return ExpectNormalExecution()
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations)
 
 	f.Fuzz(func(t *testing.T, seed int64) {
-		initState := func(state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
-			state.GetRegistersRef()[2] = arch.SysBrk
-			testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-		}
-
-		setExpectations := func(expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
-			expected.ExpectStep()
-			expected.ActiveThread().Registers[2] = program.PROGRAM_BREAK // Return fixed BRK value
-			expected.ActiveThread().Registers[7] = 0                     // No error
-			return ExpectNormalExecution()
-		}
-
-		NewSingletonDiffTester().
-			InitState(initState).
-			SetExpectations(setExpectations).
-			Run(t, WithVms(vms), WithRandomSeed(seed))
+		tests := []testCase{{seed}}
+		diffTester.Run(t, tests, WithVms(vms), WithRandomSeed(seed))
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_common_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_common_test.go
@@ -231,64 +231,77 @@ func FuzzStateHintRead(f *testing.F) {
 }
 
 func FuzzStatePreimageRead(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
-	f.Fuzz(func(t *testing.T, addr arch.Word, pc arch.Word, count arch.Word, preimageOffset arch.Word, seed int64) {
-		for _, v := range versions {
-			t.Run(v.Name, func(t *testing.T) {
-				effAddr := addr & arch.AddressMask
-				pc = pc & arch.AddressMask
-				preexistingMemoryVal := ^arch.Word(0)
-				preimageValue := []byte("hello world")
-				preimageData := mtutil.AddPreimageLengthPrefix(preimageValue)
-				if preimageOffset >= Word(len(preimageData)) || pc == effAddr {
-					t.SkipNow()
-				}
-				preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
-				oracle := testutil.StaticOracle(t, preimageValue)
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		addr           arch.Word
+		pc             arch.Word
+		count          arch.Word
+		preimageOffset arch.Word
+	}
 
-				goVm := v.VMFactory(oracle, os.Stdout, os.Stderr, testutil.CreateLogger(),
-					mtutil.WithRandomization(seed), mtutil.WithPreimageKey(preimageKey), mtutil.WithPreimageOffset(preimageOffset), mtutil.WithPCAndNextPC(pc))
-				state := goVm.GetState()
-				state.GetRegistersRef()[2] = arch.SysRead
-				state.GetRegistersRef()[4] = exec.FdPreimageRead
-				state.GetRegistersRef()[5] = addr
-				state.GetRegistersRef()[6] = count
-				testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
-				state.GetMemory().SetWord(effAddr, preexistingMemoryVal)
-				step := state.GetStep()
+	preexistingMemoryVal := ^arch.Word(0)
+	preimageValue := []byte("hello world")
+	preimageData := mtutil.AddPreimageLengthPrefix(preimageValue)
+	preimageKey := preimage.Keccak256Key(crypto.Keccak256Hash(preimageValue)).PreimageKey()
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
+		state.PreimageKey = preimageKey
+		state.PreimageOffset = c.preimageOffset
+		state.GetCurrentThread().Cpu.PC = c.pc
+		state.GetCurrentThread().Cpu.NextPC = c.pc + 4
+		state.GetRegistersRef()[2] = arch.SysRead
+		state.GetRegistersRef()[4] = exec.FdPreimageRead
+		state.GetRegistersRef()[5] = c.addr
+		state.GetRegistersRef()[6] = c.count
+		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
+		state.GetMemory().SetWord(testutil.EffAddr(c.addr), preexistingMemoryVal)
+	}
 
-				alignment := addr & arch.ExtMask
-				writeLen := arch.WordSizeBytes - alignment
-				if count < writeLen {
-					writeLen = count
-				}
-				// Cap write length to remaining bytes of the preimage
-				preimageDataLen := Word(len(preimageData))
-				if preimageOffset+writeLen > preimageDataLen {
-					writeLen = preimageDataLen - preimageOffset
-				}
-
-				expected := mtutil.NewExpectedState(t, state)
-				expected.ExpectStep()
-				expected.ActiveThread().Registers[2] = writeLen
-				expected.ActiveThread().Registers[7] = 0 // no error
-				expected.PreimageOffset += writeLen
-				if writeLen > 0 {
-					// Expect a memory write
-					var expectedMemory []byte
-					expectedMemory = arch.ByteOrderWord.AppendWord(expectedMemory, preexistingMemoryVal)
-					copy(expectedMemory[alignment:], preimageData[preimageOffset:preimageOffset+writeLen])
-					expected.ExpectMemoryWrite(effAddr, arch.ByteOrderWord.Word(expectedMemory[:]))
-				}
-
-				stepWitness, err := goVm.Step(true)
-				require.NoError(t, err)
-				require.True(t, stepWitness.HasPreimage())
-
-				expected.Validate(t, state)
-				testutil.ValidateEVM(t, stepWitness, step, goVm, v.StateHashFn, v.Contracts)
-			})
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
+		alignment := c.addr & arch.ExtMask
+		writeLen := arch.WordSizeBytes - alignment
+		if c.count < writeLen {
+			writeLen = c.count
 		}
+		// Cap write length to remaining bytes of the preimage
+		preimageDataLen := Word(len(preimageData))
+		if c.preimageOffset+writeLen > preimageDataLen {
+			writeLen = preimageDataLen - c.preimageOffset
+		}
+
+		expected.ExpectStep()
+		expected.ActiveThread().Registers[2] = writeLen
+		expected.ActiveThread().Registers[7] = 0 // no error
+		expected.PreimageOffset += writeLen
+		if writeLen > 0 {
+			// Expect a memory write
+			var expectedMemory []byte
+			expectedMemory = arch.ByteOrderWord.AppendWord(expectedMemory, preexistingMemoryVal)
+			copy(expectedMemory[alignment:], preimageData[c.preimageOffset:c.preimageOffset+writeLen])
+			expected.ExpectMemoryWrite(testutil.EffAddr(c.addr), arch.ByteOrderWord.Word(expectedMemory[:]))
+		}
+		return ExpectNormalExecution()
+	}
+
+	postCheck := func(t require.TestingT, c testCase, vm VersionedVMTestCase, deps *TestDependencies, stepWitness *mipsevm.StepWitness) {
+		require.True(t, stepWitness.HasPreimage())
+	}
+
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations).
+		PostCheck(postCheck)
+
+	f.Fuzz(func(t *testing.T, addr arch.Word, pc arch.Word, count arch.Word, preimageOffset arch.Word, seed int64) {
+		pc = testutil.EffAddr(pc)
+		if preimageOffset >= Word(len(preimageData)) || pc == testutil.EffAddr(addr) {
+			t.SkipNow()
+		}
+		po := func() mipsevm.PreimageOracle {
+			return testutil.StaticOracle(t, preimageValue)
+		}
+
+		tests := []testCase{{addr, pc, count, preimageOffset}}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed, WithPreimageOracle(po))...)
 	})
 }
 

--- a/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
+++ b/cannon/mipsevm/tests/fuzz_evm_multithreaded_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,51 +14,54 @@ import (
 )
 
 func FuzzStateSyscallCloneMT(f *testing.F) {
-	versions := GetMipsVersionTestCases(f)
-	require.NotZero(f, len(versions), "must have at least one multithreaded version supported")
-	f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64, version uint) {
-		v := versions[int(version)%len(versions)]
-		goVm := v.VMFactory(nil, os.Stdout, os.Stderr, testutil.CreateLogger(), mtutil.WithRandomization(seed))
-		state := mtutil.GetMtState(t, goVm)
+	vms := GetMipsVersionTestCases(f)
+	type testCase struct {
+		nextThreadId Word
+		stackPtr     Word
+	}
+
+	initState := func(t require.TestingT, c testCase, state *multithreaded.State, vm VersionedVMTestCase, r *testutil.RandHelper) {
 		// Update existing threads to avoid collision with nextThreadId
-		if mtutil.FindThread(state, nextThreadId) != nil {
+		if mtutil.FindThread(state, c.nextThreadId) != nil {
 			for i, t := range mtutil.GetAllThreads(state) {
-				t.ThreadId = nextThreadId - Word(i+1)
+				t.ThreadId = c.nextThreadId - Word(i+1)
 			}
 		}
 
-		// Setup
-		state.NextThreadId = nextThreadId
+		state.NextThreadId = c.nextThreadId
 		testutil.StoreInstruction(state.GetMemory(), state.GetPC(), syscallInsn)
 		state.GetRegistersRef()[2] = arch.SysClone
 		state.GetRegistersRef()[4] = exec.ValidCloneFlags
-		state.GetRegistersRef()[5] = stackPtr
-		step := state.GetStep()
+		state.GetRegistersRef()[5] = c.stackPtr
+	}
 
-		// Set up expectations
-		expected := mtutil.NewExpectedState(t, state)
+	setExpectations := func(t require.TestingT, c testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
 		expected.Step += 1
 		// Set original thread expectations
-		expected.PrestateActiveThread().PC = state.GetCpu().NextPC
-		expected.PrestateActiveThread().NextPC = state.GetCpu().NextPC + 4
-		expected.PrestateActiveThread().Registers[2] = nextThreadId
+		prestateNextPC := expected.PrestateActiveThread().NextPC
+		expected.PrestateActiveThread().PC = prestateNextPC
+		expected.PrestateActiveThread().NextPC = prestateNextPC + 4
+		expected.PrestateActiveThread().Registers[2] = c.nextThreadId
 		expected.PrestateActiveThread().Registers[7] = 0
 		// Set expectations for new, cloned thread
 		expectedNewThread := expected.ExpectNewThread()
-		expectedNewThread.PC = state.GetCpu().NextPC
-		expectedNewThread.NextPC = state.GetCpu().NextPC + 4
+		expectedNewThread.PC = prestateNextPC
+		expectedNewThread.NextPC = prestateNextPC + 4
 		expectedNewThread.Registers[register.RegSyscallNum] = 0
 		expectedNewThread.Registers[register.RegSyscallErrno] = 0
-		expectedNewThread.Registers[register.RegSP] = stackPtr
-		expected.ExpectActiveThreadId(nextThreadId)
-		expected.ExpectNextThreadId(nextThreadId + 1)
+		expectedNewThread.Registers[register.RegSP] = c.stackPtr
+		expected.ExpectActiveThreadId(c.nextThreadId)
+		expected.ExpectNextThreadId(c.nextThreadId + 1)
 		expected.ExpectContextSwitch()
+		return ExpectNormalExecution()
+	}
 
-		stepWitness, err := goVm.Step(true)
-		require.NoError(t, err)
-		require.False(t, stepWitness.HasPreimage())
+	diffTester := NewDiffTester(NoopTestNamer[testCase]).
+		InitState(initState).
+		SetExpectations(setExpectations)
 
-		expected.Validate(t, state)
-		testutil.ValidateEVM(t, stepWitness, step, goVm, multithreaded.GetStateHashFn(), v.Contracts)
+	f.Fuzz(func(t *testing.T, nextThreadId, stackPtr Word, seed int64) {
+		tests := []testCase{{nextThreadId, stackPtr}}
+		diffTester.Run(t, tests, fuzzTestOptions(vms, seed)...)
 	})
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Migrate fuzz tests to use the `DiffTester` framework introduced [here](https://github.com/ethereum-optimism/optimism/pull/16608). 

As part of this migration, tweaked the `DiffTester` to improve performance:
- Allow `VersionedVMTestCase` objects to be injected once to save time on setup (these are expensive to generate because we are loading / reading contract data)
- Cache test setup objects that are created in `generateTestModifiers()`

And made a few other adjustments to support the tests:
- Allow the randomSeed to be injected into `DiffTester`
- Give the `PostStateCheckFn` access to the final `StepWitness` produced

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/16483
