### PR TITLE
`op-proposer` developer documentation

### DIFF
--- a/op-proposer/contracts/disputegamefactory.go
+++ b/op-proposer/contracts/disputegamefactory.go
@@ -24,7 +24,7 @@ const (
 	methodClaim = "claimData"
 )
 
-// Contains metadata regarding the current game.
+// gameMetadata contains metadata regarding the current game.
 // (internal)
 type gameMetadata struct {
 	GameType  uint32
@@ -34,7 +34,7 @@ type gameMetadata struct {
 	Claim     common.Hash
 }
 
-// Encapsulates the dispute game factory (DGF) contract.
+// DisputeGameFactory encapsulates the dispute game factory (DGF) contract.
 //
 // Responsible for querying the DGF contract and constructing proposal tansactions to be submitted
 // to an RPC.
@@ -45,7 +45,7 @@ type DisputeGameFactory struct {
 	networkTimeout time.Duration
 }
 
-// Constructs the DGF contract interface.
+// NewDisputeGameFactory constructs the DGF contract interface.
 func NewDisputeGameFactory(addr common.Address, caller *batching.MultiCaller, networkTimeout time.Duration) *DisputeGameFactory {
 	factoryABI := snapshots.LoadDisputeGameFactoryABI()
 	// Note: Games might have different ABIs (eg SuperFaultDisputeGame) but since only a very small part of the ABI
@@ -60,7 +60,7 @@ func NewDisputeGameFactory(addr common.Address, caller *batching.MultiCaller, ne
 	}
 }
 
-// Queries the DGF contract for its current version.
+// Version queries the DGF contract for its current version.
 //
 // Errors if a contract call to `version()` errors.
 func (f *DisputeGameFactory) Version(ctx context.Context) (string, error) {
@@ -73,7 +73,7 @@ func (f *DisputeGameFactory) Version(ctx context.Context) (string, error) {
 	return result.GetString(0), nil
 }
 
-// Attempts to find a game with the specified game type created by the specified proposer after the
+// HasProposedSince attempts to find a game with the specified game type created by the specified proposer after the
 // given cut off time. If one is found, returns true and the time the game was created at.
 // If no matching proposal is found, returns false, time.Time{}, nil.
 //
@@ -106,7 +106,7 @@ func (f *DisputeGameFactory) HasProposedSince(ctx context.Context, proposer comm
 	}
 }
 
-// Constructs a proposal transaction to be submitted to an RPC.
+// ProposalTx constructs a proposal transaction to be submitted to an RPC.
 //
 // Errors if the contract call to `initBonds(gameType)` or `create(gameType, outputRoot, l2BlockNum)` errors.
 func (f *DisputeGameFactory) ProposalTx(ctx context.Context, gameType uint32, outputRoot common.Hash, l2BlockNum uint64) (txmgr.TxCandidate, error) {
@@ -126,7 +126,7 @@ func (f *DisputeGameFactory) ProposalTx(ctx context.Context, gameType uint32, ou
 	return candidate, err
 }
 
-// Queries the DGF contract for the number of games created.
+// gameCount queries the DGF contract for the number of games created.
 //
 // Errors if the contract call to `gameCount()` errors.
 func (f *DisputeGameFactory) gameCount(ctx context.Context) (uint64, error) {
@@ -139,7 +139,7 @@ func (f *DisputeGameFactory) gameCount(ctx context.Context) (uint64, error) {
 	return result.GetBigInt(0).Uint64(), nil
 }
 
-// Queries the DGF contract for the game at the given index.
+// gameAtIndex queries the DGF contract for the game at the given index.
 //
 // Errors if the contract call to `gameAtIndex(index)` or `claimData(0)` errors.
 func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameMetadata, error) {

--- a/op-proposer/contracts/disputegamefactory.go
+++ b/op-proposer/contracts/disputegamefactory.go
@@ -24,6 +24,8 @@ const (
 	methodClaim = "claimData"
 )
 
+// Contains metadata regarding the current game.
+// (internal)
 type gameMetadata struct {
 	GameType  uint32
 	Timestamp time.Time
@@ -32,6 +34,10 @@ type gameMetadata struct {
 	Claim     common.Hash
 }
 
+// Encapsulates the dispute game factory (DGF) contract.
+//
+// Responsible for querying the DGF contract and constructing proposal tansactions to be submitted
+// to an RPC.
 type DisputeGameFactory struct {
 	caller         *batching.MultiCaller
 	contract       *batching.BoundContract
@@ -39,6 +45,7 @@ type DisputeGameFactory struct {
 	networkTimeout time.Duration
 }
 
+// Constructs the DGF contract interface.
 func NewDisputeGameFactory(addr common.Address, caller *batching.MultiCaller, networkTimeout time.Duration) *DisputeGameFactory {
 	factoryABI := snapshots.LoadDisputeGameFactoryABI()
 	// Note: Games might have different ABIs (eg SuperFaultDisputeGame) but since only a very small part of the ABI
@@ -53,6 +60,9 @@ func NewDisputeGameFactory(addr common.Address, caller *batching.MultiCaller, ne
 	}
 }
 
+// Queries the DGF contract for its current version.
+//
+// Errors if a contract call to `version()` errors.
 func (f *DisputeGameFactory) Version(ctx context.Context) (string, error) {
 	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()
@@ -63,9 +73,11 @@ func (f *DisputeGameFactory) Version(ctx context.Context) (string, error) {
 	return result.GetString(0), nil
 }
 
-// HasProposedSince attempts to find a game with the specified game type created by the specified proposer after the
+// Attempts to find a game with the specified game type created by the specified proposer after the
 // given cut off time. If one is found, returns true and the time the game was created at.
-// If no matching proposal is found, returns false, time.Time{}, nil
+// If no matching proposal is found, returns false, time.Time{}, nil.
+//
+// Errors if `DisputeGameFactory.gameCount` fails to load the game count or `DisputeGameFactory.gameAtIndex` fails to load the game at the given index.
 func (f *DisputeGameFactory) HasProposedSince(ctx context.Context, proposer common.Address, cutoff time.Time, gameType uint32) (bool, time.Time, common.Hash, error) {
 	gameCount, err := f.gameCount(ctx)
 	if err != nil {
@@ -94,6 +106,9 @@ func (f *DisputeGameFactory) HasProposedSince(ctx context.Context, proposer comm
 	}
 }
 
+// Constructs a proposal transaction to be submitted to an RPC.
+//
+// Errors if the contract call to `initBonds(gameType)` or `create(gameType, outputRoot, l2BlockNum)` errors.
 func (f *DisputeGameFactory) ProposalTx(ctx context.Context, gameType uint32, outputRoot common.Hash, l2BlockNum uint64) (txmgr.TxCandidate, error) {
 	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()
@@ -111,6 +126,9 @@ func (f *DisputeGameFactory) ProposalTx(ctx context.Context, gameType uint32, ou
 	return candidate, err
 }
 
+// Queries the DGF contract for the number of games created.
+//
+// Errors if the contract call to `gameCount()` errors.
 func (f *DisputeGameFactory) gameCount(ctx context.Context) (uint64, error) {
 	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()
@@ -121,6 +139,9 @@ func (f *DisputeGameFactory) gameCount(ctx context.Context) (uint64, error) {
 	return result.GetBigInt(0).Uint64(), nil
 }
 
+// Queries the DGF contract for the game at the given index.
+//
+// Errors if the contract call to `gameAtIndex(index)` or `claimData(0)` errors.
 func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameMetadata, error) {
 	cCtx, cancel := context.WithTimeout(ctx, f.networkTimeout)
 	defer cancel()

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -23,7 +23,7 @@ func prefixEnvVars(name string) []string {
 var (
 	// Required Flags
 
-	// L1 Ethereum RPC URL (required).
+	// L1EthRpcFlag is the L1 Ethereum RPC URL (required).
 	L1EthRpcFlag = &cli.StringFlag{
 		Name:    "l1-eth-rpc",
 		Usage:   "HTTP provider URL for L1",
@@ -32,7 +32,7 @@ var (
 
 	// Optional flags
 
-	// Rollup RPC URL (optional).
+	// RollupRpcFlag is the Rollup RPC URL (optional).
 	//
 	// MAY be a comma-separated list of URLs.
 	RollupRpcFlag = &cli.StringFlag{
@@ -41,7 +41,7 @@ var (
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
 
-	// Supervisor RPC URLs (optional).
+	// SupervisorRpcsFlag is the Supervisor RPC URL(s) (optional).
 	//
 	// MAY be a comma-separated list of URLs.
 	SupervisorRpcsFlag = &cli.StringSliceFlag{
@@ -50,14 +50,14 @@ var (
 		EnvVars: prefixEnvVars("SUPERVISOR_RPCS"),
 	}
 
-	// L2 output orgcle contract address (optional).
+	// L2OOAddressFlag is the L2 output oracle contract address (optional).
 	L2OOAddressFlag = &cli.StringFlag{
 		Name:    "l2oo-address",
 		Usage:   "Address of the L2OutputOracle contract",
 		EnvVars: prefixEnvVars("L2OO_ADDRESS"),
 	}
 
-	// Poll interval for output root proposals (optional).
+	// PollIntervalFlag is the poll interval for output root proposals (optional).
 	PollIntervalFlag = &cli.DurationFlag{
 		Name:    "poll-interval",
 		Usage:   "Delay between periodic checks on whether it is time to load an output root and propose it.",
@@ -65,28 +65,28 @@ var (
 		EnvVars: prefixEnvVars("POLL_INTERVAL"),
 	}
 
-	// Allow proposals for non-finalized L1 blocks (optional).
+	// AllowNonFinalizedFlag is the allow proposals for non-finalized L1 blocks (optional).
 	AllowNonFinalizedFlag = &cli.BoolFlag{
 		Name:    "allow-non-finalized",
 		Usage:   "Allow the proposer to submit proposals for L2 blocks derived from non-finalized L1 blocks.",
 		EnvVars: prefixEnvVars("ALLOW_NON_FINALIZED"),
 	}
 
-	// Dispute game factory contract address (optional).
+	// DisputeGameFactoryAddressFlag is the dispute game factory contract address (optional).
 	DisputeGameFactoryAddressFlag = &cli.StringFlag{
 		Name:    "game-factory-address",
 		Usage:   "Address of the DisputeGameFactory contract",
 		EnvVars: prefixEnvVars("GAME_FACTORY_ADDRESS"),
 	}
 
-	// Interval between L2 proposals (only when DisputeGameFactoryAddress is set) (optional).
+	// ProposalIntervalFlag is the interval between L2 proposals (only when DisputeGameFactoryAddress is set) (optional).
 	ProposalIntervalFlag = &cli.DurationFlag{
 		Name:    "proposal-interval",
 		Usage:   "Interval between submitting L2 output proposals when the dispute game factory address is set",
 		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
 	}
 
-	// Dispute game type (only when DisputeGameFactoryAddress is set) (optional).
+	// DisputeGameTypeFlag is the dispute game type (only when DisputeGameFactoryAddress is set) (optional).
 	DisputeGameTypeFlag = &cli.UintFlag{
 		Name:    "game-type",
 		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
@@ -94,7 +94,7 @@ var (
 		EnvVars: prefixEnvVars("GAME_TYPE"),
 	}
 
-	// Time between checks for active sequencer (optional).
+	// ActiveSequencerCheckDurationFlag is the time between checks for active sequencer (optional).
 	ActiveSequencerCheckDurationFlag = &cli.DurationFlag{
 		Name:    "active-sequencer-check-duration",
 		Usage:   "The duration between checks to determine the active sequencer endpoint.",
@@ -102,7 +102,7 @@ var (
 		EnvVars: prefixEnvVars("ACTIVE_SEQUENCER_CHECK_DURATION"),
 	}
 
-	// Wait for node sync before starting (optional).
+	// WaitNodeSyncFlag is the wait for node sync before starting (optional).
 	WaitNodeSyncFlag = &cli.BoolFlag{
 		Name: "wait-node-sync",
 		Usage: "Indicates if, during startup, the proposer should wait for the rollup node to sync to " +
@@ -111,7 +111,7 @@ var (
 		EnvVars: prefixEnvVars("WAIT_NODE_SYNC"),
 	}
 
-	// Legacy Flags
+	// L2OutputHDPathFlag is the legacy L2 output HD path flag.
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
 
@@ -133,7 +133,7 @@ var optionalFlags = []cli.Flag{
 	WaitNodeSyncFlag,
 }
 
-// Appends RPC, logger, metrics, profile, and tx manager flags to local flags.
+// init appends RPC, logger, metrics, profile, and tx manager flags to local flags.
 func init() {
 	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
@@ -147,7 +147,7 @@ func init() {
 // Flags contains the list of configuration options available to the binary.
 var Flags []cli.Flag
 
-// Checks for required flags.
+// CheckRequired checks for required flags.
 func CheckRequired(ctx *cli.Context) error {
 	for _, f := range requiredFlags {
 		if !ctx.IsSet(f.Names()[0]) {

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -22,61 +22,87 @@ func prefixEnvVars(name string) []string {
 
 var (
 	// Required Flags
+
+	// L1 Ethereum RPC URL (required).
 	L1EthRpcFlag = &cli.StringFlag{
 		Name:    "l1-eth-rpc",
 		Usage:   "HTTP provider URL for L1",
 		EnvVars: prefixEnvVars("L1_ETH_RPC"),
 	}
+
+	// Optional flags
+
+	// Rollup RPC URL (optional).
+	//
+	// MAY be a comma-separated list of URLs.
 	RollupRpcFlag = &cli.StringFlag{
 		Name:    "rollup-rpc",
 		Usage:   "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
+
+	// Supervisor RPC URLs (optional).
+	//
+	// MAY be a comma-separated list of URLs.
 	SupervisorRpcsFlag = &cli.StringSliceFlag{
 		Name:    "supervisor-rpcs",
 		Usage:   "HTTP provider URLs for the supervisor nodes. Multiple URLs can be provided to automatically fail over.",
 		EnvVars: prefixEnvVars("SUPERVISOR_RPCS"),
 	}
 
-	// Optional flags
+	// L2 output orgcle contract address (optional).
 	L2OOAddressFlag = &cli.StringFlag{
 		Name:    "l2oo-address",
 		Usage:   "Address of the L2OutputOracle contract",
 		EnvVars: prefixEnvVars("L2OO_ADDRESS"),
 	}
+
+	// Poll interval for output root proposals (optional).
 	PollIntervalFlag = &cli.DurationFlag{
 		Name:    "poll-interval",
 		Usage:   "Delay between periodic checks on whether it is time to load an output root and propose it.",
 		Value:   12 * time.Second,
 		EnvVars: prefixEnvVars("POLL_INTERVAL"),
 	}
+
+	// Allow proposals for non-finalized L1 blocks (optional).
 	AllowNonFinalizedFlag = &cli.BoolFlag{
 		Name:    "allow-non-finalized",
 		Usage:   "Allow the proposer to submit proposals for L2 blocks derived from non-finalized L1 blocks.",
 		EnvVars: prefixEnvVars("ALLOW_NON_FINALIZED"),
 	}
+
+	// Dispute game factory contract address (optional).
 	DisputeGameFactoryAddressFlag = &cli.StringFlag{
 		Name:    "game-factory-address",
 		Usage:   "Address of the DisputeGameFactory contract",
 		EnvVars: prefixEnvVars("GAME_FACTORY_ADDRESS"),
 	}
+
+	// Interval between L2 proposals (only when DisputeGameFactoryAddress is set) (optional).
 	ProposalIntervalFlag = &cli.DurationFlag{
 		Name:    "proposal-interval",
 		Usage:   "Interval between submitting L2 output proposals when the dispute game factory address is set",
 		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
 	}
+
+	// Dispute game type (only when DisputeGameFactoryAddress is set) (optional).
 	DisputeGameTypeFlag = &cli.UintFlag{
 		Name:    "game-type",
 		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
 		Value:   0,
 		EnvVars: prefixEnvVars("GAME_TYPE"),
 	}
+
+	// Time between checks for active sequencer (optional).
 	ActiveSequencerCheckDurationFlag = &cli.DurationFlag{
 		Name:    "active-sequencer-check-duration",
 		Usage:   "The duration between checks to determine the active sequencer endpoint.",
 		Value:   2 * time.Minute,
 		EnvVars: prefixEnvVars("ACTIVE_SEQUENCER_CHECK_DURATION"),
 	}
+
+	// Wait for node sync before starting (optional).
 	WaitNodeSyncFlag = &cli.BoolFlag{
 		Name: "wait-node-sync",
 		Usage: "Indicates if, during startup, the proposer should wait for the rollup node to sync to " +
@@ -84,6 +110,7 @@ var (
 		Value:   false,
 		EnvVars: prefixEnvVars("WAIT_NODE_SYNC"),
 	}
+
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
@@ -106,6 +133,7 @@ var optionalFlags = []cli.Flag{
 	WaitNodeSyncFlag,
 }
 
+// Appends RPC, logger, metrics, profile, and tx manager flags to local flags.
 func init() {
 	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
@@ -119,6 +147,7 @@ func init() {
 // Flags contains the list of configuration options available to the binary.
 var Flags []cli.Flag
 
+// Checks for required flags.
 func CheckRequired(ctx *cli.Context) error {
 	for _, f := range requiredFlags {
 		if !ctx.IsSet(f.Names()[0]) {

--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -16,9 +16,10 @@ import (
 
 const Namespace = "op_proposer"
 
-// implements the Registry getter, for metrics HTTP server to hook into
+// implements the Registry getter, for metrics HTTP server to hook into.
 var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
 
+// Metricer is the interface that wraps the basic methods for recording metrics.
 type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
@@ -37,6 +38,7 @@ type Metricer interface {
 	RecordL2BlocksProposed(l2ref eth.L2BlockRef)
 }
 
+// Metrics implements the Metricer interface.
 type Metrics struct {
 	ns       string
 	registry *prometheus.Registry
@@ -54,6 +56,7 @@ type Metrics struct {
 
 var _ Metricer = (*Metrics)(nil)
 
+// NewMetrics constructs a new Metrics instance.
 func NewMetrics(procName string) *Metrics {
 	if procName == "" {
 		procName = "default"
@@ -92,21 +95,22 @@ func NewMetrics(procName string) *Metrics {
 	}
 }
 
+// Registry returns the prometheus registry.
 func (m *Metrics) Registry() *prometheus.Registry {
 	return m.registry
 }
 
+// StartBalanceMetrics starts the balance metrics.
 func (m *Metrics) StartBalanceMetrics(l log.Logger, client *ethclient.Client, account common.Address) io.Closer {
 	return opmetrics.LaunchBalanceMetrics(l, m.registry, m.ns, client, account)
 }
 
-// RecordInfo sets a pseudo-metric that contains versioning and
-// config info for the op-proposer.
+// RecordInfo sets a pseudo-metric that contains versioning and config info for the op-proposer.
 func (m *Metrics) RecordInfo(version string) {
 	m.info.WithLabelValues(version).Set(1)
 }
 
-// RecordUp sets the up metric to 1.
+// RecordUp sets the `up` metric to 1.
 func (m *Metrics) RecordUp() {
 	m.up.Set(1)
 }
@@ -115,15 +119,17 @@ const (
 	BlockProposed = "proposed"
 )
 
-// RecordL2BlocksProposed should be called when new L2 block is proposed
+// RecordL2BlocksProposed records when new L2 block is proposed.
 func (m *Metrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {
 	m.RecordL2Ref(BlockProposed, l2ref)
 }
 
+// RecordL2Proposal records when a new L2 proposal is created.
 func (m *Metrics) RecordL2Proposal(seqNum uint64) {
 	m.proposalSequenceNum.Set(float64(seqNum))
 }
 
+// Document returns the documented metrics.
 func (m *Metrics) Document() []opmetrics.DocumentedMetric {
 	return m.factory.Document()
 }

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -32,6 +32,7 @@ var (
 )
 
 // CLIConfig is a well typed config that is parsed from the CLI params.
+//
 // This also contains config options for auxiliary services.
 // It is transformed into a `Config` before the L2 output submitter is started.
 type CLIConfig struct {
@@ -82,7 +83,7 @@ type CLIConfig struct {
 	WaitNodeSync bool
 }
 
-// Checks the CLI config.
+// Check checks the CLI config.
 //
 // There are three distinct configurations, L2 Output Oracle, DGF (pre-interop), and
 // DGF (post-interop). Fields prefixed with "NOT" are required to be empty.

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -82,6 +82,38 @@ type CLIConfig struct {
 	WaitNodeSync bool
 }
 
+// Checks the CLI config.
+//
+// There are three distinct configurations, L2 Output Oracle, DGF (pre-interop), and
+// DGF (post-interop). Fields prefixed with "NOT" are required to be empty.
+//
+// Always requires:
+//
+//   - `L1EthRpc`
+//   - `RPCConfig`
+//   - `MetricsConfig`
+//   - `PprofConfig`
+//   - `TxMgrConfig`
+//
+// 1. L2OO only:
+//
+//   - `L2OOAddress`
+//   - `RollupRpc`
+//   - NOT `ProposalInterval`
+//
+// 2. DGF (pre-interop):
+//
+//   - `DGFAddress`
+//   - `ProposalInterval`
+//   - `RollupRpc`
+//   - `DisputeGameType` MUST be in `preInteropGameTypes`
+//
+// 3. DGF (post-interop):
+//
+//   - `DGFAddress`
+//   - `ProposalInterval`
+//   - `SupervisorRpcs`
+//   - `DisputeGameType` MUST be in `postInteropGameTypes`
 func (c *CLIConfig) Check() error {
 	if err := c.RPCConfig.Check(); err != nil {
 		return err

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -29,6 +29,7 @@ var (
 	ErrProposerNotRunning = errors.New("proposer is not running")
 )
 
+// Client for the L1 chain.
 type L1Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	// CodeAt returns the code of the given account. This is needed to differentiate
@@ -40,22 +41,28 @@ type L1Client interface {
 	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 }
 
+// L2OO contract interface.
 type L2OOContract interface {
 	Version(*bind.CallOpts) (string, error)
 	NextBlockNumber(*bind.CallOpts) (*big.Int, error)
 }
 
+// DGF contract interface.
 type DGFContract interface {
 	Version(ctx context.Context) (string, error)
 	HasProposedSince(ctx context.Context, proposer common.Address, cutoff time.Time, gameType uint32) (bool, time.Time, common.Hash, error)
 	ProposalTx(ctx context.Context, gameType uint32, outputRoot common.Hash, l2BlockNum uint64) (txmgr.TxCandidate, error)
 }
 
+// Rollup Client interface.
 type RollupClient interface {
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
 }
 
+// Contains logger, metrics, config, tx manager, L1 client, multicaller, and proposal source.
+//
+// Embedded in `L2OutputSubmitter`.
 type DriverSetup struct {
 	Log         log.Logger
 	Metr        metrics.Metricer
@@ -68,7 +75,7 @@ type DriverSetup struct {
 	ProposalSource source.ProposalSource
 }
 
-// L2OutputSubmitter is responsible for proposing outputs
+// Responsible for proposing outputs.
 type L2OutputSubmitter struct {
 	DriverSetup
 
@@ -86,7 +93,15 @@ type L2OutputSubmitter struct {
 	dgfContract DGFContract
 }
 
-// NewL2OutputSubmitter creates a new L2 Output Submitter
+// Constructs a new `L2OutputSubmitter`.
+//
+// May be constructed for L2OO, pre-interop DGF, or post-interop DGF.
+//
+// Errors if:
+//
+//   - Neither `L2OutputOracle` nor `DisputeGameFactory` addresses are provided
+//   - The `L2OutputOracle` contract fails to be created
+//   - The `DisputeGameFactory` contract fails to be created
 func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// The above context is long-lived, and passed to the `L2OutputSubmitter` instance. This context is closed by
@@ -107,6 +122,13 @@ func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 	}
 }
 
+// Constructs a new `L2OutputSubmitter` for L2OO.
+//
+// Errors if:
+//
+//   - The `L2OutputOracle` contract fails to be created.
+//   - The `L2OutputOracle` contract fails to return a version.
+//   - The `L2OutputOracle` contract ABI parsing fails.
 func newL2OOSubmitter(ctx context.Context, cancel context.CancelFunc, setup DriverSetup) (*L2OutputSubmitter, error) {
 	l2ooContract, err := bindings.NewL2OutputOracleCaller(*setup.Cfg.L2OutputOracleAddr, setup.L1Client)
 	if err != nil {
@@ -140,6 +162,9 @@ func newL2OOSubmitter(ctx context.Context, cancel context.CancelFunc, setup Driv
 	}, nil
 }
 
+// Constructs a new `L2OutputSubmitter` for DGF.
+//
+// Errors if the `DisputeGameFactory` contract fails to return a version.
 func newDGFSubmitter(ctx context.Context, cancel context.CancelFunc, setup DriverSetup) (*L2OutputSubmitter, error) {
 	dgfCaller := contracts.NewDisputeGameFactory(*setup.Cfg.DisputeGameFactoryAddr, setup.Multicaller, setup.Cfg.NetworkTimeout)
 
@@ -160,6 +185,12 @@ func newDGFSubmitter(ctx context.Context, cancel context.CancelFunc, setup Drive
 	}, nil
 }
 
+// Starts the `L2OutputSubmitter` loop.
+//
+// Errors if:
+//
+//   - The `L2OutputSubmitter` is already running.
+//   - The `L2OutputSubmitter` fails to wait for node to sync.
 func (l *L2OutputSubmitter) StartL2OutputSubmitting() error {
 	l.Log.Info("Starting Proposer")
 
@@ -181,6 +212,9 @@ func (l *L2OutputSubmitter) StartL2OutputSubmitting() error {
 	return nil
 }
 
+// Stops the `L2OutputSubmitter` loop if it is running.
+//
+// Errors if the `L2OutputSubmitter` fails to stop (and is also running).
 func (l *L2OutputSubmitter) StopL2OutputSubmittingIfRunning() error {
 	err := l.StopL2OutputSubmitting()
 	if errors.Is(err, ErrProposerNotRunning) {
@@ -189,6 +223,9 @@ func (l *L2OutputSubmitter) StopL2OutputSubmittingIfRunning() error {
 	return err
 }
 
+// Stops the `L2OutputSubmitter` loop.
+//
+// Errors if the `L2OutputSubmitter` is not running.
 func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 	l.Log.Info("Stopping Proposer")
 
@@ -204,11 +241,19 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 	return nil
 }
 
-// FetchL2OOOutput gets the next output proposal for the L2OO.
-// It queries the L2OO for the earliest next block number that should be proposed.
-// It returns the output to propose, and whether the proposal should be submitted at all.
-// The passed context is expected to be a lifecycle context. A network timeout
-// context will be derived from it.
+// Gets the next output proposal for the L2OO.
+//
+// It queries the L2OO for the earliest next block number that should be proposed, then returns the output to propose,
+// and whether the proposal should be submitted at all.
+//
+// The passed context is expected to be a lifecycle context. A network timeout context will be derived from it.
+//
+// Errors if:
+//
+//   - The `L2OutputOracle` contract is not set.
+//   - The `L2OutputOracle` contract fails to return a next block number.
+//   - The `L2OutputOracle` contract fails to return a valid current block number.
+//   - The `L2OutputOracle` contract fails to fetch the output at the next checkpoint block number.
 func (l *L2OutputSubmitter) FetchL2OOOutput(ctx context.Context) (source.Proposal, bool, error) {
 	if l.l2ooContract == nil {
 		return source.Proposal{}, false, fmt.Errorf("L2OutputOracle contract not set, cannot fetch next output info")
@@ -254,11 +299,18 @@ func (l *L2OutputSubmitter) FetchL2OOOutput(ctx context.Context) (source.Proposa
 	return output, true, nil
 }
 
-// FetchDGFOutput queries the DGF for the latest game and infers whether it is time to make another proposal
-// If necessary, it gets the next output proposal for the DGF, and returns it along with
-// a boolean for whether the proposal should be submitted at all.
-// The passed context is expected to be a lifecycle context. A network timeout
-// context will be derived from it.
+// Queries the DGF for the latest game and infers whether it is time to make another proposal.
+//
+// If necessary, it gets the next output proposal for the DGF, and returns it along with a boolean for whether the
+// proposal should be submitted at all.
+//
+// The passed context is expected to be a lifecycle context. A network timeout context will be derived from it.
+//
+// Errors if:
+//
+//   - The `DisputeGameFactory` contract fails to check for recent proposal.
+//   - The `DisputeGameFactory` contract fails to fetch current block number.
+//   - The `DisputeGameFactory` contract fails to fetch output at current block number.
 func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal, bool, error) {
 	cutoff := time.Now().Add(-l.Cfg.ProposalInterval)
 	proposedRecently, proposalTime, claim, err := l.dgfContract.HasProposedSince(ctx, l.Txmgr.From(), cutoff, l.Cfg.DisputeGameType)
@@ -297,8 +349,11 @@ func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal
 	return output, true, nil
 }
 
-// FetchCurrentBlockNumber gets the current block number from the [L2OutputSubmitter]'s [RollupClient]. If the `AllowNonFinalized` configuration
-// option is set, it will return the safe head block number, and if not, it will return the finalized head block number.
+// Gets the current block number from the `L2OutputSubmitter`'s `RollupClient`.
+//
+// If the `AllowNonFinalized` configuration option is set, it will return the safe head block number, and if not, it will return the finalized head block number.
+//
+// Errors if the `RollupClient` fails to return a sync status.
 func (l *L2OutputSubmitter) FetchCurrentBlockNumber(ctx context.Context) (uint64, error) {
 	status, err := l.ProposalSource.SyncStatus(ctx)
 	if err != nil {
@@ -312,6 +367,12 @@ func (l *L2OutputSubmitter) FetchCurrentBlockNumber(ctx context.Context) (uint64
 	return status.FinalizedL2, nil
 }
 
+// Fetches the output at the given block number.
+//
+// Errors if:
+//
+//   - The `ProposalSource` fails to return a proposal.
+//   - The `ProposalSource` returns a proposal with a mismatched block number.
 func (l *L2OutputSubmitter) FetchOutput(ctx context.Context, block uint64) (source.Proposal, error) {
 	output, err := l.ProposalSource.ProposalAtSequenceNum(ctx, block)
 	if err != nil {
@@ -323,12 +384,16 @@ func (l *L2OutputSubmitter) FetchOutput(ctx context.Context, block uint64) (sour
 	return output, nil
 }
 
-// ProposeL2OutputTxData creates the transaction data for the ProposeL2Output function
+// Creates proposal transaction data for L2OO.
 func (l *L2OutputSubmitter) ProposeL2OutputTxData(output source.Proposal) ([]byte, error) {
 	return proposeL2OutputTxData(l.l2ooABI, output)
 }
 
-// proposeL2OutputTxData creates the transaction data for the ProposeL2Output function
+// Creates proposal transaction data for L2OO.
+//
+// Errors if the ABI packing fails.
+//
+// TODO: do we need this? The `ProposeL2OutputTxData` function wraps this.
 func proposeL2OutputTxData(abi *abi.ABI, output source.Proposal) ([]byte, error) {
 	return abi.Pack(
 		"proposeL2Output",
@@ -338,18 +403,29 @@ func proposeL2OutputTxData(abi *abi.ABI, output source.Proposal) ([]byte, error)
 		new(big.Int).SetUint64(output.CurrentL1.Number))
 }
 
+// Creates a proposal transaction candidate for DGF.
+//
+// Errors if the `DisputeGameFactory` contract fails to return a proposal transaction candidate.
 func (l *L2OutputSubmitter) ProposeL2OutputDGFTxCandidate(ctx context.Context, output source.Proposal) (txmgr.TxCandidate, error) {
 	cCtx, cancel := context.WithTimeout(ctx, l.Cfg.NetworkTimeout)
 	defer cancel()
 	return l.dgfContract.ProposalTx(cCtx, l.Cfg.DisputeGameType, output.Root, output.SequenceNum)
 }
 
-// We wait until l1head advances beyond blocknum. This is used to make sure proposal tx won't
-// immediately fail when checking the l1 blockhash. Note that EstimateGas uses "latest" state to
-// execute the transaction by default, meaning inside the call, the head block is considered
-// "pending" instead of committed. In the case l1blocknum == l1head then, blockhash(l1blocknum)
-// will produce a value of 0 within EstimateGas, and the call will fail when the contract checks
-// that l1blockhash matches blockhash(l1blocknum).
+// Waits until L1 head advances beyond the given block number.
+//
+// This is used to make sure proposal tx won't immediately fail when checking the l1 blockhash.
+//
+// Note: EstimateGas uses "latest" state to execute the transaction by default, meaning inside the call, the head block
+// is considered "pending" instead of committed.
+//
+// In the case `l1blocknum == l1head` then, `blockhash(l1blocknum)` will produce a value of 0 within EstimateGas, and
+// the call will fail when the contract checks that l1blockhash matches blockhash(l1blocknum).
+//
+// Errors if:
+//
+//   - The `Txmgr` fails to return the current L1 block number.
+//   - The `
 func (l *L2OutputSubmitter) waitForL1Head(ctx context.Context, blockNum uint64) error {
 	ticker := time.NewTicker(l.Cfg.PollInterval)
 	defer ticker.Stop()
@@ -372,7 +448,17 @@ func (l *L2OutputSubmitter) waitForL1Head(ctx context.Context, blockNum uint64) 
 	return nil
 }
 
-// sendTransaction creates & sends transactions through the underlying transaction manager.
+// Creates & sends transactions through the underlying transaction manager.
+//
+// Errors if:
+//
+//   - If DGF:
+//   - The `DisputeGameFactory` contract fails to return a proposal transaction candidate.
+//   - The `Txmgr` fails to send the proposal transaction.
+//   - If L2OO:
+//   - The `waitForL1Head` fails.
+//   - The `ProposeL2OutputTxData` fails.
+//   - The `Txmgr` fails to send the proposal transaction.
 func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output source.Proposal) error {
 	l.Log.Info("Proposing output root", "output", output.Root, "block", output.SequenceNum)
 	var receipt *types.Receipt
@@ -415,7 +501,8 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output source.P
 	return nil
 }
 
-// loop is responsible for creating & submitting the next outputs
+// Creates & submits the next outputs.
+//
 // The loop regularly polls the L2 chain to infer whether to make the next proposal.
 func (l *L2OutputSubmitter) loop() {
 	defer l.wg.Done()
@@ -460,6 +547,12 @@ func (l *L2OutputSubmitter) loop() {
 
 }
 
+// Waits for the node to sync.
+//
+// Errors if:
+//
+//   - The `Txmgr` fails to return the current L1 block number.
+//   - The `ProposalSource` fails to return a sync status.
 func (l *L2OutputSubmitter) waitNodeSync() error {
 	cCtx, cancel := context.WithTimeout(l.ctx, l.Cfg.NetworkTimeout)
 	defer cancel()
@@ -478,6 +571,7 @@ func (l *L2OutputSubmitter) waitNodeSync() error {
 	})
 }
 
+// Proposes the output.
 func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Proposal) {
 	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -29,7 +29,7 @@ var (
 	ErrProposerNotRunning = errors.New("proposer is not running")
 )
 
-// Client for the L1 chain.
+// L1Client is the client for the L1 chain.
 type L1Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	// CodeAt returns the code of the given account. This is needed to differentiate
@@ -41,26 +41,26 @@ type L1Client interface {
 	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 }
 
-// L2OO contract interface.
+// L2OOContract is the L2OO contract interface.
 type L2OOContract interface {
 	Version(*bind.CallOpts) (string, error)
 	NextBlockNumber(*bind.CallOpts) (*big.Int, error)
 }
 
-// DGF contract interface.
+// DGFContract is the DGF contract interface.
 type DGFContract interface {
 	Version(ctx context.Context) (string, error)
 	HasProposedSince(ctx context.Context, proposer common.Address, cutoff time.Time, gameType uint32) (bool, time.Time, common.Hash, error)
 	ProposalTx(ctx context.Context, gameType uint32, outputRoot common.Hash, l2BlockNum uint64) (txmgr.TxCandidate, error)
 }
 
-// Rollup Client interface.
+// RollupClient is the rollup client interface.
 type RollupClient interface {
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
 }
 
-// Contains logger, metrics, config, tx manager, L1 client, multicaller, and proposal source.
+// DriverSetup contains logger, metrics, config, tx manager, L1 client, multicaller, and proposal source.
 //
 // Embedded in `L2OutputSubmitter`.
 type DriverSetup struct {
@@ -75,7 +75,7 @@ type DriverSetup struct {
 	ProposalSource source.ProposalSource
 }
 
-// Responsible for proposing outputs.
+// L2OutputSubmitter is responsible for proposing outputs.
 type L2OutputSubmitter struct {
 	DriverSetup
 
@@ -93,7 +93,7 @@ type L2OutputSubmitter struct {
 	dgfContract DGFContract
 }
 
-// Constructs a new `L2OutputSubmitter`.
+// NewL2OutputSubmitter constructs a new `L2OutputSubmitter`.
 //
 // May be constructed for L2OO, pre-interop DGF, or post-interop DGF.
 //
@@ -122,7 +122,7 @@ func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 	}
 }
 
-// Constructs a new `L2OutputSubmitter` for L2OO.
+// newL2OOSubmitter constructs a new `L2OutputSubmitter` for L2OO.
 //
 // Errors if:
 //
@@ -162,7 +162,7 @@ func newL2OOSubmitter(ctx context.Context, cancel context.CancelFunc, setup Driv
 	}, nil
 }
 
-// Constructs a new `L2OutputSubmitter` for DGF.
+// newDGFSubmitter constructs a new `L2OutputSubmitter` for DGF.
 //
 // Errors if the `DisputeGameFactory` contract fails to return a version.
 func newDGFSubmitter(ctx context.Context, cancel context.CancelFunc, setup DriverSetup) (*L2OutputSubmitter, error) {
@@ -185,7 +185,7 @@ func newDGFSubmitter(ctx context.Context, cancel context.CancelFunc, setup Drive
 	}, nil
 }
 
-// Starts the `L2OutputSubmitter` loop.
+// StartL2OutputSubmitting starts the `L2OutputSubmitter` loop.
 //
 // Errors if:
 //
@@ -212,7 +212,7 @@ func (l *L2OutputSubmitter) StartL2OutputSubmitting() error {
 	return nil
 }
 
-// Stops the `L2OutputSubmitter` loop if it is running.
+// StopL2OutputSubmittingIfRunning stops the `L2OutputSubmitter` loop if it is running.
 //
 // Errors if the `L2OutputSubmitter` fails to stop (and is also running).
 func (l *L2OutputSubmitter) StopL2OutputSubmittingIfRunning() error {
@@ -223,7 +223,7 @@ func (l *L2OutputSubmitter) StopL2OutputSubmittingIfRunning() error {
 	return err
 }
 
-// Stops the `L2OutputSubmitter` loop.
+// StopL2OutputSubmitting stops the `L2OutputSubmitter` loop.
 //
 // Errors if the `L2OutputSubmitter` is not running.
 func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
@@ -241,7 +241,7 @@ func (l *L2OutputSubmitter) StopL2OutputSubmitting() error {
 	return nil
 }
 
-// Gets the next output proposal for the L2OO.
+// FetchL2OOOutput gets the next output proposal for the L2OO.
 //
 // It queries the L2OO for the earliest next block number that should be proposed, then returns the output to propose,
 // and whether the proposal should be submitted at all.
@@ -299,7 +299,7 @@ func (l *L2OutputSubmitter) FetchL2OOOutput(ctx context.Context) (source.Proposa
 	return output, true, nil
 }
 
-// Queries the DGF for the latest game and infers whether it is time to make another proposal.
+// FetchDGFOutput queries the DGF for the latest game and infers whether it is time to make another proposal.
 //
 // If necessary, it gets the next output proposal for the DGF, and returns it along with a boolean for whether the
 // proposal should be submitted at all.
@@ -349,7 +349,7 @@ func (l *L2OutputSubmitter) FetchDGFOutput(ctx context.Context) (source.Proposal
 	return output, true, nil
 }
 
-// Gets the current block number from the `L2OutputSubmitter`'s `RollupClient`.
+// FetchCurrentBlockNumber gets the current block number from the `L2OutputSubmitter`'s `RollupClient`.
 //
 // If the `AllowNonFinalized` configuration option is set, it will return the safe head block number, and if not, it will return the finalized head block number.
 //
@@ -367,7 +367,7 @@ func (l *L2OutputSubmitter) FetchCurrentBlockNumber(ctx context.Context) (uint64
 	return status.FinalizedL2, nil
 }
 
-// Fetches the output at the given block number.
+// FetchOutput fetches the output at the given block number.
 //
 // Errors if:
 //
@@ -384,12 +384,12 @@ func (l *L2OutputSubmitter) FetchOutput(ctx context.Context, block uint64) (sour
 	return output, nil
 }
 
-// Creates proposal transaction data for L2OO.
+// ProposeL2OutputTxData creates proposal transaction data for L2OO.
 func (l *L2OutputSubmitter) ProposeL2OutputTxData(output source.Proposal) ([]byte, error) {
 	return proposeL2OutputTxData(l.l2ooABI, output)
 }
 
-// Creates proposal transaction data for L2OO.
+// proposeL2OutputTxData creates proposal transaction data for L2OO.
 //
 // Errors if the ABI packing fails.
 //
@@ -403,7 +403,7 @@ func proposeL2OutputTxData(abi *abi.ABI, output source.Proposal) ([]byte, error)
 		new(big.Int).SetUint64(output.CurrentL1.Number))
 }
 
-// Creates a proposal transaction candidate for DGF.
+// ProposeL2OutputDGFTxCandidate creates a proposal transaction candidate for DGF.
 //
 // Errors if the `DisputeGameFactory` contract fails to return a proposal transaction candidate.
 func (l *L2OutputSubmitter) ProposeL2OutputDGFTxCandidate(ctx context.Context, output source.Proposal) (txmgr.TxCandidate, error) {
@@ -412,7 +412,7 @@ func (l *L2OutputSubmitter) ProposeL2OutputDGFTxCandidate(ctx context.Context, o
 	return l.dgfContract.ProposalTx(cCtx, l.Cfg.DisputeGameType, output.Root, output.SequenceNum)
 }
 
-// Waits until L1 head advances beyond the given block number.
+// waitForL1Head waits until L1 head advances beyond the given block number.
 //
 // This is used to make sure proposal tx won't immediately fail when checking the l1 blockhash.
 //
@@ -448,7 +448,7 @@ func (l *L2OutputSubmitter) waitForL1Head(ctx context.Context, blockNum uint64) 
 	return nil
 }
 
-// Creates & sends transactions through the underlying transaction manager.
+// sendTransaction creates & sends transactions through the underlying transaction manager.
 //
 // Errors if:
 //
@@ -501,7 +501,7 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output source.P
 	return nil
 }
 
-// Creates & submits the next outputs.
+// loop creates & submits the next outputs.
 //
 // The loop regularly polls the L2 chain to infer whether to make the next proposal.
 func (l *L2OutputSubmitter) loop() {
@@ -547,7 +547,7 @@ func (l *L2OutputSubmitter) loop() {
 
 }
 
-// Waits for the node to sync.
+// waitNodeSync waits for the node to sync.
 //
 // Errors if:
 //
@@ -571,7 +571,7 @@ func (l *L2OutputSubmitter) waitNodeSync() error {
 	})
 }
 
-// Proposes the output.
+// proposeOutput proposes the output.
 func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Proposal) {
 	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -12,8 +12,9 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 )
 
-// Main is the entrypoint into the L2OutputSubmitter.
-// This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed L2Output-submitter
+// Main is the entrypoint into the `L2OutputSubmitter`.
+//
+// This method returns a `cliapp.LifecycleAction`, to create an `op-service` CLI-lifecycle-managed `L2OutputSubmitter`.
 func Main(version string) cliapp.LifecycleAction {
 	return func(cliCtx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, error) {
 		if err := flags.CheckRequired(cliCtx); err != nil {

--- a/op-proposer/proposer/rpc/api.go
+++ b/op-proposer/proposer/rpc/api.go
@@ -10,11 +10,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
+// ProposerDriver is the interface for starting and stopping the proposer.
 type ProposerDriver interface {
 	StartL2OutputSubmitting() error
 	StopL2OutputSubmitting() error
 }
 
+// adminAPI implements the `ProposerAdminServer` interface.
 type adminAPI struct {
 	*rpc.CommonAdminAPI
 	b ProposerDriver
@@ -22,6 +24,7 @@ type adminAPI struct {
 
 var _ apis.ProposerAdminServer = (*adminAPI)(nil)
 
+// NewAdminAPI constructs a new `adminAPI` instance.
 func NewAdminAPI(dr ProposerDriver, log log.Logger) *adminAPI {
 	return &adminAPI{
 		CommonAdminAPI: rpc.NewCommonAdminAPI(log),
@@ -29,6 +32,7 @@ func NewAdminAPI(dr ProposerDriver, log log.Logger) *adminAPI {
 	}
 }
 
+// GetAdminAPI returns the `admin` API.
 func GetAdminAPI(api *adminAPI) gethrpc.API {
 	return gethrpc.API{
 		Namespace: "admin",
@@ -36,10 +40,12 @@ func GetAdminAPI(api *adminAPI) gethrpc.API {
 	}
 }
 
+// StartProposer starts the proposer.
 func (a *adminAPI) StartProposer(_ context.Context) error {
 	return a.b.StartL2OutputSubmitting()
 }
 
+// StopProposer stops the proposer.
 func (a *adminAPI) StopProposer(ctx context.Context) error {
 	return a.b.StopL2OutputSubmitting()
 }

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -241,9 +241,9 @@ func (ps *ProposerService) initPProf(cfg *CLIConfig) error {
 
 // Initializes the metrics server if enabled.
 //
-// Errors on any of the following:
+// Errors if:
 //
-// - Metrics enabled but no registry
+// - Metrics are enabled but there is no registry
 // - Metrics server fails to start
 func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 	if !cfg.MetricsConfig.Enabled {

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -31,7 +31,7 @@ import (
 
 var ErrAlreadyStopped = errors.New("already stopped")
 
-// Configuration for the proposer.
+// ProposerConfig is the configuration for the proposer.
 type ProposerConfig struct {
 	// How frequently to poll L2 for new finalized outputs
 	PollInterval   time.Duration
@@ -53,7 +53,7 @@ type ProposerConfig struct {
 	WaitNodeSync bool
 }
 
-// Configuration for the proposer service.
+// ProposerService is the configuration for the proposer service.
 //
 // Contains logging, metrics, and encapsulates the proposer's components.
 //
@@ -81,7 +81,7 @@ type ProposerService struct {
 	stopped atomic.Bool
 }
 
-// ProposerServiceFromCLIConfig creates a new ProposerService from a CLIConfig.
+// ProposerServiceFromCLIConfig creates a new `ProposerService` from a `CLIConfig`.
 //
 // The service components are fully started, except for the driver,
 // which will not be submitting state (if it was configured to) until the Start part of the lifecycle.
@@ -93,7 +93,7 @@ func ProposerServiceFromCLIConfig(ctx context.Context, version string, cfg *CLIC
 	return &ps, nil
 }
 
-// Initializes the ProposerService from a CLIConfig.
+// initFromCLIConfig initializes the `ProposerService` from a `CLIConfig`.
 //
 // Errors if any of the following initialiations fail:
 //
@@ -144,7 +144,7 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	return nil
 }
 
-// Initializes the RPC clients.
+// initRPCClients initializes the RPC clients.
 //
 // Errors if any of the following fail:
 //
@@ -187,7 +187,7 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	return nil
 }
 
-// Initializes the metrics if enabled.
+// initMetrics initializes the metrics if enabled.
 func (ps *ProposerService) initMetrics(cfg *CLIConfig) {
 	if cfg.MetricsConfig.Enabled {
 		procName := "default"
@@ -197,7 +197,7 @@ func (ps *ProposerService) initMetrics(cfg *CLIConfig) {
 	}
 }
 
-// Initializes the balance monitor.
+// initBalanceMonitor initializes the balance monitor.
 //
 // Depends on Metrics, L1Client and TxManager to start background-monitoring of the Proposer
 // balance.
@@ -207,7 +207,7 @@ func (ps *ProposerService) initBalanceMonitor(cfg *CLIConfig) {
 	}
 }
 
-// Initializes the transaction manager.
+// initTxManager initializes the transaction manager.
 //
 // Errors if `txmgr.NewSimpleTxManager` fails to initialize.
 func (ps *ProposerService) initTxManager(cfg *CLIConfig) error {
@@ -219,7 +219,7 @@ func (ps *ProposerService) initTxManager(cfg *CLIConfig) error {
 	return nil
 }
 
-// Initializes the pprof service.
+// initPProf initializes the pprof service.
 //
 // Errors if `oppprof.Service.Start` fails.
 func (ps *ProposerService) initPProf(cfg *CLIConfig) error {
@@ -239,7 +239,7 @@ func (ps *ProposerService) initPProf(cfg *CLIConfig) error {
 	return nil
 }
 
-// Initializes the metrics server if enabled.
+// initMetricsServer initializes the metrics server if enabled.
 //
 // Errors if:
 //
@@ -264,7 +264,7 @@ func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 	return nil
 }
 
-// Initializes the L2 Output Oracle address.
+// initL2ooAddress initializes the L2 Output Oracle address.
 //
 // If the address is invalid or missing, it will not be set.
 func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) {
@@ -276,7 +276,7 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) {
 	ps.L2OutputOracleAddr = &l2ooAddress
 }
 
-// Initializes the Dispute Game Factory address.
+// initDGF initializes the Dispute Game Factory address.
 //
 // If the address is invalid or missing it will not be set.
 func (ps *ProposerService) initDGF(cfg *CLIConfig) {
@@ -290,7 +290,7 @@ func (ps *ProposerService) initDGF(cfg *CLIConfig) {
 	ps.DisputeGameType = cfg.DisputeGameType
 }
 
-// Initializes the L2 output submitter driver.
+// initDriver initializes the L2 output submitter driver.
 //
 // Errors if `proposer.NewL2OutputSubmitter` fails.
 func (ps *ProposerService) initDriver() error {
@@ -310,7 +310,7 @@ func (ps *ProposerService) initDriver() error {
 	return nil
 }
 
-// Initializes the RPC server.
+// initRPCServer initializes the RPC server.
 //
 // Errors if the RPC server fails to start.
 func (ps *ProposerService) initRPCServer(cfg *CLIConfig) error {
@@ -335,14 +335,14 @@ func (ps *ProposerService) initRPCServer(cfg *CLIConfig) error {
 	return nil
 }
 
-// Start runs once upon start of the proposer lifecycle,
-// and starts L2Output-submission work if the proposer is configured to start submit data on startup.
+// Start runs once upon start of the proposer lifecycle and starts L2Output-submission work if the proposer is configured
+// to start submit data on startup.
 func (ps *ProposerService) Start(_ context.Context) error {
 	ps.Log.Info("Starting Proposer")
 	return ps.driver.StartL2OutputSubmitting()
 }
 
-// Returns whether or not the ProposerService has been stopped.
+// Stopped returns whether or not the `ProposerService` has been stopped.
 func (ps *ProposerService) Stopped() bool {
 	return ps.stopped.Load()
 }
@@ -419,7 +419,7 @@ func (ps *ProposerService) Driver() rpc.ProposerDriver {
 	return ps.driver
 }
 
-// Returns the HTTP endpoint of the RPC server.
+// HTTPEndpoint returns the HTTP endpoint of the RPC server.
 func (ps *ProposerService) HTTPEndpoint() string {
 	if ps.rpcServer == nil {
 		return ""

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -31,6 +31,7 @@ import (
 
 var ErrAlreadyStopped = errors.New("already stopped")
 
+// Configuration for the proposer.
 type ProposerConfig struct {
 	// How frequently to poll L2 for new finalized outputs
 	PollInterval   time.Duration
@@ -52,6 +53,11 @@ type ProposerConfig struct {
 	WaitNodeSync bool
 }
 
+// Configuration for the proposer service.
+//
+// Contains logging, metrics, and encapsulates the proposer's components.
+//
+// Implements the `cliapp.Lifecycle` interface.
 type ProposerService struct {
 	Log     log.Logger
 	Metrics metrics.Metricer
@@ -76,6 +82,7 @@ type ProposerService struct {
 }
 
 // ProposerServiceFromCLIConfig creates a new ProposerService from a CLIConfig.
+//
 // The service components are fully started, except for the driver,
 // which will not be submitting state (if it was configured to) until the Start part of the lifecycle.
 func ProposerServiceFromCLIConfig(ctx context.Context, version string, cfg *CLIConfig, log log.Logger) (*ProposerService, error) {
@@ -86,6 +93,18 @@ func ProposerServiceFromCLIConfig(ctx context.Context, version string, cfg *CLIC
 	return &ps, nil
 }
 
+// Initializes the ProposerService from a CLIConfig.
+//
+// Errors if any of the following initialiations fail:
+//
+//   - metrics
+//   - rpc client
+//   - tx manager
+//   - balance monitor
+//   - metrics server
+//   - profile
+//   - driver
+//   - rpc server
 func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string, cfg *CLIConfig, log log.Logger) error {
 	ps.Version = version
 	ps.Log = log
@@ -125,6 +144,13 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	return nil
 }
 
+// Initializes the RPC clients.
+//
+// Errors if any of the following fail:
+//
+//   - L1 client connection
+//   - L2 provider connection (if L2OO)
+//   - Supervisor RPC clients (if DGF post-interop)
 func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) error {
 	l1Client, err := dial.DialEthClientWithTimeout(ctx, dial.DefaultDialTimeout, ps.Log, cfg.L1EthRpc)
 	if err != nil {
@@ -161,6 +187,7 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	return nil
 }
 
+// Initializes the metrics if enabled.
 func (ps *ProposerService) initMetrics(cfg *CLIConfig) {
 	if cfg.MetricsConfig.Enabled {
 		procName := "default"
@@ -170,13 +197,19 @@ func (ps *ProposerService) initMetrics(cfg *CLIConfig) {
 	}
 }
 
-// initBalanceMonitor depends on Metrics, L1Client and TxManager to start background-monitoring of the Proposer balance.
+// Initializes the balance monitor.
+//
+// Depends on Metrics, L1Client and TxManager to start background-monitoring of the Proposer
+// balance.
 func (ps *ProposerService) initBalanceMonitor(cfg *CLIConfig) {
 	if cfg.MetricsConfig.Enabled {
 		ps.balanceMetricer = ps.Metrics.StartBalanceMetrics(ps.Log, ps.L1Client, ps.TxManager.From())
 	}
 }
 
+// Initializes the transaction manager.
+//
+// Errors if `txmgr.NewSimpleTxManager` fails to initialize.
 func (ps *ProposerService) initTxManager(cfg *CLIConfig) error {
 	txManager, err := txmgr.NewSimpleTxManager("proposer", ps.Log, ps.Metrics, cfg.TxMgrConfig)
 	if err != nil {
@@ -186,6 +219,9 @@ func (ps *ProposerService) initTxManager(cfg *CLIConfig) error {
 	return nil
 }
 
+// Initializes the pprof service.
+//
+// Errors if `oppprof.Service.Start` fails.
 func (ps *ProposerService) initPProf(cfg *CLIConfig) error {
 	ps.pprofService = oppprof.New(
 		cfg.PprofConfig.ListenEnabled,
@@ -203,6 +239,12 @@ func (ps *ProposerService) initPProf(cfg *CLIConfig) error {
 	return nil
 }
 
+// Initializes the metrics server if enabled.
+//
+// Errors on any of the following:
+//
+// - Metrics enabled but no registry
+// - Metrics server fails to start
 func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 	if !cfg.MetricsConfig.Enabled {
 		ps.Log.Info("Metrics disabled")
@@ -222,6 +264,9 @@ func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 	return nil
 }
 
+// Initializes the L2 Output Oracle address.
+//
+// If the address is invalid or missing, it will not be set.
 func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) {
 	l2ooAddress, err := opservice.ParseAddress(cfg.L2OOAddress)
 	if err != nil {
@@ -231,6 +276,9 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) {
 	ps.L2OutputOracleAddr = &l2ooAddress
 }
 
+// Initializes the Dispute Game Factory address.
+//
+// If the address is invalid or missing it will not be set.
 func (ps *ProposerService) initDGF(cfg *CLIConfig) {
 	dgfAddress, err := opservice.ParseAddress(cfg.DGFAddress)
 	if err != nil {
@@ -242,6 +290,9 @@ func (ps *ProposerService) initDGF(cfg *CLIConfig) {
 	ps.DisputeGameType = cfg.DisputeGameType
 }
 
+// Initializes the L2 output submitter driver.
+//
+// Errors if `proposer.NewL2OutputSubmitter` fails.
 func (ps *ProposerService) initDriver() error {
 	driver, err := NewL2OutputSubmitter(DriverSetup{
 		Log:            ps.Log,
@@ -259,6 +310,9 @@ func (ps *ProposerService) initDriver() error {
 	return nil
 }
 
+// Initializes the RPC server.
+//
+// Errors if the RPC server fails to start.
 func (ps *ProposerService) initRPCServer(cfg *CLIConfig) error {
 	server := oprpc.NewServer(
 		cfg.RPCConfig.ListenAddr,
@@ -288,6 +342,7 @@ func (ps *ProposerService) Start(_ context.Context) error {
 	return ps.driver.StartL2OutputSubmitting()
 }
 
+// Returns whether or not the ProposerService has been stopped.
 func (ps *ProposerService) Stopped() bool {
 	return ps.stopped.Load()
 }
@@ -364,6 +419,7 @@ func (ps *ProposerService) Driver() rpc.ProposerDriver {
 	return ps.driver
 }
 
+// Returns the HTTP endpoint of the RPC server.
 func (ps *ProposerService) HTTPEndpoint() string {
 	if ps.rpcServer == nil {
 		return ""

--- a/op-proposer/proposer/source/source.go
+++ b/op-proposer/proposer/source/source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// Proposal data for L2OO & DGF.
 type Proposal struct {
 	// Root is the proposal hash
 	Root common.Hash
@@ -21,6 +22,7 @@ type Proposal struct {
 	Legacy LegacyProposalData
 }
 
+// Legacy proposal data for L2OO and pre-interop DGF.
 type LegacyProposalData struct {
 	HeadL1      eth.L1BlockRef
 	SafeL2      eth.L2BlockRef
@@ -30,6 +32,7 @@ type LegacyProposalData struct {
 	BlockRef eth.L2BlockRef
 }
 
+// Common interface for all proposal sources.
 type ProposalSource interface {
 	ProposalAtSequenceNum(ctx context.Context, seqNum uint64) (Proposal, error)
 	SyncStatus(ctx context.Context) (SyncStatus, error)
@@ -38,6 +41,7 @@ type ProposalSource interface {
 	Close()
 }
 
+// Sync status for all proposal sources.
 type SyncStatus struct {
 	CurrentL1   eth.L1BlockRef
 	SafeL2      uint64

--- a/op-proposer/proposer/source/source.go
+++ b/op-proposer/proposer/source/source.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// Proposal data for L2OO & DGF.
+// Proposal is the proposal data for L2OO & DGF.
 type Proposal struct {
 	// Root is the proposal hash
 	Root common.Hash
@@ -22,7 +22,7 @@ type Proposal struct {
 	Legacy LegacyProposalData
 }
 
-// Legacy proposal data for L2OO and pre-interop DGF.
+// LegacyProposalData is the legacy proposal data for L2OO and pre-interop DGF.
 type LegacyProposalData struct {
 	HeadL1      eth.L1BlockRef
 	SafeL2      eth.L2BlockRef
@@ -32,7 +32,7 @@ type LegacyProposalData struct {
 	BlockRef eth.L2BlockRef
 }
 
-// Common interface for all proposal sources.
+// ProposalSource is the common interface for all proposal sources.
 type ProposalSource interface {
 	ProposalAtSequenceNum(ctx context.Context, seqNum uint64) (Proposal, error)
 	SyncStatus(ctx context.Context) (SyncStatus, error)
@@ -41,7 +41,7 @@ type ProposalSource interface {
 	Close()
 }
 
-// Sync status for all proposal sources.
+// SyncStatus is the sync status for all proposal sources.
 type SyncStatus struct {
 	CurrentL1   eth.L1BlockRef
 	SafeL2      uint64

--- a/op-proposer/proposer/source/source_rollup.go
+++ b/op-proposer/proposer/source/source_rollup.go
@@ -11,20 +11,26 @@ import (
 
 var supportedL2OutputVersion = eth.Bytes32{}
 
+// Encapsulates a rollup provider for L2OO & pre-interop DGF.
 type RollupProposalSource struct {
 	provider dial.RollupProvider
 }
 
+// Constructs a new `RollupProposalSource`.
 func NewRollupProposalSource(provider dial.RollupProvider) *RollupProposalSource {
 	return &RollupProposalSource{
 		provider: provider,
 	}
 }
 
+// Close the underlying rollup provider.
 func (r *RollupProposalSource) Close() {
 	r.provider.Close()
 }
 
+// Returns the current L1 block, safe L2 block number, and finalized L2 block number.
+//
+// Errors if the provider fails to select an active rollup client or if the rollup client fails to return a sync status.
 func (r *RollupProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
 	client, err := r.provider.RollupClient(ctx)
 	if err != nil {
@@ -41,6 +47,13 @@ func (r *RollupProposalSource) SyncStatus(ctx context.Context) (SyncStatus, erro
 	}, nil
 }
 
+// Returns the proposal data for the given sequence number.
+//
+// Errors if:
+//
+//   - The provider fails to select an active rollup client
+//   - The rollup client fails to return an output
+//   - The output is for an unsupported version
 func (r *RollupProposalSource) ProposalAtSequenceNum(ctx context.Context, blockNum uint64) (Proposal, error) {
 	client, err := r.provider.RollupClient(ctx)
 	if err != nil {

--- a/op-proposer/proposer/source/source_rollup.go
+++ b/op-proposer/proposer/source/source_rollup.go
@@ -11,24 +11,24 @@ import (
 
 var supportedL2OutputVersion = eth.Bytes32{}
 
-// Encapsulates a rollup provider for L2OO & pre-interop DGF.
+// RollupProposalSource encapsulates a rollup provider for L2OO & pre-interop DGF.
 type RollupProposalSource struct {
 	provider dial.RollupProvider
 }
 
-// Constructs a new `RollupProposalSource`.
+// NewRollupProposalSource constructs a new `RollupProposalSource`.
 func NewRollupProposalSource(provider dial.RollupProvider) *RollupProposalSource {
 	return &RollupProposalSource{
 		provider: provider,
 	}
 }
 
-// Close the underlying rollup provider.
+// Close closes the underlying rollup provider.
 func (r *RollupProposalSource) Close() {
 	r.provider.Close()
 }
 
-// Returns the current L1 block, safe L2 block number, and finalized L2 block number.
+// SyncStatus returns the current L1 block, safe L2 block number, and finalized L2 block number.
 //
 // Errors if the provider fails to select an active rollup client or if the rollup client fails to return a sync status.
 func (r *RollupProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
@@ -47,13 +47,13 @@ func (r *RollupProposalSource) SyncStatus(ctx context.Context) (SyncStatus, erro
 	}, nil
 }
 
-// Returns the proposal data for the given sequence number.
+// ProposalAtSequenceNum returns the proposal data for the given sequence number.
 //
 // Errors if:
 //
-//   - The provider fails to select an active rollup client
-//   - The rollup client fails to return an output
-//   - The output is for an unsupported version
+//   - The provider fails to select an active rollup client.
+//   - The rollup client fails to return an output.
+//   - The output is for an unsupported version.
 func (r *RollupProposalSource) ProposalAtSequenceNum(ctx context.Context, blockNum uint64) (Proposal, error) {
 	client, err := r.provider.RollupClient(ctx)
 	if err != nil {

--- a/op-proposer/proposer/source/source_supervisor.go
+++ b/op-proposer/proposer/source/source_supervisor.go
@@ -14,20 +14,20 @@ import (
 
 var ErrNilL1View = errors.New("every supervisor node L1 block view is nil")
 
-// Supervisor Client for post-interop DGF.
+// SupervisorClient is the post-interop DGF client interface.
 type SupervisorClient interface {
 	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
 	Close()
 }
 
-// Supervisor Proposal Source for post-interop DGF.
+// SupervisorProposalSource is the post-interop DGF proposal source interface.
 type SupervisorProposalSource struct {
 	log     log.Logger
 	clients []SupervisorClient
 }
 
-// Constructs a new `SupervisorProposalSource`.
+// NewSupervisorProposalSource constructs a new `SupervisorProposalSource`.
 //
 // Panics if no supervisor clients are provided.
 func NewSupervisorProposalSource(logger log.Logger, clients ...SupervisorClient) *SupervisorProposalSource {
@@ -47,7 +47,7 @@ type statusResult struct {
 	err    error
 }
 
-// Returns the earliest L1 block, safe L2 block number, and finalized L2 block number from all supervisor clients.
+// SyncStatus returns the earliest L1 block, safe L2 block number, and finalized L2 block number from all supervisor clients.
 //
 // Errors if no clients return a valid minimum L1 block.
 //
@@ -97,7 +97,7 @@ func (s *SupervisorProposalSource) SyncStatus(ctx context.Context) (SyncStatus, 
 	}, nil
 }
 
-// Returns the proposal data for the given timestamp.
+// ProposalAtSequenceNum returns the proposal data for the given timestamp.
 //
 // Errors if all clients fail to return a proposal.
 func (s *SupervisorProposalSource) ProposalAtSequenceNum(ctx context.Context, timestamp uint64) (Proposal, error) {
@@ -121,7 +121,7 @@ func (s *SupervisorProposalSource) ProposalAtSequenceNum(ctx context.Context, ti
 	return Proposal{}, fmt.Errorf("no available proposal sources: %w", errors.Join(errs...))
 }
 
-// Close the underlying supervisor clients.
+// Close closes the underlying supervisor clients.
 func (s *SupervisorProposalSource) Close() {
 	for _, client := range s.clients {
 		client.Close()

--- a/op-proposer/proposer/source/source_supervisor.go
+++ b/op-proposer/proposer/source/source_supervisor.go
@@ -14,17 +14,22 @@ import (
 
 var ErrNilL1View = errors.New("every supervisor node L1 block view is nil")
 
+// Supervisor Client for post-interop DGF.
 type SupervisorClient interface {
 	SyncStatus(ctx context.Context) (eth.SupervisorSyncStatus, error)
 	SuperRootAtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootResponse, error)
 	Close()
 }
 
+// Supervisor Proposal Source for post-interop DGF.
 type SupervisorProposalSource struct {
 	log     log.Logger
 	clients []SupervisorClient
 }
 
+// Constructs a new `SupervisorProposalSource`.
+//
+// Panics if no supervisor clients are provided.
 func NewSupervisorProposalSource(logger log.Logger, clients ...SupervisorClient) *SupervisorProposalSource {
 	if len(clients) == 0 {
 		panic("no supervisor clients provided")
@@ -35,12 +40,18 @@ func NewSupervisorProposalSource(logger log.Logger, clients ...SupervisorClient)
 	}
 }
 
+// Contains client sync information for message passing.
 type statusResult struct {
 	idx    int
 	status eth.SupervisorSyncStatus
 	err    error
 }
 
+// Returns the earliest L1 block, safe L2 block number, and finalized L2 block number from all supervisor clients.
+//
+// Errors if no clients return a valid minimum L1 block.
+//
+// Note: Errors accumulate if any client returns an error, but the function only fails if no clients return a valid minimum L1 block.
 func (s *SupervisorProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
 	var wg sync.WaitGroup
 	results := make(chan statusResult, len(s.clients))
@@ -86,6 +97,9 @@ func (s *SupervisorProposalSource) SyncStatus(ctx context.Context) (SyncStatus, 
 	}, nil
 }
 
+// Returns the proposal data for the given timestamp.
+//
+// Errors if all clients fail to return a proposal.
 func (s *SupervisorProposalSource) ProposalAtSequenceNum(ctx context.Context, timestamp uint64) (Proposal, error) {
 	var errs []error
 	for i, client := range s.clients {
@@ -107,6 +121,7 @@ func (s *SupervisorProposalSource) ProposalAtSequenceNum(ctx context.Context, ti
 	return Proposal{}, fmt.Errorf("no available proposal sources: %w", errors.Join(errs...))
 }
 
+// Close the underlying supervisor clients.
 func (s *SupervisorProposalSource) Close() {
 	for _, client := range s.clients {
 		client.Close()


### PR DESCRIPTION
## Description

Adds some developer documentation to the functions & data types in `op-proposer`.

Generally, the pattern strived for is:

```
// One-Liner Description
//
// Relevant Details (if any)
//
// Notes (if any)
//
// Error Cases (if any)
thing
```

Where error cases describe either what causes the error case or defers it to the relevant function which may fail. Ideally, this lets developers hover an identifier and reason about what it does from a high level, including error cases without visiting the item directly.

## Tests

N/A

## Metadata

- Fixes #16800 
