### PR TITLE
feat(op-acceptance-tests): op-acceptor v3.0.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -38,7 +38,7 @@ anvil = "1.1.0"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v2.1.0"
+op-acceptor = "op-acceptor/v3.0.0"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v2.1.0")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.0.0")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 
@@ -94,6 +94,8 @@ acceptance-test devnet="" gate="holocene":
         CMD_ARGS+=("--devnet" "{{devnet}}")
         # Include kurtosis-dir for devnet deployment
         CMD_ARGS+=("--kurtosis-dir" "{{KURTOSIS_DIR}}")
+        # For now, run sysext in serial mode
+        CMD_ARGS+=("--serial")
     fi
 
     # Execute the command


### PR DESCRIPTION
Upgrades op-acceptor to [v3.0.0](https://github.com/ethereum-optimism/infra/releases/tag/op-acceptor%2Fv3.0.0) which introduces parallel test runs.
