### PR TITLE
Remove timeout parameter from dial functions

### DIFF
--- a/op-chain-ops/cmd/check-ecotone/main.go
+++ b/op-chain-ops/cmd/check-ecotone/main.go
@@ -176,7 +176,7 @@ func makeCommandAction(fn CheckAction) func(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to dial L2 RPC: %w", err)
 		}
-		rollupCl, err := dial.DialRollupClientWithTimeout(c.Context, time.Second*20, logger, c.String(EndpointRollup.Name))
+		rollupCl, err := dial.DialRollupClientWithTimeout(c.Context, logger, c.String(EndpointRollup.Name))
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup node RPC: %w", err)
 		}

--- a/op-chain-ops/cmd/withdrawal/util.go
+++ b/op-chain-ops/cmd/withdrawal/util.go
@@ -84,7 +84,7 @@ func loadDepsetConfig(ctx *cli.Context, depSetFlag string) (depset.DependencySet
 }
 
 func createSupervisorClient(ctx *cli.Context, supervisorFlag string) (*sources.SupervisorClient, error) {
-	rpcCl, err := dial.DialRPCClientWithTimeout(ctx.Context, 1*time.Minute, log.Root(), ctx.String(supervisorFlag))
+	rpcCl, err := dial.DialRPCClientWithTimeout(ctx.Context, log.Root(), ctx.String(supervisorFlag))
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial rollup client: %w", err)
 	}

--- a/op-challenger/game/fault/clients.go
+++ b/op-challenger/game/fault/clients.go
@@ -64,7 +64,7 @@ func (c *clientProvider) RollupClient() (RollupClient, error) {
 	if c.rollupClient != nil {
 		return c.rollupClient, nil
 	}
-	rollupClient, err := dial.DialRollupClientWithTimeout(c.ctx, dial.DefaultDialTimeout, c.logger, c.cfg.RollupRpc)
+	rollupClient, err := dial.DialRollupClientWithTimeout(c.ctx, c.logger, c.cfg.RollupRpc)
 	if err != nil {
 		return nil, fmt.Errorf("dial rollup client %v: %w", c.cfg.RollupRpc, err)
 	}

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -89,7 +89,7 @@ func (r *Runner) Start(ctx context.Context) error {
 	var rollupClient *sources.RollupClient
 	if r.cfg.RollupRpc != "" {
 		r.log.Info("Dialling rollup client", "url", r.cfg.RollupRpc)
-		cl, err := dial.DialRollupClientWithTimeout(ctx, 1*time.Minute, r.log, r.cfg.RollupRpc)
+		cl, err := dial.DialRollupClientWithTimeout(ctx, r.log, r.cfg.RollupRpc)
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client: %w", err)
 		}
@@ -98,14 +98,14 @@ func (r *Runner) Start(ctx context.Context) error {
 	var supervisorClient *sources.SupervisorClient
 	if r.cfg.SupervisorRPC != "" {
 		r.log.Info("Dialling supervisor client", "url", r.cfg.SupervisorRPC)
-		rpcCl, err := dial.DialRPCClientWithTimeout(ctx, 1*time.Minute, r.log, r.cfg.SupervisorRPC)
+		rpcCl, err := dial.DialRPCClientWithTimeout(ctx, r.log, r.cfg.SupervisorRPC)
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client: %w", err)
 		}
 		supervisorClient = sources.NewSupervisorClient(client.NewBaseRPCClient(rpcCl))
 	}
 
-	l1Client, err := dial.DialRPCClientWithTimeout(ctx, 1*time.Minute, r.log, r.cfg.L1EthRpc)
+	l1Client, err := dial.DialRPCClientWithTimeout(ctx, r.log, r.cfg.L1EthRpc)
 	if err != nil {
 		return fmt.Errorf("failed to dial l1 client: %w", err)
 	}

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -281,7 +281,7 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 			Service:   execMinerProxy,
 		})
 
-		nodeClient, err := dial.DialRollupClientWithTimeout(ctx, 1*time.Minute, oc.log, oc.cfg.NodeRPC)
+		nodeClient, err := dial.DialRollupClientWithTimeout(ctx, oc.log, oc.cfg.NodeRPC)
 		if err != nil {
 			return errors.Wrap(err, "failed to create node rpc client")
 		}

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -177,10 +177,10 @@ func WithL2ELP2PConnection(l2EL1ID, l2EL2ID stack.L2ELNodeID) stack.Option[*Orch
 		ctx := orch.P().Ctx()
 		logger := orch.P().Logger()
 
-		rpc1, err := dial.DialRPCClientWithTimeout(ctx, 30*time.Second, logger, l2EL1.userRPC)
+		rpc1, err := dial.DialRPCClientWithTimeout(ctx, logger, l2EL1.userRPC)
 		require.NoError(err, "failed to connect to el1 rpc")
 		defer rpc1.Close()
-		rpc2, err := dial.DialRPCClientWithTimeout(ctx, 30*time.Second, logger, l2EL2.userRPC)
+		rpc2, err := dial.DialRPCClientWithTimeout(ctx, logger, l2EL2.userRPC)
 		require.NoError(err, "failed to connect to el2 rpc")
 		defer rpc2.Close()
 

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -177,7 +177,7 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 		return nil
 	}
 	for _, rpc := range cfg.RollupRpcs {
-		client, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
+		client, err := dial.DialRollupClientWithTimeout(ctx, s.logger, rpc)
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client %s: %w", rpc, err)
 		}
@@ -191,7 +191,7 @@ func (s *Service) initSupervisorClients(ctx context.Context, cfg *config.Config)
 		return nil
 	}
 	for _, rpc := range cfg.SupervisorRpcs {
-		rpcClient, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, rpc)
+		rpcClient, err := dial.DialRPCClientWithTimeout(ctx, s.logger, rpc)
 		if err != nil {
 			return fmt.Errorf("failed to dial supervisor client %s: %w", rpc, err)
 		}
@@ -202,7 +202,7 @@ func (s *Service) initSupervisorClients(ctx context.Context, cfg *config.Config)
 }
 
 func (s *Service) initL1Client(ctx context.Context, cfg *config.Config) error {
-	l1RPC, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.L1EthRpc)
+	l1RPC, err := dial.DialRPCClientWithTimeout(ctx, s.logger, cfg.L1EthRpc)
 	if err != nil {
 		return fmt.Errorf("failed to dial L1: %w", err)
 	}

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/stretchr/testify/require"
@@ -240,7 +241,7 @@ func (v *L2Verifier) InteropSyncNode(t Testing) syncnode.SyncNode {
 	require.True(t, ok, "Interop sub-system must be in managed-mode if used as sync-node")
 	auth := rpc.WithHTTPAuth(gnode.NewJWTAuth(m.JWTSecret()))
 	opts := []client.RPCOption{client.WithGethRPCOptions(auth)}
-	cl, err := client.CheckAndDial(t.Ctx(), v.log, m.WSEndpoint(), auth)
+	cl, err := client.CheckAndDial(t.Ctx(), v.log, m.WSEndpoint(), 5*time.Second, auth)
 	require.NoError(t, err)
 	t.Cleanup(cl.Close)
 	bCl := client.NewBaseRPCClient(cl)

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -425,7 +425,9 @@ func TestProposals(t *testing.T) {
 		require.NotNil(t, proposer.DisputeGameFactoryAddr)
 		gameFactoryAddr := *proposer.DisputeGameFactoryAddr
 
-		rpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), time.Minute, logger, s2.L1().UserRPC().RPC())
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Minute)
+		rpcClient, err := dial.DialRPCClientWithTimeout(dialCtx, logger, s2.L1().UserRPC().RPC())
+		dialCancel()
 		require.NoError(t, err)
 		caller := batching.NewMultiCaller(rpcClient, batching.DefaultBatchSize)
 		factory := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, gameFactoryAddr, caller)

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -425,9 +425,7 @@ func TestProposals(t *testing.T) {
 		require.NotNil(t, proposer.DisputeGameFactoryAddr)
 		gameFactoryAddr := *proposer.DisputeGameFactoryAddr
 
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Minute)
-		rpcClient, err := dial.DialRPCClientWithTimeout(dialCtx, logger, s2.L1().UserRPC().RPC())
-		dialCancel()
+		rpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), logger, s2.L1().UserRPC().RPC())
 		require.NoError(t, err)
 		caller := batching.NewMultiCaller(rpcClient, batching.DefaultBatchSize)
 		factory := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, gameFactoryAddr, caller)

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -590,9 +590,7 @@ func (s *interopE2ESystem) DependencySet() *depset.StaticConfigDependencySet {
 
 func mustDial(t *testing.T, logger log.Logger) func(v string) *rpc.Client {
 	return func(v string) *rpc.Client {
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		cl, err := dial.DialRPCClientWithTimeout(dialCtx, logger, v)
-		dialCancel()
+		cl, err := dial.DialRPCClientWithTimeout(context.Background(), logger, v)
 		require.NoError(t, err, "failed to dial")
 		return cl
 	}

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -433,7 +433,7 @@ func (s *interopE2ESystem) L1GethClient() *ethclient.Client {
 		rpcEndpoint,
 		func(v string) *rpc.Client {
 			logger := testlog.Logger(s.t, log.LevelInfo)
-			cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
+			cl, err := dial.DialRPCClientWithTimeout(context.Background(), logger, v)
 			require.NoError(s.t, err, "failed to dial L1 eth node instance")
 			return cl
 		})
@@ -590,7 +590,9 @@ func (s *interopE2ESystem) DependencySet() *depset.StaticConfigDependencySet {
 
 func mustDial(t *testing.T, logger log.Logger) func(v string) *rpc.Client {
 	return func(v string) *rpc.Client {
-		cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cl, err := dial.DialRPCClientWithTimeout(dialCtx, logger, v)
+		dialCancel()
 		require.NoError(t, err, "failed to dial")
 		return cl
 	}

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -76,7 +76,7 @@ func (s *interopE2ESystem) L2GethClient(id string, name string) *ethclient.Clien
 		rpcEndpoint,
 		func(v string) *rpc.Client {
 			logger := testlog.Logger(s.t, log.LevelInfo).New("node", id)
-			cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
+			cl, err := dial.DialRPCClientWithTimeout(context.Background(), logger, v)
 			require.NoError(s.t, err, "failed to dial eth node instance %s", id)
 			return cl
 		})
@@ -98,9 +98,9 @@ func (s *interopE2ESystem) L2RollupClient(id string, name string) *sources.Rollu
 	}
 	rollupClA, err := dial.DialRollupClientWithTimeout(
 		context.Background(),
-		time.Second*15,
 		s.logger,
-		node.opNode.UserRPC().RPC())
+		node.opNode.UserRPC().RPC(),
+	)
 	require.NoError(s.t, err, "failed to dial rollup client")
 	node.rollupClient = rollupClA
 	return node.rollupClient

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -1133,7 +1133,7 @@ func (sys *System) RollupClient(name string) *sources.RollupClient {
 	}
 	rpcClient := endpoint.DialRPC(endpoint.PreferAnyRPC, sys.RollupEndpoint(name), func(v string) *rpc.Client {
 		logger := testlog.Logger(sys.t, log.LevelInfo).New("rollupClient", name)
-		cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
+		cl, err := dial.DialRPCClientWithTimeout(context.Background(), logger, v)
 		require.NoError(sys.t, err, "failed to dial rollup instance %s", name)
 		return cl
 	})
@@ -1152,7 +1152,7 @@ func (sys *System) NodeClient(name string) *ethclient.Client {
 	}
 	rpcCl := endpoint.DialRPC(endpoint.PreferAnyRPC, sys.NodeEndpoint(name), func(v string) *rpc.Client {
 		logger := testlog.Logger(sys.t, log.LevelInfo).New("node", name)
-		cl, err := dial.DialRPCClientWithTimeout(context.Background(), 30*time.Second, logger, v)
+		cl, err := dial.DialRPCClientWithTimeout(context.Background(), logger, v)
 		require.NoError(sys.t, err, "failed to dial eth node instance %s", name)
 		return cl
 	})

--- a/op-e2e/system/runcfg/protocol_versions_test.go
+++ b/op-e2e/system/runcfg/protocol_versions_test.go
@@ -128,10 +128,8 @@ func TestRequiredProtocolVersionChangeAndHalt(t *testing.T) {
 	// Checking if the engine is down is not trivial in op-e2e.
 	// In op-geth we have halting tests covering the Engine API, in op-e2e we instead check if the API stops.
 	_, err = retry.Do(context.Background(), 10, retry.Fixed(time.Second*10), func() (struct{}, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		available := client.IsURLAvailable(ctx, sys.NodeEndpoint("verifier").(endpoint.HttpRPC).HttpRPC())
-		if !available && ctx.Err() == nil { // waiting for client to stop responding to RPC requests (slow dials with timeout don't count)
+		available := client.IsURLAvailable(context.Background(), sys.NodeEndpoint("verifier").(endpoint.HttpRPC).HttpRPC(), 5*time.Second)
+		if !available { // waiting for client to stop responding to RPC requests (slow dials with timeout don't count)
 			return struct{}{}, nil
 		}
 		return struct{}{}, errors.New("verifier EL node is not closed yet")

--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -58,7 +58,7 @@ func (c *ConductorClient) initialize(ctx context.Context) error {
 		return fmt.Errorf("no conductor RPC endpoint available: %w", err)
 	}
 	metricsOpt := rpc.WithRecorder(c.metrics.NewRecorder("conductor"))
-	conductorRpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), time.Minute*1, c.log, endpoint, metricsOpt)
+	conductorRpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), c.log, endpoint, metricsOpt)
 	if err != nil {
 		return fmt.Errorf("failed to dial conductor RPC: %w", err)
 	}

--- a/op-program/verify/verify.go
+++ b/op-program/verify/verify.go
@@ -50,7 +50,7 @@ func NewRunner(l1RpcUrl string, l1RpcKind string, l1BeaconUrl string, l2RpcUrl s
 
 	setupLog := oplog.NewLogger(os.Stderr, logCfg)
 
-	l2RawRpc, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, setupLog, l2RpcUrl)
+	l2RawRpc, err := dial.DialRPCClientWithTimeout(ctx, setupLog, l2RpcUrl)
 	if err != nil {
 		return nil, fmt.Errorf("dial L2 client: %w", err)
 	}
@@ -112,7 +112,7 @@ func (r *Runner) RunBetweenBlocks(ctx context.Context, l1Head common.Hash, start
 }
 
 func (r *Runner) createL2Client(ctx context.Context) (*sources.L2Client, error) {
-	l2RawRpc, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, r.setupLog, r.l2RpcUrl)
+	l2RawRpc, err := dial.DialRPCClientWithTimeout(ctx, r.setupLog, r.l2RpcUrl)
 	if err != nil {
 		return nil, fmt.Errorf("dial L2 client: %w", err)
 	}

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -148,7 +148,7 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	if len(cfg.SupervisorRpcs) != 0 {
 		var clients []source.SupervisorClient
 		for _, url := range cfg.SupervisorRpcs {
-			supervisorRpc, err := dial.DialRPCClientWithTimeout(ctx, dial.DefaultDialTimeout, ps.Log, url)
+			supervisorRpc, err := dial.DialRPCClientWithTimeout(ctx, ps.Log, url)
 			if err != nil {
 				return fmt.Errorf("failed to dial supervisor RPC client (%v): %w", url, err)
 			}

--- a/op-service/client/dial_test.go
+++ b/op-service/client/dial_test.go
@@ -6,9 +6,12 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+const defaultConnectTimeout = 5 * time.Second
 
 func TestIsURLAvailableLocal(t *testing.T) {
 	listener, err := net.Listen("tcp4", ":0")
@@ -20,38 +23,38 @@ func TestIsURLAvailableLocal(t *testing.T) {
 	addr := fmt.Sprintf("http://localhost:%s", parts[1])
 
 	// True & False with ports
-	require.True(t, IsURLAvailable(context.Background(), addr))
-	require.False(t, IsURLAvailable(context.Background(), "http://localhost:0"))
+	require.True(t, IsURLAvailable(context.Background(), addr, defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "http://localhost:0", defaultConnectTimeout))
 
 	// Fail open if we don't recognize the scheme
-	require.True(t, IsURLAvailable(context.Background(), "mailto://example.com"))
+	require.True(t, IsURLAvailable(context.Background(), "mailto://example.com", defaultConnectTimeout))
 
 }
 
 func TestIsURLAvailableNonLocal(t *testing.T) {
-	if !IsURLAvailable(context.Background(), "http://example.com") {
+	if !IsURLAvailable(context.Background(), "http://example.com", defaultConnectTimeout) {
 		t.Skip("No internet connection found, skipping this test")
 	}
 
 	// True without ports. http & https
-	require.True(t, IsURLAvailable(context.Background(), "http://example.com"))
-	require.True(t, IsURLAvailable(context.Background(), "http://example.com/hello"))
-	require.True(t, IsURLAvailable(context.Background(), "https://example.com"))
-	require.True(t, IsURLAvailable(context.Background(), "https://example.com/hello"))
+	require.True(t, IsURLAvailable(context.Background(), "http://example.com", defaultConnectTimeout))
+	require.True(t, IsURLAvailable(context.Background(), "http://example.com/hello", defaultConnectTimeout))
+	require.True(t, IsURLAvailable(context.Background(), "https://example.com", defaultConnectTimeout))
+	require.True(t, IsURLAvailable(context.Background(), "https://example.com/hello", defaultConnectTimeout))
 
 	// True without ports. ws & wss
-	require.True(t, IsURLAvailable(context.Background(), "ws://example.com"))
-	require.True(t, IsURLAvailable(context.Background(), "ws://example.com/hello"))
-	require.True(t, IsURLAvailable(context.Background(), "wss://example.com"))
-	require.True(t, IsURLAvailable(context.Background(), "wss://example.com/hello"))
+	require.True(t, IsURLAvailable(context.Background(), "ws://example.com", defaultConnectTimeout))
+	require.True(t, IsURLAvailable(context.Background(), "ws://example.com/hello", defaultConnectTimeout))
+	require.True(t, IsURLAvailable(context.Background(), "wss://example.com", defaultConnectTimeout))
+	require.True(t, IsURLAvailable(context.Background(), "wss://example.com/hello", defaultConnectTimeout))
 
 	// False without ports
-	require.False(t, IsURLAvailable(context.Background(), "http://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable(context.Background(), "http://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
-	require.False(t, IsURLAvailable(context.Background(), "https://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable(context.Background(), "https://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
-	require.False(t, IsURLAvailable(context.Background(), "ws://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable(context.Background(), "ws://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
-	require.False(t, IsURLAvailable(context.Background(), "wss://fakedomainnamethatdoesnotexistandshouldneverexist.com"))
-	require.False(t, IsURLAvailable(context.Background(), "wss://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello"))
+	require.False(t, IsURLAvailable(context.Background(), "http://fakedomainnamethatdoesnotexistandshouldneverexist.com", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "http://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "https://fakedomainnamethatdoesnotexistandshouldneverexist.com", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "https://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "ws://fakedomainnamethatdoesnotexistandshouldneverexist.com", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "ws://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "wss://fakedomainnamethatdoesnotexistandshouldneverexist.com", defaultConnectTimeout))
+	require.False(t, IsURLAvailable(context.Background(), "wss://fakedomainnamethatdoesnotexistandshouldneverexist.com/hello", defaultConnectTimeout))
 }

--- a/op-service/dial/static_rollup_provider.go
+++ b/op-service/dial/static_rollup_provider.go
@@ -25,7 +25,7 @@ type StaticL2RollupProvider struct {
 }
 
 func NewStaticL2RollupProvider(ctx context.Context, log log.Logger, rollupClientUrl string) (*StaticL2RollupProvider, error) {
-	rollupClient, err := DialRollupClientWithTimeout(ctx, DefaultDialTimeout, log, rollupClientUrl)
+	rollupClient, err := DialRollupClientWithTimeout(ctx, log, rollupClientUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/op-supervisor/supervisor/service_test.go
+++ b/op-supervisor/supervisor/service_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-service/dial"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -66,7 +67,7 @@ func TestSupervisorService(t *testing.T) {
 	{
 		endpoint := "http://" + supervisor.rpcServer.Endpoint()
 		t.Logf("dialing %s", endpoint)
-		cl, err := dial.DialRPCClientWithTimeout(context.Background(), time.Second*5, logger, endpoint)
+		cl, err := opclient.NewRPC(context.Background(), logger, endpoint, opclient.WithConnectTimeout(5*time.Second))
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		err = cl.CallContext(ctx, nil, "supervisor_checkAccessList",


### PR DESCRIPTION
`DialRollupClientWithTimeout()` and `DialRPCClientWithTimeout()` had a timeout parameter that didn't actually work, since `IsURLAvailable()` had a hard-coded timeout anyway, and it prevented lazy dial from working since a context with a timeout was passed down and the timeout was relative to the context creation time.

This PR removes the `timeout` parameter to `DialRollupClientWithTimeout()` and `DialRPCClientWithTimeout()` and creates a sub-context inside `CheckAndDial()` which manages the timeout. Wherever a hard-coded timeout was passed in explicitly as the `timeout` parameter it has just been removed since it was ineffective before anyway.