### PR TITLE
chore: remove unnecessary todo comment

### DIFF
--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -86,8 +86,6 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		}
 	}
 
-	// TODO: can batch be non nil while err == io.EOF
-	// This depends on the behavior of rlp.Stream
 	batchData, err := cr.nextBatchFn()
 	if err == io.EOF {
 		cr.NextChannel()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

https://github.com/ethereum-optimism/optimism/blob/7c59c8c262d4495bf6d982c67cfbd2804b7db1a7/op-node/rollup/derive/channel.go#L215
This code line have make sure when err != nil, batchData is nil.  
So I think this todo comment is unnecessary.   

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
