### PR TITLE
op-node, op-devstack: initial execution multiplexing

### DIFF
--- a/op-acceptance-tests/tests/exec_multiplexing/main_test.go
+++ b/op-acceptance-tests/tests/exec_multiplexing/main_test.go
@@ -1,0 +1,27 @@
+package execmultiplexing
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestMain(m *testing.M) {
+	nodes := 3
+	presets.DoMain(m, presets.WithMultiELNodes(nodes),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}
+
+func TestExecMultiplexing(gt *testing.T) {
+	t := devtest.SerialT(gt)
+
+	nodes := 3
+	sys := presets.NewMultiELNodes(t, nodes)
+
+	dsl.CheckAll(t, sys.L2CL.AdvancedFn(types.LocalUnsafe, 5, 30))
+}

--- a/op-devstack/presets/multi_el_nodes.go
+++ b/op-devstack/presets/multi_el_nodes.go
@@ -1,0 +1,30 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+type MultiELNodes struct {
+	Minimal
+
+	ELs []stack.L2ELNodeID
+}
+
+func WithMultiELNodes(n int) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainMultiELNodesSystem(&sysgo.DefaultSingleChainMultiELNodesSystemIDs{}, n))
+}
+
+func NewMultiELNodes(t devtest.T, n int) *MultiELNodes {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+	minimal := minimalFromSystem(t, system, orch)
+	ids := sysgo.NewDefaultSingleChainMultiELNodesSystemIDs(sysgo.DefaultL1ID, sysgo.DefaultL2AID, n)
+	return &MultiELNodes{
+		Minimal: *minimal,
+		ELs:     ids.L2ELs,
+	}
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -50,6 +50,7 @@ type L2CLNode struct {
 	p                devtest.P
 	logger           log.Logger
 	el               stack.L2ELNodeID
+	els              []stack.L2ELNodeID
 	userProxy        *tcpproxy.Proxy
 	interopProxy     *tcpproxy.Proxy
 }
@@ -143,7 +144,7 @@ func WithL2CLOption(opt L2CLOption) stack.Option[*Orchestrator] {
 	})
 }
 
-func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELIDs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
 
@@ -158,11 +159,17 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, 
 		l1CL, ok := orch.l1CLs.Get(l1CLID)
 		require.True(ok, "l1 CL node required")
 
-		l2EL, ok := orch.l2ELs.Get(l2ELID)
-		require.True(ok, "l2 EL node required")
+		require.True(len(l2ELIDs) > 0, "at least one l2 EL node is required")
+
+		var l2ELs []*L2ELNode
+		for _, l2ELID := range l2ELIDs {
+			l2EL, ok := orch.l2ELs.Get(l2ELID)
+			require.True(ok, "l2 EL node required")
+			l2ELs = append(l2ELs, l2EL)
+		}
 
 		var depSet depset.DependencySet
-		if cluster, ok := orch.ClusterForL2(l2ELID.ChainID()); ok {
+		if cluster, ok := orch.ClusterForL2(l2ELIDs[0].ChainID()); ok {
 			depSet = cluster.DepSet()
 		}
 
@@ -225,6 +232,14 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, 
 			}
 		}
 
+		var l2sEndpointConfig []config.L2EndpointSetup
+		for _, l2EL := range l2ELs {
+			l2sEndpointConfig = append(l2sEndpointConfig, &config.L2EndpointConfig{
+				L2EngineAddr:      l2EL.authRPC,
+				L2EngineJWTSecret: jwtSecret,
+			})
+		}
+
 		nodeCfg := &config.Config{
 			L1: &config.L1EndpointConfig{
 				L1NodeAddr:       l1EL.userRPC,
@@ -237,9 +252,10 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, 
 				CacheSize:        0, // auto-adjust to sequence window
 			},
 			L2: &config.L2EndpointConfig{
-				L2EngineAddr:      l2EL.authRPC,
+				L2EngineAddr:      l2ELs[0].authRPC,
 				L2EngineJWTSecret: jwtSecret,
 			},
+			L2s: l2sEndpointConfig,
 			Beacon: &config.L1BeaconEndpointConfig{
 				BeaconAddr: l1CL.beacon.BeaconAddr(),
 			},
@@ -288,7 +304,8 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, isSequencer bool, indexingMode bool, 
 			cfg:    nodeCfg,
 			logger: logger,
 			p:      p,
-			el:     l2ELID,
+			el:     l2ELIDs[0],
+			els:    l2ELIDs,
 		}
 		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), "must not already exist")
 		l2CLNode.Start()

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -65,7 +65,7 @@ func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestra
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
 	opt.Add(WithL2ELNode(ids.L2EL, nil))
-	opt.Add(WithL2CLNode(ids.L2CL, true, false, ids.L1CL, ids.L1EL, ids.L2EL))
+	opt.Add(WithL2CLNode(ids.L2CL, true, false, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2EL}))
 
 	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
 	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
@@ -169,7 +169,7 @@ func baseInteropSystem(ids *DefaultSingleChainInteropSystemIDs) stack.Option[*Or
 	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
 
 	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
-	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2AEL}))
 	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
 	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
 
@@ -219,7 +219,7 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 		WithInteropAtGenesis(), // this can be overridden by later options
 	))
 	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
-	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))
+	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2BEL}))
 	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
 
 	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
@@ -279,9 +279,9 @@ func defaultSuperProofsSystem(dest *DefaultInteropSystemIDs, deployerOpts ...Dep
 	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
 
 	opt.Add(WithL2ELNode(ids.L2AEL, &ids.Supervisor))
-	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithL2CLNode(ids.L2ACL, true, true, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2AEL}))
 	opt.Add(WithL2ELNode(ids.L2BEL, &ids.Supervisor))
-	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, ids.L2BEL))
+	opt.Add(WithL2CLNode(ids.L2BCL, true, true, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2BEL}))
 
 	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
 
@@ -341,10 +341,10 @@ func MultiSupervisorInteropSystem(dest *MultiSupervisorInteropSystemIDs) stack.O
 	opt.Add(WithSupervisor(ids.SupervisorSecondary, ids.Cluster, ids.L1EL))
 
 	opt.Add(WithL2ELNode(ids.L2A2EL, &ids.SupervisorSecondary))
-	opt.Add(WithL2CLNode(ids.L2A2CL, false, true, ids.L1CL, ids.L1EL, ids.L2A2EL))
+	opt.Add(WithL2CLNode(ids.L2A2CL, false, true, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2A2EL}))
 
 	opt.Add(WithL2ELNode(ids.L2B2EL, &ids.SupervisorSecondary))
-	opt.Add(WithL2CLNode(ids.L2B2CL, false, true, ids.L1CL, ids.L1EL, ids.L2B2EL))
+	opt.Add(WithL2CLNode(ids.L2B2CL, false, true, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2B2EL}))
 
 	// verifier must be also managed or it cannot advance
 	// we attach verifier L2CL with backup supervisor

--- a/op-devstack/sysgo/system_singlechain_multielnodes.go
+++ b/op-devstack/sysgo/system_singlechain_multielnodes.go
@@ -1,0 +1,81 @@
+package sysgo
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type DefaultSingleChainMultiELNodesSystemIDs struct {
+	DefaultMinimalSystemIDs
+
+	L2ELs []stack.L2ELNodeID
+}
+
+func NewDefaultSingleChainMultiELNodesSystemIDs(l1ID, l2ID eth.ChainID, n int) DefaultSingleChainMultiELNodesSystemIDs {
+	minimal := NewDefaultMinimalSystemIDs(l1ID, l2ID)
+
+	ids := make([]stack.L2ELNodeID, n)
+	for i := 0; i < n; i++ {
+		ids[i] = stack.NewL2ELNodeID(fmt.Sprintf("verifier_%d", i), l2ID)
+	}
+
+	return DefaultSingleChainMultiELNodesSystemIDs{
+		DefaultMinimalSystemIDs: minimal,
+		L2ELs:                   ids,
+	}
+}
+
+func DefaultSingleChainMultiELNodesSystem(dest *DefaultSingleChainMultiELNodesSystemIDs, n int) stack.Option[*Orchestrator] {
+	ids := NewDefaultSingleChainMultiELNodesSystemIDs(DefaultL1ID, DefaultL2AID, n)
+
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Logger().Info("Setting up")
+	}))
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithDeployer(),
+		WithDeployerOptions(
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2.ChainID()),
+		),
+	)
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithL2ELNode(ids.L2EL, nil))
+	for _, l2ELID := range ids.L2ELs {
+		opt.Add(WithL2ELNode(l2ELID, nil))
+	}
+
+	opt.Add(WithL2CLNode(ids.L2CL, false, false, ids.L1CL, ids.L1EL, append([]stack.L2ELNodeID{ids.L2EL}, ids.L2ELs...)))
+
+	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
+	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
+
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
+
+	opt.Add(WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
+		ids.L2EL,
+	}))
+
+	// P2P connect L2CL nodes
+	for i := 0; i < len(ids.L2ELs); i++ {
+		opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELs[i])) // sequencer to other verifiers
+		for j := i + 1; j < len(ids.L2ELs); j++ {
+			opt.Add(WithL2ELP2PConnection(ids.L2ELs[i], ids.L2ELs[j]))
+		}
+	}
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+	return opt
+}

--- a/op-devstack/sysgo/system_singlechain_multinode.go
+++ b/op-devstack/sysgo/system_singlechain_multinode.go
@@ -28,7 +28,7 @@ func DefaultSingleChainMultiNodeSystem(dest *DefaultSingleChainMultiNodeSystemID
 	opt.Add(DefaultMinimalSystem(&dest.DefaultMinimalSystemIDs))
 
 	opt.Add(WithL2ELNode(ids.L2ELB, nil))
-	opt.Add(WithL2CLNode(ids.L2CLB, false, false, ids.L1CL, ids.L1EL, ids.L2ELB))
+	opt.Add(WithL2CLNode(ids.L2CLB, false, false, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2ELB}))
 
 	// P2P connect L2CL nodes
 	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CLB))

--- a/op-node/config/config.go
+++ b/op-node/config/config.go
@@ -23,8 +23,9 @@ import (
 )
 
 type Config struct {
-	L1 L1EndpointSetup
-	L2 L2EndpointSetup
+	L1  L1EndpointSetup
+	L2  L2EndpointSetup // TODO(99999): remove this
+	L2s []L2EndpointSetup
 
 	Beacon L1BeaconEndpointSetup
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -66,7 +66,8 @@ type OpNode struct {
 
 	l1Source  *sources.L1Client     // L1 Client to fetch data from
 	l2Driver  *driver.Driver        // L2 Engine to Sync
-	l2Source  *sources.EngineClient // L2 Execution Engine RPC bindings
+	l2Source  *sources.EngineClient // L2 Execution Engine RPC bindings; TODO(99999): remove this
+	l2Sources []*sources.EngineClient
 	server    *oprpc.Server         // RPC server hosting the rollup-node API
 	p2pNode   *p2p.NodeP2P          // P2P node functionality
 	p2pMu     gosync.Mutex          // protects p2pNode
@@ -416,20 +417,27 @@ func (n *OpNode) initL1BeaconAPI(ctx context.Context, cfg *config.Config) error 
 }
 
 func (n *OpNode) initL2(ctx context.Context, cfg *config.Config) error {
-	rpcClient, rpcCfg, err := cfg.L2.Setup(ctx, n.log, &cfg.Rollup, n.metrics)
-	if err != nil {
-		return fmt.Errorf("failed to setup L2 execution-engine RPC client: %w", err)
+	for _, l2 := range cfg.L2s {
+		rpcClient, rpcCfg, err := l2.Setup(ctx, n.log, &cfg.Rollup, n.metrics)
+		if err != nil {
+			return fmt.Errorf("failed to setup L2 execution-engine RPC client: %w", err)
+		}
+		// TODO(99999): decide if we want to panic the node if a L2 is not setup correctly?
+
+		rpcCfg.FetchWithdrawalRootFromState = cfg.FetchWithdrawalRootFromState
+
+		// TODO(99999): decide how to handle metrics cache for multiple L2s, and what's it used for?
+		l2Source, err := sources.NewEngineClient(rpcClient, n.log, n.metrics.L2SourceCache, rpcCfg)
+		if err != nil {
+			return fmt.Errorf("failed to create Engine client: %w", err)
+		}
+		n.l2Sources = append(n.l2Sources, l2Source)
 	}
 
-	rpcCfg.FetchWithdrawalRootFromState = cfg.FetchWithdrawalRootFromState
-
-	n.l2Source, err = sources.NewEngineClient(rpcClient, n.log, n.metrics.L2SourceCache, rpcCfg)
-	if err != nil {
-		return fmt.Errorf("failed to create Engine client: %w", err)
-	}
-
-	if err := cfg.Rollup.ValidateL2Config(ctx, n.l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
-		return err
+	for _, l2Source := range n.l2Sources {
+		if err := cfg.Rollup.ValidateL2Config(ctx, l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
+			return err
+		}
 	}
 
 	indexingMode := false
@@ -468,7 +476,9 @@ func (n *OpNode) initL2(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("cfg.Rollup.ChainOpConfig is nil. Please see https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.11.0: %w", err)
 	}
 
-	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, cfg.DependencySet, n.l2Source, n.l1Source,
+	mplexer := driver.NewMultiplexer(n.l2Sources)
+
+	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, cfg.DependencySet, mplexer, n.l1Source,
 		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, indexingMode)
 	return nil
 }

--- a/op-node/rollup/driver/multiplexer.go
+++ b/op-node/rollup/driver/multiplexer.go
@@ -1,0 +1,57 @@
+package driver
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var _ L2Chain = (*Multiplexer)(nil)
+
+type Multiplexer struct {
+	l2Sources []*sources.EngineClient
+}
+
+func NewMultiplexer(l2Sources []*sources.EngineClient) *Multiplexer {
+	return &Multiplexer{
+		l2Sources: l2Sources,
+	}
+}
+
+func (m *Multiplexer) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	return m.l2Sources[0].L2BlockRefByLabel(ctx, label)
+}
+
+func (m *Multiplexer) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
+	return m.l2Sources[0].L2BlockRefByHash(ctx, hash)
+}
+
+func (m *Multiplexer) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
+	return m.l2Sources[0].L2BlockRefByNumber(ctx, number)
+}
+
+func (m *Multiplexer) GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	return m.l2Sources[0].GetPayload(ctx, payloadInfo)
+}
+
+func (m *Multiplexer) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+	return m.l2Sources[0].ForkchoiceUpdate(ctx, state, attr)
+}
+
+func (m *Multiplexer) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
+	return m.l2Sources[0].NewPayload(ctx, payload, parentBeaconBlockRoot)
+}
+
+func (m *Multiplexer) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
+	return m.l2Sources[0].PayloadByHash(ctx, hash)
+}
+
+func (m *Multiplexer) PayloadByNumber(ctx context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	return m.l2Sources[0].PayloadByNumber(ctx, number)
+}
+
+func (m *Multiplexer) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
+	return m.l2Sources[0].SystemConfigByL2Hash(ctx, hash)
+}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -135,6 +135,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*config.Config, error) {
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
+
 	return cfg, nil
 }
 

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -72,7 +72,7 @@ func run() error {
 		sysgo.WithL1Nodes(ids.L1EL, ids.L1CL),
 
 		sysgo.WithL2ELNode(ids.L2EL, nil),
-		sysgo.WithL2CLNode(ids.L2CL, true, false, ids.L1CL, ids.L1EL, ids.L2EL),
+		sysgo.WithL2CLNode(ids.L2CL, true, false, ids.L1CL, ids.L1EL, []stack.L2ELNodeID{ids.L2EL}),
 
 		sysgo.WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL),
 		sysgo.WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil),


### PR DESCRIPTION
**Description**

This PR is adding support for op-node to run multiple execution engines for a given chain.

Design document at: https://www.notion.so/oplabs/Execution-Multiplexing-Specific-Implementation-and-Plan-23af153ee1628051a7e4ece97fff689e

Fixes: https://github.com/ethereum-optimism/optimism/issues/16822