### PR TITLE
feat(op-chain-ops): add get text sigs from 4byte db

### DIFF
--- a/op-chain-ops/clients/four_byte_client.go
+++ b/op-chain-ops/clients/four_byte_client.go
@@ -1,0 +1,90 @@
+package clients
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FourByteResponse 4byte.directory API response structure
+type FourByteResponse struct {
+	Count    int              `json:"count"`
+	Next     *string          `json:"next"`
+	Previous *string          `json:"previous"`
+	Results  []FourByteResult `json:"results"`
+}
+
+// FourByteResult represents a single result from the 4byte.directory API
+type FourByteResult struct {
+	ID             int    `json:"id"`
+	CreatedAt      string `json:"created_at"`
+	TextSignature  string `json:"text_signature"`
+	HexSignature   string `json:"hex_signature"`
+	BytesSignature string `json:"bytes_signature"`
+}
+
+// FourByteClient is a client for interacting with the 4byte.directory API
+type FourByteClient struct {
+	client  *http.Client
+	url     string
+	timeout time.Duration
+}
+
+// NewFourByteClient creates a new FourByteClient with a default timeout
+func NewFourByteClient() *FourByteClient {
+	return &FourByteClient{
+		client:  &http.Client{},
+		url:     "https://www.4byte.directory/api/v1/signatures/",
+		timeout: 10 * time.Second,
+	}
+}
+
+var DefaultFourByteClient = NewFourByteClient()
+
+// LookupBy4ByteDirectory looks up a 4-byte selector in the 4byte.directory API
+func (c *FourByteClient) LookupBy4ByteDirectory(selector string) ([]string, error) {
+	// 移除 0x 前缀
+	if strings.HasPrefix(selector, "0x") {
+		selector = selector[2:]
+	}
+
+	// 确保是 8 位十六进制
+	if len(selector) < 8 {
+		selector = strings.Repeat("0", 8-len(selector)) + selector
+	}
+
+	url := fmt.Sprintf("%s?hex_signature=0x%s", c.url, selector)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "cast4byte-go/1.0")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response FourByteResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+
+	var signatures []string
+	for _, result := range response.Results {
+		signatures = append(signatures, result.TextSignature)
+	}
+
+	return signatures, nil
+}

--- a/op-chain-ops/clients/four_byte_client_test.go
+++ b/op-chain-ops/clients/four_byte_client_test.go
@@ -1,0 +1,68 @@
+package clients
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFourByteClient_LookupBy4ByteDirectory(t *testing.T) {
+
+	mockResponse := FourByteResponse{
+		Count:    1,
+		Next:     nil,
+		Previous: nil,
+		Results: []FourByteResult{
+			{
+				ID:             1,
+				CreatedAt:      "2023-01-01T00:00:00Z",
+				TextSignature:  "transfer(address,uint256)",
+				HexSignature:   "0xa9059cbb",
+				BytesSignature: "a9059cbb",
+			},
+		},
+	}
+
+	// 创建测试服务器
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 验证请求路径和参数
+		expectedPath := "/api/v1/signatures/"
+		if r.URL.Path != expectedPath {
+			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		if r.URL.Query().Get("hex_signature") != "0xa9059cbb" {
+			t.Errorf("Expected hex_signature=0xa9059cbb, got %s", r.URL.Query().Get("hex_signature"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(mockResponse)
+	}))
+	defer server.Close()
+
+	client := NewFourByteClient()
+	client.url = server.URL + "/api/v1/signatures/"
+
+	signatures, err := client.LookupBy4ByteDirectory("0xa9059cbb")
+
+	if err != nil {
+		t.Fatalf("LookupBy4ByteDirectory() error = %v", err)
+	}
+
+	if len(signatures) == 0 {
+		t.Fatal("Expected at least one signature, got none")
+	}
+
+	found := false
+	for _, sig := range signatures {
+		if sig == "transfer(address,uint256)" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected to find 'transfer(address,uint256)' in results, got %v", signatures)
+	}
+}

--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
 	"math/big"
 	"strings"
 
@@ -611,7 +612,14 @@ func (h *Host) onFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpCon
 	if len(scope.CallInput()) >= 4 {
 		byte4 = hexutil.Encode(scope.CallInput()[:4])
 	}
-	h.log.Warn("Fault", "addr", scope.Address(), "label", h.labels[scope.Address()], "err", err, "depth", depth, "op", op, "byte4", byte4)
+
+	var maybeSigs string
+	if byte4 != "" {
+		sigs, _ := clients.DefaultFourByteClient.LookupBy4ByteDirectory(byte4)
+		maybeSigs = strings.Join(sigs, ", ")
+	}
+
+	h.log.Warn("Fault", "addr", scope.Address(), "label", h.labels[scope.Address()], "err", err, "depth", depth, "op", op, "byte4", byte4, "possible error sigs", maybeSigs)
 }
 
 // unwindCallstack is a helper to remove call-stack entries.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
OnFault happens, show the text sigs from 4byte db online, if it's possible.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
