### PR TITLE
op-challenger: Ensure mocked claims have non-negative clocks

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -767,6 +767,9 @@ func TestFaultDisputeGame_IsResolved(t *testing.T) {
 						ClaimData: faultTypes.ClaimData{
 							Bond: bond,
 						},
+						Clock: faultTypes.Clock{
+							Timestamp: time.Unix(0, 0),
+						},
 					})
 				}
 			} else {


### PR DESCRIPTION
A negative clock value prevents a recent version of upstream geth's abi package from decoding mocked claims. In Go, zero-valued `time.Time` values predates the year 1970, which results in a negative value when converted to a Unix timestamp.

This patch is done in anticipation of an [update](https://github.com/ethereum-optimism/op-geth/pull/652) to the op-geth dependency that breaks this test.