### PR TITLE
Eliminate PromoteUnsafeEvent → UnsafeUpdateEvent async pattern

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -246,13 +246,15 @@ func NewDriver(
 		sequencerConfDepth := confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
 		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
 		sys.Register("origin-selector", findL1Origin)
-		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
+		concreteSequencer := sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, ec, metrics)
-		sys.Register("sequencer", sequencer)
+		sys.Register("sequencer", concreteSequencer)
 
 		// Wire up the Sequencer to use the EngDeriver for block building and sealing
-		sequencer.SetBuildStarter(engDeriver)
-		sequencer.SetBuildSealer(engDeriver)
+		concreteSequencer.SetBuildStarter(engDeriver)
+		concreteSequencer.SetBuildSealer(engDeriver)
+
+		sequencer = concreteSequencer
 	} else {
 		sequencer = sequencing.DisabledSequencer{}
 	}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -364,6 +364,17 @@ func (e *EngineController) SetBackupUnsafeL2Head(r eth.L2BlockRef, triggerReorg 
 	e.needFCUCallForBackupUnsafeReorg = triggerReorg
 }
 
+// PromoteUnsafe promotes a block to unsafe head, backing up the current unsafe head if needed.
+// This replaces the PromoteUnsafeEvent -> UnsafeUpdateEvent pattern with a direct function call.
+func (e *EngineController) PromoteUnsafe(ctx context.Context, ref eth.L2BlockRef, emitter event.Emitter) {
+	// Backup unsafeHead when new block is not built on original unsafe head.
+	if e.unsafeHead.Number >= ref.Number {
+		e.SetBackupUnsafeL2Head(e.unsafeHead, false)
+	}
+	e.SetUnsafeHead(ref)
+	emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
+}
+
 // logSyncProgressMaybe helps log forkchoice state-changes when applicable.
 // First, the pre-state is registered.
 // A callback is returned to then log the changes to the pre-state, if any.

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -40,21 +40,7 @@ func (ev ForkchoiceUpdateEvent) String() string {
 	return "forkchoice-update"
 }
 
-// PromoteUnsafeEvent signals that the given block may now become a canonical unsafe block.
-// This is pre-forkchoice update; the change may not be reflected yet in the EL.
-// Note that the legacy pre-event-refactor code-path (processing P2P blocks) does fire this,
-// but manually, duplicate with the newer events processing code-path.
-// See EngineController.InsertUnsafePayload.
-type PromoteUnsafeEvent struct {
-	Ref eth.L2BlockRef
-}
-
-func (ev PromoteUnsafeEvent) String() string {
-	return "promote-unsafe"
-}
-
-// UnsafeUpdateEvent signals that the given block is now considered safe.
-// This is pre-forkchoice update; the change may not be reflected yet in the EL.
+// UnsafeUpdateEvent signals that the given block is now considered unsafe.
 type UnsafeUpdateEvent struct {
 	Ref eth.L2BlockRef
 }
@@ -391,13 +377,6 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 			"cross_safe", v.CrossSafe,
 			"finalized", v.Finalized,
 		)
-	case PromoteUnsafeEvent:
-		// Backup unsafeHead when new block is not built on original unsafe head.
-		if d.ec.unsafeHead.Number >= x.Ref.Number {
-			d.ec.SetBackupUnsafeL2Head(d.ec.unsafeHead, false)
-		}
-		d.ec.SetUnsafeHead(x.Ref)
-		d.emitter.Emit(ctx, UnsafeUpdateEvent(x))
 	case UnsafeUpdateEvent:
 		// pre-interop everything that is local-unsafe is also immediately cross-unsafe.
 		if !d.cfg.IsInterop(x.Ref.Time) {

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -47,7 +47,7 @@ func (eq *EngDeriver) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEve
 		return
 	}
 
-	eq.emitter.Emit(ctx, PromoteUnsafeEvent{Ref: ev.Ref})
+	eq.ec.PromoteUnsafe(ctx, ev.Ref, eq.emitter)
 
 	// If derived from L1, then it can be considered (pending) safe
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {


### PR DESCRIPTION
Eliminate PromoteUnsafeEvent → UnsafeUpdateEvent async pattern

**Summary:** Replace asynchronous PromoteUnsafeEvent → UnsafeUpdateEvent roundtrip with direct function calls

**Changes:**
- Add `EngineController.PromoteUnsafe()` method encapsulating unsafe head promotion logic
- Replace `PromoteUnsafeEvent` emission in `payload_success.go` with direct method call  
- Remove `PromoteUnsafeEvent` struct definition and event handler
- Preserve `UnsafeUpdateEvent` emissions for downstream component notifications
- Fix sequencer interface casting in driver setup

**Impact:** Eliminates async roundtrip while maintaining event notifications that multiple components depend on.