### PR TITLE
op-e2e: fix bug in intentbuilder

### DIFF
--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -156,7 +156,6 @@ func RoleToAddrProvider(t require.TestingT, dk devkeys.Keys, chainID eth.ChainID
 }
 
 type intentBuilder struct {
-	t                require.TestingT
 	l1StartBlockHash *common.Hash
 	intent           *state.Intent
 }
@@ -219,7 +218,9 @@ func (b *intentBuilder) WithGlobalOverride(key string, value any) Builder {
 }
 
 func (b *intentBuilder) Build() (*state.Intent, error) {
-	require.NoError(b.t, b.intent.Check(), "invalid intent")
+	if err := b.intent.Check(); err != nil {
+		return nil, fmt.Errorf("check intent: %w", err)
+	}
 	return b.intent, nil
 }
 


### PR DESCRIPTION
The `t` field is unused and unset, leading to a panic when the intent is invalid.
