### PR TITLE
op-devstack/sysgo: remove transitive dependency on e2eutils/config

### DIFF
--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-service/client"
@@ -73,7 +73,7 @@ func WithL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stack.Option[
 		blobPath := clP.TempDir()
 
 		clLogger := clP.Logger()
-		bcn := fakebeacon.NewBeacon(clLogger, e2eutils.NewBlobStore(), l1Net.genesis.Timestamp, blockTimeL1)
+		bcn := fakebeacon.NewBeacon(clLogger, blobstore.New(), l1Net.genesis.Timestamp, blockTimeL1)
 		clP.Cleanup(func() {
 			_ = bcn.Close()
 		})

--- a/op-e2e/actions/helpers/l1_miner.go
+++ b/op-e2e/actions/helpers/l1_miner.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -26,7 +26,7 @@ import (
 type L1Miner struct {
 	L1Replica
 
-	blobStore *e2eutils.BlobsStore
+	blobStore *blobstore.Store
 
 	// L1 block building preferences
 	prefCoinbase common.Address
@@ -49,7 +49,7 @@ func NewL1Miner(t Testing, log log.Logger, genesis *core.Genesis) *L1Miner {
 	rep := NewL1Replica(t, log, genesis)
 	return &L1Miner{
 		L1Replica: *rep,
-		blobStore: e2eutils.NewBlobStore(),
+		blobStore: blobstore.New(),
 	}
 }
 
@@ -57,7 +57,7 @@ func (s *L1Miner) BlobSource() prefetcher.L1BlobSource {
 	return s.blobStore
 }
 
-func (s *L1Miner) BlobStore() *e2eutils.BlobsStore {
+func (s *L1Miner) BlobStore() *blobstore.Store {
 	return s.blobStore
 }
 

--- a/op-e2e/e2eutils/blobstore/blobs.go
+++ b/op-e2e/e2eutils/blobstore/blobs.go
@@ -1,4 +1,4 @@
-package e2eutils
+package blobstore
 
 import (
 	"context"
@@ -11,17 +11,17 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// BlobsStore is a simple in-memory store of blobs, for testing purposes
-type BlobsStore struct {
+// Store is a simple in-memory store of blobs, for testing purposes
+type Store struct {
 	// block timestamp -> blob versioned hash -> blob
 	blobs map[uint64]map[eth.IndexedBlobHash]*eth.Blob
 }
 
-func NewBlobStore() *BlobsStore {
-	return &BlobsStore{blobs: make(map[uint64]map[eth.IndexedBlobHash]*eth.Blob)}
+func New() *Store {
+	return &Store{blobs: make(map[uint64]map[eth.IndexedBlobHash]*eth.Blob)}
 }
 
-func (store *BlobsStore) StoreBlob(blockTime uint64, indexedHash eth.IndexedBlobHash, blob *eth.Blob) {
+func (store *Store) StoreBlob(blockTime uint64, indexedHash eth.IndexedBlobHash, blob *eth.Blob) {
 	m, ok := store.blobs[blockTime]
 	if !ok {
 		m = make(map[eth.IndexedBlobHash]*eth.Blob)
@@ -30,7 +30,7 @@ func (store *BlobsStore) StoreBlob(blockTime uint64, indexedHash eth.IndexedBlob
 	m[indexedHash] = blob
 }
 
-func (store *BlobsStore) GetBlobs(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.Blob, error) {
+func (store *Store) GetBlobs(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.Blob, error) {
 	out := make([]*eth.Blob, 0, len(hashes))
 	m, ok := store.blobs[ref.Time]
 	if !ok {
@@ -46,7 +46,7 @@ func (store *BlobsStore) GetBlobs(ctx context.Context, ref eth.L1BlockRef, hashe
 	return out, nil
 }
 
-func (store *BlobsStore) GetBlobSidecars(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.BlobSidecar, error) {
+func (store *Store) GetBlobSidecars(ctx context.Context, ref eth.L1BlockRef, hashes []eth.IndexedBlobHash) ([]*eth.BlobSidecar, error) {
 	out := make([]*eth.BlobSidecar, 0, len(hashes))
 	m, ok := store.blobs[ref.Time]
 	if !ok {
@@ -79,7 +79,7 @@ func (store *BlobsStore) GetBlobSidecars(ctx context.Context, ref eth.L1BlockRef
 	return out, nil
 }
 
-func (store *BlobsStore) GetAllSidecars(ctx context.Context, l1Timestamp uint64) ([]*eth.BlobSidecar, error) {
+func (store *Store) GetAllSidecars(ctx context.Context, l1Timestamp uint64) ([]*eth.BlobSidecar, error) {
 	m, ok := store.blobs[l1Timestamp]
 	if !ok {
 		return nil, fmt.Errorf("no blobs known with given time: %w", ethereum.NotFound)
@@ -108,4 +108,4 @@ func (store *BlobsStore) GetAllSidecars(ctx context.Context, l1Timestamp uint64)
 	return out, nil
 }
 
-var _ derive.L1BlobsFetcher = (*BlobsStore)(nil)
+var _ derive.L1BlobsFetcher = (*Store)(nil)

--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -29,7 +29,7 @@ type FakeBeacon struct {
 	log log.Logger
 
 	// in-memory blob store
-	blobStore *e2eutils.BlobsStore
+	blobStore *blobstore.Store
 	blobsLock sync.Mutex
 
 	beaconSrv         *http.Server
@@ -39,7 +39,7 @@ type FakeBeacon struct {
 	blockTime   uint64
 }
 
-func NewBeacon(log log.Logger, blobStore *e2eutils.BlobsStore, genesisTime uint64, blockTime uint64) *FakeBeacon {
+func NewBeacon(log log.Logger, blobStore *blobstore.Store, genesisTime uint64, blockTime uint64) *FakeBeacon {
 	return &FakeBeacon{
 		log:         log,
 		blobStore:   blobStore,

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/inbox"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
@@ -201,7 +201,7 @@ func (s *interopE2ESystem) prepareL1() (*fakebeacon.FakeBeacon, *geth.GethInstan
 	blockTimeL1 := uint64(6)
 	blobPath := s.t.TempDir()
 	bcn := fakebeacon.NewBeacon(s.logger.New("role", "l1_cl"),
-		e2eutils.NewBlobStore(), genesisTimestampL1, blockTimeL1)
+		blobstore.New(), genesisTimestampL1, blockTimeL1)
 	s.t.Cleanup(func() {
 		_ = bcn.Close()
 	})

--- a/op-e2e/system/da/l1_beacon_client_test.go
+++ b/op-e2e/system/da/l1_beacon_client_test.go
@@ -6,7 +6,7 @@ import (
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -22,7 +22,7 @@ func TestGetVersion(t *testing.T) {
 
 	l := testlog.Logger(t, log.LevelInfo)
 
-	blobStore := e2eutils.NewBlobStore()
+	blobStore := blobstore.New()
 	beaconApi := fakebeacon.NewBeacon(l, blobStore, uint64(0), uint64(0))
 	t.Cleanup(func() {
 		_ = beaconApi.Close()
@@ -42,7 +42,7 @@ func Test404NotFound(t *testing.T) {
 
 	l := testlog.Logger(t, log.LevelInfo)
 
-	blobStore := e2eutils.NewBlobStore()
+	blobStore := blobstore.New()
 	beaconApi := fakebeacon.NewBeacon(l, blobStore, uint64(0), uint64(12))
 	t.Cleanup(func() {
 		_ = beaconApi.Close()

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/batcher"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/fakebeacon"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
@@ -730,7 +731,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 
 	// Create a fake Beacon node to hold on to blobs created by the L1 miner, and to serve them to L2
 	bcn := fakebeacon.NewBeacon(testlog.Logger(t, log.LevelInfo).New("role", "l1_cl"),
-		e2eutils.NewBlobStore(), l1Genesis.Timestamp, cfg.DeployConfig.L1BlockTime)
+		blobstore.New(), l1Genesis.Timestamp, cfg.DeployConfig.L1BlockTime)
 	t.Cleanup(func() {
 		_ = bcn.Close()
 	})


### PR DESCRIPTION
Any code that runs as a standalone binary outside the monorepo should not depend on the external forge artifacts at runtime.

The `op-e2e/e2eutils/config` package contains an `init` function that requires forge artifacts. Any package that transitively depends on `e2eutils/config` will trigger this `init` function, rendering it unshippable.

The `sysgo` package depends on the `e2eutils/config` package by using the `e2eutils.BlobStore`. Because the `BlobStore` implementation does not depend on `e2eutils/config`, we break the transitive dependency by moving it to a separate package.
