### PR TITLE
Remove event for unsafe payload received via p2p

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -287,8 +287,7 @@ func (s *l2VerifierBackend) OverrideLeader(ctx context.Context) error {
 	return nil
 }
 
-func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
-	return nil
+func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
 }
 
 func (s *l2VerifierBackend) ConductorEnabled(ctx context.Context) (bool, error) {

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -36,7 +36,7 @@ type driverClient interface {
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
 	SequencerActive(context.Context) (bool, error)
-	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope)
 	OverrideLeader(ctx context.Context) error
 	ConductorEnabled(ctx context.Context) (bool, error)
 	SetRecoverMode(ctx context.Context, mode bool) error
@@ -84,8 +84,8 @@ func (n *adminAPI) PostUnsafePayload(ctx context.Context, envelope *eth.Executio
 		log.Error("payload has bad block hash", "bad_hash", payload.BlockHash.String(), "actual", actual.String())
 		return fmt.Errorf("payload has bad block hash: %s, actual block hash is: %s", payload.BlockHash.String(), actual.String())
 	}
-
-	return n.dr.OnUnsafeL2Payload(ctx, envelope)
+	n.dr.OnUnsafeL2Payload(ctx, envelope)
+	return nil
 }
 
 // OverrideLeader disables sequencer conductor interactions and allow sequencer to run in non-HA mode during disaster recovery scenarios.

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -314,8 +314,8 @@ func (c *mockDriverClient) SequencerActive(ctx context.Context) (bool, error) {
 	return c.Mock.MethodCalled("SequencerActive").Get(0).(bool), nil
 }
 
-func (c *mockDriverClient) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
-	return c.Mock.MethodCalled("OnUnsafeL2Payload").Get(0).(error)
+func (c *mockDriverClient) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) {
+	c.Mock.MethodCalled("OnUnsafeL2Payload")
 }
 
 func (c *mockDriverClient) OverrideLeader(ctx context.Context) error {

--- a/op-node/node/tracer/comms.go
+++ b/op-node/node/tracer/comms.go
@@ -45,7 +45,8 @@ func NewTracerDeriver(tracer Tracer) *TracerDeriver {
 }
 
 func (t *TracerDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
-	// Listening p2p.ReceivedBlockEvent is removed and tracer.OnUnsafeL2Payload is synchronously called at p2p.NewBlockReceiver
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  ReceivedBlockEvent is removed and tracer.OnUnsafeL2Payload is synchronously called at NewBlockReceiver
 	switch x := ev.(type) {
 	case status.L1UnsafeEvent:
 		t.tracer.OnNewL1Head(t.ctx, x.L1Unsafe)

--- a/op-node/node/tracer/comms.go
+++ b/op-node/node/tracer/comms.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
@@ -46,11 +45,10 @@ func NewTracerDeriver(tracer Tracer) *TracerDeriver {
 }
 
 func (t *TracerDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
+	// Listening p2p.ReceivedBlockEvent is removed and tracer.OnUnsafeL2Payload is synchronously called at p2p.NewBlockReceiver
 	switch x := ev.(type) {
 	case status.L1UnsafeEvent:
 		t.tracer.OnNewL1Head(t.ctx, x.L1Unsafe)
-	case p2p.ReceivedBlockEvent:
-		t.tracer.OnUnsafeL2Payload(t.ctx, x.From, x.Envelope)
 	case TracePublishBlockEvent:
 		t.tracer.OnPublishL2Payload(t.ctx, x.Envelope)
 	default:

--- a/op-node/node/tracer/comms_test.go
+++ b/op-node/node/tracer/comms_test.go
@@ -32,7 +32,6 @@ func (t *testTracer) OnPublishL2Payload(ctx context.Context, payload *eth.Execut
 var _ Tracer = (*testTracer)(nil)
 
 // TestTracer tests that the tracer traces each thing as expected
-// We are removing the event system incrementally, first removing ReceivedBlockEvent
 func TestTracer(t *testing.T) {
 	tr := &testTracer{}
 	d := NewTracerDeriver(tr)

--- a/op-node/node/tracer/comms_test.go
+++ b/op-node/node/tracer/comms_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -33,6 +32,7 @@ func (t *testTracer) OnPublishL2Payload(ctx context.Context, payload *eth.Execut
 var _ Tracer = (*testTracer)(nil)
 
 // TestTracer tests that the tracer traces each thing as expected
+// We are removing the event system incrementally, first removing ReceivedBlockEvent
 func TestTracer(t *testing.T) {
 	tr := &testTracer{}
 	d := NewTracerDeriver(tr)
@@ -47,10 +47,6 @@ func TestTracer(t *testing.T) {
 	block := &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{
 			BlockHash: id.Hash, BlockNumber: eth.Uint64Quantity(id.Number)}}
-
-	d.OnEvent(context.Background(), p2p.ReceivedBlockEvent{From: "foo", Envelope: block})
-	require.Equal(t, "P2P in: from: foo id: "+id.String()+"\n", tr.got)
-	tr.got = ""
 
 	d.OnEvent(context.Background(), TracePublishBlockEvent{Envelope: block})
 	require.Equal(t, "P2P out: "+id.String()+"\n", tr.got)

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/clsync"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -247,8 +246,6 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		// On "safe" L1 blocks: no step, justified L1 information does not do anything for L2 derivation or status.
 		// On "finalized" L1 blocks: we may be able to mark more L2 data as finalized now.
 		s.Emitter.Emit(ctx, StepReqEvent{})
-	case p2p.ReceivedBlockEvent:
-		s.onIncomingP2PBlock(ctx, x.Envelope)
 	case StepEvent:
 		s.SyncStep()
 	case rollup.ResetEvent:
@@ -281,7 +278,7 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	return true
 }
 
-func (s *SyncDeriver) onIncomingP2PBlock(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
+func (s *SyncDeriver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
 	// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
 	if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
 		s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
@@ -443,14 +440,6 @@ func (s *Driver) ResetDerivationPipeline(ctx context.Context) error {
 			return nil
 		}
 	}
-}
-
-func (s *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
-	s.emitter.Emit(ctx, p2p.ReceivedBlockEvent{
-		From:     "",
-		Envelope: payload,
-	})
-	return nil
 }
 
 func (s *Driver) StartSequencer(ctx context.Context, blockHash common.Hash) error {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -237,7 +237,7 @@ func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
 func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	// TODO(#16917) Remove Event System Refactor Comments
 	//  ELSyncStartedEvent is removed and OnELSyncStarted is synchronously called at EngineController
-
+	//  ReceivedBlockEvent is removed and OnUnsafeL2Payload is synchronously called at NewBlockReceiver
 	switch x := ev.(type) {
 	case status.L1UnsafeEvent:
 		// a new L1 head may mean we have the data to not get an EOF again.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes `p2p.ReceivedBlockEvent` event to a procedural call.

**Key Changes**

`BlockReceiver` embeds syncDeriver and Tracer(optional).

**Tests**

There is a p2p sync coverage at our acceptance tests at https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go and they are all passing. Also existing unit tests are all green.

Needed to remove some parts of tracer unit tests at comms_test.go because we removed `ReceivedBlockEvent`.