### PR TITLE
Dispute-mon uses lazy dial, and add new `DialSupervisorClientWithTimeout()`

### DIFF
--- a/devnet-sdk/system/system.go
+++ b/devnet-sdk/system/system.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/descriptors"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/shell/env"
-	"github.com/ethereum-optimism/optimism/op-service/client"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 )
 
 type system struct {
@@ -102,11 +101,10 @@ func (i *interopSystem) Supervisor(ctx context.Context) (Supervisor, error) {
 		return i.supervisor, nil
 	}
 
-	cl, err := client.NewRPC(ctx, nil, i.supervisorRPC)
+	supervisor, err := dial.DialSupervisorClientWithTimeout(ctx, nil, i.supervisorRPC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial supervisor RPC: %w", err)
 	}
-	supervisor := sources.NewSupervisorClient(cl)
 	i.supervisor = supervisor
 	return supervisor, nil
 }

--- a/op-chain-ops/cmd/withdrawal/util.go
+++ b/op-chain-ops/cmd/withdrawal/util.go
@@ -84,9 +84,9 @@ func loadDepsetConfig(ctx *cli.Context, depSetFlag string) (depset.DependencySet
 }
 
 func createSupervisorClient(ctx *cli.Context, supervisorFlag string) (*sources.SupervisorClient, error) {
-	rpcCl, err := dial.DialRPCClientWithTimeout(ctx.Context, log.Root(), ctx.String(supervisorFlag))
+	cl, err := dial.DialSupervisorClientWithTimeout(ctx.Context, log.Root(), ctx.String(supervisorFlag))
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial rollup client: %w", err)
+		return nil, fmt.Errorf("failed to dial supervisor: %w", err)
 	}
-	return sources.NewSupervisorClient(client.NewBaseRPCClient(rpcCl)), nil
+	return cl, nil
 }

--- a/op-challenger/game/fault/clients.go
+++ b/op-challenger/game/fault/clients.go
@@ -7,9 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -75,11 +73,10 @@ func (c *clientProvider) RollupClient() (RollupClient, error) {
 }
 
 func (c *clientProvider) SuperchainClients() (super.RootProvider, *super.SyncValidator, error) {
-	cl, err := client.NewRPC(context.Background(), c.logger, c.cfg.SupervisorRPC)
+	supervisorClient, err := dial.DialSupervisorClientWithTimeout(c.ctx, c.logger, c.cfg.SupervisorRPC)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to dial supervisor: %w", err)
 	}
-	supervisorClient := sources.NewSupervisorClient(cl)
 	c.rootProvider = supervisorClient
 	c.toClose = append(c.toClose, supervisorClient.Close)
 	return supervisorClient, super.NewSyncValidator(supervisorClient), nil

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -98,11 +97,11 @@ func (r *Runner) Start(ctx context.Context) error {
 	var supervisorClient *sources.SupervisorClient
 	if r.cfg.SupervisorRPC != "" {
 		r.log.Info("Dialling supervisor client", "url", r.cfg.SupervisorRPC)
-		rpcCl, err := dial.DialRPCClientWithTimeout(ctx, r.log, r.cfg.SupervisorRPC)
+		cl, err := dial.DialSupervisorClientWithTimeout(ctx, r.log, r.cfg.SupervisorRPC)
 		if err != nil {
-			return fmt.Errorf("failed to dial rollup client: %w", err)
+			return fmt.Errorf("failed to dial supervisor: %w", err)
 		}
-		supervisorClient = sources.NewSupervisorClient(client.NewBaseRPCClient(rpcCl))
+		supervisorClient = cl
 	}
 
 	l1Client, err := dial.DialRPCClientWithTimeout(ctx, r.log, r.cfg.L1EthRpc)

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -224,11 +224,10 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 
 	var supervisor health.SupervisorHealthAPI
 	if c.cfg.SupervisorRPC != "" {
-		sc, err := opclient.NewRPC(ctx, c.log, c.cfg.SupervisorRPC)
+		supervisor, err = dial.DialSupervisorClientWithTimeout(ctx, c.log, c.cfg.SupervisorRPC)
 		if err != nil {
-			return errors.Wrap(err, "failed to create supervisor rpc client")
+			return errors.Wrap(err, "failed to dial supervisor")
 		}
-		supervisor = sources.NewSupervisorClient(sc)
 	}
 
 	c.hmon = health.NewSequencerHealthMonitor(

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -14,11 +14,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/delegatecallproxy"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -199,9 +197,8 @@ func getSuperRoot(t devtest.CommonT, o *Orchestrator, timestamp uint64, supervis
 	supervisor, ok := o.supervisors.Get(supervisorID)
 	t.Require().True(ok, "must have supervisor")
 
-	clientRPC, err := client.NewRPC(t.Ctx(), t.Logger(), supervisor.userRPC)
+	client, err := dial.DialSupervisorClientWithTimeout(t.Ctx(), t.Logger(), supervisor.userRPC)
 	t.Require().NoError(err)
-	client := sources.NewSupervisorClient(clientRPC)
 	super, err := client.SuperRootAtTimestamp(t.Ctx(), hexutil.Uint64(timestamp))
 	t.Require().NoError(err, "super root at timestamp failed")
 	return super.SuperRoot

--- a/op-devstack/sysgo/supervisor.go
+++ b/op-devstack/sysgo/supervisor.go
@@ -10,12 +10,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	supervisorConfig "github.com/ethereum-optimism/optimism/op-supervisor/config"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/syncnode"
@@ -162,9 +162,8 @@ func WithManagedBySupervisor(l2CLID stack.L2CLNodeID, supervisorID stack.Supervi
 		require.True(ok, "looking for supervisor")
 
 		ctx := orch.P().Ctx()
-		rpcClient, err := client.NewRPC(ctx, orch.P().Logger(), s.userRPC, client.WithLazyDial())
+		supClient, err := dial.DialSupervisorClientWithTimeout(ctx, orch.P().Logger(), s.userRPC, client.WithLazyDial())
 		orch.P().Require().NoError(err)
-		supClient := sources.NewSupervisorClient(rpcClient)
 
 		err = retry.Do0(ctx, 10, retry.Exponential(), func() error {
 			return supClient.AddL2RPC(ctx, interopEndpoint, secret)

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -177,7 +177,7 @@ func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config
 		return nil
 	}
 	for _, rpc := range cfg.RollupRpcs {
-		client, err := dial.DialRollupClientWithTimeout(ctx, s.logger, rpc)
+		client, err := dial.DialRollupClientWithTimeout(ctx, s.logger, rpc, rpcclient.WithLazyDial())
 		if err != nil {
 			return fmt.Errorf("failed to dial rollup client %s: %w", rpc, err)
 		}
@@ -191,11 +191,10 @@ func (s *Service) initSupervisorClients(ctx context.Context, cfg *config.Config)
 		return nil
 	}
 	for _, rpc := range cfg.SupervisorRpcs {
-		rpcClient, err := dial.DialRPCClientWithTimeout(ctx, s.logger, rpc)
+		client, err := dial.DialSupervisorClientWithTimeout(ctx, s.logger, rpc, rpcclient.WithLazyDial())
 		if err != nil {
 			return fmt.Errorf("failed to dial supervisor client %s: %w", rpc, err)
 		}
-		client := sources.NewSupervisorClient(rpcclient.NewBaseRPCClient(rpcClient))
 		s.supervisorClients = append(s.supervisorClients, client)
 	}
 	return nil

--- a/op-e2e/interop/supersystem.go
+++ b/op-e2e/interop/supersystem.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
@@ -326,9 +325,8 @@ func (s *interopE2ESystem) SupervisorClient() *sources.SupervisorClient {
 	if s.superClient != nil {
 		return s.superClient
 	}
-	cl, err := client.NewRPC(context.Background(), s.logger, s.supervisor.RPC())
+	superClient, err := dial.DialSupervisorClientWithTimeout(context.Background(), s.logger, s.supervisor.RPC())
 	require.NoError(s.t, err, "failed to dial supervisor RPC")
-	superClient := sources.NewSupervisorClient(cl)
 	s.superClient = superClient
 	return superClient
 }

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -20,7 +20,6 @@ import (
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
@@ -148,12 +147,11 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	if len(cfg.SupervisorRpcs) != 0 {
 		var clients []source.SupervisorClient
 		for _, url := range cfg.SupervisorRpcs {
-			supervisorRpc, err := dial.DialRPCClientWithTimeout(ctx, ps.Log, url)
+			cl, err := dial.DialSupervisorClientWithTimeout(ctx, ps.Log, url,
+				client.WithRPCRecorder(ps.Metrics.NewRecorder("supervisor")))
 			if err != nil {
 				return fmt.Errorf("failed to dial supervisor RPC client (%v): %w", url, err)
 			}
-			cl := sources.NewSupervisorClient(client.NewBaseRPCClient(supervisorRpc,
-				client.WithRPCRecorder(ps.Metrics.NewRecorder("supervisor"))))
 			clients = append(clients, cl)
 		}
 		ps.ProposalSource = source.NewSupervisorProposalSource(ps.Log, clients...)

--- a/op-service/dial/dial.go
+++ b/op-service/dial/dial.go
@@ -33,9 +33,8 @@ func DialEthClientWithTimeout(ctx context.Context, timeout time.Duration, log lo
 	return ethclient.NewClient(c), nil
 }
 
-// DialRollupClientWithTimeout attempts to dial the RPC provider using the provided URL.
-// The timeout and retry logic is handled internally by the client.
-func DialRollupClientWithTimeout(ctx context.Context, log log.Logger, url string, callerOpts ...client.RPCOption) (*sources.RollupClient, error) {
+// dialClientWithTimeout dials an RPC client with a timeout.
+func dialClientWithTimeout(ctx context.Context, log log.Logger, url string, callerOpts ...client.RPCOption) (client.RPC, error) {
 	opts := []client.RPCOption{
 		client.WithFixedDialBackoff(defaultRetryTime),
 		client.WithDialAttempts(defaultRetryCount),
@@ -43,12 +42,27 @@ func DialRollupClientWithTimeout(ctx context.Context, log log.Logger, url string
 	}
 	opts = append(opts, callerOpts...)
 
-	rpcCl, err := client.NewRPC(ctx, log, url, opts...)
+	return client.NewRPC(ctx, log, url, opts...)
+}
+
+// DialRollupClientWithTimeout attempts to dial the RPC provider using the provided URL.
+// The timeout and retry logic is handled internally by the client.
+func DialRollupClientWithTimeout(ctx context.Context, log log.Logger, url string, callerOpts ...client.RPCOption) (*sources.RollupClient, error) {
+	rpcCl, err := dialClientWithTimeout(ctx, log, url, callerOpts...)
 	if err != nil {
 		return nil, err
 	}
 
 	return sources.NewRollupClient(rpcCl), nil
+}
+
+func DialSupervisorClientWithTimeout(ctx context.Context, log log.Logger, url string, callerOpts ...client.RPCOption) (*sources.SupervisorClient, error) {
+	rpcCl, err := dialClientWithTimeout(ctx, log, url, callerOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return sources.NewSupervisorClient(rpcCl), nil
 }
 
 // DialRPCClientWithTimeout attempts to dial the RPC provider using the provided URL.


### PR DESCRIPTION
Add a new `DialSupervisorClientWithTimeout` that supports lazy dial in the same way as `DialRollupClientWithTimeout`, and use lazy dial for both of them in dispute-mon so that it doesn't fail on startup if some of the supervisor or rollup nodes are down.

Also refactors all the places where we previously did `sources.NewSupervisorClient()` to use the new `DialSupervisorClientWithTimeout()`.

Closes https://github.com/ethereum-optimism/optimism/issues/11019