### PR TITLE
Remove event for new L1 unsafe/safe

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -369,11 +369,7 @@ func (s *L2Verifier) ActL1HeadSignal(t Testing) {
 func (s *L2Verifier) ActL1SafeSignal(t Testing) {
 	safe, err := s.l1.L1BlockRefByLabel(t.Ctx(), eth.Safe)
 	require.NoError(t, err)
-	s.synchronousEvents.Emit(t.Ctx(), status.L1SafeEvent{L1Safe: safe})
-	require.NoError(t, s.drainer.DrainUntil(func(ev event.Event) bool {
-		x, ok := ev.(status.L1SafeEvent)
-		return ok && x.L1Safe == safe
-	}, false))
+	s.syncStatus.OnL1Safe(safe)
 	require.Equal(t, safe, s.syncStatus.SyncStatus().SafeL1)
 }
 

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -65,6 +65,7 @@ type L2Verifier struct {
 	engine            *engine.EngineController
 	derivationMetrics *testutils.TestDerivationMetrics
 	derivation        *derive.DerivationPipeline
+	syncDeriver       *driver.SyncDeriver
 
 	safeHeadListener rollup.SafeHeadListener
 	syncCfg          *sync.Config
@@ -172,13 +173,14 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	sys.Register("status", syncStatusTracker, opts)
 
 	syncDeriver := &driver.SyncDeriver{
-		Derivation:          pipeline,
-		SafeHeadNotifs:      safeHeadListener,
-		CLSync:              clSync,
-		Engine:              ec,
-		SyncCfg:             syncCfg,
-		Config:              cfg,
-		L1:                  l1,
+		Derivation:     pipeline,
+		SafeHeadNotifs: safeHeadListener,
+		CLSync:         clSync,
+		Engine:         ec,
+		SyncCfg:        syncCfg,
+		Config:         cfg,
+		L1:             l1,
+		// No need to initialize L1Tracker because no L1 block cache is used for testing
 		L2:                  eng,
 		Log:                 log,
 		Ctx:                 ctx,
@@ -198,6 +200,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		engine:            ec,
 		derivationMetrics: metrics,
 		derivation:        pipeline,
+		syncDeriver:       syncDeriver,
 		safeHeadListener:  safeHeadListener,
 		syncCfg:           syncCfg,
 		drainer:           executor,
@@ -358,11 +361,8 @@ func (s *L2Verifier) ActRPCFail(t Testing) {
 func (s *L2Verifier) ActL1HeadSignal(t Testing) {
 	head, err := s.l1.L1BlockRefByLabel(t.Ctx(), eth.Unsafe)
 	require.NoError(t, err)
-	s.synchronousEvents.Emit(t.Ctx(), status.L1UnsafeEvent{L1Unsafe: head})
-	require.NoError(t, s.drainer.DrainUntil(func(ev event.Event) bool {
-		x, ok := ev.(status.L1UnsafeEvent)
-		return ok && x.L1Unsafe == head
-	}, false))
+	s.syncStatus.OnL1Unsafe(head)
+	s.syncDeriver.OnL1Unsafe(t.Ctx())
 	require.Equal(t, head, s.syncStatus.SyncStatus().HeadL1)
 }
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -144,6 +144,9 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config) error {
 	if err := n.initL2(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init L2: %w", err)
 	}
+	if err := n.initTracer(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init the trace: %w", err)
+	}
 	if err := n.initL1Handlers(cfg); err != nil {
 		return fmt.Errorf("failed to init L1 Handlers: %w", err)
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -148,7 +148,9 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config) error {
 	if err := n.initL2(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init L2: %w", err)
 	}
-	n.initL1Handlers(cfg)
+	if err := n.initL1Handlers(cfg); err != nil {
+		return fmt.Errorf("failed to init L1 Handlers: %w", err)
+	}
 	if err := n.initRuntimeConfig(ctx, cfg); err != nil { // depends on L2, to signal initial runtime values to
 		return fmt.Errorf("failed to init the runtime config: %w", err)
 	}
@@ -211,20 +213,19 @@ func (n *OpNode) initL1Source(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
-func (n *OpNode) initL1Handlers(cfg *config.Config) {
+func (n *OpNode) initL1Handlers(cfg *config.Config) error {
+	if n.l2Driver == nil {
+		return errors.New("l2 driver must be initialized")
+	}
 	emitter := n.eventSys.Register("l1-signals", nil)
 	onL1Head := func(ctx context.Context, sig eth.L1BlockRef) {
-		// At initTracer
-		// comms.go      TracerDeriver records L1Unsafe
+		// TODO(#16917) Remove Event System Refactor Comments
+		//  L1UnsafeEvent fan out is updated to procedural method calls
 		if n.cfg.Tracer != nil {
 			n.cfg.Tracer.OnNewL1Head(ctx, sig)
 		}
-		// At initL2
-		// l1_tracker.go L1Tracker inserts L1unsafe to cache
 		n.l2Driver.L1Tracker.OnL1Unsafe(sig)
-		// status.go     StatusTracker updates L1Head
 		n.l2Driver.StatusTracker.OnL1Unsafe(sig)
-		// state.go      SyncDeriver listens to event and emit stepReqEvent
 		n.l2Driver.SyncDeriver.OnL1Unsafe(ctx)
 	}
 	onL1Safe := func(ctx context.Context, sig eth.L1BlockRef) {
@@ -255,6 +256,8 @@ func (n *OpNode) initL1Handlers(cfg *config.Config) {
 		cfg.L1EpochPollInterval, time.Second*10)
 	n.l1FinalizedSub = eth.PollBlockChanges(n.log, n.l1Source, onL1Finalized, eth.Finalized,
 		cfg.L1EpochPollInterval, time.Second*10)
+
+	return nil
 }
 
 func (n *OpNode) initRuntimeConfig(ctx context.Context, cfg *config.Config) error {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -229,7 +228,7 @@ func (n *OpNode) initL1Handlers(cfg *config.Config) error {
 		n.l2Driver.SyncDeriver.OnL1Unsafe(ctx)
 	}
 	onL1Safe := func(ctx context.Context, sig eth.L1BlockRef) {
-		emitter.Emit(ctx, status.L1SafeEvent{L1Safe: sig})
+		n.l2Driver.StatusTracker.OnL1Safe(sig)
 	}
 	onL1Finalized := func(ctx context.Context, sig eth.L1BlockRef) {
 		emitter.Emit(ctx, finality.FinalizeL1Event{FinalizedL1: sig})

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -142,12 +142,13 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config) error {
 	if err := n.initL1BeaconAPI(ctx, cfg); err != nil {
 		return err
 	}
+	if err := n.initL1Source(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to init L1 Source: %w", err)
+	}
 	if err := n.initL2(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init L2: %w", err)
 	}
-	if err := n.initTracer(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to init the trace: %w", err)
-	}
+	n.initL1Handlers(cfg)
 	if err := n.initRuntimeConfig(ctx, cfg); err != nil { // depends on L2, to signal initial runtime values to
 		return fmt.Errorf("failed to init the runtime config: %w", err)
 	}
@@ -190,7 +191,7 @@ func (n *OpNode) initTracer(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
-func (n *OpNode) initL1(ctx context.Context, cfg *config.Config) error {
+func (n *OpNode) initL1Source(ctx context.Context, cfg *config.Config) error {
 	// Cache 3/2 worth of sequencing window of receipts and txs
 	defaultCacheSize := int(cfg.Rollup.SeqWindowSize) * 3 / 2
 	l1RPC, l1Cfg, err := cfg.L1.Setup(ctx, n.log, defaultCacheSize, n.metrics)
@@ -207,11 +208,17 @@ func (n *OpNode) initL1(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to validate the L1 config: %w", err)
 	}
 
+	return nil
+}
+
+func (n *OpNode) initL1Handlers(cfg *config.Config) {
 	emitter := n.eventSys.Register("l1-signals", nil)
 	onL1Head := func(ctx context.Context, sig eth.L1BlockRef) {
 		// At initTracer
 		// comms.go      TracerDeriver records L1Unsafe
-		n.cfg.Tracer.OnNewL1Head(ctx, sig)
+		if n.cfg.Tracer != nil {
+			n.cfg.Tracer.OnNewL1Head(ctx, sig)
+		}
 		// At initL2
 		// l1_tracker.go L1Tracker inserts L1unsafe to cache
 		n.l2Driver.L1Tracker.OnL1Unsafe(sig)
@@ -248,7 +255,6 @@ func (n *OpNode) initL1(ctx context.Context, cfg *config.Config) error {
 		cfg.L1EpochPollInterval, time.Second*10)
 	n.l1FinalizedSub = eth.PollBlockChanges(n.log, n.l1Source, onL1Finalized, eth.Finalized,
 		cfg.L1EpochPollInterval, time.Second*10)
-	return nil
 }
 
 func (n *OpNode) initRuntimeConfig(ctx context.Context, cfg *config.Config) error {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -135,9 +135,6 @@ func New(ctx context.Context, cfg *config.Config, log log.Logger, appVersion str
 func (n *OpNode) init(ctx context.Context, cfg *config.Config) error {
 	n.log.Info("Initializing rollup node", "version", n.appVersion)
 	n.initEventSystem()
-	if err := n.initL1(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to init L1: %w", err)
-	}
 	if err := n.initL1BeaconAPI(ctx, cfg); err != nil {
 		return err
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -209,7 +209,16 @@ func (n *OpNode) initL1(ctx context.Context, cfg *config.Config) error {
 
 	emitter := n.eventSys.Register("l1-signals", nil)
 	onL1Head := func(ctx context.Context, sig eth.L1BlockRef) {
-		emitter.Emit(ctx, status.L1UnsafeEvent{L1Unsafe: sig})
+		// At initTracer
+		// comms.go      TracerDeriver records L1Unsafe
+		n.cfg.Tracer.OnNewL1Head(ctx, sig)
+		// At initL2
+		// l1_tracker.go L1Tracker inserts L1unsafe to cache
+		n.l2Driver.L1Tracker.OnL1Unsafe(sig)
+		// status.go     StatusTracker updates L1Head
+		n.l2Driver.StatusTracker.OnL1Unsafe(sig)
+		// state.go      SyncDeriver listens to event and emit stepReqEvent
+		n.l2Driver.SyncDeriver.OnL1Unsafe(ctx)
 	}
 	onL1Safe := func(ctx context.Context, sig eth.L1BlockRef) {
 		emitter.Emit(ctx, status.L1SafeEvent{L1Safe: sig})

--- a/op-node/node/tracer/comms.go
+++ b/op-node/node/tracer/comms.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 )
@@ -49,8 +48,6 @@ func (t *TracerDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	//  ReceivedBlockEvent is removed and tracer.OnUnsafeL2Payload is synchronously called at NewBlockReceiver
 	//  L1UnsafeEvent is removed and OnNewL1Head is synchronously called at L1Handler
 	switch x := ev.(type) {
-	case status.L1UnsafeEvent:
-		t.tracer.OnNewL1Head(t.ctx, x.L1Unsafe)
 	case TracePublishBlockEvent:
 		t.tracer.OnPublishL2Payload(t.ctx, x.Envelope)
 	default:

--- a/op-node/node/tracer/comms.go
+++ b/op-node/node/tracer/comms.go
@@ -47,6 +47,7 @@ func NewTracerDeriver(tracer Tracer) *TracerDeriver {
 func (t *TracerDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	// TODO(#16917) Remove Event System Refactor Comments
 	//  ReceivedBlockEvent is removed and tracer.OnUnsafeL2Payload is synchronously called at NewBlockReceiver
+	//  L1UnsafeEvent is removed and OnNewL1Head is synchronously called at L1Handler
 	switch x := ev.(type) {
 	case status.L1UnsafeEvent:
 		t.tracer.OnNewL1Head(t.ctx, x.L1Unsafe)

--- a/op-node/node/tracer/comms_test.go
+++ b/op-node/node/tracer/comms_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )

--- a/op-node/node/tracer/comms_test.go
+++ b/op-node/node/tracer/comms_test.go
@@ -37,11 +37,6 @@ func TestTracer(t *testing.T) {
 	d := NewTracerDeriver(tr)
 	rng := rand.New(rand.NewSource(123))
 
-	l1Head := testutils.RandomBlockRef(rng)
-	d.OnEvent(context.Background(), status.L1UnsafeEvent{L1Unsafe: l1Head})
-	require.Equal(t, "L1Head: "+l1Head.ID().String()+"\n", tr.got)
-	tr.got = ""
-
 	id := testutils.RandomBlockID(rng)
 	block := &eth.ExecutionPayloadEnvelope{
 		ExecutionPayload: &eth.ExecutionPayload{

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -119,6 +119,7 @@ type SyncStatusTracker interface {
 	event.Deriver
 	SyncStatus() *eth.SyncStatus
 	L1Head() eth.L1BlockRef
+	OnL1Unsafe(x eth.L1BlockRef)
 }
 
 type Network interface {
@@ -182,7 +183,6 @@ func NewDriver(
 	sys.Register("status", statusTracker)
 
 	l1Tracker := status.NewL1Tracker(l1)
-	sys.Register("l1-blocks", l1Tracker)
 
 	l1 = metered.NewMeteredL1Fetcher(l1Tracker, metrics)
 	verifConfDepth := confdepth.NewConfDepth(driverCfg.VerifierConfDepth, statusTracker.L1Head, l1)
@@ -220,6 +220,7 @@ func NewDriver(
 		SyncCfg:             syncCfg,
 		Config:              cfg,
 		L1:                  l1,
+		L1Tracker:           l1Tracker,
 		L2:                  l2,
 		Log:                 log,
 		Ctx:                 driverCtx,
@@ -251,7 +252,7 @@ func NewDriver(
 
 	driverEmitter := sys.Register("driver", nil)
 	driver := &Driver{
-		statusTracker: statusTracker,
+		StatusTracker: statusTracker,
 		SyncDeriver:   syncDeriver,
 		sched:         schedDeriv,
 		emitter:       driverEmitter,

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -120,6 +120,7 @@ type SyncStatusTracker interface {
 	SyncStatus() *eth.SyncStatus
 	L1Head() eth.L1BlockRef
 	OnL1Unsafe(x eth.L1BlockRef)
+	OnL1Safe(x eth.L1BlockRef)
 }
 
 type Network interface {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -245,6 +245,7 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	// TODO(#16917) Remove Event System Refactor Comments
 	//  ELSyncStartedEvent is removed and OnELSyncStarted is synchronously called at EngineController
 	//  ReceivedBlockEvent is removed and OnUnsafeL2Payload is synchronously called at NewBlockReceiver
+	//  L1UnsafeEvent is removed and OnL1Unsafe is synchronously called at L1Handler
 	switch x := ev.(type) {
 	case finality.FinalizeL1Event:
 		// On "safe" L1 blocks: no step, justified L1 information does not do anything for L2 derivation or status.

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -26,7 +26,7 @@ import (
 type SyncStatus = eth.SyncStatus
 
 type Driver struct {
-	statusTracker SyncStatusTracker
+	StatusTracker SyncStatusTracker
 
 	*SyncDeriver
 
@@ -217,7 +217,9 @@ type SyncDeriver struct {
 	Config *rollup.Config
 
 	L1 L1Chain
-	L2 L2Chain
+	// Track L1 view when new unsafe L1 block is observed
+	L1Tracker *status.L1Tracker
+	L2        L2Chain
 
 	Emitter event.Emitter
 
@@ -234,14 +236,16 @@ func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
 	s.Emitter = em
 }
 
+func (s *SyncDeriver) OnL1Unsafe(ctx context.Context) {
+	// a new L1 head may mean we have the data to not get an EOF again.
+	s.Emitter.Emit(ctx, StepReqEvent{})
+}
+
 func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	// TODO(#16917) Remove Event System Refactor Comments
 	//  ELSyncStartedEvent is removed and OnELSyncStarted is synchronously called at EngineController
 	//  ReceivedBlockEvent is removed and OnUnsafeL2Payload is synchronously called at NewBlockReceiver
 	switch x := ev.(type) {
-	case status.L1UnsafeEvent:
-		// a new L1 head may mean we have the data to not get an EOF again.
-		s.Emitter.Emit(ctx, StepReqEvent{})
 	case finality.FinalizeL1Event:
 		// On "safe" L1 blocks: no step, justified L1 information does not do anything for L2 derivation or status.
 		// On "finalized" L1 blocks: we may be able to mark more L2 data as finalized now.
@@ -469,14 +473,14 @@ func (s *Driver) SetRecoverMode(ctx context.Context, mode bool) error {
 
 // SyncStatus blocks the driver event loop and captures the syncing status.
 func (s *Driver) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
-	return s.statusTracker.SyncStatus(), nil
+	return s.StatusTracker.SyncStatus(), nil
 }
 
 // BlockRefWithStatus blocks the driver event loop and captures the syncing status,
 // along with an L2 block reference by number consistent with that same status.
 // If the event loop is too busy and the context expires, a context error is returned.
 func (s *Driver) BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2BlockRef, *eth.SyncStatus, error) {
-	resp := s.statusTracker.SyncStatus()
+	resp := s.StatusTracker.SyncStatus()
 	if resp.FinalizedL2.Number >= num { // If finalized, we are certain it does not reorg, and don't have to lock.
 		ref, err := s.L2.L2BlockRefByNumber(ctx, num)
 		return ref, resp, err
@@ -484,7 +488,7 @@ func (s *Driver) BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2Bloc
 	wait := make(chan struct{})
 	select {
 	case s.stateReq <- wait:
-		resp := s.statusTracker.SyncStatus()
+		resp := s.StatusTracker.SyncStatus()
 		ref, err := s.L2.L2BlockRefByNumber(ctx, num)
 		<-wait
 		return ref, resp, err

--- a/op-node/rollup/status/l1_tracker.go
+++ b/op-node/rollup/status/l1_tracker.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
 // L1Tracker implements the L1Fetcher interface while proactively maintaining a reorg-aware cache
-// of L1 block references by number. This handles the L1UnsafeEvent in order to populate the cache with
-// the latest L1 block references.
+// of L1 block references by number. Populate the cache with the latest L1 block references.
 type L1Tracker struct {
 	derive.L1Fetcher
 	cache *l1HeadBuffer
@@ -23,15 +21,8 @@ func NewL1Tracker(inner derive.L1Fetcher) *L1Tracker {
 	}
 }
 
-func (st *L1Tracker) OnEvent(ctx context.Context, ev event.Event) bool {
-	switch x := ev.(type) {
-	case L1UnsafeEvent:
-		st.cache.Insert(x.L1Unsafe)
-	default:
-		return false
-	}
-
-	return true
+func (st *L1Tracker) OnL1Unsafe(l1Unsafe eth.BlockRef) {
+	st.cache.Insert(l1Unsafe)
 }
 
 func (l *L1Tracker) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {

--- a/op-node/rollup/status/l1_tracker_test.go
+++ b/op-node/rollup/status/l1_tracker_test.go
@@ -14,10 +14,8 @@ func mockL1BlockRef(num uint64) eth.L1BlockRef {
 	return eth.L1BlockRef{Number: num, Hash: common.Hash{byte(num)}, ParentHash: common.Hash{byte(num - 1)}}
 }
 
-func newL1HeadEvent(l1Tracker *L1Tracker, head eth.L1BlockRef) {
-	l1Tracker.OnEvent(context.Background(), L1UnsafeEvent{
-		L1Unsafe: head,
-	})
+func newL1Head(l1Tracker *L1Tracker, head eth.L1BlockRef) {
+	l1Tracker.OnL1Unsafe(head)
 }
 
 func TestCachingHeadReorg(t *testing.T) {
@@ -35,21 +33,21 @@ func TestCachingHeadReorg(t *testing.T) {
 
 	// from cache
 	l1Head = mockL1BlockRef(100)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 100)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(101)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(102)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 102)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -57,7 +55,7 @@ func TestCachingHeadReorg(t *testing.T) {
 	// trigger a reorg of block 102
 	l1Head = mockL1BlockRef(102)
 	l1Head.Hash = common.Hash{0xde, 0xad, 0xbe, 0xef}
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 102)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -83,28 +81,28 @@ func TestCachingHeadRewind(t *testing.T) {
 
 	// from cache
 	l1Head = mockL1BlockRef(100)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 100)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(101)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(102)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 102)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// 101 is the new head, invalidating 102
 	l1Head = mockL1BlockRef(101)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -138,21 +136,21 @@ func TestCachingChainShorteningReorg(t *testing.T) {
 
 	// from cache
 	l1Head = mockL1BlockRef(100)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 100)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(101)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(102)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 102)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -160,7 +158,7 @@ func TestCachingChainShorteningReorg(t *testing.T) {
 	// trigger a reorg of block 101, invalidating the following cache elements (102)
 	l1Head = mockL1BlockRef(101)
 	l1Head.Hash = common.Hash{0xde, 0xad, 0xbe, 0xef}
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -180,21 +178,21 @@ func TestCachingDeepReorg(t *testing.T) {
 
 	// from cache
 	l1Head := mockL1BlockRef(100)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err := l1Tracker.L1BlockRefByNumber(ctx, 100)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(101)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(102)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 102)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -203,7 +201,7 @@ func TestCachingDeepReorg(t *testing.T) {
 	parentHash := common.Hash{0xde, 0xad, 0xbe, 0xef}
 	l1Head = mockL1BlockRef(102)
 	l1Head.ParentHash = parentHash
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 102)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
@@ -230,21 +228,21 @@ func TestCachingSkipAhead(t *testing.T) {
 
 	// from cache
 	l1Head := mockL1BlockRef(100)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err := l1Tracker.L1BlockRefByNumber(ctx, 100)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// from cache
 	l1Head = mockL1BlockRef(101)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 101)
 	require.NoError(t, err)
 	require.Equal(t, l1Head, ret)
 
 	// head jumps ahead from 101->103, invalidating the entire cache
 	l1Head = mockL1BlockRef(103)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 	ret, err = l1Tracker.L1BlockRefByNumber(ctx, 103)
 	require.NoError(t, err)
 	require.Equal(t, mockL1BlockRef(103), ret)
@@ -266,7 +264,7 @@ func TestCacheSizeEviction(t *testing.T) {
 	// insert 1000 elements into the cache
 	for idx := 1000; idx < 2000; idx++ {
 		l1Head := mockL1BlockRef(uint64(idx))
-		newL1HeadEvent(l1Tracker, l1Head)
+		newL1Head(l1Tracker, l1Head)
 	}
 
 	// request each element from cache
@@ -278,7 +276,7 @@ func TestCacheSizeEviction(t *testing.T) {
 
 	// insert 1001st element, removing the first
 	l1Head := mockL1BlockRef(2000)
-	newL1HeadEvent(l1Tracker, l1Head)
+	newL1Head(l1Tracker, l1Head)
 
 	// request first element, which now requires a live fetch instead
 	l1Fetcher.ExpectL1BlockRefByNumber(1000, mockL1BlockRef(1000), nil)

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -51,10 +51,11 @@ func NewStatusTracker(log log.Logger, metrics Metrics) *StatusTracker {
 }
 
 func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  L1UnsafeEvent is removed and OnL1Unsafe is synchronously called at L1Handler
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
-	// L1UnsafeEvent removed
 	switch x := ev.(type) {
 	case engine.ForkchoiceUpdateEvent:
 		st.log.Debug("Forkchoice update", "unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -15,14 +15,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
-type L1UnsafeEvent struct {
-	L1Unsafe eth.L1BlockRef
-}
-
-func (ev L1UnsafeEvent) String() string {
-	return "l1-unsafe"
-}
-
 type L1SafeEvent struct {
 	L1Safe eth.L1BlockRef
 }
@@ -62,6 +54,7 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
+	// L1UnsafeEvent removed
 	switch x := ev.(type) {
 	case engine.ForkchoiceUpdateEvent:
 		st.log.Debug("Forkchoice update", "unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
@@ -87,27 +80,6 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.data.LocalSafeL2 = x.LocalSafe
 	case derive.DeriverL1StatusEvent:
 		st.data.CurrentL1 = x.Origin
-	case L1UnsafeEvent:
-		st.metrics.RecordL1Ref("l1_head", x.L1Unsafe)
-		// We don't need to do anything if the head hasn't changed.
-		if st.data.HeadL1 == (eth.L1BlockRef{}) {
-			st.log.Info("Received first L1 head signal", "l1_head", x.L1Unsafe)
-		} else if st.data.HeadL1.Hash == x.L1Unsafe.Hash {
-			st.log.Trace("Received L1 head signal that is the same as the current head", "l1_head", x.L1Unsafe)
-		} else if st.data.HeadL1.Hash == x.L1Unsafe.ParentHash {
-			// We got a new L1 block whose parent hash is the same as the current L1 head. Means we're
-			// dealing with a linear extension (new block is the immediate child of the old one).
-			st.log.Debug("L1 head moved forward", "l1_head", x.L1Unsafe)
-		} else {
-			if st.data.HeadL1.Number >= x.L1Unsafe.Number {
-				st.metrics.RecordL1ReorgDepth(st.data.HeadL1.Number - x.L1Unsafe.Number)
-			}
-			// New L1 block is not the same as the current head or a single step linear extension.
-			// This could either be a long L1 extension, or a reorg, or we simply missed a head update.
-			st.log.Warn("L1 head signal indicates a possible L1 re-org",
-				"old_l1_head", st.data.HeadL1, "new_l1_head_parent", x.L1Unsafe.ParentHash, "new_l1_head", x.L1Unsafe)
-		}
-		st.data.HeadL1 = x.L1Unsafe
 	case L1SafeEvent:
 		st.log.Info("New L1 safe block", "l1_safe", x.L1Safe)
 		st.metrics.RecordL1Ref("l1_safe", x.L1Safe)
@@ -141,6 +113,29 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.published.Store(&published)
 	}
 	return true
+}
+
+func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {
+	st.metrics.RecordL1Ref("l1_head", x)
+	// We don't need to do anything if the head hasn't changed.
+	if st.data.HeadL1 == (eth.L1BlockRef{}) {
+		st.log.Info("Received first L1 head signal", "l1_head", x)
+	} else if st.data.HeadL1.Hash == x.Hash {
+		st.log.Trace("Received L1 head signal that is the same as the current head", "l1_head", x)
+	} else if st.data.HeadL1.Hash == x.ParentHash {
+		// We got a new L1 block whose parent hash is the same as the current L1 head. Means we're
+		// dealing with a linear extension (new block is the immediate child of the old one).
+		st.log.Debug("L1 head moved forward", "l1_head", x)
+	} else {
+		if st.data.HeadL1.Number >= x.Number {
+			st.metrics.RecordL1ReorgDepth(st.data.HeadL1.Number - x.Number)
+		}
+		// New L1 block is not the same as the current head or a single step linear extension.
+		// This could either be a long L1 extension, or a reorg, or we simply missed a head update.
+		st.log.Warn("L1 head signal indicates a possible L1 re-org",
+			"old_l1_head", st.data.HeadL1, "new_l1_head_parent", x.ParentHash, "new_l1_head", x)
+	}
+	st.data.HeadL1 = x
 }
 
 // SyncStatus is thread safe, and reads the latest view of L1 and L2 block labels

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -104,6 +104,11 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		return false
 	}
 
+	st.UpdateSyncStatus()
+	return true
+}
+
+func (st *StatusTracker) UpdateSyncStatus() {
 	// If anything changes, then copy the state to the published SyncStatus
 	// @dev: If this becomes a performance bottleneck during sync (because mem copies onto heap, and 1KB comparisons),
 	// we can rate-limit updates of the published data.
@@ -112,7 +117,6 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		published = st.data
 		st.published.Store(&published)
 	}
-	return true
 }
 
 func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {
@@ -136,6 +140,7 @@ func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {
 			"old_l1_head", st.data.HeadL1, "new_l1_head_parent", x.ParentHash, "new_l1_head", x)
 	}
 	st.data.HeadL1 = x
+	st.UpdateSyncStatus()
 }
 
 // SyncStatus is thread safe, and reads the latest view of L1 and L2 block labels

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -15,14 +15,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
-type L1SafeEvent struct {
-	L1Safe eth.L1BlockRef
-}
-
-func (ev L1SafeEvent) String() string {
-	return "l1-safe"
-}
-
 type Metrics interface {
 	RecordL1ReorgDepth(d uint64)
 	RecordL1Ref(name string, ref eth.L1BlockRef)
@@ -52,7 +44,7 @@ func NewStatusTracker(log log.Logger, metrics Metrics) *StatusTracker {
 
 func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	// TODO(#16917) Remove Event System Refactor Comments
-	//  L1UnsafeEvent is removed and OnL1Unsafe is synchronously called at L1Handler
+	//  L1UnsafeEvent, L1SafeEvent is removed and OnL1Unsafe is synchronously called at L1Handler
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
@@ -81,10 +73,6 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.data.LocalSafeL2 = x.LocalSafe
 	case derive.DeriverL1StatusEvent:
 		st.data.CurrentL1 = x.Origin
-	case L1SafeEvent:
-		st.log.Info("New L1 safe block", "l1_safe", x.L1Safe)
-		st.metrics.RecordL1Ref("l1_safe", x.L1Safe)
-		st.data.SafeL1 = x.L1Safe
 	case finality.FinalizeL1Event:
 		st.log.Info("New L1 finalized block", "l1_finalized", x.FinalizedL1)
 		st.metrics.RecordL1Ref("l1_finalized", x.FinalizedL1)
@@ -141,6 +129,13 @@ func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {
 			"old_l1_head", st.data.HeadL1, "new_l1_head_parent", x.ParentHash, "new_l1_head", x)
 	}
 	st.data.HeadL1 = x
+	st.UpdateSyncStatus()
+}
+
+func (st *StatusTracker) OnL1Safe(x eth.L1BlockRef) {
+	st.log.Info("New L1 safe block", "l1_safe", x)
+	st.metrics.RecordL1Ref("l1_safe", x)
+	st.data.SafeL1 = x
 	st.UpdateSyncStatus()
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes `L1UnsafeEvent`, `L1SafeEvent` event to a procedural call.

**Key Changes**

Rewired the op-node initialization process(op-node/node/node.go). Previously we initialized L1 and then L2. Now we follow the below process
1. Initialize L1 source(L1 client)
2. Initialize L2 components. This uses L1 source.
3. Initialize L1 handlers. This listens to L1 events(new unsafe L1 block etc) and tells L1 components to do the action via procedural call.

Driver now exposes SyncStatus, and L1Tracker is embedded. SyncDeriver was already embedded, and Tracer can be accessed via config.

L1UnsafeEvent was fan-out to Tracer(optional), L1Tracker, StatusTracker, SyncDeriver.
L1SafeEvent was fan out only to StatusTracker.

**Tests**

Existing tests are all passing.
