### PR TITLE
Remove event for EL Sync Started

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -171,7 +171,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	syncStatusTracker := status.NewStatusTracker(log, metrics)
 	sys.Register("status", syncStatusTracker, opts)
 
-	sys.Register("sync", &driver.SyncDeriver{
+	syncDeriver := &driver.SyncDeriver{
 		Derivation:          pipeline,
 		SafeHeadNotifs:      safeHeadListener,
 		CLSync:              clSync,
@@ -183,7 +183,11 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		Log:                 log,
 		Ctx:                 ctx,
 		ManagedBySupervisor: indexingMode,
-	}, opts)
+	}
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  Couple SyncDeriver and EngineController for event refactoring
+	ec.SyncDeriver = syncDeriver
+	sys.Register("sync", syncDeriver, opts)
 
 	sys.Register("engine", engine.NewEngDeriver(log, ctx, cfg, metrics, ec), opts)
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -225,8 +225,9 @@ func NewDriver(
 		Ctx:                 driverCtx,
 		ManagedBySupervisor: indexingMode,
 	}
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  Couple SyncDeriver and EngineController for event refactoring
 	ec.SyncDeriver = syncDeriver
-
 	sys.Register("sync", syncDeriver)
 
 	sys.Register("engine", engine.NewEngDeriver(log, driverCtx, cfg, metrics, ec))

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -225,6 +225,8 @@ func NewDriver(
 		Ctx:                 driverCtx,
 		ManagedBySupervisor: indexingMode,
 	}
+	ec.SyncDeriver = syncDeriver
+
 	sys.Register("sync", syncDeriver)
 
 	sys.Register("engine", engine.NewEngDeriver(log, driverCtx, cfg, metrics, ec))

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -236,6 +236,9 @@ func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
 }
 
 func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  ELSyncStartedEvent is removed and OnELSyncStarted is synchronously called at EngineController
+
 	switch x := ev.(type) {
 	case status.L1UnsafeEvent:
 		// a new L1 head may mean we have the data to not get an EOF again.
@@ -270,8 +273,6 @@ func (s *SyncDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		s.Emitter.Emit(ctx, StepReqEvent{ResetBackoff: true})
 	case engine.SafeDerivedEvent:
 		s.onSafeDerivedBlock(ctx, x)
-	case engine.ELSyncStartedEvent:
-		s.onELSyncStarted()
 	case derive.ProvideL1Traversal:
 		s.Emitter.Emit(ctx, StepReqEvent{})
 	default:
@@ -314,7 +315,7 @@ func (s *SyncDeriver) onSafeDerivedBlock(ctx context.Context, x engine.SafeDeriv
 	}
 }
 
-func (s *SyncDeriver) onELSyncStarted() {
+func (s *SyncDeriver) OnELSyncStarted() {
 	// The EL sync may progress the safe head in the EL without deriving those blocks from L1
 	// which means the safe head db will miss entries so we need to remove all entries to avoid returning bad data
 	s.Log.Warn("Clearing safe head db because EL sync started")

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -100,6 +100,8 @@ type EngineController struct {
 	needFCUCallForBackupUnsafeReorg bool
 
 	// For clearing safe head db when EL sync started
+	// EngineController is first initialized and used to initialize SyncDeriver.
+	// Embed SyncDeriver into EngineController after initializing SyncDeriver
 	SyncDeriver SyncDeriver
 }
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -50,6 +50,10 @@ type ECMetrics interface {
 	RecordL2Ref(name string, ref eth.L2BlockRef)
 }
 
+type SyncDeriver interface {
+	OnELSyncStarted()
+}
+
 type EngineController struct {
 	engine     ExecEngine // Underlying execution engine RPC
 	log        log.Logger
@@ -94,6 +98,9 @@ type EngineController struct {
 	// because engine may forgot backupUnsafeHead or backupUnsafeHead is not part
 	// of the chain.
 	needFCUCallForBackupUnsafeReorg bool
+
+	// For clearing safe head db when EL sync started
+	SyncDeriver SyncDeriver
 }
 
 func NewEngineController(engine ExecEngine, log log.Logger, metrics ECMetrics,
@@ -384,7 +391,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 			e.syncStatus = syncStatusStartedEL
 			e.log.Info("Starting EL sync")
 			e.elStart = e.clock.Now()
-			e.emitter.Emit(ctx, ELSyncStartedEvent{})
+			e.SyncDeriver.OnELSyncStarted()
 		} else if err == nil {
 			e.syncStatus = syncStatusFinishedEL
 			e.log.Info("Skipping EL sync and going straight to CL sync because there is a finalized block", "id", b.ID())

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -299,12 +299,6 @@ func (ev InteropReplacedBlockEvent) String() string {
 	return "interop-replaced-block"
 }
 
-type ELSyncStartedEvent struct{}
-
-func (ev ELSyncStartedEvent) String() string {
-	return "el-sync-started"
-}
-
 type EngDeriver struct {
 	metrics Metrics
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes `ELSyncStartedEvent` event to a procedural call

**Key Changes**

EngineController called syncDeriver to remove the safehead db when EL sync started. We now embed syncDeriver into the EngineController for direct procedural call.

So EngineController embeds syncDeriver(introduced in this PR), and syncDeriver also embeds EngineController.

**Tests**

All existing tests are passing
