### PR TITLE
fix(op-acceptance-tests): temporarily disable flaky test.

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -43,8 +43,9 @@ gates:
         timeout: 6h
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee
         timeout: 6h
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/withdrawal_root
-        timeout: 20m
+      # TODO: Re-enable this test when the withdrawal root is no longer flaky
+      # - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/withdrawal_root
+      #   timeout: 20m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/erc20_bridge
         timeout: 10m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/pectra


### PR DESCRIPTION
TestWithdrawalRoot has been flaking and failing a lot lately; let's disable it until we fix it.
