### PR TITLE
op-batcher: decrement pending bytes metrics when pruning pending blocks

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -507,12 +507,16 @@ var ErrPendingAfterClose = errors.New("pending channels remain after closing cha
 
 // PruneSafeBlocks dequeues the provided number of blocks from the internal blocks queue
 func (s *channelManager) PruneSafeBlocks(num int) {
-	_, ok := s.blocks.DequeueN(int(num))
+	discardedBlocks, ok := s.blocks.DequeueN(int(num))
 	if !ok {
 		panic("tried to prune more blocks than available")
 	}
 	s.blockCursor -= int(num)
 	if s.blockCursor < 0 {
+		numDiscardedPendingBlocks := -1 * s.blockCursor
+		for i := 0; i < numDiscardedPendingBlocks; i++ {
+			s.metr.RecordPendingBlockPruned(discardedBlocks[i])
+		}
 		s.blockCursor = 0
 	}
 }

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -513,6 +513,9 @@ func (s *channelManager) PruneSafeBlocks(num int) {
 	}
 	s.blockCursor -= int(num)
 	if s.blockCursor < 0 {
+		// This is a rare edge case where a block is loaded and pruned before it gets into a channel.
+		// This may happen if a previous batcher instance build a channel with that block
+		// which was confirmed _after_ the current batcher pulled it from the sequencer.
 		numDiscardedPendingBlocks := -1 * s.blockCursor
 		for i := 0; i < numDiscardedPendingBlocks; i++ {
 			s.metr.RecordPendingBlockPruned(discardedBlocks[i])

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -394,9 +394,12 @@ func (m *Metrics) RecordL2BlockInPendingQueue(block *types.Block) {
 	atomic.AddInt64(&m.pendingDABytes, int64(daSize))
 }
 
+// This method is called when a pending block is pruned.
+// It is a rare edge case where a block is loaded and pruned before it gets into a channel.
+// This may happen if a previous batcher instance build a channel with that block
+// which was confirmed _after_ the current batcher pulled it from the sequencer.
 func (m *Metrics) RecordPendingBlockPruned(block *types.Block) {
 	daSize, rawSize := estimateBatchSize(block)
-	m.pendingBlocksBytesTotal.Add(-1.0 * float64(rawSize))
 	m.pendingBlocksBytesCurrent.Add(-1.0 * float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, -1*int64(daSize))
 }

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -49,6 +49,7 @@ type Metricer interface {
 	RecordThrottleParams(maxTxSize, maxBlockSize uint64)
 	RecordThrottleControllerType(controllerType config.ThrottleControllerType)
 	RecordPendingBytesVsThreshold(pendingBytes, threshold uint64, controllerType config.ThrottleControllerType)
+	RecordPendingBlockPruned(block *types.Block)
 
 	// PID Controller specific metrics
 	RecordThrottleControllerState(error, integral, derivative float64)
@@ -391,6 +392,13 @@ func (m *Metrics) RecordL2BlockInPendingQueue(block *types.Block) {
 	m.pendingBlocksBytesTotal.Add(float64(rawSize))
 	m.pendingBlocksBytesCurrent.Add(float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, int64(daSize))
+}
+
+func (m *Metrics) RecordPendingBlockPruned(block *types.Block) {
+	daSize, rawSize := estimateBatchSize(block)
+	m.pendingBlocksBytesTotal.Add(-1.0 * float64(rawSize))
+	m.pendingBlocksBytesCurrent.Add(-1.0 * float64(rawSize))
+	atomic.AddInt64(&m.pendingDABytes, -1*int64(daSize))
 }
 
 func (m *Metrics) RecordL2BlockInChannel(block *types.Block) {

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -36,6 +36,7 @@ func (*noopMetrics) RecordChannelOpened(derive.ChannelID, int)              {}
 func (*noopMetrics) RecordL2BlocksAdded(eth.L2BlockRef, int, int, int, int) {}
 func (*noopMetrics) RecordL2BlockInPendingQueue(*types.Block)               {}
 func (*noopMetrics) RecordL2BlockInChannel(*types.Block)                    {}
+func (*noopMetrics) RecordPendingBlockPruned(*types.Block)                  {}
 
 func (*noopMetrics) RecordChannelClosed(derive.ChannelID, int, int, int, int, error) {}
 

--- a/op-batcher/metrics/test.go
+++ b/op-batcher/metrics/test.go
@@ -34,3 +34,9 @@ func (m *TestMetrics) ClearAllStateMetrics() {
 	m.ChannelQueueLength = 0
 	m.pendingDABytes = 0
 }
+
+func (m *TestMetrics) RecordPendingBlockPruned(block *types.Block) {
+	daSize, rawSize := estimateBatchSize(block)
+	m.PendingBlocksBytesCurrent -= float64(rawSize)
+	m.pendingDABytes -= float64(daSize)
+}


### PR DESCRIPTION
This can happen if there is a race between a fresh batcher loading a block (it becomes pending initially) and a sequencer ingesting a transaction which makes that block safe. It then gets pruned despite being _pending_, and we are forgetting to update key metrics when this happens.

This could happen during a restart of the batcher, since blocks which were in channels essentially become pending again for a short time. It is in effect a sort of rewind of the batcher's data pipeline, and we aren't binding metrics update to that event. 

Towards https://github.com/ethereum-optimism/optimism/issues/14559

failling test fixed in first commit, patch in second
