### PR TITLE
Remove event for Promote Pending Safe / Promote Local Safe / Promote Unsafe

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -161,8 +161,8 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	}
 	sys.Register("finalizer", finalizer, opts)
 
-	sys.Register("attributes-handler",
-		attributes.NewAttributesHandler(log, cfg, ctx, eng), opts)
+	attrHandler := attributes.NewAttributesHandler(log, cfg, ctx, eng)
+	sys.Register("attributes-handler", attrHandler, opts)
 
 	indexingMode := interopSys != nil
 	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, indexingMode)
@@ -191,8 +191,9 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	//  Couple SyncDeriver and EngineController for event refactoring
 	ec.SyncDeriver = syncDeriver
 	sys.Register("sync", syncDeriver, opts)
-
-	sys.Register("engine", engine.NewEngDeriver(log, ctx, cfg, metrics, ec), opts)
+	engDeriver := engine.NewEngDeriver(log, ctx, cfg, metrics, ec)
+	sys.Register("engine", engDeriver, opts)
+	attrHandler.EngDeriver = engDeriver
 
 	rollupNode := &L2Verifier{
 		eventSys:          sys,

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -436,21 +436,6 @@ func (s *L2Verifier) ActL2EventsUntil(t Testing, fn func(ev event.Event) bool, m
 	t.Fatalf("event condition did not hit, ran maximum number of steps: %d", max)
 }
 
-func (s *L2Verifier) ActL2EventsDrainAll(t Testing) {
-	t.Helper()
-	if s.l2Building {
-		t.InvalidAction("cannot derive new data while building L2 block")
-		return
-	}
-	err := s.drainer.Drain()
-	if err == nil {
-		return
-	}
-	if err == io.EOF {
-		s.synchronousEvents.Emit(t.Ctx(), driver.StepEvent{})
-	}
-}
-
 func (s *L2Verifier) ActL2PipelineFull(t Testing) {
 	s.synchronousEvents.Emit(t.Ctx(), driver.StepEvent{})
 	require.NoError(t, s.drainer.Drain(), "complete all event processing triggered by deriver step")

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -436,6 +436,21 @@ func (s *L2Verifier) ActL2EventsUntil(t Testing, fn func(ev event.Event) bool, m
 	t.Fatalf("event condition did not hit, ran maximum number of steps: %d", max)
 }
 
+func (s *L2Verifier) ActL2EventsDrainAll(t Testing) {
+	t.Helper()
+	if s.l2Building {
+		t.InvalidAction("cannot derive new data while building L2 block")
+		return
+	}
+	err := s.drainer.Drain()
+	if err == nil {
+		return
+	}
+	if err == io.EOF {
+		s.synchronousEvents.Emit(t.Ctx(), driver.StepEvent{})
+	}
+}
+
 func (s *L2Verifier) ActL2PipelineFull(t Testing) {
 	s.synchronousEvents.Emit(t.Ctx(), driver.StepEvent{})
 	require.NoError(t, s.drainer.Drain(), "complete all event processing triggered by deriver step")

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -189,6 +189,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	}
 	// TODO(#16917) Remove Event System Refactor Comments
 	//  Couple SyncDeriver and EngineController for event refactoring
+	//  Couple EngDeriver and NewAttributesHandler for event refactoring
 	ec.SyncDeriver = syncDeriver
 	sys.Register("sync", syncDeriver, opts)
 	engDeriver := engine.NewEngDeriver(log, ctx, cfg, metrics, ec)

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -1053,12 +1053,7 @@ func TestSpanBatchAtomicity_Consolidation(gt *testing.T) {
 		} else {
 			// Make sure we do the post-processing of what safety updates might happen
 			// after the pending-safe event, before the next pending-safe event.
-
-			// This does not work
-			// verifier.ActL2EventsUntil(t, event.Is[engine2.PromoteSafeEvent], 100, true)
-			// but this works. why?
-			verifier.ActL2EventsDrainAll(t)
-
+			verifier.ActL2EventsUntil(t, event.Is[engine2.TryUpdateEngineEvent], 100, true)
 			// Once the span batch is fully processed, the safe head must advance to the end of span batch.
 			require.Equal(t, verifier.L2Safe().Number, targetHeadNumber)
 			require.Equal(t, verifier.L2Safe(), verifier.L2PendingSafe())

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -1053,7 +1053,12 @@ func TestSpanBatchAtomicity_Consolidation(gt *testing.T) {
 		} else {
 			// Make sure we do the post-processing of what safety updates might happen
 			// after the pending-safe event, before the next pending-safe event.
-			verifier.ActL2EventsUntil(t, event.Is[engine2.PendingSafeUpdateEvent], 100, true)
+
+			// This does not work
+			// verifier.ActL2EventsUntil(t, event.Is[engine2.PromoteSafeEvent], 100, true)
+			// but this works. why?
+			verifier.ActL2EventsDrainAll(t)
+
 			// Once the span batch is fully processed, the safe head must advance to the end of span batch.
 			require.Equal(t, verifier.L2Safe().Number, targetHeadNumber)
 			require.Equal(t, verifier.L2Safe(), verifier.L2PendingSafe())

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -1052,7 +1052,7 @@ func TestSpanBatchAtomicity_Consolidation(gt *testing.T) {
 			require.Equal(t, verifier.L2Safe().Number, uint64(0))
 		} else {
 			// Make sure we do the post-processing of what safety updates might happen
-			// after the pending-safe event, before the next pending-safe event.
+			// Digest events until EngDeriver implicitly consumes PromoteSafeEvent
 			verifier.ActL2EventsUntil(t, event.Is[engine2.TryUpdateEngineEvent], 100, true)
 			// Once the span batch is fully processed, the safe head must advance to the end of span batch.
 			require.Equal(t, verifier.L2Safe().Number, targetHeadNumber)

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -37,15 +37,8 @@ type AttributesHandler struct {
 	attributes     *derive.AttributesWithParent
 	sentAttributes bool
 
-	EngDeriver EngDeriver
+	EngDeriver engine.EngDeriverInterface
 }
-
-type EngDeriver interface {
-	TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
-	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
-}
-
-var _ EngDeriver = (*engine.EngDeriver)(nil)
 
 func NewAttributesHandler(log log.Logger, cfg *rollup.Config, ctx context.Context, l2 L2) *AttributesHandler {
 	return &AttributesHandler{

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -36,7 +36,16 @@ type AttributesHandler struct {
 
 	attributes     *derive.AttributesWithParent
 	sentAttributes bool
+
+	EngDeriver EngDeriver
 }
+
+type EngDeriver interface {
+	TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
+	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
+}
+
+var _ EngDeriver = (*engine.EngDeriver)(nil)
 
 func NewAttributesHandler(log log.Logger, cfg *rollup.Config, ctx context.Context, l2 L2) *AttributesHandler {
 	return &AttributesHandler{
@@ -200,11 +209,8 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 			eq.log.Error("Failed to compute block-ref from execution payload")
 			return
 		}
-		eq.emitter.Emit(eq.ctx, engine.PromotePendingSafeEvent{
-			Ref:        ref,
-			Concluding: attributes.Concluding,
-			Source:     attributes.DerivedFrom,
-		})
+		eq.EngDeriver.TryUpdatePendingSafe(eq.ctx, ref, attributes.Concluding, attributes.DerivedFrom)
+		eq.EngDeriver.TryUpdateLocalSafe(eq.ctx, ref, attributes.Concluding, attributes.DerivedFrom)
 	}
 
 	// unsafe head stays the same, we did not reorg the chain.

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -41,7 +41,6 @@ type AttributesHandler struct {
 }
 
 type EngDeriver interface {
-	TryUpdateUnsafe(ctx context.Context, ref eth.L2BlockRef)
 	TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
 	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
 }

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -41,6 +41,7 @@ type AttributesHandler struct {
 }
 
 type EngDeriver interface {
+	TryUpdateUnsafe(ctx context.Context, ref eth.L2BlockRef)
 	TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
 	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
 }

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -170,8 +170,10 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
+		engDeriver := &testutils.MockEngDeriver{}
 		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 		ah.AttachEmitter(emitter)
+		ah.EngDeriver = engDeriver
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 		emitter.ExpectOnce(engine.PendingSafeRequestEvent{})
@@ -192,8 +194,10 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
+		engDeriver := &testutils.MockEngDeriver{}
 		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 		ah.AttachEmitter(emitter)
+		ah.EngDeriver = engDeriver
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 		emitter.ExpectOnce(engine.PendingSafeRequestEvent{})
@@ -217,8 +221,10 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
+		engDeriver := &testutils.MockEngDeriver{}
 		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 		ah.AttachEmitter(emitter)
+		ah.EngDeriver = engDeriver
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 		emitter.ExpectOnce(engine.PendingSafeRequestEvent{})
@@ -243,8 +249,10 @@ func TestAttributesHandler(t *testing.T) {
 			logger := testlog.Logger(t, log.LevelInfo)
 			l2 := &testutils.MockL2Client{}
 			emitter := &testutils.MockEmitter{}
+			engDeriver := &testutils.MockEngDeriver{}
 			ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 			ah.AttachEmitter(emitter)
+			ah.EngDeriver = engDeriver
 
 			// attrA1Alt does not match block A1, so will cause force-reorg.
 			emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
@@ -336,8 +344,10 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
+		engDeriver := &testutils.MockEngDeriver{}
 		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 		ah.AttachEmitter(emitter)
+		ah.EngDeriver = engDeriver
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
 		emitter.ExpectOnce(engine.PendingSafeRequestEvent{})
@@ -373,8 +383,10 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
+		engDeriver := &testutils.MockEngDeriver{}
 		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 		ah.AttachEmitter(emitter)
+		ah.EngDeriver = engDeriver
 
 		emitter.ExpectOnceType("ResetEvent")
 		ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
@@ -389,8 +401,10 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
+		engDeriver := &testutils.MockEngDeriver{}
 		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 		ah.AttachEmitter(emitter)
+		ah.EngDeriver = engDeriver
 
 		// If there are no attributes, we expect the pipeline to be requested to generate attributes.
 		emitter.ExpectOnce(derive.PipelineStepEvent{PendingSafe: refA1})

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -280,8 +280,10 @@ func TestAttributesHandler(t *testing.T) {
 				logger := testlog.Logger(t, log.LevelInfo)
 				l2 := &testutils.MockL2Client{}
 				emitter := &testutils.MockEmitter{}
+				engDeriver := &testutils.MockEngDeriver{}
 				ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
 				ah.AttachEmitter(emitter)
+				ah.EngDeriver = engDeriver
 
 				attr := &derive.AttributesWithParent{
 					Attributes:  attrA1.Attributes, // attributes will match, passing consolidation
@@ -298,15 +300,15 @@ func TestAttributesHandler(t *testing.T) {
 				// Call during consolidation.
 				l2.ExpectPayloadByNumber(refA1.Number, payloadA1, nil)
 
-				emitter.ExpectOnce(engine.PromotePendingSafeEvent{
-					Ref:        refA1,
-					Concluding: concluding,
-					Source:     refB,
-				})
+				// AttributesHandler will call EngDeriver methods for updating pending safe and local safe
+				engDeriver.On("TryUpdatePendingSafe", ah.ctx, refA1, concluding, refB).Return()
+				engDeriver.On("TryUpdateLocalSafe", ah.ctx, refA1, concluding, refB).Return()
+
 				ah.OnEvent(context.Background(), engine.PendingSafeUpdateEvent{
 					PendingSafe: refA0,
 					Unsafe:      refA1,
 				})
+				engDeriver.AssertExpectations(t)
 				l2.AssertExpectations(t)
 				emitter.AssertExpectations(t)
 				require.NotNil(t, ah.attributes, "still have attributes, processing still unconfirmed")

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -207,8 +207,8 @@ func NewDriver(
 	}
 	sys.Register("finalizer", finalizer)
 
-	sys.Register("attributes-handler",
-		attributes.NewAttributesHandler(log, cfg, driverCtx, l2))
+	attrHandler := attributes.NewAttributesHandler(log, cfg, driverCtx, l2)
+	sys.Register("attributes-handler", attrHandler)
 
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, depSet, verifConfDepth, l1Blobs, altDA, l2, metrics, indexingMode)
 
@@ -231,10 +231,12 @@ func NewDriver(
 	}
 	// TODO(#16917) Remove Event System Refactor Comments
 	//  Couple SyncDeriver and EngineController for event refactoring
+	//  Couple EngDeriver and NewAttributesHandler for event refactoring
 	ec.SyncDeriver = syncDeriver
 	sys.Register("sync", syncDeriver)
-
-	sys.Register("engine", engine.NewEngDeriver(log, driverCtx, cfg, metrics, ec))
+	engDeriver := engine.NewEngDeriver(log, driverCtx, cfg, metrics, ec)
+	sys.Register("engine", engDeriver)
+	attrHandler.EngDeriver = engDeriver
 
 	schedDeriv := NewStepSchedulingDeriver(log)
 	sys.Register("step-scheduler", schedDeriv)

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -102,27 +102,6 @@ func (ev PendingSafeUpdateEvent) String() string {
 	return "pending-safe-update"
 }
 
-// PromotePendingSafeEvent signals that a block can be marked as pending-safe, and/or safe.
-type PromotePendingSafeEvent struct {
-	Ref        eth.L2BlockRef
-	Concluding bool // Concludes the pending phase, so can be promoted to (local) safe
-	Source     eth.L1BlockRef
-}
-
-func (ev PromotePendingSafeEvent) String() string {
-	return "promote-pending-safe"
-}
-
-// PromoteLocalSafeEvent signals that a block can be promoted to local-safe.
-type PromoteLocalSafeEvent struct {
-	Ref    eth.L2BlockRef
-	Source eth.L1BlockRef
-}
-
-func (ev PromoteLocalSafeEvent) String() string {
-	return "promote-local-safe"
-}
-
 type CrossSafeUpdateEvent struct {
 	CrossSafe eth.L2BlockRef
 	LocalSafe eth.L2BlockRef
@@ -330,6 +309,8 @@ func (d *EngDeriver) AttachEmitter(em event.Emitter) {
 func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	d.ec.mu.Lock()
 	defer d.ec.mu.Unlock()
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  PromotePendingSafeEvent, PromoteLocalSafeEvent fan out is updated to procedural method calls
 	switch x := ev.(type) {
 	case TryUpdateEngineEvent:
 		// If we don't need to call FCU, keep going b/c this was a no-op. If we needed to
@@ -432,27 +413,6 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 			PendingSafe: d.ec.PendingSafeL2Head(),
 			Unsafe:      d.ec.UnsafeL2Head(),
 		})
-	case PromotePendingSafeEvent:
-		// Only promote if not already stale.
-		// Resets/overwrites happen through engine-resets, not through promotion.
-		if x.Ref.Number > d.ec.PendingSafeL2Head().Number {
-			d.log.Debug("Updating pending safe", "pending_safe", x.Ref, "local_safe", d.ec.LocalSafeL2Head(), "unsafe", d.ec.UnsafeL2Head(), "concluding", x.Concluding)
-			d.ec.SetPendingSafeL2Head(x.Ref)
-			d.emitter.Emit(ctx, PendingSafeUpdateEvent{
-				PendingSafe: d.ec.PendingSafeL2Head(),
-				Unsafe:      d.ec.UnsafeL2Head(),
-			})
-		}
-		if x.Concluding && x.Ref.Number > d.ec.LocalSafeL2Head().Number {
-			d.emitter.Emit(ctx, PromoteLocalSafeEvent{
-				Ref:    x.Ref,
-				Source: x.Source,
-			})
-		}
-	case PromoteLocalSafeEvent:
-		d.log.Debug("Updating local safe", "local_safe", x.Ref, "safe", d.ec.SafeL2Head(), "unsafe", d.ec.UnsafeL2Head())
-		d.ec.SetLocalSafeHead(x.Ref)
-		d.emitter.Emit(ctx, LocalSafeUpdateEvent(x))
 	case LocalSafeUpdateEvent:
 		// pre-interop everything that is local-safe is also immediately cross-safe.
 		if !d.cfg.IsInterop(x.Ref.Time) {
@@ -556,4 +516,26 @@ func ForceEngineReset(ec ResetEngineControl, x rollup.ForceResetEvent) {
 	ec.SetFinalizedHead(x.Finalized)
 
 	ec.SetBackupUnsafeL2Head(eth.L2BlockRef{}, false)
+}
+
+func (d *EngDeriver) TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
+	// Only promote if not already stale.
+	// Resets/overwrites happen through engine-resets, not through promotion.
+	if ref.Number > d.ec.PendingSafeL2Head().Number {
+		d.log.Debug("Updating pending safe", "pending_safe", ref, "local_safe", d.ec.LocalSafeL2Head(), "unsafe", d.ec.UnsafeL2Head(), "concluding", concluding)
+		d.ec.SetPendingSafeL2Head(ref)
+		d.emitter.Emit(ctx, PendingSafeUpdateEvent{
+			PendingSafe: d.ec.PendingSafeL2Head(),
+			Unsafe:      d.ec.UnsafeL2Head(),
+		})
+	}
+}
+
+func (d *EngDeriver) TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
+	if concluding && ref.Number > d.ec.LocalSafeL2Head().Number {
+		// Promote to local safe
+		d.log.Debug("Updating local safe", "local_safe", ref, "safe", d.ec.SafeL2Head(), "unsafe", d.ec.UnsafeL2Head())
+		d.ec.SetLocalSafeHead(ref)
+		d.emitter.Emit(ctx, LocalSafeUpdateEvent{Ref: ref, Source: source})
+	}
 }

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -300,22 +300,7 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	//  PromoteUnsafeEvent, PromotePendingSafeEvent, PromoteLocalSafeEvent fan out is updated to procedural method calls
 	switch x := ev.(type) {
 	case TryUpdateEngineEvent:
-		// If we don't need to call FCU, keep going b/c this was a no-op. If we needed to
-		// perform a network call, then we should yield even if we did not encounter an error.
-		if err := d.ec.TryUpdateEngine(d.ctx); err != nil && !errors.Is(err, ErrNoFCUNeeded) {
-			if errors.Is(err, derive.ErrReset) {
-				d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
-			} else if errors.Is(err, derive.ErrTemporary) {
-				d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
-			} else {
-				d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
-					Err: fmt.Errorf("unexpected TryUpdateEngine error type: %w", err),
-				})
-			}
-		} else if x.triggeredByPayloadSuccess() {
-			logValues := x.getBlockProcessingMetrics()
-			d.log.Info("Inserted new L2 unsafe block", logValues...)
-		}
+		d.TryUpdateEngine(ctx, x)
 	case ProcessUnsafePayloadEvent:
 		ref, err := derive.PayloadToBlockRef(d.cfg, x.Envelope.ExecutionPayload)
 		if err != nil {

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -275,7 +275,13 @@ type EngDeriver struct {
 	emitter event.Emitter
 }
 
+type EngDeriverInterface interface {
+	TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
+	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
+}
+
 var _ event.Deriver = (*EngDeriver)(nil)
+var _ EngDeriverInterface = (*EngDeriver)(nil)
 
 func NewEngDeriver(log log.Logger, ctx context.Context, cfg *rollup.Config,
 	metrics Metrics, ec *EngineController,

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -51,19 +51,6 @@ func (ev ForkchoiceUpdateEvent) String() string {
 	return "forkchoice-update"
 }
 
-// PromoteUnsafeEvent signals that the given block may now become a canonical unsafe block.
-// This is pre-forkchoice update; the change may not be reflected yet in the EL.
-// Note that the legacy pre-event-refactor code-path (processing P2P blocks) does fire this,
-// but manually, duplicate with the newer events processing code-path.
-// See EngineController.InsertUnsafePayload.
-type PromoteUnsafeEvent struct {
-	Ref eth.L2BlockRef
-}
-
-func (ev PromoteUnsafeEvent) String() string {
-	return "promote-unsafe"
-}
-
 // UnsafeUpdateEvent signals that the given block is now considered safe.
 // This is pre-forkchoice update; the change may not be reflected yet in the EL.
 type UnsafeUpdateEvent struct {
@@ -310,7 +297,7 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 	d.ec.mu.Lock()
 	defer d.ec.mu.Unlock()
 	// TODO(#16917) Remove Event System Refactor Comments
-	//  PromotePendingSafeEvent, PromoteLocalSafeEvent fan out is updated to procedural method calls
+	//  PromoteUnsafeEvent, PromotePendingSafeEvent, PromoteLocalSafeEvent fan out is updated to procedural method calls
 	switch x := ev.(type) {
 	case TryUpdateEngineEvent:
 		// If we don't need to call FCU, keep going b/c this was a no-op. If we needed to
@@ -388,13 +375,6 @@ func (d *EngDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 			"cross_safe", v.CrossSafe,
 			"finalized", v.Finalized,
 		)
-	case PromoteUnsafeEvent:
-		// Backup unsafeHead when new block is not built on original unsafe head.
-		if d.ec.unsafeHead.Number >= x.Ref.Number {
-			d.ec.SetBackupUnsafeL2Head(d.ec.unsafeHead, false)
-		}
-		d.ec.SetUnsafeHead(x.Ref)
-		d.emitter.Emit(ctx, UnsafeUpdateEvent(x))
 	case UnsafeUpdateEvent:
 		// pre-interop everything that is local-unsafe is also immediately cross-unsafe.
 		if !d.cfg.IsInterop(x.Ref.Time) {
@@ -516,6 +496,17 @@ func ForceEngineReset(ec ResetEngineControl, x rollup.ForceResetEvent) {
 	ec.SetFinalizedHead(x.Finalized)
 
 	ec.SetBackupUnsafeL2Head(eth.L2BlockRef{}, false)
+}
+
+// Signals that the given block may now become a canonical unsafe block.
+// This is pre-forkchoice update; the change may not be reflected yet in the EL.
+func (d *EngDeriver) TryUpdateUnsafe(ctx context.Context, ref eth.L2BlockRef) {
+	// Backup unsafeHead when new block is not built on original unsafe head.
+	if d.ec.unsafeHead.Number >= ref.Number {
+		d.ec.SetBackupUnsafeL2Head(d.ec.unsafeHead, false)
+	}
+	d.ec.SetUnsafeHead(ref)
+	d.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
 }
 
 func (d *EngDeriver) TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -47,8 +47,9 @@ func (eq *EngDeriver) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEve
 		return
 	}
 
-	eq.emitter.Emit(ctx, PromoteUnsafeEvent{Ref: ev.Ref})
-
+	// TryUpdateUnsafe, TryUpdatePendingSafe, TryUpdateLocalSafe must be sequentially invoked
+	// to satisfy attributeHandler invariant: Unsafe.Number >= PendingSafe.Number
+	eq.TryUpdateUnsafe(ctx, ev.Ref)
 	// If derived from L1, then it can be considered (pending) safe
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
 		eq.TryUpdatePendingSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -2,9 +2,12 @@ package engine
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -47,18 +50,36 @@ func (eq *EngDeriver) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEve
 		return
 	}
 
-	// TryUpdateUnsafe, TryUpdatePendingSafe, TryUpdateLocalSafe must be sequentially invoked
-	// to satisfy attributeHandler invariant: Unsafe.Number >= PendingSafe.Number
+	// TryUpdateUnsafe, TryUpdatePendingSafe, TryUpdateLocalSafe, TryUpdateEngine must be sequentially invoked
 	eq.TryUpdateUnsafe(ctx, ev.Ref)
 	// If derived from L1, then it can be considered (pending) safe
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
 		eq.TryUpdatePendingSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
 		eq.TryUpdateLocalSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
 	}
-
-	eq.emitter.Emit(ctx, TryUpdateEngineEvent{
+	// Now if possible synchronously call FCU
+	eq.TryUpdateEngine(ctx, TryUpdateEngineEvent{
 		BuildStarted:  ev.BuildStarted,
 		InsertStarted: ev.InsertStarted,
 		Envelope:      ev.Envelope,
 	})
+}
+
+func (d *EngDeriver) TryUpdateEngine(ctx context.Context, x TryUpdateEngineEvent) {
+	// If we don't need to call FCU, keep going b/c this was a no-op. If we needed to
+	// perform a network call, then we should yield even if we did not encounter an error.
+	if err := d.ec.TryUpdateEngine(d.ctx); err != nil && !errors.Is(err, ErrNoFCUNeeded) {
+		if errors.Is(err, derive.ErrReset) {
+			d.emitter.Emit(ctx, rollup.ResetEvent{Err: err})
+		} else if errors.Is(err, derive.ErrTemporary) {
+			d.emitter.Emit(ctx, rollup.EngineTemporaryErrorEvent{Err: err})
+		} else {
+			d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
+				Err: fmt.Errorf("unexpected TryUpdateEngine error type: %w", err),
+			})
+		}
+	} else if x.triggeredByPayloadSuccess() {
+		logValues := x.getBlockProcessingMetrics()
+		d.log.Info("Inserted new L2 unsafe block", logValues...)
+	}
 }

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -51,11 +51,8 @@ func (eq *EngDeriver) onPayloadSuccess(ctx context.Context, ev PayloadSuccessEve
 
 	// If derived from L1, then it can be considered (pending) safe
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
-		eq.emitter.Emit(ctx, PromotePendingSafeEvent{
-			Ref:        ev.Ref,
-			Concluding: ev.Concluding,
-			Source:     ev.DerivedFrom,
-		})
+		eq.TryUpdatePendingSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
+		eq.TryUpdateLocalSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
 	}
 
 	eq.emitter.Emit(ctx, TryUpdateEngineEvent{

--- a/op-service/testutils/mock_eng_deriver.go
+++ b/op-service/testutils/mock_eng_deriver.go
@@ -1,0 +1,20 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockEngDeriver struct {
+	mock.Mock
+}
+
+func (m *MockEngDeriver) TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
+	m.Mock.MethodCalled("TryUpdatePendingSafe", ctx, ref, concluding, source)
+}
+
+func (m *MockEngDeriver) TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
+	m.Mock.MethodCalled("TryUpdateLocalSafe", ctx, ref, concluding, source)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes `PromoteUnsafeEvent`, `PromotePendingSafeEvent`, `PromoteLocalSafeEvent` to a procedural call.

**Key Changes**

Now AttributeHandler embeds EngDeriver. AttributeHandler directly invokes methods of EngDeriver in this PR.

**Notes**

Inside `onPayloadSuccess` which is emitted by sequencer, we originally had four event emissions in the happy path. `PromoteUnsafeEvent -> TryUpdatePendingSafe -> TryUpdateLocalSafe -> TryUpdateEngineEvent`. I initially only picked two events `TryUpdatePendingSafe` and `TryUpdateLocalSafe` and took quite a time what was wrong. What happened was two events exec order were mixed with procedural calls, leading to test failure.

For further refactoring, we may be aware of this observations and make sure to convert the sequential events in a sequential procedural method call.

**Tests**

All existing tests are passing.

There are changes at `TestSpanBatchAtomicity_Consolidation` at `sync_test.go`. The point of the test is to check the safe head is bumped after we consolidated the whole span batch. This is done when `PromoteSafeEvent` is consumed and `TryUpdateEngineEvent` is emitted. Changed the condition since the test were failing, and did not find out exactly why the test was failing.
