### PR TITLE
ci: Increase op-e2e-cannon-tests job timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2211,7 +2211,7 @@ workflows:
           notify: true
           mentions: "@proofs-team"
           no_output_timeout: 90m
-          test_timeout: 120m
+          test_timeout: 240m
           resource_class: ethereum-optimism/latitude-fps-1
           context:
             - slack


### PR DESCRIPTION
Recent test introduced is quite expensive and has [timed out](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/97007/workflows/e5d84250-148b-4b4e-928a-fa9c4e942854/jobs/3739812/steps) on the latitude box when it's under load. Let's bump the test timeout to prevent failures.