### PR TITLE
op-challenger: Update challenger_test to play past split depth

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -22,12 +22,16 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	)
 
 	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
-	attacker := sys.FunderL1.NewFundedEOA(eth.OneTenthEther)
+	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(15))
 	dgf := sys.DisputeGameFactory()
 
 	game := dgf.StartSuperCannonGame(attacker, badClaim)
 
-	// Wait for the challenger to counter the bad root claim
-	claim := game.RootClaim()
-	claim.WaitForCounterClaim()
+	claim := game.RootClaim()                   // This is the bad claim from attacker
+	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger
+	for counterClaim.Depth() <= game.SplitDepth() {
+		// Wait for the challenger to counter the attacker's claim, then attack again
+		counterClaim = claim.WaitForCounterClaim()
+		claim = counterClaim.Attack(attacker, badClaim)
+	}
 }

--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -31,13 +31,18 @@ func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 	return o
 }
 
-// Write makes a user to write a tx by using the planned contract bindings
+// Write sends a tx to a contract, requiring the tx to succeed
 func Write[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) *types.Receipt {
-	checkTestable(call)
-	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
-	o, err := contractio.Write(call, call.Test().Ctx(), finalOpts)
+	o, err := MaybeWrite(user, call, opts...)
 	call.Test().Require().NoError(err)
 	return o
+}
+
+// MaybeWrite sends a tx to a contract, which may fail
+func MaybeWrite[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) (*types.Receipt, error) {
+	checkTestable(call)
+	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
+	return contractio.Write(call, call.Test().Ctx(), finalOpts)
 }
 
 var _ TestCallView[any] = (*bindings.TypedCall[any])(nil)

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -59,8 +60,22 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx int64, newClaim common.
 	newPosition := claim.Position.Attack().ToGIndex()
 	requiredBond := contract.Read(g.game.GetRequiredBond((*bindings.Uint128)(newPosition)))
 
-	receipt := contract.Write(eoa, g.game.Attack(claim.Value, big.NewInt(claimIdx), newClaim), txplan.WithValue(requiredBond))
-	g.require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+	attackCall := g.game.Attack(claim.Value, big.NewInt(claimIdx), newClaim)
+
+	// TODO: Debug why we need this retry
+	g.require.Eventually(func() bool {
+		receipt, err := contract.MaybeWrite(eoa, attackCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
+		if err != nil {
+			err := errutil.TryAddRevertReason(err)
+			g.t.Logf("Attack tx failed: %v", err)
+			return false
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			g.t.Logf("Attack tx not successful: %v", receipt.Status)
+			return false
+		}
+		return true
+	}, 5*time.Minute, 5*time.Second)
 }
 
 func (g *FaultDisputeGame) newClaim(claimIndex int64, claim bindings.Claim) *Claim {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Update the `op-challenger` acceptance test to play the game past the split depth.  This ensures the challenger is able to respond to invalid claims corresponding to VM execution trace steps.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/16454

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/15948
