### PR TITLE
fix(op-batcher): introduce `unsafe_da_bytes` metric for driving the throttling controller

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -165,7 +165,7 @@ func (c *channel) CheckTimeout(l1BlockNum uint64) {
 	c.channelBuilder.CheckTimeout(l1BlockNum)
 }
 
-func (c *channel) AddBlock(block BlockWithDABytes) (*derive.L1BlockInfo, error) {
+func (c *channel) AddBlock(block SizedBlock) (*derive.L1BlockInfo, error) {
 	return c.channelBuilder.AddBlock(block)
 }
 

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -166,7 +165,7 @@ func (c *channel) CheckTimeout(l1BlockNum uint64) {
 	c.channelBuilder.CheckTimeout(l1BlockNum)
 }
 
-func (c *channel) AddBlock(block *types.Block) (*derive.L1BlockInfo, error) {
+func (c *channel) AddBlock(block BlockWithDABytes) (*derive.L1BlockInfo, error) {
 	return c.channelBuilder.AddBlock(block)
 }
 

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/queue"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
@@ -66,7 +65,7 @@ type ChannelBuilder struct {
 	// current channel
 	co derive.ChannelOut
 	// list of blocks in the channel. Saved in case the channel must be rebuilt
-	blocks queue.Queue[*types.Block]
+	blocks queue.Queue[BlockWithDABytes]
 	// latestL1Origin is the latest L1 origin of all the L2 blocks that have been added to the channel
 	latestL1Origin eth.BlockID
 	// oldestL1Origin is the oldest L1 origin of all the L2 blocks that have been added to the channel
@@ -136,7 +135,7 @@ func (c *ChannelBuilder) OutputBytes() int {
 
 // Blocks returns a backup list of all blocks that were added to the channel. It
 // can be used in case the channel needs to be rebuilt.
-func (c *ChannelBuilder) Blocks() []*types.Block {
+func (c *ChannelBuilder) Blocks() []BlockWithDABytes {
 	return c.blocks
 }
 
@@ -171,12 +170,12 @@ func (c *ChannelBuilder) OldestL2() eth.BlockID {
 // first transaction for subsequent use by the caller.
 //
 // Call OutputFrames() afterwards to create frames.
-func (c *ChannelBuilder) AddBlock(block *types.Block) (*derive.L1BlockInfo, error) {
+func (c *ChannelBuilder) AddBlock(block BlockWithDABytes) (*derive.L1BlockInfo, error) {
 	if c.IsFull() {
 		return nil, c.FullErr()
 	}
 
-	l1info, err := c.co.AddBlock(c.rollupCfg, block)
+	l1info, err := c.co.AddBlock(c.rollupCfg, block.Block)
 	if errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.ErrCompressorFull) {
 		c.setFullErr(err)
 		return l1info, c.FullErr()

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -65,7 +65,7 @@ type ChannelBuilder struct {
 	// current channel
 	co derive.ChannelOut
 	// list of blocks in the channel. Saved in case the channel must be rebuilt
-	blocks queue.Queue[BlockWithDABytes]
+	blocks queue.Queue[SizedBlock]
 	// latestL1Origin is the latest L1 origin of all the L2 blocks that have been added to the channel
 	latestL1Origin eth.BlockID
 	// oldestL1Origin is the oldest L1 origin of all the L2 blocks that have been added to the channel
@@ -135,7 +135,7 @@ func (c *ChannelBuilder) OutputBytes() int {
 
 // Blocks returns a backup list of all blocks that were added to the channel. It
 // can be used in case the channel needs to be rebuilt.
-func (c *ChannelBuilder) Blocks() []BlockWithDABytes {
+func (c *ChannelBuilder) Blocks() []SizedBlock {
 	return c.blocks
 }
 
@@ -170,7 +170,7 @@ func (c *ChannelBuilder) OldestL2() eth.BlockID {
 // first transaction for subsequent use by the caller.
 //
 // Call OutputFrames() afterwards to create frames.
-func (c *ChannelBuilder) AddBlock(block BlockWithDABytes) (*derive.L1BlockInfo, error) {
+func (c *ChannelBuilder) AddBlock(block SizedBlock) (*derive.L1BlockInfo, error) {
 	if c.IsFull() {
 		return nil, c.FullErr()
 	}

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -44,7 +44,7 @@ func newChannelBuilder(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1Orig
 // ChannelBuilder.AddBlock method.
 func addMiniBlock(cb *ChannelBuilder) error {
 	a := newMiniL2Block(0)
-	_, err := cb.AddBlock(a)
+	_, err := cb.AddBlock(BlockWithDABytes{Block: a})
 	return err
 }
 
@@ -156,7 +156,7 @@ func addTooManyBlocks(cb *ChannelBuilder, blockCount int) (int, error) {
 
 	for i := 0; i < blockCount; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, 1000, defaultTestRollupConfig.L2ChainID, t.Add(time.Duration(i)*time.Second))
-		_, err := cb.AddBlock(block)
+		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
 		if err != nil {
 			return i + 1, err
 		}
@@ -651,7 +651,7 @@ func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 	ti := time.Now()
 	for i := 0; ; i++ {
 		a := dtest.RandomL2BlockWithChainIdAndTime(rng, 1000, defaultTestRollupConfig.L2ChainID, ti.Add(time.Duration(i)*time.Second))
-		_, err = cb.AddBlock(a)
+		_, err = cb.AddBlock(BlockWithDABytes{Block: a})
 		if cb.IsFull() {
 			fullErr := cb.FullErr()
 			require.ErrorIs(t, fullErr, derive.ErrCompressorFull)
@@ -685,9 +685,9 @@ func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(420))
 	a := dtest.RandomL2BlockWithChainId(rng, 1, defaultTestRollupConfig.L2ChainID)
-	_, err = cb.AddBlock(a)
+	_, err = cb.AddBlock(BlockWithDABytes{Block: a})
 	require.NoError(err)
-	_, err = cb.AddBlock(a)
+	_, err = cb.AddBlock(BlockWithDABytes{Block: a})
 	require.ErrorIs(err, derive.ErrCompressorFull)
 	// without fix, adding the second block would succeed and then adding a
 	// third block would fail with full error and the compressor would be full.
@@ -807,19 +807,19 @@ func TestChannelBuilder_LatestL1Origin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.LatestL1Origin())
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.LatestL1Origin().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.LatestL1Origin().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), cb.LatestL1Origin().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), cb.LatestL1Origin().Number)
 }
@@ -829,19 +829,19 @@ func TestChannelBuilder_OldestL1Origin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.OldestL1Origin())
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 }
@@ -851,19 +851,19 @@ func TestChannelBuilder_LatestL2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.LatestL2())
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.LatestL2().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), cb.LatestL2().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), cb.LatestL2().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), cb.LatestL2().Number)
 }
@@ -873,19 +873,19 @@ func TestChannelBuilder_OldestL2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.OldestL2())
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 
-	_, err = cb.AddBlock(newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110))
+	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 }
@@ -910,7 +910,7 @@ func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
 	// fill up
 	for i := 0; ; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, 4, defaultTestRollupConfig.L2ChainID, ti.Add(time.Duration(i)*time.Second))
-		_, err := cb.AddBlock(block)
+		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
 		if cb.IsFull() {
 			break
 		}
@@ -967,7 +967,7 @@ func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 			require.NoError(batch.EncodeRLP(&buf))
 			l = buf.Len()
 		}
-		_, err := cb.AddBlock(block)
+		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
 		require.NoError(err)
 		require.Equal(cb.InputBytes(), l)
 	}
@@ -989,7 +989,7 @@ func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 	ti := time.Now()
 	for i := 0; ; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, rng.Intn(32), defaultTestRollupConfig.L2ChainID, ti.Add(time.Duration(i)*time.Second))
-		_, err := cb.AddBlock(block)
+		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
 		if errors.Is(err, derive.ErrCompressorFull) {
 			break
 		}

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -44,7 +44,7 @@ func newChannelBuilder(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1Orig
 // ChannelBuilder.AddBlock method.
 func addMiniBlock(cb *ChannelBuilder) error {
 	a := newMiniL2Block(0)
-	_, err := cb.AddBlock(BlockWithDABytes{Block: a})
+	_, err := cb.AddBlock(SizedBlock{Block: a})
 	return err
 }
 
@@ -156,7 +156,7 @@ func addTooManyBlocks(cb *ChannelBuilder, blockCount int) (int, error) {
 
 	for i := 0; i < blockCount; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, 1000, defaultTestRollupConfig.L2ChainID, t.Add(time.Duration(i)*time.Second))
-		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
+		_, err := cb.AddBlock(SizedBlock{Block: block})
 		if err != nil {
 			return i + 1, err
 		}
@@ -651,7 +651,7 @@ func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 	ti := time.Now()
 	for i := 0; ; i++ {
 		a := dtest.RandomL2BlockWithChainIdAndTime(rng, 1000, defaultTestRollupConfig.L2ChainID, ti.Add(time.Duration(i)*time.Second))
-		_, err = cb.AddBlock(BlockWithDABytes{Block: a})
+		_, err = cb.AddBlock(SizedBlock{Block: a})
 		if cb.IsFull() {
 			fullErr := cb.FullErr()
 			require.ErrorIs(t, fullErr, derive.ErrCompressorFull)
@@ -685,9 +685,9 @@ func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(420))
 	a := dtest.RandomL2BlockWithChainId(rng, 1, defaultTestRollupConfig.L2ChainID)
-	_, err = cb.AddBlock(BlockWithDABytes{Block: a})
+	_, err = cb.AddBlock(SizedBlock{Block: a})
 	require.NoError(err)
-	_, err = cb.AddBlock(BlockWithDABytes{Block: a})
+	_, err = cb.AddBlock(SizedBlock{Block: a})
 	require.ErrorIs(err, derive.ErrCompressorFull)
 	// without fix, adding the second block would succeed and then adding a
 	// third block would fail with full error and the compressor would be full.
@@ -807,19 +807,19 @@ func TestChannelBuilder_LatestL1Origin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.LatestL1Origin())
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.LatestL1Origin().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.LatestL1Origin().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), cb.LatestL1Origin().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), cb.LatestL1Origin().Number)
 }
@@ -829,19 +829,19 @@ func TestChannelBuilder_OldestL1Origin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.OldestL1Origin())
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL1Origin().Number)
 }
@@ -851,19 +851,19 @@ func TestChannelBuilder_LatestL2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.LatestL2())
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.LatestL2().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), cb.LatestL2().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), cb.LatestL2().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), cb.LatestL2().Number)
 }
@@ -873,19 +873,19 @@ func TestChannelBuilder_OldestL2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.OldestL2())
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 2, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 
-	_, err = cb.AddBlock(BlockWithDABytes{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 1, 110)})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cb.OldestL2().Number)
 }
@@ -910,7 +910,7 @@ func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
 	// fill up
 	for i := 0; ; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, 4, defaultTestRollupConfig.L2ChainID, ti.Add(time.Duration(i)*time.Second))
-		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
+		_, err := cb.AddBlock(SizedBlock{Block: block})
 		if cb.IsFull() {
 			break
 		}
@@ -967,7 +967,7 @@ func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 			require.NoError(batch.EncodeRLP(&buf))
 			l = buf.Len()
 		}
-		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
+		_, err := cb.AddBlock(SizedBlock{Block: block})
 		require.NoError(err)
 		require.Equal(cb.InputBytes(), l)
 	}
@@ -989,7 +989,7 @@ func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 	ti := time.Now()
 	for i := 0; ; i++ {
 		block := dtest.RandomL2BlockWithChainIdAndTime(rng, rng.Intn(32), defaultTestRollupConfig.L2ChainID, ti.Add(time.Duration(i)*time.Second))
-		_, err := cb.AddBlock(BlockWithDABytes{Block: block})
+		_, err := cb.AddBlock(SizedBlock{Block: block})
 		if errors.Is(err, derive.ErrCompressorFull) {
 			break
 		}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -36,7 +36,7 @@ type channelManager struct {
 	outFactory ChannelOutFactory
 
 	// All blocks which are not yet safe
-	blocks queue.Queue[*types.Block]
+	blocks queue.Queue[BlockWithDABytes]
 	// blockCursor is an index into blocks queue. It points at the next block
 	// to build a channel with. blockCursor = len(blocks) is reserved for when
 	// there are no blocks ready to build with.
@@ -143,7 +143,7 @@ func (s *channelManager) rewindToBlock(block eth.BlockID) {
 		if !ok {
 			panic("rewindToBlock: block not found at index " + fmt.Sprint(i))
 		}
-		s.metr.RecordL2BlockInPendingQueue(block)
+		s.metr.RecordL2BlockInPendingQueue(block.Block)
 	}
 }
 
@@ -424,8 +424,8 @@ func (s *channelManager) processBlocks() error {
 		s.log.Debug("Added block to channel", "id", s.currentChannel.ID(), "block", eth.ToBlockID(block))
 
 		blocksAdded += 1
-		latestL2ref = l2BlockRefFromBlockAndL1Info(block, l1info)
-		s.metr.RecordL2BlockInChannel(block)
+		latestL2ref = l2BlockRefFromBlockAndL1Info(block.Block, l1info)
+		s.metr.RecordL2BlockInChannel(block.Block)
 		// current block got added but channel is now full
 		if s.currentChannel.IsFull() {
 			break
@@ -486,7 +486,7 @@ func (s *channelManager) AddL2Block(block *types.Block) error {
 	}
 
 	s.metr.RecordL2BlockInPendingQueue(block)
-	s.blocks.Enqueue(block)
+	s.blocks.Enqueue(BlockWithDABytes{Block: block})
 	s.tip = block.Hash()
 
 	return nil
@@ -518,7 +518,7 @@ func (s *channelManager) PruneSafeBlocks(num int) {
 		// which was confirmed _after_ the current batcher pulled it from the sequencer.
 		numDiscardedPendingBlocks := -1 * s.blockCursor
 		for i := 0; i < numDiscardedPendingBlocks; i++ {
-			s.metr.RecordPendingBlockPruned(discardedBlocks[i])
+			s.metr.RecordPendingBlockPruned(discardedBlocks[i].Block)
 		}
 		s.blockCursor = 0
 	}
@@ -558,4 +558,45 @@ func (m *channelManager) LastStoredBlock() eth.BlockID {
 		return eth.BlockID{}
 	}
 	return eth.ToBlockID(m.blocks[m.blocks.Len()-1])
+}
+
+func (s *channelManager) UnsafeDABytes() int64 {
+	return s.unsafeBytesInPendingBlocks() + s.unsafeBytesInOpenChannels() + s.unsafeBytesInClosedChannels()
+}
+
+func (s *channelManager) unsafeBytesInPendingBlocks() int64 {
+	var bytesNotYetInChannels int64
+	for _, block := range s.blocks[s.blockCursor:] {
+		bytesNotYetInChannels += int64(block.EstimatedDABytes())
+	}
+	return bytesNotYetInChannels
+}
+
+func (s *channelManager) unsafeBytesInOpenChannels() int64 {
+	// In theory, an open channel can provide accurate estimate of
+	// the DA bytes in the channel so far. However, in practice,
+	// the compressors we use can only provide such an estimate in a
+	// way which leads to a worse compression ratio. So increased
+	// observability actually hurts the bottom line.
+	// Therefore, for now just use a block-by-block estimate which should match
+	// the estimate for the blocks before they were added.
+	var bytesInOpenChannels int64
+	for _, channel := range s.channelQueue {
+		if channel.TotalFrames() == 0 {
+			for _, block := range channel.channelBuilder.blocks {
+				bytesInOpenChannels += int64(block.EstimatedDABytes())
+			}
+		}
+	}
+	return bytesInOpenChannels
+}
+
+func (s *channelManager) unsafeBytesInClosedChannels() int64 {
+	var bytesInClosedChannels int64
+	for _, channel := range s.channelQueue {
+		if channel.TotalFrames() > 0 {
+			bytesInClosedChannels += int64(channel.OutputBytes())
+		}
+	}
+	return bytesInClosedChannels
 }

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -36,7 +36,7 @@ type channelManager struct {
 	outFactory ChannelOutFactory
 
 	// All blocks which are not yet safe
-	blocks queue.Queue[BlockWithDABytes]
+	blocks queue.Queue[SizedBlock]
 	// blockCursor is an index into blocks queue. It points at the next block
 	// to build a channel with. blockCursor = len(blocks) is reserved for when
 	// there are no blocks ready to build with.
@@ -485,7 +485,7 @@ func (s *channelManager) AddL2Block(block *types.Block) error {
 		return ErrReorg
 	}
 
-	b := ToBlockWithDABytes(block)
+	b := ToSizedBlock(block)
 	s.metr.RecordL2BlockInPendingQueue(b.RawSize(), b.EstimatedDABytes())
 	s.blocks.Enqueue(b)
 	s.tip = block.Hash()

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -143,7 +143,7 @@ func (s *channelManager) rewindToBlock(block eth.BlockID) {
 		if !ok {
 			panic("rewindToBlock: block not found at index " + fmt.Sprint(i))
 		}
-		s.metr.RecordL2BlockInPendingQueue(block.Block)
+		s.metr.RecordL2BlockInPendingQueue(block.RawSize(), block.EstimatedDABytes())
 	}
 }
 
@@ -425,7 +425,7 @@ func (s *channelManager) processBlocks() error {
 
 		blocksAdded += 1
 		latestL2ref = l2BlockRefFromBlockAndL1Info(block.Block, l1info)
-		s.metr.RecordL2BlockInChannel(block.Block)
+		s.metr.RecordL2BlockInChannel(block.RawSize(), block.EstimatedDABytes())
 		// current block got added but channel is now full
 		if s.currentChannel.IsFull() {
 			break
@@ -485,8 +485,9 @@ func (s *channelManager) AddL2Block(block *types.Block) error {
 		return ErrReorg
 	}
 
-	s.metr.RecordL2BlockInPendingQueue(block)
-	s.blocks.Enqueue(BlockWithDABytes{Block: block})
+	b := ToBlockWithDABytes(block)
+	s.metr.RecordL2BlockInPendingQueue(b.RawSize(), b.EstimatedDABytes())
+	s.blocks.Enqueue(b)
 	s.tip = block.Hash()
 
 	return nil
@@ -518,7 +519,9 @@ func (s *channelManager) PruneSafeBlocks(num int) {
 		// which was confirmed _after_ the current batcher pulled it from the sequencer.
 		numDiscardedPendingBlocks := -1 * s.blockCursor
 		for i := 0; i < numDiscardedPendingBlocks; i++ {
-			s.metr.RecordPendingBlockPruned(discardedBlocks[i].Block)
+			s.metr.RecordPendingBlockPruned(
+				discardedBlocks[i].RawSize(),
+				discardedBlocks[i].EstimatedDABytes())
 		}
 		s.blockCursor = 0
 	}

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,7 +87,7 @@ func ChannelManagerReturnsErrReorg(t *testing.T, batchType uint) {
 	require.NoError(t, m.AddL2Block(c))
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
 
-	require.Equal(t, queue.Queue[*types.Block]{a, b, c}, m.blocks)
+	require.Equal(t, queue.Queue[BlockWithDABytes]{{Block: a}, {Block: b}, {Block: c}}, m.blocks)
 }
 
 // ChannelManagerReturnsErrReorgWhenDrained ensures that the channel manager
@@ -359,7 +361,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			// Seed channel manager with a block
 			rng := rand.New(rand.NewSource(99))
 			blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
-			m.blocks = []*types.Block{blockA}
+			m.blocks = queue.Queue[BlockWithDABytes]{BlockWithDABytes{Block: blockA}}
 
 			// Call TxData a first time to trigger blocks->channels pipeline
 			_, err := m.TxData(eth.BlockID{}, false, false, false)
@@ -380,7 +382,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			// we get some data to submit
 			var data txData
 			for {
-				m.blocks = append(m.blocks, blockA)
+				m.blocks.Enqueue(BlockWithDABytes{Block: blockA})
 				data, err = m.TxData(eth.BlockID{}, false, false, false)
 				if err == nil && data.Len() > 0 {
 					break
@@ -415,7 +417,7 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 
 	// This is the snapshot of channel manager state we want to reinstate
 	// when we requeue
-	stateSnapshot := queue.Queue[*types.Block]{blockA, blockB}
+	stateSnapshot := queue.Queue[BlockWithDABytes]{BlockWithDABytes{Block: blockA}, BlockWithDABytes{Block: blockB}}
 	m.blocks = stateSnapshot
 	require.Empty(t, m.channelQueue)
 	require.Equal(t, metrics.ChannelQueueLength, 0)
@@ -453,6 +455,7 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 	channelToInvalidate := m.currentChannel
 	m.currentChannel.Close()
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
+	newerChannel := m.currentChannel
 	require.Len(t, m.channelQueue, 3)
 	require.Equal(t, metrics.ChannelQueueLength, 3)
 	require.NoError(t, m.processBlocks())
@@ -464,7 +467,7 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 	require.Equal(t, m.blocks, stateSnapshot)
 	require.Contains(t, m.channelQueue, oldChannel)
 	require.NotContains(t, m.channelQueue, channelToInvalidate)
-	require.NotContains(t, m.channelQueue, newChannel)
+	require.NotContains(t, m.channelQueue, newerChannel)
 	require.Len(t, m.channelQueue, 1)
 	require.Equal(t, metrics.ChannelQueueLength, 1)
 
@@ -486,24 +489,24 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 func TestChannelManager_PruneBlocks(t *testing.T) {
 	cfg := channelManagerTestConfig(100, derive.SingularBatchType)
 	cfg.InitNoneCompressor()
-	a := types.NewBlock(&types.Header{
+	a := BlockWithDABytes{Block: types.NewBlock(&types.Header{
 		Number: big.NewInt(0),
-	}, nil, nil, nil, types.DefaultBlockConfig)
-	b := types.NewBlock(&types.Header{
+	}, nil, nil, nil, types.DefaultBlockConfig)}
+	b := BlockWithDABytes{Block: types.NewBlock(&types.Header{
 		Number:     big.NewInt(1),
 		ParentHash: a.Hash(),
-	}, nil, nil, nil, types.DefaultBlockConfig)
-	c := types.NewBlock(&types.Header{
+	}, nil, nil, nil, types.DefaultBlockConfig)}
+	c := BlockWithDABytes{Block: types.NewBlock(&types.Header{
 		Number:     big.NewInt(2),
 		ParentHash: b.Hash(),
-	}, nil, nil, nil, types.DefaultBlockConfig)
+	}, nil, nil, nil, types.DefaultBlockConfig)}
 
 	type testCase struct {
 		name                          string
-		initialQ                      queue.Queue[*types.Block]
+		initialQ                      queue.Queue[BlockWithDABytes]
 		initialBlockCursor            int
 		numBlocksToPrune              int
-		expectedQ                     queue.Queue[*types.Block]
+		expectedQ                     queue.Queue[BlockWithDABytes]
 		expectedBlockCursor           int
 		expectedPendingBytesDecreases bool
 	}
@@ -511,56 +514,56 @@ func TestChannelManager_PruneBlocks(t *testing.T) {
 	for _, tc := range []testCase{
 		{
 			name:                "[A,B,C]*+1->[B,C]*", // * denotes the cursor
-			initialQ:            queue.Queue[*types.Block]{a, b, c},
+			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    1,
-			expectedQ:           queue.Queue[*types.Block]{b, c},
+			expectedQ:           queue.Queue[BlockWithDABytes]{b, c},
 			expectedBlockCursor: 2,
 		},
 		{
 			name:                "[A,B,C*]+1->[B,C*]",
-			initialQ:            queue.Queue[*types.Block]{a, b, c},
+			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:  2,
 			numBlocksToPrune:    1,
-			expectedQ:           queue.Queue[*types.Block]{b, c},
+			expectedQ:           queue.Queue[BlockWithDABytes]{b, c},
 			expectedBlockCursor: 1,
 		},
 		{
 			name:                "[A,B,C]*+2->[C]*",
-			initialQ:            queue.Queue[*types.Block]{a, b, c},
+			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    2,
-			expectedQ:           queue.Queue[*types.Block]{c},
+			expectedQ:           queue.Queue[BlockWithDABytes]{c},
 			expectedBlockCursor: 1,
 		},
 		{
 			name:                "[A,B,C*]+2->[C*]",
-			initialQ:            queue.Queue[*types.Block]{a, b, c},
+			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:  2,
 			numBlocksToPrune:    2,
-			expectedQ:           queue.Queue[*types.Block]{c},
+			expectedQ:           queue.Queue[BlockWithDABytes]{c},
 			expectedBlockCursor: 0,
 		},
 		{
 			name:                          "[A*,B,C]+1->[B*,C]",
-			initialQ:                      queue.Queue[*types.Block]{a, b, c},
+			initialQ:                      queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:            0,
 			numBlocksToPrune:              1,
-			expectedQ:                     queue.Queue[*types.Block]{b, c},
+			expectedQ:                     queue.Queue[BlockWithDABytes]{b, c},
 			expectedBlockCursor:           0,
 			expectedPendingBytesDecreases: true, // we removed a pending block
 		},
 		{
 			name:                "[A,B,C]+3->[]",
-			initialQ:            queue.Queue[*types.Block]{a, b, c},
+			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    3,
-			expectedQ:           queue.Queue[*types.Block]{},
+			expectedQ:           queue.Queue[BlockWithDABytes]{},
 			expectedBlockCursor: 0,
 		},
 		{
 			name:                "[A,B,C]*+4->panic",
-			initialQ:            queue.Queue[*types.Block]{a, b, c},
+			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    4,
 			expectedQ:           nil, // declare that the prune method should panic
@@ -568,10 +571,10 @@ func TestChannelManager_PruneBlocks(t *testing.T) {
 		},
 		{
 			name:                          "[A,B,C]+3->[]",
-			initialQ:                      queue.Queue[*types.Block]{a, b, c},
+			initialQ:                      queue.Queue[BlockWithDABytes]{a, b, c},
 			initialBlockCursor:            2, // we will prune _past_ the block cursor
 			numBlocksToPrune:              3,
-			expectedQ:                     queue.Queue[*types.Block]{},
+			expectedQ:                     queue.Queue[BlockWithDABytes]{},
 			expectedBlockCursor:           0,
 			expectedPendingBytesDecreases: true, // we removed a pending block
 		},
@@ -726,5 +729,240 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	// The channel should be full and ready to send
 	require.Len(t, m.channelQueue, 1)
 	require.True(t, m.channelQueue[0].IsFull())
+}
 
+func newBlock(parent *types.Block, numTransactions int) *types.Block {
+	var rng *rand.Rand
+	if parent == nil {
+		rng = rand.New(rand.NewSource(123))
+	} else {
+		rng = rand.New(rand.NewSource(int64(parent.Header().Number.Uint64())))
+	}
+	block := derivetest.RandomL2BlockWithChainId(rng, numTransactions, defaultTestRollupConfig.L2ChainID)
+	header := block.Header()
+	if parent == nil {
+		header.Number = new(big.Int)
+		header.ParentHash = common.Hash{}
+		header.Time = 1675
+	} else {
+		header.Number = big.NewInt(0).Add(parent.Header().Number, big.NewInt(1))
+		header.ParentHash = parent.Header().Hash()
+		header.Time = parent.Header().Time + 2
+	}
+	return types.NewBlock(header, block.Body(), nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
+}
+
+// TestChannelManagerUnsafeBytes tests the unsafe bytes in the channel manager
+// by adding blocks to the unsafe block queue, adding them to a channel,
+// and then sealing the channel. It asserts on the final state of the channel
+// manager and tracks the unsafe DA estimate as blocks move through the pipeline.
+func TestChannelManagerUnsafeBytes(t *testing.T) {
+
+	type testCase struct {
+		blocks                        []*types.Block
+		batchType                     uint
+		compressor                    string
+		afterAddingToUnsafeBlockQueue int64
+		afterAddingToChannel          int64
+		afterSealingChannel           int64
+	}
+
+	a := newBlock(nil, 3)
+	b := newBlock(a, 3)
+	c := newBlock(b, 3)
+
+	emptyA := newBlock(nil, 0)
+	emptyB := newBlock(emptyA, 0)
+	emptyC := newBlock(emptyB, 0)
+
+	// TODO add a scenario with hundreds of blocks
+
+	testChannelManagerUnsafeBytes := func(t *testing.T, tc testCase) {
+		cfg := ChannelConfig{
+			MaxFrameSize:    120000 - 1,
+			TargetNumFrames: 5,
+			BatchType:       tc.batchType,
+			CompressorConfig: compressor.Config{
+				TargetOutputSize: 120000,
+				CompressionAlgo:  derive.Brotli10,
+			},
+		}
+
+		if tc.batchType == derive.SingularBatchType {
+			// Span batches use their own compression tricks
+			switch tc.compressor {
+			case "shadow":
+				cfg.InitShadowCompressor(derive.Brotli10)
+			case "ratio":
+				cfg.InitRatioCompressor(1, derive.Brotli10)
+			default:
+				t.Fatalf("unknown compressor: %s", tc.compressor)
+			}
+		}
+
+		manager := NewChannelManager(log.New(), metrics.NoopMetrics, cfg, defaultTestRollupConfig)
+
+		for _, block := range tc.blocks {
+			require.NoError(t, manager.AddL2Block(block))
+		}
+
+		assert.Equal(t, tc.afterAddingToUnsafeBlockQueue, manager.UnsafeDABytes())
+		assert.Equal(t, tc.afterAddingToUnsafeBlockQueue, manager.unsafeBytesInPendingBlocks())
+		assert.Zero(t, manager.unsafeBytesInOpenChannels())
+		assert.Zero(t, manager.unsafeBytesInClosedChannels())
+
+		for err := error(nil); err != io.EOF; {
+			require.NoError(t, err)
+			_, err = manager.TxData(eth.BlockID{
+				Hash:   common.Hash{},
+				Number: 0,
+			}, true, false, false)
+		}
+
+		assert.Equal(t, tc.afterAddingToChannel, manager.UnsafeDABytes())
+		assert.Zero(t, manager.unsafeBytesInPendingBlocks())
+		assert.Equal(t, tc.afterAddingToChannel, manager.unsafeBytesInOpenChannels())
+		assert.Zero(t, manager.unsafeBytesInClosedChannels())
+
+		manager.currentChannel.Close()
+		err := manager.currentChannel.OutputFrames()
+		require.NoError(t, err)
+
+		assert.Equal(t, tc.afterSealingChannel, manager.UnsafeDABytes())
+		assert.Zero(t, manager.unsafeBytesInPendingBlocks())
+		assert.Zero(t, manager.unsafeBytesInOpenChannels())
+		assert.Equal(t, tc.afterSealingChannel, manager.unsafeBytesInClosedChannels())
+	}
+
+	t.Run("case1", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 2138,
+			afterAddingToChannel:          2138,
+			afterSealingChannel:           2660,
+		})
+	})
+
+	t.Run("case2", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a, b},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 3813,
+			afterAddingToChannel:          3813,
+			afterSealingChannel:           4754,
+		})
+	})
+
+	t.Run("case3", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a, b, c},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 5794,
+			afterAddingToChannel:          5794,
+			afterSealingChannel:           7199,
+		})
+	})
+
+	t.Run("case4", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 2138,
+			afterAddingToChannel:          2138,
+			afterSealingChannel:           2660,
+		})
+	})
+
+	t.Run("case5", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a, b, c},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 5794,
+			afterAddingToChannel:          5794,
+			afterSealingChannel:           7199,
+		})
+	})
+
+	t.Run("case6", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a},
+			batchType:                     derive.SpanBatchType,
+			compressor:                    "",
+			afterAddingToUnsafeBlockQueue: 2138,
+			afterAddingToChannel:          2138,
+			afterSealingChannel:           2606, // in block queue, in open channel, in closed channel
+		})
+	})
+
+	t.Run("case7", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a, b},
+			batchType:                     derive.SpanBatchType,
+			compressor:                    "",
+			afterAddingToUnsafeBlockQueue: 3813,
+			afterAddingToChannel:          3813,
+			afterSealingChannel:           4590,
+		})
+	})
+
+	t.Run("case8", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{a, b, c},
+			batchType:                     derive.SpanBatchType,
+			compressor:                    "",
+			afterAddingToUnsafeBlockQueue: 5794,
+			afterAddingToChannel:          5794,
+			afterSealingChannel:           6929,
+		})
+	})
+
+	t.Run("case9", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{emptyA},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 70,
+			afterAddingToChannel:          70,
+			afterSealingChannel:           108,
+		})
+	})
+
+	t.Run("case10", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{emptyA, emptyB, emptyC},
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 210,
+			afterAddingToChannel:          210,
+			afterSealingChannel:           267,
+		})
+	})
+
+	t.Run("case11", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{emptyA},
+			batchType:                     derive.SpanBatchType,
+			compressor:                    "",
+			afterAddingToUnsafeBlockQueue: 70,
+			afterAddingToChannel:          70,
+			afterSealingChannel:           79,
+		})
+	})
+
+	t.Run("case12", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        []*types.Block{emptyA, emptyB, emptyC},
+			batchType:                     derive.SpanBatchType,
+			compressor:                    "",
+			afterAddingToUnsafeBlockQueue: 210,
+			afterAddingToChannel:          210,
+			afterSealingChannel:           81,
+		})
+	})
 }

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -753,6 +753,15 @@ func newBlock(parent *types.Block, numTransactions int) *types.Block {
 	return types.NewBlock(header, block.Body(), nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
 }
 
+func newChain(numBlocks int) []*types.Block {
+	blocks := make([]*types.Block, numBlocks)
+	blocks[0] = newBlock(nil, 10)
+	for i := 1; i < numBlocks; i++ {
+		blocks[i] = newBlock(blocks[i-1], 10)
+	}
+	return blocks
+}
+
 // TestChannelManagerUnsafeBytes tests the unsafe bytes in the channel manager
 // by adding blocks to the unsafe block queue, adding them to a channel,
 // and then sealing the channel. It asserts on the final state of the channel
@@ -776,7 +785,8 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 	emptyB := newBlock(emptyA, 0)
 	emptyC := newBlock(emptyB, 0)
 
-	// TODO add a scenario with hundreds of blocks
+	twentyBlocks := newChain(20)
+	tenBlocks := newChain(10)
 
 	testChannelManagerUnsafeBytes := func(t *testing.T, tc testCase) {
 		cfg := ChannelConfig{
@@ -964,6 +974,28 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			afterAddingToUnsafeBlockQueue: 210,
 			afterAddingToChannel:          210,
 			afterSealingChannel:           81,
+		})
+	})
+
+	t.Run("case13", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        twentyBlocks,
+			batchType:                     derive.SingularBatchType,
+			compressor:                    "shadow",
+			afterAddingToUnsafeBlockQueue: 103070,
+			afterAddingToChannel:          103070,
+			afterSealingChannel:           128120,
+		})
+	})
+
+	t.Run("case14", func(t *testing.T) {
+		testChannelManagerUnsafeBytes(t, testCase{
+			blocks:                        tenBlocks,
+			batchType:                     derive.SpanBatchType,
+			compressor:                    "",
+			afterAddingToUnsafeBlockQueue: 50971,
+			afterAddingToChannel:          50971,
+			afterSealingChannel:           61869,
 		})
 	})
 }

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -87,7 +87,7 @@ func ChannelManagerReturnsErrReorg(t *testing.T, batchType uint) {
 	require.NoError(t, m.AddL2Block(c))
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
 
-	require.Equal(t, queue.Queue[BlockWithDABytes]{{Block: a}, {Block: b}, {Block: c}}, m.blocks)
+	require.Equal(t, queue.Queue[BlockWithDABytes]{ToBlockWithDABytes(a), ToBlockWithDABytes(b), ToBlockWithDABytes(c)}, m.blocks)
 }
 
 // ChannelManagerReturnsErrReorgWhenDrained ensures that the channel manager
@@ -178,7 +178,8 @@ func ChannelManager_Clear(t *testing.T, batchType uint) {
 	}
 
 	// Artificially pump up some metrics which need to be cleared
-	m.metr.RecordL2BlockInPendingQueue(a)
+	A := ToBlockWithDABytes(a)
+	m.metr.RecordL2BlockInPendingQueue(A.RawSize(), A.EstimatedDABytes())
 	require.NotZero(m.metr.PendingDABytes())
 
 	// Clear the channel manager
@@ -412,12 +413,12 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 
 	// Seed channel manager with blocks
 	rng := rand.New(rand.NewSource(99))
-	blockA := derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID)
-	blockB := derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID)
+	blockA := ToBlockWithDABytes(derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID))
+	blockB := ToBlockWithDABytes(derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID))
 
 	// This is the snapshot of channel manager state we want to reinstate
 	// when we requeue
-	stateSnapshot := queue.Queue[BlockWithDABytes]{BlockWithDABytes{Block: blockA}, BlockWithDABytes{Block: blockB}}
+	stateSnapshot := queue.Queue[BlockWithDABytes]{blockA, blockB}
 	m.blocks = stateSnapshot
 	require.Empty(t, m.channelQueue)
 	require.Equal(t, metrics.ChannelQueueLength, 0)
@@ -432,8 +433,8 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 	require.Equal(t, metrics.ChannelQueueLength, 1)
 
 	// Setup initial metrics
-	metrics.RecordL2BlockInPendingQueue(blockA)
-	metrics.RecordL2BlockInPendingQueue(blockB)
+	metrics.RecordL2BlockInPendingQueue(blockA.RawSize(), blockA.EstimatedDABytes())
+	metrics.RecordL2BlockInPendingQueue(blockB.RawSize(), blockB.EstimatedDABytes())
 	pendingBytesBefore := metrics.PendingBlocksBytesCurrent
 
 	// Trigger the blocks -> channelQueue data pipelining
@@ -707,7 +708,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	// Seed channel manager with a block
 	rng := rand.New(rand.NewSource(99))
 	blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
-	m.blocks = []*types.Block{blockA}
+	m.blocks = queue.Queue[BlockWithDABytes]{BlockWithDABytes{Block: blockA}}
 
 	// Call TxData a first time to trigger blocks->channels pipeline
 	txData, err := m.TxData(eth.BlockID{}, false, false, false)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -87,7 +87,7 @@ func ChannelManagerReturnsErrReorg(t *testing.T, batchType uint) {
 	require.NoError(t, m.AddL2Block(c))
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
 
-	require.Equal(t, queue.Queue[BlockWithDABytes]{ToBlockWithDABytes(a), ToBlockWithDABytes(b), ToBlockWithDABytes(c)}, m.blocks)
+	require.Equal(t, queue.Queue[SizedBlock]{ToSizedBlock(a), ToSizedBlock(b), ToSizedBlock(c)}, m.blocks)
 }
 
 // ChannelManagerReturnsErrReorgWhenDrained ensures that the channel manager
@@ -178,7 +178,7 @@ func ChannelManager_Clear(t *testing.T, batchType uint) {
 	}
 
 	// Artificially pump up some metrics which need to be cleared
-	A := ToBlockWithDABytes(a)
+	A := ToSizedBlock(a)
 	m.metr.RecordL2BlockInPendingQueue(A.RawSize(), A.EstimatedDABytes())
 	require.NotZero(m.metr.PendingDABytes())
 
@@ -362,7 +362,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			// Seed channel manager with a block
 			rng := rand.New(rand.NewSource(99))
 			blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
-			m.blocks = queue.Queue[BlockWithDABytes]{BlockWithDABytes{Block: blockA}}
+			m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 			// Call TxData a first time to trigger blocks->channels pipeline
 			_, err := m.TxData(eth.BlockID{}, false, false, false)
@@ -383,7 +383,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			// we get some data to submit
 			var data txData
 			for {
-				m.blocks.Enqueue(BlockWithDABytes{Block: blockA})
+				m.blocks.Enqueue(SizedBlock{Block: blockA})
 				data, err = m.TxData(eth.BlockID{}, false, false, false)
 				if err == nil && data.Len() > 0 {
 					break
@@ -413,12 +413,12 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 
 	// Seed channel manager with blocks
 	rng := rand.New(rand.NewSource(99))
-	blockA := ToBlockWithDABytes(derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID))
-	blockB := ToBlockWithDABytes(derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID))
+	blockA := ToSizedBlock(derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID))
+	blockB := ToSizedBlock(derivetest.RandomL2BlockWithChainId(rng, 10, defaultTestRollupConfig.L2ChainID))
 
 	// This is the snapshot of channel manager state we want to reinstate
 	// when we requeue
-	stateSnapshot := queue.Queue[BlockWithDABytes]{blockA, blockB}
+	stateSnapshot := queue.Queue[SizedBlock]{blockA, blockB}
 	m.blocks = stateSnapshot
 	require.Empty(t, m.channelQueue)
 	require.Equal(t, metrics.ChannelQueueLength, 0)
@@ -490,24 +490,24 @@ func TestChannelManager_handleChannelInvalidated(t *testing.T) {
 func TestChannelManager_PruneBlocks(t *testing.T) {
 	cfg := channelManagerTestConfig(100, derive.SingularBatchType)
 	cfg.InitNoneCompressor()
-	a := BlockWithDABytes{Block: types.NewBlock(&types.Header{
+	a := SizedBlock{Block: types.NewBlock(&types.Header{
 		Number: big.NewInt(0),
 	}, nil, nil, nil, types.DefaultBlockConfig)}
-	b := BlockWithDABytes{Block: types.NewBlock(&types.Header{
+	b := SizedBlock{Block: types.NewBlock(&types.Header{
 		Number:     big.NewInt(1),
 		ParentHash: a.Hash(),
 	}, nil, nil, nil, types.DefaultBlockConfig)}
-	c := BlockWithDABytes{Block: types.NewBlock(&types.Header{
+	c := SizedBlock{Block: types.NewBlock(&types.Header{
 		Number:     big.NewInt(2),
 		ParentHash: b.Hash(),
 	}, nil, nil, nil, types.DefaultBlockConfig)}
 
 	type testCase struct {
 		name                          string
-		initialQ                      queue.Queue[BlockWithDABytes]
+		initialQ                      queue.Queue[SizedBlock]
 		initialBlockCursor            int
 		numBlocksToPrune              int
-		expectedQ                     queue.Queue[BlockWithDABytes]
+		expectedQ                     queue.Queue[SizedBlock]
 		expectedBlockCursor           int
 		expectedPendingBytesDecreases bool
 	}
@@ -515,56 +515,56 @@ func TestChannelManager_PruneBlocks(t *testing.T) {
 	for _, tc := range []testCase{
 		{
 			name:                "[A,B,C]*+1->[B,C]*", // * denotes the cursor
-			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:            queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    1,
-			expectedQ:           queue.Queue[BlockWithDABytes]{b, c},
+			expectedQ:           queue.Queue[SizedBlock]{b, c},
 			expectedBlockCursor: 2,
 		},
 		{
 			name:                "[A,B,C*]+1->[B,C*]",
-			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:            queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:  2,
 			numBlocksToPrune:    1,
-			expectedQ:           queue.Queue[BlockWithDABytes]{b, c},
+			expectedQ:           queue.Queue[SizedBlock]{b, c},
 			expectedBlockCursor: 1,
 		},
 		{
 			name:                "[A,B,C]*+2->[C]*",
-			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:            queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    2,
-			expectedQ:           queue.Queue[BlockWithDABytes]{c},
+			expectedQ:           queue.Queue[SizedBlock]{c},
 			expectedBlockCursor: 1,
 		},
 		{
 			name:                "[A,B,C*]+2->[C*]",
-			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:            queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:  2,
 			numBlocksToPrune:    2,
-			expectedQ:           queue.Queue[BlockWithDABytes]{c},
+			expectedQ:           queue.Queue[SizedBlock]{c},
 			expectedBlockCursor: 0,
 		},
 		{
 			name:                          "[A*,B,C]+1->[B*,C]",
-			initialQ:                      queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:                      queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:            0,
 			numBlocksToPrune:              1,
-			expectedQ:                     queue.Queue[BlockWithDABytes]{b, c},
+			expectedQ:                     queue.Queue[SizedBlock]{b, c},
 			expectedBlockCursor:           0,
 			expectedPendingBytesDecreases: true, // we removed a pending block
 		},
 		{
 			name:                "[A,B,C]+3->[]",
-			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:            queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    3,
-			expectedQ:           queue.Queue[BlockWithDABytes]{},
+			expectedQ:           queue.Queue[SizedBlock]{},
 			expectedBlockCursor: 0,
 		},
 		{
 			name:                "[A,B,C]*+4->panic",
-			initialQ:            queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:            queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:  3,
 			numBlocksToPrune:    4,
 			expectedQ:           nil, // declare that the prune method should panic
@@ -572,10 +572,10 @@ func TestChannelManager_PruneBlocks(t *testing.T) {
 		},
 		{
 			name:                          "[A,B,C]+3->[]",
-			initialQ:                      queue.Queue[BlockWithDABytes]{a, b, c},
+			initialQ:                      queue.Queue[SizedBlock]{a, b, c},
 			initialBlockCursor:            2, // we will prune _past_ the block cursor
 			numBlocksToPrune:              3,
-			expectedQ:                     queue.Queue[BlockWithDABytes]{},
+			expectedQ:                     queue.Queue[SizedBlock]{},
 			expectedBlockCursor:           0,
 			expectedPendingBytesDecreases: true, // we removed a pending block
 		},
@@ -708,7 +708,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	// Seed channel manager with a block
 	rng := rand.New(rand.NewSource(99))
 	blockA := derivetest.RandomL2BlockWithChainId(rng, 200, defaultTestRollupConfig.L2ChainID)
-	m.blocks = queue.Queue[BlockWithDABytes]{BlockWithDABytes{Block: blockA}}
+	m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 	// Call TxData a first time to trigger blocks->channels pipeline
 	txData, err := m.TxData(eth.BlockID{}, false, false, false)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -793,14 +792,13 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			MaxFrameSize:    120000 - 1,
 			TargetNumFrames: 5,
 			BatchType:       tc.batchType,
-			CompressorConfig: compressor.Config{
-				TargetOutputSize: 120000,
-				CompressionAlgo:  derive.Brotli10,
-			},
 		}
 
-		if tc.batchType == derive.SingularBatchType {
-			// Span batches use their own compression tricks
+		switch tc.batchType {
+		case derive.SpanBatchType:
+			cfg.CompressorConfig.CompressionAlgo = derive.Brotli10
+			cfg.CompressorConfig.TargetOutputSize = MaxDataSize(cfg.TargetNumFrames, cfg.MaxFrameSize)
+		case derive.SingularBatchType:
 			switch tc.compressor {
 			case "shadow":
 				cfg.InitShadowCompressor(derive.Brotli10)
@@ -809,6 +807,8 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			default:
 				t.Fatalf("unknown compressor: %s", tc.compressor)
 			}
+		default:
+			panic("unknown batch type")
 		}
 
 		manager := NewChannelManager(log.New(), metrics.NoopMetrics, cfg, defaultTestRollupConfig)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -897,7 +897,7 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			compressor:                    "",
 			afterAddingToUnsafeBlockQueue: 2138,
 			afterAddingToChannel:          2138,
-			afterSealingChannel:           2606, // in block queue, in open channel, in closed channel
+			afterSealingChannel:           2606,
 		})
 	})
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -172,22 +172,22 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 	l.txpoolState = TxpoolGood // no need to lock mutex as no other routines yet exist
 
 	// Channels used to signal between the loops
-	pendingBytesUpdated := make(chan int64, 1)
+	unsafeBytesUpdated := make(chan int64, 1)
 	publishSignal := make(chan bool, 1)
 	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)
 	if l.Config.ThrottleParams.Threshold > 0 {
 		l.wg.Add(1)
-		go l.throttlingLoop(l.wg, pendingBytesUpdated) // ranges over pendingBytesUpdated channel
+		go l.throttlingLoop(l.wg, unsafeBytesUpdated) // ranges over unsafeBytesUpdated channel
 	} else {
 		l.Log.Warn("Throttling loop is DISABLED due to 0 throttle-threshold. This should not be disabled in prod.")
 	}
 
 	l.wg.Add(3)
-	go l.receiptsLoop(l.wg, receiptsCh)                                            // ranges over receiptsCh channel
-	go l.publishingLoop(l.killCtx, l.wg, receiptsCh, publishSignal)                // ranges over publishSignal, spawns routines which send on receiptsCh. Closes receiptsCh when done.
-	go l.blockLoadingLoop(l.shutdownCtx, l.wg, pendingBytesUpdated, publishSignal) // sends on pendingBytesUpdated (if throttling enabled), and publishSignal. Closes them both when done
+	go l.receiptsLoop(l.wg, receiptsCh)                                           // ranges over receiptsCh channel
+	go l.publishingLoop(l.killCtx, l.wg, receiptsCh, publishSignal)               // ranges over publishSignal, spawns routines which send on receiptsCh. Closes receiptsCh when done.
+	go l.blockLoadingLoop(l.shutdownCtx, l.wg, unsafeBytesUpdated, publishSignal) // sends on unsafeBytesUpdated (if throttling enabled), and publishSignal. Closes them both when done
 
 	l.Log.Info("Batch Submitter started")
 	return nil
@@ -274,7 +274,7 @@ func (l *BatchSubmitter) Flush(ctx context.Context) error {
 
 // loadBlocksIntoState loads the blocks between start and end (inclusive).
 // If there is a reorg, it will return an error.
-func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uint64, publishSignal chan bool, pendingBytesUpdated chan int64) error {
+func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uint64, publishSignal chan bool, unsafeBytesUpdated chan int64) error {
 	if end < start {
 		return fmt.Errorf("start number is > end number %d,%d", start, end)
 	}
@@ -301,8 +301,8 @@ func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uin
 			// Every 100 blocks, signal the publishing loop to publish.
 			// This allows the batcher to start publishing sooner in the
 			// case of a large backlog of blocks to load.
+			l.sendToThrottlingLoop(unsafeBytesUpdated)
 			trySignal(publishSignal, false)
-			l.sendToThrottlingLoop(pendingBytesUpdated)
 		}
 
 	}
@@ -417,20 +417,23 @@ const (
 	TxpoolCancelPending
 )
 
-// sendToThrottlingLoop sends the current pending bytes to the throttling loop.
+func (l *BatchSubmitter) unsafeDABytes() int64 {
+	l.channelMgrMutex.Lock()
+	unsafeDABytes := l.channelMgr.UnsafeDABytes()
+	l.channelMgrMutex.Unlock()
+	return unsafeDABytes
+}
+
+// sendToThrottlingLoop sends the current unsafe bytes to the throttling loop.
 // It is not blocking, no signal will be sent if the channel is full.
-func (l *BatchSubmitter) sendToThrottlingLoop(pendingBytesUpdated chan int64) {
+func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
 	if l.Config.ThrottleParams.Threshold == 0 {
 		return
 	}
 
-	l.channelMgrMutex.Lock()
-	pendingBytes := l.channelMgr.PendingDABytes()
-	l.channelMgrMutex.Unlock()
-
 	// notify the throttling loop it may be time to initiate throttling without blocking
 	select {
-	case pendingBytesUpdated <- pendingBytes:
+	case unsafeBytesUpdated <- l.unsafeDABytes():
 	default:
 	}
 }
@@ -522,10 +525,10 @@ func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup,
 // -  polls the sequencer,
 // -  prunes the channel manager state (i.e. safe blocks)
 // -  loads unsafe blocks from the sequencer
-func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGroup, pendingBytesUpdated chan int64, publishSignal chan bool) {
+func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGroup, unsafeBytesUpdated chan int64, publishSignal chan bool) {
 	ticker := time.NewTicker(l.Config.PollInterval)
 	defer ticker.Stop()
-	defer close(pendingBytesUpdated)
+	defer close(unsafeBytesUpdated)
 	defer close(publishSignal)
 	defer wg.Done()
 	for {
@@ -541,7 +544,7 @@ func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGrou
 
 			if blocksToLoad != nil {
 				// Get fresh unsafe blocks
-				err := l.loadBlocksIntoState(ctx, blocksToLoad.start, blocksToLoad.end, publishSignal, pendingBytesUpdated)
+				err := l.loadBlocksIntoState(ctx, blocksToLoad.start, blocksToLoad.end, publishSignal, unsafeBytesUpdated)
 				switch {
 				case errors.Is(err, ErrReorg):
 					l.Log.Warn("error loading blocks, clearing state and waiting for node sync", "err", err)
@@ -551,7 +554,7 @@ func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGrou
 					l.Log.Warn("error loading blocks, retrying on next tick", "err", err)
 					continue
 				default:
-					l.sendToThrottlingLoop(pendingBytesUpdated) // we have increased the pending data. Signal the throttling loop to check if it should throttle.
+					l.sendToThrottlingLoop(unsafeBytesUpdated) // we have increased the unsafe data. Signal the throttling loop to check if it should throttle.
 				}
 			}
 			trySignal(publishSignal, false) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
@@ -669,8 +672,8 @@ func (l *BatchSubmitter) singleEndpointThrottler(wg *sync.WaitGroup, throttleSig
 }
 
 // throttlingLoop acts as a distributor that spawns individual throttling loops for each endpoint
-// and fans out the pending bytes updates to each endpoint
-func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated chan int64) {
+// and fans out the unsafe bytes updates to each endpoint
+func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, unsafeBytesUpdated chan int64) {
 	defer wg.Done()
 	l.Log.Info("Starting DA throttling loop",
 		"controller_type", l.throttleController.GetType(),
@@ -687,20 +690,21 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, pendingBytesUpdated 
 		go l.singleEndpointThrottler(&innerWg, updateChans[i], endpoint)
 	}
 
-	for pb := range pendingBytesUpdated {
-		newParams := l.throttleController.Update(uint64(pb))
+	for unsafeBytes := range unsafeBytesUpdated {
+		l.Metr.RecordUnsafeDABytes(unsafeBytes)
+		newParams := l.throttleController.Update(uint64(unsafeBytes))
 		controllerType := l.throttleController.GetType()
 
 		l.Metr.RecordThrottleIntensity(newParams.Intensity, controllerType)
 		l.Metr.RecordThrottleParams(newParams.MaxTxSize, newParams.MaxBlockSize)
 		if l.Config.ThrottleParams.Threshold > 0 {
-			l.Metr.RecordPendingBytesVsThreshold(uint64(pb), l.Config.ThrottleParams.Threshold, controllerType)
+			l.Metr.RecordUnsafeBytesVsThreshold(uint64(unsafeBytes), l.Config.ThrottleParams.Threshold, controllerType)
 		}
 
 		// Update throttling state
 		if newParams.IsThrottling() {
-			l.Log.Warn("Throttling loop: pending bytes above threshold, scaling endpoint throttling based on intensity",
-				"pending_bytes", pb,
+			l.Log.Warn("Throttling loop: unsafe bytes above threshold, scaling endpoint throttling based on intensity",
+				"unsafe_bytes", unsafeBytes,
 				"threshold", l.Config.ThrottleParams.Threshold,
 				"intensity", newParams.Intensity,
 				"max_tx_size", newParams.MaxTxSize,
@@ -1163,16 +1167,11 @@ func (l *BatchSubmitter) SetThrottleController(newType config.ThrottleController
 func (l *BatchSubmitter) GetThrottleControllerInfo() (config.ThrottleControllerInfo, error) {
 	controllerType, params := l.throttleController.Load()
 
-	// Get current pending bytes
-	l.channelMgrMutex.Lock()
-	currentLoad := uint64(l.channelMgr.PendingDABytes())
-	l.channelMgrMutex.Unlock()
-
 	info := config.ThrottleControllerInfo{
 		Type:         string(controllerType),
 		Threshold:    l.Config.ThrottleParams.Threshold,
 		MaxThreshold: l.Config.ThrottleParams.MaxThreshold(),
-		CurrentLoad:  currentLoad,
+		CurrentLoad:  uint64(l.unsafeDABytes()),
 		Intensity:    params.Intensity,
 		MaxTxSize:    params.MaxTxSize,
 		MaxBlockSize: params.MaxBlockSize,

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -419,9 +419,8 @@ const (
 
 func (l *BatchSubmitter) unsafeDABytes() int64 {
 	l.channelMgrMutex.Lock()
-	unsafeDABytes := l.channelMgr.UnsafeDABytes()
-	l.channelMgrMutex.Unlock()
-	return unsafeDABytes
+	defer l.channelMgrMutex.Unlock()
+	return l.channelMgr.UnsafeDABytes()
 }
 
 // sendToThrottlingLoop sends the current unsafe bytes to the throttling loop.

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -54,7 +54,7 @@ func isZero[T comparable](x T) bool {
 func computeSyncActions[T channelStatuser](
 	newSyncStatus eth.SyncStatus,
 	prevCurrentL1 eth.L1BlockRef,
-	blocks queue.Queue[BlockWithDABytes],
+	blocks queue.Queue[SizedBlock],
 	channels []T,
 	l log.Logger,
 ) (syncActions, bool) {

--- a/op-batcher/batcher/sync_actions.go
+++ b/op-batcher/batcher/sync_actions.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/queue"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -55,7 +54,7 @@ func isZero[T comparable](x T) bool {
 func computeSyncActions[T channelStatuser](
 	newSyncStatus eth.SyncStatus,
 	prevCurrentL1 eth.L1BlockRef,
-	blocks queue.Queue[*types.Block],
+	blocks queue.Queue[BlockWithDABytes],
 	channels []T,
 	l log.Logger,
 ) (syncActions, bool) {

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -35,9 +35,9 @@ func (tcs testChannelStatuser) isTimedOut() bool {
 
 func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 
-	block101 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(101)})}
-	block102 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(102)})}
-	block103 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(103)})}
+	block101 := SizedBlock{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(101)})}
+	block102 := SizedBlock{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(102)})}
+	block103 := SizedBlock{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(103)})}
 
 	channel103 := testChannelStatuser{
 		latestL2:       eth.ToBlockID(block103),
@@ -46,7 +46,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		timedOut:       false,
 	}
 
-	block104 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(104)})}
+	block104 := SizedBlock{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(104)})}
 
 	channel104 := testChannelStatuser{
 		latestL2:       eth.ToBlockID(block104),
@@ -63,7 +63,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		// inputs
 		newSyncStatus eth.SyncStatus
 		prevCurrentL1 eth.L1BlockRef
-		blocks        queue.Queue[BlockWithDABytes]
+		blocks        queue.Queue[SizedBlock]
 		channels      []channelStatuser
 		// expectations
 		expected             syncActions
@@ -104,7 +104,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block102, block103}, // note absence of block101
+			blocks:        queue.Queue[SizedBlock]{block102, block103}, // note absence of block101
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -122,7 +122,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
+			blocks:        queue.Queue[SizedBlock]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -140,7 +140,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
+			blocks:        queue.Queue[SizedBlock]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -158,7 +158,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
+			blocks:        queue.Queue[SizedBlock]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -175,7 +175,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block102, block103},
+			blocks:        queue.Queue[SizedBlock]{block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState: &eth.BlockID{Number: 1},
@@ -194,7 +194,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
+			blocks:        queue.Queue[SizedBlock]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{104, 109},
@@ -210,7 +210,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{},
+			blocks:        queue.Queue[SizedBlock]{},
 			channels:      []channelStatuser{},
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{104, 109},
@@ -226,7 +226,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
+			blocks:        queue.Queue[SizedBlock]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				blocksToPrune:   3,
@@ -243,7 +243,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103, block104},
+			blocks:        queue.Queue[SizedBlock]{block101, block102, block103, block104},
 			channels:      []channelStatuser{channel103, channel104},
 			expected: syncActions{
 				blocksToPrune:   3,
@@ -260,7 +260,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 100},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{},
+			blocks:        queue.Queue[SizedBlock]{},
 			channels:      []channelStatuser{},
 			expected:      syncActions{},
 			expectedLogs:  noBlocksLogs,
@@ -273,7 +273,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{block101},
+			blocks:        queue.Queue[SizedBlock]{block101},
 			channels:      []channelStatuser{},
 			expected: syncActions{
 				blocksToPrune: 1,
@@ -290,7 +290,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[BlockWithDABytes]{},
+			blocks:        queue.Queue[SizedBlock]{},
 			channels:      []channelStatuser{},
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{105, 109},
@@ -305,7 +305,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:  eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1:        eth.BlockRef{Number: 1},
-			blocks:               queue.Queue[BlockWithDABytes]{},
+			blocks:               queue.Queue[SizedBlock]{},
 			channels:             []channelStatuser{},
 			expected:             syncActions{},
 			expectedLogs:         []string{"empty BlockRef in sync status"},

--- a/op-batcher/batcher/sync_actions_test.go
+++ b/op-batcher/batcher/sync_actions_test.go
@@ -35,9 +35,9 @@ func (tcs testChannelStatuser) isTimedOut() bool {
 
 func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 
-	block101 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(101)})
-	block102 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(102)})
-	block103 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(103)})
+	block101 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(101)})}
+	block102 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(102)})}
+	block103 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(103)})}
 
 	channel103 := testChannelStatuser{
 		latestL2:       eth.ToBlockID(block103),
@@ -46,7 +46,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		timedOut:       false,
 	}
 
-	block104 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(104)})
+	block104 := BlockWithDABytes{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(104)})}
 
 	channel104 := testChannelStatuser{
 		latestL2:       eth.ToBlockID(block104),
@@ -63,7 +63,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 		// inputs
 		newSyncStatus eth.SyncStatus
 		prevCurrentL1 eth.L1BlockRef
-		blocks        queue.Queue[*types.Block]
+		blocks        queue.Queue[BlockWithDABytes]
 		channels      []channelStatuser
 		// expectations
 		expected             syncActions
@@ -104,7 +104,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block102, block103}, // note absence of block101
+			blocks:        queue.Queue[BlockWithDABytes]{block102, block103}, // note absence of block101
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -122,7 +122,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
+			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -140,7 +140,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
+			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -158,7 +158,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
+			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState:   &eth.BlockID{Number: 1},
@@ -175,7 +175,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block102, block103},
+			blocks:        queue.Queue[BlockWithDABytes]{block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				clearState: &eth.BlockID{Number: 1},
@@ -194,7 +194,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
+			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{104, 109},
@@ -210,7 +210,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{},
+			blocks:        queue.Queue[BlockWithDABytes]{},
 			channels:      []channelStatuser{},
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{104, 109},
@@ -226,7 +226,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101, block102, block103},
+			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103},
 			channels:      []channelStatuser{channel103},
 			expected: syncActions{
 				blocksToPrune:   3,
@@ -243,7 +243,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101, block102, block103, block104},
+			blocks:        queue.Queue[BlockWithDABytes]{block101, block102, block103, block104},
 			channels:      []channelStatuser{channel103, channel104},
 			expected: syncActions{
 				blocksToPrune:   3,
@@ -260,7 +260,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 100},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{},
+			blocks:        queue.Queue[BlockWithDABytes]{},
 			channels:      []channelStatuser{},
 			expected:      syncActions{},
 			expectedLogs:  noBlocksLogs,
@@ -273,7 +273,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 101},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{block101},
+			blocks:        queue.Queue[BlockWithDABytes]{block101},
 			channels:      []channelStatuser{},
 			expected: syncActions{
 				blocksToPrune: 1,
@@ -290,7 +290,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:    eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1: eth.BlockRef{Number: 1},
-			blocks:        queue.Queue[*types.Block]{},
+			blocks:        queue.Queue[BlockWithDABytes]{},
 			channels:      []channelStatuser{},
 			expected: syncActions{
 				blocksToLoad: &inclusiveBlockRange{105, 109},
@@ -305,7 +305,7 @@ func TestBatchSubmitter_computeSyncActions(t *testing.T) {
 				UnsafeL2:  eth.L2BlockRef{Number: 109},
 			},
 			prevCurrentL1:        eth.BlockRef{Number: 1},
-			blocks:               queue.Queue[*types.Block]{},
+			blocks:               queue.Queue[BlockWithDABytes]{},
 			channels:             []channelStatuser{},
 			expected:             syncActions{},
 			expectedLogs:         []string{"empty BlockRef in sync status"},

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -1,18 +1,51 @@
 package batcher
 
 import (
-	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type BlockWithDABytes struct {
 	*types.Block
+	rawSize          uint64
 	estimatedDABytes uint64
+}
+
+func ToBlockWithDABytes(block *types.Block) BlockWithDABytes {
+	b := BlockWithDABytes{Block: block}
+	// populate caches
+	b.RawSize()
+	b.EstimatedDABytes()
+	return b
+}
+
+func (b *BlockWithDABytes) RawSize() uint64 {
+	if b.rawSize == 0 {
+		b.rawSize = uint64(70)
+		for _, tx := range b.Transactions() {
+			// Deposit transactions are not included in batches
+			if tx.IsDepositTx() {
+				continue
+			}
+			// Add 2 for the overhead of encoding the tx bytes in a RLP list
+			b.rawSize += tx.Size() + 2
+		}
+	}
+	return b.rawSize
 }
 
 func (b *BlockWithDABytes) EstimatedDABytes() uint64 {
 	if b.estimatedDABytes == 0 {
-		daSize, _ := metrics.EstimateBatchSize(b.Block)
+		daSize := uint64(70) // estimated overhead of batch metadata
+		for _, tx := range b.Transactions() {
+			// Deposit transactions are not included in batches
+			if tx.IsDepositTx() {
+				continue
+			}
+			bigSize := tx.RollupCostData().EstimatedDASize()
+			if bigSize.IsUint64() { // this should always be true, but if not just ignore
+				daSize += bigSize.Uint64()
+			}
+		}
 		b.estimatedDABytes = daSize
 	}
 	return b.estimatedDABytes

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -4,21 +4,21 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-type BlockWithDABytes struct {
+type SizedBlock struct {
 	*types.Block
 	rawSize          uint64
 	estimatedDABytes uint64
 }
 
-func ToBlockWithDABytes(block *types.Block) BlockWithDABytes {
-	b := BlockWithDABytes{Block: block}
+func ToSizedBlock(block *types.Block) SizedBlock {
+	b := SizedBlock{Block: block}
 	// populate caches
 	b.RawSize()
 	b.EstimatedDABytes()
 	return b
 }
 
-func (b *BlockWithDABytes) RawSize() uint64 {
+func (b *SizedBlock) RawSize() uint64 {
 	if b.rawSize == 0 {
 		b.rawSize = uint64(70)
 		for _, tx := range b.Transactions() {
@@ -33,7 +33,7 @@ func (b *BlockWithDABytes) RawSize() uint64 {
 	return b.rawSize
 }
 
-func (b *BlockWithDABytes) EstimatedDABytes() uint64 {
+func (b *SizedBlock) EstimatedDABytes() uint64 {
 	if b.estimatedDABytes == 0 {
 		daSize := uint64(70) // estimated overhead of batch metadata
 		for _, tx := range b.Transactions() {

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -41,10 +41,9 @@ func (b *BlockWithDABytes) EstimatedDABytes() uint64 {
 			if tx.IsDepositTx() {
 				continue
 			}
-			bigSize := tx.RollupCostData().EstimatedDASize()
-			if bigSize.IsUint64() { // this should always be true, but if not just ignore
-				daSize += bigSize.Uint64()
-			}
+			// It is safe to assume that the estimated DA size is always a uint64,
+			// so calling Uint64() is safe
+			daSize += tx.RollupCostData().EstimatedDASize().Uint64()
 		}
 		b.estimatedDABytes = daSize
 	}

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -1,0 +1,19 @@
+package batcher
+
+import (
+	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type BlockWithDABytes struct {
+	*types.Block
+	estimatedDABytes uint64
+}
+
+func (b *BlockWithDABytes) EstimatedDABytes() uint64 {
+	if b.estimatedDABytes == 0 {
+		daSize, _ := metrics.EstimateBatchSize(b.Block)
+		b.estimatedDABytes = daSize
+	}
+	return b.estimatedDABytes
+}

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -167,7 +167,7 @@ var (
 	}
 	ThrottleThresholdFlag = &cli.IntFlag{
 		Name:    "throttle-threshold",
-		Usage:   "The threshold on pending-blocks-bytes-current beyond which the batcher will instruct the block builder to start throttling transactions with larger DA demands. Zero disables throttling.",
+		Usage:   "The threshold on unsafe_da_bytes beyond which the batcher will start to throttle the block builder. Zero disables throttling.",
 		Value:   1_000_000,
 		EnvVars: prefixEnvVars("THROTTLE_THRESHOLD"),
 	}

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -39,8 +38,8 @@ type Metricer interface {
 	RecordL2BlocksLoaded(l2ref eth.L2BlockRef)
 	RecordChannelOpened(id derive.ChannelID, numPendingBlocks int)
 	RecordL2BlocksAdded(l2ref eth.L2BlockRef, numBlocksAdded, numPendingBlocks, inputBytes, outputComprBytes int)
-	RecordL2BlockInPendingQueue(block *types.Block)
-	RecordL2BlockInChannel(block *types.Block)
+	RecordL2BlockInPendingQueue(rawSize, daSize uint64)
+	RecordL2BlockInChannel(rawSize, daSize uint64)
 	RecordChannelClosed(id derive.ChannelID, numPendingBlocks int, numFrames int, inputBytes int, outputComprBytes int, reason error)
 	RecordChannelFullySubmitted(id derive.ChannelID)
 	RecordChannelTimedOut(id derive.ChannelID)
@@ -50,7 +49,7 @@ type Metricer interface {
 	RecordThrottleControllerType(controllerType config.ThrottleControllerType)
 	RecordUnsafeBytesVsThreshold(unsafeBytes, threshold uint64, controllerType config.ThrottleControllerType)
 	RecordUnsafeDABytes(int64)
-	RecordPendingBlockPruned(block *types.Block)
+	RecordPendingBlockPruned(rawSize, daSize uint64)
 
 	// PID Controller specific metrics
 	RecordThrottleControllerState(error, integral, derivative float64)
@@ -395,8 +394,7 @@ func (m *Metrics) RecordChannelClosed(id derive.ChannelID, numPendingBlocks int,
 	m.channelClosedReason.Set(float64(ClosedReasonToNum(reason)))
 }
 
-func (m *Metrics) RecordL2BlockInPendingQueue(block *types.Block) {
-	daSize, rawSize := EstimateBatchSize(block)
+func (m *Metrics) RecordL2BlockInPendingQueue(rawSize, daSize uint64) {
 	m.pendingBlocksBytesTotal.Add(float64(rawSize))
 	m.pendingBlocksBytesCurrent.Add(float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, int64(daSize))
@@ -406,14 +404,12 @@ func (m *Metrics) RecordL2BlockInPendingQueue(block *types.Block) {
 // It is a rare edge case where a block is loaded and pruned before it gets into a channel.
 // This may happen if a previous batcher instance build a channel with that block
 // which was confirmed _after_ the current batcher pulled it from the sequencer.
-func (m *Metrics) RecordPendingBlockPruned(block *types.Block) {
-	daSize, rawSize := EstimateBatchSize(block)
+func (m *Metrics) RecordPendingBlockPruned(rawSize, daSize uint64) {
 	m.pendingBlocksBytesCurrent.Add(-1.0 * float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, -1*int64(daSize))
 }
 
-func (m *Metrics) RecordL2BlockInChannel(block *types.Block) {
-	daSize, rawSize := EstimateBatchSize(block)
+func (m *Metrics) RecordL2BlockInChannel(rawSize, daSize uint64) {
 	m.pendingBlocksBytesCurrent.Add(-1.0 * float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, -1*int64(daSize))
 	// Refer to RecordL2BlocksAdded to see the current + count of bytes added to a channel
@@ -502,26 +498,6 @@ func (m *Metrics) ClearAllStateMetrics() {
 	m.RecordChannelQueueLength(0)
 	atomic.StoreInt64(&m.pendingDABytes, 0)
 	m.pendingBlocksBytesCurrent.Set(0)
-}
-
-// EstimateBatchSize returns the estimated size of the block in a batch both with compression ('daSize') and without
-// ('rawSize').
-func EstimateBatchSize(block *types.Block) (daSize, rawSize uint64) {
-	daSize = uint64(70) // estimated overhead of batch metadata
-	rawSize = uint64(70)
-	for _, tx := range block.Transactions() {
-		// Deposit transactions are not included in batches
-		if tx.IsDepositTx() {
-			continue
-		}
-		bigSize := tx.RollupCostData().EstimatedDASize()
-		if bigSize.IsUint64() { // this should always be true, but if not just ignore
-			daSize += bigSize.Uint64()
-		}
-		// Add 2 for the overhead of encoding the tx bytes in a RLP list
-		rawSize += tx.Size() + 2
-	}
-	return
 }
 
 // RecordThrottleControllerState records the state of the PID controller

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -48,7 +48,8 @@ type Metricer interface {
 	RecordThrottleIntensity(intensity float64, controllerType config.ThrottleControllerType)
 	RecordThrottleParams(maxTxSize, maxBlockSize uint64)
 	RecordThrottleControllerType(controllerType config.ThrottleControllerType)
-	RecordPendingBytesVsThreshold(pendingBytes, threshold uint64, controllerType config.ThrottleControllerType)
+	RecordUnsafeBytesVsThreshold(unsafeBytes, threshold uint64, controllerType config.ThrottleControllerType)
+	RecordUnsafeDABytes(int64)
 	RecordPendingBlockPruned(block *types.Block)
 
 	// PID Controller specific metrics
@@ -92,6 +93,8 @@ type Metrics struct {
 	pendingDABytes          int64
 	pendingDABytesGaugeFunc prometheus.GaugeFunc
 
+	unsafeDABytesGauge prometheus.Gauge
+
 	blocksAddedCount prometheus.Gauge
 
 	channelInputBytes       prometheus.GaugeVec
@@ -112,7 +115,7 @@ type Metrics struct {
 	throttleMaxTxSize      prometheus.Gauge
 	throttleMaxBlockSize   prometheus.Gauge
 	throttleControllerType prometheus.GaugeVec
-	pendingBytesRatio      prometheus.GaugeVec
+	unsafeBytesRatio       prometheus.GaugeVec
 	throttleHistory        prometheus.Summary
 
 	// PID Controller specific metrics
@@ -255,10 +258,10 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "throttle_controller_type",
 			Help:      "Type of throttle controller in use",
 		}, []string{"type"}),
-		pendingBytesRatio: *factory.NewGaugeVec(prometheus.GaugeOpts{
+		unsafeBytesRatio: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
-			Name:      "pending_bytes_ratio",
-			Help:      "Ratio of pending bytes to threshold",
+			Name:      "unsafe_bytes_ratio",
+			Help:      "Ratio of unsafe bytes to threshold",
 		}, []string{"type"}),
 		throttleHistory: factory.NewSummary(prometheus.SummaryOpts{
 			Namespace: ns,
@@ -290,6 +293,11 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "pid_response_time",
 			Help:      "Response time of the PID controller",
 			Buckets:   prometheus.DefBuckets,
+		}),
+		unsafeDABytesGauge: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "unsafe_da_bytes",
+			Help:      "The estimated number of unsafe DA bytes",
 		}),
 	}
 	m.pendingDABytesGaugeFunc = factory.NewGaugeFunc(prometheus.GaugeOpts{
@@ -388,7 +396,7 @@ func (m *Metrics) RecordChannelClosed(id derive.ChannelID, numPendingBlocks int,
 }
 
 func (m *Metrics) RecordL2BlockInPendingQueue(block *types.Block) {
-	daSize, rawSize := estimateBatchSize(block)
+	daSize, rawSize := EstimateBatchSize(block)
 	m.pendingBlocksBytesTotal.Add(float64(rawSize))
 	m.pendingBlocksBytesCurrent.Add(float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, int64(daSize))
@@ -399,13 +407,13 @@ func (m *Metrics) RecordL2BlockInPendingQueue(block *types.Block) {
 // This may happen if a previous batcher instance build a channel with that block
 // which was confirmed _after_ the current batcher pulled it from the sequencer.
 func (m *Metrics) RecordPendingBlockPruned(block *types.Block) {
-	daSize, rawSize := estimateBatchSize(block)
+	daSize, rawSize := EstimateBatchSize(block)
 	m.pendingBlocksBytesCurrent.Add(-1.0 * float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, -1*int64(daSize))
 }
 
 func (m *Metrics) RecordL2BlockInChannel(block *types.Block) {
-	daSize, rawSize := estimateBatchSize(block)
+	daSize, rawSize := EstimateBatchSize(block)
 	m.pendingBlocksBytesCurrent.Add(-1.0 * float64(rawSize))
 	atomic.AddInt64(&m.pendingDABytes, -1*int64(daSize))
 	// Refer to RecordL2BlocksAdded to see the current + count of bytes added to a channel
@@ -470,15 +478,19 @@ func (m *Metrics) RecordThrottleControllerType(controllerType config.ThrottleCon
 	}
 }
 
-func (m *Metrics) RecordPendingBytesVsThreshold(pendingBytes, threshold uint64, controllerType config.ThrottleControllerType) {
-	ratio := float64(pendingBytes) / float64(threshold)
+func (m *Metrics) RecordUnsafeBytesVsThreshold(unsafeBytes, threshold uint64, controllerType config.ThrottleControllerType) {
+	ratio := float64(unsafeBytes) / float64(threshold)
 	for _, t := range config.ThrottleControllerTypes {
 		if t == controllerType {
-			m.pendingBytesRatio.WithLabelValues(string(t)).Set(ratio)
+			m.unsafeBytesRatio.WithLabelValues(string(t)).Set(ratio)
 		} else {
-			m.pendingBytesRatio.WithLabelValues(string(t)).Set(0)
+			m.unsafeBytesRatio.WithLabelValues(string(t)).Set(0)
 		}
 	}
+}
+
+func (m *Metrics) RecordUnsafeDABytes(unsafeDABytes int64) {
+	m.unsafeDABytesGauge.Set(float64(unsafeDABytes))
 }
 
 // ClearAllStateMetrics clears all state metrics.
@@ -492,9 +504,9 @@ func (m *Metrics) ClearAllStateMetrics() {
 	m.pendingBlocksBytesCurrent.Set(0)
 }
 
-// estimateBatchSize returns the estimated size of the block in a batch both with compression ('daSize') and without
+// EstimateBatchSize returns the estimated size of the block in a batch both with compression ('daSize') and without
 // ('rawSize').
-func estimateBatchSize(block *types.Block) (daSize, rawSize uint64) {
+func EstimateBatchSize(block *types.Block) (daSize, rawSize uint64) {
 	daSize = uint64(70) // estimated overhead of batch metadata
 	rawSize = uint64(70)
 	for _, tx := range block.Transactions() {

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -48,8 +48,10 @@ func (*noopMetrics) RecordThrottleIntensity(intensity float64, controllerType co
 }
 func (*noopMetrics) RecordThrottleParams(maxTxSize, maxBlockSize uint64)                       {}
 func (*noopMetrics) RecordThrottleControllerType(controllerType config.ThrottleControllerType) {}
-func (*noopMetrics) RecordPendingBytesVsThreshold(pendingBytes, threshold uint64, controllerType config.ThrottleControllerType) {
+func (*noopMetrics) RecordUnsafeBytesVsThreshold(pendingBytes, threshold uint64, controllerType config.ThrottleControllerType) {
 }
+
+func (*noopMetrics) RecordUnsafeDABytes(int64) {}
 
 // PID Controller specific metrics
 func (*noopMetrics) RecordThrottleControllerState(error, integral, derivative float64) {}

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -34,9 +33,9 @@ func (*noopMetrics) RecordLatestL1Block(l1ref eth.L1BlockRef)               {}
 func (*noopMetrics) RecordL2BlocksLoaded(eth.L2BlockRef)                    {}
 func (*noopMetrics) RecordChannelOpened(derive.ChannelID, int)              {}
 func (*noopMetrics) RecordL2BlocksAdded(eth.L2BlockRef, int, int, int, int) {}
-func (*noopMetrics) RecordL2BlockInPendingQueue(*types.Block)               {}
-func (*noopMetrics) RecordL2BlockInChannel(*types.Block)                    {}
-func (*noopMetrics) RecordPendingBlockPruned(*types.Block)                  {}
+func (*noopMetrics) RecordL2BlockInPendingQueue(uint64, uint64)             {}
+func (*noopMetrics) RecordL2BlockInChannel(uint64, uint64)                  {}
+func (*noopMetrics) RecordPendingBlockPruned(uint64, uint64)                {}
 
 func (*noopMetrics) RecordChannelClosed(derive.ChannelID, int, int, int, int, error) {}
 

--- a/op-batcher/metrics/test.go
+++ b/op-batcher/metrics/test.go
@@ -14,12 +14,12 @@ type TestMetrics struct {
 var _ Metricer = new(TestMetrics)
 
 func (m *TestMetrics) RecordL2BlockInPendingQueue(block *types.Block) {
-	daSize, rawSize := estimateBatchSize(block)
+	daSize, rawSize := EstimateBatchSize(block)
 	m.PendingBlocksBytesCurrent += float64(rawSize)
 	m.pendingDABytes += float64(daSize)
 }
 func (m *TestMetrics) RecordL2BlockInChannel(block *types.Block) {
-	daSize, rawSize := estimateBatchSize(block)
+	daSize, rawSize := EstimateBatchSize(block)
 	m.PendingBlocksBytesCurrent -= float64(rawSize)
 	m.pendingDABytes -= float64(daSize)
 }
@@ -36,7 +36,7 @@ func (m *TestMetrics) ClearAllStateMetrics() {
 }
 
 func (m *TestMetrics) RecordPendingBlockPruned(block *types.Block) {
-	daSize, rawSize := estimateBatchSize(block)
+	daSize, rawSize := EstimateBatchSize(block)
 	m.PendingBlocksBytesCurrent -= float64(rawSize)
 	m.pendingDABytes -= float64(daSize)
 }

--- a/op-batcher/metrics/test.go
+++ b/op-batcher/metrics/test.go
@@ -1,9 +1,5 @@
 package metrics
 
-import (
-	"github.com/ethereum/go-ethereum/core/types"
-)
-
 type TestMetrics struct {
 	noopMetrics
 	PendingBlocksBytesCurrent float64
@@ -13,13 +9,11 @@ type TestMetrics struct {
 
 var _ Metricer = new(TestMetrics)
 
-func (m *TestMetrics) RecordL2BlockInPendingQueue(block *types.Block) {
-	daSize, rawSize := EstimateBatchSize(block)
+func (m *TestMetrics) RecordL2BlockInPendingQueue(rawSize, daSize uint64) {
 	m.PendingBlocksBytesCurrent += float64(rawSize)
 	m.pendingDABytes += float64(daSize)
 }
-func (m *TestMetrics) RecordL2BlockInChannel(block *types.Block) {
-	daSize, rawSize := EstimateBatchSize(block)
+func (m *TestMetrics) RecordL2BlockInChannel(rawSize, daSize uint64) {
 	m.PendingBlocksBytesCurrent -= float64(rawSize)
 	m.pendingDABytes -= float64(daSize)
 }
@@ -35,8 +29,7 @@ func (m *TestMetrics) ClearAllStateMetrics() {
 	m.pendingDABytes = 0
 }
 
-func (m *TestMetrics) RecordPendingBlockPruned(block *types.Block) {
-	daSize, rawSize := EstimateBatchSize(block)
+func (m *TestMetrics) RecordPendingBlockPruned(rawSize, daSize uint64) {
 	m.PendingBlocksBytesCurrent -= float64(rawSize)
 	m.pendingDABytes -= float64(daSize)
 }

--- a/op-service/testutils/random.go
+++ b/op-service/testutils/random.go
@@ -355,7 +355,11 @@ func RandomBlock(rng *rand.Rand, txCount uint64) (*types.Block, []*types.Receipt
 
 func RandomBlockPrependTxsWithTime(rng *rand.Rand, txCount int, t uint64, ptxs ...*types.Transaction) (*types.Block, []*types.Receipt) {
 	header := RandomHeaderWithTime(rng, t)
-	chainID := big.NewInt(rng.Int63n(1000))
+	chainIDInt := rng.Int63n(1000)
+	if chainIDInt == 0 { // Zero chainID is invalid.
+		chainIDInt++
+	}
+	chainID := big.NewInt(chainIDInt)
 	signer := types.NewIsthmusSigner(chainID)
 	txs := make([]*types.Transaction, 0, txCount+len(ptxs))
 	txs = append(txs, ptxs...)


### PR DESCRIPTION
The pending da bytes metric is not appropriate for driving throttling, because it reduces (often to zero) when blocks start getting packed into channels. 

Instead, this PR hooks throttling to a new variable `unsafe_da_bytes`, which is an estimate of the total DA footprint of all unsafe blocks. As blocks are loaded, it increases. As the blocks move through the batcher's data pipeline, the estimate becomes more accurate. As blocks become safe (via submission in batcher txs to L1, and subsequent derivation), the metric decreases.

Future work will make the estimate even more accurate, but this incremental step is important to deliver soon as it is a massive improvement over using pending da bytes. 

The DA estimation is cached so that performance is not adversely impacted. 

See individual commit messages for further detail. 

Subsumes #16828 and #16871

Towards #14559 

co-authored by @joshklop 

<img width="396" height="247" alt="Screenshot 2025-08-01 at 22 01 48" src="https://github.com/user-attachments/assets/9d405fe8-78c0-4730-a2b7-76f6443f014f" />
