### PR TITLE
op-batcher: set throttling defaults

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -100,9 +100,13 @@ type CLIConfig struct {
 	// ActiveSequencerCheckDuration is the duration between checks to determine the active sequencer endpoint.
 	ActiveSequencerCheckDuration time.Duration
 
-	// ThrottleThreshold is the number of pending bytes beyond which the batcher will start throttling future bytes. Set to 0 to
+	// ThrottleThreshold is the number of pending unsafe_da_bytes beyond which the batcher will start throttling future bytes. Set to 0 to
 	// disable sequencer throttling entirely (only recommended for testing).
 	ThrottleThreshold uint64
+
+	// ThrottleMaxThreshold is the number of pending_usafe_da_bytes at (and beyond) which the batcher will be throttling at 100% intensity.
+	ThrottleMaxThreshold uint64
+
 	// ThrottleTxSize is the DA size of a transaction to start throttling when we are over the throttling threshold.
 	ThrottleTxSize uint64
 	// ThrottleBlockSize is the total per-block DA limit to start imposing on block building when we are over the throttling threshold.
@@ -127,9 +131,6 @@ type CLIConfig struct {
 	ThrottlePidIntegralMax float64
 	ThrottlePidOutputMax   float64
 	ThrottlePidSampleTime  time.Duration
-
-	// ThrottleThresholdMultiplier is the threshold multiplier for the quadratic controller
-	ThrottleThresholdMultiplier float64
 
 	TxMgrConfig   txmgr.CLIConfig
 	LogConfig     oplog.CLIConfig
@@ -245,6 +246,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		ThrottlePidIntegralMax:        ctx.Float64(flags.ThrottlePidIntegralMaxFlag.Name),
 		ThrottlePidOutputMax:          ctx.Float64(flags.ThrottlePidOutputMaxFlag.Name),
 		ThrottlePidSampleTime:         ctx.Duration(flags.ThrottlePidSampleTimeFlag.Name),
-		ThrottleThresholdMultiplier:   ctx.Float64(flags.ThrottleThresholdMultiplierFlag.Name),
+		ThrottleMaxThreshold:          ctx.Uint64(flags.ThrottleMaxThresholdFlag.Name),
 	}
 }

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -188,6 +188,10 @@ func (c *CLIConfig) Check() error {
 		return fmt.Errorf("invalid throttle controller type: %s (must be one of: %v)", c.ThrottleControllerType, config.ThrottleControllerTypes)
 	}
 
+	if c.ThrottleThreshold != 0 && c.ThrottleMaxThreshold <= c.ThrottleThreshold {
+		return fmt.Errorf("throttle-max-threshold must be greater than throttle-threshold")
+	}
+
 	if err := c.MetricsConfig.Check(); err != nil {
 		return err
 	}

--- a/op-batcher/batcher/config_test.go
+++ b/op-batcher/batcher/config_test.go
@@ -121,6 +121,24 @@ func TestBatcherConfig(t *testing.T) {
 			},
 			errString: "invalid ApproxComprRatio 4.2 for ratio compressor",
 		},
+		{
+			name: "throttle_max_threshold=throttle_threshold",
+			override: func(c *batcher.CLIConfig) {
+				c.ThrottleThreshold = 5
+				c.ThrottleMaxThreshold = 5
+
+			},
+			errString: "throttle-max-threshold must be greater than throttle-threshold",
+		},
+		{
+			name: "throttle_max_threshold=throttle_threshold",
+			override: func(c *batcher.CLIConfig) {
+				c.ThrottleThreshold = 5
+				c.ThrottleMaxThreshold = 4
+
+			},
+			errString: "throttle-max-threshold must be greater than throttle-threshold",
+		},
 	}
 
 	for _, test := range tests {

--- a/op-batcher/batcher/config_test.go
+++ b/op-batcher/batcher/config_test.go
@@ -40,7 +40,8 @@ func validBatcherConfig() batcher.CLIConfig {
 		// The compressor config is not checked in config.Check()
 		RPC:                    rpc.DefaultCLIConfig(),
 		CompressionAlgo:        derive.Zlib,
-		ThrottleThreshold:      0, // no DA throttling
+		ThrottleThreshold:      flags.DefaultThrottleThreshold,
+		ThrottleMaxThreshold:   flags.DefaultThrottleMaxThreshold,
 		ThrottleTxSize:         0,
 		ThrottleControllerType: "step", // default controller type
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -677,7 +677,7 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, unsafeBytesUpdated c
 	l.Log.Info("Starting DA throttling loop",
 		"controller_type", l.throttleController.GetType(),
 		"threshold", l.Config.ThrottleParams.Threshold,
-		"max_threshold", l.Config.ThrottleParams.MaxThreshold(),
+		"max_threshold", l.Config.ThrottleParams.MaxThreshold,
 	)
 	updateChans := make([]chan struct{}, len(l.Config.ThrottleParams.Endpoints))
 
@@ -1169,7 +1169,7 @@ func (l *BatchSubmitter) GetThrottleControllerInfo() (config.ThrottleControllerI
 	info := config.ThrottleControllerInfo{
 		Type:         string(controllerType),
 		Threshold:    l.Config.ThrottleParams.Threshold,
-		MaxThreshold: l.Config.ThrottleParams.MaxThreshold(),
+		MaxThreshold: l.Config.ThrottleParams.MaxThreshold,
 		CurrentLoad:  uint64(l.unsafeDABytes()),
 		Intensity:    params.Intensity,
 		MaxTxSize:    params.MaxTxSize,

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -107,13 +107,13 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	bs.WaitNodeSync = cfg.WaitNodeSync
 
 	bs.ThrottleParams = config.ThrottleParams{
-		Threshold:           cfg.ThrottleThreshold,
-		TxSize:              cfg.ThrottleTxSize,
-		BlockSize:           cfg.ThrottleBlockSize,
-		AlwaysBlockSize:     cfg.ThrottleAlwaysBlockSize,
-		ThresholdMultiplier: cfg.ThrottleThresholdMultiplier,
-		ControllerType:      cfg.ThrottleControllerType,
-		Endpoints:           slices.Union(cfg.L2EthRpc, cfg.AdditionalThrottlingEndpoints),
+		Threshold:       cfg.ThrottleThreshold,
+		MaxThreshold:    cfg.ThrottleMaxThreshold,
+		TxSize:          cfg.ThrottleTxSize,
+		BlockSize:       cfg.ThrottleBlockSize,
+		AlwaysBlockSize: cfg.ThrottleAlwaysBlockSize,
+		ControllerType:  cfg.ThrottleControllerType,
+		Endpoints:       slices.Union(cfg.L2EthRpc, cfg.AdditionalThrottlingEndpoints),
 	}
 
 	if bs.ThrottleParams.ControllerType == config.PIDControllerType {

--- a/op-batcher/batcher/throttler/controller.go
+++ b/op-batcher/batcher/throttler/controller.go
@@ -182,9 +182,9 @@ func (f *ThrottleControllerFactory) CreateController(
 	case config.StepControllerType:
 		strategy = NewStepStrategy(throttleParams.Threshold)
 	case config.LinearControllerType:
-		strategy = NewLinearStrategy(throttleParams.Threshold, throttleParams.MaxThreshold(), f.log)
+		strategy = NewLinearStrategy(throttleParams.Threshold, throttleParams.MaxThreshold, f.log)
 	case config.QuadraticControllerType:
-		strategy = NewQuadraticStrategy(throttleParams.Threshold, throttleParams.MaxThreshold(), f.log)
+		strategy = NewQuadraticStrategy(throttleParams.Threshold, throttleParams.MaxThreshold, f.log)
 	case config.PIDControllerType:
 		log.Warn("EXPERIMENTAL FEATURE")
 		log.Warn("PID controller is an EXPERIMENTAL feature that should only be used by experts. PID controller requires deep understanding of control theory and careful tuning. Improper configuration can lead to system instability or poor performance. Use with extreme caution in production environments.")

--- a/op-batcher/batcher/throttler/controller_test.go
+++ b/op-batcher/batcher/throttler/controller_test.go
@@ -21,7 +21,7 @@ const (
 	TestAlwaysBlockSize   = 130_000 // 130KB block size limit (always enforced)
 
 	// Multiplier for gradual controllers (linear, quadratic) - defines max throttling point
-	TestThresholdMultiplier = 2.0 // 2x threshold = maximum throttling point (2MB)
+	TestMaxThreshold = 2_000_000 // 2x threshold = maximum throttling point (2MB)
 )
 
 // Test load scenarios - All relative to TestThresholdBytes for easy understanding
@@ -89,10 +89,10 @@ var (
 		return NewStepStrategy(TestThresholdBytes)
 	}
 	testLinearStrategy = func(t *testing.T) *LinearStrategy {
-		return NewLinearStrategy(TestThresholdBytes, TestThresholdMultiplier*TestThresholdBytes, newTestLogger(t))
+		return NewLinearStrategy(TestThresholdBytes, TestMaxThreshold, newTestLogger(t))
 	}
 	testQuadraticStrategy = func(t *testing.T) *QuadraticStrategy {
-		return NewQuadraticStrategy(TestThresholdBytes, TestThresholdMultiplier*TestThresholdBytes, newTestLogger(t))
+		return NewQuadraticStrategy(TestThresholdBytes, TestMaxThreshold, newTestLogger(t))
 	}
 	testPIDStrategy = func(t *testing.T) *PIDStrategy {
 		return NewPIDStrategy(TestThresholdBytes, TestPIDConfig)
@@ -178,11 +178,11 @@ func TestControllerFactory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			controller, err := factory.CreateController(
 				tt.controllerType, config.ThrottleParams{
-					Threshold:           TestThresholdBytes,
-					TxSize:              TestThrottleTxSize,
-					BlockSize:           TestThrottleBlockSize,
-					AlwaysBlockSize:     TestAlwaysBlockSize,
-					ThresholdMultiplier: TestThresholdMultiplier,
+					Threshold:       TestThresholdBytes,
+					MaxThreshold:    TestMaxThreshold,
+					TxSize:          TestThrottleTxSize,
+					BlockSize:       TestThrottleBlockSize,
+					AlwaysBlockSize: TestAlwaysBlockSize,
 				}, tt.pidConfig)
 
 			if tt.expectError {
@@ -317,11 +317,11 @@ func TestControllerTypeConsistency(t *testing.T) {
 		t.Run(string(tc.controllerType), func(t *testing.T) {
 			controller, err := factory.CreateController(
 				tc.controllerType, config.ThrottleParams{
-					Threshold:           TestThresholdBytes,
-					TxSize:              TestThrottleTxSize,
-					BlockSize:           TestThrottleBlockSize,
-					AlwaysBlockSize:     TestAlwaysBlockSize,
-					ThresholdMultiplier: TestThresholdMultiplier,
+					Threshold:       TestThresholdBytes,
+					MaxThreshold:    TestMaxThreshold,
+					TxSize:          TestThrottleTxSize,
+					BlockSize:       TestThrottleBlockSize,
+					AlwaysBlockSize: TestAlwaysBlockSize,
 				}, tc.pidConfig)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/op-batcher/config/types.go
+++ b/op-batcher/config/types.go
@@ -88,16 +88,12 @@ func (p *PIDConfig) UnmarshalJSON(data []byte) error {
 }
 
 type ThrottleParams struct {
-	Threshold           uint64
-	TxSize              uint64
-	BlockSize           uint64
-	AlwaysBlockSize     uint64
-	ThresholdMultiplier float64
-	PIDConfig           *PIDConfig
-	ControllerType      ThrottleControllerType
-	Endpoints           []string
-}
-
-func (t *ThrottleParams) MaxThreshold() uint64 {
-	return uint64(float64(t.Threshold) * t.ThresholdMultiplier)
+	Threshold       uint64
+	MaxThreshold    uint64
+	TxSize          uint64
+	BlockSize       uint64
+	AlwaysBlockSize uint64
+	PIDConfig       *PIDConfig
+	ControllerType  ThrottleControllerType
+	Endpoints       []string
 }

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -21,14 +21,17 @@ import (
 )
 
 const (
-	EnvVarPrefix          = "OP_BATCHER"
-	DefaultMaxThreshold   = 10
-	DefaultPIDSampleTime  = 2 * time.Second
-	DefaultPIDKp          = 0.33
-	DefaultPIDKi          = 0.01
-	DefaultPIDKd          = 0.05
-	DefaultPIDIntegralMax = 1000.0
-	DefaultPIDOutputMax   = 1.0
+	EnvVarPrefix = "OP_BATCHER"
+
+	// Throttling
+	DefaultThrottleThreshold    = 1_600_000 // allows for 2x (6 blobs, 1 tx) channels at ~131KB per blob
+	DefaultThrottleMaxThreshold = DefaultThrottleThreshold * 5
+	DefaultPIDSampleTime        = 2 * time.Second
+	DefaultPIDKp                = 0.33
+	DefaultPIDKi                = 0.01
+	DefaultPIDKd                = 0.05
+	DefaultPIDIntegralMax       = 1000.0
+	DefaultPIDOutputMax         = 1.0
 )
 
 func prefixEnvVars(name string) []string {
@@ -174,7 +177,7 @@ var (
 	ThrottleMaxThresholdFlag = &cli.Uint64Flag{
 		Name:    "throttle-max-threshold",
 		Usage:   "Threshold at which throttling has the maximum intensity (linear and quadratic controllers only)",
-		Value:   DefaultMaxThreshold,
+		Value:   DefaultThrottleMaxThreshold,
 		EnvVars: prefixEnvVars("THROTTLE_MAX_THRESHOLD"),
 	}
 	ThrottleTxSizeFlag = &cli.IntFlag{
@@ -202,8 +205,8 @@ var (
 	}
 	ThrottleControllerTypeFlag = &cli.StringFlag{
 		Name:    "throttle-controller-type",
-		Usage:   "Type of throttle controller to use: 'step' (default), 'linear', 'quadratic' or 'pid' (EXPERIMENTAL - use with caution)",
-		Value:   "step",
+		Usage:   "Type of throttle controller to use: 'step', 'linear', 'quadratic' (default) or 'pid' (EXPERIMENTAL - use with caution)",
+		Value:   "quadratic",
 		EnvVars: prefixEnvVars("THROTTLE_CONTROLLER_TYPE"),
 		Action: func(ctx *cli.Context, value string) error {
 			validTypes := []string{"step", "linear", "quadratic", "pid"}

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -171,6 +171,12 @@ var (
 		Value:   1_000_000,
 		EnvVars: prefixEnvVars("THROTTLE_THRESHOLD"),
 	}
+	ThrottleMaxThresholdFlag = &cli.Uint64Flag{
+		Name:    "throttle-max-threshold",
+		Usage:   "Threshold at which throttling has the maximum intensity (linear and quadratic controllers only)",
+		Value:   DefaultMaxThreshold,
+		EnvVars: prefixEnvVars("THROTTLE_MAX_THRESHOLD"),
+	}
 	ThrottleTxSizeFlag = &cli.IntFlag{
 		Name:    "throttle-tx-size",
 		Usage:   "The DA size of transactions to start throttling when we are over the throttle threshold",
@@ -275,12 +281,7 @@ var (
 		Value:   DefaultPIDSampleTime,
 		EnvVars: prefixEnvVars("THROTTLE_PID_SAMPLE_TIME"),
 	}
-	ThrottleMaxThresholdFlag = &cli.Uint64Flag{
-		Name:    "throttle-max-threshold",
-		Usage:   "Threshold at which throttling has the maximum intensity (linear and quadratic controllers only)",
-		Value:   DefaultMaxThreshold,
-		EnvVars: prefixEnvVars("THROTTLE_MAX_THRESHOLD"),
-	}
+
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -21,14 +21,14 @@ import (
 )
 
 const (
-	EnvVarPrefix                  = "OP_BATCHER"
-	DefaultPIDSampleTime          = 2 * time.Second
-	DefaultPIDKp                  = 0.33
-	DefaultPIDKi                  = 0.01
-	DefaultPIDKd                  = 0.05
-	DefaultPIDIntegralMax         = 1000.0
-	DefaultPIDOutputMax           = 1.0
-	DefaultPIDThresholdMultiplier = 2.0
+	EnvVarPrefix          = "OP_BATCHER"
+	DefaultMaxThreshold   = 10
+	DefaultPIDSampleTime  = 2 * time.Second
+	DefaultPIDKp          = 0.33
+	DefaultPIDKi          = 0.01
+	DefaultPIDKd          = 0.05
+	DefaultPIDIntegralMax = 1000.0
+	DefaultPIDOutputMax   = 1.0
 )
 
 func prefixEnvVars(name string) []string {
@@ -275,17 +275,11 @@ var (
 		Value:   DefaultPIDSampleTime,
 		EnvVars: prefixEnvVars("THROTTLE_PID_SAMPLE_TIME"),
 	}
-	ThrottleThresholdMultiplierFlag = &cli.Float64Flag{
-		Name:    "throttle-threshold-multiplier",
-		Usage:   "Multiplier for the max threshold used by linear and quadratic controllers (multiplied by base threshold)",
-		Value:   DefaultPIDThresholdMultiplier,
-		EnvVars: prefixEnvVars("THROTTLE_THRESHOLD_MULTIPLIER"),
-		Action: func(ctx *cli.Context, value float64) error {
-			if value < 1 {
-				return fmt.Errorf("throttle-threshold-multiplier must be >= 1, got %f", value)
-			}
-			return nil
-		},
+	ThrottleMaxThresholdFlag = &cli.Uint64Flag{
+		Name:    "throttle-max-threshold",
+		Usage:   "Threshold at which throttling has the maximum intensity (linear and quadratic controllers only)",
+		Value:   DefaultMaxThreshold,
+		EnvVars: prefixEnvVars("THROTTLE_MAX_THRESHOLD"),
 	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
@@ -327,7 +321,7 @@ var optionalFlags = []cli.Flag{
 	ThrottlePidIntegralMaxFlag,
 	ThrottlePidOutputMaxFlag,
 	ThrottlePidSampleTimeFlag,
-	ThrottleThresholdMultiplierFlag,
+	ThrottleMaxThresholdFlag,
 }
 
 func init() {


### PR DESCRIPTION
* replaces `ThrottleThresholdMultiplier` CLI flag with `ThrottleMaxThreshold`
* sets default params to quadratic controller, 1.6MB to 8MB range


~⚠️ stacked on https://github.com/ethereum-optimism/optimism/pull/16950~