### PR TITLE
backports/op-deployer: remove default l1-contracts-release val

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -85,7 +85,6 @@ var (
 		Name:    L1ContractsReleaseFlagName,
 		Usage:   "L1 contracts release",
 		EnvVars: deployer.PrefixEnvVar("L1_CONTRACTS_RELEASE"),
-		Value:   "dev",
 	}
 	ProtocolVersionsOwnerFlag = &cli.StringFlag{
 		Name:    ProtocolVersionsOwnerFlagName,


### PR DESCRIPTION
Removes the default `l1-contracts-release` value, which was preventing `op-deployer bootstrap implementations` from running due to cfg incompatibilities when attempting to deploy a tagged version of contract artifacts. Was hitting the following error because the cfg.L1ContractsRelease was always set to `dev` even when not set by user.
```
Application failed: failed to deploy implementations: invalid config for Implementations: l1 contracts release cannot be specified if using an artifacts tag
```