### PR TITLE
op-acceptance-tests: Disable flaky interop tests

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -19,6 +19,8 @@ import (
 type checksFunc func(t devtest.T, sys *presets.SimpleInterop)
 
 func TestL2ReorgAfterL1Reorg(gt *testing.T) {
+	gt.Skip("TODO(#16972): skipping due to flakiness and impending op-node/supervisor refactor")
+
 	gt.Run("unsafe reorg", func(gt *testing.T) {
 		var crossSafeRef, localSafeRef, unsafeRef eth.BlockID
 		pre := func(t devtest.T, sys *presets.SimpleInterop) {

--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -131,6 +131,8 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 // TestUnsafeChainKnownToL2CL tests the below scenario:
 // supervisor cross-safe ahead of L2CL cross-safe, aka L2CL can "skip" forward to match safety of supervisor.
 func TestUnsafeChainKnownToL2CL(gt *testing.T) {
+	gt.Skip("TODO(#16972): skipping due to flakiness and impending op-node/supervisor refactor")
+
 	t := devtest.SerialT(gt)
 
 	sys := presets.NewMultiSupervisorInterop(t)


### PR DESCRIPTION
These tests are causing a lot of CI flakes. After debugging them, they seem to be finding real bugs in the Supervisor/OP Node. Normally we'd fix the bugs, however since we're refactoring the OP Node and removing the Supervisor entirely this would likely be wasted work. Therefore I've skipped over these tests for now. We'll bring them back once the OP Node V2 project completes.
