### PR TITLE
op-e2e: Retry first valid tx, reset before deposit

### DIFF
--- a/op-e2e/actions/helpers/tx_helper.go
+++ b/op-e2e/actions/helpers/tx_helper.go
@@ -2,10 +2,12 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -27,23 +29,28 @@ func firstValidTx(
 	// Wait for the tx to be in the pending tx queue
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	err := wait.For(ctx, time.Second, func() (bool, error) {
+
+	err := retry.Do0(ctx, 30, retry.Fixed(time.Second), func() error {
 		i = pendingIndices(from)
 		txs, q = contentFrom(from)
 		// Remove any transactions that have already been included in the head block
 		// The tx pool only prunes included transactions async so they may still be in the list
 		nonce, err := nonceAt(ctx, from, nil)
 		if err != nil {
-			return false, err
+			return err
 		}
 		for len(txs) > 0 && txs[0].Nonce() < nonce {
 			t.Logf("Removing already included transaction from list of length %v", len(txs))
 			txs = txs[1:]
 		}
-		return uint64(len(txs)) > i, nil
+
+		if uint64(len(txs)) <= i {
+			return fmt.Errorf("no pending txs from %s, and have %d unprocessable queued txs from this account", from, len(q))
+		}
+
+		return nil
 	})
-	require.NoError(t, err,
-		"no pending txs from %s, and have %d unprocessable queued txs from this account: %w", from, len(q), err)
+	require.NoError(t, err)
 
 	return txs[i]
 }

--- a/op-e2e/actions/helpers/tx_helper.go
+++ b/op-e2e/actions/helpers/tx_helper.go
@@ -27,15 +27,19 @@ func firstValidTx(
 	var txs []*types.Transaction
 	var q []*types.Transaction
 	// Wait for the tx to be in the pending tx queue
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 31*time.Second)
 	defer cancel()
 
-	err := retry.Do0(ctx, 30, retry.Fixed(time.Second), func() error {
+	err := retry.Do0(ctx, 10, retry.Exponential(), func() error {
 		i = pendingIndices(from)
 		txs, q = contentFrom(from)
 		// Remove any transactions that have already been included in the head block
 		// The tx pool only prunes included transactions async so they may still be in the list
-		nonce, err := nonceAt(ctx, from, nil)
+
+		subCtx, subCancel := context.WithTimeout(ctx, time.Second)
+		defer subCancel()
+
+		nonce, err := nonceAt(subCtx, from, nil)
 		if err != nil {
 			return err
 		}

--- a/op-e2e/actions/helpers/user_test.go
+++ b/op-e2e/actions/helpers/user_test.go
@@ -263,6 +263,7 @@ func runCrossLayerUserTest(gt *testing.T, test hardforkScheduledTest) {
 	alice.L1.ActCheckReceiptStatusOfLastTx(true)(t)
 
 	// regular Deposit, in new L1 block
+	alice.L1.ActResetTxOpts(t)
 	alice.ActDeposit(t)
 	miner.ActL1StartBlock(12)(t)
 	miner.ActL1IncludeTx(alice.Address())(t)


### PR DESCRIPTION
Calls to the ethclient were failing on CI. My hypothesis is that this is related to system load: the RPC client is fully in-memory, so some upstream service was failing to respond before the client's write deadline.

I also updated the action test to reset the transaction data before the withdrawal; this was leading to `nonce too low` errors sometimes.