### PR TITLE
Use the name but not rawName when translate the same method names but with different parameters.

### DIFF
--- a/op-chain-ops/script/deploy.go
+++ b/op-chain-ops/script/deploy.go
@@ -132,18 +132,34 @@ func NewDeployScriptWithOutput[I any, O any](script ForgeScript, methodName stri
 func newDeployScriptWithoutOutput[I any](script ForgeScript, methodName string) (*deployScriptWithoutOutputImpl[I], error) {
 	// Just to keep things DRY a bit
 	scriptName := script.Name()
-
-	// Make sure the method exists on the ABI
-	method, ok := script.ABI().Methods[methodName]
-	if !ok {
-		return nil, fmt.Errorf("script %s does not have a method called %s", scriptName, methodName)
-	}
-
-	// Now make sure the ABI has exactly one argument of the correct type
 	inputType := reflect.TypeOf(*new(I))
-	err := matchArguments(method.Inputs, inputType)
+
+	var (
+		method abi.Method
+		name   = methodName
+		err    error
+	)
+	for i := 0; ; i++ {
+		// Make sure the method exists on the ABI
+		var ok bool
+		method, ok = script.ABI().Methods[name]
+		if !ok {
+			if err == nil {
+				err = fmt.Errorf("script %s does not have a method called %s", scriptName, methodName)
+			}
+			break
+		}
+
+		// Now make sure the ABI has exactly one argument of the correct type
+		mErr := matchArguments(method.Inputs, inputType)
+		if mErr == nil {
+			break
+		}
+		err = fmt.Errorf("script %s does not have a method %s that accepts an argument of type %v: %w", scriptName, name, inputType, mErr)
+		name = fmt.Sprintf("%v%d", methodName, i)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("script %s does not have a method %s that accepts an argument of type %v: %w", scriptName, methodName, inputType, err)
+		return nil, err
 	}
 
 	// Then after all that we're good to create the script
@@ -297,7 +313,7 @@ func (d *deployScriptWithoutOutputImpl[I]) Name() string {
 func (d *deployScriptWithoutOutputImpl[I]) run(input I) (result []byte, err error) {
 	// Just to keep things DRY a tiny bit
 	scriptName := d.Name()
-	methodName := d.method.RawName
+	methodName := d.method.Name
 
 	packed, err := d.ABI().Pack(methodName, input)
 	if err != nil {
@@ -331,7 +347,7 @@ type deployScriptWithOutputImpl[I any, O any] struct {
 func (d *deployScriptWithOutputImpl[I, O]) Run(input I) (output O, err error) {
 	// Just to keep things DRY a tiny bit
 	scriptName := d.Name()
-	methodName := d.method.RawName
+	methodName := d.method.Name
 
 	// We use the run to get the raw output of the contract call
 	result, err := d.deployScriptWithoutOutputImpl.run(input)

--- a/op-chain-ops/script/deploy.go
+++ b/op-chain-ops/script/deploy.go
@@ -153,6 +153,7 @@ func newDeployScriptWithoutOutput[I any](script ForgeScript, methodName string) 
 		// Now make sure the ABI has exactly one argument of the correct type
 		mErr := matchArguments(method.Inputs, inputType)
 		if mErr == nil {
+			err = nil
 			break
 		}
 		err = fmt.Errorf("script %s does not have a method %s that accepts an argument of type %v: %w", scriptName, name, inputType, mErr)

--- a/op-chain-ops/script/deploy_test.go
+++ b/op-chain-ops/script/deploy_test.go
@@ -292,7 +292,7 @@ func TestDeployScriptWithoutOutputImpl(t *testing.T) {
 		script := &mockForgeScript{
 			abi: abi.ABI{
 				Methods: map[string]abi.Method{
-					"run": abi.NewMethod("Run", "run", abi.Function, "", false, false, []abi.Argument{
+					"run": abi.NewMethod("run", "run", abi.Function, "", false, false, []abi.Argument{
 						{
 							Name: "_input",
 							Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),
@@ -334,7 +334,7 @@ func TestDeployScriptWithOutputImpl(t *testing.T) {
 		script := &mockForgeScript{
 			abi: abi.ABI{
 				Methods: map[string]abi.Method{
-					"run": abi.NewMethod("Run", "run", abi.Function, "", false, false, []abi.Argument{
+					"run": abi.NewMethod("run", "run", abi.Function, "", false, false, []abi.Argument{
 						{
 							Name: "_input",
 							Type: die(abi.NewType("uint256", "", []abi.ArgumentMarshaling{})),


### PR DESCRIPTION
The bugs appear in the condition, translate the same method names, but with different parameters:
1. Enhance `newDeployScriptWithoutOutput` by scanning all the same methods.
3. Choice `method.name` as the `Pack` method's parameter, but not rawname.
4. Don't need to add the unnecessary `Run name` and `run rawName` test cases, because the `abi sdk` translates the original name.