### PR TITLE
op-batcher: implement channel close reason metric mapping

### DIFF
--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -1,7 +1,9 @@
 package metrics
 
 import (
+	"errors"
 	"io"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -412,8 +414,49 @@ func (m *Metrics) RecordL2BlockInChannel(block *types.Block) {
 }
 
 func ClosedReasonToNum(reason error) int {
-	// CLI-3640
-	return 0
+	// Numerical encoding of channel close reasons for Prometheus gauge.
+	// 0 is reserved for unknown/other to preserve backward compatibility.
+	const (
+		closedReasonUnknown          = 0
+		closedReasonCompressorFull   = 1
+		closedReasonTooManyRLPBytes  = 2
+		closedReasonMaxFrameIndex    = 3
+		closedReasonMaxDuration      = 4
+		closedReasonChannelTimeout   = 5
+		closedReasonSeqWindowTimeout = 6
+		closedReasonTerminated       = 7
+	)
+
+	if reason == nil {
+		return closedReasonUnknown
+	}
+
+	// Prefer robust sentinel checks where available.
+	if errors.Is(reason, derive.ErrCompressorFull) {
+		return closedReasonCompressorFull
+	}
+	if errors.Is(reason, derive.ErrTooManyRLPBytes) {
+		return closedReasonTooManyRLPBytes
+	}
+
+	// The remaining reasons are defined in the batcher package and are not exported here to avoid
+	// import cycles. We conservatively match on well-defined error messages as a best-effort mapping.
+	// ChannelFullError prefixes with "channel full: ", so we do substring matching on lower-cased text.
+	msg := strings.ToLower(reason.Error())
+	switch {
+	case strings.Contains(msg, "max frame index"):
+		return closedReasonMaxFrameIndex
+	case strings.Contains(msg, "max channel duration reached"):
+		return closedReasonMaxDuration
+	case strings.Contains(msg, "close to channel timeout"):
+		return closedReasonChannelTimeout
+	case strings.Contains(msg, "close to sequencer window timeout"):
+		return closedReasonSeqWindowTimeout
+	case strings.Contains(msg, "channel terminated"):
+		return closedReasonTerminated
+	default:
+		return closedReasonUnknown
+	}
 }
 
 func (m *Metrics) RecordChannelFullySubmitted(id derive.ChannelID) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This pull request addresses an issue where the channel_closed_reason metric was consistently recorded as 0. To provide immediate insight into why a channel was closed directly from the operational dashboard, I've added a mapping for closure reasons in ClosedReasonToNum.

The new mappings are as follows:
- compressor full → 1
- too many RLP bytes → 2
- max frame index → 3
- max channel duration reached → 4
- close to channel timeout → 5
- close to sequencer window timeout → 6
- channel terminated → 7
- unknown/other → 0

- derive.ErrCompressorFull and derive.ErrTooManyRLPBytes are precisely matched using errors.Is.
- Due to the nature of ChannelFullError's message prefix, internal batcher reasons (frame index/timeout/termination) are matched using safe substring matching based on the message content.
- unknown=0 is maintained for backward compatibility.

**Tests**

I have confirmed that all tests in go test ./op-batcher/... pass successfully.

**Additional context**

This change enhances observability by clearly indicating the specific reason for a channel's closure, which was previously not possible as the reason was always logged as a generic 0.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
