### PR TITLE
op-devstack: Use tcpproxy in more places

### DIFF
--- a/op-devstack/sysgo/control_plane_test.go
+++ b/op-devstack/sysgo/control_plane_test.go
@@ -3,7 +3,6 @@ package sysgo
 import (
 	"context"
 	"errors"
-	"syscall"
 	"testing"
 	"time"
 
@@ -81,7 +80,7 @@ func testSupervisorRestart(ids DefaultInteropSystemIDs, system stack.System, con
 			return supervisor.QueryAPI().SyncStatus(ctx)
 		})
 		cancel()
-		require.True(t, errors.Is(err, syscall.ECONNREFUSED))
+		require.Error(t, err)
 	}
 
 	// restart supervisor
@@ -126,7 +125,7 @@ func testL2CLRestart(ids DefaultInteropSystemIDs, system stack.System, control s
 			return seqA.RollupAPI().SyncStatus(ctx)
 		})
 		cancel()
-		require.True(t, errors.Is(err, syscall.ECONNREFUSED))
+		require.Error(t, err)
 	}
 
 	// restart L2CL

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -83,7 +83,7 @@ func (n *L2CLNode) Start() {
 	}
 
 	if n.userProxy == nil {
-		n.userProxy = tcpproxy.New(n.logger)
+		n.userProxy = tcpproxy.New(n.logger.New("proxy", "l2cl-user"))
 		n.p.Require().NoError(n.userProxy.Start())
 		n.p.Cleanup(func() {
 			n.userProxy.Close()
@@ -92,12 +92,12 @@ func (n *L2CLNode) Start() {
 	}
 
 	if n.interopProxy == nil {
-		n.interopProxy = tcpproxy.New(n.logger)
+		n.interopProxy = tcpproxy.New(n.logger.New("proxy", "l2cl-interop"))
 		n.p.Require().NoError(n.interopProxy.Start())
 		n.p.Cleanup(func() {
 			n.interopProxy.Close()
 		})
-		n.interopEndpoint = "http://" + n.interopProxy.Addr()
+		n.interopEndpoint = "ws://" + n.interopProxy.Addr()
 	}
 
 	n.logger.Info("Starting op-node")
@@ -110,7 +110,6 @@ func (n *L2CLNode) Start() {
 	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), opNode.UserRPC().RPC()))
 	interopEndpoint, interopJwtSecret := opNode.InteropRPC()
 	n.interopProxy.SetUpstream(ProxyAddr(n.p.Require(), interopEndpoint))
-	n.interopEndpoint = interopEndpoint
 	n.interopJwtSecret = interopJwtSecret
 }
 

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -129,6 +129,12 @@ func (n *L2CLNode) Stop() {
 	n.opNode = nil
 }
 
+func (n *L2CLNode) InteropRPC() (string, eth.Bytes32) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.interopEndpoint, n.interopJwtSecret
+}
+
 type L2CLOption func(p devtest.P, id stack.L2CLNodeID, cfg *config.Config)
 
 func WithL2CLOption(opt L2CLOption) stack.Option[*Orchestrator] {

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
+
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -48,6 +50,8 @@ type L2CLNode struct {
 	p                devtest.P
 	logger           log.Logger
 	el               stack.L2ELNodeID
+	userProxy        *tcpproxy.Proxy
+	interopProxy     *tcpproxy.Proxy
 }
 
 var _ stack.Lifecycle = (*L2CLNode)(nil)
@@ -70,20 +74,6 @@ func (n *L2CLNode) hydrate(system stack.ExtensibleSystem) {
 	sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
 }
 
-func (n *L2CLNode) rememberPort() {
-	userRPCPort, err := n.opNode.UserRPCPort()
-	n.p.Require().NoError(err)
-	n.cfg.RPC.ListenPort = userRPCPort
-
-	cfg, ok := n.cfg.InteropConfig.(*interop.Config)
-	n.p.Require().True(ok)
-
-	if interopRPCPort, err := n.opNode.InteropRPCPort(); err == nil {
-		cfg.RPCPort = interopRPCPort
-	}
-	n.cfg.InteropConfig = cfg
-}
-
 func (n *L2CLNode) Start() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -91,6 +81,25 @@ func (n *L2CLNode) Start() {
 		n.logger.Warn("Op-node already started")
 		return
 	}
+
+	if n.userProxy == nil {
+		n.userProxy = tcpproxy.New(n.logger)
+		n.p.Require().NoError(n.userProxy.Start())
+		n.p.Cleanup(func() {
+			n.userProxy.Close()
+		})
+		n.userRPC = "http://" + n.userProxy.Addr()
+	}
+
+	if n.interopProxy == nil {
+		n.interopProxy = tcpproxy.New(n.logger)
+		n.p.Require().NoError(n.interopProxy.Start())
+		n.p.Cleanup(func() {
+			n.interopProxy.Close()
+		})
+		n.interopEndpoint = "http://" + n.interopProxy.Addr()
+	}
+
 	n.logger.Info("Starting op-node")
 	opNode, err := opnode.NewOpnode(n.logger, n.cfg, func(err error) {
 		n.p.Require().NoError(err, "op-node critical error")
@@ -98,15 +107,11 @@ func (n *L2CLNode) Start() {
 	n.p.Require().NoError(err, "op-node failed to start")
 	n.logger.Info("Started op-node")
 	n.opNode = opNode
-
-	// store endpoints to reuse when restart
-	n.userRPC = opNode.UserRPC().RPC()
+	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), opNode.UserRPC().RPC()))
 	interopEndpoint, interopJwtSecret := opNode.InteropRPC()
+	n.interopProxy.SetUpstream(ProxyAddr(n.p.Require(), interopEndpoint))
 	n.interopEndpoint = interopEndpoint
 	n.interopJwtSecret = interopJwtSecret
-	// for p2p endpoints / node keys, they are already persistent, stored at p2p configs
-
-	n.rememberPort()
 }
 
 func (n *L2CLNode) Stop() {

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -71,7 +71,7 @@ func (n *L2ELNode) Start() {
 	}
 
 	if n.authProxy == nil {
-		n.authProxy = tcpproxy.New(n.logger)
+		n.authProxy = tcpproxy.New(n.logger.New("proxy", "l2el-auth"))
 		n.p.Require().NoError(n.authProxy.Start())
 		n.p.Cleanup(func() {
 			n.authProxy.Close()
@@ -79,7 +79,7 @@ func (n *L2ELNode) Start() {
 		n.authRPC = "ws://" + n.authProxy.Addr()
 	}
 	if n.userProxy == nil {
-		n.userProxy = tcpproxy.New(n.logger)
+		n.userProxy = tcpproxy.New(n.logger.New("proxy", "l2el-user"))
 		n.p.Require().NoError(n.userProxy.Start())
 		n.p.Cleanup(func() {
 			n.userProxy.Close()

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -102,8 +102,8 @@ func (n *L2ELNode) Start() {
 	require.NoError(err)
 	require.NoError(l2Geth.Node.Start())
 	n.l2Geth = l2Geth
-	n.authProxy.SetUpstream(proxyAddr(require, l2Geth.AuthRPC().RPC()))
-	n.userProxy.SetUpstream(proxyAddr(require, l2Geth.UserRPC().RPC()))
+	n.authProxy.SetUpstream(ProxyAddr(require, l2Geth.AuthRPC().RPC()))
+	n.userProxy.SetUpstream(ProxyAddr(require, l2Geth.UserRPC().RPC()))
 }
 
 func (n *L2ELNode) Stop() {
@@ -119,7 +119,7 @@ func (n *L2ELNode) Stop() {
 	n.l2Geth = nil
 }
 
-func proxyAddr(require *testreq.Assertions, urlStr string) string {
+func ProxyAddr(require *testreq.Assertions, urlStr string) string {
 	u, err := url.Parse(urlStr)
 	require.NoError(err)
 	return net.JoinHostPort(u.Hostname(), u.Port())

--- a/op-devstack/sysgo/supervisor.go
+++ b/op-devstack/sysgo/supervisor.go
@@ -161,7 +161,7 @@ func WithManagedBySupervisor(l2CLID stack.L2CLNodeID, supervisorID stack.Supervi
 
 		l2CL, ok := orch.l2CLs.Get(l2CLID)
 		require.True(ok, "looking for L2 CL node to connect to supervisor")
-		interopEndpoint, secret := l2CL.opNode.InteropRPC()
+		interopEndpoint, secret := l2CL.InteropRPC()
 
 		s, ok := orch.supervisors.Get(supervisorID)
 		require.True(ok, "looking for supervisor")

--- a/op-devstack/sysgo/supervisor.go
+++ b/op-devstack/sysgo/supervisor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -32,6 +34,8 @@ type Supervisor struct {
 	logger log.Logger
 
 	service *supervisor.SupervisorService
+
+	proxy *tcpproxy.Proxy
 }
 
 var _ stack.Lifecycle = (*Supervisor)(nil)
@@ -49,12 +53,6 @@ func (s *Supervisor) hydrate(sys stack.ExtensibleSystem) {
 	}))
 }
 
-func (s *Supervisor) rememberPort() {
-	port, err := s.service.Port()
-	s.p.Require().NoError(err)
-	s.cfg.RPC.ListenPort = port
-}
-
 func (s *Supervisor) Start() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -62,6 +60,16 @@ func (s *Supervisor) Start() {
 		s.logger.Warn("Supervisor already started")
 		return
 	}
+
+	if s.proxy == nil {
+		s.proxy = tcpproxy.New(s.logger)
+		s.p.Require().NoError(s.proxy.Start())
+		s.p.Cleanup(func() {
+			s.proxy.Close()
+		})
+		s.userRPC = "http://" + s.proxy.Addr()
+	}
+
 	super, err := supervisor.SupervisorFromConfig(context.Background(), s.cfg, s.logger)
 	s.p.Require().NoError(err)
 
@@ -70,10 +78,7 @@ func (s *Supervisor) Start() {
 	err = super.Start(context.Background())
 	s.p.Require().NoError(err, "supervisor failed to start")
 	s.logger.Info("Started supervisor")
-
-	s.userRPC = super.RPC()
-
-	s.rememberPort()
+	s.proxy.SetUpstream(ProxyAddr(s.p.Require(), s.userRPC))
 }
 
 func (s *Supervisor) Stop() {

--- a/op-devstack/sysgo/supervisor.go
+++ b/op-devstack/sysgo/supervisor.go
@@ -62,7 +62,7 @@ func (s *Supervisor) Start() {
 	}
 
 	if s.proxy == nil {
-		s.proxy = tcpproxy.New(s.logger)
+		s.proxy = tcpproxy.New(s.logger.New("proxy", "supervisor"))
 		s.p.Require().NoError(s.proxy.Start())
 		s.p.Cleanup(func() {
 			s.proxy.Close()
@@ -78,7 +78,7 @@ func (s *Supervisor) Start() {
 	err = super.Start(context.Background())
 	s.p.Require().NoError(err, "supervisor failed to start")
 	s.logger.Info("Started supervisor")
-	s.proxy.SetUpstream(ProxyAddr(s.p.Require(), s.userRPC))
+	s.proxy.SetUpstream(ProxyAddr(s.p.Require(), super.RPC()))
 }
 
 func (s *Supervisor) Stop() {

--- a/op-service/testutils/tcpproxy/proxy.go
+++ b/op-service/testutils/tcpproxy/proxy.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"io"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 
 	"github.com/ethereum/go-ethereum/log"
 )

--- a/op-service/testutils/tcpproxy/proxy.go
+++ b/op-service/testutils/tcpproxy/proxy.go
@@ -1,11 +1,15 @@
 package tcpproxy
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"io"
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -34,6 +38,7 @@ func (p *Proxy) Addr() string {
 func (p *Proxy) SetUpstream(addr string) {
 	p.mu.Lock()
 	p.upstreamAddr = addr
+	p.lgr.Info("set upstream", "addr", addr)
 	p.mu.Unlock()
 }
 
@@ -50,10 +55,10 @@ func (p *Proxy) Start() error {
 
 		for {
 			downConn, err := p.lis.Accept()
+			if p.stopped.Load() {
+				return
+			}
 			if err != nil {
-				if p.stopped.Load() {
-					return
-				}
 				p.lgr.Error("failed to accept downstream", "err", err)
 				continue
 			}
@@ -80,7 +85,11 @@ func (p *Proxy) handleConn(downConn net.Conn) {
 		return
 	}
 
-	upConn, err := net.Dial("tcp", addr)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	upConn, err := retry.Do(ctx, 3, retry.Exponential(), func() (net.Conn, error) {
+		return net.Dial("tcp", addr)
+	})
+	cancel()
 	if err != nil {
 		p.mu.Unlock()
 		p.lgr.Error("failed to dial upstream", "err", err)
@@ -93,10 +102,20 @@ func (p *Proxy) handleConn(downConn net.Conn) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
+
+	closeBoth := func() {
+		downConn.Close()
+		upConn.Close()
+		wg.Done()
+	}
+
 	pump := func(dst io.Writer, src io.Reader, direction string) {
-		defer wg.Done()
+		defer closeBoth()
 		if _, err := io.Copy(dst, src); err != nil {
-			p.lgr.Error("failed to proxy", "direction", direction, "err", err)
+			// ignore net.ErrClosed since it creates a huge amount of log spam
+			if !errors.Is(err, net.ErrClosed) {
+				p.lgr.Error("failed to proxy", "direction", direction, "err", err)
+			}
 		}
 	}
 	go pump(downConn, upConn, "downstream")


### PR DESCRIPTION
I found a few more services which weren't using tcpproxy to preserve port assignments across service restarts. This was causing some flakiness in CI.
