### PR TITLE
op-batcher: better to use builtin functions max/min

### DIFF
--- a/op-batcher/batcher/throttler/pid_strategy.go
+++ b/op-batcher/batcher/throttler/pid_strategy.go
@@ -1,7 +1,6 @@
 package throttler
 
 import (
-	"math"
 	"sync"
 	"time"
 
@@ -118,7 +117,7 @@ func (p *PIDStrategy) Update(currentPendingBytes uint64) float64 {
 		pidOutput := proportional + integralTerm + derivativeTerm
 
 		// Clamp output to valid range [0, OutputMax]
-		intensity = math.Max(0, math.Min(p.config.OutputMax, pidOutput))
+		intensity = max(0, min(p.config.OutputMax, pidOutput))
 
 		p.lastError = normalizedError
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Replace math.Max/math.Min with max/min because:

Works with any ordered type
No type casts or precision loss
Cleaner, shorter code
Faster (intrinsic, no NaN overhead)
No math import needed
Use math.Max/math.Min only if you need strict IEEE-754 NaN semantics.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
