### PR TITLE
Fix HTTP response body leak in etherscan verification polling

### DIFF
--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -175,10 +175,12 @@ func (c *EtherscanClient) pollVerificationStatus(reqId string) error {
 		if err != nil {
 			return fmt.Errorf("failed to send checkverifystatus request: %w", err)
 		}
-		defer resp.Body.Close()
 
 		var result EtherscanGenericResp
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			return fmt.Errorf("failed to decode checkverifystatus response: %w", decodeErr)
 			return fmt.Errorf("failed to decode checkverifystatus response: %w", err)
 		}
 


### PR DESCRIPTION


## Description
```markdown
## Summary
Fixes a resource leak in `pollVerificationStatus` where HTTP response bodies were not properly closed within the polling loop.

## Changes
- **Removed** `defer resp.Body.Close()` from inside the loop
- **Added** immediate `resp.Body.Close()` after response decoding
- **Improved** error handling for JSON decoding

## Why
Using `defer` inside a loop delays resource cleanup until function exit, potentially causing:
- Connection pool exhaustion
- Memory leaks during long polling operations
- Reduced connection reuse efficiency

```

