### PR TITLE
fix go release op up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2066,9 +2066,9 @@ workflows:
           module: op-up
           context:
             - oplabs-gcr-release
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
-
   release:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2050,6 +2050,7 @@ workflows:
           module: op-deployer
           context:
             - oplabs-gcr-release
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request makes a minor update to the CircleCI configuration. It adds an additional context to the `op-up` module to provide a read-only authenticated GitHub token during the workflow execution. 

- CircleCI configuration:
  * [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R2069-L2071): Added the `circleci-repo-readonly-authenticated-github-token` context to the `op-up` module to enable authenticated, read-only GitHub access during CI workflows.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
