### PR TITLE
devtest: cancel package-wide context in Close

### DIFF
--- a/op-devstack/devtest/package.go
+++ b/op-devstack/devtest/package.go
@@ -184,6 +184,8 @@ func (t *implP) Require() *testreq.Assertions {
 // even continuing to clean up when panics happen.
 // It does not recover the go-routine from panicking however, that is up to the caller.
 func (t *implP) Close() {
+	// Cancel the package-wide context before running cleanups
+	t.cancel()
 	// run remaining cleanups, even if a cleanup panics,
 	// but don't recover the panic
 	defer func() {


### PR DESCRIPTION
Call t.cancel() at the start of implP.Close() to cancel the package-wide context as documented.
Aligns behavior with comments and prevents potential context/goroutine leaks.
Change is idempotent and does not alter other behavior.