### PR TITLE
Remove event for FinalizeL1Event

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -376,11 +376,8 @@ func (s *L2Verifier) ActL1SafeSignal(t Testing) {
 func (s *L2Verifier) ActL1FinalizedSignal(t Testing) {
 	finalized, err := s.l1.L1BlockRefByLabel(t.Ctx(), eth.Finalized)
 	require.NoError(t, err)
-	s.synchronousEvents.Emit(t.Ctx(), finality.FinalizeL1Event{FinalizedL1: finalized})
-	require.NoError(t, s.drainer.DrainUntil(func(ev event.Event) bool {
-		x, ok := ev.(finality.FinalizeL1Event)
-		return ok && x.FinalizedL1 == finalized
-	}, false))
+	s.syncStatus.OnL1Finalized(finalized)
+	s.syncDeriver.OnL1Finalized(t.Ctx())
 	require.Equal(t, finalized, s.syncStatus.SyncStatus().FinalizedL1)
 }
 

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -66,6 +66,7 @@ type L2Verifier struct {
 	derivationMetrics *testutils.TestDerivationMetrics
 	derivation        *derive.DerivationPipeline
 	syncDeriver       *driver.SyncDeriver
+	finalizer         driver.Finalizer
 
 	safeHeadListener rollup.SafeHeadListener
 	syncCfg          *sync.Config
@@ -201,6 +202,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		derivationMetrics: metrics,
 		derivation:        pipeline,
 		syncDeriver:       syncDeriver,
+		finalizer:         finalizer,
 		safeHeadListener:  safeHeadListener,
 		syncCfg:           syncCfg,
 		drainer:           executor,
@@ -377,6 +379,7 @@ func (s *L2Verifier) ActL1FinalizedSignal(t Testing) {
 	finalized, err := s.l1.L1BlockRefByLabel(t.Ctx(), eth.Finalized)
 	require.NoError(t, err)
 	s.syncStatus.OnL1Finalized(finalized)
+	s.finalizer.OnL1Finalized(finalized)
 	s.syncDeriver.OnL1Finalized(t.Ctx())
 	require.Equal(t, finalized, s.syncStatus.SyncStatus().FinalizedL1)
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -103,6 +103,7 @@ type AttributesHandler interface {
 
 type Finalizer interface {
 	FinalizedL1() eth.L1BlockRef
+	OnL1Finalized(x eth.L1BlockRef)
 	event.Deriver
 }
 
@@ -121,6 +122,7 @@ type SyncStatusTracker interface {
 	L1Head() eth.L1BlockRef
 	OnL1Unsafe(x eth.L1BlockRef)
 	OnL1Safe(x eth.L1BlockRef)
+	OnL1Finalized(x eth.L1BlockRef)
 }
 
 type Network interface {
@@ -254,6 +256,7 @@ func NewDriver(
 	driverEmitter := sys.Register("driver", nil)
 	driver := &Driver{
 		StatusTracker: statusTracker,
+		Finalizer:     finalizer,
 		SyncDeriver:   syncDeriver,
 		sched:         schedDeriv,
 		emitter:       driverEmitter,

--- a/op-node/rollup/finality/altda.go
+++ b/op-node/rollup/finality/altda.go
@@ -37,7 +37,7 @@ func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config,
 	// Finality signal will come from the DA contract or L1 finality whichever is last.
 	// The AltDA module will then call the inner.Finalize function when applicable.
 	backend.OnFinalizedHeadSignal(func(ref eth.L1BlockRef) {
-		inner.OnEvent(ctx, FinalizeL1Event{FinalizedL1: ref})
+		inner.OnL1Finalized(ref)
 	})
 
 	return &AltDAFinalizer{
@@ -47,11 +47,11 @@ func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config,
 }
 
 func (fi *AltDAFinalizer) OnEvent(ctx context.Context, ev event.Event) bool {
-	switch x := ev.(type) {
-	case FinalizeL1Event:
-		fi.backend.Finalize(x.FinalizedL1)
-		return true
-	default:
-		return fi.Finalizer.OnEvent(ctx, ev)
-	}
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  FinalizeL1Event is removed and OnL1Finalized is synchronously called at L1Handler
+	return fi.Finalizer.OnEvent(ctx, ev)
+}
+
+func (fi *AltDAFinalizer) OnL1Finalized(l1Origin eth.L1BlockRef) {
+	fi.backend.Finalize(l1Origin)
 }

--- a/op-node/rollup/finality/altda_test.go
+++ b/op-node/rollup/finality/altda_test.go
@@ -110,7 +110,7 @@ func TestAltDAFinalityData(t *testing.T) {
 	// and post processing.
 	for i := uint64(0); i < 200; i++ {
 		if i == 10 { // finalize a L1 commitment
-			fi.OnEvent(context.Background(), FinalizeL1Event{FinalizedL1: l1parent})
+			fi.OnL1Finalized(l1parent)
 			emitter.AssertExpectations(t) // no events emitted upon L1 finality
 			require.Equal(t, l1parent, commitmentInclusionFinalized, "altda backend received L1 signal")
 		}

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -123,14 +123,6 @@ func (fi *Finalizer) FinalizedL1() (out eth.L1BlockRef) {
 	return
 }
 
-type FinalizeL1Event struct {
-	FinalizedL1 eth.L1BlockRef
-}
-
-func (ev FinalizeL1Event) String() string {
-	return "finalized-l1"
-}
-
 type TryFinalizeEvent struct {
 }
 
@@ -139,9 +131,9 @@ func (ev TryFinalizeEvent) String() string {
 }
 
 func (fi *Finalizer) OnEvent(ctx context.Context, ev event.Event) bool {
+	// TODO(#16917) Remove Event System Refactor Comments
+	//  FinalizeL1Event is removed and OnL1Finalized is synchronously called at L1Handler
 	switch x := ev.(type) {
-	case FinalizeL1Event:
-		fi.onL1Finalized(x.FinalizedL1)
 	case engine.SafeDerivedEvent:
 		fi.onDerivedSafeBlock(x.Safe, x.Source)
 	case derive.DeriverIdleEvent:
@@ -159,7 +151,7 @@ func (fi *Finalizer) OnEvent(ctx context.Context, ev event.Event) bool {
 }
 
 // onL1Finalized applies a L1 finality signal
-func (fi *Finalizer) onL1Finalized(l1Origin eth.L1BlockRef) {
+func (fi *Finalizer) OnL1Finalized(l1Origin eth.L1BlockRef) {
 	fi.mu.Lock()
 	defer fi.mu.Unlock()
 	prevFinalizedL1 := fi.finalizedL1

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -208,6 +208,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		// Let's finalize D from which we fully derived C1, but not D0
 		// This will trigger an attempt of L2 finalization.
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refD)
 
 		// C1 was included in finalized D, and should now be finalized
@@ -240,6 +241,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// let's finalize D from which we fully derived C1, but not D0
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refD)
 		// C1 was included in finalized D, but finality could not be verified yet, due to temporary test error
 		emitter.ExpectOnceType("L1TemporaryErrorEvent")
@@ -276,6 +278,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// L1 finality signal will trigger L2 finality attempt
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refD)
 
 		// C1 was included in D, and should be finalized now
@@ -287,6 +290,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		l1F.AssertExpectations(t)
 
 		// Another L1 finality event, trigger L2 finality attempt again
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refE)
 
 		// D0 was included in E, and should be finalized now
@@ -323,6 +327,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// Now L1 block H is actually finalized, and we can proceed with another attempt
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refH)
 
 		// F1 should be finalized now, since it was included in H
@@ -358,6 +363,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// let's finalize D, from which we fully derived B1, but not C0 (referenced L1 origin in L2 block != inclusion of L2 block in L1 chain)
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refD)
 
 		// B1 was included in finalized D, and should now be finalized
@@ -418,6 +424,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		// The finality signal was for a new chain, while derivation is on an old stale chain.
 		// It should be detected that C0Alt and C1Alt cannot actually be finalized,
 		// even though they are older than the latest finality signal.
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refF)
 
 		// cannot verify refC0Alt and refC1Alt, and refB1 is older and not checked
@@ -483,6 +490,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(ctx, derive.DeriverIdleEvent{Origin: refD})
 		emitter.AssertExpectations(t)
 
+		emitter.ExpectOnce(TryFinalizeEvent{})
 		fi.OnL1Finalized(refD)
 
 		// C1 was Interop, C0 was not yet interop and can be finalized

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -208,9 +208,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		// Let's finalize D from which we fully derived C1, but not D0
 		// This will trigger an attempt of L2 finalization.
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refD})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refD)
 
 		// C1 was included in finalized D, and should now be finalized
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refC1})
@@ -242,9 +240,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// let's finalize D from which we fully derived C1, but not D0
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refD})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refD)
 		// C1 was included in finalized D, but finality could not be verified yet, due to temporary test error
 		emitter.ExpectOnceType("L1TemporaryErrorEvent")
 		fi.OnEvent(ctx, TryFinalizeEvent{})
@@ -280,9 +276,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// L1 finality signal will trigger L2 finality attempt
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refD})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refD)
 
 		// C1 was included in D, and should be finalized now
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refC1})
@@ -293,9 +287,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		l1F.AssertExpectations(t)
 
 		// Another L1 finality event, trigger L2 finality attempt again
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refE})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refE)
 
 		// D0 was included in E, and should be finalized now
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refD0})
@@ -331,9 +323,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// Now L1 block H is actually finalized, and we can proceed with another attempt
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refH})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refH)
 
 		// F1 should be finalized now, since it was included in H
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refF1})
@@ -368,9 +358,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 
 		// let's finalize D, from which we fully derived B1, but not C0 (referenced L1 origin in L2 block != inclusion of L2 block in L1 chain)
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refD})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refD)
 
 		// B1 was included in finalized D, and should now be finalized
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refB1})
@@ -430,9 +418,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		// The finality signal was for a new chain, while derivation is on an old stale chain.
 		// It should be detected that C0Alt and C1Alt cannot actually be finalized,
 		// even though they are older than the latest finality signal.
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refF})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refF)
+
 		// cannot verify refC0Alt and refC1Alt, and refB1 is older and not checked
 		emitter.ExpectOnceType("ResetEvent")
 		fi.OnEvent(ctx, TryFinalizeEvent{})
@@ -496,9 +483,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(ctx, derive.DeriverIdleEvent{Origin: refD})
 		emitter.AssertExpectations(t)
 
-		emitter.ExpectOnce(TryFinalizeEvent{})
-		fi.OnEvent(ctx, FinalizeL1Event{FinalizedL1: refD})
-		emitter.AssertExpectations(t)
+		fi.OnL1Finalized(refD)
 
 		// C1 was Interop, C0 was not yet interop and can be finalized
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refC0})


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes `FinalizeL1Event` to a procedural call.

**Key Changes**

When new L1 finalized block is detected, it spans out the new finalized L1 block to `syncStatus`, `finalizer`, `syncDeriver`.

Based on this, we remove the `l1-signals` eventSys at the node which originally tracked all the L1 info and routed via events.

**Tests**

All existing tests are passing.