### PR TITLE
VerifyOPCM spearbit review fixes

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -517,12 +517,9 @@ contract VerifyOPCM is Script {
                 continue;
             }
 
-            // This getter should be verified via environment variable
-            string memory envVarName = verificationMethod;
-
             // Get expected address from environment variable
             // nosemgrep: sol-style-vm-env-only-in-config-sol
-            address expectedAddress = vm.envAddress(envVarName);
+            address expectedAddress = vm.envAddress(verificationMethod);
 
             // Call the function to retrieve the actual address
             // nosemgrep: sol-style-use-abi-encodecall

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -509,7 +509,8 @@ contract VerifyOPCM is Script {
             // All getters must be accounted for in expectedGetters mapping
             if (bytes(verificationMethod).length == 0) {
                 console.log("ERROR: Getter '%s' is not accounted for in expectedGetters mapping", functionName);
-                return false;
+                success = false;
+                continue;
             }
 
             // Skip getters that don't need env var verification

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -500,6 +500,9 @@ contract VerifyOPCM is Script {
         bool success = true;
 
         // Get all OPCM getters and iterate over them
+        // Note: We use the pattern `success = false; continue;` for failures to ensure
+        // comprehensive reporting. Once success is false, it should never be reset to true.
+        // This allows us to collect and report ALL issues in a single verification run.
         string[] memory allGetters = _getOpcmGetters();
 
         for (uint256 i = 0; i < allGetters.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/ethereum-optimism/optimism/pull/16795/files#r2246312179 by removing the unnecessary creation of `envVarName`.

Fixes https://github.com/ethereum-optimism/optimism/pull/16795/files#r2246316308 by being consistent on non returning, we want to do all the processing even if there is a fail in order to have better debugging.

Does not fix https://github.com/ethereum-optimism/optimism/pull/16733/files#r2246252005 as there is not a source of truth to get the `expectedContainer`, instead the only thing we can do is get the first one.