### PR TITLE
Disintermediate and delete ForkchoiceRequestEvent

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -150,7 +150,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	sys.Register("engine-reset",
 		engine.NewEngineResetDeriver(ctx, log, cfg, l1, eng, syncCfg), opts)
 
-	clSync := clsync.NewCLSync(log, cfg, metrics)
+	clSync := clsync.NewCLSync(log, cfg, metrics, ec)
 	sys.Register("cl-sync", clSync, opts)
 
 	var finalizer driver.Finalizer

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -24,6 +24,8 @@ type EngineController interface {
 	TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
 	// TryUpdateLocalSafe updates the local safe head if the new reference is newer and concluding
 	TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef)
+	// RequestForkchoiceUpdate requests a forkchoice update
+	RequestForkchoiceUpdate(ctx context.Context)
 }
 
 type L2 interface {

--- a/op-node/rollup/attributes/testutils.go
+++ b/op-node/rollup/attributes/testutils.go
@@ -20,3 +20,7 @@ func (m *MockEngineController) TryUpdatePendingSafe(ctx context.Context, ref eth
 func (m *MockEngineController) TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
 	m.Mock.MethodCalled("TryUpdateLocalSafe", ctx, ref, concluding, source)
 }
+
+func (m *MockEngineController) RequestForkchoiceUpdate(ctx context.Context) {
+	m.Mock.MethodCalled("RequestForkchoiceUpdate", ctx)
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -196,7 +196,7 @@ func NewDriver(
 	sys.Register("engine-reset",
 		engine.NewEngineResetDeriver(driverCtx, log, cfg, l1, l2, syncCfg))
 
-	clSync := clsync.NewCLSync(log, cfg, metrics) // alt-sync still uses cl-sync state to determine what to sync to
+	clSync := clsync.NewCLSync(log, cfg, metrics, ec) // alt-sync still uses cl-sync state to determine what to sync to
 	sys.Register("cl-sync", clSync)
 
 	var finalizer Finalizer
@@ -247,7 +247,7 @@ func NewDriver(
 		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
 		sys.Register("origin-selector", findL1Origin)
 		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
-			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)
+			sequencerStateListener, sequencerConductor, asyncGossiper, metrics, ec)
 		sys.Register("sequencer", sequencer)
 	} else {
 		sequencer = sequencing.DisabledSequencer{}

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -22,17 +22,6 @@ var ReplaceBlockSource = eth.L1BlockRef{
 
 // no local metrics interface; engine depends directly on op-node/metrics.Metricer
 
-// ForkchoiceRequestEvent signals to the engine that it should emit an artificial
-// forkchoice-update event, to signal the latest forkchoice to other derivers.
-// This helps decouple derivers from the actual engine state,
-// while also not making the derivers wait for a forkchoice update at random.
-type ForkchoiceRequestEvent struct {
-}
-
-func (ev ForkchoiceRequestEvent) String() string {
-	return "forkchoice-request"
-}
-
 type ForkchoiceUpdateEvent struct {
 	UnsafeL2Head, SafeL2Head, FinalizedL2Head eth.L2BlockRef
 }

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -161,6 +161,16 @@ func (f *FakeAsyncGossip) Start() {
 
 var _ AsyncGossiper = (*FakeAsyncGossip)(nil)
 
+type fakeEngController struct{}
+
+func (fakeEngController) RequestForkchoiceUpdate(ctx context.Context) {}
+
+func (fakeEngController) TryUpdatePendingSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
+}
+
+func (fakeEngController) TryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
+}
+
 // TestSequencer_StartStop runs through start/stop state back and forth to test state changes.
 func TestSequencer_StartStop(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelError)
@@ -174,7 +184,7 @@ func TestSequencer_StartStop(t *testing.T) {
 	deps.conductor.leader = true
 
 	testCtx := context.Background()
-	emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
+	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	require.NoError(t, seq.Init(testCtx, false))
 	emitter.AssertExpectations(t)
 	require.False(t, deps.conductor.closed, "conductor is ready")
@@ -264,7 +274,7 @@ func TestSequencer_StaleBuild(t *testing.T) {
 	deps.conductor.leader = true
 
 	testCtx := context.Background()
-	emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
+	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	require.NoError(t, seq.Init(testCtx, false))
 	emitter.AssertExpectations(t)
 	require.False(t, deps.conductor.closed, "conductor is ready")
@@ -474,13 +484,13 @@ func TestSequencerBuild(t *testing.T) {
 
 	testCtx := context.Background()
 	// Init will request a forkchoice update
-	emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
+	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	require.NoError(t, seq.Init(testCtx, true))
 	emitter.AssertExpectations(t)
 	require.True(t, seq.Active(), "started in active mode")
 
 	// It will request a forkchoice update, it needs the head before being able to build on top of it
-	emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
+	// TODO(#16917): direct call used now; no ForkchoiceRequestEvent expected
 	seq.OnEvent(context.Background(), SequencerActionEvent{})
 	emitter.AssertExpectations(t)
 
@@ -631,16 +641,12 @@ func TestSequencerL1TemporaryErrorEvent(t *testing.T) {
 	seq.AttachEmitter(emitter)
 
 	testCtx := context.Background()
-	// Init will request a forkchoice update
-	emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
+	// Init
 	require.NoError(t, seq.Init(testCtx, true))
-	emitter.AssertExpectations(t)
 	require.True(t, seq.Active(), "started in active mode")
 
-	// It will request a forkchoice update, it needs the head before being able to build on top of it
-	emitter.ExpectOnce(engine.ForkchoiceRequestEvent{})
+	// It needs the head before being able to build on top of it
 	seq.OnEvent(context.Background(), SequencerActionEvent{})
-	emitter.AssertExpectations(t)
 
 	// Now send the forkchoice data, for the sequencer to learn what to build on top of.
 	head := eth.L2BlockRef{
@@ -723,7 +729,7 @@ func createSequencer(log log.Logger) (*Sequencer, *sequencerTestDeps) {
 	}
 	seq := NewSequencer(context.Background(), log, cfg, deps.attribBuilder,
 		deps.l1OriginSelector, deps.seqState, deps.conductor,
-		deps.asyncGossip, metrics.NoopMetrics)
+		deps.asyncGossip, metrics.NoopMetrics, fakeEngController{})
 	// We create mock payloads, with the epoch-id as tx[0], rather than proper L1Block-info deposit tx.
 	seq.toBlockRef = func(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.L2BlockRef, error) {
 		return eth.L2BlockRef{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds an EngController reference anywhere `ForkchoiceRequestEvent` was emitted and instead calls `RequestForkchoiceUpdate()`.

**Tests**

Tests must be updated but no new coverage is required.
