### PR TITLE
fix context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2046,6 +2046,8 @@ workflows:
             branches:
               ignore: /.*/
           build_args: --skip test
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - go-release:
           module: op-deployer
           context:
@@ -2063,6 +2065,8 @@ workflows:
             branches:
               ignore: /.*/
           build_args: --skip test
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - go-release:
           module: op-up
           context:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
This pull request updates the CircleCI workflow configuration to improve security when running builds. The main change is the addition of a context to provide a GitHub token for authenticated, read-only access during the build steps for certain modules.

**CircleCI workflow improvements:**

* Added the `circleci-repo-readonly-authenticated-github-token` context to the build steps for the `op-deployer` and `op-up` modules in `.circleci/config.yml` to enable secure, authenticated access to GitHub during builds. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R2049-R2050) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R2068-R2069)
**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
