### PR TITLE
op-acceptance-tests: interop: assert transaction is successful in smoke test

### DIFF
--- a/op-acceptance-tests/tests/interop/smoke/smoke_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/smoke_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // TestWrapETH checks WETH interactions, testing both reading and writing on the chain.
@@ -63,7 +64,8 @@ func TestWrapETH(gt *testing.T) {
 	require.True(contract.Read(weth.Transfer(bob.Address(), eth.OneHundredthEther), txplan.WithSender(alice.Address())))
 
 	// Write: Alice sends Bob 0.01 WETH
-	contract.Write(alice, weth.Transfer(bob.Address(), eth.OneHundredthEther))
+	receipt := contract.Write(alice, weth.Transfer(bob.Address(), eth.OneHundredthEther))
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 
 	// Read: Alice has 0.01 WETH
 	require.Equal(eth.OneHundredthEther, contract.Read(weth.BalanceOf(alice.Address())))


### PR DESCRIPTION
The smoke test failed in ci [here]. It is unclear whether it is due to some sort of race condition or if it is an actual interop bug. Adding this check will help narrow down the problem if we encounter it in the future.

[here]: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/97649/workflows/74233a6b-0682-457d-9692-4d1a5b82b208/jobs/3754460/tests

