### PR TITLE
op-node: make `reason` field more complete in "Sync progress"

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	gosync "sync"
 	"time"
 
@@ -245,7 +246,7 @@ func (e *EngineController) logSyncProgressMaybe() func() {
 		}
 		if reason != "" {
 			e.log.Info("Sync progress",
-				"reason", reason,
+				"reason", strings.TrimPrefix(reason, "|"),
 				"l2_finalized", e.finalizedHead,
 				"l2_safe", e.safeHead,
 				"l2_pending_safe", e.pendingSafeHead,

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -225,19 +225,23 @@ func (e *EngineController) logSyncProgressMaybe() func() {
 		}
 		var reason string
 		if prevFinalized != e.finalizedHead {
-			reason = "finalized block"
-		} else if prevSafe != e.safeHead {
+			reason += "|finalized block"
+		}
+		if prevSafe != e.safeHead {
 			if prevSafe == prevUnsafe {
-				reason = "derived safe block from L1"
+				reason += "|derived safe block from L1"
 			} else {
-				reason = "consolidated block with L1"
+				reason += "|consolidated block with L1"
 			}
-		} else if prevUnsafe != e.unsafeHead {
-			reason = "new chain head block"
-		} else if prevPendingSafe != e.pendingSafeHead {
-			reason = "pending new safe block"
-		} else if prevBackupUnsafe != e.backupUnsafeHead {
-			reason = "new backup unsafe block"
+		}
+		if prevUnsafe != e.unsafeHead {
+			reason += "|new chain head block"
+		}
+		if prevPendingSafe != e.pendingSafeHead {
+			reason += "|pending new safe block"
+		}
+		if prevBackupUnsafe != e.backupUnsafeHead {
+			reason += "|new backup unsafe block"
 		}
 		if reason != "" {
 			e.log.Info("Sync progress",


### PR DESCRIPTION
Currently if more than 1 heads are changed, only 1 reason will be output.

This PR concats all reasons with `|`.