### PR TITLE
op-node: pass caller context to DialRPCClientWithTimeout in conductor initialize

### DIFF
--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -58,7 +58,8 @@ func (c *ConductorClient) initialize(ctx context.Context) error {
 		return fmt.Errorf("no conductor RPC endpoint available: %w", err)
 	}
 	metricsOpt := rpc.WithRecorder(c.metrics.NewRecorder("conductor"))
-	conductorRpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), c.log, endpoint, metricsOpt)
+	// Use the passed ctx to allow cancellation/timeouts from the caller during dialing
+	conductorRpcClient, err := dial.DialRPCClientWithTimeout(ctx, c.log, endpoint, metricsOpt)
 	if err != nil {
 		return fmt.Errorf("failed to dial conductor RPC: %w", err)
 	}


### PR DESCRIPTION
Replace context.Background() with the passed ctx when dialing the op-conductor RPC.
This makes the dial cancellable and subject to upstream timeouts, avoiding long,
uninterruptible retries (~6 minutes) if the endpoint is unreachable. Aligns with
usage elsewhere in the repo and improves shutdown/timeout behavior.