### PR TITLE
op-challenger: Update challenger_test to play past split depth

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -22,12 +22,16 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	)
 
 	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
-	attacker := sys.FunderL1.NewFundedEOA(eth.OneTenthEther)
+	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(15))
 	dgf := sys.DisputeGameFactory()
 
 	game := dgf.StartSuperCannonGame(attacker, badClaim)
 
-	// Wait for the challenger to counter the bad root claim
-	claim := game.RootClaim()
-	claim.WaitForCounterClaim()
+	claim := game.RootClaim()                   // This is the bad claim from attacker
+	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger
+	for counterClaim.Depth() <= game.SplitDepth() {
+		// Wait for the challenger to counter the attacker's claim, then attack again
+		counterClaim = claim.WaitForCounterClaim()
+		claim = counterClaim.Attack(attacker, badClaim)
+	}
 }

--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -30,8 +30,8 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	claim := game.RootClaim()                   // This is the bad claim from attacker
 	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger
 	for counterClaim.Depth() <= game.SplitDepth() {
+		claim = counterClaim.Attack(attacker, badClaim)
 		// Wait for the challenger to counter the attacker's claim, then attack again
 		counterClaim = claim.WaitForCounterClaim()
-		claim = counterClaim.Attack(attacker, badClaim)
 	}
 }

--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -31,13 +31,18 @@ func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 	return o
 }
 
-// Write makes a user to write a tx by using the planned contract bindings
+// Write sends a tx to a contract, requiring the tx to succeed
 func Write[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) *types.Receipt {
-	checkTestable(call)
-	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
-	o, err := contractio.Write(call, call.Test().Ctx(), finalOpts)
+	o, err := MaybeWrite(user, call, opts...)
 	call.Test().Require().NoError(err)
 	return o
+}
+
+// MaybeWrite sends a tx to a contract, which may fail
+func MaybeWrite[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) (*types.Receipt, error) {
+	checkTestable(call)
+	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
+	return contractio.Write(call, call.Test().Ctx(), finalOpts)
 }
 
 var _ TestCallView[any] = (*bindings.TypedCall[any])(nil)

--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -31,18 +32,13 @@ func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 	return o
 }
 
-// Write sends a tx to a contract, requiring the tx to succeed
+// Write makes a user to write a tx by using the planned contract bindings
 func Write[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) *types.Receipt {
-	o, err := MaybeWrite(user, call, opts...)
-	call.Test().Require().NoError(err)
-	return o
-}
-
-// MaybeWrite sends a tx to a contract, which may fail
-func MaybeWrite[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) (*types.Receipt, error) {
 	checkTestable(call)
 	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
-	return contractio.Write(call, call.Test().Ctx(), finalOpts)
+	o, err := contractio.Write(call, call.Test().Ctx(), finalOpts)
+	call.Test().Require().NoError(err, "contract write failed: %v", errutil.TryAddRevertReason(err))
+	return o
 }
 
 var _ TestCallView[any] = (*bindings.TypedCall[any])(nil)

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -62,8 +61,7 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx int64, newClaim common.
 
 	attackCall := g.game.Attack(claim.Value, big.NewInt(claimIdx), newClaim)
 
-	receipt, err := contract.MaybeWrite(eoa, attackCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
-	g.t.Require().NoErrorf(err, "error sending tx: %v", errutil.TryAddRevertReason(err))
+	receipt := contract.Write(eoa, attackCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
 	g.t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful)
 }
 

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -59,8 +60,22 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx int64, newClaim common.
 	newPosition := claim.Position.Attack().ToGIndex()
 	requiredBond := contract.Read(g.game.GetRequiredBond((*bindings.Uint128)(newPosition)))
 
-	receipt := contract.Write(eoa, g.game.Attack(claim.Value, big.NewInt(claimIdx), newClaim), txplan.WithValue(requiredBond))
-	g.require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+	attackCall := g.game.Attack(claim.Value, big.NewInt(claimIdx), newClaim)
+
+	// TODO: Debug why we need this retry
+	g.require.Eventually(func() bool {
+		receipt, err := contract.MaybeWrite(eoa, attackCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
+		if err != nil {
+			err := errutil.TryAddRevertReason(err)
+			g.t.Logf("Attack tx failed: %v", err)
+			return false
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			g.t.Logf("Attack tx not successful: %v", receipt.Status)
+			return false
+		}
+		return true
+	}, 5*time.Minute, 5*time.Second)
 }
 
 func (g *FaultDisputeGame) newClaim(claimIndex int64, claim bindings.Claim) *Claim {

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -62,20 +62,9 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx int64, newClaim common.
 
 	attackCall := g.game.Attack(claim.Value, big.NewInt(claimIdx), newClaim)
 
-	// TODO: Debug why we need this retry
-	g.require.Eventually(func() bool {
-		receipt, err := contract.MaybeWrite(eoa, attackCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
-		if err != nil {
-			err := errutil.TryAddRevertReason(err)
-			g.t.Logf("Attack tx failed: %v", err)
-			return false
-		}
-		if receipt.Status != types.ReceiptStatusSuccessful {
-			g.t.Logf("Attack tx not successful: %v", receipt.Status)
-			return false
-		}
-		return true
-	}, 5*time.Minute, 5*time.Second)
+	receipt, err := contract.MaybeWrite(eoa, attackCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
+	g.t.Require().NoErrorf(err, "error sending tx: %v", errutil.TryAddRevertReason(err))
+	g.t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful)
 }
 
 func (g *FaultDisputeGame) newClaim(claimIndex int64, claim bindings.Claim) *Claim {

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -100,7 +101,7 @@ type Gas interface {
 
 type EthCall interface {
 	// Call executes a message call transaction but never mined into the blockchain.
-	Call(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
+	Call(ctx context.Context, msg ethereum.CallMsg, blockNumber rpc.BlockNumber) ([]byte, error)
 }
 
 type TransactionSender interface {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -524,9 +524,9 @@ func (s *EthClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 }
 
 // Call executes a message call transaction but never mined into the blockchain.
-func (s *EthClient) Call(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+func (s *EthClient) Call(ctx context.Context, msg ethereum.CallMsg, blockNumber rpc.BlockNumber) ([]byte, error) {
 	var hex hexutil.Bytes
-	err := s.client.CallContext(ctx, &hex, "eth_call", ToCallArg(msg), "pending")
+	err := s.client.CallContext(ctx, &hex, "eth_call", ToCallArg(msg), blockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/plan"
@@ -314,7 +315,7 @@ func WithAgainstLatestBlock(cl AgainstLatestBlock) Option {
 // Reader uses eth_call to view(read) the blockchain, and does not write persistent changes to the chain.
 // A call will return a byte string (that may be ABI-decoded), and does not have a receipt, as it was only simulated and not a persistent transaction.
 type Reader interface {
-	Call(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
+	Call(ctx context.Context, msg ethereum.CallMsg, blockNumber rpc.BlockNumber) ([]byte, error)
 }
 
 func WithReader(cl Reader) Option {
@@ -327,6 +328,7 @@ func WithReader(cl Reader) Option {
 			&tx.Value,
 			&tx.Data,
 			&tx.AccessList,
+			&tx.AgainstBlock,
 		)
 		tx.Read.Fn(func(ctx context.Context) ([]byte, error) {
 			msg := ethereum.CallMsg{
@@ -340,7 +342,7 @@ func WithReader(cl Reader) Option {
 				Data:       tx.Data.Value(),
 				AccessList: tx.AccessList.Value(),
 			}
-			return cl.Call(ctx, msg)
+			return cl.Call(ctx, msg, rpc.BlockNumber(tx.AgainstBlock.Value().NumberU64()))
 		})
 	}
 }


### PR DESCRIPTION
Builds on https://github.com/ethereum-optimism/optimism/pull/16943 to update the op-challenger acceptance test to play the game past the split depth. This ensures the challenger is able to respond to invalid claims corresponding to VM execution trace steps.

#### Metadata

part of https://github.com/ethereum-optimism/optimism/issues/15948