### PR TITLE

ci: make target-branch detection reusable; update checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,33 @@ commands:
           when: on_fail
 
 
+  get-target-branch:
+    description: "Determine the PR target branch and export TARGET_BRANCH for subsequent steps"
+    steps:
+      - run:
+          name: Determine target branch for this pipeline
+          command: |
+            # Derive PR number if available
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+            else
+              PR_NUMBER=""
+            fi
+
+            TARGET_BRANCH=""
+            if [ -n "$PR_NUMBER" ]; then
+              # Fetch base branch of the PR via GitHub API
+              TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .base.ref)
+            fi
+
+            # Fallbacks when not a PR or API did not return a branch
+            if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "null" ]; then
+              TARGET_BRANCH="<< pipeline.git.branch >>"
+            fi
+
+            echo "Resolved TARGET_BRANCH=$TARGET_BRANCH"
+            echo "export TARGET_BRANCH=$TARGET_BRANCH" >> "$BASH_ENV"
+
   run-contracts-check:
     parameters:
       command:
@@ -658,17 +685,12 @@ jobs:
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock
+      - get-target-branch
       - run:
           name: Check if target branch is develop
           command: |
-            # Get PR number from CIRCLE_PULL_REQUEST
-            PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | rev | cut -d/ -f1 | rev)
-
-            # Use GitHub API to get target branch
-            TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .base.ref)
-
             # If the target branch is not develop, do not run this check
-            if [ "$TARGET_BRANCH" != "develop" ]; then
+            if [ "${TARGET_BRANCH}" != "develop" ]; then
               echo "Target branch is not develop, skipping frozen files check"
               circleci-agent step halt
             fi
@@ -949,6 +971,7 @@ jobs:
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock,op-node
+      - get-target-branch
       - run:
           name: print forge version
           command: forge --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,17 +232,9 @@ commands:
       - run:
           name: Determine target branch for this pipeline
           command: |
-            # Derive PR number if available
-            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-              PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
-            else
-              PR_NUMBER=""
-            fi
-
             TARGET_BRANCH=""
-            if [ -n "$PR_NUMBER" ]; then
-              # Fetch base branch of the PR via GitHub API
-              TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .base.ref)
+            if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+              TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PULL_REQUEST##*/}" | jq -r .base.ref)
             fi
 
             # Fallbacks when not a PR or API did not return a branch


### PR DESCRIPTION
Some jobs assumed the target branch is `develop`, which is not always true. This caused checks to run or skip incorrectly on PRs targeting other branches and on non-PR runs. Changes: 
- Add reusable CircleCI command `get-target-branch` that exports `TARGET_BRANCH`
- Use it in `contracts-bedrock-frozen-code` and `contracts-bedrock-checks`. 
- Update `check-semver-diff.sh` to respect `TARGET_BRANCH` (defaults to `develop`) and use `origin/` for diffs and file retrieval.

