### PR TITLE
op-acceptance-tests: Add preinterop challenger test

### DIFF
--- a/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
@@ -1,0 +1,37 @@
+package preinterop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestChallengerPlaysGame(gt *testing.T) {
+	gt.Skip("TODO(#16166): Re-enable once the supervisor endpoint supports super roots before interop")
+	t := devtest.ParallelT(gt)
+	sys := presets.NewSimpleInterop(t)
+	dsl.CheckAll(t,
+		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
+		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
+	)
+
+	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
+	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(15))
+	dgf := sys.DisputeGameFactory()
+
+	game := dgf.StartSuperCannonGame(attacker, badClaim)
+
+	claim := game.RootClaim()                   // This is the bad claim from attacker
+	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger
+	for counterClaim.Depth() <= game.SplitDepth() {
+		claim = counterClaim.Attack(attacker, badClaim)
+		// Wait for the challenger to counter the attacker's claim, then attack again
+		counterClaim = claim.WaitForCounterClaim()
+	}
+}


### PR DESCRIPTION
Introduce acceptance tests for the challenger in the preinterop case. The test is skipped until the supervisor RPC supports super roots before interop.

fixes https://github.com/ethereum-optimism/optimism/issues/15948