### PR TITLE
op-acceptance-tests: Reenable TestWithdrawalRoot test for syskt

### DIFF
--- a/kurtosis-devnet/isthmus.yaml
+++ b/kurtosis-devnet/isthmus.yaml
@@ -8,7 +8,7 @@ optimism_package:
         node0:
           el:
             type: op-geth
-            image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3"
+            image: ""
             log_level: ""
             extra_env_vars: {}
             extra_labels: {}
@@ -35,7 +35,7 @@ optimism_package:
         node1:
           el:
             type: op-reth
-            image: "ghcr.io/paradigmxyz/op-reth@sha256:7d83174c900a623897d5cf3a42764f19047ca47034f9726f5a9fad2c7ed32fee"
+            image: ""
             log_level: ""
             extra_env_vars: {}
             extra_labels: {}

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -43,9 +43,8 @@ gates:
         timeout: 6h
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee
         timeout: 6h
-      # TODO: Re-enable this test when the withdrawal root is no longer flaky
-      # - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/withdrawal_root
-      #   timeout: 20m
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/withdrawal_root
+        timeout: 20m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/erc20_bridge
         timeout: 10m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/pectra


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Reenables TestWithdrawalRoot acceptance test, removing flakiness. Added correct gas fee calculation logic, considering operator fee(introduced at isthmus).

Also bumps op-geth/op-reth versions to latest. The previous versions were from April(`us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.2-rc.3`) and it is better to test against the latest ELs.

**Additional context**

The test flaked because of the operator fee was not considered while calculating actual fee spent by L2 transaction.

Before `TestWithdrawalRoot` is ran, `TestOperatorFeeDevstack` is ran prior. `TestOperatorFeeDevstack` sets the (operator fee scalar, operator fee constant) to (300, 400), and sets back to (0, 0) after the test ran. 

When `TestWithdrawalRoot` failed:

1. `TestOperatorFeeDevstack` is done and (operator fee scalar, operator fee constant) is initialized back to (0, 0) by L1 transaction.
2. (Race condition) `TestWithdrawalRoot` triggers L2 user transaction, but the operator fee update was not yet propagated to L2. Operator fee is charged.
3. `TestWithdrawalRoot` calculates the expected total fee. The original testing suite did not consider the operating fee, so the expected value will be always less or equal to the actual value.

When `TestWithdrawalRoot` succeeded:

1. `TestOperatorFeeDevstack` is done and (operator fee scalar, operator fee constant) is initialized back to (0, 0) by L1 transaction.
2. (Race condition) `TestWithdrawalRoot` triggers L2 user transaction, and the operator fee update was propagated to L2.
3. `TestWithdrawalRoot` calculates the expected total fee. The original testing suite did not consider the operating fee, but the test succeeds because since (operator fee scalar, operator fee constant) = (0, 0), the charged operator fee is zero.

The cause of flakiness was a mix of race condition and not considering the operator fee.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16936
