### PR TITLE
chore: Use svm-rs from github releases

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,9 +11,6 @@ shellcheck = "0.10.0"
 direnv = "2.35.0"
 just = "1.37.0"
 
-# Cargo dependencies
-"cargo:svm-rs" = "0.5.8"
-
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
 "go:gotest.tools/gotestsum" = "1.12.1"
@@ -39,6 +36,7 @@ codecov-uploader = "0.8.0"
 goreleaser-pro = "2.3.2-pro"
 kurtosis = "1.8.1"
 op-acceptor = "op-acceptor/v3.0.0"
+svm-rs = "0.5.19"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't
@@ -57,6 +55,7 @@ codecov-uploader = "ubi:codecov/uploader"
 goreleaser-pro = "ubi:goreleaser/goreleaser-pro[exe=goreleaser]"
 kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"
 op-acceptor = "ubi:ethereum-optimism/infra[exe=op-acceptor,tag_prefix=op-acceptor/]"
+svm-rs = "ubi:alloy-rs/svm-rs[exe=svm]"
 
 [settings]
 experimental = true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`alloy-rs` team were kind enough to provide us with github releases of `svm-rs` (thanks @mattsse @DaniPopes). Using github releases instead of the `cargo:` backend for mise gives us the ability to store checksums in `mise.lock` file, an important upcoming security feature.