### PR TITLE
fix: Aqua repository for yq is dead

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -57,6 +57,7 @@ codecov-uploader = "ubi:codecov/uploader"
 goreleaser-pro = "ubi:goreleaser/goreleaser-pro[exe=goreleaser]"
 kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"
 op-acceptor = "ubi:ethereum-optimism/infra[exe=op-acceptor,tag_prefix=op-acceptor/]"
+yq = "ubi:mikefarah/yq"
 
 [settings]
 experimental = true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes an issue with a dead `yq` repository

<img width="887" height="152" alt="Screenshot 2025-08-13 at 8 30 31 AM" src="https://github.com/user-attachments/assets/7068eed8-df63-4eaa-8cab-f685e7f0feb8" />
