### PR TITLE
op-devstack: Batch calls to retrieve FaultDisputeGame claims

### DIFF
--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -42,8 +42,7 @@ func ReadArray[T any](countCall bindings.TypedCall[*big.Int], elemCall func(i *b
 
 	caller := countCall.Client().NewMultiCaller(batching.DefaultBatchSize)
 
-	count := Read(countCall).Uint64()
-	o, err := contractio.ReadArray(ctx, caller, count, elemCall)
+	o, err := contractio.ReadArray(ctx, caller, countCall, elemCall)
 	test.Require().NoError(err)
 	return o
 }

--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -2,9 +2,11 @@ package contract
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/errutil"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -29,6 +31,20 @@ func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 	checkTestable(call)
 	o, err := contractio.Read(call, call.Test().Ctx(), opts...)
 	call.Test().Require().NoError(err)
+	return o
+}
+
+// ReadArray retrieves all data from an array in batches
+func ReadArray[T any](countCall bindings.TypedCall[*big.Int], elemCall func(i *big.Int) bindings.TypedCall[T]) []T {
+	checkTestable(countCall)
+	test := countCall.Test()
+	ctx := countCall.Test().Ctx()
+
+	caller := countCall.Client().NewMultiCaller(batching.DefaultBatchSize)
+
+	count := Read(countCall).Uint64()
+	o, err := contractio.ReadArray(ctx, caller, count, elemCall)
+	test.Require().NoError(err)
 	return o
 }
 

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -74,12 +74,14 @@ func (g *FaultDisputeGame) claimAtIndex(claimIndex int64) bindings.Claim {
 }
 
 func (g *FaultDisputeGame) allClaims() []bindings.Claim {
-	// TODO(#15948) - do we need to batch these? See: op-service/sources/batching.ReadArray
-	claimCount := contract.Read(g.game.ClaimDataLen())
+	allClaimData := contract.ReadArray(g.game.ClaimDataLen(), func(i *big.Int) bindings.TypedCall[bindings.ClaimData] {
+		return g.game.ClaimData(i)
+	})
+
+	// Decode claims
 	var claims []bindings.Claim
-	for i := int64(0); i < claimCount.Int64(); i++ {
-		claim := g.claimAtIndex(i)
-		claims = append(claims, claim)
+	for _, claimData := range allClaimData {
+		claims = append(claims, claimData.Decode())
 	}
 
 	return claims

--- a/op-service/sources/batching/call.go
+++ b/op-service/sources/batching/call.go
@@ -73,3 +73,7 @@ func (c *CallResult) GetBytes32Slice(i int) [][32]byte {
 func (c *CallResult) GetString(i int) string {
 	return *abi.ConvertType(c.out[i], new(string)).(*string)
 }
+
+func (c *CallResult) Get(i int) interface{} {
+	return c.out[i]
+}

--- a/op-service/txintent/contractio/batch.go
+++ b/op-service/txintent/contractio/batch.go
@@ -1,0 +1,73 @@
+package contractio
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+)
+
+// BatchableCall represents a contract read call (eth_call) that can be executed as part of a larger batch of requests
+// using `batching.MultiCaller`
+type BatchableCall[T any] struct {
+	typedCall bindings.TypedCall[T]
+}
+
+var _ batching.Call = (*BatchableCall[any])(nil)
+
+func NewBatchableCall[T any](typedCall bindings.TypedCall[T]) *BatchableCall[T] {
+	return &BatchableCall[T]{
+		typedCall: typedCall,
+	}
+}
+
+func (c *BatchableCall[T]) ToBatchElemCreator() (batching.BatchElementCreator, error) {
+	args, err := c.callArgs()
+	if err != nil {
+		return nil, err
+	}
+	f := func(block rpcblock.Block) (any, rpc.BatchElem) {
+		out := new(hexutil.Bytes)
+		return out, rpc.BatchElem{
+			Method: "eth_call",
+			Args:   []interface{}{args, block.ArgValue()},
+			Result: &out,
+		}
+	}
+	return f, nil
+}
+
+func (c *BatchableCall[T]) HandleResult(result interface{}) (*batching.CallResult, error) {
+	hex := *result.(*hexutil.Bytes)
+	out, err := c.typedCall.DecodeOutput(hex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode output: %w", err)
+	}
+	return batching.NewCallResult([]any{out}), nil
+}
+
+func (c *BatchableCall[T]) input() ([]byte, error) {
+	return c.typedCall.EncodeInputLambda()
+}
+
+func (c *BatchableCall[T]) callArgs() (interface{}, error) {
+	data, err := c.input()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode input data: %w", err)
+	}
+
+	to, err := c.typedCall.To()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine contract address: %w", err)
+	}
+
+	arg := map[string]interface{}{
+		"to":    to,
+		"input": hexutil.Bytes(data),
+	}
+	return arg, nil
+}

--- a/op-service/txintent/contractio/call.go
+++ b/op-service/txintent/contractio/call.go
@@ -59,7 +59,7 @@ func ReadArray[T any](ctx context.Context, caller *batching.MultiCaller, countCa
 
 	countResult, err := Read(countCall, ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error reading array size: %v", err)
+		return nil, fmt.Errorf("error reading array size: %w", err)
 	}
 
 	count := countResult.Uint64()

--- a/op-service/txintent/contractio/call.go
+++ b/op-service/txintent/contractio/call.go
@@ -2,7 +2,11 @@ package contractio
 
 import (
 	"context"
+	"fmt"
+	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
@@ -47,6 +51,34 @@ func Read[O any](view bindings.TypedCall[O], ctx context.Context, opts ...txplan
 		return *new(O), err
 	}
 	return decoded, nil
+}
+
+// ReadArray uses batch calls to load all entries from an array.
+func ReadArray[T any](ctx context.Context, caller *batching.MultiCaller, count uint64, elemCall func(i *big.Int) bindings.TypedCall[T]) ([]T, error) {
+	block := rpcblock.Latest
+
+	calls := make([]batching.Call, count)
+	for i := uint64(0); i < count; i++ {
+		typedCall := elemCall(new(big.Int).SetUint64(i))
+		calls[i] = NewBatchableCall(typedCall)
+	}
+
+	callResults, err := caller.Call(ctx, block, calls...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch array data: %w", err)
+	}
+
+	// Convert results to expected type
+	var results []T
+	for _, callResult := range callResults {
+		result, ok := callResult.Get(0).(T)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast result: %v", callResult)
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
 }
 
 func Plan[O any](call bindings.TypedCall[O]) (txplan.Option, error) {

--- a/op-service/txintent/contractio/call.go
+++ b/op-service/txintent/contractio/call.go
@@ -54,9 +54,15 @@ func Read[O any](view bindings.TypedCall[O], ctx context.Context, opts ...txplan
 }
 
 // ReadArray uses batch calls to load all entries from an array.
-func ReadArray[T any](ctx context.Context, caller *batching.MultiCaller, count uint64, elemCall func(i *big.Int) bindings.TypedCall[T]) ([]T, error) {
+func ReadArray[T any](ctx context.Context, caller *batching.MultiCaller, countCall bindings.TypedCall[*big.Int], elemCall func(i *big.Int) bindings.TypedCall[T]) ([]T, error) {
 	block := rpcblock.Latest
 
+	countResult, err := Read(countCall, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error reading array size: %v", err)
+	}
+
+	count := countResult.Uint64()
 	calls := make([]batching.Call, count)
 	for i := uint64(0); i < count; i++ {
 		typedCall := elemCall(new(big.Int).SetUint64(i))


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Address TODO around batching requests to retrieve all claims from a game in `FaultDisputeGame.allClaims()` helper.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/15948
