### PR TITLE
ci: Check out sources from shared job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2500,12 +2500,17 @@ workflows:
       not:
         equal: [<< pipeline.git.branch >>, "develop"]
     jobs:
+      - initialize
       - contracts-bedrock-build:  # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - cannon-prestate-quick:  # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       # IN-PROCESS (base)
       - op-acceptance-tests:
           # Acceptance Testing params
@@ -2530,6 +2535,8 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
+          requires:
+            - initialize
       # KURTOSIS (Isthmus)
       - op-acceptance-tests:
           # Acceptance Testing params
@@ -2541,6 +2548,8 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
+          requires:
+            - initialize
       # KURTOSIS (Interop)
       - op-acceptance-tests:
           # Acceptance Testing params
@@ -2552,6 +2561,8 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
+          requires:
+            - initialize
       # Generate flaky test report
       - generate-flaky-report:
           name: generate-flaky-tests-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,7 +264,26 @@ commands:
           environment:
             FOUNDRY_PROFILE: ci
 
+  checkout-from-workspace:
+    steps:
+      - attach_workspace:
+          at: "."
+      - utils/install-mise
+
+
 jobs:
+  initialize:
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: large
+    steps:
+      - utils/checkout-with-mise
+      - install-contracts-dependencies
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - "."
+
   cannon-go-lint-and-test:
     machine: true
     resource_class: ethereum-optimism/latitude-1
@@ -281,11 +300,9 @@ jobs:
         type: boolean
         default: false
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
-      - attach_workspace:
-          at: "."
       - run:
           name: prep Cannon results dir
           command: |
@@ -331,7 +348,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - run:
           name: Check `RISCV.sol` bytecode
           working_directory: packages/contracts-bedrock
@@ -380,8 +397,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - utils/checkout-with-mise
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - run:
           name: Print forge version
           command: forge --version
@@ -475,9 +491,7 @@ jobs:
       resource_class: "<<parameters.resource_class>>"
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace:
-          at: /tmp/docker_images
+      - checkout-from-workspace
       - run:
           command: mkdir -p /tmp/docker_images
       - when:
@@ -668,13 +682,12 @@ jobs:
             docker pull $image_name || exit 1
             docker run $image_name <<parameters.op_component>> --version || exit 1
 
+
   contracts-bedrock-frozen-code:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - check-changed:
           patterns: contracts-bedrock
       - get-target-branch
@@ -731,9 +744,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - run:
           name: Check if test list is empty
           command: |
@@ -810,9 +821,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - check-changed:
           patterns: contracts-bedrock,op-node
       - run:
@@ -885,9 +894,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - check-changed:
           patterns: contracts-bedrock,op-node
       - run:
@@ -958,9 +965,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace: { at: "." }
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - check-changed:
           patterns: contracts-bedrock,op-node
       - get-target-branch
@@ -1029,7 +1034,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - check-changed:
           patterns: "<<parameters.package_name>>"
       - attach_workspace:
@@ -1055,7 +1060,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - run:
           name: run Go linter
           command: |
@@ -1095,9 +1100,7 @@ jobs:
     machine: true
     resource_class: <<parameters.resource_class>>
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace:
-          at: "."
+      - checkout-from-workspace
       - run:
           name: Run all Go tests via Makefile
           no_output_timeout: <<parameters.no_output_timeout>>
@@ -1152,9 +1155,7 @@ jobs:
     machine: true
     resource_class: <<parameters.resource_class>>
     steps:
-      - utils/checkout-with-mise
-      - attach_workspace:
-          at: "."
+      - checkout-from-workspace
       - run:
           name: build op-program-client
           command: make op-program-client
@@ -1215,15 +1216,7 @@ jobs:
       docker_layer_caching: true # Since we are building docker images for components, we'll cache the layers for faster builds
     resource_class: xlarge
     steps:
-      - utils/checkout-with-mise
-      - install-contracts-dependencies
-      # Attach workspace for cannon dependencies if using sysgo orchestrator (empty devnet)
-      - when:
-          condition:
-            equal: ["", << parameters.devnet >>]
-          steps:
-            - attach_workspace:
-                at: "."
+      - checkout-from-workspace
       - run:
           name: Setup Kurtosis (if needed)
           command: |
@@ -1366,7 +1359,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - run:
           name: Install tools
           command: |
@@ -1387,7 +1380,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - restore_cache:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
@@ -1414,7 +1407,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - setup_remote_docker
       - run:
           name: Build prestates
@@ -1562,7 +1555,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - setup_remote_docker
       - run:
           name: Run Analyzer
@@ -1574,7 +1567,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - run:
           name: Verify Compatibility
           command: |
@@ -1585,7 +1578,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - check-changed:
           patterns: op-node
       - run:
@@ -1596,7 +1589,7 @@ jobs:
     machine: true
     resource_class: ethereum-optimism/latitude-1
     steps:
-      - utils/checkout-with-mise
+      - checkout-from-workspace
       - check-changed:
           patterns: op-service
       - run:
@@ -1692,15 +1685,13 @@ jobs:
           command: |
             goreleaser release --clean -f ./<<parameters.module>>/<<parameters.filename>>
 
+
   diff-fetcher-forge-artifacts:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: medium
     steps:
-      - utils/checkout-with-mise
-      - check-changed:
-          patterns: packages/contracts-bedrock
-      - install-contracts-dependencies
+      - checkout-from-workspace
       - run:
           name: Build contracts
           command: |
@@ -1719,6 +1710,7 @@ jobs:
             fi
 
             echo "✅ Checked-in forge artifacts match the ci build"
+
 
   stale-check:
       machine:
@@ -1782,6 +1774,7 @@ jobs:
             # Upload to the date-partitioned folder structure
             gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/$FOLDER_NAME/metrics-$CIRCLE_SHA1.csv
 
+
   generate-flaky-report:
     machine: true
     resource_class: medium
@@ -1820,12 +1813,15 @@ workflows:
           - equal: ["api",<< pipeline.trigger_source >>]
           - equal: [<< pipeline.parameters.github-event-type >>, "__not_set__"] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
     jobs:
+      - initialize
       - contracts-bedrock-build:
           name: contracts-bedrock-build
           # Build with just core + script contracts.
           build_args: --deny-warnings --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - check-kontrol-build:
           requires:
             - contracts-bedrock-build
@@ -1837,12 +1833,16 @@ workflows:
           test_list: find test -name "*.t.sol" -not -name "PreimageOracle.t.sol"
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-tests:
           # PreimageOracle test is slow, run it separately to unblock CI.
           name: contracts-bedrock-tests-preimage-oracle
           test_list: find test -name "PreimageOracle.t.sol"
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-tests:
           # Heavily fuzz any fuzz tests within added or modified test files.
           name: contracts-bedrock-tests-heavy-fuzz-modified
@@ -1851,6 +1851,8 @@ workflows:
           test_profile: ciheavy
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-coverage:
           # Generate coverage reports.
           name: contracts-bedrock-coverage
@@ -1868,6 +1870,8 @@ workflows:
           fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade base-mainnet
           fork_op_chain: base
@@ -1875,6 +1879,8 @@ workflows:
           fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade ink-mainnet
           fork_op_chain: ink
@@ -1882,6 +1888,8 @@ workflows:
           fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade unichain-mainnet
           fork_op_chain: unichain
@@ -1889,6 +1897,8 @@ workflows:
           fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build
@@ -1902,9 +1912,13 @@ workflows:
       - diff-fetcher-forge-artifacts:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - contracts-bedrock-build
       - diff-asterisc-bytecode:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
@@ -1918,6 +1932,8 @@ workflows:
       - go-lint:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - fuzz-golang:
           name: fuzz-golang-<<matrix.package_name>>
           on_changes: <<matrix.package_name>>
@@ -1930,22 +1946,26 @@ workflows:
                 - op-chain-ops
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - fuzz-golang:
           name: cannon-fuzz
           package_name: cannon
           on_changes: cannon,packages/contracts-bedrock/src/cannon
           uses_artifacts: true
-          requires: ["contracts-bedrock-build"]
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - contracts-bedrock-build
       - fuzz-golang:
           name: op-e2e-fuzz
           package_name: op-e2e
           on_changes: op-e2e,packages/contracts-bedrock/src
           uses_artifacts: true
-          requires: ["contracts-bedrock-build"]
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - contracts-bedrock-build
       - go-tests:
           name: go-tests-short
           no_output_timeout: 19m
@@ -1976,9 +1996,13 @@ workflows:
       - analyze-op-program-client:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - op-program-compat:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - bedrock-go-tests:
           requires:
             - go-lint
@@ -2019,9 +2043,13 @@ workflows:
                 - op-interop-mon
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - sanitize-op-program:
           requires:
             - cannon-prestate-quick
@@ -2030,9 +2058,13 @@ workflows:
       - check-generated-mocks-op-node:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - check-generated-mocks-op-service:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build


### PR DESCRIPTION
Refactors CI to check out the code in a shared `initialize` job, then pass the sources to downstream jobs via a workspace. This helps reduce pressure on GitHub, which has been causing flakiness and slow checkouts.
