### PR TITLE
fix: alternating turns in counter-claim

### DIFF
--- a/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
@@ -30,7 +30,7 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	claim := game.RootClaim()                   // This is the bad claim from attacker
 	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger
 	for counterClaim.Depth() <= game.SplitDepth() {
-		claim = counterClaim.Attack(attacker, badClaim)
+		claim = counterClaim.Attack(counterClaim.Player(), badClaim)
 		// Wait for the challenger to counter the attacker's claim, then attack again
 		counterClaim = claim.WaitForCounterClaim()
 	}


### PR DESCRIPTION
**Description**
switched to `counterClaim.Player()` so turns actually alternate.
before, the same player kept attacking, which could break the game or hang `WaitForCounterClaim()`.

**Tests**
verified that turns now correctly alternate between attacker and countering player. no infinite waits occur in `WaitForCounterClaim()`.

**Additional context**
this fixes a subtle bug in the super-canon game loop logic.

**Metadata**
fixes: turn handling in counter-claim loop
affected module: game/turns