### PR TITLE
feat(op-service/event): add call graph tracer and wire it under trace logging

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -176,6 +176,10 @@ func (n *OpNode) initEventSystem() {
 	executor := event.NewGlobalSynchronous(n.resourcesCtx).WithMetrics(n.metrics)
 	sys := event.NewSystem(n.log, executor)
 	sys.AddTracer(event.NewMetricsTracer(n.metrics))
+	// Register a call-graph tracer when trace logging is enabled to visualize event flow
+	if n.log.Enabled(context.Background(), log.LevelTrace) {
+		sys.AddTracer(event.NewCallGraphTracer(n.log))
+	}
 	sys.Register("node", event.DeriverFunc(n.onEvent))
 	n.eventSys = sys
 	n.eventDrain = executor

--- a/op-service/event/tracer_callgraph.go
+++ b/op-service/event/tracer_callgraph.go
@@ -1,0 +1,140 @@
+package event
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// CallGraphTracer reconstructs a hierarchical call graph of events based on derivContext and emitContext.
+// It logs lines like:
+// p2p.ReceivedBlockEvent [09ab623c]
+// └── clsync.ReceivedUnsafePayloadEvent [9277ffe6]
+//     └── engine.ForkchoiceUpdateEvent [e024a814]
+//
+// Depth and parent-child relationships are inferred from:
+// - OnDeriveStart: maps derivContext -> emitContext for the event being processed
+// - OnEmit: links a new emitContext to the parent emitContext via the current derivContext
+//
+// Note: This focuses on visualizing the flow; it does not attempt lifecycle/cleanup beyond basic bookkeeping.
+// It is safe for concurrent use.
+type CallGraphTracer struct {
+	log log.Logger
+
+	mu sync.Mutex
+	// Map a derivation context to the emit-context of the event being derived
+	derivToEmit map[uint64]uint64
+	// Nodes, keyed by emit-context
+	nodes map[uint64]*cgNode
+}
+
+type cgNode struct {
+	EmitContext uint64
+	Emitter    string
+	EventType  string
+	Parent     uint64 // 0 if root
+	Children   []uint64
+}
+
+var _ Tracer = (*CallGraphTracer)(nil)
+
+func NewCallGraphTracer(l log.Logger) *CallGraphTracer {
+	return &CallGraphTracer{
+		log:        l,
+		derivToEmit: make(map[uint64]uint64),
+		nodes:       make(map[uint64]*cgNode),
+	}
+}
+
+func (t *CallGraphTracer) OnDeriveStart(name string, ev AnnotatedEvent, derivContext uint64, startTime time.Time) {
+	// Link the derivation context to the emit-context so we can attach children emitted during derivation
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.derivToEmit[derivContext] = ev.EmitContext
+}
+
+func (t *CallGraphTracer) OnDeriveEnd(name string, ev AnnotatedEvent, derivContext uint64, startTime time.Time, duration time.Duration, effect bool) {
+	// No-op for now; we log as events are emitted to show flow in real-time
+}
+
+func (t *CallGraphTracer) OnRateLimited(name string, derivContext uint64) {
+	// No-op
+}
+
+func (t *CallGraphTracer) OnEmit(name string, ev AnnotatedEvent, derivContext uint64, emitTime time.Time) {
+	// Build or find the node for this emission
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Determine the Go type name of the event for readability (e.g. ForkchoiceUpdateEvent)
+	evtType := typeName(ev.Event)
+
+	node := t.nodes[ev.EmitContext]
+	if node == nil {
+		node = &cgNode{
+			EmitContext: ev.EmitContext,
+			Emitter:    name,
+			EventType:  evtType,
+		}
+		t.nodes[ev.EmitContext] = node
+	}
+	// Find parent by derivation context
+	if derivContext != 0 {
+		if parentEmit, ok := t.derivToEmit[derivContext]; ok {
+			node.Parent = parentEmit
+			parent := t.nodes[parentEmit]
+			if parent != nil {
+				parent.Children = append(parent.Children, node.EmitContext)
+			}
+		}
+	}
+
+	// Log the node within the current call graph
+	t.logLine(ev.EmitContext)
+}
+
+func (t *CallGraphTracer) OnAfterProcessed(evtype string) {}
+
+func (t *CallGraphTracer) logLine(emitCtx uint64) {
+	// Walk up to compute depth, then print a single line representing this node
+	n, ok := t.nodes[emitCtx]
+	if !ok {
+		return
+	}
+	depth := 0
+	p := n.Parent
+	for p != 0 {
+		depth++
+		pn, ok := t.nodes[p]
+		if !ok {
+			break
+		}
+		p = pn.Parent
+	}
+	indent := ""
+	if depth > 0 {
+		indent = strings.Repeat("    ", depth-1) + "└── "
+	}
+	// Use 8-hex digits for readability like the example
+	ctxStr := fmt.Sprintf("[%08x]", n.EmitContext)
+	msg := fmt.Sprintf("%s%s.%s %s", indent, n.Emitter, n.EventType, ctxStr)
+	// Log at trace level to avoid noise at higher levels
+	if t.log != nil {
+		t.log.Log(log.LevelTrace, msg)
+	}
+}
+
+func typeName(ev Event) string {
+	if ev == nil {
+		return "(nil)"
+	}
+	t := reflect.TypeOf(ev)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t.Name()
+}

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -137,6 +137,9 @@ func NewSupervisorBackend(ctx context.Context, logger log.Logger,
 
 	eventSys := event.NewSystem(logger, eventExec)
 	eventSys.AddTracer(event.NewMetricsTracer(m))
+	if logger.Enabled(context.Background(), log.LevelTrace) {
+		eventSys.AddTracer(event.NewCallGraphTracer(logger))
+	}
 
 	sysCtx, sysCancel := context.WithCancel(ctx)
 


### PR DESCRIPTION
**Description**

- Add CallGraphTracer to op-service/event to visualize hierarchical event flow across OnDeriveStart and OnEmit.
- Logs a compact call graph with 8-char correlation IDs, e.g.:
p2p.ReceivedBlockEvent [09ab623c]
└── clsync.ReceivedUnsafePayloadEvent [9277ffe6]
    └── engine.ForkchoiceRequestEvent [aca04240]
        └── engine.ForkchoiceUpdateEvent [e024a814]
            └── engine.ProcessUnsafePayloadEvent [78c3546d]

**Tests**

- No unit tests added: the tracer is observational only and gated by trace level.
- Manually verified by running with trace logs enabled and observing expected call graphs during block processing.

Repro:
- Build: go build ./...
- Run with trace: --log.level=trace (or equivalent) and check logs for call graph lines.


**Metadata**

- Fixes #16874 

