### PR TITLE
Use getCode consistent with other in new ASR address computation

### DIFF
--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1046,7 +1046,8 @@ contract OPContractsManager_NoSuperchainOrProtocolVersionsUpgrade_Test is Test {
                 "AnchorStateRegistry"
             )
         );
-        bytes memory initCode = bytes.concat(Bytes.slice(opcm.blueprints().proxy.code, 3), abi.encode(proxyAdmin));
+
+        bytes memory initCode = bytes.concat(vm.getCode("Proxy"), abi.encode(proxyAdmin));
         address newAnchorStateRegistryProxy = vm.computeCreate2Address(salt, keccak256(initCode), _delegateCaller);
         vm.label(newAnchorStateRegistryProxy, "NewAnchorStateRegistryProxy");
 


### PR DESCRIPTION
**Description**

A one line change to use vm.getCode which matches the approach used in other tests.