### PR TITLE
op-sync-tester: Verifier Engine APIs for Isthmus

### DIFF
--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -270,14 +270,13 @@ type ExecutionPayload struct {
 	WithdrawalsRoot *common.Hash `json:"withdrawalsRoot,omitempty"`
 }
 
-func (p *ExecutionPayload) Compare(o *ExecutionPayload) error {
+func (p *ExecutionPayload) CheckEqual(o *ExecutionPayload) error {
 	if p == nil || o == nil {
 		if p == o {
 			return nil
 		}
 		return fmt.Errorf("one of the payloads is nil: p=%v, o=%v", p, o)
 	}
-
 	if p.ParentHash != o.ParentHash {
 		return fmt.Errorf("ParentHash mismatch: %v != %v", p.ParentHash, o.ParentHash)
 	}
@@ -359,7 +358,6 @@ func (p *ExecutionPayload) Compare(o *ExecutionPayload) error {
 	if p.WithdrawalsRoot != nil && *p.WithdrawalsRoot != *o.WithdrawalsRoot {
 		return fmt.Errorf("WithdrawalsRoot mismatch: %v != %v", *p.WithdrawalsRoot, *o.WithdrawalsRoot)
 	}
-
 	return nil
 }
 

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -270,6 +270,99 @@ type ExecutionPayload struct {
 	WithdrawalsRoot *common.Hash `json:"withdrawalsRoot,omitempty"`
 }
 
+func (p *ExecutionPayload) Compare(o *ExecutionPayload) error {
+	if p == nil || o == nil {
+		if p == o {
+			return nil
+		}
+		return fmt.Errorf("one of the payloads is nil: p=%v, o=%v", p, o)
+	}
+
+	if p.ParentHash != o.ParentHash {
+		return fmt.Errorf("ParentHash mismatch: %v != %v", p.ParentHash, o.ParentHash)
+	}
+	if p.FeeRecipient != o.FeeRecipient {
+		return fmt.Errorf("FeeRecipient mismatch: %v != %v", p.FeeRecipient, o.FeeRecipient)
+	}
+	if p.StateRoot != o.StateRoot {
+		return fmt.Errorf("StateRoot mismatch: %v != %v", p.StateRoot, o.StateRoot)
+	}
+	if p.ReceiptsRoot != o.ReceiptsRoot {
+		return fmt.Errorf("ReceiptsRoot mismatch: %v != %v", p.ReceiptsRoot, o.ReceiptsRoot)
+	}
+	if p.LogsBloom != o.LogsBloom {
+		return fmt.Errorf("LogsBloom mismatch")
+	}
+	if p.PrevRandao != o.PrevRandao {
+		return fmt.Errorf("PrevRandao mismatch: %v != %v", p.PrevRandao, o.PrevRandao)
+	}
+	if p.BlockNumber != o.BlockNumber {
+		return fmt.Errorf("BlockNumber mismatch: %v != %v", p.BlockNumber, o.BlockNumber)
+	}
+	if p.GasLimit != o.GasLimit {
+		return fmt.Errorf("GasLimit mismatch: %v != %v", p.GasLimit, o.GasLimit)
+	}
+	if p.GasUsed != o.GasUsed {
+		return fmt.Errorf("GasUsed mismatch: %v != %v", p.GasUsed, o.GasUsed)
+	}
+	if p.Timestamp != o.Timestamp {
+		return fmt.Errorf("timestamp mismatch: %v != %v", p.Timestamp, o.Timestamp)
+	}
+	if p.BaseFeePerGas != o.BaseFeePerGas {
+		return fmt.Errorf("BaseFeePerGas mismatch: %v != %v", p.BaseFeePerGas, o.BaseFeePerGas)
+	}
+	if p.BlockHash != o.BlockHash {
+		return fmt.Errorf("BlockHash mismatch: %v != %v", p.BlockHash, o.BlockHash)
+	}
+	if !bytes.Equal(p.ExtraData, o.ExtraData) {
+		return fmt.Errorf("ExtraData mismatch")
+	}
+	if len(p.Transactions) != len(o.Transactions) {
+		return fmt.Errorf("transactions length mismatch: %d != %d", len(p.Transactions), len(o.Transactions))
+	}
+	for i := range p.Transactions {
+		if !bytes.Equal(p.Transactions[i], o.Transactions[i]) {
+			return fmt.Errorf("transaction[%d] mismatch", i)
+		}
+	}
+	if (p.Withdrawals == nil) != (o.Withdrawals == nil) {
+		return fmt.Errorf("withdrawals nil mismatch: %v != %v", p.Withdrawals == nil, o.Withdrawals == nil)
+	}
+	if p.Withdrawals != nil {
+		if p.Withdrawals.Len() != o.Withdrawals.Len() {
+			return fmt.Errorf("withdrawals length mismatch: %d != %d", p.Withdrawals.Len(), o.Withdrawals.Len())
+		}
+		for i := range p.Withdrawals.Len() {
+			if ((*p.Withdrawals)[i] == nil) != ((*o.Withdrawals)[i] == nil) {
+				return fmt.Errorf("withdrawals[%d] nil mismatch", i)
+			}
+			if (*p.Withdrawals)[i] != nil && *(*p.Withdrawals)[i] != *(*o.Withdrawals)[i] {
+				return fmt.Errorf("withdrawals[%d] mismatch", i)
+			}
+		}
+	}
+	if (p.BlobGasUsed == nil) != (o.BlobGasUsed == nil) {
+		return fmt.Errorf("BlobGasUsed nil mismatch")
+	}
+	if p.BlobGasUsed != nil && *p.BlobGasUsed != *o.BlobGasUsed {
+		return fmt.Errorf("BlobGasUsed mismatch: %v != %v", *p.BlobGasUsed, *o.BlobGasUsed)
+	}
+	if (p.ExcessBlobGas == nil) != (o.ExcessBlobGas == nil) {
+		return fmt.Errorf("ExcessBlobGas nil mismatch")
+	}
+	if p.ExcessBlobGas != nil && *p.ExcessBlobGas != *o.ExcessBlobGas {
+		return fmt.Errorf("ExcessBlobGas mismatch: %v != %v", *p.ExcessBlobGas, *o.ExcessBlobGas)
+	}
+	if (p.WithdrawalsRoot == nil) != (o.WithdrawalsRoot == nil) {
+		return fmt.Errorf("WithdrawalsRoot nil mismatch")
+	}
+	if p.WithdrawalsRoot != nil && *p.WithdrawalsRoot != *o.WithdrawalsRoot {
+		return fmt.Errorf("WithdrawalsRoot mismatch: %v != %v", *p.WithdrawalsRoot, *o.WithdrawalsRoot)
+	}
+
+	return nil
+}
+
 func (payload *ExecutionPayload) ID() BlockID {
 	return BlockID{Hash: payload.BlockHash, Number: uint64(payload.BlockNumber)}
 }

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -36,8 +36,12 @@ func SessionFromContext(ctx context.Context) (*Session, bool) {
 type Session struct {
 	SessionID string
 
+	// Non canonical view of the chain
+	Validated uint64
 	// Canonical view of the chain
 	CurrentState FCUState
+	// payloads
+	Payloads map[eth.PayloadID]*eth.ExecutionPayloadEnvelope
 
 	InitialState FCUState
 }

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -46,6 +46,12 @@ type Session struct {
 	InitialState FCUState
 }
 
+func (s *Session) UpdateFCUState(latest, safe, finalized uint64) {
+	s.CurrentState.Latest = latest
+	s.CurrentState.Safe = safe
+	s.CurrentState.Finalized = finalized
+}
+
 type FCUState struct {
 	Latest    uint64
 	Safe      uint64

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -239,6 +239,10 @@ func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) 
 	return nil, nil
 }
 
+// GetPayloadV4 retrieves an execution payload previously initialized by
+// ForkchoiceUpdated engine APIs when valid payload attributes were provided.
+// Retrieved payloads are deleted from the session after being served to
+// emulate one-time consumption by the consensus layer.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	if !payloadID.Is(engine.PayloadV3) {
 		return nil, engine.UnsupportedFork
@@ -265,12 +269,32 @@ func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.Forkcho
 	return nil, nil
 }
 
+// ForkchoiceUpdatedV3 processes a forkchoice state update from the consensus
+// layer, validates the request against the current execution layer state, and
+// optionally initializes a new payload build process if payload attributes are
+// provided. When payload attributes are not nil and validation succeeds, the
+// derived payload is stored for later retrieval via GetPayload.
+//
+// Return values:
+//   - {status: VALID, latestValidHash: headBlockHash, payloadId: id} when the
+//     forkchoice state is applied successfully and payload attributes were
+//     provided and validated.
+//   - {status: VALID, latestValidHash: headBlockHash, payloadId: null} when the
+//     forkchoice state is applied successfully but no payload build was started
+//     (attr was not provided).
+//   - {status: INVALID, latestValidHash: null, validationError: err} when payload
+//     attributes are malformed or finalized/safe blocks are not canonical.
+//   - {status: SYNCING} when the head block is unknown or not yet validated, or
+//     when block data cannot be retrieved from the execution layer.
 func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	session, err := s.fetchSession(ctx)
 	if err != nil {
 		return nil, err
 	}
+	// Validate attributes shape
 	if attr != nil {
+		// https://github.com/ethereum/execution-apis/blob/bc5a37ee69a64769bd8d0a2056672361ef5f3839/src/engine/cancun.md#engine_forkchoiceupdatedv3
+		// Spec: payloadAttributes matches the PayloadAttributesV3 structure, return -38003: Invalid payload attributes on failure.
 		if attr.Withdrawals == nil {
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing withdrawals"))
 		}
@@ -278,27 +302,23 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing beacon root"))
 		}
 	}
+	// Simulate head block hash check
 	candLatest, err := s.elReader.GetBlockByHash(ctx, state.HeadBlockHash)
+	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
+	// Spec: {payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null} if forkchoiceState.headBlockHash references an unknown payload or a payload that can't be validated because requisite data for the validation is missing
 	if err != nil {
+		// Consider as sync error if read only EL interaction fails because we cannot validate
 		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 	}
 	if candLatest.NumberU64() > session.Validated {
 		// Let CL backfill via newPayload
 		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 	}
-	var safeNum uint64
-	if state.SafeBlockHash != (common.Hash{}) {
-		candSafe, err := s.elReader.GetBlockByHash(ctx, state.SafeBlockHash)
-		if err != nil {
-			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not available"))
-		}
-		safeNum = candSafe.NumberU64()
-		if session.CurrentState.Latest < safeNum {
-			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not canonical"))
-		}
-	}
+	// Simulate db check for finalized head
 	var finalizedNum uint64
 	if state.FinalizedBlockHash != (common.Hash{}) {
+		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
+		// Spec: MUST return -38002: Invalid forkchoice state error if the payload referenced by forkchoiceState.headBlockHash is VALID and a payload referenced by either forkchoiceState.finalizedBlockHash or forkchoiceState.safeBlockHash does not belong to the chain defined by forkchoiceState.headBlockHash.
 		candFinalized, err := s.elReader.GetBlockByHash(ctx, state.FinalizedBlockHash)
 		if err != nil {
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("finalized block not available"))
@@ -308,19 +328,38 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("finalized block not canonical"))
 		}
 	}
+	// Simulate db check for safe head
+	var safeNum uint64
+	if state.SafeBlockHash != (common.Hash{}) {
+		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
+		// Spec: MUST return -38002: Invalid forkchoice state error if the payload referenced by forkchoiceState.headBlockHash is VALID and a payload referenced by either forkchoiceState.finalizedBlockHash or forkchoiceState.safeBlockHash does not belong to the chain defined by forkchoiceState.headBlockHash.
+		candSafe, err := s.elReader.GetBlockByHash(ctx, state.SafeBlockHash)
+		if err != nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not available"))
+		}
+		safeNum = candSafe.NumberU64()
+		if session.CurrentState.Latest < safeNum {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not canonical"))
+		}
+	}
 	var id *engine.PayloadID
 	if attr != nil {
 		// attr is the ingredient for the block built after the head block
 		candNum := int64(candLatest.NumberU64())
+		// Query read only EL to fetch block which is desired to be produced from attr
 		newBlock, err := s.elReader.GetBlockByNumber(ctx, rpc.BlockNumber(candNum+1))
 		if err != nil {
-			// Wait for backend EL to catch up
+			// Consider as sync error if read only EL interaction fails because we cannot validate
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 		}
-		// sanity check attr comparing with targetBlock
-		if err := s.attrCheck(attr, newBlock, true); err != nil {
+		// Sanity check attr comparing with newBlock
+		if err := s.validateAttributesForBlock(attr, newBlock, true); err != nil {
+			// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
+			// Client software MUST respond to this method call in the following way: {error: {code: -38003, message: "Invalid payload attributes"}} if the payload is deemed VALID and forkchoiceState has been applied successfully, but no build process has been started due to invalid payloadAttributes.
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(err)
 		}
+		// Initialize payload args for sane payload ID
+		// All attr fields already sanity checked
 		args := miner.BuildPayloadArgs{
 			Parent:        state.HeadBlockHash,
 			Timestamp:     uint64(attr.Timestamp),
@@ -336,22 +375,38 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 		}
 		payloadID := args.Id()
 		id = &payloadID
+		// Activate Shanghai(Canyon) and Isthmus
 		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
 		payloadEnv, err := eth.BlockAsPayloadEnv(newBlock, config)
 		if err != nil {
-			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(err)
+			// The failure is from the EL processing so consider as a server error and make CL retry
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.GenericServerError.With(err)
 		}
+		// Store payload and payloadID. This will be processed using GetPayload engine API
 		session.Payloads[payloadID] = payloadEnv
 	}
-	// Update FCU State
-	session.CurrentState.Latest = candLatest.NumberU64()
-	session.CurrentState.Safe = safeNum
-	session.CurrentState.Finalized = finalizedNum
+	session.UpdateFCUState(candLatest.NumberU64(), safeNum, finalizedNum)
 	s.storeSession(session)
+	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
+	// Spec: Client software MUST respond to this method call in the following way: {payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId} if the payload is deemed VALID and the build process has begun
 	return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: id}, nil
 }
 
-func (s *SyncTester) attrCheck(attr *eth.PayloadAttributes, block *types.Block, isHolocene bool) error {
+// validateAttributesForBlock verifies that a given block matches the expected
+// execution payload attributes. It ensures consistency between the provided
+// PayloadAttributes and the block header and body.
+//
+// OP Stack additions:
+//   - Transaction count and raw transaction bytes must match exactly.
+//   - NoTxPool must be always true, since sync tester only runs in verifier mode.
+//   - Gas limit must match.
+//   - If Holocene is active:
+//   - Extra data must be exactly 9 bytes.
+//   - The version byte must equal 0.
+//   - The remaining 8 bytes must match the EIP-1559 parameters.
+//
+// Returns an error if any mismatch or invalid condition is found, otherwise nil.
+func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, block *types.Block, isHolocene bool) error {
 	h := block.Header()
 	if h.Time != uint64(attr.Timestamp) {
 		return fmt.Errorf("timestamp mismatch: header=%d, attr=%d", h.Time, attr.Timestamp)
@@ -371,7 +426,7 @@ func (s *SyncTester) attrCheck(attr *eth.PayloadAttributes, block *types.Block, 
 	if (*attr.ParentBeaconBlockRoot).Cmp(*h.ParentBeaconRoot) != 0 {
 		return fmt.Errorf("parentBeaconBlockRoot mismatch: attr=%s, header=%s", *attr.ParentBeaconBlockRoot, *h.ParentBeaconRoot)
 	}
-	// Optimism additions
+	// OP Stack additions
 	if len(attr.Transactions) != len(block.Transactions()) {
 		return fmt.Errorf("tx count mismatch: attr=%d, header=%d", len(attr.Transactions), len(block.Transactions()))
 	}
@@ -386,15 +441,29 @@ func (s *SyncTester) attrCheck(attr *eth.PayloadAttributes, block *types.Block, 
 		}
 	}
 	if !attr.NoTxPool {
-		// Verifier is only supported
+		// Sync Tester only supports verifier sync
 		return errors.New("txpool cannot be enabled yet")
 	}
 	if *attr.GasLimit != eth.Uint64Quantity(h.GasLimit) {
 		return fmt.Errorf("gaslimit mismatch: attr=%d, header=%d", *attr.GasLimit, h.GasLimit)
 	}
-	if isHolocene && !bytes.Equal(block.Extra()[1:], (*attr.EIP1559Params)[:]) {
-		// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md
-		return fmt.Errorf("invalid eip1559Params params: %s", *attr.EIP1559Params)
+	if isHolocene {
+		if len(block.Extra()) != 9 {
+			// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header
+			// there is no additional data beyond these 9 bytes
+			return fmt.Errorf("extradata length: %d, desired: 9", len(block.Extra()))
+		}
+		version := block.Extra()[0]
+		if version != 0 {
+			// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header
+			// version must be 0
+			return fmt.Errorf("eip1559Params version: %d, desired: 0", version)
+		}
+		if !bytes.Equal(block.Extra()[1:], (*attr.EIP1559Params)[:]) {
+			// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-payloadattributesv3
+			// At and after Holocene activation, eip1559Parameters in PayloadAttributeV3 must be exactly 8 bytes with the following format:
+			return fmt.Errorf("invalid eip1559Params params: %s", *attr.EIP1559Params)
+		}
 	}
 	return nil
 }
@@ -411,6 +480,120 @@ func (s *SyncTester) NewPayloadV3(ctx context.Context, payload *eth.ExecutionPay
 	return nil, nil
 }
 
+// NewPayloadV4 validates and processes a new execution payload according to the
+// Engine API rules to simulate consensus-layer to execution-layer interactions
+// without advancing canonical chain state.
+//
+// The method enforces mandatory post-fork fields, including withdrawals, excessBlobGas,
+// blobGasUsed, versionedHashes, beaconRoot, executionRequests, and withdrawalsRoot,
+// returning an InvalidParams error if any are missing or improperly shaped.
+//
+// Additional validation includes:
+//   - Ensuring versionedHashes and executionRequests arrays are empty as required
+//     post isthmus.
+//   - Comparing the provided payload against the locally reconstructed payload
+//     from the execution client to detect mismatches.
+//   - Verifying the block hash via the execution payload envelope.
+//
+// Return values:
+//   - {status: VALID, latestValidHash: payload.blockHash} if validation succeeds.
+//   - {status: INVALID, latestValidHash: null, validationError: err} on mismatch
+//     or malformed payloads.
+//   - {status: SYNCING} when the block cannot be executed because its parent is missing.
+//   - Errors surfaced as engine.InvalidParams or engine.GenericServerError to
+//     trigger appropriate consensus-layer retries.
+func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Validate request shape, fork required fields
+	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2
+	// Spec: Client software MUST return -32602: Invalid params error if the wrong version of the structure is used in the method call.
+	if payload.Withdrawals == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
+	}
+	if payload.ExcessBlobGas == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
+	}
+	if payload.BlobGasUsed == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil blobGasUsed post-cancun"))
+	}
+	if versionedHashes == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
+	}
+	if beaconRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil beaconRoot post-cancun"))
+	}
+	if executionRequests == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil executionRequests post-prague"))
+	}
+	// OP Stack specific request shape validation
+	if payload.WithdrawalsRoot == nil {
+		// https://github.com/ethereum-optimism/specs/blob/a773587fca6756f8468164613daa79fcee7bbbe4/specs/protocol/exec-engine.md#engine_newpayloadv3
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+	}
+	if len(versionedHashes) != 0 {
+		// https://github.com/ethereum-optimism/specs/blob/a773587fca6756f8468164613daa79fcee7bbbe4/specs/protocol/exec-engine.md#engine_newpayloadv3
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(fmt.Errorf("versionedHashes length non-zero: %d", len(versionedHashes)))
+	}
+	if len(executionRequests) != 0 {
+		// https://github.com/ethereum-optimism/specs/blob/a773587fca6756f8468164613daa79fcee7bbbe4/specs/protocol/exec-engine.md#engine_newpayloadv4
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(fmt.Errorf("executionRequests must be empty array but got %d", len(executionRequests)))
+	}
+	// Look up canonical block for relay comparison
+	block, err := s.elReader.GetBlockByHash(ctx, payload.BlockHash)
+	if err != nil {
+		// Do not know block hash included in payload is correct or not. Consider as a server error and make CL retry
+		if errors.Is(err, ethereum.NotFound) {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("block not found", err))
+		}
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to fetch block", err))
+	}
+	blockHash := block.Hash()
+	// We only attempt to advance non-canonical view of the chain, following the read only EL
+	if block.NumberU64() <= session.Validated+1 {
+		// Already have the block locally or advance single block without setting the head
+		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#specification
+		// Spec: MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
+		// Activate Shanghai(Canyon) and Isthmus
+		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
+		correctPayload, err := eth.BlockAsPayload(block, config)
+		if err != nil {
+			// The failure is from the EL processing so consider as a server error and make CL retry
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed convert block to payload: %w", err))
+		}
+		// Check given payload matches the payload derived using the read only EL block
+		if err := correctPayload.CheckEqual(payload); err != nil {
+			// Consider as block hash validation error when payload mismatch
+			return s.newPayloadInvalid(fmt.Errorf("payload check mismatch: %w", err), nil), nil
+		}
+		// Sanity check parent beacon block root and block hash by recomputation
+		execEnvelope := eth.ExecutionPayloadEnvelope{ParentBeaconBlockRoot: beaconRoot, ExecutionPayload: payload}
+		actual, ok := execEnvelope.CheckBlockHash()
+		if blockHash != payload.BlockHash || !ok {
+			return s.newPayloadInvalid(fmt.Errorf("block hash check from execution envelope failed. %s != %s", blockHash, actual), nil), nil
+		}
+		if block.NumberU64() == session.Validated+1 {
+			// Advance single block without setting the head, equivalent to geth InsertBlockWithoutSetHead
+			session.Validated += 1
+			s.storeSession(session)
+		}
+		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
+		// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
+		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &blockHash}, nil
+	}
+	// Block not available so mark as syncing
+	return &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil
+}
+
+func wrapSyncTesterError(msg string, err error) error {
+	if err == nil {
+		return fmt.Errorf("sync tester: %s", msg)
+	}
+	return fmt.Errorf("sync tester: %s: %w", msg, err)
+}
+
 func (s *SyncTester) newPayloadInvalid(err error, latestValid *types.Header) *eth.PayloadStatusV1 {
 	var currentHash *common.Hash
 	if latestValid != nil {
@@ -425,84 +608,4 @@ func (s *SyncTester) newPayloadInvalid(err error, latestValid *types.Header) *et
 	}
 	errorMsg := err.Error()
 	return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid, LatestValidHash: currentHash, ValidationError: &errorMsg}
-}
-
-func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// NewPayloadV4 is used starting from Isthmus HF. Activate necessary configs in field to populate execution payload fields
-	// https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/isthmus/exec-engine.md#engine_newpayloadv4-api
-	// Validate request shape, fork required fields
-	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2
-	// Spec: Client software MUST return -32602: Invalid params error if the wrong version of the structure is used in the method call.
-	if payload.Withdrawals == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
-	}
-	if payload.ExcessBlobGas == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
-	}
-	if payload.BlobGasUsed == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil blobGasUsed post-cancun"))
-	}
-	if payload.WithdrawalsRoot == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
-	}
-	if versionedHashes == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
-	}
-	if len(versionedHashes) != 0 {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("op stack does not use blob txs"))
-	}
-	if beaconRoot == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil beaconRoot post-cancun"))
-	}
-	if executionRequests == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("executionRequests must be an empty array for isthmus/prague"))
-	}
-	if len(executionRequests) != 0 {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("executionRequests should be empty for isthmus/prague"))
-	}
-	// Look up canonical block for relay comparison
-	block, err := s.elReader.GetBlockByHash(ctx, payload.BlockHash)
-	if err != nil {
-		// Do not know block hash included in payload is correct or not. Consider as a server error and make CL retry
-		if errors.Is(err, ethereum.NotFound) {
-			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("sync tester: block not found: %w", err))
-		}
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("sync tester: failed to fetch block: %w", err))
-	}
-	hash := block.Hash()
-	// We only attempt to advance non-canonical view of the chain, following the read only EL
-	if block.NumberU64() <= session.Validated+1 {
-		// Already have the block locally or advance single block without setting the head
-		// Spec: Client software MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
-		// Validate beacon root by recomputing hash
-		execEnvelope := eth.ExecutionPayloadEnvelope{ParentBeaconBlockRoot: beaconRoot, ExecutionPayload: payload}
-		_, ok := execEnvelope.CheckBlockHash()
-		if block.Hash() != payload.BlockHash || !ok {
-			return s.newPayloadInvalid(errors.New("sync tester: hash mismatch"), nil), nil
-		}
-		// Activate Shanghai and Isthmus
-		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
-		correctPayload, err := eth.BlockAsPayload(block, config)
-		if err != nil {
-			// The failure is from the EL processing so consider as a server error
-			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("sync tester: failed convert block to payload: %w", err))
-		}
-		// Check that the payload matches the real one, and if not consider as blockHash validation failure
-		if err := correctPayload.Compare(payload); err != nil {
-			return s.newPayloadInvalid(fmt.Errorf("sync tester: payload mismatch: %w", err), nil), nil
-		}
-		if block.NumberU64() == session.Validated+1 {
-			// Advance single block without setting the head
-			session.Validated += 1
-			s.storeSession(session)
-		}
-		// If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
-		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &hash}, nil
-	}
-	// Block not available so mark as syncing
-	return &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,11 +11,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/miner"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
@@ -236,7 +240,21 @@ func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) 
 }
 
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return nil, nil
+	if !payloadID.Is(engine.PayloadV3) {
+		return nil, engine.UnsupportedFork
+	}
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	payloadEnv, ok := session.Payloads[payloadID]
+	if !ok {
+		return nil, engine.UnknownPayload
+	}
+	// Clean up payload
+	delete(session.Payloads, payloadID)
+	s.storeSession(session)
+	return payloadEnv, nil
 }
 
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
@@ -248,7 +266,137 @@ func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.Forkcho
 }
 
 func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if attr != nil {
+		if attr.Withdrawals == nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing withdrawals"))
+		}
+		if attr.ParentBeaconBlockRoot == nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing beacon root"))
+		}
+	}
+	candLatest, err := s.elReader.GetBlockByHash(ctx, state.HeadBlockHash)
+	if err != nil {
+		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+	}
+	if candLatest.NumberU64() > session.Validated {
+		// Let CL backfill via newPayload
+		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+	}
+	var safeNum uint64
+	if state.SafeBlockHash != (common.Hash{}) {
+		candSafe, err := s.elReader.GetBlockByHash(ctx, state.SafeBlockHash)
+		if err != nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not available"))
+		}
+		safeNum = candSafe.NumberU64()
+		if session.CurrentState.Latest < safeNum {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not canonical"))
+		}
+	}
+	var finalizedNum uint64
+	if state.FinalizedBlockHash != (common.Hash{}) {
+		candFinalized, err := s.elReader.GetBlockByHash(ctx, state.FinalizedBlockHash)
+		if err != nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("finalized block not available"))
+		}
+		finalizedNum = candFinalized.NumberU64()
+		if session.CurrentState.Latest < finalizedNum {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("finalized block not canonical"))
+		}
+	}
+	var id *engine.PayloadID
+	if attr != nil {
+		// attr is the ingredient for the block built after the head block
+		candNum := int64(candLatest.NumberU64())
+		newBlock, err := s.elReader.GetBlockByNumber(ctx, rpc.BlockNumber(candNum+1))
+		if err != nil {
+			// Wait for backend EL to catch up
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+		}
+		// sanity check attr comparing with targetBlock
+		if err := s.attrCheck(attr, newBlock, true); err != nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(err)
+		}
+		args := miner.BuildPayloadArgs{
+			Parent:        state.HeadBlockHash,
+			Timestamp:     uint64(attr.Timestamp),
+			FeeRecipient:  attr.SuggestedFeeRecipient,
+			Random:        common.Hash(attr.PrevRandao),
+			Withdrawals:   *attr.Withdrawals,
+			BeaconRoot:    attr.ParentBeaconBlockRoot,
+			NoTxPool:      attr.NoTxPool,
+			Transactions:  newBlock.Transactions(),
+			GasLimit:      &newBlock.Header().GasLimit,
+			Version:       engine.PayloadV3,
+			EIP1559Params: (*attr.EIP1559Params)[:],
+		}
+		payloadID := args.Id()
+		id = &payloadID
+		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
+		payloadEnv, err := eth.BlockAsPayloadEnv(newBlock, config)
+		if err != nil {
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(err)
+		}
+		session.Payloads[payloadID] = payloadEnv
+	}
+	// Update FCU State
+	session.CurrentState.Latest = candLatest.NumberU64()
+	session.CurrentState.Safe = safeNum
+	session.CurrentState.Finalized = finalizedNum
+	s.storeSession(session)
+	return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: id}, nil
+}
+
+func (s *SyncTester) attrCheck(attr *eth.PayloadAttributes, block *types.Block, isHolocene bool) error {
+	h := block.Header()
+	if h.Time != uint64(attr.Timestamp) {
+		return fmt.Errorf("timestamp mismatch: header=%d, attr=%d", h.Time, attr.Timestamp)
+	}
+	if h.MixDigest != common.Hash(attr.PrevRandao) {
+		return fmt.Errorf("prevRandao mismatch: header=%s, attr=%s", h.MixDigest, attr.PrevRandao)
+	}
+	if h.Coinbase != attr.SuggestedFeeRecipient {
+		return fmt.Errorf("coinbase mismatch: header=%s, attr=%s", h.Coinbase, attr.SuggestedFeeRecipient)
+	}
+	if attr.Withdrawals != nil && len(*attr.Withdrawals) != 0 {
+		return errors.New("withdrawals must be nil or empty")
+	}
+	if attr.ParentBeaconBlockRoot == nil || h.ParentBeaconRoot == nil {
+		return fmt.Errorf("parentBeaconBlockRoot must be provided")
+	}
+	if (*attr.ParentBeaconBlockRoot).Cmp(*h.ParentBeaconRoot) != 0 {
+		return fmt.Errorf("parentBeaconBlockRoot mismatch: attr=%s, header=%s", *attr.ParentBeaconBlockRoot, *h.ParentBeaconRoot)
+	}
+	// Optimism additions
+	if len(attr.Transactions) != len(block.Transactions()) {
+		return fmt.Errorf("tx count mismatch: attr=%d, header=%d", len(attr.Transactions), len(block.Transactions()))
+	}
+	for idx := range len(attr.Transactions) {
+		blockTx := block.Transactions()[idx]
+		blockTxRaw, err := blockTx.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("failed to marshal block tx: %w", err)
+		}
+		if !bytes.Equal([]byte(attr.Transactions[idx]), blockTxRaw) {
+			return fmt.Errorf("tx mismatch: tx=%s, idx=%d", attr.Transactions[idx], idx)
+		}
+	}
+	if !attr.NoTxPool {
+		// Verifier is only supported
+		return errors.New("txpool cannot be enabled yet")
+	}
+	if *attr.GasLimit != eth.Uint64Quantity(h.GasLimit) {
+		return fmt.Errorf("gaslimit mismatch: attr=%d, header=%d", *attr.GasLimit, h.GasLimit)
+	}
+	if isHolocene && !bytes.Equal(block.Extra()[1:], (*attr.EIP1559Params)[:]) {
+		// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md
+		return fmt.Errorf("invalid eip1559Params params: %s", *attr.EIP1559Params)
+	}
+	return nil
 }
 
 func (s *SyncTester) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
@@ -263,6 +411,98 @@ func (s *SyncTester) NewPayloadV3(ctx context.Context, payload *eth.ExecutionPay
 	return nil, nil
 }
 
+func (s *SyncTester) newPayloadInvalid(err error, latestValid *types.Header) *eth.PayloadStatusV1 {
+	var currentHash *common.Hash
+	if latestValid != nil {
+		if latestValid.Difficulty.BitLen() != 0 {
+			// Set latest valid hash to 0x0 if parent is PoW block
+			currentHash = &common.Hash{}
+		} else {
+			// Otherwise set latest valid hash to parent hash
+			h := latestValid.Hash()
+			currentHash = &h
+		}
+	}
+	errorMsg := err.Error()
+	return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid, LatestValidHash: currentHash, ValidationError: &errorMsg}
+}
+
 func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// NewPayloadV4 is used starting from Isthmus HF. Activate necessary configs in field to populate execution payload fields
+	// https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/isthmus/exec-engine.md#engine_newpayloadv4-api
+	// Validate request shape, fork required fields
+	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2
+	// Spec: Client software MUST return -32602: Invalid params error if the wrong version of the structure is used in the method call.
+	if payload.Withdrawals == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
+	}
+	if payload.ExcessBlobGas == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
+	}
+	if payload.BlobGasUsed == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil blobGasUsed post-cancun"))
+	}
+	if payload.WithdrawalsRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+	}
+	if versionedHashes == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
+	}
+	if len(versionedHashes) != 0 {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("op stack does not use blob txs"))
+	}
+	if beaconRoot == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil beaconRoot post-cancun"))
+	}
+	if executionRequests == nil {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("executionRequests must be an empty array for isthmus/prague"))
+	}
+	if len(executionRequests) != 0 {
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("executionRequests should be empty for isthmus/prague"))
+	}
+	// Look up canonical block for relay comparison
+	block, err := s.elReader.GetBlockByHash(ctx, payload.BlockHash)
+	if err != nil {
+		// Do not know block hash included in payload is correct or not. Consider as a server error and make CL retry
+		if errors.Is(err, ethereum.NotFound) {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("sync tester: block not found: %w", err))
+		}
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("sync tester: failed to fetch block: %w", err))
+	}
+	hash := block.Hash()
+	// We only attempt to advance non-canonical view of the chain, following the read only EL
+	if block.NumberU64() <= session.Validated+1 {
+		// Already have the block locally or advance single block without setting the head
+		// Spec: Client software MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
+		// Validate beacon root by recomputing hash
+		execEnvelope := eth.ExecutionPayloadEnvelope{ParentBeaconBlockRoot: beaconRoot, ExecutionPayload: payload}
+		_, ok := execEnvelope.CheckBlockHash()
+		if block.Hash() != payload.BlockHash || !ok {
+			return s.newPayloadInvalid(errors.New("sync tester: hash mismatch"), nil), nil
+		}
+		// Activate Shanghai and Isthmus
+		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
+		correctPayload, err := eth.BlockAsPayload(block, config)
+		if err != nil {
+			// The failure is from the EL processing so consider as a server error
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("sync tester: failed convert block to payload: %w", err))
+		}
+		// Check that the payload matches the real one, and if not consider as blockHash validation failure
+		if err := correctPayload.Compare(payload); err != nil {
+			return s.newPayloadInvalid(fmt.Errorf("sync tester: payload mismatch: %w", err), nil), nil
+		}
+		if block.NumberU64() == session.Validated+1 {
+			// Advance single block without setting the head
+			session.Validated += 1
+			s.storeSession(session)
+		}
+		// If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
+		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &hash}, nil
+	}
+	// Block not available so mark as syncing
+	return &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -375,8 +375,8 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 		}
 		payloadID := args.Id()
 		id = &payloadID
-		// Activate Shanghai(Canyon) and Isthmus
-		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
+		// Activate Canyon and Isthmus
+		config := &params.ChainConfig{CanyonTime: new(uint64), IsthmusTime: new(uint64)}
 		payloadEnv, err := eth.BlockAsPayloadEnv(newBlock, config)
 		if err != nil {
 			// The failure is from the EL processing so consider as a server error and make CL retry
@@ -556,8 +556,8 @@ func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPay
 		// Already have the block locally or advance single block without setting the head
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#specification
 		// Spec: MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
-		// Activate Shanghai(Canyon) and Isthmus
-		config := &params.ChainConfig{ShanghaiTime: new(uint64), IsthmusTime: new(uint64)}
+		// Activate Canyon and Isthmus
+		config := &params.ChainConfig{CanyonTime: new(uint64), IsthmusTime: new(uint64)}
 		correctPayload, err := eth.BlockAsPayload(block, config)
 		if err != nil {
 			// The failure is from the EL processing so consider as a server error and make CL retry

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -64,11 +64,13 @@ func parseSession(r *http.Request, log log.Logger) (*http.Request, error) {
 		}
 		session := &backend.Session{
 			SessionID: sessionID,
+			Validated: latest,
 			CurrentState: backend.FCUState{
 				Latest:    latest,
 				Safe:      safe,
 				Finalized: finalized,
 			},
+			Payloads: make(map[eth.PayloadID]*eth.ExecutionPayloadEnvelope),
 			InitialState: backend.FCUState{
 				Latest:    latest,
 				Safe:      safe,

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -40,6 +40,7 @@ func TestParseSession_Valid(t *testing.T) {
 	require.Equal(t, uint64(100), session.InitialState.Latest)
 	require.Equal(t, uint64(90), session.InitialState.Safe)
 	require.Equal(t, uint64(80), session.InitialState.Finalized)
+	require.Equal(t, session.InitialState.Latest, session.Validated)
 	require.Equal(t, session.InitialState, session.CurrentState)
 	require.Equal(t, "/chain/1/synctest", newReq.URL.Path)
 }
@@ -59,6 +60,7 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 	require.Equal(t, uint64(0), session.InitialState.Latest)
 	require.Equal(t, uint64(0), session.InitialState.Safe)
 	require.Equal(t, uint64(0), session.InitialState.Finalized)
+	require.Equal(t, session.InitialState.Latest, session.Validated)
 	require.Equal(t, session.InitialState, session.CurrentState)
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Implements engine API relay for Isthmus syncing: `ForkchoiceUpdatedV3`, `NewPayloadV4`, `GetPayloadV4`.

All the remaining engine API endpoints will be the subset of these, and will be implemented at the follow up PR.

Extends the session model to behave as a thin EL wrapper, maintaining minimal state.
```go
type Session struct {
	SessionID string

	// Non canonical view of the chain
	Validated uint64
	// Canonical view of the chain
	CurrentState FCUState
	// payloads
	Payloads map[eth.PayloadID]*eth.ExecutionPayloadEnvelope

	InitialState FCUState
}
```

Each API supports sanity checking and returns appropriate engine API response based on the engine API spec.

In a high level view, when we sync single block, we step below engine API calls

1. `ForkchoiceUpdatedV3` with attrs not nil: Adds `Session.Payloads` and returning payload id
2. `GetPayloadV4`: Fetches payloads using payload id
3. `NewPayloadV4`: Advances EL state without advancing head, actually producing blocks via execution
4. `ForkchoiceUpdatedV3` with attrs nil: Actually advances head

We do the upper steps using the read only EL. Sync tester session will never hold a fork of a chain, but always maintain a canonical(`session.CurrentState`) and non canonical view(`session.Validated`) of chain that follows the read only EL.

**Tests**

There are no unit tests and acceptance test yet. But I validated the sync tester using the 
1. local kurtosis devnet
2. op-sepolia

All post isthmus.

To reproduce(example: op-sepolia), 

Spin up sync tester, make sure `example_config.yaml` contains op-sepolia read only EL endpoint.
```
cd optimism/op-sync-tester
just
./bin/op-sync-tester --config example_config.yaml --rpc.port=8551
```

Connect op-node to the sync tester and wait to advance its `session.CurrentState`
```
cd optimism/op-node
just
./op-node --l2="http://127.0.0.1:8551/chain/11155420/synctest/7b39fb24-4acf-4d45-8920-ab27b6a31ee4?latest=31987000&safe=31987000&finalized=31987000" --l2.jwt-secret=./jwt.txt --network op-sepolia --rpc.addr=0.0.0.0 --rpc.port=8547 --l1=<l1-sepolia-endpoint> --l1.beacon=<l1-sepolia-beacon-endpoint>  --p2p.disable=true --sequencer.enabled=false --log.level=DEBUG
```

Query op-node using `optimism_SyncStatus` and compare the response with original op-node.

Note that I only tested with no CL p2p sync, so every L2 blocks were derived from L1 while testing.

**Metadata**

- Partially fixes https://github.com/ethereum-optimism/optimism/issues/16701. Next steps will be supporting all the engine API namespaces, to support every OP Stack hardforks.
