### PR TITLE
op-deployer: fix bootstrap implementations flags

### DIFF
--- a/op-deployer/book/src/user-guide/bootstrap.md
+++ b/op-deployer/book/src/user-guide/bootstrap.md
@@ -3,8 +3,8 @@
 > Note: if you are joining an existing superchain, you can skip to the `init` and `apply` commands to create your L2 chain(s)
 
 Bootstrap commands are used to deploy global singletons and implementation contracts for new superchains.
-The deployed contract be then be use with future invocations of `apply` so that new L2 chains can join that superchain.
-Most users won't need to use these commands, since `op-deployer apply` will automatically use predeployed contracts if they are available. However, you may need to use bootstrap commands if you're deploying chains to an L1 that isn't natively supported by `op-deployer`.
+The deployed contracts can then be used with future invocations of `apply` so that new L2 chains can join that superchain.
+Most users won't need to use these commands, since `op-deployer apply` will automatically use standard predeployed contracts for the L1/settlement-layer you are deploying on. However, you will need to use bootstrap commands if you're creating a new superchain.
 
 There are several bootstrap commands available, which you can view by running `op-deployer bootstrap --help`. We'll
 focus on the most important ones, which should be run in the sequence listed below.
@@ -18,7 +18,6 @@ so the deployment address has no further control over the system.
 op-deployer bootstrap superchain \
   --l1-rpc-url="<rpc url>" \
   --private-key="<contract deployer private key>" \
-  --artifacts-locator="<locator>" \
   --outfile="./.deployer/bootstrap_superchain.json" \
   --superchain-proxy-admin-owner="<role address>" \
   --protocol-versions-owner="<role address>" \
@@ -49,13 +48,13 @@ This command will deploy several contracts, and output a JSON like the one below
 
 ```shell
 op-deployer bootstrap implementations \
-  --artifacts-locator="<locator>" \
   --l1-rpc-url="<rpc url>" \
   --outfile="./.deployer/bootstrap_implementations.json" \
-  --mips-version="<1 or 2, for MIPS32 or MIPS64>" \
   --private-key="<contract deployer private key>" \
-  --protocol-versions-proxy="<address output from bootstrap superchain>" \
-  --superchain-config-proxy="<address output from bootstrap superchain>" \
+  --protocol-versions-proxy="<contract address output from bootstrap superchain>" \
+  --superchain-config-proxy="<contract address output from bootstrap superchain>" \
+  --superchain-proxy-admin="<contract address from bootstrap superchain>" \
+  --challenger="<role address for the superchain's challenger>" \
   --upgrade-controller="<superchain-proxy-admin-owner used in bootstrap superchain>"
 ```
 
@@ -70,19 +69,26 @@ The command will output a JSON like the one below:
 
 ```json
 {
-  "Opcm": "0x4eeb114aaf812e21285e5b076030110e7e18fed9",
-  "DelayedWETHImpl": "0x5e40b9231b86984b5150507046e354dbfbed3d9e",
-  "OptimismPortalImpl": "0x2d7e764a0d9919e16983a46595cfa81fc34fa7cd",
-  "PreimageOracleSingleton": "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3",
-  "MipsSingleton": "0xf027f4a985560fb13324e943edf55ad6f1d15dc1",
-  "SystemConfigImpl": "0x760c48c62a85045a6b69f07f4a9f22868659cbcc",
-  "L1CrossDomainMessengerImpl": "0x3ea6084748ed1b2a9b5d4426181f1ad8c93f6231",
-  "L1ERC721BridgeImpl": "0x276d3730f219f7ec22274f7263180b8452b46d47",
-  "L1StandardBridgeImpl": "0x78972e88ab8bbb517a36caea23b931bab58ad3c6",
-  "OptimismMintableERC20FactoryImpl": "0x5493f4677a186f64805fe7317d6993ba4863988f",
-  "DisputeGameFactoryImpl": "0x4bba758f006ef09402ef31724203f316ab74e4a0",
-  "AnchorStateRegistryImpl": "0x7b465370bb7a333f99edd19599eb7fb1c2d3f8d2",
-  "SuperchainConfigImpl": "0x4da82a327773965b8d4d85fa3db8249b387458e7",
-  "ProtocolVersionsImpl": "0x37e15e4d6dffa9e5e320ee1ec036922e563cb76c"
+  "opcmAddress": "0x82879934658738b6d5e8f781933ae7bbae05ba31",
+  "opcmContractsContainerAddress": "0x1e8de1574a2e085b7a292c760d90cf982d3c1a11",
+  "opcmGameTypeAdderAddress": "0xcab868d42d9088b86598a96d010db5819c19b847",
+  "opcmDeployerAddress": "0xf8b6718b28fa36b430334e78adaf97174fed818c",
+  "opcmUpgraderAddress": "0xa4d0a44890fafce541bdc4c1ca36fca1b5d22f56",
+  "opcmInteropMigratorAddress": "0xf0fca53bb450dd2230c7eb58a39a5dbfc8492fb6",
+  "opcmStandardValidatorAddress": "0x1364a02f64f03cd990f105058b8cc93a9a0ab2a1",
+  "delayedWETHImplAddress": "0x570da3694c06a250aea4855b4adcd09505801f9a",
+  "optimismPortalImplAddress": "0x1aa1d3fc9b39d7edd7ca69f54a35c66dcf1168f1",
+  "ethLockboxImplAddress": "0xe6e51fa10d481002301534445612c61bae6b3258",
+  "preimageOracleSingletonAddress": "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3",
+  "mipsSingletonAddress": "0x7a8456ba22df0cb303ae1c93d3cf68ea3a067006",
+  "systemConfigImplAddress": "0x9f2b1fffd8a7aeef7aeeb002fd8477a4868e7e0a",
+  "l1CrossDomainMessengerImplAddress": "0x085952eb0f0c3d1ca82061e20e0fe8203cdd630a",
+  "l1ERC721BridgeImplAddress": "0xbafd2cae054ddf69af27517c6bea912de6b7eb8f",
+  "l1StandardBridgeImplAddress": "0x6abaa7b42b9a947047c01f41b9bcb8684427bf24",
+  "optimismMintableERC20FactoryImplAddress": "0xdd0b293b8789e9208481cee5a0c7e78f451d32bf",
+  "disputeGameFactoryImplAddress": "0xe7ab0c07ee92aae31f213b23a132a155f5c2c7cc",
+  "anchorStateRegistryImplAddress": "0xda4f46fad0e38d763c56da62c4bc1e9428624893",
+  "superchainConfigImplAddress": "0xdaf60e3c5ef116810779719da88410cce847c2a4",
+  "protocolVersionsImplAddress": "0xa95ac4790fedd68d9c3b30ed730afaec6029eb31"
 }
 ```

--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -132,6 +132,11 @@ var (
 		Usage:   "Path to a JSON file",
 		EnvVars: deployer.PrefixEnvVar("CONFIG"),
 	}
+	ChallengerFlag = &cli.StringFlag{
+		Name:    "challenger",
+		Usage:   "Challenger.",
+		EnvVars: deployer.PrefixEnvVar("CHALLENGER"),
+	}
 )
 
 var ImplementationsFlags = []cli.Flag{
@@ -149,6 +154,7 @@ var ImplementationsFlags = []cli.Flag{
 	ProtocolVersionsProxyFlag,
 	UpgradeControllerFlag,
 	SuperchainProxyAdminFlag,
+	ChallengerFlag,
 }
 
 var ProxyFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	mipsVersion "github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
@@ -115,6 +116,13 @@ func ImplementationsCLI(cliCtx *cli.Context) error {
 		return fmt.Errorf("failed to populate config: %w", err)
 	}
 	cfg.Logger = l
+
+	artifactsURLStr := cliCtx.String(deployer.ArtifactsLocatorFlagName)
+	artifactsLocator := new(artifacts.Locator)
+	if err := artifactsLocator.UnmarshalText([]byte(artifactsURLStr)); err != nil {
+		return fmt.Errorf("failed to parse artifacts URL: %w", err)
+	}
+	cfg.ArtifactsLocator = artifactsLocator
 
 	ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
 	outfile := cliCtx.String(OutfileFlagName)


### PR DESCRIPTION
# Overview
This pr fixes a few bugs related to the following cli command: `op-deployer bootstrap implementations`.

Bugs:
* `challenger` is now a required input, but was not a flag recognized by `bootstrap implementations`
* `bootstrap implementations` should support `embedded` artifacts locator (same as `bootstrap superchain`) but it was producing the error `failed to deploy implementations: invalid config for Implementations: artifacts locator must be specified` without adding the code in this pr to process the artifacts-locator cli flag 

# Follow-up work
Extend op-deployer integration tests so that they cover cli inputs instead of starting at the underlying library functions that are invoked after the cli flags are interpreted.