### PR TITLE
op-node: Remove TryUpdateEngine event

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -125,7 +125,7 @@ func (s *L2Sequencer) ActL2EndBlock(t Testing) {
 
 	// After having built a L2 block, make sure to get an engine update processed,
 	// and request a forkchoice update directly.
-	s.synchronousEvents.Emit(t.Ctx(), engine.TryUpdateEngineEvent{})
+	s.engine.TryUpdateEngine(t.Ctx())
 	s.engine.RequestForkchoiceUpdate(t.Ctx())
 	require.NoError(t, s.drainer.DrainUntil(func(ev event.Event) bool {
 		x, ok := ev.(engine.ForkchoiceUpdateEvent)

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -1053,7 +1053,7 @@ func TestSpanBatchAtomicity_Consolidation(gt *testing.T) {
 		} else {
 			// Make sure we do the post-processing of what safety updates might happen
 			// Digest events until EngDeriver implicitly consumes PromoteSafeEvent
-			verifier.ActL2EventsUntil(t, event.Is[engine2.TryUpdateEngineEvent], 100, true)
+			verifier.ActL2PipelineFull(t)
 			// Once the span batch is fully processed, the safe head must advance to the end of span batch.
 			require.Equal(t, verifier.L2Safe().Number, targetHeadNumber)
 			require.Equal(t, verifier.L2Safe(), verifier.L2PendingSafe())

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -83,7 +83,6 @@ type EngineController interface {
 	engine.LocalEngineControl
 	IsEngineSyncing() bool
 	InsertUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error
-	TryUpdateEngine(ctx context.Context) error
 	TryBackupUnsafeReorg(ctx context.Context) (bool, error)
 }
 

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -407,7 +407,7 @@ func (s *SyncDeriver) SyncStep() {
 
 	s.tryBackupUnsafeReorg()
 
-	s.Emitter.Emit(s.Ctx, engine.TryUpdateEngineEvent{})
+	s.Engine.TryUpdateEngine(s.Ctx)
 
 	if s.Engine.IsEngineSyncing() {
 		// The pipeline cannot move forwards if doing EL sync.

--- a/op-node/rollup/engine/api.go
+++ b/op-node/rollup/engine/api.go
@@ -138,7 +138,7 @@ func (ec *EngineController) CommitBlock(ctx context.Context, signed *opsigner.Si
 
 	ec.SetUnsafeHead(ref)
 	ec.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
-	if err := ec.TryUpdateEngine(ctx); err != nil {
+	if err := ec.tryUpdateEngine(ctx); err != nil {
 		return fmt.Errorf("failed to update engine forkchoice: %w", err)
 	}
 	return nil

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -41,13 +41,13 @@ func (eq *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucc
 			Ref:      ev.Ref.BlockRef(),
 		})
 		// Apply it to the execution engine
-		eq.emitter.Emit(ctx, TryUpdateEngineEvent{})
+		eq.TryUpdateEngine(ctx)
 		// Not a regular reset, since we don't wind back to any L2 block.
 		// We start specifically from the replacement block.
 		return
 	}
 
-	// TryUpdateUnsafe, TryUpdatePendingSafe, TryUpdateLocalSafe, TryUpdateEngine must be sequentially invoked
+	// TryUpdateUnsafe, TryUpdatePendingSafe, TryUpdateLocalSafe, tryUpdateEngine must be sequentially invoked
 	eq.TryUpdateUnsafe(ctx, ev.Ref)
 	// If derived from L1, then it can be considered (pending) safe
 	if ev.DerivedFrom != (eth.L1BlockRef{}) {
@@ -55,7 +55,7 @@ func (eq *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucc
 		eq.TryUpdateLocalSafe(ctx, ev.Ref, ev.Concluding, ev.DerivedFrom)
 	}
 	// Now if possible synchronously call FCU
-	err := eq.TryUpdateEngine(ctx)
+	err := eq.tryUpdateEngine(ctx)
 	if err != nil {
 		eq.log.Error("Failed to update engine", "error", err)
 	}


### PR DESCRIPTION
Removes the `TryUpdateEngine` event. The `BuildStarted` and `Envelope` fields were never populated, so all of the metrics collection logic was unused. This made for a pretty clean refactor.

I'll try the other `Try*` family of events in a subsequent PR - I bet they'll be similar in scope.
