### PR TITLE
refactor: optimize nested fmt.Sprintf in formatBigIntFixedPrecision

### DIFF
--- a/op-chain-ops/script/console.go
+++ b/op-chain-ops/script/console.go
@@ -57,8 +57,7 @@ func formatBigIntFixedPrecision(x *big.Int, precision uint) string {
 	prec := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
 	integer, remainder := new(big.Int).QuoRem(x, prec, new(big.Int))
 	if remainder.Sign() != 0 {
-		decimal := fmt.Sprintf("%0"+fmt.Sprintf("%d", precision)+"d",
-			new(big.Int).Abs(remainder))
+		decimal := fmt.Sprintf("%0*d", int(precision), new(big.Int).Abs(remainder))
 		decimal = strings.TrimRight(decimal, "0")
 		return fmt.Sprintf("%d.%s", integer, decimal)
 	} else {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Replace nested fmt.Sprintf calls with Go's standard dynamic width field specifier (%0*d) for better performance and readability. This eliminates unnecessary string concatenation and reduces the function from two fmt.Sprintf calls to one.

All existing tests pass, confirming the change is functionally equivalent while being more efficient and idiomatic Go code.
