### PR TITLE
feat(op-batcher,op-node): improve unsafe_da_bytes accuracy using channel DA estimates

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -133,6 +133,14 @@ func (c *ChannelBuilder) OutputBytes() int {
 	return c.outputBytes
 }
 
+func (c *ChannelBuilder) DAEstimate() int {
+	type daEstimator interface{ DAEstimate() int }
+	if estCo, ok := c.co.(daEstimator); ok {
+		return estCo.DAEstimate()
+	}
+	return 0
+}
+
 // Blocks returns a backup list of all blocks that were added to the channel. It
 // can be used in case the channel needs to be rebuilt.
 func (c *ChannelBuilder) Blocks() []SizedBlock {

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -586,6 +586,10 @@ func (s *channelManager) unsafeBytesInOpenChannels() int64 {
 	var bytesInOpenChannels int64
 	for _, channel := range s.channelQueue {
 		if channel.TotalFrames() == 0 {
+			if est := channel.channelBuilder.DAEstimate(); est > 0 {
+				bytesInOpenChannels += int64(est)
+				continue
+			}
 			for _, block := range channel.channelBuilder.blocks {
 				bytesInOpenChannels += int64(block.EstimatedDABytes())
 			}

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -222,6 +222,10 @@ func (co *SingularChannelOut) OutputFrame(w *bytes.Buffer, maxSize uint64) (uint
 	}
 }
 
+func (co *SingularChannelOut) DAEstimate() int {
+	return co.compress.Len()
+}
+
 // BlockToSingularBatch transforms a block into a batch object that can easily be RLP encoded.
 func BlockToSingularBatch(rollupCfg *rollup.Config, block *types.Block) (*SingularBatch, *L1BlockInfo, error) {
 	if len(block.Transactions()) == 0 {

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -45,6 +45,9 @@ type SpanChannelOut struct {
 	// to seal full span batches (that have reached the max block count) in the rlp slices.
 	sealedRLPBytes int
 
+	// cached estimate of DA size for the current span channel. Updated on optimization branch and after compress.
+	daSizeEstimate int
+
 	chainSpec *rollup.ChainSpec
 
 	// for testing purposes, this can be overridden to modify the raw span batch
@@ -129,6 +132,7 @@ func (co *SpanChannelOut) Reset() error {
 	co.lastCompressedRLPSize = 0
 	co.compressor.Reset()
 	co.resetSpanBatch()
+	co.daSizeEstimate = 0
 	// setting the new randomID is the only part of the reset that can fail
 	return co.setRandomID()
 }
@@ -223,6 +227,7 @@ func (co *SpanChannelOut) addSingularBatch(batch *SingularBatch, seqNum uint64) 
 	// this optimizes out cases where the compressor will obviously come in under the target size
 	rlpGrowth := active.Len() - co.lastCompressedRLPSize
 	if uint64(co.compressor.Len()+rlpGrowth) < co.target {
+		co.daSizeEstimate += rlpGrowth // best-effort estimate without forcing compression
 		return nil
 	}
 
@@ -290,6 +295,8 @@ func (co *SpanChannelOut) compress() error {
 		return err
 	}
 	co.checkFull()
+	// note: full case already handled because compress is then called again on backup rlp buffer without last block
+	co.daSizeEstimate = co.compressor.Len()
 	return nil
 }
 
@@ -374,4 +381,8 @@ func (co *SpanChannelOut) OutputFrame(w *bytes.Buffer, maxSize uint64) (uint16, 
 	} else {
 		return fn, nil
 	}
+}
+
+func (co *SpanChannelOut) DAEstimate() int {
+	return co.daSizeEstimate
 }


### PR DESCRIPTION
1. Add cached DA size estimate to SpanChannelOut and update it:
- Increment on fast-path when compression is skipped (rlpGrowth).
- Set to compressor.Len() after compression.
- Reset on Reset().
- Expose via DAEstimate().

2. Expose DAEstimate() for SingularChannelOut (returns compress.Len()).
3. Add ChannelBuilder.DAEstimate() wrapper to surface channel-out estimates.
4., Use DAEstimate() in channel_manager.unsafeBytesInOpenChannels() for open channels (when TotalFrames()==0), with a fallback to per-block EstimatedDABytes().

Closes #17081