### PR TITLE
fix: add missing Addr() method to Oracle interface

### DIFF
--- a/op-challenger/game/keccak/challenger.go
+++ b/op-challenger/game/keccak/challenger.go
@@ -16,6 +16,7 @@ import (
 type Oracle interface {
 	VerifierPreimageOracle
 	ChallengeTx(ident keccakTypes.LargePreimageIdent, challenge keccakTypes.Challenge) (txmgr.TxCandidate, error)
+	Addr() common.Address
 }
 
 type ChallengeMetrics interface {


### PR DESCRIPTION
Add missing Addr() common.Address method to the Oracle interface to match the embedded VerifierPreimageOracle interface requirements.

**Why separate:** This is a specific interface fix for the keccak challenger.
