### PR TITLE
fix: set explicit IPv4 binding for op-devstack services

### DIFF
--- a/op-devstack/sysgo/faucet.go
+++ b/op-devstack/sysgo/faucet.go
@@ -94,7 +94,9 @@ func WithFaucets(l1ELs []stack.L1ELNodeID, l2ELs []stack.L2ELNodeID) stack.Optio
 			}
 		}
 		cfg := &config.Config{
-			RPC: oprpc.CLIConfig{},
+			RPC: oprpc.CLIConfig{
+				ListenAddr: "127.0.0.1",
+			},
 			Faucets: &fconf.Config{
 				Faucets: faucets,
 			},

--- a/op-devstack/sysgo/l2_proposer.go
+++ b/op-devstack/sysgo/l2_proposer.go
@@ -96,7 +96,9 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 		PollInterval:      500 * time.Millisecond,
 		AllowNonFinalized: true,
 		TxMgrConfig:       setuputils.NewTxMgrConfig(endpoint.URL(l1EL.userRPC), proposerSecret),
-		RPCConfig:         oprpc.CLIConfig{},
+		RPCConfig: oprpc.CLIConfig{
+			ListenAddr: "127.0.0.1",
+		},
 		LogConfig: oplog.CLIConfig{
 			Level:  log.LvlInfo,
 			Format: oplog.FormatText,

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -67,7 +67,9 @@ func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 		}
 
 		cfg := &config.Config{
-			RPC: oprpc.CLIConfig{},
+			RPC: oprpc.CLIConfig{
+				ListenAddr: "127.0.0.1",
+			},
 			SyncTesters: &stconf.Config{
 				SyncTesters: syncTesters,
 			},

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -340,11 +340,13 @@ func TestBackendCallsMetrics(t *testing.T) {
 
 	fullCfgSet := fullConfigSet(t, 1)
 	cfg := &config.Config{
-		Version:               "test",
-		LogConfig:             oplog.CLIConfig{},
-		MetricsConfig:         opmetrics.CLIConfig{},
-		PprofConfig:           oppprof.CLIConfig{},
-		RPC:                   oprpc.CLIConfig{},
+		Version:       "test",
+		LogConfig:     oplog.CLIConfig{},
+		MetricsConfig: opmetrics.CLIConfig{},
+		PprofConfig:   oppprof.CLIConfig{},
+		RPC: oprpc.CLIConfig{
+			ListenAddr: "127.0.0.1",
+		},
 		FullConfigSetSource:   fullCfgSet,
 		SynchronousProcessors: true,
 		MockRun:               false,
@@ -535,11 +537,13 @@ func TestAsyncVerifyAccessWithRPC(t *testing.T) {
 
 	// Initialize backend with mock metrics
 	cfg := &config.Config{
-		Version:               "test",
-		LogConfig:             oplog.CLIConfig{},
-		MetricsConfig:         opmetrics.CLIConfig{},
-		PprofConfig:           oppprof.CLIConfig{},
-		RPC:                   oprpc.CLIConfig{},
+		Version:       "test",
+		LogConfig:     oplog.CLIConfig{},
+		MetricsConfig: opmetrics.CLIConfig{},
+		PprofConfig:   oppprof.CLIConfig{},
+		RPC: oprpc.CLIConfig{
+			ListenAddr: "127.0.0.1",
+		},
 		FullConfigSetSource:   fullCfgSet,
 		SynchronousProcessors: true,
 		MockRun:               false,


### PR DESCRIPTION
Fixes #17082 by explicitly setting ListenAddr to "127.0.0.1" in all oprpc.CLIConfig initializations.

Problem: Services were binding to IPv6 [::] by default, causing connection errors and test failures.

Changes:
- op-devstack/sysgo/faucet.go
- op-devstack/sysgo/sync_tester.go  
- op-devstack/sysgo/l2_proposer.go
- op-supervisor/supervisor/backend/backend_test.go

All services now consistently bind to IPv4 127.0.0.1, resolving the "broken pipe" errors reported by Base users.