### PR TITLE
ci: Have contracts-bedrock-tests depend on op-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,6 +743,10 @@ jobs:
         description: Profile to use for testing
         type: string
         default: ci
+      check_changed_patterns:
+        description: List of changed files to run tests on
+        type: string
+        default: contracts-bedrock
     steps:
       - checkout-from-workspace
       - run:
@@ -755,7 +759,7 @@ jobs:
             fi
           working_directory: packages/contracts-bedrock
       - check-changed:
-          patterns: contracts-bedrock
+          patterns: <<parameters.check_changed_patterns>>
       - run:
           name: Print dependencies
           command: just dep-status
@@ -1843,6 +1847,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+          check_changed_patterns: contracts-bedrock,op-node
       - contracts-bedrock-tests:
           # PreimageOracle test is slow, run it separately to unblock CI.
           name: contracts-bedrock-tests-preimage-oracle


### PR DESCRIPTION
Turns out we need to do this because `go-ffi` depends on the op-node. We only re-enable the `op-node` dependency for the core unit tests - not upgrade or coverage tests.
