### PR TITLE
feat: creator pattern integrate FaultDisputeGameV2 into DGF

### DIFF
--- a/packages/contracts-bedrock/interfaces/dispute/IDisputeGameFactory.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IDisputeGameFactory.sol
@@ -21,6 +21,7 @@ interface IDisputeGameFactory is IProxyAdminOwnedBase, IReinitializableBase {
 
     event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
     event ImplementationSet(address indexed impl, GameType indexed gameType);
+    event ImplementationArgsSet(GameType indexed gameType, bytes args);
     event InitBondUpdated(GameType indexed gameType, uint256 indexed newBond);
     event Initialized(uint8 version);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
@@ -46,6 +47,7 @@ interface IDisputeGameFactory is IProxyAdminOwnedBase, IReinitializableBase {
         view
         returns (GameType gameType_, Timestamp timestamp_, IDisputeGame proxy_);
     function gameCount() external view returns (uint256 gameCount_);
+    function gameArgs(GameType) external view returns (bytes memory);
     function gameImpls(GameType) external view returns (IDisputeGame);
     function games(
         GameType _gameType,
@@ -68,6 +70,8 @@ interface IDisputeGameFactory is IProxyAdminOwnedBase, IReinitializableBase {
     function owner() external view returns (address);
     function renounceOwnership() external;
     function setImplementation(GameType _gameType, IDisputeGame _impl) external;
+    function setImplementation(GameType _gameType, IDisputeGame _impl, bytes calldata _args) external;
+    function setImplementationArgs(GameType _gameType, bytes calldata _args) external;
     function setInitBond(GameType _gameType, uint256 _initBond) external;
     function transferOwnership(address newOwner) external; // nosemgrep
     function version() external view returns (string memory);

--- a/packages/contracts-bedrock/interfaces/dispute/IDisputeGameFactory.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IDisputeGameFactory.sol
@@ -71,7 +71,6 @@ interface IDisputeGameFactory is IProxyAdminOwnedBase, IReinitializableBase {
     function renounceOwnership() external;
     function setImplementation(GameType _gameType, IDisputeGame _impl) external;
     function setImplementation(GameType _gameType, IDisputeGame _impl, bytes calldata _args) external;
-    function setImplementationArgs(GameType _gameType, bytes calldata _args) external;
     function setInitBond(GameType _gameType, uint256 _initBond) external;
     function transferOwnership(address newOwner) external; // nosemgrep
     function version() external view returns (string memory);

--- a/packages/contracts-bedrock/interfaces/dispute/v2/IFaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/IFaultDisputeGameV2.sol
@@ -28,15 +28,10 @@ interface IFaultDisputeGameV2 is IDisputeGame {
 
     struct GameConstructorParams {
         GameType gameType;
-        Claim absolutePrestate;
         uint256 maxGameDepth;
         uint256 splitDepth;
         Duration clockExtension;
         Duration maxClockDuration;
-        IBigStepper vm;
-        IDelayedWETH weth;
-        IAnchorStateRegistry anchorStateRegistry;
-        uint256 l2ChainId;
     }
 
     error AlreadyInitialized();

--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -351,6 +351,7 @@ var excludedPaths = []string{
 	// These naming inconsistencies may indicate the presence of specialized test
 	// infrastructure beyond standard harnesses or different setup contracts patterns.
 	"test/dispute/FaultDisputeGame.t.sol",               // Contains contracts not matching FaultDisputeGame base name
+	"test/dispute/v2/FaultDisputeGameV2.t.sol",          // Contains contracts not matching FaultDisputeGameV2 base name
 	"test/dispute/SuperFaultDisputeGame.t.sol",          // Contains contracts not matching SuperFaultDisputeGame base name
 	"test/L1/ResourceMetering.t.sol",                    // Contains contracts not matching ResourceMetering base name
 	"test/L1/OPContractsManagerStandardValidator.t.sol", // Contains contracts not matching OPContractsManagerStandardValidator base name

--- a/packages/contracts-bedrock/snapshots/abi/DisputeGameFactory.json
+++ b/packages/contracts-bedrock/snapshots/abi/DisputeGameFactory.json
@@ -372,24 +372,6 @@
         "type": "uint32"
       },
       {
-        "internalType": "bytes",
-        "name": "_args",
-        "type": "bytes"
-      }
-    ],
-    "name": "setImplementationArgs",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "GameType",
-        "name": "_gameType",
-        "type": "uint32"
-      },
-      {
         "internalType": "uint256",
         "name": "_initBond",
         "type": "uint256"

--- a/packages/contracts-bedrock/snapshots/abi/DisputeGameFactory.json
+++ b/packages/contracts-bedrock/snapshots/abi/DisputeGameFactory.json
@@ -92,6 +92,25 @@
   {
     "inputs": [
       {
+        "internalType": "GameType",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "gameArgs",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_index",
         "type": "uint256"
@@ -330,6 +349,47 @@
         "type": "uint32"
       },
       {
+        "internalType": "contract IDisputeGame",
+        "name": "_impl",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_args",
+        "type": "bytes"
+      }
+    ],
+    "name": "setImplementation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_args",
+        "type": "bytes"
+      }
+    ],
+    "name": "setImplementationArgs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
         "internalType": "uint256",
         "name": "_initBond",
         "type": "uint256"
@@ -389,6 +449,25 @@
       }
     ],
     "name": "DisputeGameCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "args",
+        "type": "bytes"
+      }
+    ],
+    "name": "ImplementationArgsSet",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameV2.json
@@ -9,11 +9,6 @@
             "type": "uint32"
           },
           {
-            "internalType": "Claim",
-            "name": "absolutePrestate",
-            "type": "bytes32"
-          },
-          {
             "internalType": "uint256",
             "name": "maxGameDepth",
             "type": "uint256"
@@ -32,26 +27,6 @@
             "internalType": "Duration",
             "name": "maxClockDuration",
             "type": "uint64"
-          },
-          {
-            "internalType": "contract IBigStepper",
-            "name": "vm",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IDelayedWETH",
-            "name": "weth",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IAnchorStateRegistry",
-            "name": "anchorStateRegistry",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "l2ChainId",
-            "type": "uint256"
           }
         ],
         "internalType": "struct FaultDisputeGameV2.GameConstructorParams",
@@ -72,7 +47,7 @@
         "type": "bytes32"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -108,7 +83,7 @@
         "type": "address"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -563,7 +538,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -926,7 +901,7 @@
         "type": "address"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -952,7 +927,7 @@
         "type": "address"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -172,8 +172,8 @@
     "sourceCodeHash": "0x8fdd69d4bcd33a3d8b49a73ff5b6855f9ad5f7e2b7393e67cd755973b127b1e8"
   },
   "src/dispute/v2/FaultDisputeGameV2.sol:FaultDisputeGameV2": {
-    "initCodeHash": "0x783f53074c734fbbbd99211bd06a7d98189bc266bb0ab5cf58b9e09a6e717eb5",
-    "sourceCodeHash": "0xacb3a97464c5ecc4b8777dcb79cf886f6d0138aa2271d7d3f91ae5521bd54b54"
+    "initCodeHash": "0x13ef27ad793c95be884dea8259ac06619bf13d10868c5fc9980bc402b59efb8d",
+    "sourceCodeHash": "0x47c141889e647820759a2eaa84c31be8acdce6427cc4fe7c00a482ba44d62b87"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xdebf2ab3af4d5549c40e9dd9db6b2458af286f323b6891f3b0c4e89f3c8928db"
   },
   "src/dispute/DisputeGameFactory.sol:DisputeGameFactory": {
-    "initCodeHash": "0xa3e6a7466e16e6b7a8ce7a257ec543c1bf675e24f53565080d826404654b9262",
-    "sourceCodeHash": "0x1871aaeba0658f17270190cc95ffff172d92dca795d698401ec34a7462bf5242"
+    "initCodeHash": "0xc8a6b7ddff5b3977244d97fa1cf21af90fd79a729733fe614cca95eb1f5ee1e3",
+    "sourceCodeHash": "0xf57a2880f568494217351fbd0ef3a89ba6bf5673d3f241cc5a8f3f9b05b33661"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
     "initCodeHash": "0xe7d3c982532946d196d7efadb9e2576c76b8f9e0d1f885ac36977d6f3fb72a65",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -172,8 +172,8 @@
     "sourceCodeHash": "0x8fdd69d4bcd33a3d8b49a73ff5b6855f9ad5f7e2b7393e67cd755973b127b1e8"
   },
   "src/dispute/v2/FaultDisputeGameV2.sol:FaultDisputeGameV2": {
-    "initCodeHash": "0xe7d3c982532946d196d7efadb9e2576c76b8f9e0d1f885ac36977d6f3fb72a65",
-    "sourceCodeHash": "0x691ed84b678a9429513e72eb995f88a359072218ce5b434d82817ae85f296a3e"
+    "initCodeHash": "0x1e58280efd3031fd6c208714bde5f832687537d2984d78e1a640bafb3cba675f",
+    "sourceCodeHash": "0x01ed8a3d23f373057b663a6b0dc83a2240f30470b79eb76512b734ac5ce549ce"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xbafeb3a2d475a450fb1c51fe54d87a44a0875432b06d217f9bc9e5c25905d1f5",
-    "sourceCodeHash": "0x9cf8f0e75ed0d6a433ed23ad3e7e18c3b1489e97aa1a055172ad39d06279b052"
+    "initCodeHash": "0x8bcb4af509ca349a0c681117bfa4422af80b4500bf3abd9820c3abd98beeec82",
+    "sourceCodeHash": "0x462b7f6e98cf3991377e8eea81086da9686991a54a12bb983dd92a3f343ae767"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x3e8a3bed20aa10b6d285cd926903c4d8c34aad3ba5c0e9e32da3cde13b179238",
-    "sourceCodeHash": "0x6a31abe2f73c7279a00a8fcecb6741af8e6fe54a1112420e6a15859753487dbb"
+    "initCodeHash": "0xbafeb3a2d475a450fb1c51fe54d87a44a0875432b06d217f9bc9e5c25905d1f5",
+    "sourceCodeHash": "0x9cf8f0e75ed0d6a433ed23ad3e7e18c3b1489e97aa1a055172ad39d06279b052"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",
@@ -152,8 +152,8 @@
     "sourceCodeHash": "0xdebf2ab3af4d5549c40e9dd9db6b2458af286f323b6891f3b0c4e89f3c8928db"
   },
   "src/dispute/DisputeGameFactory.sol:DisputeGameFactory": {
-    "initCodeHash": "0xc8a6b7ddff5b3977244d97fa1cf21af90fd79a729733fe614cca95eb1f5ee1e3",
-    "sourceCodeHash": "0xf57a2880f568494217351fbd0ef3a89ba6bf5673d3f241cc5a8f3f9b05b33661"
+    "initCodeHash": "0x41ea0025ffbbb7dabc45da9b8afe4bce6b8ec1f132b424f351cf8c7d3fe15579",
+    "sourceCodeHash": "0x81ffb8f29b29774847e8b699d8719aaf6c633070841b8e2c3a651105822ce9ea"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
     "initCodeHash": "0xe7d3c982532946d196d7efadb9e2576c76b8f9e0d1f885ac36977d6f3fb72a65",
@@ -172,8 +172,8 @@
     "sourceCodeHash": "0x8fdd69d4bcd33a3d8b49a73ff5b6855f9ad5f7e2b7393e67cd755973b127b1e8"
   },
   "src/dispute/v2/FaultDisputeGameV2.sol:FaultDisputeGameV2": {
-    "initCodeHash": "0x1e58280efd3031fd6c208714bde5f832687537d2984d78e1a640bafb3cba675f",
-    "sourceCodeHash": "0x01ed8a3d23f373057b663a6b0dc83a2240f30470b79eb76512b734ac5ce549ce"
+    "initCodeHash": "0x783f53074c734fbbbd99211bd06a7d98189bc266bb0ab5cf58b9e09a6e717eb5",
+    "sourceCodeHash": "0xacb3a97464c5ecc4b8777dcb79cf886f6d0138aa2271d7d3f91ae5521bd54b54"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x168bcbeb70286b2b915b88d153d4136b350a4347d8b4d08ba186a3bc3461d113",
-    "sourceCodeHash": "0x477cb7396a533d917a16bde620a1e7199e7a91573c43ff51ad588c231dd11d2a"
+    "initCodeHash": "0xf75d4f70513aaaab0aaa2914ffe8a5614041940970624637fe5923244f81c422",
+    "sourceCodeHash": "0x422fb56d89bcfd4fb7825632b0dffc6ea90e6c53b2b593a1de512b101dfd9002"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x8bcb4af509ca349a0c681117bfa4422af80b4500bf3abd9820c3abd98beeec82",
-    "sourceCodeHash": "0x462b7f6e98cf3991377e8eea81086da9686991a54a12bb983dd92a3f343ae767"
+    "initCodeHash": "0x168bcbeb70286b2b915b88d153d4136b350a4347d8b4d08ba186a3bc3461d113",
+    "sourceCodeHash": "0x477cb7396a533d917a16bde620a1e7199e7a91573c43ff51ad588c231dd11d2a"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/snapshots/storageLayout/DisputeGameFactory.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/DisputeGameFactory.json
@@ -61,5 +61,12 @@
     "offset": 0,
     "slot": "104",
     "type": "GameId[]"
+  },
+  {
+    "bytes": "32",
+    "label": "gameArgs",
+    "offset": 0,
+    "slot": "105",
+    "type": "mapping(GameType => bytes)"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -211,7 +211,7 @@ contract OPContractsManagerStandardValidator is ISemver {
 
     /// @notice Returns the expected DisputeGameFactory version.
     function disputeGameFactoryVersion() public pure returns (string memory) {
-        return "1.2.0";
+        return "1.3.0";
     }
 
     /// @notice Returns the expected AnchorStateRegistry version.

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -36,8 +36,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.9.0
-    string public constant version = "1.9.0";
+    /// @custom:semver 1.10.0
+    string public constant version = "1.10.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -168,15 +168,15 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         // Clone the implementation contract and initialize it with the given parameters.
         //
         // CWIA Calldata Layout:
-        // ┌───────────────┬─────────────────────────────────────┐
-        // │     Bytes     │            Description              │
-        // ├───────────────┼─────────────────────────────────────┤
-        // │ [0, 20)       │ Game creator address                │
-        // │ [20, 52)      │ Root claim                          │
-        // │ [52, 84)      │ Parent block hash at creation time  │
-        // │ [84, 84 + n)  │ Extra data (opaque)                 │
-        // │ [84+n, 84+n+m)│ implementation Args (opaque)        │
-        // └───────────────┴─────────────────────────────────────┘
+        // ┌──────────────────────┬─────────────────────────────────────┐
+        // │        Bytes         │            Description              │
+        // ├──────────────────────┼─────────────────────────────────────┤
+        // │ [0, 20)              │ Game creator address                │
+        // │ [20, 52)             │ Root claim                          │
+        // │ [52, 84)             │ Parent block hash at creation time  │
+        // │ [84, 84 + n)         │ Extra data (opaque)                 │
+        // │ [84 + n, 84 + n + m) │ Implementation args (opaque)        │
+        // └──────────────────────┴─────────────────────────────────────┘
         proxy_ = IDisputeGame(
             address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData, gameArgs[_gameType]))
         );

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -36,6 +36,11 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     /// @param gameType The type of the DisputeGame.
     event ImplementationSet(address indexed impl, GameType indexed gameType);
 
+    /// @notice Emitted when a game type's implementation args are set
+    /// @param gameType The type of the DisputeGame.
+    /// @param args The constructor args for the game type.
+    event ImplementationArgsSet(GameType indexed gameType, bytes args);
+
     /// @notice Emitted when a game type's initialization bond is updated
     /// @param gameType The type of the DisputeGame.
     /// @param newBond The new bond (in wei) for initializing the game type.
@@ -51,8 +56,8 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.0
-    string public constant version = "1.2.0";
+    /// @custom:semver 1.3.0
+    string public constant version = "1.3.0";
 
     /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
     ///         `IDisputeGame` implementations.
@@ -68,6 +73,10 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     /// @notice An append-only array of disputeGames that have been created. Used by offchain game solvers to
     ///         efficiently track dispute games.
     GameId[] internal _disputeGameList;
+
+    /// @notice Maps each Game Type to an associated configuration to use with it, but because we need to pass them
+    ///         to a clone with immutable args so they have to be stored as arbitrary bytes unfortunately
+    mapping(GameType => bytes) public gameArgs;
 
     /// @notice Constructs a new DisputeGameFactory contract.
     constructor() OwnableUpgradeable() ReinitializableBase(1) {
@@ -165,9 +174,17 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         // │ [0, 20)      │ Game creator address               │
         // │ [20, 52)     │ Root claim                         │
         // │ [52, 84)     │ Parent block hash at creation time │
-        // │ [84, 84 + n) │ Extra data (opaque)                │
+        // │ [84, 116)    │ Extra data (32 bytes, padded)      │
+        // │ [116, 148)   │ Absolute prestate                  │
+        // │ [148, 168)   │ VM address                         │
+        // │ [168, 188)   │ Anchor state registry address      │
+        // │ [188, 208)   │ WETH address                       │
+        // │ [208, 240)   │ L2 Chain ID (32 bytes)             │
+        // │ [240, ..)    │ Additional game-specific args      │
         // └──────────────┴────────────────────────────────────┘
-        proxy_ = IDisputeGame(address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData)));
+        proxy_ = IDisputeGame(
+            address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData, gameArgs[_gameType]))
+        );
         proxy_.initialize{ value: msg.value }();
 
         // Compute the unique identifier for the dispute game.
@@ -266,6 +283,28 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     function setImplementation(GameType _gameType, IDisputeGame _impl) external onlyOwner {
         gameImpls[_gameType] = _impl;
         emit ImplementationSet(address(_impl), _gameType);
+    }
+
+    /// @notice Sets the implementation contract for a specific `GameType`.
+    /// @dev May only be called by the `owner`.
+    /// @param _gameType The type of the DisputeGame.
+    /// @param _impl The implementation contract for the given `GameType`.
+    /// @param _args The constructor args to be passed for each implementation
+    function setImplementation(GameType _gameType, IDisputeGame _impl, bytes calldata _args) external onlyOwner {
+        gameImpls[_gameType] = _impl;
+        gameArgs[_gameType] = _args;
+
+        emit ImplementationSet(address(_impl), _gameType);
+        emit ImplementationArgsSet(_gameType, _args);
+    }
+
+    /// @notice Sets the implementation args for a specific `GameType`.
+    /// @dev May only be called by the `owner`. Maintains backwards compatibility.
+    /// @param _gameType The type of the DisputeGame.
+    /// @param _args The constructor args to be passed for the implementation.
+    function setImplementationArgs(GameType _gameType, bytes calldata _args) external onlyOwner {
+        gameArgs[_gameType] = _args;
+        emit ImplementationArgsSet(_gameType, _args);
     }
 
     /// @notice Sets the bond (in wei) for initializing a game type.

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -298,15 +298,6 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         emit ImplementationArgsSet(_gameType, _args);
     }
 
-    /// @notice Sets the implementation args for a specific `GameType`.
-    /// @dev May only be called by the `owner`. Maintains backwards compatibility.
-    /// @param _gameType The type of the DisputeGame.
-    /// @param _args The constructor args to be passed for the implementation.
-    function setImplementationArgs(GameType _gameType, bytes calldata _args) external onlyOwner {
-        gameArgs[_gameType] = _args;
-        emit ImplementationArgsSet(_gameType, _args);
-    }
-
     /// @notice Sets the bond (in wei) for initializing a game type.
     /// @dev May only be called by the `owner`.
     /// @param _gameType The type of the DisputeGame.

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -168,20 +168,15 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         // Clone the implementation contract and initialize it with the given parameters.
         //
         // CWIA Calldata Layout:
-        // ┌──────────────┬────────────────────────────────────┐
-        // │    Bytes     │            Description             │
-        // ├──────────────┼────────────────────────────────────┤
-        // │ [0, 20)      │ Game creator address               │
-        // │ [20, 52)     │ Root claim                         │
-        // │ [52, 84)     │ Parent block hash at creation time │
-        // │ [84, 116)    │ Extra data (32 bytes, padded)      │
-        // │ [116, 148)   │ Absolute prestate                  │
-        // │ [148, 168)   │ VM address                         │
-        // │ [168, 188)   │ Anchor state registry address      │
-        // │ [188, 208)   │ WETH address                       │
-        // │ [208, 240)   │ L2 Chain ID (32 bytes)             │
-        // │ [240, ..)    │ Additional game-specific args      │
-        // └──────────────┴────────────────────────────────────┘
+        // ┌───────────────┬─────────────────────────────────────┐
+        // │     Bytes     │            Description              │
+        // ├───────────────┼─────────────────────────────────────┤
+        // │ [0, 20)       │ Game creator address                │
+        // │ [20, 52)      │ Root claim                          │
+        // │ [52, 84)      │ Parent block hash at creation time  │
+        // │ [84, 84 + n)  │ Extra data (opaque)                 │
+        // │ [84+n, 84+n+m)│ implementation Args (opaque)        │
+        // └───────────────┴─────────────────────────────────────┘
         proxy_ = IDisputeGame(
             address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData, gameArgs[_gameType]))
         );

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -296,7 +296,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // configured starting block number.
         if (l2BlockNumber() <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
 
-        // Validate VM-related parameters that require access to the VM.
+        // Validate parameters that require access to the VM.
         // The PreimageOracle challenge period must fit into uint64 so we can safely use it here.
         if (vm().oracle().challengePeriod() > type(uint64).max) revert InvalidChallengePeriod();
 

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -98,15 +98,10 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     ///         avoid stack-too-deep errors when compiling without the optimizer enabled.
     struct GameConstructorParams {
         GameType gameType;
-        Claim absolutePrestate;
         uint256 maxGameDepth;
         uint256 splitDepth;
         Duration clockExtension;
         Duration maxClockDuration;
-        IBigStepper vm;
-        IDelayedWETH weth;
-        IAnchorStateRegistry anchorStateRegistry;
-        uint256 l2ChainId;
     }
 
     ////////////////////////////////////////////////////////////////
@@ -130,10 +125,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     //                         State Vars                         //
     ////////////////////////////////////////////////////////////////
 
-    /// @notice The absolute prestate of the instruction trace. This is a constant that is defined
-    ///         by the program that is being used to execute the trace.
-    Claim internal immutable ABSOLUTE_PRESTATE;
-
     /// @notice The max depth of the game.
     uint256 internal immutable MAX_GAME_DEPTH;
 
@@ -144,20 +135,8 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     /// @notice The maximum duration that may accumulate on a team's chess clock before they may no longer respond.
     Duration internal immutable MAX_CLOCK_DURATION;
 
-    /// @notice An onchain VM that performs single instruction steps on a fault proof program trace.
-    IBigStepper internal immutable VM;
-
     /// @notice The game type ID.
     GameType internal immutable GAME_TYPE;
-
-    /// @notice WETH contract for holding ETH.
-    IDelayedWETH internal immutable WETH;
-
-    /// @notice The anchor state registry.
-    IAnchorStateRegistry internal immutable ANCHOR_STATE_REGISTRY;
-
-    /// @notice The chain ID of the L2 network this contract argues about.
-    uint256 internal immutable L2_CHAIN_ID;
 
     /// @notice The duration of the clock extension. Will be doubled if the grandchild is the root claim of an execution
     ///         trace bisection subgame.
@@ -245,40 +224,26 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // The split depth cannot be 0 or 1 to stay in bounds of clock extension arithmetic.
         if (_params.splitDepth < 2) revert InvalidSplitDepth();
 
-        // The PreimageOracle challenge period must fit into uint64 so we can safely use it here.
-        // Runtime check was added instead of changing the ABI since the contract is already
-        // deployed in production. We perform the same check within the PreimageOracle for the
-        // benefit of developers but also perform this check here defensively.
-        if (_params.vm.oracle().challengePeriod() > type(uint64).max) revert InvalidChallengePeriod();
-
-        // Determine the maximum clock extension which is either the split depth extension or the
-        // maximum game depth extension depending on the configuration of these contracts.
-        uint256 splitDepthExtension = uint256(_params.clockExtension.raw()) * 2;
-        uint256 maxGameDepthExtension =
-            uint256(_params.clockExtension.raw()) + uint256(_params.vm.oracle().challengePeriod());
-        uint256 maxClockExtension = Math.max(splitDepthExtension, maxGameDepthExtension);
-
-        // The maximum clock extension must fit into a uint64.
-        if (maxClockExtension > type(uint64).max) revert InvalidClockExtension();
-
-        // The maximum clock extension may not be greater than the maximum clock duration.
-        if (uint64(maxClockExtension) > _params.maxClockDuration.raw()) revert InvalidClockExtension();
-
         // Block type(uint32).max from being used as a game type so that it can be used in the
         // OptimismPortal respected game type trick.
         if (_params.gameType.raw() == type(uint32).max) revert ReservedGameType();
 
+        // Validate clock extension bounds that don't require VM access.
+        // The split depth extension is always clockExtension * 2.
+        uint256 splitDepthExtension = uint256(_params.clockExtension.raw()) * 2;
+
+        // The split depth extension must fit into a uint64.
+        if (splitDepthExtension > type(uint64).max) revert InvalidClockExtension();
+
+        // The split depth extension may not be greater than the maximum clock duration.
+        if (uint64(splitDepthExtension) > _params.maxClockDuration.raw()) revert InvalidClockExtension();
+
         // Set up initial game state.
         GAME_TYPE = _params.gameType;
-        ABSOLUTE_PRESTATE = _params.absolutePrestate;
         MAX_GAME_DEPTH = _params.maxGameDepth;
         SPLIT_DEPTH = _params.splitDepth;
         CLOCK_EXTENSION = _params.clockExtension;
         MAX_CLOCK_DURATION = _params.maxClockDuration;
-        VM = _params.vm;
-        WETH = _params.weth;
-        ANCHOR_STATE_REGISTRY = _params.anchorStateRegistry;
-        L2_CHAIN_ID = _params.l2ChainId;
     }
 
     /// @notice Initializes the contract.
@@ -299,7 +264,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         if (initialized) revert AlreadyInitialized();
 
         // Grab the latest anchor root.
-        (Hash root, uint256 rootBlockNumber) = ANCHOR_STATE_REGISTRY.getAnchorRoot();
+        (Hash root, uint256 rootBlockNumber) = anchorStateRegistry().getAnchorRoot();
 
         // Should only happen if this is a new game type that hasn't been set up yet.
         if (root.raw() == bytes32(0)) revert AnchorRootNotFound();
@@ -313,18 +278,39 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // in the factory, but are not used by the game, which would allow for multiple dispute games for the same
         // output proposal to be created.
         //
-        // Expected length: 122 bytes
-        // - 4 bytes selector
-        // - 20 bytes creator address
-        // - 32 bytes root claim
-        // - 32 bytes l1 head
-        // - 32 bytes extraData
-        // - 2 bytes CWIA length
-        if (msg.data.length != 122) revert BadExtraData();
+        // Expected length: 246 bytes
+        // - 4 bytes: selector
+        // - 2 bytes: CWIA length prefix
+        // - 20 bytes: creator address
+        // - 32 bytes: root claim
+        // - 32 bytes: l1 head
+        // - 32 bytes: extraData
+        // - 32 bytes: absolutePrestate
+        // - 20 bytes: vm address
+        // - 20 bytes: anchorStateRegistry address
+        // - 20 bytes: weth address
+        // - 32 bytes: l2ChainId
+        if (msg.data.length != 246) revert BadExtraData();
 
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
         if (l2BlockNumber() <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
+
+        // Validate VM-related parameters that require access to the VM.
+        // The PreimageOracle challenge period must fit into uint64 so we can safely use it here.
+        if (vm().oracle().challengePeriod() > type(uint64).max) revert InvalidChallengePeriod();
+
+        // Determine the maximum clock extension which is either the split depth extension or the
+        // maximum game depth extension depending on the configuration of these contracts.
+        uint256 splitDepthExtension = uint256(CLOCK_EXTENSION.raw()) * 2;
+        uint256 maxGameDepthExtension = uint256(CLOCK_EXTENSION.raw()) + uint64(vm().oracle().challengePeriod());
+        uint256 maxClockExtension = Math.max(splitDepthExtension, maxGameDepthExtension);
+
+        // The maximum clock extension must fit into a uint64.
+        if (maxClockExtension > type(uint64).max) revert InvalidClockExtension();
+
+        // The maximum clock extension may not be greater than the maximum clock duration.
+        if (uint64(maxClockExtension) > MAX_CLOCK_DURATION.raw()) revert InvalidClockExtension();
 
         // Set the root claim
         claimData.push(
@@ -344,14 +330,14 @@ contract FaultDisputeGameV2 is Clone, ISemver {
 
         // Deposit the bond.
         refundModeCredit[gameCreator()] += msg.value;
-        WETH.deposit{ value: msg.value }();
+        weth().deposit{ value: msg.value }();
 
         // Set the game's starting timestamp
         createdAt = Timestamp.wrap(uint64(block.timestamp));
 
         // Set whether the game type was respected when the game was created.
         wasRespectedGameTypeWhenCreated =
-            GameType.unwrap(ANCHOR_STATE_REGISTRY.respectedGameType()) == GameType.unwrap(GAME_TYPE);
+            GameType.unwrap(anchorStateRegistry().respectedGameType()) == GameType.unwrap(GAME_TYPE);
     }
 
     ////////////////////////////////////////////////////////////////
@@ -405,7 +391,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
             //       which is the number of leaves in each execution trace subgame. This is so that we can
             //       determine whether or not the step position is represents the `ABSOLUTE_PRESTATE`.
             preStateClaim = (stepPos.indexAtDepth() % (1 << (MAX_GAME_DEPTH - SPLIT_DEPTH))) == 0
-                ? ABSOLUTE_PRESTATE
+                ? absolutePrestate()
                 : _findTraceAncestor(Position.wrap(parentPos.raw() - 1), parent.parentIndex, false).claim;
             // For all attacks, the poststate is the parent claim.
             postState = parent;
@@ -437,7 +423,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // SAFETY:    While the `attack` path does not need an extra check for the post
         //            state's depth in relation to the parent, we don't need another
         //            branch because (n - n) % 2 == 0.
-        bool validStep = VM.step(_stateData, _proof, uuid.raw()) == postState.claim.raw();
+        bool validStep = vm().step(_stateData, _proof, uuid.raw()) == postState.claim.raw();
         bool parentPostAgree = (parentPos.depth() - postState.position.depth()) % 2 == 0;
         if (parentPostAgree == validStep) revert ValidStep();
 
@@ -515,7 +501,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
             // If the next position is `MAX_GAME_DEPTH - 1` then we're about to execute a step. Our
             // clock extension must therefore account for the LPP challenge period in addition to
             // the standard clock extension.
-            actualExtension = CLOCK_EXTENSION.raw() + uint64(VM.oracle().challengePeriod());
+            actualExtension = CLOCK_EXTENSION.raw() + uint64(vm().oracle().challengePeriod());
         } else if (nextPositionDepth == SPLIT_DEPTH - 1) {
             // If the next position is `SPLIT_DEPTH - 1` then we're about to begin an execution
             // trace bisection and we need to give extra time for the off-chain challenge agent to
@@ -560,7 +546,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
 
         // Deposit the bond.
         refundModeCredit[msg.sender] += msg.value;
-        WETH.deposit{ value: msg.value }();
+        weth().deposit{ value: msg.value }();
 
         // Emit the appropriate event for the attack or defense.
         emit Move(_challengeIndex, _claim, msg.sender);
@@ -596,7 +582,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
             _findStartingAndDisputedOutputs(_execLeafIdx);
         Hash uuid = _computeLocalContext(starting, startingPos, disputed, disputedPos);
 
-        IPreimageOracle oracle = VM.oracle();
+        IPreimageOracle oracle = vm().oracle();
         if (_ident == LocalPreimageKey.L1_HEAD_HASH) {
             // Load the L1 head hash
             oracle.loadLocalData(_ident, uuid.raw(), l1Head().raw(), 32, _partOffset);
@@ -620,7 +606,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
             oracle.loadLocalData(_ident, uuid.raw(), bytes32(l2Number << 0xC0), 8, _partOffset);
         } else if (_ident == LocalPreimageKey.CHAIN_ID) {
             // Load the chain ID as a big-endian uint64 in the high order 8 bytes of the word.
-            oracle.loadLocalData(_ident, uuid.raw(), bytes32(L2_CHAIN_ID << 0xC0), 8, _partOffset);
+            oracle.loadLocalData(_ident, uuid.raw(), bytes32(l2ChainId() << 0xC0), 8, _partOffset);
         } else {
             revert InvalidLocalIdent();
         }
@@ -843,14 +829,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         }
     }
 
-    /// @notice Getter for the game type.
-    /// @dev The reference impl should be entirely different depending on the type (fault, validity)
-    ///      i.e. The game type should indicate the security model.
-    /// @return gameType_ The type of proof system being used.
-    function gameType() public view returns (GameType gameType_) {
-        gameType_ = GAME_TYPE;
-    }
-
     /// @notice Getter for the creator of the dispute game.
     /// @dev `clones-with-immutable-args` argument #1
     /// @return creator_ The creator of the dispute game.
@@ -881,6 +859,41 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         extraData_ = _getArgBytes(84, 32);
     }
 
+    /// @notice Getter for the absolute prestate of the instruction trace.
+    /// @dev `clones-with-immutable-args` argument #5
+    /// @return absolutePrestate_ The absolute prestate of the instruction trace.
+    function absolutePrestate() public pure returns (Claim absolutePrestate_) {
+        absolutePrestate_ = Claim.wrap(_getArgBytes32(116));
+    }
+
+    /// @notice Getter for the VM implementation.
+    /// @dev `clones-with-immutable-args` argument #6
+    /// @return vm_ The onchain VM implementation address.
+    function vm() public pure returns (IBigStepper vm_) {
+        vm_ = IBigStepper(_getArgAddress(148));
+    }
+
+    /// @notice Getter for the anchor state registry.
+    /// @dev `clones-with-immutable-args` argument #7
+    /// @return registry_ The anchor state registry contract address.
+    function anchorStateRegistry() public pure returns (IAnchorStateRegistry registry_) {
+        registry_ = IAnchorStateRegistry(_getArgAddress(168));
+    }
+
+    /// @notice Getter for the WETH contract.
+    /// @dev `clones-with-immutable-args` argument #8
+    /// @return weth_ The WETH contract for holding ETH.
+    function weth() public pure returns (IDelayedWETH weth_) {
+        weth_ = IDelayedWETH(payable(_getArgAddress(188)));
+    }
+
+    /// @notice Getter for the L2 chain ID.
+    /// @dev `clones-with-immutable-args` argument #9
+    /// @return l2ChainId_ The L2 chain ID.
+    function l2ChainId() public pure returns (uint256 l2ChainId_) {
+        l2ChainId_ = _getArgUint256(208);
+    }
+
     /// @notice A compliant implementation of this interface should return the components of the
     ///         game UUID's preimage provided in the cwia payload. The preimage of the UUID is
     ///         constructed as `keccak256(gameType . rootClaim . extraData)` where `.` denotes
@@ -892,6 +905,14 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         gameType_ = gameType();
         rootClaim_ = rootClaim();
         extraData_ = extraData();
+    }
+
+    /// @notice Getter for the game type.
+    /// @dev The reference impl should be entirely different depending on the type (fault, validity)
+    ///      i.e. The game type should indicate the security model.
+    /// @return gameType_ The type of proof system being used.
+    function gameType() public view returns (GameType gameType_) {
+        gameType_ = GAME_TYPE;
     }
 
     ////////////////////////////////////////////////////////////////
@@ -970,7 +991,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // credit, we unlock it and return early.
         if (!hasUnlockedCredit[_recipient]) {
             hasUnlockedCredit[_recipient] = true;
-            WETH.unlock(_recipient, recipientCredit);
+            weth().unlock(_recipient, recipientCredit);
             return;
         }
 
@@ -982,7 +1003,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         normalModeCredit[_recipient] = 0;
 
         // Try to withdraw the WETH amount so it can be used here.
-        WETH.withdraw(_recipient, recipientCredit);
+        weth().withdraw(_recipient, recipientCredit);
 
         // Transfer the credit to the recipient.
         (bool success,) = _recipient.call{ value: recipientCredit }(hex"");
@@ -1008,7 +1029,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // system is paused, the game will only go into refund mode if it ends up being explicitly
         // invalidated in the AnchorStateRegistry. If the game has already been closed and a refund
         // mode has been selected, we'll already have returned and we won't hit this revert.
-        if (ANCHOR_STATE_REGISTRY.paused()) {
+        if (anchorStateRegistry().paused()) {
             revert GamePaused();
         }
 
@@ -1019,7 +1040,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         }
 
         // Game must be finalized according to the AnchorStateRegistry.
-        bool finalized = ANCHOR_STATE_REGISTRY.isGameFinalized(IDisputeGame(address(this)));
+        bool finalized = anchorStateRegistry().isGameFinalized(IDisputeGame(address(this)));
         if (!finalized) {
             revert GameNotFinalized();
         }
@@ -1027,10 +1048,10 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // Try to update the anchor game first. Won't always succeed because delays can lead
         // to situations in which this game might not be eligible to be a new anchor game.
         // eip150-safe
-        try ANCHOR_STATE_REGISTRY.setAnchorState(IDisputeGame(address(this))) { } catch { }
+        try anchorStateRegistry().setAnchorState(IDisputeGame(address(this))) { } catch { }
 
         // Check if the game is a proper game, which will determine the bond distribution mode.
-        bool properGame = ANCHOR_STATE_REGISTRY.isGameProper(IDisputeGame(address(this)));
+        bool properGame = anchorStateRegistry().isGameProper(IDisputeGame(address(this)));
 
         // If the game is a proper game, the bonds should be distributed normally. Otherwise, go
         // into refund mode and distribute bonds back to their original depositors.
@@ -1090,11 +1111,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     //                     IMMUTABLE GETTERS                      //
     ////////////////////////////////////////////////////////////////
 
-    /// @notice Returns the absolute prestate of the instruction trace.
-    function absolutePrestate() external view returns (Claim absolutePrestate_) {
-        absolutePrestate_ = ABSOLUTE_PRESTATE;
-    }
-
     /// @notice Returns the max game depth.
     function maxGameDepth() external view returns (uint256 maxGameDepth_) {
         maxGameDepth_ = MAX_GAME_DEPTH;
@@ -1113,26 +1129,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     /// @notice Returns the clock extension constant.
     function clockExtension() external view returns (Duration clockExtension_) {
         clockExtension_ = CLOCK_EXTENSION;
-    }
-
-    /// @notice Returns the address of the VM.
-    function vm() external view returns (IBigStepper vm_) {
-        vm_ = VM;
-    }
-
-    /// @notice Returns the WETH contract for holding ETH.
-    function weth() external view returns (IDelayedWETH weth_) {
-        weth_ = WETH;
-    }
-
-    /// @notice Returns the anchor state registry contract.
-    function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_) {
-        registry_ = ANCHOR_STATE_REGISTRY;
-    }
-
-    /// @notice Returns the chain ID of the L2 network this contract argues about.
-    function l2ChainId() external view returns (uint256 l2ChainId_) {
-        l2ChainId_ = L2_CHAIN_ID;
     }
 
     ////////////////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -151,9 +151,9 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.9.0
+    /// @custom:semver 2.0.0
     function version() public pure virtual returns (string memory) {
-        return "1.9.0";
+        return "2.0.0";
     }
 
     /// @notice The starting timestamp of the game

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -263,15 +263,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // INVARIANT: The game must not have already been initialized.
         if (initialized) revert AlreadyInitialized();
 
-        // Grab the latest anchor root.
-        (Hash root, uint256 rootBlockNumber) = anchorStateRegistry().getAnchorRoot();
-
-        // Should only happen if this is a new game type that hasn't been set up yet.
-        if (root.raw() == bytes32(0)) revert AnchorRootNotFound();
-
-        // Set the starting proposal.
-        startingOutputRoot = Proposal({ l2SequenceNumber: rootBlockNumber, root: root });
-
         // Revert if the calldata size is not the expected length.
         //
         // This is to prevent adding extra or omitting bytes from to `extraData` that result in a different game UUID
@@ -291,6 +282,15 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // - 20 bytes: weth address
         // - 32 bytes: l2ChainId
         if (msg.data.length != 246) revert BadExtraData();
+
+        // Grab the latest anchor root.
+        (Hash root, uint256 rootBlockNumber) = anchorStateRegistry().getAnchorRoot();
+
+        // Should only happen if this is a new game type that hasn't been set up yet.
+        if (root.raw() == bytes32(0)) revert AnchorRootNotFound();
+
+        // Set the starting proposal.
+        startingOutputRoot = Proposal({ l2SequenceNumber: rootBlockNumber, root: root });
 
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -151,9 +151,9 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.8.0
+    /// @custom:semver 1.9.0
     function version() public pure virtual returns (string memory) {
-        return "1.8.0";
+        return "1.9.0";
     }
 
     /// @notice The starting timestamp of the game

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -512,7 +512,7 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_TestIni
     }
 
     /// @notice Tests that the `setImplementation` function with args reverts when called by a non-owner.
-    function test_setImplementation_withArgs_notOwner_reverts() public {
+    function test_setImplementationArgs_notOwner_reverts() public {
         bytes memory args = abi.encode(uint256(123), address(0xdead));
 
         // Ensure that the `setImplementation` function reverts when called by a non-owner.

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -9,6 +9,7 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
+import {console} from "forge-std/console.sol";
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";
 
@@ -222,7 +223,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             vm_, // 20 bytes
             anchorStateRegistry, // 20 bytes
             delayedWeth, // 20 bytes
-            uint256(0) // 32 bytes (l2ChainId)
+            uint256(111) // 32 bytes (l2ChainId)
         );
 
         _setGame(gameImpl_, GameTypes.CANNON, implArgs);
@@ -433,7 +434,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
 
         Claim rootClaim = changeClaimStatus(Claim.wrap(bytes32(hex"beef")), VMStatuses.INVALID);
         // extraData should contain the l2BlockNumber as first 32 bytes
-        bytes memory extraData = abi.encode(uint256(type(uint32).max));
+        bytes memory extraData = bytes.concat(bytes32(uint256(type(uint32).max)));
 
         uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON);
         vm.deal(address(this), bondAmount);
@@ -454,7 +455,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
         assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
         assertEq(gameV2.extraData(), extraData);
-        assertEq(gameV2.l2ChainId(), 0);
+        assertEq(gameV2.l2ChainId(), 111);
         assertEq(address(gameV2.vm()), address(vm_));
         assertEq(address(gameV2.weth()), address(delayedWeth));
         assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -129,9 +129,13 @@ contract DisputeGameFactory_TestInit is CommonTest {
         params_ = abi.decode(args, (ISuperFaultDisputeGame.GameConstructorParams));
     }
 
-    function _setGame(address _gameImpl, GameType _gameType) internal {
+    function _setGame(address _gameImpl, GameType _gameType, bytes memory _implArgs) internal {
         vm.startPrank(disputeGameFactory.owner());
-        disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl));
+        if (_implArgs.length > 0) {
+            disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl), _implArgs);
+        } else {
+            disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl));
+        }
         disputeGameFactory.setInitBond(_gameType, 0.08 ether);
         vm.stopPrank();
     }
@@ -153,7 +157,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             )
         });
 
-        _setGame(gameImpl_, GameTypes.SUPER_CANNON);
+        _setGame(gameImpl_, GameTypes.SUPER_CANNON, "");
     }
 
     /// @notice Sets up a super permissioned game implementation
@@ -181,7 +185,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             )
         });
 
-        _setGame(gameImpl_, GameTypes.SUPER_PERMISSIONED_CANNON);
+        _setGame(gameImpl_, GameTypes.SUPER_PERMISSIONED_CANNON, "");
     }
 
     /// @notice Sets up a fault game implementation
@@ -199,7 +203,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             )
         });
 
-        _setGame(gameImpl_, GameTypes.CANNON);
+        _setGame(gameImpl_, GameTypes.CANNON, "");
     }
 
     /// @notice Sets up a fault game v2 implementation
@@ -227,10 +231,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             uint256(0) // 32 bytes (l2ChainId)
         );
 
-        vm.startPrank(disputeGameFactory.owner());
-        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(gameImpl_), implArgs);
-        disputeGameFactory.setInitBond(GameTypes.CANNON, 0.08 ether);
-        vm.stopPrank();
+        _setGame(gameImpl_, GameTypes.CANNON, implArgs);
     }
 
     function setupPermissionedDisputeGame(
@@ -256,7 +257,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             )
         });
 
-        _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON);
+        _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON, "");
     }
 
     function changeClaimStatus(Claim _claim, VMStatus _status) public pure returns (Claim out_) {

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -432,7 +432,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
     }
 
-    function test_create_implArgs() public {
+    function test_create_implArgs_succeeds() public {
         Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
         (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -98,13 +98,9 @@ contract DisputeGameFactory_TestInit is CommonTest {
         });
     }
 
-    function _getGameConstructorParamsV2(
-        Claim _absolutePrestate,
-        AlphabetVM _vm,
-        GameType _gameType
-    )
+    function _getGameConstructorParamsV2(GameType _gameType)
         internal
-        view
+        pure
         returns (IFaultDisputeGameV2.GameConstructorParams memory params_)
     {
         return IFaultDisputeGameV2.GameConstructorParams({
@@ -215,10 +211,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
         gameImpl_ = DeployUtils.create1({
             _name: "FaultDisputeGameV2",
             _args: DeployUtils.encodeConstructor(
-                abi.encodeCall(
-                    IFaultDisputeGameV2.__constructor__,
-                    (_getGameConstructorParamsV2(_absolutePrestate, vm_, GameTypes.CANNON))
-                )
+                abi.encodeCall(IFaultDisputeGameV2.__constructor__, (_getGameConstructorParamsV2(GameTypes.CANNON)))
             )
         });
 
@@ -435,7 +428,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
     function test_create_implArgs_succeeds() public {
         // skipIfForkTest("Not supported on testnet");
         Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
-        (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
+        (, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
 
         Claim rootClaim = changeClaimStatus(Claim.wrap(bytes32(hex"beef")), VMStatuses.INVALID);
         // extraData should contain the l2BlockNumber as first 32 bytes

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -427,7 +427,6 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
     }
 
     function test_create_implArgs_succeeds() public {
-        // skipIfForkTest("Not supported on testnet");
         Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
         (, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -433,12 +433,13 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
     }
 
     function test_create_implArgs_succeeds() public {
+        // skipIfForkTest("Not supported on testnet");
         Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
         (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
 
         Claim rootClaim = changeClaimStatus(Claim.wrap(bytes32(hex"beef")), VMStatuses.INVALID);
         // extraData should contain the l2BlockNumber as first 32 bytes
-        bytes memory extraData = abi.encode(uint256(424242));
+        bytes memory extraData = abi.encode(uint256(type(uint32).max));
 
         uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON);
         vm.deal(address(this), bondAmount);

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -654,24 +654,8 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
 
 /// @title DisputeGameFactory_FaultDisputeGameV2_Test
 /// @notice Tests for FaultDisputeGameV2 creation in the `DisputeGameFactory` contract.
-contract DisputeGameFactory_FaultDisputeGameV2_Test is DisputeGameFactory_TestInit {
-    function test_setupFaultDisputeGameV2_works() public {
-        Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
-
-        // Just test the setup function works
-        (address gameImpl, AlphabetVM vm_, IPreimageOracle preimageOracle_) = setupFaultDisputeGameV2(absolutePrestate);
-
-        // Verify the implementation was deployed and set
-        assertNotEq(gameImpl, address(0));
-        assertNotEq(address(vm_), address(0));
-        assertNotEq(address(preimageOracle_), address(0));
-
-        // Verify the game type was set in the factory
-        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON_2)), gameImpl);
-        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON_2), 0.08 ether);
-    }
-
-    function test_createFaultDisputeGameV2_withCWIA_succeeds() public {
+contract DisputeGameFactory_Unclassified_Test is DisputeGameFactory_TestInit {
+    function test_create() public {
         Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
         (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
 
@@ -703,28 +687,5 @@ contract DisputeGameFactory_FaultDisputeGameV2_Test is DisputeGameFactory_TestIn
         assertEq(address(gameV2.vm()), address(vm_));
         assertEq(address(gameV2.weth()), address(delayedWeth));
         assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));
-    }
-}
-
-/// @title DisputeGameFactory_Unclassified_Test
-/// @notice General tests that are not testing any function directly of the `DisputeGameFactory`
-///         contract or are testing multiple functions at once.
-contract DisputeGameFactory_Unclassified_Test is DisputeGameFactory_TestInit {
-    /// @notice Tests that the `owner` function returns the correct address after deployment.
-    function test_owner_succeeds() public view {
-        assertEq(disputeGameFactory.owner(), address(this));
-    }
-
-    /// @notice Tests that the `transferOwnership` function succeeds when called by the owner.
-    function test_transferOwnership_succeeds() public {
-        disputeGameFactory.transferOwnership(address(1));
-        assertEq(disputeGameFactory.owner(), address(1));
-    }
-
-    /// @notice Tests that the `transferOwnership` function reverts when called by a non-owner.
-    function test_transferOwnership_notOwner_reverts() public {
-        vm.prank(address(0));
-        vm.expectRevert("Ownable: caller is not the owner");
-        disputeGameFactory.transferOwnership(address(1));
     }
 }

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -228,8 +228,8 @@ contract DisputeGameFactory_TestInit is CommonTest {
         );
 
         vm.startPrank(disputeGameFactory.owner());
-        disputeGameFactory.setImplementation(GameTypes.CANNON_2, IDisputeGame(gameImpl_), implArgs);
-        disputeGameFactory.setInitBond(GameTypes.CANNON_2, 0.08 ether);
+        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(gameImpl_), implArgs);
+        disputeGameFactory.setInitBond(GameTypes.CANNON, 0.08 ether);
         vm.stopPrank();
     }
 
@@ -439,14 +439,14 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         // extraData should contain the l2BlockNumber as first 32 bytes
         bytes memory extraData = abi.encode(uint256(424242));
 
-        uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON_2);
+        uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON);
         vm.deal(address(this), bondAmount);
 
         // Create the game
-        IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(GameTypes.CANNON_2, rootClaim, extraData);
+        IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(GameTypes.CANNON, rootClaim, extraData);
 
         // Verify the game was created and stored
-        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(GameTypes.CANNON_2, rootClaim, extraData);
+        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(GameTypes.CANNON, rootClaim, extraData);
 
         assertEq(address(game), address(proxy));
         assertEq(Timestamp.unwrap(timestamp), block.timestamp);
@@ -458,7 +458,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
         assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
         assertEq(gameV2.extraData(), extraData);
-        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON_2));
+        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON));
         assertEq(gameV2.l2ChainId(), 0);
         assertEq(address(gameV2.vm()), address(vm_));
         assertEq(address(gameV2.weth()), address(delayedWeth));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -109,15 +109,10 @@ contract DisputeGameFactory_TestInit is CommonTest {
     {
         return IFaultDisputeGameV2.GameConstructorParams({
             gameType: _gameType,
-            absolutePrestate: _absolutePrestate,
             maxGameDepth: 2 ** 3,
             splitDepth: 2 ** 2,
             clockExtension: Duration.wrap(3 hours),
-            maxClockDuration: Duration.wrap(3.5 days),
-            vm: _vm,
-            weth: delayedWeth,
-            anchorStateRegistry: anchorStateRegistry,
-            l2ChainId: 0
+            maxClockDuration: Duration.wrap(3.5 days)
         });
     }
 
@@ -223,7 +218,19 @@ contract DisputeGameFactory_TestInit is CommonTest {
             )
         });
 
-        _setGame(gameImpl_, GameTypes.CANNON);
+        // Encode the implementation args for CWIA (tightly packed)
+        bytes memory implArgs = abi.encodePacked(
+            _absolutePrestate, // 32 bytes
+            vm_, // 20 bytes
+            anchorStateRegistry, // 20 bytes
+            delayedWeth, // 20 bytes
+            uint256(0) // 32 bytes (l2ChainId)
+        );
+
+        vm.startPrank(disputeGameFactory.owner());
+        disputeGameFactory.setImplementation(GameTypes.CANNON_2, IDisputeGame(gameImpl_), implArgs);
+        disputeGameFactory.setInitBond(GameTypes.CANNON_2, 0.08 ether);
+        vm.stopPrank();
     }
 
     function setupPermissionedDisputeGame(
@@ -250,6 +257,12 @@ contract DisputeGameFactory_TestInit is CommonTest {
         });
 
         _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON);
+    }
+
+    function changeClaimStatus(Claim _claim, VMStatus _status) public pure returns (Claim out_) {
+        assembly {
+            out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+        }
     }
 }
 
@@ -416,12 +429,6 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
             abi.encodeWithSelector(GameAlreadyExists.selector, disputeGameFactory.getGameUUID(gt, rootClaim, extraData))
         );
         disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
-    }
-
-    function changeClaimStatus(Claim _claim, VMStatus _status) public pure returns (Claim out_) {
-        assembly {
-            out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
-        }
     }
 }
 
@@ -642,6 +649,60 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
         IDisputeGameFactory.GameSearchResult[] memory games =
             disputeGameFactory.findLatestGames(GameType.wrap(0), start, _n);
         assertEq(games.length, _n);
+    }
+}
+
+/// @title DisputeGameFactory_FaultDisputeGameV2_Test
+/// @notice Tests for FaultDisputeGameV2 creation in the `DisputeGameFactory` contract.
+contract DisputeGameFactory_FaultDisputeGameV2_Test is DisputeGameFactory_TestInit {
+    function test_setupFaultDisputeGameV2_works() public {
+        Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
+
+        // Just test the setup function works
+        (address gameImpl, AlphabetVM vm_, IPreimageOracle preimageOracle_) = setupFaultDisputeGameV2(absolutePrestate);
+
+        // Verify the implementation was deployed and set
+        assertNotEq(gameImpl, address(0));
+        assertNotEq(address(vm_), address(0));
+        assertNotEq(address(preimageOracle_), address(0));
+
+        // Verify the game type was set in the factory
+        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON_2)), gameImpl);
+        assertEq(disputeGameFactory.initBonds(GameTypes.CANNON_2), 0.08 ether);
+    }
+
+    function test_createFaultDisputeGameV2_withCWIA_succeeds() public {
+        Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
+        (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
+
+        Claim rootClaim = changeClaimStatus(Claim.wrap(bytes32(hex"beef")), VMStatuses.INVALID);
+        // extraData should contain the l2BlockNumber as first 32 bytes
+        bytes memory extraData = abi.encode(uint256(424242));
+
+        uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON_2);
+        vm.deal(address(this), bondAmount);
+
+        // Create the game
+        IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(GameTypes.CANNON_2, rootClaim, extraData);
+
+        // Verify the game was created and stored
+        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(GameTypes.CANNON_2, rootClaim, extraData);
+
+        assertEq(address(game), address(proxy));
+        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
+
+        // Verify the game has the correct parameters via CWIA
+        IFaultDisputeGameV2 gameV2 = IFaultDisputeGameV2(address(proxy));
+
+        // Test CWIA getters
+        assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
+        assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
+        assertEq(gameV2.extraData(), extraData);
+        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON_2));
+        assertEq(gameV2.l2ChainId(), 0);
+        assertEq(address(gameV2.vm()), address(vm_));
+        assertEq(address(gameV2.weth()), address(delayedWeth));
+        assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -454,11 +454,16 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
         assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
         assertEq(gameV2.extraData(), extraData);
-        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON));
         assertEq(gameV2.l2ChainId(), 0);
         assertEq(address(gameV2.vm()), address(vm_));
         assertEq(address(gameV2.weth()), address(delayedWeth));
         assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));
+        // Test Constructor args
+        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON));
+        assertEq(gameV2.maxGameDepth(), 2 ** 3);
+        assertEq(gameV2.splitDepth(), 2 ** 2);
+        assertEq(Duration.unwrap(gameV2.clockExtension()), Duration.unwrap(Duration.wrap(3 hours)));
+        assertEq(Duration.unwrap(gameV2.maxClockDuration()), Duration.unwrap(Duration.wrap(3.5 days)));
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -430,6 +430,40 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         );
         disputeGameFactory.create{ value: bondAmount }(gt, rootClaim, extraData);
     }
+
+    function test_create_implArgs() public {
+        Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
+        (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
+
+        Claim rootClaim = changeClaimStatus(Claim.wrap(bytes32(hex"beef")), VMStatuses.INVALID);
+        // extraData should contain the l2BlockNumber as first 32 bytes
+        bytes memory extraData = abi.encode(uint256(424242));
+
+        uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON_2);
+        vm.deal(address(this), bondAmount);
+
+        // Create the game
+        IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(GameTypes.CANNON_2, rootClaim, extraData);
+
+        // Verify the game was created and stored
+        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(GameTypes.CANNON_2, rootClaim, extraData);
+
+        assertEq(address(game), address(proxy));
+        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
+
+        // Verify the game has the correct parameters via CWIA
+        IFaultDisputeGameV2 gameV2 = IFaultDisputeGameV2(address(proxy));
+
+        // Test CWIA getters
+        assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
+        assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
+        assertEq(gameV2.extraData(), extraData);
+        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON_2));
+        assertEq(gameV2.l2ChainId(), 0);
+        assertEq(address(gameV2.vm()), address(vm_));
+        assertEq(address(gameV2.weth()), address(delayedWeth));
+        assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));
+    }
 }
 
 /// @title DisputeGameFactory_SetImplementation_Test
@@ -655,37 +689,5 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
 /// @title DisputeGameFactory_FaultDisputeGameV2_Test
 /// @notice Tests for FaultDisputeGameV2 creation in the `DisputeGameFactory` contract.
 contract DisputeGameFactory_Unclassified_Test is DisputeGameFactory_TestInit {
-    function test_create() public {
-        Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
-        (address gameImpl, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
 
-        Claim rootClaim = changeClaimStatus(Claim.wrap(bytes32(hex"beef")), VMStatuses.INVALID);
-        // extraData should contain the l2BlockNumber as first 32 bytes
-        bytes memory extraData = abi.encode(uint256(424242));
-
-        uint256 bondAmount = disputeGameFactory.initBonds(GameTypes.CANNON_2);
-        vm.deal(address(this), bondAmount);
-
-        // Create the game
-        IDisputeGame proxy = disputeGameFactory.create{ value: bondAmount }(GameTypes.CANNON_2, rootClaim, extraData);
-
-        // Verify the game was created and stored
-        (IDisputeGame game, Timestamp timestamp) = disputeGameFactory.games(GameTypes.CANNON_2, rootClaim, extraData);
-
-        assertEq(address(game), address(proxy));
-        assertEq(Timestamp.unwrap(timestamp), block.timestamp);
-
-        // Verify the game has the correct parameters via CWIA
-        IFaultDisputeGameV2 gameV2 = IFaultDisputeGameV2(address(proxy));
-
-        // Test CWIA getters
-        assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
-        assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
-        assertEq(gameV2.extraData(), extraData);
-        assertEq(GameType.unwrap(gameV2.gameType()), GameType.unwrap(GameTypes.CANNON_2));
-        assertEq(gameV2.l2ChainId(), 0);
-        assertEq(address(gameV2.vm()), address(vm_));
-        assertEq(address(gameV2.weth()), address(delayedWeth));
-        assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));
-    }
 }

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -455,6 +455,8 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
         assertEq(gameV2.extraData(), extraData);
         assertEq(gameV2.l2ChainId(), 111);
+        assertEq(address(gameV2.gameCreator()), address(this));
+        assertEq(gameV2.l2BlockNumber(), uint256(type(uint32).max));
         assertEq(address(gameV2.vm()), address(vm_));
         assertEq(address(gameV2.weth()), address(delayedWeth));
         assertEq(address(gameV2.anchorStateRegistry()), address(anchorStateRegistry));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -686,8 +686,25 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
     }
 }
 
-/// @title DisputeGameFactory_FaultDisputeGameV2_Test
-/// @notice Tests for FaultDisputeGameV2 creation in the `DisputeGameFactory` contract.
+/// @title DisputeGameFactory_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `DisputeGameFactory`
+///         contract or are testing multiple functions at once.
 contract DisputeGameFactory_Unclassified_Test is DisputeGameFactory_TestInit {
+    /// @notice Tests that the `owner` function returns the correct address after deployment.
+    function test_owner_succeeds() public view {
+        assertEq(disputeGameFactory.owner(), address(this));
+    }
 
+    /// @notice Tests that the `transferOwnership` function succeeds when called by the owner.
+    function test_transferOwnership_succeeds() public {
+        disputeGameFactory.transferOwnership(address(1));
+        assertEq(disputeGameFactory.owner(), address(1));
+    }
+
+    /// @notice Tests that the `transferOwnership` function reverts when called by a non-owner.
+    function test_transferOwnership_notOwner_reverts() public {
+        vm.prank(address(0));
+        vm.expectRevert("Ownable: caller is not the owner");
+        disputeGameFactory.transferOwnership(address(1));
+    }
 }

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -9,7 +9,6 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
-import {console} from "forge-std/console.sol";
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -51,6 +51,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
 
     event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
     event ImplementationSet(address indexed impl, GameType indexed gameType);
+    event ImplementationArgsSet(GameType indexed gameType, bytes args);
     event InitBondUpdated(GameType indexed gameType, uint256 indexed newBond);
 
     function setUp() public virtual override {
@@ -483,6 +484,35 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_TestIni
         vm.prank(address(0));
         vm.expectRevert("Ownable: caller is not the owner");
         disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(1)));
+    }
+
+    /// @notice Tests that the `setImplementation` function with args properly sets the implementation
+    ///         and args for a given `GameType`.
+    function test_setImplementation_withArgs_succeeds() public {
+        bytes memory args = abi.encode(uint256(123), address(0xdead), "test");
+
+        vm.expectEmit(true, true, true, true, address(disputeGameFactory));
+        emit ImplementationSet(address(1), GameTypes.CANNON);
+        vm.expectEmit(true, true, true, true, address(disputeGameFactory));
+        emit ImplementationArgsSet(GameTypes.CANNON, args);
+
+        // Set the implementation and args for the `GameTypes.CANNON` enum value.
+        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(1)), args);
+
+        // Ensure that the implementation for the `GameTypes.CANNON` enum value is set.
+        assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON)), address(1));
+        // Ensure that the args for the `GameTypes.CANNON` enum value are set.
+        assertEq(disputeGameFactory.gameArgs(GameTypes.CANNON), args);
+    }
+
+    /// @notice Tests that the `setImplementation` function with args reverts when called by a non-owner.
+    function test_setImplementation_withArgs_notOwner_reverts() public {
+        bytes memory args = abi.encode(uint256(123), address(0xdead));
+
+        // Ensure that the `setImplementation` function reverts when called by a non-owner.
+        vm.prank(address(0));
+        vm.expectRevert("Ownable: caller is not the owner");
+        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(1)), args);
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -495,7 +495,20 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_TestIni
     /// @notice Tests that the `setImplementation` function with args properly sets the implementation
     ///         and args for a given `GameType`.
     function test_setImplementation_withArgs_succeeds() public {
-        bytes memory args = abi.encode(uint256(123), address(0xdead), "test");
+        address fakeGame = address(1);
+        Claim absolutePrestate = Claim.wrap(bytes32(hex"dead"));
+        AlphabetVM vm_;
+        IPreimageOracle preimageOracle_;
+        (vm_, preimageOracle_) = _createVM(absolutePrestate);
+        uint256 l2ChainId = 111;
+
+        bytes memory args = abi.encodePacked(
+            absolutePrestate, // 32 bytes
+            vm_, // 20 bytes
+            anchorStateRegistry, // 20 bytes
+            delayedWeth, // 20 bytes
+            l2ChainId // 32 bytes (l2ChainId)
+        );
 
         vm.expectEmit(true, true, true, true, address(disputeGameFactory));
         emit ImplementationSet(address(1), GameTypes.CANNON);
@@ -503,7 +516,7 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_TestIni
         emit ImplementationArgsSet(GameTypes.CANNON, args);
 
         // Set the implementation and args for the `GameTypes.CANNON` enum value.
-        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(1)), args);
+        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(fakeGame), args);
 
         // Ensure that the implementation for the `GameTypes.CANNON` enum value is set.
         assertEq(address(disputeGameFactory.gameImpls(GameTypes.CANNON)), address(1));

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameV2.t.sol
@@ -1,0 +1,3195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Testing
+import { Vm } from "forge-std/Vm.sol";
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
+import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
+import { stdError } from "forge-std/StdError.sol";
+
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Contracts
+import { DisputeActor, HonestDisputeActor } from "test/actors/FaultDisputeActors.sol";
+
+// Libraries
+import { Types } from "src/libraries/Types.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
+import { LibClock } from "src/dispute/lib/LibUDT.sol";
+import { LibPosition } from "src/dispute/lib/LibPosition.sol";
+import "src/dispute/lib/Types.sol";
+import "src/dispute/lib/Errors.sol";
+
+// Interfaces
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IPreimageOracle } from "interfaces/dispute/IBigStepper.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IFaultDisputeGameV2 } from "interfaces/dispute/v2/IFaultDisputeGameV2.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+
+contract ClaimCreditReenter {
+    Vm internal immutable vm;
+    IFaultDisputeGameV2 internal immutable GAME;
+    uint256 public numCalls;
+
+    constructor(IFaultDisputeGameV2 _gameProxy, Vm _vm) {
+        GAME = _gameProxy;
+        vm = _vm;
+    }
+
+    function claimCredit(address _recipient) public {
+        numCalls += 1;
+        if (numCalls > 1) {
+            vm.expectRevert(NoCreditToClaim.selector);
+        }
+        GAME.claimCredit(_recipient);
+    }
+
+    receive() external payable {
+        if (numCalls == 5) {
+            return;
+        }
+        claimCredit(address(this));
+    }
+}
+
+/// @notice Helper to change the VM status byte of a claim.
+function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
+    assembly {
+        out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+    }
+}
+
+/// @title BaseFaultDisputeGameV2_TestInit
+/// @notice Base test initializer that can be used by other contracts outside of this test suite.
+contract BaseFaultDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
+    /// @dev The type of the game being tested.
+    GameType internal immutable GAME_TYPE = GameTypes.CANNON;
+
+    /// @dev The initial bond for the game.
+    uint256 internal initBond;
+
+    /// @dev The implementation of the game.
+    IFaultDisputeGameV2 internal gameImpl;
+    /// @dev The `Clone` proxy of the game.
+    IFaultDisputeGameV2 internal gameProxy;
+
+    /// @dev The extra data passed to the game for initialization.
+    bytes internal extraData;
+
+    event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
+    event GameClosed(BondDistributionMode bondDistributionMode);
+
+    event ReceiveETH(uint256 amount);
+
+    function init(Claim rootClaim, Claim absolutePrestate, uint256 l2BlockNumber) public {
+        // Set the time to a realistic date.
+        if (!isForkTest()) {
+            vm.warp(1690906994);
+        }
+
+        // Set the extra data for the game creation
+        extraData = abi.encode(l2BlockNumber);
+
+        (address _impl, AlphabetVM _vm,) = setupFaultDisputeGameV2(absolutePrestate);
+        gameImpl = IFaultDisputeGameV2(_impl);
+
+        // Set the init bond for the given game type.
+        initBond = disputeGameFactory.initBonds(GAME_TYPE);
+
+        // Warp ahead of the game retirement timestamp if needed.
+        if (block.timestamp <= anchorStateRegistry.retirementTimestamp()) {
+            vm.warp(anchorStateRegistry.retirementTimestamp() + 1);
+        }
+
+        // Create a new game.
+        gameProxy = IFaultDisputeGameV2(
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, rootClaim, extraData)))
+        );
+
+        // Check immutables
+        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
+        assertEq(gameProxy.absolutePrestate().raw(), absolutePrestate.raw());
+        assertEq(gameProxy.maxGameDepth(), 2 ** 3);
+        assertEq(gameProxy.splitDepth(), 2 ** 2);
+        assertEq(gameProxy.clockExtension().raw(), 3 hours);
+        assertEq(gameProxy.maxClockDuration().raw(), 3.5 days);
+        assertEq(address(gameProxy.weth()), address(delayedWeth));
+        assertEq(address(gameProxy.anchorStateRegistry()), address(anchorStateRegistry));
+        assertEq(address(gameProxy.vm()), address(_vm));
+
+        // Label the proxy
+        vm.label(address(gameProxy), "FaultDisputeGame_Clone");
+    }
+
+    fallback() external payable { }
+
+    receive() external payable { }
+}
+
+/// @title FaultDisputeGameV2_TestInit
+/// @notice Reusable test initialization for `FaultDisputeGame` tests.
+contract FaultDisputeGameV2_TestInit is BaseFaultDisputeGameV2_TestInit {
+    /// @dev The root claim of the game.
+    Claim internal ROOT_CLAIM;
+    /// @dev An arbitrary root claim for testing.
+    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
+
+    /// @dev The preimage of the absolute prestate claim
+    bytes internal absolutePrestateData;
+    /// @dev The absolute prestate of the trace.
+    Claim internal absolutePrestate;
+    /// @dev A valid l2BlockNumber that comes after the current anchor root block.
+    uint256 internal validL2BlockNumber;
+
+    function setUp() public virtual override {
+        absolutePrestateData = abi.encode(0);
+        absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
+
+        super.setUp();
+
+        // Get the actual anchor roots
+        (Hash root, uint256 l2Bn) = anchorStateRegistry.getAnchorRoot();
+        validL2BlockNumber = l2Bn + 1;
+
+        ROOT_CLAIM = Claim.wrap(Hash.unwrap(root));
+
+        super.init({ rootClaim: ROOT_CLAIM, absolutePrestate: absolutePrestate, l2BlockNumber: validL2BlockNumber });
+    }
+
+    /// @notice Helper to generate a mock RLP encoded header (with only a real block number) & an
+    ///         output root proof.
+    function _generateOutputRootProof(
+        bytes32 _storageRoot,
+        bytes32 _withdrawalRoot,
+        bytes memory _l2BlockNumber
+    )
+        internal
+        pure
+        returns (Types.OutputRootProof memory proof_, bytes32 root_, bytes memory rlp_)
+    {
+        // L2 Block header
+        bytes[] memory rawHeaderRLP = new bytes[](9);
+        rawHeaderRLP[0] = hex"83FACADE";
+        rawHeaderRLP[1] = hex"83FACADE";
+        rawHeaderRLP[2] = hex"83FACADE";
+        rawHeaderRLP[3] = hex"83FACADE";
+        rawHeaderRLP[4] = hex"83FACADE";
+        rawHeaderRLP[5] = hex"83FACADE";
+        rawHeaderRLP[6] = hex"83FACADE";
+        rawHeaderRLP[7] = hex"83FACADE";
+        rawHeaderRLP[8] = RLPWriter.writeBytes(_l2BlockNumber);
+        rlp_ = RLPWriter.writeList(rawHeaderRLP);
+
+        // Output root
+        proof_ = Types.OutputRootProof({
+            version: 0,
+            stateRoot: _storageRoot,
+            messagePasserStorageRoot: _withdrawalRoot,
+            latestBlockhash: keccak256(rlp_)
+        });
+        root_ = Hashing.hashOutputRootProof(proof_);
+    }
+
+    /// @notice Helper to get the required bond for the given claim index.
+    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
+        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
+        Position pos = parent.move(true);
+        bond_ = gameProxy.getRequiredBond(pos);
+    }
+
+    /// @notice Helper to return a pseudo-random claim
+    function _dummyClaim() internal view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(gasleft())));
+    }
+
+    /// @notice Helper to get the localized key for an identifier in the context of the game proxy.
+    function _getKey(uint256 _ident, bytes32 _localContext) internal view returns (bytes32) {
+        bytes32 h = keccak256(abi.encode(_ident | (1 << 248), address(gameProxy), _localContext));
+        return bytes32((uint256(h) & ~uint256(0xFF << 248)) | (1 << 248));
+    }
+}
+
+/// @title FaultDisputeGame_Version_Test
+/// @notice Tests the `version` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_Version_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game's version function returns a string.
+    function test_version_works() public view {
+        assertTrue(bytes(gameProxy.version()).length > 0);
+    }
+}
+
+/// @title FaultDisputeGame_Constructor_Test
+/// @notice Tests the constructor of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_Constructor_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the
+    ///         `MAX_GAME_DEPTH` parameter is greater than `LibPosition.MAX_POSITION_BITLEN - 1`.
+    function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
+        IPreimageOracle oracle = IPreimageOracle(
+            DeployUtils.create1({
+                _name: "PreimageOracle",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+            })
+        );
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, oracle);
+
+        _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
+        vm.expectRevert(MaxDepthTooLarge.selector);
+        DeployUtils.create1({
+            _name: "FaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    IFaultDisputeGameV2.__constructor__,
+                    (
+                        IFaultDisputeGameV2.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            maxGameDepth: _maxGameDepth,
+                            splitDepth: _maxGameDepth + 1,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
+    ///         parameter is greater than or equal to the `MAX_GAME_DEPTH`
+    function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate,
+            IPreimageOracle(
+                DeployUtils.create1({
+                    _name: "PreimageOracle",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+                })
+            )
+        );
+
+        uint256 maxGameDepth = 2 ** 3;
+        _splitDepth = bound(_splitDepth, maxGameDepth - 1, type(uint256).max);
+        vm.expectRevert(InvalidSplitDepth.selector);
+        DeployUtils.create1({
+            _name: "FaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    IFaultDisputeGameV2.__constructor__,
+                    (
+                        IFaultDisputeGameV2.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            maxGameDepth: maxGameDepth,
+                            splitDepth: _splitDepth,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
+    ///         parameter is less than the minimum split depth (currently 2).
+    function testFuzz_constructor_lowSplitDepth_reverts(uint256 _splitDepth) public {
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate,
+            IPreimageOracle(
+                DeployUtils.create1({
+                    _name: "PreimageOracle",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+                })
+            )
+        );
+
+        uint256 minSplitDepth = 2;
+        _splitDepth = bound(_splitDepth, 0, minSplitDepth - 1);
+        vm.expectRevert(InvalidSplitDepth.selector);
+        DeployUtils.create1({
+            _name: "FaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    IFaultDisputeGameV2.__constructor__,
+                    (
+                        IFaultDisputeGameV2.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            maxGameDepth: 2 ** 3,
+                            splitDepth: _splitDepth,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when clock
+    ///         extension * 2 is greater than the max clock duration.
+    function testFuzz_constructor_clockExtensionTooLong_reverts(
+        uint64 _maxClockDuration,
+        uint64 _clockExtension
+    )
+        public
+    {
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate,
+            IPreimageOracle(
+                DeployUtils.create1({
+                    _name: "PreimageOracle",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+                })
+            )
+        );
+
+        // Force the clock extension * 2 to be greater than the max clock duration, but keep things
+        // within bounds of the uint64 type.
+        _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max / 2 - 1));
+        _clockExtension = uint64(bound(_clockExtension, _maxClockDuration / 2 + 1, type(uint64).max / 2));
+
+        vm.expectRevert(InvalidClockExtension.selector);
+        DeployUtils.create1({
+            _name: "FaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    IFaultDisputeGameV2.__constructor__,
+                    (
+                        IFaultDisputeGameV2.GameConstructorParams({
+                            gameType: GAME_TYPE,
+                            maxGameDepth: 16,
+                            splitDepth: 8,
+                            clockExtension: Duration.wrap(_clockExtension),
+                            maxClockDuration: Duration.wrap(_maxClockDuration)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_gameType`
+    ///         parameter is set to the reserved `type(uint32).max` game type.
+    function test_constructor_reservedGameType_reverts() public {
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate,
+            IPreimageOracle(
+                DeployUtils.create1({
+                    _name: "PreimageOracle",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IPreimageOracle.__constructor__, (0, 0)))
+                })
+            )
+        );
+
+        vm.expectRevert(ReservedGameType.selector);
+        DeployUtils.create1({
+            _name: "FaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    IFaultDisputeGameV2.__constructor__,
+                    (
+                        IFaultDisputeGameV2.GameConstructorParams({
+                            gameType: GameType.wrap(type(uint32).max),
+                            maxGameDepth: 16,
+                            splitDepth: 8,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+}
+
+/// @title FaultDisputeGame_Initialize_Test
+/// @notice Tests the initialization of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game cannot be initialized with an output root that commits to <=
+    ///         the configured starting block number
+    function testFuzz_initialize_cannotProposeGenesis_reverts(uint256 _blockNumber) public {
+        (, uint256 startingL2Block) = gameProxy.startingOutputRoot();
+        _blockNumber = bound(_blockNumber, 0, startingL2Block);
+
+        Claim claim = _dummyClaim();
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, claim));
+        gameProxy = IFaultDisputeGameV2(
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, claim, abi.encode(_blockNumber))))
+        );
+    }
+
+    /// @notice Tests that the proxy receives ETH from the dispute game factory.
+    function test_initialize_receivesETH_succeeds() public {
+        uint256 _value = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.deal(address(this), _value);
+
+        assertEq(address(gameProxy).balance, 0);
+        gameProxy = IFaultDisputeGameV2(
+            payable(
+                address(
+                    disputeGameFactory.create{ value: _value }(
+                        GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber)
+                    )
+                )
+            )
+        );
+        assertEq(address(gameProxy).balance, 0);
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), _value);
+    }
+
+    /// @notice Tests that the game cannot be initialized with incorrect CWIA calldata length
+    ///         (must be exactly 246 bytes)
+    function test_initialize_wrongCalldataLength_reverts(uint256 _extraDataLen) public {
+                // The `DisputeGameFactory` will pack the root claim and the extra data into a single
+        // array, which is enforced to be at least 64 bytes long.
+        // We bound the upper end to 23.5KB to ensure that the minimal proxy never surpasses the
+        // contract size limit in this test, as CWIA proxies store the immutable args in their
+        // bytecode.
+        // [0 bytes, 31 bytes] u [33 bytes, 23.5 KB]
+        _extraDataLen = bound(_extraDataLen, 0, 23_500);
+        if (_extraDataLen == 32) {
+            _extraDataLen++;
+        }
+        bytes memory _extraData = new bytes(_extraDataLen);
+
+        // Assign the first 32 bytes in `extraData` to a valid L2 block number passed the starting
+        // block.
+        (, uint256 startingL2Block) = gameProxy.startingOutputRoot();
+        assembly {
+            mstore(add(_extraData, 0x20), add(startingL2Block, 1))
+        }
+
+        Claim claim = _dummyClaim();
+        /// We actually never reach the BadExtraData selector because it shifts the arg layout
+        vm.expectRevert();
+        gameProxy = IFaultDisputeGameV2(
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, claim, _extraData)))
+        );
+    }
+
+    /// @notice Tests that the game is initialized with the correct data.
+    function test_initialize_correctData_succeeds() public view {
+        // Assert that the root claim is initialized correctly.
+        (
+            uint32 parentIndex,
+            address counteredBy,
+            address claimant,
+            uint128 bond,
+            Claim claim,
+            Position position,
+            Clock clock
+        ) = gameProxy.claimData(0);
+        assertEq(parentIndex, type(uint32).max);
+        assertEq(counteredBy, address(0));
+        assertEq(claimant, address(this));
+        assertEq(bond, initBond);
+        assertEq(claim.raw(), ROOT_CLAIM.raw());
+        assertEq(position.raw(), 1);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        // Assert that the `createdAt` timestamp is correct.
+        assertEq(gameProxy.createdAt().raw(), block.timestamp);
+
+        // Assert that the blockhash provided is correct.
+        assertEq(gameProxy.l1Head().raw(), blockhash(block.number - 1));
+    }
+
+    /// @notice Tests that the game cannot be initialized when the anchor root is not found.
+    function test_initialize_anchorRootNotFound_reverts() public {
+        // Mock the AnchorStateRegistry to return a zero root.
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(IAnchorStateRegistry.getAnchorRoot, ()),
+            abi.encode(Hash.wrap(bytes32(0)), 0)
+        );
+
+        // Creation should fail.
+        vm.expectRevert(AnchorRootNotFound.selector);
+        gameProxy = IFaultDisputeGameV2(
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, _dummyClaim(), new bytes(uint256(32)))))
+        );
+    }
+
+    /// @notice Tests that the game cannot be initialized twice.
+    function test_initialize_onlyOnce_succeeds() public {
+        vm.expectRevert(AlreadyInitialized.selector);
+        gameProxy.initialize();
+    }
+
+    /// @notice Tests that initialization reverts when oracle challenge period is too large.
+    /// @dev V2 validates oracle challenge period during initialize(), not constructor
+    function testFuzz_initialize_oracleChallengePeriodTooLarge_reverts(uint256 _challengePeriod) public {
+        // Bound to values larger than uint64.max
+        _challengePeriod = bound(_challengePeriod, uint256(type(uint64).max) + 1, type(uint256).max);
+
+        // Get the current AlphabetVM from the setup
+        (, AlphabetVM vm_,) = setupFaultDisputeGameV2(absolutePrestate);
+
+        // Mock the VM's oracle to return invalid challenge period
+        vm.mockCall(
+            address(vm_.oracle()),
+            abi.encodeCall(IPreimageOracle.challengePeriod, ()),
+            abi.encode(_challengePeriod)
+        );
+
+        // Expect the initialize call to revert with InvalidChallengePeriod
+        vm.expectRevert(InvalidChallengePeriod.selector);
+
+        // Create game via factory - initialize() is called automatically and should revert
+        gameProxy = IFaultDisputeGameV2(
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, _dummyClaim(), abi.encode(validL2BlockNumber))))
+        );
+    }
+}
+
+/// @title FaultDisputeGame_Step_Test
+/// @notice Tests the step functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_Step_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that a claim cannot be stepped against twice.
+    function test_step_duplicateStep_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.attack{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+
+        vm.expectRevert(DuplicateStep.selector);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+    }
+
+    /// @notice Tests that successfully step with true attacking claim when there is a true defend
+    ///         claim(claim5) in the middle of the dispute game.
+    function test_stepAttackDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bytes memory claimData5 = abi.encode(5, 5);
+        Claim claim5 = Claim.wrap(keccak256(claimData5));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, claimData5, hex"");
+    }
+
+    /// @notice Tests that successfully step with true defend claim when there is a true defend
+    ///         claim(claim7) in the middle of the dispute game.
+    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(7, 7);
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(7);
+
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, Claim.wrap(keccak256(claimData7)));
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, false, claimData7, hex"");
+    }
+
+    /// @notice Tests that step reverts with false attacking claim when there is a true defend
+    ///         claim(claim5) in the middle of the dispute game.
+    function test_stepAttackTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bytes memory claimData5 = abi.encode(5, 5);
+        Claim claim5 = Claim.wrap(keccak256(claimData5));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, true, claimData5, hex"");
+    }
+
+    /// @notice Tests that step reverts with false defending claim when there is a true defend
+    ///         claim(postState_) in the middle of the dispute game.
+    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(5, 5);
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+
+        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
+        Claim dummyClaim7 = Claim.wrap(keccak256(_dummyClaimData));
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, dummyClaim7);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, false, _dummyClaimData, hex"");
+    }
+
+    /// @notice Tests that step reverts with true defending claim when there is a true defend
+    ///         claim(postState_) in the middle of the dispute game.
+    function test_stepDefendTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
+        // Give the test contract some ether
+        vm.deal(address(this), 1000 ether);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        bytes memory claimData7 = abi.encode(5, 5);
+        Claim claim7 = Claim.wrap(keccak256(claimData7));
+        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, claim7);
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+
+        vm.expectRevert(ValidStep.selector);
+        gameProxy.step(8, false, claimData7, hex"");
+    }
+}
+
+/// @title FaultDisputeGame_Move_Test
+/// @notice Tests the move functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_Move_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that a move while the game status is not `IN_PROGRESS` causes the call to
+    ///         revert with the `GameNotInProgress` error
+    function test_move_gameNotInProgress_reverts() public {
+        uint256 chalWins = uint256(GameStatus.CHALLENGER_WINS);
+
+        // Replace the game status in storage. It exists in slot 0 at offset 16.
+        uint256 slot = uint256(vm.load(address(gameProxy), bytes32(0)));
+        uint256 offset = 16 << 3;
+        uint256 mask = 0xFF << offset;
+        // Replace the byte in the slot value with the challenger wins status.
+        slot = (slot & ~mask) | (chalWins << offset);
+        vm.store(address(gameProxy), bytes32(0), bytes32(slot));
+
+        // Ensure that the game status was properly updated.
+        GameStatus status = gameProxy.status();
+        assertEq(uint256(status), chalWins);
+
+        (,,,, Claim root,,) = gameProxy.claimData(0);
+        // Attempt to make a move. Should revert.
+        vm.expectRevert(GameNotInProgress.selector);
+        gameProxy.attack(root, 0, Claim.wrap(0));
+    }
+
+    /// @notice Tests that an attempt to defend the root claim reverts with the
+    ///         `CannotDefendRootClaim` error.
+    function test_move_defendRoot_reverts() public {
+        (,,,, Claim root,,) = gameProxy.claimData(0);
+        vm.expectRevert(CannotDefendRootClaim.selector);
+        gameProxy.defend(root, 0, _dummyClaim());
+    }
+
+    /// @notice Tests that an attempt to move against a claim that does not exist reverts with the
+    ///         `ParentDoesNotExist` error.
+    function test_move_nonExistentParent_reverts() public {
+        Claim claim = _dummyClaim();
+
+        // Expect an out of bounds revert for an attack
+        vm.expectRevert(stdError.indexOOBError);
+        gameProxy.attack(_dummyClaim(), 1, claim);
+
+        // Expect an out of bounds revert for a defense
+        vm.expectRevert(stdError.indexOOBError);
+        gameProxy.defend(_dummyClaim(), 1, claim);
+    }
+
+    /// @notice Tests that an attempt to move at the maximum game depth reverts with the
+    ///         `GameDepthExceeded` error.
+    function test_move_gameDepthExceeded_reverts() public {
+        Claim claim = _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC);
+
+        uint256 maxDepth = gameProxy.maxGameDepth();
+
+        for (uint256 i = 0; i <= maxDepth; i++) {
+            (,,,, Claim disputed,,) = gameProxy.claimData(i);
+            // At the max game depth, the `_move` function should revert with
+            // the `GameDepthExceeded` error.
+            if (i == maxDepth) {
+                vm.expectRevert(GameDepthExceeded.selector);
+                gameProxy.attack{ value: 100 ether }(disputed, i, claim);
+            } else {
+                gameProxy.attack{ value: _getRequiredBond(i) }(disputed, i, claim);
+            }
+        }
+    }
+
+    /// @notice Tests that a move made after the clock time has exceeded reverts with the
+    ///         `ClockTimeExceeded` error.
+    function test_move_clockTimeExceeded_reverts() public {
+        // Warp ahead past the clock time for the first move (3 1/2 days)
+        vm.warp(block.timestamp + 3 days + 12 hours + 1);
+        uint256 bond = _getRequiredBond(0);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.expectRevert(ClockTimeExceeded.selector);
+        gameProxy.attack{ value: bond }(disputed, 0, _dummyClaim());
+    }
+
+    /// @notice Static unit test for the correctness of the chess clock incrementation.
+    function test_move_clockCorrectness_succeeds() public {
+        (,,,,,, Clock clock) = gameProxy.claimData(0);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        Claim claim = _dummyClaim();
+
+        vm.warp(block.timestamp + 15);
+        uint256 bond = _getRequiredBond(0);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: bond }(disputed, 0, claim);
+        (,,,,,, clock) = gameProxy.claimData(1);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(15), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        vm.warp(block.timestamp + 10);
+        bond = _getRequiredBond(1);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: bond }(disputed, 1, claim);
+        (,,,,,, clock) = gameProxy.claimData(2);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(10), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        // We are at the split depth, so we need to set the status byte of the claim for the next
+        // move.
+        claim = _changeClaimStatus(claim, VMStatuses.PANIC);
+
+        vm.warp(block.timestamp + 10);
+        bond = _getRequiredBond(2);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: bond }(disputed, 2, claim);
+        (,,,,,, clock) = gameProxy.claimData(3);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(25), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        vm.warp(block.timestamp + 10);
+        bond = _getRequiredBond(3);
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: bond }(disputed, 3, claim);
+        (,,,,,, clock) = gameProxy.claimData(4);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(20), Timestamp.wrap(uint64(block.timestamp))).raw());
+    }
+
+    /// @notice Tests that the standard clock extension is triggered for a move that is not the
+    ///         split depth or the max game depth.
+    function test_move_standardClockExtension_succeeds() public {
+        (,,,,,, Clock clock) = gameProxy.claimData(0);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        uint256 bond;
+        Claim disputed;
+        Claim claim = _dummyClaim();
+        uint256 splitDepth = gameProxy.splitDepth();
+        uint64 halfGameDuration = gameProxy.maxClockDuration().raw();
+        uint64 clockExtension = gameProxy.clockExtension().raw();
+
+        // Warp ahead so that the next move will trigger a clock extension. We warp to the very
+        // first timestamp where a clock extension should be triggered.
+        vm.warp(block.timestamp + halfGameDuration - clockExtension + 1 seconds);
+
+        // Execute a move that should cause a clock extension.
+        bond = _getRequiredBond(0);
+        (,,,, disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: bond }(disputed, 0, claim);
+        (,,,,,, clock) = gameProxy.claimData(1);
+
+        // The clock should have been pushed back to the clock extension time.
+        assertEq(clock.duration().raw(), halfGameDuration - clockExtension);
+
+        // Warp ahead again so that clock extensions will also trigger for the other team. Here we
+        // only warp to the clockExtension time because we'll be warping ahead by one second during
+        // each additional move.
+        vm.warp(block.timestamp + halfGameDuration - clockExtension);
+
+        // Work our way down to the split depth.
+        for (uint256 i = 1; i < splitDepth - 2; i++) {
+            // Warp ahead by one second so that the next move will trigger a clock extension.
+            vm.warp(block.timestamp + 1 seconds);
+
+            // Execute a move that should cause a clock extension.
+            bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, claim);
+            (,,,,,, clock) = gameProxy.claimData(i + 1);
+
+            // The clock should have been pushed back to the clock extension time.
+            assertEq(clock.duration().raw(), halfGameDuration - clockExtension);
+        }
+    }
+
+    function test_move_splitDepthClockExtension_succeeds() public {
+        (,,,,,, Clock clock) = gameProxy.claimData(0);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        uint256 bond;
+        Claim disputed;
+        Claim claim = _dummyClaim();
+        uint256 splitDepth = gameProxy.splitDepth();
+        uint64 halfGameDuration = gameProxy.maxClockDuration().raw();
+        uint64 clockExtension = gameProxy.clockExtension().raw();
+
+        // Work our way down to the split depth without moving ahead in time, we don't care about
+        // the exact clock here, just don't want take the clock below the clock extension time that
+        // we're trying to test here.
+        for (uint256 i = 0; i < splitDepth - 2; i++) {
+            bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, claim);
+        }
+
+        // Warp ahead to the very first timestamp where a clock extension should be triggered.
+        vm.warp(block.timestamp + halfGameDuration - clockExtension * 2 + 1 seconds);
+
+        // Execute a move that should cause a clock extension.
+        bond = _getRequiredBond(splitDepth - 2);
+        (,,,, disputed,,) = gameProxy.claimData(splitDepth - 2);
+        gameProxy.attack{ value: bond }(disputed, splitDepth - 2, claim);
+        (,,,,,, clock) = gameProxy.claimData(splitDepth - 1);
+
+        // The clock should have been pushed back to the clock extension time.
+        assertEq(clock.duration().raw(), halfGameDuration - clockExtension * 2);
+    }
+
+    function test_move_maxGameDepthClockExtension_succeeds() public {
+        (,,,,,, Clock clock) = gameProxy.claimData(0);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        uint256 bond;
+        Claim disputed;
+        Claim claim = _dummyClaim();
+        uint256 splitDepth = gameProxy.splitDepth();
+        uint64 halfGameDuration = gameProxy.maxClockDuration().raw();
+        uint64 clockExtension = gameProxy.clockExtension().raw();
+
+        // Work our way down to the split depth without moving ahead in time, we don't care about
+        // the exact clock here, just don't want take the clock below the clock extension time that
+        // we're trying to test here.
+        for (uint256 i = 0; i < gameProxy.maxGameDepth() - 2; i++) {
+            bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, claim);
+
+            // Change the claim status when we're crossing the split depth.
+            if (i == splitDepth - 2) {
+                claim = _changeClaimStatus(claim, VMStatuses.PANIC);
+            }
+        }
+
+        // Warp ahead to the very first timestamp where a clock extension should be triggered.
+        vm.warp(block.timestamp + halfGameDuration - (clockExtension + gameProxy.vm().oracle().challengePeriod()) + 1);
+
+        // Execute a move that should cause a clock extension.
+        bond = _getRequiredBond(gameProxy.maxGameDepth() - 2);
+        (,,,, disputed,,) = gameProxy.claimData(gameProxy.maxGameDepth() - 2);
+        gameProxy.attack{ value: bond }(disputed, gameProxy.maxGameDepth() - 2, claim);
+        (,,,,,, clock) = gameProxy.claimData(gameProxy.maxGameDepth() - 1);
+
+        // The clock should have been pushed back to the clock extension time.
+        assertEq(
+            clock.duration().raw(), halfGameDuration - (clockExtension + gameProxy.vm().oracle().challengePeriod())
+        );
+    }
+
+    /// @notice Tests that an identical claim cannot be made twice. The duplicate claim attempt
+    ///         should revert with the `ClaimAlreadyExists` error.
+    function test_move_duplicateClaim_reverts() public {
+        Claim claim = _dummyClaim();
+
+        // Make the first move. This should succeed.
+        uint256 bond = _getRequiredBond(0);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: bond }(disputed, 0, claim);
+
+        // Attempt to make the same move again.
+        vm.expectRevert(ClaimAlreadyExists.selector);
+        gameProxy.attack{ value: bond }(disputed, 0, claim);
+    }
+
+    /// @notice Static unit test asserting that identical claims at the same position can be made
+    ///         in different subgames.
+    function test_move_duplicateClaimsDifferentSubgames_succeeds() public {
+        Claim claimA = _dummyClaim();
+        Claim claimB = _dummyClaim();
+
+        // Make the first moves. This should succeed.
+        uint256 bond = _getRequiredBond(0);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: bond }(disputed, 0, claimA);
+        gameProxy.attack{ value: bond }(disputed, 0, claimB);
+
+        // Perform an attack at the same position with the same claim value in both subgames.
+        // These both should succeed.
+        bond = _getRequiredBond(1);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: bond }(disputed, 1, claimA);
+        bond = _getRequiredBond(2);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: bond }(disputed, 2, claimA);
+    }
+
+    /// @notice Static unit test for the correctness of an opening attack.
+    function test_move_simpleAttack_succeeds() public {
+        // Warp ahead 5 seconds.
+        vm.warp(block.timestamp + 5);
+
+        Claim counter = _dummyClaim();
+
+        // Perform the attack.
+        uint256 reqBond = _getRequiredBond(0);
+        vm.expectEmit(true, true, true, false);
+        emit Move(0, counter, address(this));
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: reqBond }(disputed, 0, counter);
+
+        // Grab the claim data of the attack.
+        (
+            uint32 parentIndex,
+            address counteredBy,
+            address claimant,
+            uint128 bond,
+            Claim claim,
+            Position position,
+            Clock clock
+        ) = gameProxy.claimData(1);
+
+        // Assert correctness of the attack claim's data.
+        assertEq(parentIndex, 0);
+        assertEq(counteredBy, address(0));
+        assertEq(claimant, address(this));
+        assertEq(bond, reqBond);
+        assertEq(claim.raw(), counter.raw());
+        assertEq(position.raw(), Position.wrap(1).move(true).raw());
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(5), Timestamp.wrap(uint64(block.timestamp))).raw());
+
+        // Grab the claim data of the parent.
+        (parentIndex, counteredBy, claimant, bond, claim, position, clock) = gameProxy.claimData(0);
+
+        // Assert correctness of the parent claim's data.
+        assertEq(parentIndex, type(uint32).max);
+        assertEq(counteredBy, address(0));
+        assertEq(claimant, address(this));
+        assertEq(bond, initBond);
+        assertEq(claim.raw(), ROOT_CLAIM.raw());
+        assertEq(position.raw(), 1);
+        assertEq(clock.raw(), LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp - 5))).raw());
+    }
+
+    /// @notice Tests that making a claim at the execution trace bisection root level with an
+    ///         invalid status byte reverts with the `UnexpectedRootClaim` error.
+    function test_move_incorrectStatusExecRoot_reverts() public {
+        Claim disputed;
+        for (uint256 i; i < 4; i++) {
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: _getRequiredBond(i) }(disputed, i, _dummyClaim());
+        }
+
+        uint256 bond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, bytes32(0)));
+        gameProxy.attack{ value: bond }(disputed, 4, Claim.wrap(bytes32(0)));
+    }
+
+    /// @notice Tests that making a claim at the execution trace bisection root level with a valid
+    ///         status byte succeeds.
+    function test_move_correctStatusExecRoot_succeeds() public {
+        Claim disputed;
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, _dummyClaim());
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+    }
+
+    /// @notice Static unit test asserting that a move reverts when the bonded amount is incorrect.
+    function test_move_incorrectBondAmount_reverts() public {
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.expectRevert(IncorrectBondAmount.selector);
+        gameProxy.attack{ value: 0 }(disputed, 0, _dummyClaim());
+    }
+
+    /// @notice Static unit test asserting that a move reverts when the disputed claim does not
+    ///         match its index.
+    function test_move_incorrectDisputedIndex_reverts() public {
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        uint256 bond = _getRequiredBond(1);
+        vm.expectRevert(InvalidDisputedClaimIndex.selector);
+        gameProxy.attack{ value: bond }(disputed, 1, _dummyClaim());
+    }
+}
+
+/// @title FaultDisputeGame_AddLocalData_Test
+/// @notice Tests the addLocalData functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_AddLocalData_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that adding local data with an out of bounds identifier reverts.
+    function testFuzz_addLocalData_oob_reverts(uint256 _ident) public {
+        Claim disputed;
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, _dummyClaim());
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        // [1, 5] are valid local data identifiers.
+        if (_ident <= 5) _ident = 0;
+
+        vm.expectRevert(InvalidLocalIdent.selector);
+        gameProxy.addLocalData(_ident, 5, 0);
+    }
+
+    /// @notice Tests that local data is loaded into the preimage oracle correctly in the subgame
+    ///         that is disputing the transition from `GENESIS -> GENESIS + 1`
+    function test_addLocalDataGenesisTransition_static_succeeds() public {
+        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
+        Claim disputed;
+
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: lastBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        // Expected start/disputed claims
+        (Hash root,) = gameProxy.startingOutputRoot();
+        bytes32 startingClaim = root.raw();
+        bytes32 disputedClaim = bytes32(uint256(3));
+        Position disputedPos = LibPosition.wrap(4, 0);
+
+        // Expected local data
+        bytes32[5] memory data = [
+            gameProxy.l1Head().raw(),
+            startingClaim,
+            disputedClaim,
+            bytes32(validL2BlockNumber << 0xC0),
+            bytes32(gameProxy.l2ChainId() << 0xC0)
+        ];
+
+        for (uint256 i = 1; i <= 5; i++) {
+            uint256 expectedLen = i > 3 ? 8 : 32;
+            bytes32 key = _getKey(i, keccak256(abi.encode(disputedClaim, disputedPos)));
+
+            gameProxy.addLocalData(i, 5, 0);
+            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+            assertEq(dat >> 0xC0, bytes32(expectedLen));
+            // Account for the length prefix if i > 3 (the data stored at identifiers i <= 3 are
+            // 32 bytes long, so the expected length is already correct. If i > 3, the data is only
+            // 8 bytes long, so the length prefix + the data is 16 bytes total.)
+            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
+
+            gameProxy.addLocalData(i, 5, 8);
+            (dat, datLen) = oracle.readPreimage(key, 8);
+            assertEq(dat, data[i - 1]);
+            assertEq(datLen, expectedLen);
+        }
+    }
+
+    /// @notice Tests that local data is loaded into the preimage oracle correctly.
+    function test_addLocalDataMiddle_static_succeeds() public {
+        IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
+        Claim disputed;
+
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        for (uint256 i; i < 4; i++) {
+            uint256 bond = _getRequiredBond(i);
+            (,,,, disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+        }
+        uint256 lastBond = _getRequiredBond(4);
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID));
+
+        // Expected start/disputed claims
+        bytes32 startingClaim = bytes32(uint256(3));
+        Position startingPos = LibPosition.wrap(4, 0);
+        bytes32 disputedClaim = bytes32(uint256(2));
+        Position disputedPos = LibPosition.wrap(3, 0);
+
+        // Expected local data
+        bytes32[5] memory data = [
+            gameProxy.l1Head().raw(),
+            startingClaim,
+            disputedClaim,
+            bytes32(validL2BlockNumber << 0xC0),
+            bytes32(gameProxy.l2ChainId() << 0xC0)
+        ];
+
+        for (uint256 i = 1; i <= 5; i++) {
+            uint256 expectedLen = i > 3 ? 8 : 32;
+            bytes32 key = _getKey(i, keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos)));
+
+            gameProxy.addLocalData(i, 5, 0);
+            (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+            assertEq(dat >> 0xC0, bytes32(expectedLen));
+            // Account for the length prefix if i > 3 (the data stored at identifiers i <= 3 are
+            // 32 bytes long, so the expected length is already correct. If i > 3, the data is only
+            // 8 bytes long, so the length prefix + the data is 16 bytes total.)
+            assertEq(datLen, expectedLen + (i > 3 ? 8 : 0));
+
+            gameProxy.addLocalData(i, 5, 8);
+            (dat, datLen) = oracle.readPreimage(key, 8);
+            assertEq(dat, data[i - 1]);
+            assertEq(datLen, expectedLen);
+        }
+    }
+
+    /// @notice Tests that the L2 block number claim is favored over the bisected-to block when
+    ///         adding data.
+    function test_addLocalData_l2BlockNumberExtension_succeeds() public {
+        // Deploy a new dispute game with a L2 block number claim of 8. This is directly in the
+        // middle of the leaves in our output bisection test tree, at SPLIT_DEPTH = 2 ** 2
+        IFaultDisputeGameV2 game = IFaultDisputeGameV2(
+            address(
+                disputeGameFactory.create{ value: initBond }(
+                    GAME_TYPE, Claim.wrap(bytes32(uint256(0xFF))), abi.encode(validL2BlockNumber)
+                )
+            )
+        );
+
+        // Get a claim below the split depth so that we can add local data for an execution trace
+        // subgame.
+        {
+            Claim disputed;
+            Position parent;
+            Position pos;
+
+            for (uint256 i; i < 4; i++) {
+                (,,,,, parent,) = game.claimData(i);
+                pos = parent.move(true);
+                uint256 bond = game.getRequiredBond(pos);
+
+                (,,,, disputed,,) = game.claimData(i);
+                if (i == 0) {
+                    game.attack{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+                } else {
+                    game.defend{ value: bond }(disputed, i, Claim.wrap(bytes32(i)));
+                }
+            }
+            (,,,,, parent,) = game.claimData(4);
+            pos = parent.move(true);
+            uint256 lastBond = game.getRequiredBond(pos);
+            (,,,, disputed,,) = game.claimData(4);
+            game.defend{ value: lastBond }(disputed, 4, _changeClaimStatus(ROOT_CLAIM, VMStatuses.INVALID));
+        }
+
+        // Expected start/disputed claims
+        bytes32 startingClaim = bytes32(uint256(3));
+        Position startingPos = LibPosition.wrap(4, 14);
+        bytes32 disputedClaim = bytes32(uint256(0xFF));
+        Position disputedPos = LibPosition.wrap(0, 0);
+
+        // Expected local data. This should be `l2BlockNumber`, and not the actual bisected-to
+        // block, as we choose the minimum between the two.
+        bytes32 expectedNumber = bytes32(validL2BlockNumber << 0xC0);
+        uint256 expectedLen = 8;
+        uint256 l2NumberIdent = LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER;
+
+        // Compute the preimage key for the local data
+        bytes32 localContext = keccak256(abi.encode(startingClaim, startingPos, disputedClaim, disputedPos));
+        bytes32 rawKey = keccak256(abi.encode(l2NumberIdent | (1 << 248), address(game), localContext));
+        bytes32 key = bytes32((uint256(rawKey) & ~uint256(0xFF << 248)) | (1 << 248));
+
+        IPreimageOracle oracle = IPreimageOracle(address(game.vm().oracle()));
+        game.addLocalData(l2NumberIdent, 5, 0);
+
+        (bytes32 dat, uint256 datLen) = oracle.readPreimage(key, 0);
+        assertEq(dat >> 0xC0, bytes32(expectedLen));
+        assertEq(datLen, expectedLen + 8);
+
+        game.addLocalData(l2NumberIdent, 5, 8);
+        (dat, datLen) = oracle.readPreimage(key, 8);
+        assertEq(dat, expectedNumber);
+        assertEq(datLen, expectedLen);
+    }
+}
+
+/// @title FaultDisputeGame_ChallengeRootL2Block_Test
+/// @notice Tests the challengeRootL2Block functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_ChallengeRootL2Block_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that challenging the root claim's L2 block number by providing the real
+    ///         preimage of the output root succeeds.
+    function testFuzz_challengeRootL2Block_succeeds(
+        bytes32 _storageRoot,
+        bytes32 _withdrawalRoot,
+        uint256 _l2BlockNumber
+    )
+        public
+    {
+        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max - 1);
+
+        (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot, bytes memory headerRLP) =
+            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(_l2BlockNumber));
+
+        // Create the dispute game with the output root at the wrong L2 block number.
+        uint256 wrongL2BlockNumber = bound(vm.randomUint(), _l2BlockNumber + 1, type(uint256).max);
+        IDisputeGame game = disputeGameFactory.create{ value: initBond }(
+            GAME_TYPE, Claim.wrap(outputRoot), abi.encode(wrongL2BlockNumber)
+        );
+
+        // Challenge the L2 block number.
+        IFaultDisputeGameV2 fdg = IFaultDisputeGameV2(address(game));
+        fdg.challengeRootL2Block(outputRootProof, headerRLP);
+
+        // Ensure that a duplicate challenge reverts.
+        vm.expectRevert(L2BlockNumberChallenged.selector);
+        fdg.challengeRootL2Block(outputRootProof, headerRLP);
+
+        // Warp past the clocks, resolve the game.
+        vm.warp(block.timestamp + 3 days + 12 hours + 1);
+        fdg.resolveClaim(0, 0);
+        fdg.resolve();
+
+        // Ensure the challenge was successful.
+        assertEq(uint8(fdg.status()), uint8(GameStatus.CHALLENGER_WINS));
+        assertTrue(fdg.l2BlockNumberChallenged());
+    }
+
+    /// @notice Tests that challenging the root claim's L2 block number by providing the real
+    ///         preimage of the output root succeeds. Also, this claim should always receive the
+    ///         bond when there is another counter that is as far left as possible.
+    function testFuzz_challengeRootL2Block_receivesBond_succeeds(
+        bytes32 _storageRoot,
+        bytes32 _withdrawalRoot,
+        uint256 _l2BlockNumber
+    )
+        public
+    {
+        vm.deal(address(0xb0b), 1 ether);
+        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max - 1);
+
+        (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot, bytes memory headerRLP) =
+            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(_l2BlockNumber));
+
+        // Create the dispute game with the output root at the wrong L2 block number.
+        disputeGameFactory.setInitBond(GAME_TYPE, 0.1 ether);
+        uint256 balanceBefore = address(this).balance;
+        _l2BlockNumber = bound(vm.randomUint(), _l2BlockNumber + 1, type(uint256).max);
+        IDisputeGame game =
+            disputeGameFactory.create{ value: 0.1 ether }(GAME_TYPE, Claim.wrap(outputRoot), abi.encode(_l2BlockNumber));
+        IFaultDisputeGameV2 fdg = IFaultDisputeGameV2(address(game));
+
+        // Attack the root as 0xb0b
+        uint256 bond = _getRequiredBond(0);
+        (,,,, Claim disputed,,) = fdg.claimData(0);
+        vm.prank(address(0xb0b));
+        fdg.attack{ value: bond }(disputed, 0, Claim.wrap(0));
+
+        // Challenge the L2 block number as 0xace. This claim should receive the root claim's bond.
+        vm.prank(address(0xace));
+        fdg.challengeRootL2Block(outputRootProof, headerRLP);
+
+        // Warp past the clocks, resolve the game.
+        vm.warp(block.timestamp + 3 days + 12 hours + 1);
+        fdg.resolveClaim(1, 0);
+        fdg.resolveClaim(0, 0);
+        fdg.resolve();
+
+        // Ensure the challenge was successful.
+        assertEq(uint8(fdg.status()), uint8(GameStatus.CHALLENGER_WINS));
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        fdg.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        fdg.claimCredit(address(this));
+        fdg.claimCredit(address(0xb0b));
+        fdg.claimCredit(address(0xace));
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // Claim credit
+        vm.expectRevert(NoCreditToClaim.selector);
+        fdg.claimCredit(address(this));
+        fdg.claimCredit(address(0xb0b));
+        fdg.claimCredit(address(0xace));
+
+        // Ensure that the party who challenged the L2 block number with the special move received
+        // the bond.
+        // - Root claim loses their bond
+        // - 0xace receives the root claim's bond
+        // - 0xb0b receives their bond back
+        assertEq(address(this).balance, balanceBefore - 0.1 ether);
+        assertEq(address(0xb0b).balance, 1 ether);
+        assertEq(address(0xace).balance, 0.1 ether);
+    }
+
+    /// @notice Tests that challenging the root claim's L2 block number by providing the real
+    ///         preimage of the output root never succeeds.
+    function testFuzz_challengeRootL2Block_rightBlockNumber_reverts(
+        bytes32 _storageRoot,
+        bytes32 _withdrawalRoot,
+        uint256 _l2BlockNumber
+    )
+        public
+    {
+        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max);
+
+        (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot, bytes memory headerRLP) =
+            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(_l2BlockNumber));
+
+        // Create the dispute game with the output root at the wrong L2 block number.
+        IDisputeGame game =
+            disputeGameFactory.create{ value: initBond }(GAME_TYPE, Claim.wrap(outputRoot), abi.encode(_l2BlockNumber));
+
+        // Challenge the L2 block number.
+        IFaultDisputeGameV2 fdg = IFaultDisputeGameV2(address(game));
+        vm.expectRevert(BlockNumberMatches.selector);
+        fdg.challengeRootL2Block(outputRootProof, headerRLP);
+
+        // Warp past the clocks, resolve the game.
+        vm.warp(block.timestamp + 3 days + 12 hours + 1);
+        fdg.resolveClaim(0, 0);
+        fdg.resolve();
+
+        // Ensure the challenge was successful.
+        assertEq(uint8(fdg.status()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    /// @notice Tests that challenging the root claim's L2 block number with a bad output root
+    ///         proof reverts.
+    function test_challengeRootL2Block_badProof_reverts() public {
+        Types.OutputRootProof memory outputRootProof =
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 });
+
+        vm.expectRevert(InvalidOutputRootProof.selector);
+        gameProxy.challengeRootL2Block(outputRootProof, hex"");
+    }
+
+    /// @notice Tests that challenging the root claim's L2 block number with a bad output root
+    ///         proof reverts.
+    function test_challengeRootL2Block_badHeaderRLP_reverts() public {
+        Types.OutputRootProof memory outputRootProof =
+            Types.OutputRootProof({ version: 0, stateRoot: 0, messagePasserStorageRoot: 0, latestBlockhash: 0 });
+        bytes32 outputRoot = Hashing.hashOutputRootProof(outputRootProof);
+
+        // Create the dispute game with the output root at the wrong L2 block number.
+        IDisputeGame game = disputeGameFactory.create{ value: initBond }(
+            GAME_TYPE, Claim.wrap(outputRoot), abi.encode(validL2BlockNumber)
+        );
+        IFaultDisputeGameV2 fdg = IFaultDisputeGameV2(address(game));
+
+        vm.expectRevert(InvalidHeaderRLP.selector);
+        fdg.challengeRootL2Block(outputRootProof, hex"");
+    }
+
+    /// @notice Tests that challenging the root claim's L2 block number with a bad output root
+    ///         proof reverts.
+    function test_challengeRootL2Block_badHeaderRLPBlockNumberLength_reverts() public {
+        (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot,) =
+            _generateOutputRootProof(0, 0, new bytes(64));
+
+        // Create the dispute game with the output root at the wrong L2 block number.
+        IDisputeGame game = disputeGameFactory.create{ value: initBond }(
+            GAME_TYPE, Claim.wrap(outputRoot), abi.encode(validL2BlockNumber)
+        );
+        IFaultDisputeGameV2 fdg = IFaultDisputeGameV2(address(game));
+
+        vm.expectRevert(InvalidHeaderRLP.selector);
+        fdg.challengeRootL2Block(outputRootProof, hex"");
+    }
+}
+
+/// @title FaultDisputeGame_Resolve_Test
+/// @notice Tests the resolve functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_Resolve_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Static unit test for the correctness an uncontested root resolution.
+    function test_resolve_rootUncontested_succeeds() public {
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    /// @notice Static unit test for the correctness an uncontested root resolution.
+    function test_resolve_rootUncontestedClockNotExpired_succeeds() public {
+        vm.warp(block.timestamp + 3 days + 12 hours - 1 seconds);
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(0, 0);
+    }
+
+    /// @notice Static unit test for the correctness of a multi-part resolution of a single claim.
+    function test_resolve_multiPart_succeeds() public {
+        vm.deal(address(this), 10_000 ether);
+
+        uint256 bond = _getRequiredBond(0);
+        for (uint256 i = 0; i < 2048; i++) {
+            (,,,, Claim disputed,,) = gameProxy.claimData(0);
+            gameProxy.attack{ value: bond }(disputed, 0, Claim.wrap(bytes32(i)));
+        }
+
+        // Warp past the clock period.
+        vm.warp(block.timestamp + 3 days + 12 hours + 1 seconds);
+
+        // Resolve all children of the root subgame. Every single one of these will be uncontested.
+        for (uint256 i = 1; i <= 2048; i++) {
+            gameProxy.resolveClaim(i, 0);
+        }
+
+        // Resolve the first half of the root claim subgame.
+        gameProxy.resolveClaim(0, 1024);
+
+        // Fetch the resolution checkpoint for the root subgame and assert correctness.
+        (bool initCheckpoint, uint32 subgameIndex, Position leftmostPosition, address counteredBy) =
+            gameProxy.resolutionCheckpoints(0);
+        assertTrue(initCheckpoint);
+        assertEq(subgameIndex, 1024);
+        assertEq(leftmostPosition.raw(), Position.wrap(1).move(true).raw());
+        assertEq(counteredBy, address(this));
+
+        // The root subgame should not be resolved.
+        assertFalse(gameProxy.resolvedSubgames(0));
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolve();
+
+        // Resolve the second half of the root claim subgame.
+        uint256 numToResolve = gameProxy.getNumToResolve(0);
+        assertEq(numToResolve, 1024);
+        gameProxy.resolveClaim(0, numToResolve);
+
+        // Fetch the resolution checkpoint for the root subgame and assert correctness.
+        (initCheckpoint, subgameIndex, leftmostPosition, counteredBy) = gameProxy.resolutionCheckpoints(0);
+        assertTrue(initCheckpoint);
+        assertEq(subgameIndex, 2048);
+        assertEq(leftmostPosition.raw(), Position.wrap(1).move(true).raw());
+        assertEq(counteredBy, address(this));
+
+        // The root subgame should now be resolved
+        assertTrue(gameProxy.resolvedSubgames(0));
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
+    }
+
+    /// @notice Static unit test asserting that resolve reverts when the absolute root
+    ///      subgame has not been resolved.
+    function test_resolve_rootUncontestedButUnresolved_reverts() public {
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolve();
+    }
+
+    /// @notice Static unit test asserting that resolve reverts when the game state is
+    ///      not in progress.
+    function test_resolve_notInProgress_reverts() public {
+        uint256 chalWins = uint256(GameStatus.CHALLENGER_WINS);
+
+        // Replace the game status in storage. It exists in slot 0 at offset 16.
+        uint256 slot = uint256(vm.load(address(gameProxy), bytes32(0)));
+        uint256 offset = 16 << 3;
+        uint256 mask = 0xFF << offset;
+        // Replace the byte in the slot value with the challenger wins status.
+        slot = (slot & ~mask) | (chalWins << offset);
+
+        vm.store(address(gameProxy), bytes32(uint256(0)), bytes32(slot));
+        vm.expectRevert(GameNotInProgress.selector);
+        gameProxy.resolveClaim(0, 0);
+    }
+
+    /// @notice Static unit test for the correctness of resolving a single attack game state.
+    function test_resolve_rootContested_succeeds() public {
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        gameProxy.resolveClaim(1, 0);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
+    }
+
+    /// @notice Static unit test for the correctness of resolving a game with a contested challenge
+    ///         claim.
+    function test_resolve_challengeContested_succeeds() public {
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        gameProxy.resolveClaim(2, 0);
+        gameProxy.resolveClaim(1, 0);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    /// @notice Static unit test for the correctness of resolving a game with multiplayer moves.
+    function test_resolve_teamDeathmatch_succeeds() public {
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        gameProxy.defend{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        gameProxy.resolveClaim(4, 0);
+        gameProxy.resolveClaim(3, 0);
+        gameProxy.resolveClaim(2, 0);
+        gameProxy.resolveClaim(1, 0);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
+    }
+
+    /// @notice Static unit test for the correctness of resolving a game that reaches max game
+    ///         depth.
+    function test_resolve_stepReached_succeeds() public {
+        Claim claim = _dummyClaim();
+        for (uint256 i; i < gameProxy.splitDepth(); i++) {
+            (,,,, Claim disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: _getRequiredBond(i) }(disputed, i, claim);
+        }
+
+        claim = _changeClaimStatus(claim, VMStatuses.PANIC);
+        for (uint256 i = gameProxy.claimDataLen() - 1; i < gameProxy.maxGameDepth(); i++) {
+            (,,,, Claim disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: _getRequiredBond(i) }(disputed, i, claim);
+        }
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        for (uint256 i = 9; i > 0; i--) {
+            gameProxy.resolveClaim(i - 1, 0);
+        }
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve a
+    ///         subgame multiple times
+    function test_resolve_claimAlreadyResolved_reverts() public {
+        Claim claim = _dummyClaim();
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(address(this), firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, claim);
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(address(this), secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: secondBond }(disputed, 1, claim);
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        gameProxy.resolveClaim(2, 0);
+        gameProxy.resolveClaim(1, 0);
+
+        vm.expectRevert(ClaimAlreadyResolved.selector);
+        gameProxy.resolveClaim(1, 0);
+    }
+
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve a
+    ///         subgame at max depth
+    function test_resolve_claimAtMaxDepthAlreadyResolved_reverts() public {
+        Claim claim = _dummyClaim();
+        for (uint256 i; i < gameProxy.splitDepth(); i++) {
+            (,,,, Claim disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: _getRequiredBond(i) }(disputed, i, claim);
+        }
+
+        vm.deal(address(this), 10000 ether);
+        claim = _changeClaimStatus(claim, VMStatuses.PANIC);
+        for (uint256 i = gameProxy.claimDataLen() - 1; i < gameProxy.maxGameDepth(); i++) {
+            (,,,, Claim disputed,,) = gameProxy.claimData(i);
+            gameProxy.attack{ value: _getRequiredBond(i) }(disputed, i, claim);
+        }
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        gameProxy.resolveClaim(8, 0);
+
+        vm.expectRevert(ClaimAlreadyResolved.selector);
+        gameProxy.resolveClaim(8, 0);
+    }
+
+    /// @notice Static unit test asserting that resolve reverts when attempting to resolve
+    ///         subgames out of order
+    function test_resolve_outOfOrderResolution_reverts() public {
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+    }
+
+    /// @notice Static unit test asserting that resolve pays out bonds on step, output bisection,
+    ///         and execution trace moves.
+    function test_resolve_bondPayouts_succeeds() public {
+        // Give the test contract some ether
+        uint256 bal = 1000 ether;
+        vm.deal(address(this), bal);
+
+        // Make claims all the way down the tree.
+        uint256 bond = _getRequiredBond(0);
+        uint256 totalBonded = bond;
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: bond }(disputed, 0, _dummyClaim());
+        bond = _getRequiredBond(1);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: bond }(disputed, 1, _dummyClaim());
+        bond = _getRequiredBond(2);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: bond }(disputed, 2, _dummyClaim());
+        bond = _getRequiredBond(3);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: bond }(disputed, 3, _dummyClaim());
+        bond = _getRequiredBond(4);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: bond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        bond = _getRequiredBond(5);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: bond }(disputed, 5, _dummyClaim());
+        bond = _getRequiredBond(6);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.attack{ value: bond }(disputed, 6, _dummyClaim());
+        bond = _getRequiredBond(7);
+        totalBonded += bond;
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: bond }(disputed, 7, _dummyClaim());
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+
+        // Ensure that the step successfully countered the leaf claim.
+        (, address counteredBy,,,,,) = gameProxy.claimData(8);
+        assertEq(counteredBy, address(this));
+
+        // Ensure we bonded the correct amounts
+        assertEq(address(this).balance, bal - totalBonded);
+        assertEq(address(gameProxy).balance, 0);
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), initBond + totalBonded);
+
+        // Resolve all claims
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        for (uint256 i = gameProxy.claimDataLen(); i > 0; i--) {
+            (bool success,) = address(gameProxy).call(abi.encodeCall(gameProxy.resolveClaim, (i - 1, 0)));
+            assertTrue(success);
+        }
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // Claim credit again to get the bond back.
+        gameProxy.claimCredit(address(this));
+
+        // Ensure that bonds were paid out correctly.
+        assertEq(address(this).balance, bal + initBond);
+        assertEq(address(gameProxy).balance, 0);
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), 0);
+
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
+        assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
+    }
+
+    /// @notice Static unit test asserting that resolve pays out bonds on step, output bisection,
+    ///         and execution trace moves with 2 actors and a dishonest root claim.
+    function test_resolve_bondPayoutsSeveralActors_succeeds() public {
+        // Give the test contract and bob some ether
+        // We use the "1000 ether" literal for `bal`, the initial balance, to avoid stack too deep
+        //uint256 bal = 1000 ether;
+        address bob = address(0xb0b);
+        vm.deal(address(this), 1000 ether);
+        vm.deal(bob, 1000 ether);
+
+        // Make claims all the way down the tree, trading off between bob and the test contract.
+        uint256 firstBond = _getRequiredBond(0);
+        uint256 thisBonded = firstBond;
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, _dummyClaim());
+
+        uint256 secondBond = _getRequiredBond(1);
+        uint256 bobBonded = secondBond;
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        vm.prank(bob);
+        gameProxy.attack{ value: secondBond }(disputed, 1, _dummyClaim());
+
+        uint256 thirdBond = _getRequiredBond(2);
+        thisBonded += thirdBond;
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: thirdBond }(disputed, 2, _dummyClaim());
+
+        uint256 fourthBond = _getRequiredBond(3);
+        bobBonded += fourthBond;
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        vm.prank(bob);
+        gameProxy.attack{ value: fourthBond }(disputed, 3, _dummyClaim());
+
+        uint256 fifthBond = _getRequiredBond(4);
+        thisBonded += fifthBond;
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: fifthBond }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+
+        uint256 sixthBond = _getRequiredBond(5);
+        bobBonded += sixthBond;
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        vm.prank(bob);
+        gameProxy.attack{ value: sixthBond }(disputed, 5, _dummyClaim());
+
+        uint256 seventhBond = _getRequiredBond(6);
+        thisBonded += seventhBond;
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.attack{ value: seventhBond }(disputed, 6, _dummyClaim());
+
+        uint256 eighthBond = _getRequiredBond(7);
+        bobBonded += eighthBond;
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        vm.prank(bob);
+        gameProxy.attack{ value: eighthBond }(disputed, 7, _dummyClaim());
+
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+
+        // Ensure that the step successfully countered the leaf claim.
+        (, address counteredBy,,,,,) = gameProxy.claimData(8);
+        assertEq(counteredBy, address(this));
+
+        // Ensure we bonded the correct amounts
+        assertEq(address(this).balance, 1000 ether - thisBonded);
+        assertEq(bob.balance, 1000 ether - bobBonded);
+        assertEq(address(gameProxy).balance, 0);
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), initBond + thisBonded + bobBonded);
+
+        // Resolve all claims
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        for (uint256 i = gameProxy.claimDataLen(); i > 0; i--) {
+            (bool success,) = address(gameProxy).call(abi.encodeCall(gameProxy.resolveClaim, (i - 1, 0)));
+            assertTrue(success);
+        }
+
+        // Resolve the game.
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+        gameProxy.claimCredit(bob);
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // Claim credit again to get the bond back.
+        gameProxy.claimCredit(address(this));
+
+        // Bob's claim should revert since it's value is 0
+        vm.expectRevert(NoCreditToClaim.selector);
+        gameProxy.claimCredit(bob);
+
+        // Ensure that bonds were paid out correctly.
+        assertEq(address(this).balance, 1000 ether + initBond + bobBonded);
+        assertEq(bob.balance, 1000 ether - bobBonded);
+        assertEq(address(gameProxy).balance, 0);
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), 0);
+
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
+        assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
+    }
+
+    /// @notice Static unit test asserting that resolve pays out bonds on moves to the leftmost
+    ///         actor in subgames containing successful counters.
+    function test_resolve_leftmostBondPayout_succeeds() public {
+        uint256 bal = 1000 ether;
+        address alice = address(0xa11ce);
+        address bob = address(0xb0b);
+        address charlie = address(0xc0c);
+        vm.deal(address(this), bal);
+        vm.deal(alice, bal);
+        vm.deal(bob, bal);
+        vm.deal(charlie, bal);
+
+        // Make claims with bob, charlie and the test contract on defense, and alice as the
+        // challenger charlie is successfully countered by alice alice is successfully countered by
+        // both bob and the test contract
+        uint256 firstBond = _getRequiredBond(0);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.prank(alice);
+        gameProxy.attack{ value: firstBond }(disputed, 0, _dummyClaim());
+
+        uint256 secondBond = _getRequiredBond(1);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        vm.prank(bob);
+        gameProxy.defend{ value: secondBond }(disputed, 1, _dummyClaim());
+        vm.prank(charlie);
+        gameProxy.attack{ value: secondBond }(disputed, 1, _dummyClaim());
+        gameProxy.attack{ value: secondBond }(disputed, 1, _dummyClaim());
+
+        uint256 thirdBond = _getRequiredBond(3);
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        vm.prank(alice);
+        gameProxy.attack{ value: thirdBond }(disputed, 3, _dummyClaim());
+
+        // Resolve all claims
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        for (uint256 i = gameProxy.claimDataLen(); i > 0; i--) {
+            (bool success,) = address(gameProxy).call(abi.encodeCall(gameProxy.resolveClaim, (i - 1, 0)));
+            assertTrue(success);
+        }
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(this));
+        gameProxy.claimCredit(alice);
+        gameProxy.claimCredit(bob);
+        gameProxy.claimCredit(charlie);
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // All of these claims should work.
+        gameProxy.claimCredit(address(this));
+        gameProxy.claimCredit(alice);
+        gameProxy.claimCredit(bob);
+
+        // Charlie's claim should revert since it's value is 0
+        vm.expectRevert(NoCreditToClaim.selector);
+        gameProxy.claimCredit(charlie);
+
+        // Ensure that bonds were paid out correctly.
+        uint256 aliceLosses = firstBond;
+        uint256 charlieLosses = secondBond;
+        assertEq(address(this).balance, bal + aliceLosses + initBond, "incorrect this balance");
+        assertEq(alice.balance, bal - aliceLosses + charlieLosses, "incorrect alice balance");
+        assertEq(bob.balance, bal, "incorrect bob balance");
+        assertEq(charlie.balance, bal - charlieLosses, "incorrect charlie balance");
+        assertEq(address(gameProxy).balance, 0);
+
+        // Ensure that the init bond for the game is 0, in case we change it in the test suite in
+        // the future.
+        assertEq(disputeGameFactory.initBonds(GAME_TYPE), initBond);
+    }
+
+    /// @notice Static unit test asserting that the anchor state updates when the game resolves in
+    ///         favor of the defender and the anchor state is older than the game state.
+    function test_resolve_validNewerStateUpdatesAnchor_succeeds() public {
+        // Confirm that the anchor state is older than the game state.
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
+        assert(l2BlockNumber < gameProxy.l2BlockNumber());
+
+        // Resolve the game.
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Confirm that the anchor state is now the same as the game state.
+        (root, l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
+        assertEq(l2BlockNumber, gameProxy.l2BlockNumber());
+        assertEq(root.raw(), gameProxy.rootClaim().raw());
+    }
+
+    /// @notice Static unit test asserting that the anchor state does not change when the game
+    ///         resolves in favor of the defender but the game state is not newer than the anchor
+    ///         state.
+    function test_resolve_validOlderStateSameAnchor_succeeds() public {
+        // Mock the game block to be older than the game state.
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(0));
+
+        // Confirm that the anchor state is newer than the game state.
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
+        assert(l2BlockNumber >= gameProxy.l2SequenceNumber());
+
+        // Resolve the game.
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(0));
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Confirm that the anchor state is the same as the initial anchor state.
+        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
+        assertEq(updatedL2BlockNumber, l2BlockNumber);
+        assertEq(updatedRoot.raw(), root.raw());
+    }
+
+    /// @notice Static unit test asserting that the anchor state does not change when the game
+    ///         resolves in favor of the challenger, even if the game state is newer than the
+    ///         anchor state.
+    function test_resolve_invalidStateSameAnchor_succeeds() public {
+        // Confirm that the anchor state is older than the game state.
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
+        assert(l2BlockNumber < gameProxy.l2BlockNumber());
+
+        // Challenge the claim and resolve it.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(1, 0);
+        gameProxy.resolveClaim(0, 0);
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.CHALLENGER_WINS));
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Confirm that the anchor state is the same as the initial anchor state.
+        (Hash updatedRoot, uint256 updatedL2BlockNumber) = anchorStateRegistry.anchors(gameProxy.gameType());
+        assertEq(updatedL2BlockNumber, l2BlockNumber);
+        assertEq(updatedRoot.raw(), root.raw());
+    }
+}
+
+/// @title FaultDisputeGame_GameType_Test
+/// @notice Tests the `gameType` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_GameType_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game's type is set correctly.
+    function test_gameType_succeeds() public view {
+        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
+    }
+}
+
+/// @title FaultDisputeGame_RootClaim_Test
+/// @notice Tests the `rootClaim` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_RootClaim_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game's root claim is set correctly.
+    function test_rootClaim_succeeds() public view {
+        assertEq(gameProxy.rootClaim().raw(), ROOT_CLAIM.raw());
+    }
+}
+
+/// @title FaultDisputeGame_ExtraData_Test
+/// @notice Tests the `extraData` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_ExtraData_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game's extra data is set correctly.
+    function test_extraData_succeeds() public view {
+        assertEq(gameProxy.extraData(), extraData);
+    }
+}
+
+/// @title FaultDisputeGame_GameData_Test
+/// @notice Tests the `gameData` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_GameData_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game's data is set correctly.
+    function test_gameData_succeeds() public view {
+        (GameType gameType, Claim rootClaim, bytes memory _extraData) = gameProxy.gameData();
+
+        assertEq(gameType.raw(), GAME_TYPE.raw());
+        assertEq(rootClaim.raw(), ROOT_CLAIM.raw());
+        assertEq(_extraData, extraData);
+    }
+}
+
+/// @title FaultDisputeGame_GetRequiredBond_Test
+/// @notice Tests the `getRequiredBond` function of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_GetRequiredBond_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the bond during the bisection game depths is correct.
+    function test_getRequiredBond_succeeds() public view {
+        for (uint8 i = 0; i < uint8(gameProxy.splitDepth()); i++) {
+            Position pos = LibPosition.wrap(i, 0);
+            uint256 bond = gameProxy.getRequiredBond(pos);
+
+            // Reasonable approximation for a max depth of 8.
+            uint256 expected = 0.08 ether;
+            for (uint64 j = 0; j < i; j++) {
+                expected = expected * 22876;
+                expected = expected / 10000;
+            }
+
+            assertApproxEqAbs(bond, expected, 0.01 ether);
+        }
+    }
+
+    /// @notice Tests that the bond at a depth greater than the maximum game depth reverts.
+    function test_getRequiredBond_outOfBounds_reverts() public {
+        Position pos = LibPosition.wrap(uint8(gameProxy.maxGameDepth() + 1), 0);
+        vm.expectRevert(GameDepthExceeded.selector);
+        gameProxy.getRequiredBond(pos);
+    }
+}
+
+/// @title FaultDisputeGame_ClaimCredit_Test
+/// @notice Tests the claimCredit functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_ClaimCredit_Test is FaultDisputeGameV2_TestInit {
+    function test_claimCredit_refundMode_succeeds() public {
+        // Set up actors.
+        address alice = address(0xa11ce);
+        address bob = address(0xb0b);
+
+        // Give the game proxy 1 extra ether, unregistered.
+        vm.deal(address(gameProxy), 1 ether);
+
+        // Perform a bonded move.
+        Claim claim = _dummyClaim();
+
+        // Bond the first claim.
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(alice, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.prank(alice);
+        gameProxy.attack{ value: firstBond }(disputed, 0, claim);
+
+        // Bond the second claim.
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(bob, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        vm.prank(bob);
+        gameProxy.attack{ value: secondBond }(disputed, 1, claim);
+
+        // Warp past the finalization period
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        // Resolve the game.
+        // Second claim wins, so bob should get alice's credit.
+        gameProxy.resolveClaim(2, 0);
+        gameProxy.resolveClaim(1, 0);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Mock that the game proxy is not proper, trigger refund mode.
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(anchorStateRegistry.isGameProper, (gameProxy)),
+            abi.encode(false)
+        );
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Assert bond distribution mode is refund mode.
+        assertTrue(gameProxy.bondDistributionMode() == BondDistributionMode.REFUND);
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(alice);
+        gameProxy.claimCredit(bob);
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // Grab balances before claim.
+        uint256 aliceBalanceBefore = alice.balance;
+        uint256 bobBalanceBefore = bob.balance;
+
+        // Claim credit again to get the bond back.
+        gameProxy.claimCredit(alice);
+        gameProxy.claimCredit(bob);
+
+        // Should have original balance again.
+        assertEq(alice.balance, aliceBalanceBefore + firstBond);
+        assertEq(bob.balance, bobBalanceBefore + secondBond);
+    }
+
+    /// @notice Tests that claimCredit reverts if the game is paused.
+    function test_claimCredit_gamePaused_reverts() public {
+        // Pause the system with the Superchain-wide identifier (address(0)).
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+
+        // Attempting to claim credit should now revert.
+        vm.expectRevert(GamePaused.selector);
+        gameProxy.claimCredit(address(0));
+    }
+
+    /// @notice Static unit test asserting that credit may not be drained past allowance through
+    ///         reentrancy.
+    function test_claimCredit_claimAlreadyResolved_reverts() public {
+        ClaimCreditReenter reenter = new ClaimCreditReenter(gameProxy, vm);
+        vm.startPrank(address(reenter));
+
+        // Give the game proxy 1 extra ether, unregistered.
+        vm.deal(address(gameProxy), 1 ether);
+
+        // Perform a bonded move.
+        Claim claim = _dummyClaim();
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(address(reenter), firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, claim);
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(address(reenter), secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: secondBond }(disputed, 1, claim);
+        uint256 reenterBond = firstBond + secondBond;
+
+        // Warp past the finalization period
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        // Ensure that we bonded all the test contract's ETH
+        assertEq(address(reenter).balance, 0);
+        // Ensure the game proxy has 1 ether in it.
+        assertEq(address(gameProxy).balance, 1 ether);
+        // Ensure the game has a balance of reenterBond in the delayedWeth contract.
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), initBond + reenterBond);
+
+        // Resolve the claim at index 2 first so that index 1 can be resolved.
+        gameProxy.resolveClaim(2, 0);
+
+        // Resolve the claim at index 1 and claim the reenter contract's credit.
+        gameProxy.resolveClaim(1, 0);
+
+        // Ensure that the game registered the `reenter` contract's credit.
+        assertEq(gameProxy.credit(address(reenter)), reenterBond);
+
+        // Resolve the root claim.
+        gameProxy.resolveClaim(0, 0);
+
+        // Resolve the game.
+        gameProxy.resolve();
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(address(reenter));
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // Initiate the reentrant credit claim.
+        reenter.claimCredit(address(reenter));
+
+        // The reenter contract should have performed 2 calls to `claimCredit`.
+        // Once all the credit is claimed, all subsequent calls will revert since there is 0 credit
+        // left to claim.
+        // The claimant must only have received the amount bonded for the gindex 1 subgame.
+        // The root claim bond and the unregistered ETH should still exist in the game proxy.
+        assertEq(reenter.numCalls(), 2);
+        assertEq(address(reenter).balance, reenterBond);
+        assertEq(address(gameProxy).balance, 1 ether);
+        assertEq(delayedWeth.balanceOf(address(gameProxy)), initBond);
+
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that claimCredit reverts when recipient can't receive value.
+    function test_claimCredit_recipientCantReceiveValue_reverts() public {
+        // Set up actors.
+        address alice = address(0xa11ce);
+        address bob = address(0xb0b);
+
+        // Give the game proxy 1 extra ether, unregistered.
+        vm.deal(address(gameProxy), 1 ether);
+
+        // Perform a bonded move.
+        Claim claim = _dummyClaim();
+
+        // Bond the first claim.
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(alice, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.prank(alice);
+        gameProxy.attack{ value: firstBond }(disputed, 0, claim);
+
+        // Bond the second claim.
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(bob, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        vm.prank(bob);
+        gameProxy.attack{ value: secondBond }(disputed, 1, claim);
+
+        // Warp past the finalization period
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        // Resolve the game.
+        // Second claim wins, so bob should get alice's credit.
+        gameProxy.resolveClaim(2, 0);
+        gameProxy.resolveClaim(1, 0);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay.
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game.
+        gameProxy.closeGame();
+
+        // Claim credit once to trigger unlock period.
+        gameProxy.claimCredit(alice);
+        gameProxy.claimCredit(bob);
+
+        // Wait for the withdrawal delay.
+        vm.warp(block.timestamp + delayedWeth.delay() + 1 seconds);
+
+        // Make bob not be able to receive value by setting his contract code to something without
+        // `receive`
+        vm.etch(address(bob), address(L1Token).code);
+
+        vm.expectRevert(BondTransferFailed.selector);
+        gameProxy.claimCredit(address(bob));
+    }
+}
+
+/// @title FaultDisputeGame_CloseGame_Test
+/// @notice Tests the closeGame functionality of the `FaultDisputeGame` contract.
+contract FaultDisputeGameV2_CloseGame_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that closeGame reverts if the game is not resolved
+    function test_closeGame_gameNotResolved_reverts() public {
+        vm.expectRevert(GameNotResolved.selector);
+        gameProxy.closeGame();
+    }
+
+    /// @notice Tests that closeGame reverts if the game is paused
+    function test_closeGame_gamePaused_reverts() public {
+        // Pause the system with the Superchain-wide identifier (address(0)).
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+
+        // Attempting to close the game should now revert.
+        vm.expectRevert(GamePaused.selector);
+        gameProxy.closeGame();
+    }
+
+    /// @notice Tests that closeGame reverts if the game is not finalized
+    function test_closeGame_gameNotFinalized_reverts() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Don't wait the finalization delay
+        vm.expectRevert(GameNotFinalized.selector);
+        gameProxy.closeGame();
+    }
+
+    /// @notice Tests that closeGame succeeds for a proper game (normal distribution)
+    function test_closeGame_properGame_succeeds() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Close the game and verify normal distribution mode
+        vm.expectEmit(true, true, true, true);
+        emit GameClosed(BondDistributionMode.NORMAL);
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        // Check that the anchor state was set correctly.
+        assertEq(address(gameProxy.anchorStateRegistry().anchorGame()), address(gameProxy));
+    }
+
+    /// @notice Tests that closeGame succeeds for an improper game (refund mode)
+    function test_closeGame_improperGame_succeeds() public {
+        // Resolve the game
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Mock the anchor registry to return improper game
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(anchorStateRegistry.isGameProper, (IDisputeGame(address(gameProxy)))),
+            abi.encode(false, "")
+        );
+
+        // Close the game and verify refund mode
+        vm.expectEmit(true, true, true, true);
+        emit GameClosed(BondDistributionMode.REFUND);
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
+    }
+
+    /// @notice Tests that multiple calls to closeGame succeed after initial distribution mode is
+    ///         set
+    function test_closeGame_multipleCallsAfterSet_succeeds() public {
+        // Resolve and close the game first
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // First close sets the mode
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        // Subsequent closes should succeed without changing the mode
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+
+        gameProxy.closeGame();
+        assertEq(uint8(gameProxy.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
+    }
+
+    /// @notice Tests that closeGame called with any amount of gas either reverts (with OOG) or
+    ///      updates the anchor state. This is specifically to verify that the try/catch inside
+    ///      closeGame can't be called with just enough gas to OOG when calling the
+    ///      AnchorStateRegistry but successfully execute the remainder of the function.
+    /// @param _gas Amount of gas to provide to closeGame.
+    function testFuzz_closeGame_canUpdateAnchorStateAndDoes_succeeds(uint256 _gas) public {
+        // Resolve and close the game first
+        vm.warp(block.timestamp + 3 days + 12 hours);
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        // Wait for finalization delay
+        vm.warp(block.timestamp + 3.5 days + 1 seconds);
+
+        // Since providing *too* much gas isn't the issue here, bounding it to half the block gas
+        // limit is sufficient. We want to know that either (1) the function reverts or (2) the
+        // anchor state gets updated. If the function doesn't revert and the anchor state isn't
+        // updated then we have a problem.
+        _gas = bound(_gas, 0, block.gaslimit / 2);
+
+        // The anchor state should not be the game proxy.
+        assert(address(gameProxy.anchorStateRegistry().anchorGame()) != address(gameProxy));
+
+        // Try closing the game.
+        try gameProxy.closeGame{ gas: _gas }() {
+            // If we got here, the function didn't revert, so the anchor state should have updated.
+            assert(address(gameProxy.anchorStateRegistry().anchorGame()) == address(gameProxy));
+        } catch {
+            // Ok, function reverted.
+        }
+    }
+}
+
+/// @title FaultDisputeGame_GetChallengerDuration_Test
+/// @notice Tests the getChallengerDuration functionality and related resolution tests.
+contract FaultDisputeGameV2_GetChallengerDuration_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that if the game is not in progress, querying of `getChallengerDuration`
+    ///         reverts
+    function test_getChallengerDuration_gameNotInProgress_reverts() public {
+        // resolve the game
+        vm.warp(block.timestamp + gameProxy.maxClockDuration().raw());
+
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        vm.expectRevert(GameNotInProgress.selector);
+        gameProxy.getChallengerDuration(1);
+    }
+
+    /// @notice Static unit test asserting that resolveClaim isn't possible if there's time left
+    ///         for a counter.
+    function test_resolution_lastSecondDisputes_succeeds() public {
+        // The honest proposer created an honest root claim during setup - node 0
+
+        // Defender's turn
+        vm.warp(block.timestamp + 3.5 days - 1 seconds);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days - 1 seconds);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 0);
+
+        // Advance time by 1 second, so that the root claim challenger clock is expired.
+        vm.warp(block.timestamp + 1 seconds);
+        // Attempt a second attack against the root claim. This should revert since the challenger
+        // clock is expired.
+        uint256 expectedBond = _getRequiredBond(0);
+        vm.expectRevert(ClockTimeExceeded.selector);
+        gameProxy.attack{ value: expectedBond }(disputed, 0, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 1 seconds);
+
+        // Should not be able to resolve the root claim or second counter yet.
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        // Warp to the last second of the root claim defender clock.
+        vm.warp(block.timestamp + 3.5 days - 2 seconds);
+        // Attack the challenge to the root claim. This should succeed, since the defender clock is
+        // not expired.
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days - 1 seconds);
+        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - gameProxy.clockExtension().raw());
+
+        // Should not be able to resolve any claims yet.
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(2, 0);
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        vm.warp(block.timestamp + gameProxy.clockExtension().raw() - 1 seconds);
+
+        // Should not be able to resolve any claims yet.
+        vm.expectRevert(ClockNotExpired.selector);
+        gameProxy.resolveClaim(2, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days - 1 seconds);
+
+        // Warp past the challenge period for the root claim defender. Defending the root claim
+        // should now revert.
+        vm.warp(block.timestamp + 1 seconds);
+        expectedBond = _getRequiredBond(1);
+        vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
+        gameProxy.attack{ value: expectedBond }(disputed, 1, _dummyClaim());
+        expectedBond = _getRequiredBond(2);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        vm.expectRevert(ClockTimeExceeded.selector); // no further move can be made
+        gameProxy.attack{ value: expectedBond }(disputed, 2, _dummyClaim());
+        // Chess clock time accumulated:
+        assertEq(gameProxy.getChallengerDuration(0).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(1).raw(), 3.5 days);
+        assertEq(gameProxy.getChallengerDuration(2).raw(), 3.5 days);
+
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(1, 0);
+        vm.expectRevert(OutOfOrderResolution.selector);
+        gameProxy.resolveClaim(0, 0);
+
+        // All clocks are expired. Resolve the game.
+        gameProxy.resolveClaim(2, 0); // Node 2 is resolved as UNCOUNTERED by default since it has no children
+        gameProxy.resolveClaim(1, 0); // Node 1 is resolved as COUNTERED since it has an UNCOUNTERED child
+        gameProxy.resolveClaim(0, 0); // Node 0 is resolved as UNCOUNTERED since it has no UNCOUNTERED children
+
+        // Defender wins game since the root claim is uncountered
+        assertEq(uint8(gameProxy.resolve()), uint8(GameStatus.DEFENDER_WINS));
+    }
+}
+
+/// @title FaultDisputeGame_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the `FaultDisputeGame`
+///         contract or are testing multiple functions at once.
+contract FaultDisputeGameV2_Unclassified_Test is FaultDisputeGameV2_TestInit {
+    /// @notice Tests that the game's starting timestamp is set correctly.
+    function test_createdAt_succeeds() public view {
+        assertEq(gameProxy.createdAt().raw(), block.timestamp);
+    }
+
+    /// @notice Tests that startingOutputRoot and it's getters are set correctly.
+    function test_startingOutputRootGetters_succeeds() public view {
+        (Hash root, uint256 l2BlockNumber) = gameProxy.startingOutputRoot();
+        (Hash anchorRoot, uint256 anchorRootBlockNumber) = anchorStateRegistry.anchors(GAME_TYPE);
+
+        assertEq(gameProxy.startingBlockNumber(), l2BlockNumber);
+        assertEq(gameProxy.startingBlockNumber(), anchorRootBlockNumber);
+        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(root));
+        assertEq(Hash.unwrap(gameProxy.startingRootHash()), Hash.unwrap(anchorRoot));
+    }
+
+    /// @notice Tests that the user cannot control the first 4 bytes of the CWIA data, disallowing
+    ///         them to control the entrypoint when no calldata is provided to a call.
+    function test_cwiaCalldata_userCannotControlSelector_succeeds() public {
+        // Construct the expected CWIA data that the proxy will pass to the implementation,
+        // alongside any extra calldata passed by the user.
+        Hash l1Head = gameProxy.l1Head();
+        bytes memory cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+
+        // We expect a `ReceiveETH` event to be emitted when 0 bytes of calldata are sent; The
+        // fallback is always reached *within the minimal proxy* in `LibClone`'s version of
+        // `clones-with-immutable-args`
+        vm.expectEmit(false, false, false, true);
+        emit ReceiveETH(0);
+        // We expect no delegatecall to the implementation contract if 0 bytes are sent. Assert
+        // that this happens 0 times.
+        vm.expectCall(address(gameImpl), cwiaData, 0);
+        (bool successA,) = address(gameProxy).call(hex"");
+        assertTrue(successA);
+
+        // When calldata is forwarded, we do expect a delegatecall to the implementation.
+        bytes memory data = abi.encodePacked(gameProxy.l1Head.selector);
+        vm.expectCall(address(gameImpl), abi.encodePacked(data, cwiaData), 1);
+        (bool successB, bytes memory returnData) = address(gameProxy).call(data);
+        assertTrue(successB);
+        assertEq(returnData, abi.encode(l1Head));
+    }
+}
+
+contract FaultDispute_1v1_Actors_Test is FaultDisputeGameV2_TestInit {
+    /// @notice The honest actor
+    DisputeActor internal honest;
+    /// @notice The dishonest actor
+    DisputeActor internal dishonest;
+
+    function setUp() public override {
+        // Setup the `FaultDisputeGame`
+        super.setUp();
+    }
+
+    /// @notice Fuzz test for a 1v1 output bisection dispute.
+    /// @notice The alphabet game has a constant status byte, and is not safe from someone being
+    ///         dishonest in output bisection and then posting a correct execution trace bisection
+    ///         root claim. This test does not cover this case (i.e. root claim of output bisection
+    ///         is dishonest, root claim of execution trace bisection is made by the dishonest
+    ///         actor but is honest, honest actor cannot attack it without risk of losing).
+    function testFuzz_outputBisection1v1honestRoot_succeeds(uint8 _divergeOutput, uint8 _divergeStep) public {
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        uint256 divergeAtOutput = bound(_divergeOutput, 0, 15);
+        uint256 divergeAtStep = bound(_divergeStep, 0, 7);
+        uint256 divergeStepOffset = (divergeAtOutput << 4) + divergeAtStep;
+
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i >= divergeAtOutput ? 0xFF : i + 1;
+        }
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i >= divergeStepOffset ? bytes1(uint8(0xFF)) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 16,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.DEFENDER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1honestRootGenesisAbsolutePrestate_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are from [2, 17] in this game.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i + 2;
+        }
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all set bits.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = bytes1(0xFF);
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 16,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.DEFENDER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1dishonestRootGenesisAbsolutePrestate_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are from [2, 17] in this game.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i + 2;
+        }
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
+        // of all set bits.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = bytes1(0xFF);
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 17,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.CHALLENGER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1honestRoot_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
+        // of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are from [2, 17] in this game.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i + 2;
+        }
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all zeros.
+        bytes memory dishonestTrace = new bytes(256);
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 16,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.DEFENDER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1dishonestRoot_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are from [2, 17] in this game.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i + 2;
+        }
+        // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of all zeros.
+        bytes memory dishonestTrace = new bytes(256);
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 17,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.CHALLENGER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1correctRootHalfWay_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are half correct, half incorrect.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
+        }
+        // The dishonest trace is half correct, half incorrect.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i > (127 + 4) ? bytes1(0xFF) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 16,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.DEFENDER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1dishonestRootHalfWay_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are half correct, half incorrect.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
+        }
+        // The dishonest trace is half correct, half incorrect.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i > (127 + 4) ? bytes1(0xFF) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 0xFF,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.CHALLENGER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1correctAbsolutePrestate_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are half correct, half incorrect.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
+        }
+        // The dishonest trace correct is half correct, half incorrect.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i > 127 ? bytes1(0xFF) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 16,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.DEFENDER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1dishonestAbsolutePrestate_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are half correct, half incorrect.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
+        }
+        // The dishonest trace correct is half correct, half incorrect.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i > 127 ? bytes1(0xFF) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 0xFF,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.CHALLENGER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1honestRootFinalInstruction_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are half correct, half incorrect.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
+        }
+        // The dishonest trace is half correct, and correct all the way up to the final instruction
+        // of the exec subgame.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i > (127 + 7) ? bytes1(0xFF) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 16,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.DEFENDER_WINS
+        });
+    }
+
+    /// @notice Static unit test for a 1v1 output bisection dispute.
+    function test_static_1v1dishonestRootFinalInstruction_succeeds() public {
+        // The honest l2 outputs are from [1, 16] in this game.
+        uint256[] memory honestL2Outputs = new uint256[](16);
+        for (uint256 i; i < honestL2Outputs.length; i++) {
+            honestL2Outputs[i] = i + 1;
+        }
+        // The honest trace covers all block -> block + 1 transitions, and is 256 bytes long,
+        // consisting of bytes [0, 255].
+        bytes memory honestTrace = new bytes(256);
+        for (uint256 i; i < honestTrace.length; i++) {
+            honestTrace[i] = bytes1(uint8(i));
+        }
+
+        // The dishonest l2 outputs are half correct, half incorrect.
+        uint256[] memory dishonestL2Outputs = new uint256[](16);
+        for (uint256 i; i < dishonestL2Outputs.length; i++) {
+            dishonestL2Outputs[i] = i > 7 ? 0xFF : i + 1;
+        }
+        // The dishonest trace is half correct, and correct all the way up to the final instruction
+        // of the exec subgame.
+        bytes memory dishonestTrace = new bytes(256);
+        for (uint256 i; i < dishonestTrace.length; i++) {
+            dishonestTrace[i] = i > (127 + 7) ? bytes1(0xFF) : bytes1(uint8(i));
+        }
+
+        // Run the actor test
+        _actorTest({
+            _rootClaim: 0xFF,
+            _absolutePrestateData: 0,
+            _honestTrace: honestTrace,
+            _honestL2Outputs: honestL2Outputs,
+            _dishonestTrace: dishonestTrace,
+            _dishonestL2Outputs: dishonestL2Outputs,
+            _expectedStatus: GameStatus.CHALLENGER_WINS
+        });
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                          HELPERS                           //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Helper to run a 1v1 actor test
+    function _actorTest(
+        uint256 _rootClaim,
+        uint256 _absolutePrestateData,
+        bytes memory _honestTrace,
+        uint256[] memory _honestL2Outputs,
+        bytes memory _dishonestTrace,
+        uint256[] memory _dishonestL2Outputs,
+        GameStatus _expectedStatus
+    )
+        internal
+    {
+        if (isForkTest()) {
+            // Mock the call anchorStateRegistry.getAnchorRoot() to return 0 as the block number
+            (Hash root,) = anchorStateRegistry.getAnchorRoot();
+            vm.mockCall(
+                address(anchorStateRegistry),
+                abi.encodeCall(IAnchorStateRegistry.getAnchorRoot, ()),
+                abi.encode(root, 0)
+            );
+        }
+
+        // Setup the environment
+        bytes memory absolutePrestateData =
+            _setup({ _absolutePrestateData: _absolutePrestateData, _rootClaim: _rootClaim });
+
+        // Create actors
+        _createActors({
+            _honestTrace: _honestTrace,
+            _honestPreStateData: absolutePrestateData,
+            _honestL2Outputs: _honestL2Outputs,
+            _dishonestTrace: _dishonestTrace,
+            _dishonestPreStateData: absolutePrestateData,
+            _dishonestL2Outputs: _dishonestL2Outputs
+        });
+
+        // Exhaust all moves from both actors
+        _exhaustMoves();
+
+        // Resolve the game and assert that the defender won
+        _warpAndResolve();
+        assertEq(uint8(gameProxy.status()), uint8(_expectedStatus));
+    }
+
+    /// @notice Helper to setup the 1v1 test
+    function _setup(
+        uint256 _absolutePrestateData,
+        uint256 _rootClaim
+    )
+        internal
+        returns (bytes memory absolutePrestateData_)
+    {
+        absolutePrestateData_ = abi.encode(_absolutePrestateData);
+        Claim absolutePrestateExec =
+            _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData_)), VMStatuses.UNFINISHED);
+        Claim rootClaim = Claim.wrap(bytes32(uint256(_rootClaim)));
+        super.init({ rootClaim: rootClaim, absolutePrestate: absolutePrestateExec, l2BlockNumber: _rootClaim });
+    }
+
+    /// @notice Helper to create actors for the 1v1 dispute.
+    function _createActors(
+        bytes memory _honestTrace,
+        bytes memory _honestPreStateData,
+        uint256[] memory _honestL2Outputs,
+        bytes memory _dishonestTrace,
+        bytes memory _dishonestPreStateData,
+        uint256[] memory _dishonestL2Outputs
+    )
+        internal
+    {
+        honest = new HonestDisputeActor({
+            _gameProxy: IFaultDisputeGame(address(gameProxy)),
+            _l2Outputs: _honestL2Outputs,
+            _trace: _honestTrace,
+            _preStateData: _honestPreStateData
+        });
+        dishonest = new HonestDisputeActor({
+            _gameProxy: IFaultDisputeGame(address(gameProxy)),
+            _l2Outputs: _dishonestL2Outputs,
+            _trace: _dishonestTrace,
+            _preStateData: _dishonestPreStateData
+        });
+
+        vm.deal(address(honest), 100 ether);
+        vm.deal(address(dishonest), 100 ether);
+        vm.label(address(honest), "HonestActor");
+        vm.label(address(dishonest), "DishonestActor");
+    }
+
+    /// @notice Helper to exhaust all moves from both actors.
+    function _exhaustMoves() internal {
+        while (true) {
+            // Allow the dishonest actor to make their moves, and then the honest actor.
+            (uint256 numMovesA,) = dishonest.move();
+            (uint256 numMovesB, bool success) = honest.move();
+
+            require(success, "FaultDispute_1v1_Actors_Test: Honest actor's moves should always be successful");
+
+            // If both actors have run out of moves, we're done.
+            if (numMovesA == 0 && numMovesB == 0) break;
+        }
+    }
+
+    /// @notice Helper to warp past the chess clock and resolve all claims within the dispute game.
+    function _warpAndResolve() internal {
+        // Warp past the chess clock
+        vm.warp(block.timestamp + 3 days + 12 hours);
+
+        // Resolve all claims in reverse order. We allow `resolveClaim` calls to fail due to the
+        // check that prevents claims with no subgames attached from being passed to
+        // `resolveClaim`. There's also a check in `resolve` to ensure all children have been
+        // resolved before global resolution, which catches any unresolved subgames here.
+        for (uint256 i = gameProxy.claimDataLen(); i > 0; i--) {
+            (bool success,) = address(gameProxy).call(abi.encodeCall(gameProxy.resolveClaim, (i - 1, 0)));
+            assertTrue(success);
+        }
+        gameProxy.resolve();
+    }
+}

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameV2.t.sol
@@ -625,7 +625,7 @@ contract FaultDisputeGameV2_Step_Test is FaultDisputeGameV2_TestInit {
         gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
 
         bytes memory claimData7 = abi.encode(7, 7);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+        Claim postState_ = Claim.wrap(gameProxy.vm().step(claimData7, hex"", bytes32(0)));
 
         (,,,, disputed,,) = gameProxy.claimData(5);
         gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
@@ -661,7 +661,7 @@ contract FaultDisputeGameV2_Step_Test is FaultDisputeGameV2_TestInit {
         gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
         (,,,, disputed,,) = gameProxy.claimData(6);
         gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
+        Claim postState_ = Claim.wrap(gameProxy.vm().step(claimData5, hex"", bytes32(0)));
         (,,,, disputed,,) = gameProxy.claimData(7);
         gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
@@ -689,7 +689,7 @@ contract FaultDisputeGameV2_Step_Test is FaultDisputeGameV2_TestInit {
         gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
 
         bytes memory claimData7 = abi.encode(5, 5);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+        Claim postState_ = Claim.wrap(gameProxy.vm().step(claimData7, hex"", bytes32(0)));
 
         (,,,, disputed,,) = gameProxy.claimData(5);
         gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
@@ -725,7 +725,7 @@ contract FaultDisputeGameV2_Step_Test is FaultDisputeGameV2_TestInit {
 
         bytes memory claimData7 = abi.encode(5, 5);
         Claim claim7 = Claim.wrap(keccak256(claimData7));
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
+        Claim postState_ = Claim.wrap(gameProxy.vm().step(claimData7, hex"", bytes32(0)));
 
         (,,,, disputed,,) = gameProxy.claimData(5);
         gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameV2.t.sol
@@ -257,7 +257,6 @@ contract FaultDisputeGameV2_Constructor_Test is FaultDisputeGameV2_TestInit {
         });
     }
 
-
     /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///         parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
@@ -443,7 +442,7 @@ contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
     /// @notice Tests that the game cannot be initialized with incorrect CWIA calldata length
     ///         (must be exactly 246 bytes)
     function test_initialize_wrongCalldataLength_reverts(uint256 _extraDataLen) public {
-                // The `DisputeGameFactory` will pack the root claim and the extra data into a single
+        // The `DisputeGameFactory` will pack the root claim and the extra data into a single
         // array, which is enforced to be at least 64 bytes long.
         // We bound the upper end to 23.5KB to ensure that the minimal proxy never surpasses the
         // contract size limit in this test, as CWIA proxies store the immutable args in their
@@ -509,7 +508,9 @@ contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
         // Creation should fail.
         vm.expectRevert(AnchorRootNotFound.selector);
         gameProxy = IFaultDisputeGameV2(
-            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, _dummyClaim(), new bytes(uint256(32)))))
+            payable(
+                address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, _dummyClaim(), new bytes(uint256(32))))
+            )
         );
     }
 
@@ -530,9 +531,7 @@ contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
 
         // Mock the VM's oracle to return invalid challenge period
         vm.mockCall(
-            address(vm_.oracle()),
-            abi.encodeCall(IPreimageOracle.challengePeriod, ()),
-            abi.encode(_challengePeriod)
+            address(vm_.oracle()), abi.encodeCall(IPreimageOracle.challengePeriod, ()), abi.encode(_challengePeriod)
         );
 
         // Expect the initialize call to revert with InvalidChallengePeriod
@@ -540,7 +539,13 @@ contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
 
         // Create game via factory - initialize() is called automatically and should revert
         gameProxy = IFaultDisputeGameV2(
-            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, _dummyClaim(), abi.encode(validL2BlockNumber))))
+            payable(
+                address(
+                    disputeGameFactory.create{ value: initBond }(
+                        GAME_TYPE, _dummyClaim(), abi.encode(validL2BlockNumber)
+                    )
+                )
+            )
         );
     }
 }

--- a/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
@@ -28,7 +28,6 @@ import { IPreimageOracle } from "interfaces/dispute/IBigStepper.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IFaultDisputeGameV2 } from "interfaces/dispute/v2/IFaultDisputeGameV2.sol";
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 
 contract ClaimCreditReenter {
     Vm internal immutable vm;

--- a/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
@@ -462,7 +462,7 @@ contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
 
         Claim claim = _dummyClaim();
         /// We actually never reach the BadExtraData selector because it shifts the arg layout
-        vm.expectRevert();
+        vm.expectRevert(bytes(""));
         gameProxy = IFaultDisputeGameV2(
             payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, claim, _extraData)))
         );

--- a/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
@@ -461,8 +461,7 @@ contract FaultDisputeGameV2_Initialize_Test is FaultDisputeGameV2_TestInit {
         }
 
         Claim claim = _dummyClaim();
-        /// We actually never reach the BadExtraData selector because it shifts the arg layout
-        vm.expectRevert(bytes(""));
+        vm.expectRevert(IFaultDisputeGameV2.BadExtraData.selector);
         gameProxy = IFaultDisputeGameV2(
             payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, claim, _extraData)))
         );


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Introduce `FaultDisputeGameV2` as part of migrating chain-specific configuration out of the game implementation constructors. For more context, see the [associated design doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/proofs/dispute-game-creators.md) which explains the new game creation approach. 

The new `FaultDisputeGameV2` is not used anywhere in the codebase.  We will incrementally migrate to the new contracts in follow-up PRs.

**Tests**

Duplicate and update existing `FaultDisputeGame` tests.

**Additional context**

N/A

**Metadata**

Closes https://github.com/ethereum-optimism/optimism/issues/17254
