### PR TITLE
cannon,op-challenger: Add metric to report i-cache misses

### DIFF
--- a/cannon/mipsevm/debug.go
+++ b/cannon/mipsevm/debug.go
@@ -3,11 +3,13 @@ package mipsevm
 import "github.com/ethereum/go-ethereum/common/hexutil"
 
 type DebugInfo struct {
-	Pages               int            `json:"pages"`
-	MemoryUsed          hexutil.Uint64 `json:"memory_used"`
-	NumPreimageRequests int            `json:"num_preimage_requests"`
-	TotalPreimageSize   int            `json:"total_preimage_size"`
-	TotalSteps          uint64         `json:"total_steps"`
+	Pages                     int            `json:"pages"`
+	MemoryUsed                hexutil.Uint64 `json:"memory_used"`
+	NumPreimageRequests       int            `json:"num_preimage_requests"`
+	TotalPreimageSize         int            `json:"total_preimage_size"`
+	TotalSteps                uint64         `json:"total_steps"`
+	InstructionCacheMissCount uint64         `json:"instruction_cache_miss_count"`
+	HighestICacheMissPC       hexutil.Uint64 `json:"highest_icache_miss_pc"`
 	//  Multithreading-related stats below
 	RmwSuccessCount              uint64 `json:"rmw_success_count"`
 	RmwFailCount                 uint64 `json:"rmw_fail_count"`

--- a/cannon/mipsevm/debug_test.go
+++ b/cannon/mipsevm/debug_test.go
@@ -18,6 +18,8 @@ func TestDebugInfo_Serialization(t *testing.T) {
 		NumPreimageRequests:          3,
 		TotalPreimageSize:            4,
 		TotalSteps:                   123456,
+		InstructionCacheMissCount:    10,
+		HighestICacheMissPC:          11,
 		RmwSuccessCount:              5,
 		RmwFailCount:                 6,
 		MaxStepsBetweenLLAndSC:       7,

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -335,6 +335,7 @@ func (m *InstrumentedState) doMipsStep() error {
 		insn, opcode, fun = decoded.insn, decoded.opcode, decoded.fun
 	} else {
 		// PC is outside eager region
+		m.statsTracker.trackInstructionCacheMiss(pc)
 		insn, opcode, fun = exec.GetInstructionDetails(pc, m.state.Memory)
 	}
 

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -200,6 +200,7 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 			memoryUsed = fmt.Sprintf("%d", uint64(info.MemoryUsed))
 			e.metrics.RecordMemoryUsed(uint64(info.MemoryUsed))
 			e.metrics.RecordSteps(info.Steps)
+			e.metrics.RecordInstructionCacheMissCount(info.InstructionCacheMissCount)
 			e.metrics.RecordRmwSuccessCount(info.RmwSuccessCount)
 			e.metrics.RecordRmwFailCount(info.RmwFailCount)
 			e.metrics.RecordMaxStepsBetweenLLAndSC(info.MaxStepsBetweenLLAndSC)
@@ -215,6 +216,7 @@ func (e *Executor) DoGenerateProof(ctx context.Context, dir string, begin uint64
 type debugInfo struct {
 	MemoryUsed                   hexutil.Uint64 `json:"memory_used"`
 	Steps                        uint64         `json:"total_steps"`
+	InstructionCacheMissCount    uint64         `json:"instruction_cache_miss_count"`
 	RmwSuccessCount              uint64         `json:"rmw_success_count"`
 	RmwFailCount                 uint64         `json:"rmw_fail_count"`
 	MaxStepsBetweenLLAndSC       uint64         `json:"max_steps_between_ll_and_sc"`

--- a/op-challenger/game/fault/trace/vm/executor_test.go
+++ b/op-challenger/game/fault/trace/vm/executor_test.go
@@ -229,19 +229,24 @@ func newMetrics() *capturingVmMetrics {
 }
 
 type capturingVmMetrics struct {
-	executionTimeRecordCount int
-	memoryUsed               hexutil.Uint64
-	steps                    uint64
-	rmwSuccessCount          uint64
-	rmwFailCount             uint64
-	maxStepsBetweenLLAndSC   uint64
-	reservationInvalidations uint64
-	forcedPreemptions        uint64
-	idleStepsThread0         uint64
+	executionTimeRecordCount  int
+	memoryUsed                hexutil.Uint64
+	steps                     uint64
+	instructionCacheMissCount uint64
+	rmwSuccessCount           uint64
+	rmwFailCount              uint64
+	maxStepsBetweenLLAndSC    uint64
+	reservationInvalidations  uint64
+	forcedPreemptions         uint64
+	idleStepsThread0          uint64
 }
 
 func (c *capturingVmMetrics) RecordSteps(val uint64) {
 	c.steps = val
+}
+
+func (c *capturingVmMetrics) RecordInstructionCacheMissCount(val uint64) {
+	c.instructionCacheMissCount = val
 }
 
 func (c *capturingVmMetrics) RecordExecutionTime(t time.Duration) {

--- a/op-challenger/metrics/vm.go
+++ b/op-challenger/metrics/vm.go
@@ -13,6 +13,7 @@ type VmMetricer interface {
 	RecordVmMemoryUsed(vmType string, memoryUsed uint64)
 	RecordVmRmwSuccessCount(vmType string, val uint64)
 	RecordVmSteps(vmType string, val uint64)
+	RecordVmInstructionCacheMissCount(vmType string, val uint64)
 	RecordVmRmwFailCount(vmType string, val uint64)
 	RecordVmMaxStepsBetweenLLAndSC(vmType string, val uint64)
 	RecordVmReservationInvalidationCount(vmType string, val uint64)
@@ -25,6 +26,7 @@ type TypedVmMetricer interface {
 	RecordExecutionTime(t time.Duration)
 	RecordMemoryUsed(memoryUsed uint64)
 	RecordSteps(val uint64)
+	RecordInstructionCacheMissCount(val uint64)
 	RecordRmwSuccessCount(val uint64)
 	RecordRmwFailCount(val uint64)
 	RecordMaxStepsBetweenLLAndSC(val uint64)
@@ -34,15 +36,16 @@ type TypedVmMetricer interface {
 }
 
 type VmMetrics struct {
-	vmExecutionTime            *prometheus.HistogramVec
-	vmMemoryUsed               *prometheus.HistogramVec
-	vmSteps                    *prometheus.GaugeVec
-	vmRmwSuccessCount          *prometheus.GaugeVec
-	vmRmwFailCount             *prometheus.GaugeVec
-	vmMaxStepsBetweenLLAndSC   *prometheus.GaugeVec
-	vmReservationInvalidations *prometheus.GaugeVec
-	vmForcedPreemptions        *prometheus.GaugeVec
-	vmIdleStepsThread0         *prometheus.GaugeVec
+	vmExecutionTime             *prometheus.HistogramVec
+	vmMemoryUsed                *prometheus.HistogramVec
+	vmSteps                     *prometheus.GaugeVec
+	vmInstructionCacheMissCount *prometheus.GaugeVec
+	vmRmwSuccessCount           *prometheus.GaugeVec
+	vmRmwFailCount              *prometheus.GaugeVec
+	vmMaxStepsBetweenLLAndSC    *prometheus.GaugeVec
+	vmReservationInvalidations  *prometheus.GaugeVec
+	vmForcedPreemptions         *prometheus.GaugeVec
+	vmIdleStepsThread0          *prometheus.GaugeVec
 }
 
 var _ VmMetricer = (*VmMetrics)(nil)
@@ -57,6 +60,10 @@ func (m *VmMetrics) RecordVmMemoryUsed(vmType string, memoryUsed uint64) {
 
 func (m *VmMetrics) RecordVmSteps(vmType string, val uint64) {
 	m.vmSteps.WithLabelValues(vmType).Set(float64(val))
+}
+
+func (m *VmMetrics) RecordVmInstructionCacheMissCount(vmType string, val uint64) {
+	m.vmInstructionCacheMissCount.WithLabelValues(vmType).Set(float64(val))
 }
 
 func (m *VmMetrics) RecordVmRmwSuccessCount(vmType string, val uint64) {
@@ -145,6 +152,7 @@ var _ VmMetricer = NoopVmMetrics{}
 func (n NoopVmMetrics) RecordVmExecutionTime(vmType string, t time.Duration)           {}
 func (n NoopVmMetrics) RecordVmMemoryUsed(vmType string, memoryUsed uint64)            {}
 func (n NoopVmMetrics) RecordVmSteps(vmType string, val uint64)                        {}
+func (n NoopVmMetrics) RecordVmInstructionCacheMissCount(vmType string, val uint64)    {}
 func (n NoopVmMetrics) RecordVmRmwSuccessCount(vmType string, val uint64)              {}
 func (n NoopVmMetrics) RecordVmRmwFailCount(vmType string, val uint64)                 {}
 func (n NoopVmMetrics) RecordVmMaxStepsBetweenLLAndSC(vmType string, val uint64)       {}
@@ -169,6 +177,10 @@ func (m *typedVmMetricsImpl) RecordMemoryUsed(memoryUsed uint64) {
 
 func (m *typedVmMetricsImpl) RecordSteps(val uint64) {
 	m.m.RecordVmSteps(m.vmType, val)
+}
+
+func (m *typedVmMetricsImpl) RecordInstructionCacheMissCount(val uint64) {
+	m.m.RecordVmInstructionCacheMissCount(m.vmType, val)
 }
 
 func (m *typedVmMetricsImpl) RecordRmwSuccessCount(val uint64) {


### PR DESCRIPTION
The instruction pre-heap contains a cache of decoded instructions. It is initialized the first time Cannon is executed using a 2 GiB region. In almost all cases, this is sufficient to cover all instructions in a program. In rare cases, such as when the program exceeds 2 GiB or due to misconfiguration, a cache miss may occur. Detecting this today is not straightforward.

This patch adds a metric to track cache misses in the pre-heap, making it easier to identify when they happen.