### PR TITLE
op-program: Rely on mise install cache for prestate build

### DIFF
--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -36,8 +36,8 @@ do
     git checkout "${VERSION}" > "${LOG_FILE}" 2>&1
     if [ -f mise.toml ]
     then
-      echo "Install dependencies with mise" > "${LOG_FILE}" 2>&1
-      mise install go -v -y > "${LOG_FILE}" 2>&1
+      echo "Install dependencies with mise" >> "${LOG_FILE}"
+      mise install go -v -y >> "${LOG_FILE}" 2>&1
     fi
     rm -rf "${BIN_DIR}"
     make reproducible-prestate >> "${LOG_FILE}" 2>&1

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -34,11 +34,6 @@ do
     LOG_FILE="${LOGS_DIR}/build-${SHORT_VERSION}.txt"
     echo "Building Version: ${VERSION} Logs: ${LOG_FILE}"
     git checkout "${VERSION}" > "${LOG_FILE}" 2>&1
-    if [ -f mise.toml ]
-    then
-      echo "Install dependencies with mise" >> "${LOG_FILE}"
-      mise install -v -y >> "${LOG_FILE}" 2>&1
-    fi
     rm -rf "${BIN_DIR}"
     make reproducible-prestate >> "${LOG_FILE}" 2>&1
 

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -34,6 +34,11 @@ do
     LOG_FILE="${LOGS_DIR}/build-${SHORT_VERSION}.txt"
     echo "Building Version: ${VERSION} Logs: ${LOG_FILE}"
     git checkout "${VERSION}" > "${LOG_FILE}" 2>&1
+    if [ -f mise.toml ]
+    then
+      echo "Install dependencies with mise" > "${LOG_FILE}" 2>&1
+      mise install go -v -y > "${LOG_FILE}" 2>&1
+    fi
     rm -rf "${BIN_DIR}"
     make reproducible-prestate >> "${LOG_FILE}" 2>&1
 

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -33,11 +33,22 @@ do
     SHORT_VERSION=$(echo "${VERSION}" | cut -c 13-)
     LOG_FILE="${LOGS_DIR}/build-${SHORT_VERSION}.txt"
     echo "Building Version: ${VERSION} Logs: ${LOG_FILE}"
-    git checkout "${VERSION}" > "${LOG_FILE}" 2>&1
+    # use --force to overwrite any mise.toml changes
+    git checkout --force "${VERSION}" > "${LOG_FILE}" 2>&1
     if [ -f mise.toml ]
     then
       echo "Install dependencies with mise" >> "${LOG_FILE}"
-      mise install go -v -y >> "${LOG_FILE}" 2>&1
+      # we rely only on go and jq for the reproducible-prestate build.
+      # The mise cache should already have jq preinstalled
+      # But we need to ensure that this ${VERSION} has the correct go version
+      # So we replace the mise.toml with a minimal one that only specifies go
+      # Otherwise, `mise install` fails as it conflicts with other preinstalled dependencies
+      GO_VERSION=$(mise config get tools.go)
+      cat >mise.toml <<EOF
+[tools]
+go = "${GO_VERSION}"
+EOF
+      mise install -v -y >> "${LOG_FILE}" 2>&1
     fi
     rm -rf "${BIN_DIR}"
     make reproducible-prestate >> "${LOG_FILE}" 2>&1


### PR DESCRIPTION
This fixes the `preimage-reproducibility` CCI workflow.

The `reproducibility-prestate` works by running a git checkout of every op-program release, running a prestate build, and verifying that the built prestate matches the prestate hashes of each release immortalized in the superchain-registry.

Prior to running the actual prestate docker build, we run a sanity check for invalidly specified custom chain configurations. This sanity check runs in the host environment outside the prestate docker container. We also depend on `jq` to print out the prestate hashes that were generated (this isn't a strict dependency, but it's a relic present in older op-program releases. We cannot change the op-program releases so we must continue to depend on jq). `jq` is also used in the host environment. So the prestate build depends on `go` and `jq`. Both dependencies are installed using mise.

The recently introduced [mise cache](https://github.com/ethereum-optimism/optimism/pull/17040) makes it impossible to re-install mise dependencies inside the CCI workflow. I suspect that this is because the mise cache conflicts with further invocations of `mise install`, which uses an op-program release's mise.toml that reference different dependencies. Since the mise cache already contains `jq`, we can rely on that rather than reinstall it via mise.
However, the mise cache does not contain the desired `go` specified in the go.mod. So the host needs to install go manually.