### PR TITLE
op-acceptance-tests: fix TestNotTruncateDatabaseOnRestartWithExistingDatabase to run by itself

### DIFF
--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -42,14 +42,13 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNode(t)
 
-	startSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
-
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-
 	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
-	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
+
+	preRestartSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
 
 	// Restart the verifier op-node, but not the EL so the existing chain data is not deleted.
 	sys.L2CLB.Stop()
@@ -61,5 +60,5 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
 
-	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(startSafeBlock))
+	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
 }


### PR DESCRIPTION
**Description**

Safe head db doesn't record when the L2 genesis becomes safe (for many reasons but not possible to make a proposal for the genesis block because it has to be after the anchor state block).  When the test ran after the previous test, it's starting head was non-zero but when it ran by itself the initial safe block would often be 0 and then the test failed because the safe head db didn't go all the way back to 0.

Now it records the safe head after it has advanced at least once so it's always non-zero. Still requires the safe head data to persist across the restart which is the key requirement.

**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/17083
