### PR TITLE
feat(op-acceptance-tests): migrate operator fee tests from devnet-sdk to op-devstack

### DIFF
--- a/op-acceptance-tests/tests/isthmus/operator_fee/balance_reader.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/balance_reader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -15,12 +15,12 @@ import (
 // BalanceReader provides methods to read balances from the chain
 type BalanceReader struct {
 	client *ethclient.Client
-	t      systest.T
+	t      devtest.T
 	logger log.Logger
 }
 
 // NewBalanceReader creates a new BalanceReader instance
-func NewBalanceReader(t systest.T, client *ethclient.Client, logger log.Logger) *BalanceReader {
+func NewBalanceReader(t devtest.T, client *ethclient.Client, logger log.Logger) *BalanceReader {
 	return &BalanceReader{
 		client: client,
 		t:      t,

--- a/op-acceptance-tests/tests/isthmus/operator_fee/balance_snapshot.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/balance_snapshot.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,7 +72,7 @@ func (bs *BalanceSnapshot) Sub(start *BalanceSnapshot) *BalanceSnapshot {
 }
 
 // AssertSnapshotsEqual compares two balance snapshots and reports differences
-func AssertSnapshotsEqual(t systest.T, expected, actual *BalanceSnapshot) {
+func AssertSnapshotsEqual(t devtest.T, expected, actual *BalanceSnapshot) {
 	require.NotNil(t, expected, "Expected snapshot should not be nil")
 	require.NotNil(t, actual, "Actual snapshot should not be nil")
 
@@ -95,4 +95,18 @@ func AssertSnapshotsEqual(t systest.T, expected, actual *BalanceSnapshot) {
 	// Check wallet balance
 	assert.True(t, expected.FromBalance.Cmp(actual.FromBalance) == 0,
 		"WalletBalance mismatch: expected %v, got %v (diff: %v)", expected.FromBalance, actual.FromBalance, new(big.Int).Sub(actual.FromBalance, expected.FromBalance))
+}
+
+// SnapshotsEqual compares two balance snapshots and returns true if they are equal
+// This is a non-asserting version for unit tests
+func SnapshotsEqual(expected, actual *BalanceSnapshot) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	return expected.BaseFeeVaultBalance.Cmp(actual.BaseFeeVaultBalance) == 0 &&
+		expected.L1FeeVaultBalance.Cmp(actual.L1FeeVaultBalance) == 0 &&
+		expected.SequencerFeeVault.Cmp(actual.SequencerFeeVault) == 0 &&
+		expected.OperatorFeeVault.Cmp(actual.OperatorFeeVault) == 0 &&
+		expected.FromBalance.Cmp(actual.FromBalance) == 0
 }

--- a/op-acceptance-tests/tests/isthmus/operator_fee/fee_checker.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/fee_checker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -14,13 +14,13 @@ import (
 )
 
 type stateGetterAdapterFactory struct {
-	t      systest.T
+	t      devtest.T
 	client *ethclient.Client
 }
 
 // stateGetterAdapter adapts the ethclient to implement the StateGetter interface
 type stateGetterAdapter struct {
-	t           systest.T
+	t           devtest.T
 	client      *ethclient.Client
 	ctx         context.Context
 	blockNumber *big.Int
@@ -30,7 +30,7 @@ func (f *stateGetterAdapterFactory) NewStateGetterAdapter(blockNumber *big.Int) 
 	return &stateGetterAdapter{
 		t:           f.t,
 		client:      f.client,
-		ctx:         f.t.Context(),
+		ctx:         f.t.Ctx(),
 		blockNumber: blockNumber,
 	}
 }
@@ -52,7 +52,7 @@ type FeeChecker struct {
 }
 
 // NewFeeChecker creates a new FeeChecker instance
-func NewFeeChecker(t systest.T, client *ethclient.Client, chainConfig *params.ChainConfig, logger log.Logger) *FeeChecker {
+func NewFeeChecker(t devtest.T, client *ethclient.Client, chainConfig *params.ChainConfig, logger log.Logger) *FeeChecker {
 	logger.Debug("Creating fee checker", "chainID", chainConfig.ChainID)
 
 	// Create state getter adapter factory

--- a/op-acceptance-tests/tests/isthmus/operator_fee/system_config_contract_utils.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/system_config_contract_utils.go
@@ -1,21 +1,17 @@
 package operatorfee
 
+// NOTE: These utility functions have been converted from devnet-sdk to op-devstack types
+// but are currently unused by tests. They would need implementation updates if used.
+
 import (
 	"fmt"
-	"time"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
-	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/lmittmann/w3"
 )
-
-var l1ConfigSyncPollInterval = 30 * time.Second
-var l1ConfigSyncMaxWaitTime = 4 * time.Minute
 
 type TestParams struct {
 	ID                  string
@@ -25,7 +21,7 @@ type TestParams struct {
 	L1BlobBaseFeeScalar uint32
 }
 
-func GetFeeParamsL1(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet system.WalletV2) (tc TestParams, err error) {
+func GetFeeParamsL1(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet *dsl.EOA) (tc TestParams, err error) {
 	operatorFeeConstant, err := systemConfig.OperatorFeeConstant(&bind.CallOpts{BlockNumber: nil})
 	if err != nil {
 		return TestParams{}, fmt.Errorf("failed to get operator fee constant: %w", err)
@@ -50,7 +46,7 @@ func GetFeeParamsL1(systemConfig *bindings.SystemConfig, systemConfigAddress com
 	}, nil
 }
 
-func GetFeeParamsL2(l2L1BlockContract *bindings.L1Block, wallet system.WalletV2) (tc TestParams, err error) {
+func GetFeeParamsL2(l2L1BlockContract *bindings.L1Block, wallet *dsl.EOA) (tc TestParams, err error) {
 	operatorFeeConstant, err := l2L1BlockContract.OperatorFeeConstant(&bind.CallOpts{BlockNumber: nil})
 	if err != nil {
 		return TestParams{}, fmt.Errorf("failed to get operator fee constant: %w", err)
@@ -75,7 +71,7 @@ func GetFeeParamsL2(l2L1BlockContract *bindings.L1Block, wallet system.WalletV2)
 	}, nil
 }
 
-func EnsureFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet system.WalletV2, tc TestParams) (err error, reset func() error) {
+func EnsureFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet *dsl.EOA, tc TestParams) (err error, reset func() error) {
 	preFeeParams, err := GetFeeParamsL1(systemConfig, systemConfigAddress, l2L1BlockContract, wallet)
 	if err != nil {
 		return fmt.Errorf("failed to get L1 fee parameters: %w", err), nil
@@ -92,141 +88,16 @@ func EnsureFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress co
 	}
 }
 
-func UpdateFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet system.WalletV2, tc TestParams) (err error) {
-
-	_, err = UpdateOperatorFeeParams(systemConfig, systemConfigAddress, l2L1BlockContract, wallet, tc.OperatorFeeConstant, tc.OperatorFeeScalar)
-	if err != nil {
-		return fmt.Errorf("failed to update operator fee parameters: %w", err)
-	}
-
-	_, err = UpdateL1FeeParams(systemConfig, systemConfigAddress, l2L1BlockContract, wallet, tc.L1BaseFeeScalar, tc.L1BlobBaseFeeScalar)
-	if err != nil {
-		return fmt.Errorf("failed to update L1 fee parameters: %w", err)
-	}
-
-	// Wait for L2 nodes to sync with L1 origin where fee parameters were set
-	deadline := time.Now().Add(l1ConfigSyncMaxWaitTime)
-
-	for time.Now().Before(deadline) {
-
-		l2FeeParams, err := GetFeeParamsL2(l2L1BlockContract, wallet)
-		if err != nil {
-			return fmt.Errorf("failed to get L2 fee parameters: %w", err)
-		}
-		l2FeeParams.ID = tc.ID
-
-		// Check if all values match expected values
-		if l2FeeParams == tc {
-			break
-		}
-
-		// Use context-aware sleep
-		select {
-		case <-time.After(l1ConfigSyncPollInterval):
-			// Continue with next iteration
-		case <-wallet.Ctx().Done():
-			return fmt.Errorf("context canceled while waiting for L2 nodes to sync: %w", wallet.Ctx().Err())
-		}
-
-		// Check if context is canceled
-		if wallet.Ctx().Err() != nil {
-			return fmt.Errorf("context canceled while waiting for L2 nodes to sync: %w", wallet.Ctx().Err())
-		}
-	}
-	return nil
+func UpdateFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet *dsl.EOA, tc TestParams) (err error) {
+	return fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }
 
 // UpdateOperatorFeeParams updates the operator fee parameters in the SystemConfig contract.
 // It constructs and sends a transaction using txplan and returns the signed transaction, the receipt, or an error.
-func UpdateOperatorFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet system.WalletV2, operatorFeeConstant uint64, operatorFeeScalar uint32) (receipt *gethTypes.Receipt, err error) {
-	// Construct call input
-	funcSetOperatorFeeScalars := w3.MustNewFunc(`setOperatorFeeScalars(uint32, uint64)`, "")
-	args, err := funcSetOperatorFeeScalars.EncodeArgs(
-		operatorFeeScalar,
-		operatorFeeConstant,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode arguments for setOperatorFeeScalars: %w", err)
-	}
-
-	// Create a transaction using txplan
-	opts := isthmus.DefaultTxOpts(wallet)
-	ptx := txplan.NewPlannedTx(
-		opts,
-		txplan.WithTo(&systemConfigAddress),
-		txplan.WithData(args),
-	)
-
-	_, err = ptx.Success.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, fmt.Errorf("tx failed: %w", err)
-	}
-
-	// Execute the transaction and wait for inclusion
-	receipt = ptx.Included.Value()
-
-	actualOperatorFeeConstant, err := systemConfig.OperatorFeeConstant(&bind.CallOpts{BlockNumber: receipt.BlockNumber})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get operator fee constant: %w", err)
-	}
-	if operatorFeeConstant != actualOperatorFeeConstant {
-		return nil, fmt.Errorf("operator fee constant mismatch: got %d, expected %d", actualOperatorFeeConstant, operatorFeeConstant)
-	}
-
-	actualOperatorFeeScalar, err := systemConfig.OperatorFeeScalar(&bind.CallOpts{BlockNumber: receipt.BlockNumber})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get operator fee scalar: %w", err)
-	}
-	if operatorFeeScalar != actualOperatorFeeScalar {
-		return nil, fmt.Errorf("operator fee scalar mismatch: got %d, expected %d", actualOperatorFeeScalar, operatorFeeScalar)
-	}
-
-	return receipt, nil
+func UpdateOperatorFeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet *dsl.EOA, operatorFeeConstant uint64, operatorFeeScalar uint32) (receipt *gethTypes.Receipt, err error) {
+	return nil, fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }
 
-func UpdateL1FeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet system.WalletV2, l1BaseFeeScalar uint32, l1BlobBaseFeeScalar uint32) (receipt *gethTypes.Receipt, err error) {
-	// Construct call input
-	funcSetGasConfigEcotone := w3.MustNewFunc(`setGasConfigEcotone(uint32 _basefeeScalar, uint32 _blobbasefeeScalar)`, "")
-	args, err := funcSetGasConfigEcotone.EncodeArgs(
-		l1BaseFeeScalar,
-		l1BlobBaseFeeScalar,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode arguments for setGasConfigEcotone: %w", err)
-	}
-
-	// Create a transaction using txplan
-	opts := isthmus.DefaultTxOpts(wallet)
-	ptx := txplan.NewPlannedTx(
-		opts,
-		txplan.WithTo(&systemConfigAddress),
-		txplan.WithData(args),
-	)
-
-	_, err = ptx.Success.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, fmt.Errorf("tx failed: %w", err)
-	}
-
-	// Execute the transaction and wait for inclusion
-	receipt = ptx.Included.Value()
-
-	// Verify the L1 fee parameters were set correctly
-	l1BaseFeeScalarActual, err := systemConfig.BasefeeScalar(&bind.CallOpts{BlockNumber: receipt.BlockNumber})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get l1 base fee scalar: %w", err)
-	}
-	if l1BaseFeeScalarActual != l1BaseFeeScalar {
-		return nil, fmt.Errorf("l1 base fee scalar mismatch: got %d, expected %d", l1BaseFeeScalarActual, l1BaseFeeScalar)
-	}
-
-	blobBaseFeeScalar, err := systemConfig.BlobbasefeeScalar(&bind.CallOpts{BlockNumber: receipt.BlockNumber})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get l1 blob base fee scalar: %w", err)
-	}
-	if blobBaseFeeScalar != l1BlobBaseFeeScalar {
-		return nil, fmt.Errorf("l1 blob base fee scalar mismatch: got %d, expected %d", blobBaseFeeScalar, l1BlobBaseFeeScalar)
-	}
-
-	return receipt, nil
+func UpdateL1FeeParams(systemConfig *bindings.SystemConfig, systemConfigAddress common.Address, l2L1BlockContract *bindings.L1Block, wallet *dsl.EOA, l1BaseFeeScalar uint32, l1BlobBaseFeeScalar uint32) (receipt *gethTypes.Receipt, err error) {
+	return nil, fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }

--- a/op-acceptance-tests/tests/isthmus/operator_fee/tx_utils.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/tx_utils.go
@@ -1,158 +1,30 @@
 package operatorfee
 
+// NOTE: These utility functions have been converted from devnet-sdk to op-devstack types
+// but are currently unused by tests. They would need implementation updates if used.
+
 import (
 	"context"
-	"crypto/ecdsa"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
-	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
-	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus"
-	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
-func EnsureSufficientBalance(wallet system.WalletV2, to common.Address, value *big.Int) (err error) {
-	balance, err := wallet.Client().BalanceAt(wallet.Ctx(), to, nil)
-	if err != nil {
-		return fmt.Errorf("failed to get balance: %w", err)
-	}
-	if balance.Cmp(value) < 0 {
-		tx, receipt, err := SendValueTx(wallet, to, value)
-		if err != nil {
-			return fmt.Errorf("failed to send value tx: %w", err)
-		}
-		if receipt.Status != gethTypes.ReceiptStatusSuccessful {
-			return fmt.Errorf("tx %s failed with status %d", tx.Hash().Hex(), receipt.Status)
-		}
-	}
-	return nil
+func EnsureSufficientBalance(wallet *dsl.EOA, to common.Address, value *big.Int) (err error) {
+	return fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }
 
-func SendValueTx(wallet system.WalletV2, to common.Address, value *big.Int) (tx *gethTypes.Transaction, receipt *gethTypes.Receipt, err error) {
-	// ensure wallet is not the same as to address
-	if wallet.Address() == to {
-		return nil, nil, fmt.Errorf("wallet address is the same as the to address")
-	}
-
-	walletPreBalance, err := wallet.Client().BalanceAt(wallet.Ctx(), wallet.Address(), nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get balance for from address: %w", err)
-	}
-	receiverPreBalance, err := wallet.Client().BalanceAt(wallet.Ctx(), to, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get balance for to address: %w", err)
-	}
-	if walletPreBalance.Cmp(value) < 0 {
-		return nil, nil, fmt.Errorf("sender (%s) balance (%s) is less than the value (%s) attempting to send", wallet.Address(), walletPreBalance.String(), value.String())
-	}
-
-	opts := isthmus.DefaultTxOpts(wallet)
-	deployTx := txplan.NewPlannedTx(opts,
-		txplan.WithValue(value),
-		txplan.WithTo(&to),
-	)
-
-	signedTx, err := deployTx.Signed.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to sign tx: %w", err)
-	}
-
-	_, err = deployTx.Submitted.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to submit tx: %w", err)
-	}
-
-	_, err = deployTx.Success.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to check tx success: %w", err)
-	}
-
-	receipt = deployTx.Included.Value()
-
-	// verify balance of wallet
-	blockNumber := new(big.Int).SetUint64(receipt.BlockNumber.Uint64())
-	receiverPostBalance, err := wallet.Client().BalanceAt(wallet.Ctx(), to, blockNumber)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get to post-balance: %w", err)
-	}
-	if new(big.Int).Sub(receiverPostBalance, receiverPreBalance).Cmp(value) != 0 {
-		return nil, nil, fmt.Errorf("wallet balance was not updated successfully, expected %s, got %s", new(big.Int).Add(receiverPreBalance, value).String(), receiverPostBalance.String())
-	}
-
-	return signedTx, receipt, nil
+func SendValueTx(wallet *dsl.EOA, to common.Address, value *big.Int) (tx *gethTypes.Transaction, receipt *gethTypes.Receipt, err error) {
+	return nil, nil, fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }
 
-func ReturnRemainingFunds(wallet system.WalletV2, to common.Address) (receipt *gethTypes.Receipt, err error) {
-	balance, err := wallet.Client().BalanceAt(wallet.Ctx(), wallet.Address(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get balance: %w", err)
-	}
-
-	opts := isthmus.DefaultTxOpts(wallet)
-	txPlan := txplan.NewPlannedTx(opts,
-		txplan.WithTo(&to),
-	)
-	innerTx, err := txPlan.Unsigned.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get inner tx: %w", err)
-	}
-
-	dynInnerTx, ok := innerTx.(*gethTypes.DynamicFeeTx)
-	if !ok {
-		return nil, fmt.Errorf("inner tx is not a dynamic fee tx")
-	}
-
-	gasLimit := dynInnerTx.Gas
-	gasFeeCap := dynInnerTx.GasFeeCap
-	gasCost := new(big.Int).Mul(big.NewInt(int64(gasLimit)), gasFeeCap)
-
-	value := new(big.Int).Sub(balance, gasCost)
-
-	if value.Sign() < 0 {
-		// insufficient balance, so we don't need to send a tx
-		return nil, nil
-	}
-
-	dynInnerTx.Value = value
-
-	opts = isthmus.DefaultTxOpts(wallet)
-	txPlan = txplan.NewPlannedTx(opts,
-		txplan.WithUnsigned(dynInnerTx),
-	)
-
-	_, err = txPlan.Success.Eval(wallet.Ctx())
-	if err != nil {
-		return nil, fmt.Errorf("return remaining funds tx %s failed: %w", txPlan.Signed.Value().Hash().Hex(), err)
-	}
-
-	receipt = txPlan.Included.Value()
-
-	return receipt, nil
+func ReturnRemainingFunds(wallet *dsl.EOA, to common.Address) (receipt *gethTypes.Receipt, err error) {
+	return nil, fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }
 
-func NewTestWallet(ctx context.Context, chain system.Chain) (system.Wallet, error) {
-	// create new test wallet
-	testWalletPrivateKey, err := crypto.GenerateKey()
-	if err != nil {
-		return nil, err
-	}
-	testWalletPrivateKeyBytes := crypto.FromECDSA(testWalletPrivateKey)
-	testWalletPrivateKeyHex := hex.EncodeToString(testWalletPrivateKeyBytes)
-	testWalletPublicKey := testWalletPrivateKey.Public()
-	testWalletPublicKeyECDSA, ok := testWalletPublicKey.(*ecdsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("Failed to assert type: publicKey is not of type *ecdsa.PublicKey")
-	}
-	testWalletAddress := crypto.PubkeyToAddress(*testWalletPublicKeyECDSA)
-	testWallet, err := system.NewWallet(
-		testWalletPrivateKeyHex,
-		types.Address(testWalletAddress),
-		chain,
-	)
-	return testWallet, err
+func NewTestWallet(ctx context.Context, el dsl.ELNode) (*dsl.EOA, error) {
+	return nil, fmt.Errorf("not implemented for op-devstack - utility function not used by tests")
 }


### PR DESCRIPTION
Convert isthmus operator fee acceptance tests to use the new op-devstack
testing framework instead of the legacy devnet-sdk. Updates test interfaces
and types while preserving test functionality.

Main changes:
- Update imports from devnet-sdk/testing/systest to op-devstack/devtest
- Convert test interface types (systest.T → devtest.T)
- Simplify unit tests (removed implementations of unused functions)
- Mark unused utility functions with conversion notes


### Metadata
Fixes https://github.com/ethereum-optimism/infra/issues/442