### PR TITLE
op-devstack: add SyncTester to sysgo; initial E2E test with SyncTester

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimalWithSyncTester(&stconf.TargetBlocks{
-		Head:      1,
+	presets.DoMain(m, presets.WithMinimalWithSyncTester(&sttypes.FCUState{
+		Latest:    1,
 		Safe:      1,
 		Finalized: 1,
 	}),

--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -5,10 +5,15 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimalWithSyncTester(),
+	presets.DoMain(m, presets.WithMinimalWithSyncTester(&stconf.TargetBlocks{
+		Head:      1,
+		Safe:      1,
+		Finalized: 1,
+	}),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithMinimalWithSyncTester(&sttypes.FCUState{
-		Latest:    1,
-		Safe:      1,
-		Finalized: 1,
+		Latest:    0,
+		Safe:      0,
+		Finalized: 0,
 	}),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)

--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimalWithSyncTester(&sttypes.FCUState{
+	presets.DoMain(m, presets.WithMinimalWithSyncTester(sttypes.FCUState{
 		Latest:    0,
 		Safe:      0,
 		Finalized: 0,

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -1,0 +1,14 @@
+package sync_tester_e2e
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -5,10 +5,15 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(&stconf.TargetBlocks{
+		Head:      1,
+		Safe:      1,
+		Finalized: 1,
+	}),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(&sttypes.FCUState{
-		Latest:    1,
-		Safe:      1,
-		Finalized: 1,
+		Latest:    0,
+		Safe:      0,
+		Finalized: 0,
 	}),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(&stconf.TargetBlocks{
-		Head:      1,
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(&sttypes.FCUState{
+		Latest:    1,
 		Safe:      1,
 		Finalized: 1,
 	}),

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(&sttypes.FCUState{
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(sttypes.FCUState{
 		Latest:    0,
 		Safe:      0,
 		Finalized: 0,

--- a/op-acceptance-tests/tests/sync_tester_e2e/sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/sync_tester_e2e_test.go
@@ -34,8 +34,7 @@ func TestSyncTesterE2E(gt *testing.T) {
 
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalUnsafe, 5, 30),
-		// Uncomment this when we can sync L2CL2 via the SyncTester - need Engine API for that
-		// sys.L2CL2.AdvancedFn(types.LocalUnsafe, 5, 30),
+		sys.L2CL2.AdvancedFn(types.LocalUnsafe, 5, 30),
 	)
 
 	// Test that we can get chain ID from SyncTester

--- a/op-acceptance-tests/tests/sync_tester_e2e/sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/sync_tester_e2e_test.go
@@ -1,0 +1,64 @@
+package sync_tester_e2e
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestSyncTesterE2E(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	// This test uses DefaultSimpleSystemWithSyncTester which includes:
+	// - Minimal setup with L1EL, L1CL, L2EL, L2CL (sequencer)
+	// - Additional L2CL2 (verifier) that connects to SyncTester instead of L2EL
+	sys := presets.NewSimpleWithSyncTester(t)
+	require := t.Require()
+
+	// Test that we can get chain IDs from both L2CL nodes
+	l2CLChainID := sys.L2CL.ID().ChainID()
+	require.Equal(eth.ChainIDFromUInt64(901), l2CLChainID, "first L2CL should be on chain 901")
+
+	l2CL2ChainID := sys.L2CL2.ID().ChainID()
+	require.Equal(eth.ChainIDFromUInt64(901), l2CL2ChainID, "second L2CL should be on chain 901")
+
+	// Test that the network started successfully
+	require.NotNil(sys.L1EL, "L1 EL node should be available")
+	require.NotNil(sys.L2EL, "L2 EL node should be available")
+	require.NotNil(sys.L2CL, "L2 CL node should be available")
+	require.NotNil(sys.SyncTester, "SyncTester should be available")
+	require.NotNil(sys.L2CL2, "Second L2 CL node should be available")
+
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, 5, 30),
+		// Uncomment this when we can sync L2CL2 via the SyncTester - need Engine API for that
+		// sys.L2CL2.AdvancedFn(types.LocalUnsafe, 5, 30),
+	)
+
+	// Test that we can get chain ID from SyncTester
+	syncTester := sys.SyncTester.Escape()
+	syncTesterChainID, err := syncTester.API().ChainID(t.Ctx())
+	require.NoError(err, "should be able to get chain ID from SyncTester")
+	require.Equal(eth.ChainIDFromUInt64(901), syncTesterChainID, "SyncTester should be on chain 901")
+
+	// Test that both L2CL nodes and SyncTester are on the same chain
+	require.Equal(l2CLChainID, l2CL2ChainID, "both L2CL nodes should be on the same chain")
+	require.Equal(l2CLChainID, syncTesterChainID, "L2CL nodes and SyncTester should be on the same chain")
+
+	// Test that we can get sync status from L2CL nodes
+	l2CLSyncStatus := sys.L2CL.SyncStatus()
+	require.NotNil(l2CLSyncStatus, "first L2CL should have sync status")
+
+	l2CL2SyncStatus := sys.L2CL2.SyncStatus()
+	require.NotNil(l2CL2SyncStatus, "second L2CL should have sync status")
+
+	t.Logger().Info("SyncTester E2E test completed successfully",
+		"l2cl_chain_id", l2CLChainID,
+		"l2cl2_chain_id", l2CL2ChainID,
+		"sync_tester_chain_id", syncTesterChainID,
+		"l2cl_sync_status", l2CLSyncStatus,
+		"l2cl2_sync_status", l2CL2SyncStatus)
+}

--- a/op-devstack/presets/minimal_with_synctester.go
+++ b/op-devstack/presets/minimal_with_synctester.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type MinimalWithSyncTester struct {
@@ -16,7 +16,7 @@ type MinimalWithSyncTester struct {
 	SyncTester *dsl.SyncTester
 }
 
-func WithMinimalWithSyncTester(tb *stconf.TargetBlocks) stack.CommonOption {
+func WithMinimalWithSyncTester(tb *sttypes.FCUState) stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, tb))
 }
 

--- a/op-devstack/presets/minimal_with_synctester.go
+++ b/op-devstack/presets/minimal_with_synctester.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type MinimalWithSyncTester struct {
@@ -15,8 +16,8 @@ type MinimalWithSyncTester struct {
 	SyncTester *dsl.SyncTester
 }
 
-func WithMinimalWithSyncTester() stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}))
+func WithMinimalWithSyncTester(tb *stconf.TargetBlocks) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, tb))
 }
 
 func NewMinimalWithSyncTester(t devtest.T) *MinimalWithSyncTester {

--- a/op-devstack/presets/minimal_with_synctester.go
+++ b/op-devstack/presets/minimal_with_synctester.go
@@ -16,8 +16,8 @@ type MinimalWithSyncTester struct {
 	SyncTester *dsl.SyncTester
 }
 
-func WithMinimalWithSyncTester(tb *sttypes.FCUState) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, tb))
+func WithMinimalWithSyncTester(fcus sttypes.FCUState) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, fcus))
 }
 
 func NewMinimalWithSyncTester(t devtest.T) *MinimalWithSyncTester {

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -17,8 +17,8 @@ type SimpleWithSyncTester struct {
 	L2CL2      *dsl.L2CLNode
 }
 
-func WithSimpleWithSyncTester(tb *sttypes.FCUState) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, tb))
+func WithSimpleWithSyncTester(fcus sttypes.FCUState) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, fcus))
 }
 
 func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -1,0 +1,44 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+type SimpleWithSyncTester struct {
+	Minimal
+
+	SyncTester *dsl.SyncTester
+	L2CL2      *dsl.L2CLNode
+}
+
+func WithSimpleWithSyncTester() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}))
+}
+
+func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+	minimal := minimalFromSystem(t, system, orch)
+	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
+	syncTester := l2.SyncTester(match.Assume(t, match.FirstSyncTester))
+	// Get the second L2CL node (verifier) - we need to find it by name
+	l2CLs := l2.L2CLNodes()
+	var l2CL2 stack.L2CLNode
+	for _, cl := range l2CLs {
+		if cl.ID().Key() == "verifier" {
+			l2CL2 = cl
+			break
+		}
+	}
+	return &SimpleWithSyncTester{
+		Minimal:    *minimal,
+		SyncTester: dsl.NewSyncTester(syncTester),
+		L2CL2:      dsl.NewL2CLNode(l2CL2, orch.ControlPlane()),
+	}
+}

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type SimpleWithSyncTester struct {
@@ -17,7 +17,7 @@ type SimpleWithSyncTester struct {
 	L2CL2      *dsl.L2CLNode
 }
 
-func WithSimpleWithSyncTester(tb *stconf.TargetBlocks) stack.CommonOption {
+func WithSimpleWithSyncTester(tb *sttypes.FCUState) stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, tb))
 }
 

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type SimpleWithSyncTester struct {
@@ -16,8 +17,8 @@ type SimpleWithSyncTester struct {
 	L2CL2      *dsl.L2CLNode
 }
 
-func WithSimpleWithSyncTester() stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}))
+func WithSimpleWithSyncTester(tb *stconf.TargetBlocks) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, tb))
 }
 
 func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -93,3 +93,9 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		return WithOpNode(l2CLID, l1CLID, l1ELID, l2ELID, opts...)
 	}
 }
+
+// WithL2CLNodeWithSyncTester is a convenience function that accepts a SyncTester
+// This allows configuring a CL node with a SyncTester instead of an L2EL node
+func WithL2CLNodeWithSyncTester(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, opts ...L2CLOption) stack.Option[*Orchestrator] {
+	return WithOpNode(l2CLID, l1CLID, l1ELID, nil, opts...)
+}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -271,7 +271,8 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var l2EngineAddr string
 		if useSyncTester {
 			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
-			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), tb)
+			l2EngineAddr = orch.syncTester.service.NewEndpoint(syncTesterID.ChainID())
+			l2EngineAddr += fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", tb.Latest, tb.Safe, tb.Finalized)
 		} else {
 			l2EngineAddr = l2EL.EngineRPC()
 		}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"flag"
+	"fmt"
 	"sync"
 	"time"
 
@@ -47,7 +48,7 @@ type OpNode struct {
 	cfg              *config.Config
 	p                devtest.P
 	logger           log.Logger
-	el               stack.L2ELNodeID
+	el               *stack.L2ELNodeID // Optional: nil when using SyncTester
 	userProxy        *tcpproxy.Proxy
 	interopProxy     *tcpproxy.Proxy
 }
@@ -70,7 +71,9 @@ func (n *OpNode) hydrate(system stack.ExtensibleSystem) {
 	sysL2CL.SetLabel(match.LabelVendor, string(match.OpNode))
 	l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID()))
 	l2Net.(stack.ExtensibleL2Network).AddL2CLNode(sysL2CL)
-	sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
+	if n.el != nil {
+		sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
+	}
 }
 
 func (n *OpNode) UserRPC() string {
@@ -137,7 +140,7 @@ func (n *OpNode) Stop() {
 	n.opNode = nil
 }
 
-func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID, opts ...L2CLOption) stack.Option[*Orchestrator] {
+func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELOrSyncTester interface{}, opts ...L2CLOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
 
@@ -152,8 +155,34 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		l1CL, ok := orch.l1CLs.Get(l1CLID)
 		require.True(ok, "l1 CL node required")
 
-		l2EL, ok := orch.l2ELs.Get(l2ELID)
-		require.True(ok, "l2 EL node required")
+		// Handle either L2EL node or SyncTester
+		var l2EL L2ELNode
+		var l2ELID stack.L2ELNodeID
+		var syncTesterID *stack.SyncTesterID
+		var depSet depset.DependencySet
+		var useSyncTester bool
+
+		switch v := l2ELOrSyncTester.(type) {
+		case stack.L2ELNodeID:
+			l2ELID = v
+			l2EL, ok = orch.l2ELs.Get(v)
+			require.True(ok, "l2 EL node required")
+			if cluster, ok := orch.ClusterForL2(v.ChainID()); ok {
+				depSet = cluster.DepSet()
+			}
+		case nil:
+			syncTester := orch.syncTester
+			syncTesterID = &syncTester.id
+
+			useSyncTester = true
+			// When using a SyncTester, we don't need an L2EL node
+			// The SyncTester will provide the L2 endpoint
+			if cluster, ok := orch.ClusterForL2(syncTesterID.ChainID()); ok {
+				depSet = cluster.DepSet()
+			}
+		default:
+			require.Fail("l2ELOrSyncTester must be either stack.L2ELNodeID or nil")
+		}
 
 		cfg := DefaultL2CLConfig()
 		orch.l2CLOptions.Apply(p, l2CLID, cfg)       // apply global options
@@ -166,11 +195,6 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			// Can't enable ELSync on the sequencer or it will never start sequencing because
 			// ELSync needs to receive gossip from the sequencer to drive the sync
 			p.Require().NotEqual(nodeSync.ELSync, syncMode, "sequencer cannot use EL sync")
-		}
-
-		var depSet depset.DependencySet
-		if cluster, ok := orch.ClusterForL2(l2ELID.ChainID()); ok {
-			depSet = cluster.DepSet()
 		}
 
 		jwtPath, jwtSecret := orch.writeDefaultJWT()
@@ -232,6 +256,15 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			}
 		}
 
+		// Determine the L2 endpoint based on whether we're using a SyncTester or L2EL
+		var l2EngineAddr string
+		if useSyncTester {
+			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
+			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID())
+		} else {
+			l2EngineAddr = l2EL.EngineRPC()
+		}
+
 		nodeCfg := &config.Config{
 			L1: &config.L1EndpointConfig{
 				L1NodeAddr:       l1EL.userRPC,
@@ -244,7 +277,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 				CacheSize:        0, // auto-adjust to sequence window
 			},
 			L2: &config.L2EndpointConfig{
-				L2EngineAddr:      l2EL.EngineRPC(),
+				L2EngineAddr:      l2EngineAddr,
 				L2EngineJWTSecret: jwtSecret,
 			},
 			Beacon: &config.L1BeaconEndpointConfig{
@@ -296,9 +329,13 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			cfg:    nodeCfg,
 			logger: logger,
 			p:      p,
-			el:     l2ELID,
 		}
-		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), "must not already exist")
+
+		// Set the EL field only if we have an L2EL node
+		if !useSyncTester {
+			l2CLNode.el = &l2ELID
+		}
+		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), fmt.Sprintf("must not already exist: %s", l2CLID))
 		l2CLNode.Start()
 		p.Cleanup(l2CLNode.Stop)
 	})

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type OpNode struct {
@@ -161,6 +162,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var syncTesterID *stack.SyncTesterID
 		var depSet depset.DependencySet
 		var useSyncTester bool
+		var tb *stconf.TargetBlocks
 
 		switch v := l2ELOrSyncTester.(type) {
 		case stack.L2ELNodeID:
@@ -175,6 +177,15 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			syncTesterID = &syncTester.id
 
 			useSyncTester = true
+
+			for _, st := range orch.syncTester.service.SyncTesters() {
+				if st.ChainID == syncTesterID.ChainID() {
+					tb = st.Target
+					break
+				}
+			}
+			require.NotNil(tb, "target blocks not found for sync tester")
+
 			// When using a SyncTester, we don't need an L2EL node
 			// The SyncTester will provide the L2 endpoint
 			if cluster, ok := orch.ClusterForL2(syncTesterID.ChainID()); ok {
@@ -260,7 +271,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var l2EngineAddr string
 		if useSyncTester {
 			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
-			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), nil)
+			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), tb)
 		} else {
 			l2EngineAddr = l2EL.EngineRPC()
 		}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type OpNode struct {
@@ -162,7 +162,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var syncTesterID *stack.SyncTesterID
 		var depSet depset.DependencySet
 		var useSyncTester bool
-		var tb *stconf.TargetBlocks
+		var tb *sttypes.FCUState
 
 		switch v := l2ELOrSyncTester.(type) {
 		case stack.L2ELNodeID:

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -260,7 +260,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var l2EngineAddr string
 		if useSyncTester {
 			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
-			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID())
+			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), nil)
 		} else {
 			l2EngineAddr = l2EL.EngineRPC()
 		}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -162,7 +162,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var syncTesterID *stack.SyncTesterID
 		var depSet depset.DependencySet
 		var useSyncTester bool
-		var tb *sttypes.FCUState
+		var fcus sttypes.FCUState
 
 		switch v := l2ELOrSyncTester.(type) {
 		case stack.L2ELNodeID:
@@ -180,11 +180,11 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 
 			for _, st := range orch.syncTester.service.SyncTesters() {
 				if st.ChainID == syncTesterID.ChainID() {
-					tb = st.Target
+					fcus = st.Target
 					break
 				}
 			}
-			require.NotNil(tb, "target blocks not found for sync tester")
+			require.NotNil(fcus, "target blocks not found for sync tester")
 
 			// When using a SyncTester, we don't need an L2EL node
 			// The SyncTester will provide the L2 endpoint
@@ -272,7 +272,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		if useSyncTester {
 			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
 			l2EngineAddr = orch.syncTester.service.NewEndpoint(syncTesterID.ChainID())
-			l2EngineAddr += fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", tb.Latest, tb.Safe, tb.Finalized)
+			l2EngineAddr += fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", fcus.Latest, fcus.Safe, fcus.Finalized)
 		} else {
 			l2EngineAddr = l2EL.EngineRPC()
 		}

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -131,9 +131,6 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.challengers.Range(rangeHydrateFn[stack.L2ChallengerID, *L2Challenger](sys))
 	o.proposers.Range(rangeHydrateFn[stack.L2ProposerID, *L2Proposer](sys))
 	o.faucet.hydrate(sys)
-	if o.syncTester != nil {
-		o.syncTester.hydrate(sys)
-	}
 	o.sysHook.PostHydrate(sys)
 }
 

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -49,7 +49,7 @@ type Orchestrator struct {
 	challengers    locks.RWMap[stack.L2ChallengerID, *L2Challenger]
 	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
 
-	syncTester *SyncTesterService
+	syncTester *SyncTester
 	faucet     *FaucetService
 
 	controlPlane *ControlPlane

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -42,7 +42,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	}
 }
 
-func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
+func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *sttypes.FCUState) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -17,11 +17,12 @@ import (
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
-type SyncTesterService struct {
+type SyncTester struct {
+	id      stack.SyncTesterID
 	service *synctester.Service
 }
 
-func (n *SyncTesterService) hydrate(system stack.ExtensibleSystem) {
+func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
 	for syncTesterID, chainID := range n.service.SyncTesters() {
@@ -85,6 +86,6 @@ func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 			_ = srv.Stop(ctx)
 			logger.Info("Closed sync tester")
 		})
-		orch.syncTester = &SyncTesterService{service: srv}
+		orch.syncTester = &SyncTester{id: syncTesterID, service: srv}
 	})
 }

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -20,7 +20,7 @@ type SyncTester struct {
 	service *synctester.Service
 }
 
-func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *sttypes.FCUState) stack.Option[*Orchestrator] {
+func WithSyncTester(l2ELs []stack.L2ELNodeID, fcus *sttypes.FCUState) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))
@@ -42,9 +42,9 @@ func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *sttypes.FCUState) stack.Option
 				ELRPC: endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},
 				// EngineRPC: endpoint.MustRPC{Value: endpoint.URL(el.authRPC)},
 				// JwtPath:   el.jwtPath,
-				Cfg: stconf.SyncTesterConfig{
+				Cfg: stconf.EntryCfg{
 					ChainID: elID.ChainID(),
-					Target:  tb,
+					Target:  fcus,
 				},
 			}
 		}

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -42,7 +42,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	}
 }
 
-func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))
@@ -66,11 +66,7 @@ func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 				// JwtPath:   el.jwtPath,
 				Cfg: stconf.SyncTesterConfig{
 					ChainID: elID.ChainID(),
-					Target: &stconf.TargetBlocks{
-						Head:      1,
-						Safe:      1,
-						Finalized: 1,
-					},
+					Target:  tb,
 				},
 			}
 		}

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/config"
@@ -20,26 +18,6 @@ import (
 type SyncTester struct {
 	id      stack.SyncTesterID
 	service *synctester.Service
-}
-
-func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
-	require := system.T().Require()
-
-	for syncTesterID, cfg := range n.service.SyncTesters() {
-		chainID := cfg.ChainID
-		syncTesterRPC := n.service.SyncTesterEndpoint(chainID, nil)
-		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
-		require.NoError(err)
-		system.T().Cleanup(rpcCl.Close)
-		id := stack.NewSyncTesterID(syncTesterID.String(), chainID)
-		front := shim.NewSyncTester(shim.SyncTesterConfig{
-			CommonConfig: shim.NewCommonConfig(system.T()),
-			ID:           id,
-			Client:       rpcCl,
-		})
-		net := system.Network(chainID).(stack.ExtensibleNetwork)
-		net.AddSyncTester(front)
-	}
 }
 
 func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *sttypes.FCUState) stack.Option[*Orchestrator] {

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -20,7 +20,7 @@ type SyncTester struct {
 	service *synctester.Service
 }
 
-func WithSyncTester(l2ELs []stack.L2ELNodeID, fcus *sttypes.FCUState) stack.Option[*Orchestrator] {
+func WithSyncTester(l2ELs []stack.L2ELNodeID, fcus sttypes.FCUState) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -25,8 +25,9 @@ type SyncTester struct {
 func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
-	for syncTesterID, chainID := range n.service.SyncTesters() {
-		syncTesterRPC := n.service.SyncTesterEndpoint(chainID)
+	for syncTesterID, cfg := range n.service.SyncTesters() {
+		chainID := cfg.ChainID
+		syncTesterRPC := n.service.SyncTesterEndpoint(chainID, nil)
 		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
 		require.NoError(err)
 		system.T().Cleanup(rpcCl.Close)
@@ -63,7 +64,14 @@ func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 				ELRPC: endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},
 				// EngineRPC: endpoint.MustRPC{Value: endpoint.URL(el.authRPC)},
 				// JwtPath:   el.jwtPath,
-				ChainID: elID.ChainID(),
+				Cfg: stconf.SyncTesterConfig{
+					ChainID: elID.ChainID(),
+					Target: &stconf.TargetBlocks{
+						Head:      1,
+						Safe:      1,
+						Finalized: 1,
+					},
+				},
 			}
 		}
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 var (
@@ -100,7 +100,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	}
 }
 
-func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
+func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, tb *sttypes.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -100,7 +100,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	}
 }
 
-func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, fcus *sttypes.FCUState) stack.Option[*Orchestrator] {
+func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, fcus sttypes.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 var (
@@ -99,7 +100,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	}
 }
 
-func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs) stack.Option[*Orchestrator] {
+func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -135,7 +136,7 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTesters([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, tb))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -100,7 +100,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	}
 }
 
-func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, tb *sttypes.FCUState) stack.Option[*Orchestrator] {
+func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, fcus *sttypes.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -136,7 +136,7 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, tb))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, fcus))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -23,7 +23,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	}
 }
 
-func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, tb *sttypes.FCUState) stack.Option[*Orchestrator] {
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, fcus sttypes.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -59,7 +59,7 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, tb))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, fcus))
 	opt.Add(WithL2CLNodeWithSyncTester(ids.L2CL2, ids.L1CL, ids.L1EL))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type DefaultSimpleSystemWithSyncTesterIDs struct {
@@ -23,7 +23,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	}
 }
 
-func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, tb *sttypes.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type DefaultSimpleSystemWithSyncTesterIDs struct {
@@ -22,7 +23,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	}
 }
 
-func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs) stack.Option[*Orchestrator] {
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -58,7 +59,7 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTesters([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, tb))
 	opt.Add(WithL2CLNodeWithSyncTester(ids.L2CL2, ids.L1CL, ids.L1EL))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -1,0 +1,69 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type DefaultSimpleSystemWithSyncTesterIDs struct {
+	DefaultMinimalSystemIDs
+
+	L2CL2      stack.L2CLNodeID
+	SyncTester stack.SyncTesterID
+}
+
+func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimpleSystemWithSyncTesterIDs {
+	minimal := NewDefaultMinimalSystemIDs(l1ID, l2ID)
+	return DefaultSimpleSystemWithSyncTesterIDs{
+		DefaultMinimalSystemIDs: minimal,
+		L2CL2:                   stack.NewL2CLNodeID("verifier", l2ID),
+		SyncTester:              stack.NewSyncTesterID("s", l2ID),
+	}
+}
+
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs) stack.Option[*Orchestrator] {
+	l1ID := eth.ChainIDFromUInt64(900)
+	l2ID := eth.ChainIDFromUInt64(901)
+	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)
+
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Logger().Info("Setting up")
+	}))
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithDeployer(),
+		WithDeployerOptions(
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2.ChainID()),
+		),
+	)
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithL2ELNode(ids.L2EL))
+	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()))
+
+	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
+	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
+
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
+
+	opt.Add(WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
+		ids.L2EL,
+	}))
+
+	opt.Add(WithSyncTesters([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithL2CLNodeWithSyncTester(ids.L2CL2, ids.L1CL, ids.L1EL))
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -123,10 +123,10 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	return b, nil
 }
 
-func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.SyncTesterConfig) {
-	out = make(map[sttypes.SyncTesterID]config.SyncTesterConfig)
+func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.EntryCfg) {
+	out = make(map[sttypes.SyncTesterID]config.EntryCfg)
 	b.syncTesters.Range(func(key sttypes.SyncTesterID, value *SyncTester) bool {
-		out[key] = config.SyncTesterConfig{
+		out[key] = config.EntryCfg{
 			ChainID: value.cfg.ChainID,
 			Target: &sttypes.FCUState{
 				Latest:    value.cfg.Target.Latest,

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -128,7 +128,7 @@ func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.EntryCfg) {
 	b.syncTesters.Range(func(key sttypes.SyncTesterID, value *SyncTester) bool {
 		out[key] = config.EntryCfg{
 			ChainID: value.cfg.ChainID,
-			Target: &sttypes.FCUState{
+			Target: sttypes.FCUState{
 				Latest:    value.cfg.Target.Latest,
 				Safe:      value.cfg.Target.Safe,
 				Finalized: value.cfg.Target.Finalized,

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
@@ -98,7 +97,7 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	// Set up the sync tester routes
 	var syncTesterErr error
 	b.syncTesters.Range(func(id sttypes.SyncTesterID, st *SyncTester) bool {
-		path := "/chain/" + st.chainID.String() + "/synctest"
+		path := "/chain/" + st.cfg.ChainID.String() + "/synctest"
 		if err := router.AddRPC(path); err != nil {
 			syncTesterErr = errors.Join(fmt.Errorf("failed to set up synctest route: %w", err))
 			return true
@@ -129,10 +128,17 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	return b, nil
 }
 
-func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]eth.ChainID) {
-	out = make(map[sttypes.SyncTesterID]eth.ChainID)
+func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.SyncTesterConfig) {
+	out = make(map[sttypes.SyncTesterID]config.SyncTesterConfig)
 	b.syncTesters.Range(func(key sttypes.SyncTesterID, value *SyncTester) bool {
-		out[key] = value.chainID
+		out[key] = config.SyncTesterConfig{
+			ChainID: value.cfg.ChainID,
+			Target: &config.TargetBlocks{
+				Head:      value.cfg.Target.Head,
+				Safe:      value.cfg.Target.Safe,
+				Finalized: value.cfg.Target.Finalized,
+			},
+		}
 		return true
 	})
 	return out

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
@@ -38,23 +39,17 @@ type Session struct {
 	// Non canonical view of the chain
 	Validated uint64
 	// Canonical view of the chain
-	CurrentState FCUState
+	CurrentState sttypes.FCUState
 	// payloads
 	Payloads map[eth.PayloadID]*eth.ExecutionPayloadEnvelope
 
-	InitialState FCUState
+	InitialState sttypes.FCUState
 }
 
 func (s *Session) UpdateFCUState(latest, safe, finalized uint64) {
 	s.CurrentState.Latest = latest
 	s.CurrentState.Safe = safe
 	s.CurrentState.Finalized = finalized
-}
-
-type FCUState struct {
-	Latest    uint64
-	Safe      uint64
-	Finalized uint64
 }
 
 type APIRouter interface {
@@ -133,8 +128,8 @@ func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.SyncTesterC
 	b.syncTesters.Range(func(key sttypes.SyncTesterID, value *SyncTester) bool {
 		out[key] = config.SyncTesterConfig{
 			ChainID: value.cfg.ChainID,
-			Target: &config.TargetBlocks{
-				Head:      value.cfg.Target.Head,
+			Target: &sttypes.FCUState{
+				Latest:    value.cfg.Target.Latest,
 				Safe:      value.cfg.Target.Safe,
 				Finalized: value.cfg.Target.Finalized,
 			},

--- a/op-sync-tester/synctester/backend/backend_test.go
+++ b/op-sync-tester/synctester/backend/backend_test.go
@@ -53,8 +53,8 @@ func TestBackend(t *testing.T) {
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
 		Cfg: stconf.SyncTesterConfig{
 			ChainID: eth.ChainIDFromUInt64(1),
-			Target: &stconf.TargetBlocks{
-				Head:      100,
+			Target: &sttypes.FCUState{
+				Latest:    100,
 				Safe:      90,
 				Finalized: 80,
 			},
@@ -66,8 +66,8 @@ func TestBackend(t *testing.T) {
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
 		Cfg: stconf.SyncTesterConfig{
 			ChainID: eth.ChainIDFromUInt64(2),
-			Target: &stconf.TargetBlocks{
-				Head:      101,
+			Target: &sttypes.FCUState{
+				Latest:    101,
 				Safe:      91,
 				Finalized: 81,
 			},

--- a/op-sync-tester/synctester/backend/backend_test.go
+++ b/op-sync-tester/synctester/backend/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -50,11 +51,27 @@ func TestBackend(t *testing.T) {
 
 	syncTesterCfgA := &stconf.SyncTesterEntry{
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
+		Cfg: stconf.SyncTesterConfig{
+			ChainID: eth.ChainIDFromUInt64(1),
+			Target: &stconf.TargetBlocks{
+				Head:      100,
+				Safe:      90,
+				Finalized: 80,
+			},
+		},
 	}
 	syncTesterA := sttypes.SyncTesterID("syncTesterA")
 
 	syncTesterCfgB := &stconf.SyncTesterEntry{
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
+		Cfg: stconf.SyncTesterConfig{
+			ChainID: eth.ChainIDFromUInt64(2),
+			Target: &stconf.TargetBlocks{
+				Head:      101,
+				Safe:      91,
+				Finalized: 81,
+			},
+		},
 	}
 	syncTesterB := sttypes.SyncTesterID("syncTesterB")
 

--- a/op-sync-tester/synctester/backend/backend_test.go
+++ b/op-sync-tester/synctester/backend/backend_test.go
@@ -51,7 +51,7 @@ func TestBackend(t *testing.T) {
 
 	syncTesterCfgA := &stconf.SyncTesterEntry{
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
-		Cfg: stconf.SyncTesterConfig{
+		Cfg: stconf.EntryCfg{
 			ChainID: eth.ChainIDFromUInt64(1),
 			Target: &sttypes.FCUState{
 				Latest:    100,
@@ -64,7 +64,7 @@ func TestBackend(t *testing.T) {
 
 	syncTesterCfgB := &stconf.SyncTesterEntry{
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
-		Cfg: stconf.SyncTesterConfig{
+		Cfg: stconf.EntryCfg{
 			ChainID: eth.ChainIDFromUInt64(2),
 			Target: &sttypes.FCUState{
 				Latest:    101,

--- a/op-sync-tester/synctester/backend/backend_test.go
+++ b/op-sync-tester/synctester/backend/backend_test.go
@@ -53,7 +53,7 @@ func TestBackend(t *testing.T) {
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
 		Cfg: stconf.EntryCfg{
 			ChainID: eth.ChainIDFromUInt64(1),
-			Target: &sttypes.FCUState{
+			Target: sttypes.FCUState{
 				Latest:    100,
 				Safe:      90,
 				Finalized: 80,
@@ -66,7 +66,7 @@ func TestBackend(t *testing.T) {
 		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
 		Cfg: stconf.EntryCfg{
 			ChainID: eth.ChainIDFromUInt64(2),
-			Target: &sttypes.FCUState{
+			Target: sttypes.FCUState{
 				Latest:    101,
 				Safe:      91,
 				Finalized: 81,

--- a/op-sync-tester/synctester/backend/config/static.go
+++ b/op-sync-tester/synctester/backend/config/static.go
@@ -14,9 +14,19 @@ type SyncTesterEntry struct {
 
 	// ChainID is used to sanity-check we are connected to the right chain,
 	// and never accidentally try to use a different chain for sync tester work.
-	ChainID eth.ChainID `yaml:"chain_id"`
+	Cfg SyncTesterConfig `yaml:"cfg"`
 }
 
+type TargetBlocks struct {
+	Head      uint64 `yaml:"head"`
+	Safe      uint64 `yaml:"safe"`
+	Finalized uint64 `yaml:"finalized"`
+}
+
+type SyncTesterConfig struct {
+	ChainID eth.ChainID   `yaml:"chain_id"`
+	Target  *TargetBlocks `yaml:"target"`
+}
 type Config struct {
 	// SyncTesters lists all sync testers by ID
 	SyncTesters map[sttypes.SyncTesterID]*SyncTesterEntry `yaml:"synctesters,omitempty"`

--- a/op-sync-tester/synctester/backend/config/static.go
+++ b/op-sync-tester/synctester/backend/config/static.go
@@ -18,8 +18,8 @@ type SyncTesterEntry struct {
 }
 
 type EntryCfg struct {
-	ChainID eth.ChainID       `yaml:"chain_id"`
-	Target  *sttypes.FCUState `yaml:"target"`
+	ChainID eth.ChainID      `yaml:"chain_id"`
+	Target  sttypes.FCUState `yaml:"target"`
 }
 type Config struct {
 	// SyncTesters lists all sync testers by ID

--- a/op-sync-tester/synctester/backend/config/static.go
+++ b/op-sync-tester/synctester/backend/config/static.go
@@ -14,10 +14,10 @@ type SyncTesterEntry struct {
 
 	// ChainID is used to sanity-check we are connected to the right chain,
 	// and never accidentally try to use a different chain for sync tester work.
-	Cfg SyncTesterConfig `yaml:"cfg"`
+	Cfg EntryCfg `yaml:"cfg"`
 }
 
-type SyncTesterConfig struct {
+type EntryCfg struct {
 	ChainID eth.ChainID       `yaml:"chain_id"`
 	Target  *sttypes.FCUState `yaml:"target"`
 }

--- a/op-sync-tester/synctester/backend/config/static.go
+++ b/op-sync-tester/synctester/backend/config/static.go
@@ -17,15 +17,9 @@ type SyncTesterEntry struct {
 	Cfg SyncTesterConfig `yaml:"cfg"`
 }
 
-type TargetBlocks struct {
-	Head      uint64 `yaml:"head"`
-	Safe      uint64 `yaml:"safe"`
-	Finalized uint64 `yaml:"finalized"`
-}
-
 type SyncTesterConfig struct {
-	ChainID eth.ChainID   `yaml:"chain_id"`
-	Target  *TargetBlocks `yaml:"target"`
+	ChainID eth.ChainID       `yaml:"chain_id"`
+	Target  *sttypes.FCUState `yaml:"target"`
 }
 type Config struct {
 	// SyncTesters lists all sync testers by ID

--- a/op-sync-tester/synctester/backend/config/testdata/config.yaml
+++ b/op-sync-tester/synctester/backend/config/testdata/config.yaml
@@ -3,7 +3,7 @@ synctesters:
     cfg:
       chain_id: 1234
       target:
-        head: 10
+        latest: 10
         safe: 20
         finalized: 30
     el_rpc: https://localhost:8545

--- a/op-sync-tester/synctester/backend/config/testdata/config.yaml
+++ b/op-sync-tester/synctester/backend/config/testdata/config.yaml
@@ -1,4 +1,9 @@
 synctesters:
   local:
-    chain_id: 1234
+    cfg:
+      chain_id: 1234
+      target:
+        head: 10
+        safe: 20
+        finalized: 30
     el_rpc: https://localhost:8545

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -40,7 +40,7 @@ type SyncTester struct {
 	m   metrics.Metricer
 
 	id  sttypes.SyncTesterID
-	cfg config.SyncTesterConfig
+	cfg config.EntryCfg
 
 	elReader ReadOnlyELBackend
 
@@ -68,7 +68,7 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 	return NewSyncTester(logger, m, stID, stCfg.Cfg, elReader), nil
 }
 
-func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, cfg config.SyncTesterConfig, elReader ReadOnlyELBackend) *SyncTester {
+func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, cfg config.EntryCfg, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
 		log:      logger,
 		m:        m,

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -39,8 +39,8 @@ type SyncTester struct {
 	log log.Logger
 	m   metrics.Metricer
 
-	id      sttypes.SyncTesterID
-	chainID eth.ChainID
+	id  sttypes.SyncTesterID
+	cfg config.SyncTesterConfig
 
 	elReader ReadOnlyELBackend
 
@@ -59,21 +59,21 @@ var _ frontend.EngineBackend = (*SyncTester)(nil)
 var _ frontend.EthBackend = (*SyncTester)(nil)
 
 func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, stCfg *config.SyncTesterEntry) (*SyncTester, error) {
-	logger = logger.New("syncTester", stID, "chain", stCfg.ChainID)
+	logger = logger.New("syncTester", stID, "chain", stCfg.Cfg.ChainID)
 	elClient, err := ethclient.Dial(stCfg.ELRPC.Value.RPC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial EL client: %w", err)
 	}
 	elReader := NewELReader(elClient)
-	return NewSyncTester(logger, m, stID, stCfg.ChainID, elReader), nil
+	return NewSyncTester(logger, m, stID, stCfg.Cfg, elReader), nil
 }
 
-func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
+func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, cfg config.SyncTesterConfig, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
 		log:      logger,
 		m:        m,
 		id:       stID,
-		chainID:  chainID,
+		cfg:      cfg,
 		elReader: elReader,
 		sessions: make(map[string]*Session),
 	}
@@ -223,10 +223,10 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 	if err != nil {
 		return hexutil.Big{}, err
 	}
-	if chainID.ToInt().Cmp(s.chainID.ToBig()) != 0 {
-		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.chainID, chainID.ToInt())
+	if chainID.ToInt().Cmp(s.cfg.ChainID.ToBig()) != 0 {
+		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.cfg.ChainID, chainID.ToInt())
 	}
-	return hexutil.Big(*s.chainID.ToBig()), nil
+	return hexutil.Big(*s.cfg.ChainID.ToBig()), nil
 }
 
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayload, error) {

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -96,7 +96,7 @@ func (m *MockELReader) GetBlockReceipts(ctx context.Context, bnh rpc.BlockNumber
 	return receipts, nil
 }
 
-func initTestSyncTester(t *testing.T, cfg config.SyncTesterConfig, elReader ReadOnlyELBackend) *SyncTester {
+func initTestSyncTester(t *testing.T, cfg config.EntryCfg, elReader ReadOnlyELBackend) *SyncTester {
 	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), cfg, elReader)
 	return syncTester
 }
@@ -105,26 +105,26 @@ func TestSyncTester_ChainId(t *testing.T) {
 	dummySession := &Session{SessionID: uuid.New().String()}
 	tests := []struct {
 		name            string
-		cfgID           config.SyncTesterConfig
+		cfgID           config.EntryCfg
 		elID            eth.ChainID
 		session         *Session
 		wantErrContains string
 	}{
 		{
 			name:            "no session",
-			cfgID:           config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)},
+			cfgID:           config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)},
 			elID:            eth.ChainIDFromUInt64(1),
 			wantErrContains: "no session",
 		},
 		{
 			name:    "happy path",
-			cfgID:   config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(11155111)},
+			cfgID:   config.EntryCfg{ChainID: eth.ChainIDFromUInt64(11155111)},
 			elID:    eth.ChainIDFromUInt64(11155111),
 			session: dummySession,
 		},
 		{
 			name:            "mismatch",
-			cfgID:           config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)},
+			cfgID:           config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)},
 			elID:            eth.ChainIDFromUInt64(11155111),
 			session:         dummySession,
 			wantErrContains: "chainID mismatch",
@@ -192,7 +192,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			el := NewMockELReader(eth.ChainIDFromUInt64(1))
 			block := makeBlockRaw(tc.rawNumber)
 			el.BlocksByHash[hash] = block
-			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
+			st := initTestSyncTester(t, config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -318,7 +318,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 				el.BlocksByNumber[rpc.BlockNumber(tc.session.CurrentState.Finalized)] = makeBlockRaw(tc.session.CurrentState.Finalized)
 			}
 			el.BlocksByNumber[tc.inNumber] = makeBlockRaw(uint64(tc.inNumber.Int64()))
-			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
+			st := initTestSyncTester(t, config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -460,7 +460,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			if tc.seedFn != nil && tc.session != nil {
 				tc.seedFn(el, tc.session)
 			}
-			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
+			st := initTestSyncTester(t, config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -95,8 +96,8 @@ func (m *MockELReader) GetBlockReceipts(ctx context.Context, bnh rpc.BlockNumber
 	return receipts, nil
 }
 
-func initTestSyncTester(t *testing.T, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
-	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), chainID, elReader)
+func initTestSyncTester(t *testing.T, cfg config.SyncTesterConfig, elReader ReadOnlyELBackend) *SyncTester {
+	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), cfg, elReader)
 	return syncTester
 }
 
@@ -104,26 +105,26 @@ func TestSyncTester_ChainId(t *testing.T) {
 	dummySession := &Session{SessionID: uuid.New().String()}
 	tests := []struct {
 		name            string
-		cfgID           eth.ChainID
+		cfgID           config.SyncTesterConfig
 		elID            eth.ChainID
 		session         *Session
 		wantErrContains string
 	}{
 		{
 			name:            "no session",
-			cfgID:           eth.ChainIDFromUInt64(1),
+			cfgID:           config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)},
 			elID:            eth.ChainIDFromUInt64(1),
 			wantErrContains: "no session",
 		},
 		{
 			name:    "happy path",
-			cfgID:   eth.ChainIDFromUInt64(11155111),
+			cfgID:   config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(11155111)},
 			elID:    eth.ChainIDFromUInt64(11155111),
 			session: dummySession,
 		},
 		{
 			name:            "mismatch",
-			cfgID:           eth.ChainIDFromUInt64(1),
+			cfgID:           config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)},
 			elID:            eth.ChainIDFromUInt64(11155111),
 			session:         dummySession,
 			wantErrContains: "chainID mismatch",
@@ -145,7 +146,7 @@ func TestSyncTester_ChainId(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, hexutil.Big(*tc.cfgID.ToBig()), got)
+			require.Equal(t, hexutil.Big(*tc.cfgID.ChainID.ToBig()), got)
 		})
 	}
 }
@@ -191,7 +192,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			el := NewMockELReader(eth.ChainIDFromUInt64(1))
 			block := makeBlockRaw(tc.rawNumber)
 			el.BlocksByHash[hash] = block
-			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
+			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -317,7 +318,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 				el.BlocksByNumber[rpc.BlockNumber(tc.session.CurrentState.Finalized)] = makeBlockRaw(tc.session.CurrentState.Finalized)
 			}
 			el.BlocksByNumber[tc.inNumber] = makeBlockRaw(uint64(tc.inNumber.Int64()))
-			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
+			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -459,7 +460,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			if tc.seedFn != nil && tc.session != nil {
 				tc.seedFn(el, tc.session)
 			}
-			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
+			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -176,14 +176,14 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			name:            "block number greater than latest",
 			sessionLatest:   100,
 			rawNumber:       101, // greater than Latest
-			session:         &Session{SessionID: uuid.New().String(), CurrentState: FCUState{Latest: 100}},
+			session:         &Session{SessionID: uuid.New().String(), CurrentState: sttypes.FCUState{Latest: 100}},
 			wantErrContains: "not found",
 		},
 		{
 			name:          "happy path",
 			sessionLatest: 100,
 			rawNumber:     99,
-			session:       &Session{SessionID: uuid.New().String(), CurrentState: FCUState{Latest: 100}},
+			session:       &Session{SessionID: uuid.New().String(), CurrentState: sttypes.FCUState{Latest: 100}},
 		},
 	}
 
@@ -232,7 +232,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "happy path: numeric less than latest",
 			session: &Session{
 				SessionID: uuid.New().String(),
-				CurrentState: FCUState{
+				CurrentState: sttypes.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
@@ -245,7 +245,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "happy path: label latest returns latest",
 			session: &Session{
 				SessionID: uuid.New().String(),
-				CurrentState: FCUState{
+				CurrentState: sttypes.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
@@ -258,7 +258,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "happy path: label safe returns safe",
 			session: &Session{
 				SessionID: uuid.New().String(),
-				CurrentState: FCUState{
+				CurrentState: sttypes.FCUState{
 					Latest:    100,
 					Safe:      97,
 					Finalized: 90,
@@ -271,7 +271,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "happy path: label finalized returns finalized",
 			session: &Session{
 				SessionID: uuid.New().String(),
-				CurrentState: FCUState{
+				CurrentState: sttypes.FCUState{
 					Latest:    100,
 					Safe:      97,
 					Finalized: 92,
@@ -284,7 +284,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "pending returns not found",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			inNumber:        rpc.PendingBlockNumber,
 			wantErrContains: "not found",
@@ -293,7 +293,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "earliest label returns not found",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			inNumber:        rpc.EarliestBlockNumber,
 			wantErrContains: "not found",
@@ -302,7 +302,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			name: "numeric greater than latest returns not found",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			inNumber:        rpc.BlockNumber(101),
 			wantErrContains: "not found",
@@ -365,7 +365,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "happy: via hash, blockNumber less than latest",
 			session: &Session{
 				SessionID: uuid.New().String(),
-				CurrentState: FCUState{
+				CurrentState: sttypes.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
@@ -381,7 +381,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "bad: via hash, blockNumber >= latest returns not found",
 			session: &Session{
 				SessionID: uuid.New().String(),
-				CurrentState: FCUState{
+				CurrentState: sttypes.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
@@ -398,7 +398,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "happy: label latest returns latest",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 95, Finalized: 90},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 95, Finalized: 90},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber),
 			seedFn: func(el *MockELReader, s *Session) {
@@ -410,7 +410,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "happy: label safe returns safe",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 90},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 90},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.SafeBlockNumber),
 			seedFn: func(el *MockELReader, s *Session) {
@@ -422,7 +422,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "happy: label finalized returns finalized",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.FinalizedBlockNumber),
 			seedFn: func(el *MockELReader, s *Session) {
@@ -434,7 +434,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "happy: numeric less than latest",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(99)),
 			seedFn: func(el *MockELReader, _ *Session) {
@@ -446,7 +446,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			name: "bad: numeric greater than latest returns not found",
 			session: &Session{
 				SessionID:    uuid.New().String(),
-				CurrentState: FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			arg:             rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(101)),
 			wantErrContains: "not found",

--- a/op-sync-tester/synctester/backend/types/types.go
+++ b/op-sync-tester/synctester/backend/types/types.go
@@ -35,3 +35,10 @@ func (id *SyncTesterID) UnmarshalText(data []byte) error {
 	*id = SyncTesterID(data)
 	return nil
 }
+
+// FCUState represents the Fork Choice Update state with Latest, Safe, and Finalized block numbers
+type FCUState struct {
+	Latest    uint64
+	Safe      uint64
+	Finalized uint64
+}

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
 )
@@ -65,13 +66,13 @@ func parseSession(r *http.Request, log log.Logger) (*http.Request, error) {
 		session := &backend.Session{
 			SessionID: sessionID,
 			Validated: latest,
-			CurrentState: backend.FCUState{
+			CurrentState: sttypes.FCUState{
 				Latest:    latest,
 				Safe:      safe,
 				Finalized: finalized,
 			},
 			Payloads: make(map[eth.PayloadID]*eth.ExecutionPayloadEnvelope),
-			InitialState: backend.FCUState{
+			InitialState: sttypes.FCUState{
 				Latest:    latest,
 				Safe:      safe,
 				Finalized: finalized,

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -214,13 +214,9 @@ func (s *Service) RPC() string {
 	return s.httpServer.HTTPEndpoint()
 }
 
-func (s *Service) SyncTesterEndpoint(chainID eth.ChainID, target *sttypes.FCUState) string {
+func (s *Service) NewEndpoint(chainID eth.ChainID) string {
 	uuid := uuid.New()
-	endpoint := fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
-	if target != nil {
-		endpoint += fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", target.Latest, target.Safe, target.Finalized)
-	}
-	return endpoint
+	return fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
 }
 
 func (s *Service) SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig {

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -21,13 +21,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-sync-tester/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
+	bc "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type serviceBackend interface {
 	Stop(ctx context.Context) error
-	SyncTesters() map[sttypes.SyncTesterID]eth.ChainID
+	SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig
 }
 
 var _ serviceBackend = (*backend.Backend)(nil)
@@ -213,11 +214,15 @@ func (s *Service) RPC() string {
 	return s.httpServer.HTTPEndpoint()
 }
 
-func (s *Service) SyncTesterEndpoint(chainID eth.ChainID) string {
+func (s *Service) SyncTesterEndpoint(chainID eth.ChainID, target *bc.TargetBlocks) string {
 	uuid := uuid.New()
-	return fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
+	endpoint := fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
+	if target != nil {
+		endpoint += fmt.Sprintf("?head=%d&safe=%d&finalized=%d", target.Head, target.Safe, target.Finalized)
+	}
+	return endpoint
 }
 
-func (s *Service) SyncTesters() map[sttypes.SyncTesterID]eth.ChainID {
+func (s *Service) SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig {
 	return s.backend.SyncTesters()
 }

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -28,7 +28,7 @@ import (
 
 type serviceBackend interface {
 	Stop(ctx context.Context) error
-	SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig
+	SyncTesters() map[sttypes.SyncTesterID]bc.EntryCfg
 }
 
 var _ serviceBackend = (*backend.Backend)(nil)
@@ -219,6 +219,6 @@ func (s *Service) NewEndpoint(chainID eth.ChainID) string {
 	return fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
 }
 
-func (s *Service) SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig {
+func (s *Service) SyncTesters() map[sttypes.SyncTesterID]bc.EntryCfg {
 	return s.backend.SyncTesters()
 }

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -214,11 +214,11 @@ func (s *Service) RPC() string {
 	return s.httpServer.HTTPEndpoint()
 }
 
-func (s *Service) SyncTesterEndpoint(chainID eth.ChainID, target *bc.TargetBlocks) string {
+func (s *Service) SyncTesterEndpoint(chainID eth.ChainID, target *sttypes.FCUState) string {
 	uuid := uuid.New()
 	endpoint := fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
 	if target != nil {
-		endpoint += fmt.Sprintf("?head=%d&safe=%d&finalized=%d", target.Head, target.Safe, target.Finalized)
+		endpoint += fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", target.Latest, target.Safe, target.Finalized)
 	}
 	return endpoint
 }


### PR DESCRIPTION
This PR is adding a preset which initializes a network with SyncTester with the following topology:

CLB ↔ Sync-Tester ↔ EL ↔ CLA

Partially addresses: https://github.com/ethereum-optimism/optimism/issues/16703

-----

TODO in follow-up PRs:

- [x] once SyncTester Engine API is available, enable `sys.L2CL2.AdvancedFn` to confirm that L2CL2 progresses via the SyncTester
- [ ] consider improving interface for L2CL -- it should be able to start with L2EL node, or with a SyncTester -- at the moment the interface is not ideal and doesn't support nicely both of these use-cases.