### PR TITLE
op-wheel: change append to prealloc+copy

### DIFF
--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -354,7 +354,17 @@ func SetNonce(addr common.Address, nonce uint64) HeadFn {
 // blockBodyKey returns the database key to use for storing the body of a block.
 // This function was copied from Geth's core/rawdb/accessors_chain.go.
 func blockBodyKey(number uint64, hash common.Hash) []byte {
-	return append(append([]byte("b"), encodeBlockNumber(number)...), hash.Bytes()...)
+	numBytes := encodeBlockNumber(number)
+	hashBytes := hash.Bytes()
+
+	totalLen := 1 + len(numBytes) + len(hashBytes)
+	buf := make([]byte, totalLen)
+
+	buf[0] = 'b'
+	copy(buf[1:], numBytes)
+	copy(buf[1+len(numBytes):], hashBytes)
+
+	return buf
 }
 
 // encodeBlockNumber encodes a block number as big endian uint64. This function was


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

performance improve.
<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

```
package main

import (
	"encoding/binary"
	"testing"

	"github.com/ethereum/go-ethereum/common"
)

func encodeBlockNumber(number uint64) []byte {
	enc := make([]byte, 8)
	binary.BigEndian.PutUint64(enc, number)
	return enc
}

func blockBodyKeyOrig(number uint64, hash common.Hash) []byte {
	return append(append([]byte("b"), encodeBlockNumber(number)...), hash.Bytes()...)
}

func blockBodyKeyPreAlloc(number uint64, hash common.Hash) []byte {
	numBytes := encodeBlockNumber(number)
	hashBytes := hash.Bytes()

	totalLen := 1 + len(numBytes) + len(hashBytes)
	buf := make([]byte, totalLen)

	buf[0] = 'b'
	copy(buf[1:], numBytes)
	copy(buf[1+len(numBytes):], hashBytes)

	return buf
}

func BenchmarkBlockBodyKeyOrig(b *testing.B) {
	h := common.BytesToHash(make([]byte, 32))
	for i := 0; i < b.N; i++ {
		_ = blockBodyKeyOrig(123456789, h)
	}
}

func BenchmarkBlockBodyKeyPreAlloc(b *testing.B) {
	h := common.BytesToHash(make([]byte, 32))
	for i := 0; i < b.N; i++ {
		_ = blockBodyKeyPreAlloc(123456789, h)
	}
}

```

```
goos: darwin
goarch: arm64
pkg: github.com/cuiweixie/mylabs/tests/append_bench
cpu: Apple M1 Pro
BenchmarkBlockBodyKeyOrig
BenchmarkBlockBodyKeyOrig-10        	34579432	        32.92 ns/op	      64 B/op	       2 allocs/op
BenchmarkBlockBodyKeyPreAlloc
BenchmarkBlockBodyKeyPreAlloc-10    	73024348	        15.55 ns/op	      48 B/op	       1 allocs/op
PASS
```

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
