### PR TITLE
op-service: opt using builtin func clear

### DIFF
--- a/op-service/eth/blob.go
+++ b/op-service/eth/blob.go
@@ -278,9 +278,7 @@ func reassembleBytes(opos int, encodedByte []byte, output []byte) int {
 }
 
 func (b *Blob) Clear() {
-	for i := 0; i < BlobSize; i++ {
-		b[i] = 0
-	}
+	clear(b[:])
 }
 
 // CalcBlobFeeDefault calculates the blob fee for the given header using eip4844.CalcBlobFee,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

improve 

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

```
package main

import (
	"testing"
)

const BlobSize = 4096 * 32 // 131072 bytes

type Blob [BlobSize]byte

func (b *Blob) ClearLoop() {
	for i := 0; i < BlobSize; i++ {
		b[i] = 0
	}
}

func (b *Blob) ClearBuiltin() {
	clear(b[:])
}

func BenchmarkClearLoop(b *testing.B) {
	var blob Blob
	for i := 0; i < b.N; i++ {
		blob.ClearLoop()
	}
}

func BenchmarkClearBuiltin(b *testing.B) {
	var blob Blob
	for i := 0; i < b.N; i++ {
		blob.ClearBuiltin()
	}
}

```

```
goos: darwin
goarch: arm64
pkg: github.com/cuiweixie/mylabs/tests/benchmark-clear
cpu: Apple M1 Pro
BenchmarkClearLoop
BenchmarkClearLoop-10       	   27860	     42095 ns/op
BenchmarkClearBuiltin
BenchmarkClearBuiltin-10    	1000000000	         0.3222 ns/op
PASS

Process finished with the exit code 0

```

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
