### PR TITLE
op-challenger: opt copyOutGeneric

### DIFF
--- a/op-challenger/game/keccak/matrix/keccak.go
+++ b/op-challenger/game/keccak/matrix/keccak.go
@@ -63,9 +63,12 @@ func xorInGeneric(d *state, buf []byte) {
 
 // copyOutGeneric copies uint64s to a byte buffer.
 func copyOutGeneric(d *state, b []byte) {
-	for i := 0; len(b) >= 8; i++ {
-		binary.LittleEndian.PutUint64(b, d.a[i])
-		b = b[8:]
+	n := len(b) >> 3
+	if n > len(d.a) {
+		n = len(d.a)
+	}
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint64(b[i<<3:], d.a[i])
 	}
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

```
package benchmark_opt

import (
	"encoding/binary"
	"testing"
)

type state struct {
	a [25]uint64
}

func copyOutGeneric(d *state, b []byte) {
	for i := 0; len(b) >= 8; i++ {
		binary.LittleEndian.PutUint64(b, d.a[i])
		b = b[8:]
	}
}
func copyOutGenericOpt(d *state, b []byte) {
	n := len(b) >> 3
	if n > len(d.a) {
		n = len(d.a)
	}
	for i := 0; i < n; i++ {
		binary.LittleEndian.PutUint64(b[i<<3:], d.a[i])
	}
}
func BenchmarkCopyOld(b *testing.B) {
	s := &state{a: [25]uint64{}}
	buf := make([]byte, 25*8)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		copyOutGeneric(s, buf)
	}
}

func BenchmarkCopyOpt(b *testing.B) {
	s := &state{a: [25]uint64{}}
	buf := make([]byte, 25*8)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		copyOutGenericOpt(s, buf)
	}
}

```

```
goos: darwin
goarch: arm64
pkg: github.com/cuiweixie/mylabs/tests/benchmark_opt
cpu: Apple M1 Pro
BenchmarkCopyOld
BenchmarkCopyOld-10    	79065273	        15.50 ns/op
BenchmarkCopyOpt
BenchmarkCopyOpt-10    	123746348	         9.567 ns/op
PASS
```

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
