### PR TITLE
op-service/eth: fix exec payload creation from block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -304,7 +304,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250710181308-c6e05723600e
+replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101511.2-0.20250820165240-085b529eefe9
 
 //replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250710181308-c6e05723600e h1:Ur5vjH2RmYqspDBIZH4RymNB6viHFheZkvvHt9W3spQ=
-github.com/ethereum-optimism/op-geth v1.101511.1-dev.1.0.20250710181308-c6e05723600e/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
+github.com/ethereum-optimism/op-geth v1.101511.2-0.20250820165240-085b529eefe9 h1:UEVbhVN0pThhcWpeg9YBmN4iNBZDN27xuqoC9k44ae4=
+github.com/ethereum-optimism/op-geth v1.101511.2-0.20250820165240-085b529eefe9/go.mod h1:SkytozVEPtnUeBlquwl0Qv5JKvrN/Y5aqh+VkQo/EOI=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=

--- a/op-e2e/system/conductor/system_adminrpc_test.go
+++ b/op-e2e/system/conductor/system_adminrpc_test.go
@@ -182,7 +182,8 @@ func TestLoadSequencerStateOnStarted_Started(t *testing.T) {
 
 func TestPostUnsafePayload(t *testing.T) {
 	op_e2e.InitParallel(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	cfg := e2esys.DefaultSystemConfig(t)
 	cfg.Nodes["verifier"].RPC.EnableAdmin = true

--- a/op-node/rollup/attributes/engine_consolidate.go
+++ b/op-node/rollup/attributes/engine_consolidate.go
@@ -162,7 +162,7 @@ func checkWithdrawals(rollupCfg *rollup.Config, attrs *eth.PayloadAttributes, bl
 			return fmt.Errorf("%w: attributes", ErrCanyonMustHaveWithdrawals)
 		}
 		if !isIsthmus {
-			// canyon: the withdrawals root should be set to the empty value
+			// canyon: the withdrawals root should be set to the empty withdrawals hash
 			if block.WithdrawalsRoot != nil && *block.WithdrawalsRoot != types.EmptyWithdrawalsHash {
 				return fmt.Errorf("%w: got %v", ErrCanyonWithdrawalsRoot, *block.WithdrawalsRoot)
 			}

--- a/op-service/eth/status.go
+++ b/op-service/eth/status.go
@@ -22,20 +22,24 @@ func ForkchoiceUpdateErr(payloadStatus PayloadStatusV1) error {
 }
 
 func NewPayloadErr(payload *ExecutionPayload, payloadStatus *PayloadStatusV1) error {
+	vErr := "<nil>"
+	if payloadStatus.ValidationError != nil {
+		vErr = *payloadStatus.ValidationError
+	}
 	switch payloadStatus.Status {
 	case ExecutionValid:
 		return nil
 	case ExecutionSyncing:
 		return fmt.Errorf("failed to execute payload %s, node is syncing", payload.ID())
 	case ExecutionInvalid:
-		return fmt.Errorf("execution payload %s was INVALID! Latest valid hash is %s, ignoring bad block: %v", payload.ID(), payloadStatus.LatestValidHash, payloadStatus.ValidationError)
+		return fmt.Errorf("execution payload %s was INVALID! Latest valid hash is %s, ignoring bad block: %s", payload.ID(), payloadStatus.LatestValidHash, vErr)
 	case ExecutionInvalidBlockHash:
-		return fmt.Errorf("execution payload %s has INVALID BLOCKHASH! %v", payload.BlockHash, payloadStatus.ValidationError)
+		return fmt.Errorf("execution payload %s has INVALID BLOCKHASH! %s", payload.BlockHash, vErr)
 	case ExecutionInvalidTerminalBlock:
-		return fmt.Errorf("engine is misconfigured. Received invalid-terminal-block error while engine API should be active at genesis. err: %v", payloadStatus.ValidationError)
+		return fmt.Errorf("engine is misconfigured. Received invalid-terminal-block error while engine API should be active at genesis. err: %s", vErr)
 	case ExecutionAccepted:
 		return fmt.Errorf("execution payload cannot be validated yet, latest valid hash is %s", payloadStatus.LatestValidHash)
 	default:
-		return fmt.Errorf("unknown execution status on %s: %q, ", payload.ID(), string(payloadStatus.Status))
+		return fmt.Errorf("unknown execution status on %s: %q; err: %s", payload.ID(), string(payloadStatus.Status), vErr)
 	}
 }

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -344,6 +344,9 @@ func (envelope *ExecutionPayloadEnvelope) CheckBlockHash() (actual common.Hash, 
 	return blockHash, blockHash == payload.BlockHash
 }
 
+// BlockAsPayload converts a [*types.Block] to an [ExecutionPayload]. It can only be used to convert
+// OP-Stack blocks, as it follows Canyon and Isthmus rules to set the Withdrawals and
+// WithdrawalsRoot fields.
 func BlockAsPayload(bl *types.Block, config *params.ChainConfig) (*ExecutionPayload, error) {
 	baseFee, overflow := uint256.FromBig(bl.BaseFee())
 	if overflow {
@@ -381,11 +384,11 @@ func BlockAsPayload(bl *types.Block, config *params.ChainConfig) (*ExecutionPayl
 		// WithdrawalsRoot is only set starting at Isthmus
 	}
 
-	if config.ShanghaiTime != nil && uint64(payload.Timestamp) >= *config.ShanghaiTime {
+	if config.IsCanyon(uint64(payload.Timestamp)) {
 		payload.Withdrawals = &types.Withdrawals{}
 	}
 
-	if config.IsthmusTime != nil && uint64(payload.Timestamp) >= *config.IsthmusTime {
+	if config.IsIsthmus(uint64(payload.Timestamp)) {
 		payload.WithdrawalsRoot = bl.Header().WithdrawalsHash
 	}
 

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -257,24 +257,30 @@ func (block *RPCBlock) ExecutionPayloadEnvelope(trustCache bool) (*eth.Execution
 	}
 
 	payload := &eth.ExecutionPayload{
-		ParentHash:      block.ParentHash,
-		FeeRecipient:    block.Coinbase,
-		StateRoot:       eth.Bytes32(block.Root),
-		ReceiptsRoot:    eth.Bytes32(block.ReceiptHash),
-		LogsBloom:       block.Bloom,
-		PrevRandao:      eth.Bytes32(block.MixDigest), // mix-digest field is used for prevRandao post-merge
-		BlockNumber:     block.Number,
-		GasLimit:        block.GasLimit,
-		GasUsed:         block.GasUsed,
-		Timestamp:       block.Time,
-		ExtraData:       eth.BytesMax32(block.Extra),
-		BaseFeePerGas:   eth.Uint256Quantity(baseFee),
-		BlockHash:       block.Hash,
-		Transactions:    opaqueTxs,
-		Withdrawals:     block.Withdrawals,
-		BlobGasUsed:     block.BlobGasUsed,
-		ExcessBlobGas:   block.ExcessBlobGas,
-		WithdrawalsRoot: block.WithdrawalsRoot,
+		ParentHash:    block.ParentHash,
+		FeeRecipient:  block.Coinbase,
+		StateRoot:     eth.Bytes32(block.Root),
+		ReceiptsRoot:  eth.Bytes32(block.ReceiptHash),
+		LogsBloom:     block.Bloom,
+		PrevRandao:    eth.Bytes32(block.MixDigest), // mix-digest field is used for prevRandao post-merge
+		BlockNumber:   block.Number,
+		GasLimit:      block.GasLimit,
+		GasUsed:       block.GasUsed,
+		Timestamp:     block.Time,
+		ExtraData:     eth.BytesMax32(block.Extra),
+		BaseFeePerGas: eth.Uint256Quantity(baseFee),
+		BlockHash:     block.Hash,
+		Transactions:  opaqueTxs,
+		Withdrawals:   block.Withdrawals,
+		BlobGasUsed:   block.BlobGasUsed,
+		ExcessBlobGas: block.ExcessBlobGas,
+	}
+
+	// Only Isthmus execution payloads must set the withdrawals root.
+	// They are guaranteed to not be the empty withdrawals hash, which is set pre-Isthmus (post-Canyon).
+	if wr := block.WithdrawalsRoot; wr != nil && *wr != types.EmptyWithdrawalsHash {
+		wr := *wr
+		payload.WithdrawalsRoot = &wr
 	}
 
 	return &eth.ExecutionPayloadEnvelope{


### PR DESCRIPTION
**Description**

Updates op-geth dependency to https://github.com/ethereum-optimism/op-geth/pull/662 (TODO: update when merged). We have committed a sin and not checked that the previous PR https://github.com/ethereum-optimism/op-geth/pull/592 doesn't cause issues in the monorepo. Working on https://github.com/ethereum-optimism/optimism/pull/16785 I realized that we did break some tests with the additional check
```go
// checkOptimismPayload performs Optimism-specific checks on the payload data (called during [(*ConsensusAPI).newPayload]).
func checkOptimismPayload(params engine.ExecutableData, cfg *params.ChainConfig) error {
	// Canyon
	if cfg.IsCanyon(params.Timestamp) && !cfg.IsIsthmus(params.Timestamp) {
		if params.WithdrawalsRoot == nil || *params.WithdrawalsRoot != types.EmptyWithdrawalsHash {
			return errors.New("withdrawalsRoot not equal to MPT root of empty list post-Canyon and pre-Isthmus")
		}
	}
```
Apparently this is not the case in all tests that run a post-Canyon and pre-Isthmus config.

Update: there are a few wrong checks in this latest op-geth commit, fixing them now. Pre-Isthmus, the `withdrawalsRoot` field must be nil, not the Canyon empty withdrawals hash... and a few other mistakes. This is being fixed in https://github.com/ethereum-optimism/op-geth/pull/662.

While investigating, an error in the way we convert blocks to exec payloads was also fixed - we must only set the withdrawals root post-Isthmus. The same mistake was made in op-geth.

Also fixing a payload error string pointer reference.