### PR TITLE
cannon: Deploy Cannon with Go 1.24 support

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -25,7 +25,7 @@ const (
 	ChallengePeriodSeconds          uint64 = 86400
 	ProofMaturityDelaySeconds       uint64 = 604800
 	DisputeGameFinalityDelaySeconds uint64 = 302400
-	MIPSVersion                     uint64 = 7
+	MIPSVersion                     uint64 = 8
 	DisputeGameType                 uint32 = 1 // PERMISSIONED game type
 	DisputeMaxGameDepth             uint64 = 73
 	DisputeSplitDepth               uint64 = 30

--- a/packages/contracts-bedrock/scripts/deploy/StandardConstants.sol
+++ b/packages/contracts-bedrock/scripts/deploy/StandardConstants.sol
@@ -2,5 +2,5 @@
 pragma solidity 0.8.15;
 
 library StandardConstants {
-    uint256 public constant MIPS_VERSION = 7;
+    uint256 public constant MIPS_VERSION = 8;
 }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xb96c198bc5e92ada25e79d256033d823e7924bee3dd0d5a909d7aa8cb4e388bb",
-    "sourceCodeHash": "0x7a0b0f8042eebd9070bae5bba4aa888111ddd782df3a0bf8d136dcce11e82554"
+    "initCodeHash": "0xe83e83cddbcae1d6af62f9754517b25f95ae371f3843dd8ee8030ddf8ba4622d",
+    "sourceCodeHash": "0x5faad71f147b776ed4d3290d319d1f4697e4e37b50eee5a4ef52f901c04efaa0"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -709,7 +709,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = internalRequire(
             LibString.eq(getVersion(address(_mips)), mipsVersion()), string.concat(_errorPrefix, "-20"), _errors
         );
-        _errors = internalRequire(_mips.stateVersion() == 7, string.concat(_errorPrefix, "-30"), _errors);
+        _errors = internalRequire(_mips.stateVersion() == 8, string.concat(_errorPrefix, "-30"), _errors);
         return _errors;
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -36,8 +36,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.7.0
-    string public constant version = "1.7.0";
+    /// @custom:semver 1.8.0
+    string public constant version = "1.8.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
+import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 
 // Libraries
 import { GameTypes, Duration, Claim } from "src/dispute/lib/Types.sol";
@@ -871,7 +872,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
     function test_validate_permissionedDisputeGameInvalidVM_succeeds() public {
         vm.mockCall(address(pdg), abi.encodeCall(IPermissionedDisputeGame.vm, ()), abi.encode(address(0xbad)));
         vm.mockCall(address(0xbad), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
-        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(7));
+        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
         assertEq("PDDG-VM-10,PDDG-VM-20", _validate(true));
     }
 
@@ -1187,7 +1188,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
     function test_validate_faultDisputeGameInvalidVM_succeeds() public {
         vm.mockCall(address(fdg), abi.encodeCall(IFaultDisputeGame.vm, ()), abi.encode(address(0xbad)));
         vm.mockCall(address(0xbad), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
-        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(7));
+        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
         assertEq("PLDG-VM-10,PLDG-VM-20", _validate(true));
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -872,7 +872,9 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
     function test_validate_permissionedDisputeGameInvalidVM_succeeds() public {
         vm.mockCall(address(pdg), abi.encodeCall(IPermissionedDisputeGame.vm, ()), abi.encode(address(0xbad)));
         vm.mockCall(address(0xbad), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
-        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
+        vm.mockCall(
+            address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION)
+        );
         assertEq("PDDG-VM-10,PDDG-VM-20", _validate(true));
     }
 
@@ -1188,7 +1190,9 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
     function test_validate_faultDisputeGameInvalidVM_succeeds() public {
         vm.mockCall(address(fdg), abi.encodeCall(IFaultDisputeGame.vm, ()), abi.encode(address(0xbad)));
         vm.mockCall(address(0xbad), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
-        vm.mockCall(address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION));
+        vm.mockCall(
+            address(0xbad), abi.encodeCall(IMIPS64.stateVersion, ()), abi.encode(StandardConstants.MIPS_VERSION)
+        );
         assertEq("PLDG-VM-10,PLDG-VM-20", _validate(true));
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Support the deployment of [Cannon version 8](https://github.com/ethereum-optimism/optimism/blob/0b96267f0679de5fb949d1eee04ec7cd081ee561/cannon/mipsevm/versions/version.go#L28-L29) with Go 1.24 support. 

**Tests**

Existing tests were updated to validate the correct version of Cannon is deployed.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17095