### PR TITLE
update conductor scenario when builder failure

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -735,7 +735,7 @@ func (oc *OpConductor) action() {
 		// There are 2 scenarios we need to handle:
 		// 1. current node is follower, active sequencer became unhealthy and started the leadership transfer process.
 		//    however if leadership transfer took longer than the time for health monitor to treat the node as unhealthy,
-		//    then basically the entire network is stalled and we need to start sequencing in this case.
+		//    then basically the entire network is stalled and we need to start sequencing ,in this case.
 		if !oc.prevState.leader && !oc.prevState.active && !errors.Is(oc.hcerr, health.ErrSequencerConnectionDown) {
 			err = oc.startSequencer()
 			if err != nil {
@@ -754,7 +754,7 @@ func (oc *OpConductor) action() {
 		//    then we should continue to sequence blocks and try to bring ourselves back to healthy state.
 		//    note: we need to also make sure that the health error is not due to ErrSequencerConnectionDown
 		//    		because in this case, we should stop sequencing and transfer leadership to other nodes.
-		if oc.prevState.leader && !oc.prevState.healthy && !oc.prevState.active && !errors.Is(oc.hcerr, health.ErrSequencerConnectionDown) {
+		if oc.prevState.leader && !oc.prevState.healthy && !oc.prevState.active && !errors.Is(oc.hcerr, health.ErrSequencerConnectionDown) && !errors.Is(oc.hcerr, health.ErrRollupBoostPartiallyHealthy) {
 			err = errors.New("waiting for sequencing to become healthy by itself")
 			break
 		}

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -754,7 +754,7 @@ func (oc *OpConductor) action() {
 		//    then we should continue to sequence blocks and try to bring ourselves back to healthy state.
 		//    note: we need to also make sure that the health error is not due to ErrSequencerConnectionDown
 		//    		because in this case, we should stop sequencing and transfer leadership to other nodes.
-		if oc.prevState.leader && !oc.prevState.healthy && !oc.prevState.active && !errors.Is(oc.hcerr, health.ErrSequencerConnectionDown) && !errors.Is(oc.hcerr, health.ErrRollupBoostPartiallyHealthy) {
+		if oc.shouldWaitForHealthRecovery() {
 			err = errors.New("waiting for sequencing to become healthy by itself")
 			break
 		}
@@ -935,4 +935,25 @@ func (oc *OpConductor) updateSequencerActiveStatus() error {
 	oc.log.Info("sequencer active status updated", "active", active)
 	oc.seqActive.Store(active)
 	return nil
+}
+
+// shouldWaitForHealthRecovery determines if the conductor should wait for the sequencer
+// to recover health naturally instead of transferring leadership.
+func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
+	// Only wait for recovery if we transitioned from [leader, unhealthy, inactive] state
+	if !oc.prevState.leader || oc.prevState.healthy || oc.prevState.active {
+		return false
+	}
+
+	// Don't wait if the error is a connection issue - transfer leadership instead
+	if errors.Is(oc.hcerr, health.ErrSequencerConnectionDown) {
+		return false
+	}
+
+	// Don't wait if rollup boost is enabled and partially healthy - transfer leadership instead
+	if oc.cfg.RollupBoostEnabled && errors.Is(oc.hcerr, health.ErrRollupBoostPartiallyHealthy) {
+		return false
+	}
+
+	return true
 }

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -735,7 +735,7 @@ func (oc *OpConductor) action() {
 		// There are 2 scenarios we need to handle:
 		// 1. current node is follower, active sequencer became unhealthy and started the leadership transfer process.
 		//    however if leadership transfer took longer than the time for health monitor to treat the node as unhealthy,
-		//    then basically the entire network is stalled and we need to start sequencing ,in this case.
+		//    then basically the entire network is stalled and we need to start sequencing in this case.
 		if !oc.prevState.leader && !oc.prevState.active && !errors.Is(oc.hcerr, health.ErrSequencerConnectionDown) {
 			err = oc.startSequencer()
 			if err != nil {
@@ -751,9 +751,7 @@ func (oc *OpConductor) action() {
 	case status.leader && !status.healthy && status.active:
 		// There are two scenarios we need to handle here:
 		// 1. we're transitioned from case status.leader && !status.healthy && !status.active, see description above
-		//    then we should continue to sequence blocks and try to bring ourselves back to healthy state.
-		//    note: we need to also make sure that the health error is not due to ErrSequencerConnectionDown
-		//    		because in this case, we should stop sequencing and transfer leadership to other nodes.
+		//    then we should continue to sequence blocks and try to bring ourselves back to healthy state (if possible)
 		if oc.shouldWaitForHealthRecovery() {
 			err = errors.New("waiting for sequencing to become healthy by itself")
 			break

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -1184,11 +1184,17 @@ connected:
 	s.True(conductor.Stopped())
 }
 
-// TestRollupBoostHealthFailure tests that OpConductor correctly handles rollup boost health failures
+// TestRollupBoostPartialFailure tests that OpConductor correctly handles rollup boost partial health failures.
+// This test verifies that when a leader is unhealthy and actively sequencing due to ErrRollupBoostPartiallyHealthy,
+// it should stop sequencing and transfer leadership instead of waiting for health recovery.
+// Scenario: [leader, unhealthy, active] with prevState [leader, unhealthy, inactive] and ErrRollupBoostPartiallyHealthy
+// Expected: Stop sequencing and transfer leadership (not wait for recovery)
 func (s *OpConductorTestSuite) TestRollupBoostPartialFailure() {
 	s.enableSynchronization()
 
-	// set initial state as a leader that is healthy and sequencing
+	// Set initial state: leader is unhealthy and actively sequencing
+	// Previous state was [leader, unhealthy, inactive] - this simulates the scenario where
+	// the leader started sequencing during a network stall but rollup boost is partially healthy
 	s.conductor.leader.Store(true)
 	s.conductor.healthy.Store(false)
 	s.conductor.seqActive.Store(true)
@@ -1197,21 +1203,23 @@ func (s *OpConductorTestSuite) TestRollupBoostPartialFailure() {
 		healthy: false,
 		active:  false,
 	}
+	s.conductor.cfg.RollupBoostEnabled = true
 
-	// Setup expectations - leader with unhealthy rollup boost should stop sequencing and transfer leadership
+	// Setup expectations - with ErrRollupBoostPartiallyHealthy, conductor should NOT wait for recovery
+	// Instead, it should stop sequencing and transfer leadership to another node
 	s.ctrl.EXPECT().StopSequencer(mock.Anything).Return(common.Hash{}, nil).Times(1)
 	s.cons.EXPECT().TransferLeader().Return(nil).Times(1)
 
-	// Simulate a rollup boost health failure
+	// Trigger the health update with rollup boost partial failure
 	s.updateHealthStatusAndExecuteAction(health.ErrRollupBoostPartiallyHealthy)
 
-	// Verify the OpConductor transitions to follower state and stops sequencing
-	s.False(s.conductor.leader.Load(), "Should transition to follower")
-	s.False(s.conductor.healthy.Load(), "Should be marked as unhealthy")
-	s.False(s.conductor.seqActive.Load(), "Sequencer should be stopped")
-	s.Equal(health.ErrRollupBoostPartiallyHealthy, s.conductor.hcerr, "Error should be stored")
+	// Verify the conductor stops sequencing and transfers leadership instead of waiting for recovery
+	s.False(s.conductor.leader.Load(), "Should transfer leadership to another node")
+	s.False(s.conductor.healthy.Load(), "Should remain marked as unhealthy")
+	s.False(s.conductor.seqActive.Load(), "Should stop sequencing")
+	s.Equal(health.ErrRollupBoostPartiallyHealthy, s.conductor.hcerr, "Should store the rollup boost error")
 
-	// Verify method calls
+	// Verify the expected actions were taken
 	s.ctrl.AssertNumberOfCalls(s.T(), "StopSequencer", 1)
 	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
 }

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -1183,3 +1183,35 @@ connected:
 	// Verify that the conductor is stopped
 	s.True(conductor.Stopped())
 }
+
+// TestRollupBoostHealthFailure tests that OpConductor correctly handles rollup boost health failures
+func (s *OpConductorTestSuite) TestRollupBoostPartialFailure() {
+	s.enableSynchronization()
+
+	// set initial state as a leader that is healthy and sequencing
+	s.conductor.leader.Store(true)
+	s.conductor.healthy.Store(false)
+	s.conductor.seqActive.Store(true)
+	s.conductor.prevState = &state{
+		leader:  true,
+		healthy: false,
+		active:  false,
+	}
+
+	// Setup expectations - leader with unhealthy rollup boost should stop sequencing and transfer leadership
+	s.ctrl.EXPECT().StopSequencer(mock.Anything).Return(common.Hash{}, nil).Times(1)
+	s.cons.EXPECT().TransferLeader().Return(nil).Times(1)
+
+	// Simulate a rollup boost health failure
+	s.updateHealthStatusAndExecuteAction(health.ErrRollupBoostPartiallyHealthy)
+
+	// Verify the OpConductor transitions to follower state and stops sequencing
+	s.False(s.conductor.leader.Load(), "Should transition to follower")
+	s.False(s.conductor.healthy.Load(), "Should be marked as unhealthy")
+	s.False(s.conductor.seqActive.Load(), "Sequencer should be stopped")
+	s.Equal(health.ErrRollupBoostPartiallyHealthy, s.conductor.hcerr, "Error should be stored")
+
+	// Verify method calls
+	s.ctrl.AssertNumberOfCalls(s.T(), "StopSequencer", 1)
+	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This fixes a scenario where
- A sequencer is healthy itself but its builder is not healthy, rollupboost healthcheck enabled
- Leadership transfer happened it transferred to this sequencer
- This sequencer has state (leader: true, healthy: false, active: true) with previous state (leader: true, healthy:false, active:false)
- In this case, leadership is stuck in this sequencer as it keeps on waiting for itself to become healthy, when it's supposed to transfer leader because its builder is unhealthy

Adding the check so that if the unhealthy is due to builder failure and rollupboost healthcheck is enabled, it'll transfer the leader as well.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
