### PR TITLE
Remove TODO

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -153,7 +153,6 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 
 	engineResetDeriver := engine.NewEngineResetDeriver(ctx, log, cfg, l1, eng, syncCfg)
 	sys.Register("engine-reset", engineResetDeriver, opts)
-	// TODO(#17061): Refactor dependency cycles
 	engineResetDeriver.SetEngController(ec)
 
 	clSync := clsync.NewCLSync(log, cfg, metrics, ec)


### PR DESCRIPTION
**Description**

Remove TODO referencing https://github.com/ethereum-optimism/optimism/pull/17061 which has been merged. The TODO isn't really necessary as the dependency cycle and need to call a setter is pretty obvious from the code.