### PR TITLE
refactor: Remove PromoteSafeEvent

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -148,7 +148,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	ec := engine.NewEngineController(ctx, eng, log, opnodemetrics.NoopMetrics, cfg, syncCfg, sys.Register("engine-controller", nil, opts))
 
 	if mm, ok := interopSys.(*indexing.IndexingMode); ok {
-		mm.SetForceResetNotifier(ec)
+		mm.SetEngineController(ec)
 	}
 
 	engineResetDeriver := engine.NewEngineResetDeriver(ctx, log, cfg, l1, eng, syncCfg)

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -1052,7 +1052,6 @@ func TestSpanBatchAtomicity_Consolidation(gt *testing.T) {
 			require.Equal(t, verifier.L2Safe().Number, uint64(0))
 		} else {
 			// Make sure we do the post-processing of what safety updates might happen
-			// Digest events until EngDeriver implicitly consumes PromoteSafeEvent
 			verifier.ActL2PipelineFull(t)
 			// Once the span batch is fully processed, the safe head must advance to the end of span batch.
 			require.Equal(t, verifier.L2Safe().Number, targetHeadNumber)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -463,10 +463,10 @@ func (n *OpNode) initL2(ctx context.Context, cfg *config.Config) error {
 	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, cfg.DependencySet, n.l2Source, n.l1Source,
 		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, indexingMode)
 
-	// Wire up IndexingMode to engine controller for direct force reset notifications
+	// Wire up IndexingMode to engine controller for direct procedure call
 	if n.interopSys != nil {
 		if indexingMode, ok := n.interopSys.(*indexing.IndexingMode); ok {
-			indexingMode.SetForceResetNotifier(n.l2Driver.SyncDeriver.Engine)
+			indexingMode.SetEngineController(n.l2Driver.SyncDeriver.Engine)
 		}
 	}
 

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -65,18 +65,8 @@ func (ev LocalSafeUpdateEvent) String() string {
 	return "local-safe-update"
 }
 
-// PromoteSafeEvent signals that a block can be promoted to cross-safe.
-type PromoteSafeEvent struct {
-	Ref    eth.L2BlockRef
-	Source eth.L1BlockRef
-}
-
-func (ev PromoteSafeEvent) String() string {
-	return "promote-safe"
-}
-
 // SafeDerivedEvent signals that a block was determined to be safe, and derived from the given L1 block.
-// This is signaled upon successful processing of PromoteSafeEvent.
+// This is signaled upon procedural call of PromoteSafe method
 type SafeDerivedEvent struct {
 	Safe   eth.L2BlockRef
 	Source eth.L1BlockRef

--- a/op-node/rollup/interop/indexing/system.go
+++ b/op-node/rollup/interop/indexing/system.go
@@ -45,9 +45,9 @@ type L1Source interface {
 	L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error)
 	L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error)
 }
-
-type ForceResetNotifier interface {
+type EngineController interface {
 	ForceReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef)
+	PromoteSafe(ctx context.Context, ref eth.L2BlockRef, source eth.L1BlockRef)
 }
 
 // IndexingMode makes the op-node managed by an op-supervisor,
@@ -56,8 +56,6 @@ type IndexingMode struct {
 	log log.Logger
 
 	emitter event.Emitter
-
-	forceResetNotifier ForceResetNotifier
 
 	l1 L1Source
 	l2 L2Source
@@ -79,6 +77,8 @@ type IndexingMode struct {
 
 	srv       *rpc.Server
 	jwtSecret eth.Bytes32
+
+	engineController EngineController
 }
 
 func NewIndexingMode(log log.Logger, cfg *rollup.Config, addr string, port int, jwtSecret eth.Bytes32, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) *IndexingMode {
@@ -117,8 +117,8 @@ func NewIndexingMode(log log.Logger, cfg *rollup.Config, addr string, port int, 
 	return out
 }
 
-func (m *IndexingMode) SetForceResetNotifier(notifier ForceResetNotifier) {
-	m.forceResetNotifier = notifier
+func (m *IndexingMode) SetEngineController(engineController EngineController) {
+	m.engineController = engineController
 }
 
 // TestDisableEventDeduplication is a test-only function that disables event deduplication.
@@ -298,12 +298,7 @@ func (m *IndexingMode) UpdateCrossSafe(ctx context.Context, derived eth.BlockID,
 	if err != nil {
 		return fmt.Errorf("failed to get L1BlockRef: %w", err)
 	}
-	m.emitter.Emit(m.ctx, engine.PromoteSafeEvent{
-		Ref:    l2Ref,
-		Source: l1Ref,
-	})
-	// We return early: there is no point waiting for the cross-safe engine-update synchronously.
-	// All error-feedback comes to the supervisor by aborting derivation tasks with an error.
+	m.engineController.PromoteSafe(ctx, l2Ref, l1Ref)
 	return nil
 }
 
@@ -460,7 +455,7 @@ func (m *IndexingMode) Reset(ctx context.Context, lUnsafe, xUnsafe, lSafe, xSafe
 		return err
 	}
 
-	m.forceResetNotifier.ForceReset(ctx, lUnsafeRef, xUnsafeRef, lSafeRef, xSafeRef, finalizedRef)
+	m.engineController.ForceReset(ctx, lUnsafeRef, xUnsafeRef, lSafeRef, xSafeRef, finalizedRef)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes `PromoteSafeEvent`.

`PromoteSafeEvent` was emitted from `IndexingMode` and `EngineController`. `EngineController` was the only one consumed the `PromoteSafeEvent`.

`IndexingMode` was injected with `EngineController` at https://github.com/ethereum-optimism/optimism/pull/17061 as using the `ForceResetNotifier` interface. Added the `EngineController` interface to support more engine controller procedural method call like `PromoteSafe` method.

**Tests**

All existing tests pass.
