### PR TITLE
fix(op-program): add proper closer handling in pebbleKV.Get

### DIFF
--- a/op-program/host/kvstore/pebble.go
+++ b/op-program/host/kvstore/pebble.go
@@ -52,9 +52,10 @@ func (d *pebbleKV) Get(k common.Hash) ([]byte, error) {
 		}
 		return nil, err
 	}
+	defer closer.Close()
+
 	ret := make([]byte, len(dat))
 	copy(ret, dat)
-	closer.Close()
 	return ret, nil
 }
 


### PR DESCRIPTION
Moving `closer.Close()` to a defer statement ensures proper cleanup even if the function exits early. The previous implementation could leak resources if something went wrong between getting the data and the explicit close call.
This follows Go best practices for resource management and prevents potential issues with buffer flushing that could affect data integrity.