### PR TITLE
cannon: Drop version 7 feature flags

### DIFF
--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -350,7 +350,7 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 					rs <<= 1
 				}
 				return Word(i)
-			case features.SupportDclzDclo && (fun == 0x24 || fun == 0x25): // dclz, dclo
+			case fun == 0x24 || fun == 0x25: // dclz, dclo
 				assertMips64Fun(insn)
 				if fun == 0x24 {
 					rs = ^rs

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -38,7 +38,7 @@ func GetInstructionDetails(pc Word, memory *memory.Memory) (insn, opcode, fun ui
 
 // ExecMipsCoreStepLogic executes a MIPS instruction that isn't a syscall nor a RMW operation
 // If a store operation occurred, then it returns the effective address of the store memory location.
-func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory *memory.Memory, insn, opcode, fun uint32, memTracker MemTracker, stackTracker StackTracker, features mipsevm.FeatureToggles) (memUpdated bool, effMemAddr Word, err error) {
+func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory *memory.Memory, insn, opcode, fun uint32, memTracker MemTracker, stackTracker StackTracker) (memUpdated bool, effMemAddr Word, err error) {
 	// j-type j/jal
 	if opcode == 2 || opcode == 3 {
 		linkReg := Word(0)
@@ -117,7 +117,7 @@ func ExecMipsCoreStepLogic(cpu *mipsevm.CpuScalars, registers *[32]Word, memory 
 	}
 
 	// ALU
-	val := ExecuteMipsInstruction(insn, opcode, fun, rs, rt, mem, features)
+	val := ExecuteMipsInstruction(insn, opcode, fun, rs, rt, mem)
 
 	funSel := uint32(0x1c)
 	if !arch.IsMips32 {
@@ -182,7 +182,7 @@ func assertMips64Fun(fun uint32) {
 	}
 }
 
-func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem Word, features mipsevm.FeatureToggles) Word {
+func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem Word) Word {
 	if opcode == 0 || (opcode >= 8 && opcode < 0xF) || (!arch.IsMips32 && (opcode == 0x18 || opcode == 0x19)) {
 		// transform ArithLogI to SPECIAL
 		switch opcode {

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,7 +74,6 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
-	SupportDclzDclo            bool
 	SupportNoopMprotect        bool
 	SupportWorkingSysGetRandom bool
 }

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,7 +74,6 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
-	SupportNoopMprotect        bool
 	SupportWorkingSysGetRandom bool
 }
 

--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,7 +74,6 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
-	SupportMinimalSysEventFd2  bool
 	SupportDclzDclo            bool
 	SupportNoopMprotect        bool
 	SupportWorkingSysGetRandom bool

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -418,7 +418,7 @@ func runTestsAcrossVms[T any](t *testing.T, testNamer TestNamer[T], testCases []
 	}
 
 	variations := []VMVariations{
-		{name: "Go 1.23 VM", goTarget: testutil.Go1_23, features: mipsevm.FeatureToggles{SupportDclzDclo: true}},
+		{name: "Go 1.23 VM", goTarget: testutil.Go1_23, features: mipsevm.FeatureToggles{}},
 		{name: "Go 1.24 VM", goTarget: testutil.Go1_24, features: allFeaturesEnabled()},
 	}
 

--- a/cannon/mipsevm/multithreaded/instrumented_test.go
+++ b/cannon/mipsevm/multithreaded/instrumented_test.go
@@ -418,7 +418,7 @@ func runTestsAcrossVms[T any](t *testing.T, testNamer TestNamer[T], testCases []
 	}
 
 	variations := []VMVariations{
-		{name: "Go 1.23 VM", goTarget: testutil.Go1_23, features: mipsevm.FeatureToggles{SupportMinimalSysEventFd2: true, SupportDclzDclo: true}},
+		{name: "Go 1.23 VM", goTarget: testutil.Go1_23, features: mipsevm.FeatureToggles{SupportDclzDclo: true}},
 		{name: "Go 1.24 VM", goTarget: testutil.Go1_24, features: allFeaturesEnabled()},
 	}
 

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -350,7 +350,7 @@ func (m *InstrumentedState) doMipsStep() error {
 	}
 
 	// Exec the rest of the step logic
-	memUpdated, effMemAddr, err := exec.ExecMipsCoreStepLogic(m.state.getCpuRef(), m.state.GetRegistersRef(), m.state.Memory, insn, opcode, fun, m.memoryTracker, m.stackTracker, m.features)
+	memUpdated, effMemAddr, err := exec.ExecMipsCoreStepLogic(m.state.getCpuRef(), m.state.GetRegistersRef(), m.state.Memory, insn, opcode, fun, m.memoryTracker, m.stackTracker)
 	if err != nil {
 		return err
 	}

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -165,9 +165,6 @@ func (m *InstrumentedState) handleSyscall() error {
 		// Otherwise, ignored (noop)
 	case arch.SysMunmap:
 	case arch.SysMprotect:
-		if !m.features.SupportNoopMprotect {
-			m.handleUnrecognizedSyscall(syscallNum)
-		}
 	case arch.SysGetAffinity:
 	case arch.SysMadvise:
 	case arch.SysRtSigprocmask:

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -198,10 +198,6 @@ func (m *InstrumentedState) handleSyscall() error {
 	case arch.SysGetRLimit:
 	case arch.SysLseek:
 	case arch.SysEventFd2:
-		if !m.features.SupportMinimalSysEventFd2 {
-			m.handleUnrecognizedSyscall(syscallNum)
-		}
-
 		// a0 = initial value, a1 = flags
 		// Validate flags
 		if a1&exec.EFD_NONBLOCK == 0 {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -627,9 +627,6 @@ var NoopSyscalls64 = map[string]uint32{
 func getNoopSyscalls64(vmVersion versions.StateVersion) map[string]uint32 {
 	noOpCalls := maps.Clone(NoopSyscalls64)
 	features := versions.FeaturesForVersion(vmVersion)
-	if !features.SupportNoopMprotect {
-		delete(noOpCalls, "SysMprotect")
-	}
 	if features.SupportWorkingSysGetRandom {
 		delete(noOpCalls, "SysGetRandom")
 	}

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -69,9 +69,6 @@ func (s *VersionedState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, 
 func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
-	if version >= VersionMultiThreaded64_v4 {
-		features.SupportNoopMprotect = true
-	}
 	if version >= VersionMultiThreaded64_v5 {
 		features.SupportWorkingSysGetRandom = true
 	}

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -70,7 +70,6 @@ func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
 	if version >= VersionMultiThreaded64_v4 {
-		features.SupportMinimalSysEventFd2 = true
 		features.SupportDclzDclo = true
 		features.SupportNoopMprotect = true
 	}

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -70,7 +70,6 @@ func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
 	if version >= VersionMultiThreaded64_v4 {
-		features.SupportDclzDclo = true
 		features.SupportNoopMprotect = true
 	}
 	if version >= VersionMultiThreaded64_v5 {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0xbc7c3c50e8c3679576f87d79c2dae05dd1174e64bdaa4c1e0857314618e415a3",
-    "sourceCodeHash": "0xf6e87bf46edca31c2b30c83fdf7b57a7851404743e16dd4f783be3a34c481d76"
+    "initCodeHash": "0x96074659e7bb38df33588050150caff27b5d237f3a95a75d721b694de3c1e1cf",
+    "sourceCodeHash": "0x90048efbcde0df5dbe07a0633db39d8c1fdb39d4e8a661ad92e8a86f8ddacddb"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -136,8 +136,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x96074659e7bb38df33588050150caff27b5d237f3a95a75d721b694de3c1e1cf",
-    "sourceCodeHash": "0x90048efbcde0df5dbe07a0633db39d8c1fdb39d4e8a661ad92e8a86f8ddacddb"
+    "initCodeHash": "0x6a649986370d18e5fddcd89df73e520063fb373f7dba2f731a2b7e79a1c132a5",
+    "sourceCodeHash": "0x657afae82e6e3627389153736e568bf99498a272ec6d9ecc22ecfd645c56c453"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x4bf3bbdaf08989de57408b2ea88995e2f477b98add164dbf82e0dceb01417ef6",
-    "sourceCodeHash": "0x36861c793b247f4922ecd77b1b153a0f2a47a129117fbe59e7e1f6498ef46c42"
+    "initCodeHash": "0x75ca0470b7c0f86da7e474b3f44996e27493f1a636c604dee45ccd4aa8fcec5f",
+    "sourceCodeHash": "0x8ba1e3e9441a35b255597bf7d199e1fbecf261918043fa9a21b7d9b007ba3528"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x75ca0470b7c0f86da7e474b3f44996e27493f1a636c604dee45ccd4aa8fcec5f",
-    "sourceCodeHash": "0x8ba1e3e9441a35b255597bf7d199e1fbecf261918043fa9a21b7d9b007ba3528"
+    "initCodeHash": "0xb96c198bc5e92ada25e79d256033d823e7924bee3dd0d5a909d7aa8cb4e388bb",
+    "sourceCodeHash": "0x7a0b0f8042eebd9070bae5bba4aa888111ddd782df3a0bf8d136dcce11e82554"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -36,8 +36,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.6.0
-    string public constant version = "1.6.0";
+    /// @custom:semver 1.7.0
+    string public constant version = "1.7.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -201,7 +201,7 @@ contract OPContractsManagerStandardValidator is ISemver {
 
     /// @notice Returns the expected MIPS version.
     function mipsVersion() public pure returns (string memory) {
-        return "1.8.0";
+        return "1.9.0";
     }
 
     /// @notice Returns the expected OptimismMintableERC20Factory version.

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -630,10 +630,6 @@ contract MIPS64 is ISemver {
             } else if (syscall_no == sys.SYS_LSEEK) {
                 // ignored
             } else if (syscall_no == sys.SYS_EVENTFD2) {
-                if (!st.featuresForVersion(STATE_VERSION).supportMinimalSysEventFd2) {
-                    revert("MIPS64: unimplemented syscall");
-                }
-
                 // a0 = initial value, a1 = flags
                 // Validate flags
                 if (a1 & sys.EFD_NONBLOCK == 0) {

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -273,8 +273,7 @@ contract MIPS64 is ISemver {
                 memProofOffset: MIPS64Memory.memoryProofOffset(MEM_PROOF_OFFSET, 1),
                 insn: insn,
                 opcode: opcode,
-                fun: fun,
-                stateVersion: STATE_VERSION
+                fun: fun
             });
             bool memUpdated;
             uint64 effMemAddr;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.8.0
-    string public constant version = "1.8.0";
+    /// @custom:semver 1.9.0
+    string public constant version = "1.9.0";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -568,9 +568,7 @@ contract MIPS64 is ISemver {
             } else if (syscall_no == sys.SYS_MUNMAP) {
                 // ignored
             } else if (syscall_no == sys.SYS_MPROTECT) {
-                if (!st.featuresForVersion(STATE_VERSION).supportNoopMprotect) {
-                    revert("MIPS64: unimplemented syscall");
-                }
+                // ignored
             } else if (syscall_no == sys.SYS_GETAFFINITY) {
                 // ignored
             } else if (syscall_no == sys.SYS_MADVISE) {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -494,7 +494,7 @@ library MIPS64Instructions {
                         return i;
                     }
                     // dclz, dclo
-                    else if (st.featuresForVersion(stateVersion).supportDclzDclo && (fun == 0x24 || fun == 0x25)) {
+                    else if (fun == 0x24 || fun == 0x25)) {
                         if (fun == 0x24) {
                             rs = ~rs;
                         }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -494,7 +494,7 @@ library MIPS64Instructions {
                         return i;
                     }
                     // dclz, dclo
-                    else if (fun == 0x24 || fun == 0x25)) {
+                    else if (fun == 0x24 || fun == 0x25) {
                         if (fun == 0x24) {
                             rs = ~rs;
                         }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -34,8 +34,6 @@ library MIPS64Instructions {
         uint32 opcode;
         /// @param fun The function value parsed from insn.
         uint32 fun;
-        /// @param stateVersion The state version.
-        uint256 stateVersion;
     }
 
     struct ExecuteMipsInstructionParams {
@@ -51,8 +49,6 @@ library MIPS64Instructions {
         uint64 rt;
         /// @param mem The value fetched from memory for the current instruction.
         uint64 mem;
-        /// @param stateVersion The state version.
-        uint256 stateVersion;
     }
 
     /// @param _pc The program counter.
@@ -181,8 +177,7 @@ library MIPS64Instructions {
                 fun: _args.fun,
                 rs: rs,
                 rt: rt,
-                mem: mem,
-                stateVersion: _args.stateVersion
+                mem: mem
             });
             uint64 val = executeMipsInstruction(params) & U64_MASK;
 

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol
@@ -248,7 +248,6 @@ library MIPS64Instructions {
         uint64 rs = _args.rs;
         uint64 rt = _args.rt;
         uint64 mem = _args.mem;
-        uint256 stateVersion = _args.stateVersion;
         unchecked {
             if (opcode == 0 || (opcode >= 8 && opcode < 0xF) || opcode == 0x18 || opcode == 0x19) {
                 assembly {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -13,7 +13,6 @@ library MIPS64State {
     }
 
     struct Features {
-        bool supportMinimalSysEventFd2;
         bool supportDclzDclo;
         bool supportNoopMprotect;
         bool supportWorkingSysGetRandom;
@@ -27,7 +26,6 @@ library MIPS64State {
 
     function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
         if (_version >= 7) {
-            features_.supportMinimalSysEventFd2 = true;
             features_.supportDclzDclo = true;
             features_.supportNoopMprotect = true;
         }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -13,7 +13,6 @@ library MIPS64State {
     }
 
     struct Features {
-        bool supportNoopMprotect;
         bool supportWorkingSysGetRandom;
     }
 
@@ -24,9 +23,6 @@ library MIPS64State {
     }
 
     function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
-        if (_version >= 7) {
-            features_.supportNoopMprotect = true;
-        }
         if (_version >= 8) {
             features_.supportWorkingSysGetRandom = true;
         }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -13,7 +13,6 @@ library MIPS64State {
     }
 
     struct Features {
-        bool supportDclzDclo;
         bool supportNoopMprotect;
         bool supportWorkingSysGetRandom;
     }
@@ -26,7 +25,6 @@ library MIPS64State {
 
     function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
         if (_version >= 7) {
-            features_.supportDclzDclo = true;
             features_.supportNoopMprotect = true;
         }
         if (_version >= 8) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

[Cannon VM version 7](https://github.com/ethereum-optimism/optimism/blob/a59b414c178036cdc750c209dfc5e69e6e11da19/cannon/mipsevm/versions/version.go#L26-L27) is now in production, so remove the associated feature flags.
