### PR TITLE
feat(devstack/rpc): expose rpc endpoint

### DIFF
--- a/op-devstack/shim/l2_cl.go
+++ b/op-devstack/shim/l2_cl.go
@@ -49,6 +49,10 @@ func NewL2CLNode(cfg L2CLNodeConfig) stack.L2CLNode {
 	}
 }
 
+func (r *rpcL2CLNode) ClientRPC() client.RPC {
+	return r.client
+}
+
 func (r *rpcL2CLNode) ID() stack.L2CLNodeID {
 	return r.id
 }

--- a/op-devstack/stack/l2_cl.go
+++ b/op-devstack/stack/l2_cl.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -72,6 +73,7 @@ type L2CLNode interface {
 	Common
 	ID() L2CLNodeID
 
+	ClientRPC() client.RPC
 	RollupAPI() apis.RollupClient
 	P2PAPI() apis.P2PClient
 	InteropRPC() (endpoint string, jwtSecret eth.Bytes32)


### PR DESCRIPTION
**Description**

Exposes the underlying client RPC for the devstack L2 CL nodes. Useful to manually query custom RPC methods inside the devstack.