### PR TITLE
op-sync-tester: augment sync tester config

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -5,10 +5,15 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimalWithSyncTester(),
+	presets.DoMain(m, presets.WithMinimalWithSyncTester(&stconf.TargetBlocks{
+		Head:      1,
+		Safe:      1,
+		Finalized: 1,
+	}),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -5,10 +5,15 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(&stconf.TargetBlocks{
+		Head:      1,
+		Safe:      1,
+		Finalized: 1,
+	}),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-devstack/presets/minimal_with_synctester.go
+++ b/op-devstack/presets/minimal_with_synctester.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type MinimalWithSyncTester struct {
@@ -15,8 +16,8 @@ type MinimalWithSyncTester struct {
 	SyncTester *dsl.SyncTester
 }
 
-func WithMinimalWithSyncTester() stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}))
+func WithMinimalWithSyncTester(tb *stconf.TargetBlocks) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, tb))
 }
 
 func NewMinimalWithSyncTester(t devtest.T) *MinimalWithSyncTester {

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type SimpleWithSyncTester struct {
@@ -16,8 +17,8 @@ type SimpleWithSyncTester struct {
 	L2CL2      *dsl.L2CLNode
 }
 
-func WithSimpleWithSyncTester() stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}))
+func WithSimpleWithSyncTester(tb *stconf.TargetBlocks) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, tb))
 }
 
 func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type OpNode struct {
@@ -161,6 +162,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var syncTesterID *stack.SyncTesterID
 		var depSet depset.DependencySet
 		var useSyncTester bool
+		var tb *stconf.TargetBlocks
 
 		switch v := l2ELOrSyncTester.(type) {
 		case stack.L2ELNodeID:
@@ -175,6 +177,15 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			syncTesterID = &syncTester.id
 
 			useSyncTester = true
+
+			for _, st := range orch.syncTester.service.SyncTesters() {
+				if st.ChainID == syncTesterID.ChainID() {
+					tb = st.Target
+					break
+				}
+			}
+			require.NotNil(tb, "target blocks not found for sync tester")
+
 			// When using a SyncTester, we don't need an L2EL node
 			// The SyncTester will provide the L2 endpoint
 			if cluster, ok := orch.ClusterForL2(syncTesterID.ChainID()); ok {
@@ -260,7 +271,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var l2EngineAddr string
 		if useSyncTester {
 			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
-			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), nil)
+			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), tb)
 		} else {
 			l2EngineAddr = l2EL.EngineRPC()
 		}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -260,7 +260,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		var l2EngineAddr string
 		if useSyncTester {
 			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
-			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID())
+			l2EngineAddr = orch.syncTester.service.SyncTesterEndpoint(syncTesterID.ChainID(), nil)
 		} else {
 			l2EngineAddr = l2EL.EngineRPC()
 		}

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -42,7 +42,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	}
 }
 
-func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithSyncTester(l2ELs []stack.L2ELNodeID, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))
@@ -66,11 +66,7 @@ func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 				// JwtPath:   el.jwtPath,
 				Cfg: stconf.SyncTesterConfig{
 					ChainID: elID.ChainID(),
-					Target: &stconf.TargetBlocks{
-						Head:      1,
-						Safe:      1,
-						Finalized: 1,
-					},
+					Target:  tb,
 				},
 			}
 		}

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -25,8 +25,9 @@ type SyncTester struct {
 func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
-	for syncTesterID, chainID := range n.service.SyncTesters() {
-		syncTesterRPC := n.service.SyncTesterEndpoint(chainID)
+	for syncTesterID, cfg := range n.service.SyncTesters() {
+		chainID := cfg.ChainID
+		syncTesterRPC := n.service.SyncTesterEndpoint(chainID, nil)
 		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
 		require.NoError(err)
 		system.T().Cleanup(rpcCl.Close)
@@ -63,7 +64,14 @@ func WithSyncTesters(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 				ELRPC: endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},
 				// EngineRPC: endpoint.MustRPC{Value: endpoint.URL(el.authRPC)},
 				// JwtPath:   el.jwtPath,
-				ChainID: elID.ChainID(),
+				Cfg: stconf.SyncTesterConfig{
+					ChainID: elID.ChainID(),
+					Target: &stconf.TargetBlocks{
+						Head:      1,
+						Safe:      1,
+						Finalized: 1,
+					},
+				},
 			}
 		}
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 var (
@@ -99,7 +100,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	}
 }
 
-func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs) stack.Option[*Orchestrator] {
+func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -135,7 +136,7 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTesters([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, tb))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 )
 
 type DefaultSimpleSystemWithSyncTesterIDs struct {
@@ -22,7 +23,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	}
 }
 
-func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs) stack.Option[*Orchestrator] {
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, tb *stconf.TargetBlocks) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -58,7 +59,7 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTesters([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, tb))
 	opt.Add(WithL2CLNodeWithSyncTester(ids.L2CL2, ids.L1CL, ids.L1EL))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
@@ -88,7 +87,7 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	// Set up the sync tester routes
 	var syncTesterErr error
 	b.syncTesters.Range(func(id sttypes.SyncTesterID, st *SyncTester) bool {
-		path := "/chain/" + st.chainID.String() + "/synctest"
+		path := "/chain/" + st.cfg.ChainID.String() + "/synctest"
 		if err := router.AddRPC(path); err != nil {
 			syncTesterErr = errors.Join(fmt.Errorf("failed to set up synctest route: %w", err))
 			return true
@@ -119,10 +118,17 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	return b, nil
 }
 
-func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]eth.ChainID) {
-	out = make(map[sttypes.SyncTesterID]eth.ChainID)
+func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.SyncTesterConfig) {
+	out = make(map[sttypes.SyncTesterID]config.SyncTesterConfig)
 	b.syncTesters.Range(func(key sttypes.SyncTesterID, value *SyncTester) bool {
-		out[key] = value.chainID
+		out[key] = config.SyncTesterConfig{
+			ChainID: value.cfg.ChainID,
+			Target: &config.TargetBlocks{
+				Head:      value.cfg.Target.Head,
+				Safe:      value.cfg.Target.Safe,
+				Finalized: value.cfg.Target.Finalized,
+			},
+		}
 		return true
 	})
 	return out

--- a/op-sync-tester/synctester/backend/config/static.go
+++ b/op-sync-tester/synctester/backend/config/static.go
@@ -14,9 +14,19 @@ type SyncTesterEntry struct {
 
 	// ChainID is used to sanity-check we are connected to the right chain,
 	// and never accidentally try to use a different chain for sync tester work.
-	ChainID eth.ChainID `yaml:"chain_id"`
+	Cfg SyncTesterConfig `yaml:"cfg"`
 }
 
+type TargetBlocks struct {
+	Head      uint64 `yaml:"head"`
+	Safe      uint64 `yaml:"safe"`
+	Finalized uint64 `yaml:"finalized"`
+}
+
+type SyncTesterConfig struct {
+	ChainID eth.ChainID   `yaml:"chain_id"`
+	Target  *TargetBlocks `yaml:"target"`
+}
 type Config struct {
 	// SyncTesters lists all sync testers by ID
 	SyncTesters map[sttypes.SyncTesterID]*SyncTesterEntry `yaml:"synctesters,omitempty"`

--- a/op-sync-tester/synctester/backend/config/testdata/config.yaml
+++ b/op-sync-tester/synctester/backend/config/testdata/config.yaml
@@ -1,4 +1,9 @@
 synctesters:
   local:
-    chain_id: 1234
+    cfg:
+      chain_id: 1234
+      target:
+        head: 10
+        safe: 20
+        finalized: 30
     el_rpc: https://localhost:8545

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -33,8 +33,8 @@ type SyncTester struct {
 	log log.Logger
 	m   metrics.Metricer
 
-	id      sttypes.SyncTesterID
-	chainID eth.ChainID
+	id  sttypes.SyncTesterID
+	cfg config.SyncTesterConfig
 
 	elReader ReadOnlyELBackend
 
@@ -53,21 +53,21 @@ var _ frontend.EngineBackend = (*SyncTester)(nil)
 var _ frontend.EthBackend = (*SyncTester)(nil)
 
 func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, stCfg *config.SyncTesterEntry) (*SyncTester, error) {
-	logger = logger.New("syncTester", stID, "chain", stCfg.ChainID)
+	logger = logger.New("syncTester", stID, "chain", stCfg.Cfg.ChainID)
 	elClient, err := ethclient.Dial(stCfg.ELRPC.Value.RPC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial EL client: %w", err)
 	}
 	elReader := NewELReader(elClient)
-	return NewSyncTester(logger, m, stID, stCfg.ChainID, elReader), nil
+	return NewSyncTester(logger, m, stID, stCfg.Cfg, elReader), nil
 }
 
-func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
+func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, cfg config.SyncTesterConfig, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
 		log:      logger,
 		m:        m,
 		id:       stID,
-		chainID:  chainID,
+		cfg:      cfg,
 		elReader: elReader,
 		sessions: make(map[string]*Session),
 	}
@@ -217,10 +217,10 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 	if err != nil {
 		return hexutil.Big{}, err
 	}
-	if chainID.ToInt().Cmp(s.chainID.ToBig()) != 0 {
-		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.chainID, chainID.ToInt())
+	if chainID.ToInt().Cmp(s.cfg.ChainID.ToBig()) != 0 {
+		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.cfg.ChainID, chainID.ToInt())
 	}
-	return hexutil.Big(*s.chainID.ToBig()), nil
+	return hexutil.Big(*s.cfg.ChainID.ToBig()), nil
 }
 
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayload, error) {

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -95,8 +96,8 @@ func (m *MockELReader) GetBlockReceipts(ctx context.Context, bnh rpc.BlockNumber
 	return receipts, nil
 }
 
-func initTestSyncTester(t *testing.T, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
-	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), chainID, elReader)
+func initTestSyncTester(t *testing.T, cfg config.SyncTesterConfig, elReader ReadOnlyELBackend) *SyncTester {
+	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), cfg, elReader)
 	return syncTester
 }
 
@@ -104,26 +105,26 @@ func TestSyncTester_ChainId(t *testing.T) {
 	dummySession := &Session{SessionID: uuid.New().String()}
 	tests := []struct {
 		name            string
-		cfgID           eth.ChainID
+		cfgID           config.SyncTesterConfig
 		elID            eth.ChainID
 		session         *Session
 		wantErrContains string
 	}{
 		{
 			name:            "no session",
-			cfgID:           eth.ChainIDFromUInt64(1),
+			cfgID:           config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)},
 			elID:            eth.ChainIDFromUInt64(1),
 			wantErrContains: "no session",
 		},
 		{
 			name:    "happy path",
-			cfgID:   eth.ChainIDFromUInt64(11155111),
+			cfgID:   config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(11155111)},
 			elID:    eth.ChainIDFromUInt64(11155111),
 			session: dummySession,
 		},
 		{
 			name:            "mismatch",
-			cfgID:           eth.ChainIDFromUInt64(1),
+			cfgID:           config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)},
 			elID:            eth.ChainIDFromUInt64(11155111),
 			session:         dummySession,
 			wantErrContains: "chainID mismatch",
@@ -145,7 +146,7 @@ func TestSyncTester_ChainId(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, hexutil.Big(*tc.cfgID.ToBig()), got)
+			require.Equal(t, hexutil.Big(*tc.cfgID.ChainID.ToBig()), got)
 		})
 	}
 }
@@ -191,7 +192,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			el := NewMockELReader(eth.ChainIDFromUInt64(1))
 			block := makeBlockRaw(tc.rawNumber)
 			el.BlocksByHash[hash] = block
-			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
+			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -317,7 +318,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 				el.BlocksByNumber[rpc.BlockNumber(tc.session.CurrentState.Finalized)] = makeBlockRaw(tc.session.CurrentState.Finalized)
 			}
 			el.BlocksByNumber[tc.inNumber] = makeBlockRaw(uint64(tc.inNumber.Int64()))
-			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
+			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -459,7 +460,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			if tc.seedFn != nil && tc.session != nil {
 				tc.seedFn(el, tc.session)
 			}
-			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
+			st := initTestSyncTester(t, config.SyncTesterConfig{ChainID: eth.ChainIDFromUInt64(1)}, el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -21,13 +21,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-sync-tester/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
+	bc "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type serviceBackend interface {
 	Stop(ctx context.Context) error
-	SyncTesters() map[sttypes.SyncTesterID]eth.ChainID
+	SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig
 }
 
 var _ serviceBackend = (*backend.Backend)(nil)
@@ -213,11 +214,15 @@ func (s *Service) RPC() string {
 	return s.httpServer.HTTPEndpoint()
 }
 
-func (s *Service) SyncTesterEndpoint(chainID eth.ChainID) string {
+func (s *Service) SyncTesterEndpoint(chainID eth.ChainID, target *bc.TargetBlocks) string {
 	uuid := uuid.New()
-	return fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
+	endpoint := fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
+	if target != nil {
+		endpoint += fmt.Sprintf("?head=%d&safe=%d&finalized=%d", target.Head, target.Safe, target.Finalized)
+	}
+	return endpoint
 }
 
-func (s *Service) SyncTesters() map[sttypes.SyncTesterID]eth.ChainID {
+func (s *Service) SyncTesters() map[sttypes.SyncTesterID]bc.SyncTesterConfig {
 	return s.backend.SyncTesters()
 }


### PR DESCRIPTION
At the moment individual sync testers are initialized only with a `ChainID`.

This PR is modifying the initialization to a config struct, which also includes the initial block targets for `head`, `safe`, and `finalized`, which are included as part of the initial session creation / RPC endpoint.

---

Should address: https://github.com/ethereum-optimism/optimism/issues/16702