### PR TITLE
feat(kurtosis-devnet): 1/2 add flashblocks support

### DIFF
--- a/kurtosis-devnet/flash.yaml
+++ b/kurtosis-devnet/flash.yaml
@@ -5,19 +5,54 @@ optimism_package:
   chains:
     op-kurtosis:
       participants:
-        node0: &x-node
+        node0:
+          sequencer: true
           el:
             type: op-geth
+          el_builder:
+            type: op-rbuilder
+          cl_builder:
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
+          mev_params:
+            enabled: true
           cl:
             type: op-node
             image: {{ localDockerImage "op-node" }}
-            builder_type: "op-rbuilder"
-            builder_image: "us-docker.pkg.dev/oplabs-tools-artifacts/dev-images/op-rbuilder:sha-4aee498"
+          conductor_params:
+            image: {{ localDockerImage "op-conductor" }}
+            enabled: true
+            bootstrap: true
+            paused: true
+            admin: true
+            proxy: true
+            websocket_enabled: true
+            
+        node1:
+          sequencer: true
+          el:
+            type: op-reth
+          el_builder:
+            type: op-rbuilder
+          cl_builder:
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
           mev_params:
             enabled: true
-            type: "rollup-boost"
-            image: "docker.io/flashbots/rollup-boost:0.6.2"
-        node1: *x-node
+          cl:
+            type: op-node
+            image: {{ localDockerImage "op-node" }}
+          conductor_params:
+            image: {{ localDockerImage "op-conductor" }}
+            enabled: true
+            paused: true
+            admin: true
+            proxy: true
+            websocket_enabled: true
+
+      proxyd_params:
+        pprof_enabled: false
+        extra_params: []
       network_params:
         network: "kurtosis"
         network_id: "2151908"
@@ -26,13 +61,14 @@ optimism_package:
         granite_time_offset: 0
         holocene_time_offset: 0
         fund_dev_accounts: true
+        
+      flashblocks_websocket_proxy_params:
+        enabled: true
+      flashblocks_rpc_params:
+        type: op-reth
       batcher_params:
         image: {{ localDockerImage "op-batcher" }}
         extra_params: []
-      conductor_params:
-        image: {{ localDockerImage "op-conductor" }}
-        enabled: true
-        bootstrap: true
       proposer_params:
         image: {{ localDockerImage "op-proposer" }}
         extra_params: []

--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -182,6 +182,15 @@ func (f *ServiceFinder) triageByLabels(svc *inspect.Service, name string, endpoi
 	if !ok {
 		return nil
 	}
+
+	// So that we can have the same behaviour as netchef
+	if (tag == "flashblocks-websocket-proxy") && endpoints != nil {
+		if _, has := endpoints["ws-flashblocks"]; !has {
+			if ws, ok := endpoints["ws"]; ok {
+				endpoints["ws-flashblocks"] = ws
+			}
+		}
+	}
 	network_ids := f.getNetworkIDs(svc)
 	idx := -1
 	if val, ok := svc.Labels[nodeIndexLabel]; ok {

--- a/op-devstack/dsl/fb_builder.go
+++ b/op-devstack/dsl/fb_builder.go
@@ -51,5 +51,5 @@ func (c *FlashblocksBuilderNode) Conductor() *Conductor {
 }
 
 func (c *FlashblocksBuilderNode) ListenFor(logger log.Logger, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
-	return websocketListenFor(logger, c.inner.FlashblocksWsUrl(), duration, output, done)
+	return websocketListenFor(logger, c.inner.FlashblocksWsUrl(), c.inner.FlashblocksWsHeaders(), duration, output, done)
 }

--- a/op-devstack/dsl/fb_ws_proxy.go
+++ b/op-devstack/dsl/fb_ws_proxy.go
@@ -70,8 +70,14 @@ func websocketListenFor(logger log.Logger, wsURL string, headers http.Header, du
 		logger.Error("WebSocket connection failed", "url", wsURL, "error", err)
 		if resp != nil {
 			logger.Error("HTTP response details", "status", resp.Status, "headers", resp.Header)
+			resp.Body.Close()
 		}
 		return fmt.Errorf("failed to connect to Flashblocks WebSocket endpoint %s: %w", wsURL, err)
+	}
+
+	// Always close the response body to prevent resource leaks
+	if resp != nil {
+		defer resp.Body.Close()
 	}
 	defer conn.Close()
 

--- a/op-devstack/dsl/fb_ws_proxy.go
+++ b/op-devstack/dsl/fb_ws_proxy.go
@@ -47,6 +47,8 @@ func (c *FlashblocksWebsocketProxy) ListenFor(logger log.Logger, duration time.D
 	return websocketListenFor(logger, wsURL, headers, duration, output, done)
 }
 
+// TODO(#986): Revamp this function so that it's more robust,
+// easier to use in tests and handles errors more gracefully
 func websocketListenFor(logger log.Logger, wsURL string, headers http.Header, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
 	defer close(done)
 	logger.Debug("Testing WebSocket connection to", "url", wsURL, "headers", headers)
@@ -64,6 +66,7 @@ func websocketListenFor(logger log.Logger, wsURL string, headers http.Header, du
 		HandshakeTimeout: 6 * time.Second,
 	}
 
+	// Always close the response body to prevent resource leaks
 	logger.Debug("Attempting WebSocket connection", "url", wsURL)
 	conn, resp, err := dialer.Dial(wsURL, headers)
 	if err != nil {
@@ -75,7 +78,6 @@ func websocketListenFor(logger log.Logger, wsURL string, headers http.Header, du
 		return fmt.Errorf("failed to connect to Flashblocks WebSocket endpoint %s: %w", wsURL, err)
 	}
 
-	// Always close the response body to prevent resource leaks
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/op-devstack/dsl/fb_ws_proxy.go
+++ b/op-devstack/dsl/fb_ws_proxy.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -41,29 +42,47 @@ func (c *FlashblocksWebsocketProxy) Escape() stack.FlashblocksWebsocketProxy {
 }
 
 func (c *FlashblocksWebsocketProxy) ListenFor(logger log.Logger, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
-	return websocketListenFor(logger, c.Escape().WsUrl(), duration, output, done)
+	wsURL := c.Escape().WsUrl()
+	headers := c.Escape().WsHeaders()
+	return websocketListenFor(logger, wsURL, headers, duration, output, done)
 }
 
-func websocketListenFor(logger log.Logger, wsURL string, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
+func websocketListenFor(logger log.Logger, wsURL string, headers http.Header, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
 	defer close(done)
-	logger.Debug("Testing WebSocket connection to", "url", wsURL)
+	logger.Debug("Testing WebSocket connection to", "url", wsURL, "headers", headers)
+
+	// Log the headers for debug purposes
+	if headers != nil {
+		for key, values := range headers {
+			logger.Debug("Header", "key", key, "values", values)
+		}
+	} else {
+		logger.Debug("No headers provided")
+	}
 
 	dialer := &websocket.Dialer{
 		HandshakeTimeout: 6 * time.Second,
 	}
 
-	conn, _, err := dialer.Dial(wsURL, nil)
+	logger.Debug("Attempting WebSocket connection", "url", wsURL)
+	conn, resp, err := dialer.Dial(wsURL, headers)
 	if err != nil {
+		logger.Error("WebSocket connection failed", "url", wsURL, "error", err)
+		if resp != nil {
+			logger.Error("HTTP response details", "status", resp.Status, "headers", resp.Header)
+		}
 		return fmt.Errorf("failed to connect to Flashblocks WebSocket endpoint %s: %w", wsURL, err)
 	}
 	defer conn.Close()
 
-	logger.Info("WebSocket connection established, reading stream for %s", duration)
+	logger.Info("WebSocket connection established successfully", "url", wsURL, "reading stream for", duration)
 
 	timeout := time.After(duration)
+	messageCount := 0
 	for {
 		select {
 		case <-timeout:
+			logger.Info("WebSocket read timeout reached", "total_messages", messageCount)
 			return nil
 		default:
 			err = conn.SetReadDeadline(time.Now().Add(duration))
@@ -72,12 +91,17 @@ func websocketListenFor(logger log.Logger, wsURL string, duration time.Duration,
 			}
 			_, message, err := conn.ReadMessage()
 			if err != nil && !strings.Contains(err.Error(), "timeout") {
+				logger.Error("Error reading WebSocket message", "error", err, "message_count", messageCount)
 				return fmt.Errorf("error reading WebSocket message: %w", err)
 			}
 			if err == nil {
+				messageCount++
+				logger.Debug("Received WebSocket message", "message_count", messageCount, "message_length", len(message))
 				select {
 				case output <- message:
+					logger.Debug("Message sent to output channel", "message_count", messageCount)
 				case <-timeout: // to avoid indefinite hang
+					logger.Info("Timeout while sending message to output channel", "total_messages", messageCount)
 					return nil
 				}
 			}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -26,8 +26,7 @@ func WithSimpleFlashblocks() stack.CommonOption {
 	return stack.Combine(
 		stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{})),
 		// TODO(#16450): add sysgo support for flashblocks
-		// TODO(#16514): add kurtosis support for flashblocks
-		WithCompatibleTypes(compat.Persistent),
+		WithCompatibleTypes(compat.Persistent, compat.Kurtosis),
 	)
 }
 

--- a/op-devstack/shim/fb_builder.go
+++ b/op-devstack/shim/fb_builder.go
@@ -1,6 +1,8 @@
 package shim
 
 import (
+	"net/http"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -10,9 +12,10 @@ import (
 
 type FlashblocksBuilderNodeConfig struct {
 	ELNodeConfig
-	ID               stack.FlashblocksBuilderID
-	Conductor        stack.Conductor
-	FlashblocksWsUrl string
+	ID                   stack.FlashblocksBuilderID
+	Conductor            stack.Conductor
+	FlashblocksWsUrl     string
+	FlashblocksWsHeaders http.Header
 }
 
 type flashblocksBuilderNode struct {
@@ -22,7 +25,8 @@ type flashblocksBuilderNode struct {
 	id        stack.FlashblocksBuilderID
 	conductor stack.Conductor
 
-	flashblocksWsUrl string
+	flashblocksWsUrl     string
+	flashblocksWsHeaders http.Header
 }
 
 var _ stack.FlashblocksBuilderNode = (*flashblocksBuilderNode)(nil)
@@ -34,11 +38,12 @@ func NewFlashblocksBuilderNode(cfg FlashblocksBuilderNodeConfig) stack.Flashbloc
 	require.NoError(cfg.T, err)
 
 	return &flashblocksBuilderNode{
-		rpcELNode:        newRpcELNode(cfg.ELNodeConfig),
-		l2Client:         l2Client,
-		id:               cfg.ID,
-		conductor:        cfg.Conductor,
-		flashblocksWsUrl: cfg.FlashblocksWsUrl,
+		rpcELNode:            newRpcELNode(cfg.ELNodeConfig),
+		l2Client:             l2Client,
+		id:                   cfg.ID,
+		conductor:            cfg.Conductor,
+		flashblocksWsUrl:     cfg.FlashblocksWsUrl,
+		flashblocksWsHeaders: cfg.FlashblocksWsHeaders,
 	}
 }
 
@@ -56,4 +61,8 @@ func (r *flashblocksBuilderNode) L2EthClient() apis.L2EthClient {
 
 func (r *flashblocksBuilderNode) FlashblocksWsUrl() string {
 	return r.flashblocksWsUrl
+}
+
+func (r *flashblocksBuilderNode) FlashblocksWsHeaders() http.Header {
+	return r.flashblocksWsHeaders
 }

--- a/op-devstack/shim/fb_ws_proxy.go
+++ b/op-devstack/shim/fb_ws_proxy.go
@@ -1,20 +1,24 @@
 package shim
 
 import (
+	"net/http"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type FlashblocksWebsocketProxyConfig struct {
 	CommonConfig
-	ID    stack.FlashblocksWebsocketProxyID
-	WsUrl string
+	ID        stack.FlashblocksWebsocketProxyID
+	WsUrl     string
+	WsHeaders http.Header
 }
 
 type flashblocksWebsocketProxy struct {
 	commonImpl
-	id    stack.FlashblocksWebsocketProxyID
-	wsUrl string
+	id        stack.FlashblocksWebsocketProxyID
+	wsUrl     string
+	wsHeaders http.Header
 }
 
 var _ stack.FlashblocksWebsocketProxy = (*flashblocksWebsocketProxy)(nil)
@@ -25,6 +29,7 @@ func NewFlashblocksWebsocketProxy(cfg FlashblocksWebsocketProxyConfig) stack.Fla
 		commonImpl: newCommon(cfg.CommonConfig),
 		id:         cfg.ID,
 		wsUrl:      cfg.WsUrl,
+		wsHeaders:  cfg.WsHeaders,
 	}
 }
 
@@ -38,4 +43,8 @@ func (r *flashblocksWebsocketProxy) ChainID() eth.ChainID {
 
 func (r *flashblocksWebsocketProxy) WsUrl() string {
 	return r.wsUrl
+}
+
+func (r *flashblocksWebsocketProxy) WsHeaders() http.Header {
+	return r.wsHeaders
 }

--- a/op-devstack/stack/fb_builder.go
+++ b/op-devstack/stack/fb_builder.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"log/slog"
+	"net/http"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -13,6 +14,7 @@ type FlashblocksBuilderNode interface {
 	Conductor() Conductor
 	L2EthClient() apis.L2EthClient
 	FlashblocksWsUrl() string
+	FlashblocksWsHeaders() http.Header
 }
 
 type FlashblocksBuilderID idWithChain

--- a/op-devstack/stack/fb_ws_proxy.go
+++ b/op-devstack/stack/fb_ws_proxy.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"log/slog"
+	"net/http"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -11,6 +12,7 @@ type FlashblocksWebsocketProxy interface {
 	ChainID() eth.ChainID
 	ID() FlashblocksWebsocketProxyID
 	WsUrl() string
+	WsHeaders() http.Header
 }
 
 type FlashblocksWebsocketProxyID idWithChain

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -85,8 +85,19 @@ func (orch *Orchestrator) httpClient(t devtest.T, service *descriptors.Service, 
 func (orch *Orchestrator) findProtocolService(service *descriptors.Service, protocol string) (string, http.Header, error) {
 	for proto, endpoint := range service.Endpoints {
 		if proto == protocol {
-			if orch.env.Env.ReverseProxyURL != "" && len(endpoint.ReverseProxyHeader) > 0 && !orch.useDirectCnx {
-				return orch.env.Env.ReverseProxyURL, endpoint.ReverseProxyHeader, nil
+			// TODO(#): Fix websockets support by upgrading to traefik v3
+			// Force direct connect for websocket protocols
+			if protocol != WebsocketFlashblocksProtocol {
+				if orch.env.Env.ReverseProxyURL != "" && len(endpoint.ReverseProxyHeader) > 0 && !orch.useDirectCnx {
+					// For WebSocket protocols, convert HTTP URL to WebSocket URL
+					if protocol == WebsocketFlashblocksProtocol {
+						wsURL := strings.NewReplacer("http://", "ws://", "https://", "wss://").Replace(orch.env.Env.ReverseProxyURL)
+						wsURL += "/ws"
+
+						return wsURL, endpoint.ReverseProxyHeader, nil
+					}
+					return orch.env.Env.ReverseProxyURL, endpoint.ReverseProxyHeader, nil
+				}
 			}
 
 			port := endpoint.Port

--- a/op-devstack/sysext/helpers.go
+++ b/op-devstack/sysext/helpers.go
@@ -85,7 +85,7 @@ func (orch *Orchestrator) httpClient(t devtest.T, service *descriptors.Service, 
 func (orch *Orchestrator) findProtocolService(service *descriptors.Service, protocol string) (string, http.Header, error) {
 	for proto, endpoint := range service.Endpoints {
 		if proto == protocol {
-			// TODO(#): Fix websockets support by upgrading to traefik v3
+			// TODO(#17194): Fix websockets support by upgrading to traefik v3
 			// Force direct connect for websocket protocols
 			if protocol != WebsocketFlashblocksProtocol {
 				if orch.env.Env.ReverseProxyURL != "" && len(endpoint.ReverseProxyHeader) > 0 && !orch.useDirectCnx {

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -177,7 +177,7 @@ func (o *Orchestrator) hydrateFlashblocksBuilderIfPresent(node *descriptors.Node
 	associatedConductorService, ok := node.Services[ConductorServiceName]
 	require.True(ok, "L2 rbuilder service must have an associated conductor service", l2ID)
 
-	flashblocksWsUrl, _, err := o.findProtocolService(rbuilderService, WebsocketFlashblocksProtocol)
+	flashblocksWsUrl, flashblocksWsHeaders, err := o.findProtocolService(rbuilderService, WebsocketFlashblocksProtocol)
 	require.NoError(err, "failed to find websocket service for rbuilder")
 
 	flashblocksBuilder := shim.NewFlashblocksBuilderNode(shim.FlashblocksBuilderNodeConfig{
@@ -187,8 +187,9 @@ func (o *Orchestrator) hydrateFlashblocksBuilderIfPresent(node *descriptors.Node
 			Client:       o.rpcClient(l2Net.T(), rbuilderService, RPCProtocol, "/", opts...),
 			ChainID:      l2ID.ChainID(),
 		},
-		Conductor:        l2Net.Conductor(stack.ConductorID(associatedConductorService.Name)),
-		FlashblocksWsUrl: flashblocksWsUrl,
+		Conductor:            l2Net.Conductor(stack.ConductorID(associatedConductorService.Name)),
+		FlashblocksWsUrl:     flashblocksWsUrl,
+		FlashblocksWsHeaders: flashblocksWsHeaders,
 	})
 
 	l2Net.AddFlashblocksBuilder(flashblocksBuilder)
@@ -231,13 +232,14 @@ func (o *Orchestrator) hydrateFlashblocksWebsocketProxyMaybe(net *descriptors.L2
 	}
 
 	for _, instance := range fbWsProxyService {
-		wsUrl, _, err := o.findProtocolService(instance, WebsocketFlashblocksProtocol)
+		wsUrl, wsHeaders, err := o.findProtocolService(instance, WebsocketFlashblocksProtocol)
 		require.NoError(err, "failed to get the websocket url for the flashblocks websocket proxy", "service", instance.Name)
 
 		fbWsProxyShim := shim.NewFlashblocksWebsocketProxy(shim.FlashblocksWebsocketProxyConfig{
 			CommonConfig: shim.NewCommonConfig(l2Net.T()),
 			ID:           stack.NewFlashblocksWebsocketProxyID(instance.Name, l2ID.ChainID()),
 			WsUrl:        wsUrl,
+			WsHeaders:    wsHeaders,
 		})
 		fbWsProxyShim.SetLabel(match.LabelVendor, string(match.FlashblocksWebsocketProxy))
 		l2Net.AddFlashblocksWebsocketProxy(fbWsProxyShim)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Full flashblocks implementation for kurtosis, tested with `just flash-devnet && DEVNET_ENV_URL="kt://flash-devnet" DEVSTACK_ORCHESTRATOR=sysext go test -timeout 600s github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks`.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
