### PR TITLE
op-program: Disable go1.25 annotation of anonymous memory mappings.

### DIFF
--- a/op-program/client/cmd/godebug.go
+++ b/op-program/client/cmd/godebug.go
@@ -1,0 +1,8 @@
+// Disable annotating anonymous memory mappings. Cannon doesn't support this syscall
+// The directive (and functionality) only exists on go1.25 and above so this file is conditionally included.
+
+//go:build go1.25
+
+//go:debug decoratemappings=0
+
+package main


### PR DESCRIPTION
**Description**

Prepares for go 1.25 to avoid it needing the prctl syscall which cannon doesn't support.

**Tests**

Verified manually (`go list -f '{{.DefaultGODEBUG}}' ./op-program/client/cmd/` with go 1.25) and running cannon tests but we're not yet at the point where it makes sense to try and merge the go1.25 version of cannon tests due to other issues.


**Metadata**

https://github.com/ethereum-optimism/optimism/issues/17060