### PR TITLE
feat(cannon): reduce info logging frequency from %100000 to %1000000

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -99,7 +99,7 @@ var (
 	RunInfoAtFlag = &cli.GenericFlag{
 		Name:     "info-at",
 		Usage:    "step pattern to print info at: " + patternHelp,
-		Value:    MustStepMatcherFlag("%100000"),
+		Value:    MustStepMatcherFlag("%1000000"),
 		Required: false,
 	}
 	RunPProfCPU = &cli.BoolFlag{

--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -99,7 +99,7 @@ var (
 	RunInfoAtFlag = &cli.GenericFlag{
 		Name:     "info-at",
 		Usage:    "step pattern to print info at: " + patternHelp,
-		Value:    MustStepMatcherFlag("%1000000"),
+		Value:    MustStepMatcherFlag("%1000000000"),
 		Required: false,
 	}
 	RunPProfCPU = &cli.BoolFlag{


### PR DESCRIPTION
Reduce the default progress logging frequency for long-running cannon processes

The current default `--info-at "%100000"` produces excessive logs during long-running fault proof executions:

```
level=INFO msg="processing" step=100000 pc=0x00061a80 insn=0x8c0006a0 ips=4840632.11 pages=101 mem=1512KB name="main.main" time=20.658459ms
level=INFO msg="processing" step=200000 pc=0x000c3500 insn=0x8c000d40 ips=3076743.58 pages=201 mem=2512KB name="main.main" time=65.003792ms
level=INFO msg="processing" step=300000 pc=0x00124f80 insn=0x8c0003e0 ips=2794977.89 pages=301 mem=3512KB name="main.main" time=107.335375ms
```
