### PR TITLE
fix(justfiles): correct package paths using justfile_directory()

### DIFF
--- a/op-alt-da/justfile
+++ b/op-alt-da/justfile
@@ -7,10 +7,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/da-server"
+BINARY := justfile_directory() + "/bin/da-server"
+PACKAGE := justfile_directory() + "/cmd/daserver"
 
 # Build the da-server binary
-da-server: (go_build BINARY "./cmd/daserver" "-ldflags" _LDFLAGSSTRING)
+da-server: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Remove build artifacts
 clean:

--- a/op-batcher/justfile
+++ b/op-batcher/justfile
@@ -7,10 +7,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/op-batcher"
+BINARY := justfile_directory() + "/bin/op-batcher"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-batcher binary
-op-batcher: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-batcher: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-challenger/justfile
+++ b/op-challenger/justfile
@@ -9,10 +9,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X github.com/ethereum-optimism/optimism/op-challenger/version.Meta=" + _VERSION_META_STR + " " + \
     "") + "'"
 
-BINARY := "./bin/op-challenger"
+BINARY := justfile_directory() + "/bin/op-challenger"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-challenger binary
-op-challenger: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-challenger: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Run fuzzing tests
 fuzz: (go_fuzz "FuzzKeccak" "10s" "./game/keccak/matrix")

--- a/op-conductor/justfile
+++ b/op-conductor/justfile
@@ -7,10 +7,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/op-conductor"
+BINARY := justfile_directory() + "/bin/op-conductor"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-conductor binary
-op-conductor: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-conductor: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-dispute-mon/justfile
+++ b/op-dispute-mon/justfile
@@ -8,10 +8,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X github.com/ethereum-optimism/optimism/op-dispute-mon/version.Meta=" + VERSION_META + " " + \
     "") + "'"
 
-BINARY := "./bin/op-dispute-mon"
+BINARY := justfile_directory() + "/bin/op-dispute-mon"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-dispute-mon binary
-op-dispute-mon: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-dispute-mon: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-dripper/justfile
+++ b/op-dripper/justfile
@@ -7,10 +7,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/op-dripper"
+BINARY := justfile_directory() + "/bin/op-dripper"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-dripper binary
-op-dripper: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-dripper: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-faucet/justfile
+++ b/op-faucet/justfile
@@ -8,10 +8,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Meta=" + VERSION_META + " " + \
     "") + "'"
 
-BINARY := "./bin/op-faucet"
+BINARY := justfile_directory() + "/bin/op-faucet"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-faucet binary
-op-faucet: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-faucet: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-interop-mon/justfile
+++ b/op-interop-mon/justfile
@@ -7,10 +7,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/op-interop-mon"
+BINARY := justfile_directory() + "/bin/op-interop-mon"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-interop-mon binary
-op-interop-mon: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-interop-mon: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-node/justfile
+++ b/op-node/justfile
@@ -8,10 +8,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X github.com/ethereum-optimism/optimism/op-node/version.Meta=" + VERSION_META + " " + \
     "") + "'"
 
-BINARY := "./bin/op-node"
+BINARY := justfile_directory() + "/bin/op-node"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-node binary
-op-node: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-node: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-proposer/justfile
+++ b/op-proposer/justfile
@@ -7,10 +7,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/op-proposer"
+BINARY := justfile_directory() + "/bin/op-proposer"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-proposer binary
-op-proposer: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-proposer: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-supervisor/justfile
+++ b/op-supervisor/justfile
@@ -8,10 +8,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Meta=" + VERSION_META + " " + \
     "") + "'"
 
-BINARY := "./bin/op-supervisor"
+BINARY := justfile_directory() + "/bin/op-supervisor"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-supervisor binary
-op-supervisor: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-supervisor: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-sync-tester/justfile
+++ b/op-sync-tester/justfile
@@ -8,10 +8,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Meta=" + VERSION_META + " " + \
     "") + "'"
 
-BINARY := "./bin/op-sync-tester"
+BINARY := justfile_directory() + "/bin/op-sync-tester"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-sync-tester binary
-op-sync-tester: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-sync-tester: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-test-sequencer/justfile
+++ b/op-test-sequencer/justfile
@@ -8,10 +8,11 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Meta=" + VERSION_META + " " + \
     "") + "'"
 
-BINARY := "./bin/op-test-sequencer"
+BINARY := justfile_directory() + "/bin/op-test-sequencer"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-test-sequencer binary
-op-test-sequencer: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-test-sequencer: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)
 
 # Clean build artifacts
 clean:

--- a/op-wheel/justfile
+++ b/op-wheel/justfile
@@ -7,7 +7,8 @@ _LDFLAGSSTRING := "'" + trim(
     "-X main.Version=" + VERSION + " " + \
     "") + "'"
 
-BINARY := "./bin/op-wheel"
+BINARY := justfile_directory() + "/bin/op-wheel"
+PACKAGE := justfile_directory() + "/cmd"
 
 # Build op-wheel binary
-op-wheel: (go_build BINARY "./cmd" "-ldflags" _LDFLAGSSTRING)
+op-wheel: (go_build BINARY PACKAGE "-ldflags" _LDFLAGSSTRING)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

- Fix hardcoded relative paths that caused build issues
- Ensure proper path resolution across all component justfiles

This resolves build path resolution issues when running justfile recipes from different working directories.


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

When execute `make build-go`, the below error reports. It's because the target package path is wrong:

```
$ make build-go

just  ./op-node/op-node
env GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v  -ldflags '-X main.GitCommit=819a86f42b7f1474b9a2af3c1fb4cc7599332fd8 -X main.GitDate=1755936010 -X github.com/ethereum-optimism/optimism/op-node/version.Version=}} -X github.com/ethereum-optimism/optimism/op-node/version.Meta=' -o ./bin/op-node ./cmd
stat <....>/optimism/justfiles/cmd: directory not found
error: Recipe `go_build` failed on line 20 with exit code 1
make: *** [Makefile:95: op-node] Error 1
```

Wrong package path: <....>/optimism/justfiles/cmd
Corrected package path: <....>/optimism/op-node/cmd


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
