### PR TITLE
fix: correct typos in relay test documentation

### DIFF
--- a/kurtosis-devnet/pkg/kurtosis/endpoints.go
+++ b/kurtosis-devnet/pkg/kurtosis/endpoints.go
@@ -298,7 +298,7 @@ func (f *ServiceFinder) FindL2Services(s *spec.ChainSpec) ([]descriptors.Node, d
 // TODO: remove this once we remove the devnet-sdk/system test framework.
 // At that point the order of the nodes will not be important anymore.
 func reorderNodes(nodes []descriptors.Node) []descriptors.Node {
-	// This is a hack to preserve some compatibililty with prior expectations,
+	// This is a hack to preserve some compatibility with prior expectations,
 	// that were embedded in the devnet-sdk/system test framework.
 	//
 	// We need to rearrange the order of the nodes so that:

--- a/op-acceptance-tests/tests/interop/loadtest/relay_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/relay_test.go
@@ -52,7 +52,7 @@ func (r *RelaySpammer) Spam(t devtest.T) error {
 }
 
 // TestRelaySteady runs the Relay spammer on a Steady schedule. A single execution of the Relay
-// spammer sends one initating message on the source chain and one corresponding executing message
+// spammer sends one initiating message on the source chain and one corresponding executing message
 // on the destination chain.
 func TestRelaySteady(gt *testing.T) {
 	t, l2A, l2B := setupLoadTest(gt)

--- a/op-service/txinclude/txbudget.go
+++ b/op-service/txinclude/txbudget.go
@@ -38,7 +38,7 @@ func NewTxBudget(inner BasicBudget, opts ...TxBudgetOption) *TxBudget {
 
 var _ Budget = (*TxBudget)(nil)
 
-// BeforeResubmit calculates the cost of tx. If the new cost is greather than oldCost, it debits
+// BeforeResubmit calculates the cost of tx. If the new cost is greater than oldCost, it debits
 // the difference. If the new cost is less than oldCost, it credits the difference.
 func (b *TxBudget) BeforeResubmit(oldCost eth.ETH, tx *types.Transaction) (eth.ETH, error) {
 	// Gas cost.

--- a/op-service/txintent/bindings/base.go
+++ b/op-service/txintent/bindings/base.go
@@ -476,7 +476,7 @@ func (c *TypedCall[ReturnType]) DecodeOutput(data []byte) (ReturnType, error) {
 	// try to unpack assuming every field is static
 	decoded, err := outputs.Unpack(data)
 	if err != nil {
-		// at lest one dynamic field is included so unpack by mimicing abi.UnpackIntoInterface method
+		// at lest one dynamic field is included so unpack by mimicking abi.UnpackIntoInterface method
 		args := abi.Arguments{}
 		for idx, component := range components {
 			t, err := abi.NewType(component.Type, "", component.Components)

--- a/op-supervisor/supervisor/backend/db/update.go
+++ b/op-supervisor/supervisor/backend/db/update.go
@@ -111,7 +111,7 @@ func (db *ChainsDB) initializedUpdateLocalSafe(chain eth.ChainID, source eth.Blo
 			return
 		}
 		if errors.Is(err, types.ErrDataCorruption) {
-			logger.Error("DB coruption occurred", "err", err)
+			logger.Error("DB corruption occurred", "err", err)
 			return
 		}
 		logger.Warn("Failed to update local safe", "err", err)

--- a/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
+++ b/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
@@ -102,7 +102,7 @@ contract DataAvailabilityChallenge is OwnableUpgradeable, ISemver {
     /// @dev The value is estimated by measuring the cost of resolving with `bytes(0)`
     uint256 public constant fixedResolutionCost = 72925;
 
-    /// @notice The variable cost of resolving a callenge per byte scaled by the variableResolutionCostPrecision.
+    /// @notice The variable cost of resolving a challenge per byte scaled by the variableResolutionCostPrecision.
     /// @dev upper limit; The value is estimated by measuring the cost of resolving with variable size data where each
     /// byte is non-zero.
     uint256 public constant variableResolutionCost = 16640;

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -17,7 +17,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @custom:proxied true
 /// @title L1StandardBridge
-/// @notice The L1StandardBridge is responsible for transfering ETH and ERC20 tokens between L1 and
+/// @notice The L1StandardBridge is responsible for transferring ETH and ERC20 tokens between L1 and
 ///         L2. In the case that an ERC20 token is native to L1, it will be escrowed within this
 ///         contract. If the ERC20 token is native to L2, it will be burnt. Before Bedrock, ETH was
 ///         stored within this contract. After Bedrock, ETH is instead stored inside the

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -27,7 +27,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @custom:value FEE_SCALARS          Represents an update to l1 data fee scalars.
     /// @custom:value GAS_LIMIT            Represents an update to gas limit on L2.
     /// @custom:value UNSAFE_BLOCK_SIGNER  Represents an update to the signer key for unsafe
-    ///                                    block distrubution.
+    ///                                    block distribution.
     enum UpdateType {
         BATCHER,
         FEE_SCALARS,

--- a/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -15,7 +15,7 @@ import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000010
 /// @title L2StandardBridge
-/// @notice The L2StandardBridge is responsible for transfering ETH and ERC20 tokens between L1 and
+/// @notice The L2StandardBridge is responsible for transferring ETH and ERC20 tokens between L1 and
 ///         L2. In the case that an ERC20 token is native to L2, it will be escrowed within this
 ///         contract. If the ERC20 token is native to L1, it will be burnt.
 ///         NOTE: this contract is not intended to support all variations of ERC20 tokens. Examples

--- a/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol
@@ -92,7 +92,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
 
     /// @notice Emitted whenever a message is successfully relayed on this chain.
     /// @param source       Chain ID of the source chain.
-    /// @param messageNonce Nonce associated with the messsage sent
+    /// @param messageNonce Nonce associated with the message sent
     /// @param messageHash  Hash of the message that was relayed.
     /// @param returnDataHash Hash of the return data from the message that was relayed.
     event RelayedMessage(
@@ -281,7 +281,7 @@ contract L2ToL2CrossDomainMessenger is ISemver, TransientReentrancyAware {
     /// @param _payload         Payload of the SentMessage event.
     /// @return destination_    Destination chain ID.
     /// @return target_         Target contract of the message.
-    /// @return nonce_          Nonce associated with the messsage sent.
+    /// @return nonce_          Nonce associated with the message sent.
     /// @return sender_         Address initiating this message call.
     /// @return message_        Message payload to call target with.
     function _decodeSentMessagePayload(bytes calldata _payload)

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -98,7 +98,7 @@ contract PreimageOracle is ISemver {
     mapping(address => mapping(uint256 => LPPMetaData)) public proposalMetadata;
     /// @notice Mapping of claimants to proposal UUIDs to bond amounts.
     mapping(address => mapping(uint256 => uint256)) public proposalBonds;
-    /// @notice Mapping of claimants to proposal UUIDs to the preimage part picked up during the absorbtion process.
+    /// @notice Mapping of claimants to proposal UUIDs to the preimage part picked up during the absorption process.
     mapping(address => mapping(uint256 => bytes32)) public proposalParts;
     /// @notice Mapping of claimants to proposal UUIDs to blocks which leaves were added to the merkle tree.
     mapping(address => mapping(uint256 => uint64[])) public proposalBlocks;

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -91,7 +91,7 @@ library VMStatuses {
     /// @notice The VM has executed successfully and the outcome is invalid.
     VMStatus internal constant INVALID = VMStatus.wrap(1);
 
-    /// @notice The VM has paniced.
+    /// @notice The VM has panicked.
     VMStatus internal constant PANIC = VMStatus.wrap(2);
 
     /// @notice The VM execution is still in progress.

--- a/packages/contracts-bedrock/src/libraries/Bytes.sol
+++ b/packages/contracts-bedrock/src/libraries/Bytes.sol
@@ -76,7 +76,7 @@ library Bytes {
     }
 
     /// @notice Slices a byte array with a given starting index up to the end of the original byte
-    ///         array. Returns a new array rathern than a pointer to the original.
+    ///         array. Returns a new array rather than a pointer to the original.
     /// @param _bytes Byte array to slice.
     /// @param _start Starting index of the slice.
     /// @return Slice of the input byte array.

--- a/packages/contracts-bedrock/src/libraries/Storage.sol
+++ b/packages/contracts-bedrock/src/libraries/Storage.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /// @title Storage
-/// @notice Storage handles reading and writing to arbitary storage locations
+/// @notice Storage handles reading and writing to arbitrary storage locations
 library Storage {
     /// @notice Returns an address stored in an arbitrary storage slot.
     ///         These storage slots decouple the storage layout from

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -424,7 +424,7 @@ abstract contract CrossDomainMessenger is
     function _isOtherMessenger() internal view virtual returns (bool);
 
     /// @notice Checks whether a given call target is a system address that could cause the
-    ///         messenger to peform an unsafe action. This is NOT a mechanism for blocking user
+    ///         messenger to perform an unsafe action. This is NOT a mechanism for blocking user
     ///         addresses. This is ONLY used to prevent the execution of messages to specific
     ///         system addresses that could cause security issues, e.g., having the
     ///         CrossDomainMessenger send messages to itself.


### PR DESCRIPTION
## Summary
Fixed a minor spelling errors in the test documentation comment.

