### PR TITLE
op-e2e: remove deprecated Public field from RPC API definitions

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -247,7 +247,6 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 			Namespace:     "admin",
 			Version:       "",
 			Service:       node.NewAdminAPI(backend, log),
-			Public:        true, // TODO: this field is deprecated. Do we even need this anymore?
 			Authenticated: false,
 		},
 		{


### PR DESCRIPTION
Removes the deprecated `Public` field from RPC API configurations in the L2 verifier test helper.

The `Public` field has been deprecated in go-ethereum's RPC system and is no longer processed by `RegisterApis()`. Evidence:

1. **Same file consistency**: The `opstack` API definition on line 254-256 already omits the `Public` field
2. **Modern pattern**: Current RPC registrations use only `Namespace`, `Service`, and `Authenticated` fields
3. **No functional impact**: Access control is now handled via the `Authenticated` field

This cleanup removes technical debt and aligns the code with current go-ethereum RPC patterns.