### PR TITLE
docs: fix typo in documentation

### DIFF
--- a/.cursor/rules/solidity-styles.mdc
+++ b/.cursor/rules/solidity-styles.mdc
@@ -14,7 +14,7 @@ Applies to Solidity files.
 - Custom tags:
   - `@custom:proxied`: Add to a contract whenever it's meant to live behind a proxy
   - `@custom:upgradeable`: Add to a contract whenever it's meant to be inherited by an upgradeable contract
-  - `@custom:semver`: Add to `version` variable which indicate the contracts semver
+  - `@custom:semver`: Add to `version` variable which indicates the contract’s semver
   - `@custom:legacy`: Add to an event or function when it only exists for legacy support
   - `@custom:network-specific`: Add to state variables which vary between OP Chains
 


### PR DESCRIPTION
**Description**

"which indicate" → "which indicates"

