### PR TITLE
challenger: Add a metric to report the number of consecutive failures

### DIFF
--- a/op-challenger/metrics/vm.go
+++ b/op-challenger/metrics/vm.go
@@ -112,6 +112,11 @@ func NewVmMetrics(namespace string, factory metrics.Factory) *VmMetrics {
 			Name:      "vm_step_count",
 			Help:      "Number of steps executed during vm run",
 		}, []string{"vm"}),
+		vmInstructionCacheMissCount: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "vm_instruction_cache_miss_count",
+			Help:      "Number of instructions cache missed during vm run",
+		}, []string{"vm"}),
 		vmRmwSuccessCount: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "vm_rmw_success_count",


### PR DESCRIPTION
**Description**

Allows ignoring transient errors in setup because a source node is briefly offline. Currently we get alerts for even a single setup failure which creates a lot of un-actionable noise.

Also fixes a nil reference in VM metrics because the instruction cache miss count gauge wasn't created.

**Metadata**

Will at least help with https://github.com/ethereum-optimism/optimism/issues/16931