### PR TITLE
op-sync-tester: implement L2ELNode interface with sync tester

### DIFF
--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -93,9 +93,3 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		return WithOpNode(l2CLID, l1CLID, l1ELID, l2ELID, opts...)
 	}
 }
-
-// WithL2CLNodeWithSyncTester is a convenience function that accepts a SyncTester
-// This allows configuring a CL node with a SyncTester instead of an L2EL node
-func WithL2CLNodeWithSyncTester(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, opts ...L2CLOption) stack.Option[*Orchestrator] {
-	return WithOpNode(l2CLID, l1CLID, l1ELID, nil, opts...)
-}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type OpNode struct {
@@ -141,7 +140,7 @@ func (n *OpNode) Stop() {
 	n.opNode = nil
 }
 
-func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELOrSyncTester interface{}, opts ...L2CLOption) stack.Option[*Orchestrator] {
+func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID, opts ...L2CLOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
 
@@ -156,43 +155,14 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		l1CL, ok := orch.l1CLs.Get(l1CLID)
 		require.True(ok, "l1 CL node required")
 
-		// Handle either L2EL node or SyncTester
-		var l2EL L2ELNode
-		var l2ELID stack.L2ELNodeID
-		var syncTesterID *stack.SyncTesterID
+		// Get the L2EL node (which can be a regular EL node or a SyncTesterEL)
+		l2EL, ok := orch.l2ELs.Get(l2ELID)
+		require.True(ok, "l2 EL node required")
+
+		// Get dependency set from cluster if available
 		var depSet depset.DependencySet
-		var useSyncTester bool
-		var fcus sttypes.FCUState
-
-		switch v := l2ELOrSyncTester.(type) {
-		case stack.L2ELNodeID:
-			l2ELID = v
-			l2EL, ok = orch.l2ELs.Get(v)
-			require.True(ok, "l2 EL node required")
-			if cluster, ok := orch.ClusterForL2(v.ChainID()); ok {
-				depSet = cluster.DepSet()
-			}
-		case nil:
-			syncTester := orch.syncTester
-			syncTesterID = &syncTester.id
-
-			useSyncTester = true
-
-			for _, st := range orch.syncTester.service.SyncTesters() {
-				if st.ChainID == syncTesterID.ChainID() {
-					fcus = st.Target
-					break
-				}
-			}
-			require.NotNil(fcus, "target blocks not found for sync tester")
-
-			// When using a SyncTester, we don't need an L2EL node
-			// The SyncTester will provide the L2 endpoint
-			if cluster, ok := orch.ClusterForL2(syncTesterID.ChainID()); ok {
-				depSet = cluster.DepSet()
-			}
-		default:
-			require.Fail("l2ELOrSyncTester must be either stack.L2ELNodeID or nil")
+		if cluster, ok := orch.ClusterForL2(l2ELID.ChainID()); ok {
+			depSet = cluster.DepSet()
 		}
 
 		cfg := DefaultL2CLConfig()
@@ -267,15 +237,8 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			}
 		}
 
-		// Determine the L2 endpoint based on whether we're using a SyncTester or L2EL
-		var l2EngineAddr string
-		if useSyncTester {
-			require.NotNil(orch.syncTester, "sync tester service required when using SyncTester")
-			l2EngineAddr = orch.syncTester.service.NewEndpoint(syncTesterID.ChainID())
-			l2EngineAddr += fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", fcus.Latest, fcus.Safe, fcus.Finalized)
-		} else {
-			l2EngineAddr = l2EL.EngineRPC()
-		}
+		// Get the L2 engine address from the EL node (which can be a regular EL node or a SyncTesterEL)
+		l2EngineAddr := l2EL.EngineRPC()
 
 		nodeCfg := &config.Config{
 			L1: &config.L1EndpointConfig{
@@ -343,10 +306,8 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			p:      p,
 		}
 
-		// Set the EL field only if we have an L2EL node
-		if !useSyncTester {
-			l2CLNode.el = &l2ELID
-		}
+		// Set the EL field to link to the L2EL node
+		l2CLNode.el = &l2ELID
 		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), fmt.Sprintf("must not already exist: %s", l2CLID))
 		l2CLNode.Start()
 		p.Cleanup(l2CLNode.Stop)

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
@@ -20,8 +21,12 @@ type SyncTesterEL struct {
 	id      stack.L2ELNodeID
 	l2Net   *L2Network
 	jwtPath string
+
 	authRPC string
 	userRPC string
+
+	authProxy *tcpproxy.Proxy
+	userProxy *tcpproxy.Proxy
 
 	// Sync tester specific fields
 	clNodeID stack.L2CLNodeID
@@ -68,12 +73,34 @@ func (n *SyncTesterEL) Start() {
 	// Use NewEndpoint to get the correct session-specific endpoint for this chain ID
 	endpoint := n.orch.syncTester.service.NewEndpoint(n.id.ChainID())
 
-	session := fmt.Sprintf("%s?latest=%d&safe=%d&finalized=%d",
-		endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+	if n.authProxy == nil {
+		n.authProxy = tcpproxy.New(n.p.Logger().New("proxy", "l2el-synctester-auth"))
+		n.p.Require().NoError(n.authProxy.Start())
+		n.p.Cleanup(func() {
+			n.authProxy.Close()
+		})
 
-	// For sync tester, the engine RPC and user RPC should include FCU state as query parameters
-	n.userRPC = session
-	n.authRPC = session
+		rpc := "http://" + n.authProxy.Addr()
+		n.authRPC = fmt.Sprintf("%s%s?latest=%d&safe=%d&finalized=%d",
+			rpc, endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+	}
+	if n.userProxy == nil {
+		n.userProxy = tcpproxy.New(n.p.Logger().New("proxy", "l2el-synctester-user"))
+		n.p.Require().NoError(n.userProxy.Start())
+		n.p.Cleanup(func() {
+			n.userProxy.Close()
+		})
+
+		rpc := "http://" + n.userProxy.Addr()
+		n.userRPC = fmt.Sprintf("%s%s?latest=%d&safe=%d&finalized=%d",
+			rpc, endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+	}
+
+	session := fmt.Sprintf("%s%s?latest=%d&safe=%d&finalized=%d",
+		n.orch.syncTester.service.RPC(), endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+
+	n.authProxy.SetUpstream(ProxyAddr(n.p.Require(), session))
+	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), session))
 }
 
 func (n *SyncTesterEL) Stop() {
@@ -113,8 +140,6 @@ func WithSyncTesterL2ELNode(id stack.L2ELNodeID, clNodeID stack.L2CLNodeID, fcuS
 			id:       id,
 			l2Net:    l2Net,
 			jwtPath:  jwtPath,
-			authRPC:  "",
-			userRPC:  "",
 			clNodeID: clNodeID,
 			fcuState: fcuState,
 			p:        p,

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/client"
-	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
@@ -28,9 +27,6 @@ type SyncTesterEL struct {
 	clNodeID stack.L2CLNodeID
 	fcuState sttypes.FCUState
 	p        devtest.P
-
-	// Internal sync tester service
-	service *synctester.Service
 
 	// Reference to the orchestrator to find the EL node to connect to
 	orch *Orchestrator

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -66,12 +66,14 @@ func (n *SyncTesterEL) Start() {
 	}
 
 	// Use NewEndpoint to get the correct session-specific endpoint for this chain ID
-	syncTesterEndpoint := n.orch.syncTester.service.NewEndpoint(n.id.ChainID())
+	endpoint := n.orch.syncTester.service.NewEndpoint(n.id.ChainID())
 
-	n.userRPC = syncTesterEndpoint
-	// For sync tester, the engine RPC should include FCU state as query parameters
-	n.authRPC = fmt.Sprintf("%s?latest=%d&safe=%d&finalized=%d",
-		syncTesterEndpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+	session := fmt.Sprintf("%s?latest=%d&safe=%d&finalized=%d",
+		endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+
+	// For sync tester, the engine RPC and user RPC should include FCU state as query parameters
+	n.userRPC = session
+	n.authRPC = session
 }
 
 func (n *SyncTesterEL) Stop() {

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -1,0 +1,132 @@
+package sysgo
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+)
+
+// SyncTesterEL is an L2ELNode implementation that runs a sync tester service.
+// It provides RPC endpoints that can be used by CL nodes for testing sync functionality.
+type SyncTesterEL struct {
+	mu sync.Mutex
+
+	id      stack.L2ELNodeID
+	l2Net   *L2Network
+	jwtPath string
+	authRPC string
+	userRPC string
+
+	// Sync tester specific fields
+	clNodeID stack.L2CLNodeID
+	fcuState sttypes.FCUState
+	p        devtest.P
+
+	// Internal sync tester service
+	service *synctester.Service
+
+	// Reference to the orchestrator to find the EL node to connect to
+	orch *Orchestrator
+}
+
+var _ L2ELNode = (*SyncTesterEL)(nil)
+
+func (n *SyncTesterEL) hydrate(system stack.ExtensibleSystem) {
+	require := system.T().Require()
+	rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), n.userRPC, client.WithLazyDial())
+	require.NoError(err)
+	system.T().Cleanup(rpcCl.Close)
+
+	l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID()))
+	sysL2EL := shim.NewL2ELNode(shim.L2ELNodeConfig{
+		RollupCfg: l2Net.RollupConfig(),
+		ELNodeConfig: shim.ELNodeConfig{
+			CommonConfig: shim.NewCommonConfig(system.T()),
+			Client:       rpcCl,
+			ChainID:      n.id.ChainID(),
+		},
+		ID: n.id,
+	})
+	sysL2EL.SetLabel(match.LabelVendor, "sync-tester")
+	l2Net.(stack.ExtensibleL2Network).AddL2ELNode(sysL2EL)
+}
+
+func (n *SyncTesterEL) Start() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// The SyncTesterEL should connect to the existing sync tester service
+	// Get the endpoint from the orchestrator's syncTester service
+	if n.orch.syncTester == nil || n.orch.syncTester.service == nil {
+		n.p.Logger().Error("syncTester service not available in orchestrator")
+		return
+	}
+
+	// Use NewEndpoint to get the correct session-specific endpoint for this chain ID
+	syncTesterEndpoint := n.orch.syncTester.service.NewEndpoint(n.id.ChainID())
+
+	n.userRPC = syncTesterEndpoint
+	// For sync tester, the engine RPC should include FCU state as query parameters
+	n.authRPC = fmt.Sprintf("%s?latest=%d&safe=%d&finalized=%d",
+		syncTesterEndpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+}
+
+func (n *SyncTesterEL) Stop() {
+	// The SyncTesterEL is just a proxy, so there's nothing to stop
+}
+
+func (n *SyncTesterEL) UserRPC() string {
+	return n.userRPC
+}
+
+func (n *SyncTesterEL) EngineRPC() string {
+	return n.authRPC
+}
+
+func (n *SyncTesterEL) JWTPath() string {
+	return n.jwtPath
+}
+
+// WithSyncTesterL2ELNode creates a SyncTesterEL that satisfies the L2ELNode interface
+// and configures a sync tester for a given CL node.
+// The sync tester acts as an EL node that can be used by CL nodes for testing sync.
+func WithSyncTesterL2ELNode(id stack.L2ELNodeID, clNodeID stack.L2CLNodeID, fcuState sttypes.FCUState, opts ...L2ELOption) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
+		require := p.Require()
+
+		l2Net, ok := orch.l2Nets.Get(id.ChainID())
+		require.True(ok, "L2 network required")
+
+		cfg := DefaultL2ELConfig()
+		orch.l2ELOptions.Apply(p, id, cfg)       // apply global options
+		L2ELOptionBundle(opts).Apply(p, id, cfg) // apply specific options
+
+		jwtPath, _ := orch.writeDefaultJWT()
+
+		syncTesterEL := &SyncTesterEL{
+			id:       id,
+			l2Net:    l2Net,
+			jwtPath:  jwtPath,
+			authRPC:  "",
+			userRPC:  "",
+			clNodeID: clNodeID,
+			fcuState: fcuState,
+			p:        p,
+			orch:     orch,
+		}
+
+		p.Logger().Info("Starting sync tester EL", "id", id, "clNodeID", clNodeID)
+		syncTesterEL.Start()
+		p.Cleanup(syncTesterEL.Stop)
+		p.Logger().Info("sync tester EL is ready", "userRPC", syncTesterEL.userRPC, "authRPC", syncTesterEL.authRPC)
+		require.True(orch.l2ELs.SetIfMissing(id, syncTesterEL), "must be unique L2 EL node")
+	})
+}

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -42,7 +42,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	}
 }
 
-func WithSyncTester(l2ELs []stack.L2ELNodeID, fcus sttypes.FCUState) stack.Option[*Orchestrator] {
+func WithSyncTester(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))
@@ -66,7 +66,7 @@ func WithSyncTester(l2ELs []stack.L2ELNodeID, fcus sttypes.FCUState) stack.Optio
 				// JwtPath:   el.jwtPath,
 				Cfg: stconf.EntryCfg{
 					ChainID: elID.ChainID(),
-					Target:  fcus,
+					Target:  sttypes.FCUState{}, // Default empty FCU state
 				},
 			}
 		}

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -26,7 +26,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
 	for syncTesterID, chainID := range n.service.SyncTesters() {
-		syncTesterRPC := n.service.NewEndpoint(chainID)
+		syncTesterRPC := n.service.RPC() + n.service.NewEndpoint(chainID)
 		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
 		require.NoError(err)
 		system.T().Cleanup(rpcCl.Close)

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -25,8 +25,7 @@ type SyncTester struct {
 func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
-	for syncTesterID, cfg := range n.service.SyncTesters() {
-		chainID := cfg.ChainID
+	for syncTesterID, chainID := range n.service.SyncTesters() {
 		syncTesterRPC := n.service.NewEndpoint(chainID)
 		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
 		require.NoError(err)
@@ -61,13 +60,8 @@ func WithSyncTester(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 			require.True(ok, "need L2 EL for sync tester", elID)
 
 			syncTesters[id] = &stconf.SyncTesterEntry{
-				ELRPC: endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},
-				// EngineRPC: endpoint.MustRPC{Value: endpoint.URL(el.authRPC)},
-				// JwtPath:   el.jwtPath,
-				Cfg: stconf.EntryCfg{
-					ChainID: elID.ChainID(),
-					Target:  sttypes.FCUState{}, // Default empty FCU state
-				},
+				ELRPC:   endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},
+				ChainID: elID.ChainID(),
 			}
 		}
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -136,7 +136,7 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, fcus))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -59,8 +59,12 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}, fcus))
-	opt.Add(WithL2CLNodeWithSyncTester(ids.L2CL2, ids.L1CL, ids.L1EL))
+	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}))
+
+	// Create a SyncTesterEL with the same chain ID as the CL node
+	syncTesterELID := stack.NewL2ELNodeID("sync-tester-el", ids.L2CL2.ChainID())
+	opt.Add(WithSyncTesterL2ELNode(syncTesterELID, ids.L2CL2, fcus))
+	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, syncTesterELID))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -11,7 +11,7 @@ type DefaultSimpleSystemWithSyncTesterIDs struct {
 	DefaultMinimalSystemIDs
 
 	L2CL2      stack.L2CLNodeID
-	SyncTester stack.SyncTesterID
+	SyncTester stack.L2ELNodeID
 }
 
 func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimpleSystemWithSyncTesterIDs {
@@ -19,7 +19,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	return DefaultSimpleSystemWithSyncTesterIDs{
 		DefaultMinimalSystemIDs: minimal,
 		L2CL2:                   stack.NewL2CLNodeID("verifier", l2ID),
-		SyncTester:              stack.NewSyncTesterID("s", l2ID),
+		SyncTester:              stack.NewL2ELNodeID("sync-tester-el", l2ID),
 	}
 }
 
@@ -62,9 +62,8 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}))
 
 	// Create a SyncTesterEL with the same chain ID as the CL node
-	syncTesterELID := stack.NewL2ELNodeID("sync-tester-el", ids.L2CL2.ChainID())
-	opt.Add(WithSyncTesterL2ELNode(syncTesterELID, ids.L2CL2, fcus))
-	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, syncTesterELID))
+	opt.Add(WithSyncTesterL2ELNode(ids.SyncTester, ids.L2CL2, fcus))
+	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.SyncTester)))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -92,7 +92,7 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	// Set up the sync tester routes
 	var syncTesterErr error
 	b.syncTesters.Range(func(id sttypes.SyncTesterID, st *SyncTester) bool {
-		path := "/chain/" + st.cfg.ChainID.String() + "/synctest"
+		path := "/chain/" + st.chainID.String() + "/synctest"
 		if err := router.AddRPC(path); err != nil {
 			syncTesterErr = errors.Join(fmt.Errorf("failed to set up synctest route: %w", err))
 			return true
@@ -123,17 +123,10 @@ func FromConfig(log log.Logger, m metrics.Metricer, cfg *config.Config, router A
 	return b, nil
 }
 
-func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]config.EntryCfg) {
-	out = make(map[sttypes.SyncTesterID]config.EntryCfg)
+func (b *Backend) SyncTesters() (out map[sttypes.SyncTesterID]eth.ChainID) {
+	out = make(map[sttypes.SyncTesterID]eth.ChainID)
 	b.syncTesters.Range(func(key sttypes.SyncTesterID, value *SyncTester) bool {
-		out[key] = config.EntryCfg{
-			ChainID: value.cfg.ChainID,
-			Target: sttypes.FCUState{
-				Latest:    value.cfg.Target.Latest,
-				Safe:      value.cfg.Target.Safe,
-				Finalized: value.cfg.Target.Finalized,
-			},
-		}
+		out[key] = value.chainID
 		return true
 	})
 	return out

--- a/op-sync-tester/synctester/backend/backend_test.go
+++ b/op-sync-tester/synctester/backend/backend_test.go
@@ -50,28 +50,14 @@ func TestBackend(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelInfo)
 
 	syncTesterCfgA := &stconf.SyncTesterEntry{
-		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
-		Cfg: stconf.EntryCfg{
-			ChainID: eth.ChainIDFromUInt64(1),
-			Target: sttypes.FCUState{
-				Latest:    100,
-				Safe:      90,
-				Finalized: 80,
-			},
-		},
+		ELRPC:   endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
+		ChainID: eth.ChainIDFromUInt64(1),
 	}
 	syncTesterA := sttypes.SyncTesterID("syncTesterA")
 
 	syncTesterCfgB := &stconf.SyncTesterEntry{
-		ELRPC: endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
-		Cfg: stconf.EntryCfg{
-			ChainID: eth.ChainIDFromUInt64(2),
-			Target: sttypes.FCUState{
-				Latest:    101,
-				Safe:      91,
-				Finalized: 81,
-			},
-		},
+		ELRPC:   endpoint.MustRPC{Value: endpoint.URL("http://" + srv.Endpoint())},
+		ChainID: eth.ChainIDFromUInt64(2),
 	}
 	syncTesterB := sttypes.SyncTesterID("syncTesterB")
 

--- a/op-sync-tester/synctester/backend/config/static.go
+++ b/op-sync-tester/synctester/backend/config/static.go
@@ -14,13 +14,9 @@ type SyncTesterEntry struct {
 
 	// ChainID is used to sanity-check we are connected to the right chain,
 	// and never accidentally try to use a different chain for sync tester work.
-	Cfg EntryCfg `yaml:"cfg"`
+	ChainID eth.ChainID `yaml:"chain_id"`
 }
 
-type EntryCfg struct {
-	ChainID eth.ChainID      `yaml:"chain_id"`
-	Target  sttypes.FCUState `yaml:"target"`
-}
 type Config struct {
 	// SyncTesters lists all sync testers by ID
 	SyncTesters map[sttypes.SyncTesterID]*SyncTesterEntry `yaml:"synctesters,omitempty"`

--- a/op-sync-tester/synctester/backend/config/testdata/config.yaml
+++ b/op-sync-tester/synctester/backend/config/testdata/config.yaml
@@ -1,9 +1,4 @@
 synctesters:
   local:
-    cfg:
-      chain_id: 1234
-      target:
-        latest: 10
-        safe: 20
-        finalized: 30
+    chain_id: 1234
     el_rpc: https://localhost:8545

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -39,8 +39,8 @@ type SyncTester struct {
 	log log.Logger
 	m   metrics.Metricer
 
-	id  sttypes.SyncTesterID
-	cfg config.EntryCfg
+	id      sttypes.SyncTesterID
+	chainID eth.ChainID
 
 	elReader ReadOnlyELBackend
 
@@ -59,21 +59,21 @@ var _ frontend.EngineBackend = (*SyncTester)(nil)
 var _ frontend.EthBackend = (*SyncTester)(nil)
 
 func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, stCfg *config.SyncTesterEntry) (*SyncTester, error) {
-	logger = logger.New("syncTester", stID, "chain", stCfg.Cfg.ChainID)
+	logger = logger.New("syncTester", stID, "chain", stCfg.ChainID)
 	elClient, err := ethclient.Dial(stCfg.ELRPC.Value.RPC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial EL client: %w", err)
 	}
 	elReader := NewELReader(elClient)
-	return NewSyncTester(logger, m, stID, stCfg.Cfg, elReader), nil
+	return NewSyncTester(logger, m, stID, stCfg.ChainID, elReader), nil
 }
 
-func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, cfg config.EntryCfg, elReader ReadOnlyELBackend) *SyncTester {
+func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
 		log:      logger,
 		m:        m,
 		id:       stID,
-		cfg:      cfg,
+		chainID:  chainID,
 		elReader: elReader,
 		sessions: make(map[string]*Session),
 	}
@@ -223,10 +223,10 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 	if err != nil {
 		return hexutil.Big{}, err
 	}
-	if chainID.ToInt().Cmp(s.cfg.ChainID.ToBig()) != 0 {
-		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.cfg.ChainID, chainID.ToInt())
+	if chainID.ToInt().Cmp(s.chainID.ToBig()) != 0 {
+		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.chainID, chainID.ToInt())
 	}
-	return hexutil.Big(*s.cfg.ChainID.ToBig()), nil
+	return hexutil.Big(*s.chainID.ToBig()), nil
 }
 
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayload, error) {

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -96,8 +95,8 @@ func (m *MockELReader) GetBlockReceipts(ctx context.Context, bnh rpc.BlockNumber
 	return receipts, nil
 }
 
-func initTestSyncTester(t *testing.T, cfg config.EntryCfg, elReader ReadOnlyELBackend) *SyncTester {
-	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), cfg, elReader)
+func initTestSyncTester(t *testing.T, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
+	syncTester := NewSyncTester(testlog.Logger(t, log.LevelInfo), nil, sttypes.SyncTesterID("test"), chainID, elReader)
 	return syncTester
 }
 
@@ -105,26 +104,26 @@ func TestSyncTester_ChainId(t *testing.T) {
 	dummySession := &Session{SessionID: uuid.New().String()}
 	tests := []struct {
 		name            string
-		cfgID           config.EntryCfg
+		cfgID           eth.ChainID
 		elID            eth.ChainID
 		session         *Session
 		wantErrContains string
 	}{
 		{
 			name:            "no session",
-			cfgID:           config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)},
+			cfgID:           eth.ChainIDFromUInt64(1),
 			elID:            eth.ChainIDFromUInt64(1),
 			wantErrContains: "no session",
 		},
 		{
 			name:    "happy path",
-			cfgID:   config.EntryCfg{ChainID: eth.ChainIDFromUInt64(11155111)},
+			cfgID:   eth.ChainIDFromUInt64(11155111),
 			elID:    eth.ChainIDFromUInt64(11155111),
 			session: dummySession,
 		},
 		{
 			name:            "mismatch",
-			cfgID:           config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)},
+			cfgID:           eth.ChainIDFromUInt64(1),
 			elID:            eth.ChainIDFromUInt64(11155111),
 			session:         dummySession,
 			wantErrContains: "chainID mismatch",
@@ -146,7 +145,7 @@ func TestSyncTester_ChainId(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, hexutil.Big(*tc.cfgID.ChainID.ToBig()), got)
+			require.Equal(t, hexutil.Big(*tc.cfgID.ToBig()), got)
 		})
 	}
 }
@@ -192,7 +191,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			el := NewMockELReader(eth.ChainIDFromUInt64(1))
 			block := makeBlockRaw(tc.rawNumber)
 			el.BlocksByHash[hash] = block
-			st := initTestSyncTester(t, config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)}, el)
+			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -318,7 +317,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 				el.BlocksByNumber[rpc.BlockNumber(tc.session.CurrentState.Finalized)] = makeBlockRaw(tc.session.CurrentState.Finalized)
 			}
 			el.BlocksByNumber[tc.inNumber] = makeBlockRaw(uint64(tc.inNumber.Int64()))
-			st := initTestSyncTester(t, config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)}, el)
+			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)
@@ -460,7 +459,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			if tc.seedFn != nil && tc.session != nil {
 				tc.seedFn(el, tc.session)
 			}
-			st := initTestSyncTester(t, config.EntryCfg{ChainID: eth.ChainIDFromUInt64(1)}, el)
+			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
 				ctx = WithSession(ctx, tc.session)

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -215,7 +215,7 @@ func (s *Service) RPC() string {
 
 func (s *Service) NewEndpoint(chainID eth.ChainID) string {
 	uuid := uuid.New()
-	return fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
+	return fmt.Sprintf("/chain/%s/synctest/%s", chainID, uuid)
 }
 
 func (s *Service) SyncTesters() map[sttypes.SyncTesterID]eth.ChainID {

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -21,14 +21,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-sync-tester/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
-	bc "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type serviceBackend interface {
 	Stop(ctx context.Context) error
-	SyncTesters() map[sttypes.SyncTesterID]bc.EntryCfg
+	SyncTesters() map[sttypes.SyncTesterID]eth.ChainID
 }
 
 var _ serviceBackend = (*backend.Backend)(nil)
@@ -219,6 +218,6 @@ func (s *Service) NewEndpoint(chainID eth.ChainID) string {
 	return fmt.Sprintf("%s/chain/%s/synctest/%s", s.RPC(), chainID, uuid)
 }
 
-func (s *Service) SyncTesters() map[sttypes.SyncTesterID]bc.EntryCfg {
+func (s *Service) SyncTesters() map[sttypes.SyncTesterID]eth.ChainID {
 	return s.backend.SyncTesters()
 }


### PR DESCRIPTION
This PR is refactoring the SyncTester and individual sessions as a `L2ELNode` interface (similar to op-geth and op-reth), in order to simplify the setup of a network.