### PR TITLE
superchain-config: Fix fuzz test proxyAdmin constraints

### DIFF
--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -76,7 +76,7 @@ contract SuperchainConfig_Initialize_Test is SuperchainConfig_TestInit {
     ///         owner.
     /// @param _sender The address of the sender to test.
     function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not SuperProxyAdmin or SuperProxyAdmin owner.
+        // Prank as not the superchain ProxyAdmin or ProxyAdmin owner.
         vm.assume(_sender != address(superchainProxyAdmin) && _sender != superchainProxyAdminOwner);
 
         // Get the slot for _initialized.

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -76,8 +76,8 @@ contract SuperchainConfig_Initialize_Test is SuperchainConfig_TestInit {
     ///         owner.
     /// @param _sender The address of the sender to test.
     function testFuzz_initialize_notProxyAdminOrProxyAdminOwner_reverts(address _sender) public {
-        // Prank as the not ProxyAdmin or ProxyAdmin owner.
-        vm.assume(_sender != address(proxyAdmin) && _sender != proxyAdminOwner);
+        // Prank as the not SuperProxyAdmin or SuperProxyAdmin owner.
+        vm.assume(_sender != address(superchainProxyAdmin) && _sender != superchainProxyAdminOwner);
 
         // Get the slot for _initialized.
         StorageSlot memory slot = ForgeArtifacts.getSlot("SuperchainConfig", "_initialized");


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Update test to disallow the _superchain_ `ProxyAdmin` and owner rather than the regular `ProxyAdmin` and owner.  

Fixes failure reported [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/99012/workflows/6f6f7ff4-5efd-4fc1-bff8-83a38f46a761/jobs/3803217).
