### PR TITLE
op-challenger: Implement an option to restrict frequency of update cycles

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -328,6 +328,25 @@ func TestPollInterval(t *testing.T) {
 	})
 }
 
+func TestMinUpdateInterval(t *testing.T) {
+	t.Run("DefaultsToZero", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs(types.TraceTypeCannon))
+		require.Equal(t, time.Duration(0), cfg.MinUpdateInterval)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs(types.TraceTypeAlphabet, "--min-update-interval", "10m"))
+		require.Equal(t, 10*time.Minute, cfg.MinUpdateInterval)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(
+			t,
+			"invalid value \"abc\" for flag -min-update-interval",
+			addRequiredArgs(types.TraceTypeAlphabet, "--min-update-interval", "abc"))
+	})
+}
+
 func TestAsteriscOpProgramRequiredArgs(t *testing.T) {
 	traceType := types.TraceTypeAsterisc
 	t.Run(fmt.Sprintf("TestAsteriscServer-%v", traceType), func(t *testing.T) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	MaxConcurrency       uint             // Maximum number of threads to use when progressing games
 	PollInterval         time.Duration    // Polling interval for latest-block subscription when using an HTTP RPC provider
 	AllowInvalidPrestate bool             // Whether to allow responding to games where the prestate does not match
+	MinUpdateInterval    time.Duration    // Minimum duration the L1 head block time must advance before scheduling a new update cycle
 
 	AdditionalBondClaimants []common.Address // List of addresses to claim bonds for in addition to the tx manager sender
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -110,6 +110,11 @@ var (
 		EnvVars: prefixEnvVars("HTTP_POLL_INTERVAL"),
 		Value:   config.DefaultPollInterval,
 	}
+	MinUpdateInterval = &cli.DurationFlag{
+		Name:    "min-update-interval",
+		Usage:   "Minimum time between scheduling update cycles based on the L1 block time.",
+		EnvVars: prefixEnvVars("MIN_UPDATE_INTERVAL"),
+	}
 	AdditionalBondClaimants = &cli.StringSliceFlag{
 		Name:    "additional-bond-claimants",
 		Usage:   "List of addresses to claim bonds for, in addition to the configured transaction sender",
@@ -264,6 +269,7 @@ var optionalFlags = []cli.Flag{
 	L2ExperimentalEthRpcFlag,
 	MaxPendingTransactionsFlag,
 	HTTPPollInterval,
+	MinUpdateInterval,
 	AdditionalBondClaimants,
 	GameAllowlistFlag,
 	CannonL2CustomFlag,
@@ -621,6 +627,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 		L2Rpcs:                  l2Rpcs,
 		MaxPendingTx:            ctx.Uint64(MaxPendingTransactionsFlag.Name),
 		PollInterval:            ctx.Duration(HTTPPollInterval.Name),
+		MinUpdateInterval:       ctx.Duration(MinUpdateInterval.Name),
 		AdditionalBondClaimants: claimants,
 		RollupRpc:               ctx.String(RollupRpcFlag.Name),
 		SupervisorRPC:           ctx.String(SupervisorRpcFlag.Name),

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -234,7 +234,7 @@ func (s *Service) initLargePreimages() error {
 }
 
 func (s *Service) initMonitor(cfg *config.Config) {
-	s.monitor = newGameMonitor(s.logger, s.l1Clock, s.factoryContract, s.sched, s.preimages, cfg.GameWindow, s.claimer, cfg.GameAllowlist, s.pollClient)
+	s.monitor = newGameMonitor(s.logger, s.l1Clock, s.factoryContract, s.sched, s.preimages, cfg.GameWindow, s.claimer, cfg.GameAllowlist, s.pollClient, cfg.MinUpdateInterval)
 }
 
 func (s *Service) Start(ctx context.Context) error {


### PR DESCRIPTION
**Description**

Implement an option to restrict frequency of update cycles in op-challenger. By running update cycles less often, the number of calls made to the L1 node can be reduced.

**Tests**

Added unit tests and manually confirmed the behaviour.

**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/13090