### PR TITLE
op-sync-tester: Verifier Engine APIs for Bedrock, Canyon, Delta

### DIFF
--- a/op-acceptance-tests/tests/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_hfs/init_test.go
@@ -27,5 +27,4 @@ func TestMain(m *testing.M) {
 			// For supporting pre-Fjord batches
 			cfg.CompressionAlgo = derive.Zlib
 		})))
-
 }

--- a/op-acceptance-tests/tests/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_hfs/init_test.go
@@ -1,0 +1,31 @@
+package sync_tester_hfs
+
+import (
+	"testing"
+
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(sttypes.FCUState{
+		Latest:    0,
+		Safe:      0,
+		Finalized: 0,
+	}),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithHardforkSequentialActivation(rollup.Bedrock, rollup.Jovian, 15),
+		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
+			// For supporting pre-delta batches
+			cfg.BatchType = derive.SingularBatchType
+			// For supporting pre-Fjord batches
+			cfg.CompressionAlgo = derive.Zlib
+		})))
+
+}

--- a/op-acceptance-tests/tests/sync_tester_hfs/sync_tester_hfs_test.go
+++ b/op-acceptance-tests/tests/sync_tester_hfs/sync_tester_hfs_test.go
@@ -1,0 +1,34 @@
+package sync_tester_hfs
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestSyncTesterHardforks(gt *testing.T) {
+	t := devtest.SerialT(gt)
+
+	sys := presets.NewSimpleWithSyncTester(t)
+	require := t.Require()
+
+	// Hardforks will be activated from Bedrock to Isthmus, 9 hardforks with 15 second time delta between.
+	// 15 * 9 = 135s, so we need at least 69 (135 / 2 + 1) L2 blocks with block time 2 to make the CL experience scheduled hardforks.
+	targetNum := 70
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum*2+10),
+		sys.L2CL2.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum*2+10),
+	)
+
+	current := sys.L2CL2.HeadBlockRef(types.LocalUnsafe)
+
+	// Check the L2CL passed configured hardforks
+	isthmusTime := sys.L2Chain.Escape().ChainConfig().IsthmusTime
+	require.NotNil(isthmusTime, "isthmus must be activated")
+	require.Greater(current.Time, *isthmusTime, "must pass isthmus block")
+	// Check block hash state from L2CL2 which was synced using the sync tester
+	require.Equal(sys.L2EL.BlockRefByNumber(current.Number).Hash, current.Hash, "hash mismatch")
+}

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
@@ -42,4 +43,8 @@ func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {
 		SyncTester: dsl.NewSyncTester(syncTester),
 		L2CL2:      dsl.NewL2CLNode(l2CL2, orch.ControlPlane()),
 	}
+}
+
+func WithHardforkSequentialActivation(startFork, endFork rollup.ForkName, delta uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.WithDeployerOptions(sysgo.WithHardforkSequentialActivation(startFork, endFork, &delta)))
 }

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -258,6 +258,34 @@ func WithInteropAtGenesis() DeployerOption {
 	}
 }
 
+// WithHardforkSequentialActivation configures a deployment such that L2 chains
+// activate hardforks sequentially, starting from startFork and continuing
+// until (but not including) endFork. Each successive fork is scheduled at
+// an increasing offset.
+func WithHardforkSequentialActivation(startFork, endFork rollup.ForkName, delta *uint64) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithForkAtGenesis(startFork)
+			activateWithOffset := false
+			deactivate := false
+			for idx, refFork := range rollup.AllForks {
+				if deactivate || refFork == endFork {
+					l2Cfg.WithForkAtOffset(refFork, nil)
+					deactivate = true
+					continue
+				}
+				if activateWithOffset {
+					offset := *delta * uint64(idx)
+					l2Cfg.WithForkAtOffset(refFork, &offset)
+				}
+				if startFork == refFork {
+					activateWithOffset = true
+				}
+			}
+		}
+	}
+}
+
 // WithSequencingWindow overrides the number of L1 blocks in a sequencing window, applied to all L2s.
 func WithSequencingWindow(n uint64) DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -292,7 +292,7 @@ func (s *SyncTester) getPayload(session *Session, payloadID eth.PayloadID) (*eth
 	return payloadEnv, nil
 }
 
-// ForkchoiceUpdatedV2 is called for processing V1 attributes
+// ForkchoiceUpdatedV1 is called for processing V1 attributes
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	session, err := s.fetchSession(ctx)
 	if err != nil {

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -229,15 +229,31 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 	return hexutil.Big(*s.cfg.ChainID.ToBig()), nil
 }
 
-func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayload, error) {
-	return nil, nil
+// GetPayloadV1 only supports V1 payloads.
+func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+	if !payloadID.Is(engine.PayloadV1) {
+		return nil, engine.UnsupportedFork
+	}
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.getPayload(session, payloadID)
 }
 
+// GetPayloadV2 supports V1, V2 payloads.
 func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return nil, nil
+	if !payloadID.Is(engine.PayloadV1, engine.PayloadV2) {
+		return nil, engine.UnsupportedFork
+	}
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.getPayload(session, payloadID)
 }
 
-// GetPayloadV3 is functionally identical to GetPayloadV4.
+// GetPayloadV3 must be only called when Ecotone activated.
 func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	if !payloadID.Is(engine.PayloadV3) {
 		return nil, engine.UnsupportedFork
@@ -249,10 +265,7 @@ func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) 
 	return s.getPayload(session, payloadID)
 }
 
-// GetPayloadV4 retrieves an execution payload previously initialized by
-// ForkchoiceUpdated engine APIs when valid payload attributes were provided.
-// Retrieved payloads are deleted from the session after being served to
-// emulate one-time consumption by the consensus layer.
+// GetPayloadV4 must be only called when Isthmus activated.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	if !payloadID.Is(engine.PayloadV3) {
 		return nil, engine.UnsupportedFork
@@ -264,6 +277,10 @@ func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) 
 	return s.getPayload(session, payloadID)
 }
 
+// getPayload retrieves an execution payload previously initialized by
+// ForkchoiceUpdated engine APIs when valid payload attributes were provided.
+// Retrieved payloads are deleted from the session after being served to
+// emulate one-time consumption by the consensus layer.
 func (s *SyncTester) getPayload(session *Session, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	payloadEnv, ok := session.Payloads[payloadID]
 	if !ok {
@@ -275,15 +292,34 @@ func (s *SyncTester) getPayload(session *Session, payloadID eth.PayloadID) (*eth
 	return payloadEnv, nil
 }
 
+// ForkchoiceUpdatedV2 is called for processing V1 attributes
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV1, false, false)
 }
 
+// ForkchoiceUpdatedV2 is called for processing V2 attributes
 func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV2, true, false)
 }
 
-// ForkchoiceUpdatedV3 processes a forkchoice state update from the consensus
+// ForkchoiceUpdatedV3 must be only called with Ecotone attributes
+func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV3, true, true)
+}
+
+// forkchoiceUpdated processes a forkchoice state update from the consensus
 // layer, validates the request against the current execution layer state, and
 // optionally initializes a new payload build process if payload attributes are
 // provided. When payload attributes are not nil and validation succeeds, the
@@ -300,20 +336,34 @@ func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.Forkcho
 //     attributes are malformed or finalized/safe blocks are not canonical.
 //   - {status: SYNCING} when the head block is unknown or not yet validated, or
 //     when block data cannot be retrieved from the execution layer.
-func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *Session, state *eth.ForkchoiceState, attr *eth.PayloadAttributes, payloadVersion engine.PayloadVersion,
+	isCanyon, isEcotone bool,
+) (*eth.ForkchoiceUpdatedResult, error) {
 	// Validate attributes shape
 	if attr != nil {
-		// https://github.com/ethereum/execution-apis/blob/bc5a37ee69a64769bd8d0a2056672361ef5f3839/src/engine/cancun.md#engine_forkchoiceupdatedv3
-		// Spec: payloadAttributes matches the PayloadAttributesV3 structure, return -38003: Invalid payload attributes on failure.
-		if attr.Withdrawals == nil {
-			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing withdrawals"))
-		}
-		if attr.ParentBeaconBlockRoot == nil {
-			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing beacon root"))
+		if isEcotone {
+			// https://github.com/ethereum/execution-apis/blob/bc5a37ee69a64769bd8d0a2056672361ef5f3839/src/engine/cancun.md#engine_forkchoiceupdatedv3
+			// Spec: payloadAttributes matches the PayloadAttributesV3 structure, return -38003: Invalid payload attributes on failure.
+			// Ecotone activated Cancun
+			if attr.ParentBeaconBlockRoot == nil {
+				return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing beacon root"))
+			}
+			if attr.Withdrawals == nil {
+				return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing withdrawals"))
+			}
+		} else if isCanyon {
+			if attr.ParentBeaconBlockRoot != nil {
+				return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("unexpected beacon root"))
+			}
+			// Canyon activated Shanghai
+			if attr.Withdrawals == nil {
+				return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(errors.New("missing withdrawals"))
+			}
+		} else {
+			// Bedrock
+			if attr.Withdrawals != nil || attr.ParentBeaconBlockRoot != nil {
+				return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidParams.With(errors.New("withdrawals and beacon root not supported"))
+			}
 		}
 	}
 	// Simulate head block hash check
@@ -366,7 +416,8 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 			// Consider as sync error if read only EL interaction fails because we cannot validate
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 		}
-		// Implictly determine whether holocene is enabled by inspecting extraData from read only EL data
+		// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header
+		// Implicitly determine whether holocene is enabled by inspecting extraData from read only EL data
 		isHolocene := eip1559.ValidateHoloceneExtraData(newBlock.Header().Extra) == nil
 		// Sanity check attr comparing with newBlock
 		if err := s.validateAttributesForBlock(attr, newBlock, isHolocene); err != nil {
@@ -374,6 +425,9 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 			// Client software MUST respond to this method call in the following way: {error: {code: -38003, message: "Invalid payload attributes"}} if the payload is deemed VALID and forkchoiceState has been applied successfully, but no build process has been started due to invalid payloadAttributes.
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(err)
 		}
+		// https://github.com/ethereum-optimism/specs/blob/7b39adb0bea3b0a56d6d3a7d61feef5c33e49b73/specs/protocol/isthmus/exec-engine.md#header-validity-rules
+		// Implicitly determine whether isthmus is enabled by inspecting withdrawalsRoot from read only EL data
+		isIsthmus := newBlock.WithdrawalsRoot() != nil && len(*newBlock.WithdrawalsRoot()) == 32
 		// Initialize payload args for sane payload ID
 		// All attr fields already sanity checked
 		args := miner.BuildPayloadArgs{
@@ -381,20 +435,25 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 			Timestamp:    uint64(attr.Timestamp),
 			FeeRecipient: attr.SuggestedFeeRecipient,
 			Random:       common.Hash(attr.PrevRandao),
-			Withdrawals:  *attr.Withdrawals,
 			BeaconRoot:   attr.ParentBeaconBlockRoot,
 			NoTxPool:     attr.NoTxPool,
 			Transactions: newBlock.Transactions(),
 			GasLimit:     &newBlock.Header().GasLimit,
-			Version:      engine.PayloadV3,
+			Version:      payloadVersion,
+		}
+		config := &params.ChainConfig{}
+		if isCanyon {
+			args.Withdrawals = *attr.Withdrawals
+			config.CanyonTime = new(uint64)
 		}
 		if isHolocene {
 			args.EIP1559Params = (*attr.EIP1559Params)[:]
 		}
+		if isIsthmus {
+			config.IsthmusTime = new(uint64)
+		}
 		payloadID := args.Id()
 		id = &payloadID
-		// Activate Canyon and Isthmus
-		config := &params.ChainConfig{CanyonTime: new(uint64), IsthmusTime: new(uint64)}
 		payloadEnv, err := eth.BlockAsPayloadEnv(newBlock, config)
 		if err != nil {
 			// The failure is from the EL processing so consider as a server error and make CL retry
@@ -436,10 +495,10 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 	if attr.Withdrawals != nil && len(*attr.Withdrawals) != 0 {
 		return errors.New("withdrawals must be nil or empty")
 	}
-	if attr.ParentBeaconBlockRoot == nil || h.ParentBeaconRoot == nil {
-		return fmt.Errorf("parentBeaconBlockRoot must be provided")
+	if (attr.ParentBeaconBlockRoot == nil) != (h.ParentBeaconRoot == nil) {
+		return fmt.Errorf("parentBeaconBlockRoot mismatch: attr=%v, header=%v", attr.ParentBeaconBlockRoot, h.ParentBeaconRoot)
 	}
-	if (*attr.ParentBeaconBlockRoot).Cmp(*h.ParentBeaconRoot) != 0 {
+	if h.ParentBeaconRoot != nil && (*attr.ParentBeaconBlockRoot).Cmp(*h.ParentBeaconRoot) != 0 {
 		return fmt.Errorf("parentBeaconBlockRoot mismatch: attr=%s, header=%s", *attr.ParentBeaconBlockRoot, *h.ParentBeaconRoot)
 	}
 	// OP Stack additions
@@ -487,12 +546,22 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 	return nil
 }
 
+// NewPayloadV1 must be only called with Bedrock Payload
 func (s *SyncTester) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
 }
 
+// NewPayloadV2 must be only called with Bedrock, Canyon, Delta Payload
 func (s *SyncTester) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return nil, nil
+	session, err := s.fetchSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
 }
 
 // NewPayloadV3 must be only called with Ecotone Payload
@@ -534,20 +603,26 @@ func (s *SyncTester) newPayload(ctx context.Context, session *Session, payload *
 	// Validate request shape, fork required fields
 	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#engine_newpayloadv2
 	// Spec: Client software MUST return -32602: Invalid params error if the wrong version of the structure is used in the method call.
-	if payload.Withdrawals == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
-	}
-	if payload.ExcessBlobGas == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
-	}
-	if payload.BlobGasUsed == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil blobGasUsed post-cancun"))
-	}
-	if versionedHashes == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
-	}
-	if beaconRoot == nil {
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil beaconRoot post-cancun"))
+	if isEcotone {
+		if payload.ExcessBlobGas == nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil excessBlobGas post-cancun"))
+		}
+		if payload.BlobGasUsed == nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil blobGasUsed post-cancun"))
+		}
+		if versionedHashes == nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil versionedHashes post-cancun"))
+		}
+		if beaconRoot == nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil beaconRoot post-cancun"))
+		}
+	} else {
+		if payload.ExcessBlobGas != nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("non-nil excessBlobGas pre-cancun"))
+		}
+		if payload.BlobGasUsed != nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("non-nil blobGasUsed pre-cancun"))
+		}
 	}
 	if isIsthmus {
 		if executionRequests == nil {
@@ -580,13 +655,29 @@ func (s *SyncTester) newPayload(ctx context.Context, session *Session, payload *
 		}
 		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to fetch block", err))
 	}
+	// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/derivation.md#building-individual-payload-attributes
+	// Implicitly determine whether canyon is enabled by inspecting withdrawals from read only EL data
+	isCanyon := block.Withdrawals() != nil
+	if isCanyon {
+		if payload.Withdrawals == nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawals post-shanghai"))
+		}
+	} else {
+		if payload.Withdrawals != nil {
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("non-nil withdrawals pre-shanghai"))
+		}
+	}
+
 	blockHash := block.Hash()
 	// We only attempt to advance non-canonical view of the chain, following the read only EL
 	if block.NumberU64() <= session.Validated+1 {
 		// Already have the block locally or advance single block without setting the head
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#specification
 		// Spec: MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
-		config := &params.ChainConfig{CanyonTime: new(uint64)}
+		config := &params.ChainConfig{}
+		if isCanyon {
+			config.CanyonTime = new(uint64)
+		}
 		if isIsthmus {
 			config.IsthmusTime = new(uint64)
 		}

--- a/op-sync-tester/synctester/frontend/engine.go
+++ b/op-sync-tester/synctester/frontend/engine.go
@@ -9,7 +9,7 @@ import (
 )
 
 type EngineBackend interface {
-	GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayload, error)
+	GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
 	GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
 	GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
 	GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
@@ -32,7 +32,7 @@ func NewEngineFrontend(b EngineBackend) *EngineFrontend {
 	return &EngineFrontend{b: b}
 }
 
-func (e *EngineFrontend) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayload, error) {
+func (e *EngineFrontend) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	return e.b.GetPayloadV1(ctx, payloadID)
 }
 


### PR DESCRIPTION
**Description**

Added `engine_newPayloadV1, engine_getPayloadV1, engine_forkchoiceUpdatedV1, engine_newPayloadV2, engine_getPayloadV2, engine_forkchoiceUpdatedV2` to support for Bedrock, Canyon, Delta hardforks.

Note that `engine_newPayloadV1`, `engine_getPayloadV1` is never used, op-node starts with `engine_newPayloadV2` `engine_getPayloadV2` for bedrock HF.

**Tests**

Added a sysgo acceptance tests, which activates bedrock to isthmus with 15 second time offset between each HFs. Added a preset for supporting pre-fjord, pre-delta batcher.

After CL advancing is finished, the test checks the `optimism_syncStatus` API results and compare with the EL, as well as confirming that the isthmus is activated.

Example logs for HF activation:
```
t=2025-08-27T16:39:41.086+0900 lvl=info msg="Detected hardfork activation block" forkName=regolith timestamp=1756280367 blockNum=8 hash=0xc2a18fe344f5f239ac557665badc24f059c682b0552d57cf4e0f0fdd5208c60e scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:39:59.025+0900 lvl=info msg="Detected hardfork activation block" forkName=canyon timestamp=1756280381 blockNum=15 hash=0x488a50718f1d0b46f4f363958dc15525e434e17fdae65aaebff4cd553ceb6248 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:40:11.064+0900 lvl=info msg="Detected hardfork activation block" forkName=delta timestamp=1756280397 blockNum=23 hash=0x48333fe018abdebf508387c1620f4c3ec5ace3a53f573d6e3c906f20ff50ad78 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:40:29.044+0900 lvl=info msg="Detected hardfork activation block" forkName=ecotone timestamp=1756280411 blockNum=30 hash=0x0e06dae3ac7d9be481148a06d2c36cb20c7b7bf3d58f52a343cb1b6bfd8402c0 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:40:41.076+0900 lvl=info msg="Detected hardfork activation block" forkName=fjord timestamp=1756280427 blockNum=38 hash=0x19e766aebd5f0b53d5df5419be8a88b43370025cf492138c4cf72238850da004 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:40:59.019+0900 lvl=info msg="Detected hardfork activation block" forkName=granite timestamp=1756280441 blockNum=45 hash=0xd1dc2c90205356f53f76314a68f794cecf5745770d05990c2286485b0fd19094 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:41:11.034+0900 lvl=info msg="Detected hardfork activation block" forkName=holocene timestamp=1756280457 blockNum=53 hash=0x476a6d774fe841f39b972d5d6b1c7d48460d50feb56249ff146e044d34fb344c scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
t=2025-08-27T16:41:29.017+0900 lvl=info msg="Detected hardfork activation block" forkName=isthmus timestamp=1756280471 blockNum=60 hash=0xc87a38904a8be1035e7e58b434e24f28b1761778ba6ac40eca59e27fd3dd63c3 scope=/pkg chainID=901 kind=L2CLNode id=L2CLNode-verifier-901
```

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/16701
