### PR TITLE
feat: add CLI wrapper for Forge binary execution

### DIFF
--- a/op-deployer/pkg/deployer/forge/cli.go
+++ b/op-deployer/pkg/deployer/forge/cli.go
@@ -1,0 +1,253 @@
+package forge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// CLI provides a clean interface for executing forge commands
+type CLI struct {
+	binary  Binary
+	workDir string
+	env     []string
+	stdout  io.Writer
+	stderr  io.Writer
+}
+
+// CLIOption configures the CLI wrapper
+type CLIOption func(*CLI)
+
+// WithWorkDir sets the working directory for forge commands
+func WithWorkDir(dir string) CLIOption {
+	return func(c *CLI) {
+		c.workDir = dir
+	}
+}
+
+// WithEnv sets environment variables for forge commands
+func WithEnv(env []string) CLIOption {
+	return func(c *CLI) {
+		c.env = env
+	}
+}
+
+// WithStdout sets the stdout writer for forge commands
+func WithStdout(w io.Writer) CLIOption {
+	return func(c *CLI) {
+		c.stdout = w
+	}
+}
+
+// WithStderr sets the stderr writer for forge commands
+func WithStderr(w io.Writer) CLIOption {
+	return func(c *CLI) {
+		c.stderr = w
+	}
+}
+
+// NewCLI creates a new CLI wrapper around the forge binary
+func NewCLI(binary Binary, opts ...CLIOption) *CLI {
+	cli := &CLI{
+		binary: binary,
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+
+	for _, opt := range opts {
+		opt(cli)
+	}
+
+	return cli
+}
+
+// Command represents a forge command with its arguments
+func Command(args ...string) []string {
+	return args
+}
+
+// ExecuteResult contains the result of command execution
+type ExecuteResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+// ParseJSON attempts to parse the stdout as JSON into the provided interface
+func (r *ExecuteResult) ParseJSON(v interface{}) error {
+	if r.Stdout == "" {
+		return fmt.Errorf("no stdout to parse")
+	}
+
+	return json.Unmarshal([]byte(r.Stdout), v)
+}
+
+// Execute runs a forge command and returns the result
+func (c *CLI) Execute(ctx context.Context, args ...string) (*ExecuteResult, error) {
+	// Ensure the binary is available
+	if err := c.binary.Ensure(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure forge binary: %w", err)
+	}
+
+	// Create the exec command
+	execCmd := exec.CommandContext(ctx, c.binary.Path(), args...)
+
+	// Set working directory if specified
+	if c.workDir != "" {
+		execCmd.Dir = c.workDir
+	}
+
+	// Set environment variables
+	if len(c.env) > 0 {
+		execCmd.Env = append(os.Environ(), c.env...)
+	}
+
+	// Capture stdout and stderr
+	var stdout, stderr bytes.Buffer
+
+	// Use MultiWriter to write to both our buffer and the configured writers
+	execCmd.Stdout = io.MultiWriter(&stdout, c.stdout)
+	execCmd.Stderr = io.MultiWriter(&stderr, c.stderr)
+
+	// Execute the command
+	err := execCmd.Run()
+
+	result := &ExecuteResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	// Get exit code
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitError.ExitCode()
+		} else {
+			// Command failed to start
+			return result, fmt.Errorf("failed to execute forge command: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// ExecuteQuiet runs a forge command without output to stdout/stderr
+func (c *CLI) ExecuteQuiet(ctx context.Context, args ...string) (*ExecuteResult, error) {
+	// Create a temporary CLI with no output
+	quietCLI := &CLI{
+		binary:  c.binary,
+		workDir: c.workDir,
+		env:     c.env,
+		stdout:  io.Discard,
+		stderr:  io.Discard,
+	}
+
+	return quietCLI.Execute(ctx, args...)
+}
+
+// ExecuteWithInput runs a forge command with stdin input
+func (c *CLI) ExecuteWithInput(ctx context.Context, input string, args ...string) (*ExecuteResult, error) {
+	// Ensure the binary is available
+	if err := c.binary.Ensure(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure forge binary: %w", err)
+	}
+
+	// Create the exec command
+	execCmd := exec.CommandContext(ctx, c.binary.Path(), args...)
+
+	// Set working directory if specified
+	if c.workDir != "" {
+		execCmd.Dir = c.workDir
+	}
+
+	// Set environment variables
+	if len(c.env) > 0 {
+		execCmd.Env = append(os.Environ(), c.env...)
+	}
+
+	// Set stdin
+	execCmd.Stdin = strings.NewReader(input)
+
+	// Capture stdout and stderr
+	var stdout, stderr bytes.Buffer
+
+	// Use MultiWriter to write to both our buffer and the configured writers
+	execCmd.Stdout = io.MultiWriter(&stdout, c.stdout)
+	execCmd.Stderr = io.MultiWriter(&stderr, c.stderr)
+
+	// Execute the command
+	err := execCmd.Run()
+
+	result := &ExecuteResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	// Get exit code
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitError.ExitCode()
+		} else {
+			// Command failed to start
+			return result, fmt.Errorf("failed to execute forge command: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// Version returns the forge version
+func (c *CLI) Version(ctx context.Context) (string, error) {
+	result, err := c.ExecuteQuiet(ctx, "--version")
+	if err != nil {
+		return "", fmt.Errorf("failed to get forge version: %w", err)
+	}
+
+	if result.ExitCode != 0 {
+		return "", fmt.Errorf("forge --version failed with exit code %d: %s", result.ExitCode, result.Stderr)
+	}
+
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+// IsInstalled checks if forge is properly installed and accessible
+func (c *CLI) IsInstalled(ctx context.Context) bool {
+	_, err := c.Version(ctx)
+	return err == nil
+}
+
+// ExecuteForJSON executes a forge command with --json flag and parses the result
+// This is useful for commands that support JSON output as mentioned in the design doc
+func (c *CLI) ExecuteForJSON(ctx context.Context, result interface{}, args ...string) error {
+	// Add --json flag if not already present
+	hasJSONFlag := false
+	for _, arg := range args {
+		if arg == "--json" {
+			hasJSONFlag = true
+			break
+		}
+	}
+
+	if !hasJSONFlag {
+		args = append(args, "--json")
+	}
+
+	execResult, err := c.ExecuteQuiet(ctx, args...)
+	if err != nil {
+		return fmt.Errorf("failed to execute forge command: %w", err)
+	}
+
+	if execResult.ExitCode != 0 {
+		return fmt.Errorf("forge command failed with exit code %d: %s", execResult.ExitCode, execResult.Stderr)
+	}
+
+	if err := execResult.ParseJSON(result); err != nil {
+		return fmt.Errorf("failed to parse JSON output: %w", err)
+	}
+
+	return nil
+}

--- a/op-deployer/pkg/deployer/forge/cli_test.go
+++ b/op-deployer/pkg/deployer/forge/cli_test.go
@@ -1,0 +1,444 @@
+package forge
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockBinary is a mock implementation of the Binary interface for testing
+type mockBinary struct {
+	path        string
+	ensureError error
+}
+
+func (m *mockBinary) Ensure(ctx context.Context) error {
+	return m.ensureError
+}
+
+func (m *mockBinary) Path() string {
+	return m.path
+}
+
+func TestNewCLI(t *testing.T) {
+	binary := &mockBinary{path: "/usr/bin/forge"}
+
+	t.Run("default configuration", func(t *testing.T) {
+		cli := NewCLI(binary)
+		require.Equal(t, binary, cli.binary)
+		require.Equal(t, os.Stdout, cli.stdout)
+		require.Equal(t, os.Stderr, cli.stderr)
+		require.Empty(t, cli.workDir)
+		require.Empty(t, cli.env)
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		workDir := "/tmp/test"
+		env := []string{"FOO=bar"}
+
+		cli := NewCLI(binary,
+			WithWorkDir(workDir),
+			WithEnv(env),
+			WithStdout(&stdout),
+			WithStderr(&stderr),
+		)
+
+		require.Equal(t, workDir, cli.workDir)
+		require.Equal(t, env, cli.env)
+		require.Equal(t, &stdout, cli.stdout)
+		require.Equal(t, &stderr, cli.stderr)
+	})
+}
+
+func TestCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "simple command",
+			args:     []string{"--version"},
+			expected: []string{"--version"},
+		},
+		{
+			name:     "build command",
+			args:     []string{"build", "--optimize"},
+			expected: []string{"build", "--optimize"},
+		},
+		{
+			name:     "script command",
+			args:     []string{"script", "deploy.s.sol", "--rpc-url", "http://localhost:8545"},
+			expected: []string{"script", "deploy.s.sol", "--rpc-url", "http://localhost:8545"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Command(tt.args...)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCLI_Execute(t *testing.T) {
+	// Create a temporary script that acts like forge
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	// Create a simple script that echoes its arguments
+	script := `#!/bin/bash
+echo "forge called with: $@"
+echo "stderr output" >&2
+exit 0
+`
+
+	require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+	binary := &mockBinary{path: forgePath}
+
+	t.Run("successful execution", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		cli := NewCLI(binary,
+			WithStdout(&stdout),
+			WithStderr(&stderr),
+		)
+
+		result, err := cli.Execute(context.Background(), "--version")
+
+		require.NoError(t, err)
+		require.Equal(t, 0, result.ExitCode)
+		require.Contains(t, result.Stdout, "forge called with: --version")
+		require.Contains(t, result.Stderr, "stderr output")
+
+		// Check that output was also written to the configured writers
+		require.Contains(t, stdout.String(), "forge called with: --version")
+		require.Contains(t, stderr.String(), "stderr output")
+	})
+
+	t.Run("binary ensure error", func(t *testing.T) {
+		binary := &mockBinary{
+			path:        forgePath,
+			ensureError: io.ErrUnexpectedEOF,
+		}
+		cli := NewCLI(binary)
+
+		_, err := cli.Execute(context.Background(), "--version")
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to ensure forge binary")
+	})
+
+	t.Run("with working directory", func(t *testing.T) {
+		workDir := tmpDir
+		cli := NewCLI(binary, WithWorkDir(workDir))
+
+		result, err := cli.Execute(context.Background(), "--version")
+
+		require.NoError(t, err)
+		require.Equal(t, 0, result.ExitCode)
+	})
+
+	t.Run("with environment variables", func(t *testing.T) {
+		env := []string{"TEST_VAR=test_value"}
+		cli := NewCLI(binary, WithEnv(env))
+
+		result, err := cli.Execute(context.Background(), "--version")
+
+		require.NoError(t, err)
+		require.Equal(t, 0, result.ExitCode)
+	})
+}
+
+func TestCLI_ExecuteQuiet(t *testing.T) {
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	script := `#!/bin/bash
+echo "stdout output"
+echo "stderr output" >&2
+exit 0
+`
+
+	require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+	binary := &mockBinary{path: forgePath}
+
+	var stdout, stderr bytes.Buffer
+	cli := NewCLI(binary,
+		WithStdout(&stdout),
+		WithStderr(&stderr),
+	)
+
+	result, err := cli.ExecuteQuiet(context.Background(), "--version")
+
+	require.NoError(t, err)
+	require.Equal(t, 0, result.ExitCode)
+	require.Contains(t, result.Stdout, "stdout output")
+	require.Contains(t, result.Stderr, "stderr output")
+
+	// Check that no output was written to the configured writers
+	require.Empty(t, stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+func TestCLI_ExecuteWithInput(t *testing.T) {
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	// Create a script that reads from stdin and echoes it
+	script := `#!/bin/bash
+echo "Reading from stdin:"
+cat
+exit 0
+`
+
+	require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+	binary := &mockBinary{path: forgePath}
+	cli := NewCLI(binary)
+
+	input := "test input data"
+	result, err := cli.ExecuteWithInput(context.Background(), input, "--version")
+
+	require.NoError(t, err)
+	require.Equal(t, 0, result.ExitCode)
+	require.Contains(t, result.Stdout, "Reading from stdin:")
+	require.Contains(t, result.Stdout, input)
+}
+
+func TestCLI_Version(t *testing.T) {
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	t.Run("successful version check", func(t *testing.T) {
+		script := `#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "forge 0.2.0 (abc123 2023-01-01T00:00:00.000000000Z)"
+    exit 0
+fi
+exit 1
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		version, err := cli.Version(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, "forge 0.2.0 (abc123 2023-01-01T00:00:00.000000000Z)", version)
+	})
+
+	t.Run("version command fails", func(t *testing.T) {
+		script := `#!/bin/bash
+echo "error message" >&2
+exit 1
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		_, err := cli.Version(context.Background())
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forge --version failed with exit code 1")
+	})
+}
+
+func TestCLI_IsInstalled(t *testing.T) {
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	t.Run("forge is installed", func(t *testing.T) {
+		script := `#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "forge 0.2.0"
+    exit 0
+fi
+exit 1
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		require.True(t, cli.IsInstalled(context.Background()))
+	})
+
+	t.Run("forge is not installed", func(t *testing.T) {
+		binary := &mockBinary{path: "/nonexistent/forge"}
+		cli := NewCLI(binary)
+
+		require.False(t, cli.IsInstalled(context.Background()))
+	})
+}
+
+func TestExecuteResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	t.Run("non-zero exit code", func(t *testing.T) {
+		script := `#!/bin/bash
+echo "command failed" >&2
+exit 42
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		result, err := cli.Execute(context.Background(), "failing-command")
+
+		require.NoError(t, err) // Execute should not return error for non-zero exit codes
+		require.Equal(t, 42, result.ExitCode)
+		require.Contains(t, result.Stderr, "command failed")
+	})
+}
+
+// Integration test with real binary interface
+func TestCLI_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Create a temporary binary that we can use for testing
+	binary, err := AutodetectBinary()
+	require.NoError(t, err)
+
+	cli := NewCLI(binary)
+
+	// Test that we can check if forge is available
+	ctx := context.Background()
+
+	// This will either find forge on PATH or download it
+	err = binary.Ensure(ctx)
+	if err != nil {
+		t.Skipf("Could not ensure forge binary: %v", err)
+	}
+
+	// Test version command
+	version, err := cli.Version(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
+	require.True(t, strings.Contains(version, "forge"))
+
+	// Test IsInstalled
+	require.True(t, cli.IsInstalled(ctx))
+}
+
+func TestExecuteResult_ParseJSON(t *testing.T) {
+	t.Run("valid JSON", func(t *testing.T) {
+		result := &ExecuteResult{
+			Stdout: `{"name": "test", "value": 42}`,
+		}
+
+		var data struct {
+			Name  string `json:"name"`
+			Value int    `json:"value"`
+		}
+
+		err := result.ParseJSON(&data)
+		require.NoError(t, err)
+		require.Equal(t, "test", data.Name)
+		require.Equal(t, 42, data.Value)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		result := &ExecuteResult{
+			Stdout: `invalid json`,
+		}
+
+		var data map[string]interface{}
+		err := result.ParseJSON(&data)
+		require.Error(t, err)
+	})
+
+	t.Run("empty stdout", func(t *testing.T) {
+		result := &ExecuteResult{
+			Stdout: "",
+		}
+
+		var data map[string]interface{}
+		err := result.ParseJSON(&data)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no stdout to parse")
+	})
+}
+
+func TestCLI_ExecuteForJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	forgePath := filepath.Join(tmpDir, "forge")
+
+	t.Run("successful JSON execution", func(t *testing.T) {
+		script := `#!/bin/bash
+if [[ "$*" == *"--json"* ]]; then
+    echo '{"success": true, "message": "test"}'
+    exit 0
+fi
+echo "non-json output"
+exit 0
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		var result struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		}
+
+		err := cli.ExecuteForJSON(context.Background(), &result, "test-command")
+		require.NoError(t, err)
+		require.True(t, result.Success)
+		require.Equal(t, "test", result.Message)
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		script := `#!/bin/bash
+echo "error message" >&2
+exit 1
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		var result map[string]interface{}
+		err := cli.ExecuteForJSON(context.Background(), &result, "failing-command")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forge command failed with exit code 1")
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		script := `#!/bin/bash
+echo "not json output"
+exit 0
+`
+
+		require.NoError(t, os.WriteFile(forgePath, []byte(script), 0755))
+
+		binary := &mockBinary{path: forgePath}
+		cli := NewCLI(binary)
+
+		var result map[string]interface{}
+		err := cli.ExecuteForJSON(context.Background(), &result, "test-command")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse JSON output")
+	})
+}


### PR DESCRIPTION
Adds a simple CLI wrapper around the Forge binary so we can call forge commands from OP Deployer without dealing with raw exec calls everywhere.

**Changes:**
- Basic `CLI` struct that wraps forge execution 
- Methods for running commands with different output handling
- JSON parsing support for forge's `--json` output
- Works with existing binary detection/download logic

**Example:**
```go
cli := forge.NewCLI(binary)
result, err := cli.Execute(ctx, "build", "--optimize")
```

The wrapper handles stdout/stderr capture, exit codes, and lets you configure working directory and env vars as needed.

Closes #17214