### PR TITLE
fix(sync-tester): correct PayloadV4 version check in GetPayloadV4

### DIFF
--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -267,7 +267,7 @@ func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV4 must be only called when Isthmus activated.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV3) {
+	if !payloadID.Is(engine.PayloadV4) {
 		return nil, engine.UnsupportedFork
 	}
 	session, err := s.fetchSession(ctx)


### PR DESCRIPTION
V4 payloads being rejected with `UnsupportedFork` error in the previous code, potential consensus failures when Prague/Isthmus fork features are expected
