### PR TITLE
op-deployer: StandardBin enforces specific forge version

### DIFF
--- a/op-deployer/pkg/deployer/forge/binary.go
+++ b/op-deployer/pkg/deployer/forge/binary.go
@@ -165,16 +165,9 @@ func AutodetectBinary(opts ...AutodetectBinaryOpt) (*AutodetectBin, error) {
 }
 
 func (b *AutodetectBin) Ensure(ctx context.Context) error {
-	// 1) Exit early if b.path already set (via previous Ensure call) to
-	//    existing forge binary and its version matches
+	// 1) Exit early if b.path already set (via previous Ensure call)
 	if b.path != "" {
-		if _, err := os.Stat(b.path); err == nil {
-			if ver, err := getForgeVersion(ctx, b.path); err == nil && ver == Version {
-				return nil
-			}
-		}
-		// path missing or version changed; re-resolve
-		b.path = ""
+		return nil
 	}
 
 	// 2) PATH: use if version matches the pinned Version
@@ -190,17 +183,12 @@ func (b *AutodetectBin) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not provide cache dir: %w", err)
 	}
-	if err := os.MkdirAll(binDir, 0o700); err != nil {
-		return fmt.Errorf("could not create cache dir: %w", err)
-	}
 	binPath := path.Join(binDir, "forge")
 	if st, err := os.Stat(binPath); err == nil && !st.IsDir() {
+		// forge binary exists in cache; check version
 		if ver, err := getForgeVersion(ctx, binPath); err == nil && ver == Version {
 			b.path = binPath
 			return nil
-		}
-		if err := os.Remove(binPath); err != nil {
-			return fmt.Errorf("could not remove mismatched binary: %w", err)
 		}
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("could not stat %s: %w", binPath, err)

--- a/op-deployer/pkg/deployer/forge/binary.go
+++ b/op-deployer/pkg/deployer/forge/binary.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 )
 
-// Version is the Foundry version that op-deployer will download if it's not found on PATH.
-const Version = "v1.3.1"
+// StandardVersion is the Foundry version that op-deployer will download if it's not found on PATH.
+const StandardVersion = "v1.3.1"
 
 // maxDownloadSize is the maximum size of the Foundry tarball that will be downloaded. It's typically ~60MB so
 // this should be more than enough.
@@ -42,7 +42,7 @@ func getOS() string {
 }
 
 func binaryURL(sysOS, sysArch string) string {
-	return fmt.Sprintf("https://github.com/foundry-rs/foundry/releases/download/%s/foundry_%s_%s_%s.tar.gz", Version, Version, sysOS, sysArch)
+	return fmt.Sprintf("https://github.com/foundry-rs/foundry/releases/download/%s/foundry_%s_%s_%s.tar.gz", StandardVersion, StandardVersion, sysOS, sysArch)
 }
 
 type Binary interface {
@@ -87,7 +87,10 @@ func (b *PathBin) Path() string {
 	return b.path
 }
 
-type AutodetectBin struct {
+// StandardBin forces the use of the standard forge binary version by
+// first checking for the version locally, then downloading from github
+// if needed
+type StandardBin struct {
 	progressor ioutil.Progressor
 
 	cachePather func() (string, error)
@@ -96,28 +99,28 @@ type AutodetectBin struct {
 	path        string
 }
 
-type AutodetectBinaryOpt func(s *AutodetectBin)
+type StandardBinOpt func(s *StandardBin)
 
-func WithProgressor(p ioutil.Progressor) AutodetectBinaryOpt {
-	return func(s *AutodetectBin) {
+func WithProgressor(p ioutil.Progressor) StandardBinOpt {
+	return func(s *StandardBin) {
 		s.progressor = p
 	}
 }
 
-func WithURL(url string) AutodetectBinaryOpt {
-	return func(s *AutodetectBin) {
+func WithURL(url string) StandardBinOpt {
+	return func(s *StandardBin) {
 		s.url = url
 	}
 }
 
-func WithCachePather(pather func() (string, error)) AutodetectBinaryOpt {
-	return func(s *AutodetectBin) {
+func WithCachePather(pather func() (string, error)) StandardBinOpt {
+	return func(s *StandardBin) {
 		s.cachePather = pather
 	}
 }
 
-func WithChecksummer(checksummer func(r io.Reader) error) AutodetectBinaryOpt {
-	return func(s *AutodetectBin) {
+func WithChecksummer(checksummer func(r io.Reader) error) StandardBinOpt {
+	return func(s *StandardBin) {
 		s.checksummer = checksummer
 	}
 }
@@ -152,8 +155,8 @@ func githubChecksummer(r io.Reader) error {
 	return staticChecksummer(expChecksum)(r)
 }
 
-func AutodetectBinary(opts ...AutodetectBinaryOpt) (*AutodetectBin, error) {
-	bin := &AutodetectBin{
+func NewStandardBinary(opts ...StandardBinOpt) (*StandardBin, error) {
+	bin := &StandardBin{
 		url:         binaryURL(getOS(), runtime.GOARCH),
 		cachePather: homedirCachePather,
 		checksummer: githubChecksummer,
@@ -164,7 +167,7 @@ func AutodetectBinary(opts ...AutodetectBinaryOpt) (*AutodetectBin, error) {
 	return bin, nil
 }
 
-func (b *AutodetectBin) Ensure(ctx context.Context) error {
+func (b *StandardBin) Ensure(ctx context.Context) error {
 	// 1) Exit early if b.path already set (via previous Ensure call)
 	if b.path != "" {
 		return nil
@@ -172,7 +175,7 @@ func (b *AutodetectBin) Ensure(ctx context.Context) error {
 
 	// 2) PATH: use if version matches the pinned Version
 	if forgePath, err := exec.LookPath("forge"); err == nil {
-		if ver, err := getForgeVersion(ctx, forgePath); err == nil && ver == Version {
+		if ver, err := getForgeVersion(ctx, forgePath); err == nil && ver == StandardVersion {
 			b.path = forgePath
 			return nil
 		}
@@ -186,7 +189,7 @@ func (b *AutodetectBin) Ensure(ctx context.Context) error {
 	binPath := path.Join(binDir, "forge")
 	if st, err := os.Stat(binPath); err == nil && !st.IsDir() {
 		// forge binary exists in cache; check version
-		if ver, err := getForgeVersion(ctx, binPath); err == nil && ver == Version {
+		if ver, err := getForgeVersion(ctx, binPath); err == nil && ver == StandardVersion {
 			b.path = binPath
 			return nil
 		}
@@ -202,11 +205,11 @@ func (b *AutodetectBin) Ensure(ctx context.Context) error {
 	return nil
 }
 
-func (b *AutodetectBin) Path() string {
+func (b *StandardBin) Path() string {
 	return b.path
 }
 
-func (b *AutodetectBin) downloadBinary(ctx context.Context, dest string) error {
+func (b *StandardBin) downloadBinary(ctx context.Context, dest string) error {
 	tmpDir, err := os.MkdirTemp("", "op-deployer-forge-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)

--- a/op-deployer/pkg/deployer/forge/binary.go
+++ b/op-deployer/pkg/deployer/forge/binary.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"runtime"
 
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -164,30 +165,48 @@ func AutodetectBinary(opts ...AutodetectBinaryOpt) (*AutodetectBin, error) {
 }
 
 func (b *AutodetectBin) Ensure(ctx context.Context) error {
+	// 1) Exit early if b.path already set (via previous Ensure call) to
+	//    existing forge binary and its version matches
 	if b.path != "" {
-		return nil
+		if _, err := os.Stat(b.path); err == nil {
+			if ver, err := getForgeVersion(ctx, b.path); err == nil && ver == Version {
+				return nil
+			}
+		}
+		// path missing or version changed; re-resolve
+		b.path = ""
 	}
 
-	forgePath, err := exec.LookPath("forge")
-	if err == nil {
-		b.path = forgePath
-		return nil
+	// 2) PATH: use if version matches the pinned Version
+	if forgePath, err := exec.LookPath("forge"); err == nil {
+		if ver, err := getForgeVersion(ctx, forgePath); err == nil && ver == Version {
+			b.path = forgePath
+			return nil
+		}
 	}
 
+	// 3) Cache: use if version matches; otherwise replace it
 	binDir, err := b.cachePather()
 	if err != nil {
 		return fmt.Errorf("could not provide cache dir: %w", err)
 	}
-	binPath := path.Join(binDir, "forge")
-	_, err = os.Stat(binPath)
-	if err == nil {
-		b.path = binPath
-		return nil
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		return fmt.Errorf("could not create cache dir: %w", err)
 	}
-	if !os.IsNotExist(err) {
+	binPath := path.Join(binDir, "forge")
+	if st, err := os.Stat(binPath); err == nil && !st.IsDir() {
+		if ver, err := getForgeVersion(ctx, binPath); err == nil && ver == Version {
+			b.path = binPath
+			return nil
+		}
+		if err := os.Remove(binPath); err != nil {
+			return fmt.Errorf("could not remove mismatched binary: %w", err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("could not stat %s: %w", binPath, err)
 	}
 
+	// 4) Download expected version for this OS/arch and verify checksum
 	if err := b.downloadBinary(ctx, binDir); err != nil {
 		return fmt.Errorf("could not download binary: %w", err)
 	}
@@ -230,5 +249,23 @@ func (b *AutodetectBin) downloadBinary(ctx context.Context, dest string) error {
 	if err := os.Rename(path.Join(tmpDir, "forge"), path.Join(dest, "forge")); err != nil {
 		return fmt.Errorf("failed to move binary: %w", err)
 	}
+	if err := os.Chmod(path.Join(dest, "forge"), 0o755); err != nil {
+		return fmt.Errorf("failed to set executable bit: %w", err)
+	}
 	return nil
+}
+
+func getForgeVersion(ctx context.Context, forgePath string) (string, error) {
+	cmd := exec.CommandContext(ctx, forgePath, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("exec %s --version failed: %w", forgePath, err)
+	}
+	// Example output: "forge Version: 1.3.1-v1.3.1" -> capture "v1.3.1"
+	re := regexp.MustCompile(`(?mi)^\s*forge\s+version:\s+\d+\.\d+\.\d+-\s*(v\d+\.\d+\.\d+)\s*$`)
+	m := re.FindStringSubmatch(string(out))
+	if len(m) != 2 {
+		return "", fmt.Errorf("could not parse version tag from: %q", out)
+	}
+	return m[1], nil
 }

--- a/op-deployer/pkg/deployer/forge/binary_test.go
+++ b/op-deployer/pkg/deployer/forge/binary_test.go
@@ -2,6 +2,7 @@ package forge
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -97,24 +98,79 @@ func TestAutodetectBinary_Downloads(t *testing.T) {
 }
 
 func TestAutodetectBinary_OnPath(t *testing.T) {
-	forgeDir := t.TempDir()
-	forgePath := path.Join(forgeDir, "forge")
-	_, err := os.Create(forgePath)
-	require.NoError(t, err)
-	require.NoError(t, os.Chmod(forgePath, 0777))
-
-	// Set the PATH env var to the directory we just created to prevent a download.
-	t.Setenv("PATH", forgeDir)
-
-	bin, err := AutodetectBinary(
-		WithURL(""),
-		WithCachePather(func() (string, error) { return forgeDir, nil }),
-	)
+	expChecksum, err := os.ReadFile("testdata/foundry.tgz.sha256")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	require.NoError(t, bin.Ensure(ctx))
-	require.Equal(t, forgePath, bin.Path())
-	require.FileExists(t, bin.Path())
+	// Serve the test tarball so we can force the download path.
+	ts := httptest.NewServer(http.FileServer(http.Dir("testdata")))
+	defer ts.Close()
+
+	makeForge := func(dir, versionLine string) string {
+		fp := path.Join(dir, "forge")
+		script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "%s"
+  exit 0
+fi
+exit 1
+`, versionLine)
+		require.NoError(t, os.WriteFile(fp, []byte(script), 0o777))
+		require.NoError(t, os.Chmod(fp, 0o777))
+		return fp
+	}
+
+	cases := []struct {
+		name          string
+		versionLine   string
+		expectUsePath bool
+	}{
+		{
+			name:          "match_tag",
+			versionLine:   fmt.Sprintf("forge Version: %s-%s", strings.TrimPrefix(Version, "v"), Version),
+			expectUsePath: true,
+		},
+		{
+			name:          "mismatch_tag",
+			versionLine:   fmt.Sprintf("forge Version: %s-v0.0.0", strings.TrimPrefix(Version, "v")),
+			expectUsePath: false,
+		},
+		{
+			name:          "no_tag",
+			versionLine:   fmt.Sprintf("forge Version: %s", strings.TrimPrefix(Version, "v")),
+			expectUsePath: false,
+		},
+		{
+			name:          "garbage_output",
+			versionLine:   "forge something unexpected",
+			expectUsePath: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forgeDir := t.TempDir()
+			forgePath := makeForge(forgeDir, tc.versionLine)
+			t.Setenv("PATH", forgeDir)
+
+			cacheDir := t.TempDir()
+			bin, err := AutodetectBinary(
+				WithURL(ts.URL+"/foundry.tgz"),
+				WithCachePather(func() (string, error) { return cacheDir, nil }),
+				WithChecksummer(staticChecksummer(string(expChecksum))),
+			)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			require.NoError(t, bin.Ensure(ctx))
+
+			if tc.expectUsePath {
+				require.Equal(t, forgePath, bin.Path())
+				require.NoFileExists(t, path.Join(cacheDir, "forge"))
+			} else {
+				require.Equal(t, path.Join(cacheDir, "forge"), bin.Path())
+				require.FileExists(t, bin.Path())
+			}
+		})
+	}
 }

--- a/op-deployer/pkg/deployer/forge/binary_test.go
+++ b/op-deployer/pkg/deployer/forge/binary_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAutodetectBinary_ForgeBins tests that the binary can be downloaded from the
+// TestStandardBinary_ForgeBins tests that the binary can be downloaded from the
 // official release channel, and that their checksums are correct.
-func TestAutodetectBinary_ForgeBins(t *testing.T) {
+func TestStandardBinary_ForgeBins(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in -short mode")
 	}
@@ -36,7 +36,7 @@ func TestAutodetectBinary_ForgeBins(t *testing.T) {
 			tgtOS, tgtArch := split[0], split[1]
 
 			cacheDir := t.TempDir()
-			bin, err := AutodetectBinary(
+			bin, err := NewStandardBinary(
 				WithURL(binaryURL(tgtOS, tgtArch)),
 				WithCachePather(func() (string, error) { return cacheDir, nil }),
 				WithProgressor(ioutil.NewLogProgressor(lgr, "downloading").Progressor),
@@ -51,7 +51,7 @@ func TestAutodetectBinary_ForgeBins(t *testing.T) {
 	}
 }
 
-func TestAutodetectBinary_Downloads(t *testing.T) {
+func TestStandardBinary_Downloads(t *testing.T) {
 	expChecksum, err := os.ReadFile("testdata/foundry.tgz.sha256")
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestAutodetectBinary_Downloads(t *testing.T) {
 	t.Run("download OK", func(t *testing.T) {
 		var progressed atomic.Bool
 
-		bin, err := AutodetectBinary(
+		bin, err := NewStandardBinary(
 			WithURL(ts.URL+"/foundry.tgz"),
 			WithCachePather(func() (string, error) { return cacheDir, nil }),
 			WithProgressor(func(curr, total int64) {
@@ -84,7 +84,7 @@ func TestAutodetectBinary_Downloads(t *testing.T) {
 	})
 
 	t.Run("invalid checksum", func(t *testing.T) {
-		bin, err := AutodetectBinary(
+		bin, err := NewStandardBinary(
 			WithURL(ts.URL+"/foundry.tgz"),
 			WithCachePather(func() (string, error) { return "not-a-path", nil }),
 			WithChecksummer(staticChecksummer("beep beep")),
@@ -97,7 +97,7 @@ func TestAutodetectBinary_Downloads(t *testing.T) {
 	})
 }
 
-func TestAutodetectBinary_OnPath(t *testing.T) {
+func TestStandardBinary_OnPath(t *testing.T) {
 	expChecksum, err := os.ReadFile("testdata/foundry.tgz.sha256")
 	require.NoError(t, err)
 
@@ -126,17 +126,17 @@ exit 1
 	}{
 		{
 			name:          "match_tag",
-			versionLine:   fmt.Sprintf("forge Version: %s-%s", strings.TrimPrefix(Version, "v"), Version),
+			versionLine:   fmt.Sprintf("forge Version: %s-%s", strings.TrimPrefix(StandardVersion, "v"), StandardVersion),
 			expectUsePath: true,
 		},
 		{
 			name:          "mismatch_tag",
-			versionLine:   fmt.Sprintf("forge Version: %s-v0.0.0", strings.TrimPrefix(Version, "v")),
+			versionLine:   fmt.Sprintf("forge Version: %s-v0.0.0", strings.TrimPrefix(StandardVersion, "v")),
 			expectUsePath: false,
 		},
 		{
 			name:          "no_tag",
-			versionLine:   fmt.Sprintf("forge Version: %s", strings.TrimPrefix(Version, "v")),
+			versionLine:   fmt.Sprintf("forge Version: %s", strings.TrimPrefix(StandardVersion, "v")),
 			expectUsePath: false,
 		},
 		{
@@ -153,7 +153,7 @@ exit 1
 			t.Setenv("PATH", forgeDir)
 
 			cacheDir := t.TempDir()
-			bin, err := AutodetectBinary(
+			bin, err := NewStandardBinary(
 				WithURL(ts.URL+"/foundry.tgz"),
 				WithCachePather(func() (string, error) { return cacheDir, nil }),
 				WithChecksummer(staticChecksummer(string(expChecksum))),


### PR DESCRIPTION
We allow flexibility with the `PathBin` and `StaticBin` types to allow the user to use any forge version they wish. Therefore, it seems like `AutodetectBin` should be strict about enforcing a specific, known forge version. And production code should use the `AutodetectBin` type to avoid unexpected behavior. 

To make this behavior more clear, this pr also renames `AutodetectBin` --> `StandardBin`