### PR TITLE
cannon: Reduce size of heap/code cache

### DIFF
--- a/cannon/mipsevm/memory/binary_tree.go
+++ b/cannon/mipsevm/memory/binary_tree.go
@@ -7,6 +7,11 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 )
 
+const (
+	defaultCodeSize = 128 * 1024 * 1024 // 128 MiB
+	defaultHeapSize = 512 * 1024 * 1024 // 512 MiB
+)
+
 // BinaryTreeIndex is a representation of the state of the memory in a binary merkle tree.
 type BinaryTreeIndex struct {
 	// generalized index -> merkle root or nil if invalidated
@@ -19,12 +24,11 @@ func NewBinaryTreeMemory(codeSize, heapSize arch.Word) *Memory {
 	pages := make(map[arch.Word]*CachedPage)
 	index := NewBinaryTreeIndex(pages)
 
-	// Default values (2 GiB) if not provided
 	if codeSize == 0 {
-		codeSize = 1 << 31 // 2 GiB
+		codeSize = defaultCodeSize
 	}
 	if heapSize == 0 {
-		heapSize = 1 << 31 // 2 GiB
+		heapSize = defaultHeapSize
 	}
 
 	// Defensive bounds: code region must not overlap heap start

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -67,9 +67,7 @@ type PageIndex interface {
 }
 
 func NewMemoryWithLargeRegions() *Memory {
-	const codeSize = 1 << 31
-	const heapSize = 1 << 31
-	return NewBinaryTreeMemory(codeSize, heapSize)
+	return NewBinaryTreeMemory(defaultCodeSize, defaultHeapSize)
 }
 
 func NewMemory() *Memory {

--- a/cannon/mipsevm/memory/memory64_benchmark_test.go
+++ b/cannon/mipsevm/memory/memory64_benchmark_test.go
@@ -13,7 +13,7 @@ const (
 	mediumDataset         = 100_000_000
 	largeDataset          = 400_000_000
 	defaultCodeRegionSize = 4096
-	defaultHeapSize       = 4096
+	testDefaultHeapSize   = 4096
 )
 
 func BenchmarkMemoryOperations(b *testing.B) {
@@ -38,7 +38,7 @@ func BenchmarkMemoryOperations(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run("BinaryTree", func(b *testing.B) {
 			b.Run(bm.name, func(b *testing.B) {
-				m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+				m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 				b.ResetTimer()
 				bm.fn(b, m)
 			})

--- a/cannon/mipsevm/memory/memory64_benchmark_test.go
+++ b/cannon/mipsevm/memory/memory64_benchmark_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	smallDataset          = 12_500_000
-	mediumDataset         = 100_000_000
-	largeDataset          = 400_000_000
-	defaultCodeRegionSize = 4096
-	testDefaultHeapSize   = 4096
+	smallDataset              = 12_500_000
+	mediumDataset             = 100_000_000
+	largeDataset              = 400_000_000
+	testDefaultCodeRegionSize = 4096
+	testDefaultHeapSize       = 4096
 )
 
 func BenchmarkMemoryOperations(b *testing.B) {
@@ -38,7 +38,7 @@ func BenchmarkMemoryOperations(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run("BinaryTree", func(b *testing.B) {
 			b.Run(bm.name, func(b *testing.B) {
-				m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+				m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 				b.ResetTimer()
 				bm.fn(b, m)
 			})

--- a/cannon/mipsevm/memory/memory64_binary_tree_test.go
+++ b/cannon/mipsevm/memory/memory64_binary_tree_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMemory64BinaryTreeMerkleProof(t *testing.T) {
 	t.Run("nearly empty tree", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0x10000, 0xAABBCCDD_EEFF1122)
 		proof := m.MerkleProof(0x10000)
 		require.Equal(t, uint64(0xAABBCCDD_EEFF1122), binary.BigEndian.Uint64(proof[:8]))
@@ -26,7 +26,7 @@ func TestMemory64BinaryTreeMerkleProof(t *testing.T) {
 		}
 	})
 	t.Run("fuller tree", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0x10000, 0xaabbccdd)
 		m.SetWord(0x80008, 42)
 		m.SetWord(0x13370000, 123)
@@ -50,38 +50,38 @@ func TestMemory64BinaryTreeMerkleProof(t *testing.T) {
 
 func TestMemory64BinaryTreeMerkleRoot(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "fully zeroed memory should have expected zero hash")
 	})
 	t.Run("empty page", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 0)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "fully zeroed memory should have expected zero hash")
 	})
 	t.Run("single page", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 1)
 		root := m.MerkleRoot()
 		require.NotEqual(t, zeroHashes[64-5], root, "non-zero memory")
 	})
 	t.Run("repeat zero", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 0)
 		m.SetWord(0xF008, 0)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
 	t.Run("two empty pages", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(PageSize*3, 0)
 		m.SetWord(PageSize*10, 0)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
 	t.Run("random few pages", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(PageSize*3, 1)
 		m.SetWord(PageSize*5, 42)
 		m.SetWord(PageSize*6, 123)
@@ -103,7 +103,7 @@ func TestMemory64BinaryTreeMerkleRoot(t *testing.T) {
 		require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
 	})
 	t.Run("invalidate page", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 0)
 		require.Equal(t, zeroHashes[64-5], m.MerkleRoot(), "zero at first")
 		m.SetWord(0xF008, 1)
@@ -115,7 +115,7 @@ func TestMemory64BinaryTreeMerkleRoot(t *testing.T) {
 
 func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	t.Run("large random", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		data := make([]byte, 20_000)
 		_, err := rand.Read(data[:])
 		require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("repeat range", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		data := []byte(strings.Repeat("under the big bright yellow sun ", 40))
 		require.NoError(t, m.SetMemoryRange(0x1337, bytes.NewReader(data)))
 		res, err := io.ReadAll(m.ReadMemoryRange(0x1337-10, Word(len(data)+20)))
@@ -139,7 +139,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("empty range", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		addr := Word(0xAABBCC00)
 		r := bytes.NewReader(nil)
 		pre := m.MerkleRoot()
@@ -165,7 +165,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("range page overlap", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		data := bytes.Repeat([]byte{0xAA}, PageAddrSize)
 		require.NoError(t, m.SetMemoryRange(0, bytes.NewReader(data)))
 		for i := 0; i < PageAddrSize/arch.WordSizeBytes; i++ {
@@ -183,7 +183,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("read-write", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(16, 0xAABBCCDD_EEFF1122)
 		require.Equal(t, Word(0xAABBCCDD_EEFF1122), m.GetWord(16))
 		m.SetWord(16, 0xAABB1CDD_EEFF1122)
@@ -193,7 +193,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("unaligned read", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(16, Word(0xAABBCCDD_EEFF1122))
 		m.SetWord(24, 0x11223344_55667788)
 		for i := Word(17); i < 24; i++ {
@@ -207,7 +207,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("unaligned write", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(16, 0xAABBCCDD_EEFF1122)
 		require.Panics(t, func() {
 			m.SetWord(17, 0x11223344)
@@ -235,17 +235,17 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 }
 
 func TestMemory64BinaryTreeJSON(t *testing.T) {
-	m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+	m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 	m.SetWord(8, 0xAABBCCDD_EEFF1122)
 	dat, err := json.Marshal(m)
 	require.NoError(t, err)
-	res := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+	res := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 	require.NoError(t, json.Unmarshal(dat, &res))
 	require.Equal(t, Word(0xAABBCCDD_EEFF1122), res.GetWord(8))
 }
 
 func TestMemory64BinaryTreeCopy(t *testing.T) {
-	m := NewBinaryTreeMemory(defaultCodeRegionSize, defaultHeapSize)
+	m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
 	m.SetWord(0xAABBCCDD_8000, 0x000000_AABB)
 	mcpy := m.Copy()
 	require.Equal(t, Word(0xAABB), mcpy.GetWord(0xAABBCCDD_8000))

--- a/cannon/mipsevm/memory/memory64_binary_tree_test.go
+++ b/cannon/mipsevm/memory/memory64_binary_tree_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMemory64BinaryTreeMerkleProof(t *testing.T) {
 	t.Run("nearly empty tree", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0x10000, 0xAABBCCDD_EEFF1122)
 		proof := m.MerkleProof(0x10000)
 		require.Equal(t, uint64(0xAABBCCDD_EEFF1122), binary.BigEndian.Uint64(proof[:8]))
@@ -26,7 +26,7 @@ func TestMemory64BinaryTreeMerkleProof(t *testing.T) {
 		}
 	})
 	t.Run("fuller tree", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0x10000, 0xaabbccdd)
 		m.SetWord(0x80008, 42)
 		m.SetWord(0x13370000, 123)
@@ -50,38 +50,38 @@ func TestMemory64BinaryTreeMerkleProof(t *testing.T) {
 
 func TestMemory64BinaryTreeMerkleRoot(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "fully zeroed memory should have expected zero hash")
 	})
 	t.Run("empty page", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 0)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "fully zeroed memory should have expected zero hash")
 	})
 	t.Run("single page", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 1)
 		root := m.MerkleRoot()
 		require.NotEqual(t, zeroHashes[64-5], root, "non-zero memory")
 	})
 	t.Run("repeat zero", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 0)
 		m.SetWord(0xF008, 0)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
 	t.Run("two empty pages", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(PageSize*3, 0)
 		m.SetWord(PageSize*10, 0)
 		root := m.MerkleRoot()
 		require.Equal(t, zeroHashes[64-5], root, "zero still")
 	})
 	t.Run("random few pages", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(PageSize*3, 1)
 		m.SetWord(PageSize*5, 42)
 		m.SetWord(PageSize*6, 123)
@@ -103,7 +103,7 @@ func TestMemory64BinaryTreeMerkleRoot(t *testing.T) {
 		require.Equal(t, r1, r2, "expecting manual page combination to match subtree merkle func")
 	})
 	t.Run("invalidate page", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(0xF000, 0)
 		require.Equal(t, zeroHashes[64-5], m.MerkleRoot(), "zero at first")
 		m.SetWord(0xF008, 1)
@@ -115,7 +115,7 @@ func TestMemory64BinaryTreeMerkleRoot(t *testing.T) {
 
 func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	t.Run("large random", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		data := make([]byte, 20_000)
 		_, err := rand.Read(data[:])
 		require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("repeat range", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		data := []byte(strings.Repeat("under the big bright yellow sun ", 40))
 		require.NoError(t, m.SetMemoryRange(0x1337, bytes.NewReader(data)))
 		res, err := io.ReadAll(m.ReadMemoryRange(0x1337-10, Word(len(data)+20)))
@@ -139,7 +139,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("empty range", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		addr := Word(0xAABBCC00)
 		r := bytes.NewReader(nil)
 		pre := m.MerkleRoot()
@@ -165,7 +165,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("range page overlap", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		data := bytes.Repeat([]byte{0xAA}, PageAddrSize)
 		require.NoError(t, m.SetMemoryRange(0, bytes.NewReader(data)))
 		for i := 0; i < PageAddrSize/arch.WordSizeBytes; i++ {
@@ -183,7 +183,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("read-write", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(16, 0xAABBCCDD_EEFF1122)
 		require.Equal(t, Word(0xAABBCCDD_EEFF1122), m.GetWord(16))
 		m.SetWord(16, 0xAABB1CDD_EEFF1122)
@@ -193,7 +193,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("unaligned read", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(16, Word(0xAABBCCDD_EEFF1122))
 		m.SetWord(24, 0x11223344_55667788)
 		for i := Word(17); i < 24; i++ {
@@ -207,7 +207,7 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 	})
 
 	t.Run("unaligned write", func(t *testing.T) {
-		m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+		m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 		m.SetWord(16, 0xAABBCCDD_EEFF1122)
 		require.Panics(t, func() {
 			m.SetWord(17, 0x11223344)
@@ -235,17 +235,17 @@ func TestMemory64BinaryTreeReadWrite(t *testing.T) {
 }
 
 func TestMemory64BinaryTreeJSON(t *testing.T) {
-	m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+	m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 	m.SetWord(8, 0xAABBCCDD_EEFF1122)
 	dat, err := json.Marshal(m)
 	require.NoError(t, err)
-	res := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+	res := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 	require.NoError(t, json.Unmarshal(dat, &res))
 	require.Equal(t, Word(0xAABBCCDD_EEFF1122), res.GetWord(8))
 }
 
 func TestMemory64BinaryTreeCopy(t *testing.T) {
-	m := NewBinaryTreeMemory(defaultCodeRegionSize, testDefaultHeapSize)
+	m := NewBinaryTreeMemory(testDefaultCodeRegionSize, testDefaultHeapSize)
 	m.SetWord(0xAABBCCDD_8000, 0x000000_AABB)
 	mcpy := m.Copy()
 	require.Equal(t, Word(0xAABB), mcpy.GetWord(0xAABBCCDD_8000))

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -232,9 +232,9 @@ func initExecutorLimiter() {
 				panic(fmt.Sprintf("Could not parse OP_E2E_EXECUTOR_LIMIT env var %v: %v", executorLimitEnv, err))
 			}
 		} else {
-			// faultproof tests may use 6 GiB of memory. So let's be very conservative and aggressively limit the number of test executions
+			// faultproof tests may use 1 GiB of memory. So let's be very conservative and aggressively limit the number of test executions
 			// considering other processes running on the same machine.
-			executorLimit = 8
+			executorLimit = 16
 		}
 		limiter = executorLimiter{ch: make(chan struct{}, executorLimit)}
 	})


### PR DESCRIPTION
The 2 GiB heap/code cache is too large to run several Cannon instances on medium-sized machines before running out of memory. This patch reduces the cache sizes to unlock more parallelism.
The current op-program MIPS ELF is 52 MB. The chosen 128 MiB code size allows for some growth in the op-program.
Similarly, 21-day VM memory usage has been consistently under 300 MiB, and the chosen default heap cache size reflects that.

<img width="2265" height="1139" alt="image" src="https://github.com/user-attachments/assets/4b1a6224-415d-4482-a378-0d895228045c" />


