### PR TITLE
op-sync-tester: Session Types and API interfaces

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/init_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimalWithSyncTester(sttypes.FCUState{
+	presets.DoMain(m, presets.WithMinimalWithSyncTester(eth.FCUState{
 		Latest:    0,
 		Safe:      0,
 		Finalized: 0,

--- a/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/init_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(sttypes.FCUState{
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(eth.FCUState{
 		Latest:    0,
 		Safe:      0,
 		Finalized: 0,

--- a/op-acceptance-tests/tests/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_hfs/init_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(sttypes.FCUState{
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(eth.FCUState{
 		Latest:    0,
 		Safe:      0,
 		Finalized: 0,

--- a/op-devstack/presets/minimal_with_synctester.go
+++ b/op-devstack/presets/minimal_with_synctester.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type MinimalWithSyncTester struct {
@@ -16,8 +16,8 @@ type MinimalWithSyncTester struct {
 	SyncTester *dsl.SyncTester
 }
 
-func WithMinimalWithSyncTester(fcus sttypes.FCUState) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, fcus))
+func WithMinimalWithSyncTester(fcu eth.FCUState) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalSystemWithSyncTester(&sysgo.DefaultMinimalSystemWithSyncTesterIDs{}, fcu))
 }
 
 func NewMinimalWithSyncTester(t devtest.T) *MinimalWithSyncTester {

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type SimpleWithSyncTester struct {
@@ -18,7 +18,7 @@ type SimpleWithSyncTester struct {
 	L2CL2      *dsl.L2CLNode
 }
 
-func WithSimpleWithSyncTester(fcus sttypes.FCUState) stack.CommonOption {
+func WithSimpleWithSyncTester(fcus eth.FCUState) stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, fcus))
 }
 

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 // SyncTesterEL is an L2ELNode implementation that runs a sync tester service.
@@ -30,7 +30,7 @@ type SyncTesterEL struct {
 
 	// Sync tester specific fields
 	clNodeID stack.L2CLNodeID
-	fcuState sttypes.FCUState
+	fcuState eth.FCUState
 	p        devtest.P
 
 	// Reference to the orchestrator to find the EL node to connect to
@@ -122,7 +122,7 @@ func (n *SyncTesterEL) JWTPath() string {
 // WithSyncTesterL2ELNode creates a SyncTesterEL that satisfies the L2ELNode interface
 // and configures a sync tester for a given CL node.
 // The sync tester acts as an EL node that can be used by CL nodes for testing sync.
-func WithSyncTesterL2ELNode(id stack.L2ELNodeID, clNodeID stack.L2CLNodeID, fcuState sttypes.FCUState, opts ...L2ELOption) stack.Option[*Orchestrator] {
+func WithSyncTesterL2ELNode(id stack.L2ELNodeID, clNodeID stack.L2CLNodeID, fcuState eth.FCUState, opts ...L2ELOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
 		require := p.Require()

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 var (
@@ -100,7 +99,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	}
 }
 
-func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, fcus sttypes.FCUState) stack.Option[*Orchestrator] {
+func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTesterIDs, fcu eth.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID)

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
 type DefaultSimpleSystemWithSyncTesterIDs struct {
@@ -23,7 +22,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	}
 }
 
-func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, fcus sttypes.FCUState) stack.Option[*Orchestrator] {
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, fcu eth.FCUState) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -62,7 +61,7 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}))
 
 	// Create a SyncTesterEL with the same chain ID as the CL node
-	opt.Add(WithSyncTesterL2ELNode(ids.SyncTester, ids.L2CL2, fcus))
+	opt.Add(WithSyncTesterL2ELNode(ids.SyncTester, ids.L2CL2, fcu))
 	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.SyncTester)))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {

--- a/op-service/apis/sync_tester.go
+++ b/op-service/apis/sync_tester.go
@@ -2,10 +2,47 @@ package apis
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type SyncTester interface {
+	// Only expose sync namespace for encapsulation
+	SyncAPI
+	// ChainID for minimal sanity check
 	ChainID(ctx context.Context) (eth.ChainID, error)
+}
+
+type SyncAPI interface {
+	GetSession(ctx context.Context) (eth.SyncTesterSession, error)
+	DeleteSession(ctx context.Context) error
+	ListSessions(ctx context.Context) ([]string, error)
+}
+
+type EthAPI interface {
+	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error)
+	GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (json.RawMessage, error)
+	GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error)
+	ChainId(ctx context.Context) (hexutil.Big, error)
+}
+
+type EngineAPI interface {
+	GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
+	GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
+	GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
+	GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
+
+	ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
+	ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
+	ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
+
+	NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error)
+	NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error)
+	NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error)
+	NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error)
 }

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -1,0 +1,27 @@
+package eth
+
+// FCUState represents the Fork Choice Update state with Latest, Safe, and Finalized block numbers
+type FCUState struct {
+	Latest    uint64 `json:"latest"`
+	Safe      uint64 `json:"safe"`
+	Finalized uint64 `json:"finalized"`
+}
+
+type SyncTesterSession struct {
+	SessionID string `json:"sessionID"`
+
+	// Non canonical view of the chain
+	Validated uint64 `json:"validated"`
+	// Canonical view of the chain
+	CurrentState FCUState `json:"currentState"`
+	// payloads
+	Payloads map[PayloadID]*ExecutionPayloadEnvelope `json:"-"`
+
+	InitialState FCUState `json:"initialState"`
+}
+
+func (s *SyncTesterSession) UpdateFCUState(latest, safe, finalized uint64) {
+	s.CurrentState.Latest = latest
+	s.CurrentState.Safe = safe
+	s.CurrentState.Finalized = finalized
+}

--- a/op-service/sources/sync_tester_client.go
+++ b/op-service/sources/sync_tester_client.go
@@ -25,3 +25,19 @@ func (cl *SyncTesterClient) ChainID(ctx context.Context) (eth.ChainID, error) {
 	err := cl.client.CallContext(ctx, &result, "eth_chainId")
 	return result, err
 }
+
+func (cl *SyncTesterClient) GetSession(ctx context.Context) (eth.SyncTesterSession, error) {
+	var session eth.SyncTesterSession
+	err := cl.client.CallContext(ctx, &session, "sync_getSession")
+	return session, err
+}
+
+func (cl *SyncTesterClient) ListSessions(ctx context.Context) ([]string, error) {
+	var sessions []string
+	err := cl.client.CallContext(ctx, &sessions, "sync_listSessions")
+	return sessions, err
+}
+
+func (cl *SyncTesterClient) DeleteSession(ctx context.Context) error {
+	return cl.client.CallContext(ctx, nil, "sync_deleteSession")
+}

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -22,34 +22,15 @@ type sessionKeyType struct{}
 
 var ctxKeySession = sessionKeyType{}
 
-// WithSession returns a new context with the given Session.
-func WithSession(ctx context.Context, s *Session) context.Context {
+// WithSyncTesterSession returns a new context with the given Session.
+func WithSyncTesterSession(ctx context.Context, s *eth.SyncTesterSession) context.Context {
 	return context.WithValue(ctx, ctxKeySession, s)
 }
 
-// SessionFromContext retrieves the Session from the context, if present.
-func SessionFromContext(ctx context.Context) (*Session, bool) {
-	s, ok := ctx.Value(ctxKeySession).(*Session)
+// SyncTesterSessionFromContext retrieves the Session from the context, if present.
+func SyncTesterSessionFromContext(ctx context.Context) (*eth.SyncTesterSession, bool) {
+	s, ok := ctx.Value(ctxKeySession).(*eth.SyncTesterSession)
 	return s, ok
-}
-
-type Session struct {
-	SessionID string
-
-	// Non canonical view of the chain
-	Validated uint64
-	// Canonical view of the chain
-	CurrentState sttypes.FCUState
-	// payloads
-	Payloads map[eth.PayloadID]*eth.ExecutionPayloadEnvelope
-
-	InitialState sttypes.FCUState
-}
-
-func (s *Session) UpdateFCUState(latest, safe, finalized uint64) {
-	s.CurrentState.Latest = latest
-	s.CurrentState.Safe = safe
-	s.CurrentState.Finalized = finalized
 }
 
 type APIRouter interface {

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -65,12 +65,12 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 
 func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
-		log:               logger,
-		m:                 m,
-		id:                stID,
-		chainID:           chainID,
-		elReader:          elReader,
-		sessions:          make(map[string]*eth.SyncTesterSession),
+		log:      logger,
+		m:        m,
+		id:       stID,
+		chainID:  chainID,
+		elReader: elReader,
+		sessions: make(map[string]*eth.SyncTesterSession),
 	}
 }
 

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -28,11 +28,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/frontend"
 )
 
-var (
-	ErrNoSession  = errors.New("no session")
-	ErrNoReceipts = errors.New("no receipts")
-)
-
 type SyncTester struct {
 	mu sync.RWMutex
 
@@ -44,7 +39,7 @@ type SyncTester struct {
 
 	elReader ReadOnlyELBackend
 
-	sessions map[string]*Session
+	sessions map[string]*eth.SyncTesterSession
 }
 
 // HeaderNumberOnly is a lightweight header type that only contains the
@@ -70,21 +65,21 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 
 func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
-		log:      logger,
-		m:        m,
-		id:       stID,
-		chainID:  chainID,
-		elReader: elReader,
-		sessions: make(map[string]*Session),
+		log:               logger,
+		m:                 m,
+		id:                stID,
+		chainID:           chainID,
+		elReader:          elReader,
+		sessions:          make(map[string]*eth.SyncTesterSession),
 	}
 }
 
-func (s *SyncTester) storeSession(session *Session) {
+func (s *SyncTester) storeSession(session *eth.SyncTesterSession) {
 	s.sessions[session.SessionID] = session
 }
 
-func (s *SyncTester) fetchSession(ctx context.Context) (*Session, error) {
-	session, ok := SessionFromContext(ctx)
+func (s *SyncTester) fetchSession(ctx context.Context) (*eth.SyncTesterSession, error) {
+	session, ok := SyncTesterSessionFromContext(ctx)
 	if !ok || session == nil {
 		return nil, fmt.Errorf("no session found in context")
 	}
@@ -100,18 +95,18 @@ func (s *SyncTester) fetchSession(ctx context.Context) (*Session, error) {
 	}
 }
 
-func (s *SyncTester) GetSession(ctx context.Context) error {
-	_, err := s.fetchSession(ctx)
+func (s *SyncTester) GetSession(ctx context.Context) (eth.SyncTesterSession, error) {
+	session, err := s.fetchSession(ctx)
 	if err != nil {
-		return ErrNoSession
+		return eth.SyncTesterSession{}, err
 	}
-	return nil
+	return *session, nil
 }
 
 func (s *SyncTester) DeleteSession(ctx context.Context) error {
 	session, err := s.fetchSession(ctx)
 	if err != nil {
-		return ErrNoSession
+		return err
 	}
 	delete(s.sessions, session.SessionID)
 	return nil
@@ -146,7 +141,7 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 	}
 	if len(receipts) == 0 {
 		// Should never happen since every block except genesis has at least one deposit tx
-		return nil, ErrNoReceipts
+		return nil, errors.New("no receipts")
 	}
 	if receipts[0].BlockNumber.Uint64() > session.CurrentState.Latest {
 		return nil, ethereum.NotFound
@@ -173,7 +168,7 @@ func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullT
 	return raw, nil
 }
 
-func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *Session) (uint64, error) {
+func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncTesterSession) (uint64, error) {
 	var target uint64
 	switch number {
 	case rpc.LatestBlockNumber:
@@ -281,7 +276,7 @@ func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) 
 // ForkchoiceUpdated engine APIs when valid payload attributes were provided.
 // Retrieved payloads are deleted from the session after being served to
 // emulate one-time consumption by the consensus layer.
-func (s *SyncTester) getPayload(session *Session, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+func (s *SyncTester) getPayload(session *eth.SyncTesterSession, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	payloadEnv, ok := session.Payloads[payloadID]
 	if !ok {
 		return nil, engine.UnknownPayload
@@ -336,7 +331,7 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 //     attributes are malformed or finalized/safe blocks are not canonical.
 //   - {status: SYNCING} when the head block is unknown or not yet validated, or
 //     when block data cannot be retrieved from the execution layer.
-func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *Session, state *eth.ForkchoiceState, attr *eth.PayloadAttributes, payloadVersion engine.PayloadVersion,
+func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTesterSession, state *eth.ForkchoiceState, attr *eth.PayloadAttributes, payloadVersion engine.PayloadVersion,
 	isCanyon, isEcotone bool,
 ) (*eth.ForkchoiceUpdatedResult, error) {
 	// Validate attributes shape
@@ -597,7 +592,7 @@ func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPay
 //   - {status: SYNCING} when the block cannot be executed because its parent is missing.
 //   - Errors surfaced as engine.InvalidParams or engine.GenericServerError to
 //     trigger appropriate consensus-layer retries.
-func (s *SyncTester) newPayload(ctx context.Context, session *Session, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes,
+func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSession, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes,
 	isEcotone, isIsthmus bool,
 ) (*eth.PayloadStatusV1, error) {
 	// Validate request shape, fork required fields

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -101,12 +101,12 @@ func initTestSyncTester(t *testing.T, chainID eth.ChainID, elReader ReadOnlyELBa
 }
 
 func TestSyncTester_ChainId(t *testing.T) {
-	dummySession := &Session{SessionID: uuid.New().String()}
+	dummySession := &eth.SyncTesterSession{SessionID: uuid.New().String()}
 	tests := []struct {
 		name            string
 		cfgID           eth.ChainID
 		elID            eth.ChainID
-		session         *Session
+		session         *eth.SyncTesterSession
 		wantErrContains string
 	}{
 		{
@@ -136,7 +136,7 @@ func TestSyncTester_ChainId(t *testing.T) {
 			st := initTestSyncTester(t, tc.cfgID, mock)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSession(ctx, tc.session)
+				ctx = WithSyncTesterSession(ctx, tc.session)
 			}
 			got, err := st.ChainId(ctx)
 			if tc.wantErrContains != "" {
@@ -161,7 +161,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 		name            string
 		sessionLatest   uint64
 		rawNumber       uint64 // block.number returned by EL
-		session         *Session
+		session         *eth.SyncTesterSession
 		wantErrContains string
 	}{
 		{
@@ -175,14 +175,14 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			name:            "block number greater than latest",
 			sessionLatest:   100,
 			rawNumber:       101, // greater than Latest
-			session:         &Session{SessionID: uuid.New().String(), CurrentState: sttypes.FCUState{Latest: 100}},
+			session:         &eth.SyncTesterSession{SessionID: uuid.New().String(), CurrentState: eth.FCUState{Latest: 100}},
 			wantErrContains: "not found",
 		},
 		{
 			name:          "happy path",
 			sessionLatest: 100,
 			rawNumber:     99,
-			session:       &Session{SessionID: uuid.New().String(), CurrentState: sttypes.FCUState{Latest: 100}},
+			session:       &eth.SyncTesterSession{SessionID: uuid.New().String(), CurrentState: eth.FCUState{Latest: 100}},
 		},
 	}
 
@@ -194,7 +194,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSession(ctx, tc.session)
+				ctx = WithSyncTesterSession(ctx, tc.session)
 			}
 			raw, err := st.GetBlockByHash(ctx, hash, false)
 			if tc.wantErrContains != "" {
@@ -215,7 +215,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 func TestSyncTester_GetBlockByNumber(t *testing.T) {
 	type testCase struct {
 		name            string
-		session         *Session
+		session         *eth.SyncTesterSession
 		inNumber        rpc.BlockNumber
 		wantNum         uint64
 		wantErrContains string
@@ -229,9 +229,9 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 		},
 		{
 			name: "happy path: numeric less than latest",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID: uuid.New().String(),
-				CurrentState: sttypes.FCUState{
+				CurrentState: eth.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
@@ -242,9 +242,9 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 		},
 		{
 			name: "happy path: label latest returns latest",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID: uuid.New().String(),
-				CurrentState: sttypes.FCUState{
+				CurrentState: eth.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
@@ -255,9 +255,9 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 		},
 		{
 			name: "happy path: label safe returns safe",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID: uuid.New().String(),
-				CurrentState: sttypes.FCUState{
+				CurrentState: eth.FCUState{
 					Latest:    100,
 					Safe:      97,
 					Finalized: 90,
@@ -268,9 +268,9 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 		},
 		{
 			name: "happy path: label finalized returns finalized",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID: uuid.New().String(),
-				CurrentState: sttypes.FCUState{
+				CurrentState: eth.FCUState{
 					Latest:    100,
 					Safe:      97,
 					Finalized: 92,
@@ -281,27 +281,27 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 		},
 		{
 			name: "pending returns not found",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			inNumber:        rpc.PendingBlockNumber,
 			wantErrContains: "not found",
 		},
 		{
 			name: "earliest label returns not found",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			inNumber:        rpc.EarliestBlockNumber,
 			wantErrContains: "not found",
 		},
 		{
 			name: "numeric greater than latest returns not found",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			inNumber:        rpc.BlockNumber(101),
 			wantErrContains: "not found",
@@ -320,7 +320,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSession(ctx, tc.session)
+				ctx = WithSyncTesterSession(ctx, tc.session)
 			}
 			raw, err := st.GetBlockByNumber(ctx, tc.inNumber, false)
 			if tc.wantErrContains != "" {
@@ -345,9 +345,9 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 	}
 	type testCase struct {
 		name            string
-		session         *Session
+		session         *eth.SyncTesterSession
 		arg             rpc.BlockNumberOrHash
-		seedFn          func(el *MockELReader, s *Session)
+		seedFn          func(el *MockELReader, s *eth.SyncTesterSession)
 		wantFirstBN     uint64
 		wantErrContains string
 	}
@@ -362,32 +362,32 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 		},
 		{
 			name: "happy: via hash, blockNumber less than latest",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID: uuid.New().String(),
-				CurrentState: sttypes.FCUState{
+				CurrentState: eth.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
 				},
 			},
 			arg: rpc.BlockNumberOrHashWithHash(hashGood, false),
-			seedFn: func(el *MockELReader, s *Session) {
+			seedFn: func(el *MockELReader, s *eth.SyncTesterSession) {
 				el.ReceiptsByHash[hashGood] = makeReceipts(s.CurrentState.Latest - 1)
 			},
 			wantFirstBN: 99,
 		},
 		{
 			name: "bad: via hash, blockNumber >= latest returns not found",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID: uuid.New().String(),
-				CurrentState: sttypes.FCUState{
+				CurrentState: eth.FCUState{
 					Latest:    100,
 					Safe:      95,
 					Finalized: 90,
 				},
 			},
 			arg: rpc.BlockNumberOrHashWithHash(hashTooNew, false),
-			seedFn: func(el *MockELReader, s *Session) {
+			seedFn: func(el *MockELReader, s *eth.SyncTesterSession) {
 				// strictly greater than Latest so the post-check triggers NotFound
 				el.ReceiptsByHash[hashTooNew] = makeReceipts(s.CurrentState.Latest + 1)
 			},
@@ -395,57 +395,57 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 		},
 		{
 			name: "happy: label latest returns latest",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 95, Finalized: 90},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 95, Finalized: 90},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber),
-			seedFn: func(el *MockELReader, s *Session) {
+			seedFn: func(el *MockELReader, s *eth.SyncTesterSession) {
 				el.ReceiptsByNumber[rpc.BlockNumber(s.CurrentState.Latest)] = makeReceipts(s.CurrentState.Latest)
 			},
 			wantFirstBN: 100,
 		},
 		{
 			name: "happy: label safe returns safe",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 90},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 90},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.SafeBlockNumber),
-			seedFn: func(el *MockELReader, s *Session) {
+			seedFn: func(el *MockELReader, s *eth.SyncTesterSession) {
 				el.ReceiptsByNumber[rpc.BlockNumber(s.CurrentState.Safe)] = makeReceipts(s.CurrentState.Safe)
 			},
 			wantFirstBN: 97,
 		},
 		{
 			name: "happy: label finalized returns finalized",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.FinalizedBlockNumber),
-			seedFn: func(el *MockELReader, s *Session) {
+			seedFn: func(el *MockELReader, s *eth.SyncTesterSession) {
 				el.ReceiptsByNumber[rpc.BlockNumber(s.CurrentState.Finalized)] = makeReceipts(s.CurrentState.Finalized)
 			},
 			wantFirstBN: 92,
 		},
 		{
 			name: "happy: numeric less than latest",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			arg: rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(99)),
-			seedFn: func(el *MockELReader, _ *Session) {
+			seedFn: func(el *MockELReader, _ *eth.SyncTesterSession) {
 				el.ReceiptsByNumber[rpc.BlockNumber(99)] = makeReceipts(99)
 			},
 			wantFirstBN: 99,
 		},
 		{
 			name: "bad: numeric greater than latest returns not found",
-			session: &Session{
+			session: &eth.SyncTesterSession{
 				SessionID:    uuid.New().String(),
-				CurrentState: sttypes.FCUState{Latest: 100, Safe: 97, Finalized: 92},
+				CurrentState: eth.FCUState{Latest: 100, Safe: 97, Finalized: 92},
 			},
 			arg:             rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(101)),
 			wantErrContains: "not found",
@@ -462,7 +462,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSession(ctx, tc.session)
+				ctx = WithSyncTesterSession(ctx, tc.session)
 			}
 			recs, err := st.GetBlockReceipts(ctx, tc.arg)
 			if tc.wantErrContains != "" {

--- a/op-sync-tester/synctester/backend/types/types.go
+++ b/op-sync-tester/synctester/backend/types/types.go
@@ -35,10 +35,3 @@ func (id *SyncTesterID) UnmarshalText(data []byte) error {
 	*id = SyncTesterID(data)
 	return nil
 }
-
-// FCUState represents the Fork Choice Update state with Latest, Safe, and Finalized block numbers
-type FCUState struct {
-	Latest    uint64
-	Safe      uint64
-	Finalized uint64
-}

--- a/op-sync-tester/synctester/frontend/engine.go
+++ b/op-sync-tester/synctester/frontend/engine.go
@@ -3,25 +3,14 @@ package frontend
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type EngineBackend interface {
-	GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
-	GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
-	GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
-	GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
-
-	ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
-	ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
-	ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
-
-	NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error)
-	NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error)
-	NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error)
-	NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error)
+	apis.EngineAPI
 }
 
 type EngineFrontend struct {

--- a/op-sync-tester/synctester/frontend/eth.go
+++ b/op-sync-tester/synctester/frontend/eth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -11,12 +13,8 @@ import (
 )
 
 type EthBackend interface {
-	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error)
-	GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (json.RawMessage, error)
-	GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error)
-	ChainId(ctx context.Context) (hexutil.Big, error)
+	apis.EthAPI
 }
-
 type EthFrontend struct {
 	b EthBackend
 }

--- a/op-sync-tester/synctester/frontend/sync.go
+++ b/op-sync-tester/synctester/frontend/sync.go
@@ -2,14 +2,14 @@ package frontend
 
 import (
 	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type SyncBackend interface {
-	GetSession(ctx context.Context) error
-	DeleteSession(ctx context.Context) error
-	ListSessions(ctx context.Context) ([]string, error)
+	apis.SyncAPI
 }
-
 type SyncFrontend struct {
 	b SyncBackend
 }
@@ -18,7 +18,7 @@ func NewSyncFrontend(b SyncBackend) *SyncFrontend {
 	return &SyncFrontend{b: b}
 }
 
-func (s *SyncFrontend) GetSession(ctx context.Context) error {
+func (s *SyncFrontend) GetSession(ctx context.Context) (eth.SyncTesterSession, error) {
 	return s.b.GetSession(ctx)
 }
 

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
-	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
 )
@@ -42,7 +41,6 @@ func parseSession(r *http.Request, log log.Logger) (*http.Request, error) {
 		parseParam := func(name string) (uint64, error) {
 			raw := query.Get(name)
 			if raw == "" {
-				log.Warn("Parameter not provided. Defaulting to 0", "param", name)
 				return 0, nil
 			}
 			val, err := strconv.ParseUint(raw, 10, 64)
@@ -63,22 +61,22 @@ func parseSession(r *http.Request, log log.Logger) (*http.Request, error) {
 		if err != nil {
 			return r, err
 		}
-		session := &backend.Session{
+		session := &eth.SyncTesterSession{
 			SessionID: sessionID,
 			Validated: latest,
-			CurrentState: sttypes.FCUState{
+			CurrentState: eth.FCUState{
 				Latest:    latest,
 				Safe:      safe,
 				Finalized: finalized,
 			},
 			Payloads: make(map[eth.PayloadID]*eth.ExecutionPayloadEnvelope),
-			InitialState: sttypes.FCUState{
+			InitialState: eth.FCUState{
 				Latest:    latest,
 				Safe:      safe,
 				Finalized: finalized,
 			},
 		}
-		ctx := backend.WithSession(r.Context(), session)
+		ctx := backend.WithSyncTesterSession(r.Context(), session)
 		// remove uuid path for routing
 		r.URL.Path = "/" + strings.Join(segments[:3], "/")
 		r = r.WithContext(ctx)

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -33,7 +33,7 @@ func TestParseSession_Valid(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newReq)
 
-	session, ok := backend.SessionFromContext(newReq.Context())
+	session, ok := backend.SyncTesterSessionFromContext(newReq.Context())
 	require.True(t, ok)
 	require.NotNil(t, session)
 	require.Equal(t, id, session.SessionID)
@@ -53,7 +53,7 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newReq)
 
-	session, ok := backend.SessionFromContext(newReq.Context())
+	session, ok := backend.SyncTesterSessionFromContext(newReq.Context())
 	require.True(t, ok)
 	require.NotNil(t, session)
 	require.Equal(t, id, session.SessionID)
@@ -71,7 +71,7 @@ func TestParseSession_NoSessionInitialized(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, req, newReq)
 
-	_, ok := backend.SessionFromContext(newReq.Context())
+	_, ok := backend.SyncTesterSessionFromContext(newReq.Context())
 	require.False(t, ok)
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Move Sync Tester Types to `op-service/eth` and restructure API interfaces, to resolve circular dependencies. Previously we were importing sync tester types to op-service, and vice versa. Now every type is from the `op-service/eth`.

Expose `eth_chainId` and sync namespace for the api.SyncTester which is used in acceptance tests. 

Preparation of https://github.com/ethereum-optimism/optimism/issues/16778.

**Tests**

All existing tests are passing.
