### PR TITLE
op-deployer,op-up: build artifacts if they are not present

### DIFF
--- a/op-deployer/.goreleaser.yaml
+++ b/op-deployer/.goreleaser.yaml
@@ -9,6 +9,7 @@ before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
+    - just op-deployer/copy-contract-artifacts
 
 builds:
   - id: main

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -1,4 +1,6 @@
-build:
+COMPRESSED_ARTIFACTS := './pkg/deployer/artifacts/forge-artifacts/artifacts.tgz'
+
+build: copy-contract-artifacts
     go build -o bin/op-deployer cmd/op-deployer/main.go
 
 build-contracts:
@@ -8,8 +10,13 @@ test args='./...': build-contracts
     go test -v {{args}}
 
 copy-contract-artifacts:
-    rm -f ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz
-    tar -cvzf ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz -C ../packages/contracts-bedrock/forge-artifacts --exclude="*.t.sol" .
+  #!/bin/sh
+  if [ ! -f {{ COMPRESSED_ARTIFACTS }} ]; then
+    just compress-artifacts
+  fi
+
+compress-artifacts: build-contracts
+  tar -cvzf {{ COMPRESSED_ARTIFACTS }} -C '../packages/contracts-bedrock/forge-artifacts' --exclude="*.t.sol" .
 
 # ======================================
 # Deployment and Verification Utilities

--- a/op-up/.goreleaser.yaml
+++ b/op-up/.goreleaser.yaml
@@ -8,6 +8,7 @@ project_name: op-up
 before:
   hooks:
     - go mod tidy
+    - just op-deployer/copy-contract-artifacts
 
 builds:
   - id: main
@@ -25,6 +26,11 @@ builds:
       - goos: linux
         goarch: arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -X main.GitCommit={{ .FullCommit }}
+      - -X main.GitDate={{ .CommitDate }}
+      - -X main.Version={{ .Version }}
+      - -X main.VersionMeta=
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
Prevents the case where either binary is released with empty aritfacts.

Fixes #17073