### PR TITLE
fix(op-deployer): propagate Value for BroadcastCreate transactions

### DIFF
--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -206,6 +206,7 @@ func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandida
 		candidate = txmgr.TxCandidate{
 			TxData:   bcast.Input,
 			To:       nil,
+			Value:    value,
 			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, true, blockGasLimit),
 		}
 	case script.BroadcastCreate2:


### PR DESCRIPTION
 Include Value in TxCandidate for contract creation to match Broadcast semantics and avoid dropping ETH for payable constructors.