### PR TITLE
op-devstack: Explicit Sync Tester EL and API Session Binding 

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/google/uuid"
 )
 
 func TestSyncTester(gt *testing.T) {
@@ -18,7 +19,7 @@ func TestSyncTester(gt *testing.T) {
 
 	syncTester := sys.SyncTester.Escape()
 
-	chainID, err := syncTester.API().ChainID(t.Ctx())
+	chainID, err := syncTester.APIWithSession(uuid.New().String()).ChainID(t.Ctx())
 	require.NoError(err)
 
 	require.Equal(chainID, sys.L2EL.ChainID())

--- a/op-acceptance-tests/tests/sync_tester_e2e/sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/sync_tester_e2e/sync_tester_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/google/uuid"
 )
 
 func TestSyncTesterE2E(gt *testing.T) {
@@ -39,7 +40,7 @@ func TestSyncTesterE2E(gt *testing.T) {
 
 	// Test that we can get chain ID from SyncTester
 	syncTester := sys.SyncTester.Escape()
-	syncTesterChainID, err := syncTester.API().ChainID(t.Ctx())
+	syncTesterChainID, err := syncTester.APIWithSession(uuid.New().String()).ChainID(t.Ctx())
 	require.NoError(err, "should be able to get chain ID from SyncTester")
 	require.Equal(eth.ChainIDFromUInt64(901), syncTesterChainID, "SyncTester should be on chain 901")
 

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -14,8 +14,9 @@ import (
 type SimpleWithSyncTester struct {
 	Minimal
 
-	SyncTester *dsl.SyncTester
-	L2CL2      *dsl.L2CLNode
+	SyncTester     *dsl.SyncTester
+	SyncTesterL2EL *dsl.L2ELNode
+	L2CL2          *dsl.L2CLNode
 }
 
 func WithSimpleWithSyncTester(fcus eth.FCUState) stack.CommonOption {
@@ -27,21 +28,19 @@ func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {
 	orch := Orchestrator()
 	orch.Hydrate(system)
 	minimal := minimalFromSystem(t, system, orch)
-	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
-	syncTester := l2.SyncTester(match.Assume(t, match.FirstSyncTester))
-	// Get the second L2CL node (verifier) - we need to find it by name
-	l2CLs := l2.L2CLNodes()
-	var l2CL2 stack.L2CLNode
-	for _, cl := range l2CLs {
-		if cl.ID().Key() == "verifier" {
-			l2CL2 = cl
-			break
-		}
-	}
+	l2 := system.L2Network(match.L2ChainA)
+	syncTester := l2.SyncTester(match.FirstSyncTester)
+
+	// L2CL connected to L2EL initialized by sync tester
+	l2CL2 := l2.L2CLNode(match.SecondL2CL)
+	// L2EL initialized by sync tester
+	syncTesterL2EL := l2.L2ELNode(match.SecondL2EL)
+
 	return &SimpleWithSyncTester{
-		Minimal:    *minimal,
-		SyncTester: dsl.NewSyncTester(syncTester),
-		L2CL2:      dsl.NewL2CLNode(l2CL2, orch.ControlPlane()),
+		Minimal:        *minimal,
+		SyncTester:     dsl.NewSyncTester(syncTester),
+		SyncTesterL2EL: dsl.NewL2ELNode(syncTesterL2EL, orch.ControlPlane()),
+		L2CL2:          dsl.NewL2CLNode(l2CL2, orch.ControlPlane()),
 	}
 }
 

--- a/op-devstack/shim/sync_tester.go
+++ b/op-devstack/shim/sync_tester.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
-	"github.com/google/uuid"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester"
 )
 
 type SyncTesterConfig struct {
@@ -49,9 +49,7 @@ func (p *presetSyncTester) API() apis.SyncTester {
 
 func (p *presetSyncTester) APIWithSession(sessionID string) apis.SyncTester {
 	require := p.T().Require()
-	u, err := uuid.Parse(sessionID)
-	require.NoError(err, "invalid session format")
-	require.True(u.Version() == 4, "session format must satisfy uuid4 format")
+	require.NoError(synctester.IsValidSessionID(sessionID))
 	rpcCl, err := client.NewRPC(p.T().Ctx(), p.Logger(), p.addr+fmt.Sprintf("/%s", sessionID), client.WithLazyDial())
 	require.NoError(err, "sync tester failed to initialize rpc per session")
 	return sources.NewSyncTesterClient(rpcCl)

--- a/op-devstack/shim/sync_tester.go
+++ b/op-devstack/shim/sync_tester.go
@@ -1,22 +1,29 @@
 package shim
 
 import (
+	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/google/uuid"
 )
 
 type SyncTesterConfig struct {
 	CommonConfig
 	ID     stack.SyncTesterID
+	Addr   string
 	Client client.RPC
 }
 
 // presetSyncTester wraps around a syncTester-service,
 type presetSyncTester struct {
 	commonImpl
-	id               stack.SyncTesterID
+	id stack.SyncTesterID
+	// Endpoint for initializing RPC Client per session
+	addr string
+	// RPC Client initialized without session
 	syncTesterClient *sources.SyncTesterClient
 }
 
@@ -27,6 +34,7 @@ func NewSyncTester(cfg SyncTesterConfig) stack.SyncTester {
 	return &presetSyncTester{
 		id:               cfg.ID,
 		commonImpl:       newCommon(cfg.CommonConfig),
+		addr:             cfg.Addr,
 		syncTesterClient: sources.NewSyncTesterClient(cfg.Client),
 	}
 }
@@ -37,4 +45,14 @@ func (p *presetSyncTester) ID() stack.SyncTesterID {
 
 func (p *presetSyncTester) API() apis.SyncTester {
 	return p.syncTesterClient
+}
+
+func (p *presetSyncTester) APIWithSession(sessionID string) apis.SyncTester {
+	require := p.T().Require()
+	u, err := uuid.Parse(sessionID)
+	require.NoError(err, "invalid session format")
+	require.True(u.Version() == 4, "session format must satisfy uuid4 format")
+	rpcCl, err := client.NewRPC(p.T().Ctx(), p.Logger(), p.addr+fmt.Sprintf("/%s", sessionID), client.WithLazyDial())
+	require.NoError(err, "sync tester failed to initialize rpc per session")
+	return sources.NewSyncTesterClient(rpcCl)
 }

--- a/op-devstack/stack/sync_tester.go
+++ b/op-devstack/stack/sync_tester.go
@@ -71,4 +71,6 @@ type SyncTester interface {
 	Common
 	ID() SyncTesterID
 	API() apis.SyncTester
+
+	APIWithSession(sessionID string) apis.SyncTester
 }

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -29,7 +29,6 @@ type SyncTesterEL struct {
 	userProxy *tcpproxy.Proxy
 
 	// Sync tester specific fields
-	clNodeID stack.L2CLNodeID
 	fcuState eth.FCUState
 	p        devtest.P
 
@@ -71,7 +70,7 @@ func (n *SyncTesterEL) Start() {
 	}
 
 	// Use NewEndpoint to get the correct session-specific endpoint for this chain ID
-	endpoint := n.orch.syncTester.service.NewEndpoint(n.id.ChainID())
+	endpoint := n.orch.syncTester.service.SyncTesterRPCPath(n.id.ChainID(), true)
 
 	if n.authProxy == nil {
 		n.authProxy = tcpproxy.New(n.p.Logger().New("proxy", "l2el-synctester-auth"))
@@ -120,14 +119,13 @@ func (n *SyncTesterEL) JWTPath() string {
 }
 
 // WithSyncTesterL2ELNode creates a SyncTesterEL that satisfies the L2ELNode interface
-// and configures a sync tester for a given CL node.
 // The sync tester acts as an EL node that can be used by CL nodes for testing sync.
-func WithSyncTesterL2ELNode(id stack.L2ELNodeID, clNodeID stack.L2CLNodeID, fcuState eth.FCUState, opts ...L2ELOption) stack.Option[*Orchestrator] {
+func WithSyncTesterL2ELNode(id, readonlyEL stack.L2ELNodeID, fcuState eth.FCUState, opts ...L2ELOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
 		require := p.Require()
 
-		l2Net, ok := orch.l2Nets.Get(id.ChainID())
+		l2Net, ok := orch.l2Nets.Get(readonlyEL.ChainID())
 		require.True(ok, "L2 network required")
 
 		cfg := DefaultL2ELConfig()
@@ -140,13 +138,12 @@ func WithSyncTesterL2ELNode(id stack.L2ELNodeID, clNodeID stack.L2CLNodeID, fcuS
 			id:       id,
 			l2Net:    l2Net,
 			jwtPath:  jwtPath,
-			clNodeID: clNodeID,
 			fcuState: fcuState,
 			p:        p,
 			orch:     orch,
 		}
 
-		p.Logger().Info("Starting sync tester EL", "id", id, "clNodeID", clNodeID)
+		p.Logger().Info("Starting sync tester EL", "id", id)
 		syncTesterEL.Start()
 		p.Cleanup(syncTesterEL.Stop)
 		p.Logger().Info("sync tester EL is ready", "userRPC", syncTesterEL.userRPC, "authRPC", syncTesterEL.authRPC)

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -49,7 +49,7 @@ type Orchestrator struct {
 	challengers    locks.RWMap[stack.L2ChallengerID, *L2Challenger]
 	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
 
-	syncTester *SyncTester
+	syncTester *SyncTesterService
 	faucet     *FaucetService
 
 	controlPlane *ControlPlane

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -17,12 +17,11 @@ import (
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
-type SyncTester struct {
-	id      stack.SyncTesterID
+type SyncTesterService struct {
 	service *synctester.Service
 }
 
-func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
+func (n *SyncTesterService) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
 	for syncTesterID, chainID := range n.service.SyncTesters() {
@@ -84,6 +83,6 @@ func WithSyncTester(syncTesterID stack.SyncTesterID, l2ELs []stack.L2ELNodeID) s
 			_ = srv.Stop(ctx)
 			logger.Info("Closed sync tester")
 		})
-		orch.syncTester = &SyncTester{id: syncTesterID, service: srv}
+		orch.syncTester = &SyncTesterService{service: srv}
 	})
 }

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -26,7 +26,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	require := system.T().Require()
 
 	for syncTesterID, chainID := range n.service.SyncTesters() {
-		syncTesterRPC := n.service.RPC() + n.service.NewEndpoint(chainID)
+		syncTesterRPC := n.service.SyncTesterRPC(chainID, false)
 		rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), syncTesterRPC, client.WithLazyDial())
 		require.NoError(err)
 		system.T().Cleanup(rpcCl.Close)
@@ -34,6 +34,7 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 		front := shim.NewSyncTester(shim.SyncTesterConfig{
 			CommonConfig: shim.NewCommonConfig(system.T()),
 			ID:           id,
+			Addr:         syncTesterRPC,
 			Client:       rpcCl,
 		})
 		net := system.Network(chainID).(stack.ExtensibleNetwork)
@@ -41,9 +42,8 @@ func (n *SyncTester) hydrate(system stack.ExtensibleSystem) {
 	}
 }
 
-func WithSyncTester(l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithSyncTester(syncTesterID stack.SyncTesterID, l2ELs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
-		syncTesterID := stack.NewSyncTesterID("dev-sync-tester", l2ELs[0].ChainID())
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), syncTesterID))
 
 		require := p.Require()

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -17,7 +17,9 @@ import (
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
+// Caveat: id is binded by a single EL(chainID), but service can support multiple ELs
 type SyncTesterService struct {
+	id      stack.SyncTesterID
 	service *synctester.Service
 }
 
@@ -83,6 +85,6 @@ func WithSyncTester(syncTesterID stack.SyncTesterID, l2ELs []stack.L2ELNodeID) s
 			_ = srv.Stop(ctx)
 			logger.Info("Closed sync tester")
 		})
-		orch.syncTester = &SyncTesterService{service: srv}
+		orch.syncTester = &SyncTesterService{id: syncTesterID, service: srv}
 	})
 }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -95,7 +95,7 @@ func NewDefaultMinimalSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultMin
 	minimal := NewDefaultMinimalSystemIDs(l1ID, l2ID)
 	return DefaultMinimalSystemWithSyncTesterIDs{
 		DefaultMinimalSystemIDs: minimal,
-		SyncTester:              stack.NewSyncTesterID("s", l2ID),
+		SyncTester:              stack.NewSyncTesterID("sync-tester", l2ID),
 	}
 }
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -135,7 +135,7 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithSyncTester(ids.SyncTester, []stack.L2ELNodeID{ids.L2EL}))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -19,8 +19,8 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	return DefaultSimpleSystemWithSyncTesterIDs{
 		DefaultMinimalSystemIDs: minimal,
 		L2CL2:                   stack.NewL2CLNodeID("verifier", l2ID),
-		SyncTesterL2EL:          stack.NewL2ELNodeID("sync-tester-el", minimal.L2CL.ChainID()),
-		SyncTester:              stack.NewSyncTesterID("sync-tester", minimal.L2CL.ChainID()),
+		SyncTesterL2EL:          stack.NewL2ELNodeID("sync-tester-el", l2ID),
+		SyncTester:              stack.NewSyncTesterID("sync-tester", l2ID),
 	}
 }
 

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -9,8 +9,9 @@ import (
 type DefaultSimpleSystemWithSyncTesterIDs struct {
 	DefaultMinimalSystemIDs
 
-	L2CL2      stack.L2CLNodeID
-	SyncTester stack.L2ELNodeID
+	L2CL2          stack.L2CLNodeID
+	SyncTesterL2EL stack.L2ELNodeID
+	SyncTester     stack.SyncTesterID
 }
 
 func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimpleSystemWithSyncTesterIDs {
@@ -18,7 +19,8 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	return DefaultSimpleSystemWithSyncTesterIDs{
 		DefaultMinimalSystemIDs: minimal,
 		L2CL2:                   stack.NewL2CLNodeID("verifier", l2ID),
-		SyncTester:              stack.NewL2ELNodeID("sync-tester-el", l2ID),
+		SyncTesterL2EL:          stack.NewL2ELNodeID("sync-tester-el", minimal.L2CL.ChainID()),
+		SyncTester:              stack.NewSyncTesterID("sync-tester", minimal.L2CL.ChainID()),
 	}
 }
 
@@ -58,11 +60,11 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 		ids.L2EL,
 	}))
 
-	opt.Add(WithSyncTester([]stack.L2ELNodeID{ids.L2EL}))
+	opt.Add(WithSyncTester(ids.SyncTester, []stack.L2ELNodeID{ids.L2EL}))
 
-	// Create a SyncTesterEL with the same chain ID as the CL node
-	opt.Add(WithSyncTesterL2ELNode(ids.SyncTester, ids.L2CL2, fcu))
-	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.SyncTester)))
+	// Create a SyncTesterEL with the same chain ID as the EL node
+	opt.Add(WithSyncTesterL2ELNode(ids.SyncTesterL2EL, ids.L2EL, fcu))
+	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, ids.SyncTesterL2EL))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -9,12 +9,22 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
 )
 
 var ErrInvalidSessionIDFormat = errors.New("invalid UUID")
 var ErrInvalidParams = errors.New("invalid param")
+
+func IsValidSessionID(sessionID string) error {
+	u, err := uuid.Parse(sessionID)
+	if err != nil {
+		return fmt.Errorf("invalid session id format: %w", err)
+	}
+	if u.Version() == 4 {
+		return nil
+	}
+	return errors.New("session format must satisfy uuid4 format")
+}
 
 // parseSession inspects the incoming request to determine if it targets a session-specific route.
 // If the request path matches the pattern `/chain/{chain_id}/synctest/{uuid}`, it attempts to parse
@@ -30,12 +40,12 @@ var ErrInvalidParams = errors.New("invalid param")
 //	/chain/{chain_id}/synctest/{session_uuid}
 //
 // Returns an error if the session UUID is invalid or any query parameter is malformed.
-func parseSession(r *http.Request, log log.Logger) (*http.Request, error) {
+func parseSession(r *http.Request) (*http.Request, error) {
 	segments := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 	if len(segments) == 4 && segments[0] == "chain" && segments[2] == "synctest" {
 		sessionID := segments[3]
-		if _, err := uuid.Parse(sessionID); err != nil {
-			return r, ErrInvalidSessionIDFormat
+		if err := IsValidSessionID(sessionID); err != nil {
+			return r, errors.Join(ErrInvalidSessionIDFormat, err)
 		}
 		query := r.URL.Query()
 		parseParam := func(name string) (uint64, error) {

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +28,7 @@ func TestParseSession_Valid(t *testing.T) {
 	query.Set(eth.Finalized, "80")
 
 	req := newRequest("/chain/1/synctest/"+id, query)
-	newReq, err := parseSession(req, log.New())
+	newReq, err := parseSession(req)
 	require.NoError(t, err)
 	require.NotNil(t, newReq)
 
@@ -49,7 +48,7 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 	id := uuid.New().String()
 	req := newRequest("/chain/1/synctest/"+id, nil)
 
-	newReq, err := parseSession(req, log.New())
+	newReq, err := parseSession(req)
 	require.NoError(t, err)
 	require.NotNil(t, newReq)
 
@@ -67,7 +66,7 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 func TestParseSession_NoSessionInitialized(t *testing.T) {
 	req := newRequest("/chain/1/synctest", nil)
 
-	newReq, err := parseSession(req, log.New())
+	newReq, err := parseSession(req)
 	require.NoError(t, err)
 	require.Same(t, req, newReq)
 
@@ -77,7 +76,7 @@ func TestParseSession_NoSessionInitialized(t *testing.T) {
 
 func TestParseSession_InvalidSessionIDFormat(t *testing.T) {
 	req := newRequest("/chain/1/synctest/not-a-uuid", nil)
-	_, err := parseSession(req, log.New())
+	_, err := parseSession(req)
 	require.ErrorIs(t, err, ErrInvalidSessionIDFormat)
 }
 
@@ -87,6 +86,6 @@ func TestParseSession_InvalidQueryParam(t *testing.T) {
 	query.Set(eth.Unsafe, "not-a-number") // invalid uint64
 
 	req := newRequest("/chain/1/synctest/"+id, query)
-	_, err := parseSession(req, log.New())
+	_, err := parseSession(req)
 	require.ErrorIs(t, err, ErrInvalidParams)
 }

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -213,9 +213,16 @@ func (s *Service) RPC() string {
 	return s.httpServer.HTTPEndpoint()
 }
 
-func (s *Service) NewEndpoint(chainID eth.ChainID) string {
-	uuid := uuid.New()
-	return fmt.Sprintf("/chain/%s/synctest/%s", chainID, uuid)
+func (s *Service) SyncTesterRPC(chainID eth.ChainID, withSessionID bool) string {
+	return s.RPC() + s.SyncTesterRPCPath(chainID, withSessionID)
+}
+
+func (s *Service) SyncTesterRPCPath(chainID eth.ChainID, withSessionID bool) string {
+	path := fmt.Sprintf("/chain/%s/synctest", chainID)
+	if withSessionID {
+		path = fmt.Sprintf("%s/%s", path, uuid.New())
+	}
+	return path
 }
 
 func (s *Service) SyncTesters() map[sttypes.SyncTesterID]eth.ChainID {

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -147,7 +147,7 @@ func (s *Service) initHTTPServer(cfg *config.Config) error {
 	endpoint := net.JoinHostPort(cfg.RPC.ListenAddr, strconv.Itoa(cfg.RPC.ListenPort))
 	// middleware to initialize session
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r, err := parseSession(r, s.log)
+		r, err := parseSession(r)
 		if errors.Is(err, ErrInvalidSessionIDFormat) || errors.Is(err, ErrInvalidParams) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Explicitly expose read only EL to be accessed at preset. We can interact with the EL using the DSL.

Added `APIWithSession()` method to explicitly bind the session id while in tests.  Note that there will be APIs that does not require a session, such as `sync_listSessions`, in this case we can use the original `API()` method.

Preparation of https://github.com/ethereum-optimism/optimism/issues/16778.

**Tests**

All existing tests are passing

**Additional context**

Want to share my findings which can be addressed in future cleanup PRs:

There is some non-intuitive design of the devstack abstraction around sync tester.

```go
// Caveat: id is binded by a single EL(chainID), but service can support multiple ELs
type SyncTesterService struct {
	id      stack.SyncTesterID
	service *synctester.Service
}
```

```go
type SyncTesterID idWithChain
```
but the `service` can manage multiple ELs(multiple chain IDs) so there is an inconsistency.

