### PR TITLE
op-deployer: enable embedded artifacts integration test

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"log/slog"
 	"math/big"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -143,13 +142,10 @@ func TestEndToEndBootstrapApply(t *testing.T) {
 	}
 
 	t.Run("default tagged artifacts", func(t *testing.T) {
-		op_e2e.InitParallel(t)
-		testutils.RunOnBranch(t, regexp.MustCompile(`^(backports/op-deployer|proposal/op-contracts)/*`))
 		apply(t, artifacts.DefaultL1ContractsLocator)
 	})
 
 	t.Run("local artifacts", func(t *testing.T) {
-		op_e2e.InitParallel(t)
 		loc, _ := testutil.LocalArtifacts(t)
 		apply(t, loc)
 	})


### PR DESCRIPTION
Previously we only ran the op-deployer integration test for `default tagged artifacts` on backports+proposal branches. Now that the artifacts are embedded (i.e. contracts live on the same branch as op-deployer), we should always run that test.

Also had to remove the `op_e2e.InitParallel` on the two `TestEndToEndBootstrapApply` subtests because running them both led to nonce conflict.