### PR TITLE
feat: add feature flagging functionality to SystemConfig

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -26,6 +26,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     error ReinitializableBase_ZeroInitVersion();
 
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
+    event FeatureToggled(bytes32 indexed feature, bool indexed enabled);
     event Initialized(uint8 version);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
@@ -92,6 +93,8 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     function paused() external view returns (bool);
     function superchainConfig() external view returns (ISuperchainConfig);
     function guardian() external view returns (address);
+    function toggleFeature(bytes32 _feature, bool _enabled) external;
+    function isFeatureEnabled(bytes32) external view returns (bool);
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -24,9 +24,10 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     }
 
     error ReinitializableBase_ZeroInitVersion();
+    error SystemConfig_InvalidFeatureState();
 
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
-    event FeatureToggled(bytes32 indexed feature, bool indexed enabled);
+    event FeatureSet(bytes32 indexed feature, bool indexed enabled);
     event Initialized(uint8 version);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
@@ -93,7 +94,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     function paused() external view returns (bool);
     function superchainConfig() external view returns (ISuperchainConfig);
     function guardian() external view returns (address);
-    function toggleFeature(bytes32 _feature, bool _enabled) external;
+    function setFeature(bytes32 _feature, bool _enabled) external;
     function isFeatureEnabled(bytes32) external view returns (bool);
 
     function __constructor__() external;

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -414,6 +414,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isFeatureEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "l1CrossDomainMessenger",
     "outputs": [
@@ -813,6 +832,24 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "_feature",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "_enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "toggleFeature",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "newOwner",
         "type": "address"
@@ -890,6 +927,25 @@
       }
     ],
     "name": "ConfigUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "feature",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "FeatureToggled",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -726,6 +726,24 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "_feature",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "_enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setFeature",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_overhead",
         "type": "uint256"
@@ -832,24 +850,6 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "_feature",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bool",
-        "name": "_enabled",
-        "type": "bool"
-      }
-    ],
-    "name": "toggleFeature",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "address",
         "name": "newOwner",
         "type": "address"
@@ -945,7 +945,7 @@
         "type": "bool"
       }
     ],
-    "name": "FeatureToggled",
+    "name": "FeatureSet",
     "type": "event"
   },
   {
@@ -1013,6 +1013,11 @@
   {
     "inputs": [],
     "name": "ReinitializableBase_ZeroInitVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SystemConfig_InvalidFeatureState",
     "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xe83e83cddbcae1d6af62f9754517b25f95ae371f3843dd8ee8030ddf8ba4622d",
-    "sourceCodeHash": "0x5faad71f147b776ed4d3290d319d1f4697e4e37b50eee5a4ef52f901c04efaa0"
+    "initCodeHash": "0x3e8a3bed20aa10b6d285cd926903c4d8c34aad3ba5c0e9e32da3cde13b179238",
+    "sourceCodeHash": "0x6a31abe2f73c7279a00a8fcecb6741af8e6fe54a1112420e6a15859753487dbb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x07b7039de5b8a4dc57642ee9696e949d70516b7f6dce41dde4920efb17105ef2",
-    "sourceCodeHash": "0x997212ceadabb306c2abd31918b09bccbba0b21662c1d8930a3599831c374b13"
+    "initCodeHash": "0xe0313cdc286ffa7e1c0b2a94a0a57f93ee255bd38177c39321fe0f3157c220e2",
+    "sourceCodeHash": "0x1045239417412320c75698ee561b9a096e45b98db89dd97e1deb895ab99c9db5"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xe0313cdc286ffa7e1c0b2a94a0a57f93ee255bd38177c39321fe0f3157c220e2",
-    "sourceCodeHash": "0x1045239417412320c75698ee561b9a096e45b98db89dd97e1deb895ab99c9db5"
+    "initCodeHash": "0x8c6a1fb65d650525a3cd3fd617ae923d44da157b2ef928ab8ec39dbf39e25a98",
+    "sourceCodeHash": "0xdf526027678f23da79a56c1d6127a3ed3fd92927ec8d5541982b6f1c2119f70e"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
@@ -124,5 +124,12 @@
     "offset": 0,
     "slot": "108",
     "type": "contract ISuperchainConfig"
+  },
+  {
+    "bytes": "32",
+    "label": "isFeatureEnabled",
+    "offset": 0,
+    "slot": "109",
+    "type": "mapping(bytes32 => bool)"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -36,8 +36,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.8.0
-    string public constant version = "1.8.0";
+    /// @custom:semver 1.9.0
+    string public constant version = "1.9.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -176,7 +176,7 @@ contract OPContractsManagerStandardValidator is ISemver {
 
     /// @notice Returns the expected SystemConfig version.
     function systemConfigVersion() public pure returns (string memory) {
-        return "3.4.0";
+        return "3.5.0";
     }
 
     /// @notice Returns the expected OptimismPortal version.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -135,7 +135,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @notice The SuperchainConfig contract that manages the pause state.
     ISuperchainConfig public superchainConfig;
 
-    /// @notice Feature flags.
+    /// @notice Bytes32 feature flag name to boolean enabled value.
     mapping(bytes32 => bool) public isFeatureEnabled;
 
     /// @notice Emitted when configuration is updated.
@@ -144,10 +144,14 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @param data       Encoded update data.
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
-    /// @notice Emitted when a feature is toggled.
-    /// @param feature Feature that was toggled.
+    /// @notice Emitted when a feature is set.
+    /// @param feature Feature that was set.
     /// @param enabled Whether the feature is enabled.
-    event FeatureToggled(bytes32 indexed feature, bool indexed enabled);
+    event FeatureSet(bytes32 indexed feature, bool indexed enabled);
+
+    /// @notice Thrown when attempting to enable/disable a feature when already enabled/disabled,
+    ///         respectively.
+    error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
     /// @custom:semver 3.5.0
@@ -492,18 +496,25 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         _resourceConfig = _config;
     }
 
-    /// @notice Toggles a feature flag. Can only be called by the ProxyAdmin or its owner.
-    /// @param _feature Feature to toggle.
+    /// @notice Sets a feature flag enabled or disabled. Can only be called by the ProxyAdmin or
+    ///         its owner.
+    /// @param _feature Feature to set.
     /// @param _enabled Whether the feature should be enabled or disabled.
-    function toggleFeature(bytes32 _feature, bool _enabled) external {
-        // Features can only be toggled by the ProxyAdmin or its owner.
+    function setFeature(bytes32 _feature, bool _enabled) external {
+        // Features can only be set by the ProxyAdmin or its owner.
         _assertOnlyProxyAdminOrProxyAdminOwner();
 
-        // Toggle the feature.
+        // As a sanity check, prevent users from enabling the feature if already enabled or
+        // disabling the feature if already disabled. This helps to prevent accidental misuse.
+        if ((_enabled && isFeatureEnabled[_feature]) || (!_enabled && !isFeatureEnabled[_feature])) {
+            revert SystemConfig_InvalidFeatureState();
+        }
+
+        // Set the feature.
         isFeatureEnabled[_feature] = _enabled;
 
         // Emit an event.
-        emit FeatureToggled(_feature, _enabled);
+        emit FeatureSet(_feature, _enabled);
     }
 
     /// @notice Returns the current pause state of the system by checking if the SuperchainConfig is paused for this

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -135,16 +135,24 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @notice The SuperchainConfig contract that manages the pause state.
     ISuperchainConfig public superchainConfig;
 
+    /// @notice Feature flags.
+    mapping(bytes32 => bool) public isFeatureEnabled;
+
     /// @notice Emitted when configuration is updated.
     /// @param version    SystemConfig version.
     /// @param updateType Type of update.
     /// @param data       Encoded update data.
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
+    /// @notice Emitted when a feature is toggled.
+    /// @param feature Feature that was toggled.
+    /// @param enabled Whether the feature is enabled.
+    event FeatureToggled(bytes32 indexed feature, bool indexed enabled);
+
     /// @notice Semantic version.
-    /// @custom:semver 3.4.0
+    /// @custom:semver 3.5.0
     function version() public pure virtual returns (string memory) {
-        return "3.4.0";
+        return "3.5.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -482,6 +490,20 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         );
 
         _resourceConfig = _config;
+    }
+
+    /// @notice Toggles a feature flag. Can only be called by the ProxyAdmin or its owner.
+    /// @param _feature Feature to toggle.
+    /// @param _enabled Whether the feature should be enabled or disabled.
+    function toggleFeature(bytes32 _feature, bool _enabled) external {
+        // Features can only be toggled by the ProxyAdmin or its owner.
+        _assertOnlyProxyAdminOrProxyAdminOwner();
+
+        // Toggle the feature.
+        isFeatureEnabled[_feature] = _enabled;
+
+        // Emit an event.
+        emit FeatureToggled(_feature, _enabled);
     }
 
     /// @notice Returns the current pause state of the system by checking if the SuperchainConfig is paused for this

--- a/packages/contracts-bedrock/src/libraries/Features.sol
+++ b/packages/contracts-bedrock/src/libraries/Features.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @notice Features is a library that stores feature name constants. Can be used alongside the
+///         feature flagging functionality in the SystemConfig contract to selectively enable or
+///         disable customizable features of the OP Stack.
+library Features {
+    /// @notice The ETH_LOCKBOX feature determines if the system is configured to use the
+    ///         ETHLockbox contract in the OptimismPortal. When the ETH_LOCKBOX feature is active
+    ///         and the ETHLockbox contract has been configured, the OptimismPortal will use the
+    ///         ETHLockbox to store ETH instead of storing ETH directly in the portal itself.
+    bytes32 internal constant ETH_LOCKBOX = "ETH_LOCKBOX";
+}

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -475,7 +475,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Make sure that the SystemConfig is upgraded to the right version. It must also have the
         // right l2ChainId and must be properly initialized.
-        assertEq(ISemver(address(systemConfig)).version(), "3.4.0");
+        assertEq(ISemver(address(systemConfig)).version(), "3.5.0");
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(systemConfig.l2ChainId(), l2ChainId);
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -726,88 +726,88 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
     }
 }
 
-/// @title SystemConfig_ToggleFeature_Test
-/// @notice Test contract for SystemConfig `toggleFeature` function.
-contract SystemConfig_ToggleFeature_Test is SystemConfig_TestInit {
-    event FeatureToggled(bytes32 indexed feature, bool indexed enabled);
+/// @title SystemConfig_SetFeature_Test
+/// @notice Test contract for SystemConfig `setFeature` function.
+contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
+    event FeatureSet(bytes32 indexed feature, bool indexed enabled);
 
-    /// @notice Tests that `toggleFeature` reverts if the caller is not ProxyAdmin or ProxyAdmin owner.
+    /// @notice Tests that `setFeature` reverts if the caller is not ProxyAdmin or ProxyAdmin owner.
     /// @param _sender The address to test.
-    function testFuzz_toggleFeature_notProxyAdminOrProxyAdminOwner_reverts(address _sender) external {
+    function testFuzz_setFeature_notProxyAdminOrProxyAdminOwner_reverts(address _sender) external {
         // Ensure sender is not ProxyAdmin or ProxyAdmin owner
         vm.assume(_sender != address(systemConfig.proxyAdmin()) && _sender != systemConfig.proxyAdminOwner());
 
         vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
         vm.prank(_sender);
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
     }
 
-    /// @notice Tests that `toggleFeature` enables a feature successfully when called by ProxyAdmin.
-    function test_toggleFeature_enableFeatureByProxyAdmin_succeeds() external {
+    /// @notice Tests that `setFeature` enables a feature successfully when called by ProxyAdmin.
+    function test_setFeature_enableFeatureByProxyAdmin_succeeds() external {
         // Verify feature is initially disabled
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
         vm.expectEmit(address(systemConfig));
-        emit FeatureToggled(Features.ETH_LOCKBOX, true);
+        emit FeatureSet(Features.ETH_LOCKBOX, true);
 
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
 
         // Verify feature is now enabled
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
     }
 
-    /// @notice Tests that `toggleFeature` disables a feature successfully when called by ProxyAdmin.
-    function test_toggleFeature_disableFeatureByProxyAdmin_succeeds() external {
+    /// @notice Tests that `setFeature` disables a feature successfully when called by ProxyAdmin.
+    function test_setFeature_disableFeatureByProxyAdmin_succeeds() external {
         // First enable the feature
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
         vm.expectEmit(address(systemConfig));
-        emit FeatureToggled(Features.ETH_LOCKBOX, false);
+        emit FeatureSet(Features.ETH_LOCKBOX, false);
 
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, false);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
 
         // Verify feature is now disabled
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
     }
 
-    /// @notice Tests that `toggleFeature` enables a feature successfully when called by ProxyAdmin owner.
-    function test_toggleFeature_enableFeatureByProxyAdminOwner_succeeds() external {
+    /// @notice Tests that `setFeature` enables a feature successfully when called by ProxyAdmin owner.
+    function test_setFeature_enableFeatureByProxyAdminOwner_succeeds() external {
         // Verify feature is initially disabled
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
         vm.expectEmit(address(systemConfig));
-        emit FeatureToggled(Features.ETH_LOCKBOX, true);
+        emit FeatureSet(Features.ETH_LOCKBOX, true);
 
         vm.prank(systemConfig.proxyAdminOwner());
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
 
         // Verify feature is now enabled
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
     }
 
-    /// @notice Tests that `toggleFeature` works with arbitrary feature identifiers.
+    /// @notice Tests that `setFeature` works with arbitrary feature identifiers.
     /// @param _feature The feature to toggle.
     /// @param _enabled Whether to enable or disable the feature.
-    function testFuzz_toggleFeature_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
+    function testFuzz_setFeature_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
         // Verify feature is initially disabled
         assertFalse(systemConfig.isFeatureEnabled(_feature));
 
         vm.expectEmit(address(systemConfig));
-        emit FeatureToggled(_feature, _enabled);
+        emit FeatureSet(_feature, _enabled);
 
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(_feature, _enabled);
+        systemConfig.setFeature(_feature, _enabled);
 
         // Verify feature state matches expected
         assertEq(systemConfig.isFeatureEnabled(_feature), _enabled);
     }
 
-    /// @notice Tests that `toggleFeature` can toggle the same feature multiple times.
-    function test_toggleFeature_multipleToggles_succeeds() external {
+    /// @notice Tests that `setFeature` can toggle the same feature multiple times.
+    function test_setFeature_multipleToggles_succeeds() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
 
         // Initially disabled
@@ -815,18 +815,42 @@ contract SystemConfig_ToggleFeature_Test is SystemConfig_TestInit {
 
         // Enable feature
         vm.prank(proxyAdmin);
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
         // Disable feature
         vm.prank(proxyAdmin);
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, false);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
         // Enable again
         vm.prank(proxyAdmin);
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
+    /// @notice Tests that `setFeature` reverts when trying to enable a feature that is already
+    ///         enabled.
+    function test_setFeature_alreadyEnabled_reverts() external {
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+    }
+
+    /// @notice Tests that `setFeature` reverts when trying to disable a feature that is already
+    ///         disabled.
+    function test_setFeature_alreadyDisabled_reverts() external {
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
     }
 }
 
@@ -842,7 +866,7 @@ contract SystemConfig_IsFeatureEnabled_Test is SystemConfig_TestInit {
     /// @notice Tests that `isFeatureEnabled` returns correct value after feature is enabled.
     function test_isFeatureEnabled_afterEnable_succeeds() external {
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
 
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
     }
@@ -851,12 +875,12 @@ contract SystemConfig_IsFeatureEnabled_Test is SystemConfig_TestInit {
     function test_isFeatureEnabled_afterDisable_succeeds() external {
         // First enable the feature
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
         // Then disable it
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(Features.ETH_LOCKBOX, false);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
     }
 
@@ -865,7 +889,7 @@ contract SystemConfig_IsFeatureEnabled_Test is SystemConfig_TestInit {
     /// @param _enabled Whether the feature is enabled.
     function testFuzz_isFeatureEnabled_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.toggleFeature(_feature, _enabled);
+        systemConfig.setFeature(_feature, _enabled);
 
         assertEq(systemConfig.isFeatureEnabled(_feature), _enabled);
     }

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -9,6 +9,7 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
+import { Features } from "src/libraries/Features.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Interfaces
@@ -722,6 +723,151 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
 
         // Verify still not paused
         assertFalse(systemConfig.paused());
+    }
+}
+
+/// @title SystemConfig_ToggleFeature_Test
+/// @notice Test contract for SystemConfig `toggleFeature` function.
+contract SystemConfig_ToggleFeature_Test is SystemConfig_TestInit {
+    event FeatureToggled(bytes32 indexed feature, bool indexed enabled);
+
+    /// @notice Tests that `toggleFeature` reverts if the caller is not ProxyAdmin or ProxyAdmin owner.
+    /// @param _sender The address to test.
+    function testFuzz_toggleFeature_notProxyAdminOrProxyAdminOwner_reverts(address _sender) external {
+        // Ensure sender is not ProxyAdmin or ProxyAdmin owner
+        vm.assume(_sender != address(systemConfig.proxyAdmin()) && _sender != systemConfig.proxyAdminOwner());
+
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner.selector);
+        vm.prank(_sender);
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+    }
+
+    /// @notice Tests that `toggleFeature` enables a feature successfully when called by ProxyAdmin.
+    function test_toggleFeature_enableFeatureByProxyAdmin_succeeds() external {
+        // Verify feature is initially disabled
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        vm.expectEmit(address(systemConfig));
+        emit FeatureToggled(Features.ETH_LOCKBOX, true);
+
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+
+        // Verify feature is now enabled
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
+    /// @notice Tests that `toggleFeature` disables a feature successfully when called by ProxyAdmin.
+    function test_toggleFeature_disableFeatureByProxyAdmin_succeeds() external {
+        // First enable the feature
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        vm.expectEmit(address(systemConfig));
+        emit FeatureToggled(Features.ETH_LOCKBOX, false);
+
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, false);
+
+        // Verify feature is now disabled
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
+    /// @notice Tests that `toggleFeature` enables a feature successfully when called by ProxyAdmin owner.
+    function test_toggleFeature_enableFeatureByProxyAdminOwner_succeeds() external {
+        // Verify feature is initially disabled
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        vm.expectEmit(address(systemConfig));
+        emit FeatureToggled(Features.ETH_LOCKBOX, true);
+
+        vm.prank(systemConfig.proxyAdminOwner());
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+
+        // Verify feature is now enabled
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
+    /// @notice Tests that `toggleFeature` works with arbitrary feature identifiers.
+    /// @param _feature The feature to toggle.
+    /// @param _enabled Whether to enable or disable the feature.
+    function testFuzz_toggleFeature_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
+        // Verify feature is initially disabled
+        assertFalse(systemConfig.isFeatureEnabled(_feature));
+
+        vm.expectEmit(address(systemConfig));
+        emit FeatureToggled(_feature, _enabled);
+
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(_feature, _enabled);
+
+        // Verify feature state matches expected
+        assertEq(systemConfig.isFeatureEnabled(_feature), _enabled);
+    }
+
+    /// @notice Tests that `toggleFeature` can toggle the same feature multiple times.
+    function test_toggleFeature_multipleToggles_succeeds() external {
+        address proxyAdmin = address(systemConfig.proxyAdmin());
+
+        // Initially disabled
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        // Enable feature
+        vm.prank(proxyAdmin);
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        // Disable feature
+        vm.prank(proxyAdmin);
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, false);
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        // Enable again
+        vm.prank(proxyAdmin);
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+}
+
+/// @title SystemConfig_IsFeatureEnabled_Test
+/// @notice Test contract for SystemConfig `isFeatureEnabled` function.
+contract SystemConfig_IsFeatureEnabled_Test is SystemConfig_TestInit {
+    /// @notice Tests that `isFeatureEnabled` returns false for unset features.
+    /// @param _feature The feature to check.
+    function testFuzz_isFeatureEnabled_unsetFeature_succeeds(bytes32 _feature) external view {
+        assertFalse(systemConfig.isFeatureEnabled(_feature));
+    }
+
+    /// @notice Tests that `isFeatureEnabled` returns correct value after feature is enabled.
+    function test_isFeatureEnabled_afterEnable_succeeds() external {
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
+    /// @notice Tests that `isFeatureEnabled` returns correct value after feature is disabled.
+    function test_isFeatureEnabled_afterDisable_succeeds() external {
+        // First enable the feature
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, true);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+
+        // Then disable it
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(Features.ETH_LOCKBOX, false);
+        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+    }
+
+    /// @notice Tests that `isFeatureEnabled` works with arbitrary feature identifiers.
+    /// @param _feature The feature to check.
+    /// @param _enabled Whether the feature is enabled.
+    function testFuzz_isFeatureEnabled_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
+        vm.prank(address(systemConfig.proxyAdmin()));
+        systemConfig.toggleFeature(_feature, _enabled);
+
+        assertEq(systemConfig.isFeatureEnabled(_feature), _enabled);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -789,23 +789,6 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
     }
 
-    /// @notice Tests that `setFeature` works with arbitrary feature identifiers.
-    /// @param _feature The feature to toggle.
-    /// @param _enabled Whether to enable or disable the feature.
-    function testFuzz_setFeature_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
-        // Verify feature is initially disabled
-        assertFalse(systemConfig.isFeatureEnabled(_feature));
-
-        vm.expectEmit(address(systemConfig));
-        emit FeatureSet(_feature, _enabled);
-
-        vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.setFeature(_feature, _enabled);
-
-        // Verify feature state matches expected
-        assertEq(systemConfig.isFeatureEnabled(_feature), _enabled);
-    }
-
     /// @notice Tests that `setFeature` can toggle the same feature multiple times.
     function test_setFeature_multipleToggles_succeeds() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
@@ -836,8 +819,8 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
         systemConfig.setFeature(Features.ETH_LOCKBOX, true);
         assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
-        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         vm.prank(address(systemConfig.proxyAdmin()));
+        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         systemConfig.setFeature(Features.ETH_LOCKBOX, true);
     }
 
@@ -848,8 +831,8 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
         systemConfig.setFeature(Features.ETH_LOCKBOX, false);
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
 
-        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         vm.prank(address(systemConfig.proxyAdmin()));
+        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         systemConfig.setFeature(Features.ETH_LOCKBOX, false);
     }
 }
@@ -882,16 +865,6 @@ contract SystemConfig_IsFeatureEnabled_Test is SystemConfig_TestInit {
         vm.prank(address(systemConfig.proxyAdmin()));
         systemConfig.setFeature(Features.ETH_LOCKBOX, false);
         assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-    }
-
-    /// @notice Tests that `isFeatureEnabled` works with arbitrary feature identifiers.
-    /// @param _feature The feature to check.
-    /// @param _enabled Whether the feature is enabled.
-    function testFuzz_isFeatureEnabled_arbitraryFeature_succeeds(bytes32 _feature, bool _enabled) external {
-        vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.setFeature(_feature, _enabled);
-
-        assertEq(systemConfig.isFeatureEnabled(_feature), _enabled);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -828,10 +828,6 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
     ///         disabled.
     function test_setFeature_alreadyDisabled_reverts() external {
         vm.prank(address(systemConfig.proxyAdmin()));
-        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
-        assertFalse(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-
-        vm.prank(address(systemConfig.proxyAdmin()));
         vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         systemConfig.setFeature(Features.ETH_LOCKBOX, false);
     }


### PR DESCRIPTION
Adds a function to the SystemConfig for feature flagging. Features are identified by 32 byte strings and can be toggled on or off by the ProxyAdmin or the owner of the ProxyAdmin. Note that this commit does not actually use any feature flags but demonstrates what a feature flag would look like by adding in the flag for the ETHLockbox feature.