### PR TITLE
proofs: Introduce PermissionedDisputeGame v2

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -330,6 +330,7 @@ rules:
         - packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
         - packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
         - packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+        - packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
         - packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
         - packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
         - packages/contracts-bedrock/src/governance/MintManager.sol

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -25,6 +25,7 @@ compilation_restrictions = [
   { paths = "src/dispute/FaultDisputeGame.sol", optimizer_runs = 5000 },
   { paths = "src/dispute/v2/FaultDisputeGameV2.sol", optimizer_runs = 5000 },
   { paths = "src/dispute/PermissionedDisputeGame.sol", optimizer_runs = 5000 },
+  { paths = "src/dispute/v2/PermissionedDisputeGameV2.sol", optimizer_runs = 5000 },
   { paths = "src/L1/OPContractsManager.sol", optimizer_runs = 5000 },
   { paths = "src/L1/OPContractsManagerStandardValidator.sol", optimizer_runs = 5000 },
   { paths = "src/L1/OptimismPortal2.sol", optimizer_runs = 5000 }
@@ -140,6 +141,7 @@ compilation_restrictions = [
   { paths = "src/dispute/FaultDisputeGame.sol", optimizer_runs = 0 },
   { paths = "src/dispute/v2/FaultDisputeGameV2.sol", optimizer_runs = 0 },
   { paths = "src/dispute/PermissionedDisputeGame.sol", optimizer_runs = 0 },
+  { paths = "src/dispute/v2/PermissionedDisputeGameV2.sol", optimizer_runs = 0 },
   { paths = "src/L1/OPContractsManager.sol", optimizer_runs = 0 },
   { paths = "src/L1/OPContractsManagerStandardValidator.sol", optimizer_runs = 0 },
   { paths = "src/L1/OptimismPortal2.sol", optimizer_runs = 0 },

--- a/packages/contracts-bedrock/interfaces/dispute/v2/IPermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/IPermissionedDisputeGameV2.sol
@@ -8,7 +8,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
-import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IFaultDisputeGameV2 } from "interfaces/dispute/v2/IFaultDisputeGameV2.sol";
 
 interface IPermissionedDisputeGameV2 is IDisputeGame {
     struct ClaimData {
@@ -134,7 +134,7 @@ interface IPermissionedDisputeGameV2 is IDisputeGame {
     function challenger() external view returns (address challenger_);
 
     function __constructor__(
-        IFaultDisputeGame.GameConstructorParams memory _params,
+        IFaultDisputeGameV2.GameConstructorParams memory _params,
         address _proposer,
         address _challenger
     )

--- a/packages/contracts-bedrock/interfaces/dispute/v2/IPermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/IPermissionedDisputeGameV2.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Types } from "src/libraries/Types.sol";
+import { Claim, Position, Clock, Hash, Duration, BondDistributionMode } from "src/dispute/lib/Types.sol";
+
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+
+interface IPermissionedDisputeGameV2 is IDisputeGame {
+    struct ClaimData {
+        uint32 parentIndex;
+        address counteredBy;
+        address claimant;
+        uint128 bond;
+        Claim claim;
+        Position position;
+        Clock clock;
+    }
+
+    struct ResolutionCheckpoint {
+        bool initialCheckpointComplete;
+        uint32 subgameIndex;
+        Position leftmostPosition;
+        address counteredBy;
+    }
+
+    error AlreadyInitialized();
+    error AnchorRootNotFound();
+    error BadExtraData();
+    error BlockNumberMatches();
+    error BondTransferFailed();
+    error CannotDefendRootClaim();
+    error ClaimAboveSplit();
+    error ClaimAlreadyExists();
+    error ClaimAlreadyResolved();
+    error ClockNotExpired();
+    error ClockTimeExceeded();
+    error ContentLengthMismatch();
+    error DuplicateStep();
+    error EmptyItem();
+    error GameDepthExceeded();
+    error GameNotInProgress();
+    error IncorrectBondAmount();
+    error InvalidChallengePeriod();
+    error InvalidClockExtension();
+    error InvalidDataRemainder();
+    error InvalidDisputedClaimIndex();
+    error InvalidHeader();
+    error InvalidHeaderRLP();
+    error InvalidLocalIdent();
+    error InvalidOutputRootProof();
+    error InvalidParent();
+    error InvalidPrestate();
+    error InvalidSplitDepth();
+    error L2BlockNumberChallenged();
+    error MaxDepthTooLarge();
+    error NoCreditToClaim();
+    error OutOfOrderResolution();
+    error UnexpectedList();
+    error UnexpectedRootClaim(Claim rootClaim);
+    error UnexpectedString();
+    error ValidStep();
+    error InvalidBondDistributionMode();
+    error GameNotFinalized();
+    error GameNotResolved();
+    error ReservedGameType();
+    error GamePaused();
+    event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
+    event GameClosed(BondDistributionMode bondDistributionMode);
+
+    function absolutePrestate() external view returns (Claim absolutePrestate_);
+    function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external;
+    function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_);
+    function attack(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
+    function bondDistributionMode() external view returns (BondDistributionMode);
+    function challengeRootL2Block(Types.OutputRootProof memory _outputRootProof, bytes memory _headerRLP) external;
+    function claimCredit(address _recipient) external;
+    function claimData(uint256)
+        external
+        view // nosemgrep
+        returns (
+            uint32 parentIndex,
+            address counteredBy,
+            address claimant,
+            uint128 bond,
+            Claim claim,
+            Position position,
+            Clock clock
+        );
+    function claimDataLen() external view returns (uint256 len_);
+    function claims(Hash) external view returns (bool);
+    function clockExtension() external view returns (Duration clockExtension_);
+    function closeGame() external;
+    function credit(address _recipient) external view returns (uint256 credit_);
+    function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
+    function getChallengerDuration(uint256 _claimIndex) external view returns (Duration duration_);
+    function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
+    function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
+    function hasUnlockedCredit(address) external view returns (bool);
+    function initialize() external payable;
+    function l2BlockNumber() external pure returns (uint256 l2BlockNumber_);
+    function l2BlockNumberChallenged() external view returns (bool);
+    function l2BlockNumberChallenger() external view returns (address);
+    function l2ChainId() external view returns (uint256 l2ChainId_);
+    function maxClockDuration() external view returns (Duration maxClockDuration_);
+    function maxGameDepth() external view returns (uint256 maxGameDepth_);
+    function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) external payable;
+    function normalModeCredit(address) external view returns (uint256);
+    function refundModeCredit(address) external view returns (uint256);
+    function resolutionCheckpoints(uint256)
+        external
+        view
+        returns (bool initialCheckpointComplete, uint32 subgameIndex, Position leftmostPosition, address counteredBy); // nosemgrep
+    function resolveClaim(uint256 _claimIndex, uint256 _numToResolve) external;
+    function resolvedSubgames(uint256) external view returns (bool);
+    function splitDepth() external view returns (uint256 splitDepth_);
+    function startingBlockNumber() external view returns (uint256 startingBlockNumber_);
+    function startingOutputRoot() external view returns (Hash root, uint256 l2SequenceNumber); // nosemgrep
+    function startingRootHash() external view returns (Hash startingRootHash_);
+    function step(uint256 _claimIndex, bool _isAttack, bytes memory _stateData, bytes memory _proof) external;
+    function subgames(uint256, uint256) external view returns (uint256);
+    function version() external pure returns (string memory);
+    function vm() external view returns (IBigStepper vm_);
+    function wasRespectedGameTypeWhenCreated() external view returns (bool);
+    function weth() external view returns (IDelayedWETH weth_);
+
+    error BadAuth();
+
+    function proposer() external view returns (address proposer_);
+    function challenger() external view returns (address challenger_);
+
+    function __constructor__(
+        IFaultDisputeGame.GameConstructorParams memory _params,
+        address _proposer,
+        address _challenger
+    )
+        external;
+}

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGameV2.json
@@ -1,0 +1,1236 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "GameType",
+            "name": "gameType",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxGameDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "splitDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "Duration",
+            "name": "clockExtension",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Duration",
+            "name": "maxClockDuration",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct FaultDisputeGameV2.GameConstructorParams",
+        "name": "_params",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_proposer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_challenger",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "absolutePrestate",
+    "outputs": [
+      {
+        "internalType": "Claim",
+        "name": "absolutePrestate_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_ident",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_execLeafIdx",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_partOffset",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLocalData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "anchorStateRegistry",
+    "outputs": [
+      {
+        "internalType": "contract IAnchorStateRegistry",
+        "name": "registry_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "_disputed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_parentIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_claim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "attack",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bondDistributionMode",
+    "outputs": [
+      {
+        "internalType": "enum BondDistributionMode",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "version",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "stateRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "_outputRootProof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_headerRLP",
+        "type": "bytes"
+      }
+    ],
+    "name": "challengeRootL2Block",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "challenger",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "challenger_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "claimCredit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "claimData",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "parentIndex",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "counteredBy",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "claimant",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "bond",
+        "type": "uint128"
+      },
+      {
+        "internalType": "Claim",
+        "name": "claim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "Position",
+        "name": "position",
+        "type": "uint128"
+      },
+      {
+        "internalType": "Clock",
+        "name": "clock",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimDataLen",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "len_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Hash",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "claims",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clockExtension",
+    "outputs": [
+      {
+        "internalType": "Duration",
+        "name": "clockExtension_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "closeGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "createdAt",
+    "outputs": [
+      {
+        "internalType": "Timestamp",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "credit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "credit_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "_disputed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_parentIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_claim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "defend",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "extraData",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "extraData_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameCreator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "creator_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameData",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType_",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Claim",
+        "name": "rootClaim_",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameType",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType_",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "getChallengerDuration",
+    "outputs": [
+      {
+        "internalType": "Duration",
+        "name": "duration_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNumToResolve",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "numRemainingChildren_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Position",
+        "name": "_position",
+        "type": "uint128"
+      }
+    ],
+    "name": "getRequiredBond",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "requiredBond_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hasUnlockedCredit",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1Head",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "l1Head_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2BlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "l2BlockNumber_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2BlockNumberChallenged",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2BlockNumberChallenger",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2ChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "l2ChainId_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2SequenceNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "l2SequenceNumber_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxClockDuration",
+    "outputs": [
+      {
+        "internalType": "Duration",
+        "name": "maxClockDuration_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxGameDepth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxGameDepth_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "_disputed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_challengeIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_claim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isAttack",
+        "type": "bool"
+      }
+    ],
+    "name": "move",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "normalModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposer",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "proposer_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "refundModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "resolutionCheckpoints",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "initialCheckpointComplete",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "subgameIndex",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Position",
+        "name": "leftmostPosition",
+        "type": "uint128"
+      },
+      {
+        "internalType": "address",
+        "name": "counteredBy",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "resolve",
+    "outputs": [
+      {
+        "internalType": "enum GameStatus",
+        "name": "status_",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_numToResolve",
+        "type": "uint256"
+      }
+    ],
+    "name": "resolveClaim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "resolvedAt",
+    "outputs": [
+      {
+        "internalType": "Timestamp",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "resolvedSubgames",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rootClaim",
+    "outputs": [
+      {
+        "internalType": "Claim",
+        "name": "rootClaim_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "splitDepth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "splitDepth_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startingBlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "startingBlockNumber_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startingOutputRoot",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "root",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "l2SequenceNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startingRootHash",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "startingRootHash_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "status",
+    "outputs": [
+      {
+        "internalType": "enum GameStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isAttack",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_stateData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_proof",
+        "type": "bytes"
+      }
+    ],
+    "name": "step",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "subgames",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vm",
+    "outputs": [
+      {
+        "internalType": "contract IBigStepper",
+        "name": "vm_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "wasRespectedGameTypeWhenCreated",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "weth",
+    "outputs": [
+      {
+        "internalType": "contract IDelayedWETH",
+        "name": "weth_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum BondDistributionMode",
+        "name": "bondDistributionMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "GameClosed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "parentIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "Claim",
+        "name": "claim",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "claimant",
+        "type": "address"
+      }
+    ],
+    "name": "Move",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "enum GameStatus",
+        "name": "status",
+        "type": "uint8"
+      }
+    ],
+    "name": "Resolved",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AnchorRootNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BadAuth",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BadExtraData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BlockNumberMatches",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BondTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotDefendRootClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClaimAboveSplit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClaimAlreadyExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClaimAlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClockNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClockTimeExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ContentLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DuplicateStep",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyItem",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameDepthExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameNotFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameNotInProgress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameNotResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GamePaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "IncorrectBondAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBondDistributionMode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidChallengePeriod",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidClockExtension",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDataRemainder",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDisputedClaimIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidHeader",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidHeaderRLP",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidLocalIdent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidOutputRootProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidParent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPrestate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSplitDepth",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L2BlockNumberChallenged",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MaxDepthTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoCreditToClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OutOfOrderResolution",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReservedGameType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnexpectedList",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "rootClaim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UnexpectedRootClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnexpectedString",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidStep",
+    "type": "error"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -179,6 +179,10 @@
     "initCodeHash": "0x13ef27ad793c95be884dea8259ac06619bf13d10868c5fc9980bc402b59efb8d",
     "sourceCodeHash": "0x47c141889e647820759a2eaa84c31be8acdce6427cc4fe7c00a482ba44d62b87"
   },
+  "src/dispute/v2/PermissionedDisputeGameV2.sol:PermissionedDisputeGameV2": {
+    "initCodeHash": "0x7b1385d347dce625d63f71c13201fd90e63fcaeae17416911bccd9d670b3afc4",
+    "sourceCodeHash": "0xc5aa308a19fd9600607370693885155a3d6f9f7bf8a7c6ff93a389c37c136555"
+  },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x53099379ed48b87f027d55712dbdd1da7d7099925426eb0531da9c0012e02c29",
     "sourceCodeHash": "0xf22c94ed20c32a8ed2705a22d12c6969c3c3bad409c4efe2f95b0db74f210e10"

--- a/packages/contracts-bedrock/snapshots/storageLayout/PermissionedDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PermissionedDisputeGameV2.json
@@ -1,0 +1,121 @@
+[
+  {
+    "bytes": "8",
+    "label": "createdAt",
+    "offset": 0,
+    "slot": "0",
+    "type": "Timestamp"
+  },
+  {
+    "bytes": "8",
+    "label": "resolvedAt",
+    "offset": 8,
+    "slot": "0",
+    "type": "Timestamp"
+  },
+  {
+    "bytes": "1",
+    "label": "status",
+    "offset": 16,
+    "slot": "0",
+    "type": "enum GameStatus"
+  },
+  {
+    "bytes": "1",
+    "label": "initialized",
+    "offset": 17,
+    "slot": "0",
+    "type": "bool"
+  },
+  {
+    "bytes": "1",
+    "label": "l2BlockNumberChallenged",
+    "offset": 18,
+    "slot": "0",
+    "type": "bool"
+  },
+  {
+    "bytes": "20",
+    "label": "l2BlockNumberChallenger",
+    "offset": 0,
+    "slot": "1",
+    "type": "address"
+  },
+  {
+    "bytes": "32",
+    "label": "claimData",
+    "offset": 0,
+    "slot": "2",
+    "type": "struct FaultDisputeGameV2.ClaimData[]"
+  },
+  {
+    "bytes": "32",
+    "label": "normalModeCredit",
+    "offset": 0,
+    "slot": "3",
+    "type": "mapping(address => uint256)"
+  },
+  {
+    "bytes": "32",
+    "label": "claims",
+    "offset": 0,
+    "slot": "4",
+    "type": "mapping(Hash => bool)"
+  },
+  {
+    "bytes": "32",
+    "label": "subgames",
+    "offset": 0,
+    "slot": "5",
+    "type": "mapping(uint256 => uint256[])"
+  },
+  {
+    "bytes": "32",
+    "label": "resolvedSubgames",
+    "offset": 0,
+    "slot": "6",
+    "type": "mapping(uint256 => bool)"
+  },
+  {
+    "bytes": "32",
+    "label": "resolutionCheckpoints",
+    "offset": 0,
+    "slot": "7",
+    "type": "mapping(uint256 => struct FaultDisputeGameV2.ResolutionCheckpoint)"
+  },
+  {
+    "bytes": "64",
+    "label": "startingOutputRoot",
+    "offset": 0,
+    "slot": "8",
+    "type": "struct Proposal"
+  },
+  {
+    "bytes": "1",
+    "label": "wasRespectedGameTypeWhenCreated",
+    "offset": 0,
+    "slot": "10",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "label": "refundModeCredit",
+    "offset": 0,
+    "slot": "11",
+    "type": "mapping(address => uint256)"
+  },
+  {
+    "bytes": "32",
+    "label": "hasUnlockedCredit",
+    "offset": 0,
+    "slot": "12",
+    "type": "mapping(address => bool)"
+  },
+  {
+    "bytes": "1",
+    "label": "bondDistributionMode",
+    "offset": 0,
+    "slot": "13",
+    "type": "enum BondDistributionMode"
+  }
+]

--- a/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
@@ -2,21 +2,21 @@
 pragma solidity 0.8.15;
 
 // Contracts
-import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
+import { FaultDisputeGameV2 } from "src/dispute/v2/FaultDisputeGameV2.sol";
 
 // Libraries
 import { Claim } from "src/dispute/lib/Types.sol";
 import { BadAuth } from "src/dispute/lib/Errors.sol";
 
 /// @title PermissionedDisputeGameV2
-/// @notice PermissionedDisputeGameV2 is a contract that inherits from `FaultDisputeGame`, and contains two roles:
+/// @notice PermissionedDisputeGameV2 is a contract that inherits from `FaultDisputeGameV2`, and contains two roles:
 ///         - The `challenger` role, which is allowed to challenge a dispute.
 ///         - The `proposer` role, which is allowed to create proposals and participate in their game.
 ///         This contract exists as a way for networks to support the fault proof iteration of the OptimismPortal
 ///         contract without needing to support a fully permissionless system. Permissionless systems can introduce
 ///         costs that certain networks may not wish to support. This contract can also be used as a fallback mechanism
 ///         in case of a failure in the permissionless fault proof system in the stage one release.
-contract PermissionedDisputeGameV2 is FaultDisputeGame {
+contract PermissionedDisputeGameV2 is FaultDisputeGameV2 {
     /// @notice The proposer role is allowed to create proposals and participate in the dispute game.
     address internal immutable PROPOSER;
 
@@ -45,13 +45,13 @@ contract PermissionedDisputeGameV2 is FaultDisputeGame {
         address _proposer,
         address _challenger
     )
-        FaultDisputeGame(_params)
+        FaultDisputeGameV2(_params)
     {
         PROPOSER = _proposer;
         CHALLENGER = _challenger;
     }
 
-    /// @inheritdoc FaultDisputeGame
+    /// @inheritdoc FaultDisputeGameV2
     function step(
         uint256 _claimIndex,
         bool _isAttack,

--- a/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
@@ -32,9 +32,9 @@ contract PermissionedDisputeGameV2 is FaultDisputeGameV2 {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.8.0
+    /// @custom:semver 2.0.0
     function version() public pure override returns (string memory) {
-        return "1.8.0";
+        return "2.0.0";
     }
 
     /// @param _params Parameters for creating a new FaultDisputeGame.

--- a/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Contracts
+import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
+
+// Libraries
+import { Claim } from "src/dispute/lib/Types.sol";
+import { BadAuth } from "src/dispute/lib/Errors.sol";
+
+/// @title PermissionedDisputeGameV2
+/// @notice PermissionedDisputeGameV2 is a contract that inherits from `FaultDisputeGame`, and contains two roles:
+///         - The `challenger` role, which is allowed to challenge a dispute.
+///         - The `proposer` role, which is allowed to create proposals and participate in their game.
+///         This contract exists as a way for networks to support the fault proof iteration of the OptimismPortal
+///         contract without needing to support a fully permissionless system. Permissionless systems can introduce
+///         costs that certain networks may not wish to support. This contract can also be used as a fallback mechanism
+///         in case of a failure in the permissionless fault proof system in the stage one release.
+contract PermissionedDisputeGameV2 is FaultDisputeGame {
+    /// @notice The proposer role is allowed to create proposals and participate in the dispute game.
+    address internal immutable PROPOSER;
+
+    /// @notice The challenger role is allowed to participate in the dispute game.
+    address internal immutable CHALLENGER;
+
+    /// @notice Modifier that gates access to the `challenger` and `proposer` roles.
+    modifier onlyAuthorized() {
+        if (!(msg.sender == PROPOSER || msg.sender == CHALLENGER)) {
+            revert BadAuth();
+        }
+        _;
+    }
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.8.0
+    function version() public pure override returns (string memory) {
+        return "1.8.0";
+    }
+
+    /// @param _params Parameters for creating a new FaultDisputeGame.
+    /// @param _proposer Address that is allowed to create instances of this contract.
+    /// @param _challenger Address that is allowed to challenge instances of this contract.
+    constructor(
+        GameConstructorParams memory _params,
+        address _proposer,
+        address _challenger
+    )
+        FaultDisputeGame(_params)
+    {
+        PROPOSER = _proposer;
+        CHALLENGER = _challenger;
+    }
+
+    /// @inheritdoc FaultDisputeGame
+    function step(
+        uint256 _claimIndex,
+        bool _isAttack,
+        bytes calldata _stateData,
+        bytes calldata _proof
+    )
+        public
+        override
+        onlyAuthorized
+    {
+        super.step(_claimIndex, _isAttack, _stateData, _proof);
+    }
+
+    /// @notice Generic move function, used for both `attack` and `defend` moves.
+    /// @notice _disputed The disputed `Claim`.
+    /// @param _challengeIndex The index of the claim being moved against. This must match the `_disputed` claim.
+    /// @param _claim The claim at the next logical position in the game.
+    /// @param _isAttack Whether or not the move is an attack or defense.
+    function move(
+        Claim _disputed,
+        uint256 _challengeIndex,
+        Claim _claim,
+        bool _isAttack
+    )
+        public
+        payable
+        override
+        onlyAuthorized
+    {
+        super.move(_disputed, _challengeIndex, _claim, _isAttack);
+    }
+
+    /// @notice Initializes the contract.
+    function initialize() public payable override {
+        // The creator of the dispute game must be the proposer EOA.
+        if (tx.origin != PROPOSER) revert BadAuth();
+
+        // Fallthrough initialization.
+        super.initialize();
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                     IMMUTABLE GETTERS                      //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Returns the proposer address.
+    function proposer() external view returns (address proposer_) {
+        proposer_ = PROPOSER;
+    }
+
+    /// @notice Returns the challenger address.
+    function challenger() external view returns (address challenger_) {
+        challenger_ = CHALLENGER;
+    }
+}

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -276,7 +276,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
                 abi.encodeCall(
                     IPermissionedDisputeGameV2.__constructor__,
                     (
-                        _getGameConstructorParamsV2(_absolutePrestate, vm_, GameTypes.PERMISSIONED_CANNON),
+                        _getGameConstructorParamsV2(GameTypes.PERMISSIONED_CANNON),
                         _proposer,
                         _challenger
                     )
@@ -284,7 +284,16 @@ contract DisputeGameFactory_TestInit is CommonTest {
             )
         });
 
-        _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON);
+        // Encode the implementation args for CWIA (tightly packed)
+        bytes memory implArgs = abi.encodePacked(
+            _absolutePrestate, // 32 bytes
+            vm_, // 20 bytes
+            anchorStateRegistry, // 20 bytes
+            delayedWeth, // 20 bytes
+            uint256(111) // 32 bytes (l2ChainId)
+        );
+
+        _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON, implArgs);
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -55,6 +55,8 @@ contract DisputeGameFactory_TestInit is CommonTest {
     event ImplementationArgsSet(GameType indexed gameType, bytes args);
     event InitBondUpdated(GameType indexed gameType, uint256 indexed newBond);
 
+    uint256 l2ChainId = 111;
+
     function setUp() public virtual override {
         super.setUp();
         fakeClone = new DisputeGameFactory_FakeClone_Harness();
@@ -223,7 +225,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             vm_, // 20 bytes
             anchorStateRegistry, // 20 bytes
             delayedWeth, // 20 bytes
-            uint256(111) // 32 bytes (l2ChainId)
+            l2ChainId // 32 bytes (l2ChainId)
         );
 
         _setGame(gameImpl_, GameTypes.CANNON, implArgs);
@@ -290,7 +292,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             vm_, // 20 bytes
             anchorStateRegistry, // 20 bytes
             delayedWeth, // 20 bytes
-            uint256(111) // 32 bytes (l2ChainId)
+            l2ChainId // 32 bytes (l2ChainId)
         );
 
         _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON, implArgs);
@@ -489,7 +491,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         assertEq(Claim.unwrap(gameV2.absolutePrestate()), Claim.unwrap(absolutePrestate));
         assertEq(Claim.unwrap(gameV2.rootClaim()), Claim.unwrap(rootClaim));
         assertEq(gameV2.extraData(), extraData);
-        assertEq(gameV2.l2ChainId(), 111);
+        assertEq(gameV2.l2ChainId(), l2ChainId);
         assertEq(address(gameV2.gameCreator()), address(this));
         assertEq(gameV2.l2BlockNumber(), uint256(type(uint32).max));
         assertEq(address(gameV2.vm()), address(vm_));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -268,8 +268,8 @@ contract DisputeGameFactory_TestInit is CommonTest {
         address _proposer,
         address _challenger
     )
-    internal
-    returns (address gameImpl_, AlphabetVM vm_, IPreimageOracle preimageOracle_)
+        internal
+        returns (address gameImpl_, AlphabetVM vm_, IPreimageOracle preimageOracle_)
     {
         (vm_, preimageOracle_) = _createVM(_absolutePrestate);
         gameImpl_ = DeployUtils.create1({
@@ -277,11 +277,7 @@ contract DisputeGameFactory_TestInit is CommonTest {
             _args: DeployUtils.encodeConstructor(
                 abi.encodeCall(
                     IPermissionedDisputeGameV2.__constructor__,
-                    (
-                        _getGameConstructorParamsV2(GameTypes.PERMISSIONED_CANNON),
-                        _proposer,
-                        _challenger
-                    )
+                    (_getGameConstructorParamsV2(GameTypes.PERMISSIONED_CANNON), _proposer, _challenger)
                 )
             )
         });

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -21,6 +21,7 @@ import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IFaultDisputeGameV2 } from "interfaces/dispute/v2/IFaultDisputeGameV2.sol";
 import { ISuperFaultDisputeGame } from "interfaces/dispute/ISuperFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IPermissionedDisputeGameV2 } from "interfaces/dispute/v2/IPermissionedDisputeGameV2.sol";
 import { ISuperPermissionedDisputeGame } from "interfaces/dispute/ISuperPermissionedDisputeGame.sol";
 // Mocks
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
@@ -258,6 +259,32 @@ contract DisputeGameFactory_TestInit is CommonTest {
         assembly {
             out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
         }
+    }
+
+    function setupPermissionedDisputeGameV2(
+        Claim _absolutePrestate,
+        address _proposer,
+        address _challenger
+    )
+    internal
+    returns (address gameImpl_, AlphabetVM vm_, IPreimageOracle preimageOracle_)
+    {
+        (vm_, preimageOracle_) = _createVM(_absolutePrestate);
+        gameImpl_ = DeployUtils.create1({
+            _name: "PermissionedDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    IPermissionedDisputeGameV2.__constructor__,
+                    (
+                        _getGameConstructorParamsV2(_absolutePrestate, vm_, GameTypes.PERMISSIONED_CANNON),
+                        _proposer,
+                        _challenger
+                    )
+                )
+            )
+        });
+
+        _setGame(gameImpl_, GameTypes.PERMISSIONED_CANNON);
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
@@ -119,6 +119,8 @@ contract BaseFaultDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
         assertEq(address(gameProxy.weth()), address(delayedWeth));
         assertEq(address(gameProxy.anchorStateRegistry()), address(anchorStateRegistry));
         assertEq(address(gameProxy.vm()), address(_vm));
+        assertEq(address(gameProxy.gameCreator()), address(this));
+        assertEq(gameProxy.l2ChainId(), l2ChainId);
 
         // Label the proxy
         vm.label(address(gameProxy), "FaultDisputeGame_Clone");

--- a/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
@@ -128,18 +128,18 @@ contract PermissionedDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
     receive() external payable { }
 }
 
-/// @title PermissionedDisputeGame_Version_Test
+/// @title PermissionedDisputeGameV2_Version_Test
 /// @notice Tests the `version` function of the `PermissionedDisputeGame` contract.
-contract PermissionedDisputeGame_Version_Test is PermissionedDisputeGameV2_TestInit {
+contract PermissionedDisputeGameV2_Version_Test is PermissionedDisputeGameV2_TestInit {
     /// @notice Tests that the game's version function returns a string.
     function test_version_works() public view {
         assertTrue(bytes(gameProxy.version()).length > 0);
     }
 }
 
-/// @title PermissionedDisputeGame_Step_Test
+/// @title PermissionedDisputeGameV2_Step_Test
 /// @notice Tests the `step` function of the `PermissionedDisputeGame` contract.
-contract PermissionedDisputeGame_Step_Test is PermissionedDisputeGameV2_TestInit {
+contract PermissionedDisputeGameV2_Step_Test is PermissionedDisputeGameV2_TestInit {
     /// @notice Tests that step works properly.
     function test_step_succeeds() public {
         // Give the test contract some ether
@@ -191,10 +191,10 @@ contract PermissionedDisputeGame_Step_Test is PermissionedDisputeGameV2_TestInit
     }
 }
 
-/// @title PermissionedDisputeGame_Unclassified_Test
+/// @title PermissionedDisputeGameV2_Unclassified_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `PermissionedDisputeGame` contract or are testing multiple functions at once.
-contract PermissionedDisputeGame_Unclassified_Test is PermissionedDisputeGameV2_TestInit {
+contract PermissionedDisputeGameV2_Unclassified_Test is PermissionedDisputeGameV2_TestInit {
     /// @notice Tests that the proposer can create a permissioned dispute game.
     function test_createGame_proposer_succeeds() public {
         uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);

--- a/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Testing
+import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
+import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
+// Libraries
+import "src/dispute/lib/Types.sol";
+import "src/dispute/lib/Errors.sol";
+
+// Interfaces
+import { IPermissionedDisputeGameV2 } from "interfaces/dispute/v2/IPermissionedDisputeGameV2.sol";
+
+/// @title PermissionedDisputeGameV2_TestInit
+/// @notice Reusable test initialization for `PermissionedDisputeGame` tests.
+contract PermissionedDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
+    /// @notice The type of the game being tested.
+    GameType internal immutable GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
+    /// @notice Mock proposer key
+    address internal constant PROPOSER = address(0xfacade9);
+    /// @notice Mock challenger key
+    address internal constant CHALLENGER = address(0xfacadec);
+
+    /// @notice The implementation of the game.
+    IPermissionedDisputeGameV2 internal gameImpl;
+    /// @notice The `Clone` proxy of the game.
+    IPermissionedDisputeGameV2 internal gameProxy;
+
+    /// @notice The extra data passed to the game for initialization.
+    bytes internal extraData;
+
+    /// @notice The root claim of the game.
+    Claim internal rootClaim;
+    /// @notice An arbitrary root claim for testing.
+    Claim internal arbitaryRootClaim = Claim.wrap(bytes32(uint256(123)));
+    /// @notice Minimum bond value that covers all possible moves.
+    uint256 internal constant MIN_BOND = 50 ether;
+
+    /// @notice The preimage of the absolute prestate claim
+    bytes internal absolutePrestateData;
+    /// @notice The absolute prestate of the trace.
+    Claim internal absolutePrestate;
+    /// @notice A valid l2BlockNumber that comes after the current anchor root block.
+    uint256 validL2BlockNumber;
+
+    event Move(uint256 indexed parentIndex, Claim indexed pivot, address indexed claimant);
+
+    function init(Claim _rootClaim, Claim _absolutePrestate, uint256 _l2BlockNumber) public {
+        // Set the time to a realistic date.
+        if (!isForkTest()) {
+            vm.warp(1690906994);
+        }
+
+        // Fund the proposer on this fork.
+        vm.deal(PROPOSER, 100 ether);
+
+        // Set the extra data for the game creation
+        extraData = abi.encode(_l2BlockNumber);
+
+        (address _impl, AlphabetVM _vm,) = setupPermissionedDisputeGame(_absolutePrestate, PROPOSER, CHALLENGER);
+        gameImpl = IPermissionedDisputeGameV2(_impl);
+
+        // Register the game implementation with the factory.
+        disputeGameFactory.setImplementation(GAME_TYPE, gameImpl);
+
+        // Create a new game.
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(anchorStateRegistry.anchors, (GAME_TYPE)),
+            abi.encode(_rootClaim, 0)
+        );
+        vm.prank(PROPOSER, PROPOSER);
+        gameProxy = IPermissionedDisputeGameV2(
+            payable(address(disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, _rootClaim, extraData)))
+        );
+
+        // Check immutables
+        assertEq(gameProxy.proposer(), PROPOSER);
+        assertEq(gameProxy.challenger(), CHALLENGER);
+        assertEq(gameProxy.gameType().raw(), GAME_TYPE.raw());
+        assertEq(gameProxy.absolutePrestate().raw(), _absolutePrestate.raw());
+        assertEq(gameProxy.maxGameDepth(), 2 ** 3);
+        assertEq(gameProxy.splitDepth(), 2 ** 2);
+        assertEq(gameProxy.maxClockDuration().raw(), 3.5 days);
+        assertEq(address(gameProxy.vm()), address(_vm));
+
+        // Label the proxy
+        vm.label(address(gameProxy), "FaultDisputeGame_Clone");
+    }
+
+    function setUp() public override {
+        absolutePrestateData = abi.encode(0);
+        absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
+
+        super.setUp();
+
+        // Get the actual anchor roots
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+        validL2BlockNumber = l2BlockNumber + 1;
+        rootClaim = Claim.wrap(Hash.unwrap(root));
+        init({ _rootClaim: rootClaim, _absolutePrestate: absolutePrestate, _l2BlockNumber: validL2BlockNumber });
+    }
+
+    /// @dev Helper to return a pseudo-random claim
+    function _dummyClaim() internal view returns (Claim) {
+        return Claim.wrap(keccak256(abi.encode(gasleft())));
+    }
+
+    /// @dev Helper to get the required bond for the given claim index.
+    function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
+        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
+        Position pos = parent.move(true);
+        bond_ = gameProxy.getRequiredBond(pos);
+    }
+
+    /// @dev Helper to change the VM status byte of a claim.
+    function _changeClaimStatus(Claim _claim, VMStatus _status) internal pure returns (Claim out_) {
+        assembly {
+            out_ := or(and(not(shl(248, 0xFF)), _claim), shl(248, _status))
+        }
+    }
+
+    fallback() external payable { }
+
+    receive() external payable { }
+}
+
+/// @title PermissionedDisputeGame_Version_Test
+/// @notice Tests the `version` function of the `PermissionedDisputeGame` contract.
+contract PermissionedDisputeGame_Version_Test is PermissionedDisputeGameV2_TestInit {
+    /// @notice Tests that the game's version function returns a string.
+    function test_version_works() public view {
+        assertTrue(bytes(gameProxy.version()).length > 0);
+    }
+}
+
+/// @title PermissionedDisputeGame_Step_Test
+/// @notice Tests the `step` function of the `PermissionedDisputeGame` contract.
+contract PermissionedDisputeGame_Step_Test is PermissionedDisputeGameV2_TestInit {
+    /// @notice Tests that step works properly.
+    function test_step_succeeds() public {
+        // Give the test contract some ether
+        vm.deal(CHALLENGER, 1_000 ether);
+
+        vm.startPrank(CHALLENGER, CHALLENGER);
+
+        // Make claims all the way down the tree.
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(3);
+        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(4);
+        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
+        (,,,, disputed,,) = gameProxy.claimData(5);
+        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(6);
+        gameProxy.attack{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
+        (,,,, disputed,,) = gameProxy.claimData(7);
+        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
+
+        // Verify game state before step
+        assertEq(uint256(gameProxy.status()), uint256(GameStatus.IN_PROGRESS));
+
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
+        gameProxy.step(8, true, absolutePrestateData, hex"");
+
+        vm.warp(block.timestamp + gameProxy.maxClockDuration().raw() + 1);
+        gameProxy.resolveClaim(8, 0);
+        gameProxy.resolveClaim(7, 0);
+        gameProxy.resolveClaim(6, 0);
+        gameProxy.resolveClaim(5, 0);
+        gameProxy.resolveClaim(4, 0);
+        gameProxy.resolveClaim(3, 0);
+        gameProxy.resolveClaim(2, 0);
+        gameProxy.resolveClaim(1, 0);
+
+        gameProxy.resolveClaim(0, 0);
+        gameProxy.resolve();
+
+        assertEq(uint256(gameProxy.status()), uint256(GameStatus.CHALLENGER_WINS));
+        assertEq(gameProxy.resolvedAt().raw(), block.timestamp);
+        (, address counteredBy,,,,,) = gameProxy.claimData(0);
+        assertEq(counteredBy, CHALLENGER);
+    }
+}
+
+/// @title PermissionedDisputeGame_Unclassified_Test
+/// @notice General tests that are not testing any function directly of the
+///         `PermissionedDisputeGame` contract or are testing multiple functions at once.
+contract PermissionedDisputeGame_Unclassified_Test is PermissionedDisputeGameV2_TestInit {
+    /// @notice Tests that the proposer can create a permissioned dispute game.
+    function test_createGame_proposer_succeeds() public {
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.prank(PROPOSER, PROPOSER);
+        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
+    }
+
+    /// @notice Tests that the permissioned game cannot be created by any address other than the
+    ///         proposer.
+    function testFuzz_createGame_notProposer_reverts(address _p) public {
+        vm.assume(_p != PROPOSER);
+
+        uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
+        vm.deal(_p, bondAmount);
+        vm.prank(_p, _p);
+        vm.expectRevert(BadAuth.selector);
+        disputeGameFactory.create{ value: bondAmount }(GAME_TYPE, arbitaryRootClaim, abi.encode(validL2BlockNumber));
+    }
+
+    /// @notice Tests that the challenger can participate in a permissioned dispute game.
+    function test_participateInGame_challenger_succeeds() public {
+        vm.startPrank(CHALLENGER, CHALLENGER);
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(CHALLENGER, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(CHALLENGER, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
+        uint256 thirdBond = _getRequiredBond(2);
+        vm.deal(CHALLENGER, thirdBond);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that the proposer can participate in a permissioned dispute game.
+    function test_participateInGame_proposer_succeeds() public {
+        vm.startPrank(PROPOSER, PROPOSER);
+        uint256 firstBond = _getRequiredBond(0);
+        vm.deal(PROPOSER, firstBond);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        gameProxy.attack{ value: firstBond }(disputed, 0, Claim.wrap(0));
+        uint256 secondBond = _getRequiredBond(1);
+        vm.deal(PROPOSER, secondBond);
+        (,,,, disputed,,) = gameProxy.claimData(1);
+        gameProxy.defend{ value: secondBond }(disputed, 1, Claim.wrap(0));
+        uint256 thirdBond = _getRequiredBond(2);
+        vm.deal(PROPOSER, thirdBond);
+        (,,,, disputed,,) = gameProxy.claimData(2);
+        gameProxy.move{ value: thirdBond }(disputed, 2, Claim.wrap(0), true);
+        vm.stopPrank();
+    }
+
+    /// @notice Tests that addresses that are not the proposer or challenger cannot participate in
+    ///         a permissioned dispute game.
+    function test_participateInGame_notAuthorized_reverts(address _p) public {
+        vm.assume(_p != PROPOSER && _p != CHALLENGER);
+
+        vm.startPrank(_p, _p);
+        (,,,, Claim disputed,,) = gameProxy.claimData(0);
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.attack(disputed, 0, Claim.wrap(0));
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.defend(disputed, 0, Claim.wrap(0));
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.move(disputed, 0, Claim.wrap(0), true);
+        vm.expectRevert(BadAuth.selector);
+        gameProxy.step(0, true, absolutePrestateData, hex"");
+        vm.stopPrank();
+    }
+}

--- a/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
@@ -79,8 +79,13 @@ contract PermissionedDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
         assertEq(gameProxy.absolutePrestate().raw(), _absolutePrestate.raw());
         assertEq(gameProxy.maxGameDepth(), 2 ** 3);
         assertEq(gameProxy.splitDepth(), 2 ** 2);
+        assertEq(gameProxy.clockExtension().raw(), 3 hours);
         assertEq(gameProxy.maxClockDuration().raw(), 3.5 days);
+        assertEq(address(gameProxy.weth()), address(delayedWeth));
+        assertEq(address(gameProxy.anchorStateRegistry()), address(anchorStateRegistry));
         assertEq(address(gameProxy.vm()), address(_vm));
+        assertEq(address(gameProxy.gameCreator()), PROPOSER);
+        assertEq(gameProxy.l2ChainId(), l2ChainId);
 
         // Label the proxy
         vm.label(address(gameProxy), "FaultDisputeGame_Clone");

--- a/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
@@ -60,9 +60,6 @@ contract PermissionedDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
         (address _impl, AlphabetVM _vm,) = setupPermissionedDisputeGameV2(_absolutePrestate, PROPOSER, CHALLENGER);
         gameImpl = IPermissionedDisputeGameV2(_impl);
 
-        // Register the game implementation with the factory.
-        disputeGameFactory.setImplementation(GAME_TYPE, gameImpl);
-
         // Create a new game.
         uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);
         vm.mockCall(

--- a/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
@@ -57,7 +57,7 @@ contract PermissionedDisputeGameV2_TestInit is DisputeGameFactory_TestInit {
         // Set the extra data for the game creation
         extraData = abi.encode(_l2BlockNumber);
 
-        (address _impl, AlphabetVM _vm,) = setupPermissionedDisputeGame(_absolutePrestate, PROPOSER, CHALLENGER);
+        (address _impl, AlphabetVM _vm,) = setupPermissionedDisputeGameV2(_absolutePrestate, PROPOSER, CHALLENGER);
         gameImpl = IPermissionedDisputeGameV2(_impl);
 
         // Register the game implementation with the factory.

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -390,6 +390,7 @@ contract Initializer_Test is CommonTest {
         //       don't work properly. Remove these exclusions once the deployment script is fixed.
         excludes[j++] = "src/dispute/FaultDisputeGame.sol";
         excludes[j++] = "src/dispute/v2/FaultDisputeGameV2.sol";
+        excludes[j++] = "src/dispute/v2/PermissionedDisputeGameV2.sol";
         excludes[j++] = "src/dispute/SuperFaultDisputeGame.sol";
         excludes[j++] = "src/dispute/PermissionedDisputeGame.sol";
         excludes[j++] = "src/dispute/SuperPermissionedDisputeGame.sol";

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -378,7 +378,7 @@ contract Initializer_Test is CommonTest {
     function test_cannotReinitialize_succeeds() public {
         // Collect exclusions.
         uint256 j;
-        string[] memory excludes = new string[](10);
+        string[] memory excludes = new string[](11);
         // Contract is currently not being deployed as part of the standard deployment script.
         excludes[j++] = "src/L2/OptimismSuperchainERC20.sol";
         // Periphery contracts don't get deployed as part of the standard deployment script.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Introduce `PermissionedDisputeGameV2` as part of migrating chain-specific configuration out of the game implementation constructors. For more context, see the [associated design doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/proofs/dispute-game-creators.md) which explains the new game creation approach. 

The new `PermissionedDisputeGameV2` is not used anywhere in the codebase.  We will incrementally migrate to the new contracts in follow-up PRs.

**Tests**

Duplicate and update existing `PermissionedDisputeGame` tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/17119

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17255
