### PR TITLE
refactor: simplify time.Duration(0) to 0 in CLI flags

### DIFF
--- a/op-alt-da/cli.go
+++ b/op-alt-da/cli.go
@@ -59,14 +59,14 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 		&cli.DurationFlag{
 			Name:     PutTimeoutFlagName,
 			Usage:    "Timeout for put requests. 0 means no timeout.",
-			Value:    time.Duration(0),
+			Value:    0,
 			EnvVars:  altDAEnvs(envPrefix, "PUT_TIMEOUT"),
 			Category: category,
 		},
 		&cli.DurationFlag{
 			Name:     GetTimeoutFlagName,
 			Usage:    "Timeout for get requests. 0 means no timeout.",
-			Value:    time.Duration(0),
+			Value:    0,
 			EnvVars:  altDAEnvs(envPrefix, "GET_TIMEOUT"),
 			Category: category,
 		},


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Remove redundant time.Duration(0) type conversions in favor of simple 0 values.
Go automatically converts numeric zero to time.Duration(0), making this change functionally equivalent while improving code readability and following Go conventions.


