### PR TITLE
op-conductor: p2p healthcheck fix and execution_p2p_healthcheck_api_type

### DIFF
--- a/op-conductor/client/el.go
+++ b/op-conductor/client/el.go
@@ -3,9 +3,9 @@ package client
 import (
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/p2p"
 )
 
 type ElP2PClient interface {

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -150,6 +150,10 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 	if executionP2pRpcUrl == "" {
 		executionP2pRpcUrl = ctx.String(flags.ExecutionRPC.Name)
 	}
+	executionP2pCheckApi := ctx.String(flags.HealthcheckExecutionP2pCheckApi.Name)
+	if executionP2pCheckApi == "" {
+		executionP2pCheckApi = "net"
+	}
 
 	return &Config{
 		ConsensusAddr: ctx.String(flags.ConsensusAddr.Name),
@@ -180,6 +184,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 			ExecutionP2pEnabled:      ctx.Bool(flags.HealthcheckExecutionP2pEnabled.Name),
 			ExecutionP2pMinPeerCount: ctx.Uint64(flags.HealthcheckExecutionP2pMinPeerCount.Name),
 			ExecutionP2pRPCUrl:       executionP2pRpcUrl,
+			ExecutionP2pCheckApi:     executionP2pCheckApi,
 		},
 		RollupCfg:           *rollupCfg,
 		RPCEnableProxy:      ctx.Bool(flags.RPCEnableProxy.Name),
@@ -215,6 +220,9 @@ type HealthCheckConfig struct {
 	// ExecutionP2pRPC is the HTTP provider URL for EL P2P.
 	ExecutionP2pRPCUrl string
 
+	// ExecutionP2pCheckApi is the API to use for EL P2P checks.
+	ExecutionP2pCheckApi string
+
 	// ExecutionP2pMinPeerCount is the minimum number of EL P2P peers required for the sequencer to be healthy.
 	ExecutionP2pMinPeerCount uint64
 }
@@ -235,6 +243,12 @@ func (c *HealthCheckConfig) Check() error {
 		}
 		if c.ExecutionP2pRPCUrl == "" {
 			return fmt.Errorf("missing el p2p rpc")
+		}
+		if c.ExecutionP2pCheckApi == "" {
+			return fmt.Errorf("missing el p2p check api")
+		}
+		if c.ExecutionP2pCheckApi != "net" && c.ExecutionP2pCheckApi != "admin" {
+			return fmt.Errorf("invalid el p2p check api")
 		}
 	}
 	return nil

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -226,7 +226,14 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create execution rpc client out of the el p2p rpc url: "+c.cfg.HealthCheck.ExecutionP2pRPCUrl)
 		}
-		elP2p = client.NewElP2PClientAdmin(execClient)
+		switch c.cfg.HealthCheck.ExecutionP2pCheckApi {
+		case "net":
+			elP2p = client.NewElP2PClientNet(execClient)
+		case "admin":
+			elP2p = client.NewElP2PClientAdmin(execClient)
+		default:
+			return errors.New("invalid el p2p check api")
+		}
 	} else {
 		elP2p = nil
 	}

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -212,7 +212,7 @@ var optionalFlags = []cli.Flag{
 	HealthcheckExecutionP2pEnabled,
 	HealthcheckExecutionP2pMinPeerCount,
 	HealthcheckExecutionP2pRPCUrl,
-	HealthcheckExecutionP2pCheckType,
+	HealthcheckExecutionP2pCheckApi,
 }
 
 func init() {

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -174,6 +174,12 @@ var (
 		Usage:   "URL override for the execution layer RPC client for the sake of p2p healthcheck. If not set, the execution RPC URL will be used.",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_EXECUTION_P2P_RPC_URL"),
 	}
+	HealthcheckExecutionP2pCheckApi = &cli.StringFlag{
+		Name:    "healthcheck.execution-p2p-check-api",
+		Usage:   "Type of EL P2P check to perform. If not set, the default `net` type will be used corresponding to the `net_peerCount` RPC call.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_EXECUTION_P2P_CHECK_API"),
+		Value:   "net",
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -206,6 +212,7 @@ var optionalFlags = []cli.Flag{
 	HealthcheckExecutionP2pEnabled,
 	HealthcheckExecutionP2pMinPeerCount,
 	HealthcheckExecutionP2pRPCUrl,
+	HealthcheckExecutionP2pCheckType,
 }
 
 func init() {


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes EL p2p healthcheck in op-conductor to use the right p2p library, and have an option to switch the api backing that check.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
