### PR TITLE
ci: Run the publish-cannon-prestates job on circleci boxes instead of latitude

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1390,8 +1390,9 @@ jobs:
             - "op-program/bin/meta*"
 
   publish-cannon-prestates:
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: medium
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
     steps:
       - utils/checkout-with-mise
       - attach_workspace:


### PR DESCRIPTION
Run the publish-cannon-prestates job on circleci boxes instead of latitude

It doesn't need lots of resources and we're seeing network flakiness so try uploading from a different network.
