### PR TITLE
fix(kurtosis-devnet): update ethereum-package to fix Teku genesis mismatch

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -3,6 +3,6 @@ description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
   github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@89e0b8cacab9f7e9f74d53b72d4870092825d577
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@0f877c6e2b7098705478931b83c1535064b61ad1
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@637c9dea933be18e47f96cadc0d9bb0e3a5aa9d6 # v1.0.0
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@9cbdde2c55e8d1656deb87821465a2ad244d8b33 # v1.0.0


### PR DESCRIPTION
  Updates ethereum-package from 83830d4 to 0f877c6 to incorporate the minimal
  preset fix from ethpandaops/ethereum-package#1165. This resolves CI flaking
  where Teku fails to start due to genesis block root mismatches when using
  the minimal preset.

  The issue manifested as:
  - Genesis block root and genesis state latest block root mismatch
  - All Kurtosis-based acceptance tests failing with the same error
  - Teku unable to start in the devnet environment
