### PR TITLE
fix(op-acceptance-tests): storage-to-hash alignment in StateGetter GetState

### DIFF
--- a/op-acceptance-tests/tests/isthmus/operator_fee/fee_checker.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/fee_checker.go
@@ -37,11 +37,9 @@ func (f *stateGetterAdapterFactory) NewStateGetterAdapter(blockNumber *big.Int) 
 
 // GetState implements the StateGetter interface
 func (sga *stateGetterAdapter) GetState(addr common.Address, key common.Hash) common.Hash {
-	var result common.Hash
 	val, err := sga.client.StorageAt(sga.ctx, addr, key, sga.blockNumber)
 	require.NoError(sga.t, err)
-	copy(result[:], val)
-	return result
+	return common.BytesToHash(val)
 }
 
 // FeeChecker provides methods to calculate various types of fees


### PR DESCRIPTION
Replace copy into 32-byte buffer with common.BytesToHash(val) when converting ethclient.StorageAt result. This ensures right-aligned (left-padded) big-endian formatting expected by cost functions and matches storage handling elsewhere in the repo.