### PR TITLE
fix(op-node): fix p2p gossip params parsing

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -10,15 +10,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/golang/snappy"
 	lru "github.com/hashicorp/golang-lru/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -143,14 +142,30 @@ func BuildMsgIdFn(cfg *rollup.Config) pubsub.MsgIdFunction {
 	}
 }
 
-func (p *Config) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
+// BuildGossipSubParams builds the gossipsub parameters for the network,
+// starting with defaults and applying any configured overrides.
+func (p *Config) BuildGossipSubParams(rollupCfg *rollup.Config) pubsub.GossipSubParams {
 	params := BuildGlobalGossipParams(rollupCfg)
 
-	// override with CLI changes
-	params.D = p.MeshD
-	params.Dlo = p.MeshDLo
-	params.Dhi = p.MeshDHi
-	params.Dlazy = p.MeshDLazy
+	// override with CLI changes (only if non-zero)
+	if p.MeshD > 0 {
+		params.D = p.MeshD
+	}
+	if p.MeshDLo > 0 {
+		params.Dlo = p.MeshDLo
+	}
+	if p.MeshDHi > 0 {
+		params.Dhi = p.MeshDHi
+	}
+	if p.MeshDLazy > 0 {
+		params.Dlazy = p.MeshDLazy
+	}
+
+	return params
+}
+
+func (p *Config) ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option {
+	params := p.BuildGossipSubParams(rollupCfg)
 
 	// in the future we may add more advanced options like scoring and PX / direct-mesh / episub
 	return []pubsub.Option{

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -10,23 +10,21 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
-
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGuardGossipValidator(t *testing.T) {
@@ -278,6 +276,84 @@ func TestGossipTimestampThreshold(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildGossipSubParams(t *testing.T) {
+	t.Parallel()
+	rollupCfg := &rollup.Config{
+		L2ChainID: big.NewInt(100),
+	}
+
+	t.Run("UsesDefaultsWhenConfigValuesAreZero", func(t *testing.T) {
+		t.Parallel()
+		// Create config with zero values (unset)
+		cfg := &Config{}
+
+		// Build the params directly using the new function
+		params := cfg.BuildGossipSubParams(rollupCfg)
+
+		// Verify defaults are used when config values are zero
+		require.Equal(t, DefaultMeshD, params.D)
+		require.Equal(t, DefaultMeshDlo, params.Dlo)
+		require.Equal(t, DefaultMeshDhi, params.Dhi)
+		require.Equal(t, DefaultMeshDlazy, params.Dlazy)
+	})
+
+	t.Run("OverridesDefaultsWhenConfigValuesAreSet", func(t *testing.T) {
+		t.Parallel()
+		// Create config with custom values
+		cfg := &Config{
+			MeshD:     8,
+			MeshDLo:   4,
+			MeshDHi:   16,
+			MeshDLazy: 10,
+		}
+
+		// Build the params directly using the new function
+		params := cfg.BuildGossipSubParams(rollupCfg)
+
+		// Verify custom values override defaults
+		require.Equal(t, 8, params.D)
+		require.Equal(t, 4, params.Dlo)
+		require.Equal(t, 16, params.Dhi)
+		require.Equal(t, 10, params.Dlazy)
+	})
+
+	t.Run("PartialOverrideKeepsOtherDefaults", func(t *testing.T) {
+		t.Parallel()
+		// Create config with only some values set
+		cfg := &Config{
+			MeshD:     10, // Override this
+			MeshDLo:   0,  // Use default
+			MeshDHi:   20, // Override this
+			MeshDLazy: 0,  // Use default
+		}
+
+		// Build the params directly using the new function
+		params := cfg.BuildGossipSubParams(rollupCfg)
+
+		// Verify partial overrides work correctly
+		require.Equal(t, 10, params.D)
+		require.Equal(t, DefaultMeshDlo, params.Dlo)
+		require.Equal(t, 20, params.Dhi)
+		require.Equal(t, DefaultMeshDlazy, params.Dlazy)
+	})
+}
+
+func TestConfigureGossip(t *testing.T) {
+	t.Parallel()
+	rollupCfg := &rollup.Config{
+		L2ChainID: big.NewInt(100),
+	}
+
+	// Just test that ConfigureGossip returns the expected options
+	cfg := &Config{
+		FloodPublish: true,
+	}
+
+	opts := cfg.ConfigureGossip(rollupCfg)
+	require.Len(t, opts, 2) // WithGossipSubParams and WithFloodPublish
+}
+
 
 // mockGossipSetupConfigurablesWithThreshold implements GossipSetupConfigurables with configurable threshold
 type mockGossipSetupConfigurablesWithThreshold struct {


### PR DESCRIPTION
**Description**

Params should only overwrite the default values if set to non-zero values.

**Tests**
New tests included.

**Additional context**
n/a

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17308

