### PR TITLE
fix: increase interop activation offset to prevent TestPreNoInbox race condition

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
@@ -9,7 +9,7 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSingleChainInterop(),
-		presets.WithSuggestedInteropActivationOffset(30),
+		presets.WithSuggestedInteropActivationOffset(120), // Increased from 30 to 120 seconds for consistency
 		presets.WithInteropNotAtGenesis(),
 		presets.WithL2NetworkCount(1), // Specifically testing dependency set of 1 upgrade
 	)

--- a/op-acceptance-tests/tests/interop/upgrade/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/init_test.go
@@ -9,6 +9,6 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSimpleInterop(),
-		presets.WithSuggestedInteropActivationOffset(30),
+		presets.WithSuggestedInteropActivationOffset(120), // Increased from 30 to 120 seconds to prevent race condition
 		presets.WithInteropNotAtGenesis())
 }

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -26,6 +26,10 @@ func TestPreNoInbox(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 	require := t.Require()
 
+	// This test must run in pre-interop mode to verify that CrossL2Inbox
+	// is not initialized before the interop hardfork activation.
+	// The test verifies that interop messages fail with "implementation not initialized"
+	// when sent before the scheduled interop time.
 	t.Logger().Info("Starting")
 
 	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {


### PR DESCRIPTION
## Problem
TestPreNoInbox was failing intermittently due to race condition - interop activated before test completion.

## Solution
Increased interop activation offset from 30 to 120 seconds in upgrade test suites.

## Changes
- op-acceptance-tests/tests/interop/upgrade/init_test.go: 30 → 120s
- op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go: 30 → 120s
- op-acceptance-tests/tests/interop/upgrade/pre_test.go - commentary (can delete if not necessary)

## Why 120s
Provides sufficient time for test completion while maintaining pre-interop verification intent.

Fixes #17298