### PR TITLE
op-sync-tester: handle all errors for http handler

### DIFF
--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -148,10 +148,15 @@ func (s *Service) initHTTPServer(cfg *config.Config) error {
 	// middleware to initialize session
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r, err := parseSession(r)
-		if errors.Is(err, ErrInvalidSessionIDFormat) || errors.Is(err, ErrInvalidParams) {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		if err != nil {
+			if errors.Is(err, ErrInvalidSessionIDFormat) || errors.Is(err, ErrInvalidParams) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		s.rpcHandler.ServeHTTP(w, r)
 	})
 	s.httpServer = httputil.NewHTTPServer(endpoint, handler)


### PR DESCRIPTION
The http handler for `op-sync-tester` only handled the `ErrInvalidSessionIDFormat`/`ErrInvalidParams`, This pull request enhances the handler to address all other error types as well.