### PR TITLE
circleci, op-acceptance-tests: nightly ci sync tests with external networks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1193,6 +1193,12 @@ jobs:
           name: Download Go dependencies
           working_directory: op-acceptance-tests
           command: go mod download
+      # Persist schedule name into env var
+      - run:
+          name: Persist schedule name into env var
+          command: |
+            echo 'export CIRCLECI_PIPELINE_SCHEDULE_NAME="<< pipeline.schedule.name >>"' >> $BASH_ENV
+            echo 'export CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH="<< pipeline.parameters.sync_test_op_node_dispatch >>"' >> $BASH_ENV
       # Run the acceptance tests
       - run:
           name: Run acceptance tests (gate=<<parameters.gate>>)
@@ -2556,7 +2562,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
-      - op-acceptance-tests:
+      - op-acceptance-tests-docker:
           # Acceptance Testing params
           name: sync-test-op-node-daily
           gate: sync-test-op-node
@@ -2568,8 +2574,6 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-          environment:
-            SYNC_TEST_OP_NODE_DISPATCH: "true"
 
   # Acceptance tests (post-merge to develop)
   acceptance-tests:
@@ -2699,17 +2703,6 @@ workflows:
             - discord
           requires:
             - initialize
-      - op-acceptance-tests-docker:
-          name: memory-synctester
-          gate: sync-test-op-node
-          # CircleCI params
-          no_output_timeout: 30m
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
       # KURTOSIS (Isthmus)
       - op-acceptance-tests:
           # Acceptance Testing params

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1167,6 +1167,87 @@ jobs:
             - notify-failures-on-develop:
                 mentions: "<<parameters.mentions>>"
 
+  op-acceptance-tests-docker:
+    parameters:
+      gate:
+        description: The gate to run the acceptance tests against. This gate should be defined in op-acceptance-tests/acceptance-tests.yaml.
+        type: string
+        default: ""
+      no_output_timeout:
+        description: Timeout for when CircleCI kills the job if there's no output
+        type: string
+        default: 30m
+    resource_class: xlarge
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    circleci_ip_ranges: true
+    steps:
+      - checkout-from-workspace
+      # Restore cached Go modules
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-v1-
+      # Download Go dependencies
+      - run:
+          name: Download Go dependencies
+          working_directory: op-acceptance-tests
+          command: go mod download
+      # Run the acceptance tests
+      - run:
+          name: Run acceptance tests (gate=<<parameters.gate>>)
+          working_directory: op-acceptance-tests
+          no_output_timeout: 1h
+          environment:
+            GOFLAGS: "-mod=mod"
+            GO111MODULE: "on"
+            GOGC: "0"
+          command: |
+            # Run the tests
+            LOG_LEVEL=debug just acceptance-test "" "<<parameters.gate>>"
+      - run:
+          name: Print results (summary)
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            cat "$LOG_DIR/summary.log" || true
+      - run:
+          name: Print results (failures)
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            cat "$LOG_DIR/failed/*.log" || true
+          when: on_fail
+      - run:
+          name: Print results (all)
+          working_directory: op-acceptance-tests
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            cat "$LOG_DIR/all.log" || true
+      - run:
+          name: Generate JUnit XML test report for CircleCI
+          working_directory: op-acceptance-tests
+          when: always
+          command: |
+            LOG_DIR=$(ls -td -- logs/* | head -1)
+            gotestsum --junitfile results/results.xml --raw-command cat $LOG_DIR/raw_go_events.log || true
+      # Save the module cache for future runs
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      # Store test results and artifacts
+      - when:
+          condition: always
+          steps:
+            - store_test_results:
+                path: ./op-acceptance-tests/results
+      - when:
+          condition: always
+          steps:
+            - store_artifacts:
+                path: ./op-acceptance-tests/logs
+
   op-acceptance-tests:
     parameters:
       devnet:
@@ -2618,6 +2699,17 @@ workflows:
             - discord
           requires:
             - initialize
+      - op-acceptance-tests-docker:
+          name: memory-synctester
+          gate: sync-test-op-node
+          # CircleCI params
+          no_output_timeout: 30m
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
       # KURTOSIS (Isthmus)
       - op-acceptance-tests:
           # Acceptance Testing params

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ parameters:
   acceptance_tests_dispatch:
     type: boolean
     default: false
+  sync_test_op_node_dispatch:
+    type: boolean
+    default: false
   github-event-type:
     type: string
     default: "__not_set__"
@@ -2451,6 +2454,41 @@ workflows:
       - stale-check:
           context:
             - circleci-repo-optimism
+
+  scheduled-sync-test-op-node:
+    when:
+      or:
+        - equal: [build_daily, <<pipeline.schedule.name>>]
+        # Trigger on manual triggers if explicitly requested
+        - equal: [true, << pipeline.parameters.sync_test_op_node_dispatch >>]
+    jobs:
+      - initialize:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - contracts-bedrock-build:  # needed for sysgo tests
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
+      - cannon-prestate-quick:  # needed for sysgo tests
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
+      - op-acceptance-tests:
+          # Acceptance Testing params
+          name: sync-test-op-node-daily
+          gate: sync-test-op-node
+          # CircleCI params
+          no_output_timeout: 30m
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
+          environment:
+            SYNC_TEST_OP_NODE_DISPATCH: "true"
 
   # Acceptance tests (post-merge to develop)
   acceptance-tests:

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -78,3 +78,9 @@ gates:
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks
         timeout: 5m
+
+  - id: sync-test-op-node
+    description: "Sync tests for op-node with external networks via the op-sync-tester - tests run daily."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester_ext_el
+        timeout: 30m

--- a/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -1,6 +1,7 @@
 package sync_tester_ext_el
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -12,14 +13,9 @@ import (
 func TestSyncTesterExtEL(gt *testing.T) {
 	t := devtest.SerialT(gt)
 
-	// Only run this test when triggered by daily build or manual dispatch
-	// Check for environment variables that indicate this is a scheduled run or manual dispatch
-	// scheduleName := os.Getenv("CIRCLE_SCHEDULE_NAME")
-	// manualDispatch := os.Getenv("SYNC_TEST_OP_NODE_DISPATCH")
-
-	// if scheduleName != "build_daily" && manualDispatch != "true" {
-	// 	t.Skip("TestSyncTesterExtEL only runs on daily builds (build_daily) or manual dispatch")
-	// }
+	if os.Getenv("CIRCLECI_PIPELINE_SCHEDULE_NAME") != "build_daily" && os.Getenv("CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH") != "true" {
+		t.Skip("TestSyncTesterExtEL only runs on daily scheduled pipeline jobs: %s %s", os.Getenv("CIRCLECI_PIPELINE_SCHEDULE_NAME"), os.Getenv("CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH"))
+	}
 
 	sys := presets.NewMinimalExternalELWithExternalL1(t)
 	require := t.Require()

--- a/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -1,7 +1,6 @@
 package sync_tester_ext_el
 
 import (
-	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -15,12 +14,12 @@ func TestSyncTesterExtEL(gt *testing.T) {
 
 	// Only run this test when triggered by daily build or manual dispatch
 	// Check for environment variables that indicate this is a scheduled run or manual dispatch
-	scheduleName := os.Getenv("CIRCLE_SCHEDULE_NAME")
-	manualDispatch := os.Getenv("SYNC_TEST_OP_NODE_DISPATCH")
+	// scheduleName := os.Getenv("CIRCLE_SCHEDULE_NAME")
+	// manualDispatch := os.Getenv("SYNC_TEST_OP_NODE_DISPATCH")
 
-	if scheduleName != "build_daily" && manualDispatch != "true" {
-		t.Skip("TestSyncTesterExtEL only runs on daily builds (build_daily) or manual dispatch")
-	}
+	// if scheduleName != "build_daily" && manualDispatch != "true" {
+	// 	t.Skip("TestSyncTesterExtEL only runs on daily builds (build_daily) or manual dispatch")
+	// }
 
 	sys := presets.NewMinimalExternalELWithExternalL1(t)
 	require := t.Require()

--- a/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -1,6 +1,7 @@
 package sync_tester_ext_el
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -11,6 +12,15 @@ import (
 
 func TestSyncTesterExtEL(gt *testing.T) {
 	t := devtest.SerialT(gt)
+
+	// Only run this test when triggered by daily build or manual dispatch
+	// Check for environment variables that indicate this is a scheduled run or manual dispatch
+	scheduleName := os.Getenv("CIRCLE_SCHEDULE_NAME")
+	manualDispatch := os.Getenv("SYNC_TEST_OP_NODE_DISPATCH")
+
+	if scheduleName != "build_daily" && manualDispatch != "true" {
+		t.Skip("TestSyncTesterExtEL only runs on daily builds (build_daily) or manual dispatch")
+	}
 
 	sys := presets.NewMinimalExternalELWithExternalL1(t)
 	require := t.Require()


### PR DESCRIPTION
This PR adds a daily job to CircleCI to run op-acceptance-tests with op-sync-tester which verify that latest op-node syncs correctly with external real-data networks, initially OP Sepolia.