### PR TITLE
op-sync-tester: Better Session Handling

### DIFF
--- a/op-devstack/dsl/sync_tester.go
+++ b/op-devstack/dsl/sync_tester.go
@@ -30,7 +30,7 @@ func (s *SyncTester) ListSessions() []string {
 	return sessionIDs
 }
 
-func (s *SyncTester) GetSession(sessionID string) eth.SyncTesterSession {
+func (s *SyncTester) GetSession(sessionID string) *eth.SyncTesterSession {
 	session, err := s.inner.APIWithSession(sessionID).GetSession(s.ctx)
 	s.t.Require().NoError(err)
 	return session

--- a/op-service/apis/sync_tester.go
+++ b/op-service/apis/sync_tester.go
@@ -19,7 +19,7 @@ type SyncTester interface {
 }
 
 type SyncAPI interface {
-	GetSession(ctx context.Context) (eth.SyncTesterSession, error)
+	GetSession(ctx context.Context) (*eth.SyncTesterSession, error)
 	DeleteSession(ctx context.Context) error
 	ListSessions(ctx context.Context) ([]string, error)
 }

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -1,5 +1,7 @@
 package eth
 
+import "sync"
+
 // FCUState represents the Fork Choice Update state with Latest, Safe, and Finalized block numbers
 type FCUState struct {
 	Latest    uint64 `json:"latest"`
@@ -8,6 +10,8 @@ type FCUState struct {
 }
 
 type SyncTesterSession struct {
+	mu sync.RWMutex
+
 	SessionID string `json:"sessionID"`
 
 	// Non canonical view of the chain
@@ -24,4 +28,38 @@ func (s *SyncTesterSession) UpdateFCUState(latest, safe, finalized uint64) {
 	s.CurrentState.Latest = latest
 	s.CurrentState.Safe = safe
 	s.CurrentState.Finalized = finalized
+}
+
+func (s *SyncTesterSession) Lock() {
+	s.mu.Lock()
+}
+
+func (s *SyncTesterSession) RLock() {
+	s.mu.RLock()
+}
+
+func (s *SyncTesterSession) Unlock() {
+	s.mu.Unlock()
+}
+
+func (s *SyncTesterSession) RUnlock() {
+	s.mu.RUnlock()
+}
+
+func NewSyncTesterSession(sessionID string, latest, safe, finalized uint64) *SyncTesterSession {
+	return &SyncTesterSession{
+		SessionID: sessionID,
+		Validated: latest,
+		CurrentState: FCUState{
+			Latest:    latest,
+			Safe:      safe,
+			Finalized: finalized,
+		},
+		Payloads: make(map[PayloadID]*ExecutionPayloadEnvelope),
+		InitialState: FCUState{
+			Latest:    latest,
+			Safe:      safe,
+			Finalized: finalized,
+		},
+	}
 }

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -1,6 +1,9 @@
 package eth
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // FCUState represents the Fork Choice Update state with Latest, Safe, and Finalized block numbers
 type FCUState struct {
@@ -10,7 +13,8 @@ type FCUState struct {
 }
 
 type SyncTesterSession struct {
-	mu sync.RWMutex
+	mu     sync.RWMutex
+	closed atomic.Bool
 
 	SessionID string `json:"sessionID"`
 
@@ -28,6 +32,14 @@ func (s *SyncTesterSession) UpdateFCUState(latest, safe, finalized uint64) {
 	s.CurrentState.Latest = latest
 	s.CurrentState.Safe = safe
 	s.CurrentState.Finalized = finalized
+}
+
+func (s *SyncTesterSession) Close() {
+	s.closed.Store(true)
+}
+
+func (s *SyncTesterSession) IsClosed() bool {
+	return s.closed.Load()
 }
 
 func (s *SyncTesterSession) Lock() {

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"sync"
-	"sync/atomic"
 )
 
 // FCUState represents the Fork Choice Update state with Latest, Safe, and Finalized block numbers
@@ -13,8 +12,7 @@ type FCUState struct {
 }
 
 type SyncTesterSession struct {
-	mu     sync.RWMutex
-	closed atomic.Bool
+	sync.Mutex
 
 	SessionID string `json:"sessionID"`
 
@@ -32,30 +30,6 @@ func (s *SyncTesterSession) UpdateFCUState(latest, safe, finalized uint64) {
 	s.CurrentState.Latest = latest
 	s.CurrentState.Safe = safe
 	s.CurrentState.Finalized = finalized
-}
-
-func (s *SyncTesterSession) Close() {
-	s.closed.Store(true)
-}
-
-func (s *SyncTesterSession) IsClosed() bool {
-	return s.closed.Load()
-}
-
-func (s *SyncTesterSession) Lock() {
-	s.mu.Lock()
-}
-
-func (s *SyncTesterSession) RLock() {
-	s.mu.RLock()
-}
-
-func (s *SyncTesterSession) Unlock() {
-	s.mu.Unlock()
-}
-
-func (s *SyncTesterSession) RUnlock() {
-	s.mu.RUnlock()
 }
 
 func NewSyncTesterSession(sessionID string, latest, safe, finalized uint64) *SyncTesterSession {

--- a/op-service/sources/sync_tester_client.go
+++ b/op-service/sources/sync_tester_client.go
@@ -26,8 +26,8 @@ func (cl *SyncTesterClient) ChainID(ctx context.Context) (eth.ChainID, error) {
 	return result, err
 }
 
-func (cl *SyncTesterClient) GetSession(ctx context.Context) (eth.SyncTesterSession, error) {
-	var session eth.SyncTesterSession
+func (cl *SyncTesterClient) GetSession(ctx context.Context) (*eth.SyncTesterSession, error) {
+	var session *eth.SyncTesterSession
 	err := cl.client.CallContext(ctx, &session, "sync_getSession")
 	return session, err
 }

--- a/op-sync-tester/synctester/backend/backend.go
+++ b/op-sync-tester/synctester/backend/backend.go
@@ -18,21 +18,6 @@ import (
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 )
 
-type sessionKeyType struct{}
-
-var ctxKeySession = sessionKeyType{}
-
-// WithSyncTesterSession returns a new context with the given Session.
-func WithSyncTesterSession(ctx context.Context, s *eth.SyncTesterSession) context.Context {
-	return context.WithValue(ctx, ctxKeySession, s)
-}
-
-// SyncTesterSessionFromContext retrieves the Session from the context, if present.
-func SyncTesterSessionFromContext(ctx context.Context) (*eth.SyncTesterSession, bool) {
-	s, ok := ctx.Value(ctxKeySession).(*eth.SyncTesterSession)
-	return s, ok
-}
-
 type APIRouter interface {
 	AddRPC(route string) error
 	AddAPIToRPC(route string, api rpc.API) error

--- a/op-sync-tester/synctester/backend/session.go
+++ b/op-sync-tester/synctester/backend/session.go
@@ -43,9 +43,9 @@ func (s *SessionManager) IsSessionDeleted(sessionID string) bool {
 }
 
 func (s *SessionManager) DeleteSession(sessionID string) {
-	s.mu.RLock()
+	s.mu.Lock()
 	s.deletedSessionIDs[sessionID] = struct{}{}
-	s.mu.RUnlock()
+	s.mu.Unlock()
 	s.sessions.Delete(sessionID)
 	s.log.Info("Deleted session", "sessionID", sessionID)
 }

--- a/op-sync-tester/synctester/backend/session.go
+++ b/op-sync-tester/synctester/backend/session.go
@@ -1,0 +1,110 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type SessionManager struct {
+	mu                sync.RWMutex
+	deletedSessionIDs map[string]interface{}
+
+	log log.Logger
+
+	sessions sync.Map // map[string]*eth.SyncTesterSession
+}
+
+func NewSessionManager(logger log.Logger) *SessionManager {
+	return &SessionManager{log: logger, deletedSessionIDs: make(map[string]any)}
+}
+
+func (s *SessionManager) SessionIDs() []string {
+	keys := make([]string, 0)
+	s.sessions.Range(func(k, v any) bool {
+		if key, ok := k.(string); ok {
+			keys = append(keys, key)
+		}
+		return true
+	})
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *SessionManager) IsSessionDeleted(sessionID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, deleted := s.deletedSessionIDs[sessionID]
+	return deleted
+}
+
+func (s *SessionManager) DeleteSession(sessionID string) {
+	s.mu.RLock()
+	s.deletedSessionIDs[sessionID] = struct{}{}
+	s.mu.RUnlock()
+	s.sessions.Delete(sessionID)
+	s.log.Info("Deleted session", "sessionID", sessionID)
+}
+
+func (s *SessionManager) Get(given *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
+	id := given.SessionID
+	if s.IsSessionDeleted(id) {
+		s.log.Warn("Attempted to use deleted session", "sessionID", id)
+		return nil, fmt.Errorf("session already deleted: %s", id)
+	}
+	if given == nil {
+		s.log.Warn("No initial session value provided")
+		return nil, fmt.Errorf("no initial session value")
+	}
+	actual, loaded := s.sessions.LoadOrStore(id, given)
+	if loaded {
+		s.log.Debug("Using existing session", "sessionID", id)
+	} else {
+		s.log.Info("Initialized new session", "sessionID", id)
+	}
+	return actual.(*eth.SyncTesterSession), nil
+}
+
+func WithSessionWrite[T any](
+	mgr *SessionManager,
+	ctx context.Context,
+	fn func(*eth.SyncTesterSession) (T, error),
+) (T, error) {
+	var zero T
+	given, ok := SyncTesterSessionFromContext(ctx)
+	if !ok || given == nil {
+		return zero, fmt.Errorf("no session found in context")
+	}
+	session, err := mgr.Get(given)
+	if err != nil {
+		return zero, err
+	}
+	// blocking
+	session.Lock()
+	defer session.Unlock()
+	return fn(session)
+}
+
+func WithSessionRead[T any](
+	mgr *SessionManager,
+	ctx context.Context,
+	fn func(*eth.SyncTesterSession) (T, error),
+) (T, error) {
+	var zero T
+	given, ok := SyncTesterSessionFromContext(ctx)
+	if !ok || given == nil {
+		return zero, fmt.Errorf("no session found in context")
+	}
+	session, err := mgr.Get(given)
+	if err != nil {
+		return zero, err
+	}
+	// blocking
+	session.RLock()
+	defer session.RUnlock()
+	return fn(session)
+}

--- a/op-sync-tester/synctester/backend/session/session.go
+++ b/op-sync-tester/synctester/backend/session/session.go
@@ -1,4 +1,4 @@
-package backend
+package session
 
 import (
 	"context"
@@ -7,20 +7,36 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+
 	"github.com/ethereum/go-ethereum/log"
 )
 
 type SessionManager struct {
 	mu                sync.RWMutex
-	deletedSessionIDs map[string]interface{}
+	deletedSessionIDs map[string]struct{}
 
 	log log.Logger
 
 	sessions sync.Map // map[string]*eth.SyncTesterSession
 }
 
+type sessionKeyType struct{}
+
+var ctxKeySession = sessionKeyType{}
+
+// WithSyncTesterSession returns a new context with the given Session.
+func WithSyncTesterSession(ctx context.Context, s *eth.SyncTesterSession) context.Context {
+	return context.WithValue(ctx, ctxKeySession, s)
+}
+
+// SyncTesterSessionFromContext retrieves the Session from the context, if present.
+func SyncTesterSessionFromContext(ctx context.Context) (*eth.SyncTesterSession, bool) {
+	s, ok := ctx.Value(ctxKeySession).(*eth.SyncTesterSession)
+	return s, ok
+}
+
 func NewSessionManager(logger log.Logger) *SessionManager {
-	return &SessionManager{log: logger, deletedSessionIDs: make(map[string]any)}
+	return &SessionManager{log: logger, deletedSessionIDs: make(map[string]struct{})}
 }
 
 func (s *SessionManager) SessionIDs() []string {
@@ -35,7 +51,7 @@ func (s *SessionManager) SessionIDs() []string {
 	return keys
 }
 
-func (s *SessionManager) IsSessionDeleted(sessionID string) bool {
+func (s *SessionManager) isSessionDeleted(sessionID string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	_, deleted := s.deletedSessionIDs[sessionID]
@@ -46,19 +62,24 @@ func (s *SessionManager) DeleteSession(sessionID string) {
 	s.mu.Lock()
 	s.deletedSessionIDs[sessionID] = struct{}{}
 	s.mu.Unlock()
+	if v, ok := s.sessions.Load(sessionID); ok {
+		if sess, ok := v.(*eth.SyncTesterSession); ok {
+			sess.Close()
+		}
+	}
 	s.sessions.Delete(sessionID)
 	s.log.Info("Deleted session", "sessionID", sessionID)
 }
 
-func (s *SessionManager) Get(given *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
-	id := given.SessionID
-	if s.IsSessionDeleted(id) {
-		s.log.Warn("Attempted to use deleted session", "sessionID", id)
-		return nil, fmt.Errorf("session already deleted: %s", id)
-	}
+func (s *SessionManager) get(given *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
 	if given == nil {
 		s.log.Warn("No initial session value provided")
 		return nil, fmt.Errorf("no initial session value")
+	}
+	id := given.SessionID
+	if s.isSessionDeleted(id) {
+		s.log.Warn("Attempted to use deleted session", "sessionID", id)
+		return nil, fmt.Errorf("session already deleted: %s", id)
 	}
 	actual, loaded := s.sessions.LoadOrStore(id, given)
 	if loaded {
@@ -66,7 +87,17 @@ func (s *SessionManager) Get(given *eth.SyncTesterSession) (*eth.SyncTesterSessi
 	} else {
 		s.log.Info("Initialized new session", "sessionID", id)
 	}
-	return actual.(*eth.SyncTesterSession), nil
+	// close the race window
+	if s.isSessionDeleted(id) {
+		s.sessions.Delete(id)
+		s.log.Warn("Session was deleted concurrently", "sessionID", id)
+		return nil, fmt.Errorf("session already deleted: %s", id)
+	}
+	sess, ok := actual.(*eth.SyncTesterSession)
+	if !ok {
+		return nil, fmt.Errorf("invalid session type for %s", id)
+	}
+	return sess, nil
 }
 
 func WithSessionWrite[T any](
@@ -79,13 +110,16 @@ func WithSessionWrite[T any](
 	if !ok || given == nil {
 		return zero, fmt.Errorf("no session found in context")
 	}
-	session, err := mgr.Get(given)
+	session, err := mgr.get(given)
 	if err != nil {
 		return zero, err
 	}
 	// blocking
 	session.Lock()
 	defer session.Unlock()
+	if session.IsClosed() {
+		return zero, fmt.Errorf("session already deleted: %s", session.SessionID)
+	}
 	return fn(session)
 }
 
@@ -99,12 +133,15 @@ func WithSessionRead[T any](
 	if !ok || given == nil {
 		return zero, fmt.Errorf("no session found in context")
 	}
-	session, err := mgr.Get(given)
+	session, err := mgr.get(given)
 	if err != nil {
 		return zero, err
 	}
 	// blocking
 	session.RLock()
 	defer session.RUnlock()
+	if session.IsClosed() {
+		return zero, fmt.Errorf("session already deleted: %s", session.SessionID)
+	}
 	return fn(session)
 }

--- a/op-sync-tester/synctester/backend/session/session.go
+++ b/op-sync-tester/synctester/backend/session/session.go
@@ -12,12 +12,11 @@ import (
 )
 
 type SessionManager struct {
-	mu                sync.RWMutex
+	sync.Mutex
+	sessions          map[string]*eth.SyncTesterSession
 	deletedSessionIDs map[string]struct{}
 
 	log log.Logger
-
-	sessions sync.Map // map[string]*eth.SyncTesterSession
 }
 
 type sessionKeyType struct{}
@@ -36,39 +35,33 @@ func SyncTesterSessionFromContext(ctx context.Context) (*eth.SyncTesterSession, 
 }
 
 func NewSessionManager(logger log.Logger) *SessionManager {
-	return &SessionManager{log: logger, deletedSessionIDs: make(map[string]struct{})}
+	return &SessionManager{log: logger,
+		sessions:          make(map[string]*eth.SyncTesterSession),
+		deletedSessionIDs: make(map[string]struct{}),
+	}
 }
 
 func (s *SessionManager) SessionIDs() []string {
+	s.Lock()
+	defer s.Unlock()
 	keys := make([]string, 0)
-	s.sessions.Range(func(k, v any) bool {
-		if key, ok := k.(string); ok {
-			keys = append(keys, key)
-		}
-		return true
-	})
+	for key := range s.sessions {
+		keys = append(keys, key)
+	}
 	sort.Strings(keys)
 	return keys
 }
 
-func (s *SessionManager) isSessionDeleted(sessionID string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	_, deleted := s.deletedSessionIDs[sessionID]
-	return deleted
-}
-
-func (s *SessionManager) DeleteSession(sessionID string) {
-	s.mu.Lock()
-	s.deletedSessionIDs[sessionID] = struct{}{}
-	s.mu.Unlock()
-	if v, ok := s.sessions.Load(sessionID); ok {
-		if sess, ok := v.(*eth.SyncTesterSession); ok {
-			sess.Close()
-		}
+func (s *SessionManager) DeleteSession(sessionID string) error {
+	s.Lock()
+	defer s.Unlock()
+	if _, ok := s.sessions[sessionID]; !ok {
+		return fmt.Errorf("attempted to delete non-existent session: %s", sessionID)
 	}
-	s.sessions.Delete(sessionID)
+	s.deletedSessionIDs[sessionID] = struct{}{}
+	delete(s.sessions, sessionID)
 	s.log.Info("Deleted session", "sessionID", sessionID)
+	return nil
 }
 
 func (s *SessionManager) get(given *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
@@ -77,30 +70,25 @@ func (s *SessionManager) get(given *eth.SyncTesterSession) (*eth.SyncTesterSessi
 		return nil, fmt.Errorf("no initial session value")
 	}
 	id := given.SessionID
-	if s.isSessionDeleted(id) {
+	s.Lock()
+	defer s.Unlock()
+	if _, ok := s.deletedSessionIDs[id]; ok {
 		s.log.Warn("Attempted to use deleted session", "sessionID", id)
 		return nil, fmt.Errorf("session already deleted: %s", id)
 	}
-	actual, loaded := s.sessions.LoadOrStore(id, given)
-	if loaded {
+	var sess *eth.SyncTesterSession
+	sess, ok := s.sessions[id]
+	if ok {
 		s.log.Debug("Using existing session", "sessionID", id)
 	} else {
+		s.sessions[id] = given
+		sess = given
 		s.log.Info("Initialized new session", "sessionID", id)
-	}
-	// close the race window
-	if s.isSessionDeleted(id) {
-		s.sessions.Delete(id)
-		s.log.Warn("Session was deleted concurrently", "sessionID", id)
-		return nil, fmt.Errorf("session already deleted: %s", id)
-	}
-	sess, ok := actual.(*eth.SyncTesterSession)
-	if !ok {
-		return nil, fmt.Errorf("invalid session type for %s", id)
 	}
 	return sess, nil
 }
 
-func WithSessionWrite[T any](
+func WithSession[T any](
 	mgr *SessionManager,
 	ctx context.Context,
 	fn func(*eth.SyncTesterSession) (T, error),
@@ -117,31 +105,5 @@ func WithSessionWrite[T any](
 	// blocking
 	session.Lock()
 	defer session.Unlock()
-	if session.IsClosed() {
-		return zero, fmt.Errorf("session already deleted: %s", session.SessionID)
-	}
-	return fn(session)
-}
-
-func WithSessionRead[T any](
-	mgr *SessionManager,
-	ctx context.Context,
-	fn func(*eth.SyncTesterSession) (T, error),
-) (T, error) {
-	var zero T
-	given, ok := SyncTesterSessionFromContext(ctx)
-	if !ok || given == nil {
-		return zero, fmt.Errorf("no session found in context")
-	}
-	session, err := mgr.get(given)
-	if err != nil {
-		return zero, err
-	}
-	// blocking
-	session.RLock()
-	defer session.RUnlock()
-	if session.IsClosed() {
-		return zero, fmt.Errorf("session already deleted: %s", session.SessionID)
-	}
 	return fn(session)
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -73,15 +73,14 @@ func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTeste
 }
 
 func (s *SyncTester) GetSession(ctx context.Context) (*eth.SyncTesterSession, error) {
-	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
 		return session, nil
 	})
 }
 
 func (s *SyncTester) DeleteSession(ctx context.Context) error {
-	_, err := session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (any, error) {
-		s.sessMgr.DeleteSession(session.SessionID)
-		return struct{}{}, nil
+	_, err := session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (any, error) {
+		return struct{}{}, s.sessMgr.DeleteSession(session.SessionID)
 	})
 	return err
 }
@@ -91,7 +90,7 @@ func (s *SyncTester) ListSessions(ctx context.Context) ([]string, error) {
 }
 
 func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
-	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) ([]*types.Receipt, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) ([]*types.Receipt, error) {
 		number, isNumber := blockNrOrHash.Number()
 		var err error
 		var receipts []*types.Receipt
@@ -123,7 +122,7 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 }
 
 func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (json.RawMessage, error) {
-	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
 		var err error
 		var raw json.RawMessage
 		if raw, err = s.elReader.GetBlockByHashJSON(ctx, hash, fullTx); err != nil {
@@ -167,7 +166,7 @@ func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncT
 }
 
 func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error) {
-	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
 		var err error
 		var target uint64
 		if target, err = s.checkBlockNumber(number, session); err != nil {
@@ -182,7 +181,7 @@ func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumbe
 }
 
 func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
-	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (hexutil.Big, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (hexutil.Big, error) {
 		chainID, err := s.elReader.ChainId(ctx)
 		if err != nil {
 			return hexutil.Big{}, err
@@ -196,7 +195,7 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 
 // GetPayloadV1 only supports V1 payloads.
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV1) {
 			return nil, engine.UnsupportedFork
 		}
@@ -206,7 +205,7 @@ func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV2 supports V1, V2 payloads.
 func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV1, engine.PayloadV2) {
 			return nil, engine.UnsupportedFork
 		}
@@ -216,7 +215,7 @@ func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV3 must be only called when Ecotone activated.
 func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV3) {
 			return nil, engine.UnsupportedFork
 		}
@@ -226,7 +225,7 @@ func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV4 must be only called when Isthmus activated.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV3) {
 			return nil, engine.UnsupportedFork
 		}
@@ -250,21 +249,21 @@ func (s *SyncTester) getPayload(session *eth.SyncTesterSession, payloadID eth.Pa
 
 // ForkchoiceUpdatedV1 is called for processing V1 attributes
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
 		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV1, false, false)
 	})
 }
 
 // ForkchoiceUpdatedV2 is called for processing V2 attributes
 func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
 		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV2, true, false)
 	})
 }
 
 // ForkchoiceUpdatedV3 must be only called with Ecotone attributes
 func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
 		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV3, true, true)
 	})
 }
@@ -502,28 +501,28 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 
 // NewPayloadV1 must be only called with Bedrock Payload
 func (s *SyncTester) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
 	})
 }
 
 // NewPayloadV2 must be only called with Bedrock, Canyon, Delta Payload
 func (s *SyncTester) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
 	})
 }
 
 // NewPayloadV3 must be only called with Ecotone Payload
 func (s *SyncTester) NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, nil, true, false)
 	})
 }
 
 // NewPayloadV4 must be only called with Isthmus payload
 func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
-	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, executionRequests, true, true)
 	})
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/frontend"
 )
@@ -36,7 +37,7 @@ type SyncTester struct {
 
 	elReader ReadOnlyELBackend
 
-	sessMgr *SessionManager
+	sessMgr *session.SessionManager
 }
 
 // HeaderNumberOnly is a lightweight header type that only contains the
@@ -67,18 +68,18 @@ func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTeste
 		id:       stID,
 		chainID:  chainID,
 		elReader: elReader,
-		sessMgr:  NewSessionManager(logger),
+		sessMgr:  session.NewSessionManager(logger),
 	}
 }
 
 func (s *SyncTester) GetSession(ctx context.Context) (*eth.SyncTesterSession, error) {
-	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
+	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
 		return session, nil
 	})
 }
 
 func (s *SyncTester) DeleteSession(ctx context.Context) error {
-	_, err := WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (any, error) {
+	_, err := session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (any, error) {
 		s.sessMgr.DeleteSession(session.SessionID)
 		return struct{}{}, nil
 	})
@@ -90,7 +91,7 @@ func (s *SyncTester) ListSessions(ctx context.Context) ([]string, error) {
 }
 
 func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
-	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) ([]*types.Receipt, error) {
+	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) ([]*types.Receipt, error) {
 		number, isNumber := blockNrOrHash.Number()
 		var err error
 		var receipts []*types.Receipt
@@ -122,7 +123,7 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 }
 
 func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (json.RawMessage, error) {
-	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
 		var err error
 		var raw json.RawMessage
 		if raw, err = s.elReader.GetBlockByHashJSON(ctx, hash, fullTx); err != nil {
@@ -166,7 +167,7 @@ func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncT
 }
 
 func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error) {
-	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
 		var err error
 		var target uint64
 		if target, err = s.checkBlockNumber(number, session); err != nil {
@@ -181,7 +182,7 @@ func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumbe
 }
 
 func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
-	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (hexutil.Big, error) {
+	return session.WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (hexutil.Big, error) {
 		chainID, err := s.elReader.ChainId(ctx)
 		if err != nil {
 			return hexutil.Big{}, err
@@ -195,7 +196,7 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 
 // GetPayloadV1 only supports V1 payloads.
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV1) {
 			return nil, engine.UnsupportedFork
 		}
@@ -205,7 +206,7 @@ func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV2 supports V1, V2 payloads.
 func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV1, engine.PayloadV2) {
 			return nil, engine.UnsupportedFork
 		}
@@ -215,7 +216,7 @@ func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV3 must be only called when Ecotone activated.
 func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV3) {
 			return nil, engine.UnsupportedFork
 		}
@@ -225,7 +226,7 @@ func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) 
 
 // GetPayloadV4 must be only called when Isthmus activated.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
 		if !payloadID.Is(engine.PayloadV3) {
 			return nil, engine.UnsupportedFork
 		}
@@ -249,21 +250,21 @@ func (s *SyncTester) getPayload(session *eth.SyncTesterSession, payloadID eth.Pa
 
 // ForkchoiceUpdatedV1 is called for processing V1 attributes
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
 		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV1, false, false)
 	})
 }
 
 // ForkchoiceUpdatedV2 is called for processing V2 attributes
 func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
 		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV2, true, false)
 	})
 }
 
 // ForkchoiceUpdatedV3 must be only called with Ecotone attributes
 func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
 		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV3, true, true)
 	})
 }
@@ -501,28 +502,28 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 
 // NewPayloadV1 must be only called with Bedrock Payload
 func (s *SyncTester) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
 	})
 }
 
 // NewPayloadV2 must be only called with Bedrock, Canyon, Delta Payload
 func (s *SyncTester) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
 	})
 }
 
 // NewPayloadV3 must be only called with Ecotone Payload
 func (s *SyncTester) NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, nil, true, false)
 	})
 }
 
 // NewPayloadV4 must be only called with Isthmus payload
 func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
-	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+	return session.WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
 		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, executionRequests, true, true)
 	})
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
@@ -29,8 +28,6 @@ import (
 )
 
 type SyncTester struct {
-	mu sync.RWMutex
-
 	log log.Logger
 	m   metrics.Metricer
 
@@ -39,9 +36,7 @@ type SyncTester struct {
 
 	elReader ReadOnlyELBackend
 
-	sessions map[string]*eth.SyncTesterSession
-
-	deletedSessionIDs map[string]interface{}
+	sessMgr *SessionManager
 }
 
 // HeaderNumberOnly is a lightweight header type that only contains the
@@ -67,123 +62,81 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 
 func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTesterID, chainID eth.ChainID, elReader ReadOnlyELBackend) *SyncTester {
 	return &SyncTester{
-		log:               logger,
-		m:                 m,
-		id:                stID,
-		chainID:           chainID,
-		elReader:          elReader,
-		sessions:          make(map[string]*eth.SyncTesterSession),
-		deletedSessionIDs: make(map[string]interface{}),
+		log:      logger,
+		m:        m,
+		id:       stID,
+		chainID:  chainID,
+		elReader: elReader,
+		sessMgr:  NewSessionManager(logger),
 	}
 }
 
-func (s *SyncTester) storeSession(session *eth.SyncTesterSession) {
-	s.sessions[session.SessionID] = session
-}
-
-func (s *SyncTester) fetchSession(ctx context.Context) (*eth.SyncTesterSession, error) {
-	session, ok := SyncTesterSessionFromContext(ctx)
-	if !ok || session == nil {
-		return nil, fmt.Errorf("no session found in context")
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.deletedSessionIDs[session.SessionID]; ok {
-		s.log.Warn("Using deleted session", "sessionID", session.SessionID)
-		return nil, fmt.Errorf("session already deleted: %s", session.SessionID)
-	}
-	if existing, ok := s.sessions[session.SessionID]; ok {
-		s.log.Debug("Using existing session", "session", existing)
-		return existing, nil
-	} else {
-		s.storeSession(session)
-		s.log.Info("Initialized new session", "session", session)
+func (s *SyncTester) GetSession(ctx context.Context) (*eth.SyncTesterSession, error) {
+	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
 		return session, nil
-	}
-}
-
-func (s *SyncTester) GetSession(ctx context.Context) (eth.SyncTesterSession, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return eth.SyncTesterSession{}, err
-	}
-	return *session, nil
+	})
 }
 
 func (s *SyncTester) DeleteSession(ctx context.Context) error {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return err
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// mark as deleted
-	s.deletedSessionIDs[session.SessionID] = struct{}{}
-	delete(s.sessions, session.SessionID)
-	return nil
+	_, err := WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (any, error) {
+		s.sessMgr.DeleteSession(session.SessionID)
+		return struct{}{}, nil
+	})
+	return err
 }
 
 func (s *SyncTester) ListSessions(ctx context.Context) ([]string, error) {
-	// No need to fetch session
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	keys := make([]string, 0, len(s.sessions))
-	for k := range s.sessions {
-		keys = append(keys, k)
-	}
-	return keys, nil
+	return s.sessMgr.SessionIDs(), nil
 }
 
 func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	number, isNumber := blockNrOrHash.Number()
-	var receipts []*types.Receipt
-	if !isNumber {
-		// hash
-		receipts, err = s.elReader.GetBlockReceipts(ctx, blockNrOrHash)
-		if err != nil {
-			return nil, err
+	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) ([]*types.Receipt, error) {
+		number, isNumber := blockNrOrHash.Number()
+		var err error
+		var receipts []*types.Receipt
+		if !isNumber {
+			// hash
+			receipts, err = s.elReader.GetBlockReceipts(ctx, blockNrOrHash)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			var target uint64
+			if target, err = s.checkBlockNumber(number, session); err != nil {
+				return nil, err
+			}
+			receipts, err = s.elReader.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(target)))
+			if err != nil {
+				return nil, err
+			}
 		}
-	} else {
-		var target uint64
-		if target, err = s.checkBlockNumber(number, session); err != nil {
-			return nil, err
+		if len(receipts) == 0 {
+			// Should never happen since every block except genesis has at least one deposit tx
+			return nil, errors.New("no receipts")
 		}
-		receipts, err = s.elReader.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(target)))
-		if err != nil {
-			return nil, err
+		if receipts[0].BlockNumber.Uint64() > session.CurrentState.Latest {
+			return nil, ethereum.NotFound
 		}
-	}
-	if len(receipts) == 0 {
-		// Should never happen since every block except genesis has at least one deposit tx
-		return nil, errors.New("no receipts")
-	}
-	if receipts[0].BlockNumber.Uint64() > session.CurrentState.Latest {
-		return nil, ethereum.NotFound
-	}
-	return receipts, nil
+		return receipts, nil
+	})
 }
 
 func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (json.RawMessage, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var raw json.RawMessage
-	if raw, err = s.elReader.GetBlockByHashJSON(ctx, hash, fullTx); err != nil {
-		return nil, err
-	}
-	var header HeaderNumberOnly
-	if err := json.Unmarshal(raw, &header); err != nil {
-		return nil, err
-	}
-	if header.Number.ToInt().Uint64() > session.CurrentState.Latest {
-		return nil, ethereum.NotFound
-	}
-	return raw, nil
+	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+		var err error
+		var raw json.RawMessage
+		if raw, err = s.elReader.GetBlockByHashJSON(ctx, hash, fullTx); err != nil {
+			return nil, err
+		}
+		var header HeaderNumberOnly
+		if err := json.Unmarshal(raw, &header); err != nil {
+			return nil, err
+		}
+		if header.Number.ToInt().Uint64() > session.CurrentState.Latest {
+			return nil, ethereum.NotFound
+		}
+		return raw, nil
+	})
 }
 
 func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncTesterSession) (uint64, error) {
@@ -213,81 +166,71 @@ func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncT
 }
 
 func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var target uint64
-	if target, err = s.checkBlockNumber(number, session); err != nil {
-		return nil, err
-	}
-	var raw json.RawMessage
-	if raw, err = s.elReader.GetBlockByNumberJSON(ctx, rpc.BlockNumber(target), fullTx); err != nil {
-		return nil, err
-	}
-	return raw, nil
+	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+		var err error
+		var target uint64
+		if target, err = s.checkBlockNumber(number, session); err != nil {
+			return nil, err
+		}
+		var raw json.RawMessage
+		if raw, err = s.elReader.GetBlockByNumberJSON(ctx, rpc.BlockNumber(target), fullTx); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	})
 }
 
 func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
-	if _, err := s.fetchSession(ctx); err != nil {
-		return hexutil.Big{}, err
-	}
-	chainID, err := s.elReader.ChainId(ctx)
-	if err != nil {
-		return hexutil.Big{}, err
-	}
-	if chainID.ToInt().Cmp(s.chainID.ToBig()) != 0 {
-		return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.chainID, chainID.ToInt())
-	}
-	return hexutil.Big(*s.chainID.ToBig()), nil
+	return WithSessionRead(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (hexutil.Big, error) {
+		chainID, err := s.elReader.ChainId(ctx)
+		if err != nil {
+			return hexutil.Big{}, err
+		}
+		if chainID.ToInt().Cmp(s.chainID.ToBig()) != 0 {
+			return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.chainID, chainID.ToInt())
+		}
+		return hexutil.Big(*s.chainID.ToBig()), nil
+	})
 }
 
 // GetPayloadV1 only supports V1 payloads.
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV1) {
-		return nil, engine.UnsupportedFork
-	}
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.getPayload(session, payloadID)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+		if !payloadID.Is(engine.PayloadV1) {
+			return nil, engine.UnsupportedFork
+		}
+		return s.getPayload(session, payloadID)
+	})
 }
 
 // GetPayloadV2 supports V1, V2 payloads.
 func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV1, engine.PayloadV2) {
-		return nil, engine.UnsupportedFork
-	}
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.getPayload(session, payloadID)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+		if !payloadID.Is(engine.PayloadV1, engine.PayloadV2) {
+			return nil, engine.UnsupportedFork
+		}
+		return s.getPayload(session, payloadID)
+	})
 }
 
 // GetPayloadV3 must be only called when Ecotone activated.
 func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV3) {
-		return nil, engine.UnsupportedFork
-	}
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.getPayload(session, payloadID)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+		if !payloadID.Is(engine.PayloadV3) {
+			return nil, engine.UnsupportedFork
+		}
+		return s.getPayload(session, payloadID)
+	})
 }
 
 // GetPayloadV4 must be only called when Isthmus activated.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV3) {
-		return nil, engine.UnsupportedFork
-	}
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.getPayload(session, payloadID)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+		if !payloadID.Is(engine.PayloadV3) {
+			return nil, engine.UnsupportedFork
+		}
+		return s.getPayload(session, payloadID)
+	})
 }
 
 // getPayload retrieves an execution payload previously initialized by
@@ -301,35 +244,28 @@ func (s *SyncTester) getPayload(session *eth.SyncTesterSession, payloadID eth.Pa
 	}
 	// Clean up payload
 	delete(session.Payloads, payloadID)
-	s.storeSession(session)
 	return payloadEnv, nil
 }
 
 // ForkchoiceUpdatedV1 is called for processing V1 attributes
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV1, false, false)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV1, false, false)
+	})
 }
 
 // ForkchoiceUpdatedV2 is called for processing V2 attributes
 func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV2, true, false)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV2, true, false)
+	})
 }
 
 // ForkchoiceUpdatedV3 must be only called with Ecotone attributes
 func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV3, true, true)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
+		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV3, true, true)
+	})
 }
 
 // forkchoiceUpdated processes a forkchoice state update from the consensus
@@ -476,7 +412,6 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 		session.Payloads[payloadID] = payloadEnv
 	}
 	session.UpdateFCUState(candLatest.NumberU64(), safeNum, finalizedNum)
-	s.storeSession(session)
 	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
 	// Spec: Client software MUST respond to this method call in the following way: {payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId} if the payload is deemed VALID and the build process has begun
 	return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: id}, nil
@@ -561,38 +496,30 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 
 // NewPayloadV1 must be only called with Bedrock Payload
 func (s *SyncTester) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
+	})
 }
 
 // NewPayloadV2 must be only called with Bedrock, Canyon, Delta Payload
 func (s *SyncTester) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
+	})
 }
 
 // NewPayloadV3 must be only called with Ecotone Payload
 func (s *SyncTester) NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, nil, true, false)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, nil, true, false)
+	})
 }
 
 // NewPayloadV4 must be only called with Isthmus payload
 func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
-	session, err := s.fetchSession(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, executionRequests, true, true)
+	return WithSessionWrite(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
+		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, executionRequests, true, true)
+	})
 }
 
 // newPayload validates and processes a new execution payload according to the
@@ -720,7 +647,6 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 		if block.NumberU64() == session.Validated+1 {
 			// Advance single block without setting the head, equivalent to geth InsertBlockWithoutSetHead
 			session.Validated += 1
-			s.storeSession(session)
 		}
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
 		// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -451,7 +451,7 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 	}
 	// OP Stack additions
 	if len(attr.Transactions) != len(block.Transactions()) {
-		return fmt.Errorf("tx count mismatch: attr=%d, header=%d", len(attr.Transactions), len(block.Transactions()))
+		return fmt.Errorf("tx count mismatch: attr=%d, block=%d", len(attr.Transactions), len(block.Transactions()))
 	}
 	for idx := range len(attr.Transactions) {
 		blockTx := block.Transactions()[idx]
@@ -471,6 +471,11 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 		return fmt.Errorf("gaslimit mismatch: attr=%d, header=%d", *attr.GasLimit, h.GasLimit)
 	}
 	if isHolocene {
+		// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md#encoding
+		// Spec: At and after Holocene activation, eip1559Parameters in PayloadAttributeV3 must be exactly 8 bytes with the following format
+		if attr.EIP1559Params == nil {
+			return errors.New("holocene enabled but EIP1559Params nil")
+		}
 		if err := eip1559.ValidateHolocene1559Params((*attr.EIP1559Params)[:]); err != nil {
 			return fmt.Errorf("invalid eip1559Params: %w", err)
 		}
@@ -624,7 +629,7 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 		correctPayload, err := eth.BlockAsPayload(block, config)
 		if err != nil {
 			// The failure is from the EL processing so consider as a server error and make CL retry
-			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed convert block to payload: %w", err))
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to convert block to payload", err))
 		}
 		// Sanity check parent beacon block root and block hash by recomputation
 		if !isIsthmus {

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -136,7 +137,7 @@ func TestSyncTester_ChainId(t *testing.T) {
 			st := initTestSyncTester(t, tc.cfgID, mock)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSyncTesterSession(ctx, tc.session)
+				ctx = session.WithSyncTesterSession(ctx, tc.session)
 			}
 			got, err := st.ChainId(ctx)
 			if tc.wantErrContains != "" {
@@ -194,7 +195,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSyncTesterSession(ctx, tc.session)
+				ctx = session.WithSyncTesterSession(ctx, tc.session)
 			}
 			raw, err := st.GetBlockByHash(ctx, hash, false)
 			if tc.wantErrContains != "" {
@@ -320,7 +321,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSyncTesterSession(ctx, tc.session)
+				ctx = session.WithSyncTesterSession(ctx, tc.session)
 			}
 			raw, err := st.GetBlockByNumber(ctx, tc.inNumber, false)
 			if tc.wantErrContains != "" {
@@ -462,7 +463,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			st := initTestSyncTester(t, eth.ChainIDFromUInt64(1), el)
 			ctx := context.Background()
 			if tc.session != nil {
-				ctx = WithSyncTesterSession(ctx, tc.session)
+				ctx = session.WithSyncTesterSession(ctx, tc.session)
 			}
 			recs, err := st.GetBlockReceipts(ctx, tc.arg)
 			if tc.wantErrContains != "" {

--- a/op-sync-tester/synctester/frontend/sync.go
+++ b/op-sync-tester/synctester/frontend/sync.go
@@ -18,7 +18,7 @@ func NewSyncFrontend(b SyncBackend) *SyncFrontend {
 	return &SyncFrontend{b: b}
 }
 
-func (s *SyncFrontend) GetSession(ctx context.Context) (eth.SyncTesterSession, error) {
+func (s *SyncFrontend) GetSession(ctx context.Context) (*eth.SyncTesterSession, error) {
 	return s.b.GetSession(ctx)
 }
 

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -71,21 +71,7 @@ func parseSession(r *http.Request) (*http.Request, error) {
 		if err != nil {
 			return r, err
 		}
-		session := &eth.SyncTesterSession{
-			SessionID: sessionID,
-			Validated: latest,
-			CurrentState: eth.FCUState{
-				Latest:    latest,
-				Safe:      safe,
-				Finalized: finalized,
-			},
-			Payloads: make(map[eth.PayloadID]*eth.ExecutionPayloadEnvelope),
-			InitialState: eth.FCUState{
-				Latest:    latest,
-				Safe:      safe,
-				Finalized: finalized,
-			},
-		}
+		session := eth.NewSyncTesterSession(sessionID, latest, safe, finalized)
 		ctx := backend.WithSyncTesterSession(r.Context(), session)
 		// remove uuid path for routing
 		r.URL.Path = "/" + strings.Join(segments[:3], "/")

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	"github.com/google/uuid"
 )
 
@@ -71,8 +71,8 @@ func parseSession(r *http.Request) (*http.Request, error) {
 		if err != nil {
 			return r, err
 		}
-		session := eth.NewSyncTesterSession(sessionID, latest, safe, finalized)
-		ctx := backend.WithSyncTesterSession(r.Context(), session)
+		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized)
+		ctx := session.WithSyncTesterSession(r.Context(), sess)
 		// remove uuid path for routing
 		r.URL.Path = "/" + strings.Join(segments[:3], "/")
 		r = r.WithContext(ctx)

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +32,7 @@ func TestParseSession_Valid(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newReq)
 
-	session, ok := backend.SyncTesterSessionFromContext(newReq.Context())
+	session, ok := session.SyncTesterSessionFromContext(newReq.Context())
 	require.True(t, ok)
 	require.NotNil(t, session)
 	require.Equal(t, id, session.SessionID)
@@ -52,7 +52,7 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newReq)
 
-	session, ok := backend.SyncTesterSessionFromContext(newReq.Context())
+	session, ok := session.SyncTesterSessionFromContext(newReq.Context())
 	require.True(t, ok)
 	require.NotNil(t, session)
 	require.Equal(t, id, session.SessionID)
@@ -70,7 +70,7 @@ func TestParseSession_NoSessionInitialized(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, req, newReq)
 
-	_, ok := backend.SyncTesterSessionFromContext(newReq.Context())
+	_, ok := session.SyncTesterSessionFromContext(newReq.Context())
 	require.False(t, ok)
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Mutexs are now fine grained, embedded per each session.

Introduce a session Manager, which abstracts locking operations for the sessions, and each session holds their own lock to protect themselves while modification.

No logic change in the sync tester APIs except explicit locking mechanism added:

For APIs we now wrap around the logic with `WithSession`. Example:
```go
func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error) {
	return WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
		var err error
		var target uint64
		if target, err = s.checkBlockNumber(number, session); err != nil {
			return nil, err
		}
		var raw json.RawMessage
		if raw, err = s.elReader.GetBlockByNumberJSON(ctx, rpc.BlockNumber(target), fullTx); err != nil {
			return nil, err
		}
		return raw, nil
	})
}

```
which under the hood, acquires locks.

All locks are blocking, but they can be changed to TryLocks in the future.

**Tests**

All existing tests are passing.

**Additional context**

Before this PR few APIs did not properly acquire locks. This PR adds proper locking mechanisms to every APIs.

Also hardened holocene related checks(eip1559params) and tweaked error messages.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17047
