### PR TITLE
feat: updated system config pause

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xc882812dcb516870992d10245f9cd405783b2015d9149d3a25353018a718b685",
-    "sourceCodeHash": "0xc98ed634addce74347ad50aa98c8f957d9936906781f5bbfcd6ecf04cd2a54e2"
+    "initCodeHash": "0x48070c60dce026f655fbd31c490673657ed0ee48b90ff399aa5bac60abc0b796",
+    "sourceCodeHash": "0x27101f76d083e0b15e462932f5a3bfad67c10e033eeb670b76e67c370b7f2b07"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0x14ea48c6b39450b08785209132e6c7f996092ab75d7c170c756c0ef2b6565abc"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xa7c8150d8b14127e4d9be57e50783a24522cabe102e38f79d2778439c0b9b0b7",
-    "sourceCodeHash": "0x753bc5eb6cb64625ea75317eee5dc9d883f5ebb717c5582d2511ef35d1b042cb"
+    "initCodeHash": "0xd51a509f615fd2551dad0efcdf3dbb6c6aa0643d7a525753dc0b9ce04661c700",
+    "sourceCodeHash": "0x6eff040576daac4266b28a199cb8f231cc9814f5b1a9632a883581ede928cfe5"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x0bd9360663627aab37a548aca16e26b1a8017766445b3969e16bc6cca6ec801a",
@@ -45,7 +45,7 @@
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
     "initCodeHash": "0xc882812dcb516870992d10245f9cd405783b2015d9149d3a25353018a718b685",
-    "sourceCodeHash": "0xfc4698edc6332048b471498c560b7ba3b52647be6d379ce178fde76f66aeb9c4"
+    "sourceCodeHash": "0xc98ed634addce74347ad50aa98c8f957d9936906781f5bbfcd6ecf04cd2a54e2"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0x14ea48c6b39450b08785209132e6c7f996092ab75d7c170c756c0ef2b6565abc"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xd51a509f615fd2551dad0efcdf3dbb6c6aa0643d7a525753dc0b9ce04661c700",
-    "sourceCodeHash": "0x6eff040576daac4266b28a199cb8f231cc9814f5b1a9632a883581ede928cfe5"
+    "initCodeHash": "0x4bc7f764443e720172be8b1dea534937893f1eae5a4ce8528f005657d12e6e9f",
+    "sourceCodeHash": "0x73cfd587b049a2eda1f028528a756477c39414902ea7390706eb146191a29242"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x0bd9360663627aab37a548aca16e26b1a8017766445b3969e16bc6cca6ec801a",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0x14ea48c6b39450b08785209132e6c7f996092ab75d7c170c756c0ef2b6565abc"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xc127c19ea0c29ded7d482328c25c24cd82927943597a33d1eaa3b492f37ff628",
-    "sourceCodeHash": "0x232205736536490e8043dd8f384801deaa110b8d2e776bbd9ab00c55ac823d3e"
+    "initCodeHash": "0xa7c8150d8b14127e4d9be57e50783a24522cabe102e38f79d2778439c0b9b0b7",
+    "sourceCodeHash": "0x753bc5eb6cb64625ea75317eee5dc9d883f5ebb717c5582d2511ef35d1b042cb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x0bd9360663627aab37a548aca16e26b1a8017766445b3969e16bc6cca6ec801a",
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xce42986f8ae59e206814ab2eed9129d32a97462cdf6025c4e3d517d9fc569f19",
-    "sourceCodeHash": "0x45c7571a631438c344f3bccb14357df9c4bd2b79092ef0e75393dfc8df802b88"
+    "initCodeHash": "0xc882812dcb516870992d10245f9cd405783b2015d9149d3a25353018a718b685",
+    "sourceCodeHash": "0xfc4698edc6332048b471498c560b7ba3b52647be6d379ce178fde76f66aeb9c4"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -38,8 +38,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.11.0
-    string public constant version = "1.11.0";
+    /// @custom:semver 1.12.0
+    string public constant version = "1.12.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -188,7 +188,7 @@ contract OPContractsManagerStandardValidator is ISemver {
 
     /// @notice Returns the expected SystemConfig version.
     function systemConfigVersion() public pure returns (string memory) {
-        return "3.6.0";
+        return "3.7.0";
     }
 
     /// @notice Returns the expected OptimismPortal version.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -520,7 +520,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
 
     /// @notice Returns the current pause state for this network. If the network is using
     ///         ETHLockbox, the system is paused if either the global pause is active or the pause
-    ///         is active where the ETHLockbox addess is used as the identifier. If the network is
+    ///         is active where the ETHLockbox address is used as the identifier. If the network is
     ///         not using ETHLockbox, the system is paused if either the global pause is active or
     ///         the pause is active where the OptimismPortal address is used as the identifier.
     /// @return bool True if the system is paused, false otherwise.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -8,6 +8,7 @@ import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";
 
 // Libraries
 import { Storage } from "src/libraries/Storage.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -154,9 +155,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
-    /// @custom:semver 3.6.0
+    /// @custom:semver 3.7.0
     function version() public pure virtual returns (string memory) {
-        return "3.6.0";
+        return "3.7.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -517,12 +518,22 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         emit FeatureSet(_feature, _enabled);
     }
 
-    /// @notice Returns the current pause state of the system by checking if the SuperchainConfig is paused for this
-    /// chain's ETHLockbox.
+    /// @notice Returns the current pause state for this network. If the network is using
+    ///         ETHLockbox, the system is paused if either the global pause is active or the pause
+    ///         is active where the ETHLockbox addess is used as the identifier. If the network is
+    ///         not using ETHLockbox, the system is paused if either the global pause is active or
+    ///         the pause is active where the OptimismPortal address is used as the identifier.
     /// @return bool True if the system is paused, false otherwise.
     function paused() public view returns (bool) {
+        // Determine the appropriate chain identifier based on the feature flags.
+        address identifier = address(optimismPortal());
         IETHLockbox lockbox = IOptimismPortal2(payable(optimismPortal())).ethLockbox();
-        return superchainConfig.paused(address(lockbox)) || superchainConfig.paused(address(0));
+        if (address(lockbox) != address(0) && isFeatureEnabled[Features.ETH_LOCKBOX]) {
+            identifier = address(lockbox);
+        }
+
+        // Check if either global or local pause is active.
+        return superchainConfig.paused(address(0)) || superchainConfig.paused(identifier);
     }
 
     /// @notice Returns the guardian address of the SuperchainConfig.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -15,7 +15,6 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 /// @custom:proxied true
 /// @title SystemConfig
@@ -526,11 +525,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @return bool True if the system is paused, false otherwise.
     function paused() public view returns (bool) {
         // Determine the appropriate chain identifier based on the feature flags.
-        address identifier = address(optimismPortal());
-        IETHLockbox lockbox = IOptimismPortal2(payable(optimismPortal())).ethLockbox();
-        if (address(lockbox) != address(0) && isFeatureEnabled[Features.ETH_LOCKBOX]) {
-            identifier = address(lockbox);
-        }
+        address identifier = isFeatureEnabled[Features.ETH_LOCKBOX]
+            ? address(IOptimismPortal2(payable(optimismPortal())).ethLockbox())
+            : address(optimismPortal());
 
         // Check if either global or local pause is active.
         return superchainConfig.paused(address(0)) || superchainConfig.paused(identifier);

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -267,7 +267,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Make sure that the SystemConfig is upgraded to the right version. It must also have the
         // right l2ChainId and must be properly initialized.
-        assertEq(ISemver(address(systemConfig)).version(), "3.6.0");
+        assertEq(ISemver(address(systemConfig)).version(), "3.7.0");
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(systemConfig.l2ChainId(), l2ChainId);
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -736,22 +736,6 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
         assertTrue(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` returns false when ETHLockbox is paused but the
-    ///         ETH_LOCKBOX feature is disabled.
-    function test_paused_ethLockboxIdentifierFeatureDisabled_succeeds() external {
-        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
-
-        // Initially not paused
-        assertFalse(systemConfig.paused());
-
-        // Pause the system with ETHLockbox identifier
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(ethLockbox));
-
-        // Verify system is NOT paused because feature is disabled
-        assertFalse(systemConfig.paused());
-    }
-
     /// @notice Tests that `paused()` returns true when both pauses are active.
     function test_paused_bothPausesActive_succeeds() external {
         assertFalse(systemConfig.paused());

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -10,7 +10,7 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
@@ -686,29 +686,44 @@ contract SystemConfig_SetResourceConfig_Test is SystemConfig_TestInit {
 /// @title SystemConfig_Paused_Test
 /// @notice Test contract for SystemConfig `paused` function.
 contract SystemConfig_Paused_Test is SystemConfig_TestInit {
-    /// @notice Tests that `paused()` returns the correct value.
-    function test_paused_succeeds() external view {
-        assertEq(systemConfig.paused(), superchainConfig.paused(address(0)));
+    /// @notice Tests that `paused()` returns false when no pauses are active.
+    function test_paused_noPauses_succeeds() external view {
+        assertFalse(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` returns the correct value after pausing.
-    function test_paused_afterPause_succeeds() external {
+    /// @notice Tests that `paused()` returns true when global pause is active.
+    function test_paused_globalPause_succeeds() external {
         // Initially not paused
         assertFalse(systemConfig.paused());
-        assertEq(systemConfig.paused(), superchainConfig.paused(address(0)));
 
-        // Pause the system
+        // Pause the system globally
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause(address(0));
 
         // Verify paused state
         assertTrue(systemConfig.paused());
-        assertEq(systemConfig.paused(), superchainConfig.paused(address(0)));
     }
 
-    /// @notice Tests that `paused()` returns true when the ETHLockbox identifier is set.
+    /// @notice Tests that `paused()` returns true when OptimismPortal identifier is paused and
+    ///         the ETH_LOCKBOX feature is disabled.
+    function test_paused_optimismPortalIdentifier_succeeds() external {
+        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
+
+        // Initially not paused
+        assertFalse(systemConfig.paused());
+
+        // Pause the system with OptimismPortal identifier
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(optimismPortal2));
+
+        // Verify paused state
+        assertTrue(systemConfig.paused());
+    }
+
+    /// @notice Tests that `paused()` returns true when ETHLockbox identifier is paused and
+    ///         ETH_LOCKBOX feature is enabled.
     function test_paused_ethLockboxIdentifier_succeeds() external {
-        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
+        skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
 
         // Initially not paused
         assertFalse(systemConfig.paused());
@@ -721,14 +736,49 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
         assertTrue(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` returns false when any other address is set.
-    function test_paused_otherAddress_works() external {
+    /// @notice Tests that `paused()` returns false when ETHLockbox is paused but the
+    ///         ETH_LOCKBOX feature is disabled.
+    function test_paused_ethLockboxIdentifierFeatureDisabled_succeeds() external {
+        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
+
         // Initially not paused
         assertFalse(systemConfig.paused());
 
-        // Pause the system with a different address
+        // Pause the system with ETHLockbox identifier
         vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(0x1234));
+        superchainConfig.pause(address(ethLockbox));
+
+        // Verify system is NOT paused because feature is disabled
+        assertFalse(systemConfig.paused());
+    }
+
+    /// @notice Tests that `paused()` returns true when both pauses are active.
+    function test_paused_bothPausesActive_succeeds() external {
+        assertFalse(systemConfig.paused());
+
+        // Pause both globally and with identifier
+        vm.startPrank(superchainConfig.guardian());
+        superchainConfig.pause(address(0));
+        superchainConfig.pause(address(optimismPortal2));
+        vm.stopPrank();
+
+        // Verify paused state
+        assertTrue(systemConfig.paused());
+    }
+
+    /// @notice Tests that `paused()` returns false when any other address is paused.
+    /// @param _address The address to pause.
+    function testFuzz_paused_otherAddress_succeeds(address _address) external {
+        vm.assume(_address != address(0));
+        vm.assume(_address != address(optimismPortal2));
+        vm.assume(_address != address(ethLockbox));
+
+        // Initially not paused
+        assertFalse(systemConfig.paused());
+
+        // Pause the system with a different address that's not global or identifier
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(_address);
 
         // Verify still not paused
         assertFalse(systemConfig.paused());


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the SystemConfig.paused() function to look at the OptimismPortal as an identifier if the ETHLockbox feature is not active.