### PR TITLE
feat: have VerifyOPCM check for dev bitmap

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -52,6 +52,9 @@ contract VerifyOPCM is Script {
     /// @notice Thrown when there are getter functions in the ABI that are not being checked.
     error VerifyOPCM_UnaccountedGetters(string[] _unaccountedGetters);
 
+    /// @notice Thrown when the dev feature bitmap is not empty on mainnet.
+    error VerifyOPCM_DevFeatureBitmapNotEmpty();
+
     /// @notice Preamble used for blueprint contracts.
     bytes constant BLUEPRINT_PREAMBLE = hex"FE7100";
 
@@ -200,6 +203,9 @@ contract VerifyOPCM is Script {
 
         // Validate that all ABI getters are accounted for.
         _validateAllGettersAccounted();
+
+        // Validate that the dev feature bitmap is empty on mainnet.
+        _validateDevFeatureBitmap(opcm);
 
         // Collect all the references.
         OpcmContractRef[] memory refs = _collectOpcmContractRefs(opcm);
@@ -912,6 +918,21 @@ contract VerifyOPCM is Script {
             ),
             (string[])
         );
+    }
+
+    /// @notice Validates that the dev feature bitmap is empty on mainnet.
+    /// @param _opcm The OPCM contract.
+    function _validateDevFeatureBitmap(IOPContractsManager _opcm) internal view {
+        // Get the dev feature bitmap.
+        bytes32 devFeatureBitmap = _opcm.devFeatureBitmap();
+
+        // Check if we're in a testing environment.
+        bool isTestingEnvironment = address(0xbeefcafe).code.length > 0;
+
+        // Check if any dev features are enabled.
+        if (block.chainid == 1 && !isTestingEnvironment && devFeatureBitmap != bytes32(0)) {
+            revert VerifyOPCM_DevFeatureBitmapNotEmpty();
+        }
     }
 
     /// @notice Validates that all getter functions in the OPContractsManager ABI are accounted for

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -158,6 +158,7 @@ contract VerifyOPCM is Script {
 
         // Getters that don't need any sort of verification
         expectedGetters["devFeatureBitmap"] = "SKIP";
+        expectedGetters["isDevFeatureEnabled"] = "SKIP";
 
         // Mark as ready.
         ready = true;

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -87,6 +87,29 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
         harness.run(address(opcm), true);
     }
 
+    function test_run_bitmapNotEmptyOnMainnet_reverts(bytes32 _devFeatureBitmap) public {
+        // Coverage changes bytecode and causes failures, skip.
+        skipIfCoverage();
+
+        // Anything but zero!
+        _devFeatureBitmap = bytes32(bound(uint256(_devFeatureBitmap), 1, type(uint256).max));
+
+        // Mock opcm to return a non-zero dev feature bitmap.
+        vm.mockCall(
+            address(opcm), abi.encodeCall(IOPContractsManager.devFeatureBitmap, ()), abi.encode(_devFeatureBitmap)
+        );
+
+        // Set the chain ID to 1.
+        vm.chainId(1);
+
+        // Disable testing environment.
+        vm.etch(address(0xbeefcafe), bytes(""));
+
+        // Run the script.
+        vm.expectRevert(VerifyOPCM.VerifyOPCM_DevFeatureBitmapNotEmpty.selector);
+        harness.run(address(opcm), true);
+    }
+
     /// @notice Tests that the script succeeds when differences are introduced into the immutable
     ///         variables of implementation contracts. Fuzzing is too slow here, randomness is good
     ///         enough.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates VerifyOPCM so that it will check for a non-empty dev bitmap on mainnet