### PR TITLE
fix: remove duplicate bodyclose linter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ linters:
     - asciicheck
     - misspell
     - errorlint
-    - bodyclose
 
     # Only enabled in specific cases. See settings and exclusions below
     - exhaustruct


### PR DESCRIPTION
Remove duplicate(already in line 5) `bodyclose` linter entry in `.golangci.yaml` (line 9).