### PR TITLE
feat: add feature flagging functionality to SystemConfig (#17281)

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -24,8 +24,10 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     }
 
     error ReinitializableBase_ZeroInitVersion();
+    error SystemConfig_InvalidFeatureState();
 
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
+    event FeatureSet(bytes32 indexed feature, bool indexed enabled);
     event Initialized(uint8 version);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
@@ -92,6 +94,8 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     function paused() external view returns (bool);
     function superchainConfig() external view returns (ISuperchainConfig);
     function guardian() external view returns (address);
+    function setFeature(bytes32 _feature, bool _enabled) external;
+    function isFeatureEnabled(bytes32) external view returns (bool);
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -414,6 +414,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isFeatureEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "l1CrossDomainMessenger",
     "outputs": [
@@ -707,6 +726,24 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "_feature",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "_enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setFeature",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_overhead",
         "type": "uint256"
@@ -896,6 +933,25 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "feature",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "FeatureSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "uint8",
         "name": "version",
@@ -957,6 +1013,11 @@
   {
     "inputs": [],
     "name": "ReinitializableBase_ZeroInitVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SystemConfig_InvalidFeatureState",
     "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xb1264c7af50b6134c98cb82d1ffc7891adf97068fa7048ee70992fb94bc15bd1"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xde9192e313dca35250587bef0c0257322c7d0890f72ef864974910e616213b8f",
-    "sourceCodeHash": "0x1a2b30e391397cea5f3cb58e23bd5987b620609b40ad156b79d80bc8082e8515"
+    "initCodeHash": "0x611c8de2674891ae5bc03fedb6cf1fcc2005a580401e5625b29360b855f735ee",
+    "sourceCodeHash": "0x5a332a184f028147b32671e56f3b28e1be243f44e0d5de1fc09233927b5eab7c"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x785b09610b2da65d248b49150fafc85b8369c921ddae95b0ea45608b1ce5cbc6",
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0xad12c20a00dc20683bd3f68e6ee254f968da6cc2d98930be6534107ee5cb11d9"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x07b7039de5b8a4dc57642ee9696e949d70516b7f6dce41dde4920efb17105ef2",
-    "sourceCodeHash": "0x997212ceadabb306c2abd31918b09bccbba0b21662c1d8930a3599831c374b13"
+    "initCodeHash": "0x8c6a1fb65d650525a3cd3fd617ae923d44da157b2ef928ab8ec39dbf39e25a98",
+    "sourceCodeHash": "0xdf526027678f23da79a56c1d6127a3ed3fd92927ec8d5541982b6f1c2119f70e"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
@@ -124,5 +124,12 @@
     "offset": 0,
     "slot": "108",
     "type": "contract ISuperchainConfig"
+  },
+  {
+    "bytes": "32",
+    "label": "isFeatureEnabled",
+    "offset": 0,
+    "slot": "109",
+    "type": "mapping(bytes32 => bool)"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -36,8 +36,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.6.0-patch.1
-    string public constant version = "1.6.0-patch.1";
+    /// @custom:semver 1.9.0
+    string public constant version = "1.9.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -176,7 +176,7 @@ contract OPContractsManagerStandardValidator is ISemver {
 
     /// @notice Returns the expected SystemConfig version.
     function systemConfigVersion() public pure returns (string memory) {
-        return "3.4.0";
+        return "3.5.0";
     }
 
     /// @notice Returns the expected OptimismPortal version.

--- a/packages/contracts-bedrock/src/libraries/Features.sol
+++ b/packages/contracts-bedrock/src/libraries/Features.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @notice Features is a library that stores feature name constants. Can be used alongside the
+///         feature flagging functionality in the SystemConfig contract to selectively enable or
+///         disable customizable features of the OP Stack.
+library Features {
+    /// @notice The ETH_LOCKBOX feature determines if the system is configured to use the
+    ///         ETHLockbox contract in the OptimismPortal. When the ETH_LOCKBOX feature is active
+    ///         and the ETHLockbox contract has been configured, the OptimismPortal will use the
+    ///         ETHLockbox to store ETH instead of storing ETH directly in the portal itself.
+    bytes32 internal constant ETH_LOCKBOX = "ETH_LOCKBOX";
+}

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -475,7 +475,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
         // Make sure that the SystemConfig is upgraded to the right version. It must also have the
         // right l2ChainId and must be properly initialized.
-        assertEq(ISemver(address(systemConfig)).version(), "3.4.0");
+        assertEq(ISemver(address(systemConfig)).version(), "3.5.0");
         assertEq(impls.systemConfigImpl, EIP1967Helper.getImplementation(address(systemConfig)));
         assertEq(systemConfig.l2ChainId(), l2ChainId);
         DeployUtils.assertInitialized({ _contractAddress: address(systemConfig), _isProxy: true, _slot: 0, _offset: 0 });


### PR DESCRIPTION
* feat: add feature flagging functionality to SystemConfig

Adds a function to the SystemConfig for feature flagging. Features are identified by 32 byte strings and can be toggled on or off by the ProxyAdmin or the owner of the ProxyAdmin. Note that this commit does not actually use any feature flags but demonstrates what a feature flag would look like by adding in the flag for the ETHLockbox feature.

* feat: update for PR feedback

* fix: small test tweaks

* fix: broken test