### PR TITLE
feat: op-node sync tests for multiple networks in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2638,22 +2638,52 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+      # Sync tests for multiple networks (runs in parallel)
+      # OP Sepolia
       - op-acceptance-sync-tests-docker:
-          # Acceptance Testing params
-          name: sync-test-op-node-daily
+          name: sync-test-op-sepolia-daily
           gate: sync-test-op-node
-          # CircleCI params
           no_output_timeout: 30m
-          # Sync test configuration parameters
           l2_network_name: "op-sepolia"
           l1_chain_id: "11155111"
           l2_el_endpoint: "https://ci-sepolia-l2.optimism.io"
           l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
           l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
           initial_l2_block: "3201274"
-          l2_el_endpoint_tailscale: "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
-          l1_cl_beacon_endpoint_tailscale: "https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"
-          l1_el_endpoint_tailscale: "https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
+      # OP Mainnet
+      - op-acceptance-sync-tests-docker:
+          name: sync-test-op-mainnet-daily
+          gate: sync-test-op-node
+          no_output_timeout: 30m
+          l2_network_name: "op-mainnet"
+          l1_chain_id: "1"
+          l2_el_endpoint: "https://op-mainnet-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+          initial_l2_block: "140013283"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
+      # Base Mainnet
+      - op-acceptance-sync-tests-docker:
+          name: sync-test-base-mainnet-daily
+          gate: sync-test-op-node
+          no_output_timeout: 30m
+          l2_network_name: "base-mainnet"
+          l1_chain_id: "1"
+          l2_el_endpoint: "https://base-mainnet-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+          initial_l2_block: "35108016"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,22 +77,6 @@ orbs:
   github-cli: circleci/github-cli@2.7.0
 
 commands:
-  set-sync-test-env-vars:
-    description: "Set environment variables for sync testing"
-    steps:
-      - run:
-          name: Set sync test environment variables
-          command: |
-            echo 'export L2_NETWORK_NAME="op-sepolia"' >> $BASH_ENV
-            echo 'export L1_CHAIN_ID="11155111"' >> $BASH_ENV
-            echo 'export L2_EL_ENDPOINT="https://ci-sepolia-l2.optimism.io"' >> $BASH_ENV
-            echo 'export L1_CL_BEACON_ENDPOINT="https://ci-sepolia-beacon.optimism.io"' >> $BASH_ENV
-            echo 'export L1_EL_ENDPOINT="https://ci-sepolia-l1.optimism.io"' >> $BASH_ENV
-            echo 'export INITIAL_L2_BLOCK="3201274"' >> $BASH_ENV
-            echo 'export L2_EL_ENDPOINT_TAILSCALE="https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"' >> $BASH_ENV
-            echo 'export L1_CL_BEACON_ENDPOINT_TAILSCALE="https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"' >> $BASH_ENV
-            echo 'export L1_EL_ENDPOINT_TAILSCALE="https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"' >> $BASH_ENV
-
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
     parameters:
@@ -2656,6 +2640,40 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
+      # Base Sepolia
+      - op-acceptance-sync-tests-docker:
+          name: sync-test-base-sepolia-daily
+          gate: sync-test-op-node
+          no_output_timeout: 30m
+          l2_network_name: "base-sepolia"
+          l1_chain_id: "11155111"
+          l2_el_endpoint: "https://base-sepolia-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          initial_l2_block: "30621132"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
+      ## Unichain Sepolia
+      - op-acceptance-sync-tests-docker:
+          name: sync-test-unichain-sepolia-daily
+          gate: sync-test-op-node
+          no_output_timeout: 30m
+          l2_network_name: "unichain-sepolia"
+          l1_chain_id: "11155111"
+          l2_el_endpoint: "https://unichain-sepolia-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          initial_l2_block: "30145093"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
       # OP Mainnet ## TODO: Need L1 Mainnet Beacon to be exposed for CI
       # - op-acceptance-sync-tests-docker:
       #     name: sync-test-op-mainnet-daily
@@ -2673,23 +2691,7 @@ workflows:
       #     requires:
       #       - contracts-bedrock-build
       #       - cannon-prestate-quick
-      # Base Sepolia
-      - op-acceptance-sync-tests-docker:
-          name: sync-test-base-sepolia-daily
-          gate: sync-test-op-node
-          no_output_timeout: 30m
-          l2_network_name: "base-sepolia"
-          l1_chain_id: "1"
-          l2_el_endpoint: "https://base-sepolia-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
-          initial_l2_block: "30621132"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
+
 
   # Acceptance tests (post-merge to develop)
   acceptance-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,6 @@ commands:
             fi
           when: on_fail
 
-
   get-target-branch:
     description: "Determine the PR target branch and export TARGET_BRANCH for subsequent steps"
     steps:
@@ -272,7 +271,6 @@ commands:
       - attach_workspace:
           at: "."
       - utils/install-mise
-
 
 jobs:
   initialize:
@@ -776,7 +774,7 @@ jobs:
   contracts-bedrock-coverage:
     circleci_ip_ranges: true
     docker:
-        - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.default_docker_image>>
     resource_class: 2xlarge
     parameters:
       test_flags:
@@ -1285,7 +1283,7 @@ jobs:
       - checkout-from-workspace
       - unless:
           condition:
-            equal: ["",<<parameters.devnet>>]
+            equal: ["", <<parameters.devnet>>]
           steps:
             - run:
                 name: Setup Kurtosis
@@ -1765,7 +1763,6 @@ jobs:
           command: |
             goreleaser release --clean -f ./<<parameters.module>>/<<parameters.filename>>
 
-
   diff-fetcher-forge-artifacts:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
@@ -1791,20 +1788,19 @@ jobs:
 
             echo "✅ Checked-in forge artifacts match the ci build"
 
-
   stale-check:
-      machine:
-        image: ubuntu-2204:2024.08.1
-      steps:
-        - utils/github-stale:
-            stale-issue-message: 'This issue has been automatically marked as stale and will be closed in 5 days if no updates'
-            stale-pr-message: 'This pr has been automatically marked as stale and will be closed in 5 days if no updates'
-            close-issue-message: 'This issue was closed as stale.  Please reopen if this is a mistake'
-            close-pr-message: 'This PR was closed as stale.  Please reopen if this is a mistake'
-            days-before-issue-stale: 999
-            days-before-pr-stale: 14
-            days-before-issue-close: 5
-            days-before-pr-close: 5
+    machine:
+      image: ubuntu-2204:2024.08.1
+    steps:
+      - utils/github-stale:
+          stale-issue-message: "This issue has been automatically marked as stale and will be closed in 5 days if no updates"
+          stale-pr-message: "This pr has been automatically marked as stale and will be closed in 5 days if no updates"
+          close-issue-message: "This issue was closed as stale.  Please reopen if this is a mistake"
+          close-pr-message: "This PR was closed as stale.  Please reopen if this is a mistake"
+          days-before-issue-stale: 999
+          days-before-pr-stale: 14
+          days-before-issue-close: 5
+          days-before-pr-close: 5
 
   close-issue:
     machine:
@@ -1854,7 +1850,6 @@ jobs:
             # Upload to the date-partitioned folder structure
             gsutil cp .metrics--authorship--op-acceptance-tests gs://oplabs-tools-data-public-metrics/metrics-authorship/$FOLDER_NAME/metrics-$CIRCLE_SHA1.csv
 
-
   generate-flaky-report:
     machine: true
     resource_class: medium
@@ -1882,16 +1877,18 @@ jobs:
           path: ./op-acceptance-tests/reports
           destination: flaky-test-reports
 
-
 workflows:
   main:
     when:
       or:
-        - equal: ["webhook",<< pipeline.trigger_source >>]
+        - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-          - equal: [true, <<pipeline.parameters.main_dispatch>>]
-          - equal: ["api",<< pipeline.trigger_source >>]
-          - equal: [<< pipeline.parameters.github-event-type >>, "__not_set__"] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
+            - equal: [true, <<pipeline.parameters.main_dispatch>>]
+            - equal: ["api", << pipeline.trigger_source >>]
+            - equal: [
+                  << pipeline.parameters.github-event-type >>,
+                  "__not_set__",
+                ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
     jobs:
       - initialize:
           context:
@@ -2055,16 +2052,16 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           filters:
             branches:
-              ignore: develop  # Run on all branches EXCEPT develop (PR branches only)
+              ignore: develop # Run on all branches EXCEPT develop (PR branches only)
       - go-tests:
           name: go-tests-full
-          rule: "go-tests-ci"  # Run full test suite instead of short
-          no_output_timeout: 89m  # Longer timeout for full tests
+          rule: "go-tests-ci" # Run full test suite instead of short
+          no_output_timeout: 89m # Longer timeout for full tests
           test_timeout: 90m
           notify: true
           filters:
             branches:
-              only: develop  # Only runs on develop branch (post-merge)
+              only: develop # Only runs on develop branch (post-merge)
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
@@ -2365,11 +2362,15 @@ workflows:
     when:
       or:
         - and:
-          - equal: ["develop", <<pipeline.git.branch>>]
-          - equal: ["webhook",<< pipeline.trigger_source >>]
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-          - equal: [true, <<pipeline.parameters.publish_contract_artifacts_dispatch>>]
-          - equal: ["api",<< pipeline.trigger_source >>]
+            - equal:
+                [
+                  true,
+                  <<pipeline.parameters.publish_contract_artifacts_dispatch>>,
+                ]
+            - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - publish-contract-artifacts:
           context:
@@ -2379,11 +2380,11 @@ workflows:
     when:
       or:
         - and:
-          - equal: ["develop", <<pipeline.git.branch>>]
-          - equal: ["webhook",<< pipeline.trigger_source >>]
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-          - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
-          - equal: ["api",<< pipeline.trigger_source >>]
+            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
+            - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - initialize:
           context:
@@ -2430,11 +2431,11 @@ workflows:
     when:
       or:
         - and:
-          - equal: ["develop", <<pipeline.git.branch>>]
-          - equal: ["webhook",<< pipeline.trigger_source >>]
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-          - equal: [true, <<pipeline.parameters.kontrol_dispatch>>]
-          - equal: ["api",<< pipeline.trigger_source >>]
+            - equal: [true, <<pipeline.parameters.kontrol_dispatch>>]
+            - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - kontrol-tests:
           context:
@@ -2549,23 +2550,27 @@ workflows:
       - stale-check:
           context:
             - circleci-repo-optimism
-
   scheduled-sync-test-op-node:
     when:
       or:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         # Trigger on manual triggers if explicitly requested
         - equal: [true, << pipeline.parameters.sync_test_op_node_dispatch >>]
+        # Trigger on PRs
+        - and:
+            - not:
+                equal: ["develop", <<pipeline.git.branch>>]
+            - equal: ["webhook", << pipeline.trigger_source >>]
     jobs:
       - initialize:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - contracts-bedrock-build:  # needed for sysgo tests
+      - contracts-bedrock-build: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
-      - cannon-prestate-quick:  # needed for sysgo tests
+      - cannon-prestate-quick: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -2588,21 +2593,21 @@ workflows:
     when:
       or:
         - and:
-          - equal: ["develop", <<pipeline.git.branch>>]
-          - equal: ["webhook",<< pipeline.trigger_source >>]
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-          - equal: [true, <<pipeline.parameters.acceptance_tests_dispatch>>]
-          - equal: ["api",<< pipeline.trigger_source >>]
+            - equal: [true, <<pipeline.parameters.acceptance_tests_dispatch>>]
+            - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - initialize:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - contracts-bedrock-build:  # needed for sysgo tests
+      - contracts-bedrock-build: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
-      - cannon-prestate-quick:  # needed for sysgo tests
+      - cannon-prestate-quick: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -2610,7 +2615,7 @@ workflows:
       # IN-MEMORY (all)
       - op-acceptance-tests:
           name: memory-all
-          gate: ""  # Empty gate = gateless mode
+          gate: "" # Empty gate = gateless mode
           no_output_timeout: 90m
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2676,12 +2681,12 @@ workflows:
       - initialize:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - contracts-bedrock-build:  # needed for sysgo tests
+      - contracts-bedrock-build: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
-      - cannon-prestate-quick:  # needed for sysgo tests
+      - cannon-prestate-quick: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -2689,7 +2694,7 @@ workflows:
       # IN-MEMORY (all)
       - op-acceptance-tests:
           name: memory-all
-          gate: ""  # Empty gate = gateless mode
+          gate: "" # Empty gate = gateless mode
           no_output_timeout: 60m
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2754,21 +2759,21 @@ workflows:
         - equal: [<< pipeline.parameters.github-event-action >>, "labeled"]
     jobs:
       - close-issue:
-         label_name: "auto-close-trivial-contribution"
-         message: "Thank you for your interest in contributing!
-                At this time, we are not accepting contributions that primarily fix spelling, stylistic, or grammatical errors in documentation, code, or elsewhere.
-                Please check our [contribution guidelines](https://github.com/ethereum-optimism/optimism/blob/develop/CONTRIBUTING.md#contributions-related-to-spelling-and-grammar) for more information.
-                This issue will be closed now."
-         context:
-          - circleci-repo-optimism
+          label_name: "auto-close-trivial-contribution"
+          message: "Thank you for your interest in contributing!
+            At this time, we are not accepting contributions that primarily fix spelling, stylistic, or grammatical errors in documentation, code, or elsewhere.
+            Please check our [contribution guidelines](https://github.com/ethereum-optimism/optimism/blob/develop/CONTRIBUTING.md#contributions-related-to-spelling-and-grammar) for more information.
+            This issue will be closed now."
+          context:
+            - circleci-repo-optimism
 
   devnet-metrics-collect:
     when:
       or:
         - equal: [<< pipeline.trigger_source >>, "webhook"]
         - and:
-          - equal: [true, << pipeline.parameters.devnet-metrics-collect >>]
-          - equal: [<< pipeline.trigger_source >>, "api"]
+            - equal: [true, << pipeline.parameters.devnet-metrics-collect >>]
+            - equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
       - devnet-metrics-collect-authorship:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,22 @@ orbs:
   github-cli: circleci/github-cli@2.7.0
 
 commands:
+  set-sync-test-env-vars:
+    description: "Set environment variables for sync testing"
+    steps:
+      - run:
+          name: Set sync test environment variables
+          command: |
+            echo 'export L2_NETWORK_NAME="op-sepolia"' >> $BASH_ENV
+            echo 'export L1_CHAIN_ID="11155111"' >> $BASH_ENV
+            echo 'export L2_EL_ENDPOINT="https://ci-sepolia-l2.optimism.io"' >> $BASH_ENV
+            echo 'export L1_CL_BEACON_ENDPOINT="https://ci-sepolia-beacon.optimism.io"' >> $BASH_ENV
+            echo 'export L1_EL_ENDPOINT="https://ci-sepolia-l1.optimism.io"' >> $BASH_ENV
+            echo 'export INITIAL_L2_BLOCK="3201274"' >> $BASH_ENV
+            echo 'export L2_EL_ENDPOINT_TAILSCALE="https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"' >> $BASH_ENV
+            echo 'export L1_CL_BEACON_ENDPOINT_TAILSCALE="https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"' >> $BASH_ENV
+            echo 'export L1_EL_ENDPOINT_TAILSCALE="https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"' >> $BASH_ENV
+
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
     parameters:
@@ -1165,7 +1181,7 @@ jobs:
             - notify-failures-on-develop:
                 mentions: "<<parameters.mentions>>"
 
-  op-acceptance-tests-docker:
+  op-acceptance-sync-tests-docker:
     parameters:
       gate:
         description: The gate to run the acceptance tests against. This gate should be defined in op-acceptance-tests/acceptance-tests.yaml.
@@ -1175,6 +1191,43 @@ jobs:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
         default: 30m
+      # Optional sync test configuration parameters
+      l2_network_name:
+        description: L2 network name
+        type: string
+        default: ""
+      l1_chain_id:
+        description: L1 chain ID
+        type: string
+        default: ""
+      l2_el_endpoint:
+        description: L2 EL endpoint
+        type: string
+        default: ""
+      l1_cl_beacon_endpoint:
+        description: L1 CL beacon endpoint
+        type: string
+        default: ""
+      l1_el_endpoint:
+        description: L1 EL endpoint
+        type: string
+        default: ""
+      initial_l2_block:
+        description: Initial L2 block
+        type: string
+        default: ""
+      l2_el_endpoint_tailscale:
+        description: L2 EL endpoint for Tailscale networking
+        type: string
+        default: ""
+      l1_cl_beacon_endpoint_tailscale:
+        description: L1 CL beacon endpoint for Tailscale networking
+        type: string
+        default: ""
+      l1_el_endpoint_tailscale:
+        description: L1 EL endpoint for Tailscale networking
+        type: string
+        default: ""
     resource_class: xlarge
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
@@ -1206,6 +1259,16 @@ jobs:
             GOFLAGS: "-mod=mod"
             GO111MODULE: "on"
             GOGC: "0"
+            # Optional sync test configuration environment variables (only set if parameters are provided)
+            L2_NETWORK_NAME: "<<parameters.l2_network_name>>"
+            L1_CHAIN_ID: "<<parameters.l1_chain_id>>"
+            L2_EL_ENDPOINT: "<<parameters.l2_el_endpoint>>"
+            L1_CL_BEACON_ENDPOINT: "<<parameters.l1_cl_beacon_endpoint>>"
+            L1_EL_ENDPOINT: "<<parameters.l1_el_endpoint>>"
+            INITIAL_L2_BLOCK: "<<parameters.initial_l2_block>>"
+            L2_EL_ENDPOINT_TAILSCALE: "<<parameters.l2_el_endpoint_tailscale>>"
+            L1_CL_BEACON_ENDPOINT_TAILSCALE: "<<parameters.l1_cl_beacon_endpoint_tailscale>>"
+            L1_EL_ENDPOINT_TAILSCALE: "<<parameters.l1_el_endpoint_tailscale>>"
           command: |
             # Run the tests
             LOG_LEVEL=debug just acceptance-test "" "<<parameters.gate>>"
@@ -2575,20 +2638,22 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
-      - op-acceptance-tests-docker:
+      - op-acceptance-sync-tests-docker:
           # Acceptance Testing params
           name: sync-test-op-node-daily
           gate: sync-test-op-node
           # CircleCI params
           no_output_timeout: 30m
-          # op-sepolia configuration environment variables
-          environment:
-            L2_NETWORK_NAME: "op-sepolia"
-            L1_CHAIN_ID: "11155111"
-            L2_EL_ENDPOINT: "https://ci-sepolia-l2.optimism.io"
-            L1_CL_BEACON_ENDPOINT: "https://ci-sepolia-beacon.optimism.io"
-            L1_EL_ENDPOINT: "https://ci-sepolia-l1.optimism.io"
-            INITIAL_L2_BLOCK: "3201274"
+          # Sync test configuration parameters
+          l2_network_name: "op-sepolia"
+          l1_chain_id: "11155111"
+          l2_el_endpoint: "https://ci-sepolia-l2.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          initial_l2_block: "3201274"
+          l2_el_endpoint_tailscale: "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
+          l1_cl_beacon_endpoint_tailscale: "https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"
+          l1_el_endpoint_tailscale: "https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2656,34 +2656,34 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      # OP Mainnet
+      # OP Mainnet ## TODO: Need L1 Mainnet Beacon to be exposed for CI
+      # - op-acceptance-sync-tests-docker:
+      #     name: sync-test-op-mainnet-daily
+      #     gate: sync-test-op-node
+      #     no_output_timeout: 30m
+      #     l2_network_name: "op-mainnet"
+      #     l1_chain_id: "1"
+      #     l2_el_endpoint: "https://op-mainnet-rpc.optimism.io"
+      #     l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
+      #     l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+      #     initial_l2_block: "140013283"
+      #     context:
+      #       - circleci-repo-readonly-authenticated-github-token
+      #       - discord
+      #     requires:
+      #       - contracts-bedrock-build
+      #       - cannon-prestate-quick
+      # Base Sepolia
       - op-acceptance-sync-tests-docker:
-          name: sync-test-op-mainnet-daily
+          name: sync-test-base-sepolia-daily
           gate: sync-test-op-node
           no_output_timeout: 30m
-          l2_network_name: "op-mainnet"
+          l2_network_name: "base-sepolia"
           l1_chain_id: "1"
-          l2_el_endpoint: "https://op-mainnet-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
-          initial_l2_block: "140013283"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-      # Base Mainnet
-      - op-acceptance-sync-tests-docker:
-          name: sync-test-base-mainnet-daily
-          gate: sync-test-op-node
-          no_output_timeout: 30m
-          l2_network_name: "base-mainnet"
-          l1_chain_id: "1"
-          l2_el_endpoint: "https://base-mainnet-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
-          initial_l2_block: "35108016"
+          l2_el_endpoint: "https://base-sepolia-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          initial_l2_block: "30621132"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2581,6 +2581,14 @@ workflows:
           gate: sync-test-op-node
           # CircleCI params
           no_output_timeout: 30m
+          # op-sepolia configuration environment variables
+          environment:
+            L2_NETWORK_NAME: "op-sepolia"
+            L1_CHAIN_ID: "11155111"
+            L2_EL_ENDPOINT: "https://ci-sepolia-l2.optimism.io"
+            L1_CL_BEACON_ENDPOINT: "https://ci-sepolia-beacon.optimism.io"
+            L1_EL_ENDPOINT: "https://ci-sepolia-l1.optimism.io"
+            INITIAL_L2_BLOCK: "3201274"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2603,11 +2603,6 @@ workflows:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         # Trigger on manual triggers if explicitly requested
         - equal: [true, << pipeline.parameters.sync_test_op_node_dispatch >>]
-        # Trigger on PRs
-        - and:
-            - not:
-                equal: ["develop", <<pipeline.git.branch>>]
-            - equal: ["webhook", << pipeline.trigger_source >>]
     jobs:
       - initialize:
           context:

--- a/op-acceptance-tests/tests/sync_tester_ext_el/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/init_test.go
@@ -1,7 +1,9 @@
 package sync_tester_ext_el
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
@@ -9,24 +11,50 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
+// Configuration defaults for op-sepolia
+const (
+	DefaultL2NetworkName      = "op-sepolia"
+	DefaultL1ChainID          = 11155111
+	DefaultL2ELEndpoint       = "https://ci-sepolia-l2.optimism.io"
+	DefaultL1CLBeaconEndpoint = "https://ci-sepolia-beacon.optimism.io"
+	DefaultL1ELEndpoint       = "https://ci-sepolia-l1.optimism.io"
+	DefaultInitialL2Block     = 32012748
+
+	// Tailscale networking endpoints
+	DefaultL2ELEndpointTailscale       = "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
+	DefaultL1CLBeaconEndpointTailscale = "https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"
+	DefaultL1ELEndpointTailscale       = "https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"
+)
+
 var (
-	InitialL2Block = uint64(32012748)
+	InitialL2Block = getInitialL2Block()
 )
 
 func TestMain(m *testing.M) {
-	L2NetworkName := "op-sepolia"
-	L1ChainID := eth.ChainIDFromUInt64(11155111)
+	// Load configuration from environment variables with defaults
+	L2NetworkName := getEnvOrDefault("L2_NETWORK_NAME", DefaultL2NetworkName)
+	L1ChainID := eth.ChainIDFromUInt64(getEnvUint64OrDefault("L1_CHAIN_ID", DefaultL1ChainID))
 
-	L2ELEndpoint := "https://ci-sepolia-l2.optimism.io"
-	L1CLBeaconEndpoint := "https://ci-sepolia-beacon.optimism.io"
-	L1ELEndpoint := "https://ci-sepolia-l1.optimism.io"
+	// Default endpoints
+	L2ELEndpoint := getEnvOrDefault("L2_EL_ENDPOINT", DefaultL2ELEndpoint)
+	L1CLBeaconEndpoint := getEnvOrDefault("L1_CL_BEACON_ENDPOINT", DefaultL1CLBeaconEndpoint)
+	L1ELEndpoint := getEnvOrDefault("L1_EL_ENDPOINT", DefaultL1ELEndpoint)
 
-	// Endpoints when running with Tailscale networking
+	// Override with Tailscale endpoints if Tailscale networking is enabled
 	if os.Getenv("TAILSCALE_NETWORKING") == "true" {
-		L2ELEndpoint = "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
-		L1CLBeaconEndpoint = "https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"
-		L1ELEndpoint = "https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"
+		L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
+		L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
+		L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
 	}
+
+	// Print final configuration values
+	fmt.Printf("L2_NETWORK_NAME: %s\n", L2NetworkName)
+	fmt.Printf("L1_CHAIN_ID: %s\n", L1ChainID.String())
+	fmt.Printf("INITIAL_L2_BLOCK: %d\n", InitialL2Block)
+	fmt.Printf("L2_EL_ENDPOINT: %s\n", L2ELEndpoint)
+	fmt.Printf("L1_CL_BEACON_ENDPOINT: %s\n", L1CLBeaconEndpoint)
+	fmt.Printf("L1_EL_ENDPOINT: %s\n", L1ELEndpoint)
+	fmt.Printf("TAILSCALE_NETWORKING: %s\n", os.Getenv("TAILSCALE_NETWORKING"))
 
 	presets.DoMain(m, presets.WithMinimalExternalELWithSuperchainRegistry(L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName, eth.FCUState{
 		Latest:    InitialL2Block,
@@ -36,4 +64,27 @@ func TestMain(m *testing.M) {
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 
+}
+
+// getEnvOrDefault returns the environment variable value or the default if not set
+func getEnvOrDefault(envVar, defaultValue string) string {
+	if value := os.Getenv(envVar); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// getEnvUint64OrDefault returns the environment variable value as uint64 or the default if not set
+func getEnvUint64OrDefault(envVar string, defaultValue uint64) uint64 {
+	if value := os.Getenv(envVar); value != "" {
+		if parsed, err := strconv.ParseUint(value, 10, 64); err == nil {
+			return parsed
+		}
+	}
+	return defaultValue
+}
+
+// getInitialL2Block returns the initial L2 block from env var or default
+func getInitialL2Block() uint64 {
+	return getEnvUint64OrDefault("INITIAL_L2_BLOCK", DefaultInitialL2Block)
 }

--- a/op-acceptance-tests/tests/sync_tester_ext_el/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/init_test.go
@@ -1,7 +1,6 @@
 package sync_tester_ext_el
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -28,33 +27,24 @@ const (
 
 var (
 	InitialL2Block = getInitialL2Block()
+
+	// Load configuration from environment variables with defaults
+	L2NetworkName = getEnvOrDefault("L2_NETWORK_NAME", DefaultL2NetworkName)
+	L1ChainID     = eth.ChainIDFromUInt64(getEnvUint64OrDefault("L1_CHAIN_ID", DefaultL1ChainID))
+
+	// Default endpoints
+	L2ELEndpoint       = getEnvOrDefault("L2_EL_ENDPOINT", DefaultL2ELEndpoint)
+	L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT", DefaultL1CLBeaconEndpoint)
+	L1ELEndpoint       = getEnvOrDefault("L1_EL_ENDPOINT", DefaultL1ELEndpoint)
 )
 
 func TestMain(m *testing.M) {
-	// Load configuration from environment variables with defaults
-	L2NetworkName := getEnvOrDefault("L2_NETWORK_NAME", DefaultL2NetworkName)
-	L1ChainID := eth.ChainIDFromUInt64(getEnvUint64OrDefault("L1_CHAIN_ID", DefaultL1ChainID))
-
-	// Default endpoints
-	L2ELEndpoint := getEnvOrDefault("L2_EL_ENDPOINT", DefaultL2ELEndpoint)
-	L1CLBeaconEndpoint := getEnvOrDefault("L1_CL_BEACON_ENDPOINT", DefaultL1CLBeaconEndpoint)
-	L1ELEndpoint := getEnvOrDefault("L1_EL_ENDPOINT", DefaultL1ELEndpoint)
-
-	// Override with Tailscale endpoints if Tailscale networking is enabled
+	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
 	if os.Getenv("TAILSCALE_NETWORKING") == "true" {
 		L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
 		L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
 		L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
 	}
-
-	// Print final configuration values
-	fmt.Printf("L2_NETWORK_NAME: %s\n", L2NetworkName)
-	fmt.Printf("L1_CHAIN_ID: %s\n", L1ChainID.String())
-	fmt.Printf("INITIAL_L2_BLOCK: %d\n", InitialL2Block)
-	fmt.Printf("L2_EL_ENDPOINT: %s\n", L2ELEndpoint)
-	fmt.Printf("L1_CL_BEACON_ENDPOINT: %s\n", L1CLBeaconEndpoint)
-	fmt.Printf("L1_EL_ENDPOINT: %s\n", L1ELEndpoint)
-	fmt.Printf("TAILSCALE_NETWORKING: %s\n", os.Getenv("TAILSCALE_NETWORKING"))
 
 	presets.DoMain(m, presets.WithMinimalExternalELWithSuperchainRegistry(L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName, eth.FCUState{
 		Latest:    InitialL2Block,

--- a/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -6,32 +6,29 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestSyncTesterExtEL(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	l := t.Logger()
+
+	// Runtime configuration values
+	l.Info("Runtime configuration values for TestSyncTesterExtEL")
+	l.Info("L2_NETWORK_NAME", "value", L2NetworkName)
+	l.Info("L1_CHAIN_ID", "value", L1ChainID)
+	l.Info("INITIAL_L2_BLOCK", "value", InitialL2Block)
+	l.Info("L2_EL_ENDPOINT", "value", L2ELEndpoint)
+	l.Info("L1_CL_BEACON_ENDPOINT", "value", L1CLBeaconEndpoint)
+	l.Info("L1_EL_ENDPOINT", "value", L1ELEndpoint)
+	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
 
 	if os.Getenv("CIRCLECI_PIPELINE_SCHEDULE_NAME") != "build_daily" && os.Getenv("CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH") != "true" {
-		t.Skip("TestSyncTesterExtEL only runs on daily scheduled pipeline jobs: %s %s", os.Getenv("CIRCLECI_PIPELINE_SCHEDULE_NAME"), os.Getenv("CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH"))
+		t.Skipf("TestSyncTesterExtEL only runs on daily scheduled pipeline jobs: schedule=%s dispatch=%s", os.Getenv("CIRCLECI_PIPELINE_SCHEDULE_NAME"), os.Getenv("CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH"))
 	}
 
 	sys := presets.NewMinimalExternalELWithExternalL1(t)
-
 	require := t.Require()
-
-	// Test that we can get chain IDs from L2CL node
-	l2CLChainID := sys.L2CL.ID().ChainID()
-
-	// TODO 1. Currently test takes in an L1 Chain RPC and Chain ID. It should check these for validity
-	// TODO 2. Check against L2 Chain ID that is provided to the test, should not be hardcoded
-	require.Equal(eth.ChainIDFromUInt64(11155420), l2CLChainID, "L2CL should be on chain 11155420")
-
-	// Test that the network started successfully
-	require.NotNil(sys.L1EL, "L1 EL node should be available")
-	require.NotNil(sys.L2CL, "L2 CL node should be available")
-	require.NotNil(sys.SyncTester, "SyncTester should be available")
 
 	// Test that we can get sync status from L2CL node
 	l2CLSyncStatus := sys.L2CL.SyncStatus()
@@ -55,7 +52,5 @@ func TestSyncTesterExtEL(gt *testing.T) {
 	require.GreaterOrEqual(stSession.CurrentState.Latest, stSession.InitialState.Latest+blocksToSync, "SyncTester session Latest should be on the same block as L2CL")
 	require.GreaterOrEqual(stSession.CurrentState.Safe, stSession.InitialState.Safe+blocksToSync, "SyncTester session Safe should be on the same block as L2CL")
 
-	t.Logger().Info("SyncTester ExtEL test completed successfully",
-		"l2cl_chain_id", l2CLChainID,
-		"l2cl_sync_status", l2CLSyncStatus)
+	l.Info("SyncTester ExtEL test completed successfully", "l2cl_chain_id", sys.L2CL.ID().ChainID(), "l2cl_sync_status", l2CLSyncStatus)
 }

--- a/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -18,6 +18,7 @@ func TestSyncTesterExtEL(gt *testing.T) {
 	}
 
 	sys := presets.NewMinimalExternalELWithExternalL1(t)
+
 	require := t.Require()
 
 	// Test that we can get chain IDs from L2CL node

--- a/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -23,6 +23,9 @@ func TestSyncTesterExtEL(gt *testing.T) {
 
 	// Test that we can get chain IDs from L2CL node
 	l2CLChainID := sys.L2CL.ID().ChainID()
+
+	// TODO 1. Currently test takes in an L1 Chain RPC and Chain ID. It should check these for validity
+	// TODO 2. Check against L2 Chain ID that is provided to the test, should not be hardcoded
 	require.Equal(eth.ChainIDFromUInt64(11155420), l2CLChainID, "L2CL should be on chain 11155420")
 
 	// Test that the network started successfully


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

**Go test code refactoring:**

* Refactored the `op-acceptance-tests-docker` job to `op-acceptance-sync-tests-docker`, adding new parameters for L2/L1 network names, endpoints, chain IDs, and initial block numbers, including Tailscale networking support. These parameters are now passed as environment variables to the job for flexible runtime configuration. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L1170-R1168) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R1178-R1214) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R1246-R1255)
* Updated the `scheduled-sync-test-op-node` workflow to run sync tests for multiple networks (OP Sepolia, Base Sepolia, Unichain Sepolia), each with its own configuration, enabling parallel testing across different chains.

* Refactored `init_test.go` in `sync_tester_ext_el` to load configuration from environment variables with sensible defaults, supporting overrides for Tailscale endpoints and initial L2 block, improving test portability and maintainability. [[1]](diffhunk://#diff-b478e9e439ad93bca17ac7a1ba5ef955169b3940f807f6997bafc25820726620R5-R46) [[2]](diffhunk://#diff-b478e9e439ad93bca17ac7a1ba5ef955169b3940f807f6997bafc25820726620R58-R80)
* Improved logging in `sync_tester_ext_el_test.go` to print runtime configuration values and clarified skip logic for scheduled jobs, aiding debugging and transparency in CI runs. [[1]](diffhunk://#diff-f776ab30f273cdfe808db6e0a9fc2222cc6fe112cf7fa02f6df6dafa55db8ad3L9-L31) [[2]](diffhunk://#diff-f776ab30f273cdfe808db6e0a9fc2222cc6fe112cf7fa02f6df6dafa55db8ad3L54-R55)
**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[17253](https://github.com/ethereum-optimism/optimism/issues/17253)
-->
