### PR TITLE
sync_tester: add comment about SyncTester

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_e2e/sync_tester_e2e_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_e2e/sync_tester_e2e_test.go
@@ -14,7 +14,7 @@ func TestSyncTesterE2E(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	// This test uses DefaultSimpleSystemWithSyncTester which includes:
 	// - Minimal setup with L1EL, L1CL, L2EL, L2CL (sequencer)
-	// - Additional L2CL2 (verifier) that connects to SyncTester instead of L2EL
+	// - Additional SyncTester that connects to L2EL, and L2CL2 (verifier) that connects to SyncTester instead of L2EL
 	sys := presets.NewSimpleWithSyncTester(t)
 	require := t.Require()
 	logger := t.Logger()


### PR DESCRIPTION
This pr makes the comment for the setup more complete.

In this test, `SyncTester` uses `L2EL` as the underlying read-only EL node.