### PR TITLE
perf(supervisor): optimize client rotation for single-client case

### DIFF
--- a/op-supervisor/supervisor/backend/processors/chain_processor.go
+++ b/op-supervisor/supervisor/backend/processors/chain_processor.go
@@ -199,13 +199,18 @@ func (s *ChainProcessor) index() {
 
 // nextActiveClient advances the client index and sets the active client.
 func (s *ChainProcessor) nextActiveClient() {
-	s.clientLock.Lock()
-	defer s.clientLock.Unlock()
-	if len(s.clients) == 0 {
-		return
-	}
-	s.clientIndex = (s.clientIndex + 1) % len(s.clients)
-	s.activeClient = s.clients[s.clientIndex]
+    s.clientLock.Lock()
+    defer s.clientLock.Unlock()
+    if len(s.clients) == 0 {
+        return
+    }
+    if len(s.clients) == 1 {
+        s.clientIndex = 0
+        s.activeClient = s.clients[0]
+    } else {
+        s.clientIndex = (s.clientIndex + 1) % len(s.clients)
+        s.activeClient = s.clients[s.clientIndex]
+    }
 	// track that we have advanced the client index
 	s.clientsTried++
 }


### PR DESCRIPTION
When only one sync client is configured, we can skip the modulo operation and directly set the client index to 0. This avoids unnecessary arithmetic in the common single-client deployment scenario.

Maintains the same behavior while reducing CPU overhead in the hot path of client rotation.