### PR TITLE
Tighten directory permissions for file-backed KV store

### DIFF
--- a/op-program/host/kvstore/file.go
+++ b/op-program/host/kvstore/file.go
@@ -61,7 +61,7 @@ func openTempFile(dir string, nameTemplate string) (*os.File, error) {
 	f, err := os.CreateTemp(dir, nameTemplate)
 	// Directory has been deleted out from underneath us. Recreate it.
 	if errors.Is(err, os.ErrNotExist) {
-		if mkdirErr := os.MkdirAll(dir, 0777); mkdirErr != nil {
+		if mkdirErr := os.MkdirAll(dir, 0700); mkdirErr != nil {
 			return nil, errors.Join(fmt.Errorf("failed to create directory %v: %w", dir, mkdirErr), err)
 		}
 		f, err = os.CreateTemp(dir, nameTemplate)


### PR DESCRIPTION


### Description
- **What**: Use `0700` instead of `0777` when auto-creating the KV store directory in `op-program/host/kvstore/file.go`.
- **Why**: Principle of least privilege; avoids world-writable or world-readable dirs depending on `umask`. Security hardening with no functional change for single-process usage.
- **Change**: `os.MkdirAll(dir, 0777)` → `os.MkdirAll(dir, 0700)`.
- **Impact**: Should be transparent for typical deployments. If other users/processes previously relied on wider permissions, they may need explicit access.


