### PR TITLE
prestate-check: Add support for kona

### DIFF
--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -31,7 +31,7 @@ type FPProgramType interface {
 		elCommitInfo types.CommitInfo,
 		fppCommitInfo types.CommitInfo,
 		superChainRegistryCommit string,
-		prestateConfigs *superchain.ChainConfigLoader)
+		prestateConfigs types.ChainConfigs)
 }
 
 func main() {
@@ -125,7 +125,7 @@ func main() {
 			continue
 		}
 		knownChains[name] = true
-		diff, err := checkConfig(name, prestateConfigs, latestConfigs)
+		diff, err := checkConfig(name, prestateConfigs, types.NewChainConfigLoaderAdapter(latestConfigs))
 		if err != nil {
 			log.Crit("Failed to check config", "chain", name, "err", err)
 		}
@@ -172,15 +172,16 @@ func main() {
 	}
 }
 
-func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (*types.Diff, error) {
-	actualChainID, err := actual.ChainIDByName(network)
+func checkConfig(network string, actual types.ChainConfigs, expected types.ChainConfigs) (*types.Diff, error) {
+	actualChainID, actualConfig, actualGenesis, err := actual.ChainConfig(network)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get actual chain ID for %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get actual chain config for %s: %w", network, err)
 	}
-	expectedChainID, err := expected.ChainIDByName(network)
+	expectedChainID, expectedConfig, expectedGenesis, err := expected.ChainConfig(network)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get expected chain ID for %v: %w", network, err)
+		return nil, fmt.Errorf("failed to get expected chain config for %s: %w", network, err)
 	}
+
 	if actualChainID != expectedChainID {
 		return &types.Diff{
 			Msg:      "Chain ID mismatch",
@@ -188,36 +189,12 @@ func checkConfig(network string, actual *superchain.ChainConfigLoader, expected 
 			Latest:   expectedChainID,
 		}, nil
 	}
-	actualChain, err := actual.GetChain(actualChainID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get actual chain for %v: %w", network, err)
-	}
-	expectedChain, err := expected.GetChain(expectedChainID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get expected chain for %v: %w", network, err)
-	}
-	actualConfig, err := actualChain.Config()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get config for actual chain %v: %w", network, err)
-	}
-	expectedConfig, err := expectedChain.Config()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get config for expected chain %v: %w", network, err)
-	}
 	configDiff, err := checkChainConfig(actualConfig, expectedConfig)
 	if err != nil {
 		return nil, err
 	}
 	if configDiff != nil {
 		return configDiff, nil
-	}
-	actualGenesis, err := actualChain.GenesisData()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get genesis for actual chain %v: %w", network, err)
-	}
-	expectedGenesis, err := expectedChain.GenesisData()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get genesis for expected chain %v: %w", network, err)
 	}
 	if !bytes.Equal(actualGenesis, expectedGenesis) {
 		return &types.Diff{

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -26,7 +26,7 @@ type FPProgramType interface {
 		elCommitInfo types.CommitInfo,
 		fppCommitInfo types.CommitInfo,
 		superChainRegistryCommit string,
-		prestateConfigs types.ChainConfigs)
+		prestateConfigs *superchain.ChainConfigLoader)
 }
 
 func main() {
@@ -122,7 +122,7 @@ func main() {
 			continue
 		}
 		knownChains[name] = true
-		diff, err := checkConfig(name, prestateConfigs, types.NewChainConfigLoaderAdapter(latestConfigs))
+		diff, err := checkConfig(name, prestateConfigs, latestConfigs)
 		if err != nil {
 			log.Crit("Failed to check config", "chain", name, "err", err)
 		}
@@ -169,16 +169,15 @@ func main() {
 	}
 }
 
-func checkConfig(network string, actual types.ChainConfigs, expected types.ChainConfigs) (*types.Diff, error) {
-	actualChainID, actualConfig, actualGenesis, err := actual.ChainConfig(network)
+func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (*types.Diff, error) {
+	actualChainID, err := actual.ChainIDByName(network)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get actual chain config for %s: %w", network, err)
+		return nil, fmt.Errorf("failed to get actual chain ID for %v: %w", network, err)
 	}
-	expectedChainID, expectedConfig, expectedGenesis, err := expected.ChainConfig(network)
+	expectedChainID, err := expected.ChainIDByName(network)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get expected chain config for %s: %w", network, err)
+		return nil, fmt.Errorf("failed to get expected chain ID for %v: %w", network, err)
 	}
-
 	if actualChainID != expectedChainID {
 		return &types.Diff{
 			Msg:      "Chain ID mismatch",
@@ -186,12 +185,36 @@ func checkConfig(network string, actual types.ChainConfigs, expected types.Chain
 			Latest:   expectedChainID,
 		}, nil
 	}
+	actualChain, err := actual.GetChain(actualChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get actual chain for %v: %w", network, err)
+	}
+	expectedChain, err := expected.GetChain(expectedChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get expected chain for %v: %w", network, err)
+	}
+	actualConfig, err := actualChain.Config()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config for actual chain %v: %w", network, err)
+	}
+	expectedConfig, err := expectedChain.Config()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config for expected chain %v: %w", network, err)
+	}
 	configDiff, err := checkChainConfig(actualConfig, expectedConfig)
 	if err != nil {
 		return nil, err
 	}
 	if configDiff != nil {
 		return configDiff, nil
+	}
+	actualGenesis, err := actualChain.GenesisData()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get genesis for actual chain %v: %w", network, err)
+	}
+	expectedGenesis, err := expectedChain.GenesisData()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get genesis for expected chain %v: %w", network, err)
 	}
 	if !bytes.Equal(actualGenesis, expectedGenesis) {
 		return &types.Diff{

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -5,14 +5,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/prestate"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
 	"github.com/ethereum-optimism/optimism/op-program/prestates"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,45 +20,18 @@ import (
 	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/mattn/go-isatty"
 	"golang.org/x/exp/maps"
-	"golang.org/x/mod/modfile"
 )
 
 const (
-	monorepoGoModAtTag            = "https://github.com/ethereum-optimism/optimism/raw/refs/tags/%s/go.mod"
-	superchainRegistryCommitAtRef = "https://github.com/ethereum-optimism/op-geth/raw/%s/superchain-registry-commit.txt"
-	superchainConfigsZipAtTag     = "https://github.com/ethereum-optimism/op-geth/raw/refs/tags/%s/superchain/superchain-configs.zip"
-	syncSuperchainScript          = "https://github.com/ethereum-optimism/op-geth/raw/refs/heads/optimism/sync-superchain.sh"
+	syncSuperchainScript = "https://github.com/ethereum-optimism/op-geth/raw/refs/heads/optimism/sync-superchain.sh"
 )
 
-type PrestateInfo struct {
-	Hash    common.Hash `json:"hash"`
-	Version string      `json:"version"`
-	Type    string      `json:"type"`
-
-	OpProgram          CommitInfo `json:"op-program"`
-	OpGeth             CommitInfo `json:"op-geth"`
-	SuperchainRegistry CommitInfo `json:"superchain-registry"`
-
-	UpToDateChains []string        `json:"up-to-date-chains"`
-	OutdatedChains []OutdatedChain `json:"outdated-chains"`
-	MissingChains  []string        `json:"missing-chains"`
-}
-
-type OutdatedChain struct {
-	Name string `json:"name"`
-	Diff *Diff  `json:"diff,omitempty"`
-}
-
-type CommitInfo struct {
-	Commit  string `json:"commit"`
-	DiffUrl string `json:"diff-url"`
-	DiffCmd string `json:"diff-cmd"`
-}
-
-type Diff struct {
-	Msg      string `json:"message"`
-	Prestate any    `json:"prestate"`
-	Latest   any    `json:"latest"`
+type FPProgramType interface {
+	FindVersions(log log.Logger, prestateVersion string) (
+		elCommitInfo types.CommitInfo,
+		fppCommitInfo types.CommitInfo,
+		superChainRegistryCommit string,
+		prestateConfigs *superchain.ChainConfigLoader)
 }
 
 func main() {
@@ -76,6 +49,9 @@ func main() {
 	// Define and parse the command-line flags
 	flag.StringVar(&prestateHashStr, "prestate-hash", "", "Specify the absolute prestate hash to verify")
 	flag.StringVar(&chainsStr, "chains", "", "List of chains to consider in the report. Comma separated. Default: all chains in the superchain-registry")
+
+	var versionsOverrideFile string
+	flag.StringVar(&versionsOverrideFile, "versions-file", "", "Override the prestate versions TOML file")
 
 	// Parse the command-line arguments
 	flag.Parse()
@@ -101,7 +77,7 @@ func main() {
 		log.Crit("--prestate-hash is invalid")
 	}
 
-	prestateReleases, err := prestates.LoadReleases("")
+	prestateReleases, err := prestates.LoadReleases(versionsOverrideFile)
 	if err != nil {
 		log.Crit("Failed to load prestate releases list", "err", err)
 	}
@@ -120,40 +96,20 @@ func main() {
 	if prestateVersion == "" {
 		log.Crit("Failed to find a prestate release with hash", "hash", prestateHash)
 	}
-	prestateTag := fmt.Sprintf("op-program/v%s", prestateVersion)
-	log.Info("Found prestate", "version", prestateVersion, "type", prestateType, "tag", prestateTag)
+	log.Info("Found prestate", "version", prestateVersion, "type", prestateType)
 
-	modFile, err := fetchMonorepoGoMod(prestateTag)
+	var prestateImpl FPProgramType
+	switch prestateType {
+	case "cannon32", "cannon64", "interop":
+		prestateImpl = prestate.NewOPProgramPrestate()
+	default:
+		log.Crit("Invalid prestate type", "type", prestateType)
+	}
+	elCommitInfo, fppCommitInfo, commit, prestateConfigs := prestateImpl.FindVersions(log, prestateVersion)
 	if err != nil {
-		log.Crit("Failed to fetch go mod", "err", err)
+		log.Crit("Failed to load configuration for prestate info", "err", err)
 	}
-	var gethVersion string
-	for _, replace := range modFile.Replace {
-		if replace.Old.Path == "github.com/ethereum/go-ethereum" {
-			gethVersion = replace.New.Version
-			break
-		}
-	}
-	if gethVersion == "" {
-		log.Crit("Failed to find op-geth replace in go.mod")
-	}
-	log.Info("Found op-geth version", "version", gethVersion)
 
-	registryCommitBytes, err := fetch(fmt.Sprintf(superchainRegistryCommitAtRef, gethVersion))
-	if err != nil {
-		log.Crit("Failed to fetch superchain registry commit info", "err", err)
-	}
-	commit := strings.TrimSpace(string(registryCommitBytes))
-	log.Info("Found superchain registry commit info", "commit", commit)
-
-	prestateConfigData, err := fetch(fmt.Sprintf(superchainConfigsZipAtTag, gethVersion))
-	if err != nil {
-		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
-	}
-	prestateConfigs, err := superchain.NewChainConfigLoader(prestateConfigData)
-	if err != nil {
-		log.Crit("Failed to parse prestate's superchain registry config zip", "err", err)
-	}
 	prestateNames := prestateConfigs.ChainNames()
 
 	latestConfigs, err := latestSuperchainConfigs()
@@ -163,7 +119,7 @@ func main() {
 
 	knownChains := make(map[string]bool)
 	var supportedChains []string
-	outdatedChains := make(map[string]OutdatedChain)
+	outdatedChains := make(map[string]types.OutdatedChain)
 	for _, name := range prestateNames {
 		if !chainFilter(name) {
 			continue
@@ -174,7 +130,7 @@ func main() {
 			log.Crit("Failed to check config", "chain", name, "err", err)
 		}
 		if diff != nil {
-			outdatedChains[name] = OutdatedChain{
+			outdatedChains[name] = types.OutdatedChain{
 				Name: name,
 				Diff: diff,
 			}
@@ -197,12 +153,12 @@ func main() {
 		}
 	}
 
-	report := PrestateInfo{
+	report := types.PrestateInfo{
 		Hash:               prestateHash,
 		Version:            prestateVersion,
 		Type:               prestateType,
-		OpProgram:          commitInfo("optimism", prestateTag, "develop", ""),
-		OpGeth:             commitInfo("op-geth", gethVersion, "optimism", ""),
+		FppProgram:         fppCommitInfo,
+		ExecutionClient:    elCommitInfo,
 		SuperchainRegistry: commitInfo("superchain-registry", commit, "main", "superchain"),
 		UpToDateChains:     supportedChains,
 		OutdatedChains:     maps.Values(outdatedChains),
@@ -216,7 +172,7 @@ func main() {
 	}
 }
 
-func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (*Diff, error) {
+func checkConfig(network string, actual *superchain.ChainConfigLoader, expected *superchain.ChainConfigLoader) (*types.Diff, error) {
 	actualChainID, err := actual.ChainIDByName(network)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get actual chain ID for %v: %w", network, err)
@@ -226,7 +182,7 @@ func checkConfig(network string, actual *superchain.ChainConfigLoader, expected 
 		return nil, fmt.Errorf("failed to get expected chain ID for %v: %w", network, err)
 	}
 	if actualChainID != expectedChainID {
-		return &Diff{
+		return &types.Diff{
 			Msg:      "Chain ID mismatch",
 			Prestate: actualChainID,
 			Latest:   expectedChainID,
@@ -264,7 +220,7 @@ func checkConfig(network string, actual *superchain.ChainConfigLoader, expected 
 		return nil, fmt.Errorf("failed to get genesis for expected chain %v: %w", network, err)
 	}
 	if !bytes.Equal(actualGenesis, expectedGenesis) {
-		return &Diff{
+		return &types.Diff{
 			Msg:      "Genesis mismatch",
 			Prestate: string(actualGenesis),
 			Latest:   string(expectedGenesis),
@@ -273,7 +229,7 @@ func checkConfig(network string, actual *superchain.ChainConfigLoader, expected 
 	return nil, nil
 }
 
-func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.ChainConfig) (*Diff, error) {
+func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.ChainConfig) (*types.Diff, error) {
 	actualStr, err := toml.Marshal(actual)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal actual chain config: %w", err)
@@ -283,7 +239,7 @@ func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.Chain
 		return nil, fmt.Errorf("failed to marshal expected chain config: %w", err)
 	}
 	if !bytes.Equal(actualStr, expectedStr) {
-		return &Diff{
+		return &types.Diff{
 			Msg:      "Chain config mismatch",
 			Prestate: actual,
 			Latest:   expected,
@@ -296,7 +252,7 @@ func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.Chain
 // sync-superchain.sh script from op-geth to create a zip of configs that can be read by op-geth's ChainConfigLoader.
 func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
 	// Download the op-geth script to build the superchain config
-	script, err := fetch(syncSuperchainScript)
+	script, err := prestate.Fetch(syncSuperchainScript)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch sync-superchain.sh script: %w", err)
 	}
@@ -329,32 +285,10 @@ func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
 	return superchain.NewChainConfigLoader(configBytes)
 }
 
-func commitInfo(repository string, commit string, mainBranch string, dir string) CommitInfo {
-	return CommitInfo{
+func commitInfo(repository string, commit string, mainBranch string, dir string) types.CommitInfo {
+	return types.CommitInfo{
 		Commit:  commit,
 		DiffUrl: fmt.Sprintf("https://github.com/ethereum-optimism/%s/compare/%s...%s", repository, commit, mainBranch),
 		DiffCmd: fmt.Sprintf("git fetch && git diff %s...origin/%s %s", commit, mainBranch, dir),
 	}
-}
-
-func fetchMonorepoGoMod(opProgramTag string) (*modfile.File, error) {
-	goModUrl := fmt.Sprintf(monorepoGoModAtTag, opProgramTag)
-	goMod, err := fetch(goModUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch go.mod: %w", err)
-	}
-
-	return modfile.Parse("go.mod", goMod, nil)
-}
-
-func fetch(url string) ([]byte, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch %v: %w", url, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch %v: %s", url, resp.Status)
-	}
-	return io.ReadAll(resp.Body)
 }

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -6,12 +6,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/prestate"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/registry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
 	"github.com/ethereum-optimism/optimism/op-program/prestates"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -20,10 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/mattn/go-isatty"
 	"golang.org/x/exp/maps"
-)
-
-const (
-	syncSuperchainScript = "https://github.com/ethereum-optimism/op-geth/raw/refs/heads/optimism/sync-superchain.sh"
 )
 
 type FPProgramType interface {
@@ -102,6 +97,8 @@ func main() {
 	switch prestateType {
 	case "cannon32", "cannon64", "interop":
 		prestateImpl = prestate.NewOPProgramPrestate()
+	case "cannon-kona":
+		prestateImpl = prestate.NewKonaPrestate()
 	default:
 		log.Crit("Invalid prestate type", "type", prestateType)
 	}
@@ -112,13 +109,13 @@ func main() {
 
 	prestateNames := prestateConfigs.ChainNames()
 
-	latestConfigs, err := latestSuperchainConfigs()
+	latestConfigs, err := registry.LatestSuperchainConfigs()
 	if err != nil {
 		log.Crit("Failed to get latest superchain configs", "err", err)
 	}
 
 	knownChains := make(map[string]bool)
-	var supportedChains []string
+	supportedChains := make([]string, 0) // Not null for json serialization
 	outdatedChains := make(map[string]types.OutdatedChain)
 	for _, name := range prestateNames {
 		if !chainFilter(name) {
@@ -224,44 +221,6 @@ func checkChainConfig(actual *superchain.ChainConfig, expected *superchain.Chain
 	}
 	return nil, nil
 }
-
-// latestSuperchainConfigs loads the latest config from the superchain-registry main branch using the
-// sync-superchain.sh script from op-geth to create a zip of configs that can be read by op-geth's ChainConfigLoader.
-func latestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
-	// Download the op-geth script to build the superchain config
-	script, err := prestate.Fetch(syncSuperchainScript)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch sync-superchain.sh script: %w", err)
-	}
-	dir, err := os.MkdirTemp("", "checkprestate")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp dir: %w", err)
-	}
-	defer os.RemoveAll(dir)
-	if err := os.Mkdir(filepath.Join(dir, "superchain"), 0o700); err != nil {
-		return nil, fmt.Errorf("failed to create superchain dir: %w", err)
-	}
-	scriptPath := filepath.Join(dir, "sync-superchain.sh")
-	if err := os.WriteFile(scriptPath, script, 0o700); err != nil {
-		return nil, fmt.Errorf("failed to write sync-superchain.sh: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "superchain-registry-commit.txt"), []byte("main"), 0o600); err != nil {
-		return nil, fmt.Errorf("failed to write superchain-registry-commit.txt: %w", err)
-	}
-	cmd := exec.Command(scriptPath)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to build superchain config zip: %w", err)
-	}
-	configBytes, err := os.ReadFile(filepath.Join(dir, "superchain/superchain-configs.zip"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read generated superchain-configs.zip: %w", err)
-	}
-	return superchain.NewChainConfigLoader(configBytes)
-}
-
 func commitInfo(repository string, commit string, mainBranch string, dir string) types.CommitInfo {
 	return types.CommitInfo{
 		Commit:  commit,

--- a/op-chain-ops/cmd/check-prestate/prestate/fetch.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/fetch.go
@@ -1,0 +1,19 @@
+package prestate
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func Fetch(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %v: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch %v: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/op-chain-ops/cmd/check-prestate/prestate/kona.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona.go
@@ -1,0 +1,84 @@
+package prestate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/registry"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type KonaPrestate struct {
+}
+
+func NewKonaPrestate() *KonaPrestate {
+	return &KonaPrestate{}
+}
+
+func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
+	elCommitInfo types.CommitInfo,
+	fppCommitInfo types.CommitInfo,
+	superChainRegistryCommit string,
+	prestateConfigs types.ChainConfigs) {
+
+	prestateTag := fmt.Sprintf("kona-client/v%s", prestateVersion)
+	log.Info("Found prestate tag", "tag", prestateTag)
+	fppCommitInfo = types.NewCommitInfo("op-rs", "kona", prestateTag, "main", "")
+
+	superChainRegistryCommit, err := fetchSuperchainRegistryCommit(prestateTag)
+	if err != nil {
+		log.Crit("Failed to fetch superchain registry commit", "err", err)
+	}
+
+	// TODO: Load elCommit info. Unclear what that means for kona.
+
+	// kona has its own build process to convert superchain-registry config into a custom JSON format it uses
+	// Rather than re-implement that custom JSON format and work out how to convert it to the go format
+	// (which could be brittle), we use the op-geth sync process to convert the superchain registry at the same commit
+	// to the go format directly. This is unfortunately also potentially brittle since we have to use the latest
+	// sync script from op-geth rather than a fixed version but seems like the lowest risk option.
+	configs, err := registry.SuperchainConfigsForCommit(superChainRegistryCommit)
+	if err != nil {
+		log.Crit("Failed to fetch chain configs for prestate", "err", err)
+	}
+	prestateConfigs = types.NewChainConfigLoaderAdapter(configs)
+	return
+}
+
+func fetchSuperchainRegistryCommit(ref string) (string, error) {
+	endpoint := "https://api.github.com/repos/op-rs/kona/contents/crates/protocol/registry/superchain-registry?ref=" +
+		url.QueryEscape(ref)
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Parse error payloads from GitHub if status != 200.
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch superchain-registry version, http status: %s", resp.Status)
+	}
+
+	// Success path: expect a single "submodule" content object with "sha".
+	var content struct {
+		Type string `json:"type"` // should be "submodule"
+		SHA  string `json:"sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&content); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	if content.Type != "submodule" {
+		return "", fmt.Errorf("expected a submodule got type %q", content.Type)
+	}
+	return content.SHA, nil
+}

--- a/op-chain-ops/cmd/check-prestate/prestate/kona.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/registry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/superchain"
 )
 
 type KonaPrestate struct {
@@ -22,7 +23,7 @@ func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
 	elCommitInfo types.CommitInfo,
 	fppCommitInfo types.CommitInfo,
 	superChainRegistryCommit string,
-	prestateConfigs types.ChainConfigs) {
+	prestateConfigs *superchain.ChainConfigLoader) {
 
 	prestateTag := fmt.Sprintf("kona-client/v%s", prestateVersion)
 	log.Info("Found prestate tag", "tag", prestateTag)
@@ -44,7 +45,7 @@ func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
 	if err != nil {
 		log.Crit("Failed to fetch chain configs for prestate", "err", err)
 	}
-	prestateConfigs = types.NewChainConfigLoaderAdapter(configs)
+	prestateConfigs = configs
 	return
 }
 

--- a/op-chain-ops/cmd/check-prestate/prestate/kona.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona.go
@@ -34,7 +34,9 @@ func (p *KonaPrestate) FindVersions(log log.Logger, prestateVersion string) (
 		log.Crit("Failed to fetch superchain registry commit", "err", err)
 	}
 
-	// TODO: Load elCommit info. Unclear what that means for kona.
+	// Kona doesn't directly depend on op-reth but uses various crates from it.
+	// Skip attempting to report a specific op-reth version for now.
+	elCommitInfo = types.CommitInfo{}
 
 	// kona has its own build process to convert superchain-registry config into a custom JSON format it uses
 	// Rather than re-implement that custom JSON format and work out how to convert it to the go format

--- a/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
@@ -27,7 +27,7 @@ func (p *OPProgramPrestate) FindVersions(log log.Logger, prestateVersion string)
 	elCommitInfo types.CommitInfo,
 	fppCommitInfo types.CommitInfo,
 	superChainRegistryCommit string,
-	prestateConfigs *superchain.ChainConfigLoader,
+	prestateConfigs types.ChainConfigs,
 ) {
 	prestateTag := fmt.Sprintf("op-program/v%s", prestateVersion)
 	log.Info("Found prestate tag", "tag", prestateTag)
@@ -51,10 +51,11 @@ func (p *OPProgramPrestate) FindVersions(log log.Logger, prestateVersion string)
 	if err != nil {
 		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
 	}
-	prestateConfigs, err = superchain.NewChainConfigLoader(prestateConfigData)
+	configLoader, err := superchain.NewChainConfigLoader(prestateConfigData)
 	if err != nil {
 		log.Crit("Failed to parse prestate's superchain registry config zip", "err", err)
 	}
+	prestateConfigs = types.NewChainConfigLoaderAdapter(configLoader)
 	return
 }
 

--- a/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
@@ -28,7 +28,7 @@ func (p *OPProgramPrestate) FindVersions(log log.Logger, prestateVersion string)
 	elCommitInfo types.CommitInfo,
 	fppCommitInfo types.CommitInfo,
 	superChainRegistryCommit string,
-	prestateConfigs types.ChainConfigs,
+	prestateConfigs *superchain.ChainConfigLoader,
 ) {
 	prestateTag := fmt.Sprintf("op-program/v%s", prestateVersion)
 	log.Info("Found prestate tag", "tag", prestateTag)
@@ -56,7 +56,7 @@ func (p *OPProgramPrestate) FindVersions(log log.Logger, prestateVersion string)
 	if err != nil {
 		log.Crit("Failed to parse prestate's superchain registry config zip", "err", err)
 	}
-	prestateConfigs = types.NewChainConfigLoaderAdapter(configLoader)
+	prestateConfigs = configLoader
 	return
 }
 

--- a/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/util"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/superchain"
 	"golang.org/x/mod/modfile"
@@ -40,14 +41,14 @@ func (p *OPProgramPrestate) FindVersions(log log.Logger, prestateVersion string)
 	elVersion := p.findOpGethVersion(log, modFile)
 	elCommitInfo = types.NewCommitInfo("ethereum-optimism", "op-geth", elVersion, "optimism", "")
 
-	registryCommitBytes, err := Fetch(fmt.Sprintf(superchainRegistryCommitAtRef, elVersion))
+	registryCommitBytes, err := util.Fetch(fmt.Sprintf(superchainRegistryCommitAtRef, elVersion))
 	if err != nil {
 		log.Crit("Failed to fetch superchain registry commit info", "err", err)
 	}
 	superChainRegistryCommit = strings.TrimSpace(string(registryCommitBytes))
 	log.Info("Found superchain registry commit info", "commit", superChainRegistryCommit)
 
-	prestateConfigData, err := Fetch(fmt.Sprintf(superchainConfigsZipAtTag, elVersion))
+	prestateConfigData, err := util.Fetch(fmt.Sprintf(superchainConfigsZipAtTag, elVersion))
 	if err != nil {
 		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
 	}
@@ -76,7 +77,7 @@ func (p *OPProgramPrestate) findOpGethVersion(log log.Logger, modFile *modfile.F
 
 func fetchMonorepoGoMod(opProgramTag string) (*modfile.File, error) {
 	goModUrl := fmt.Sprintf(monorepoGoModAtTag, opProgramTag)
-	goMod, err := Fetch(goModUrl)
+	goMod, err := util.Fetch(goModUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch go.mod: %w", err)
 	}

--- a/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/opprogram.go
@@ -1,0 +1,84 @@
+package prestate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/superchain"
+	"golang.org/x/mod/modfile"
+)
+
+const (
+	monorepoGoModAtTag            = "https://github.com/ethereum-optimism/optimism/raw/refs/tags/%s/go.mod"
+	superchainRegistryCommitAtRef = "https://github.com/ethereum-optimism/op-geth/raw/%s/superchain-registry-commit.txt"
+	superchainConfigsZipAtTag     = "https://github.com/ethereum-optimism/op-geth/raw/refs/tags/%s/superchain/superchain-configs.zip"
+)
+
+type OPProgramPrestate struct {
+}
+
+func NewOPProgramPrestate() *OPProgramPrestate {
+	return &OPProgramPrestate{}
+}
+
+func (p *OPProgramPrestate) FindVersions(log log.Logger, prestateVersion string) (
+	elCommitInfo types.CommitInfo,
+	fppCommitInfo types.CommitInfo,
+	superChainRegistryCommit string,
+	prestateConfigs *superchain.ChainConfigLoader,
+) {
+	prestateTag := fmt.Sprintf("op-program/v%s", prestateVersion)
+	log.Info("Found prestate tag", "tag", prestateTag)
+	fppCommitInfo = types.NewCommitInfo("ethereum-optimism", "optimism", prestateTag, "develop", "")
+
+	modFile, err := fetchMonorepoGoMod(prestateTag)
+	if err != nil {
+		log.Crit("Failed to fetch go mod", "err", err)
+	}
+	elVersion := p.findOpGethVersion(log, modFile)
+	elCommitInfo = types.NewCommitInfo("ethereum-optimism", "op-geth", elVersion, "optimism", "")
+
+	registryCommitBytes, err := Fetch(fmt.Sprintf(superchainRegistryCommitAtRef, elVersion))
+	if err != nil {
+		log.Crit("Failed to fetch superchain registry commit info", "err", err)
+	}
+	superChainRegistryCommit = strings.TrimSpace(string(registryCommitBytes))
+	log.Info("Found superchain registry commit info", "commit", superChainRegistryCommit)
+
+	prestateConfigData, err := Fetch(fmt.Sprintf(superchainConfigsZipAtTag, elVersion))
+	if err != nil {
+		log.Crit("Failed to fetch prestate's superchain registry config zip", "err", err)
+	}
+	prestateConfigs, err = superchain.NewChainConfigLoader(prestateConfigData)
+	if err != nil {
+		log.Crit("Failed to parse prestate's superchain registry config zip", "err", err)
+	}
+	return
+}
+
+func (p *OPProgramPrestate) findOpGethVersion(log log.Logger, modFile *modfile.File) string {
+	var elVersion string
+	for _, replace := range modFile.Replace {
+		if replace.Old.Path == "github.com/ethereum/go-ethereum" {
+			elVersion = replace.New.Version
+			break
+		}
+	}
+	if elVersion == "" {
+		log.Crit("Failed to find op-geth replace in go.mod")
+	}
+	log.Info("Found op-geth version", "version", elVersion)
+	return elVersion
+}
+
+func fetchMonorepoGoMod(opProgramTag string) (*modfile.File, error) {
+	goModUrl := fmt.Sprintf(monorepoGoModAtTag, opProgramTag)
+	goMod, err := Fetch(goModUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch go.mod: %w", err)
+	}
+
+	return modfile.Parse("go.mod", goMod, nil)
+}

--- a/op-chain-ops/cmd/check-prestate/registry/loader.go
+++ b/op-chain-ops/cmd/check-prestate/registry/loader.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/util"
+	"github.com/ethereum/go-ethereum/superchain"
+)
+
+const (
+	// TODO: Point back to optimism instead of fixed commit from my branch
+	syncSuperchainScript = "https://raw.githubusercontent.com/ethereum-optimism/op-geth/19413ee41768ec2203873410645edf428e500c49/sync-superchain.sh"
+)
+
+// LatestSuperchainConfigs loads the latest config from the superchain-registry main branch using the
+// sync-superchain.sh script from op-geth to create a zip of configs that can be read by op-geth's ChainConfigLoader.
+func LatestSuperchainConfigs() (*superchain.ChainConfigLoader, error) {
+	return SuperchainConfigsForCommit("main")
+}
+
+func SuperchainConfigsForCommit(registryCommit string) (*superchain.ChainConfigLoader, error) {
+	// Download the op-geth script to build the superchain config
+	script, err := util.Fetch(syncSuperchainScript)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch sync-superchain.sh script: %w", err)
+	}
+	dir, err := os.MkdirTemp("", "checkprestate")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+	if err := os.Mkdir(filepath.Join(dir, "superchain"), 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create superchain dir: %w", err)
+	}
+	scriptPath := filepath.Join(dir, "sync-superchain.sh")
+	if err := os.WriteFile(scriptPath, script, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to write sync-superchain.sh: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "superchain-registry-commit.txt"), []byte(registryCommit), 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write superchain-registry-commit.txt: %w", err)
+	}
+	cmd := exec.Command(scriptPath)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to build superchain config zip: %w", err)
+	}
+	configBytes, err := os.ReadFile(filepath.Join(dir, "superchain/superchain-configs.zip"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read generated superchain-configs.zip: %w", err)
+	}
+	return superchain.NewChainConfigLoader(configBytes)
+}

--- a/op-chain-ops/cmd/check-prestate/registry/loader.go
+++ b/op-chain-ops/cmd/check-prestate/registry/loader.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	// TODO: Point back to optimism instead of fixed commit from my branch
-	syncSuperchainScript = "https://raw.githubusercontent.com/ethereum-optimism/op-geth/19413ee41768ec2203873410645edf428e500c49/sync-superchain.sh"
+	syncSuperchainScript = "https://raw.githubusercontent.com/ethereum-optimism/op-geth/optimism/sync-superchain.sh"
 )
 
 // LatestSuperchainConfigs loads the latest config from the superchain-registry main branch using the

--- a/op-chain-ops/cmd/check-prestate/types/types.go
+++ b/op-chain-ops/cmd/check-prestate/types/types.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type PrestateInfo struct {
+	Hash    common.Hash `json:"hash"`
+	Version string      `json:"version"`
+	Type    string      `json:"type"`
+
+	FppProgram         CommitInfo `json:"fpp-program"`
+	ExecutionClient    CommitInfo `json:"execution-client"`
+	SuperchainRegistry CommitInfo `json:"superchain-registry"`
+
+	UpToDateChains []string        `json:"up-to-date-chains"`
+	OutdatedChains []OutdatedChain `json:"outdated-chains"`
+	MissingChains  []string        `json:"missing-chains"`
+}
+
+type OutdatedChain struct {
+	Name string `json:"name"`
+	Diff *Diff  `json:"diff,omitempty"`
+}
+
+type CommitInfo struct {
+	Commit  string `json:"commit"`
+	DiffUrl string `json:"diff-url"`
+	DiffCmd string `json:"diff-cmd"`
+}
+
+func NewCommitInfo(org string, repository string, commit string, mainBranch string, dir string) CommitInfo {
+	return CommitInfo{
+		Commit:  commit,
+		DiffUrl: fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", org, repository, commit, mainBranch),
+		DiffCmd: fmt.Sprintf("git fetch && git diff %s...origin/%s %s", commit, mainBranch, dir),
+	}
+}
+
+type Diff struct {
+	Msg      string `json:"message"`
+	Prestate any    `json:"prestate"`
+	Latest   any    `json:"latest"`
+}

--- a/op-chain-ops/cmd/check-prestate/types/types.go
+++ b/op-chain-ops/cmd/check-prestate/types/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/superchain"
 )
 
 type PrestateInfo struct {
@@ -45,42 +44,3 @@ type Diff struct {
 	Prestate any    `json:"prestate"`
 	Latest   any    `json:"latest"`
 }
-
-type ChainConfigs interface {
-	ChainNames() []string
-	ChainConfig(name string) (chainID uint64, chainConfig *superchain.ChainConfig, genesisData []byte, err error)
-}
-
-type ChainConfigLoaderAdapter struct {
-	loader *superchain.ChainConfigLoader
-}
-
-func NewChainConfigLoaderAdapter(loader *superchain.ChainConfigLoader) *ChainConfigLoaderAdapter {
-	return &ChainConfigLoaderAdapter{loader: loader}
-}
-
-func (c *ChainConfigLoaderAdapter) ChainNames() []string {
-	return c.loader.ChainNames()
-}
-
-func (c *ChainConfigLoaderAdapter) ChainConfig(name string) (chainID uint64, chainConfig *superchain.ChainConfig, genesisData []byte, err error) {
-	chainID, err = c.loader.ChainIDByName(name)
-	if err != nil {
-		return
-	}
-	chain, err := c.loader.GetChain(chainID)
-	if err != nil {
-		return
-	}
-	chainConfig, err = chain.Config()
-	if err != nil {
-		return
-	}
-	genesisData, err = chain.GenesisData()
-	if err != nil {
-		return
-	}
-	return
-}
-
-var _ ChainConfigs = (*ChainConfigLoaderAdapter)(nil)

--- a/op-chain-ops/cmd/check-prestate/types/types.go
+++ b/op-chain-ops/cmd/check-prestate/types/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/superchain"
 )
 
 type PrestateInfo struct {
@@ -44,3 +45,42 @@ type Diff struct {
 	Prestate any    `json:"prestate"`
 	Latest   any    `json:"latest"`
 }
+
+type ChainConfigs interface {
+	ChainNames() []string
+	ChainConfig(name string) (chainID uint64, chainConfig *superchain.ChainConfig, genesisData []byte, err error)
+}
+
+type ChainConfigLoaderAdapter struct {
+	loader *superchain.ChainConfigLoader
+}
+
+func NewChainConfigLoaderAdapter(loader *superchain.ChainConfigLoader) *ChainConfigLoaderAdapter {
+	return &ChainConfigLoaderAdapter{loader: loader}
+}
+
+func (c *ChainConfigLoaderAdapter) ChainNames() []string {
+	return c.loader.ChainNames()
+}
+
+func (c *ChainConfigLoaderAdapter) ChainConfig(name string) (chainID uint64, chainConfig *superchain.ChainConfig, genesisData []byte, err error) {
+	chainID, err = c.loader.ChainIDByName(name)
+	if err != nil {
+		return
+	}
+	chain, err := c.loader.GetChain(chainID)
+	if err != nil {
+		return
+	}
+	chainConfig, err = chain.Config()
+	if err != nil {
+		return
+	}
+	genesisData, err = chain.GenesisData()
+	if err != nil {
+		return
+	}
+	return
+}
+
+var _ ChainConfigs = (*ChainConfigLoaderAdapter)(nil)

--- a/op-chain-ops/cmd/check-prestate/util/fetch.go
+++ b/op-chain-ops/cmd/check-prestate/util/fetch.go
@@ -1,4 +1,4 @@
-package prestate
+package util
 
 import (
 	"fmt"


### PR DESCRIPTION
**Description**

Adds support for kona prestates to the prestate-check file.

* The prestate needs to be in the standard prestates list as `cannon-kona` type.
* The superchain-registry config is loaded by identifying the commit used by the kona submodule and then applying the op-geth conversion process to that commit
* The "EL commit" info is left blank because kona doesn't depend on op-reth in the same way that op-program depends on op-geth - kona just pulls in specific crates from reth and they don't necessarily all come from the same commit.

**Tests**

Tested manually.

**Additional context**

Depends on https://github.com/ethereum-optimism/op-geth/pull/673

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17284