### PR TITLE
contracts: Add CANNON_KONA game type

### DIFF
--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -76,6 +76,9 @@ library GameTypes {
     /// @notice A dispute game type that uses the cannon vm with Kona.
     GameType internal constant CANNON_KONA = GameType.wrap(8);
 
+    /// @notice A dispute game type that uses the cannon vm with Kona (Super Roots).
+    GameType internal constant SUPER_CANNON_KONA = GameType.wrap(9);
+
     /// @notice A dispute game type with short game duration for testing withdrawals.
     ///         Not intended for production use.
     GameType internal constant FAST = GameType.wrap(254);

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -70,6 +70,9 @@ library GameTypes {
     /// @notice A dispute game type that uses OP Succinct
     GameType internal constant OP_SUCCINCT = GameType.wrap(6);
 
+    /// @notice A dispute game type that uses the asterisc vm with Kona (Super Roots).
+    GameType internal constant SUPER_ASTERISC_KONA = GameType.wrap(7);
+
     /// @notice A dispute game type that uses the cannon vm with Kona.
     GameType internal constant CANNON_KONA = GameType.wrap(8);
 

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -70,6 +70,9 @@ library GameTypes {
     /// @notice A dispute game type that uses OP Succinct
     GameType internal constant OP_SUCCINCT = GameType.wrap(6);
 
+    /// @notice A dispute game type that uses the cannon vm with Kona.
+    GameType internal constant CANNON_KONA = GameType.wrap(8);
+
     /// @notice A dispute game type with short game duration for testing withdrawals.
     ///         Not intended for production use.
     GameType internal constant FAST = GameType.wrap(254);


### PR DESCRIPTION
**Description**

Adds CANNON_KONA and SUPER_ASTERISC_KONA game type to the contracts to keep them in sync with the go side:
https://github.com/ethereum-optimism/optimism/pull/17356/files#diff-5745595a520662acef16da589abd98dc4bdc4cb950824dc37f57d483b5b64ac6

Fixes https://github.com/ethereum-optimism/optimism/issues/17282