### PR TITLE
docs: fix JSON syntax error in data export

### DIFF
--- a/op-chain-ops/cmd/op-run-block/README.md
+++ b/op-chain-ops/cmd/op-run-block/README.md
@@ -21,8 +21,8 @@ Where `badblock.json` looks like:
 [
   {
     "block": {
-      "timestamp": ...
-      "number": ...
+      "timestamp": ...,
+      "number": ...,
       "transactions": [ ... ],
       ...
     }


### PR DESCRIPTION
**Description**

corrected a small syntax issue in the exported JSON: a missing comma between `"timestamp"` and `"number"`.