### PR TITLE
refactor(op-e2e): use ActivateForkAtOffset utility

### DIFF
--- a/op-e2e/actions/upgrades/dencun_fork_test.go
+++ b/op-e2e/actions/upgrades/dencun_fork_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -124,12 +125,7 @@ func TestDencunL2ForkAfterGenesis(gt *testing.T) {
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	require.Zero(t, *dp.DeployConfig.L1CancunTimeOffset)
 	// This test will fork on the second block
-	offset := hexutil.Uint64(dp.DeployConfig.L2BlockTime * 2)
-	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &offset
-	dp.DeployConfig.L2GenesisFjordTimeOffset = nil
-	dp.DeployConfig.L2GenesisGraniteTimeOffset = nil
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = nil
-	// New forks have to be added here, after changing the default deploy config!
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Ecotone, dp.DeployConfig.L2BlockTime*2)
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
 	log := testlog.Logger(t, log.LevelDebug)

--- a/op-e2e/actions/upgrades/ecotone_fork_test.go
+++ b/op-e2e/actions/upgrades/ecotone_fork_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -43,17 +44,13 @@ func verifyCodeHashMatches(t helpers.Testing, client *ethclient.Client, address 
 func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-	ecotoneOffset := hexutil.Uint64(4)
+	ecotoneOffset := 4
 
 	log := testlog.Logger(t, log.LevelDebug)
 
 	require.Zero(t, *dp.DeployConfig.L1CancunTimeOffset)
 	// Activate all forks at genesis, and schedule Ecotone the block after
-	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &ecotoneOffset
-	dp.DeployConfig.L2GenesisFjordTimeOffset = nil
-	dp.DeployConfig.L2GenesisGraniteTimeOffset = nil
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = nil
-	// New forks have to be added here...
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Ecotone, uint64(ecotoneOffset))
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)

--- a/op-e2e/actions/upgrades/fjord_fork_test.go
+++ b/op-e2e/actions/upgrades/fjord_fork_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -19,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -32,21 +32,13 @@ var (
 func TestFjordNetworkUpgradeTransactions(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
-	genesisBlock := hexutil.Uint64(0)
-	fjordOffset := hexutil.Uint64(2)
 
 	log := testlog.Logger(t, log.LvlDebug)
 
-	dp.DeployConfig.L1CancunTimeOffset = &genesisBlock // can be removed once Cancun on L1 is the default
-
 	// Activate all forks at genesis, and schedule Fjord the block after
-	dp.DeployConfig.L2GenesisRegolithTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisCanyonTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisDeltaTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisBlock
-	dp.DeployConfig.L2GenesisFjordTimeOffset = &fjordOffset
-	dp.DeployConfig.L2GenesisGraniteTimeOffset = nil
-	dp.DeployConfig.L2GenesisHoloceneTimeOffset = nil
+	fjordOffset := uint64(2)
+	dp.DeployConfig.ActivateForkAtOffset(rollup.Fjord, fjordOffset)
+
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)


### PR DESCRIPTION
Currently, each time we do a new fork we need to go back and modify activation action tests for some prior forks. With this change, such modifications will no longer be necessary.
