### PR TITLE
op-sync-tester: Better logging

### DIFF
--- a/op-sync-tester/synctester/backend/session/session.go
+++ b/op-sync-tester/synctester/backend/session/session.go
@@ -79,7 +79,7 @@ func (s *SessionManager) get(given *eth.SyncTesterSession) (*eth.SyncTesterSessi
 	var sess *eth.SyncTesterSession
 	sess, ok := s.sessions[id]
 	if ok {
-		s.log.Debug("Using existing session", "sessionID", id)
+		s.log.Trace("Using existing session", "sessionID", id)
 	} else {
 		s.sessions[id] = given
 		sess = given
@@ -91,7 +91,8 @@ func (s *SessionManager) get(given *eth.SyncTesterSession) (*eth.SyncTesterSessi
 func WithSession[T any](
 	mgr *SessionManager,
 	ctx context.Context,
-	fn func(*eth.SyncTesterSession) (T, error),
+	logger log.Logger,
+	fn func(*eth.SyncTesterSession, log.Logger) (T, error),
 ) (T, error) {
 	var zero T
 	given, ok := SyncTesterSessionFromContext(ctx)
@@ -105,5 +106,7 @@ func WithSession[T any](
 	// blocking
 	session.Lock()
 	defer session.Unlock()
-	return fn(session)
+	// Bind session ID and starting fcu state
+	logger = logger.With("id", session.SessionID, "start_fcu", session.CurrentState)
+	return fn(session, logger)
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -58,6 +58,7 @@ func SyncTesterFromConfig(logger log.Logger, m metrics.Metricer, stID sttypes.Sy
 		return nil, fmt.Errorf("failed to dial EL client: %w", err)
 	}
 	elReader := NewELReader(elClient)
+	logger.Info("Initialized sync tester from config", "syncTester", stID)
 	return NewSyncTester(logger, m, stID, stCfg.ChainID, elReader), nil
 }
 
@@ -73,24 +74,29 @@ func NewSyncTester(logger log.Logger, m metrics.Metricer, stID sttypes.SyncTeste
 }
 
 func (s *SyncTester) GetSession(ctx context.Context) (*eth.SyncTesterSession, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.SyncTesterSession, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.SyncTesterSession, error) {
+		logger.Debug("GetSession")
 		return session, nil
 	})
 }
 
 func (s *SyncTester) DeleteSession(ctx context.Context) error {
-	_, err := session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (any, error) {
+	_, err := session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (any, error) {
+		logger.Debug("DeleteSession")
 		return struct{}{}, s.sessMgr.DeleteSession(session.SessionID)
 	})
 	return err
 }
 
 func (s *SyncTester) ListSessions(ctx context.Context) ([]string, error) {
-	return s.sessMgr.SessionIDs(), nil
+	ids := s.sessMgr.SessionIDs()
+	s.log.Debug("ListSessions", "count", len(ids))
+	return ids, nil
 }
 
 func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) ([]*types.Receipt, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) ([]*types.Receipt, error) {
+		logger.Debug("GetBlockReceipts", "blockNrOrHash", blockNrOrHash)
 		number, isNumber := blockNrOrHash.Number()
 		var err error
 		var receipts []*types.Receipt
@@ -102,7 +108,7 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 			}
 		} else {
 			var target uint64
-			if target, err = s.checkBlockNumber(number, session); err != nil {
+			if target, err = s.checkBlockNumber(number, session, logger); err != nil {
 				return nil, err
 			}
 			receipts, err = s.elReader.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(target)))
@@ -112,9 +118,12 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 		}
 		if len(receipts) == 0 {
 			// Should never happen since every block except genesis has at least one deposit tx
+			logger.Warn("L2 Block has zero receipts", "blockNrHash", blockNrOrHash)
 			return nil, errors.New("no receipts")
 		}
-		if receipts[0].BlockNumber.Uint64() > session.CurrentState.Latest {
+		target := receipts[0].BlockNumber.Uint64()
+		if target > session.CurrentState.Latest {
+			logger.Warn("Requested block is ahead of sync tester state", "requested", target)
 			return nil, ethereum.NotFound
 		}
 		return receipts, nil
@@ -122,7 +131,8 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 }
 
 func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullTx bool) (json.RawMessage, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (json.RawMessage, error) {
+		logger.Debug("GetBlockByHash", "hash", hash, "fullTx", fullTx)
 		var err error
 		var raw json.RawMessage
 		if raw, err = s.elReader.GetBlockByHashJSON(ctx, hash, fullTx); err != nil {
@@ -132,14 +142,16 @@ func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullT
 		if err := json.Unmarshal(raw, &header); err != nil {
 			return nil, err
 		}
-		if header.Number.ToInt().Uint64() > session.CurrentState.Latest {
+		target := header.Number.ToInt().Uint64()
+		if target > session.CurrentState.Latest {
+			logger.Warn("Requested block is ahead of sync tester state", "requested", target)
 			return nil, ethereum.NotFound
 		}
 		return raw, nil
 	})
 }
 
-func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncTesterSession) (uint64, error) {
+func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncTesterSession, logger log.Logger) (uint64, error) {
 	var target uint64
 	switch number {
 	case rpc.LatestBlockNumber:
@@ -159,6 +171,7 @@ func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncT
 		target = uint64(number.Int64())
 		// Short circuit for numeric request beyond sync tester canonical head
 		if target > session.CurrentState.Latest {
+			logger.Warn("Requested block is ahead of sync tester state", "requested", target)
 			return 0, ethereum.NotFound
 		}
 	}
@@ -166,10 +179,11 @@ func (s *SyncTester) checkBlockNumber(number rpc.BlockNumber, session *eth.SyncT
 }
 
 func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (json.RawMessage, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (json.RawMessage, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (json.RawMessage, error) {
+		logger.Debug("GetBlockByNumber", "number", number, "fullTx", fullTx)
 		var err error
 		var target uint64
-		if target, err = s.checkBlockNumber(number, session); err != nil {
+		if target, err = s.checkBlockNumber(number, session, logger); err != nil {
 			return nil, err
 		}
 		var raw json.RawMessage
@@ -181,12 +195,14 @@ func (s *SyncTester) GetBlockByNumber(ctx context.Context, number rpc.BlockNumbe
 }
 
 func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (hexutil.Big, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (hexutil.Big, error) {
+		logger.Debug("ChainId")
 		chainID, err := s.elReader.ChainId(ctx)
 		if err != nil {
 			return hexutil.Big{}, err
 		}
 		if chainID.ToInt().Cmp(s.chainID.ToBig()) != 0 {
+			logger.Error("ChainId mismatch", "config", s.chainID, "backend", chainID.ToInt())
 			return hexutil.Big{}, fmt.Errorf("chainID mismatch: config: %s, backend: %s", s.chainID, chainID.ToInt())
 		}
 		return hexutil.Big(*s.chainID.ToBig()), nil
@@ -195,41 +211,45 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 
 // GetPayloadV1 only supports V1 payloads.
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ExecutionPayloadEnvelope, error) {
+		logger.Debug("GetPayloadV1", "payloadID", payloadID)
 		if !payloadID.Is(engine.PayloadV1) {
 			return nil, engine.UnsupportedFork
 		}
-		return s.getPayload(session, payloadID)
+		return s.getPayload(session, logger, payloadID)
 	})
 }
 
 // GetPayloadV2 supports V1, V2 payloads.
 func (s *SyncTester) GetPayloadV2(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ExecutionPayloadEnvelope, error) {
+		logger.Debug("GetPayloadV2", "payloadID", payloadID)
 		if !payloadID.Is(engine.PayloadV1, engine.PayloadV2) {
 			return nil, engine.UnsupportedFork
 		}
-		return s.getPayload(session, payloadID)
+		return s.getPayload(session, logger, payloadID)
 	})
 }
 
 // GetPayloadV3 must be only called when Ecotone activated.
 func (s *SyncTester) GetPayloadV3(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ExecutionPayloadEnvelope, error) {
+		logger.Debug("GetPayloadV3", "payloadID", payloadID)
 		if !payloadID.Is(engine.PayloadV3) {
 			return nil, engine.UnsupportedFork
 		}
-		return s.getPayload(session, payloadID)
+		return s.getPayload(session, logger, payloadID)
 	})
 }
 
 // GetPayloadV4 must be only called when Isthmus activated.
 func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ExecutionPayloadEnvelope, error) {
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ExecutionPayloadEnvelope, error) {
+		logger.Debug("GetPayloadV4", "payloadID", payloadID)
 		if !payloadID.Is(engine.PayloadV3) {
 			return nil, engine.UnsupportedFork
 		}
-		return s.getPayload(session, payloadID)
+		return s.getPayload(session, logger, payloadID)
 	})
 }
 
@@ -237,34 +257,38 @@ func (s *SyncTester) GetPayloadV4(ctx context.Context, payloadID eth.PayloadID) 
 // ForkchoiceUpdated engine APIs when valid payload attributes were provided.
 // Retrieved payloads are deleted from the session after being served to
 // emulate one-time consumption by the consensus layer.
-func (s *SyncTester) getPayload(session *eth.SyncTesterSession, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
+func (s *SyncTester) getPayload(session *eth.SyncTesterSession, logger log.Logger, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	payloadEnv, ok := session.Payloads[payloadID]
 	if !ok {
 		return nil, engine.UnknownPayload
 	}
 	// Clean up payload
 	delete(session.Payloads, payloadID)
+	logger.Trace("Deleted payload", "payloadID", payloadID)
 	return payloadEnv, nil
 }
 
 // ForkchoiceUpdatedV1 is called for processing V1 attributes
 func (s *SyncTester) ForkchoiceUpdatedV1(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
-		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV1, false, false)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ForkchoiceUpdatedResult, error) {
+		logger.Debug("ForkchoiceUpdatedV1", "state", state, "attr", attr)
+		return s.forkchoiceUpdated(ctx, session, logger, state, attr, engine.PayloadV1, false, false)
 	})
 }
 
 // ForkchoiceUpdatedV2 is called for processing V2 attributes
 func (s *SyncTester) ForkchoiceUpdatedV2(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
-		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV2, true, false)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ForkchoiceUpdatedResult, error) {
+		logger.Debug("ForkchoiceUpdatedV2", "state", state, "attr", attr)
+		return s.forkchoiceUpdated(ctx, session, logger, state, attr, engine.PayloadV2, true, false)
 	})
 }
 
 // ForkchoiceUpdatedV3 must be only called with Ecotone attributes
 func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.ForkchoiceUpdatedResult, error) {
-		return s.forkchoiceUpdated(ctx, session, state, attr, engine.PayloadV3, true, true)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ForkchoiceUpdatedResult, error) {
+		logger.Debug("ForkchoiceUpdatedV3", "state", state, "attr", attr)
+		return s.forkchoiceUpdated(ctx, session, logger, state, attr, engine.PayloadV3, true, true)
 	})
 }
 
@@ -285,7 +309,7 @@ func (s *SyncTester) ForkchoiceUpdatedV3(ctx context.Context, state *eth.Forkcho
 //     attributes are malformed or finalized/safe blocks are not canonical.
 //   - {status: SYNCING} when the head block is unknown or not yet validated, or
 //     when block data cannot be retrieved from the execution layer.
-func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTesterSession, state *eth.ForkchoiceState, attr *eth.PayloadAttributes, payloadVersion engine.PayloadVersion,
+func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTesterSession, logger log.Logger, state *eth.ForkchoiceState, attr *eth.PayloadAttributes, payloadVersion engine.PayloadVersion,
 	isCanyon, isEcotone bool,
 ) (*eth.ForkchoiceUpdatedResult, error) {
 	// Validate attributes shape
@@ -409,9 +433,11 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.GenericServerError.With(err)
 		}
 		// Store payload and payloadID. This will be processed using GetPayload engine API
+		logger.Debug("Store payload", "payloadID", payloadID)
 		session.Payloads[payloadID] = payloadEnv
 	}
 	session.UpdateFCUState(candLatest.NumberU64(), safeNum, finalizedNum)
+	logger.Debug("Updated FCU State")
 	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
 	// Spec: Client software MUST respond to this method call in the following way: {payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId} if the payload is deemed VALID and the build process has begun
 	return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: id}, nil
@@ -501,29 +527,33 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 
 // NewPayloadV1 must be only called with Bedrock Payload
 func (s *SyncTester) NewPayloadV1(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
-		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.PayloadStatusV1, error) {
+		logger.Debug("NewPayloadV1", "payload", payload)
+		return s.newPayload(ctx, session, logger, payload, nil, nil, nil, false, false)
 	})
 }
 
 // NewPayloadV2 must be only called with Bedrock, Canyon, Delta Payload
 func (s *SyncTester) NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
-		return s.newPayload(ctx, session, payload, nil, nil, nil, false, false)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.PayloadStatusV1, error) {
+		logger.Debug("NewPayloadV2", "payload", payload)
+		return s.newPayload(ctx, session, logger, payload, nil, nil, nil, false, false)
 	})
 }
 
 // NewPayloadV3 must be only called with Ecotone Payload
 func (s *SyncTester) NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
-		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, nil, true, false)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.PayloadStatusV1, error) {
+		logger.Debug("NewPayloadV3", "payload", payload, "versionedHashes", versionedHashes, "beaconRoot", beaconRoot)
+		return s.newPayload(ctx, session, logger, payload, versionedHashes, beaconRoot, nil, true, false)
 	})
 }
 
 // NewPayloadV4 must be only called with Isthmus payload
 func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
-	return session.WithSession(s.sessMgr, ctx, func(session *eth.SyncTesterSession) (*eth.PayloadStatusV1, error) {
-		return s.newPayload(ctx, session, payload, versionedHashes, beaconRoot, executionRequests, true, true)
+	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.PayloadStatusV1, error) {
+		logger.Debug("NewPayloadV4", "payload", payload, "versionedHashes", versionedHashes, "beaconRoot", beaconRoot, "executionRequests", executionRequests)
+		return s.newPayload(ctx, session, logger, payload, versionedHashes, beaconRoot, executionRequests, true, true)
 	})
 }
 
@@ -542,7 +572,7 @@ func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPay
 //   - {status: SYNCING} when the block cannot be executed because its parent is missing.
 //   - Errors surfaced as engine.InvalidParams or engine.GenericServerError to
 //     trigger appropriate consensus-layer retries.
-func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSession, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes,
+func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSession, logger log.Logger, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes,
 	isEcotone, isIsthmus bool,
 ) (*eth.PayloadStatusV1, error) {
 	// Validate request shape, fork required fields
@@ -635,7 +665,7 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 		if !isIsthmus {
 			// Depopulate withdrawal root field for block hash recomputation
 			if payload.WithdrawalsRoot != nil {
-				s.log.Warn("Isthmus disabled but withdrawal roots included in payload not nil", "root", payload.WithdrawalsRoot)
+				logger.Warn("Isthmus disabled but withdrawal roots included in payload not nil", "root", payload.WithdrawalsRoot)
 			}
 			payload.WithdrawalsRoot = nil
 		}
@@ -652,6 +682,7 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 		if block.NumberU64() == session.Validated+1 {
 			// Advance single block without setting the head, equivalent to geth InsertBlockWithoutSetHead
 			session.Validated += 1
+			logger.Debug("Advanced non canonical chain", "validated", session.Validated)
 		}
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
 		// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds logging for sync tester, recording all RPC calls via debug level.

Example logs for single block building:

```log
DEBUG[09-08|21:22:11.953] ForkchoiceUpdatedV3                      syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}" state="&{HeadBlockHash:0x239a1685a10f4fb0fdde41a35081307744909b274a52e129ac93cd59c762c3e4 SafeBlockHash:0x239a1685a10f4fb0fdde41a35081307744909b274a52e129ac93cd59c762c3e4 FinalizedBlockHash:0x8061e0fe55fdf2d85bdfe9c716fe0f8127a1391da13531dd6537ac6a4418b46e}" attr="&{Timestamp:0x68beb5e6 PrevRandao:0x62e6e61e4b13311051b3a17dce747accd408f771c4b2435e20643adbad19b861 SuggestedFeeRecipient:0x4200000000000000000000000000000000000011 Withdrawals:0x14000c08f30 ParentBeaconBlockRoot:0xfc060a6565c3263b542196533332a8bccbfe4c9c77e25a55d73ae5865dab41f2 Transactions:[0x7ef90104a02985c7153975c3aeaba86a60facfabd268bbb982ac03c6a1b22d7a7e7346fa6394deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be00000558000c3c9d00000000000000040000000068beb5c800000000000000260000000000000000000000000000000000000000000000000000000000f9c52600000000000000000000000000000000000000000000000000000000000000010eb1efd2bf54305ccb4af6fd55c663e2ee17b0bd7fc99c7f7f5916a951b3147f000000000000000000000000d3f2c5afb2d76f5579f326b0cd7da5f5a4126c35000000000000000000000000] NoTxPool:true GasLimit:0x3938700 EIP1559Params:0x000000fa00000006 MinBaseFee:<nil>}"
DEBUG[09-08|21:22:11.956] Store payload                            syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}" payloadID=0x032fa9d37edde97e
DEBUG[09-08|21:22:11.956] Updated FCU State                        syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}"
DEBUG[09-08|21:22:11.956] Served engine_forkchoiceUpdatedV3        conn=127.0.0.1:49865 reqid=453 duration=2.551458ms
DEBUG[09-08|21:22:11.956] served HTTP request                      status=200 response_len=181  path=/chain/2151908/synctest duration=2.606041ms  remote_addr=127.0.0.1:49865 upgrade_attempt=false
DEBUG[09-08|21:22:11.956] GetPayloadV4                             syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}" payloadID=0x032fa9d37edde97e
DEBUG[09-08|21:22:11.956] Served engine_getPayloadV4               conn=127.0.0.1:49865 reqid=454 duration="27.917µs"
DEBUG[09-08|21:22:11.956] served HTTP request                      status=200 response_len=772  path=/chain/2151908/synctest duration="104.458µs" remote_addr=127.0.0.1:49865 upgrade_attempt=false
DEBUG[09-08|21:22:11.956] NewPayloadV4                             syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}" payload=payload(0x46838d40f5d1b29a3e85e94b6d90067cba6392249ffb9dc4748bb26a3e954638:84) versionedHashes=[] beaconRoot=fc060a..ab41f2 executionRequests=[]
DEBUG[09-08|21:22:11.957] Advanced non canonical chain             syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}" validated=84
DEBUG[09-08|21:22:11.957] Served engine_newPayloadV4               conn=127.0.0.1:49865 reqid=455 duration="795.167µs"
DEBUG[09-08|21:22:11.957] served HTTP request                      status=200 response_len=149  path=/chain/2151908/synctest duration="853.25µs"  remote_addr=127.0.0.1:49865 upgrade_attempt=false
DEBUG[09-08|21:22:11.957] ForkchoiceUpdatedV3                      syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}" state="&{HeadBlockHash:0x46838d40f5d1b29a3e85e94b6d90067cba6392249ffb9dc4748bb26a3e954638 SafeBlockHash:0x239a1685a10f4fb0fdde41a35081307744909b274a52e129ac93cd59c762c3e4 FinalizedBlockHash:0x8061e0fe55fdf2d85bdfe9c716fe0f8127a1391da13531dd6537ac6a4418b46e}" attr=<nil>
DEBUG[09-08|21:22:11.960] Updated FCU State                        syncTester=local chain=2151908 id=7b39fb24-4acf-4d45-8920-ab27b6a31ee4 start_fcu="{Latest:83 Safe:83 Finalized:10}"
DEBUG[09-08|21:22:11.960] Served engine_forkchoiceUpdatedV3        conn=127.0.0.1:49865 reqid=456 duration=2.55875ms
```