### PR TITLE
op-challenger: Fix metric label name for asterisc-kona

### DIFF
--- a/op-challenger/game/fault/trace/outputs/output_asterisc.go
+++ b/op-challenger/game/fault/trace/outputs/output_asterisc.go
@@ -45,7 +45,8 @@ func NewOutputAsteriscTraceAccessor(
 		return provider, nil
 	}
 
-	cache := NewProviderCache(m, "output_asterisc_provider", asteriscCreator)
+	metricsLabel := fmt.Sprintf("outputs_%s_provider", cfg.VmType.String())
+	cache := NewProviderCache(m, metricsLabel, asteriscCreator)
 	selector := split.NewSplitProviderSelector(outputProvider, splitDepth, OutputRootSplitAdapter(outputProvider, cache.GetOrCreate))
 	return trace.NewAccessor(selector), nil
 }


### PR DESCRIPTION
To prevent namespace collisions between potential asterisc and asterisc-kona deployments.
Currently, we don't run the standard `asterisc` (-op-program) on vm-runner, so this change effectively renames the existing `asterisc-kona` deployment's metric label from `asterisc` to `asterisc-kona` for clarity and future-proofing.