### PR TITLE
op-service: cliutils add support for common.Hash

### DIFF
--- a/op-service/cliutil/struct.go
+++ b/op-service/cliutil/struct.go
@@ -102,6 +102,17 @@ func handleSpecialTypes(fieldValue reflect.Value, fieldType reflect.Type, ctx *c
 		return nil
 	}
 
+	// Handle common.Hash
+	if fieldType == reflect.TypeOf(common.Hash{}) {
+		if !ctx.IsSet(flag) {
+			return nil
+		}
+		hashStr := ctx.String(flag)
+		hash := common.HexToHash(hashStr)
+		fieldValue.Set(reflect.ValueOf(hash))
+		return nil
+	}
+
 	// If type implements TextUnmarshaler
 	if unmarshaler, ok := fieldValue.Interface().(encoding.TextUnmarshaler); ok {
 		return unmarshaler.UnmarshalText([]byte(ctx.String(flag)))

--- a/op-service/cliutil/struct.go
+++ b/op-service/cliutil/struct.go
@@ -2,8 +2,10 @@ package cliutil
 
 import (
 	"encoding"
+	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"
@@ -107,7 +109,22 @@ func handleSpecialTypes(fieldValue reflect.Value, fieldType reflect.Type, ctx *c
 		if !ctx.IsSet(flag) {
 			return nil
 		}
-		hashStr := ctx.String(flag)
+
+		hashStr := strings.TrimPrefix(ctx.String(flag), "0x")
+
+		// Validate hex format and length
+		if hashStr != "" {
+			// Check length - common.Hash is 32 bytes = 64 hex chars + "0x" prefix = 66 total
+			if len(hashStr) != 64 {
+				return fmt.Errorf("invalid hash: length must be 64 characters")
+			}
+
+			// Validate hex characters
+			if _, err := hex.DecodeString(hashStr); err != nil {
+				return fmt.Errorf("invalid hash: non-hex characters in hash")
+			}
+		}
+
 		hash := common.HexToHash(hashStr)
 		fieldValue.Set(reflect.ValueOf(hash))
 		return nil

--- a/op-service/cliutil/struct_test.go
+++ b/op-service/cliutil/struct_test.go
@@ -26,6 +26,7 @@ func TestPopulateStruct(t *testing.T) {
 		Int64           int64                 `cli:"int64"`
 		Uint64          uint64                `cli:"uint64"`
 		Address         common.Address        `cli:"address"`
+		Hash            common.Hash           `cli:"hash"`
 		TextUnmarshaler *textUnmarshalerThing `cli:"text-unmarshaler"`
 		NotTagged       string
 	}
@@ -45,6 +46,7 @@ func TestPopulateStruct(t *testing.T) {
 				"--int64=2",
 				"--uint64=3",
 				fmt.Sprintf("--address=%s", common.HexToAddress("0x42")),
+				fmt.Sprintf("--hash=%s", common.HexToHash("43")),
 				"--text-unmarshaler=hello",
 			},
 			exp: testStruct{
@@ -54,6 +56,7 @@ func TestPopulateStruct(t *testing.T) {
 				Int64:   2,
 				Uint64:  3,
 				Address: common.HexToAddress("0x42"),
+				Hash:    common.HexToHash("0x43"),
 				TextUnmarshaler: &textUnmarshalerThing{
 					text: "hello",
 				},
@@ -94,6 +97,9 @@ func TestPopulateStruct(t *testing.T) {
 					},
 					&cli.StringFlag{
 						Name: "address",
+					},
+					&cli.StringFlag{
+						Name: "hash",
 					},
 					&cli.StringFlag{
 						Name: "text-unmarshaler",

--- a/op-service/cliutil/struct_test.go
+++ b/op-service/cliutil/struct_test.go
@@ -74,6 +74,29 @@ func TestPopulateStruct(t *testing.T) {
 			},
 			expErr: "invalid address",
 		},
+		{
+			name: "invalid hash flag (invalid length)",
+			args: []string{
+				"--hash=12345678901234567890123456789012345678901234567890123456789012345",
+			},
+			expErr: "invalid hash: length must be 64 characters",
+		},
+		{
+			name: "invalid hash flag (invalid characters)",
+			args: []string{
+				"--hash=123456789012345678901234567890123456789012345678901234567890123g",
+			},
+			expErr: "invalid hash: non-hex characters in hash",
+		},
+		{
+			name: "allow zero hash",
+			args: []string{
+				fmt.Sprintf("--hash=%s", common.HexToHash("0")),
+			},
+			exp: testStruct{
+				Hash: common.HexToHash("0x0"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Previously `cliutils` supported `common.Address` but not `common.Hash`