### PR TITLE
op-dispute-mon: Support cannon-kona games

### DIFF
--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -31,12 +31,14 @@ func DetectGameType(ctx context.Context, addr common.Address, caller *batching.M
 	switch gameType {
 	case faultTypes.CannonGameType,
 		faultTypes.PermissionedGameType,
+		faultTypes.CannonKonaGameType,
 		faultTypes.AsteriscGameType,
 		faultTypes.AlphabetGameType,
 		faultTypes.FastGameType,
 		faultTypes.AsteriscKonaGameType,
 		faultTypes.SuperCannonGameType,
 		faultTypes.SuperPermissionedGameType,
+		faultTypes.SuperCannonKonaGameType,
 		faultTypes.SuperAsteriscKonaGameType:
 		return gameType, nil
 	default:

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -81,7 +81,7 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 		return nil, fmt.Errorf("failed to detect game type: %w", err)
 	}
 	switch gameType {
-	case types.SuperCannonGameType, types.SuperPermissionedGameType, types.SuperAsteriscKonaGameType:
+	case types.SuperCannonGameType, types.SuperCannonKonaGameType, types.SuperPermissionedGameType, types.SuperAsteriscKonaGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 	default:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -53,12 +53,14 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 	switch faultTypes.GameType(game.GameType) {
 	case faultTypes.CannonGameType,
 		faultTypes.PermissionedGameType,
+		faultTypes.CannonKonaGameType,
 		faultTypes.AsteriscGameType,
 		faultTypes.AlphabetGameType,
 		faultTypes.FastGameType,
 		faultTypes.AsteriscKonaGameType,
 		faultTypes.SuperCannonGameType,
 		faultTypes.SuperPermissionedGameType,
+		faultTypes.SuperCannonKonaGameType,
 		faultTypes.SuperAsteriscKonaGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)
 		if err != nil {

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -36,6 +36,10 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 			game: types.GameMetadata{GameType: uint32(faultTypes.PermissionedGameType), Proxy: fdgAddr},
 		},
 		{
+			name: "validCannonKonaGameType",
+			game: types.GameMetadata{GameType: uint32(faultTypes.CannonKonaGameType), Proxy: fdgAddr},
+		},
+		{
 			name: "validAsteriscGameType",
 			game: types.GameMetadata{GameType: uint32(faultTypes.AsteriscGameType), Proxy: fdgAddr},
 		},
@@ -58,6 +62,10 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 		{
 			name: "validSuperPermissionedGameType",
 			game: types.GameMetadata{GameType: uint32(faultTypes.SuperPermissionedGameType), Proxy: fdgAddr},
+		},
+		{
+			name: "validSuperCannonKonaGameType",
+			game: types.GameMetadata{GameType: uint32(faultTypes.SuperCannonKonaGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validSuperAsteriscKonaGameType",
@@ -93,7 +101,10 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 
 func setupMetadataLoaderTest(t *testing.T, gameType uint32) (*batching.MultiCaller, *mockCacheMetrics) {
 	fdgAbi := snapshots.LoadFaultDisputeGameABI()
-	if gameType == uint32(faultTypes.SuperPermissionedGameType) || gameType == uint32(faultTypes.SuperCannonGameType) || gameType == uint32(faultTypes.SuperAsteriscKonaGameType) {
+	if gameType == uint32(faultTypes.SuperPermissionedGameType) ||
+		gameType == uint32(faultTypes.SuperCannonGameType) ||
+		gameType == uint32(faultTypes.SuperCannonKonaGameType) ||
+		gameType == uint32(faultTypes.SuperAsteriscKonaGameType) {
 		fdgAbi = snapshots.LoadSuperFaultDisputeGameABI()
 	}
 	stubRpc := batchingTest.NewAbiBasedRpc(t, fdgAddr, fdgAbi)


### PR DESCRIPTION
**Description**

Add support for cannon-kona games to op-dispute-mon

**Tests**

Updated tests for game type support.


**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17286