### PR TITLE
op-node: calculate gas dynamically for Isthmus L1 Block deployment

### DIFF
--- a/op-node/rollup/derive/isthmus_upgrade_transactions.go
+++ b/op-node/rollup/derive/isthmus_upgrade_transactions.go
@@ -45,6 +45,11 @@ var (
 func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 	upgradeTxns := make([]hexutil.Bytes, 0, 8)
 
+	// Calculate gas required for L1 Block contract deployment
+	// Base gas cost for contract creation + bytecode size * gas per byte
+	// 21,000 (base) + 200 (per byte) * bytecode length
+	l1BlockGas := 21000 + 200*uint64(len(l1BlockIsthmusDeploymentBytecode))
+
 	// Deploy L1 Block transaction
 	deployL1BlockTransaction, err := types.NewTx(&types.DepositTx{
 		SourceHash:          deployIsthmusL1BlockSource.SourceHash(),
@@ -52,7 +57,7 @@ func IsthmusNetworkUpgradeTransactions() ([]hexutil.Bytes, error) {
 		To:                  nil,
 		Mint:                big.NewInt(0),
 		Value:               big.NewInt(0),
-		Gas:                 425_000,
+		Gas:                 l1BlockGas,
 		IsSystemTransaction: false,
 		Data:                l1BlockIsthmusDeploymentBytecode,
 	}).MarshalBinary()

--- a/op-node/rollup/derive/isthmus_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/isthmus_upgrade_transactions_test.go
@@ -59,7 +59,11 @@ func TestIsthmusNetworkTransactions(t *testing.T) {
 	require.Equal(t, deployL1BlockSender, common.HexToAddress("0x4210000000000000000000000000000000000003"))
 	require.Equal(t, deployIsthmusL1BlockSource.SourceHash(), deployL1Block.SourceHash())
 	require.Nil(t, deployL1Block.To())
-	require.Equal(t, uint64(425_000), deployL1Block.Gas()) // TODO
+	// Verify gas value matches calculated value from contract deployment
+	// Gas calculation: 21,000 (base) + 200 * bytecode length
+	expectedGas := 21000 + 200*uint64(len(l1BlockIsthmusDeploymentBytecode))
+	t.Logf("Calculated gas: %d, bytecode length: %d", expectedGas, len(l1BlockIsthmusDeploymentBytecode))
+	require.Equal(t, expectedGas, deployL1Block.Gas())
 	require.Equal(t, l1BlockIsthmusDeploymentBytecode, deployL1Block.Data())
 
 	deployGasPriceOracleSender, deployGasPriceOracle := toDepositTxn(t, upgradeTxns[1])


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replace hardcoded gas value (425_000) with calculated value based on bytecode size.
Gas calculation: 21,000 (base) + 200 * bytecode length = 369,400

Fixes TODO comment for hardcoded gas value in isthmus_upgrade_transactions_test.go.


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
Tests performed:
- go test ./op-node/rollup/derive -run TestIsthmusNetworkTransactions -v
- go test ./op-node/rollup/derive -v (full derive package)
- All linter checks pass
- Verified calculated gas: 369,400 (bytecode length: 1,742 bytes)
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
