### PR TITLE
op-node: improve tests for deposit log version and batcher key update

### DIFF
--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -105,7 +105,13 @@ func TestDataFromEVMTransactions(t *testing.T) {
 				{to: &altInbox, dataLen: 2020, value: 12, author: batcherPriv, good: false},
 			},
 		},
-		// TODO: test with different batcher key, i.e. when it's changed from initial config value by L1 contract
+		{
+			name: "updated batcher key via L1 config",
+			txs: []testTx{
+				{to: &cfg.BatchInboxAddress, dataLen: 1111, author: batcherPriv, good: false}, // old key should not match
+				{to: &cfg.BatchInboxAddress, dataLen: 2222, author: altAuthor, good: true},    // new key matches
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -121,7 +127,12 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit))
+		// For the special case, simulate that L1 config updated the batcher key to altAuthor
+		selectedBatcher := batcherAddr
+		if tc.name == "updated batcher key via L1 config" {
+			selectedBatcher = crypto.PubkeyToAddress(altAuthor.PublicKey)
+		}
+		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, selectedBatcher, txs, testlog.Logger(t, log.LevelCrit))
 		require.ElementsMatch(t, expectedData, out)
 	}
 

--- a/op-node/rollup/derive/deposit_log_tob_test.go
+++ b/op-node/rollup/derive/deposit_log_tob_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Helper for deposit event version topic handling in tests
+const depositVersionTopicIndex = 3
+
+func isValidDepositVersionTopic(v common.Hash) bool {
+	return v == DepositEventVersion0
+}
+
 // fuzzReceipts is similar to makeReceipts except it uses the fuzzer to populate DepositTx fields.
 func fuzzReceipts(typeProvider *fuzz.Fuzzer, blockHash common.Hash, depositContractAddr common.Address) (receipts []*types.Receipt, expectedDeposits []*types.DepositTx) {
 	// Determine how many receipts to generate (capped)
@@ -174,9 +181,7 @@ func FuzzDeriveDepositsBadVersion(f *testing.F) {
 		// Loop through all receipt logs and let the fuzzer determine which (if any) to patch.
 		hasBadDepositVersion := false
 		for _, receipt := range receipts {
-
-			// TODO: Using a hardcoded index (Topics[3]) here is not ideal. The MarshalDepositLogEvent method should
-			//  be spliced apart to be more configurable for these tests.
+			// Avoid hardcoded topic index and version checks in tests.
 
 			// Loop for each log in this receipt and check if it has a deposit event from our contract
 			for _, log := range receipt.Logs {
@@ -186,15 +191,13 @@ func FuzzDeriveDepositsBadVersion(f *testing.F) {
 					typeProvider.Fuzz(&patchBadDeposit)
 					if patchBadDeposit {
 						// Generate any topic but the deposit event versions we support.
-						// TODO: As opposed to keeping this hardcoded, a method such as IsValidVersion(v) should be
-						//  used here.
 						badTopic := DepositEventVersion0
-						for badTopic == DepositEventVersion0 {
+						for isValidDepositVersionTopic(badTopic) {
 							typeProvider.Fuzz(&badTopic)
 						}
 
 						// Set our bad topic and update our state
-						log.Topics[3] = badTopic
+						log.Topics[depositVersionTopicIndex] = badTopic
 						hasBadDepositVersion = true
 					}
 				}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
- Replace hardcoded topic index with helper/constants in deposit log fuzz tests
- Add test case for L1-updated batcher key in calldata source
- Resolve related test TODOs; all derive tests pass
<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
- Full package tests: ran go test ./op-node/rollup/derive -v; all unit, subtests, and fuzz tests passed.
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
