### PR TITLE
circleci: enable OPM and Base mainnet op-node sync tests (nightly)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2687,23 +2687,23 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      # OP Mainnet ## TODO: Need L1 Mainnet Beacon to be exposed for CI
-      # - op-acceptance-sync-tests-docker:
-      #     name: sync-test-op-mainnet-daily
-      #     gate: sync-test-op-node
-      #     no_output_timeout: 30m
-      #     l2_network_name: "op-mainnet"
-      #     l1_chain_id: "1"
-      #     l2_el_endpoint: "https://op-mainnet-rpc.optimism.io"
-      #     l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
-      #     l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
-      #     initial_l2_block: "140013283"
-      #     context:
-      #       - circleci-repo-readonly-authenticated-github-token
-      #       - discord
-      #     requires:
-      #       - contracts-bedrock-build
-      #       - cannon-prestate-quick
+      ## OP Mainnet
+      - op-acceptance-sync-tests-docker:
+          name: sync-test-op-mainnet-daily
+          gate: sync-test-op-node
+          no_output_timeout: 30m
+          l2_network_name: "op-mainnet"
+          l1_chain_id: "1"
+          l2_el_endpoint: "https://op-mainnet-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+          initial_l2_block: "140013283"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
 
 
   # Acceptance tests (post-merge to develop)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1336,6 +1336,8 @@ jobs:
           steps:
             - store_artifacts:
                 path: ./op-acceptance-tests/logs
+      - notify-failures-on-develop:
+          mentions: "@changwan @Anton Evangelatov"
 
   op-acceptance-tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1337,7 +1337,7 @@ jobs:
             - store_artifacts:
                 path: ./op-acceptance-tests/logs
       - notify-failures-on-develop:
-          mentions: "@changwan @Anton Evangelatov"
+          mentions: "@changwan <@U08L5U8070U>" # @changwan @Anton Evangelatov
 
   op-acceptance-tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2704,7 +2704,23 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-
+      ## Base Mainnet
+      - op-acceptance-sync-tests-docker:
+          name: sync-test-base-mainnet-daily
+          gate: sync-test-op-node
+          no_output_timeout: 30m
+          l2_network_name: "base-mainnet"
+          l1_chain_id: "1"
+          l2_el_endpoint: "https://base-mainnet-rpc.optimism.io"
+          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
+          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+          initial_l2_block: "35318000"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - discord
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
 
   # Acceptance tests (post-merge to develop)
   acceptance-tests:


### PR DESCRIPTION
This PR is adding `OPM` and `Base` to the CircleCI configuration, so that we sync op-node with them during the nightly CI job.

Also add a Slack notification if any of `op-acceptance-sync-tests-docker` runs fail.