### PR TITLE
fix(op-acceptance-tests): wait for fund balance for persistent devnets

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -14,10 +14,6 @@ import (
 	supervisorTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimal())
-}
-
 func TestL1ToL2Deposit(gt *testing.T) {
 	// Create a test environment using op-devstack
 	t := devtest.SerialT(gt)
@@ -30,6 +26,8 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	fundingAmount := eth.ThreeHundredthsEther
 	alice := sys.FunderL1.NewFundedEOA(fundingAmount)
 	t.Log("Alice L1 address", alice.Address())
+
+	alice.WaitForBalance(fundingAmount)
 	initialBalance := alice.GetBalance()
 	t.Log("Alice L1 balance", initialBalance)
 

--- a/op-acceptance-tests/tests/base/deposit/init_test.go
+++ b/op-acceptance-tests/tests/base/deposit/init_test.go
@@ -1,0 +1,11 @@
+package deposit
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithMinimal())
+}

--- a/op-acceptance-tests/tests/isthmus/erc20_bridge/erc20_bridge_test.go
+++ b/op-acceptance-tests/tests/isthmus/erc20_bridge/erc20_bridge_test.go
@@ -40,14 +40,14 @@ func TestERC20Bridge(gt *testing.T) {
 	depositCall := wethContract.Deposit()
 	contract.Write(l1User, depositCall, txplan.WithValue(mintAmount))
 
-	l1User.VerifyTokenBalance(l1TokenAddress, mintAmount)
+	l1User.WaitForTokenBalance(l1TokenAddress, mintAmount)
 	t.Logger().Info("User has WETH tokens on L1", "balance", mintAmount)
 
 	bridge := dsl.NewStandardBridge(t, sys.L2Chain, nil, sys.L1EL)
 	l2TokenAddress := bridge.CreateL2Token(l1TokenAddress, "L2 WETH", "L2WETH", l2User)
 	t.Logger().Info("Created L2 token", "address", l2TokenAddress)
 
-	l2User.VerifyTokenBalance(l2TokenAddress, eth.ZeroWei)
+	l2User.WaitForTokenBalance(l2TokenAddress, eth.ZeroWei)
 
 	l1BridgeAddress := sys.L2Chain.Escape().Deployment().L1StandardBridgeProxyAddr()
 
@@ -63,7 +63,6 @@ func TestERC20Bridge(gt *testing.T) {
 	t.Logger().Info("Waiting for deposit to be processed on L2...")
 	l2User.WaitForTokenBalance(l2TokenAddress, bridgeAmount)
 
-	l2User.VerifyTokenBalance(l2TokenAddress, bridgeAmount)
 	t.Logger().Info("Successfully verified tokens on L2", "balance", bridgeAmount)
 
 	t.Logger().Info("ERC20 bridge test completed successfully!")

--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func TestOperatorFeeDevstack(gt *testing.T) {
+func TestOperatorFee(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	require := t.Require()
@@ -19,14 +19,18 @@ func TestOperatorFeeDevstack(gt *testing.T) {
 	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Isthmus)
 	require.NoError(err, "Isthmus fork must be active for this test")
 
-	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	fundAmount := eth.OneTenthEther
+	alice := sys.FunderL2.NewFundedEOA(fundAmount)
+
+	alice.WaitForBalance(fundAmount)
 	bob := sys.Wallet.NewEOA(sys.L2EL)
 
 	operatorFee := dsl.NewOperatorFee(t, sys.L2Chain, sys.L1EL)
 
 	operatorFee.CheckCompatibility()
 	systemOwner := operatorFee.GetSystemOwner()
-	sys.FunderL1.FundAtLeast(systemOwner, eth.OneTenthEther)
+	sys.FunderL1.FundAtLeast(systemOwner, fundAmount)
+	systemOwner.WaitForBalance(fundAmount)
 
 	// First, ensure L2 is synced with current L1 state before starting tests
 	t.Log("Ensuring L2 is synced with current L1 state...")

--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -30,7 +30,6 @@ func TestOperatorFee(gt *testing.T) {
 	operatorFee.CheckCompatibility()
 	systemOwner := operatorFee.GetSystemOwner()
 	sys.FunderL1.FundAtLeast(systemOwner, fundAmount)
-	systemOwner.WaitForBalance(fundAmount)
 
 	// First, ensure L2 is synced with current L1 state before starting tests
 	t.Log("Ensuring L2 is synced with current L1 state...")

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -153,8 +153,8 @@ func (u *EOA) VerifyBalanceAtLeast(v eth.ETH) {
 
 func (u *EOA) WaitForBalance(v eth.ETH) {
 	u.t.Require().Eventually(func() bool {
-		u.VerifyBalanceExact(v)
-		return true
+		actual := u.balance()
+		return actual == v
 	}, u.el.stackEL().TransactionTimeout(), time.Second, "awaiting balance to be updated")
 }
 

--- a/op-devstack/dsl/funder.go
+++ b/op-devstack/dsl/funder.go
@@ -68,6 +68,9 @@ func (f *Funder) FundAtLeast(wallet *EOA, amount eth.ETH) eth.ETH {
 	if currentBalance.Lt(amount) {
 		missing := amount.Sub(currentBalance)
 		f.faucet.Fund(wallet.Address(), missing)
+		finalBalance := currentBalance.Add(missing)
+		wallet.WaitForBalance(finalBalance)
+		return finalBalance
 	}
 	return currentBalance
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Makes tests wait for the balance to be present. This is required for persistent devnets, as they may not have it initially available after the funding operation / transfers have completed.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
- TestL1ToL2Deposit should now work on Eris.
- TestFees and TestOperatorFees will fail because the L1StandardBridgeProxyAddr and SystemOwnerAddr are apparently not correct when two l2s are in the same devnet env file. Needs further investigation.

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
