### PR TITLE
TimelockGuard add basic configuration functionality

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+
+
+/// @title ITimelockGuard
+/// @notice Interface for the TimelockGuard Safe guard.
+interface ITimelockGuard is IGuard, ISemver {
+    // Errors
+    error TimelockGuard_GuardNotConfigured();
+    error TimelockGuard_GuardNotEnabled();
+    error TimelockGuard_GuardStillEnabled();
+    error TimelockGuard_InvalidTimelockDelay();
+
+    // Events
+    event GuardCleared(address indexed safe);
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    // Views
+    function version() external view returns (string memory);
+
+    function viewTimelockGuardConfiguration(address _safe) external view returns (uint256);
+
+    function cancellationThreshold(address _safe) external view returns (uint256 cancellationThreshold_);
+
+    function safeCancellationThreshold(address) external view returns (uint256);
+
+    function safeConfigs(address)
+        external
+        view
+        returns (uint256 timelockDelay);
+
+    // Admin
+    function configureTimelockGuard(uint256 _timelockDelay) external;
+
+    function clearTimelockGuard() external;
+
+    // Scheduling API (placeholders until fully implemented in the guard)
+    function scheduleTransaction(
+        address _safe,
+        address _to,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation,
+        uint256 _safeTxGas,
+        uint256 _baseGas,
+        uint256 _gasPrice,
+        address _gasToken,
+        address payable _refundReceiver,
+        bytes memory _signatures
+    )
+        external
+        pure;
+
+    function checkPendingTransactions(address _safe) external pure returns (bytes32[] memory pendingTxs_);
+
+    function rejectTransaction(address _safe, bytes32 _txHash) external pure;
+
+    function rejectTransactionWithSignature(address _safe, bytes32 _txHash, bytes memory _signatures) external pure;
+
+    function cancelTransaction(address _safe, bytes32 _txHash) external pure;
+}
+

--- a/packages/contracts-bedrock/snapshots/abi/TimelockGuard.json
+++ b/packages/contracts-bedrock/snapshots/abi/TimelockGuard.json
@@ -1,0 +1,385 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "cancelTransaction",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_safe",
+        "type": "address"
+      }
+    ],
+    "name": "cancellationThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "name": "checkAfterExecution",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "checkPendingTransactions",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "enum Enum.Operation",
+        "name": "",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "checkTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clearTimelockGuard",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_timelockDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "configureTimelockGuard",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "rejectTransaction",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "rejectTransactionWithSignature",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "safeCancellationThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "safeConfigs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timelockDelay",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "enum Enum.Operation",
+        "name": "",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "scheduleTransaction",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_safe",
+        "type": "address"
+      }
+    ],
+    "name": "viewTimelockGuardConfiguration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "safe",
+        "type": "address"
+      }
+    ],
+    "name": "GuardCleared",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timelockDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "GuardConfigured",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_GuardNotConfigured",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_GuardNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_GuardStillEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_InvalidTimelockDelay",
+    "type": "error"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -207,6 +207,10 @@
     "initCodeHash": "0xde3b3273aa37604048b5fa228b90f3b05997db613dfcda45061545a669b2476a",
     "sourceCodeHash": "0x918965e52bbd358ac827ebe35998f5d8fa5ca77d8eb9ab8986b44181b9aaa48a"
   },
+  "src/safe/TimelockGuard.sol:TimelockGuard": {
+    "initCodeHash": "0x5bc2ee2e57f8e4d4713a232a8427997398e1d9cfb26d8afafcccf228820972a6",
+    "sourceCodeHash": "0x2f23c80216ea80843414d6bcab10237964a8039e4d712c7cc3e65d57278067df"
+  },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0xc3289416829b252c830ad7d389a430986a7404df4fe0be37cb19e1c40907f047",
     "sourceCodeHash": "0xf5e29dd5c750ea935c7281ec916ba5277f5610a0a9e984e53ae5d5245b3cf2f4"

--- a/packages/contracts-bedrock/snapshots/storageLayout/TimelockGuard.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/TimelockGuard.json
@@ -1,0 +1,16 @@
+[
+  {
+    "bytes": "32",
+    "label": "safeConfigs",
+    "offset": 0,
+    "slot": "0",
+    "type": "mapping(address => struct TimelockGuard.GuardConfig)"
+  },
+  {
+    "bytes": "32",
+    "label": "safeCancellationThreshold",
+    "offset": 0,
+    "slot": "1",
+    "type": "mapping(address => uint256)"
+  }
+]

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -117,17 +117,7 @@ contract TimelockGuard is IGuard, ISemver {
             return 0;
         }
 
-        // Return 0 if not configured
-        if (safeConfigs[_safe].timelockDelay == 0) {
-            return 0;
-        }
-
-        uint256 threshold = safeCancellationThreshold[_safe];
-        if (threshold == 0) {
-            // Default to 1 if not set
-            return 1;
-        }
-        return threshold;
+        return safeCancellationThreshold[_safe];
     }
 
     /// @notice Internal helper to get the guard address from a Safe

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -143,17 +143,17 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Schedule a transaction for execution after the timelock delay
     /// @dev Called by anyone using signatures from Safe owners - NOT IMPLEMENTED YET
     function scheduleTransaction(
-        address, /* safe */
-        address, /* to */
-        uint256, /* value */
-        bytes memory, /* data */
-        Enum.Operation, /* operation */
-        uint256, /* safeTxGas */
-        uint256, /* baseGas */
-        uint256, /* gasPrice */
-        address, /* gasToken */
-        address payable, /* refundReceiver */
-        bytes memory /* signatures */
+        address,
+        address,
+        uint256,
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory
     )
         external
         pure
@@ -164,42 +164,42 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
     /// @dev MUST NOT revert - NOT IMPLEMENTED YET
     /// @return List of pending transaction hashes
-    function checkPendingTransactions(address /* _safe */) external pure returns (bytes32[] memory) {
+    function checkPendingTransactions(address) external pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
     /// @notice Signal rejection of a scheduled transaction by a Safe owner
     /// @dev NOT IMPLEMENTED YET
-    function rejectTransaction(address /* safe */, bytes32 /* txHash */) external pure {
+    function rejectTransaction(address, bytes32) external pure {
         // TODO: Implement
     }
 
     /// @notice Signal rejection of a scheduled transaction using signatures
     /// @dev NOT IMPLEMENTED YET
-    function rejectTransactionWithSignature(address /* safe */, bytes32 /* txHash */, bytes memory /* signatures */) external pure {
+    function rejectTransactionWithSignature(address, bytes32, bytes memory) external pure {
         // TODO: Implement
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
     /// @dev NOT IMPLEMENTED YET
-    function cancelTransaction(address /* safe */, bytes32 /* txHash */) external pure {
+    function cancelTransaction(address, bytes32) external pure {
         // TODO: Implement
     }
 
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
-        address /* _to */,
+        address,
         uint256 _value,
-        bytes memory /* _data */,
-        Enum.Operation /* _operation */,
-        uint256 /* _safeTxGas */,
-        uint256 /* _baseGas */,
-        uint256 /* _gasPrice */,
-        address /* _gasToken */,
-        address payable /* _refundReceiver */,
-        bytes memory /* _signatures */,
-        address /* _msgSender */
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
     )
         external
         override
@@ -209,7 +209,7 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Called by the Safe after executing a transaction
     /// @dev Implementation of IGuard interface
-    function checkAfterExecution(bytes32 /* _txHash */, bool /* _success */) external override {
+    function checkAfterExecution(bytes32, bool) external override {
         // TODO: Implement
     }
 }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -58,7 +58,7 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Configure the contract as a timelock guard by setting the timelock delay
     /// @dev MUST allow an arbitrary number of Safe contracts to use the contract as a guard
-    /// @dev The contract MUST be enabled as a guard for the Safe
+    /// @dev MUST revert if the contract is not enabled as a guard for the Safe
     /// @dev MUST revert if timelock_delay is longer than 1 year
     /// @dev MUST set the caller as a Safe
     /// @dev MUST take timelock_delay as a parameter and store it as related to the Safe
@@ -85,7 +85,7 @@ contract TimelockGuard is IGuard, ISemver {
     }
 
     /// @notice Remove the timelock guard configuration by a previously enabled Safe
-    /// @dev The contract MUST NOT be enabled as a guard for the Safe
+    /// @dev MUST revert if the contract is not enabled as a guard for the Safe
     /// @dev MUST erase the existing timelock_delay data related to the calling Safe
     /// @dev MUST emit a GuardCleared event
     function clearTimelockGuard() external {
@@ -124,8 +124,6 @@ contract TimelockGuard is IGuard, ISemver {
 
         uint256 threshold = safeCancellationThreshold[_safe];
         if (threshold == 0) {
-            // NOTE: not sure if this is the right thing to do.
-            //    defaulting to one is good to prevent us from forgetting to set it to one elsewhere.
             // Default to 1 if not set
             return 1;
         }
@@ -139,7 +137,7 @@ contract TimelockGuard is IGuard, ISemver {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
         Safe safe = Safe(payable(_safe));
-        return abi.decode(safe.getStorageAt({ offset: uint256(guardSlot), length: 1 }), (address));
+        return abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
     }
 
     /// @notice Schedule a transaction for execution after the timelock delay

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -66,7 +66,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @param _timelockDelay The timelock delay in seconds
     function configureTimelockGuard(uint256 _timelockDelay) external {
         // Validate timelock delay - must be non-zero and not longer than 1 year
-        if (_timelockDelay > 365 days) {
+        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
             revert TimelockGuard_InvalidTimelockDelay();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -66,12 +66,12 @@ contract TimelockGuard is IGuard, ISemver {
     /// @param _timelockDelay The timelock delay in seconds
     function configureTimelockGuard(uint256 _timelockDelay) external {
         // Validate timelock delay - must be non-zero and not longer than 1 year
-        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
+        if (_timelockDelay > 365 days) {
             revert TimelockGuard_InvalidTimelockDelay();
         }
 
         // Check that this guard is enabled on the calling Safe
-        if (_getGuard(msg.sender) != address(this)) {
+        if (!_isGuardEnabled(msg.sender)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
@@ -95,7 +95,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that this guard is NOT enabled on the calling Safe
-        if (_getGuard(msg.sender) == address(this)) {
+        if (_isGuardEnabled(msg.sender)) {
             revert TimelockGuard_GuardStillEnabled();
         }
 
@@ -113,7 +113,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @return The current cancellation threshold
     function cancellationThreshold(address _safe) public view returns (uint256) {
         // Return 0 if guard is not enabled
-        if (_getGuard(_safe) != address(this)) {
+        if (!_isGuardEnabled(_safe)) {
             return 0;
         }
 
@@ -123,11 +123,12 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Internal helper to get the guard address from a Safe
     /// @param _safe The Safe address
     /// @return The current guard address
-    function _getGuard(address _safe) internal view returns (address) {
+    function _isGuardEnabled(address _safe) internal view returns (bool) {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
         Safe safe = Safe(payable(_safe));
-        return abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
+        address guard = abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
+        return guard == address(this);
     }
 
     /// @notice Schedule a transaction for execution after the timelock delay

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -141,63 +141,48 @@ contract TimelockGuard is IGuard, ISemver {
     }
 
     /// @notice Schedule a transaction for execution after the timelock delay
-    /// @dev Called by anyone using signatures from Safe owners
-    /// @param safe The Safe address
-    /// @param to Transaction target address
-    /// @param value Transaction value
-    /// @param data Transaction data
-    /// @param operation Transaction operation type
-    /// @param safeTxGas Safe transaction gas
-    /// @param baseGas Base gas for transaction
-    /// @param gasPrice Gas price
-    /// @param gasToken Gas token address
-    /// @param refundReceiver Refund receiver address
-    /// @param signatures Transaction signatures
+    /// @dev Called by anyone using signatures from Safe owners - NOT IMPLEMENTED YET
     function scheduleTransaction(
-        address safe,
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver,
-        bytes memory signatures
+        address, /* safe */
+        address, /* to */
+        uint256, /* value */
+        bytes memory, /* data */
+        Enum.Operation, /* operation */
+        uint256, /* safeTxGas */
+        uint256, /* baseGas */
+        uint256, /* gasPrice */
+        address, /* gasToken */
+        address payable, /* refundReceiver */
+        bytes memory /* signatures */
     )
         external
+        pure
     {
         revert("Not implemented yet");
     }
 
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
-    /// @dev MUST NOT revert
-    /// @param _safe The Safe address to query
+    /// @dev MUST NOT revert - NOT IMPLEMENTED YET
     /// @return List of pending transaction hashes
-    function checkPendingTransactions(address _safe) external view returns (bytes32[] memory) {
+    function checkPendingTransactions(address /* _safe */) external pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
     /// @notice Signal rejection of a scheduled transaction by a Safe owner
-    /// @param safe The Safe address that scheduled the transaction
-    /// @param txHash The transaction hash to reject
-    function rejectTransaction(address safe, bytes32 txHash) external {
+    /// @dev NOT IMPLEMENTED YET
+    function rejectTransaction(address /* safe */, bytes32 /* txHash */) external pure {
         revert("Not implemented yet");
     }
 
     /// @notice Signal rejection of a scheduled transaction using signatures
-    /// @param safe The Safe address that scheduled the transaction
-    /// @param txHash The transaction hash to reject
-    /// @param signatures Owner signatures rejecting the transaction
-    function rejectTransactionWithSignature(address safe, bytes32 txHash, bytes memory signatures) external {
+    /// @dev NOT IMPLEMENTED YET
+    function rejectTransactionWithSignature(address /* safe */, bytes32 /* txHash */, bytes memory /* signatures */) external pure {
         revert("Not implemented yet");
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
-    /// @param safe The Safe address that scheduled the transaction
-    /// @param txHash The transaction hash to cancel
-    function cancelTransaction(address safe, bytes32 txHash) external {
+    /// @dev NOT IMPLEMENTED YET
+    function cancelTransaction(address /* safe */, bytes32 /* txHash */) external pure {
         revert("Not implemented yet");
     }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Safe
+import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { GuardManager, Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+
+// Interfaces
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+/// @title TimelockGuard
+/// @notice This guard provides timelock functionality for Safe transactions
+/// @dev This is a singleton contract. To use it:
+///      1. The Safe must first enable this guard using GuardManager.setGuard()
+///      2. The Safe must then configure the guard by calling configureTimelockGuard()
+contract TimelockGuard is IGuard, ISemver {
+    /// @notice Configuration for a Safe's timelock guard
+    struct GuardConfig {
+        uint256 timelockDelay;
+    }
+
+    /// @notice Mapping from Safe address to its guard configuration
+    mapping(address => GuardConfig) public safeConfigs;
+
+    /// @notice Error for when guard is not enabled for the Safe
+    error TimelockGuard_GuardNotEnabled();
+
+    /// @notice Error for invalid timelock delay
+    error TimelockGuard_InvalidTimelockDelay();
+
+    /// @notice Emitted when a Safe configures the guard
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.0.0
+    string public constant version = "1.0.0";
+
+    /// @notice Returns the timelock delay for a given Safe
+    /// @dev MUST never revert
+    /// @param _safe The Safe address to query
+    /// @return The timelock delay in seconds
+    function viewTimelockGuardConfiguration(address _safe) public view returns (uint256) {
+        return safeConfigs[_safe].timelockDelay;
+    }
+
+    /// @notice Configure the contract as a timelock guard by setting the timelock delay
+    /// @dev MUST allow an arbitrary number of Safe contracts to use the contract as a guard
+    /// @dev The contract MUST be enabled as a guard for the Safe
+    /// @dev MUST revert if timelock_delay is longer than 1 year
+    /// @dev MUST set the caller as a Safe
+    /// @dev MUST take timelock_delay as a parameter and store it as related to the Safe
+    /// @dev MUST emit a GuardConfigured event with at least timelock_delay as a parameter
+    /// @param _timelockDelay The timelock delay in seconds
+    function configureTimelockGuard(uint256 _timelockDelay) external {
+        // Validate timelock delay - must be non-zero and not longer than 1 year
+        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
+            revert TimelockGuard_InvalidTimelockDelay();
+        }
+
+        // Check that this guard is enabled on the calling Safe
+        Safe safe = Safe(payable(msg.sender));
+        // The Safe contract does not expose a getGuard function, so we need to provide the
+        // the storage slot to the getStorageAt function.
+        // keccak256("guard_manager.guard.address") from GuardManager
+        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
+
+        if (guard != address(this)) {
+            revert TimelockGuard_GuardNotEnabled();
+        }
+
+        // Store the configuration for this safe
+        safeConfigs[msg.sender].timelockDelay = _timelockDelay;
+
+        emit GuardConfigured(msg.sender, _timelockDelay);
+    }
+
+    /// @notice Called by the Safe before executing a transaction
+    /// @dev Implementation of IGuard interface
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external override {
+        // Empty implementation for now - will be filled in when implementing checkTransaction
+    }
+
+    /// @notice Called by the Safe after executing a transaction
+    /// @dev Implementation of IGuard interface
+    function checkAfterExecution(bytes32 txHash, bool success) external override {
+        // Empty implementation for now
+    }
+}

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -142,6 +142,67 @@ contract TimelockGuard is IGuard, ISemver {
         return abi.decode(safe.getStorageAt({ offset: uint256(guardSlot), length: 1 }), (address));
     }
 
+    /// @notice Schedule a transaction for execution after the timelock delay
+    /// @dev Called by anyone using signatures from Safe owners
+    /// @param safe The Safe address
+    /// @param to Transaction target address
+    /// @param value Transaction value
+    /// @param data Transaction data
+    /// @param operation Transaction operation type
+    /// @param safeTxGas Safe transaction gas
+    /// @param baseGas Base gas for transaction
+    /// @param gasPrice Gas price
+    /// @param gasToken Gas token address
+    /// @param refundReceiver Refund receiver address
+    /// @param signatures Transaction signatures
+    function scheduleTransaction(
+        address safe,
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures
+    )
+        external
+    {
+        revert("Not implemented yet");
+    }
+
+    /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
+    /// @dev MUST NOT revert
+    /// @param _safe The Safe address to query
+    /// @return List of pending transaction hashes
+    function checkPendingTransactions(address _safe) external view returns (bytes32[] memory) {
+        return new bytes32[](0);
+    }
+
+    /// @notice Signal rejection of a scheduled transaction by a Safe owner
+    /// @param safe The Safe address that scheduled the transaction
+    /// @param txHash The transaction hash to reject
+    function rejectTransaction(address safe, bytes32 txHash) external {
+        revert("Not implemented yet");
+    }
+
+    /// @notice Signal rejection of a scheduled transaction using signatures
+    /// @param safe The Safe address that scheduled the transaction
+    /// @param txHash The transaction hash to reject
+    /// @param signatures Owner signatures rejecting the transaction
+    function rejectTransactionWithSignature(address safe, bytes32 txHash, bytes memory signatures) external {
+        revert("Not implemented yet");
+    }
+
+    /// @notice Cancel a scheduled transaction if cancellation threshold is met
+    /// @param safe The Safe address that scheduled the transaction
+    /// @param txHash The transaction hash to cancel
+    function cancelTransaction(address safe, bytes32 txHash) external {
+        revert("Not implemented yet");
+    }
+
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
@@ -160,7 +221,7 @@ contract TimelockGuard is IGuard, ISemver {
         external
         override
     {
-        // Empty implementation for now - will be filled in when implementing checkTransaction
+        // Empty implementation for now
     }
 
     /// @notice Called by the Safe after executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -158,7 +158,7 @@ contract TimelockGuard is IGuard, ISemver {
         external
         pure
     {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
@@ -171,45 +171,45 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Signal rejection of a scheduled transaction by a Safe owner
     /// @dev NOT IMPLEMENTED YET
     function rejectTransaction(address /* safe */, bytes32 /* txHash */) external pure {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Signal rejection of a scheduled transaction using signatures
     /// @dev NOT IMPLEMENTED YET
     function rejectTransactionWithSignature(address /* safe */, bytes32 /* txHash */, bytes memory /* signatures */) external pure {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
     /// @dev NOT IMPLEMENTED YET
     function cancelTransaction(address /* safe */, bytes32 /* txHash */) external pure {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver,
-        bytes memory signatures,
-        address msgSender
+        address /* _to */,
+        uint256 _value,
+        bytes memory /* _data */,
+        Enum.Operation /* _operation */,
+        uint256 /* _safeTxGas */,
+        uint256 /* _baseGas */,
+        uint256 /* _gasPrice */,
+        address /* _gasToken */,
+        address payable /* _refundReceiver */,
+        bytes memory /* _signatures */,
+        address /* _msgSender */
     )
         external
         override
     {
-        // Empty implementation for now
+        // TODO: Implement
     }
 
     /// @notice Called by the Safe after executing a transaction
     /// @dev Implementation of IGuard interface
-    function checkAfterExecution(bytes32 txHash, bool success) external override {
-        // Empty implementation for now
+    function checkAfterExecution(bytes32 /* _txHash */, bool /* _success */) external override {
+        // TODO: Implement
     }
 }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -23,6 +23,9 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Mapping from Safe address to its guard configuration
     mapping(address => GuardConfig) public safeConfigs;
 
+    /// @notice Mapping from Safe address to its current cancellation threshold
+    mapping(address => uint256) public safeCancellationThreshold;
+
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
 
@@ -75,6 +78,9 @@ contract TimelockGuard is IGuard, ISemver {
         // Store the configuration for this safe
         safeConfigs[msg.sender].timelockDelay = _timelockDelay;
 
+        // Initialize cancellation threshold to 1
+        safeCancellationThreshold[msg.sender] = 1;
+
         emit GuardConfigured(msg.sender, _timelockDelay);
     }
 
@@ -95,8 +101,35 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Erase the configuration data for this safe
         delete safeConfigs[msg.sender];
+        delete safeCancellationThreshold[msg.sender];
 
         emit GuardCleared(msg.sender);
+    }
+
+    /// @notice Returns the cancellation threshold for a given safe
+    /// @dev MUST NOT revert
+    /// @dev MUST return 0 if the contract is not enabled as a guard for the safe
+    /// @param _safe The Safe address to query
+    /// @return The current cancellation threshold
+    function cancellationThreshold(address _safe) public view returns (uint256) {
+        // Return 0 if guard is not enabled
+        if (_getGuard(_safe) != address(this)) {
+            return 0;
+        }
+
+        // Return 0 if not configured
+        if (safeConfigs[_safe].timelockDelay == 0) {
+            return 0;
+        }
+
+        uint256 threshold = safeCancellationThreshold[_safe];
+        if (threshold == 0) {
+            // NOTE: not sure if this is the right thing to do.
+            //    defaulting to one is good to prevent us from forgetting to set it to one elsewhere.
+            // Default to 1 if not set
+            return 1;
+        }
+        return threshold;
     }
 
     /// @notice Internal helper to get the guard address from a Safe
@@ -106,7 +139,7 @@ contract TimelockGuard is IGuard, ISemver {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
         Safe safe = Safe(payable(_safe));
-        return abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
+        return abi.decode(safe.getStorageAt({ offset: uint256(guardSlot), length: 1 }), (address));
     }
 
     /// @notice Called by the Safe before executing a transaction
@@ -123,7 +156,10 @@ contract TimelockGuard is IGuard, ISemver {
         address payable refundReceiver,
         bytes memory signatures,
         address msgSender
-    ) external override {
+    )
+        external
+        override
+    {
         // Empty implementation for now - will be filled in when implementing checkTransaction
     }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -68,14 +68,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that this guard is enabled on the calling Safe
-        Safe safe = Safe(payable(msg.sender));
-        // The Safe contract does not expose a getGuard function, so we need to provide the
-        // the storage slot to the getStorageAt function.
-        // keccak256("guard_manager.guard.address") from GuardManager
-        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
-        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
-
-        if (guard != address(this)) {
+        if (_getGuard(msg.sender) != address(this)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
@@ -96,12 +89,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that this guard is NOT enabled on the calling Safe
-        Safe safe = Safe(payable(msg.sender));
-        // keccak256("guard_manager.guard.address") from GuardManager
-        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
-        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
-
-        if (guard == address(this)) {
+        if (_getGuard(msg.sender) == address(this)) {
             revert TimelockGuard_GuardStillEnabled();
         }
 
@@ -109,6 +97,16 @@ contract TimelockGuard is IGuard, ISemver {
         delete safeConfigs[msg.sender];
 
         emit GuardCleared(msg.sender);
+    }
+
+    /// @notice Internal helper to get the guard address from a Safe
+    /// @param _safe The Safe address
+    /// @return The current guard address
+    function _getGuard(address _safe) internal view returns (address) {
+        // keccak256("guard_manager.guard.address") from GuardManager
+        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+        Safe safe = Safe(payable(_safe));
+        return abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
     }
 
     /// @notice Called by the Safe before executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -26,11 +26,20 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
 
+    /// @notice Error for when Safe is not configured for this guard
+    error TimelockGuard_GuardNotConfigured();
+
+    /// @notice Error for when attempt to clear guard while it is still enabled for the Safe
+    error TimelockGuard_GuardStillEnabled();
+
     /// @notice Error for invalid timelock delay
     error TimelockGuard_InvalidTimelockDelay();
 
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    /// @notice Emitted when a Safe clears the guard configuration
+    event GuardCleared(address indexed safe);
 
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
@@ -74,6 +83,32 @@ contract TimelockGuard is IGuard, ISemver {
         safeConfigs[msg.sender].timelockDelay = _timelockDelay;
 
         emit GuardConfigured(msg.sender, _timelockDelay);
+    }
+
+    /// @notice Remove the timelock guard configuration by a previously enabled Safe
+    /// @dev The contract MUST NOT be enabled as a guard for the Safe
+    /// @dev MUST erase the existing timelock_delay data related to the calling Safe
+    /// @dev MUST emit a GuardCleared event
+    function clearTimelockGuard() external {
+        // Check if the calling safe has configuration set
+        if (safeConfigs[msg.sender].timelockDelay == 0) {
+            revert TimelockGuard_GuardNotConfigured();
+        }
+
+        // Check that this guard is NOT enabled on the calling Safe
+        Safe safe = Safe(payable(msg.sender));
+        // keccak256("guard_manager.guard.address") from GuardManager
+        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
+
+        if (guard == address(this)) {
+            revert TimelockGuard_GuardStillEnabled();
+        }
+
+        // Erase the configuration data for this safe
+        delete safeConfigs[msg.sender];
+
+        emit GuardCleared(msg.sender);
     }
 
     /// @notice Called by the Safe before executing a transaction

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { GuardManager } from "safe-contracts/base/GuardManager.sol";
+import { StorageAccessible } from "safe-contracts/common/StorageAccessible.sol";
+import "test/safe-tools/SafeTestTools.sol";
+
+import { TimelockGuard } from "src/safe/TimelockGuard.sol";
+
+/// @title TimelockGuard_TestInit
+/// @notice Reusable test initialization for `TimelockGuard` tests.
+contract TimelockGuard_TestInit is Test, SafeTestTools {
+    using SafeTestLib for SafeInstance;
+
+    // Events
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    uint256 constant INIT_TIME = 10;
+    uint256 constant TIMELOCK_DELAY = 7 days;
+    uint256 constant NUM_OWNERS = 5;
+    uint256 constant THRESHOLD = 3;
+    uint256 constant ONE_YEAR = 365 days;
+
+    TimelockGuard timelockGuard;
+    SafeInstance safeInstance;
+    SafeInstance safeInstance2;
+    address[] owners;
+    uint256[] ownerPKs;
+
+    function setUp() public virtual {
+        vm.warp(INIT_TIME);
+
+        // Deploy the singleton TimelockGuard
+        timelockGuard = new TimelockGuard();
+
+        // Create Safe owners
+        (address[] memory _owners, uint256[] memory _keys) = SafeTestLib.makeAddrsAndKeys("owners", NUM_OWNERS);
+        owners = _owners;
+        ownerPKs = _keys;
+
+        // Set up Safe with owners
+        safeInstance = _setupSafe(ownerPKs, THRESHOLD);
+
+        // Enable the guard on the Safe
+        SafeTestLib.execTransaction(
+            safeInstance,
+            address(safeInstance.safe),
+            0,
+            abi.encodeCall(GuardManager.setGuard, (address(timelockGuard))),
+            Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to configure the TimelockGuard for a Safe
+    function _configureGuard(SafeInstance memory _safe, uint256 _delay) internal {
+        SafeTestLib.execTransaction(
+            _safe,
+            address(timelockGuard),
+            0,
+            abi.encodeCall(TimelockGuard.configureTimelockGuard, (_delay)),
+            Enum.Operation.Call
+        );
+    }
+}
+
+/// @title TimelockGuard_ViewTimelockGuardConfiguration_Test
+/// @notice Tests for viewTimelockGuardConfiguration function
+contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_TestInit {
+    function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe() external view {
+        uint256 delay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        assertEq(delay, 0);
+    }
+}
+
+/// @title TimelockGuard_ConfigureTimelockGuard_Test
+/// @notice Tests for configureTimelockGuard function
+contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
+    function test_configureTimelockGuard_succeeds() external {
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(address(safeInstance.safe), TIMELOCK_DELAY);
+
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+
+        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        assertEq(storedDelay, TIMELOCK_DELAY);
+    }
+
+    function test_configureTimelockGuard_revertsIfGuardNotEnabled() external {
+        // Create a safe without enabling the guard
+        // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
+        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD-1);
+
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
+        vm.prank(address(unguardedSafe.safe));
+        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
+    }
+
+    function test_configureTimelockGuard_revertsIfDelayTooLong() external {
+        uint256 tooLongDelay = ONE_YEAR + 1;
+
+        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(tooLongDelay);
+    }
+
+    function test_configureTimelockGuard_revertsIfDelayZero() external {
+        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(0);
+    }
+
+    function test_configureTimelockGuard_acceptsMaxValidDelay() external {
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);
+
+        _configureGuard(safeInstance, ONE_YEAR);
+
+        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        assertEq(storedDelay, ONE_YEAR);
+    }
+
+    function test_configureTimelockGuard_allowsReconfiguration() external {
+        // Initial configuration
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
+
+        // Reconfigure with different delay
+        uint256 newDelay = 14 days;
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(address(safeInstance.safe), newDelay);
+
+        _configureGuard(safeInstance, newDelay);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), newDelay);
+    }
+}

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -120,12 +120,6 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(tooLongDelay);
     }
 
-    function test_configureTimelockGuard_revertsIfDelayZero_reverts() external {
-        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
-        vm.prank(address(safeInstance.safe));
-        timelockGuard.configureTimelockGuard(0);
-    }
-
     function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -68,22 +68,14 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     /// @notice Helper to disable guard on a Safe
     function _disableGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe,
-            address(_safe.safe),
-            0,
-            abi.encodeCall(GuardManager.setGuard, (address(0))),
-            Enum.Operation.Call
+            _safe, address(_safe.safe), 0, abi.encodeCall(GuardManager.setGuard, (address(0))), Enum.Operation.Call
         );
     }
 
     /// @notice Helper to clear the TimelockGuard configuration for a Safe
     function _clearGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe,
-            address(timelockGuard),
-            0,
-            abi.encodeCall(TimelockGuard.clearTimelockGuard, ()),
-            Enum.Operation.Call
+            _safe, address(timelockGuard), 0, abi.encodeCall(TimelockGuard.clearTimelockGuard, ()), Enum.Operation.Call
         );
     }
 }
@@ -113,7 +105,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     function test_configureTimelockGuard_revertsIfGuardNotEnabled() external {
         // Create a safe without enabling the guard
         // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
-        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD-1);
+        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
         vm.prank(address(unguardedSafe.safe));
@@ -178,6 +170,9 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 
         // Configuration should be cleared
         assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), 0);
+        // Ensure cancellation threshold is reset to 0
+        assertEq(timelockGuard.cancellationThreshold(address(safeInstance.safe)), 0);
+
         // TODO: Check that any active challenge is cancelled
     }
 
@@ -197,4 +192,34 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         vm.prank(address(safeInstance.safe));
         timelockGuard.clearTimelockGuard();
     }
+}
+
+/// @title TimelockGuard_CancellationThreshold_Test
+/// @notice Tests for cancellationThreshold function
+contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
+    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled() external {
+        // Safe without guard enabled should return 0
+        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
+
+        uint256 threshold = timelockGuard.cancellationThreshold(address(unguardedSafe.safe));
+        assertEq(threshold, 0);
+    }
+
+    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured() external {
+        // Safe with guard enabled but not configured should return 0
+        uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        assertEq(threshold, 0);
+    }
+
+    function test_cancellationThreshold_returnsOneAfterConfiguration() external {
+        // Configure the guard
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+
+        // Should default to 1 after configuration
+        uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        assertEq(threshold, 1);
+    }
+
+    // Note: Testing increment/decrement behavior will require scheduleTransaction,
+    // cancelTransaction and execution functions to be implemented first
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -83,7 +83,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 /// @title TimelockGuard_ViewTimelockGuardConfiguration_Test
 /// @notice Tests for viewTimelockGuardConfiguration function
 contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_TestInit {
-    function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe() external view {
+    function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe_succeeds() external view {
         uint256 delay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
         assertEq(delay, 0);
     }
@@ -102,7 +102,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         assertEq(storedDelay, TIMELOCK_DELAY);
     }
 
-    function test_configureTimelockGuard_revertsIfGuardNotEnabled() external {
+    function test_configureTimelockGuard_revertsIfGuardNotEnabled_reverts() external {
         // Create a safe without enabling the guard
         // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
         SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
@@ -112,7 +112,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }
 
-    function test_configureTimelockGuard_revertsIfDelayTooLong() external {
+    function test_configureTimelockGuard_revertsIfDelayTooLong_reverts() external {
         uint256 tooLongDelay = ONE_YEAR + 1;
 
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
@@ -120,13 +120,13 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(tooLongDelay);
     }
 
-    function test_configureTimelockGuard_revertsIfDelayZero() external {
+    function test_configureTimelockGuard_revertsIfDelayZero_reverts() external {
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
         vm.prank(address(safeInstance.safe));
         timelockGuard.configureTimelockGuard(0);
     }
 
-    function test_configureTimelockGuard_acceptsMaxValidDelay() external {
+    function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);
 
@@ -136,7 +136,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         assertEq(storedDelay, ONE_YEAR);
     }
 
-    function test_configureTimelockGuard_allowsReconfiguration() external {
+    function test_configureTimelockGuard_allowsReconfiguration_succeeds() external {
         // Initial configuration
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
@@ -176,7 +176,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         // TODO: Check that any active challenge is cancelled
     }
 
-    function test_clearTimelockGuard_revertsIfGuardStillEnabled() external {
+    function test_clearTimelockGuard_revertsIfGuardStillEnabled_reverts() external {
         // First configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 
@@ -186,7 +186,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.clearTimelockGuard();
     }
 
-    function test_clearTimelockGuard_revertsIfNotConfigured() external {
+    function test_clearTimelockGuard_revertsIfNotConfigured_reverts() external {
         // Try to clear - should revert because not configured
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
         vm.prank(address(safeInstance.safe));
@@ -197,7 +197,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 /// @title TimelockGuard_CancellationThreshold_Test
 /// @notice Tests for cancellationThreshold function
 contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
-    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled() external {
+    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled_succeeds() external {
         // Safe without guard enabled should return 0
         SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
 
@@ -205,13 +205,13 @@ contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
         assertEq(threshold, 0);
     }
 
-    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured() external {
+    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured_succeeds() external {
         // Safe with guard enabled but not configured should return 0
         uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
         assertEq(threshold, 0);
     }
 
-    function test_cancellationThreshold_returnsOneAfterConfiguration() external {
+    function test_cancellationThreshold_returnsOneAfterConfiguration_succeeds() external {
         // Configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -16,6 +16,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
     // Events
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
+    event GuardCleared(address indexed safe);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -60,6 +61,28 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
             address(timelockGuard),
             0,
             abi.encodeCall(TimelockGuard.configureTimelockGuard, (_delay)),
+            Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to disable guard on a Safe
+    function _disableGuard(SafeInstance memory _safe) internal {
+        SafeTestLib.execTransaction(
+            _safe,
+            address(_safe.safe),
+            0,
+            abi.encodeCall(GuardManager.setGuard, (address(0))),
+            Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to clear the TimelockGuard configuration for a Safe
+    function _clearGuard(SafeInstance memory _safe) internal {
+        SafeTestLib.execTransaction(
+            _safe,
+            address(timelockGuard),
+            0,
+            abi.encodeCall(TimelockGuard.clearTimelockGuard, ()),
             Enum.Operation.Call
         );
     }
@@ -133,5 +156,45 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
         _configureGuard(safeInstance, newDelay);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), newDelay);
+    }
+}
+
+/// @title TimelockGuard_ClearTimelockGuard_Test
+/// @notice Tests for clearTimelockGuard function
+contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
+    function test_clearTimelockGuard_succeeds() external {
+        // First configure the guard
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
+
+        // Disable the guard first
+        _disableGuard(safeInstance);
+
+        // Clear should succeed and emit event
+        vm.expectEmit(true, true, true, true);
+        emit GuardCleared(address(safeInstance.safe));
+
+        _clearGuard(safeInstance);
+
+        // Configuration should be cleared
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), 0);
+        // TODO: Check that any active challenge is cancelled
+    }
+
+    function test_clearTimelockGuard_revertsIfGuardStillEnabled() external {
+        // First configure the guard
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+
+        // Try to clear without disabling guard first - should revert
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardStillEnabled.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.clearTimelockGuard();
+    }
+
+    function test_clearTimelockGuard_revertsIfNotConfigured() external {
+        // Try to clear - should revert because not configured
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.clearTimelockGuard();
     }
 }


### PR DESCRIPTION
**Description**

This is the first PR in a forthcoming stack (expect 1 or 2 more PRs), which establishes the outline of the TimelockGuard contract.

It fully implements and tests the following functions of the TimelockGuard listed in the [specs](https://github.com/ethereum-optimism/specs/pull/761):

- `viewTimelockGuardConfiguration`
- `configureTimelockGuard`
- `clearTimelockGuard`
- `cancellationThreshold`

It also includes empty placeholders for the following functions: 
- `scheduleTransaction`
- `checkTransaction`
- `checkPendingTransactions`
- `rejectTransaction`
- `rejectTransactionWithSignature`
- `cancelTransaction`

This PR does not combine the TimelockGuard and LivenessModule2, that is done in #17402. 