### PR TITLE
codecov: enable coverage for MIPS64 contracts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,11 +15,6 @@ ignore:
   - "packages/contracts-bedrock/scripts/**/*.sol"
   - "packages/contracts-bedrock/src/vendor/**/*.sol"
   - "packages/contracts-bedrock/src/interfaces/**/*.sol"
-  # TODO: add coverage for MIPS64 back once tests are merged in
-  - "packages/contracts-bedrock/src/cannon/MIPS64.sol"
-  - "packages/contracts-bedrock/src/cannon/libraries/MIPS64Instructions.sol"
-  - "packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol"
-  - "packages/contracts-bedrock/src/cannon/libraries/MIPS64Syscalls.sol"
 
 coverage:
   status:


### PR DESCRIPTION
Remove outdated MIPS64 exclusions from codecov configuration.

The TODO comment mentioned adding coverage "once tests are merged in" - this condition has been met since October 2024. MIPS64 tests and implementations are fully merged and running in CI.

**Evidence that tests are merged:**
- #12653: MIPS64Memory.sol implementation and tests (Oct 29, 2024)  
- #12665: Complete 64-bit Solidity VM with differential testing (Oct 30, 2024)
- #12483: Full 64-bit instruction emulation with extensive test coverage (Oct 23, 2024)
- #16211: Test structure improvements and documentation (Jun 4, 2025)