### PR TITLE
fix(op-deployer): EnsureDefaultCacheDir

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -2,9 +2,6 @@ package deployer
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 
@@ -31,40 +28,6 @@ const (
 	ContractNameFlagName     = "contract-name"
 )
 
-type DeploymentTarget string
-
-const (
-	DeploymentTargetLive     DeploymentTarget = "live"
-	DeploymentTargetGenesis  DeploymentTarget = "genesis"
-	DeploymentTargetCalldata DeploymentTarget = "calldata"
-	DeploymentTargetNoop     DeploymentTarget = "noop"
-)
-
-func NewDeploymentTarget(s string) (DeploymentTarget, error) {
-	switch s {
-	case string(DeploymentTargetLive):
-		return DeploymentTargetLive, nil
-	case string(DeploymentTargetGenesis):
-		return DeploymentTargetGenesis, nil
-	case string(DeploymentTargetCalldata):
-		return DeploymentTargetCalldata, nil
-	case string(DeploymentTargetNoop):
-		return DeploymentTargetNoop, nil
-	default:
-		return "", fmt.Errorf("invalid deployment target: %s", s)
-	}
-}
-
-func GetDefaultCacheDir() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		fallbackDir := ".op-deployer/cache"
-		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, fallbackDir)
-		return fallbackDir
-	}
-	return path.Join(homeDir, ".op-deployer/cache")
-}
-
 var (
 	L1RPCURLFlag = &cli.StringFlag{
 		Name: L1RPCURLFlagName,
@@ -85,7 +48,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   GetDefaultCacheDir(),
+		Value:   EnsureDefaultCacheDir(),
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,
@@ -186,12 +149,4 @@ var VerifyFlags = []cli.Flag{
 
 func PrefixEnvVar(name string) []string {
 	return op_service.PrefixEnvVar(EnvVarPrefix, name)
-}
-
-func cwd() string {
-	dir, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	return dir
 }

--- a/op-deployer/pkg/deployer/utils.go
+++ b/op-deployer/pkg/deployer/utils.go
@@ -1,0 +1,58 @@
+package deployer
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+type DeploymentTarget string
+
+const (
+	DeploymentTargetLive     DeploymentTarget = "live"
+	DeploymentTargetGenesis  DeploymentTarget = "genesis"
+	DeploymentTargetCalldata DeploymentTarget = "calldata"
+	DeploymentTargetNoop     DeploymentTarget = "noop"
+)
+
+func NewDeploymentTarget(s string) (DeploymentTarget, error) {
+	switch s {
+	case string(DeploymentTargetLive):
+		return DeploymentTargetLive, nil
+	case string(DeploymentTargetGenesis):
+		return DeploymentTargetGenesis, nil
+	case string(DeploymentTargetCalldata):
+		return DeploymentTargetCalldata, nil
+	case string(DeploymentTargetNoop):
+		return DeploymentTargetNoop, nil
+	default:
+		return "", fmt.Errorf("invalid deployment target: %s", s)
+	}
+}
+
+func cwd() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return dir
+}
+
+func EnsureDefaultCacheDir() string {
+	var cacheDir string
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		cacheDir = ".op-deployer/cache"
+		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, cacheDir)
+	} else {
+		cacheDir = path.Join(homeDir, ".op-deployer/cache")
+	}
+
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		panic(fmt.Sprintf("failed to create cache directory %s: %v", cacheDir, err))
+	}
+
+	return cacheDir
+}

--- a/op-deployer/pkg/deployer/utils_test.go
+++ b/op-deployer/pkg/deployer/utils_test.go
@@ -1,0 +1,12 @@
+package deployer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureDefaultCacheDir(t *testing.T) {
+	cacheDir := EnsureDefaultCacheDir()
+	require.NotNil(t, cacheDir)
+}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -88,7 +88,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse l1 contracts release locator: %w", err)
 	}
-	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.GetDefaultCacheDir())
+	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.EnsureDefaultCacheDir())
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}


### PR DESCRIPTION
Fixes a bug: previously if the default cache dir didn't exist, downstream code would fail