### PR TITLE
afix slack in semgrep-scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2065,11 +2065,13 @@ workflows:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
           context:
+            - slack
             - circleci-repo-readonly-authenticated-github-token
       - semgrep-scan:
           name: semgrep-test
           scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/
           context:
+            - slack
             - circleci-repo-readonly-authenticated-github-token
       - go-lint:
           context:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request makes a small update to the CircleCI workflow configuration by adding the `slack` context to specific jobs. This enables these jobs to access Slack-related environment variables or secrets, likely for notification purposes.

- CircleCI configuration:
  * Added the `slack` context to the `semgrep-scan-local` and `semgrep-test` jobs in `.circleci/config.yml`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
