### PR TITLE
chore(op-acceptance-tests): ci timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2833,7 +2833,7 @@ workflows:
       - op-acceptance-tests:
           name: memory-all
           gate: "" # Empty gate = gateless mode
-          no_output_timeout: 60m
+          no_output_timeout: 90m
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord


### PR DESCRIPTION
Temporarily increase the 'no_output' CircleCI timeout as there's an issue making the tests occasionally stall for a long time.
