### PR TITLE
op-batcher: throttle config overhaul (pending-DA defaults, always-limit, step alignment)

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -29,12 +29,14 @@ type ThrottleConfig struct {
 
 	TxSizeLowerLimit    uint64
 	TxSizeUpperLimit    uint64
+	TxSizeAlwaysLimit   uint64
 	BlockSizeLowerLimit uint64
 	BlockSizeUpperLimit uint64
 
 	ControllerType config.ThrottleControllerType
 	LowerThreshold uint64
 	UpperThreshold uint64
+	StepAlignment  config.StepThresholdAlignment
 
 	// PID Controller specific parameters
 	PidKp          float64
@@ -219,7 +221,7 @@ func (c *CLIConfig) Check() error {
 
 // NewConfig parses the Config from the provided flags or environment variables.
 func NewConfig(ctx *cli.Context) *CLIConfig {
-	return &CLIConfig{
+	cfg := &CLIConfig{
 		/* Required Flags */
 		L1EthRpc:        ctx.String(flags.L1EthRpcFlag.Name),
 		L2EthRpc:        ctx.StringSlice(flags.L2EthRpcFlag.Name),
@@ -252,11 +254,13 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 			AdditionalEndpoints: ctx.StringSlice(flags.AdditionalThrottlingEndpointsFlag.Name),
 			TxSizeLowerLimit:    ctx.Uint64(flags.ThrottleTxSizeLowerLimitFlag.Name),
 			TxSizeUpperLimit:    ctx.Uint64(flags.ThrottleTxSizeUpperLimitFlag.Name),
+			TxSizeAlwaysLimit:   ctx.Uint64(flags.ThrottleTxSizeAlwaysLimitFlag.Name),
 			BlockSizeLowerLimit: ctx.Uint64(flags.ThrottleBlockSizeLowerLimitFlag.Name),
 			BlockSizeUpperLimit: ctx.Uint64(flags.ThrottleBlockSizeUpperLimitFlag.Name),
 			ControllerType:      config.ThrottleControllerType(ctx.String(flags.ThrottleControllerTypeFlag.Name)),
 			LowerThreshold:      ctx.Uint64(flags.ThrottleUsafeDABytesLowerThresholdFlag.Name),
 			UpperThreshold:      ctx.Uint64(flags.ThrottleUsafeDABytesUpperThresholdFlag.Name),
+			StepAlignment:       config.StepThresholdAlignment(ctx.String(flags.ThrottleStepAlignmentFlag.Name)),
 			PidKp:               ctx.Float64(flags.ThrottlePidKpFlag.Name),
 			PidKi:               ctx.Float64(flags.ThrottlePidKiFlag.Name),
 			PidKd:               ctx.Float64(flags.ThrottlePidKdFlag.Name),
@@ -265,4 +269,15 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 			PidSampleTime:       ctx.Duration(flags.ThrottlePidSampleTimeFlag.Name),
 		},
 	}
+
+	// Backwards-compat for deprecated multiplier flag: only apply if explicit upper threshold not set
+	if !ctx.IsSet(flags.ThrottleUsafeDABytesUpperThresholdFlag.Name) {
+		mult := ctx.Float64(flags.ThrottleThresholdMultiplierFlag.Name)
+		if mult > 0 {
+			lt := cfg.ThrottleConfig.LowerThreshold
+			cfg.ThrottleConfig.UpperThreshold = uint64(float64(lt) * mult)
+		}
+	}
+
+	return cfg
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -423,6 +423,12 @@ func (l *BatchSubmitter) unsafeDABytes() int64 {
 	return l.channelMgr.UnsafeDABytes()
 }
 
+func (l *BatchSubmitter) pendingDABytes() int64 {
+	l.channelMgrMutex.Lock()
+	defer l.channelMgrMutex.Unlock()
+	return l.channelMgr.PendingDABytes()
+}
+
 // sendToThrottlingLoop sends the current unsafe bytes to the throttling loop.
 // It is not blocking, no signal will be sent if the channel is full.
 func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
@@ -690,21 +696,27 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, unsafeBytesUpdated c
 		go l.singleEndpointThrottler(&innerWg, updateChans[i], endpoint)
 	}
 
-	for unsafeBytes := range unsafeBytesUpdated {
-		l.Metr.RecordUnsafeDABytes(unsafeBytes)
-		newParams := l.throttleController.Update(uint64(unsafeBytes))
+	for range unsafeBytesUpdated {
+		// Record current unsafe bytes for visibility
+		currentUnsafe := l.unsafeDABytes()
+		l.Metr.RecordUnsafeDABytes(currentUnsafe)
+
+		// Compute throttle based on pending DA bytes (more immediately actionable backlog)
+		pendingBytes := l.pendingDABytes()
+		newParams := l.throttleController.Update(uint64(pendingBytes))
 		controllerType := l.throttleController.GetType()
 
 		l.Metr.RecordThrottleIntensity(newParams.Intensity, controllerType)
 		l.Metr.RecordThrottleParams(newParams.MaxTxSize, newParams.MaxBlockSize)
 		if l.Config.ThrottleParams.LowerThreshold > 0 {
-			l.Metr.RecordUnsafeBytesVsThreshold(uint64(unsafeBytes), l.Config.ThrottleParams.LowerThreshold, controllerType)
+			l.Metr.RecordUnsafeBytesVsThreshold(uint64(pendingBytes), l.Config.ThrottleParams.LowerThreshold, controllerType)
 		}
 
 		// Update throttling state
 		if newParams.IsThrottling() {
-			l.Log.Warn("Throttling loop: unsafe bytes above threshold, scaling endpoint throttling based on intensity",
-				"unsafe_bytes", unsafeBytes,
+			l.Log.Warn("Throttling loop: pending bytes above threshold, scaling endpoint throttling based on intensity",
+				"pending_bytes", pendingBytes,
+				"unsafe_bytes", currentUnsafe,
 				"intensity", newParams.Intensity,
 				"max_tx_size", newParams.MaxTxSize,
 				"max_block_size", newParams.MaxBlockSize,

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -111,10 +111,12 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 		UpperThreshold:      cfg.ThrottleConfig.UpperThreshold,
 		TxSizeLowerLimit:    cfg.ThrottleConfig.TxSizeLowerLimit,
 		TxSizeUpperLimit:    cfg.ThrottleConfig.TxSizeUpperLimit,
+		TxSizeAlwaysLimit:   cfg.ThrottleConfig.TxSizeAlwaysLimit,
 		BlockSizeLowerLimit: cfg.ThrottleConfig.BlockSizeLowerLimit,
 		BlockSizeUpperLimit: cfg.ThrottleConfig.BlockSizeUpperLimit,
 		ControllerType:      cfg.ThrottleConfig.ControllerType,
 		Endpoints:           slices.Union(cfg.L2EthRpc, cfg.ThrottleConfig.AdditionalEndpoints),
+		StepAlignment:       cfg.ThrottleConfig.StepAlignment,
 	}
 
 	if bs.ThrottleParams.ControllerType == config.PIDControllerType {

--- a/op-batcher/batcher/throttler/controller.go
+++ b/op-batcher/batcher/throttler/controller.go
@@ -115,12 +115,17 @@ func (tc *ThrottleController) intensityToBlockSize(intensity float64, cfg Thrott
 
 // intensityToTxSize converts intensity in [0,1] to tx size
 func (tc *ThrottleController) intensityToTxSize(intensity float64, cfg ThrottleConfig) uint64 {
+	// If no throttling lower limit is set, return always-on limit if configured
 	if cfg.TxSizeLowerLimit == 0 {
-		return 0
+		return cfg.TxSizeAlwaysLimit
 	}
 
 	if intensity == 0 {
-		return 0 // Transactions are not throttled at 0 intensity
+		// Apply always-on limit if configured; otherwise no tx throttling at zero intensity
+		if cfg.TxSizeAlwaysLimit > 0 {
+			return cfg.TxSizeAlwaysLimit
+		}
+		return 0
 	} else {
 		switch tc.strategy.GetType() {
 		case config.StepControllerType:
@@ -212,6 +217,7 @@ func (f *ThrottleControllerFactory) CreateController(
 	throttleConfig := ThrottleConfig{
 		TxSizeLowerLimit:    throttleParams.TxSizeLowerLimit,
 		TxSizeUpperLimit:    throttleParams.TxSizeUpperLimit,
+		TxSizeAlwaysLimit:   throttleParams.TxSizeAlwaysLimit,
 		BlockSizeLowerLimit: throttleParams.BlockSizeLowerLimit,
 		BlockSizeUpperLimit: throttleParams.BlockSizeUpperLimit,
 	}
@@ -223,7 +229,23 @@ func (f *ThrottleControllerFactory) CreateController(
 
 	switch controllerType {
 	case config.StepControllerType:
-		strategy = NewStepStrategy(throttleParams.LowerThreshold)
+		// Align the step threshold within the [lower, upper] range based on configuration
+		stepThreshold := throttleParams.LowerThreshold
+		switch throttleParams.StepAlignment {
+		case config.StepAlignStart:
+			stepThreshold = throttleParams.LowerThreshold
+		case config.StepAlignEnd:
+			if throttleParams.UpperThreshold > throttleParams.LowerThreshold {
+				stepThreshold = throttleParams.UpperThreshold
+			}
+		case config.StepAlignMiddle:
+			fallthrough
+		default:
+			if throttleParams.UpperThreshold > throttleParams.LowerThreshold {
+				stepThreshold = throttleParams.LowerThreshold + (throttleParams.UpperThreshold-throttleParams.LowerThreshold)/2
+			}
+		}
+		strategy = NewStepStrategy(stepThreshold)
 	case config.LinearControllerType:
 		strategy = NewLinearStrategy(throttleParams.LowerThreshold, throttleParams.UpperThreshold, f.log)
 	case config.QuadraticControllerType:

--- a/op-batcher/batcher/throttler/quadratic_strategy_test.go
+++ b/op-batcher/batcher/throttler/quadratic_strategy_test.go
@@ -14,8 +14,8 @@ const (
 	TestQuadraticTxSize       = 3_500                                                             // 3.5KB transaction size limit
 	TestQuadraticBlockSize    = 16_000                                                            // 16KB block size limit
 	TestQuadraticAlwaysSize   = 110_000                                                           // 110KB always block size
-	TestQuadraticMultiplier   = 2.0                                                               // 3x threshold multiplier
-	TestQuadraticMaxThreshold = uint64(float64(TestQuadraticThreshold) * TestQuadraticMultiplier) // 1.8MB max threshold
+	TestQuadraticMultiplier   = 2.0                                                               // 2x threshold multiplier
+	TestQuadraticMaxThreshold = uint64(float64(TestQuadraticThreshold) * TestQuadraticMultiplier) // 1.2MB max threshold
 )
 
 func TestQuadraticStrategy_NewQuadraticStrategy(t *testing.T) {

--- a/op-batcher/batcher/throttler/types.go
+++ b/op-batcher/batcher/throttler/types.go
@@ -37,6 +37,7 @@ type ThrottleStrategy interface {
 type ThrottleConfig struct {
 	TxSizeLowerLimit    uint64
 	TxSizeUpperLimit    uint64
+	TxSizeAlwaysLimit   uint64
 	BlockSizeLowerLimit uint64
 	BlockSizeUpperLimit uint64
 }

--- a/op-batcher/config/types.go
+++ b/op-batcher/config/types.go
@@ -92,9 +92,21 @@ type ThrottleParams struct {
 	UpperThreshold      uint64
 	TxSizeLowerLimit    uint64
 	TxSizeUpperLimit    uint64
+	TxSizeAlwaysLimit   uint64
 	BlockSizeLowerLimit uint64
 	BlockSizeUpperLimit uint64
 	PIDConfig           *PIDConfig
 	ControllerType      ThrottleControllerType
 	Endpoints           []string
+	StepAlignment       StepThresholdAlignment
 }
+
+// StepThresholdAlignment controls where the step controller threshold is aligned
+// relative to the linear/quadratic controller range.
+type StepThresholdAlignment string
+
+const (
+	StepAlignStart  StepThresholdAlignment = "start"
+	StepAlignMiddle StepThresholdAlignment = "middle"
+	StepAlignEnd    StepThresholdAlignment = "end"
+)

--- a/op-batcher/flags/throttle_flags.go
+++ b/op-batcher/flags/throttle_flags.go
@@ -16,8 +16,10 @@ const (
 
 	// Controller side
 	DefaultThrottleControllerType = "quadratic"
-	DefaultThrottleLowerThreshold = 3_200_000 // allows for 4x 6-blob-tx channels at ~131KB per blob
-	DefaultThrottleUpperThreshold = DefaultThrottleLowerThreshold * 4
+	// Default thresholds tuned for unsafe_da_bytes metric: allow ~2 channels worth before throttling
+	DefaultThrottleLowerThreshold = 2_000_000
+	// Upper threshold defaults to 20x the lower threshold for smoothness
+	DefaultThrottleUpperThreshold = DefaultThrottleLowerThreshold * 20
 	DefaultPIDSampleTime          = 2 * time.Second
 	DefaultPIDKp                  = 0.33
 	DefaultPIDKi                  = 0.01
@@ -40,6 +42,13 @@ var (
 		Usage:   "The limit on the DA size of transactions when we are at maximum throttle intensity. 0 means no limits will ever be applied, so consider 1 the smallest effective limit.",
 		Value:   DefaultThrottleTxSizeLowerLimit,
 		EnvVars: prefixEnvVars("THROTTLE_TX_SIZE_LOWER_LIMIT"),
+	}
+	// Always-on Tx-size limit (applies even when intensity == 0)
+	ThrottleTxSizeAlwaysLimitFlag = &cli.Uint64Flag{
+		Name:    "throttle.tx-size-always-limit",
+		Usage:   "Optional always-on limit on the DA size of transactions, applied even when throttling is inactive (intensity == 0). 0 disables this always-on limit.",
+		Value:   0,
+		EnvVars: prefixEnvVars("THROTTLE_TX_SIZE_ALWAYS_LIMIT"),
 	}
 	ThrottleTxSizeUpperLimitFlag = &cli.Uint64Flag{
 		Name:    "throttle.tx-size-upper-limit",
@@ -78,6 +87,21 @@ var (
 			return fmt.Errorf("throttle.controller-type must be one of %v, got %s", validTypes, value)
 		},
 	}
+	// Step controller threshold alignment within [lower, upper] range
+	ThrottleStepAlignmentFlag = &cli.StringFlag{
+		Name:    "throttle.step-threshold-alignment",
+		Usage:   "Alignment for the step controller threshold within [lower, upper] range: 'start' | 'middle' | 'end'. Only relevant for 'step' controller.",
+		Value:   "middle",
+		EnvVars: prefixEnvVars("THROTTLE_STEP_THRESHOLD_ALIGNMENT"),
+		Action: func(_ *cli.Context, value string) error {
+			switch value {
+			case "start", "middle", "end":
+				return nil
+			default:
+				return fmt.Errorf("invalid throttle.step-threshold-alignment: %s (must be 'start' | 'middle' | 'end')", value)
+			}
+		},
+	}
 	ThrottleUsafeDABytesLowerThresholdFlag = &cli.Uint64Flag{
 		Name:    "throttle.unsafe-da-bytes-lower-threshold",
 		Usage:   "The threshold on unsafe_da_bytes beyond which the batcher will start to throttle the block builder. Zero disables throttling.",
@@ -89,6 +113,20 @@ var (
 		Usage:   "Threshold on unsafe_da_bytes at which throttling has the maximum intensity (linear and quadratic controllers only)",
 		Value:   DefaultThrottleUpperThreshold,
 		EnvVars: prefixEnvVars("THROTTLE_UNSAFE_DA_BYTES_UPPER_THRESHOLD"),
+	}
+	// Deprecated: multiplier for upper threshold. Prefer explicit upper threshold flag above.
+	ThrottleThresholdMultiplierFlag = &cli.Float64Flag{
+		Name:    "throttle.threshold-multiplier",
+		Usage:   "DEPRECATED: Multiplier applied to lower-threshold to derive upper-threshold. Use throttle.unsafe-da-bytes-upper-threshold instead.",
+		Value:   0,
+		EnvVars: prefixEnvVars("THROTTLE_THRESHOLD_MULTIPLIER"),
+		Hidden:  true,
+		Action: func(_ *cli.Context, value float64) error {
+			if value < 0 {
+				return fmt.Errorf("throttle.threshold-multiplier must be >= 0, got %f", value)
+			}
+			return nil
+		},
 	}
 
 	// Controller side (EXPERIMENTAL PID Controller only)
@@ -163,12 +201,15 @@ var (
 var ThrottleFlags = []cli.Flag{
 	AdditionalThrottlingEndpointsFlag,
 	ThrottleTxSizeLowerLimitFlag,
+	ThrottleTxSizeAlwaysLimitFlag,
 	ThrottleTxSizeUpperLimitFlag,
 	ThrottleBlockSizeLowerLimitFlag,
 	ThrottleBlockSizeUpperLimitFlag,
 	ThrottleControllerTypeFlag,
+	ThrottleStepAlignmentFlag,
 	ThrottleUsafeDABytesLowerThresholdFlag,
 	ThrottleUsafeDABytesUpperThresholdFlag,
+	ThrottleThresholdMultiplierFlag,
 	// PID controller flags (only used when controller type is 'pid')
 	ThrottlePidKpFlag,
 	ThrottlePidKiFlag,

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -150,9 +150,13 @@ The batcher includes sophisticated throttling mechanisms to manage data availabi
 
 **Quick Start:**
 ```bash
-# Configure basic throttling
---throttle-threshold=1000000
---throttle-controller-type=quadratic
+# Configure basic throttling (pending DA bytes)
+--throttle.unsafe-da-bytes-lower-threshold=2000000
+--throttle.unsafe-da-bytes-upper-threshold=40000000  # ~20x lower threshold
+--throttle.controller-type=quadratic
+
+# Optional: always-on tx-size limit even when not throttling
+--throttle.tx-size-always-limit=0
 
 # Runtime controller switching
 curl -X POST -H "Content-Type: application/json" \

--- a/op-batcher/throttling.md
+++ b/op-batcher/throttling.md
@@ -19,11 +19,9 @@ The batcher supports four throttling strategies, each with different response ch
 diagram:
 ![Throttling Strategies](./images/throttling.png)
 
-* Each strategy responds to the `unsafe_da_bytes` metric and corresponding thresholds `throttle.unsafe-da-bytes-lower/upper-threshold`, and results a throttling "intensity" between 0 and 1.
-
-* This intensity is then mapped to a maximum tx size and maximum block size to control the `miner_setMaxDASize(maxTxSize, maxBlockSize)` API calls made to block builders, depending on the configuration variables shown in the diagram above.
-
-* When the throttling intensity is zero (the `unsafe_da_bytes` is less than `unsafe-da-bytes-lower-threshold`), blocks will continue to be limited at `throttle.block-size-upper-limit`, whereas transactions are not throttled at all (by using `maxTxSize=0`).
+- Each strategy responds primarily to the number of pending DA bytes (derived from blocks fetched but not yet in a channel) and the configured thresholds `throttle.unsafe-da-bytes-lower/upper-threshold`, producing a throttling intensity between 0 and 1.
+- This intensity is then mapped to a maximum tx size and maximum block size to control the `miner_setMaxDASize(maxTxSize, maxBlockSize)` API calls made to block builders, depending on the configuration variables shown in the diagram above.
+- When the throttling intensity is zero (below the lower threshold), blocks are limited at `throttle.block-size-upper-limit`. Transactions can either be unthrottled (`maxTxSize=0`) or honor an optional always-on limit via `throttle.tx-size-always-limit`.
 
 > NOTE
 > Be aware that using `0` for either
@@ -37,6 +35,11 @@ diagram:
 - **Above threshold**: Maximum throttling applied immediately
 - **Use case**: Simple, predictable throttling behavior
 - **Best for**: Environments requiring clear, binary throttling states
+
+You can choose how the step threshold aligns within the linear/quadratic range using `--throttle.step-threshold-alignment`:
+- `start`: aligns to lower threshold
+- `middle` (default): aligns to the midpoint of [lower, upper]
+- `end`: aligns to upper threshold
 
 > [!WARNING]
 > If selecting the step controller, you should **not** rely on default throttling parameters as this could cause too much throttling to be applied too quickly.
@@ -85,47 +88,25 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:8545
 ```
 
-**Response:**
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "type": "quadratic",
-    "threshold": 1000000,
-    "current_load": 750000,
-    "intensity": 0.25,
-    "max_tx_size": 128000,
-    "max_block_size": 1500000
-  },
-  "id": 1
-}
-```
-
 ### Switch Controller Type
 
-**Step Controller:**
 ```bash
+# Step
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_setThrottleController","params":["step", null],"id":1}' \
   http://localhost:8545
-```
 
-**Linear Controller:**
-```bash
+# Linear
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_setThrottleController","params":["linear", null],"id":1}' \
   http://localhost:8545
-```
 
-**Quadratic Controller:**
-```bash
+# Quadratic
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_setThrottleController","params":["quadratic", null],"id":1}' \
   http://localhost:8545
-```
 
-**PID Controller:**
-```bash
+# PID (experimental)
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_setThrottleController","params":["pid", {"kp": 0.3, "ki": 0.15, "kd": 0.08, "integral_max": 50.0, "output_max": 1.0, "sample_time": "5s"}],"id":1}' \
   http://localhost:8545
@@ -138,218 +119,35 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:8545
 ```
 
-## PID Controller Configuration
+## Configuration
 
-### Parameters
+Key flags:
+- `--throttle.unsafe-da-bytes-lower-threshold`: start throttling above this many pending DA bytes
+- `--throttle.unsafe-da-bytes-upper-threshold`: full throttling above this value (linear/quadratic)
+- `--throttle.tx-size-lower-limit` / `--throttle.tx-size-upper-limit`: bounds for interpolating max tx size when throttling
+- `--throttle.tx-size-always-limit`: optional always-on tx size cap, even when intensity == 0
+- `--throttle.block-size-lower-limit` / `--throttle.block-size-upper-limit`: bounds for interpolating max block size
+- `--throttle.controller-type`: step | linear | quadratic | pid
+- `--throttle.step-threshold-alignment`: start | middle | end (step only)
 
-The PID controller uses six key parameters:
+Deprecated:
+- `--throttle.threshold-multiplier`: deprecated in favor of explicit upper threshold; if set and `--throttle.unsafe-da-bytes-upper-threshold` is not provided, the multiplier is applied to the lower threshold to derive the upper threshold.
 
-**Core PID Parameters:**
-- `kp` (Proportional Gain): Controls immediate response to current error
-  - Higher values: Faster response but may cause overshoot
-  - Lower values: Slower response but more stable
-- `ki` (Integral Gain): Controls response to accumulated error over time
-  - Higher values: Faster elimination of steady-state error
-  - Lower values: Slower correction but less prone to oscillation
-- `kd` (Derivative Gain): Controls response to rate of error change
-  - Higher values: Better anticipation of future error
-  - Lower values: Less noise sensitivity but slower prediction
+### Recommended defaults
+- Minimum threshold should allow one to two channels to fill without throttling.
+- Max threshold should be 10× to 50× the lower threshold for smoother behavior. Default is 20×.
 
-**Protection Parameters:**
-- `integral_max`: Maximum accumulated integral to prevent windup
-- `output_max`: Maximum controller output (typically 1.0)
-- `sample_time`: Controller update frequency (nanoseconds, e.g., 5000000000 = 5ms)
+## How It Works
 
-### Predefined Profiles
+1. Batcher tracks both unsafe bytes and pending DA bytes.
+2. Throttling intensity is computed from pending DA bytes against thresholds.
+3. Intensity maps to tx/block size limits.
+4. Limits are pushed to endpoints via `miner_setMaxDASize`.
 
-> ⚠️ **EXPERIMENTAL**: These profiles are starting points only. Proper tuning requires understanding your specific system characteristics and extensive testing.
-
-**Gentle Throttling** (Conservative, stable):
-```json
-{
-  "kp": 0.1,
-  "ki": 0.05,
-  "kd": 0.02,
-  "integral_max": 1000.0,
-  "output_max": 1.0,
-  "sample_time": "10s"
-}
-```
-- Slow, stable response
-- Minimal overshoot
-- Good for predictable loads
-
-**Balanced Throttling** (Recommended default):
-```json
-{
-  "kp": 0.3,
-  "ki": 0.15,
-  "kd": 0.08,
-  "integral_max": 1000.0,
-  "output_max": 1.0,
-  "sample_time": "2s"
-}
-```
-- Balanced responsiveness and stability
-- General-purpose throttling
-- Good starting point for most scenarios
-
-**Aggressive Throttling** (Fast response, may overshoot):
-```json
-{
-  "kp": 0.8,
-  "ki": 0.4,
-  "kd": 0.2,
-  "integral_max": 2000.0,
-  "output_max": 1.0,
-  "sample_time": "2s"
-}
-```
-- Fast response to load changes
-- Good for highly variable loads
-- May overshoot and oscillate
-
-### Tuning Guidelines
-
-> ⚠️ **WARNING**: PID tuning requires expertise. Improper tuning can cause instability.
-
-1. **Start Conservative**: Begin with gentle settings and gradually increase responsiveness
-2. **Tune One Parameter at a Time**: Change kp first, then ki, then kd
-3. **Monitor System Response**: Watch for oscillations, overshoot, and stability
-4. **Test Under Load**: Validate behavior under various load conditions
-5. **Have Rollback Plan**: Be prepared to switch back to step/linear controllers
-
-**Basic Tuning Process:**
-1. Set ki=0, kd=0, start with small kp (0.1)
-2. Increase kp until system responds adequately without overshoot
-3. Add small ki (0.05) to eliminate steady-state error
-4. Add small kd (0.02) to improve transient response
-5. Adjust integral_max to prevent windup
-6. Fine-tune based on observed behavior
-
-## Throttling Operation
-
-### How It Works
-
-1. **Monitoring**: Batcher continuously monitors pending DA bytes in its queue
-2. **Threshold Checking**: Compares current load against configured threshold
-3. **Intensity Calculation**: Controller calculates throttling intensity (0.0 to 1.0)
-4. **Parameter Mapping**: Intensity maps to specific tx/block size limits
-5. **Endpoint Updates**: Sends `miner_setMaxDASize` RPC calls to configured endpoints
-6. **Enforcement**: Sequencers/builders enforce the limits during block construction
-
-### Endpoint Communication
-
-The throttling system communicates with multiple endpoints in parallel:
-
-- **Primary sequencer endpoints**: Configured via `--l2-eth-rpc`
-- **Additional endpoints**: Configured via `--additional-throttling-endpoints`
-- **Builder endpoints**: In rollup-boost setups, builders receive throttling signals
-
-Each endpoint runs in its own goroutine with:
-- **Retry logic**: Automatic retries for failed RPC calls
-- **Error handling**: Graceful handling of unavailable endpoints
-- **Parallel updates**: All endpoints updated simultaneously
-
-### Metrics and Monitoring
-
-The batcher exposes Prometheus metrics for throttling monitoring:
-
-- `op_batcher_throttle_intensity`: Current throttling intensity (0.0-1.0)
-- `op_batcher_throttle_pending_bytes`: Current pending DA bytes
-- `op_batcher_throttle_max_tx_size`: Current max transaction size limit
-- `op_batcher_throttle_max_block_size`: Current max block size limit
-- `op_batcher_throttle_controller_type`: Current controller type
-- `op_batcher_throttle_pid_error`: PID controller error term (PID only)
-- `op_batcher_throttle_pid_integral`: PID controller integral term (PID only)
-- `op_batcher_throttle_pid_derivative`: PID controller derivative term (PID only)
-
-## Best Practices
-
-### Controller Selection
-
-**Use Step Controller when:**
-- Simple, predictable behavior is required
-- Binary throttling states are acceptable
-- Minimal configuration complexity is desired
-
-**Use Linear Controller when:**
-- Gradual response to load changes is preferred
-- Load patterns are relatively steady
-- Proportional throttling is sufficient
-
-**Use Quadratic Controller when:**
-- Tolerance for brief load spikes is needed
-- Strong protection against sustained overload is required
-- Variable load patterns are common
-
-**Use PID Controller when:**
-- Expert control theory knowledge is available
-- Complex load patterns require sophisticated control
-- Extensive testing and tuning resources are available
-- Experimental features are acceptable
-
-### General Recommendations
-
-1. **Start Simple**: Begin with step or linear controllers
-2. **Monitor Closely**: Watch metrics and system behavior
-3. **Test Thoroughly**: Validate under various load conditions
-4. **Plan for Failure**: Have fallback controllers configured
-5. **Document Changes**: Record configuration changes and their effects
-6. **Regular Review**: Periodically assess controller performance
-
-### Common Pitfalls
-
-- **Over-tuning**: Making too many adjustments too quickly
-- **Ignoring Metrics**: Not monitoring system response to changes
-- **Production Testing**: Testing new controllers directly in production
-- **Parameter Copying**: Using other systems' PID parameters without validation
-- **Insufficient Monitoring**: Not tracking key performance indicators
-
-## Troubleshooting
-
-### Common Issues
-
-**Controller Not Responding:**
-- Check RPC connectivity to endpoints
-- Verify `miner_setMaxDASize` method availability
-- Confirm threshold configuration is correct
-
-**Oscillating Behavior (PID):**
-- Reduce proportional gain (kp)
-- Decrease derivative gain (kd)
-- Increase sample time
-- Check for noise in load measurements
-
-**Slow Response:**
-- Increase proportional gain (kp)
-- Decrease sample time
-- Check threshold multiplier settings
-
-**High Error Rates:**
-- Verify endpoint availability
-- Check network connectivity
-- Review retry logic configuration
-
-### Diagnostic Commands
-
-**Check controller status:**
-```bash
-curl -s -X POST -H "Content-Type: application/json" \
-  --data '{"jsonrpc":"2.0","method":"admin_getThrottleController","params":[],"id":1}' \
-  http://localhost:8545 | jq
-```
-
-**Reset and start fresh:**
-```bash
-curl -X POST -H "Content-Type: application/json" \
-  --data '{"jsonrpc":"2.0","method":"admin_resetThrottleController","params":[],"id":1}' \
-  http://localhost:8545
-```
-
-**Switch to safe mode (step controller):**
-```bash
-curl -X POST -H "Content-Type: application/json" \
-  --data '{"jsonrpc":"2.0","method":"admin_setThrottleController","params":["step", null],"id":1}' \
-  http://localhost:8545
-```
+## Metrics and Monitoring
+- `op_batcher_throttle_intensity`
+- `op_batcher_throttle_max_tx_size`
+- `op_batcher_throttle_max_block_size`
+- `op_batcher_throttle_controller_type`
+- `op_batcher_unsafe_bytes_ratio` (vs threshold, based on pending bytes)
+- `op_batcher_unsafe_da_bytes` (raw)


### PR DESCRIPTION
- Deprecate flag throttle.threshold-multiplier; keep backward-compat if --throttle.unsafe-da-bytes-upper-threshold is not set.
- Add throttle.tx-size-always-limit to cap tx size even at zero intensity.
- Add throttle.step-threshold-alignment (start|middle|end) to position the step threshold within the [lower, upper] range.
- Compute throttling intensity from pending DA bytes; still record unsafe DA bytes for visibility; update ratio metric to use pending bytes.
- Update defaults: lower=2,000,000 bytes (~1–2 channels), upper=lower20 (within 10–50x guidance).
- Controller: apply always-on tx limit at intensity 0; respect step alignment when selecting threshold.
- Docs: refresh op-batcher/throttling.md and op-batcher/readme.md with new flags, defaults, and guidance.
- Minor tests/docs comments adjusted for consistency.

Fix #16947 