### PR TITLE
feat: support OPSuccinct game type detection

### DIFF
--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -39,7 +39,8 @@ func DetectGameType(ctx context.Context, addr common.Address, caller *batching.M
 		faultTypes.SuperCannonGameType,
 		faultTypes.SuperPermissionedGameType,
 		faultTypes.SuperCannonKonaGameType,
-		faultTypes.SuperAsteriscKonaGameType:
+		faultTypes.SuperAsteriscKonaGameType,
+		faultTypes.OPSuccinctGameType:
 		return gameType, nil
 	default:
 		return faultTypes.UnknownGameType, fmt.Errorf("unsupported game type: %d", gameType)

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -61,7 +61,8 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 		faultTypes.SuperCannonGameType,
 		faultTypes.SuperPermissionedGameType,
 		faultTypes.SuperCannonKonaGameType,
-		faultTypes.SuperAsteriscKonaGameType:
+		faultTypes.SuperAsteriscKonaGameType,
+		faultTypes.OPSuccinctGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create fault dispute game contract: %w", err)

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -72,6 +72,10 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 			game: types.GameMetadata{GameType: uint32(faultTypes.SuperAsteriscKonaGameType), Proxy: fdgAddr},
 		},
 		{
+			name: "validOPSuccinctGameType",
+			game: types.GameMetadata{GameType: uint32(faultTypes.OPSuccinctGameType), Proxy: fdgAddr},
+		},
+		{
 			name:        "InvalidGameType",
 			game:        types.GameMetadata{GameType: 6, Proxy: fdgAddr},
 			expectedErr: fmt.Errorf("unsupported game type: 6"),


### PR DESCRIPTION
**Description**

Mainnets with OPSuccinct game type are missing monitoring through the dispute-mon tool. Without OPSuccinct game type support, chain operators cannot automatically detect if a malicious or faulty proposer submits an invalid state root, creating a significant security risk.

This PR adds support for OPSuccinct game type (type 6) in dispute-mon tool.

**Tests**

Added OPSuccinct game type for caller test.