### PR TITLE
feat(op-acceptance-tests): cgt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
   contracts-bedrock-build:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     parameters:
       build_args:
         description: Forge build arguments
@@ -720,7 +720,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     parameters:
       test_list:
         description: List of test files to run

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -100,4 +100,9 @@ gates:
     description: "Jovian network tests."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/jovian
+
+  - id: cgt
+    description: "Custom Gas Token (CGT) network tests."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/custom_gas_token
         timeout: 10m

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_introspection_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_introspection_test.go
@@ -1,0 +1,25 @@
+package custom_gas_token
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+// TestCGT_IntrospectionViaL1Block verifies that the L2 L1Block predeploy reports
+// that CGT mode is enabled and exposes non-empty token metadata (name, symbol).
+func TestCGT_IntrospectionViaL1Block(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	name, symbol := ensureCGTOrSkip(t, sys)
+
+	// Metadata should be non-empty.
+	if name == "" {
+		t.Require().Fail("gasPayingTokenName() returned empty string")
+	}
+	if symbol == "" {
+		t.Require().Fail("gasPayingTokenSymbol() returned empty string")
+	}
+}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
@@ -1,0 +1,55 @@
+package custom_gas_token
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// TestCGT_L1PortalIntrospection checks that the L1 OptimismPortal exposes
+// a valid SystemConfig address via its systemConfig() view.
+func TestCGT_L1PortalIntrospection(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	// Skip if this devnet is not CGT-enabled (uses your existing gate).
+	ensureCGTOrSkip(t, sys)
+
+	l1c := sys.L1EL.EthClient()
+	portal := sys.L2Chain.DepositContractAddr()
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	// Portal exposes systemConfig() -> address
+	const portalABI = `[
+	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
+	]`
+	pa, err := abi.JSON(strings.NewReader(portalABI))
+	if err != nil {
+		t.Require().Fail("parse portal ABI: %v", err)
+	}
+
+	data, _ := pa.Pack("systemConfig")
+	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Require().Fail("portal.systemConfig() call failed: %v", err)
+	}
+	vals, err := pa.Unpack("systemConfig", out)
+	if err != nil {
+		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
+	}
+	sysCfg := vals[0].(common.Address)
+	if sysCfg == (common.Address{}) {
+		t.Require().Fail("portal.systemConfig() returned zero address")
+	}
+}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_native_payment_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_native_payment_test.go
@@ -1,0 +1,48 @@
+package custom_gas_token
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TestCGT_ValueTransferPaysGasInToken verifies that on CGT chains a simple L2
+// value transfer charges gas in the native ERC-20, and balances reflect
+// recipient +amount and sender > amount decrease (amount + gas).
+func TestCGT_ValueTransferPaysGasInToken(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	ensureCGTOrSkip(t, sys)
+
+	sender := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	recipient := sys.Wallet.NewEOA(sys.L2EL)
+
+	amount := eth.OneHundredthEther
+	beforeS := sender.GetBalance()
+	beforeR := recipient.GetBalance()
+
+	// This sends L2 native (CGT) value.
+	sender.Transfer(recipient.Address(), amount)
+
+	// Wait until recipient reflects the transfer.
+	// We don't wait on sender balance; it includes gas and is non-deterministic.
+	recipient.WaitForBalance(beforeR.Add(amount))
+
+	afterS := sender.GetBalance()
+	afterR := recipient.GetBalance()
+
+	// Recipient increased by amount
+	wantR := beforeR.Add(amount)
+	if afterR != wantR {
+		t.Require().Fail("recipient balance mismatch: got %s, want %s", afterR, wantR)
+	}
+
+	// Sender decreased by at least amount (amount + gas). Strict inequality:
+	if !(beforeS.Sub(afterS)).Gt(amount) {
+		t.Require().Fail("sender delta must exceed transferred amount (gas must be paid): before=%s after=%s amount=%s",
+			beforeS, afterS, amount)
+	}
+}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_portal_reverts_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_portal_reverts_test.go
@@ -1,0 +1,34 @@
+package custom_gas_token
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestCGT_PortalReceiveReverts asserts that sending ETH to the L1 OptimismPortal
+// (receive() -> depositTransaction) reverts under CGT, preventing ETH from getting stuck.
+func TestCGT_PortalReceiveReverts(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	ensureCGTOrSkip(t, sys)
+
+	l1c := sys.L1EL.EthClient()
+	portal := sys.L2Chain.DepositContractAddr()
+
+	// Try to send 1 wei to the Portal (receive() -> depositTransaction); should revert in CGT mode.
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+	_, err := l1c.EstimateGas(ctx, ethereum.CallMsg{
+		To:    &portal,
+		Value: common.Big1,
+	})
+	if err == nil {
+		t.Require().Fail("expected L1 Portal to revert on direct ETH send in CGT mode, but estimator returned no error")
+	}
+}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_reverts_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_reverts_test.go
@@ -1,0 +1,80 @@
+package custom_gas_token
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// TestCGT_MessengerRejectsValue ensures that sending native value to the
+// L2CrossDomainMessenger reverts under CGT (non-payable path).
+func TestCGT_MessengerRejectsValue(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	ensureCGTOrSkip(t, sys)
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 30*time.Second)
+	defer cancel()
+
+	from := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther).Address()
+	_, err := sys.L2EL.Escape().L2EthClient().EstimateGas(ctx, ethereum.CallMsg{
+		From:  from,
+		To:    &l2XDMAddr,
+		Value: big.NewInt(1), // 1 wei native
+		Data:  nil,
+	})
+	if err == nil {
+		t.Require().Fail("expected estimation error when sending value to L2CrossDomainMessenger in CGT mode")
+	}
+}
+
+// TestCGT_L2StandardBridge_LegacyWithdrawReverts verifies that the legacy
+// ETH-specific withdraw path on L2StandardBridge reverts under CGT.
+func TestCGT_L2StandardBridge_LegacyWithdrawReverts(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	ensureCGTOrSkip(t, sys)
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 30*time.Second)
+	defer cancel()
+
+	bridgeABIJSON := `[
+		{"inputs":[
+			{"internalType":"address","name":"_l2Token","type":"address"},
+			{"internalType":"uint256","name":"_amount","type":"uint256"},
+			{"internalType":"uint32","name":"_minGasLimit","type":"uint32"},
+			{"internalType":"bytes","name":"_extraData","type":"bytes"}
+		],
+		"name":"withdraw","outputs":[],"stateMutability":"payable","type":"function"}
+	]`
+	bridgeABI, err := abi.JSON(strings.NewReader(bridgeABIJSON))
+	if err != nil {
+		t.Require().Fail("%v", err)
+	}
+	// Any address is fine; the ETH-specific legacy path should be disabled under CGT.
+	anyAddress := l2XDMAddr
+	data, err := bridgeABI.Pack("withdraw", anyAddress, big.NewInt(1), uint32(100_000), []byte{})
+	if err != nil {
+		t.Require().Fail("%v", err)
+	}
+
+	from := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther).Address()
+	_, err = sys.L2EL.Escape().L2EthClient().EstimateGas(ctx, ethereum.CallMsg{
+		From: from,
+		To:   &l2BridgeAddr,
+		Data: data,
+	})
+	if err == nil {
+		t.Require().Fail("expected estimation error for L2StandardBridge.withdraw under CGT")
+	}
+}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
@@ -1,0 +1,132 @@
+package custom_gas_token
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// TestCGT_SystemConfigFlagOnL1 checks that the L1 SystemConfig contract reports
+// CGT=true via isCustomGasToken(). Skips if the devnet does not wire this flag.
+func TestCGT_SystemConfigFlagOnL1(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	ensureCGTOrSkip(t, sys)
+
+	l1c := sys.L1EL.EthClient()
+	portal := sys.L2Chain.DepositContractAddr()
+
+	portalABI := `[
+	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
+	]`
+	igasToken := `[
+	  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}
+	]`
+
+	pa, err := abi.JSON(strings.NewReader(portalABI))
+	if err != nil {
+		t.Require().Fail("%v", err)
+	}
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	// Resolve SystemConfig via Portal.systemConfig()
+	data, _ := pa.Pack("systemConfig")
+	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Require().Fail("portal.systemConfig() call failed: %v", err)
+	}
+	vals, err := pa.Unpack("systemConfig", out)
+	if err != nil {
+		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
+	}
+	sysCfg := vals[0].(common.Address)
+	if (sysCfg == common.Address{}) {
+		t.Require().Fail("portal.systemConfig() returned zero address")
+	}
+
+	// Ask SystemConfig whether CGT is enabled.
+	ga, _ := abi.JSON(strings.NewReader(igasToken))
+	data, _ = ga.Pack("isCustomGasToken")
+	out, err = l1c.Call(ctx, ethereum.CallMsg{To: &sysCfg, Data: data}, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Require().Fail("SystemConfig.isCustomGasToken() call failed: %v", err)
+	}
+	vals, err = ga.Unpack("isCustomGasToken", out)
+	if err != nil {
+		t.Require().Fail("unpack isCustomGasToken failed: %v", err)
+	}
+	if !vals[0].(bool) {
+		t.Skip("SystemConfig.isCustomGasToken() = false on this devnet; skipping")
+	}
+}
+
+// TestCGT_SystemConfigFeatureFlag re-validates the CGT flag on SystemConfig,
+// using locally encoded calls (mirrors the previous test structure). Skips on devnets without the flag.
+func TestCGT_SystemConfigFeatureFlag(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	// Skip if not in CGT mode (uses L2 L1Block.isCustomGasToken()).
+	ensureCGTOrSkip(t, sys)
+
+	l1c := sys.L1EL.EthClient()
+	portal := sys.L2Chain.DepositContractAddr()
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	// Resolve SystemConfig via Portal.systemConfig()
+	const portalABI = `[
+	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
+	]`
+	pa, err := abi.JSON(strings.NewReader(portalABI))
+	if err != nil {
+		t.Require().Fail("parse portal ABI: %v", err)
+	}
+	data, _ := pa.Pack("systemConfig")
+	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Require().Fail("portal.systemConfig() call failed: %v", err)
+	}
+	vals, err := pa.Unpack("systemConfig", out)
+	if err != nil {
+		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
+	}
+	sysCfg := vals[0].(common.Address) // keep as interface; ABI unpack returns []interface{}
+
+	// Query the CGT flag on SystemConfig via IGasToken.isCustomGasToken().
+	const igasTokenABI = `[
+	  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}
+	]`
+	ga, err := abi.JSON(strings.NewReader(igasTokenABI))
+	if err != nil {
+		t.Require().Fail("parse IGasToken ABI: %v", err)
+	}
+
+	// Build the call
+	data, _ = ga.Pack("isCustomGasToken")
+	out, err = l1c.Call(ctx, ethereum.CallMsg{
+		To:   &sysCfg,
+		Data: data,
+	}, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Require().Fail("SystemConfig.isCustomGasToken() call failed: %v", err)
+	}
+	flag, err := ga.Unpack("isCustomGasToken", out)
+	if err != nil {
+		t.Require().Fail("unpack isCustomGasToken failed: %v", err)
+	}
+	if !flag[0].(bool) {
+		t.Skip("SystemConfig.isCustomGasToken() = false on this devnet; skipping")
+	}
+}

--- a/op-acceptance-tests/tests/custom_gas_token/helpers.go
+++ b/op-acceptance-tests/tests/custom_gas_token/helpers.go
@@ -1,0 +1,72 @@
+// op-acceptance-tests/tests/custom_gas_token/helpers.go
+package custom_gas_token
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var (
+	// L2 predeploy: L1Block (address is stable across OP Stack chains)
+	l1BlockAddr = common.HexToAddress("0x4200000000000000000000000000000000000015")
+
+	// L2 predeploy: L2CrossDomainMessenger & L2StandardBridge (for revert checks)
+	l2XDMAddr    = common.HexToAddress("0x4200000000000000000000000000000000000007")
+	l2BridgeAddr = common.HexToAddress("0x4200000000000000000000000000000000000010")
+)
+
+const igasTokenABI = `[
+  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},
+  {"inputs":[],"name":"gasPayingTokenName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},
+  {"inputs":[],"name":"gasPayingTokenSymbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}
+]`
+
+// ensureCGTOrSkip probes L2 L1Block for CGT mode. If not enabled, the test is skipped.
+// Returns (name, symbol).
+func ensureCGTOrSkip(t devtest.T, sys *presets.Minimal) (string, string) {
+	l2 := sys.L2EL.Escape().L2EthClient()
+
+	abiGT, err := abi.JSON(strings.NewReader(igasTokenABI))
+	t.Require().NoError(err)
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	// isCustomGasToken()
+	data, _ := abiGT.Pack("isCustomGasToken")
+	out, err := l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
+	if err != nil {
+		t.Skipf("CGT not enabled (isCustomGasToken() call failed): %v", err)
+	}
+	vals, err := abiGT.Unpack("isCustomGasToken", out)
+	t.Require().NoError(err)
+	if !vals[0].(bool) {
+		t.Skip("CGT disabled on this devnet (native ETH mode detected)")
+	}
+
+	// Read metadata (name/symbol)
+	data, _ = abiGT.Pack("gasPayingTokenName")
+	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
+	t.Require().NoError(err)
+	vn, err := abiGT.Unpack("gasPayingTokenName", out)
+	t.Require().NoError(err)
+	name := vn[0].(string)
+
+	data, _ = abiGT.Pack("gasPayingTokenSymbol")
+	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
+	t.Require().NoError(err)
+	vs, err := abiGT.Unpack("gasPayingTokenSymbol", out)
+	t.Require().NoError(err)
+	symbol := vs[0].(string)
+
+	return name, symbol
+}

--- a/op-acceptance-tests/tests/custom_gas_token/init_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/init_test.go
@@ -1,0 +1,22 @@
+package custom_gas_token
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	// Create a CGT-enabled devnet with 1M tokens of liquidity
+	liq := new(big.Int).Mul(big.NewInt(1_000_000), big.NewInt(1e18)) // 1M tokens * 18 decimals
+
+	presets.DoMain(m,
+		presets.WithMinimal(),
+		stack.MakeCommon(sysgo.WithDeployerOptions(
+			sysgo.WithCustomGasToken(true, "Custom Gas Token", "CGT", liq),
+		)),
+	)
+}


### PR DESCRIPTION
## Description
Adds CGT acceptance tests.

Locally:
<img width="1126" height="202" alt="Screenshot 2025-09-22 at 14 47 03" src="https://github.com/user-attachments/assets/d9d1c12d-f7fb-4f6f-97af-e8cfd1026a4a" />
<img width="1740" height="700" alt="Screenshot 2025-09-22 at 14 47 20" src="https://github.com/user-attachments/assets/2bfeafbb-18df-4cd3-a31f-0aa822020703" />


In CI:
<img width="1737" height="652" alt="Screenshot 2025-09-22 at 16 53 39" src="https://github.com/user-attachments/assets/daf3bdb7-244a-439c-86b7-3c8f62f86fee" />
([source](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/101531/workflows/831e7bf7-d980-4600-8bda-1610c6dbeb99/jobs/3888883/artifacts))


## Metadata
Intended to be merged into https://github.com/ethereum-optimism/optimism/pull/17412