### PR TITLE
feat(ci): parallelise go-tests jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1110,13 +1110,18 @@ jobs:
         description: Rule to run the tests
         type: string
         default: "go-tests-short-ci"
+      parallelism:
+        description: Number machines to distribute the tests across
+        type: integer
+        default: 1
     machine: true
     resource_class: <<parameters.resource_class>>
     circleci_ip_ranges: true
+    parallelism: <<parameters.parallelism>>
     steps:
       - checkout-from-workspace
       - run:
-          name: Run all Go tests via Makefile
+          name: Run Go tests via Makefile
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
             <<parameters.environment_overrides>>
@@ -1126,10 +1131,15 @@ jobs:
           path: ./tmp/test-results
       - run:
           name: Compress test logs
-          command: tar -czf testlogs.tar.gz -C ./tmp testlogs
+          command: |
+            if [ -n "$CIRCLE_NODE_TOTAL" ] && [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
+              tar -czf testlogs-${CIRCLE_NODE_INDEX}-of-${CIRCLE_NODE_TOTAL}.tar.gz -C ./tmp testlogs
+            else
+              tar -czf testlogs.tar.gz -C ./tmp testlogs
+            fi
           when: always
       - store_artifacts:
-          path: testlogs.tar.gz
+          path: testlogs*.tar.gz
           when: always
       - when:
           condition: "<<parameters.notify>>"
@@ -2112,6 +2122,7 @@ workflows:
             - contracts-bedrock-build
       - go-tests:
           name: go-tests-short
+          parallelism: 8
           no_output_timeout: 19m
           test_timeout: 20m
           requires:
@@ -2125,6 +2136,7 @@ workflows:
       - go-tests:
           name: go-tests-full
           rule: "go-tests-ci" # Run full test suite instead of short
+          parallelism: 8
           no_output_timeout: 89m # Longer timeout for full tests
           test_timeout: 90m
           notify: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2122,7 +2122,7 @@ workflows:
             - contracts-bedrock-build
       - go-tests:
           name: go-tests-short
-          parallelism: 8
+          parallelism: 4
           no_output_timeout: 19m
           test_timeout: 20m
           requires:
@@ -2136,7 +2136,7 @@ workflows:
       - go-tests:
           name: go-tests-full
           rule: "go-tests-ci" # Run full test suite instead of short
-          parallelism: 8
+          parallelism: 4
           no_output_timeout: 89m # Longer timeout for full tests
           test_timeout: 90m
           notify: true

--- a/Makefile
+++ b/Makefile
@@ -267,13 +267,32 @@ go-tests-short-ci: ## Runs short Go tests with gotestsum for CI (assumes deps bu
 	@echo 'Running Go tests (short) with gotestsum...'
 	$(DEFAULT_TEST_ENV_VARS) && \
 	$(CI_ENV_VARS) && \
-	gotestsum --format=testname \
-		--junitfile=./tmp/test-results/results.xml \
-		--jsonfile=./tmp/testlogs/log.json \
-		--rerun-fails=3 \
-		--rerun-fails-max-failures=50 \
-		--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
-		-- -parallel=$$PARALLEL -coverprofile=coverage.out -short -timeout=$(TEST_TIMEOUT) -tags="ci"
+	if [ -n "$$CIRCLE_NODE_TOTAL" ] && [ "$$CIRCLE_NODE_TOTAL" -gt 1 ]; then \
+		export NODE_INDEX=$${CIRCLE_NODE_INDEX:-0} && \
+		export NODE_TOTAL=$${CIRCLE_NODE_TOTAL:-1} && \
+		export PARALLEL_PACKAGES=$$(echo "$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" | tr ' ' '\n' | awk -v idx=$$NODE_INDEX -v total=$$NODE_TOTAL 'NR % total == idx' | tr '\n' ' ') && \
+		if [ -n "$$PARALLEL_PACKAGES" ]; then \
+			echo "Node $$NODE_INDEX/$$NODE_TOTAL running packages: $$PARALLEL_PACKAGES"; \
+			gotestsum --format=testname \
+				--junitfile=./tmp/test-results/results-$$NODE_INDEX.xml \
+				--jsonfile=./tmp/testlogs/log-$$NODE_INDEX.json \
+				--rerun-fails=3 \
+				--rerun-fails-max-failures=50 \
+				--packages="$$PARALLEL_PACKAGES" \
+				-- -parallel=$$PARALLEL -coverprofile=coverage-$$NODE_INDEX.out -short -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+		else \
+			echo "Node $$NODE_INDEX/$$NODE_TOTAL has no packages to run"; \
+			touch ./tmp/test-results/results-$$NODE_INDEX.xml; \
+		fi; \
+	else \
+		gotestsum --format=testname \
+			--junitfile=./tmp/test-results/results.xml \
+			--jsonfile=./tmp/testlogs/log.json \
+			--rerun-fails=3 \
+			--rerun-fails-max-failures=50 \
+			--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
+			-- -parallel=$$PARALLEL -coverprofile=coverage.out -short -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+	fi
 .PHONY: go-tests-short-ci
 
 go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps built by CI)
@@ -282,13 +301,32 @@ go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps 
 	@echo "Running Go tests with gotestsum..."
 	$(DEFAULT_TEST_ENV_VARS) && \
 	$(CI_ENV_VARS) && \
-	gotestsum --format=testname \
-		--junitfile=./tmp/test-results/results.xml \
-		--jsonfile=./tmp/testlogs/log.json \
-		--rerun-fails=3 \
-		--rerun-fails-max-failures=50 \
-		--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
-		-- -parallel=$$PARALLEL -coverprofile=coverage.out -timeout=$(TEST_TIMEOUT) -tags="ci"
+	if [ -n "$$CIRCLE_NODE_TOTAL" ] && [ "$$CIRCLE_NODE_TOTAL" -gt 1 ]; then \
+		export NODE_INDEX=$${CIRCLE_NODE_INDEX:-0} && \
+		export NODE_TOTAL=$${CIRCLE_NODE_TOTAL:-1} && \
+		export PARALLEL_PACKAGES=$$(echo "$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" | tr ' ' '\n' | awk -v idx=$$NODE_INDEX -v total=$$NODE_TOTAL 'NR % total == idx' | tr '\n' ' ') && \
+		if [ -n "$$PARALLEL_PACKAGES" ]; then \
+			echo "Node $$NODE_INDEX/$$NODE_TOTAL running packages: $$PARALLEL_PACKAGES"; \
+			gotestsum --format=testname \
+				--junitfile=./tmp/test-results/results-$$NODE_INDEX.xml \
+				--jsonfile=./tmp/testlogs/log-$$NODE_INDEX.json \
+				--rerun-fails=3 \
+				--rerun-fails-max-failures=50 \
+				--packages="$$PARALLEL_PACKAGES" \
+				-- -parallel=$$PARALLEL -coverprofile=coverage-$$NODE_INDEX.out -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+		else \
+			echo "Node $$NODE_INDEX/$$NODE_TOTAL has no packages to run"; \
+			touch ./tmp/test-results/results-$$NODE_INDEX.xml; \
+		fi; \
+	else \
+		gotestsum --format=testname \
+			--junitfile=./tmp/test-results/results.xml \
+			--jsonfile=./tmp/testlogs/log.json \
+			--rerun-fails=3 \
+			--rerun-fails-max-failures=50 \
+			--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
+			-- -parallel=$$PARALLEL -coverprofile=coverage.out -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+	fi
 .PHONY: go-tests-ci
 
 go-tests-fraud-proofs-ci: ## Runs fraud proofs Go tests with gotestsum for CI (assumes deps built by CI)

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,9 @@ RPC_TEST_PKGS := \
 	./op-deployer/pkg/deployer/pipeline/... \
 	./op-deployer/pkg/deployer/upgrade/...
 
+# All test packages used by CI (combination of all package groups)
+ALL_TEST_PACKAGES := $(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)
+
 # Common test environment variables
 # For setting PARALLEL, nproc is for linux, sysctl for Mac and then fallback to 4 if neither is available
 define DEFAULT_TEST_ENV_VARS
@@ -261,41 +264,9 @@ go-tests-short: $(TEST_DEPS) ## Runs comprehensive Go tests with -short flag
 	go test -short -parallel=$$PARALLEL -timeout=$(TEST_TIMEOUT) $(TEST_PKGS)
 .PHONY: go-tests-short
 
-go-tests-short-ci: ## Runs short Go tests with gotestsum for CI (assumes deps built by CI)
-	@echo "Setting up test directories..."
-	mkdir -p ./tmp/test-results ./tmp/testlogs
-	@echo 'Running Go tests (short) with gotestsum...'
-	$(DEFAULT_TEST_ENV_VARS) && \
-	$(CI_ENV_VARS) && \
-	if [ -n "$$CIRCLE_NODE_TOTAL" ] && [ "$$CIRCLE_NODE_TOTAL" -gt 1 ]; then \
-		export NODE_INDEX=$${CIRCLE_NODE_INDEX:-0} && \
-		export NODE_TOTAL=$${CIRCLE_NODE_TOTAL:-1} && \
-		export PARALLEL_PACKAGES=$$(echo "$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" | tr ' ' '\n' | awk -v idx=$$NODE_INDEX -v total=$$NODE_TOTAL 'NR % total == idx' | tr '\n' ' ') && \
-		if [ -n "$$PARALLEL_PACKAGES" ]; then \
-			echo "Node $$NODE_INDEX/$$NODE_TOTAL running packages: $$PARALLEL_PACKAGES"; \
-			gotestsum --format=testname \
-				--junitfile=./tmp/test-results/results-$$NODE_INDEX.xml \
-				--jsonfile=./tmp/testlogs/log-$$NODE_INDEX.json \
-				--rerun-fails=3 \
-				--rerun-fails-max-failures=50 \
-				--packages="$$PARALLEL_PACKAGES" \
-				-- -parallel=$$PARALLEL -coverprofile=coverage-$$NODE_INDEX.out -short -timeout=$(TEST_TIMEOUT) -tags="ci"; \
-		else \
-			echo "Node $$NODE_INDEX/$$NODE_TOTAL has no packages to run"; \
-			touch ./tmp/test-results/results-$$NODE_INDEX.xml; \
-		fi; \
-	else \
-		gotestsum --format=testname \
-			--junitfile=./tmp/test-results/results.xml \
-			--jsonfile=./tmp/testlogs/log.json \
-			--rerun-fails=3 \
-			--rerun-fails-max-failures=50 \
-			--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
-			-- -parallel=$$PARALLEL -coverprofile=coverage.out -short -timeout=$(TEST_TIMEOUT) -tags="ci"; \
-	fi
-.PHONY: go-tests-short-ci
-
-go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps built by CI)
+# Internal target for running Go tests with gotestsum for CI
+# Usage: make _go-tests-ci-internal GO_TEST_FLAGS="-short"
+_go-tests-ci-internal:
 	@echo "Setting up test directories..."
 	mkdir -p ./tmp/test-results ./tmp/testlogs
 	@echo "Running Go tests with gotestsum..."
@@ -304,7 +275,7 @@ go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps 
 	if [ -n "$$CIRCLE_NODE_TOTAL" ] && [ "$$CIRCLE_NODE_TOTAL" -gt 1 ]; then \
 		export NODE_INDEX=$${CIRCLE_NODE_INDEX:-0} && \
 		export NODE_TOTAL=$${CIRCLE_NODE_TOTAL:-1} && \
-		export PARALLEL_PACKAGES=$$(echo "$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" | tr ' ' '\n' | awk -v idx=$$NODE_INDEX -v total=$$NODE_TOTAL 'NR % total == idx' | tr '\n' ' ') && \
+		export PARALLEL_PACKAGES=$$(echo "$(ALL_TEST_PACKAGES)" | tr ' ' '\n' | awk -v idx=$$NODE_INDEX -v total=$$NODE_TOTAL 'NR % total == idx' | tr '\n' ' ') && \
 		if [ -n "$$PARALLEL_PACKAGES" ]; then \
 			echo "Node $$NODE_INDEX/$$NODE_TOTAL running packages: $$PARALLEL_PACKAGES"; \
 			gotestsum --format=testname \
@@ -313,10 +284,10 @@ go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps 
 				--rerun-fails=3 \
 				--rerun-fails-max-failures=50 \
 				--packages="$$PARALLEL_PACKAGES" \
-				-- -parallel=$$PARALLEL -coverprofile=coverage-$$NODE_INDEX.out -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+				-- -parallel=$$PARALLEL -coverprofile=coverage-$$NODE_INDEX.out $(GO_TEST_FLAGS) -timeout=$(TEST_TIMEOUT) -tags="ci"; \
 		else \
-			echo "Node $$NODE_INDEX/$$NODE_TOTAL has no packages to run"; \
-			touch ./tmp/test-results/results-$$NODE_INDEX.xml; \
+			echo "ERROR: Node $$NODE_INDEX/$$NODE_TOTAL has no packages to run! Perhaps parallelism is set too high? (ALL_TEST_PACKAGES has $$(echo '$(ALL_TEST_PACKAGES)' | wc -w) packages)"; \
+			exit 1; \
 		fi; \
 	else \
 		gotestsum --format=testname \
@@ -324,9 +295,17 @@ go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps 
 			--jsonfile=./tmp/testlogs/log.json \
 			--rerun-fails=3 \
 			--rerun-fails-max-failures=50 \
-			--packages="$(TEST_PKGS) $(RPC_TEST_PKGS) $(FRAUD_PROOF_TEST_PKGS)" \
-			-- -parallel=$$PARALLEL -coverprofile=coverage.out -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+			--packages="$(ALL_TEST_PACKAGES)" \
+			-- -parallel=$$PARALLEL -coverprofile=coverage.out $(GO_TEST_FLAGS) -timeout=$(TEST_TIMEOUT) -tags="ci"; \
 	fi
+.PHONY: _go-tests-ci-internal
+
+go-tests-short-ci: ## Runs short Go tests with gotestsum for CI (assumes deps built by CI)
+	$(MAKE) _go-tests-ci-internal GO_TEST_FLAGS="-short"
+.PHONY: go-tests-short-ci
+
+go-tests-ci: ## Runs comprehensive Go tests with gotestsum for CI (assumes deps built by CI)
+	$(MAKE) _go-tests-ci-internal GO_TEST_FLAGS=""
 .PHONY: go-tests-ci
 
 go-tests-fraud-proofs-ci: ## Runs fraud proofs Go tests with gotestsum for CI (assumes deps built by CI)


### PR DESCRIPTION
## Description
Parallelised the "go-test" CI job across multiple machines (8). By doing so I expect these jobs to:
1. Run faster
2. Be more reliable/robust (each machine won't have as much load)
3. (Hopefully) Assist with our debugging

The local makefile jobs which it uses were slightly modified to facilitate package splitting/distribution across machines (when in parallel mode). They still work locally and on one machine. I also took the opportunity to simplify these two makefile targets by reusing a common base target.

### Further improvements
In this change I have implemented a simple/naive round-robin workload balancing. The runtime could be further improved by splitting on package test duration time. This is possible, but I have left it as a future improvement as it'd modify these jobs further and possibly require a new dependency on the circleci CLI.

## CI
In CI, we can see these jobs now parallelise
<img width="1627" height="449" alt="Screenshot 2025-09-16 at 15 45 47" src="https://github.com/user-attachments/assets/a13ff3a0-2ac0-4ea6-8adf-f6ed77d1c266" />

### Results
Over the last 1,066 runs of `go-tests-short` in CI [the p95 time is ~28m55s](https://app.circleci.com/insights/github/ethereum-optimism/optimism/workflows/main/jobs?branch=b1d8acd4-8701-4c76-8a87-7ff2320aa95f).
The same job after this change ran in [6m48s](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/100981/workflows/8dbae3dc-963e-4b1d-937d-01fdd3a9b3c6/jobs/3869148). A solid 4x speedup!

## Reference
https://circleci.com/docs/guides/optimize/parallelism-faster-jobs
