### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/op-challenger/cmd/credits.go
+++ b/op-challenger/cmd/credits.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
@@ -78,7 +79,8 @@ func listCredits(ctx context.Context, game contracts.FaultDisputeGameContract) e
 		return fmt.Errorf("failed to get withdrawals: %w", err)
 	}
 	lineFormat := "%-42v %12v %-19v\n"
-	info := fmt.Sprintf(lineFormat, "Claimant", "ETH", "Unlock Time")
+	var info strings.Builder
+	info.WriteString(fmt.Sprintf(lineFormat, "Claimant", "ETH", "Unlock Time"))
 	for i, withdrawal := range withdrawals {
 		var amount string
 		if withdrawal.Amount.Cmp(big.NewInt(0)) == 0 {
@@ -92,10 +94,10 @@ func listCredits(ctx context.Context, game contracts.FaultDisputeGameContract) e
 		} else {
 			unlockTime = time.Unix(withdrawal.Timestamp.Int64(), 0).Add(withdrawalDelay).Format(time.DateTime)
 		}
-		info += fmt.Sprintf(lineFormat, claimants[i], amount, unlockTime)
+		info.WriteString(fmt.Sprintf(lineFormat, claimants[i], amount, unlockTime))
 	}
 	fmt.Printf("DelayedWETH Contract: %v • Total Balance (ETH): %12.8f • Delay: %v\n%v\n",
-		wethAddress, eth.WeiToEther(balance), withdrawalDelay, info)
+		wethAddress, eth.WeiToEther(balance), withdrawalDelay, info.String())
 	return nil
 }
 

--- a/op-program/prestates/verify/verify.go
+++ b/op-program/prestates/verify/verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-program/prestates"
 )
@@ -65,7 +66,7 @@ func main() {
 	slices.SortFunc(actual, sortFunc)
 
 	differs := false
-	report := ""
+	var report strings.Builder
 	for _, release := range actual {
 		var expectedPrestate prestates.Prestate
 		standardVersion := expected.Prestates[release.Version]
@@ -92,7 +93,7 @@ func main() {
 			marker = "❌"
 			differs = true
 		}
-		report += fmt.Sprintf("%v Expected: %v\tActual: %v\n", marker, expectedStr, actualStr)
+		report.WriteString(fmt.Sprintf("%v Expected: %v\tActual: %v\n", marker, expectedStr, actualStr))
 	}
 	// Verify there aren't any additional entries in expected
 	totalExpected := 0
@@ -111,16 +112,16 @@ func main() {
 				Hash:    prestate.Hash,
 				Type:    prestate.Type,
 			})
-			report += fmt.Sprintf("❌ Expected: %v\tActual: <missing>\n", expectedStr)
+			report.WriteString(fmt.Sprintf("❌ Expected: %v\tActual: <missing>\n", expectedStr))
 			differs = true
 		}
 	}
 	// Sanity check entries are not duplicated in the standard prestates
 	if totalExpected != len(actual) {
-		report += fmt.Sprintf("❌ Found %v expected prestates but %v actual\n", totalExpected, len(actual))
+		report.WriteString(fmt.Sprintf("❌ Found %v expected prestates but %v actual\n", totalExpected, len(actual)))
 		differs = true
 	}
-	fmt.Println(report)
+	fmt.Println(report.String())
 	if differs {
 		os.Exit(1)
 	}

--- a/op-service/plan/node.go
+++ b/op-service/plan/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -311,13 +312,14 @@ func (p *Lazy[V]) Close() {
 func (p *Lazy[V]) String() string {
 	p.upstream.RLock()
 	defer p.upstream.RUnlock()
-	out := fmt.Sprintf("%T(", p)
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("%T(", p))
 	for i, up := range p.upstream.Value {
 		if i > 0 {
-			out += ", "
+			out.WriteString(", ")
 		}
-		out += fmt.Sprintf("%T", up)
+		out.WriteString(fmt.Sprintf("%T", up))
 	}
-	out += ")"
-	return out
+	out.WriteString(")")
+	return out.String()
 }

--- a/op-service/sources/batching/test/generic_stub.go
+++ b/op-service/sources/batching/test/generic_stub.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -54,15 +55,15 @@ func (r *RpcStub) CallContext(_ context.Context, out interface{}, method string,
 }
 
 func (r *RpcStub) findExpectedCall(rpcMethod string, args ...interface{}) ExpectedRpcCall {
-	var matchResults string
+	var matchResults strings.Builder
 	for _, call := range r.expectedCalls {
 		if err := call.Matches(rpcMethod, args...); err == nil {
 			return call
 		} else {
-			matchResults += fmt.Sprintf("%v: %v\n", call, err)
+			matchResults.WriteString(fmt.Sprintf("%v: %v\n", call, err))
 		}
 	}
-	require.Failf(r.t, "No matching expected calls.", matchResults)
+	require.Failf(r.t, "No matching expected calls.", matchResults.String())
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/fromda/db_invariants_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -61,11 +62,11 @@ func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
 }
 
 func fmtEntries(entries []Entry) string {
-	out := ""
+	var out strings.Builder
 	for i, entry := range entries {
-		out += fmt.Sprintf("%v: %x\n", i, entry)
+		out.WriteString(fmt.Sprintf("%v: %x\n", i, entry))
 	}
-	return out
+	return out.String()
 }
 
 func invariantFileSizeMultipleOfEntrySize(stat os.FileInfo, _ *stubMetrics) error {

--- a/op-supervisor/supervisor/backend/db/logs/db_invariants_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_invariants_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,11 +59,11 @@ func checkDBInvariants(t *testing.T, dbPath string, m *stubMetrics) {
 }
 
 func fmtEntries(entries []Entry) string {
-	out := ""
+	var out strings.Builder
 	for i, entry := range entries {
-		out += fmt.Sprintf("%v: %x\n", i, entry)
+		out.WriteString(fmt.Sprintf("%v: %x\n", i, entry))
 	}
-	return out
+	return out.String()
 }
 
 func invariantFileSizeMultipleOfEntrySize(stat os.FileInfo, _ *stubMetrics) error {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**


strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
