### PR TITLE
op-devstack: op-sync-tester: Add configurable preset

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
@@ -75,7 +76,7 @@ func getEnvUint64OrDefault(envVar string, defaultValue uint64) uint64 {
 }
 
 // setupOrchestrator initializes and configures the orchestrator for the test
-func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrator {
+func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) stack.Orchestrator {
 	l := t.Logger()
 
 	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
@@ -114,14 +115,17 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrat
 	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
 
 	// Create orchestrator with the same configuration that was in TestMain
-	opt := sysgo.DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(&sysgo.DefaultMinimalExternalELSystemIDs{}, l1CLBeaconEndpoint, l1ELEndpoint, l2ELEndpoint, L1ChainID, L2NetworkName, eth.FCUState{
-		Latest:    blk,
-		Safe:      blk,
-		Finalized: blk,
-	})
+	opt := stack.Combine(
+		presets.WithMinimalExternalELWithSuperchainRegistry(L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName),
+		presets.WithSyncTesterELInitialState(eth.FCUState{
+			Latest:    blk,
+			Safe:      blk,
+			Finalized: blk,
+		}),
+	)
 
-	orch := sysgo.NewOrchestrator(p, stack.SystemHook(opt))
-	stack.ApplyOptionLifecycle[*sysgo.Orchestrator](opt, orch)
+	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	return orch
 }

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -76,7 +76,7 @@ func getEnvUint64OrDefault(envVar string, defaultValue uint64) uint64 {
 }
 
 // setupOrchestrator initializes and configures the orchestrator for the test
-func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) stack.Orchestrator {
+func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrator {
 	l := t.Logger()
 
 	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
@@ -127,7 +127,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) stack.Orchestrato
 	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
 	stack.ApplyOptionLifecycle(opt, orch)
 
-	return orch
+	return orch.(*sysgo.Orchestrator)
 }
 
 func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName) {

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_e2e/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_e2e/init_test.go
@@ -5,15 +5,10 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(eth.FCUState{
-		Latest:    0,
-		Safe:      0,
-		Finalized: 0,
-	}),
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -108,7 +108,7 @@ func setupSystem(gt *testing.T, t devtest.T) (*presets.MinimalExternalEL, uint64
 }
 
 // setupOrchestrator initializes and configures the orchestrator for the test and returns the orchestrator and the initial block number of the session
-func setupOrchestrator(gt *testing.T, t devtest.T) (stack.Orchestrator, uint64) {
+func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64) {
 	l := t.Logger()
 	ctx := t.Ctx()
 	require := t.Require()
@@ -165,7 +165,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (stack.Orchestrator, uint64) 
 	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
 	stack.ApplyOptionLifecycle(opt, orch)
 
-	return orch, initial
+	return orch.(*sysgo.Orchestrator), initial
 }
 
 // getEnvOrDefault returns the environment variable value or the default if not set

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -108,7 +108,7 @@ func setupSystem(gt *testing.T, t devtest.T) (*presets.MinimalExternalEL, uint64
 }
 
 // setupOrchestrator initializes and configures the orchestrator for the test and returns the orchestrator and the initial block number of the session
-func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64) {
+func setupOrchestrator(gt *testing.T, t devtest.T) (stack.Orchestrator, uint64) {
 	l := t.Logger()
 	ctx := t.Ctx()
 	require := t.Require()
@@ -153,14 +153,17 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	initial := latestBlock.NumberU64() - 1000
 	l.Info("LATEST_BLOCK", "latest_block", latestBlock.NumberU64(), "session_initial_block", initial)
 
-	opt := sysgo.DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(&sysgo.DefaultMinimalExternalELSystemIDs{}, L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName, eth.FCUState{
-		Latest:    initial,
-		Safe:      initial,
-		Finalized: initial,
-	})
+	opt := stack.Combine(
+		presets.WithMinimalExternalELWithSuperchainRegistry(L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName),
+		presets.WithSyncTesterELInitialState(eth.FCUState{
+			Latest:    initial,
+			Safe:      initial,
+			Finalized: initial,
+		}),
+	)
 
-	orch := sysgo.NewOrchestrator(p, stack.SystemHook(opt))
-	stack.ApplyOptionLifecycle[*sysgo.Orchestrator](opt, orch)
+	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
+	stack.ApplyOptionLifecycle(opt, orch)
 
 	return orch, initial
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -10,15 +10,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleWithSyncTester(eth.FCUState{
-		Latest:    0,
-		Safe:      0,
-		Finalized: 0,
-	}),
+	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
 		presets.WithHardforkSequentialActivation(rollup.Bedrock, rollup.Jovian, 15),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {

--- a/op-devstack/presets/minimal_external_el.go
+++ b/op-devstack/presets/minimal_external_el.go
@@ -6,6 +6,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type MinimalExternalEL struct {
@@ -27,4 +29,8 @@ func (m *MinimalExternalEL) L2Networks() []*dsl.L2Network {
 	return []*dsl.L2Network{
 		m.L2Chain,
 	}
+}
+
+func WithMinimalExternalELWithSuperchainRegistry(l1CLBeaconRPC, l1ELRPC, l2ELRPC string, l1ChainID eth.ChainID, networkName string) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(&sysgo.DefaultMinimalExternalELSystemIDs{}, l1CLBeaconRPC, l1ELRPC, l2ELRPC, l1ChainID, networkName))
 }

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type SimpleWithSyncTester struct {
@@ -19,8 +18,8 @@ type SimpleWithSyncTester struct {
 	L2CL2          *dsl.L2CLNode
 }
 
-func WithSimpleWithSyncTester(fcus eth.FCUState) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}, fcus))
+func WithSimpleWithSyncTester() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSimpleSystemWithSyncTester(&sysgo.DefaultSimpleSystemWithSyncTesterIDs{}))
 }
 
 func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {

--- a/op-devstack/presets/sync_tester_config.go
+++ b/op-devstack/presets/sync_tester_config.go
@@ -1,0 +1,25 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func WithSyncTesterELInitialState(fcu eth.FCUState) stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
+			func(_ devtest.P, id stack.L2ELNodeID, cfg *sysgo.SyncTesterELConfig) {
+				cfg.FCUState = fcu
+			})))
+}
+
+func WithELSyncTarget(elSyncTarget uint64) stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
+			func(_ devtest.P, id stack.L2ELNodeID, cfg *sysgo.SyncTesterELConfig) {
+				cfg.ELSyncEnabled = true
+				cfg.ELSyncTarget = elSyncTarget
+			})))
+}

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -28,12 +28,64 @@ type SyncTesterEL struct {
 	authProxy *tcpproxy.Proxy
 	userProxy *tcpproxy.Proxy
 
-	// Sync tester specific fields
-	fcuState eth.FCUState
-	p        devtest.P
+	config *SyncTesterELConfig
+	p      devtest.P
 
 	// Reference to the orchestrator to find the EL node to connect to
 	orch *Orchestrator
+}
+
+type SyncTesterELConfig struct {
+	FCUState      eth.FCUState
+	ELSyncEnabled bool
+	ELSyncTarget  uint64
+}
+
+func (cfg *SyncTesterELConfig) Path() string {
+	path := fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", cfg.FCUState.Latest, cfg.FCUState.Safe, cfg.FCUState.Finalized)
+	if cfg.ELSyncEnabled {
+		path += fmt.Sprintf("&el_sync_target=%d", cfg.ELSyncTarget)
+	}
+	return path
+}
+
+func DefaultSyncTesterELConfig() *SyncTesterELConfig {
+	return &SyncTesterELConfig{
+		FCUState:      eth.FCUState{Latest: 0, Safe: 0, Finalized: 0},
+		ELSyncEnabled: false,
+		ELSyncTarget:  0,
+	}
+}
+
+type SyncTesterELOption interface {
+	Apply(p devtest.P, id stack.L2ELNodeID, cfg *SyncTesterELConfig)
+}
+
+// WithGlobalSyncTesterELOption applies the SyncTesterELOption to all SyncTesterEL instances in this orchestrator
+func WithGlobalSyncTesterELOption(opt SyncTesterELOption) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.SyncTesterELOptions = append(o.SyncTesterELOptions, opt)
+	})
+}
+
+type SyncTesterELOptionFn func(p devtest.P, id stack.L2ELNodeID, cfg *SyncTesterELConfig)
+
+var _ SyncTesterELOption = SyncTesterELOptionFn(nil)
+
+func (fn SyncTesterELOptionFn) Apply(p devtest.P, id stack.L2ELNodeID, cfg *SyncTesterELConfig) {
+	fn(p, id, cfg)
+}
+
+// SyncTesterELOptionBundle a list of multiple SyncTesterELOption, to all be applied in order.
+type SyncTesterELOptionBundle []SyncTesterELOption
+
+var _ SyncTesterELOptionBundle = SyncTesterELOptionBundle(nil)
+
+func (l SyncTesterELOptionBundle) Apply(p devtest.P, id stack.L2ELNodeID, cfg *SyncTesterELConfig) {
+	for _, opt := range l {
+		p.Require().NotNil(opt, "cannot Apply nil SyncTesterELOption")
+		opt.Apply(p, id, cfg)
+	}
 }
 
 var _ L2ELNode = (*SyncTesterEL)(nil)
@@ -72,6 +124,8 @@ func (n *SyncTesterEL) Start() {
 	// Use NewEndpoint to get the correct session-specific endpoint for this chain ID
 	endpoint := n.orch.syncTester.service.SyncTesterRPCPath(n.id.ChainID(), true)
 
+	path := endpoint + n.config.Path()
+
 	if n.authProxy == nil {
 		n.authProxy = tcpproxy.New(n.p.Logger().New("proxy", "l2el-synctester-auth"))
 		n.p.Require().NoError(n.authProxy.Start())
@@ -80,8 +134,7 @@ func (n *SyncTesterEL) Start() {
 		})
 
 		rpc := "http://" + n.authProxy.Addr()
-		n.authRPC = fmt.Sprintf("%s%s?latest=%d&safe=%d&finalized=%d",
-			rpc, endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+		n.authRPC = rpc + path
 	}
 	if n.userProxy == nil {
 		n.userProxy = tcpproxy.New(n.p.Logger().New("proxy", "l2el-synctester-user"))
@@ -91,15 +144,13 @@ func (n *SyncTesterEL) Start() {
 		})
 
 		rpc := "http://" + n.userProxy.Addr()
-		n.userRPC = fmt.Sprintf("%s%s?latest=%d&safe=%d&finalized=%d",
-			rpc, endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+		n.userRPC = rpc + path
 	}
 
-	session := fmt.Sprintf("%s%s?latest=%d&safe=%d&finalized=%d",
-		n.orch.syncTester.service.RPC(), endpoint, n.fcuState.Latest, n.fcuState.Safe, n.fcuState.Finalized)
+	sessionURL := n.orch.syncTester.service.RPC() + path
 
-	n.authProxy.SetUpstream(ProxyAddr(n.p.Require(), session))
-	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), session))
+	n.authProxy.SetUpstream(ProxyAddr(n.p.Require(), sessionURL))
+	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), sessionURL))
 }
 
 func (n *SyncTesterEL) Stop() {
@@ -120,7 +171,7 @@ func (n *SyncTesterEL) JWTPath() string {
 
 // WithSyncTesterL2ELNode creates a SyncTesterEL that satisfies the L2ELNode interface
 // The sync tester acts as an EL node that can be used by CL nodes for testing sync.
-func WithSyncTesterL2ELNode(id, readonlyEL stack.L2ELNodeID, fcuState eth.FCUState, opts ...L2ELOption) stack.Option[*Orchestrator] {
+func WithSyncTesterL2ELNode(id, readonlyEL stack.L2ELNodeID, opts ...SyncTesterELOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
 		require := p.Require()
@@ -128,19 +179,19 @@ func WithSyncTesterL2ELNode(id, readonlyEL stack.L2ELNodeID, fcuState eth.FCUSta
 		l2Net, ok := orch.l2Nets.Get(readonlyEL.ChainID())
 		require.True(ok, "L2 network required")
 
-		cfg := DefaultL2ELConfig()
-		orch.l2ELOptions.Apply(p, id, cfg)       // apply global options
-		L2ELOptionBundle(opts).Apply(p, id, cfg) // apply specific options
+		cfg := DefaultSyncTesterELConfig()
+		orch.SyncTesterELOptions.Apply(p, id, cfg)       // apply global options
+		SyncTesterELOptionBundle(opts).Apply(p, id, cfg) // apply specific options
 
 		jwtPath, _ := orch.writeDefaultJWT()
 
 		syncTesterEL := &SyncTesterEL{
-			id:       id,
-			l2Net:    l2Net,
-			jwtPath:  jwtPath,
-			fcuState: fcuState,
-			p:        p,
-			orch:     orch,
+			id:      id,
+			l2Net:   l2Net,
+			jwtPath: jwtPath,
+			config:  cfg,
+			p:       p,
+			orch:    orch,
 		}
 
 		p.Logger().Info("Starting sync tester EL", "id", id)

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -33,6 +33,7 @@ type Orchestrator struct {
 	proposerOptions         []ProposerOption
 	l2CLOptions             L2CLOptionBundle
 	l2ELOptions             L2ELOptionBundle
+	SyncTesterELOptions     SyncTesterELOptionBundle
 	deployerPipelineOptions []DeployerPipelineOption
 
 	superchains    locks.RWMap[stack.SuperchainID, *Superchain]

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -24,7 +24,7 @@ func NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID eth.ChainID) DefaultSimp
 	}
 }
 
-func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs, fcu eth.FCUState) stack.Option[*Orchestrator] {
+func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterIDs) stack.Option[*Orchestrator] {
 	l1ID := eth.ChainIDFromUInt64(900)
 	l2ID := eth.ChainIDFromUInt64(901)
 	ids := NewDefaultSimpleSystemWithSyncTesterIDs(l1ID, l2ID)
@@ -63,7 +63,7 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 	opt.Add(WithSyncTester(ids.SyncTester, []stack.L2ELNodeID{ids.L2EL}))
 
 	// Create a SyncTesterEL with the same chain ID as the EL node
-	opt.Add(WithSyncTesterL2ELNode(ids.SyncTesterL2EL, ids.L2EL, fcu))
+	opt.Add(WithSyncTesterL2ELNode(ids.SyncTesterL2EL, ids.L2EL))
 	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, ids.SyncTesterL2EL))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {

--- a/op-devstack/sysgo/system_synctester_ext.go
+++ b/op-devstack/sysgo/system_synctester_ext.go
@@ -39,7 +39,7 @@ func NewDefaultMinimalExternalELSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimal
 
 // DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry creates a minimal external EL system
 // using a network from the superchain registry instead of the deployer
-func DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExternalELSystemIDs, l1CLBeaconRPC, l1ELRPC, l2ELRPC string, l1ChainID eth.ChainID, networkName string, fcu eth.FCUState) stack.Option[*Orchestrator] {
+func DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExternalELSystemIDs, l1CLBeaconRPC, l1ELRPC, l2ELRPC string, l1ChainID eth.ChainID, networkName string) stack.Option[*Orchestrator] {
 	chainCfg := chaincfg.ChainByName(networkName)
 	if chainCfg == nil {
 		panic(fmt.Sprintf("network %s not found in superchain registry", networkName))
@@ -83,7 +83,7 @@ func DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(dest *Defau
 	opt.Add(WithSyncTesterWithExternalEndpoint(ids.SyncTester, l2ELRPC, l2ChainID))
 
 	// Add SyncTesterL2ELNode as the L2EL replacement for real-world EL endpoint
-	opt.Add(WithSyncTesterL2ELNode(ids.L2EL, ids.L2EL, fcu))
+	opt.Add(WithSyncTesterL2ELNode(ids.L2EL, ids.L2EL))
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Follow an Option pattern to config the Sync Tester EL. Now we can initialize tests using below pattern
```go
	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
		presets.WithCompatibleTypes(compat.SysGo),
		presets.WithSyncTesterELInitialState(eth.FCUState{
			Latest:    100,
			Safe:      100,
			Finalized: 100,
		})
	)
```

**Tests**

CI has flaky tests failing, but all the sync tester acceptance tests are passing.

**Additional context**

Preset `WithELSyncTarget` is added, although it is a no-op now. Follow-up PR for enabling EL Sync test using the Sync Tester will utilize this and propagate the info to the sync tester EL.
