### PR TITLE
op-acceptance-tests: Increase timeout for interop msg tests

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -61,6 +61,7 @@ gates:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
         timeout: 10m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/message
+        timeout: 30m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/sync
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/smoke
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/contract


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`TestExecMsgDifferEventIndexInSingleTx` is marked as failed and observed as flaky
```
=== RUN   TestExecMsgDifferEventIndexInSingleTx
    l2.go:420:             [32mINFO [0m[09-17|03:41:14.588] Loaded devnet keys: 12 L1 system keys, 30 L2 user keys
    l2.go:148:                  [32mINFO [0m[09-17|03:41:14.588] Found endpoint for CL service            [32mendpoint[0m=http://127.0.0.1:32783
    l2.go:420:             [32mINFO [0m[09-17|03:41:14.590] Loaded devnet keys: 12 L1 system keys, 30 L2 user keys
    l2.go:148:                  [32mINFO [0m[09-17|03:41:14.590] Found endpoint for CL service            [32mendpoint[0m=http://127.0.0.1:32792
```

while running the `TestExecMsgDifferEventIndexInSingleTx`, it got timeout
https://output.circle-artifacts.com/output/job/b015c061-afa9-4bf8-89d5-28c205df64f1/artifacts/0/op-acceptance-tests/logs/testrun-7dfe00f0-7a15-422e-a6e4-faf8b863377c/failed/interop_message_github.com_ethereum-optimism_optimism_op-acceptance-tests_tests_interop_message.txt


```log
*** TIMEOUT ERROR ***
TIMEOUT: Test timed out after 5m0s (actual duration: 5m0.205372202s) - 10 subtests detected in partial output
*** END TIMEOUT ERROR ***
```

Increasing timeout may fix the flakiness.