### PR TITLE
op-node: Do not set unsafe head while payload is syncing

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -518,9 +518,12 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 			payload.ID(), payload.ParentID(), eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)))
 	}
 	fcu2Finish := time.Now()
-	e.SetUnsafeHead(ref)
-	e.needFCUCall = false
-	e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
+
+	if fcRes.PayloadStatus.Status == eth.ExecutionValid {
+		e.SetUnsafeHead(ref)
+		e.needFCUCall = false
+		e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
+	}
 
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		e.log.Info("Finished EL sync", "sync_duration", e.clock.Since(e.elStart), "finalized_block", ref.ID().String())


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

While we EL Sync,  op-node receives new payloads, and attempts to tell the EL. It loops using below steps until the EL is ready(returning `VALID`):
1. Call `engine_newPayload`, and EL yet synced so response is `SYNCING`.
2. Call `engine_forkchoiceupdated`, and EL yet synced to response is `SYNCING`.

While op-node waits till the EL is ready, and returns `VALID` response to the engine APIs, op-node's `syncStatus`(response of `optimism_syncStatus` must not be updated since the underlying EL is not yet synced.

This PR fixes the case that when op-node is operating in EL Sync, and connected EL is not yet fully synced (returning `SYNCING` and not `VALID`), op-node updated its unsafe head view. 


