### PR TITLE
op-acceptance-tests: Deflake `TestPreNoInbox`

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/init_test.go
@@ -9,6 +9,6 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSimpleInterop(),
-		presets.WithSuggestedInteropActivationOffset(30),
+		presets.WithSuggestedInteropActivationOffset(60),
 		presets.WithInteropNotAtGenesis())
 }


### PR DESCRIPTION
**Description**

Deflake `TestPreNoInBox` by adjusting interop hardfork time to more future: adding 30 seconds. The reason is described at the attached issue.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17298
