### PR TITLE
op-acceptance-tests: De-flake

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -61,6 +61,7 @@ gates:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop
         timeout: 10m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/message
+        timeout: 30m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/sync
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/smoke
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/contract

--- a/op-acceptance-tests/tests/interop/upgrade/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/init_test.go
@@ -9,6 +9,6 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSimpleInterop(),
-		presets.WithSuggestedInteropActivationOffset(30),
+		presets.WithSuggestedInteropActivationOffset(60),
 		presets.WithInteropNotAtGenesis())
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Two orthogonal flake sources are are blocking the CI pipeline, and each cannot be merged separately. 
- https://github.com/ethereum-optimism/optimism/pull/17492
- https://github.com/ethereum-optimism/optimism/pull/17495

Merging them into one.