### PR TITLE
remove hold job phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2316,17 +2316,7 @@ workflows:
       not:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
-      # Wait for approval on the release
-      - hold:
-          type: approval
-          filters:
-            tags:
-              only: /^(da-server|cannon|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
-            branches:
-              ignore: /.*/
       - initialize:
-          requires:
-            - hold
           context:
             - circleci-repo-readonly-authenticated-github-token
           filters:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request makes a small change to the CircleCI workflow configuration by removing the manual approval step for releases. The `hold` job, which previously required approval before proceeding with initialization, has been deleted from `.circleci/config.yml`. This streamlines the release process by allowing the `initialize` job to start without waiting for approval.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
