### PR TITLE
fix: remove duplicate invalidBatchCount increment in batch decoder

### DIFF
--- a/op-node/cmd/batch_decoder/fetch/fetch.go
+++ b/op-node/cmd/batch_decoder/fetch/fetch.go
@@ -100,7 +100,6 @@ func fetchBatchesPerBlock(ctx context.Context, client *ethclient.Client, beacon 
 			validSender := true
 			if _, ok := config.BatchSenders[sender]; !ok {
 				fmt.Printf("Found a transaction (%s) from an invalid sender (%s)\n", tx.Hash().String(), sender.String())
-				invalidBatchCount += 1
 				validSender = false
 			}
 			var datas []hexutil.Bytes


### PR DESCRIPTION
Fix double counting of invalid batches in batch decoder fetch logic

The invalidBatchCount was being incremented twice for transactions with
invalid senders:
1. First increment on line 103 when detecting invalid sender
2. Second increment on line 164 in the final validation check

This caused transactions with invalid senders to be counted twice in the
invalid batch statistics, leading to incorrect reporting of batch
validation results.