### PR TITLE
opcm: Support cannon+kona games in addGameType

### DIFF
--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -240,4 +240,9 @@ library Config {
     function devFeatureInterop() internal view returns (bool) {
         return vm.envOr("DEV_FEATURE__OPTIMISM_PORTAL_INTEROP", false);
     }
+
+    /// @notice Returns true if the development feature cannon_kona is enabled.
+    function devFeatureCannonKona() internal view returns (bool) {
+        return vm.envOr("DEV_FEATURE__CANNON_KONA", false);
+    }
 }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x38dfaa504d646a48b85da1d2cf853263241070ac25a93d16f12468d948aa5f96",
-    "sourceCodeHash": "0xb5cb0e204bde0e5ab59c3be61e234c2c6b0efa60f9e550c25f64b8d5eeffae4e"
+    "initCodeHash": "0xe94325cd292ec3131cae7525eb1487abfea94c16aa4f000d594c1fd5a5bbbadd",
+    "sourceCodeHash": "0x144818d225cea78696e7ccdc486d79958b04ef6cd82d08e968db594ac2a571a3"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x17a40747da8a9978f7294f071ea371b8c021504b898919431e6acf62623e8adc",
-    "sourceCodeHash": "0xa80dcd2ebafc5a6a437f712d8073f8a48998807aa317ad7762b3fc9dc2caa133"
+    "initCodeHash": "0xcc5dacb9e1c2b9395aa5f9c300f03c18af1ff5a9efd6a7ce4d5135dfbe7b1e2b",
+    "sourceCodeHash": "0x0c63dc35ccf59cc583fbbfc0f2251ba95d026c11540f08806a48cb3934e73ae4"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x8faaaf0aa74a8f7a98674e94009a516dddae7bb1feb687f4a6d43641c23efe45",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -461,7 +461,13 @@ contract OPContractsManagerGameTypeAdder is OPContractsManagerBase {
                 OPContractsManager.Blueprints memory bps = getBlueprints();
 
                 // Determine the contract name and blueprints for the game type.
-                if (gameConfig.disputeGameType.raw() == GameTypes.CANNON.raw()) {
+                if (
+                    gameConfig.disputeGameType.raw() == GameTypes.CANNON.raw()
+                        || (
+                            isDevFeatureEnabled(DevFeatures.CANNON_KONA)
+                                && gameConfig.disputeGameType.raw() == GameTypes.CANNON_KONA.raw()
+                        )
+                ) {
                     gameContractName = "FaultDisputeGame";
                     blueprint1 = bps.permissionlessDisputeGame1;
                     blueprint2 = bps.permissionlessDisputeGame2;
@@ -471,7 +477,13 @@ contract OPContractsManagerGameTypeAdder is OPContractsManagerBase {
                     blueprint1 = bps.permissionedDisputeGame1;
                     blueprint2 = bps.permissionedDisputeGame2;
                     gameL2ChainId = l2ChainId;
-                } else if (gameConfig.disputeGameType.raw() == GameTypes.SUPER_CANNON.raw()) {
+                } else if (
+                    gameConfig.disputeGameType.raw() == GameTypes.SUPER_CANNON.raw()
+                        || (
+                            isDevFeatureEnabled(DevFeatures.CANNON_KONA)
+                                && gameConfig.disputeGameType.raw() == GameTypes.SUPER_CANNON_KONA.raw()
+                        )
+                ) {
                     gameContractName = "SuperFaultDisputeGame";
                     blueprint1 = bps.superPermissionlessDisputeGame1;
                     blueprint2 = bps.superPermissionlessDisputeGame2;
@@ -1786,9 +1798,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 3.3.0
+    /// @custom:semver 3.4.0
     function version() public pure virtual returns (string memory) {
-        return "3.3.0";
+        return "3.4.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -38,8 +38,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.16.0
-    string public constant version = "1.16.0";
+    /// @custom:semver 1.17.0
+    string public constant version = "1.17.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/libraries/DevFeatures.sol
+++ b/packages/contracts-bedrock/src/libraries/DevFeatures.sol
@@ -14,6 +14,8 @@ library DevFeatures {
     bytes32 public constant OPTIMISM_PORTAL_INTEROP =
         bytes32(0x0000000000000000000000000000000000000000000000000000000000000001);
 
+    bytes32 public constant CANNON_KONA = bytes32(0x0000000000000000000000000000000000000000000000000000000000000010);
+
     /// @notice Checks if a feature is enabled in a bitmap. Note that this function does not check
     ///         that the input feature represents a single feature and the bitwise AND operation
     ///         allows for multiple features to be enabled at once. Users should generally check

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -550,7 +550,6 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     function test_addGameType_cannonKonaGameTypeDisabled_reverts() public {
         skipIfDevFeatureEnabled(DevFeatures.CANNON_KONA);
         IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON_KONA);
-        input.disputeGameType = GameTypes.CANNON_KONA;
 
         // Run the addGameType call, should revert.
         IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
@@ -563,7 +562,6 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     function test_addGameType_superCannonKonaGameTypeDisabled_reverts() public {
         skipIfDevFeatureEnabled(DevFeatures.CANNON_KONA);
         IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.SUPER_CANNON_KONA);
-        input.disputeGameType = GameTypes.CANNON_KONA;
 
         // Run the addGameType call, should revert.
         IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -435,7 +435,7 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     /// @notice Tests that we can add a PermissionedDisputeGame implementation with addGameType.
     function test_addGameType_permissioned_succeeds() public {
         // Create the input for the Permissioned game type.
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.PERMISSIONED_CANNON);
 
         // Run the addGameType call.
         IOPContractsManager.AddGameOutput memory output = addGameType(input);
@@ -454,9 +454,9 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     }
 
     /// @notice Tests that we can add a FaultDisputeGame implementation with addGameType.
-    function test_addGameType_permissionless_succeeds() public {
+    function test_addGameType_cannon_succeeds() public {
         // Create the input for the Permissionless game type.
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON);
 
         // Run the addGameType call.
         IOPContractsManager.AddGameOutput memory output = addGameType(input);
@@ -476,7 +476,7 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     /// @notice Tests that we can add a SuperPermissionedDisputeGame implementation with addGameType.
     function test_addGameType_permissionedSuper_succeeds() public {
         // Create the input for the Super game type.
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.SUPER_PERMISSIONED_CANNON);
         input.disputeGameType = GameTypes.SUPER_PERMISSIONED_CANNON;
 
         // Since OPCM will start with the standard Permissioned (non-Super) game type we won't have
@@ -515,10 +515,9 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     }
 
     /// @notice Tests that we can add a SuperFaultDisputeGame implementation with addGameType.
-    function test_addGameType_permissionlessSuper_succeeds() public {
+    function test_addGameType_superCannon_succeeds() public {
         // Create the input for the Super game type.
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
-        input.disputeGameType = GameTypes.SUPER_CANNON;
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.SUPER_CANNON);
 
         // Run the addGameType call.
         IOPContractsManager.AddGameOutput memory output = addGameType(input);
@@ -538,8 +537,33 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
 
     /// @notice Tests that addGameType will revert if the game type is not supported.
     function test_addGameType_unsupportedGameType_reverts() public {
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
-        input.disputeGameType = GameType.wrap(2000);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameType.wrap(2000));
+
+        // Run the addGameType call, should revert.
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
+        inputs[0] = input;
+        (bool success,) = address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.addGameType, (inputs)));
+        assertFalse(success, "addGameType should have failed");
+    }
+
+    /// @notice Tests that addGameType will revert if the game type is cannon-kona and the dev feature is not enabled
+    function test_addGameType_cannonKonaGameTypeDisabled_reverts() public {
+        skipIfDevFeatureEnabled(DevFeatures.CANNON_KONA);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON_KONA);
+        input.disputeGameType = GameTypes.CANNON_KONA;
+
+        // Run the addGameType call, should revert.
+        IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
+        inputs[0] = input;
+        (bool success,) = address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.addGameType, (inputs)));
+        assertFalse(success, "addGameType should have failed");
+    }
+
+    /// @notice Tests that addGameType will revert if the game type is cannon-kona and the dev feature is not enabled
+    function test_addGameType_superCannonKonaGameTypeDisabled_reverts() public {
+        skipIfDevFeatureEnabled(DevFeatures.CANNON_KONA);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.SUPER_CANNON_KONA);
+        input.disputeGameType = GameTypes.CANNON_KONA;
 
         // Run the addGameType call, should revert.
         IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
@@ -560,7 +584,7 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
             )
         );
         vm.etch(address(delayedWETH), hex"01");
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON);
         input.delayedWETH = delayedWETH;
         IOPContractsManager.AddGameOutput memory output = addGameType(input);
         assertValidGameType(input, output);
@@ -568,10 +592,8 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     }
 
     function test_addGameType_outOfOrderInputs_reverts() public {
-        IOPContractsManager.AddGameInput memory input1 = newGameInputFactory(false);
-        input1.disputeGameType = GameType.wrap(2);
-        IOPContractsManager.AddGameInput memory input2 = newGameInputFactory(false);
-        input2.disputeGameType = GameType.wrap(1);
+        IOPContractsManager.AddGameInput memory input1 = newGameInputFactory(GameType.wrap(2));
+        IOPContractsManager.AddGameInput memory input2 = newGameInputFactory(GameType.wrap(1));
         IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](2);
         inputs[0] = input1;
         inputs[1] = input2;
@@ -582,7 +604,7 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     }
 
     function test_addGameType_duplicateGameType_reverts() public {
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(false);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON);
         IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](2);
         inputs[0] = input;
         inputs[1] = input;
@@ -604,7 +626,7 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
     }
 
     function test_addGameType_notDelegateCall_reverts() public {
-        IOPContractsManager.AddGameInput memory input = newGameInputFactory(true);
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.PERMISSIONED_CANNON);
         IOPContractsManager.AddGameInput[] memory inputs = new IOPContractsManager.AddGameInput[](1);
         inputs[0] = input;
 
@@ -637,13 +659,13 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
         return addGameOutAll[0];
     }
 
-    function newGameInputFactory(bool permissioned) internal view returns (IOPContractsManager.AddGameInput memory) {
+    function newGameInputFactory(GameType _gameType) internal view returns (IOPContractsManager.AddGameInput memory) {
         return IOPContractsManager.AddGameInput({
             saltMixer: "hello",
             systemConfig: chainDeployOutput1.systemConfigProxy,
             proxyAdmin: chainDeployOutput1.opChainProxyAdmin,
             delayedWETH: IDelayedWETH(payable(address(0))),
-            disputeGameType: GameType.wrap(permissioned ? 1 : 0),
+            disputeGameType: _gameType,
             disputeAbsolutePrestate: Claim.wrap(bytes32(hex"deadbeef1234")),
             disputeMaxGameDepth: 73,
             disputeSplitDepth: 30,
@@ -651,7 +673,8 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
             disputeMaxClockDuration: Duration.wrap(302400),
             initialBond: 1 ether,
             vm: IBigStepper(address(opcm.implementations().mipsImpl)),
-            permissioned: permissioned
+            permissioned: _gameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()
+                || _gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
         });
     }
 
@@ -702,6 +725,58 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
         assertEq(
             chainDeployOutput1.disputeGameFactoryProxy.initBonds(agi.disputeGameType), agi.initialBond, "bond mismatch"
         );
+    }
+}
+
+/// @title OPContractsManager_AddGameTypeCannonKonaEnabled_Test
+/// @notice Tests the `addGameType` function of the `OPContractsManager` contract with CANNON_KONA enabled.
+contract OPContractsManager_AddGameTypeCannonKonaEnabled_Test is OPContractsManager_AddGameType_Test {
+    function setUp() public override {
+        setDevFeatureEnabled(DevFeatures.CANNON_KONA);
+        super.setUp();
+    }
+
+    /// @notice Tests that addGameType will revert if the game type is cannon-kona and the dev feature is not enabled
+    function test_addGameType_cannonKonaGameType_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.CANNON_KONA);
+        // Create the input for the cannon-kona game type.
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON_KONA);
+
+        // Run the addGameType call.
+        IOPContractsManager.AddGameOutput memory output = addGameType(input);
+        assertValidGameType(input, output);
+
+        // Check the values on the new game type.
+        IPermissionedDisputeGame notPDG = IPermissionedDisputeGame(address(output.faultDisputeGame));
+
+        // Proposer call should revert because this is a permissionless game.
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        notPDG.proposer();
+
+        // L2 chain ID call should not revert because this is not a Super game.
+        assertNotEq(notPDG.l2ChainId(), 0, "l2ChainId should not be zero");
+    }
+
+    /// @notice Tests that addGameType will revert if the game type is cannon-kona and the dev feature is not enabled
+    function test_addGameType_superCannonKonaGameType_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.CANNON_KONA);
+        // Create the input for the cannon-kona game type.
+        IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.SUPER_CANNON_KONA);
+
+        // Run the addGameType call.
+        IOPContractsManager.AddGameOutput memory output = addGameType(input);
+        assertValidGameType(input, output);
+
+        // Grab the new game type.
+        IPermissionedDisputeGame notPDG = IPermissionedDisputeGame(address(output.faultDisputeGame));
+
+        // Proposer should fail, this is a permissionless game.
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        notPDG.proposer();
+
+        // Super games don't have the l2ChainId function.
+        vm.expectRevert(); // nosemgrep: sol-safety-expectrevert-no-args
+        notPDG.l2ChainId();
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -730,7 +730,7 @@ contract OPContractsManager_AddGameType_Test is OPContractsManager_TestInit {
 
 /// @title OPContractsManager_AddGameTypeCannonKonaEnabled_Test
 /// @notice Tests the `addGameType` function of the `OPContractsManager` contract with CANNON_KONA enabled.
-contract OPContractsManager_AddGameTypeCannonKonaEnabled_Test is OPContractsManager_AddGameType_Test {
+contract OPContractsManager_AddGameType_CannonKonaEnabled_Test is OPContractsManager_AddGameType_Test {
     function setUp() public override {
         setDevFeatureEnabled(DevFeatures.CANNON_KONA);
         super.setUp();

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -738,7 +738,6 @@ contract OPContractsManager_AddGameType_CannonKonaEnabled_Test is OPContractsMan
 
     /// @notice Tests that addGameType will revert if the game type is cannon-kona and the dev feature is not enabled
     function test_addGameType_cannonKonaGameType_succeeds() public {
-        skipIfDevFeatureDisabled(DevFeatures.CANNON_KONA);
         // Create the input for the cannon-kona game type.
         IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.CANNON_KONA);
 
@@ -759,7 +758,6 @@ contract OPContractsManager_AddGameType_CannonKonaEnabled_Test is OPContractsMan
 
     /// @notice Tests that addGameType will revert if the game type is cannon-kona and the dev feature is not enabled
     function test_addGameType_superCannonKonaGameType_succeeds() public {
-        skipIfDevFeatureDisabled(DevFeatures.CANNON_KONA);
         // Create the input for the cannon-kona game type.
         IOPContractsManager.AddGameInput memory input = newGameInputFactory(GameTypes.SUPER_CANNON_KONA);
 

--- a/packages/contracts-bedrock/test/setup/FeatureFlags.sol
+++ b/packages/contracts-bedrock/test/setup/FeatureFlags.sol
@@ -36,6 +36,10 @@ contract FeatureFlags {
             console.log("Setup: DEV_FEATURE__OPTIMISM_PORTAL_INTEROP is enabled");
             devFeatureBitmap |= DevFeatures.OPTIMISM_PORTAL_INTEROP;
         }
+        if (Config.devFeatureCannonKona()) {
+            console.log("Setup: DEV_FEATURE__CANNON_KONA is enabled");
+            devFeatureBitmap |= DevFeatures.CANNON_KONA;
+        }
     }
 
     /// @notice Enables a feature.


### PR DESCRIPTION
**Description**

Support cannon+kona games in addGameType behind a dev feature toggle.

The OPCM tests are updated to pass a GameType to the helper method rather than just a permissioned boolean.
