### PR TITLE
chore(op-acceptance-tests): isthmus into base gate.

### DIFF
--- a/op-acceptance-tests/README.md
+++ b/op-acceptance-tests/README.md
@@ -54,7 +54,6 @@ just acceptance-test "" base
 
 # Run against Kurtosis devnets (requires Docker + Kurtosis)
 just acceptance-test simple base
-just acceptance-test isthmus isthmus
 just acceptance-test interop interop
 ```
 
@@ -106,7 +105,7 @@ For integration testing against realistic networks:
 
 1. **Automated approach** (rebuilds devnet each time):
    ```bash
-   just acceptance-test isthmus isthmus
+   just acceptance-test interop interop
    ```
 
 2. **Manual approach** (once-off)

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -7,14 +7,24 @@
 
 
 gates:
-  - id: conductor
-    description: "Sanity/smoke acceptance tests for networks with conductors."
+  - id: isthmus
+    description: "Isthmus network tests."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/conductor
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
+        timeout: 6h
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee
+        timeout: 6h
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/withdrawal_root
+        timeout: 20m
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/erc20_bridge
+        timeout: 10m
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/pectra
         timeout: 10m
 
   - id: base
     description: "Sanity/smoke acceptance tests for all networks."
+    inherits:
+      - isthmus
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/deposit
@@ -28,20 +38,10 @@ gates:
       #  timeout: 10m
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/fjord
 
-  - id: isthmus
-    inherits:
-      - base
-    description: "Isthmus network tests."
+  - id: conductor
+    description: "Sanity/smoke acceptance tests for networks with conductors."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus
-        timeout: 6h
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/operator_fee
-        timeout: 6h
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/withdrawal_root
-        timeout: 20m
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/erc20_bridge
-        timeout: 10m
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/isthmus/pectra
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/conductor
         timeout: 10m
 
   - id: pre-interop
@@ -82,7 +82,7 @@ gates:
 
   - id: flashblocks-with-isthmus
     inherits:
-      - isthmus
+      - base
     description: "Flashblocks network tests with Isthmus."
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -8,12 +8,6 @@ ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-ac
 default:
     @just acceptance-test "" base
 
-holocene:
-    @just acceptance-test "" holocene
-
-isthmus:
-    @just acceptance-test "" isthmus
-
 jovian:
     @just acceptance-test jovian jovian
 
@@ -28,7 +22,7 @@ interop:
 #   just acceptance-test "" ""           # In-process gateless mode (all tests)
 #   just acceptance-test "simple" base     # External devnet with specific gate
 #   just acceptance-test "simple" ""       # External devnet gateless mode (all tests)
-acceptance-test devnet="" gate="holocene":
+acceptance-test devnet="" gate="base":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -132,7 +126,7 @@ acceptance-test devnet="" gate="holocene":
 
 
 # Run acceptance tests against a devnet using Docker (fallback if needed)
-acceptance-test-docker devnet="simple" gate="holocene":
+acceptance-test-docker devnet="simple" gate="base":
     #!/usr/bin/env bash
     set -euo pipefail
 


### PR DESCRIPTION
As Isthmus is on Mainnet, we now move this gate into the 'base' gate which should work against all devnets.
