### PR TITLE
chore(op-acceptance-tests): op-acceptor v3.3.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -37,7 +37,7 @@ anvil = "1.1.0"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v3.2.1"
+op-acceptor = "op-acceptor/v3.3.1"
 
 # Fake dependencies
 # Put things here if you need to track versions of tools or projects that can't

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`  # path to the root of the optimism monorepo
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.2.1")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.3.1")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 


### PR DESCRIPTION
## Description
Updates op-acceptor to [v3.3.1](https://github.com/ethereum-optimism/infra/releases/tag/op-acceptor%2Fv3.3.1)

## Note
DO NOT MERGE until ALL github checks are green.
