### PR TITLE
op-sync-tester: Support EL Sync

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
@@ -1,0 +1,62 @@
+package sync_tester_elsync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestSyncTesterELSync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleWithSyncTester(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	target := uint64(5)
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, target, 30),
+		sys.L2CL2.AdvancedFn(types.LocalUnsafe, target, 30),
+	)
+
+	// Stop L2CL2 attached to Sync Tester EL Endpoint
+	sys.L2CL2.Stop()
+
+	// Reset Sync Tester EL
+	sessionIDs := sys.SyncTester.ListSessions()
+	require.GreaterOrEqual(len(sessionIDs), 1, "at least one session")
+	sessionID := sessionIDs[0]
+	logger.Info("SyncTester EL", "sessionID", sessionID)
+	syncTesterClient := sys.SyncTester.Escape().APIWithSession(sessionID)
+	require.NoError(syncTesterClient.ResetSession(ctx))
+
+	// Wait for L2CL to advance more unsafe blocks
+	sys.L2CL.Advanced(types.LocalUnsafe, target+5, 30)
+
+	// EL Sync not done yet
+	session, err := syncTesterClient.GetSession(ctx)
+	require.NoError(err)
+	require.True(session.ELSyncEnabled)
+
+	// Restarting will trigger EL sync since unsafe head payload will arrive to L2CL2 via P2P
+	sys.L2CL2.Start()
+
+	// Wait until P2P is connected
+	sys.L2CL2.IsP2PConnected(sys.L2CL)
+
+	// Reaches EL Sync Target and advances
+	target = uint64(40)
+	sys.L2CL2.Reached(types.LocalUnsafe, target, 30)
+
+	session, err = syncTesterClient.GetSession(ctx)
+	require.NoError(err)
+	require.False(session.ELSyncEnabled)
+
+	// Check CL2 view is consistent with read only EL
+	unsafeHead := sys.L2CL2.SyncStatus().UnsafeL2
+	require.GreaterOrEqual(unsafeHead.Number, target)
+	require.Equal(sys.L2EL.BlockRefByNumber(unsafeHead.Number).Hash, unsafeHead.Hash)
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
@@ -39,7 +39,7 @@ func TestSyncTesterELSync(gt *testing.T) {
 	// EL Sync not done yet
 	session, err := syncTesterClient.GetSession(ctx)
 	require.NoError(err)
-	require.True(session.ELSyncEnabled)
+	require.True(session.ELSyncActive)
 
 	// Restarting will trigger EL sync since unsafe head payload will arrive to L2CL2 via P2P
 	sys.L2CL2.Start()
@@ -53,7 +53,7 @@ func TestSyncTesterELSync(gt *testing.T) {
 
 	session, err = syncTesterClient.GetSession(ctx)
 	require.NoError(err)
-	require.False(session.ELSyncEnabled)
+	require.False(session.ELSyncActive)
 
 	// Check CL2 view is consistent with read only EL
 	unsafeHead := sys.L2CL2.SyncStatus().UnsafeL2

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/init_test.go
@@ -1,0 +1,17 @@
+package sync_tester_elsync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		presets.WithSimpleWithSyncTester(),
+		presets.WithELSyncTarget(35),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -316,6 +316,20 @@ func (cl *L2CLNode) ConnectPeer(peer *L2CLNode) {
 	cl.require.NoError(err, "failed to connect peer")
 }
 
+func (cl *L2CLNode) IsP2PConnected(peer *L2CLNode) {
+	myInfo := cl.PeerInfo()
+	strategy := &retry.ExponentialStrategy{Min: 10 * time.Second, Max: 30 * time.Second, MaxJitter: 250 * time.Millisecond}
+	err := retry.Do0(cl.ctx, 5, strategy, func() error {
+		for _, p := range peer.Peers().Peers {
+			if p.PeerID == myInfo.PeerID {
+				return nil
+			}
+		}
+		return errors.New("peer not connected yet")
+	})
+	cl.require.NoError(err, "peer not connected")
+}
+
 type safeHeadDbMatchOpts struct {
 	minRequiredL2Block *uint64
 }

--- a/op-devstack/presets/sync_tester_config.go
+++ b/op-devstack/presets/sync_tester_config.go
@@ -19,7 +19,7 @@ func WithELSyncTarget(elSyncTarget uint64) stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
 			func(_ devtest.P, id stack.L2ELNodeID, cfg *sysgo.SyncTesterELConfig) {
-				cfg.ELSyncEnabled = true
+				cfg.ELSyncActive = true
 				cfg.ELSyncTarget = elSyncTarget
 			})))
 }

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -36,14 +36,14 @@ type SyncTesterEL struct {
 }
 
 type SyncTesterELConfig struct {
-	FCUState      eth.FCUState
-	ELSyncEnabled bool
-	ELSyncTarget  uint64
+	FCUState     eth.FCUState
+	ELSyncActive bool
+	ELSyncTarget uint64
 }
 
 func (cfg *SyncTesterELConfig) Path() string {
 	path := fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", cfg.FCUState.Latest, cfg.FCUState.Safe, cfg.FCUState.Finalized)
-	if cfg.ELSyncEnabled {
+	if cfg.ELSyncActive {
 		path += fmt.Sprintf("&el_sync_target=%d", cfg.ELSyncTarget)
 	}
 	return path
@@ -51,9 +51,9 @@ func (cfg *SyncTesterELConfig) Path() string {
 
 func DefaultSyncTesterELConfig() *SyncTesterELConfig {
 	return &SyncTesterELConfig{
-		FCUState:      eth.FCUState{Latest: 0, Safe: 0, Finalized: 0},
-		ELSyncEnabled: false,
-		ELSyncTarget:  0,
+		FCUState:     eth.FCUState{Latest: 0, Safe: 0, Finalized: 0},
+		ELSyncActive: false,
+		ELSyncTarget: 0,
 	}
 }
 

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -66,6 +66,9 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 	opt.Add(WithSyncTesterL2ELNode(ids.SyncTesterL2EL, ids.L2EL))
 	opt.Add(WithL2CLNode(ids.L2CL2, ids.L1CL, ids.L1EL, ids.SyncTesterL2EL))
 
+	// P2P Connect CLs to signal unsafe heads
+	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CL2))
+
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))

--- a/op-service/apis/sync_tester.go
+++ b/op-service/apis/sync_tester.go
@@ -21,6 +21,7 @@ type SyncTester interface {
 type SyncAPI interface {
 	GetSession(ctx context.Context) (*eth.SyncTesterSession, error)
 	DeleteSession(ctx context.Context) error
+	ResetSession(ctx context.Context) error
 	ListSessions(ctx context.Context) ([]string, error)
 }
 

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -23,11 +23,11 @@ type SyncTesterSession struct {
 	// payloads
 	Payloads map[PayloadID]*ExecutionPayloadEnvelope `json:"-"`
 
-	ELSyncTarget  uint64 `json:"el_sync_target"`
-	ELSyncEnabled bool   `json:"el_sync_enabled"`
+	ELSyncTarget uint64 `json:"el_sync_target"`
+	ELSyncActive bool   `json:"el_sync_active"`
 
-	InitialState         FCUState `json:"initial_state"`
-	InitialELSyncEnabled bool     `json:"initial_el_sync_enabled"`
+	InitialState        FCUState `json:"initial_state"`
+	InitialELSyncActive bool     `json:"initial_el_sync_active"`
 }
 
 func (s *SyncTesterSession) UpdateFCULatest(latest uint64) {
@@ -43,22 +43,22 @@ func (s *SyncTesterSession) UpdateFCUFinalized(finalized uint64) {
 }
 
 func (s *SyncTesterSession) FinishELSync(target uint64) {
-	s.ELSyncEnabled = false
+	s.ELSyncActive = false
 	s.Validated = target
 }
 
 func (s *SyncTesterSession) IsELSyncFinished() bool {
-	return !s.ELSyncEnabled
+	return !s.ELSyncActive
 }
 
 func (s *SyncTesterSession) ResetSession() {
 	s.CurrentState = s.InitialState
 	s.Validated = s.InitialState.Latest
 	s.Payloads = make(map[PayloadID]*ExecutionPayloadEnvelope)
-	s.ELSyncEnabled = s.InitialELSyncEnabled
+	s.ELSyncActive = s.InitialELSyncActive
 }
 
-func NewSyncTesterSession(sessionID string, latest, safe, finalized, elSyncTarget uint64, elSyncEnabled bool) *SyncTesterSession {
+func NewSyncTesterSession(sessionID string, latest, safe, finalized, elSyncTarget uint64, elSyncActive bool) *SyncTesterSession {
 	return &SyncTesterSession{
 		SessionID: sessionID,
 		Validated: latest,
@@ -67,14 +67,14 @@ func NewSyncTesterSession(sessionID string, latest, safe, finalized, elSyncTarge
 			Safe:      safe,
 			Finalized: finalized,
 		},
-		Payloads:      make(map[PayloadID]*ExecutionPayloadEnvelope),
-		ELSyncTarget:  elSyncTarget,
-		ELSyncEnabled: elSyncEnabled,
+		Payloads:     make(map[PayloadID]*ExecutionPayloadEnvelope),
+		ELSyncTarget: elSyncTarget,
+		ELSyncActive: elSyncActive,
 		InitialState: FCUState{
 			Latest:    latest,
 			Safe:      safe,
 			Finalized: finalized,
 		},
-		InitialELSyncEnabled: elSyncEnabled,
+		InitialELSyncActive: elSyncActive,
 	}
 }

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -14,25 +14,51 @@ type FCUState struct {
 type SyncTesterSession struct {
 	sync.Mutex
 
-	SessionID string `json:"sessionID"`
+	SessionID string `json:"session_id"`
 
 	// Non canonical view of the chain
 	Validated uint64 `json:"validated"`
 	// Canonical view of the chain
-	CurrentState FCUState `json:"currentState"`
+	CurrentState FCUState `json:"current_state"`
 	// payloads
 	Payloads map[PayloadID]*ExecutionPayloadEnvelope `json:"-"`
 
-	InitialState FCUState `json:"initialState"`
+	ELSyncTarget  uint64 `json:"el_sync_target"`
+	ELSyncEnabled bool   `json:"el_sync_enabled"`
+
+	InitialState         FCUState `json:"initial_state"`
+	InitialELSyncEnabled bool     `json:"initial_el_sync_enabled"`
 }
 
-func (s *SyncTesterSession) UpdateFCUState(latest, safe, finalized uint64) {
+func (s *SyncTesterSession) UpdateFCULatest(latest uint64) {
 	s.CurrentState.Latest = latest
+}
+
+func (s *SyncTesterSession) UpdateFCUSafe(safe uint64) {
 	s.CurrentState.Safe = safe
+}
+
+func (s *SyncTesterSession) UpdateFCUFinalized(finalized uint64) {
 	s.CurrentState.Finalized = finalized
 }
 
-func NewSyncTesterSession(sessionID string, latest, safe, finalized uint64) *SyncTesterSession {
+func (s *SyncTesterSession) FinishELSync(target uint64) {
+	s.ELSyncEnabled = false
+	s.Validated = target
+}
+
+func (s *SyncTesterSession) IsELSyncFinished() bool {
+	return !s.ELSyncEnabled
+}
+
+func (s *SyncTesterSession) ResetSession() {
+	s.CurrentState = s.InitialState
+	s.Validated = s.InitialState.Latest
+	s.Payloads = make(map[PayloadID]*ExecutionPayloadEnvelope)
+	s.ELSyncEnabled = s.InitialELSyncEnabled
+}
+
+func NewSyncTesterSession(sessionID string, latest, safe, finalized, elSyncTarget uint64, elSyncEnabled bool) *SyncTesterSession {
 	return &SyncTesterSession{
 		SessionID: sessionID,
 		Validated: latest,
@@ -41,11 +67,14 @@ func NewSyncTesterSession(sessionID string, latest, safe, finalized uint64) *Syn
 			Safe:      safe,
 			Finalized: finalized,
 		},
-		Payloads: make(map[PayloadID]*ExecutionPayloadEnvelope),
+		Payloads:      make(map[PayloadID]*ExecutionPayloadEnvelope),
+		ELSyncTarget:  elSyncTarget,
+		ELSyncEnabled: elSyncEnabled,
 		InitialState: FCUState{
 			Latest:    latest,
 			Safe:      safe,
 			Finalized: finalized,
 		},
+		InitialELSyncEnabled: elSyncEnabled,
 	}
 }

--- a/op-service/sources/sync_tester_client.go
+++ b/op-service/sources/sync_tester_client.go
@@ -41,3 +41,7 @@ func (cl *SyncTesterClient) ListSessions(ctx context.Context) ([]string, error) 
 func (cl *SyncTesterClient) DeleteSession(ctx context.Context) error {
 	return cl.client.CallContext(ctx, nil, "sync_deleteSession")
 }
+
+func (cl *SyncTesterClient) ResetSession(ctx context.Context) error {
+	return cl.client.CallContext(ctx, nil, "sync_resetSession")
+}

--- a/op-sync-tester/example_config.yaml
+++ b/op-sync-tester/example_config.yaml
@@ -1,7 +1,7 @@
 synctesters:
   local:
     chain_id: 2151908
-    el_rpc: http://localhost:62654/
+    el_rpc: http://localhost:65293/
   sepolia:
     chain_id: 11155420
     el_rpc: https://sepolia.optimism.io

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -88,6 +88,15 @@ func (s *SyncTester) DeleteSession(ctx context.Context) error {
 	return err
 }
 
+func (s *SyncTester) ResetSession(ctx context.Context) error {
+	_, err := session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (any, error) {
+		logger.Debug("ResetSession")
+		session.ResetSession()
+		return struct{}{}, nil
+	})
+	return err
+}
+
 func (s *SyncTester) ListSessions(ctx context.Context) ([]string, error) {
 	ids := s.sessMgr.SessionIDs()
 	s.log.Debug("ListSessions", "count", len(ids))
@@ -351,8 +360,10 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 		// Let CL backfill via newPayload
 		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 	}
+	// Equivalent to SetCanonical
+	session.UpdateFCULatest(candLatest.NumberU64())
+	logger.Debug("Updated FCU State", "latest", session.CurrentState.Latest)
 	// Simulate db check for finalized head
-	var finalizedNum uint64
 	if state.FinalizedBlockHash != (common.Hash{}) {
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
 		// Spec: MUST return -38002: Invalid forkchoice state error if the payload referenced by forkchoiceState.headBlockHash is VALID and a payload referenced by either forkchoiceState.finalizedBlockHash or forkchoiceState.safeBlockHash does not belong to the chain defined by forkchoiceState.headBlockHash.
@@ -360,13 +371,15 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 		if err != nil {
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("finalized block not available"))
 		}
-		finalizedNum = candFinalized.NumberU64()
+		finalizedNum := candFinalized.NumberU64()
 		if session.CurrentState.Latest < finalizedNum {
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("finalized block not canonical"))
 		}
+		// Equivalent to SetFinalized
+		session.UpdateFCUFinalized(finalizedNum)
+		logger.Debug("Updated FCU State", "finalized", session.CurrentState.Finalized)
 	}
 	// Simulate db check for safe head
-	var safeNum uint64
 	if state.SafeBlockHash != (common.Hash{}) {
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
 		// Spec: MUST return -38002: Invalid forkchoice state error if the payload referenced by forkchoiceState.headBlockHash is VALID and a payload referenced by either forkchoiceState.finalizedBlockHash or forkchoiceState.safeBlockHash does not belong to the chain defined by forkchoiceState.headBlockHash.
@@ -374,10 +387,13 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 		if err != nil {
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not available"))
 		}
-		safeNum = candSafe.NumberU64()
+		safeNum := candSafe.NumberU64()
 		if session.CurrentState.Latest < safeNum {
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidForkChoiceState.With(errors.New("safe block not canonical"))
 		}
+		// Equivalent to SetSafe
+		session.UpdateFCUSafe(safeNum)
+		logger.Debug("Updated FCU State", "safe", session.CurrentState.Safe)
 	}
 	var id *engine.PayloadID
 	if attr != nil {
@@ -436,8 +452,6 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 		logger.Debug("Store payload", "payloadID", payloadID)
 		session.Payloads[payloadID] = payloadEnv
 	}
-	session.UpdateFCUState(candLatest.NumberU64(), safeNum, finalizedNum)
-	logger.Debug("Updated FCU State")
 	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
 	// Spec: Client software MUST respond to this method call in the following way: {payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId} if the payload is deemed VALID and the build process has begun
 	return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &state.HeadBlockHash}, PayloadID: id}, nil
@@ -557,6 +571,44 @@ func (s *SyncTester) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPay
 	})
 }
 
+func (s *SyncTester) validatePayload(logger log.Logger, isCanyon, isIsthmus bool, block *types.Block, payload *eth.ExecutionPayload, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error) {
+	// Already have the block locally or advance single block without setting the head
+	// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#specification
+	// Spec: MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
+	blockHash := block.Hash()
+	config := &params.ChainConfig{}
+	if isCanyon {
+		config.CanyonTime = new(uint64)
+	}
+	if isIsthmus {
+		config.IsthmusTime = new(uint64)
+	}
+	correctPayload, err := eth.BlockAsPayload(block, config)
+	if err != nil {
+		// The failure is from the EL processing so consider as a server error and make CL retry
+		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to convert block to payload", err))
+	}
+	// Sanity check parent beacon block root and block hash by recomputation
+	if !isIsthmus {
+		// Depopulate withdrawal root field for block hash recomputation
+		if payload.WithdrawalsRoot != nil {
+			logger.Warn("Isthmus disabled but withdrawal roots included in payload not nil", "root", payload.WithdrawalsRoot)
+		}
+		payload.WithdrawalsRoot = nil
+	}
+	// Check given payload matches the payload derived using the read only EL block
+	if err := correctPayload.CheckEqual(payload); err != nil {
+		// Consider as block hash validation error when payload mismatch
+		return s.newPayloadInvalid(fmt.Errorf("payload check mismatch: %w", err), nil), nil
+	}
+	execEnvelope := eth.ExecutionPayloadEnvelope{ParentBeaconBlockRoot: beaconRoot, ExecutionPayload: payload}
+	actual, ok := execEnvelope.CheckBlockHash()
+	if blockHash != payload.BlockHash || !ok {
+		return s.newPayloadInvalid(fmt.Errorf("block hash check from execution envelope failed. %s != %s", blockHash, actual), nil), nil
+	}
+	return nil, nil
+}
+
 // newPayload validates and processes a new execution payload according to the
 // Engine API rules to simulate consensus-layer to execution-layer interactions
 // without advancing canonical chain state.
@@ -642,51 +694,43 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("non-nil withdrawals pre-shanghai"))
 		}
 	}
-
 	blockHash := block.Hash()
+	blockNumber := block.NumberU64()
 	// We only attempt to advance non-canonical view of the chain, following the read only EL
-	if block.NumberU64() <= session.Validated+1 {
-		// Already have the block locally or advance single block without setting the head
-		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/shanghai.md#specification
-		// Spec: MUST return {status: INVALID, latestValidHash: null, validationError: errorMessage | null} if the blockHash validation has failed.
-		config := &params.ChainConfig{}
-		if isCanyon {
-			config.CanyonTime = new(uint64)
+	if blockNumber <= session.Validated+1 {
+		if status, err := s.validatePayload(logger, isCanyon, isIsthmus, block, payload, beaconRoot); status != nil {
+			return status, err
 		}
-		if isIsthmus {
-			config.IsthmusTime = new(uint64)
-		}
-		correctPayload, err := eth.BlockAsPayload(block, config)
-		if err != nil {
-			// The failure is from the EL processing so consider as a server error and make CL retry
-			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to convert block to payload", err))
-		}
-		// Sanity check parent beacon block root and block hash by recomputation
-		if !isIsthmus {
-			// Depopulate withdrawal root field for block hash recomputation
-			if payload.WithdrawalsRoot != nil {
-				logger.Warn("Isthmus disabled but withdrawal roots included in payload not nil", "root", payload.WithdrawalsRoot)
-			}
-			payload.WithdrawalsRoot = nil
-		}
-		// Check given payload matches the payload derived using the read only EL block
-		if err := correctPayload.CheckEqual(payload); err != nil {
-			// Consider as block hash validation error when payload mismatch
-			return s.newPayloadInvalid(fmt.Errorf("payload check mismatch: %w", err), nil), nil
-		}
-		execEnvelope := eth.ExecutionPayloadEnvelope{ParentBeaconBlockRoot: beaconRoot, ExecutionPayload: payload}
-		actual, ok := execEnvelope.CheckBlockHash()
-		if blockHash != payload.BlockHash || !ok {
-			return s.newPayloadInvalid(fmt.Errorf("block hash check from execution envelope failed. %s != %s", blockHash, actual), nil), nil
-		}
-		if block.NumberU64() == session.Validated+1 {
+		if blockNumber == session.Validated+1 {
 			// Advance single block without setting the head, equivalent to geth InsertBlockWithoutSetHead
 			session.Validated += 1
 			logger.Debug("Advanced non canonical chain", "validated", session.Validated)
 		}
+		if !session.IsELSyncFinished() && session.Validated == session.ELSyncTarget {
+			// Can reach here when not doing EL Sync on CL side but session is configured for EL Sync
+			logger.Debug("Non canonical chain reached EL Sync target", "validated", session.Validated)
+			session.FinishELSync(session.Validated)
+		}
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
 		// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
 		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &blockHash}, nil
+	} else if !session.IsELSyncFinished() {
+		if blockNumber == session.ELSyncTarget {
+			logger.Debug("Attempting to finish EL Sync on non canonical chain", "target", session.ELSyncTarget)
+			if status, err := s.validatePayload(logger, isCanyon, isIsthmus, block, payload, beaconRoot); status != nil {
+				return status, err
+			}
+			session.FinishELSync(blockNumber)
+			logger.Debug("Finished EL Sync by advancing non canonical chain", "validated", session.Validated)
+			// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
+			// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
+			return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &blockHash}, nil
+		} else if blockNumber < session.ELSyncTarget {
+			logger.Trace("EL Sync on progress", "target", blockNumber)
+		} else if blockNumber > session.ELSyncTarget {
+			// L2CL may never reach the EL Sync Target because the current number may keep increasing
+			logger.Warn("Received payload which has larger block number than EL Sync target", "current", blockNumber, "target", session.ELSyncTarget)
+		}
 	}
 	// Block not available so mark as syncing
 	return &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil

--- a/op-sync-tester/synctester/frontend/sync.go
+++ b/op-sync-tester/synctester/frontend/sync.go
@@ -29,3 +29,7 @@ func (s *SyncFrontend) DeleteSession(ctx context.Context) error {
 func (s *SyncFrontend) ListSessions(ctx context.Context) ([]string, error) {
 	return s.b.ListSessions(ctx)
 }
+
+func (s *SyncFrontend) ResetSession(ctx context.Context) error {
+	return s.b.ResetSession(ctx)
+}

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -79,14 +79,14 @@ func parseSession(r *http.Request) (*http.Request, error) {
 		if err != nil {
 			return r, err
 		}
-		elSyncEnabled := false
+		elSyncActive := false
 		if elSyncTarget != 0 {
 			if elSyncTarget < latest {
 				return r, ErrInvalidELSyncTarget
 			}
-			elSyncEnabled = true
+			elSyncActive = true
 		}
-		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncTarget, elSyncEnabled)
+		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncTarget, elSyncActive)
 		ctx := session.WithSyncTesterSession(r.Context(), sess)
 		// remove uuid path for routing
 		r.URL.Path = "/" + strings.Join(segments[:3], "/")

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -14,6 +14,9 @@ import (
 
 var ErrInvalidSessionIDFormat = errors.New("invalid UUID")
 var ErrInvalidParams = errors.New("invalid param")
+var ErrInvalidELSyncTarget = errors.New("invalid el sync target")
+
+const ELSyncTargetKey = "el_sync_target"
 
 func IsValidSessionID(sessionID string) error {
 	u, err := uuid.Parse(sessionID)
@@ -28,7 +31,8 @@ func IsValidSessionID(sessionID string) error {
 
 // parseSession inspects the incoming request to determine if it targets a session-specific route.
 // If the request path matches the pattern `/chain/{chain_id}/synctest/{uuid}`, it attempts to parse
-// the UUID and optional query parameters (`latest`, `safe`, `finalized`) used to initialize the session.
+// the UUID and optional query parameters (`latest`, `safe`, `finalized`, `el_sync_target`) used to
+// initialize the session.
 //
 // If parsing succeeds, a backend.Session is attached to the request context, and the URL path is
 // rewritten to `/chain/{chain_id}/synctest` to enable consistent routing downstream.
@@ -71,7 +75,18 @@ func parseSession(r *http.Request) (*http.Request, error) {
 		if err != nil {
 			return r, err
 		}
-		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized)
+		elSyncTarget, err := parseParam(ELSyncTargetKey)
+		if err != nil {
+			return r, err
+		}
+		elSyncEnabled := false
+		if elSyncTarget != 0 {
+			if elSyncTarget < latest {
+				return r, ErrInvalidELSyncTarget
+			}
+			elSyncEnabled = true
+		}
+		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncTarget, elSyncEnabled)
 		ctx := session.WithSyncTesterSession(r.Context(), sess)
 		// remove uuid path for routing
 		r.URL.Path = "/" + strings.Join(segments[:3], "/")

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -85,7 +85,7 @@ func TestParseSession_ELSyncTarget(t *testing.T) {
 	require.Equal(t, uint64(0), session.InitialState.Finalized)
 	require.Equal(t, session.InitialState.Latest, session.Validated)
 	require.Equal(t, session.InitialState, session.CurrentState)
-	require.True(t, session.ELSyncEnabled)
+	require.True(t, session.ELSyncActive)
 	require.Equal(t, session.ELSyncTarget, elSyncTarget)
 }
 

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -3,6 +3,7 @@ package synctester
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -63,6 +64,31 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 	require.Equal(t, session.InitialState, session.CurrentState)
 }
 
+func TestParseSession_ELSyncTarget(t *testing.T) {
+	id := uuid.New().String()
+	query := url.Values{}
+	elSyncTarget := uint64(4)
+	query.Set(ELSyncTargetKey, strconv.Itoa(int(elSyncTarget)))
+
+	req := newRequest("/chain/1/synctest/"+id, query)
+
+	newReq, err := parseSession(req)
+	require.NoError(t, err)
+	require.NotNil(t, newReq)
+
+	session, ok := session.SyncTesterSessionFromContext(newReq.Context())
+	require.True(t, ok)
+	require.NotNil(t, session)
+	require.Equal(t, id, session.SessionID)
+	require.Equal(t, uint64(0), session.InitialState.Latest)
+	require.Equal(t, uint64(0), session.InitialState.Safe)
+	require.Equal(t, uint64(0), session.InitialState.Finalized)
+	require.Equal(t, session.InitialState.Latest, session.Validated)
+	require.Equal(t, session.InitialState, session.CurrentState)
+	require.True(t, session.ELSyncEnabled)
+	require.Equal(t, session.ELSyncTarget, elSyncTarget)
+}
+
 func TestParseSession_NoSessionInitialized(t *testing.T) {
 	req := newRequest("/chain/1/synctest", nil)
 
@@ -88,4 +114,17 @@ func TestParseSession_InvalidQueryParam(t *testing.T) {
 	req := newRequest("/chain/1/synctest/"+id, query)
 	_, err := parseSession(req)
 	require.ErrorIs(t, err, ErrInvalidParams)
+}
+
+func TestParseSession_InvalidELSyncTarget(t *testing.T) {
+	id := uuid.New().String()
+	query := url.Values{}
+	latest := 4
+	elSyncTarget := latest - 1
+	query.Set(eth.Unsafe, strconv.Itoa(latest))
+	query.Set(ELSyncTargetKey, strconv.Itoa(elSyncTarget))
+
+	req := newRequest("/chain/1/synctest/"+id, query)
+	_, err := parseSession(req)
+	require.ErrorIs(t, err, ErrInvalidELSyncTarget)
 }

--- a/op-sync-tester/synctester/service.go
+++ b/op-sync-tester/synctester/service.go
@@ -148,7 +148,7 @@ func (s *Service) initHTTPServer(cfg *config.Config) error {
 	// middleware to initialize session
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r, err := parseSession(r)
-		if errors.Is(err, ErrInvalidSessionIDFormat) || errors.Is(err, ErrInvalidParams) {
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds EL Sync support for sync tester.

While L2CL is configured to do EL Sync, the L2CL will optimistically signal the underlying L2EL with future blocks. The L2EL will respond `SYNCING` to the engine API(`engine_getPayload`, `engine_forkChoiceUpdate`) till the L2EL reaches the point that it can validate the optimistically added payload by the L2CL, eventually returning `VALID` response.

Sync Tester is a mock EL, and it can be configured to whether return `SYNCING` to make the L2CL think the L2EL is working to fill in the gaps, gaining ability to validate the optimistically inserted payload, or `VALID` to make the L2CL think the EL Sync is completed, and falling back to the CL Sync(or L1 Sync).

Sync Tester may now optionally initialize the session using the `el_sync_target=<uint64>` query parameter. On the happy path with sync tester configured with the `el_sync_target` plus L2CL configured to do EL Sync,
1. L2CL will receive unsafe payloads from sequencer. At this point the L2CL EL Sync is started.
2. L2CL will send `engine_getPayload`, `engine_forkChoiceUpdate` to the Sync Tester and receive `SYNCING`
3. Sequencer will eventually send the payload which the block number is equal to the `el_sync_target`.
4. L2CL will send `engine_getPayload`, `engine_forkChoiceUpdate` to the Sync Tester and receive `VALID`. At this point the L2CL EL Sync is finished.
5. L2CL will start CL Sync(or L1 Sync).

Note that `el_sync_target` cannot be set less that `latest`, and handled as an error when initializing session. It makes no sense since when `el_sync_target < latest`, EL sync has been already done.

**Tests**

The happy path test is added at `TestSyncTesterELSync`.

Note that the L2CL connected to Sync Tester must have L2 P2P enabled, connected to the sequencer. L2CL must be signaled with new latest unsafe head, to trigger and finish EL Sync.

**Additional context**

Adds a new API `sync_resetSession` to intentionally roll back the sync tester session to initial state, making gaps between `latest` and `el_sync_target`.

Fixes a bug in `engine_newPayload` implementation; previously all three heads(latest, safe, finalized) where atomically updated together. This behavior mismatched with op-geth, causing EL Sync to fail. 

Ideas: It would be nice to enhance the observability that the op-node is doing EL Sync, or CL Sync. Currently no internal state is exposed for this.
