### PR TITLE
op-acceptance-tests: move presets into tests, away from config.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1224,40 +1224,8 @@ jobs:
         type: string
         default: 30m
       # Optional sync test configuration parameters
-      l2_network_name:
-        description: L2 network name
-        type: string
-        default: ""
-      l1_chain_id:
-        description: L1 chain ID
-        type: string
-        default: ""
-      l2_el_endpoint:
-        description: L2 EL endpoint
-        type: string
-        default: ""
-      l1_cl_beacon_endpoint:
-        description: L1 CL beacon endpoint
-        type: string
-        default: ""
-      l1_el_endpoint:
-        description: L1 EL endpoint
-        type: string
-        default: ""
-      initial_l2_block:
-        description: Initial L2 block
-        type: string
-        default: ""
-      l2_el_endpoint_tailscale:
-        description: L2 EL endpoint for Tailscale networking
-        type: string
-        default: ""
-      l1_cl_beacon_endpoint_tailscale:
-        description: L1 CL beacon endpoint for Tailscale networking
-        type: string
-        default: ""
-      l1_el_endpoint_tailscale:
-        description: L1 EL endpoint for Tailscale networking
+      network_preset:
+        description: Network preset
         type: string
         default: ""
     resource_class: xlarge
@@ -1292,15 +1260,7 @@ jobs:
             GO111MODULE: "on"
             GOGC: "0"
             # Optional sync test configuration environment variables (only set if parameters are provided)
-            L2_NETWORK_NAME: "<<parameters.l2_network_name>>"
-            L1_CHAIN_ID: "<<parameters.l1_chain_id>>"
-            L2_EL_ENDPOINT: "<<parameters.l2_el_endpoint>>"
-            L1_CL_BEACON_ENDPOINT: "<<parameters.l1_cl_beacon_endpoint>>"
-            L1_EL_ENDPOINT: "<<parameters.l1_el_endpoint>>"
-            INITIAL_L2_BLOCK: "<<parameters.initial_l2_block>>"
-            L2_EL_ENDPOINT_TAILSCALE: "<<parameters.l2_el_endpoint_tailscale>>"
-            L1_CL_BEACON_ENDPOINT_TAILSCALE: "<<parameters.l1_cl_beacon_endpoint_tailscale>>"
-            L1_EL_ENDPOINT_TAILSCALE: "<<parameters.l1_el_endpoint_tailscale>>"
+            NETWORK_PRESET: "<<parameters.network_preset>>"
           command: |
             # Run the tests
             LOG_LEVEL=debug just acceptance-test "" "<<parameters.gate>>"
@@ -2642,80 +2602,55 @@ workflows:
           requires:
             - initialize
       # Sync tests for multiple networks (runs in parallel)
-      # OP Sepolia
       - op-acceptance-sync-tests-docker:
           name: sync-test-op-sepolia-daily
           gate: sync-test-op-node
           no_output_timeout: 30m
-          l2_network_name: "op-sepolia"
-          l1_chain_id: "11155111"
-          l2_el_endpoint: "https://ci-sepolia-l2.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          network_preset: "op-sepolia"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      # Base Sepolia
       - op-acceptance-sync-tests-docker:
           name: sync-test-base-sepolia-daily
           gate: sync-test-op-node
           no_output_timeout: 30m
-          l2_network_name: "base-sepolia"
-          l1_chain_id: "11155111"
-          l2_el_endpoint: "https://base-sepolia-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          network_preset: "base-sepolia"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      ## Unichain Sepolia
       - op-acceptance-sync-tests-docker:
           name: sync-test-unichain-sepolia-daily
           gate: sync-test-op-node
           no_output_timeout: 30m
-          l2_network_name: "unichain-sepolia"
-          l1_chain_id: "11155111"
-          l2_el_endpoint: "https://unichain-sepolia-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-sepolia-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-sepolia-l1.optimism.io"
+          network_preset: "unichain-sepolia"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      ## OP Mainnet
       - op-acceptance-sync-tests-docker:
           name: sync-test-op-mainnet-daily
           gate: sync-test-op-node
           no_output_timeout: 30m
-          l2_network_name: "op-mainnet"
-          l1_chain_id: "1"
-          l2_el_endpoint: "https://op-mainnet-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+          network_preset: "op-mainnet"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      ## Base Mainnet
       - op-acceptance-sync-tests-docker:
           name: sync-test-base-mainnet-daily
           gate: sync-test-op-node
           no_output_timeout: 30m
-          l2_network_name: "base-mainnet"
-          l1_chain_id: "1"
-          l2_el_endpoint: "https://base-mainnet-rpc.optimism.io"
-          l1_cl_beacon_endpoint: "https://ci-mainnet-beacon.optimism.io"
-          l1_el_endpoint: "https://ci-mainnet-l1.optimism.io"
+          network_preset: "base-mainnet"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -114,9 +114,17 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrat
 	l.Info("L1_EL_ENDPOINT", "value", l1ELEndpoint)
 	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
 
+	config := stack.ExtNetworkConfig{
+		L2NetworkName:      L2NetworkName,
+		L1ChainID:          L1ChainID,
+		L2ELEndpoint:       L2ELEndpoint,
+		L1CLBeaconEndpoint: L1CLBeaconEndpoint,
+		L1ELEndpoint:       L1ELEndpoint,
+	}
+
 	// Create orchestrator with the same configuration that was in TestMain
 	opt := stack.Combine(
-		presets.WithMinimalExternalELWithSuperchainRegistry(L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName),
+		presets.WithExternalELWithSuperchainRegistry(config),
 		presets.WithSyncTesterELInitialState(eth.FCUState{
 			Latest:    blk,
 			Safe:      blk,

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -43,6 +43,51 @@ var (
 	L2ELEndpoint       = getEnvOrDefault("L2_EL_ENDPOINT", DefaultL2ELEndpoint)
 	L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT", DefaultL1CLBeaconEndpoint)
 	L1ELEndpoint       = getEnvOrDefault("L1_EL_ENDPOINT", DefaultL1ELEndpoint)
+
+	// Network presets for different networks against which we test op-node syncing
+	networkPresets = map[string]struct {
+		L2NetworkName      string
+		L1ChainID          uint64
+		L2ELEndpoint       string
+		L1CLBeaconEndpoint string
+		L1ELEndpoint       string
+	}{
+		"op-sepolia": {
+			L2NetworkName:      "op-sepolia",
+			L1ChainID:          11155111,
+			L2ELEndpoint:       "https://ci-sepolia-l2.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
+		},
+		"base-sepolia": {
+			L2NetworkName:      "base-sepolia",
+			L1ChainID:          11155111,
+			L2ELEndpoint:       "https://base-sepolia-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
+		},
+		"unichain-sepolia": {
+			L2NetworkName:      "unichain-sepolia",
+			L1ChainID:          11155111,
+			L2ELEndpoint:       "https://unichain-sepolia-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
+		},
+		"op-mainnet": {
+			L2NetworkName:      "op-mainnet",
+			L1ChainID:          1,
+			L2ELEndpoint:       "https://op-mainnet-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
+		},
+		"base-mainnet": {
+			L2NetworkName:      "base-mainnet",
+			L1ChainID:          1,
+			L2ELEndpoint:       "https://base-mainnet-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
+		},
+	}
 )
 
 func TestSyncTesterExtEL(gt *testing.T) {
@@ -120,8 +165,21 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 		L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
 	}
 
+	if os.Getenv("NETWORK_PRESET") != "" {
+		preset, ok := networkPresets[os.Getenv("NETWORK_PRESET")]
+		if !ok {
+			gt.Errorf("NETWORK_PRESET %s not found", os.Getenv("NETWORK_PRESET"))
+		}
+		L2NetworkName = preset.L2NetworkName
+		L1ChainID = eth.ChainIDFromUInt64(preset.L1ChainID)
+		L2ELEndpoint = preset.L2ELEndpoint
+		L1CLBeaconEndpoint = preset.L1CLBeaconEndpoint
+		L1ELEndpoint = preset.L1ELEndpoint
+	}
+
 	// Runtime configuration values
 	l.Info("Runtime configuration values for TestSyncTesterExtEL")
+	l.Info("NETWORK_PRESET", "value", os.Getenv("NETWORK_PRESET"))
 	l.Info("L2_NETWORK_NAME", "value", L2NetworkName)
 	l.Info("L1_CHAIN_ID", "value", L1ChainID)
 	l.Info("L2_EL_ENDPOINT", "value", L2ELEndpoint)

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -2,7 +2,6 @@ package sync_tester_ext_el
 
 import (
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -22,11 +21,7 @@ import (
 
 // Configuration defaults for op-sepolia
 const (
-	DefaultL2NetworkName      = "op-sepolia"
-	DefaultL1ChainID          = 11155111
-	DefaultL2ELEndpoint       = "https://ci-sepolia-l2.optimism.io"
-	DefaultL1CLBeaconEndpoint = "https://ci-sepolia-beacon.optimism.io"
-	DefaultL1ELEndpoint       = "https://ci-sepolia-l1.optimism.io"
+	DefaultNetworkPreset = "op-sepolia"
 
 	// Tailscale networking endpoints
 	DefaultL2ELEndpointTailscale       = "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
@@ -35,15 +30,6 @@ const (
 )
 
 var (
-	// Load configuration from environment variables with defaults
-	L2NetworkName = getEnvOrDefault("L2_NETWORK_NAME", DefaultL2NetworkName)
-	L1ChainID     = eth.ChainIDFromUInt64(getEnvUint64OrDefault("L1_CHAIN_ID", DefaultL1ChainID))
-
-	// Default endpoints
-	L2ELEndpoint       = getEnvOrDefault("L2_EL_ENDPOINT", DefaultL2ELEndpoint)
-	L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT", DefaultL1CLBeaconEndpoint)
-	L1ELEndpoint       = getEnvOrDefault("L1_EL_ENDPOINT", DefaultL1ELEndpoint)
-
 	// Network presets for different networks against which we test op-node syncing
 	networkPresets = map[string]struct {
 		L2NetworkName      string
@@ -158,33 +144,31 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	ctx := t.Ctx()
 	require := t.Require()
 
+	preset := networkPresets[DefaultNetworkPreset]
+
 	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
 	if os.Getenv("TAILSCALE_NETWORKING") == "true" {
-		L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
-		L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
-		L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
+		preset.L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
+		preset.L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
+		preset.L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
 	}
 
 	if os.Getenv("NETWORK_PRESET") != "" {
-		preset, ok := networkPresets[os.Getenv("NETWORK_PRESET")]
+		var ok bool
+		preset, ok = networkPresets[os.Getenv("NETWORK_PRESET")]
 		if !ok {
 			gt.Errorf("NETWORK_PRESET %s not found", os.Getenv("NETWORK_PRESET"))
 		}
-		L2NetworkName = preset.L2NetworkName
-		L1ChainID = eth.ChainIDFromUInt64(preset.L1ChainID)
-		L2ELEndpoint = preset.L2ELEndpoint
-		L1CLBeaconEndpoint = preset.L1CLBeaconEndpoint
-		L1ELEndpoint = preset.L1ELEndpoint
 	}
 
 	// Runtime configuration values
 	l.Info("Runtime configuration values for TestSyncTesterExtEL")
 	l.Info("NETWORK_PRESET", "value", os.Getenv("NETWORK_PRESET"))
-	l.Info("L2_NETWORK_NAME", "value", L2NetworkName)
-	l.Info("L1_CHAIN_ID", "value", L1ChainID)
-	l.Info("L2_EL_ENDPOINT", "value", L2ELEndpoint)
-	l.Info("L1_CL_BEACON_ENDPOINT", "value", L1CLBeaconEndpoint)
-	l.Info("L1_EL_ENDPOINT", "value", L1ELEndpoint)
+	l.Info("L2_NETWORK_NAME", "value", preset.L2NetworkName)
+	l.Info("L1_CHAIN_ID", "value", preset.L1ChainID)
+	l.Info("L2_EL_ENDPOINT", "value", preset.L2ELEndpoint)
+	l.Info("L1_CL_BEACON_ENDPOINT", "value", preset.L1CLBeaconEndpoint)
+	l.Info("L1_EL_ENDPOINT", "value", preset.L1ELEndpoint)
 	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
 
 	// Setup orchestrator
@@ -203,7 +187,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	gt.Cleanup(p.Close)
 
 	// Fetch the latest block number from the remote L2EL node
-	cl, err := ethclient.DialContext(ctx, L2ELEndpoint)
+	cl, err := ethclient.DialContext(ctx, preset.L2ELEndpoint)
 	require.NoError(err)
 	latestBlock, err := cl.BlockByNumber(ctx, nil)
 	require.NoError(err)
@@ -212,7 +196,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	l.Info("LATEST_BLOCK", "latest_block", latestBlock.NumberU64(), "session_initial_block", initial)
 
 	opt := stack.Combine(
-		presets.WithMinimalExternalELWithSuperchainRegistry(L1CLBeaconEndpoint, L1ELEndpoint, L2ELEndpoint, L1ChainID, L2NetworkName),
+		presets.WithMinimalExternalELWithSuperchainRegistry(preset.L1CLBeaconEndpoint, preset.L1ELEndpoint, preset.L2ELEndpoint, eth.ChainIDFromUInt64(preset.L1ChainID), preset.L2NetworkName),
 		presets.WithSyncTesterELInitialState(eth.FCUState{
 			Latest:    initial,
 			Safe:      initial,
@@ -230,16 +214,6 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 func getEnvOrDefault(envVar, defaultValue string) string {
 	if value := os.Getenv(envVar); value != "" {
 		return value
-	}
-	return defaultValue
-}
-
-// getEnvUint64OrDefault returns the environment variable value as uint64 or the default if not set
-func getEnvUint64OrDefault(envVar string, defaultValue uint64) uint64 {
-	if value := os.Getenv(envVar); value != "" {
-		if parsed, err := strconv.ParseUint(value, 10, 64); err == nil {
-			return parsed
-		}
 	}
 	return defaultValue
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -31,44 +31,38 @@ const (
 
 var (
 	// Network presets for different networks against which we test op-node syncing
-	networkPresets = map[string]struct {
-		L2NetworkName      string
-		L1ChainID          uint64
-		L2ELEndpoint       string
-		L1CLBeaconEndpoint string
-		L1ELEndpoint       string
-	}{
+	networkPresets = map[string]stack.ExtNetworkConfig{
 		"op-sepolia": {
 			L2NetworkName:      "op-sepolia",
-			L1ChainID:          11155111,
+			L1ChainID:          eth.ChainIDFromUInt64(11155111),
 			L2ELEndpoint:       "https://ci-sepolia-l2.optimism.io",
 			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
 			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
 		},
 		"base-sepolia": {
 			L2NetworkName:      "base-sepolia",
-			L1ChainID:          11155111,
+			L1ChainID:          eth.ChainIDFromUInt64(11155111),
 			L2ELEndpoint:       "https://base-sepolia-rpc.optimism.io",
 			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
 			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
 		},
 		"unichain-sepolia": {
 			L2NetworkName:      "unichain-sepolia",
-			L1ChainID:          11155111,
+			L1ChainID:          eth.ChainIDFromUInt64(11155111),
 			L2ELEndpoint:       "https://unichain-sepolia-rpc.optimism.io",
 			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
 			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
 		},
 		"op-mainnet": {
 			L2NetworkName:      "op-mainnet",
-			L1ChainID:          1,
+			L1ChainID:          eth.ChainIDFromUInt64(1),
 			L2ELEndpoint:       "https://op-mainnet-rpc.optimism.io",
 			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
 			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
 		},
 		"base-mainnet": {
 			L2NetworkName:      "base-mainnet",
-			L1ChainID:          1,
+			L1ChainID:          eth.ChainIDFromUInt64(1),
 			L2ELEndpoint:       "https://base-mainnet-rpc.optimism.io",
 			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
 			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
@@ -144,18 +138,18 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	ctx := t.Ctx()
 	require := t.Require()
 
-	preset := networkPresets[DefaultNetworkPreset]
+	config := networkPresets[DefaultNetworkPreset]
 
 	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
 	if os.Getenv("TAILSCALE_NETWORKING") == "true" {
-		preset.L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
-		preset.L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
-		preset.L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
+		config.L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
+		config.L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
+		config.L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
 	}
 
 	if os.Getenv("NETWORK_PRESET") != "" {
 		var ok bool
-		preset, ok = networkPresets[os.Getenv("NETWORK_PRESET")]
+		config, ok = networkPresets[os.Getenv("NETWORK_PRESET")]
 		if !ok {
 			gt.Errorf("NETWORK_PRESET %s not found", os.Getenv("NETWORK_PRESET"))
 		}
@@ -164,11 +158,11 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	// Runtime configuration values
 	l.Info("Runtime configuration values for TestSyncTesterExtEL")
 	l.Info("NETWORK_PRESET", "value", os.Getenv("NETWORK_PRESET"))
-	l.Info("L2_NETWORK_NAME", "value", preset.L2NetworkName)
-	l.Info("L1_CHAIN_ID", "value", preset.L1ChainID)
-	l.Info("L2_EL_ENDPOINT", "value", preset.L2ELEndpoint)
-	l.Info("L1_CL_BEACON_ENDPOINT", "value", preset.L1CLBeaconEndpoint)
-	l.Info("L1_EL_ENDPOINT", "value", preset.L1ELEndpoint)
+	l.Info("L2_NETWORK_NAME", "value", config.L2NetworkName)
+	l.Info("L1_CHAIN_ID", "value", config.L1ChainID)
+	l.Info("L2_EL_ENDPOINT", "value", config.L2ELEndpoint)
+	l.Info("L1_CL_BEACON_ENDPOINT", "value", config.L1CLBeaconEndpoint)
+	l.Info("L1_EL_ENDPOINT", "value", config.L1ELEndpoint)
 	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
 
 	// Setup orchestrator
@@ -187,7 +181,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	gt.Cleanup(p.Close)
 
 	// Fetch the latest block number from the remote L2EL node
-	cl, err := ethclient.DialContext(ctx, preset.L2ELEndpoint)
+	cl, err := ethclient.DialContext(ctx, config.L2ELEndpoint)
 	require.NoError(err)
 	latestBlock, err := cl.BlockByNumber(ctx, nil)
 	require.NoError(err)
@@ -196,7 +190,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	l.Info("LATEST_BLOCK", "latest_block", latestBlock.NumberU64(), "session_initial_block", initial)
 
 	opt := stack.Combine(
-		presets.WithMinimalExternalELWithSuperchainRegistry(preset.L1CLBeaconEndpoint, preset.L1ELEndpoint, preset.L2ELEndpoint, eth.ChainIDFromUInt64(preset.L1ChainID), preset.L2NetworkName),
+		presets.WithExternalELWithSuperchainRegistry(config),
 		presets.WithSyncTesterELInitialState(eth.FCUState{
 			Latest:    initial,
 			Safe:      initial,

--- a/op-devstack/presets/minimal_external_el.go
+++ b/op-devstack/presets/minimal_external_el.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type MinimalExternalEL struct {
@@ -31,6 +30,6 @@ func (m *MinimalExternalEL) L2Networks() []*dsl.L2Network {
 	}
 }
 
-func WithMinimalExternalELWithSuperchainRegistry(l1CLBeaconRPC, l1ELRPC, l2ELRPC string, l1ChainID eth.ChainID, networkName string) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(&sysgo.DefaultMinimalExternalELSystemIDs{}, l1CLBeaconRPC, l1ELRPC, l2ELRPC, l1ChainID, networkName))
+func WithExternalELWithSuperchainRegistry(networkPreset stack.ExtNetworkConfig) stack.CommonOption {
+	return stack.MakeCommon(sysgo.ExternalELSystemWithEndpointAndSuperchainRegistry(&sysgo.DefaultMinimalExternalELSystemIDs{}, networkPreset))
 }

--- a/op-devstack/stack/ext_network_config.go
+++ b/op-devstack/stack/ext_network_config.go
@@ -1,0 +1,11 @@
+package stack
+
+import "github.com/ethereum-optimism/optimism/op-service/eth"
+
+type ExtNetworkConfig struct {
+	L2NetworkName      string
+	L1ChainID          eth.ChainID
+	L2ELEndpoint       string
+	L1CLBeaconEndpoint string
+	L1ELEndpoint       string
+}

--- a/op-devstack/sysgo/system_synctester_ext.go
+++ b/op-devstack/sysgo/system_synctester_ext.go
@@ -24,7 +24,7 @@ type DefaultMinimalExternalELSystemIDs struct {
 	SyncTester stack.SyncTesterID
 }
 
-func NewDefaultMinimalExternalELSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimalExternalELSystemIDs {
+func NewExternalELSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimalExternalELSystemIDs {
 	ids := DefaultMinimalExternalELSystemIDs{
 		L1:         stack.L1NetworkID(l1ID),
 		L1EL:       stack.NewL1ELNodeID("l1", l1ID),
@@ -37,20 +37,20 @@ func NewDefaultMinimalExternalELSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimal
 	return ids
 }
 
-// DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry creates a minimal external EL system
+// ExternalELSystemWithEndpointAndSuperchainRegistry creates a minimal external EL system
 // using a network from the superchain registry instead of the deployer
-func DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExternalELSystemIDs, l1CLBeaconRPC, l1ELRPC, l2ELRPC string, l1ChainID eth.ChainID, networkName string) stack.Option[*Orchestrator] {
-	chainCfg := chaincfg.ChainByName(networkName)
+func ExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExternalELSystemIDs, networkPreset stack.ExtNetworkConfig) stack.Option[*Orchestrator] {
+	chainCfg := chaincfg.ChainByName(networkPreset.L2NetworkName)
 	if chainCfg == nil {
-		panic(fmt.Sprintf("network %s not found in superchain registry", networkName))
+		panic(fmt.Sprintf("network %s not found in superchain registry", networkPreset.L2NetworkName))
 	}
 	l2ChainID := eth.ChainIDFromUInt64(chainCfg.ChainID)
 
-	ids := NewDefaultMinimalExternalELSystemIDs(l1ChainID, l2ChainID)
+	ids := NewExternalELSystemIDs(networkPreset.L1ChainID, l2ChainID)
 
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
-		o.P().Logger().Info("Setting up with superchain registry network", "network", networkName)
+		o.P().Logger().Info("Setting up with superchain registry network", "network", networkPreset.L2NetworkName)
 	}))
 
 	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
@@ -71,16 +71,16 @@ func DefaultMinimalExternalELSystemWithEndpointAndSuperchainRegistry(dest *Defau
 		o.l1Nets.Set(ids.L1.ChainID(), l1Net)
 	}))
 
-	opt.Add(WithExtL1Nodes(ids.L1EL, ids.L1CL, l1ELRPC, l1CLBeaconRPC))
+	opt.Add(WithExtL1Nodes(ids.L1EL, ids.L1CL, networkPreset.L1ELEndpoint, networkPreset.L1CLBeaconEndpoint))
 
 	// Use superchain registry instead of deployer
 	opt.Add(WithL2NetworkFromSuperchainRegistryWithDependencySet(
 		stack.L2NetworkID(l2ChainID),
-		networkName,
+		networkPreset.L2NetworkName,
 	))
 
 	// Add SyncTester service with external endpoint
-	opt.Add(WithSyncTesterWithExternalEndpoint(ids.SyncTester, l2ELRPC, l2ChainID))
+	opt.Add(WithSyncTesterWithExternalEndpoint(ids.SyncTester, networkPreset.L2ELEndpoint, l2ChainID))
 
 	// Add SyncTesterL2ELNode as the L2EL replacement for real-world EL endpoint
 	opt.Add(WithSyncTesterL2ELNode(ids.L2EL, ids.L2EL))


### PR DESCRIPTION
This PR is moving network presets from `.circleci/config.yaml` into the actual test, so that we keep `config.yaml` minimal.

We leave support for running the test against `op-sepolia` from local machines via the TAILSCALE_NETWORKING env var, which overrides the default endpoints.

---

Fixes: https://github.com/ethereum-optimism/optimism/issues/17253