### PR TITLE
opcm: Zero out cannon-kona game types in migrate.

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xf022e035aedf6c7979160ef59d18dd9faa8450879eca55447858709c8c521eb0"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x7886e330be7302173d487d61ecb32ebc28b5ba2aa450fdecc1713f70c9a1e271",
-    "sourceCodeHash": "0x69aea62b3a216ed3d98fb6d290f57f7881b93b393260843ce1fb6119838eb2bb"
+    "initCodeHash": "0x31c8cb0efb0cc4880b0d2720e933aab08df48d07d89c8e2d1344886207b11409",
+    "sourceCodeHash": "0x1d58891954cf782d2fe4f112b0c7fd25be991c2b8873f10d8545c653b517cac9"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x5bf576ea7f566e402a997204988471fc9b971410aa9dff8fe810b10baf6b7456",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0xe94325cd292ec3131cae7525eb1487abfea94c16aa4f000d594c1fd5a5bbbadd",
-    "sourceCodeHash": "0x144818d225cea78696e7ccdc486d79958b04ef6cd82d08e968db594ac2a571a3"
+    "initCodeHash": "0x70a8d6d2f59f5e014f5a5ce4d1ba6e81d051f89b662f6942f53b086961761dca",
+    "sourceCodeHash": "0xfca4958050ce96fbda5caa249a4da1f3a7fe1bebb4c8dc9a0fbab2e1bdb6acd3"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xcc5dacb9e1c2b9395aa5f9c300f03c18af1ff5a9efd6a7ce4d5135dfbe7b1e2b",
-    "sourceCodeHash": "0x0c63dc35ccf59cc583fbbfc0f2251ba95d026c11540f08806a48cb3934e73ae4"
+    "initCodeHash": "0x7886e330be7302173d487d61ecb32ebc28b5ba2aa450fdecc1713f70c9a1e271",
+    "sourceCodeHash": "0x69aea62b3a216ed3d98fb6d290f57f7881b93b393260843ce1fb6119838eb2bb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x5bf576ea7f566e402a997204988471fc9b971410aa9dff8fe810b10baf6b7456",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x70a8d6d2f59f5e014f5a5ce4d1ba6e81d051f89b662f6942f53b086961761dca",
-    "sourceCodeHash": "0xfca4958050ce96fbda5caa249a4da1f3a7fe1bebb4c8dc9a0fbab2e1bdb6acd3"
+    "initCodeHash": "0x90527840505f5c7a74e2c4492dda6fa7f73c90ef68fa5a36bed2ce874b2ea226",
+    "sourceCodeHash": "0xf022e035aedf6c7979160ef59d18dd9faa8450879eca55447858709c8c521eb0"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x7886e330be7302173d487d61ecb32ebc28b5ba2aa450fdecc1713f70c9a1e271",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xf022e035aedf6c7979160ef59d18dd9faa8450879eca55447858709c8c521eb0"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x31c8cb0efb0cc4880b0d2720e933aab08df48d07d89c8e2d1344886207b11409",
-    "sourceCodeHash": "0x1d58891954cf782d2fe4f112b0c7fd25be991c2b8873f10d8545c653b517cac9"
+    "initCodeHash": "0xcc5dacb9e1c2b9395aa5f9c300f03c18af1ff5a9efd6a7ce4d5135dfbe7b1e2b",
+    "sourceCodeHash": "0x0c63dc35ccf59cc583fbbfc0f2251ba95d026c11540f08806a48cb3934e73ae4"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x5bf576ea7f566e402a997204988471fc9b971410aa9dff8fe810b10baf6b7456",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1802,9 +1802,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 3.4.1
+    /// @custom:semver 3.5.0
     function version() public pure virtual returns (string memory) {
-        return "3.4.1";
+        return "3.5.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1559,6 +1559,10 @@ contract OPContractsManagerInteropMigrator is OPContractsManagerBase {
             oldDisputeGameFactory.setImplementation(GameTypes.SUPER_CANNON, IDisputeGame(address(0)));
             oldDisputeGameFactory.setImplementation(GameTypes.PERMISSIONED_CANNON, IDisputeGame(address(0)));
             oldDisputeGameFactory.setImplementation(GameTypes.SUPER_PERMISSIONED_CANNON, IDisputeGame(address(0)));
+            if (isDevFeatureEnabled(DevFeatures.CANNON_KONA)) {
+                oldDisputeGameFactory.setImplementation(GameTypes.CANNON_KONA, IDisputeGame(address(0)));
+                oldDisputeGameFactory.setImplementation(GameTypes.SUPER_CANNON_KONA, IDisputeGame(address(0)));
+            }
 
             // Migrate the portal to the new ETHLockbox and AnchorStateRegistry.
             portals[i].migrateToSuperRoots(newEthLockbox, newAnchorStateRegistry);
@@ -1798,9 +1802,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 3.4.0
+    /// @custom:semver 3.4.1
     function version() public pure virtual returns (string memory) {
-        return "3.4.0";
+        return "3.4.1";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -38,8 +38,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.18.0
-    string public constant version = "1.18.0";
+    /// @custom:semver 1.17.0
+    string public constant version = "1.17.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -38,8 +38,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.17.1
-    string public constant version = "1.17.1";
+    /// @custom:semver 1.18.0
+    string public constant version = "1.18.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -38,8 +38,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.17.0
-    string public constant version = "1.17.0";
+    /// @custom:semver 1.17.1
+    string public constant version = "1.17.1";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;


### PR DESCRIPTION
**Description**

If CANNON_KONA dev feature is enabled, zero out the relevant game impls when migrating to super roots. Actually deploying the SUPER_CANNON_KONA game type will be addressed separately in a follow up. Just trying to pick off as many changes as possible, separate to having to change the ABI to keep diffs small.

**Tests**

Added unit test.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/17513

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/17285