### PR TITLE
op-deployer: create generic forge.BytesScriptEncoder

### DIFF
--- a/op-deployer/pkg/deployer/forge/binary_test.go
+++ b/op-deployer/pkg/deployer/forge/binary_test.go
@@ -44,7 +44,7 @@ func TestStandardBinary_ForgeBins(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			require.NoError(t, bin.Ensure(ctx))
 		})

--- a/op-deployer/pkg/deployer/forge/client.go
+++ b/op-deployer/pkg/deployer/forge/client.go
@@ -40,7 +40,7 @@ func NewClient(binary Binary) *Client {
 func (c *Client) Version(ctx context.Context) (VersionInfo, error) {
 	buf := new(bytes.Buffer)
 	if err := c.execCmd(ctx, buf, io.Discard, "--version"); err != nil {
-		return VersionInfo{}, fmt.Errorf("failed to execute command: %w", err)
+		return VersionInfo{}, fmt.Errorf("failed to run forge version command: %w", err)
 	}
 	outputStr := buf.String()
 	matches := versionRegexp.FindAllStringSubmatch(outputStr, -1)
@@ -67,7 +67,7 @@ func (c *Client) RunScript(ctx context.Context, script string, sig string, args 
 	cliOpts = append(cliOpts, opts...)
 	cliOpts = append(cliOpts, "--sig", sig, script, "0x"+hex.EncodeToString(args))
 	if err := c.execCmd(ctx, buf, io.Discard, cliOpts...); err != nil {
-		return "", fmt.Errorf("failed to execute command: %w", err)
+		return "", fmt.Errorf("failed to execute forge script: %w", err)
 	}
 	return buf.String(), nil
 }
@@ -93,7 +93,7 @@ func (c *Client) execCmd(ctx context.Context, stdout io.Writer, stderr io.Writer
 	cmd.Stderr = mwStderr
 	cmd.Dir = c.Wd
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to execute forge: %w", err)
+		return fmt.Errorf("failed to run forge command: %w", err)
 	}
 	return nil
 }
@@ -106,6 +106,11 @@ type ScriptCallDecoder[O any] interface {
 	Decode(raw []byte) (O, error)
 }
 
+// ScriptCaller is a function that calls a forge script
+// Ouputs:
+// - Return value of the script (decoded into go type)
+// - Bool indicating if the script was recompiled (mostly used for testing)
+// - Error if the script fails to run
 type ScriptCaller[I any, O any] func(ctx context.Context, input I, opts ...string) (O, bool, error)
 
 func NewScriptCaller[I any, O any](client *Client, script string, sig string, encoder ScriptCallEncoder[I], decoder ScriptCallDecoder[O]) ScriptCaller[I, O] {
@@ -117,7 +122,7 @@ func NewScriptCaller[I any, O any](client *Client, script string, sig string, en
 		}
 		rawOut, err := client.RunScript(ctx, script, sig, encArgs, opts...)
 		if err != nil {
-			return out, false, fmt.Errorf("failed to execute forge: %w", err)
+			return out, false, fmt.Errorf("failed to run forge script: %w", err)
 		}
 		sigilMatches := sigilRegexp.FindAllStringSubmatch(rawOut, -1)
 		if len(sigilMatches) != 1 || len(sigilMatches[0]) != 2 {

--- a/op-deployer/pkg/deployer/forge/client_test.go
+++ b/op-deployer/pkg/deployer/forge/client_test.go
@@ -3,26 +3,23 @@ package forge
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
-
 	"github.com/stretchr/testify/require"
 )
 
 type ioStruct struct {
-	ID   uint8
-	Data []byte
+	ID    uint8
+	Data  []byte
+	Slice []uint32
 }
 
 func TestMinimalSources(t *testing.T) {
@@ -44,19 +41,26 @@ func TestMinimalSources(t *testing.T) {
 
 	// Then see if we can successfully run a script
 	cl.Wd = tmpDir
-	encDec := new(testEncoderDecoder)
-	caller := NewScriptCaller[ioStruct, ioStruct](cl, "script/Test.s.sol:TestScript", "run(bytes)", encDec, encDec)
+	caller := NewScriptCaller(
+		cl,
+		"script/Test.s.sol:TestScript",
+		"runEncoded(bytes)",
+		&BytesScriptEncoder[ioStruct]{TypeName: "ioStruct"},
+		&BytesScriptDecoder[ioStruct]{TypeName: "ioStruct"},
+	)
 	// It should not recompile since we included the cache.
 	in := ioStruct{
-		ID:   1,
-		Data: []byte{0x01, 0x02, 0x03, 0x04},
+		ID:    1,
+		Data:  []byte{0x01, 0x02, 0x03, 0x04},
+		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
 	}
 	out, changed, err := caller(ctx, in)
 	require.NoError(t, err)
 	require.False(t, changed)
 	require.EqualValues(t, ioStruct{
-		ID:   2,
-		Data: in.Data,
+		ID:    2,
+		Data:  in.Data,
+		Slice: in.Slice,
 	}, out)
 }
 
@@ -90,63 +94,35 @@ func TestScriptCaller(t *testing.T) {
 	cl.Wd = projDir(t)
 
 	require.NoError(t, cl.Clean(ctx))
-	encDec := new(testEncoderDecoder)
-	caller := NewScriptCaller[ioStruct, ioStruct](cl, "script/Test.s.sol:TestScript", "run(bytes)", encDec, encDec)
+	caller := NewScriptCaller(
+		cl,
+		"script/Test.s.sol:TestScript",
+		"runEncoded(bytes)",
+		&BytesScriptEncoder[ioStruct]{TypeName: "ioStruct"},
+		&BytesScriptDecoder[ioStruct]{TypeName: "ioStruct"},
+	)
+
 	in := ioStruct{
-		ID:   1,
-		Data: []byte{0x01, 0x02},
+		ID:    1,
+		Data:  []byte{0x01, 0x02},
+		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
 	}
 	out, recompiled, err := caller(context.Background(), in)
 	require.NoError(t, err)
 	require.True(t, recompiled)
 	require.EqualValues(t, ioStruct{
-		ID:   2,
-		Data: []byte{0x01, 0x02},
+		ID:    2,
+		Data:  []byte{0x01, 0x02},
+		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
 	}, out)
 	out, recompiled, err = caller(context.Background(), in)
 	require.NoError(t, err)
 	require.False(t, recompiled)
 	require.EqualValues(t, ioStruct{
-		ID:   2,
-		Data: []byte{0x01, 0x02},
+		ID:    2,
+		Data:  []byte{0x01, 0x02},
+		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
 	}, out)
-}
-
-var (
-	runArgs = abi.Arguments{{Type: mustTuple()}}
-)
-
-func mustTuple() abi.Type {
-	t, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
-		{Name: "ID", Type: "uint8"},
-		{Name: "Data", Type: "bytes"},
-	})
-	if err != nil {
-		panic(err)
-	}
-	return t
-}
-
-type testEncoderDecoder struct {
-}
-
-func (t *testEncoderDecoder) Encode(in ioStruct) ([]byte, error) {
-	return runArgs.Pack(in)
-}
-
-func (t *testEncoderDecoder) Decode(v []byte) (ioStruct, error) {
-	var out ioStruct
-	decoded, err := runArgs.Unpack(v)
-	if err != nil {
-		return out, fmt.Errorf("error unpacking args: %w", err)
-	}
-	// Geth's ABI decoding library returns an anonymous strut
-	// which requires reflection to parse.
-	anonStruct := decoded[0]
-	val := reflect.ValueOf(anonStruct)
-	out.ID = uint8(val.FieldByName("ID").Uint())
-	out.Data = val.FieldByName("Data").Bytes()
-	return out, nil
 }
 
 func copyDir(src, dst string) error {

--- a/op-deployer/pkg/deployer/forge/client_test.go
+++ b/op-deployer/pkg/deployer/forge/client_test.go
@@ -20,6 +20,7 @@ type ioStruct struct {
 	ID    uint8
 	Data  []byte
 	Slice []uint32
+	Array [3]uint64
 }
 
 func TestMinimalSources(t *testing.T) {
@@ -53,6 +54,7 @@ func TestMinimalSources(t *testing.T) {
 		ID:    1,
 		Data:  []byte{0x01, 0x02, 0x03, 0x04},
 		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
+		Array: [3]uint64{0x01, 0x02, 0x03},
 	}
 	out, changed, err := caller(ctx, in)
 	require.NoError(t, err)
@@ -61,6 +63,7 @@ func TestMinimalSources(t *testing.T) {
 		ID:    2,
 		Data:  in.Data,
 		Slice: in.Slice,
+		Array: in.Array,
 	}, out)
 }
 
@@ -106,22 +109,25 @@ func TestScriptCaller(t *testing.T) {
 		ID:    1,
 		Data:  []byte{0x01, 0x02},
 		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
+		Array: [3]uint64{0x01, 0x02, 0x03},
 	}
 	out, recompiled, err := caller(context.Background(), in)
 	require.NoError(t, err)
 	require.True(t, recompiled)
 	require.EqualValues(t, ioStruct{
 		ID:    2,
-		Data:  []byte{0x01, 0x02},
-		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
+		Data:  in.Data,
+		Slice: in.Slice,
+		Array: in.Array,
 	}, out)
 	out, recompiled, err = caller(context.Background(), in)
 	require.NoError(t, err)
 	require.False(t, recompiled)
 	require.EqualValues(t, ioStruct{
 		ID:    2,
-		Data:  []byte{0x01, 0x02},
-		Slice: []uint32{0x01, 0x02, 0x03, 0x04},
+		Data:  in.Data,
+		Slice: in.Slice,
+		Array: in.Array,
 	}, out)
 }
 

--- a/op-deployer/pkg/deployer/forge/encoding.go
+++ b/op-deployer/pkg/deployer/forge/encoding.go
@@ -31,22 +31,39 @@ func GoStructToABITuple(structType reflect.Type, tupleName string) (abi.Type, er
 }
 
 func GoTypeToABIType(goType reflect.Type) (string, error) {
+	// handle pointers by dereferencing
+	if goType.Kind() == reflect.Ptr {
+		goType = goType.Elem()
+	}
+
 	// standard go types
 	switch goType.Kind() {
 	case reflect.Slice:
 		elemType := goType.Elem()
 
-		// Special case: []byte -> "bytes"
+		// special case: []byte -> "bytes"
 		if elemType.Kind() == reflect.Uint8 {
 			return "bytes", nil
 		}
 
-		// Recursive: []T -> "T[]"
+		// recursive: []T -> "T[]"
 		elemABI, err := GoTypeToABIType(elemType)
 		if err != nil {
 			return "", fmt.Errorf("unsupported slice element type: %w", err)
 		}
 		return elemABI + "[]", nil
+
+	case reflect.Array:
+		elemType := goType.Elem()
+		arrayLen := goType.Len()
+
+		// recursive: [N]T -> "T[N]"
+		elemABI, err := GoTypeToABIType(elemType)
+		if err != nil {
+			return "", fmt.Errorf("unsupported array element type: %w", err)
+		}
+		return fmt.Sprintf("%s[%d]", elemABI, arrayLen), nil
+
 	case reflect.String:
 		return "string", nil
 	case reflect.Bool:
@@ -57,7 +74,7 @@ func GoTypeToABIType(goType reflect.Type) (string, error) {
 		return "uint16", nil
 	case reflect.Uint32:
 		return "uint32", nil
-	case reflect.Uint64:
+	case reflect.Uint64, reflect.Uint:
 		return "uint64", nil
 	case reflect.Int8:
 		return "int8", nil
@@ -65,7 +82,7 @@ func GoTypeToABIType(goType reflect.Type) (string, error) {
 		return "int16", nil
 	case reflect.Int32:
 		return "int32", nil
-	case reflect.Int64:
+	case reflect.Int64, reflect.Int:
 		return "int64", nil
 	}
 

--- a/op-deployer/pkg/deployer/forge/encoding.go
+++ b/op-deployer/pkg/deployer/forge/encoding.go
@@ -1,0 +1,153 @@
+package forge
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func GoStructToABITuple(structType reflect.Type, tupleName string) (abi.Type, error) {
+	var components []abi.ArgumentMarshaling
+
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+
+		abiType, err := GoTypeToABIType(field.Type)
+		if err != nil {
+			return abi.Type{}, fmt.Errorf("unsupported field type %s: %w", field.Type, err)
+		}
+
+		components = append(components, abi.ArgumentMarshaling{
+			Name: field.Name,
+			Type: abiType,
+		})
+	}
+
+	return abi.NewType("tuple", tupleName, components)
+}
+
+func GoTypeToABIType(goType reflect.Type) (string, error) {
+	// standard go types
+	switch goType.Kind() {
+	case reflect.Slice:
+		elemType := goType.Elem()
+
+		// Special case: []byte -> "bytes"
+		if elemType.Kind() == reflect.Uint8 {
+			return "bytes", nil
+		}
+
+		// Recursive: []T -> "T[]"
+		elemABI, err := GoTypeToABIType(elemType)
+		if err != nil {
+			return "", fmt.Errorf("unsupported slice element type: %w", err)
+		}
+		return elemABI + "[]", nil
+	case reflect.String:
+		return "string", nil
+	case reflect.Bool:
+		return "bool", nil
+	case reflect.Uint8:
+		return "uint8", nil
+	case reflect.Uint16:
+		return "uint16", nil
+	case reflect.Uint32:
+		return "uint32", nil
+	case reflect.Uint64:
+		return "uint64", nil
+	case reflect.Int8:
+		return "int8", nil
+	case reflect.Int16:
+		return "int16", nil
+	case reflect.Int32:
+		return "int32", nil
+	case reflect.Int64:
+		return "int64", nil
+	}
+
+	// non-standard go types
+	switch goType {
+	case reflect.TypeOf(common.Address{}):
+		return "address", nil
+	case reflect.TypeOf(common.Hash{}):
+		return "bytes32", nil
+	case reflect.TypeOf(params.ProtocolVersion{}):
+		return "bytes32", nil
+	case reflect.TypeOf(big.NewInt(0)).Elem():
+		return "uint256", nil
+	}
+
+	return "", fmt.Errorf("unable to convert go type to abi type: %s", goType)
+}
+
+func ConvertAnonStructToTyped[T any](anonStruct interface{}) (T, error) {
+	var result T
+
+	srcVal := reflect.ValueOf(anonStruct)
+	destVal := reflect.ValueOf(&result).Elem()
+
+	// Ensure both are structs
+	if srcVal.Kind() != reflect.Struct || destVal.Kind() != reflect.Struct {
+		return result, fmt.Errorf("both source and destination must be structs")
+	}
+
+	// Check field count matches
+	if srcVal.NumField() != destVal.NumField() {
+		return result, fmt.Errorf("field count mismatch: source has %d, destination has %d",
+			srcVal.NumField(), destVal.NumField())
+	}
+
+	// Copy fields by index (assumes same field order)
+	for i := 0; i < srcVal.NumField(); i++ {
+		srcField := srcVal.Field(i)
+		destField := destVal.Field(i)
+
+		if destField.CanSet() {
+			destField.Set(srcField)
+		}
+	}
+
+	return result, nil
+}
+
+type BytesScriptEncoder[T any] struct {
+	TypeName string // e.g., "DeploySuperchainInput"
+}
+
+func (e *BytesScriptEncoder[T]) Encode(input T) ([]byte, error) {
+	inputType, err := GoStructToABITuple(reflect.TypeOf(input), e.TypeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create input type: %w", err)
+	}
+
+	args := abi.Arguments{{Type: inputType}}
+	return args.Pack(input)
+}
+
+type BytesScriptDecoder[T any] struct {
+	TypeName string // e.g., "DeploySuperchainOutput"
+}
+
+func (d *BytesScriptDecoder[T]) Decode(rawOutput []byte) (T, error) {
+	var zero T
+	outputType, err := GoStructToABITuple(reflect.TypeOf(zero), d.TypeName)
+	if err != nil {
+		return zero, fmt.Errorf("failed to create output type: %w", err)
+	}
+
+	args := abi.Arguments{{Type: outputType}}
+	unpacked, err := args.Unpack(rawOutput)
+	if err != nil {
+		return zero, fmt.Errorf("failed to unpack output: %w", err)
+	}
+
+	if len(unpacked) != 1 {
+		return zero, fmt.Errorf("expected 1 unpacked value, got %d", len(unpacked))
+	}
+
+	return ConvertAnonStructToTyped[T](unpacked[0])
+}

--- a/op-deployer/pkg/deployer/forge/testdata/testproject/script/Test.s.sol
+++ b/op-deployer/pkg/deployer/forge/testdata/testproject/script/Test.s.sol
@@ -6,16 +6,18 @@ contract TestScript {
         uint8 id;
         bytes data;
         uint32[] slice;
+        uint256[3] array;
     }
 
     struct Output {
         uint8 id;
         bytes data;
         uint32[] slice;
+        uint256[3] array;
     }
 
     function _run(Input memory _input) public pure returns (Output memory) {
-        return Output({ id: 0x02, data: _input.data, slice: _input.slice });
+        return Output({ id: 0x02, data: _input.data, slice: _input.slice, array: _input.array });
     }
 
     function runEncoded(bytes memory _input) public pure returns (bytes memory) {

--- a/op-deployer/pkg/deployer/forge/testdata/testproject/script/Test.s.sol
+++ b/op-deployer/pkg/deployer/forge/testdata/testproject/script/Test.s.sol
@@ -5,18 +5,20 @@ contract TestScript {
     struct Input {
         uint8 id;
         bytes data;
+        uint32[] slice;
     }
 
     struct Output {
         uint8 id;
         bytes data;
+        uint32[] slice;
     }
 
     function _run(Input memory _input) public pure returns (Output memory) {
-        return Output({ id: 0x02, data: _input.data });
+        return Output({ id: 0x02, data: _input.data, slice: _input.slice });
     }
 
-    function run(bytes memory _input) public pure returns (bytes memory) {
+    function runEncoded(bytes memory _input) public pure returns (bytes memory) {
         Input memory input = abi.decode(_input, (Input));
         Output memory output = _run(input);
         return abi.encode(output);


### PR DESCRIPTION
# Overview
Creates a generic `BytesScriptEncoder` and `BytesScriptDecoder` for use when calling the following solidity function:
```
    function runEncoded(bytes memory _input) public pure returns (bytes memory) {
        Input memory input = abi.decode(_input, (Input));
        Output memory output = _run(input);
        return abi.encode(output);
    }
```
This gives us re-usable types so that each forge script we want to invoke via op-deployer does not need to implement their own Encoder/Decoder unless they are forced to use a different function definition. Instead, if the forge script just has  (or adds) the above function, the generic codec will work out-of-the-box.

Follow-up pr will add the `runEncoded` function to `DeploySuperchain.s.sol`, `DeployImplementations.s.sol`, and `DeployOPChain.s.sol` so that we can use the generic codec for all three.

# Tests
Updates `client_test.go` so that it uses the generic codec. Also updates its test solidity contract to ensure more complex types like slices and arrays are handled properly. 