### PR TITLE
op-node/rollup: remove ReceivedUnsafePayloadEvent event

### DIFF
--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -54,7 +54,8 @@ type L2Verifier struct {
 
 	log log.Logger
 
-	Eng L2API
+	Eng    L2API
+	CLSync *clsync.CLSync
 
 	syncStatus driver.SyncStatusTracker
 
@@ -213,6 +214,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		eventSys:          sys,
 		log:               log,
 		Eng:               eng,
+		CLSync:            clSync,
 		engine:            ec,
 		derivationMetrics: metrics,
 		derivation:        pipeline,
@@ -455,7 +457,7 @@ func (s *L2Verifier) ActL2PipelineFull(t Testing) {
 // ActL2UnsafeGossipReceive creates an action that can receive an unsafe execution payload, like gossipsub
 func (s *L2Verifier) ActL2UnsafeGossipReceive(payload *eth.ExecutionPayloadEnvelope) Action {
 	return func(t Testing) {
-		s.synchronousEvents.Emit(t.Ctx(), clsync.ReceivedUnsafePayloadEvent{Envelope: payload})
+		s.CLSync.OnUnsafePayload(t.Ctx(), payload)
 	}
 }
 

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -457,7 +457,7 @@ func (s *L2Verifier) ActL2PipelineFull(t Testing) {
 // ActL2UnsafeGossipReceive creates an action that can receive an unsafe execution payload, like gossipsub
 func (s *L2Verifier) ActL2UnsafeGossipReceive(payload *eth.ExecutionPayloadEnvelope) Action {
 	return func(t Testing) {
-		s.CLSync.OnUnsafePayload(t.Ctx(), payload)
+		s.CLSync.AddUnsafePayload(t.Ctx(), payload)
 	}
 }
 

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -67,14 +67,6 @@ func (eq *CLSync) LowestQueuedUnsafeBlock() eth.L2BlockRef {
 	return ref
 }
 
-type ReceivedUnsafePayloadEvent struct {
-	Envelope *eth.ExecutionPayloadEnvelope
-}
-
-func (ev ReceivedUnsafePayloadEvent) String() string {
-	return "received-unsafe-payload"
-}
-
 func (eq *CLSync) OnEvent(ctx context.Context, ev event.Event) bool {
 	// Events may be concurrent in the future. Prevent unsafe concurrent modifications to the payloads queue.
 	eq.mu.Lock()
@@ -85,8 +77,6 @@ func (eq *CLSync) OnEvent(ctx context.Context, ev event.Event) bool {
 		eq.onInvalidPayload(x)
 	case engine.ForkchoiceUpdateEvent:
 		eq.onForkchoiceUpdate(ctx, x)
-	case ReceivedUnsafePayloadEvent:
-		eq.onUnsafePayload(ctx, x)
 	default:
 		return false
 	}
@@ -139,15 +129,15 @@ func (eq *CLSync) onForkchoiceUpdate(ctx context.Context, event engine.Forkchoic
 }
 
 // AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1.
-func (eq *CLSync) onUnsafePayload(ctx context.Context, event ReceivedUnsafePayloadEvent) {
-	eq.log.Debug("CL sync received payload", "payload", event.Envelope.ExecutionPayload.ID())
-	if event.Envelope == nil {
-		eq.log.Error("cannot add nil unsafe payload")
+func (eq *CLSync) OnUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
+	if envelope == nil {
+		eq.log.Error("CL sync OnUnsafePayload cannot add nil unsafe payload")
 		return
 	}
+	eq.log.Debug("CL sync received payload", "payload", envelope.ExecutionPayload.ID())
 
-	if err := eq.unsafePayloads.Push(event.Envelope); err != nil {
-		eq.log.Warn("Could not add unsafe payload", "id", event.Envelope.ExecutionPayload.ID(), "timestamp", uint64(event.Envelope.ExecutionPayload.Timestamp), "err", err)
+	if err := eq.unsafePayloads.Push(envelope); err != nil {
+		eq.log.Warn("Could not add unsafe payload", "id", envelope.ExecutionPayload.ID(), "timestamp", uint64(envelope.ExecutionPayload.Timestamp), "err", err)
 		return
 	}
 	p := eq.unsafePayloads.Peek()

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -129,11 +129,14 @@ func (eq *CLSync) onForkchoiceUpdate(ctx context.Context, event engine.Forkchoic
 }
 
 // AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1.
-func (eq *CLSync) OnUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
+func (eq *CLSync) AddUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) {
 	if envelope == nil {
-		eq.log.Error("CL sync OnUnsafePayload cannot add nil unsafe payload")
+		eq.log.Error("CL sync AddUnsafePayload cannot add nil unsafe payload")
 		return
 	}
+	eq.mu.Lock()
+	defer eq.mu.Unlock()
+
 	eq.log.Debug("CL sync received payload", "payload", envelope.ExecutionPayload.ID())
 
 	if err := eq.unsafePayloads.Push(envelope); err != nil {

--- a/op-node/rollup/clsync/clsync_test.go
+++ b/op-node/rollup/clsync/clsync_test.go
@@ -44,7 +44,7 @@ func TestCLSync_InvalidPayloadDropsHead(t *testing.T) {
 	}}
 
 	// Adding an unsafe payload requests a forkchoice update via engine controller
-	cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payload})
+	cl.OnUnsafePayload(context.Background(), payload)
 	require.Equal(t, 1, fe.calls)
 	require.NotNil(t, cl.unsafePayloads.Peek())
 
@@ -141,7 +141,7 @@ func TestCLSync_OnUnsafePayload_EnqueueEmitAndRecord(t *testing.T) {
 	cl := NewCLSync(logger, cfg, metrics, fe)
 	cl.AttachEmitter(emitter)
 
-	cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+	cl.OnUnsafePayload(context.Background(), payloadA1)
 	require.Equal(t, 1, fe.calls)
 
 	// queued and metrics recorded
@@ -164,7 +164,7 @@ func TestCLSync_OnForkchoiceUpdate_ProcessRetryAndPop(t *testing.T) {
 	cl.AttachEmitter(emitter)
 
 	// queue payload A1
-	cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: payloadA1})
+	cl.OnUnsafePayload(context.Background(), payloadA1)
 	require.Equal(t, 1, fe.calls)
 
 	// applicable forkchoice -> process once
@@ -225,8 +225,8 @@ func TestCLSync_InvalidPayloadForNonHead_NoDrop(t *testing.T) {
 		BlockHash:   common.Hash{0x02},
 	}}
 
-	cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: head})
-	cl.OnEvent(context.Background(), ReceivedUnsafePayloadEvent{Envelope: other})
+	cl.OnUnsafePayload(context.Background(), head)
+	cl.OnUnsafePayload(context.Background(), other)
 	require.Equal(t, 2, fe.calls)
 
 	// Invalidate non-head should not drop head

--- a/op-node/rollup/clsync/clsync_test.go
+++ b/op-node/rollup/clsync/clsync_test.go
@@ -44,7 +44,7 @@ func TestCLSync_InvalidPayloadDropsHead(t *testing.T) {
 	}}
 
 	// Adding an unsafe payload requests a forkchoice update via engine controller
-	cl.OnUnsafePayload(context.Background(), payload)
+	cl.AddUnsafePayload(context.Background(), payload)
 	require.Equal(t, 1, fe.calls)
 	require.NotNil(t, cl.unsafePayloads.Peek())
 
@@ -141,7 +141,7 @@ func TestCLSync_OnUnsafePayload_EnqueueEmitAndRecord(t *testing.T) {
 	cl := NewCLSync(logger, cfg, metrics, fe)
 	cl.AttachEmitter(emitter)
 
-	cl.OnUnsafePayload(context.Background(), payloadA1)
+	cl.AddUnsafePayload(context.Background(), payloadA1)
 	require.Equal(t, 1, fe.calls)
 
 	// queued and metrics recorded
@@ -164,7 +164,7 @@ func TestCLSync_OnForkchoiceUpdate_ProcessRetryAndPop(t *testing.T) {
 	cl.AttachEmitter(emitter)
 
 	// queue payload A1
-	cl.OnUnsafePayload(context.Background(), payloadA1)
+	cl.AddUnsafePayload(context.Background(), payloadA1)
 	require.Equal(t, 1, fe.calls)
 
 	// applicable forkchoice -> process once
@@ -225,8 +225,8 @@ func TestCLSync_InvalidPayloadForNonHead_NoDrop(t *testing.T) {
 		BlockHash:   common.Hash{0x02},
 	}}
 
-	cl.OnUnsafePayload(context.Background(), head)
-	cl.OnUnsafePayload(context.Background(), other)
+	cl.AddUnsafePayload(context.Background(), head)
+	cl.AddUnsafePayload(context.Background(), other)
 	require.Equal(t, 2, fe.calls)
 
 	// Invalidate non-head should not drop head

--- a/op-node/rollup/driver/interfaces.go
+++ b/op-node/rollup/driver/interfaces.go
@@ -69,10 +69,6 @@ type EngineController interface {
 	TryBackupUnsafeReorg(ctx context.Context) (bool, error)
 }
 
-type CLSync interface {
-	LowestQueuedUnsafeBlock() eth.L2BlockRef
-}
-
 type AttributesHandler interface {
 	// HasAttributes returns if there are any block attributes to process.
 	// HasAttributes is for EngineQueue testing only, and can be removed when attribute processing is fully independent.

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -110,7 +110,7 @@ func (s *SyncDeriver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.Execu
 	// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
 	if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
 		s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
-		s.CLSync.OnUnsafePayload(ctx, envelope)
+		s.CLSync.AddUnsafePayload(ctx, envelope)
 	} else if s.SyncCfg.SyncMode == sync.ELSync {
 		ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
 		if err != nil {

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -23,7 +23,7 @@ type SyncDeriver struct {
 
 	SafeHeadNotifs rollup.SafeHeadListener // notified when safe head is updated
 
-	CLSync CLSync
+	CLSync *clsync.CLSync
 
 	// The engine controller is used by the sequencer & Derivation components.
 	// We will also use it for EL sync in a future PR.
@@ -110,7 +110,7 @@ func (s *SyncDeriver) OnUnsafeL2Payload(ctx context.Context, envelope *eth.Execu
 	// If we are doing CL sync or done with engine syncing, fallback to the unsafe payload queue & CL P2P sync.
 	if s.SyncCfg.SyncMode == sync.CLSync || !s.Engine.IsEngineSyncing() {
 		s.Log.Info("Optimistically queueing unsafe L2 execution payload", "id", envelope.ExecutionPayload.ID())
-		s.Emitter.Emit(ctx, clsync.ReceivedUnsafePayloadEvent{Envelope: envelope})
+		s.CLSync.OnUnsafePayload(ctx, envelope)
 	} else if s.SyncCfg.SyncMode == sync.ELSync {
 		ref, err := derive.PayloadToBlockRef(s.Config, envelope.ExecutionPayload)
 		if err != nil {


### PR DESCRIPTION
This PR is removing `ReceivedUnsafePayloadEvent` event, as well as the `CLSync` interface, which has only a single implementation.