### PR TITLE
op-acceptance-tests: Ext Network EL Sync Test using Sync Tester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1228,6 +1228,10 @@ jobs:
         description: Network preset
         type: string
         default: ""
+      l2_cl_syncmode:
+        description: L2 CL Sync mode - can be EL Sync or CL Sync
+        type: string
+        default: ""
     resource_class: xlarge
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
@@ -1261,6 +1265,7 @@ jobs:
             GOGC: "0"
             # Optional sync test configuration environment variables (only set if parameters are provided)
             NETWORK_PRESET: "<<parameters.network_preset>>"
+            L2_CL_SYNCMODE: "<<parameters.l2_cl_syncmode>>"
           command: |
             # Run the tests
             LOG_LEVEL=debug just acceptance-test "" "<<parameters.gate>>"
@@ -2602,63 +2607,20 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
-      # Sync tests for multiple networks (runs in parallel)
       - op-acceptance-sync-tests-docker:
-          name: sync-test-op-sepolia-daily
+          name: "sync-test-<<matrix.network_preset>>-daily-<<matrix.l2_cl_syncmode>>"
           gate: sync-test-op-node
           no_output_timeout: 30m
-          network_preset: "op-sepolia"
           context:
             - circleci-repo-readonly-authenticated-github-token
             - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-      - op-acceptance-sync-tests-docker:
-          name: sync-test-base-sepolia-daily
-          gate: sync-test-op-node
-          no_output_timeout: 30m
-          network_preset: "base-sepolia"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-      - op-acceptance-sync-tests-docker:
-          name: sync-test-unichain-sepolia-daily
-          gate: sync-test-op-node
-          no_output_timeout: 30m
-          network_preset: "unichain-sepolia"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-      - op-acceptance-sync-tests-docker:
-          name: sync-test-op-mainnet-daily
-          gate: sync-test-op-node
-          no_output_timeout: 30m
-          network_preset: "op-mainnet"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-      - op-acceptance-sync-tests-docker:
-          name: sync-test-base-mainnet-daily
-          gate: sync-test-op-node
-          no_output_timeout: 30m
-          network_preset: "base-mainnet"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-
+          matrix:
+            parameters:
+              network_preset: ["op-sepolia", "base-sepolia", "unichain-sepolia", "op-mainnet", "base-mainnet"]
+              l2_cl_syncmode: ["consensus-layer", "execution-layer"]
   # Acceptance tests (post-merge to develop)
   acceptance-tests:
     when:

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -127,14 +127,26 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 	// Create orchestrator with the same configuration that was in TestMain
 	opt := stack.Combine(
 		presets.WithExternalELWithSuperchainRegistry(config),
-		presets.WithSyncTesterELInitialState(eth.FCUState{
-			Latest:    blk,
-			Safe:      blk,
-			Finalized: blk,
-		}),
 	)
 	if l2CLSyncMode == sync.ELSync {
-		opt = stack.Combine(opt, presets.WithELSyncTarget(targetBlock))
+		opt = stack.Combine(opt,
+			presets.WithExecutionLayerSyncOnVerifiers(),
+			presets.WithELSyncTarget(targetBlock),
+			presets.WithSyncTesterELInitialState(eth.FCUState{
+				Latest: blk,
+				Safe:   0,
+				// Need to set finalized to genesis to unskip EL Sync
+				Finalized: 0,
+			}),
+		)
+	} else {
+		opt = stack.Combine(opt,
+			presets.WithSyncTesterELInitialState(eth.FCUState{
+				Latest:    blk,
+				Safe:      blk,
+				Finalized: blk,
+			}),
+		)
 	}
 
 	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
@@ -163,27 +175,36 @@ func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode s
 	syncTester := l2.SyncTester(match.FirstSyncTester)
 
 	sys := &struct {
-		L2CL       *dsl.L2CLNode
-		L2EL       *dsl.L2ELNode
-		SyncTester *dsl.SyncTester
-		L2         *dsl.L2Network
+		L2CL         *dsl.L2CLNode
+		L2ELReadOnly *dsl.L2ELNode
+		L2EL         *dsl.L2ELNode
+		SyncTester   *dsl.SyncTester
+		L2           *dsl.L2Network
 	}{
-		L2CL:       dsl.NewL2CLNode(verifierCL, orch.ControlPlane()),
-		L2EL:       dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL), orch.ControlPlane()),
-		SyncTester: dsl.NewSyncTester(syncTester),
-		L2:         dsl.NewL2Network(l2, orch.ControlPlane()),
+		L2CL:         dsl.NewL2CLNode(verifierCL, orch.ControlPlane()),
+		L2ELReadOnly: dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL), orch.ControlPlane()),
+		L2EL:         dsl.NewL2ELNode(l2.L2ELNode(match.SecondL2EL), orch.ControlPlane()),
+		SyncTester:   dsl.NewSyncTester(syncTester),
+		L2:           dsl.NewL2Network(l2, orch.ControlPlane()),
 	}
 	require := t.Require()
 
 	if l2CLSyncMode == sync.ELSync {
-		// Signal L2CL for triggering EL Sync
-		sys.L2CL.SignalTarget(sys.L2EL, targetBlock)
+		// Signal L2CL for starting EL Sync
+		signalTarget := networkUpgradeBlocks[upgradeName] - 1
+		sys.L2CL.SignalTarget(sys.L2ELReadOnly, signalTarget)
+		// EL Sync is still progressing at this point
 	}
 
 	l2CLSyncStatus := sys.L2CL.WaitForNonZeroUnsafeTime(t.Ctx())
 
 	ft := sys.L2.Escape().RollupConfig().ActivationTimeFor(upgradeName)
 	require.Less(l2CLSyncStatus.UnsafeL2.Time, *ft, "L2CL unsafe time should be less than fork timestamp before upgrade")
+
+	if l2CLSyncMode == sync.ELSync {
+		// Signal L2CL for finishing EL Sync
+		sys.L2CL.SignalTarget(sys.L2ELReadOnly, targetBlock)
+	}
 
 	sys.L2CL.Reached(types.LocalUnsafe, targetBlock, 1000)
 	l.Info("L2CL unsafe reached", "targetBlock", targetBlock, "upgrade_name", upgradeName)

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -125,9 +125,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 	}
 
 	// Create orchestrator with the same configuration that was in TestMain
-	opt := stack.Combine(
-		presets.WithExternalELWithSuperchainRegistry(config),
-	)
+	opt := presets.WithExternalELWithSuperchainRegistry(config)
 	if l2CLSyncMode == sync.ELSync {
 		opt = stack.Combine(opt,
 			presets.WithExecutionLayerSyncOnVerifiers(),

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -76,7 +77,7 @@ func getEnvUint64OrDefault(envVar string, defaultValue uint64) uint64 {
 }
 
 // setupOrchestrator initializes and configures the orchestrator for the test
-func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrator {
+func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CLSyncMode sync.Mode) *sysgo.Orchestrator {
 	l := t.Logger()
 
 	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
@@ -113,6 +114,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrat
 	l.Info("L1_CL_BEACON_ENDPOINT", "value", l1CLBeaconEndpoint)
 	l.Info("L1_EL_ENDPOINT", "value", l1ELEndpoint)
 	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
+	l.Info("L2_CL_SYNCMODE", "value", l2CLSyncMode)
 
 	config := stack.ExtNetworkConfig{
 		L2NetworkName:      L2NetworkName,
@@ -131,6 +133,9 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrat
 			Finalized: blk,
 		}),
 	)
+	if l2CLSyncMode == sync.ELSync {
+		opt = stack.Combine(opt, presets.WithELSyncTarget(targetBlock))
+	}
 
 	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
 	stack.ApplyOptionLifecycle(opt, orch)
@@ -138,15 +143,18 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk uint64) *sysgo.Orchestrat
 	return orch.(*sysgo.Orchestrator)
 }
 
-func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName) {
+func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode sync.Mode) {
 	t := devtest.SerialT(gt)
 	l := t.Logger()
 
 	// Initial block number to sync from before the upgrade
 	blk := networkUpgradeBlocks[upgradeName] - 5
 
+	blocksToSync := uint64(10)
+	targetBlock := blk + blocksToSync
 	// Initialize orchestrator
-	orch := setupOrchestrator(gt, t, blk)
+
+	orch := setupOrchestrator(gt, t, blk, targetBlock, l2CLSyncMode)
 	system := shim.NewSystem(t)
 	orch.Hydrate(system)
 
@@ -167,13 +175,16 @@ func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName) {
 	}
 	require := t.Require()
 
+	if l2CLSyncMode == sync.ELSync {
+		// Signal L2CL for triggering EL Sync
+		sys.L2CL.SignalTarget(sys.L2EL, targetBlock)
+	}
+
 	l2CLSyncStatus := sys.L2CL.WaitForNonZeroUnsafeTime(t.Ctx())
 
 	ft := sys.L2.Escape().RollupConfig().ActivationTimeFor(upgradeName)
 	require.Less(l2CLSyncStatus.UnsafeL2.Time, *ft, "L2CL unsafe time should be less than fork timestamp before upgrade")
 
-	blocksToSync := uint64(10)
-	targetBlock := blk + blocksToSync
 	sys.L2CL.Reached(types.LocalUnsafe, targetBlock, 1000)
 	l.Info("L2CL unsafe reached", "targetBlock", targetBlock, "upgrade_name", upgradeName)
 	sys.L2CL.Reached(types.LocalSafe, targetBlock, 1000)

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -2,6 +2,7 @@ package hardforks_ext
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -127,6 +129,10 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 	// Create orchestrator with the same configuration that was in TestMain
 	opt := presets.WithExternalELWithSuperchainRegistry(config)
 	if l2CLSyncMode == sync.ELSync {
+		chainCfg := chaincfg.ChainByName(config.L2NetworkName)
+		if chainCfg == nil {
+			panic(fmt.Sprintf("network %s not found in superchain registry", config.L2NetworkName))
+		}
 		opt = stack.Combine(opt,
 			presets.WithExecutionLayerSyncOnVerifiers(),
 			presets.WithELSyncTarget(targetBlock),
@@ -134,7 +140,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 				Latest: blk,
 				Safe:   0,
 				// Need to set finalized to genesis to unskip EL Sync
-				Finalized: 0,
+				Finalized: chainCfg.Genesis.L2.Number,
 			}),
 		)
 	} else {

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -193,21 +193,14 @@ func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode s
 	}
 	require := t.Require()
 
-	if l2CLSyncMode == sync.ELSync {
-		// Signal L2CL for starting EL Sync
-		signalTarget := networkUpgradeBlocks[upgradeName] - 1
-		sys.L2CL.SignalTarget(sys.L2ELReadOnly, signalTarget)
-		// EL Sync is still progressing at this point
-	}
-
-	l2CLSyncStatus := sys.L2CL.WaitForNonZeroUnsafeTime(t.Ctx())
-
 	ft := sys.L2.Escape().RollupConfig().ActivationTimeFor(upgradeName)
-	require.Less(l2CLSyncStatus.UnsafeL2.Time, *ft, "L2CL unsafe time should be less than fork timestamp before upgrade")
-
+	var l2CLSyncStatus *eth.SyncStatus
 	if l2CLSyncMode == sync.ELSync {
 		// Signal L2CL for finishing EL Sync
 		sys.L2CL.SignalTarget(sys.L2ELReadOnly, targetBlock)
+	} else {
+		l2CLSyncStatus := sys.L2CL.WaitForNonZeroUnsafeTime(t.Ctx())
+		require.Less(l2CLSyncStatus.UnsafeL2.Time, *ft, "L2CL unsafe time should be less than fork timestamp before upgrade")
 	}
 
 	sys.L2CL.Reached(types.LocalUnsafe, targetBlock, 1000)

--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -143,6 +144,11 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 				Finalized: chainCfg.Genesis.L2.Number,
 			}),
 		)
+		// TODO(#17564): op-node has a suspected race during EL Sync.
+		// To temporarily mitigate and stabilize tests, restrict runtime
+		// parallelism to 1 (no true concurrency). This masks the race;
+		// remove once the underlying issue is fixed.
+		runtime.GOMAXPROCS(1)
 	} else {
 		opt = stack.Combine(opt,
 			presets.WithSyncTesterELInitialState(eth.FCUState{
@@ -195,7 +201,10 @@ func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode s
 
 	ft := sys.L2.Escape().RollupConfig().ActivationTimeFor(upgradeName)
 	var l2CLSyncStatus *eth.SyncStatus
+	attempts := 1000
 	if l2CLSyncMode == sync.ELSync {
+		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
+		attempts = 5
 		// Signal L2CL for finishing EL Sync
 		sys.L2CL.SignalTarget(sys.L2ELReadOnly, targetBlock)
 	} else {
@@ -203,9 +212,9 @@ func SyncTesterHFSExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode s
 		require.Less(l2CLSyncStatus.UnsafeL2.Time, *ft, "L2CL unsafe time should be less than fork timestamp before upgrade")
 	}
 
-	sys.L2CL.Reached(types.LocalUnsafe, targetBlock, 1000)
+	sys.L2CL.Reached(types.LocalUnsafe, targetBlock, attempts)
 	l.Info("L2CL unsafe reached", "targetBlock", targetBlock, "upgrade_name", upgradeName)
-	sys.L2CL.Reached(types.LocalSafe, targetBlock, 1000)
+	sys.L2CL.Reached(types.LocalSafe, targetBlock, attempts)
 	l.Info("L2CL safe reached", "targetBlock", targetBlock, "upgrade_name", upgradeName)
 
 	l2CLSyncStatus = sys.L2CL.SyncStatus()

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -139,7 +139,8 @@ func setupSystem(gt *testing.T, t devtest.T, blocksToSync uint64) (*presets.Mini
 		L1EL:         dsl.NewL1ELNode(system.L1Network(match.FirstL1Network).L1ELNode(match.FirstL1EL)),
 		L2Chain:      dsl.NewL2Network(l2, orch.ControlPlane()),
 		L2CL:         dsl.NewL2CLNode(verifierCL, orch.ControlPlane()),
-		L2EL:         dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL), orch.ControlPlane()),
+		L2ELReadOnly: dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL), orch.ControlPlane()),
+		L2EL:         dsl.NewL2ELNode(l2.L2ELNode(match.SecondL2EL), orch.ControlPlane()),
 		SyncTester:   dsl.NewSyncTester(syncTester),
 	}
 

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -93,7 +93,7 @@ func TestSyncTesterExtEL(gt *testing.T) {
 
 	if L2CLSyncMode == sync.ELSync {
 		// Signal L2CL for triggering EL Sync
-		sys.L2CL.SignalTarget(sys.L2EL, target)
+		sys.L2CL.SignalTarget(sys.L2ELReadOnly, target)
 	}
 
 	// Test that we can get sync status from L2CL node
@@ -208,15 +208,27 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 
 	opt := stack.Combine(
 		presets.WithExternalELWithSuperchainRegistry(config),
-		presets.WithSyncTesterELInitialState(eth.FCUState{
-			Latest:    initial,
-			Safe:      initial,
-			Finalized: initial,
-		}),
 	)
 
 	if L2CLSyncMode == sync.ELSync {
-		opt = stack.Combine(opt, presets.WithELSyncTarget(target))
+		opt = stack.Combine(opt,
+			presets.WithExecutionLayerSyncOnVerifiers(),
+			presets.WithELSyncTarget(target),
+			presets.WithSyncTesterELInitialState(eth.FCUState{
+				Latest: initial,
+				Safe:   0,
+				// Need to set finalized to genesis to unskip EL Sync
+				Finalized: 0,
+			}),
+		)
+	} else {
+		opt = stack.Combine(opt,
+			presets.WithSyncTesterELInitialState(eth.FCUState{
+				Latest:    initial,
+				Safe:      initial,
+				Finalized: initial,
+			}),
+		)
 	}
 
 	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -206,10 +206,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 	target := initial + blocksToSync
 	l.Info("LATEST_BLOCK", "latest_block", latestBlock.NumberU64(), "session_initial_block", initial, "target_block", target)
 
-	opt := stack.Combine(
-		presets.WithExternalELWithSuperchainRegistry(config),
-	)
-
+	opt := presets.WithExternalELWithSuperchainRegistry(config)
 	if L2CLSyncMode == sync.ELSync {
 		opt = stack.Combine(opt,
 			presets.WithExecutionLayerSyncOnVerifiers(),

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -3,6 +3,7 @@ package sync_tester_ext_el
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -93,7 +94,10 @@ func TestSyncTesterExtEL(gt *testing.T) {
 	blocksToSync := uint64(20)
 	sys, target := setupSystem(gt, t, blocksToSync)
 
+	attempts := 50
 	if L2CLSyncMode == sync.ELSync {
+		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
+		attempts = 5
 		// Signal L2CL for triggering EL Sync
 		sys.L2CL.SignalTarget(sys.L2ELReadOnly, target)
 	}
@@ -102,7 +106,7 @@ func TestSyncTesterExtEL(gt *testing.T) {
 	l2CLSyncStatus := sys.L2CL.SyncStatus()
 	require.NotNil(l2CLSyncStatus, "L2CL should have sync status")
 
-	sys.L2CL.Reached(types.LocalUnsafe, target, 500)
+	sys.L2CL.Reached(types.LocalUnsafe, target, attempts)
 
 	l2CLSyncStatus = sys.L2CL.SyncStatus()
 	require.NotNil(l2CLSyncStatus, "L2CL should have sync status")
@@ -224,6 +228,11 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 				Finalized: chainCfg.Genesis.L2.Number,
 			}),
 		)
+		// TODO(#17564): op-node has a suspected race during EL Sync.
+		// To temporarily mitigate and stabilize tests, restrict runtime
+		// parallelism to 1 (no true concurrency). This masks the race;
+		// remove once the underlying issue is fixed.
+		runtime.GOMAXPROCS(1)
 	} else {
 		opt = stack.Combine(opt,
 			presets.WithSyncTesterELInitialState(eth.FCUState{

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -1,6 +1,7 @@
 package sync_tester_ext_el
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -208,6 +210,10 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 
 	opt := presets.WithExternalELWithSuperchainRegistry(config)
 	if L2CLSyncMode == sync.ELSync {
+		chainCfg := chaincfg.ChainByName(config.L2NetworkName)
+		if chainCfg == nil {
+			panic(fmt.Sprintf("network %s not found in superchain registry", config.L2NetworkName))
+		}
 		opt = stack.Combine(opt,
 			presets.WithExecutionLayerSyncOnVerifiers(),
 			presets.WithELSyncTarget(target),
@@ -215,7 +221,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 				Latest: initial,
 				Safe:   0,
 				// Need to set finalized to genesis to unskip EL Sync
-				Finalized: 0,
+				Finalized: chainCfg.Genesis.L2.Number,
 			}),
 		)
 	} else {

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 
@@ -68,7 +69,15 @@ var (
 			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
 		},
 	}
+	L2CLSyncMode = getSyncMode("L2_CL_SYNCMODE")
 )
+
+func getSyncMode(envVar string) sync.Mode {
+	if value := os.Getenv(envVar); value == sync.ELSyncString {
+		return sync.ELSync
+	}
+	return sync.CLSync
+}
 
 func TestSyncTesterExtEL(gt *testing.T) {
 	t := devtest.SerialT(gt)
@@ -79,14 +88,19 @@ func TestSyncTesterExtEL(gt *testing.T) {
 
 	l := t.Logger()
 	require := t.Require()
-	sys, initial := setupSystem(gt, t)
+	blocksToSync := uint64(20)
+	sys, target := setupSystem(gt, t, blocksToSync)
+
+	if L2CLSyncMode == sync.ELSync {
+		// Signal L2CL for triggering EL Sync
+		sys.L2CL.SignalTarget(sys.L2EL, target)
+	}
 
 	// Test that we can get sync status from L2CL node
 	l2CLSyncStatus := sys.L2CL.SyncStatus()
 	require.NotNil(l2CLSyncStatus, "L2CL should have sync status")
 
-	blocksToSync := uint64(20)
-	sys.L2CL.Reached(types.LocalUnsafe, initial+blocksToSync, 500)
+	sys.L2CL.Reached(types.LocalUnsafe, target, 500)
 
 	l2CLSyncStatus = sys.L2CL.SyncStatus()
 	require.NotNil(l2CLSyncStatus, "L2CL should have sync status")
@@ -105,10 +119,10 @@ func TestSyncTesterExtEL(gt *testing.T) {
 	l.Info("SyncTester ExtEL test completed successfully", "l2cl_chain_id", sys.L2CL.ID().ChainID(), "l2cl_sync_status", l2CLSyncStatus)
 }
 
-// setupSystem initializes the system for the test and returns the system and the initial block number of the session
-func setupSystem(gt *testing.T, t devtest.T) (*presets.MinimalExternalEL, uint64) {
+// setupSystem initializes the system for the test and returns the system and the target block number of the session
+func setupSystem(gt *testing.T, t devtest.T, blocksToSync uint64) (*presets.MinimalExternalEL, uint64) {
 	// Initialize orchestrator
-	orch, initial := setupOrchestrator(gt, t)
+	orch, target := setupOrchestrator(gt, t, blocksToSync)
 	system := shim.NewSystem(t)
 	orch.Hydrate(system)
 
@@ -129,11 +143,11 @@ func setupSystem(gt *testing.T, t devtest.T) (*presets.MinimalExternalEL, uint64
 		SyncTester:   dsl.NewSyncTester(syncTester),
 	}
 
-	return sys, initial
+	return sys, target
 }
 
-// setupOrchestrator initializes and configures the orchestrator for the test and returns the orchestrator and the initial block number of the session
-func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64) {
+// setupOrchestrator initializes and configures the orchestrator for the test and returns the orchestrator and the target block number of the session
+func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.Orchestrator, uint64) {
 	l := t.Logger()
 	ctx := t.Ctx()
 	require := t.Require()
@@ -164,6 +178,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	l.Info("L1_CL_BEACON_ENDPOINT", "value", config.L1CLBeaconEndpoint)
 	l.Info("L1_EL_ENDPOINT", "value", config.L1ELEndpoint)
 	l.Info("TAILSCALE_NETWORKING", "value", os.Getenv("TAILSCALE_NETWORKING"))
+	l.Info("L2_CL_SYNCMODE", "value", L2CLSyncMode)
 
 	// Setup orchestrator
 	logger := testlog.Logger(gt, log.LevelInfo)
@@ -187,7 +202,8 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 	require.NoError(err)
 
 	initial := latestBlock.NumberU64() - 1000
-	l.Info("LATEST_BLOCK", "latest_block", latestBlock.NumberU64(), "session_initial_block", initial)
+	target := initial + blocksToSync
+	l.Info("LATEST_BLOCK", "latest_block", latestBlock.NumberU64(), "session_initial_block", initial, "target_block", target)
 
 	opt := stack.Combine(
 		presets.WithExternalELWithSuperchainRegistry(config),
@@ -198,10 +214,14 @@ func setupOrchestrator(gt *testing.T, t devtest.T) (*sysgo.Orchestrator, uint64)
 		}),
 	)
 
+	if L2CLSyncMode == sync.ELSync {
+		opt = stack.Combine(opt, presets.WithELSyncTarget(target))
+	}
+
 	var orch stack.Orchestrator = sysgo.NewOrchestrator(p, stack.SystemHook(opt))
 	stack.ApplyOptionLifecycle(opt, orch)
 
-	return orch.(*sysgo.Orchestrator), initial
+	return orch.(*sysgo.Orchestrator), target
 }
 
 // getEnvOrDefault returns the environment variable value or the default if not set

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_canyon/sync_tester_hfs_ext_canyon_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_canyon/sync_tester_hfs_ext_canyon_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Canyon(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Canyon)
+func TestSyncTesterHFS_Canyon_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Canyon, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Canyon_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Canyon, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_delta/sync_tester_hfs_ext_delta_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_delta/sync_tester_hfs_ext_delta_test.go
@@ -12,6 +12,6 @@ func TestSyncTesterHFS_Delta_CLSync(gt *testing.T) {
 	hardforks_ext.SyncTesterHFSExt(gt, rollup.Delta, sync.CLSync)
 }
 
-func TestSyncTesterHFS_Canyon_ELSync(gt *testing.T) {
+func TestSyncTesterHFS_Delta_ELSync(gt *testing.T) {
 	hardforks_ext.SyncTesterHFSExt(gt, rollup.Delta, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_delta/sync_tester_hfs_ext_delta_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_delta/sync_tester_hfs_ext_delta_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Delta(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Delta)
+func TestSyncTesterHFS_Delta_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Delta, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Canyon_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Delta, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_ecotone/sync_tester_hfs_ext_ecotone_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_ecotone/sync_tester_hfs_ext_ecotone_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Ecotone(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Ecotone)
+func TestSyncTesterHFS_Ecotone_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Ecotone, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Ecotone_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Ecotone, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_fjord/sync_tester_hfs_ext_fjord_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_fjord/sync_tester_hfs_ext_fjord_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Fjord(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Fjord)
+func TestSyncTesterHFS_Fjord_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Fjord, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Fjord_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Fjord, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_granite/sync_tester_hfs_ext_granite_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_granite/sync_tester_hfs_ext_granite_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Granite(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Granite)
+func TestSyncTesterHFS_Granite_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Granite, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Granite_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Granite, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_holocene/sync_tester_hfs_ext_holocene_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_holocene/sync_tester_hfs_ext_holocene_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Holocene(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Holocene)
+func TestSyncTesterHFS_Holocene_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Holocene, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Holocene_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Holocene, sync.ELSync)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_isthmus/sync_tester_hfs_ext_isthmus_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_isthmus/sync_tester_hfs_ext_isthmus_test.go
@@ -5,8 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/hardforks_ext"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 )
 
-func TestSyncTesterHFS_Isthmus(gt *testing.T) {
-	hardforks_ext.SyncTesterHFSExt(gt, rollup.Isthmus)
+func TestSyncTesterHFS_Isthmus_CLSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Isthmus, sync.CLSync)
+}
+
+func TestSyncTesterHFS_Isthmus_ELSync(gt *testing.T) {
+	hardforks_ext.SyncTesterHFSExt(gt, rollup.Isthmus, sync.ELSync)
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -368,6 +368,7 @@ func (cl *L2CLNode) WaitForNonZeroUnsafeTime(ctx context.Context) *eth.SyncStatu
 }
 
 func (cl *L2CLNode) SignalTarget(el *L2ELNode, targetNum uint64) {
+	cl.log.Info("Signaling L2CL", "target", targetNum)
 	payload := el.PayloadByNumber(targetNum)
 	err := retry.Do0(cl.ctx, 3, retry.Fixed(2*time.Second), func() error {
 		return cl.inner.RollupAPI().PostUnsafePayload(cl.ctx, payload)

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -366,3 +366,11 @@ func (cl *L2CLNode) WaitForNonZeroUnsafeTime(ctx context.Context) *eth.SyncStatu
 
 	return ss
 }
+
+func (cl *L2CLNode) SignalTarget(el *L2ELNode, targetNum uint64) {
+	payload := el.PayloadByNumber(targetNum)
+	err := retry.Do0(cl.ctx, 3, retry.Fixed(2*time.Second), func() error {
+		return cl.inner.RollupAPI().PostUnsafePayload(cl.ctx, payload)
+	})
+	cl.require.NoErrorf(err, "failed to post unsafe payload via admin API: target %d", targetNum)
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -188,3 +188,9 @@ func (el *L2ELNode) Start() {
 func (el *L2ELNode) PeerWith(peer *L2ELNode) {
 	sysgo.ConnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC())
 }
+
+func (el *L2ELNode) PayloadByNumber(number uint64) *eth.ExecutionPayloadEnvelope {
+	payload, err := el.inner.L2EthExtendedClient().PayloadByNumber(el.ctx, number)
+	el.require.NoError(err, "failed to get payload")
+	return payload
+}

--- a/op-devstack/presets/minimal_external_el.go
+++ b/op-devstack/presets/minimal_external_el.go
@@ -17,9 +17,10 @@ type MinimalExternalEL struct {
 	L1Network *dsl.L1Network
 	L1EL      *dsl.L1ELNode
 
-	L2Chain *dsl.L2Network
-	L2CL    *dsl.L2CLNode
-	L2EL    *dsl.L2ELNode
+	L2Chain      *dsl.L2Network
+	L2CL         *dsl.L2CLNode
+	L2EL         *dsl.L2ELNode
+	L2ELReadOnly *dsl.L2ELNode
 
 	SyncTester *dsl.SyncTester
 }

--- a/op-devstack/shim/l2_el.go
+++ b/op-devstack/shim/l2_el.go
@@ -45,3 +45,7 @@ func (r *rpcL2ELNode) ID() stack.L2ELNodeID {
 func (r *rpcL2ELNode) L2EthClient() apis.L2EthClient {
 	return r.l2Client
 }
+
+func (r *rpcL2ELNode) L2EthExtendedClient() apis.L2EthExtendedClient {
+	return r.l2Client
+}

--- a/op-devstack/stack/l2_el.go
+++ b/op-devstack/stack/l2_el.go
@@ -71,6 +71,7 @@ func (id L2ELNodeID) Match(elems []L2ELNode) []L2ELNode {
 type L2ELNode interface {
 	ID() L2ELNodeID
 	L2EthClient() apis.L2EthClient
+	L2EthExtendedClient() apis.L2EthExtendedClient
 
 	ELNode
 }

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -73,3 +73,16 @@ func WithL2ELNode(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchest
 		return WithOpGeth(id, opts...)
 	}
 }
+
+func WithExtL2Node(id stack.L2ELNodeID, elRPCEndpoint string) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		require := orch.P().Require()
+
+		// Create L2 EL node with external RPC
+		l2ELNode := &OpGeth{
+			id:      id,
+			userRPC: elRPCEndpoint,
+		}
+		require.True(orch.l2ELs.SetIfMissing(id, l2ELNode), "must not already exist")
+	})
+}

--- a/op-devstack/sysgo/system_synctester_ext.go
+++ b/op-devstack/sysgo/system_synctester_ext.go
@@ -17,22 +17,24 @@ type DefaultMinimalExternalELSystemIDs struct {
 	L1EL stack.L1ELNodeID
 	L1CL stack.L1CLNodeID
 
-	L2   stack.L2NetworkID
-	L2CL stack.L2CLNodeID
-	L2EL stack.L2ELNodeID
+	L2           stack.L2NetworkID
+	L2CL         stack.L2CLNodeID
+	L2EL         stack.L2ELNodeID
+	L2ELReadOnly stack.L2ELNodeID
 
 	SyncTester stack.SyncTesterID
 }
 
 func NewExternalELSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimalExternalELSystemIDs {
 	ids := DefaultMinimalExternalELSystemIDs{
-		L1:         stack.L1NetworkID(l1ID),
-		L1EL:       stack.NewL1ELNodeID("l1", l1ID),
-		L1CL:       stack.NewL1CLNodeID("l1", l1ID),
-		L2:         stack.L2NetworkID(l2ID),
-		L2CL:       stack.NewL2CLNodeID("verifier", l2ID),
-		L2EL:       stack.NewL2ELNodeID("sync-tester-el", l2ID),
-		SyncTester: stack.NewSyncTesterID("sync-tester", l2ID),
+		L1:           stack.L1NetworkID(l1ID),
+		L1EL:         stack.NewL1ELNodeID("l1", l1ID),
+		L1CL:         stack.NewL1CLNodeID("l1", l1ID),
+		L2:           stack.L2NetworkID(l2ID),
+		L2CL:         stack.NewL2CLNodeID("verifier", l2ID),
+		L2EL:         stack.NewL2ELNodeID("sync-tester-el", l2ID),
+		L2ELReadOnly: stack.NewL2ELNodeID("l2-el-readonly", l2ID),
+		SyncTester:   stack.NewSyncTesterID("sync-tester", l2ID),
 	}
 	return ids
 }
@@ -85,6 +87,8 @@ func ExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExter
 	// Add SyncTesterL2ELNode as the L2EL replacement for real-world EL endpoint
 	opt.Add(WithSyncTesterL2ELNode(ids.L2EL, ids.L2EL))
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL))
+
+	opt.Add(WithExtL2Node(ids.L2ELReadOnly, l2ELRPC))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester_ext.go
+++ b/op-devstack/sysgo/system_synctester_ext.go
@@ -88,7 +88,7 @@ func ExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExter
 	opt.Add(WithSyncTesterL2ELNode(ids.L2EL, ids.L2EL))
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL))
 
-	opt.Add(WithExtL2Node(ids.L2ELReadOnly, l2ELRPC))
+	opt.Add(WithExtL2Node(ids.L2ELReadOnly, networkPreset.L2ELEndpoint))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -658,16 +658,16 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 	}
 	// OP Stack specific request shape validation
 	if isEcotone {
-		if payload.WithdrawalsRoot == nil {
-			// https://github.com/ethereum-optimism/specs/blob/a773587fca6756f8468164613daa79fcee7bbbe4/specs/protocol/exec-engine.md#engine_newpayloadv3
-			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
-		}
 		if len(versionedHashes) != 0 {
 			// https://github.com/ethereum-optimism/specs/blob/a773587fca6756f8468164613daa79fcee7bbbe4/specs/protocol/exec-engine.md#engine_newpayloadv3
 			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(fmt.Errorf("versionedHashes length non-zero: %d", len(versionedHashes)))
 		}
 	}
 	if isIsthmus {
+		if payload.WithdrawalsRoot == nil {
+			// https://github.com/ethereum-optimism/specs/blob/7b39adb0bea3b0a56d6d3a7d61feef5c33e49b73/specs/protocol/isthmus/exec-engine.md#update-to-executionpayload
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+		}
 		if len(executionRequests) != 0 {
 			// https://github.com/ethereum-optimism/specs/blob/a773587fca6756f8468164613daa79fcee7bbbe4/specs/protocol/exec-engine.md#engine_newpayloadv4
 			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.InvalidParams.With(fmt.Errorf("executionRequests must be empty array but got %d", len(executionRequests)))


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Enables EL Sync Tests using real chain data. 

Example logs:
```log
# sync tester initialized: latest=31388892&safe=0&finalized=0&el_sync_target=31388912
    l2_el_synctester.go:200:    INFO [09-22|13:34:34.295] sync tester EL is ready                  userRPC="http://127.0.0.1:38983/chain/84532/synctest/b77c6aef-8aa3-4306-923f-799a3c3d8714?latest=31388892&safe=0&finalized=0&el_sync_target=31388912" authRPC="http://127.0.0.1:46791/chain/84532/synctest/b77c6aef-8aa3-4306-923f-799a3c3d8714?latest=31388892&safe=0&finalized=0&el_sync_target=31388912"
# op-node started
    l2_cl_opnode.go:113:        INFO [09-22|13:34:34.299] Starting op-node
...
    driver.go:227:              INFO [09-22|13:34:35.684] State loop started
# test logic signaled op-node
    l2_cl.go:371:               INFO [09-22|13:34:35.685] Signaling L2CL                           target=31,388,912
    sync_deriver.go:123:        INFO [09-22|13:34:35.861] Optimistically inserting unsafe L2 execution payload to drive EL sync id=e7f4df..f68249:31388912
# op-node starts EL Sync
    engine_controller.go:452:   INFO [09-22|13:34:35.982] Starting EL sync
    sync_deriver.go:146:        [33mWARN [09-22|13:34:35.982] Clearing safe head db because EL sync started
    chain_spec.go:207:          INFO [09-22|13:34:36.142] Current hardfork version detected        forkName=isthmus
    engine_controller.go:399:   [33mWARN [09-22|13:34:36.143] Attempting to update forkchoice state while EL syncing
    engine_controller.go:383:   INFO [09-22|13:34:36.143] Set initial cross-unsafe block ref to match cross-safe cross_unsafe=e7f4df..f68249:31388912
# finds out the underlying EL(sync tester EL) reached the signal block
# finish EL Sync
    engine_controller.go:526:   INFO [09-22|13:34:36.662] Finished EL sync                         sync_duration=679.908261ms finalized_block=0xe7f4df32411daeeeea145642129c99bd6e99b6e7e4f4d5491d6b707695f68249:31388912
    engine_controller.go:539:   INFO [09-22|13:34:36.662] Inserted new L2 unsafe block (synchronous) hash=e7f4df..f68249 number=31,388,912 newpayload_time=160.280ms fcu2_time=519.464ms total_time=679.865ms mgas=7.499 mgasps=11.030
    l2_cl.go:172:               INFO [09-22|13:34:36.666] Expecting chain to reach                 id=L2CLNode-verifier-84532 chain=84532 label=unsafe target=31,388,912
    l2_cl.go:180:               INFO [09-22|13:34:36.668] Chain sync status                        id=L2CLNode-verifier-84532 chain=84532 label=unsafe target=31,388,912 current=0
# no logs shown but op-node will start progressing
```

**Tests**

For daily CI Job `scheduled-sync-test-op-node`, added a matrix(`l2_cl_syncmode: ["consensus-layer", "execution-layer"]`) to cover EL Sync as well. Validated using manual CircleCI API Call. [Ref](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/101560/workflows/0f12a720-17ca-4a38-b6cf-242f5a942c42)

<p align="center">

<img width="573" height="792" alt="image" src="https://github.com/user-attachments/assets/a3acaf25-24ce-474e-b442-df29a1d4579f" />

</p>

For sync-tester acceptance tests that runs every commit: `op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go`, also tested EL Sync.

While testing, we need to make the L2 CL be aware of new head. The tests use the `admin_PostUnsafePayload` to signal the L2 CL to trigger and finish the EL Sync.

To start EL Sync, the EL sync's finalized head should be set to genesis. Manually set the finalized head to genesis:
https://github.com/ethereum-optimism/optimism/blob/565ec51924ce48deef27002cc6fa7151bb02e42c/op-node/rollup/engine/engine_controller.go#L445-L450

**Additional context**

Needed to access the read only L2 EL for creating payload for signaling. Added `WithExtL2Node` op-devstack helper to access the Read only L2 EL at tests.

Fixed op-sync-tester bug, to check withdrawal root is not nil when isthmus is enabled, while proxying `engine_newPayloadV4` RPC.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17388
