### PR TITLE
Add enumerableSet and get pending functionality

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -8,7 +8,6 @@ library Enum {
 library TimelockGuard {
     struct GuardConfig {
         uint256 timelockDelay;
-        bool configured;
     }
 
     struct ScheduledTransaction {
@@ -69,7 +68,7 @@ interface Interface {
         external
         view
         returns (TimelockGuard.ScheduledTransaction memory);
-    function safeConfigs(address) external view returns (uint256 timelockDelay, bool configured);
+    function safeConfigs(address) external view returns (uint256 timelockDelay);
     function scheduleTransaction(
         address _safe,
         uint256 _nonce,

--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -39,7 +39,6 @@ interface Interface {
     error TimelockGuard_TransactionNotScheduled();
 
     event CancellationThresholdUpdated(address indexed safe, uint256 oldThreshold, uint256 newThreshold);
-    event GuardCleared(address indexed safe);
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
     event TransactionCancelled(address indexed safe, bytes32 indexed txId);
     event TransactionScheduled(address indexed safe, bytes32 indexed txId, uint256 when);
@@ -62,7 +61,6 @@ interface Interface {
         bytes memory,
         address
     ) external;
-    function clearTimelockGuard() external;
     function configureTimelockGuard(uint256 _timelockDelay) external;
     function getScheduledTransaction(address _safe, bytes32 _txHash)
         external

--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -1,65 +1,81 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
 
-import { Enum } from "safe-contracts/common/Enum.sol";
-import { ISemver } from "interfaces/universal/ISemver.sol";
-import { Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+library Enum {
+    type Operation is uint8;
+}
 
-
-/// @title ITimelockGuard
-/// @notice Interface for the TimelockGuard Safe guard.
-interface ITimelockGuard is IGuard, ISemver {
-    // Errors
-    error TimelockGuard_GuardNotConfigured();
-    error TimelockGuard_GuardNotEnabled();
-    error TimelockGuard_GuardStillEnabled();
-    error TimelockGuard_InvalidTimelockDelay();
-
-    // Events
-    event GuardCleared(address indexed safe);
-    event GuardConfigured(address indexed safe, uint256 timelockDelay);
-
+library TimelockGuard {
     struct GuardConfig {
         uint256 timelockDelay;
         bool configured;
     }
 
-    // Views
-    function version() external view returns (string memory);
-
-    function viewTimelockGuardConfiguration(address _safe) external view returns (GuardConfig memory);
-
-    function cancellationThreshold(address _safe) external view returns (uint256 cancellationThreshold_);
-
-    function safeConfigs(address)
-        external
-        view
-        returns (uint256 timelockDelay);
-
-    // Admin
-    function configureTimelockGuard(uint256 _timelockDelay) external;
-
-    function clearTimelockGuard() external;
-
-    // Scheduling API (placeholders until fully implemented in the guard)
-    function scheduleTransaction(
-        address _safe,
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation,
-        uint256 _safeTxGas,
-        uint256 _baseGas,
-        uint256 _gasPrice,
-        address _gasToken,
-        address payable _refundReceiver,
-        bytes memory _signatures
-    )
-        external
-        pure;
-
-    function checkPendingTransactions(address _safe) external pure returns (bytes32[] memory pendingTxs_);
-
-    function cancelTransaction(address _safe, bytes32 _txHash) external pure;
+    struct ScheduledTransaction {
+        uint256 executionTime;
+        bool cancelled;
+        bool executed;
+    }
 }
 
+interface Interface {
+    struct ExecTransactionParams {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address payable refundReceiver;
+    }
+
+    error TimelockGuard_GuardNotConfigured();
+    error TimelockGuard_GuardNotEnabled();
+    error TimelockGuard_GuardStillEnabled();
+    error TimelockGuard_InvalidTimelockDelay();
+    error TimelockGuard_TransactionAlreadyCancelled();
+    error TimelockGuard_TransactionAlreadyScheduled();
+    error TimelockGuard_TransactionNotScheduled();
+
+    event CancellationThresholdUpdated(address indexed safe, uint256 oldThreshold, uint256 newThreshold);
+    event GuardCleared(address indexed safe);
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+    event TransactionCancelled(address indexed safe, bytes32 indexed txId);
+    event TransactionScheduled(address indexed safe, bytes32 indexed txId, uint256 when);
+
+    function blockingThreshold(address) external pure returns (uint256);
+    function cancelTransaction(address _safe, bytes32 _txHash, uint256 _nonce, bytes memory _signatures) external;
+    function cancellationThreshold(address _safe) external view returns (uint256);
+    function checkAfterExecution(bytes32, bool) external;
+    function checkPendingTransactions(address) external pure returns (bytes32[] memory);
+    function checkTransaction(
+        address,
+        uint256 _value,
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
+    ) external;
+    function clearTimelockGuard() external;
+    function configureTimelockGuard(uint256 _timelockDelay) external;
+    function getScheduledTransaction(address _safe, bytes32 _txHash)
+        external
+        view
+        returns (TimelockGuard.ScheduledTransaction memory);
+    function safeConfigs(address) external view returns (uint256 timelockDelay, bool configured);
+    function scheduleTransaction(
+        address _safe,
+        uint256 _nonce,
+        ExecTransactionParams memory _params,
+        bytes memory _signatures
+    ) external;
+    function version() external view returns (string memory);
+    function viewTimelockGuardConfiguration(address _safe) external view returns (TimelockGuard.GuardConfig memory);
+}

--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+
+
+/// @title ITimelockGuard
+/// @notice Interface for the TimelockGuard Safe guard.
+interface ITimelockGuard is IGuard, ISemver {
+    // Errors
+    error TimelockGuard_GuardNotConfigured();
+    error TimelockGuard_GuardNotEnabled();
+    error TimelockGuard_GuardStillEnabled();
+    error TimelockGuard_InvalidTimelockDelay();
+
+    // Events
+    event GuardCleared(address indexed safe);
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    // Views
+    function version() external view returns (string memory);
+
+    function viewTimelockGuardConfiguration(address _safe) external view returns (uint256);
+
+    function cancellationThreshold(address _safe) external view returns (uint256 cancellationThreshold_);
+
+    function safeCancellationThreshold(address) external view returns (uint256);
+
+    function safeConfigs(address)
+        external
+        view
+        returns (uint256 timelockDelay);
+
+    // Admin
+    function configureTimelockGuard(uint256 _timelockDelay) external;
+
+    function clearTimelockGuard() external;
+
+    // Scheduling API (placeholders until fully implemented in the guard)
+    function scheduleTransaction(
+        address _safe,
+        address _to,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation,
+        uint256 _safeTxGas,
+        uint256 _baseGas,
+        uint256 _gasPrice,
+        address _gasToken,
+        address payable _refundReceiver,
+        bytes memory _signatures
+    )
+        external
+        pure;
+
+    function checkPendingTransactions(address _safe) external pure returns (bytes32[] memory pendingTxs_);
+
+    function rejectTransaction(address _safe, bytes32 _txHash) external pure;
+
+    function rejectTransactionWithSignature(address _safe, bytes32 _txHash, bytes memory _signatures) external pure;
+
+    function cancelTransaction(address _safe, bytes32 _txHash) external pure;
+}
+

--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -19,14 +19,17 @@ interface ITimelockGuard is IGuard, ISemver {
     event GuardCleared(address indexed safe);
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
 
+    struct GuardConfig {
+        uint256 timelockDelay;
+        bool configured;
+    }
+
     // Views
     function version() external view returns (string memory);
 
-    function viewTimelockGuardConfiguration(address _safe) external view returns (uint256);
+    function viewTimelockGuardConfiguration(address _safe) external view returns (GuardConfig memory);
 
     function cancellationThreshold(address _safe) external view returns (uint256 cancellationThreshold_);
-
-    function safeCancellationThreshold(address) external view returns (uint256);
 
     function safeConfigs(address)
         external
@@ -56,10 +59,6 @@ interface ITimelockGuard is IGuard, ISemver {
         pure;
 
     function checkPendingTransactions(address _safe) external pure returns (bytes32[] memory pendingTxs_);
-
-    function rejectTransaction(address _safe, bytes32 _txHash) external pure;
-
-    function rejectTransactionWithSignature(address _safe, bytes32 _txHash, bytes memory _signatures) external pure;
 
     function cancelTransaction(address _safe, bytes32 _txHash) external pure;
 }

--- a/packages/contracts-bedrock/snapshots/abi/TimelockGuard.json
+++ b/packages/contracts-bedrock/snapshots/abi/TimelockGuard.json
@@ -2,25 +2,54 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract GnosisSafe",
         "name": "",
         "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
       }
     ],
-    "name": "cancelTransaction",
-    "outputs": [],
+    "name": "blockingThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract GnosisSafe",
+        "name": "_safe",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_txHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signatures",
+        "type": "bytes"
+      }
+    ],
+    "name": "cancelTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract GnosisSafe",
         "name": "_safe",
         "type": "address"
       }
@@ -77,7 +106,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_to",
         "type": "address"
       },
       {
@@ -87,37 +116,37 @@
       },
       {
         "internalType": "bytes",
-        "name": "",
+        "name": "_data",
         "type": "bytes"
       },
       {
         "internalType": "enum Enum.Operation",
-        "name": "",
+        "name": "_operation",
         "type": "uint8"
       },
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "_safeTxGas",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "_baseGas",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "_gasPrice",
         "type": "uint256"
       },
       {
         "internalType": "address",
-        "name": "",
+        "name": "_gasToken",
         "type": "address"
       },
       {
         "internalType": "address payable",
-        "name": "",
+        "name": "_refundReceiver",
         "type": "address"
       },
       {
@@ -159,58 +188,39 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "",
+        "internalType": "contract GnosisSafe",
+        "name": "_safe",
         "type": "address"
       },
       {
         "internalType": "bytes32",
-        "name": "",
+        "name": "_txHash",
         "type": "bytes32"
       }
     ],
-    "name": "rejectTransaction",
-    "outputs": [],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes",
-        "name": "",
-        "type": "bytes"
-      }
-    ],
-    "name": "rejectTransactionWithSignature",
-    "outputs": [],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "safeCancellationThreshold",
+    "name": "getScheduledTransaction",
     "outputs": [
       {
-        "internalType": "uint256",
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "executionTime",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "cancelled",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "executed",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct TimelockGuard.ScheduledTransaction",
         "name": "",
-        "type": "uint256"
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
@@ -219,7 +229,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract GnosisSafe",
         "name": "",
         "type": "address"
       }
@@ -230,6 +240,11 @@
         "internalType": "uint256",
         "name": "timelockDelay",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "configured",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -238,64 +253,76 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "",
+        "internalType": "contract GnosisSafe",
+        "name": "_safe",
         "type": "address"
       },
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "_nonce",
         "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "enum Enum.Operation",
+            "name": "operation",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "safeTxGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "gasToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address payable",
+            "name": "refundReceiver",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ExecTransactionParams",
+        "name": "_params",
+        "type": "tuple"
       },
       {
         "internalType": "bytes",
-        "name": "",
-        "type": "bytes"
-      },
-      {
-        "internalType": "enum Enum.Operation",
-        "name": "",
-        "type": "uint8"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "address payable",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "",
+        "name": "_signatures",
         "type": "bytes"
       }
     ],
     "name": "scheduleTransaction",
     "outputs": [],
-    "stateMutability": "pure",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -314,7 +341,7 @@
   {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "contract GnosisSafe",
         "name": "_safe",
         "type": "address"
       }
@@ -322,9 +349,21 @@
     "name": "viewTimelockGuardConfiguration",
     "outputs": [
       {
-        "internalType": "uint256",
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "timelockDelay",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "configured",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct TimelockGuard.GuardConfig",
         "name": "",
-        "type": "uint256"
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
@@ -335,7 +374,32 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
+        "internalType": "contract GnosisSafe",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldThreshold",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newThreshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "CancellationThresholdUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract GnosisSafe",
         "name": "safe",
         "type": "address"
       }
@@ -348,7 +412,7 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
+        "internalType": "contract GnosisSafe",
         "name": "safe",
         "type": "address"
       },
@@ -360,6 +424,75 @@
       }
     ],
     "name": "GuardConfigured",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract GnosisSafe",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract GnosisSafe",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "txHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract GnosisSafe",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "when",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransactionScheduled",
     "type": "event"
   },
   {
@@ -380,6 +513,26 @@
   {
     "inputs": [],
     "name": "TimelockGuard_InvalidTimelockDelay",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_TransactionAlreadyCancelled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_TransactionAlreadyScheduled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_TransactionNotReady",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_TransactionNotScheduled",
     "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/abi/TimelockGuard.json
+++ b/packages/contracts-bedrock/snapshots/abi/TimelockGuard.json
@@ -1,0 +1,385 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "cancelTransaction",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_safe",
+        "type": "address"
+      }
+    ],
+    "name": "cancellationThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "name": "checkAfterExecution",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "checkPendingTransactions",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "enum Enum.Operation",
+        "name": "",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "checkTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clearTimelockGuard",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_timelockDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "configureTimelockGuard",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "rejectTransaction",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "rejectTransactionWithSignature",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "safeCancellationThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "safeConfigs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timelockDelay",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "enum Enum.Operation",
+        "name": "",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "scheduleTransaction",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_safe",
+        "type": "address"
+      }
+    ],
+    "name": "viewTimelockGuardConfiguration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "safe",
+        "type": "address"
+      }
+    ],
+    "name": "GuardCleared",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timelockDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "GuardConfigured",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_GuardNotConfigured",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_GuardNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_GuardStillEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TimelockGuard_InvalidTimelockDelay",
+    "type": "error"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -207,6 +207,10 @@
     "initCodeHash": "0xde3b3273aa37604048b5fa228b90f3b05997db613dfcda45061545a669b2476a",
     "sourceCodeHash": "0x918965e52bbd358ac827ebe35998f5d8fa5ca77d8eb9ab8986b44181b9aaa48a"
   },
+  "src/safe/TimelockGuard.sol:TimelockGuard": {
+    "initCodeHash": "0x5bc2ee2e57f8e4d4713a232a8427997398e1d9cfb26d8afafcccf228820972a6",
+    "sourceCodeHash": "0x2f23c80216ea80843414d6bcab10237964a8039e4d712c7cc3e65d57278067df"
+  },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0xc3289416829b252c830ad7d389a430986a7404df4fe0be37cb19e1c40907f047",
     "sourceCodeHash": "0xf5e29dd5c750ea935c7281ec916ba5277f5610a0a9e984e53ae5d5245b3cf2f4"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x918965e52bbd358ac827ebe35998f5d8fa5ca77d8eb9ab8986b44181b9aaa48a"
   },
   "src/safe/TimelockGuard.sol:TimelockGuard": {
-    "initCodeHash": "0x5bc2ee2e57f8e4d4713a232a8427997398e1d9cfb26d8afafcccf228820972a6",
-    "sourceCodeHash": "0x2f23c80216ea80843414d6bcab10237964a8039e4d712c7cc3e65d57278067df"
+    "initCodeHash": "0xb1a6237837c6f2ab8219f3fd51f8d76a911e84ca05656757ea875006f6327465",
+    "sourceCodeHash": "0x3f102f6379bf6386ef5e5a7af1d7b1b03d37d8cda3ff06eddf279a70c5f1dd48"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0xc3289416829b252c830ad7d389a430986a7404df4fe0be37cb19e1c40907f047",

--- a/packages/contracts-bedrock/snapshots/storageLayout/TimelockGuard.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/TimelockGuard.json
@@ -1,0 +1,16 @@
+[
+  {
+    "bytes": "32",
+    "label": "safeConfigs",
+    "offset": 0,
+    "slot": "0",
+    "type": "mapping(address => struct TimelockGuard.GuardConfig)"
+  },
+  {
+    "bytes": "32",
+    "label": "safeCancellationThreshold",
+    "offset": 0,
+    "slot": "1",
+    "type": "mapping(address => uint256)"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/storageLayout/TimelockGuard.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/TimelockGuard.json
@@ -4,13 +4,20 @@
     "label": "safeConfigs",
     "offset": 0,
     "slot": "0",
-    "type": "mapping(address => struct TimelockGuard.GuardConfig)"
+    "type": "mapping(contract GnosisSafe => struct TimelockGuard.GuardConfig)"
+  },
+  {
+    "bytes": "32",
+    "label": "scheduledTransactions",
+    "offset": 0,
+    "slot": "1",
+    "type": "mapping(contract GnosisSafe => mapping(bytes32 => struct TimelockGuard.ScheduledTransaction))"
   },
   {
     "bytes": "32",
     "label": "safeCancellationThreshold",
     "offset": 0,
-    "slot": "1",
-    "type": "mapping(address => uint256)"
+    "slot": "2",
+    "type": "mapping(contract GnosisSafe => uint256)"
   }
 ]

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -59,6 +59,9 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Error for when a transaction is not scheduled
     error TimelockGuard_TransactionNotScheduled();
 
+    /// @notice Error for when a transaction is not ready to execute (timelock delay not passed)
+    error TimelockGuard_TransactionNotReady();
+
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
 
@@ -78,6 +81,12 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Emitted when the cancellation threshold is updated
     event CancellationThresholdUpdated(Safe indexed safe, uint256 oldThreshold, uint256 newThreshold);
+
+    /// @notice Emitted when a transaction is executed for a Safe.
+    /// @param safe The Safe whose transaction is executed.
+    /// @param nonce The nonce of the Safe for the transaction being executed.
+    /// @param txHash The identifier of the executed transaction (nonce-independent).
+    event TransactionExecuted(Safe indexed safe, uint256 indexed nonce, bytes32 txHash);
 
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
@@ -329,22 +338,66 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
-        address,
+        address _to,
         uint256 _value,
-        bytes memory,
-        Enum.Operation,
-        uint256,
-        uint256,
-        uint256,
-        address,
-        address payable,
+        bytes memory _data,
+        Enum.Operation _operation,
+        uint256 _safeTxGas,
+        uint256 _baseGas,
+        uint256 _gasPrice,
+        address _gasToken,
+        address payable _refundReceiver,
         bytes memory,
         address
     )
         external
         override
     {
-        // TODO: Implement
+        Safe callingSafe = Safe(payable(msg.sender));
+
+        if (safeConfigs[callingSafe].configured == false) {
+            // We return immediately. This is important in order to allow a Safe which has the
+            // guard set, but not configured to complete the setup process.
+            // It is also just a reasonable thing to do, since an unconfigured Safe must have a
+            // delay of zero.
+            return;
+        }
+
+        // Get the nonce of the Safe for the transaction being executed,
+        // since the Safe's nonce is incremented before the transaction is executed,
+        // we must subtract 1.
+        uint256 nonce = callingSafe.nonce() - 1;
+
+        // Get the transaction hash from the Safe's getTransactionHash function
+        bytes32 txHash = callingSafe.getTransactionHash(
+            _to, _value, _data, _operation, _safeTxGas, _baseGas, _gasPrice, _gasToken, _refundReceiver, nonce
+        );
+
+        // Get the scheduled transaction
+        ScheduledTransaction storage scheduledTx = scheduledTransactions[callingSafe][txHash];
+
+        // Check if the transaction has been scheduled
+        if (scheduledTx.executionTime == 0) {
+            revert TimelockGuard_TransactionNotScheduled();
+        }
+
+        // Check if the transaction was cancelled
+        if (scheduledTx.cancelled) {
+            revert TimelockGuard_TransactionAlreadyCancelled();
+        }
+
+        // Check if the timelock delay has passed
+        if (scheduledTx.executionTime > block.timestamp) {
+            revert TimelockGuard_TransactionNotReady();
+        }
+
+        // Set the transaction as executed
+        scheduledTx.executed = true;
+
+        // Reset the cancellation threshold
+        resetCancellationThreshold(callingSafe);
+
+        emit TransactionExecuted(callingSafe, nonce, txHash);
     }
 
     /// @notice Called by the Safe after executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -154,9 +154,8 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Returns the blocking threshold threshold for a given safe
     /// @dev MUST NOT revert
-    /// @param _safe The Safe address to query
     /// @return The current blocking threshold
-    function blockingThreshold(address _safe) public view returns (uint256) {
+    function blockingThreshold(address /* _safe */) public pure returns (uint256) {
         return 0;
         // return min(quorum, total_owners - quorum + 1) for _safe;
     }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -43,9 +43,6 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Error for when Safe is not configured for this guard
     error TimelockGuard_GuardNotConfigured();
 
-    /// @notice Error for when attempt to clear guard while it is still enabled for the Safe
-    error TimelockGuard_GuardStillEnabled();
-
     /// @notice Error for invalid timelock delay
     error TimelockGuard_InvalidTimelockDelay();
 
@@ -63,9 +60,6 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
-
-    /// @notice Emitted when a Safe clears the guard configuration
-    event GuardCleared(Safe indexed safe);
 
     /// @notice Emitted when a transaction is scheduled for a Safe.
     /// @param safe The Safe whose transaction is scheduled.
@@ -113,48 +107,33 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev MUST set the caller as a Safe
     /// @dev MUST take timelock_delay as a parameter and store it as related to the Safe
     /// @dev MUST emit a GuardConfigured event with at least timelock_delay as a parameter
-    /// @param _timelockDelay The timelock delay in seconds
+    /// @dev If _timelockDelay is 0, clears the configuration for the Safe
+    /// @param _timelockDelay The timelock delay in seconds (0 to clear configuration)
     function configureTimelockGuard(uint256 _timelockDelay) external {
         Safe callingSafe = Safe(payable(msg.sender));
-        // Validate timelock delay - must be non-zero and not longer than 1 year
-        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
-            revert TimelockGuard_InvalidTimelockDelay();
-        }
 
         // Check that this guard is enabled on the calling Safe
         if (!_isGuardEnabled(callingSafe)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
+        // Validate timelock delay - must not be longer than 1 year
+        if (_timelockDelay > 365 days) {
+            revert TimelockGuard_InvalidTimelockDelay();
+        }
+
         // Store the configuration for this safe
         safeConfigs[callingSafe].timelockDelay = _timelockDelay;
 
-        // Initialize cancellation threshold to 1
-        safeCancellationThreshold[callingSafe] = 1;
-
         emit GuardConfigured(callingSafe, _timelockDelay);
-    }
 
-    /// @notice Remove the timelock guard configuration by a previously enabled Safe
-    /// @dev MUST revert if the contract is not enabled as a guard for the Safe
-    /// @dev MUST erase the existing timelock_delay data related to the calling Safe
-    /// @dev MUST emit a GuardCleared event
-    function clearTimelockGuard() external {
-        Safe callingSafe = Safe(payable(msg.sender));
-        // Check if the calling safe has configuration set
-        if (safeConfigs[callingSafe].timelockDelay == 0) {
-            revert TimelockGuard_GuardNotConfigured();
+        // If timelock delay is 0, ensure the cancellation threshold is deleted
+        if (_timelockDelay == 0) {
+            delete safeCancellationThreshold[callingSafe];
+        } else {
+            // Initialize cancellation threshold to 1
+            safeCancellationThreshold[callingSafe] = 1;
         }
-
-        // Check that this guard is NOT enabled on the calling Safe
-        if (_isGuardEnabled(callingSafe)) {
-            revert TimelockGuard_GuardStillEnabled();
-        }
-
-        // Erase the configuration data for this safe
-        delete safeConfigs[callingSafe];
-
-        emit GuardCleared(callingSafe);
     }
 
     /// @notice Returns the cancellation threshold for a given safe

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -249,7 +249,6 @@ contract TimelockGuard is IGuard, ISemver {
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
-    /// @dev NOT IMPLEMENTED YET
     /// @dev This function aims to mimic the approach which would be used by a quorum of signers to
     ///      cancel a partially signed transaction, which would be to sign and execute an empty
     ///      transaction at the same nonce. This enables us to deterministically generate the
@@ -259,29 +258,16 @@ contract TimelockGuard is IGuard, ISemver {
     ///      transaction hash.
     function cancelTransaction(
         Safe _safe,
-        ExecTransactionParams memory _params,
+        bytes32 _txHash,
         uint256 _nonce,
         bytes memory _signatures
     )
         external
     {
-        // Calculate the transaction hash
-        bytes32 txHash = _safe.getTransactionHash(
-            _params.to,
-            _params.value,
-            _params.data,
-            _params.operation,
-            _params.safeTxGas,
-            _params.baseGas,
-            _params.gasPrice,
-            _params.gasToken,
-            _params.refundReceiver,
-            _nonce
-        );
-        if (scheduledTransactions[_safe][txHash].cancelled) {
+        if (scheduledTransactions[_safe][_txHash].cancelled) {
             revert TimelockGuard_TransactionAlreadyCancelled();
         }
-        if (scheduledTransactions[_safe][txHash].executionTime == 0) {
+        if (scheduledTransactions[_safe][_txHash].executionTime == 0) {
             revert TimelockGuard_TransactionNotScheduled();
         }
 
@@ -294,7 +280,7 @@ contract TimelockGuard is IGuard, ISemver {
         // This function call reverts if the signatures are invalid.
         _safe.checkNSignatures(cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[_safe]);
 
-        scheduledTransactions[_safe][txHash].cancelled = true;
+        scheduledTransactions[_safe][_txHash].cancelled = true;
     }
 
     /// @notice Increase the cancellation threshold for a safe

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -117,17 +117,7 @@ contract TimelockGuard is IGuard, ISemver {
             return 0;
         }
 
-        // Return 0 if not configured
-        if (safeConfigs[_safe].timelockDelay == 0) {
-            return 0;
-        }
-
-        uint256 threshold = safeCancellationThreshold[_safe];
-        if (threshold == 0) {
-            // Default to 1 if not set
-            return 1;
-        }
-        return threshold;
+        return safeCancellationThreshold[_safe];
     }
 
     /// @notice Internal helper to get the guard address from a Safe

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -143,17 +143,17 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Schedule a transaction for execution after the timelock delay
     /// @dev Called by anyone using signatures from Safe owners - NOT IMPLEMENTED YET
     function scheduleTransaction(
-        address, /* safe */
-        address, /* to */
-        uint256, /* value */
-        bytes memory, /* data */
-        Enum.Operation, /* operation */
-        uint256, /* safeTxGas */
-        uint256, /* baseGas */
-        uint256, /* gasPrice */
-        address, /* gasToken */
-        address payable, /* refundReceiver */
-        bytes memory /* signatures */
+        address,
+        address,
+        uint256,
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory
     )
         external
         pure
@@ -164,42 +164,42 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
     /// @dev MUST NOT revert - NOT IMPLEMENTED YET
     /// @return List of pending transaction hashes
-    function checkPendingTransactions(address /* _safe */) external pure returns (bytes32[] memory) {
+    function checkPendingTransactions(address) external pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
     /// @notice Signal rejection of a scheduled transaction by a Safe owner
     /// @dev NOT IMPLEMENTED YET
-    function rejectTransaction(address /* safe */, bytes32 /* txHash */) external pure {
+    function rejectTransaction(address, bytes32) external pure {
         // TODO: Implement
     }
 
     /// @notice Signal rejection of a scheduled transaction using signatures
     /// @dev NOT IMPLEMENTED YET
-    function rejectTransactionWithSignature(address /* safe */, bytes32 /* txHash */, bytes memory /* signatures */) external pure {
+    function rejectTransactionWithSignature(address, bytes32, bytes memory) external pure {
         // TODO: Implement
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
     /// @dev NOT IMPLEMENTED YET
-    function cancelTransaction(address /* safe */, bytes32 /* txHash */) external pure {
+    function cancelTransaction(address, bytes32) external pure {
         // TODO: Implement
     }
 
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
-        address /* _to */,
+        address,
         uint256 _value,
-        bytes memory /* _data */,
-        Enum.Operation /* _operation */,
-        uint256 /* _safeTxGas */,
-        uint256 /* _baseGas */,
-        uint256 /* _gasPrice */,
-        address /* _gasToken */,
-        address payable /* _refundReceiver */,
-        bytes memory /* _signatures */,
-        address /* _msgSender */
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
     )
         external
         override
@@ -209,7 +209,7 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Called by the Safe after executing a transaction
     /// @dev Implementation of IGuard interface
-    function checkAfterExecution(bytes32 /* _txHash */, bool /* _success */) external override {
+    function checkAfterExecution(bytes32, bool) external override {
         // TODO: Implement
     }
 }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -315,7 +315,7 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Reset the cancellation threshold for a safe
     /// @dev This function must be called only once and only when calling checkAfterExecution
-    function resetCancellationThreshold(Safe _safe, bytes32 _txHash) internal {
+    function resetCancellationThreshold(Safe _safe) internal {
         uint256 oldThreshold = safeCancellationThreshold[_safe];
         safeCancellationThreshold[_safe] = 1;
         emit CancellationThresholdUpdated(_safe, oldThreshold, 1);

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -299,14 +299,14 @@ contract TimelockGuard is IGuard, ISemver {
         _safe.checkNSignatures(cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[_safe]);
 
         scheduledTransactions[_safe][_txHash].cancelled = true;
-        increaseCancellationThreshold(_safe, _txHash);
+        increaseCancellationThreshold(_safe);
 
         emit TransactionCancelled(_safe, _txHash, safeCancellationThreshold[_safe]);
     }
 
     /// @notice Increase the cancellation threshold for a safe
     /// @dev This function must be caled only once and only when calling cancel
-    function increaseCancellationThreshold(Safe _safe, bytes32 _txHash) internal {
+    function increaseCancellationThreshold(Safe _safe) internal {
         if (safeCancellationThreshold[_safe] < blockingThreshold(_safe)) {
             safeCancellationThreshold[_safe]++;
         }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 // Safe
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
-import { GuardManager, Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+import { Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
 import { ExecTransactionParams } from "src/safe/Types.sol";
 
 // Interfaces

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -25,16 +25,17 @@ contract TimelockGuard is IGuard, ISemver {
     struct ScheduledTransaction {
         uint256 executionTime;
         bool cancelled;
+        bool executed;
     }
 
     /// @notice Mapping from Safe address to its guard configuration
     mapping(address => GuardConfig) public safeConfigs;
 
-    /// @notice Mapping from Safe address to its current cancellation threshold
-    mapping(address => uint256) public safeCancellationThreshold;
-
     /// @notice Mapping from Safe and tx id to scheduled transaction.
-    mapping(Safe => mapping(bytes32 => ScheduledTransaction)) public scheduledTransactions;
+    mapping(Safe => mapping(bytes32 => ScheduledTransaction)) internal scheduledTransactions;
+
+    /// @notice Mapping from Safe to cancellation threshold.
+    mapping(address => uint256) internal safeCancellationThreshold;
 
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
@@ -50,6 +51,9 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Error for when a transaction is already scheduled
     error TimelockGuard_TransactionAlreadyScheduled();
+
+    /// @notice Error for when a transaction is already cancelled
+    error TimelockGuard_TransactionAlreadyCancelled();
 
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
@@ -73,6 +77,13 @@ contract TimelockGuard is IGuard, ISemver {
     /// @return The timelock delay in seconds
     function viewTimelockGuardConfiguration(address _safe) public view returns (uint256) {
         return safeConfigs[_safe].timelockDelay;
+    }
+
+    /// @notice Returns the scheduled transaction for a given Safe and tx hash
+    /// @dev This function is necessary to properly expose the scheduledTransactions mapping, as
+    ///      simply making the mapping public will return a tuple instead of a struct.
+    function getScheduledTransaction(Safe _safe, bytes32 _txHash) public view returns (ScheduledTransaction memory) {
+        return scheduledTransactions[_safe][_txHash];
     }
 
     /// @notice Configure the contract as a timelock guard by setting the timelock delay
@@ -120,7 +131,6 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Erase the configuration data for this safe
         delete safeConfigs[msg.sender];
-        delete safeCancellationThreshold[msg.sender];
 
         emit GuardCleared(msg.sender);
     }
@@ -137,6 +147,15 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         return safeCancellationThreshold[_safe];
+    }
+
+    /// @notice Returns the blocking threshold threshold for a given safe
+    /// @dev MUST NOT revert
+    /// @param _safe The Safe address to query
+    /// @return The current blocking threshold
+    function blockingThreshold(address _safe) public view returns (uint256) {
+        return 0;
+        // return min(quorum, total_owners - quorum + 1) for _safe;
     }
 
     /// @notice Internal helper to get the guard address from a Safe
@@ -206,7 +225,8 @@ contract TimelockGuard is IGuard, ISemver {
         uint256 executionTime = block.timestamp + safeConfigs[address(_safe)].timelockDelay;
 
         // Schedule the transaction
-        scheduledTransactions[_safe][txHash] = ScheduledTransaction({ executionTime: executionTime, cancelled: false });
+        scheduledTransactions[_safe][txHash] =
+            ScheduledTransaction({ executionTime: executionTime, cancelled: false, executed: false });
 
         emit TransactionScheduled(_safe, txHash, executionTime);
     }
@@ -218,22 +238,58 @@ contract TimelockGuard is IGuard, ISemver {
         return new bytes32[](0);
     }
 
-    /// @notice Signal rejection of a scheduled transaction by a Safe owner
-    /// @dev NOT IMPLEMENTED YET
-    function rejectTransaction(address, bytes32) external pure {
-        // TODO: Implement
-    }
-
-    /// @notice Signal rejection of a scheduled transaction using signatures
-    /// @dev NOT IMPLEMENTED YET
-    function rejectTransactionWithSignature(address, bytes32, bytes memory) external pure {
-        // TODO: Implement
-    }
-
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
     /// @dev NOT IMPLEMENTED YET
-    function cancelTransaction(address, bytes32) external pure {
-        // TODO: Implement
+    /// @dev This function aims to mimic the approach which would be used by a quorum of signers to
+    ///      cancel a partially signed transaction, which would be to sign and execute an empty
+    ///      transaction at the same nonce. This enables us to deterministically generate the
+    ///      transaction inputs for a cancellation transaction from the transaction being cancelled.
+    ///      Thus in order for an owners to sign their cancellation transaction, they must first sign
+    ///      an empty transaction at the same nonce, or call approveHash on the Safe for that
+    ///      transaction hash.
+    function cancelTransaction(Safe _safe, ExecTransactionParams memory _params, uint256 _nonce) external {
+        // Calculate the transaction hash
+        bytes32 txHash = _safe.getTransactionHash(
+            _params.to,
+            _params.value,
+            _params.data,
+            _params.operation,
+            _params.safeTxGas,
+            _params.baseGas,
+            _params.gasPrice,
+            _params.gasToken,
+            _params.refundReceiver,
+            _nonce
+        );
+        if (scheduledTransactions[_safe][txHash].cancelled) {
+            revert TimelockGuard_TransactionAlreadyCancelled();
+        }
+
+        // Generate the cancellation transaction data
+        bytes memory cancellationTxData =
+            _safe.encodeTransactionData(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
+        bytes32 cancellationTxHash =
+            _safe.getTransactionHash(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
+        // Verify signatures using the Safe's signature checking logic
+        // This function call reverts if the signatures are invalid.
+        _safe.checkNSignatures(
+            cancellationTxHash, cancellationTxData, _params.signatures, safeCancellationThreshold[address(_safe)]
+        );
+
+        scheduledTransactions[_safe][txHash].cancelled = true;
+    }
+
+    /// @notice Increase the cancellation threshold for a safe
+    /// @dev This function must be caled only once and only when calling cancel
+    function increaseCancellationThresholds(address _safe, bytes32 txHash) internal pure {
+        // if safeCancellationThreshold[_safe] < blockingThreshold(_safe)
+        //   safeCancellationThreshold[_safe]++
+    }
+
+    /// @notice Reset the cancellation threshold for a safe
+    /// @dev This function must be called only once and only when calling checkAfterExecution
+    function resetCancellationThreshold(address _safe, bytes32 txHash) external pure {
+        // safeCancellationThreshold[_safe] = 1
     }
 
     /// @notice Called by the Safe before executing a transaction
@@ -261,5 +317,8 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev Implementation of IGuard interface
     function checkAfterExecution(bytes32, bool) external override {
         // TODO: Implement
+        // extract txHash
+        // resetCancellationThreshold(_safe, txHash)
+        // scheduledTransactions[_safe][txHash].executed = true
     }
 }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -55,6 +55,9 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Error for when a transaction is already cancelled
     error TimelockGuard_TransactionAlreadyCancelled();
 
+    /// @notice Error for when a transaction is not scheduled
+    error TimelockGuard_TransactionNotScheduled();
+
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
 
@@ -263,6 +266,9 @@ contract TimelockGuard is IGuard, ISemver {
         );
         if (scheduledTransactions[_safe][txHash].cancelled) {
             revert TimelockGuard_TransactionAlreadyCancelled();
+        }
+        if (scheduledTransactions[_safe][txHash].executionTime == 0) {
+            revert TimelockGuard_TransactionNotScheduled();
         }
 
         // Generate the cancellation transaction data

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -58,7 +58,7 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Configure the contract as a timelock guard by setting the timelock delay
     /// @dev MUST allow an arbitrary number of Safe contracts to use the contract as a guard
-    /// @dev The contract MUST be enabled as a guard for the Safe
+    /// @dev MUST revert if the contract is not enabled as a guard for the Safe
     /// @dev MUST revert if timelock_delay is longer than 1 year
     /// @dev MUST set the caller as a Safe
     /// @dev MUST take timelock_delay as a parameter and store it as related to the Safe
@@ -85,7 +85,7 @@ contract TimelockGuard is IGuard, ISemver {
     }
 
     /// @notice Remove the timelock guard configuration by a previously enabled Safe
-    /// @dev The contract MUST NOT be enabled as a guard for the Safe
+    /// @dev MUST revert if the contract is not enabled as a guard for the Safe
     /// @dev MUST erase the existing timelock_delay data related to the calling Safe
     /// @dev MUST emit a GuardCleared event
     function clearTimelockGuard() external {
@@ -124,8 +124,6 @@ contract TimelockGuard is IGuard, ISemver {
 
         uint256 threshold = safeCancellationThreshold[_safe];
         if (threshold == 0) {
-            // NOTE: not sure if this is the right thing to do.
-            //    defaulting to one is good to prevent us from forgetting to set it to one elsewhere.
             // Default to 1 if not set
             return 1;
         }
@@ -139,7 +137,7 @@ contract TimelockGuard is IGuard, ISemver {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
         Safe safe = Safe(payable(_safe));
-        return abi.decode(safe.getStorageAt({ offset: uint256(guardSlot), length: 1 }), (address));
+        return abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
     }
 
     /// @notice Schedule a transaction for execution after the timelock delay

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -70,6 +70,11 @@ contract TimelockGuard is IGuard, ISemver {
     /// @param when The timestamp when execution becomes valid.
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
 
+    /// @notice Emitted when a transaction is cancelled for a Safe.
+    /// @param safe The Safe whose transaction is cancelled.
+    /// @param txId The identifier of the cancelled transaction (nonce-independent).
+    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId, uint256 newCancellationThreshold);
+
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
     string public constant version = "1.0.0";
@@ -157,8 +162,9 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Returns the blocking threshold threshold for a given safe
     /// @dev MUST NOT revert
     /// @return The current blocking threshold
-    function blockingThreshold(address /* _safe */ ) public pure returns (uint256) {
-        return 0;
+    function blockingThreshold(Safe /* _safe */ ) public pure returns (uint256) {
+        // TODO: Implement this
+        return 10;
         // return min(quorum, total_owners - quorum + 1) for _safe;
     }
 
@@ -276,23 +282,28 @@ contract TimelockGuard is IGuard, ISemver {
             _safe.encodeTransactionData(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
         bytes32 cancellationTxHash =
             _safe.getTransactionHash(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
+
         // Verify signatures using the Safe's signature checking logic
         // This function call reverts if the signatures are invalid.
         _safe.checkNSignatures(cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[_safe]);
 
         scheduledTransactions[_safe][_txHash].cancelled = true;
+        increaseCancellationThreshold(_safe, _txHash);
+
+        emit TransactionCancelled(_safe, _txHash, safeCancellationThreshold[_safe]);
     }
 
     /// @notice Increase the cancellation threshold for a safe
     /// @dev This function must be caled only once and only when calling cancel
-    function increaseCancellationThresholds(Safe _safe, bytes32 txHash) internal pure {
-        // if safeCancellationThreshold[_safe] < blockingThreshold(_safe)
-        //   safeCancellationThreshold[_safe]++
+    function increaseCancellationThreshold(Safe _safe, bytes32 _txHash) internal {
+        if (safeCancellationThreshold[_safe] < blockingThreshold(_safe)) {
+            safeCancellationThreshold[_safe]++;
+        }
     }
 
     /// @notice Reset the cancellation threshold for a safe
     /// @dev This function must be called only once and only when calling checkAfterExecution
-    function resetCancellationThreshold(Safe _safe, bytes32 txHash) external pure {
+    function resetCancellationThreshold(Safe _safe, bytes32 _txHash) external pure {
         // safeCancellationThreshold[_safe] = 1
     }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -229,15 +229,15 @@ contract TimelockGuard is IGuard, ISemver {
             _nonce
         );
 
-        // Verify signatures using the Safe's signature checking logic
-        // This function call reverts if the signatures are invalid.
-        _safe.checkSignatures(txHash, txHashData, _signatures);
-
         // Check if the transaction exists
         // A transaction can only be scheduled once, regardless of whether it has been cancelled or not.
         if (scheduledTransactions[_safe][txHash].executionTime != 0) {
             revert TimelockGuard_TransactionAlreadyScheduled();
         }
+
+        // Verify signatures using the Safe's signature checking logic
+        // This function call reverts if the signatures are invalid.
+        _safe.checkSignatures(txHash, txHashData, _signatures);
 
         // Calculate the execution time
         uint256 executionTime = block.timestamp + safeConfigs[_safe].timelockDelay;

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.15;
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 import { GuardManager, Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+import { ExecTransactionParams } from "src/safe/Types.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -20,11 +21,20 @@ contract TimelockGuard is IGuard, ISemver {
         uint256 timelockDelay;
     }
 
+    /// @notice Scheduled transaction
+    struct ScheduledTransaction {
+        uint256 executionTime;
+        bool cancelled;
+    }
+
     /// @notice Mapping from Safe address to its guard configuration
     mapping(address => GuardConfig) public safeConfigs;
 
     /// @notice Mapping from Safe address to its current cancellation threshold
     mapping(address => uint256) public safeCancellationThreshold;
+
+    /// @notice Mapping from Safe and tx id to scheduled transaction.
+    mapping(Safe => mapping(bytes32 => ScheduledTransaction)) public scheduledTransactions;
 
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
@@ -38,11 +48,20 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Error for invalid timelock delay
     error TimelockGuard_InvalidTimelockDelay();
 
+    /// @notice Error for when a transaction is already scheduled
+    error TimelockGuard_TransactionAlreadyScheduled();
+
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
 
     /// @notice Emitted when a Safe clears the guard configuration
     event GuardCleared(address indexed safe);
+
+    /// @notice Emitted when a transaction is scheduled for a Safe.
+    /// @param safe The Safe whose transaction is scheduled.
+    /// @param txId The identifier of the scheduled transaction (nonce-independent).
+    /// @param when The timestamp when execution becomes valid.
+    event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
 
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
@@ -131,25 +150,65 @@ contract TimelockGuard is IGuard, ISemver {
         return guard == address(this);
     }
 
-    /// @notice Schedule a transaction for execution after the timelock delay
-    /// @dev Called by anyone using signatures from Safe owners - NOT IMPLEMENTED YET
-    function scheduleTransaction(
-        address,
-        address,
-        uint256,
-        bytes memory,
-        Enum.Operation,
-        uint256,
-        uint256,
-        uint256,
-        address,
-        address payable,
-        bytes memory
-    )
-        external
-        pure
-    {
-        // TODO: Implement
+    /// @notice Schedule a transaction for execution after the timelock delay.
+    /// @dev Minimal implementation: checks enabled+configured, uniqueness, cancellation, stores execution time and
+    /// emits.
+    /// @dev The txId is computed independent of Safe nonce using all exec params (with keccak(data)).
+    function scheduleTransaction(Safe _safe, uint256 _nonce, ExecTransactionParams memory _params) external {
+        // Check that this guard is enabled on the calling Safe
+        if (!_isGuardEnabled(address(_safe))) {
+            revert TimelockGuard_GuardNotEnabled();
+        }
+
+        // Get the encoded transaction data as defined in the Safe
+        // The format of the string returned is: "0x1901{domainSeparator}{safeTxHash}"
+        bytes memory txHashData = _safe.encodeTransactionData(
+            _params.to,
+            _params.value,
+            _params.data,
+            _params.operation,
+            _params.safeTxGas,
+            _params.baseGas,
+            _params.gasPrice,
+            _params.gasToken,
+            _params.refundReceiver,
+            _nonce
+        );
+
+        // Get the transaction hash and data as defined in the Safe
+        // This value is identical to keccak256(txHashData), but we prefer to use the Safe's own
+        // internal logic as it is more future-proof in case future versions of the Safe change
+        // the transaction hash derivation.
+        bytes32 txHash = _safe.getTransactionHash(
+            _params.to,
+            _params.value,
+            _params.data,
+            _params.operation,
+            _params.safeTxGas,
+            _params.baseGas,
+            _params.gasPrice,
+            _params.gasToken,
+            _params.refundReceiver,
+            _nonce
+        );
+
+        // Verify signatures using the Safe's signature checking logic
+        // This function call reverts if the signatures are invalid.
+        _safe.checkSignatures(txHash, txHashData, _params.signatures);
+
+        // Check if the transaction exists
+        // A transaction can only be scheduled once, regardless of whether it has been cancelled or not.
+        if (scheduledTransactions[_safe][txHash].executionTime != 0) {
+            revert TimelockGuard_TransactionAlreadyScheduled();
+        }
+
+        // Calculate the execution time
+        uint256 executionTime = block.timestamp + safeConfigs[address(_safe)].timelockDelay;
+
+        // Schedule the transaction
+        scheduledTransactions[_safe][txHash] = ScheduledTransaction({ executionTime: executionTime, cancelled: false });
+
+        emit TransactionScheduled(_safe, txHash, executionTime);
     }
 
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -66,7 +66,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @param _timelockDelay The timelock delay in seconds
     function configureTimelockGuard(uint256 _timelockDelay) external {
         // Validate timelock delay - must be non-zero and not longer than 1 year
-        if (_timelockDelay > 365 days) {
+        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
             revert TimelockGuard_InvalidTimelockDelay();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -403,9 +403,8 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Called by the Safe after executing a transaction
     /// @dev Implementation of IGuard interface
     function checkAfterExecution(bytes32, bool) external override {
-        // TODO: Implement
-        // extract txHash
-        // resetCancellationThreshold(_safe, txHash)
-        // scheduledTransactions[_safe][txHash].executed = true
+        // Do nothing
+        // In order to follow the Checks-Effects-Interactions pattern,
+        // all checks and effects should be done in the checkTransaction function.
     }
 }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -74,7 +74,10 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Emitted when a transaction is cancelled for a Safe.
     /// @param safe The Safe whose transaction is cancelled.
     /// @param txId The identifier of the cancelled transaction (nonce-independent).
-    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId, uint256 newCancellationThreshold);
+    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
+
+    /// @notice Emitted when the cancellation threshold is updated
+    event CancellationThresholdUpdated(Safe indexed safe, uint256 oldThreshold, uint256 newThreshold);
 
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
@@ -262,7 +265,8 @@ contract TimelockGuard is IGuard, ISemver {
     ///      transaction at the same nonce.
     ///      This enables us to deterministically generate the transaction inputs for a cancellation
     ///      transaction from the transaction being cancelled.
-    ///      In this case however we cannot use a completely empty transaction (with all inputs other than the nonce being null),
+    ///      In this case however we cannot use a completely empty transaction (with all inputs other than the nonce
+    /// being null),
     ///      as that would allow for the signatures used to cancel one transaction at nonce X to
     ///      be used to cancel all transactions at nonce X.
     ///
@@ -272,14 +276,7 @@ contract TimelockGuard is IGuard, ISemver {
     ///      Since the Safe's checkNSignatures function is used, the owner can use any method
     ///      to sign the cancellation transaction inputs, including signing with a private key,
     ///      calling the Safe's approveHash function, or EIP1271 contract signatures.
-    function cancelTransaction(
-        Safe _safe,
-        bytes32 _txHash,
-        uint256 _nonce,
-        bytes memory _signatures
-    )
-        external
-    {
+    function cancelTransaction(Safe _safe, bytes32 _txHash, uint256 _nonce, bytes memory _signatures) external {
         if (scheduledTransactions[_safe][_txHash].cancelled) {
             revert TimelockGuard_TransactionAlreadyCancelled();
         }
@@ -289,10 +286,12 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Generate the cancellation transaction data
         bytes memory txData = abi.encodeWithSignature("cancelTransaction(bytes32)", _txHash);
-        bytes memory cancellationTxData =
-            _safe.encodeTransactionData(address(_safe), 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
-        bytes32 cancellationTxHash =
-            _safe.getTransactionHash(address(_safe), 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
+        bytes memory cancellationTxData = _safe.encodeTransactionData(
+            address(_safe), 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce
+        );
+        bytes32 cancellationTxHash = _safe.getTransactionHash(
+            address(_safe), 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce
+        );
 
         // Verify signatures using the Safe's signature checking logic
         // This function call reverts if the signatures are invalid.
@@ -301,21 +300,25 @@ contract TimelockGuard is IGuard, ISemver {
         scheduledTransactions[_safe][_txHash].cancelled = true;
         increaseCancellationThreshold(_safe);
 
-        emit TransactionCancelled(_safe, _txHash, safeCancellationThreshold[_safe]);
+        emit TransactionCancelled(_safe, _txHash);
     }
 
     /// @notice Increase the cancellation threshold for a safe
     /// @dev This function must be caled only once and only when calling cancel
     function increaseCancellationThreshold(Safe _safe) internal {
         if (safeCancellationThreshold[_safe] < blockingThreshold(_safe)) {
+            uint256 oldThreshold = safeCancellationThreshold[_safe];
             safeCancellationThreshold[_safe]++;
+            emit CancellationThresholdUpdated(_safe, oldThreshold, safeCancellationThreshold[_safe]);
         }
     }
 
     /// @notice Reset the cancellation threshold for a safe
     /// @dev This function must be called only once and only when calling checkAfterExecution
-    function resetCancellationThreshold(Safe _safe, bytes32 _txHash) external pure {
-        // safeCancellationThreshold[_safe] = 1
+    function resetCancellationThreshold(Safe _safe, bytes32 _txHash) internal {
+        uint256 oldThreshold = safeCancellationThreshold[_safe];
+        safeCancellationThreshold[_safe] = 1;
+        emit CancellationThresholdUpdated(_safe, oldThreshold, 1);
     }
 
     /// @notice Called by the Safe before executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -200,6 +200,11 @@ contract TimelockGuard is IGuard, ISemver {
             revert TimelockGuard_GuardNotEnabled();
         }
 
+        // Check that the guard has been configured for the Safe
+        if (!safeConfigs[_safe].configured) {
+            revert TimelockGuard_GuardNotConfigured();
+        }
+
         // Get the encoded transaction data as defined in the Safe
         // The format of the string returned is: "0x1901{domainSeparator}{safeTxHash}"
         bytes memory txHashData = _safe.encodeTransactionData(

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -110,6 +110,24 @@ contract TimelockGuard is IGuard, ISemver {
         return scheduledTransactions[_safe][_txHash];
     }
 
+    /// @notice Returns the list of all scheduled but not cancelled or executed transactions for
+    /// for a given safe
+    /// @dev WARNING: This operation will copy the entire set of pending transactions to memory,
+    /// which can be quite expensive. This is designed only to be used by view accessors that are
+    /// queried without any gas fees. Developers should keep in mind that this function has an
+    /// unbounded cost, and using it as part of a state-changing function may render the function
+    /// uncallable if the set grows to a point where copying to memory consumes too much gas to fit
+    /// in a block.
+    /// @return List of pending transaction hashes
+    function getScheduledTransactions(Safe _safe) external view returns (ScheduledTransaction[] memory) {
+        bytes32[] memory hashes = safePendingTxHashes[_safe].values();
+        ScheduledTransaction[] memory scheduled = new ScheduledTransaction[](hashes.length);
+        for (uint256 i = 0; i < hashes.length; i++) {
+            scheduled[i] = scheduledTransactions[_safe][hashes[i]];
+        }
+        return scheduled;
+    }
+
     /// @notice Configure the contract as a timelock guard by setting the timelock delay
     /// @dev MUST allow an arbitrary number of Safe contracts to use the contract as a guard
     /// @dev MUST revert if the contract is not enabled as a guard for the Safe
@@ -248,21 +266,10 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Schedule the transaction
         scheduledTransactions[_safe][txHash] =
-            ScheduedTransaction({ executionTime: executionTime, cancelled: false, executed: false, params: _params });
+            ScheduledTransaction({ executionTime: executionTime, cancelled: false, executed: false, params: _params });
         safePendingTxHashes[_safe].add(txHash);
 
         emit TransactionScheduled(_safe, txHash, executionTime);
-    }
-
-    /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
-    /// @dev WARNING: This operation will copy the entire set of pending transactions to memory, which can be quite expensive. This is designed
-    ///      to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
-    ///      this function has an unbounded cost, and using it as part of a state-changing function may render the function
-    ///      uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
-     */
-    /// @return List of pending transaction hashes
-    function checkPendingTransactions(Safe _safe) external view returns (bytes32[] memory) {
-        return safePendingTxHashes[_safe].values();
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
@@ -303,7 +310,7 @@ contract TimelockGuard is IGuard, ISemver {
         // This function call reverts if the signatures are invalid.
         _safe.checkNSignatures(cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[_safe]);
 
-        scheduledTansactions[_safe][_txHash].cancelled = true;
+        scheduledTransactions[_safe][_txHash].cancelled = true;
         safePendingTxHashes[_safe].remove(_txHash);
         increaseCancellationThreshold(_safe);
 
@@ -386,7 +393,7 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Set the transaction as executed
         scheduledTx.executed = true;
-        safePendingTxHashes[_safe].remove(txHash);
+        safePendingTxHashes[callingSafe].remove(txHash);
 
         // Reset the cancellation threshold
         resetCancellationThreshold(callingSafe);

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -66,12 +66,12 @@ contract TimelockGuard is IGuard, ISemver {
     /// @param _timelockDelay The timelock delay in seconds
     function configureTimelockGuard(uint256 _timelockDelay) external {
         // Validate timelock delay - must be non-zero and not longer than 1 year
-        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
+        if (_timelockDelay > 365 days) {
             revert TimelockGuard_InvalidTimelockDelay();
         }
 
         // Check that this guard is enabled on the calling Safe
-        if (_getGuard(msg.sender) != address(this)) {
+        if (!_isGuardEnabled(msg.sender)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
@@ -95,7 +95,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that this guard is NOT enabled on the calling Safe
-        if (_getGuard(msg.sender) == address(this)) {
+        if (_isGuardEnabled(msg.sender)) {
             revert TimelockGuard_GuardStillEnabled();
         }
 
@@ -113,7 +113,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @return The current cancellation threshold
     function cancellationThreshold(address _safe) public view returns (uint256) {
         // Return 0 if guard is not enabled
-        if (_getGuard(_safe) != address(this)) {
+        if (!_isGuardEnabled(_safe)) {
             return 0;
         }
 
@@ -123,11 +123,12 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Internal helper to get the guard address from a Safe
     /// @param _safe The Safe address
     /// @return The current guard address
-    function _getGuard(address _safe) internal view returns (address) {
+    function _isGuardEnabled(address _safe) internal view returns (bool) {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
         Safe safe = Safe(payable(_safe));
-        return abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
+        address guard = abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
+        return guard == address(this);
     }
 
     /// @notice Schedule a transaction for execution after the timelock delay

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -29,13 +29,13 @@ contract TimelockGuard is IGuard, ISemver {
     }
 
     /// @notice Mapping from Safe address to its guard configuration
-    mapping(address => GuardConfig) public safeConfigs;
+    mapping(Safe => GuardConfig) public safeConfigs;
 
     /// @notice Mapping from Safe and tx id to scheduled transaction.
     mapping(Safe => mapping(bytes32 => ScheduledTransaction)) internal scheduledTransactions;
 
     /// @notice Mapping from Safe to cancellation threshold.
-    mapping(address => uint256) internal safeCancellationThreshold;
+    mapping(Safe => uint256) internal safeCancellationThreshold;
 
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
@@ -59,10 +59,10 @@ contract TimelockGuard is IGuard, ISemver {
     error TimelockGuard_TransactionNotScheduled();
 
     /// @notice Emitted when a Safe configures the guard
-    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+    event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
 
     /// @notice Emitted when a Safe clears the guard configuration
-    event GuardCleared(address indexed safe);
+    event GuardCleared(Safe indexed safe);
 
     /// @notice Emitted when a transaction is scheduled for a Safe.
     /// @param safe The Safe whose transaction is scheduled.
@@ -78,7 +78,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev MUST never revert
     /// @param _safe The Safe address to query
     /// @return The timelock delay in seconds
-    function viewTimelockGuardConfiguration(address _safe) public view returns (uint256) {
+    function viewTimelockGuardConfiguration(Safe _safe) public view returns (uint256) {
         return safeConfigs[_safe].timelockDelay;
     }
 
@@ -98,23 +98,24 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev MUST emit a GuardConfigured event with at least timelock_delay as a parameter
     /// @param _timelockDelay The timelock delay in seconds
     function configureTimelockGuard(uint256 _timelockDelay) external {
+        Safe callingSafe = Safe(payable(msg.sender));
         // Validate timelock delay - must be non-zero and not longer than 1 year
         if (_timelockDelay == 0 || _timelockDelay > 365 days) {
             revert TimelockGuard_InvalidTimelockDelay();
         }
 
         // Check that this guard is enabled on the calling Safe
-        if (!_isGuardEnabled(msg.sender)) {
+        if (!_isGuardEnabled(callingSafe)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
         // Store the configuration for this safe
-        safeConfigs[msg.sender].timelockDelay = _timelockDelay;
+        safeConfigs[callingSafe].timelockDelay = _timelockDelay;
 
         // Initialize cancellation threshold to 1
-        safeCancellationThreshold[msg.sender] = 1;
+        safeCancellationThreshold[callingSafe] = 1;
 
-        emit GuardConfigured(msg.sender, _timelockDelay);
+        emit GuardConfigured(callingSafe, _timelockDelay);
     }
 
     /// @notice Remove the timelock guard configuration by a previously enabled Safe
@@ -122,20 +123,21 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev MUST erase the existing timelock_delay data related to the calling Safe
     /// @dev MUST emit a GuardCleared event
     function clearTimelockGuard() external {
+        Safe callingSafe = Safe(payable(msg.sender));
         // Check if the calling safe has configuration set
-        if (safeConfigs[msg.sender].timelockDelay == 0) {
+        if (safeConfigs[callingSafe].timelockDelay == 0) {
             revert TimelockGuard_GuardNotConfigured();
         }
 
         // Check that this guard is NOT enabled on the calling Safe
-        if (_isGuardEnabled(msg.sender)) {
+        if (_isGuardEnabled(callingSafe)) {
             revert TimelockGuard_GuardStillEnabled();
         }
 
         // Erase the configuration data for this safe
-        delete safeConfigs[msg.sender];
+        delete safeConfigs[callingSafe];
 
-        emit GuardCleared(msg.sender);
+        emit GuardCleared(callingSafe);
     }
 
     /// @notice Returns the cancellation threshold for a given safe
@@ -143,7 +145,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev MUST return 0 if the contract is not enabled as a guard for the safe
     /// @param _safe The Safe address to query
     /// @return The current cancellation threshold
-    function cancellationThreshold(address _safe) public view returns (uint256) {
+    function cancellationThreshold(Safe _safe) public view returns (uint256) {
         // Return 0 if guard is not enabled
         if (!_isGuardEnabled(_safe)) {
             return 0;
@@ -155,7 +157,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Returns the blocking threshold threshold for a given safe
     /// @dev MUST NOT revert
     /// @return The current blocking threshold
-    function blockingThreshold(address /* _safe */) public pure returns (uint256) {
+    function blockingThreshold(address /* _safe */ ) public pure returns (uint256) {
         return 0;
         // return min(quorum, total_owners - quorum + 1) for _safe;
     }
@@ -163,11 +165,10 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Internal helper to get the guard address from a Safe
     /// @param _safe The Safe address
     /// @return The current guard address
-    function _isGuardEnabled(address _safe) internal view returns (bool) {
+    function _isGuardEnabled(Safe _safe) internal view returns (bool) {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
-        Safe safe = Safe(payable(_safe));
-        address guard = abi.decode(safe.getStorageAt(uint256(guardSlot), 1), (address));
+        address guard = abi.decode(_safe.getStorageAt(uint256(guardSlot), 1), (address));
         return guard == address(this);
     }
 
@@ -175,9 +176,16 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev Minimal implementation: checks enabled+configured, uniqueness, cancellation, stores execution time and
     /// emits.
     /// @dev The txId is computed independent of Safe nonce using all exec params (with keccak(data)).
-    function scheduleTransaction(Safe _safe, uint256 _nonce, ExecTransactionParams memory _params, bytes memory _signatures) external {
+    function scheduleTransaction(
+        Safe _safe,
+        uint256 _nonce,
+        ExecTransactionParams memory _params,
+        bytes memory _signatures
+    )
+        external
+    {
         // Check that this guard is enabled on the calling Safe
-        if (!_isGuardEnabled(address(_safe))) {
+        if (!_isGuardEnabled(_safe)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
@@ -224,7 +232,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Calculate the execution time
-        uint256 executionTime = block.timestamp + safeConfigs[address(_safe)].timelockDelay;
+        uint256 executionTime = block.timestamp + safeConfigs[_safe].timelockDelay;
 
         // Schedule the transaction
         scheduledTransactions[_safe][txHash] =
@@ -249,7 +257,14 @@ contract TimelockGuard is IGuard, ISemver {
     ///      Thus in order for an owners to sign their cancellation transaction, they must first sign
     ///      an empty transaction at the same nonce, or call approveHash on the Safe for that
     ///      transaction hash.
-    function cancelTransaction(Safe _safe, ExecTransactionParams memory _params, uint256 _nonce, bytes memory _signatures) external {
+    function cancelTransaction(
+        Safe _safe,
+        ExecTransactionParams memory _params,
+        uint256 _nonce,
+        bytes memory _signatures
+    )
+        external
+    {
         // Calculate the transaction hash
         bytes32 txHash = _safe.getTransactionHash(
             _params.to,
@@ -277,23 +292,21 @@ contract TimelockGuard is IGuard, ISemver {
             _safe.getTransactionHash(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
         // Verify signatures using the Safe's signature checking logic
         // This function call reverts if the signatures are invalid.
-        _safe.checkNSignatures(
-            cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[address(_safe)]
-        );
+        _safe.checkNSignatures(cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[_safe]);
 
         scheduledTransactions[_safe][txHash].cancelled = true;
     }
 
     /// @notice Increase the cancellation threshold for a safe
     /// @dev This function must be caled only once and only when calling cancel
-    function increaseCancellationThresholds(address _safe, bytes32 txHash) internal pure {
+    function increaseCancellationThresholds(Safe _safe, bytes32 txHash) internal pure {
         // if safeCancellationThreshold[_safe] < blockingThreshold(_safe)
         //   safeCancellationThreshold[_safe]++
     }
 
     /// @notice Reset the cancellation threshold for a safe
     /// @dev This function must be called only once and only when calling checkAfterExecution
-    function resetCancellationThreshold(address _safe, bytes32 txHash) external pure {
+    function resetCancellationThreshold(Safe _safe, bytes32 txHash) external pure {
         // safeCancellationThreshold[_safe] = 1
     }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -173,7 +173,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev Minimal implementation: checks enabled+configured, uniqueness, cancellation, stores execution time and
     /// emits.
     /// @dev The txId is computed independent of Safe nonce using all exec params (with keccak(data)).
-    function scheduleTransaction(Safe _safe, uint256 _nonce, ExecTransactionParams memory _params) external {
+    function scheduleTransaction(Safe _safe, uint256 _nonce, ExecTransactionParams memory _params, bytes memory _signatures) external {
         // Check that this guard is enabled on the calling Safe
         if (!_isGuardEnabled(address(_safe))) {
             revert TimelockGuard_GuardNotEnabled();
@@ -213,7 +213,7 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Verify signatures using the Safe's signature checking logic
         // This function call reverts if the signatures are invalid.
-        _safe.checkSignatures(txHash, txHashData, _params.signatures);
+        _safe.checkSignatures(txHash, txHashData, _signatures);
 
         // Check if the transaction exists
         // A transaction can only be scheduled once, regardless of whether it has been cancelled or not.
@@ -247,7 +247,7 @@ contract TimelockGuard is IGuard, ISemver {
     ///      Thus in order for an owners to sign their cancellation transaction, they must first sign
     ///      an empty transaction at the same nonce, or call approveHash on the Safe for that
     ///      transaction hash.
-    function cancelTransaction(Safe _safe, ExecTransactionParams memory _params, uint256 _nonce) external {
+    function cancelTransaction(Safe _safe, ExecTransactionParams memory _params, uint256 _nonce, bytes memory _signatures) external {
         // Calculate the transaction hash
         bytes32 txHash = _safe.getTransactionHash(
             _params.to,
@@ -273,7 +273,7 @@ contract TimelockGuard is IGuard, ISemver {
         // Verify signatures using the Safe's signature checking logic
         // This function call reverts if the signatures are invalid.
         _safe.checkNSignatures(
-            cancellationTxHash, cancellationTxData, _params.signatures, safeCancellationThreshold[address(_safe)]
+            cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[address(_safe)]
         );
 
         scheduledTransactions[_safe][txHash].cancelled = true;

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -141,63 +141,48 @@ contract TimelockGuard is IGuard, ISemver {
     }
 
     /// @notice Schedule a transaction for execution after the timelock delay
-    /// @dev Called by anyone using signatures from Safe owners
-    /// @param safe The Safe address
-    /// @param to Transaction target address
-    /// @param value Transaction value
-    /// @param data Transaction data
-    /// @param operation Transaction operation type
-    /// @param safeTxGas Safe transaction gas
-    /// @param baseGas Base gas for transaction
-    /// @param gasPrice Gas price
-    /// @param gasToken Gas token address
-    /// @param refundReceiver Refund receiver address
-    /// @param signatures Transaction signatures
+    /// @dev Called by anyone using signatures from Safe owners - NOT IMPLEMENTED YET
     function scheduleTransaction(
-        address safe,
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver,
-        bytes memory signatures
+        address, /* safe */
+        address, /* to */
+        uint256, /* value */
+        bytes memory, /* data */
+        Enum.Operation, /* operation */
+        uint256, /* safeTxGas */
+        uint256, /* baseGas */
+        uint256, /* gasPrice */
+        address, /* gasToken */
+        address payable, /* refundReceiver */
+        bytes memory /* signatures */
     )
         external
+        pure
     {
         revert("Not implemented yet");
     }
 
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
-    /// @dev MUST NOT revert
-    /// @param _safe The Safe address to query
+    /// @dev MUST NOT revert - NOT IMPLEMENTED YET
     /// @return List of pending transaction hashes
-    function checkPendingTransactions(address _safe) external view returns (bytes32[] memory) {
+    function checkPendingTransactions(address /* _safe */) external pure returns (bytes32[] memory) {
         return new bytes32[](0);
     }
 
     /// @notice Signal rejection of a scheduled transaction by a Safe owner
-    /// @param safe The Safe address that scheduled the transaction
-    /// @param txHash The transaction hash to reject
-    function rejectTransaction(address safe, bytes32 txHash) external {
+    /// @dev NOT IMPLEMENTED YET
+    function rejectTransaction(address /* safe */, bytes32 /* txHash */) external pure {
         revert("Not implemented yet");
     }
 
     /// @notice Signal rejection of a scheduled transaction using signatures
-    /// @param safe The Safe address that scheduled the transaction
-    /// @param txHash The transaction hash to reject
-    /// @param signatures Owner signatures rejecting the transaction
-    function rejectTransactionWithSignature(address safe, bytes32 txHash, bytes memory signatures) external {
+    /// @dev NOT IMPLEMENTED YET
+    function rejectTransactionWithSignature(address /* safe */, bytes32 /* txHash */, bytes memory /* signatures */) external pure {
         revert("Not implemented yet");
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
-    /// @param safe The Safe address that scheduled the transaction
-    /// @param txHash The transaction hash to cancel
-    function cancelTransaction(address safe, bytes32 txHash) external {
+    /// @dev NOT IMPLEMENTED YET
+    function cancelTransaction(address /* safe */, bytes32 /* txHash */) external pure {
         revert("Not implemented yet");
     }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Safe
+import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { GuardManager, Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
+
+// Interfaces
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+/// @title TimelockGuard
+/// @notice This guard provides timelock functionality for Safe transactions
+/// @dev This is a singleton contract. To use it:
+///      1. The Safe must first enable this guard using GuardManager.setGuard()
+///      2. The Safe must then configure the guard by calling configureTimelockGuard()
+contract TimelockGuard is IGuard, ISemver {
+    /// @notice Configuration for a Safe's timelock guard
+    struct GuardConfig {
+        uint256 timelockDelay;
+    }
+
+    /// @notice Mapping from Safe address to its guard configuration
+    mapping(address => GuardConfig) public safeConfigs;
+
+    /// @notice Error for when guard is not enabled for the Safe
+    error TimelockGuard_GuardNotEnabled();
+
+    /// @notice Error for invalid timelock delay
+    error TimelockGuard_InvalidTimelockDelay();
+
+    /// @notice Emitted when a Safe configures the guard
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.0.0
+    string public constant version = "1.0.0";
+
+    /// @notice Returns the timelock delay for a given Safe
+    /// @dev MUST never revert
+    /// @param _safe The Safe address to query
+    /// @return The timelock delay in seconds
+    function viewTimelockGuardConfiguration(address _safe) public view returns (uint256) {
+        return safeConfigs[_safe].timelockDelay;
+    }
+
+    /// @notice Configure the contract as a timelock guard by setting the timelock delay
+    /// @dev MUST allow an arbitrary number of Safe contracts to use the contract as a guard
+    /// @dev The contract MUST be enabled as a guard for the Safe
+    /// @dev MUST revert if timelock_delay is longer than 1 year
+    /// @dev MUST set the caller as a Safe
+    /// @dev MUST take timelock_delay as a parameter and store it as related to the Safe
+    /// @dev MUST emit a GuardConfigured event with at least timelock_delay as a parameter
+    /// @param _timelockDelay The timelock delay in seconds
+    function configureTimelockGuard(uint256 _timelockDelay) external {
+        // Validate timelock delay - must be non-zero and not longer than 1 year
+        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
+            revert TimelockGuard_InvalidTimelockDelay();
+        }
+
+        // Check that this guard is enabled on the calling Safe
+        Safe safe = Safe(payable(msg.sender));
+        // The Safe contract does not expose a getGuard function, so we need to provide the
+        // the storage slot to the getStorageAt function.
+        // keccak256("guard_manager.guard.address") from GuardManager
+        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
+
+        if (guard != address(this)) {
+            revert TimelockGuard_GuardNotEnabled();
+        }
+
+        // Store the configuration for this safe
+        safeConfigs[msg.sender].timelockDelay = _timelockDelay;
+
+        emit GuardConfigured(msg.sender, _timelockDelay);
+    }
+
+    /// @notice Called by the Safe before executing a transaction
+    /// @dev Implementation of IGuard interface
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external override {
+        // Empty implementation for now - will be filled in when implementing checkTransaction
+    }
+
+    /// @notice Called by the Safe after executing a transaction
+    /// @dev Implementation of IGuard interface
+    function checkAfterExecution(bytes32 txHash, bool success) external override {
+        // Empty implementation for now
+    }
+}

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -142,6 +142,67 @@ contract TimelockGuard is IGuard, ISemver {
         return abi.decode(safe.getStorageAt({ offset: uint256(guardSlot), length: 1 }), (address));
     }
 
+    /// @notice Schedule a transaction for execution after the timelock delay
+    /// @dev Called by anyone using signatures from Safe owners
+    /// @param safe The Safe address
+    /// @param to Transaction target address
+    /// @param value Transaction value
+    /// @param data Transaction data
+    /// @param operation Transaction operation type
+    /// @param safeTxGas Safe transaction gas
+    /// @param baseGas Base gas for transaction
+    /// @param gasPrice Gas price
+    /// @param gasToken Gas token address
+    /// @param refundReceiver Refund receiver address
+    /// @param signatures Transaction signatures
+    function scheduleTransaction(
+        address safe,
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures
+    )
+        external
+    {
+        revert("Not implemented yet");
+    }
+
+    /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
+    /// @dev MUST NOT revert
+    /// @param _safe The Safe address to query
+    /// @return List of pending transaction hashes
+    function checkPendingTransactions(address _safe) external view returns (bytes32[] memory) {
+        return new bytes32[](0);
+    }
+
+    /// @notice Signal rejection of a scheduled transaction by a Safe owner
+    /// @param safe The Safe address that scheduled the transaction
+    /// @param txHash The transaction hash to reject
+    function rejectTransaction(address safe, bytes32 txHash) external {
+        revert("Not implemented yet");
+    }
+
+    /// @notice Signal rejection of a scheduled transaction using signatures
+    /// @param safe The Safe address that scheduled the transaction
+    /// @param txHash The transaction hash to reject
+    /// @param signatures Owner signatures rejecting the transaction
+    function rejectTransactionWithSignature(address safe, bytes32 txHash, bytes memory signatures) external {
+        revert("Not implemented yet");
+    }
+
+    /// @notice Cancel a scheduled transaction if cancellation threshold is met
+    /// @param safe The Safe address that scheduled the transaction
+    /// @param txHash The transaction hash to cancel
+    function cancelTransaction(address safe, bytes32 txHash) external {
+        revert("Not implemented yet");
+    }
+
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
@@ -160,7 +221,7 @@ contract TimelockGuard is IGuard, ISemver {
         external
         override
     {
-        // Empty implementation for now - will be filled in when implementing checkTransaction
+        // Empty implementation for now
     }
 
     /// @notice Called by the Safe after executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -158,7 +158,7 @@ contract TimelockGuard is IGuard, ISemver {
         external
         pure
     {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
@@ -171,45 +171,45 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Signal rejection of a scheduled transaction by a Safe owner
     /// @dev NOT IMPLEMENTED YET
     function rejectTransaction(address /* safe */, bytes32 /* txHash */) external pure {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Signal rejection of a scheduled transaction using signatures
     /// @dev NOT IMPLEMENTED YET
     function rejectTransactionWithSignature(address /* safe */, bytes32 /* txHash */, bytes memory /* signatures */) external pure {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
     /// @dev NOT IMPLEMENTED YET
     function cancelTransaction(address /* safe */, bytes32 /* txHash */) external pure {
-        revert("Not implemented yet");
+        // TODO: Implement
     }
 
     /// @notice Called by the Safe before executing a transaction
     /// @dev Implementation of IGuard interface
     function checkTransaction(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver,
-        bytes memory signatures,
-        address msgSender
+        address /* _to */,
+        uint256 _value,
+        bytes memory /* _data */,
+        Enum.Operation /* _operation */,
+        uint256 /* _safeTxGas */,
+        uint256 /* _baseGas */,
+        uint256 /* _gasPrice */,
+        address /* _gasToken */,
+        address payable /* _refundReceiver */,
+        bytes memory /* _signatures */,
+        address /* _msgSender */
     )
         external
         override
     {
-        // Empty implementation for now
+        // TODO: Implement
     }
 
     /// @notice Called by the Safe after executing a transaction
     /// @dev Implementation of IGuard interface
-    function checkAfterExecution(bytes32 txHash, bool success) external override {
-        // Empty implementation for now
+    function checkAfterExecution(bytes32 /* _txHash */, bool /* _success */) external override {
+        // TODO: Implement
     }
 }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -23,6 +23,9 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Mapping from Safe address to its guard configuration
     mapping(address => GuardConfig) public safeConfigs;
 
+    /// @notice Mapping from Safe address to its current cancellation threshold
+    mapping(address => uint256) public safeCancellationThreshold;
+
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
 
@@ -75,6 +78,9 @@ contract TimelockGuard is IGuard, ISemver {
         // Store the configuration for this safe
         safeConfigs[msg.sender].timelockDelay = _timelockDelay;
 
+        // Initialize cancellation threshold to 1
+        safeCancellationThreshold[msg.sender] = 1;
+
         emit GuardConfigured(msg.sender, _timelockDelay);
     }
 
@@ -95,8 +101,35 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Erase the configuration data for this safe
         delete safeConfigs[msg.sender];
+        delete safeCancellationThreshold[msg.sender];
 
         emit GuardCleared(msg.sender);
+    }
+
+    /// @notice Returns the cancellation threshold for a given safe
+    /// @dev MUST NOT revert
+    /// @dev MUST return 0 if the contract is not enabled as a guard for the safe
+    /// @param _safe The Safe address to query
+    /// @return The current cancellation threshold
+    function cancellationThreshold(address _safe) public view returns (uint256) {
+        // Return 0 if guard is not enabled
+        if (_getGuard(_safe) != address(this)) {
+            return 0;
+        }
+
+        // Return 0 if not configured
+        if (safeConfigs[_safe].timelockDelay == 0) {
+            return 0;
+        }
+
+        uint256 threshold = safeCancellationThreshold[_safe];
+        if (threshold == 0) {
+            // NOTE: not sure if this is the right thing to do.
+            //    defaulting to one is good to prevent us from forgetting to set it to one elsewhere.
+            // Default to 1 if not set
+            return 1;
+        }
+        return threshold;
     }
 
     /// @notice Internal helper to get the guard address from a Safe
@@ -106,7 +139,7 @@ contract TimelockGuard is IGuard, ISemver {
         // keccak256("guard_manager.guard.address") from GuardManager
         bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
         Safe safe = Safe(payable(_safe));
-        return abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
+        return abi.decode(safe.getStorageAt({ offset: uint256(guardSlot), length: 1 }), (address));
     }
 
     /// @notice Called by the Safe before executing a transaction
@@ -123,7 +156,10 @@ contract TimelockGuard is IGuard, ISemver {
         address payable refundReceiver,
         bytes memory signatures,
         address msgSender
-    ) external override {
+    )
+        external
+        override
+    {
         // Empty implementation for now - will be filled in when implementing checkTransaction
     }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -7,6 +7,9 @@ import { Enum } from "safe-contracts/common/Enum.sol";
 import { Guard as IGuard } from "safe-contracts/base/GuardManager.sol";
 import { ExecTransactionParams } from "src/safe/Types.sol";
 
+// Libraries
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -16,6 +19,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      1. The Safe must first enable this guard using GuardManager.setGuard()
 ///      2. The Safe must then configure the guard by calling configureTimelockGuard()
 contract TimelockGuard is IGuard, ISemver {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
     /// @notice Configuration for a Safe's timelock guard
     struct GuardConfig {
         uint256 timelockDelay;
@@ -26,6 +31,7 @@ contract TimelockGuard is IGuard, ISemver {
         uint256 executionTime;
         bool cancelled;
         bool executed;
+        ExecTransactionParams params;
     }
 
     /// @notice Mapping from Safe address to its guard configuration
@@ -33,6 +39,10 @@ contract TimelockGuard is IGuard, ISemver {
 
     /// @notice Mapping from Safe and tx id to scheduled transaction.
     mapping(Safe => mapping(bytes32 => ScheduledTransaction)) internal scheduledTransactions;
+
+    /// @notice Mapping from a Safe to an enumerable set of tx hashes used to store the list of tx
+    ///         hashes which have been scheduled, but not yet exeuted or cancelled.
+    mapping(Safe => EnumerableSet.Bytes32Set) internal safePendingTxHashes;
 
     /// @notice Mapping from Safe to cancellation threshold.
     mapping(Safe => uint256) internal safeCancellationThreshold;
@@ -238,16 +248,21 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Schedule the transaction
         scheduledTransactions[_safe][txHash] =
-            ScheduledTransaction({ executionTime: executionTime, cancelled: false, executed: false });
+            ScheduedTransaction({ executionTime: executionTime, cancelled: false, executed: false, params: _params });
+        safePendingTxHashes[_safe].add(txHash);
 
         emit TransactionScheduled(_safe, txHash, executionTime);
     }
 
     /// @notice Returns the list of all scheduled but not cancelled transactions for a given safe
-    /// @dev MUST NOT revert - NOT IMPLEMENTED YET
+    /// @dev WARNING: This operation will copy the entire set of pending transactions to memory, which can be quite expensive. This is designed
+    ///      to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+    ///      this function has an unbounded cost, and using it as part of a state-changing function may render the function
+    ///      uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
     /// @return List of pending transaction hashes
-    function checkPendingTransactions(address) external pure returns (bytes32[] memory) {
-        return new bytes32[](0);
+    function checkPendingTransactions(Safe _safe) external view returns (bytes32[] memory) {
+        return safePendingTxHashes[_safe].values();
     }
 
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
@@ -288,7 +303,8 @@ contract TimelockGuard is IGuard, ISemver {
         // This function call reverts if the signatures are invalid.
         _safe.checkNSignatures(cancellationTxHash, cancellationTxData, _signatures, safeCancellationThreshold[_safe]);
 
-        scheduledTransactions[_safe][_txHash].cancelled = true;
+        scheduledTansactions[_safe][_txHash].cancelled = true;
+        safePendingTxHashes[_safe].remove(_txHash);
         increaseCancellationThreshold(_safe);
 
         emit TransactionCancelled(_safe, _txHash);
@@ -370,6 +386,7 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Set the transaction as executed
         scheduledTx.executed = true;
+        safePendingTxHashes[_safe].remove(txHash);
 
         // Reset the cancellation threshold
         resetCancellationThreshold(callingSafe);

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -68,14 +68,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that this guard is enabled on the calling Safe
-        Safe safe = Safe(payable(msg.sender));
-        // The Safe contract does not expose a getGuard function, so we need to provide the
-        // the storage slot to the getStorageAt function.
-        // keccak256("guard_manager.guard.address") from GuardManager
-        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
-        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
-
-        if (guard != address(this)) {
+        if (_getGuard(msg.sender) != address(this)) {
             revert TimelockGuard_GuardNotEnabled();
         }
 
@@ -96,12 +89,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that this guard is NOT enabled on the calling Safe
-        Safe safe = Safe(payable(msg.sender));
-        // keccak256("guard_manager.guard.address") from GuardManager
-        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
-        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
-
-        if (guard == address(this)) {
+        if (_getGuard(msg.sender) == address(this)) {
             revert TimelockGuard_GuardStillEnabled();
         }
 
@@ -109,6 +97,16 @@ contract TimelockGuard is IGuard, ISemver {
         delete safeConfigs[msg.sender];
 
         emit GuardCleared(msg.sender);
+    }
+
+    /// @notice Internal helper to get the guard address from a Safe
+    /// @param _safe The Safe address
+    /// @return The current guard address
+    function _getGuard(address _safe) internal view returns (address) {
+        // keccak256("guard_manager.guard.address") from GuardManager
+        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+        Safe safe = Safe(payable(_safe));
+        return abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
     }
 
     /// @notice Called by the Safe before executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -259,11 +259,19 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Cancel a scheduled transaction if cancellation threshold is met
     /// @dev This function aims to mimic the approach which would be used by a quorum of signers to
     ///      cancel a partially signed transaction, which would be to sign and execute an empty
-    ///      transaction at the same nonce. This enables us to deterministically generate the
-    ///      transaction inputs for a cancellation transaction from the transaction being cancelled.
-    ///      Thus in order for an owners to sign their cancellation transaction, they must first sign
-    ///      an empty transaction at the same nonce, or call approveHash on the Safe for that
-    ///      transaction hash.
+    ///      transaction at the same nonce.
+    ///      This enables us to deterministically generate the transaction inputs for a cancellation
+    ///      transaction from the transaction being cancelled.
+    ///      In this case however we cannot use a completely empty transaction (with all inputs other than the nonce being null),
+    ///      as that would allow for the signatures used to cancel one transaction at nonce X to
+    ///      be used to cancel all transactions at nonce X.
+    ///
+    ///      Therefore we define a custom set of inputs for a cancellation transaction, based on the
+    ///      Safe's address as well as the nonce and hash of the transaction being cancelled.
+    ///
+    ///      Since the Safe's checkNSignatures function is used, the owner can use any method
+    ///      to sign the cancellation transaction inputs, including signing with a private key,
+    ///      calling the Safe's approveHash function, or EIP1271 contract signatures.
     function cancelTransaction(
         Safe _safe,
         bytes32 _txHash,
@@ -280,10 +288,11 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Generate the cancellation transaction data
+        bytes memory txData = abi.encodeWithSignature("cancelTransaction(bytes32)", _txHash);
         bytes memory cancellationTxData =
-            _safe.encodeTransactionData(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
+            _safe.encodeTransactionData(address(_safe), 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
         bytes32 cancellationTxHash =
-            _safe.getTransactionHash(address(0), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
+            _safe.getTransactionHash(address(_safe), 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), address(0), _nonce);
 
         // Verify signatures using the Safe's signature checking logic
         // This function call reverts if the signatures are invalid.

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -19,7 +19,6 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Configuration for a Safe's timelock guard
     struct GuardConfig {
         uint256 timelockDelay;
-        bool configured;
     }
 
     /// @notice Scheduled transaction
@@ -129,7 +128,6 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Store the configuration for this safe
         safeConfigs[callingSafe].timelockDelay = _timelockDelay;
-        safeConfigs[callingSafe].configured = true;
 
         // Initialize cancellation threshold to 1
         safeCancellationThreshold[callingSafe] = 1;
@@ -144,7 +142,7 @@ contract TimelockGuard is IGuard, ISemver {
     function clearTimelockGuard() external {
         Safe callingSafe = Safe(payable(msg.sender));
         // Check if the calling safe has configuration set
-        if (safeConfigs[callingSafe].configured == false) {
+        if (safeConfigs[callingSafe].timelockDelay == 0) {
             revert TimelockGuard_GuardNotConfigured();
         }
 
@@ -210,7 +208,7 @@ contract TimelockGuard is IGuard, ISemver {
         }
 
         // Check that the guard has been configured for the Safe
-        if (!safeConfigs[_safe].configured) {
+        if (safeConfigs[_safe].timelockDelay == 0) {
             revert TimelockGuard_GuardNotConfigured();
         }
 
@@ -355,7 +353,7 @@ contract TimelockGuard is IGuard, ISemver {
     {
         Safe callingSafe = Safe(payable(msg.sender));
 
-        if (safeConfigs[callingSafe].configured == false) {
+        if (safeConfigs[callingSafe].timelockDelay == 0) {
             // We return immediately. This is important in order to allow a Safe which has the
             // guard set, but not configured to complete the setup process.
             // It is also just a reasonable thing to do, since an unconfigured Safe must have a

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -26,11 +26,20 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Error for when guard is not enabled for the Safe
     error TimelockGuard_GuardNotEnabled();
 
+    /// @notice Error for when Safe is not configured for this guard
+    error TimelockGuard_GuardNotConfigured();
+
+    /// @notice Error for when attempt to clear guard while it is still enabled for the Safe
+    error TimelockGuard_GuardStillEnabled();
+
     /// @notice Error for invalid timelock delay
     error TimelockGuard_InvalidTimelockDelay();
 
     /// @notice Emitted when a Safe configures the guard
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    /// @notice Emitted when a Safe clears the guard configuration
+    event GuardCleared(address indexed safe);
 
     /// @notice Semantic version.
     /// @custom:semver 1.0.0
@@ -74,6 +83,32 @@ contract TimelockGuard is IGuard, ISemver {
         safeConfigs[msg.sender].timelockDelay = _timelockDelay;
 
         emit GuardConfigured(msg.sender, _timelockDelay);
+    }
+
+    /// @notice Remove the timelock guard configuration by a previously enabled Safe
+    /// @dev The contract MUST NOT be enabled as a guard for the Safe
+    /// @dev MUST erase the existing timelock_delay data related to the calling Safe
+    /// @dev MUST emit a GuardCleared event
+    function clearTimelockGuard() external {
+        // Check if the calling safe has configuration set
+        if (safeConfigs[msg.sender].timelockDelay == 0) {
+            revert TimelockGuard_GuardNotConfigured();
+        }
+
+        // Check that this guard is NOT enabled on the calling Safe
+        Safe safe = Safe(payable(msg.sender));
+        // keccak256("guard_manager.guard.address") from GuardManager
+        bytes32 guardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+        address guard = abi.decode(safe.getStorageAt({offset: uint256(guardSlot), length: 1}), (address));
+
+        if (guard == address(this)) {
+            revert TimelockGuard_GuardStillEnabled();
+        }
+
+        // Erase the configuration data for this safe
+        delete safeConfigs[msg.sender];
+
+        emit GuardCleared(msg.sender);
     }
 
     /// @notice Called by the Safe before executing a transaction

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -135,7 +135,7 @@ contract TimelockGuard is IGuard, ISemver {
     function clearTimelockGuard() external {
         Safe callingSafe = Safe(payable(msg.sender));
         // Check if the calling safe has configuration set
-        if (safeConfigs[callingSafe].timelockDelay == 0) {
+        if (safeConfigs[callingSafe].configured == false) {
             revert TimelockGuard_GuardNotConfigured();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -19,6 +19,7 @@ contract TimelockGuard is IGuard, ISemver {
     /// @notice Configuration for a Safe's timelock guard
     struct GuardConfig {
         uint256 timelockDelay;
+        bool configured;
     }
 
     /// @notice Scheduled transaction
@@ -83,8 +84,8 @@ contract TimelockGuard is IGuard, ISemver {
     /// @dev MUST never revert
     /// @param _safe The Safe address to query
     /// @return The timelock delay in seconds
-    function viewTimelockGuardConfiguration(Safe _safe) public view returns (uint256) {
-        return safeConfigs[_safe].timelockDelay;
+    function viewTimelockGuardConfiguration(Safe _safe) public view returns (GuardConfig memory) {
+        return safeConfigs[_safe];
     }
 
     /// @notice Returns the scheduled transaction for a given Safe and tx hash
@@ -116,6 +117,7 @@ contract TimelockGuard is IGuard, ISemver {
 
         // Store the configuration for this safe
         safeConfigs[callingSafe].timelockDelay = _timelockDelay;
+        safeConfigs[callingSafe].configured = true;
 
         // Initialize cancellation threshold to 1
         safeCancellationThreshold[callingSafe] = 1;

--- a/packages/contracts-bedrock/src/safe/Types.sol
+++ b/packages/contracts-bedrock/src/safe/Types.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Enum } from "safe-contracts/common/Enum.sol";
+
+/// @notice Parameters for the Safe's execTransaction function
+struct ExecTransactionParams {
+    address to;
+    uint256 value;
+    bytes data;
+    Enum.Operation operation;
+    uint256 safeTxGas;
+    uint256 baseGas;
+    uint256 gasPrice;
+    address gasToken;
+    address payable refundReceiver;
+    // TODO: Life might be easier if this was left out of the struct
+    bytes signatures;
+}

--- a/packages/contracts-bedrock/src/safe/Types.sol
+++ b/packages/contracts-bedrock/src/safe/Types.sol
@@ -14,6 +14,4 @@ struct ExecTransactionParams {
     uint256 gasPrice;
     address gasToken;
     address payable refundReceiver;
-    // TODO: Life might be easier if this was left out of the struct
-    bytes signatures;
 }

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -191,7 +191,7 @@ library SafeTestLib {
                 refundReceiver: refundReceiver,
                 _nonce: _nonce
             });
-            console.log('txDataHash:');
+            console.log("txDataHash:");
             console.logBytes32(txDataHash);
         }
 

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -191,8 +191,6 @@ library SafeTestLib {
                 refundReceiver: refundReceiver,
                 _nonce: _nonce
             });
-            console.log("txDataHash:");
-            console.logBytes32(txDataHash);
         }
 
         (v, r, s) = Vm(VM_ADDR).sign(pk, txDataHash);

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -191,6 +191,8 @@ library SafeTestLib {
                 refundReceiver: refundReceiver,
                 _nonce: _nonce
             });
+            console.log('txDataHash:');
+            console.logBytes32(txDataHash);
         }
 
         (v, r, s) = Vm(VM_ADDR).sign(pk, txDataHash);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -707,3 +707,14 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         );
     }
 }
+
+/// @title TimelockGuard_Integration_Test
+/// @notice Integration tests for TimelockGuard with full Safe execution flow
+contract TimelockGuard_Integration_Test is TimelockGuard_TestInit {
+// TODO: Add end-to-end tests that verify the complete flow:
+// - Schedule a transaction
+// - Wait for delay to pass
+// - Execute transaction through Safe.execTransaction()
+// - Verify that the target contract was actually called
+// - Test various failure scenarios in the full execution context
+}

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -81,20 +81,20 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
         // Get the tx hash
         bytes32 txHash;
-            {
-                txHash = safeInstance.safe.getTransactionHash({
-                    to: dummyTxParams.to,
-                    value: dummyTxParams.value,
-                    data: dummyTxParams.data,
-                    operation: dummyTxParams.operation,
-                    safeTxGas: dummyTxParams.safeTxGas,
-                    baseGas: dummyTxParams.baseGas,
-                    gasPrice: dummyTxParams.gasPrice,
-                    gasToken: dummyTxParams.gasToken,
-                    refundReceiver: dummyTxParams.refundReceiver,
-                    _nonce: nonce
-                });
-            }
+        {
+            txHash = safeInstance.safe.getTransactionHash({
+                to: dummyTxParams.to,
+                value: dummyTxParams.value,
+                data: dummyTxParams.data,
+                operation: dummyTxParams.operation,
+                safeTxGas: dummyTxParams.safeTxGas,
+                baseGas: dummyTxParams.baseGas,
+                gasPrice: dummyTxParams.gasPrice,
+                gasToken: dummyTxParams.gasToken,
+                refundReceiver: dummyTxParams.refundReceiver,
+                _nonce: nonce
+            });
+        }
 
         // Sign the tx hash with the owners' private keys
         for (uint256 i; i < THRESHOLD; ++i) {
@@ -295,4 +295,26 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     function test_scheduleTransaction_guardNotConfigured_reverts() external { }
 
     function test_scheduleTransaction_canScheduleIdenticalWithSalt_succeeds() external { }
+}
+
+/// @title TimelockGuard_CancelTransaction_Test
+/// @notice Tests for cancelTransaction function
+contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
+    function setUp() public override {
+        super.setUp();
+
+        // Configure the guard and schedule a transaction
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+
+        // verify that the transaction is scheduled
+        TimelockGuard.ScheduledTransaction memory scheduledTransaction =
+            timelockGuard.getScheduledTransaction(safeInstance.safe, txHash);
+        assertEq(scheduledTransaction.executionTime, block.timestamp + TIMELOCK_DELAY);
+        assertEq(scheduledTransaction.cancelled, false);
+        assertEq(scheduledTransaction.executed, false);
+    }
+
+    function test_cancelTransaction_succeeds() external { }
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -205,7 +205,11 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     /// @notice Helper to clear the TimelockGuard configuration for a Safe
     function _clearGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe, address(timelockGuard), 0, abi.encodeCall(TimelockGuard.configureTimelockGuard, (0)), Enum.Operation.Call
+            _safe,
+            address(timelockGuard),
+            0,
+            abi.encodeCall(TimelockGuard.configureTimelockGuard, (0)),
+            Enum.Operation.Call
         );
     }
 }
@@ -440,6 +444,14 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(safe, newTxHash, INIT_TIME + TIMELOCK_DELAY);
         timelockGuard.scheduleTransaction(safeInstance.safe, newNonce, dummyTxParams, newSignatures);
+    }
+}
+
+contract TimelockGuard_GetScheduledTransactions_Test is TimelockGuard_ScheduleTransaction_Test {
+    function test_getScheduleTransactions_succeeds() external {
+        // schedule a transaction
+        test_scheduleTransaction_succeeds();
+        timelockGuard.getScheduledTransactions(safe);
     }
 }
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -2,10 +2,14 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
+import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 import { GuardManager } from "safe-contracts/base/GuardManager.sol";
 import { StorageAccessible } from "safe-contracts/common/StorageAccessible.sol";
+import { ExecTransactionParams } from "src/safe/Types.sol";
 import "test/safe-tools/SafeTestTools.sol";
+
+import { console2 as console } from "forge-std/console2.sol";
 
 import { TimelockGuard } from "src/safe/TimelockGuard.sol";
 
@@ -17,6 +21,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     // Events
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
     event GuardCleared(address indexed safe);
+    event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -26,9 +31,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
     TimelockGuard timelockGuard;
     SafeInstance safeInstance;
-    SafeInstance safeInstance2;
-    address[] owners;
-    uint256[] ownerPKs;
+    SafeInstance unguardedSafe;
 
     function setUp() public virtual {
         vm.warp(INIT_TIME);
@@ -37,12 +40,14 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         timelockGuard = new TimelockGuard();
 
         // Create Safe owners
-        (address[] memory _owners, uint256[] memory _keys) = SafeTestLib.makeAddrsAndKeys("owners", NUM_OWNERS);
-        owners = _owners;
-        ownerPKs = _keys;
+        (, uint256[] memory keys) = SafeTestLib.makeAddrsAndKeys("owners", NUM_OWNERS);
 
         // Set up Safe with owners
-        safeInstance = _setupSafe(ownerPKs, THRESHOLD);
+        safeInstance = _setupSafe(keys, THRESHOLD);
+
+        // Safe without guard enabled
+        // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
+        unguardedSafe = _setupSafe(keys, THRESHOLD - 1);
 
         // Enable the guard on the Safe
         SafeTestLib.execTransaction(
@@ -52,6 +57,53 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
             abi.encodeCall(GuardManager.setGuard, (address(timelockGuard))),
             Enum.Operation.Call
         );
+    }
+
+    /// @notice Helper to create a dummy transaction with signatures and a tx hash
+    function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes32) {
+        // Get the nonce of the safe to sign
+        uint256 nonce = safeInstance.safe.nonce();
+
+        // Declare the dummy transaction params with an empty signature
+        ExecTransactionParams memory dummyTxParams = ExecTransactionParams({
+            to: address(0xabba),
+            value: 0,
+            data: hex"acdc",
+            operation: Enum.Operation.Call,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: payable(address(0)),
+            signatures: new bytes(0)
+        });
+
+        // Get the tx hash
+        bytes32 txHash;
+            {
+                txHash = safeInstance.safe.getTransactionHash({
+                    to: dummyTxParams.to,
+                    value: dummyTxParams.value,
+                    data: dummyTxParams.data,
+                    operation: dummyTxParams.operation,
+                    safeTxGas: dummyTxParams.safeTxGas,
+                    baseGas: dummyTxParams.baseGas,
+                    gasPrice: dummyTxParams.gasPrice,
+                    gasToken: dummyTxParams.gasToken,
+                    refundReceiver: dummyTxParams.refundReceiver,
+                    _nonce: nonce
+                });
+            }
+
+        // Sign the tx hash with the owners' private keys
+        for (uint256 i; i < THRESHOLD; ++i) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(safeInstance.ownerPKs[i], txHash);
+
+            // The signature format is a compact form of: {bytes32 r}{bytes32 s}{uint8 v}
+            dummyTxParams.signatures = bytes.concat(dummyTxParams.signatures, abi.encodePacked(r, s, v));
+        }
+
+        return (dummyTxParams, txHash);
     }
 
     /// @notice Helper to configure the TimelockGuard for a Safe
@@ -103,10 +155,6 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     }
 
     function test_configureTimelockGuard_revertsIfGuardNotEnabled_reverts() external {
-        // Create a safe without enabling the guard
-        // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
-        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
-
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
         vm.prank(address(unguardedSafe.safe));
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
@@ -192,14 +240,11 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 /// @notice Tests for cancellationThreshold function
 contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
     function test_cancellationThreshold_returnsZeroIfGuardNotEnabled_succeeds() external {
-        // Safe without guard enabled should return 0
-        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
-
         uint256 threshold = timelockGuard.cancellationThreshold(address(unguardedSafe.safe));
         assertEq(threshold, 0);
     }
 
-    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured_succeeds() external {
+    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured_succeeds() external view {
         // Safe with guard enabled but not configured should return 0
         uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
         assertEq(threshold, 0);
@@ -216,4 +261,37 @@ contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
 
     // Note: Testing increment/decrement behavior will require scheduleTransaction,
     // cancelTransaction and execution functions to be implemented first
+}
+
+/// @title TimelockGuard_ScheduleTransaction_Test
+/// @notice Tests for scheduleTransaction function
+contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
+    function setUp() public override {
+        super.setUp();
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+    }
+
+    function test_scheduleTransaction_succeeds() public {
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+
+        vm.expectEmit(true, true, true, true);
+        emit TransactionScheduled(safeInstance.safe, txHash, INIT_TIME + TIMELOCK_DELAY);
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+    }
+
+    function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
+        (ExecTransactionParams memory dummyTxParams,) = _getDummyTx();
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+
+        vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+    }
+
+    function test_scheduleTransaction_identicalPreviouslyCancelled_reverts() external { }
+
+    function test_scheduleTransaction_guardNotEnabled_reverts() external { }
+
+    function test_scheduleTransaction_guardNotConfigured_reverts() external { }
+
+    function test_scheduleTransaction_canScheduleIdenticalWithSalt_succeeds() external { }
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -60,25 +60,23 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         );
     }
 
-    /// @notice Helper to generate a dummy transaction
-    function _getDummyTxParams() internal pure returns (ExecTransactionParams memory) {
-        return ExecTransactionParams({
-            to: address(0xabba),
-            value: 0,
-            data: hex"acdc",
-            operation: Enum.Operation.Call,
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: 0,
-            gasToken: address(0),
-            refundReceiver: payable(address(0))
+    /// @notice Helper to generate the transaction hash for a given transaction params and nonce
+    function _getTxHash(ExecTransactionParams memory _params, uint256 _nonce) internal view returns (bytes32) {
+        return safeInstance.safe.getTransactionHash({
+            to: _params.to,
+            value: _params.value,
+            data: _params.data,
+            operation: _params.operation,
+            safeTxGas: _params.safeTxGas,
+            baseGas: _params.baseGas,
+            gasPrice: _params.gasPrice,
+            gasToken: _params.gasToken,
+            refundReceiver: _params.refundReceiver,
+            _nonce: _nonce
         });
     }
 
     /// @notice Helper to generate signatures for an arbitrary transaction
-    /// @param _txHash The transaction hash to sign
-    /// @param _numSignatures The number of signatures to generate
-    /// @return signatures The packed signatures for the transaction
     function _getSignaturesForTx(bytes32 _txHash, uint256 _numSignatures) internal view returns (bytes memory) {
         bytes memory signatures = new bytes(0);
         for (uint256 i; i < _numSignatures; ++i) {
@@ -90,29 +88,23 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         return signatures;
     }
 
-    /// @notice Helper to create a dummy transaction with signatures and a tx hash
-    function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes32) {
-        // Get the nonce of the safe to sign
+    /// @notice Helper to generate everything needed to schedule a transaction for the current nonce
+    function _getDummyTxWithSignaturesAndHash() internal view returns (ExecTransactionParams memory, bytes32, bytes memory) {
         uint256 nonce = safeInstance.safe.nonce();
-
-        // Get the dummy transaction params
-        ExecTransactionParams memory dummyTxParams = _getDummyTxParams();
-
-        // Get the tx hash
-        bytes32 txHash = safeInstance.safe.getTransactionHash({
-            to: dummyTxParams.to,
-            value: dummyTxParams.value,
-            data: dummyTxParams.data,
-            operation: dummyTxParams.operation,
-            safeTxGas: dummyTxParams.safeTxGas,
-            baseGas: dummyTxParams.baseGas,
-            gasPrice: dummyTxParams.gasPrice,
-            gasToken: dummyTxParams.gasToken,
-            refundReceiver: dummyTxParams.refundReceiver,
-            _nonce: nonce
+        ExecTransactionParams memory dummyTxParams = ExecTransactionParams({
+            to: address(0xabba),
+            value: 0,
+            data: hex"acdc",
+            operation: Enum.Operation.Call,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: payable(address(0))
         });
-
-        return (dummyTxParams, txHash);
+        bytes32 txHash = _getTxHash(dummyTxParams, nonce);
+        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
+        return (dummyTxParams, txHash, signatures);
     }
 
     /// @notice Helper to configure the TimelockGuard for a Safe
@@ -281,8 +273,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_scheduleTransaction_succeeds() public {
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
-        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
 
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(safeInstance.safe, txHash, INIT_TIME + TIMELOCK_DELAY);
@@ -292,8 +283,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
         uint256 nonce = safeInstance.safe.nonce();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
-        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
         timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
@@ -302,7 +292,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
 
     function test_scheduleTransaction_identicalPreviouslyCancelled_reverts() external {
         // TODO: Implement once cancelTransaction is implemented and tested
-     }
+    }
 
     function test_scheduleTransaction_guardNotEnabled_reverts() external { }
 
@@ -322,9 +312,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     }
 
     function _scheduleTransaction() internal {
-        // Schedule a transaction
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
-        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
         // Confirm that the transaction is scheduled
@@ -335,13 +323,20 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         assertEq(scheduledTransaction.executed, false);
     }
 
-    function test_cancelTransaction_succeeds() external {
+    function test_cancelTransaction_withPrivKeySignature_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
         uint256 numSignatures = timelockGuard.cancellationThreshold(address(safeInstance.safe));
-        bytes memory signatures = _getSignaturesForTx(txHash, numSignatures);
-        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), signatures);
+        bytes memory cancelSignatures = _getSignaturesForTx(txHash, numSignatures);
+        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
+
+        // Confirm that the transaction is cancelled
+        TimelockGuard.ScheduledTransaction memory scheduledTransaction =
+            timelockGuard.getScheduledTransaction(safeInstance.safe, txHash);
+        assertEq(scheduledTransaction.cancelled, true);
+    }
+
 
         // Confirm that the transaction is cancelled
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =
@@ -350,7 +345,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_cancelTransaction_revertsIfTransactionNotScheduled_reverts() external {
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
         uint256 nonce = safeInstance.safe.nonce();
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, nonce, new bytes(0));

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { GuardManager } from "safe-contracts/base/GuardManager.sol";
+import { StorageAccessible } from "safe-contracts/common/StorageAccessible.sol";
+import "test/safe-tools/SafeTestTools.sol";
+
+import { TimelockGuard } from "src/safe/TimelockGuard.sol";
+
+/// @title TimelockGuard_TestInit
+/// @notice Reusable test initialization for `TimelockGuard` tests.
+contract TimelockGuard_TestInit is Test, SafeTestTools {
+    using SafeTestLib for SafeInstance;
+
+    // Events
+    event GuardConfigured(address indexed safe, uint256 timelockDelay);
+
+    uint256 constant INIT_TIME = 10;
+    uint256 constant TIMELOCK_DELAY = 7 days;
+    uint256 constant NUM_OWNERS = 5;
+    uint256 constant THRESHOLD = 3;
+    uint256 constant ONE_YEAR = 365 days;
+
+    TimelockGuard timelockGuard;
+    SafeInstance safeInstance;
+    SafeInstance safeInstance2;
+    address[] owners;
+    uint256[] ownerPKs;
+
+    function setUp() public virtual {
+        vm.warp(INIT_TIME);
+
+        // Deploy the singleton TimelockGuard
+        timelockGuard = new TimelockGuard();
+
+        // Create Safe owners
+        (address[] memory _owners, uint256[] memory _keys) = SafeTestLib.makeAddrsAndKeys("owners", NUM_OWNERS);
+        owners = _owners;
+        ownerPKs = _keys;
+
+        // Set up Safe with owners
+        safeInstance = _setupSafe(ownerPKs, THRESHOLD);
+
+        // Enable the guard on the Safe
+        SafeTestLib.execTransaction(
+            safeInstance,
+            address(safeInstance.safe),
+            0,
+            abi.encodeCall(GuardManager.setGuard, (address(timelockGuard))),
+            Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to configure the TimelockGuard for a Safe
+    function _configureGuard(SafeInstance memory _safe, uint256 _delay) internal {
+        SafeTestLib.execTransaction(
+            _safe,
+            address(timelockGuard),
+            0,
+            abi.encodeCall(TimelockGuard.configureTimelockGuard, (_delay)),
+            Enum.Operation.Call
+        );
+    }
+}
+
+/// @title TimelockGuard_ViewTimelockGuardConfiguration_Test
+/// @notice Tests for viewTimelockGuardConfiguration function
+contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_TestInit {
+    function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe() external view {
+        uint256 delay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        assertEq(delay, 0);
+    }
+}
+
+/// @title TimelockGuard_ConfigureTimelockGuard_Test
+/// @notice Tests for configureTimelockGuard function
+contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
+    function test_configureTimelockGuard_succeeds() external {
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(address(safeInstance.safe), TIMELOCK_DELAY);
+
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+
+        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        assertEq(storedDelay, TIMELOCK_DELAY);
+    }
+
+    function test_configureTimelockGuard_revertsIfGuardNotEnabled() external {
+        // Create a safe without enabling the guard
+        // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
+        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD-1);
+
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
+        vm.prank(address(unguardedSafe.safe));
+        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
+    }
+
+    function test_configureTimelockGuard_revertsIfDelayTooLong() external {
+        uint256 tooLongDelay = ONE_YEAR + 1;
+
+        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(tooLongDelay);
+    }
+
+    function test_configureTimelockGuard_revertsIfDelayZero() external {
+        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(0);
+    }
+
+    function test_configureTimelockGuard_acceptsMaxValidDelay() external {
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);
+
+        _configureGuard(safeInstance, ONE_YEAR);
+
+        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        assertEq(storedDelay, ONE_YEAR);
+    }
+
+    function test_configureTimelockGuard_allowsReconfiguration() external {
+        // Initial configuration
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
+
+        // Reconfigure with different delay
+        uint256 newDelay = 14 days;
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(address(safeInstance.safe), newDelay);
+
+        _configureGuard(safeInstance, newDelay);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), newDelay);
+    }
+}

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -120,12 +120,6 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(tooLongDelay);
     }
 
-    function test_configureTimelockGuard_revertsIfDelayZero_reverts() external {
-        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
-        vm.prank(address(safeInstance.safe));
-        timelockGuard.configureTimelockGuard(0);
-    }
-
     function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -138,7 +138,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         return (dummyTxParams, txHash, signatures);
     }
 
-    function _getCancellationTx(SafeInstance memory _safe)
+    function _getCancellationTx()
         internal
         pure
         returns (ExecTransactionParams memory)
@@ -191,8 +191,16 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 /// @notice Tests for viewTimelockGuardConfiguration function
 contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_TestInit {
     function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe_succeeds() external view {
-        uint256 delay = timelockGuard.viewTimelockGuardConfiguration(safeInstance.safe);
-        assertEq(delay, 0);
+        TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safeInstance.safe);
+        assertEq(config.timelockDelay, 0);
+        assertEq(config.configured, false);
+    }
+
+    function test_viewTimelockGuardConfiguration_returnsConfigurationForConfiguredSafe_succeeds() external {
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+        TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safeInstance.safe);
+        assertEq(config.timelockDelay, TIMELOCK_DELAY);
+        assertEq(config.configured, true);
     }
 }
 
@@ -205,8 +213,9 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 
-        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(safe);
-        assertEq(storedDelay, TIMELOCK_DELAY);
+        TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safe);
+        assertEq(config.timelockDelay, TIMELOCK_DELAY);
+        assertEq(config.configured, true);
     }
 
     function test_configureTimelockGuard_revertsIfGuardNotEnabled_reverts() external {
@@ -229,14 +238,15 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
         _configureGuard(safeInstance, ONE_YEAR);
 
-        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(safe);
-        assertEq(storedDelay, ONE_YEAR);
+        TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safe);
+        assertEq(config.timelockDelay, ONE_YEAR);
+        assertEq(config.configured, true);
     }
 
     function test_configureTimelockGuard_allowsReconfiguration_succeeds() external {
         // Initial configuration
         _configureGuard(safeInstance, TIMELOCK_DELAY);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, TIMELOCK_DELAY);
 
         // Reconfigure with different delay
         uint256 newDelay = 14 days;
@@ -244,7 +254,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         emit GuardConfigured(safe, newDelay);
 
         _configureGuard(safeInstance, newDelay);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), newDelay);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, newDelay);
     }
 }
 
@@ -254,7 +264,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
     function test_clearTimelockGuard_succeeds() external {
         // First configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, TIMELOCK_DELAY);
 
         // Disable the guard first
         _disableGuard(safeInstance);
@@ -266,7 +276,8 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         _clearGuard(safeInstance);
 
         // Configuration should be cleared
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), 0);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, 0);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).configured, false);
         // Ensure cancellation threshold is reset to 0
         assertEq(timelockGuard.cancellationThreshold(safe), 0);
 
@@ -340,7 +351,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     function test_scheduleTransaction_guardNotConfigured_succeeds() external {
         // Enable the guard on the unguarded Safe, but don't configure it
         _enableGuard(unguardedSafe);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(unguardedSafe.safe), 0);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(unguardedSafe.safe).timelockDelay, 0);
 
         (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(unguardedSafe);
 
@@ -427,7 +438,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
         // Get the cancellation signatures
         uint256 numSignatures = timelockGuard.cancellationThreshold(safeInstance.safe);
-        ExecTransactionParams memory cancellationTxParams = _getCancellationTx(safeInstance);
+        ExecTransactionParams memory cancellationTxParams = _getCancellationTx();
         bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
         bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, cancellationTxHash, numSignatures);
 
@@ -452,7 +463,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         uint256 nonce = safeInstance.safe.nonce();
 
         // Get the cancellation transaction hash
-        ExecTransactionParams memory cancellationTxParams = _getCancellationTx(safeInstance);
+        ExecTransactionParams memory cancellationTxParams = _getCancellationTx();
         bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
 
         // Get the owner

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -138,13 +138,14 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         return (dummyTxParams, txHash, signatures);
     }
 
-    function _getCancellationTx()
+    function _getCancellationTx(address _safe, bytes32 _txHash)
         internal
         pure
         returns (ExecTransactionParams memory)
     {
+        bytes memory txData = abi.encodeWithSignature("cancelTransaction(bytes32)", _txHash);
         ExecTransactionParams memory cancellationTxParams = ExecTransactionParams(
-            address(0), 0, hex"", Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0))
+            _safe, 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0))
         );
 
         return cancellationTxParams;
@@ -438,7 +439,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
         // Get the cancellation signatures
         uint256 numSignatures = timelockGuard.cancellationThreshold(safeInstance.safe);
-        ExecTransactionParams memory cancellationTxParams = _getCancellationTx();
+        ExecTransactionParams memory cancellationTxParams = _getCancellationTx(address(safeInstance.safe), txHash);
         bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
         bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, cancellationTxHash, numSignatures);
 
@@ -463,7 +464,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         uint256 nonce = safeInstance.safe.nonce();
 
         // Get the cancellation transaction hash
-        ExecTransactionParams memory cancellationTxParams = _getCancellationTx();
+        ExecTransactionParams memory cancellationTxParams = _getCancellationTx(address(safeInstance.safe), txHash);
         bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
 
         // Get the owner

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -22,7 +22,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
     event GuardCleared(Safe indexed safe);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
-    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
+    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId, uint256 newCancellationThreshold);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -401,6 +401,8 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         _configureGuard(safeInstance, TIMELOCK_DELAY);
     }
 
+    /// @notice Helper to schedule a transaction in order to test cancelTransaction.
+    ///         Will always schedule the dummy transaction using the Safe's current nonce.
     function _scheduleTransaction() internal {
         (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
             _getDummyTxWithSignaturesAndHash(safeInstance);
@@ -430,6 +432,8 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, cancellationTxHash, numSignatures);
 
         // Cancel the transaction
+        vm.expectEmit(true, true, true, true);
+        emit TransactionCancelled(safeInstance.safe, txHash, numSignatures + 1);
         timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, cancelSignatures);
 
         // Confirm that the transaction is cancelled
@@ -461,7 +465,12 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         // Encode the prevalidated cancellation signature
         bytes memory signatures = abi.encodePacked(bytes32(uint256(uint160(owner))), bytes32(0), uint8(1));
 
+        // Get the cancellation threshold
+        uint256 cancellationThreshold = timelockGuard.cancellationThreshold(safeInstance.safe);
+
         // Cancel the transaction
+        vm.expectEmit(true, true, true, true);
+        emit TransactionCancelled(safeInstance.safe, txHash, cancellationThreshold + 1);
         timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, signatures);
 
         // Confirm that the transaction is cancelled

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -138,6 +138,18 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         return (dummyTxParams, txHash, signatures);
     }
 
+    function _getCancellationTx(SafeInstance memory _safe)
+        internal
+        pure
+        returns (ExecTransactionParams memory)
+    {
+        ExecTransactionParams memory cancellationTxParams = ExecTransactionParams(
+            address(0), 0, hex"", Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0))
+        );
+
+        return cancellationTxParams;
+    }
+
     /// @notice Helper to configure the TimelockGuard for a Safe
     function _configureGuard(SafeInstance memory _safe, uint256 _delay) internal {
         SafeTestLib.execTransaction(
@@ -357,11 +369,12 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
 
     function test_scheduleTransaction_guardNotEnabled_reverts() external {
         // Attempt to schedule a transaction with a Safe that has not enabled the guard
+        uint256 nonce = unguardedSafe.safe.nonce();
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
-        timelockGuard.scheduleTransaction(unguardedSafe.safe, unguardedSafe.safe.nonce(), _getDummyTxParams(), "");
+        timelockGuard.scheduleTransaction(unguardedSafe.safe, nonce, _getDummyTxParams(), "");
     }
 
-    function test_scheduleTransaction_canScheduleIdenticalWithSalt_succeeds() external {
+    function test_scheduleTransaction_canScheduleIdenticalWithDifferentNonce_succeeds() external {
         // Schedule a transaction with a specific nonce
         (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) =
             _getDummyTxWithSignaturesAndHash(safeInstance);
@@ -369,18 +382,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
 
         // Schedule an identical transaction with a different nonce (salt)
         uint256 newNonce = safeInstance.safe.nonce() + 1;
-        bytes32 newTxHash = safeInstance.safe.getTransactionHash({
-            to: dummyTxParams.to,
-            value: dummyTxParams.value,
-            data: dummyTxParams.data,
-            operation: dummyTxParams.operation,
-            safeTxGas: dummyTxParams.safeTxGas,
-            baseGas: dummyTxParams.baseGas,
-            gasPrice: dummyTxParams.gasPrice,
-            gasToken: dummyTxParams.gasToken,
-            refundReceiver: dummyTxParams.refundReceiver,
-            _nonce: newNonce
-        });
+        bytes32 newTxHash = _getTxHash(safeInstance, dummyTxParams, newNonce);
         bytes memory newSignatures = _getSignaturesForTx(safeInstance, newTxHash, THRESHOLD);
 
         vm.expectEmit(true, true, true, true);
@@ -415,10 +417,20 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     function test_cancelTransaction_withPrivKeySignature_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
+        // Get the transaction hash
+        (, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
+
+        // Get the nonce
+        uint256 nonce = safeInstance.safe.nonce();
+
+        // Get the cancellation signatures
         uint256 numSignatures = timelockGuard.cancellationThreshold(safeInstance.safe);
-        bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, txHash, numSignatures);
-        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
+        ExecTransactionParams memory cancellationTxParams = _getCancellationTx(safeInstance);
+        bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
+        bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, cancellationTxHash, numSignatures);
+
+        // Cancel the transaction
+        timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, cancelSignatures);
 
         // Confirm that the transaction is cancelled
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =
@@ -429,15 +441,28 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     function test_cancelTransaction_withApproveHash_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
+        // Get the transaction hash
+        (, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
+
+        // Get the nonce
+        uint256 nonce = safeInstance.safe.nonce();
+
+        // Get the cancellation transaction hash
+        ExecTransactionParams memory cancellationTxParams = _getCancellationTx(safeInstance);
+        bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
+
+        // Get the owner
         address owner = safeInstance.safe.getOwners()[0];
 
+        // Approve the cancellation transaction hash
         vm.prank(owner);
-        safeInstance.safe.approveHash(txHash);
+        safeInstance.safe.approveHash(cancellationTxHash);
 
-        // Generate a prevalidated signature
-        bytes memory cancelSignatures = abi.encodePacked(bytes32(uint256(uint160(owner))), bytes32(0), uint8(1));
-        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
+        // Encode the prevalidated cancellation signature
+        bytes memory signatures = abi.encodePacked(bytes32(uint256(uint160(owner))), bytes32(0), uint8(1));
+
+        // Cancel the transaction
+        timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, signatures);
 
         // Confirm that the transaction is cancelled
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =
@@ -446,9 +471,14 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_cancelTransaction_revertsIfTransactionNotScheduled_reverts() external {
-        (ExecTransactionParams memory dummyTxParams,,) = _getDummyTxWithSignaturesAndHash(safeInstance);
+        // Get the transaction hash
+        (, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
+
+        // Get the cancellation signatures
         uint256 nonce = safeInstance.safe.nonce();
+
+        // Attempt to cancel the transaction
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
-        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, nonce, new bytes(0));
+        timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, new bytes(0));
     }
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -5,11 +5,8 @@ import { Test } from "forge-std/Test.sol";
 import { GnosisSafe as Safe } from "safe-contracts/GnosisSafe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 import { GuardManager } from "safe-contracts/base/GuardManager.sol";
-import { StorageAccessible } from "safe-contracts/common/StorageAccessible.sol";
 import { ExecTransactionParams } from "src/safe/Types.sol";
 import "test/safe-tools/SafeTestTools.sol";
-
-import { console2 as console } from "forge-std/console2.sol";
 
 import { TimelockGuard } from "src/safe/TimelockGuard.sol";
 
@@ -140,7 +137,10 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to generate everything needed to schedule a transaction for the current nonce
-    function _getTxWithSignaturesAndHash(SafeInstance memory _safe, ExecTransactionParams memory _params)
+    function _getTxWithSignaturesAndHash(
+        SafeInstance memory _safe,
+        ExecTransactionParams memory _params
+    )
         internal
         view
         returns (bytes32, bytes memory)
@@ -286,7 +286,9 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
             refundReceiver: payable(address(0))
         });
         (, bytes memory signatures) = _getTxWithSignaturesAndHash(safeInstance, reconfigureGuardTxParams);
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), reconfigureGuardTxParams, signatures);
+        timelockGuard.scheduleTransaction(
+            safeInstance.safe, safeInstance.safe.nonce(), reconfigureGuardTxParams, signatures
+        );
         vm.warp(block.timestamp + TIMELOCK_DELAY);
 
         // Reconfigure with different delay
@@ -566,6 +568,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 /// @notice Tests for checkTransaction function
 contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
     using stdStorage for StdStorage;
+
     function setUp() public override {
         super.setUp();
         _configureGuard(safeInstance, TIMELOCK_DELAY);
@@ -582,13 +585,17 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         // Fast forward past the timelock delay
         vm.warp(block.timestamp + TIMELOCK_DELAY);
         // Increment the nonce, as would normally happen when the transaction is executed
-        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(nonce+1)));
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(nonce + 1)));
 
         // increment the cancellation threshold so that we can test that it is reset
         uint256 slot = stdstore.target(address(timelockGuard)).sig("cancellationThreshold(address)").with_key(
             address(safeInstance.safe)
         ).find();
-        vm.store(address(timelockGuard), bytes32(slot), bytes32(uint256(timelockGuard.cancellationThreshold(safeInstance.safe)+1)));
+        vm.store(
+            address(timelockGuard),
+            bytes32(slot),
+            bytes32(uint256(timelockGuard.cancellationThreshold(safeInstance.safe) + 1))
+        );
 
         vm.prank(address(safeInstance.safe));
         vm.expectEmit(true, true, true, true);
@@ -625,7 +632,7 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
         // Increment the nonce, as would normally happen when the transaction is executed
-        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce()+1)));
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce() + 1)));
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotReady.selector);
         vm.prank(address(safeInstance.safe));
@@ -664,7 +671,7 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         // Fast forward past the timelock delay
         vm.warp(block.timestamp + TIMELOCK_DELAY);
         // Increment the nonce, as would normally happen when the transaction is executed
-        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce()+1)));
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce() + 1)));
 
         // Should revert because transaction was cancelled
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyCancelled.selector);
@@ -706,15 +713,4 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
             address(0)
         );
     }
-}
-
-/// @title TimelockGuard_Integration_Test
-/// @notice Integration tests for TimelockGuard with full Safe execution flow
-contract TimelockGuard_Integration_Test is TimelockGuard_TestInit {
-// TODO: Add end-to-end tests that verify the complete flow:
-// - Schedule a transaction
-// - Wait for delay to pass
-// - Execute transaction through Safe.execTransaction()
-// - Verify that the target contract was actually called
-// - Test various failure scenarios in the full execution context
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -283,7 +283,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
         uint256 nonce = safeInstance.safe.nonce();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
         timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
@@ -326,7 +326,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     function test_cancelTransaction_withPrivKeySignature_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash();
         uint256 numSignatures = timelockGuard.cancellationThreshold(address(safeInstance.safe));
         bytes memory cancelSignatures = _getSignaturesForTx(txHash, numSignatures);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
@@ -340,7 +340,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     function test_cancelTransaction_withApproveHash_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash();
         address owner = safeInstance.safe.getOwners()[0];
 
         vm.prank(owner);
@@ -357,7 +357,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_cancelTransaction_revertsIfTransactionNotScheduled_reverts() external {
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams,,) = _getDummyTxWithSignaturesAndHash();
         uint256 nonce = safeInstance.safe.nonce();
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, nonce, new bytes(0));

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -68,22 +68,14 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     /// @notice Helper to disable guard on a Safe
     function _disableGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe,
-            address(_safe.safe),
-            0,
-            abi.encodeCall(GuardManager.setGuard, (address(0))),
-            Enum.Operation.Call
+            _safe, address(_safe.safe), 0, abi.encodeCall(GuardManager.setGuard, (address(0))), Enum.Operation.Call
         );
     }
 
     /// @notice Helper to clear the TimelockGuard configuration for a Safe
     function _clearGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe,
-            address(timelockGuard),
-            0,
-            abi.encodeCall(TimelockGuard.clearTimelockGuard, ()),
-            Enum.Operation.Call
+            _safe, address(timelockGuard), 0, abi.encodeCall(TimelockGuard.clearTimelockGuard, ()), Enum.Operation.Call
         );
     }
 }
@@ -113,7 +105,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     function test_configureTimelockGuard_revertsIfGuardNotEnabled() external {
         // Create a safe without enabling the guard
         // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
-        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD-1);
+        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
         vm.prank(address(unguardedSafe.safe));
@@ -178,6 +170,9 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 
         // Configuration should be cleared
         assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), 0);
+        // Ensure cancellation threshold is reset to 0
+        assertEq(timelockGuard.cancellationThreshold(address(safeInstance.safe)), 0);
+
         // TODO: Check that any active challenge is cancelled
     }
 
@@ -197,4 +192,34 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         vm.prank(address(safeInstance.safe));
         timelockGuard.clearTimelockGuard();
     }
+}
+
+/// @title TimelockGuard_CancellationThreshold_Test
+/// @notice Tests for cancellationThreshold function
+contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
+    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled() external {
+        // Safe without guard enabled should return 0
+        SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
+
+        uint256 threshold = timelockGuard.cancellationThreshold(address(unguardedSafe.safe));
+        assertEq(threshold, 0);
+    }
+
+    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured() external {
+        // Safe with guard enabled but not configured should return 0
+        uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        assertEq(threshold, 0);
+    }
+
+    function test_cancellationThreshold_returnsOneAfterConfiguration() external {
+        // Configure the guard
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+
+        // Should default to 1 after configuration
+        uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        assertEq(threshold, 1);
+    }
+
+    // Note: Testing increment/decrement behavior will require scheduleTransaction,
+    // cancelTransaction and execution functions to be implemented first
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -19,8 +19,8 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
     // Events
-    event GuardConfigured(address indexed safe, uint256 timelockDelay);
-    event GuardCleared(address indexed safe);
+    event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
+    event GuardCleared(Safe indexed safe);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
     event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
 
@@ -31,7 +31,12 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     uint256 constant ONE_YEAR = 365 days;
 
     TimelockGuard timelockGuard;
+
+    // The Safe address will be the same as SafeInstance.safe, but it has the Safe type.
+    // This is useful for testing functions that take a Safe as an argument.
+    Safe safe;
     SafeInstance safeInstance;
+
     SafeInstance unguardedSafe;
 
     function setUp() public virtual {
@@ -45,6 +50,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
         // Set up Safe with owners
         safeInstance = _setupSafe(keys, THRESHOLD);
+        safe = Safe(payable(safeInstance.safe));
 
         // Safe without guard enabled
         // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
@@ -89,7 +95,11 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to generate everything needed to schedule a transaction for the current nonce
-    function _getDummyTxWithSignaturesAndHash() internal view returns (ExecTransactionParams memory, bytes32, bytes memory) {
+    function _getDummyTxWithSignaturesAndHash()
+        internal
+        view
+        returns (ExecTransactionParams memory, bytes32, bytes memory)
+    {
         uint256 nonce = safeInstance.safe.nonce();
         ExecTransactionParams memory dummyTxParams = ExecTransactionParams({
             to: address(0xabba),
@@ -137,7 +147,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 /// @notice Tests for viewTimelockGuardConfiguration function
 contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_TestInit {
     function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe_succeeds() external view {
-        uint256 delay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        uint256 delay = timelockGuard.viewTimelockGuardConfiguration(safeInstance.safe);
         assertEq(delay, 0);
     }
 }
@@ -147,11 +157,11 @@ contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_Test
 contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     function test_configureTimelockGuard_succeeds() external {
         vm.expectEmit(true, true, true, true);
-        emit GuardConfigured(address(safeInstance.safe), TIMELOCK_DELAY);
+        emit GuardConfigured(safe, TIMELOCK_DELAY);
 
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 
-        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(safe);
         assertEq(storedDelay, TIMELOCK_DELAY);
     }
 
@@ -171,26 +181,26 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
     function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);
-        emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);
+        emit GuardConfigured(safe, ONE_YEAR);
 
         _configureGuard(safeInstance, ONE_YEAR);
 
-        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
+        uint256 storedDelay = timelockGuard.viewTimelockGuardConfiguration(safe);
         assertEq(storedDelay, ONE_YEAR);
     }
 
     function test_configureTimelockGuard_allowsReconfiguration_succeeds() external {
         // Initial configuration
         _configureGuard(safeInstance, TIMELOCK_DELAY);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), TIMELOCK_DELAY);
 
         // Reconfigure with different delay
         uint256 newDelay = 14 days;
         vm.expectEmit(true, true, true, true);
-        emit GuardConfigured(address(safeInstance.safe), newDelay);
+        emit GuardConfigured(safe, newDelay);
 
         _configureGuard(safeInstance, newDelay);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), newDelay);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), newDelay);
     }
 }
 
@@ -200,21 +210,21 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
     function test_clearTimelockGuard_succeeds() external {
         // First configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), TIMELOCK_DELAY);
 
         // Disable the guard first
         _disableGuard(safeInstance);
 
         // Clear should succeed and emit event
         vm.expectEmit(true, true, true, true);
-        emit GuardCleared(address(safeInstance.safe));
+        emit GuardCleared(safe);
 
         _clearGuard(safeInstance);
 
         // Configuration should be cleared
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), 0);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe), 0);
         // Ensure cancellation threshold is reset to 0
-        assertEq(timelockGuard.cancellationThreshold(address(safeInstance.safe)), 0);
+        assertEq(timelockGuard.cancellationThreshold(safe), 0);
 
         // TODO: Check that any active challenge is cancelled
     }
@@ -241,13 +251,13 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 /// @notice Tests for cancellationThreshold function
 contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
     function test_cancellationThreshold_returnsZeroIfGuardNotEnabled_succeeds() external view {
-        uint256 threshold = timelockGuard.cancellationThreshold(address(unguardedSafe.safe));
+        uint256 threshold = timelockGuard.cancellationThreshold(Safe(payable(unguardedSafe.safe)));
         assertEq(threshold, 0);
     }
 
     function test_cancellationThreshold_returnsZeroIfGuardNotConfigured_succeeds() external view {
         // Safe with guard enabled but not configured should return 0
-        uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        uint256 threshold = timelockGuard.cancellationThreshold(safe);
         assertEq(threshold, 0);
     }
 
@@ -256,7 +266,7 @@ contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 
         // Should default to 1 after configuration
-        uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        uint256 threshold = timelockGuard.cancellationThreshold(safe);
         assertEq(threshold, 1);
     }
 
@@ -273,10 +283,11 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_scheduleTransaction_succeeds() public {
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash();
 
         vm.expectEmit(true, true, true, true);
-        emit TransactionScheduled(safeInstance.safe, txHash, INIT_TIME + TIMELOCK_DELAY);
+        emit TransactionScheduled(safe, txHash, INIT_TIME + TIMELOCK_DELAY);
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
     }
 
@@ -312,7 +323,8 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     }
 
     function _scheduleTransaction() internal {
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash();
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
         // Confirm that the transaction is scheduled
@@ -327,7 +339,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         _scheduleTransaction();
 
         (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash();
-        uint256 numSignatures = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        uint256 numSignatures = timelockGuard.cancellationThreshold(safeInstance.safe);
         bytes memory cancelSignatures = _getSignaturesForTx(txHash, numSignatures);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -22,7 +22,8 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
     event GuardCleared(Safe indexed safe);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
-    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId, uint256 newCancellationThreshold);
+    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
+    event CancellationThresholdUpdated(Safe indexed safe, uint256 oldThreshold, uint256 newThreshold);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -138,15 +139,10 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         return (dummyTxParams, txHash, signatures);
     }
 
-    function _getCancellationTx(address _safe, bytes32 _txHash)
-        internal
-        pure
-        returns (ExecTransactionParams memory)
-    {
+    function _getCancellationTx(address _safe, bytes32 _txHash) internal pure returns (ExecTransactionParams memory) {
         bytes memory txData = abi.encodeWithSignature("cancelTransaction(bytes32)", _txHash);
-        ExecTransactionParams memory cancellationTxParams = ExecTransactionParams(
-            _safe, 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0))
-        );
+        ExecTransactionParams memory cancellationTxParams =
+            ExecTransactionParams(_safe, 0, txData, Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)));
 
         return cancellationTxParams;
     }
@@ -445,7 +441,9 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
         // Cancel the transaction
         vm.expectEmit(true, true, true, true);
-        emit TransactionCancelled(safeInstance.safe, txHash, numSignatures + 1);
+        emit CancellationThresholdUpdated(safeInstance.safe, numSignatures, numSignatures + 1);
+        vm.expectEmit(true, true, true, true);
+        emit TransactionCancelled(safeInstance.safe, txHash);
         timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, cancelSignatures);
 
         // Confirm that the transaction is cancelled
@@ -482,7 +480,9 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
         // Cancel the transaction
         vm.expectEmit(true, true, true, true);
-        emit TransactionCancelled(safeInstance.safe, txHash, cancellationThreshold + 1);
+        emit CancellationThresholdUpdated(safeInstance.safe, cancellationThreshold, cancellationThreshold + 1);
+        vm.expectEmit(true, true, true, true);
+        emit TransactionCancelled(safeInstance.safe, txHash);
         timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, signatures);
 
         // Confirm that the transaction is cancelled

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -337,6 +337,18 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         assertEq(scheduledTransaction.cancelled, true);
     }
 
+    function test_cancelTransaction_withApproveHash_succeeds() external {
+        _scheduleTransaction();
+
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        address owner = safeInstance.safe.getOwners()[0];
+
+        vm.prank(owner);
+        safeInstance.safe.approveHash(txHash);
+
+        // Generate a prevalidated signature
+        bytes memory cancelSignatures = abi.encodePacked(bytes32(uint256(uint160(owner))), bytes32(0), uint8(1));
+        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
 
         // Confirm that the transaction is cancelled
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -358,6 +358,8 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(unguardedSafe.safe, txHash, INIT_TIME + 0);
         timelockGuard.scheduleTransaction(unguardedSafe.safe, nonce, dummyTxParams, signatures);
+
+        // TODO: show that an unscheduled tx will be executed immediately.
     }
 
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
@@ -376,6 +378,15 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_scheduleTransaction_guardNotEnabled_reverts() external {
+        // Attempt to schedule a transaction with a Safe that has enabled the guard but
+        // has not configured it.
+        _enableGuard(unguardedSafe);
+        uint256 nonce = unguardedSafe.safe.nonce();
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
+        timelockGuard.scheduleTransaction(unguardedSafe.safe, nonce, _getDummyTxParams(), "");
+    }
+
+    function test_scheduleTransaction_guardNotConfigured_reverts() external {
         // Attempt to schedule a transaction with a Safe that has not enabled the guard
         uint256 nonce = unguardedSafe.safe.nonce();
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -17,7 +17,6 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
     // Events
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
-    event GuardCleared(Safe indexed safe);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
     event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
     event CancellationThresholdUpdated(Safe indexed safe, uint256 oldThreshold, uint256 newThreshold);
@@ -206,7 +205,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     /// @notice Helper to clear the TimelockGuard configuration for a Safe
     function _clearGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe, address(timelockGuard), 0, abi.encodeCall(TimelockGuard.clearTimelockGuard, ()), Enum.Operation.Call
+            _safe, address(timelockGuard), 0, abi.encodeCall(TimelockGuard.configureTimelockGuard, (0)), Enum.Operation.Call
         );
     }
 }
@@ -302,50 +301,30 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         _configureGuard(safeInstance, newDelay);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, newDelay);
     }
-}
 
-/// @title TimelockGuard_ClearTimelockGuard_Test
-/// @notice Tests for clearTimelockGuard function
-contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
-    function test_clearTimelockGuard_succeeds() external {
+    function test_configureTimelockGuard_clearConfiguration_succeeds() external {
         // First configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, TIMELOCK_DELAY);
 
-        // Disable the guard
-        _disableGuard(safeInstance);
-
-        // Clear should succeed and emit event
+        // Configure timelock delay to 0 should succeed and emit event
         vm.expectEmit(true, true, true, true);
-        emit GuardCleared(safe);
+        emit GuardConfigured(safe, 0);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(0);
 
-        _clearGuard(safeInstance);
-
-        // Configuration should be cleared
+        // Timelock delay should be set to 0
         assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, 0);
-        // configured is now determined by timelockDelay == 0
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay == 0, true);
-        // Ensure cancellation threshold is reset to 0
+        // Cancellation threshold should be reset to 0
         assertEq(timelockGuard.cancellationThreshold(safe), 0);
-
-        // TODO: Check that any active challenge is cancelled
     }
 
-    function test_clearTimelockGuard_revertsIfGuardStillEnabled_reverts() external {
-        // First configure the guard
-        _configureGuard(safeInstance, TIMELOCK_DELAY);
-
-        // Try to clear without disabling guard first - should revert
-        vm.expectRevert(TimelockGuard.TimelockGuard_GuardStillEnabled.selector);
+    function test_configureTimelockGuard_notConfigured_succeeds() external {
+        // Try to clear - should succeed even if not yet configured
+        vm.expectEmit(true, true, true, true);
+        emit GuardConfigured(safe, 0);
         vm.prank(address(safeInstance.safe));
-        timelockGuard.clearTimelockGuard();
-    }
-
-    function test_clearTimelockGuard_revertsIfNotConfigured_reverts() external {
-        // Try to clear - should revert because not configured
-        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
-        vm.prank(address(safeInstance.safe));
-        timelockGuard.clearTimelockGuard();
+        timelockGuard.configureTimelockGuard(0);
     }
 }
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -60,6 +60,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to create a dummy transaction with signatures and a tx hash
+    // TODO: separate into two functions: one for the params+hash, one for the signatures
     function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes32) {
         // Get the nonce of the safe to sign
         uint256 nonce = safeInstance.safe.nonce();

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -59,13 +59,9 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         );
     }
 
-    /// @notice Helper to create a dummy transaction with signatures and a tx hash
-    function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes memory, bytes32) {
-        // Get the nonce of the safe to sign
-        uint256 nonce = safeInstance.safe.nonce();
-
-        // Declare the dummy transaction params
-        ExecTransactionParams memory dummyTxParams = ExecTransactionParams({
+    /// @notice Helper to generate a dummy transaction
+    function _getDummyTxParams() internal pure returns (ExecTransactionParams memory) {
+        return ExecTransactionParams({
             to: address(0xabba),
             value: 0,
             data: hex"acdc",
@@ -76,34 +72,46 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
             gasToken: address(0),
             refundReceiver: payable(address(0))
         });
+    }
 
-        // Get the tx hash
-        bytes32 txHash;
-        {
-            txHash = safeInstance.safe.getTransactionHash({
-                to: dummyTxParams.to,
-                value: dummyTxParams.value,
-                data: dummyTxParams.data,
-                operation: dummyTxParams.operation,
-                safeTxGas: dummyTxParams.safeTxGas,
-                baseGas: dummyTxParams.baseGas,
-                gasPrice: dummyTxParams.gasPrice,
-                gasToken: dummyTxParams.gasToken,
-                refundReceiver: dummyTxParams.refundReceiver,
-                _nonce: nonce
-            });
-        }
-
-        // Sign the tx hash with the owners' private keys
+    /// @notice Helper to generate signatures for an arbitrary transaction
+    /// @param _txHash The transaction hash to sign
+    /// @param _numSignatures The number of signatures to generate
+    /// @return signatures The packed signatures for the transaction
+    function _getSignaturesForTx(bytes32 _txHash, uint256 _numSignatures) internal view returns (bytes memory) {
         bytes memory signatures = new bytes(0);
-        for (uint256 i; i < THRESHOLD; ++i) {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(safeInstance.ownerPKs[i], txHash);
+        for (uint256 i; i < _numSignatures; ++i) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(safeInstance.ownerPKs[i], _txHash);
 
             // The signature format is a compact form of: {bytes32 r}{bytes32 s}{uint8 v}
             signatures = bytes.concat(signatures, abi.encodePacked(r, s, v));
         }
+        return signatures;
+    }
 
-        return (dummyTxParams, signatures, txHash);
+    /// @notice Helper to create a dummy transaction with signatures and a tx hash
+    function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes32) {
+        // Get the nonce of the safe to sign
+        uint256 nonce = safeInstance.safe.nonce();
+
+        // Get the dummy transaction params
+        ExecTransactionParams memory dummyTxParams = _getDummyTxParams();
+
+        // Get the tx hash
+        bytes32 txHash = safeInstance.safe.getTransactionHash({
+            to: dummyTxParams.to,
+            value: dummyTxParams.value,
+            data: dummyTxParams.data,
+            operation: dummyTxParams.operation,
+            safeTxGas: dummyTxParams.safeTxGas,
+            baseGas: dummyTxParams.baseGas,
+            gasPrice: dummyTxParams.gasPrice,
+            gasToken: dummyTxParams.gasToken,
+            refundReceiver: dummyTxParams.refundReceiver,
+            _nonce: nonce
+        });
+
+        return (dummyTxParams, txHash);
     }
 
     /// @notice Helper to configure the TimelockGuard for a Safe
@@ -239,7 +247,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 /// @title TimelockGuard_CancellationThreshold_Test
 /// @notice Tests for cancellationThreshold function
 contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
-    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled_succeeds() external {
+    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled_succeeds() external view {
         uint256 threshold = timelockGuard.cancellationThreshold(address(unguardedSafe.safe));
         assertEq(threshold, 0);
     }
@@ -272,7 +280,8 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_scheduleTransaction_succeeds() public {
-        (ExecTransactionParams memory dummyTxParams, bytes memory signatures, bytes32 txHash) = _getDummyTx();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
 
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(safeInstance.safe, txHash, INIT_TIME + TIMELOCK_DELAY);
@@ -280,11 +289,14 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
-        (ExecTransactionParams memory dummyTxParams, bytes memory signatures,) = _getDummyTx();
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
+        uint256 nonce = safeInstance.safe.nonce();
+
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
+        timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
+        timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
     }
 
     function test_scheduleTransaction_identicalPreviouslyCancelled_reverts() external { }
@@ -305,9 +317,14 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         // Configure the guard and schedule a transaction
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         (ExecTransactionParams memory dummyTxParams, bytes memory signatures, bytes32 txHash) = _getDummyTx();
+
+    function _scheduleTransaction() internal {
+        // Schedule a transaction
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
-        // verify that the transaction is scheduled
+        // Confirm that the transaction is scheduled
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =
             timelockGuard.getScheduledTransaction(safeInstance.safe, txHash);
         assertEq(scheduledTransaction.executionTime, block.timestamp + TIMELOCK_DELAY);
@@ -315,5 +332,24 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         assertEq(scheduledTransaction.executed, false);
     }
 
-    function test_cancelTransaction_succeeds() external { }
+    function test_cancelTransaction_succeeds() external {
+        _scheduleTransaction();
+
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        uint256 numSignatures = timelockGuard.cancellationThreshold(address(safeInstance.safe));
+        bytes memory signatures = _getSignaturesForTx(txHash, numSignatures);
+        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), signatures);
+
+        // Confirm that the transaction is cancelled
+        TimelockGuard.ScheduledTransaction memory scheduledTransaction =
+            timelockGuard.getScheduledTransaction(safeInstance.safe, txHash);
+        assertEq(scheduledTransaction.cancelled, true);
+    }
+
+    function test_cancelTransaction_revertsIfTransactionNotScheduled_reverts() external {
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        uint256 nonce = safeInstance.safe.nonce();
+        vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
+        timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, nonce, new bytes(0));
+    }
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -217,14 +217,16 @@ contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_Test
     function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe_succeeds() external view {
         TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safeInstance.safe);
         assertEq(config.timelockDelay, 0);
-        assertEq(config.configured, false);
+        // configured is now determined by timelockDelay == 0
+        assertEq(config.timelockDelay == 0, true);
     }
 
     function test_viewTimelockGuardConfiguration_returnsConfigurationForConfiguredSafe_succeeds() external {
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safeInstance.safe);
         assertEq(config.timelockDelay, TIMELOCK_DELAY);
-        assertEq(config.configured, true);
+        // configured is now determined by timelockDelay != 0
+        assertEq(config.timelockDelay != 0, true);
     }
 }
 
@@ -239,7 +241,8 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
         TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safe);
         assertEq(config.timelockDelay, TIMELOCK_DELAY);
-        assertEq(config.configured, true);
+        // configured is now determined by timelockDelay != 0
+        assertEq(config.timelockDelay != 0, true);
     }
 
     function test_configureTimelockGuard_revertsIfGuardNotEnabled_reverts() external {
@@ -264,7 +267,8 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
         TimelockGuard.GuardConfig memory config = timelockGuard.viewTimelockGuardConfiguration(safe);
         assertEq(config.timelockDelay, ONE_YEAR);
-        assertEq(config.configured, true);
+        // configured is now determined by timelockDelay != 0
+        assertEq(config.timelockDelay != 0, true);
     }
 
     function test_configureTimelockGuard_allowsReconfiguration_succeeds() external {
@@ -319,7 +323,8 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 
         // Configuration should be cleared
         assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, 0);
-        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).configured, false);
+        // configured is now determined by timelockDelay == 0
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay == 0, true);
         // Ensure cancellation threshold is reset to 0
         assertEq(timelockGuard.cancellationThreshold(safe), 0);
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -22,6 +22,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
     event GuardCleared(address indexed safe);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
+    event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -299,7 +300,9 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
     }
 
-    function test_scheduleTransaction_identicalPreviouslyCancelled_reverts() external { }
+    function test_scheduleTransaction_identicalPreviouslyCancelled_reverts() external {
+        // TODO: Implement once cancelTransaction is implemented and tested
+     }
 
     function test_scheduleTransaction_guardNotEnabled_reverts() external { }
 
@@ -316,7 +319,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
         // Configure the guard and schedule a transaction
         _configureGuard(safeInstance, TIMELOCK_DELAY);
-        (ExecTransactionParams memory dummyTxParams, bytes memory signatures, bytes32 txHash) = _getDummyTx();
+    }
 
     function _scheduleTransaction() internal {
         // Schedule a transaction

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -67,8 +67,8 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to generate the transaction hash for a given transaction params and nonce
-    function _getTxHash(ExecTransactionParams memory _params, uint256 _nonce) internal view returns (bytes32) {
-        return safeInstance.safe.getTransactionHash({
+    function _getTxHash(SafeInstance memory _safeInstance, ExecTransactionParams memory _params, uint256 _nonce) internal view returns (bytes32) {
+        return _safeInstance.safe.getTransactionHash({
             to: _params.to,
             value: _params.value,
             data: _params.data,
@@ -83,10 +83,10 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to generate signatures for an arbitrary transaction
-    function _getSignaturesForTx(bytes32 _txHash, uint256 _numSignatures) internal view returns (bytes memory) {
+    function _getSignaturesForTx(SafeInstance memory _safeInstance, bytes32 _txHash, uint256 _numSignatures) internal pure returns (bytes memory) {
         bytes memory signatures = new bytes(0);
         for (uint256 i; i < _numSignatures; ++i) {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(safeInstance.ownerPKs[i], _txHash);
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(_safeInstance.ownerPKs[i], _txHash);
 
             // The signature format is a compact form of: {bytes32 r}{bytes32 s}{uint8 v}
             signatures = bytes.concat(signatures, abi.encodePacked(r, s, v));
@@ -94,14 +94,9 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         return signatures;
     }
 
-    /// @notice Helper to generate everything needed to schedule a transaction for the current nonce
-    function _getDummyTxWithSignaturesAndHash()
-        internal
-        view
-        returns (ExecTransactionParams memory, bytes32, bytes memory)
-    {
-        uint256 nonce = safeInstance.safe.nonce();
-        ExecTransactionParams memory dummyTxParams = ExecTransactionParams({
+    /// @notice Helper to generate dummy transaction parameters
+    function _getDummyTxParams() internal pure returns (ExecTransactionParams memory) {
+        return ExecTransactionParams({
             to: address(0xabba),
             value: 0,
             data: hex"acdc",
@@ -112,8 +107,18 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
             gasToken: address(0),
             refundReceiver: payable(address(0))
         });
-        bytes32 txHash = _getTxHash(dummyTxParams, nonce);
-        bytes memory signatures = _getSignaturesForTx(txHash, THRESHOLD);
+    }
+
+    /// @notice Helper to generate everything needed to schedule a transaction for the current nonce
+    function _getDummyTxWithSignaturesAndHash(SafeInstance memory _safe)
+        internal
+        view
+        returns (ExecTransactionParams memory, bytes32, bytes memory)
+    {
+        uint256 nonce = _safe.safe.nonce();
+        ExecTransactionParams memory dummyTxParams = _getDummyTxParams();
+        bytes32 txHash = _getTxHash(_safe, dummyTxParams, nonce);
+        bytes memory signatures = _getSignaturesForTx(_safe, txHash, THRESHOLD);
         return (dummyTxParams, txHash, signatures);
     }
 
@@ -132,6 +137,13 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     function _disableGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
             _safe, address(_safe.safe), 0, abi.encodeCall(GuardManager.setGuard, (address(0))), Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to enable guard on a Safe
+    function _enableGuard(SafeInstance memory _safe) internal {
+        SafeTestLib.execTransaction(
+            _safe, address(_safe.safe), 0, abi.encodeCall(GuardManager.setGuard, (address(timelockGuard))), Enum.Operation.Call
         );
     }
 
@@ -284,17 +296,35 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
 
     function test_scheduleTransaction_succeeds() public {
         (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
-            _getDummyTxWithSignaturesAndHash();
+            _getDummyTxWithSignaturesAndHash(safeInstance);
 
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(safe, txHash, INIT_TIME + TIMELOCK_DELAY);
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
     }
 
+    // A test which demonstrates that if the guard is enabled but not explicitly configured,
+    // the timelock delay is set to 0.
+    function test_scheduleTransaction_guardNotConfigured_succeeds() external {
+        // Enable the guard on the unguarded Safe, but don't configure it
+        _enableGuard(unguardedSafe);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(unguardedSafe.safe), 0);
+
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, ) =
+            _getDummyTxWithSignaturesAndHash(unguardedSafe);
+
+        bytes memory signatures = _getSignaturesForTx(unguardedSafe, txHash, THRESHOLD - 1);
+
+        uint256 nonce = unguardedSafe.safe.nonce();
+        vm.expectEmit(true, true, true, true);
+        emit TransactionScheduled(unguardedSafe.safe, txHash, INIT_TIME + 0);
+        timelockGuard.scheduleTransaction(unguardedSafe.safe, nonce, dummyTxParams, signatures);
+    }
+
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
         uint256 nonce = safeInstance.safe.nonce();
 
-        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) = _getDummyTxWithSignaturesAndHash(safeInstance);
         timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
@@ -305,11 +335,38 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         // TODO: Implement once cancelTransaction is implemented and tested
     }
 
-    function test_scheduleTransaction_guardNotEnabled_reverts() external { }
+    function test_scheduleTransaction_guardNotEnabled_reverts() external {
+        // Attempt to schedule a transaction with a Safe that has not enabled the guard
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotEnabled.selector);
+        timelockGuard.scheduleTransaction(unguardedSafe.safe, unguardedSafe.safe.nonce(), _getDummyTxParams(), "");
+    }
 
-    function test_scheduleTransaction_guardNotConfigured_reverts() external { }
+    function test_scheduleTransaction_canScheduleIdenticalWithSalt_succeeds() external {
+        // Schedule a transaction with a specific nonce
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash(safeInstance);
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
-    function test_scheduleTransaction_canScheduleIdenticalWithSalt_succeeds() external { }
+        // Schedule an identical transaction with a different nonce (salt)
+        uint256 newNonce = safeInstance.safe.nonce() + 1;
+        bytes32 newTxHash = safeInstance.safe.getTransactionHash({
+            to: dummyTxParams.to,
+            value: dummyTxParams.value,
+            data: dummyTxParams.data,
+            operation: dummyTxParams.operation,
+            safeTxGas: dummyTxParams.safeTxGas,
+            baseGas: dummyTxParams.baseGas,
+            gasPrice: dummyTxParams.gasPrice,
+            gasToken: dummyTxParams.gasToken,
+            refundReceiver: dummyTxParams.refundReceiver,
+            _nonce: newNonce
+        });
+        bytes memory newSignatures = _getSignaturesForTx(safeInstance, newTxHash, THRESHOLD);
+
+        vm.expectEmit(true, true, true, true);
+        emit TransactionScheduled(safe, newTxHash, INIT_TIME + TIMELOCK_DELAY);
+        timelockGuard.scheduleTransaction(safeInstance.safe, newNonce, dummyTxParams, newSignatures);
+    }
 }
 
 /// @title TimelockGuard_CancelTransaction_Test
@@ -324,7 +381,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
     function _scheduleTransaction() internal {
         (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
-            _getDummyTxWithSignaturesAndHash();
+            _getDummyTxWithSignaturesAndHash(safeInstance);
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
         // Confirm that the transaction is scheduled
@@ -338,9 +395,9 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     function test_cancelTransaction_withPrivKeySignature_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
         uint256 numSignatures = timelockGuard.cancellationThreshold(safeInstance.safe);
-        bytes memory cancelSignatures = _getSignaturesForTx(txHash, numSignatures);
+        bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, txHash, numSignatures);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, safeInstance.safe.nonce(), cancelSignatures);
 
         // Confirm that the transaction is cancelled
@@ -352,7 +409,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     function test_cancelTransaction_withApproveHash_succeeds() external {
         _scheduleTransaction();
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(safeInstance);
         address owner = safeInstance.safe.getOwners()[0];
 
         vm.prank(owner);
@@ -369,7 +426,7 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_cancelTransaction_revertsIfTransactionNotScheduled_reverts() external {
-        (ExecTransactionParams memory dummyTxParams,,) = _getDummyTxWithSignaturesAndHash();
+        (ExecTransactionParams memory dummyTxParams,,) = _getDummyTxWithSignaturesAndHash(safeInstance);
         uint256 nonce = safeInstance.safe.nonce();
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTxParams, nonce, new bytes(0));

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -83,7 +83,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 /// @title TimelockGuard_ViewTimelockGuardConfiguration_Test
 /// @notice Tests for viewTimelockGuardConfiguration function
 contract TimelockGuard_ViewTimelockGuardConfiguration_Test is TimelockGuard_TestInit {
-    function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe() external view {
+    function test_viewTimelockGuardConfiguration_returnsZeroForUnconfiguredSafe_succeeds() external view {
         uint256 delay = timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe));
         assertEq(delay, 0);
     }
@@ -102,7 +102,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         assertEq(storedDelay, TIMELOCK_DELAY);
     }
 
-    function test_configureTimelockGuard_revertsIfGuardNotEnabled() external {
+    function test_configureTimelockGuard_revertsIfGuardNotEnabled_reverts() external {
         // Create a safe without enabling the guard
         // Reduce the threshold just to prevent a CREATE2 collision when deploying this safe.
         SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
@@ -112,7 +112,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }
 
-    function test_configureTimelockGuard_revertsIfDelayTooLong() external {
+    function test_configureTimelockGuard_revertsIfDelayTooLong_reverts() external {
         uint256 tooLongDelay = ONE_YEAR + 1;
 
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
@@ -120,13 +120,13 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(tooLongDelay);
     }
 
-    function test_configureTimelockGuard_revertsIfDelayZero() external {
+    function test_configureTimelockGuard_revertsIfDelayZero_reverts() external {
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidTimelockDelay.selector);
         vm.prank(address(safeInstance.safe));
         timelockGuard.configureTimelockGuard(0);
     }
 
-    function test_configureTimelockGuard_acceptsMaxValidDelay() external {
+    function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit GuardConfigured(address(safeInstance.safe), ONE_YEAR);
 
@@ -136,7 +136,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         assertEq(storedDelay, ONE_YEAR);
     }
 
-    function test_configureTimelockGuard_allowsReconfiguration() external {
+    function test_configureTimelockGuard_allowsReconfiguration_succeeds() external {
         // Initial configuration
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
@@ -176,7 +176,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         // TODO: Check that any active challenge is cancelled
     }
 
-    function test_clearTimelockGuard_revertsIfGuardStillEnabled() external {
+    function test_clearTimelockGuard_revertsIfGuardStillEnabled_reverts() external {
         // First configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 
@@ -186,7 +186,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.clearTimelockGuard();
     }
 
-    function test_clearTimelockGuard_revertsIfNotConfigured() external {
+    function test_clearTimelockGuard_revertsIfNotConfigured_reverts() external {
         // Try to clear - should revert because not configured
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
         vm.prank(address(safeInstance.safe));
@@ -197,7 +197,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
 /// @title TimelockGuard_CancellationThreshold_Test
 /// @notice Tests for cancellationThreshold function
 contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
-    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled() external {
+    function test_cancellationThreshold_returnsZeroIfGuardNotEnabled_succeeds() external {
         // Safe without guard enabled should return 0
         SafeInstance memory unguardedSafe = _setupSafe(ownerPKs, THRESHOLD - 1);
 
@@ -205,13 +205,13 @@ contract TimelockGuard_CancellationThreshold_Test is TimelockGuard_TestInit {
         assertEq(threshold, 0);
     }
 
-    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured() external {
+    function test_cancellationThreshold_returnsZeroIfGuardNotConfigured_succeeds() external {
         // Safe with guard enabled but not configured should return 0
         uint256 threshold = timelockGuard.cancellationThreshold(address(safeInstance.safe));
         assertEq(threshold, 0);
     }
 
-    function test_cancellationThreshold_returnsOneAfterConfiguration() external {
+    function test_cancellationThreshold_returnsOneAfterConfiguration_succeeds() external {
         // Configure the guard
         _configureGuard(safeInstance, TIMELOCK_DELAY);
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -67,7 +67,15 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to generate the transaction hash for a given transaction params and nonce
-    function _getTxHash(SafeInstance memory _safeInstance, ExecTransactionParams memory _params, uint256 _nonce) internal view returns (bytes32) {
+    function _getTxHash(
+        SafeInstance memory _safeInstance,
+        ExecTransactionParams memory _params,
+        uint256 _nonce
+    )
+        internal
+        view
+        returns (bytes32)
+    {
         return _safeInstance.safe.getTransactionHash({
             to: _params.to,
             value: _params.value,
@@ -83,7 +91,15 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to generate signatures for an arbitrary transaction
-    function _getSignaturesForTx(SafeInstance memory _safeInstance, bytes32 _txHash, uint256 _numSignatures) internal pure returns (bytes memory) {
+    function _getSignaturesForTx(
+        SafeInstance memory _safeInstance,
+        bytes32 _txHash,
+        uint256 _numSignatures
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
         bytes memory signatures = new bytes(0);
         for (uint256 i; i < _numSignatures; ++i) {
             (uint8 v, bytes32 r, bytes32 s) = vm.sign(_safeInstance.ownerPKs[i], _txHash);
@@ -143,7 +159,11 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     /// @notice Helper to enable guard on a Safe
     function _enableGuard(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(
-            _safe, address(_safe.safe), 0, abi.encodeCall(GuardManager.setGuard, (address(timelockGuard))), Enum.Operation.Call
+            _safe,
+            address(_safe.safe),
+            0,
+            abi.encodeCall(GuardManager.setGuard, (address(timelockGuard))),
+            Enum.Operation.Call
         );
     }
 
@@ -310,8 +330,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         _enableGuard(unguardedSafe);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(unguardedSafe.safe), 0);
 
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, ) =
-            _getDummyTxWithSignaturesAndHash(unguardedSafe);
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash,) = _getDummyTxWithSignaturesAndHash(unguardedSafe);
 
         bytes memory signatures = _getSignaturesForTx(unguardedSafe, txHash, THRESHOLD - 1);
 
@@ -324,7 +343,8 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
         uint256 nonce = safeInstance.safe.nonce();
 
-        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) = _getDummyTxWithSignaturesAndHash(safeInstance);
+        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash(safeInstance);
         timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
@@ -343,7 +363,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
 
     function test_scheduleTransaction_canScheduleIdenticalWithSalt_succeeds() external {
         // Schedule a transaction with a specific nonce
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
+        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) =
             _getDummyTxWithSignaturesAndHash(safeInstance);
         timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -16,6 +16,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
     // Events
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
+    event GuardCleared(address indexed safe);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -60,6 +61,28 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
             address(timelockGuard),
             0,
             abi.encodeCall(TimelockGuard.configureTimelockGuard, (_delay)),
+            Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to disable guard on a Safe
+    function _disableGuard(SafeInstance memory _safe) internal {
+        SafeTestLib.execTransaction(
+            _safe,
+            address(_safe.safe),
+            0,
+            abi.encodeCall(GuardManager.setGuard, (address(0))),
+            Enum.Operation.Call
+        );
+    }
+
+    /// @notice Helper to clear the TimelockGuard configuration for a Safe
+    function _clearGuard(SafeInstance memory _safe) internal {
+        SafeTestLib.execTransaction(
+            _safe,
+            address(timelockGuard),
+            0,
+            abi.encodeCall(TimelockGuard.clearTimelockGuard, ()),
             Enum.Operation.Call
         );
     }
@@ -133,5 +156,45 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
 
         _configureGuard(safeInstance, newDelay);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), newDelay);
+    }
+}
+
+/// @title TimelockGuard_ClearTimelockGuard_Test
+/// @notice Tests for clearTimelockGuard function
+contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
+    function test_clearTimelockGuard_succeeds() external {
+        // First configure the guard
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), TIMELOCK_DELAY);
+
+        // Disable the guard first
+        _disableGuard(safeInstance);
+
+        // Clear should succeed and emit event
+        vm.expectEmit(true, true, true, true);
+        emit GuardCleared(address(safeInstance.safe));
+
+        _clearGuard(safeInstance);
+
+        // Configuration should be cleared
+        assertEq(timelockGuard.viewTimelockGuardConfiguration(address(safeInstance.safe)), 0);
+        // TODO: Check that any active challenge is cancelled
+    }
+
+    function test_clearTimelockGuard_revertsIfGuardStillEnabled() external {
+        // First configure the guard
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+
+        // Try to clear without disabling guard first - should revert
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardStillEnabled.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.clearTimelockGuard();
+    }
+
+    function test_clearTimelockGuard_revertsIfNotConfigured() external {
+        // Try to clear - should revert because not configured
+        vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.clearTimelockGuard();
     }
 }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -60,12 +60,11 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     }
 
     /// @notice Helper to create a dummy transaction with signatures and a tx hash
-    // TODO: separate into two functions: one for the params+hash, one for the signatures
-    function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes32) {
+    function _getDummyTx() internal view returns (ExecTransactionParams memory, bytes memory, bytes32) {
         // Get the nonce of the safe to sign
         uint256 nonce = safeInstance.safe.nonce();
 
-        // Declare the dummy transaction params with an empty signature
+        // Declare the dummy transaction params
         ExecTransactionParams memory dummyTxParams = ExecTransactionParams({
             to: address(0xabba),
             value: 0,
@@ -75,8 +74,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
             baseGas: 0,
             gasPrice: 0,
             gasToken: address(0),
-            refundReceiver: payable(address(0)),
-            signatures: new bytes(0)
+            refundReceiver: payable(address(0))
         });
 
         // Get the tx hash
@@ -97,14 +95,15 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         }
 
         // Sign the tx hash with the owners' private keys
+        bytes memory signatures = new bytes(0);
         for (uint256 i; i < THRESHOLD; ++i) {
             (uint8 v, bytes32 r, bytes32 s) = vm.sign(safeInstance.ownerPKs[i], txHash);
 
             // The signature format is a compact form of: {bytes32 r}{bytes32 s}{uint8 v}
-            dummyTxParams.signatures = bytes.concat(dummyTxParams.signatures, abi.encodePacked(r, s, v));
+            signatures = bytes.concat(signatures, abi.encodePacked(r, s, v));
         }
 
-        return (dummyTxParams, txHash);
+        return (dummyTxParams, signatures, txHash);
     }
 
     /// @notice Helper to configure the TimelockGuard for a Safe
@@ -273,19 +272,19 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     }
 
     function test_scheduleTransaction_succeeds() public {
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
+        (ExecTransactionParams memory dummyTxParams, bytes memory signatures, bytes32 txHash) = _getDummyTx();
 
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(safeInstance.safe, txHash, INIT_TIME + TIMELOCK_DELAY);
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
     }
 
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
-        (ExecTransactionParams memory dummyTxParams,) = _getDummyTx();
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+        (ExecTransactionParams memory dummyTxParams, bytes memory signatures,) = _getDummyTx();
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
     }
 
     function test_scheduleTransaction_identicalPreviouslyCancelled_reverts() external { }
@@ -305,8 +304,8 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
 
         // Configure the guard and schedule a transaction
         _configureGuard(safeInstance, TIMELOCK_DELAY);
-        (ExecTransactionParams memory dummyTxParams, bytes32 txHash) = _getDummyTx();
-        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams);
+        (ExecTransactionParams memory dummyTxParams, bytes memory signatures, bytes32 txHash) = _getDummyTx();
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
 
         // verify that the transaction is scheduled
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -24,6 +24,7 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
     event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
     event CancellationThresholdUpdated(Safe indexed safe, uint256 oldThreshold, uint256 newThreshold);
+    event TransactionExecuted(Safe indexed safe, uint256 indexed nonce, bytes32 txHash);
 
     uint256 constant INIT_TIME = 10;
     uint256 constant TIMELOCK_DELAY = 7 days;
@@ -132,11 +133,22 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
         view
         returns (ExecTransactionParams memory, bytes32, bytes memory)
     {
-        uint256 nonce = _safe.safe.nonce();
         ExecTransactionParams memory dummyTxParams = _getDummyTxParams();
-        bytes32 txHash = _getTxHash(_safe, dummyTxParams, nonce);
-        bytes memory signatures = _getSignaturesForTx(_safe, txHash, THRESHOLD);
+        (bytes32 txHash, bytes memory signatures) = _getTxWithSignaturesAndHash(_safe, dummyTxParams);
+
         return (dummyTxParams, txHash, signatures);
+    }
+
+    /// @notice Helper to generate everything needed to schedule a transaction for the current nonce
+    function _getTxWithSignaturesAndHash(SafeInstance memory _safe, ExecTransactionParams memory _params)
+        internal
+        view
+        returns (bytes32, bytes memory)
+    {
+        uint256 nonce = _safe.safe.nonce();
+        bytes32 txHash = _getTxHash(_safe, _params, nonce);
+        bytes memory signatures = _getSignaturesForTx(_safe, txHash, THRESHOLD);
+        return (txHash, signatures);
     }
 
     function _getCancellationTx(address _safe, bytes32 _txHash) internal pure returns (ExecTransactionParams memory) {
@@ -160,6 +172,21 @@ contract TimelockGuard_TestInit is Test, SafeTestTools {
 
     /// @notice Helper to disable guard on a Safe
     function _disableGuard(SafeInstance memory _safe) internal {
+        // Schedule the disable guard transaction
+        ExecTransactionParams memory disableGuardTxParams = ExecTransactionParams({
+            to: address(_safe.safe),
+            value: 0,
+            data: abi.encodeCall(GuardManager.setGuard, (address(0))),
+            operation: Enum.Operation.Call,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: payable(address(0))
+        });
+        (, bytes memory signatures) = _getTxWithSignaturesAndHash(_safe, disableGuardTxParams);
+        timelockGuard.scheduleTransaction(_safe.safe, _safe.safe.nonce(), disableGuardTxParams, signatures);
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
         SafeTestLib.execTransaction(
             _safe, address(_safe.safe), 0, abi.encodeCall(GuardManager.setGuard, (address(0))), Enum.Operation.Call
         );
@@ -245,8 +272,24 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, TIMELOCK_DELAY);
 
+        uint256 newDelay = TIMELOCK_DELAY + 1;
+        // Schedule the reconfiguration transaction
+        ExecTransactionParams memory reconfigureGuardTxParams = ExecTransactionParams({
+            to: address(timelockGuard),
+            value: 0,
+            data: abi.encodeCall(TimelockGuard.configureTimelockGuard, (newDelay)),
+            operation: Enum.Operation.Call,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: payable(address(0))
+        });
+        (, bytes memory signatures) = _getTxWithSignaturesAndHash(safeInstance, reconfigureGuardTxParams);
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), reconfigureGuardTxParams, signatures);
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+
         // Reconfigure with different delay
-        uint256 newDelay = 14 days;
         vm.expectEmit(true, true, true, true);
         emit GuardConfigured(safe, newDelay);
 
@@ -263,7 +306,7 @@ contract TimelockGuard_ClearTimelockGuard_Test is TimelockGuard_TestInit {
         _configureGuard(safeInstance, TIMELOCK_DELAY);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(safe).timelockDelay, TIMELOCK_DELAY);
 
-        // Disable the guard first
+        // Disable the guard
         _disableGuard(safeInstance);
 
         // Clear should succeed and emit event
@@ -346,6 +389,9 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
     // A test which demonstrates that if the guard is enabled but not explicitly configured,
     // the timelock delay is set to 0.
     function test_scheduleTransaction_guardNotConfigured_succeeds() external {
+        // TODO: Determine what the actual behavior should be here, ie. if unconfigured,
+        // should scheduleTransaction revert, or should it schedule and allow immediate execution?
+        vm.skip(true);
         // Enable the guard on the unguarded Safe, but don't configure it
         _enableGuard(unguardedSafe);
         assertEq(timelockGuard.viewTimelockGuardConfiguration(unguardedSafe.safe).timelockDelay, 0);
@@ -355,6 +401,7 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         bytes memory signatures = _getSignaturesForTx(unguardedSafe, txHash, THRESHOLD - 1);
 
         uint256 nonce = unguardedSafe.safe.nonce();
+
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(unguardedSafe.safe, txHash, INIT_TIME + 0);
         timelockGuard.scheduleTransaction(unguardedSafe.safe, nonce, dummyTxParams, signatures);
@@ -512,5 +559,151 @@ contract TimelockGuard_CancelTransaction_Test is TimelockGuard_TestInit {
         // Attempt to cancel the transaction
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
         timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, new bytes(0));
+    }
+}
+
+/// @title TimelockGuard_CheckTransaction_Test
+/// @notice Tests for checkTransaction function
+contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
+    using stdStorage for StdStorage;
+    function setUp() public override {
+        super.setUp();
+        _configureGuard(safeInstance, TIMELOCK_DELAY);
+    }
+
+    /// @notice Test that scheduled transactions can execute after the delay period
+    function test_checkTransaction_scheduledTransactionAfterDelay_succeeds() external {
+        // Schedule a transaction
+        uint256 nonce = safeInstance.safe.nonce();
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash(safeInstance);
+        timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
+
+        // Fast forward past the timelock delay
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        // Increment the nonce, as would normally happen when the transaction is executed
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(nonce+1)));
+
+        // increment the cancellation threshold so that we can test that it is reset
+        uint256 slot = stdstore.target(address(timelockGuard)).sig("cancellationThreshold(address)").with_key(
+            address(safeInstance.safe)
+        ).find();
+        vm.store(address(timelockGuard), bytes32(slot), bytes32(uint256(timelockGuard.cancellationThreshold(safeInstance.safe)+1)));
+
+        vm.prank(address(safeInstance.safe));
+        vm.expectEmit(true, true, true, true);
+        emit TransactionExecuted(safeInstance.safe, nonce, txHash);
+        timelockGuard.checkTransaction(
+            dummyTxParams.to,
+            dummyTxParams.value,
+            dummyTxParams.data,
+            dummyTxParams.operation,
+            dummyTxParams.safeTxGas,
+            dummyTxParams.baseGas,
+            dummyTxParams.gasPrice,
+            dummyTxParams.gasToken,
+            dummyTxParams.refundReceiver,
+            "",
+            address(0)
+        );
+
+        // Confirm that the transaction is executed
+        TimelockGuard.ScheduledTransaction memory scheduledTransaction =
+            timelockGuard.getScheduledTransaction(safeInstance.safe, txHash);
+        assertEq(scheduledTransaction.executed, true);
+
+        // Confirm that the cancellation threshold is reset
+        assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 1);
+    }
+
+    /// @notice Test that checkTransaction reverts when scheduled transaction delay hasn't passed
+    function test_checkTransaction_scheduledTransactionNotReady_reverts() external {
+        (ExecTransactionParams memory dummyTxParams,, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash(safeInstance);
+
+        // Schedule the transaction but do not advance time past the timelock delay
+        timelockGuard.scheduleTransaction(safeInstance.safe, safeInstance.safe.nonce(), dummyTxParams, signatures);
+
+        // Increment the nonce, as would normally happen when the transaction is executed
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce()+1)));
+
+        vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotReady.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.checkTransaction(
+            dummyTxParams.to,
+            dummyTxParams.value,
+            dummyTxParams.data,
+            dummyTxParams.operation,
+            dummyTxParams.safeTxGas,
+            dummyTxParams.baseGas,
+            dummyTxParams.gasPrice,
+            dummyTxParams.gasToken,
+            dummyTxParams.refundReceiver,
+            "",
+            address(0)
+        );
+    }
+
+    /// @notice Test that checkTransaction reverts when scheduled transaction was cancelled
+    function test_checkTransaction_scheduledTransactionCancelled_reverts() external {
+        // Schedule a transaction
+        (ExecTransactionParams memory dummyTxParams, bytes32 txHash, bytes memory signatures) =
+            _getDummyTxWithSignaturesAndHash(safeInstance);
+        uint256 nonce = safeInstance.safe.nonce();
+        timelockGuard.scheduleTransaction(safeInstance.safe, nonce, dummyTxParams, signatures);
+
+        // new scope for the compiler error which must not be named
+        {
+            // Cancel the transaction
+            uint256 numSignatures = timelockGuard.cancellationThreshold(safeInstance.safe);
+            ExecTransactionParams memory cancellationTxParams = _getCancellationTx(address(safeInstance.safe), txHash);
+            bytes32 cancellationTxHash = _getTxHash(safeInstance, cancellationTxParams, nonce);
+            bytes memory cancelSignatures = _getSignaturesForTx(safeInstance, cancellationTxHash, numSignatures);
+            timelockGuard.cancelTransaction(safeInstance.safe, txHash, nonce, cancelSignatures);
+        }
+        // Fast forward past the timelock delay
+        vm.warp(block.timestamp + TIMELOCK_DELAY);
+        // Increment the nonce, as would normally happen when the transaction is executed
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce()+1)));
+
+        // Should revert because transaction was cancelled
+        vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyCancelled.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.checkTransaction(
+            dummyTxParams.to,
+            dummyTxParams.value,
+            dummyTxParams.data,
+            dummyTxParams.operation,
+            dummyTxParams.safeTxGas,
+            dummyTxParams.baseGas,
+            dummyTxParams.gasPrice,
+            dummyTxParams.gasToken,
+            dummyTxParams.refundReceiver,
+            "",
+            address(0)
+        );
+    }
+
+    /// @notice Test that checkTransaction reverts when a transaction has not been scheduled
+    function test_checkTransaction_transactionNotScheduled_reverts() external {
+        // Get transaction parameters but don't schedule the transaction
+        ExecTransactionParams memory dummyTxParams = _getDummyTxParams();
+
+        // Should revert because transaction was not scheduled
+        vm.expectRevert(TimelockGuard.TimelockGuard_TransactionNotScheduled.selector);
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.checkTransaction(
+            dummyTxParams.to,
+            dummyTxParams.value,
+            dummyTxParams.data,
+            dummyTxParams.operation,
+            dummyTxParams.safeTxGas,
+            dummyTxParams.baseGas,
+            dummyTxParams.gasPrice,
+            dummyTxParams.gasToken,
+            dummyTxParams.refundReceiver,
+            "",
+            address(0)
+        );
     }
 }


### PR DESCRIPTION
This is a draft PR intended primarily to get feedback on the proof of concept implementation of a getter that will return all pending transactions.

It uses OZ's Enumerable set, which a well battle tested dependency, including within [the LivenessGuard](https://github.com/ethereum-optimism/optimism/blob/aba269e4e535572c72b3b8a9ff3dac341131e259/packages/contracts-bedrock/src/safe/LivenessGuard.sol#L26).