### PR TITLE
fix(op-deployer): forge verbose install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2150,6 +2150,7 @@ workflows:
                 - op-proposer
                 - op-challenger
                 - op-dispute-mon
+                - op-deployer
                 - op-conductor
                 - da-server
                 - op-supervisor

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -42,8 +42,18 @@ RUN mise install -v -y just && cp $(mise which just) /usr/local/bin/just && just
 COPY ./op-deployer/pkg/deployer/forge/version.json /tmp/op-deployer-versions.json
 RUN set -e && \
     FORGE_VERSION=$(jq -r '.forge' /tmp/op-deployer-versions.json) && \
-    curl -fsSL https://github.com/foundry-rs/foundry/releases/download/${FORGE_VERSION}/foundry_${FORGE_VERSION}_alpine_${TARGETARCH}.tar.gz | \
-    tar -xzf - -C /usr/local/bin forge && \
+    mkdir -p /usr/local/bin && \
+    FORGE_URL="https://github.com/foundry-rs/foundry/releases/download/${FORGE_VERSION}/foundry_${FORGE_VERSION}_alpine_${TARGETARCH}.tar.gz" && \
+    echo "Downloading forge from: ${FORGE_URL}" && \
+    if ! curl -SL "${FORGE_URL}" -o /tmp/foundry.tar.gz; then \
+        echo "Failed to download forge from ${FORGE_URL}" >&2; \
+        exit 1; \
+    fi && \
+    ls -la /tmp/foundry.tar.gz && \
+    tar -tzf /tmp/foundry.tar.gz && \
+    tar -xzf /tmp/foundry.tar.gz -C /usr/local/bin forge && \
+    rm /tmp/foundry.tar.gz && \
+    chmod +x /usr/local/bin/forge && \
     forge --version
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR adds extra verbose output to the forge download step, so as to figure out if something went wrong when building in CI.
It also adds the op-deployer as a docker build target in CI PR jobs.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
