### PR TITLE
fix(op-deployer): remove forge version check

### DIFF
--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -53,8 +53,8 @@ RUN set -e && \
     tar -tzf /tmp/foundry.tar.gz && \
     tar -xzf /tmp/foundry.tar.gz -C /usr/local/bin forge && \
     rm /tmp/foundry.tar.gz && \
-    chmod +x /usr/local/bin/forge && \
-    forge --version
+    chmod +x /usr/local/bin/forge
+# Note: can't check the forge version because in CI we're building arm64 images using a non-emulated x86_64 host, therefore the version check would fail
 
 # We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
 COPY ./go.mod /app/go.mod


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Can't check the forge version because in CI we're building arm64 images using a non-emulated x86_64 host, therefore the version check would fail

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
