### PR TITLE
devex(op-up): proxy admin override and l1 static ip

### DIFF
--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -339,6 +339,22 @@ func WithDisputeGameFinalityDelaySeconds(seconds uint64) DeployerOption {
 	}
 }
 
+func WithL1ProxyAdminOwner(address common.Address) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithL1ProxyAdminOwner(address)
+		}
+	}
+}
+
+func WithL2ProxyAdminOwner(address common.Address) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithL2ProxyAdminOwner(address)
+		}
+	}
+}
+
 func (wb *worldBuilder) buildL1Genesis() {
 	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
 	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")

--- a/op-e2e/e2eutils/geth/geth.go
+++ b/op-e2e/e2eutils/geth/geth.go
@@ -47,7 +47,7 @@ func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c
 	nodeConfig := &node.Config{
 		Name:        "l1-geth",
 		HTTPHost:    "127.0.0.1",
-		HTTPPort:    0,
+		HTTPPort:    8544,
 		WSHost:      "127.0.0.1",
 		WSPort:      0,
 		WSModules:   []string{"debug", "admin", "eth", "txpool", "net", "rpc", "web3", "personal", "engine", "miner"},

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -115,6 +116,31 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 	p := newP(ctx, stderr)
 	defer p.Close()
 
+	// Get ProxyAdmin owner addresses
+	l1ProxyAdminOwner, l1ProxyAdminPrivKeyAny, err := getActor(10001)
+	if err != nil {
+		return fmt.Errorf("get L1 proxy admin owner: %w", err)
+	}
+	l2ProxyAdminOwner, l2ProxyAdminPrivKeyAny, err := getActor(10002)
+	if err != nil {
+		return fmt.Errorf("get L2 proxy admin owner: %w", err)
+	}
+	// Get funder address for logging
+	funderAddress, funderPrivKeyAny, err := getActor(10000)
+	if err != nil {
+		return fmt.Errorf("get funder actor: %w", err)
+	}
+
+	// Print all addresses and private keys
+	fmt.Fprintf(stderr, "Test Account Address: %s\n", funderAddress)
+	fmt.Fprintf(stderr, "Test Account Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(funderPrivKeyAny.(*ecdsa.PrivateKey))))
+	fmt.Fprintf(stderr, "L1 ProxyAdmin Owner Address: %s\n", l1ProxyAdminOwner)
+	fmt.Fprintf(stderr, "L1 ProxyAdmin Owner Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(l1ProxyAdminPrivKeyAny.(*ecdsa.PrivateKey))))
+	fmt.Fprintf(stderr, "L2 ProxyAdmin Owner Address: %s\n", l2ProxyAdminOwner)
+	fmt.Fprintf(stderr, "L2 ProxyAdmin Owner Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(l2ProxyAdminPrivKeyAny.(*ecdsa.PrivateKey))))
+	fmt.Fprintf(stderr, "L1 Node URL: %s\n", "http://localhost:8544")
+	fmt.Fprintf(stderr, "L2 Node URL: %s\n", "http://localhost:8545")
+
 	ids := sysgo.NewDefaultMinimalSystemIDs(sysgo.DefaultL1ID, sysgo.DefaultL2AID)
 	opts := stack.Combine(
 		sysgo.WithMnemonicKeys(devkeys.TestMnemonic),
@@ -124,6 +150,8 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 			sysgo.WithEmbeddedContractSources(),
 			sysgo.WithCommons(ids.L1.ChainID()),
 			sysgo.WithPrefundedL2(ids.L1.ChainID(), ids.L2.ChainID()),
+			sysgo.WithL1ProxyAdminOwner(l1ProxyAdminOwner),
+			sysgo.WithL2ProxyAdminOwner(l2ProxyAdminOwner),
 		),
 		sysgo.WithDeployerPipelineOption(sysgo.WithDeployerCacheDir(deployerCacheDir)),
 
@@ -168,26 +196,25 @@ func newP(ctx context.Context, stderr io.Writer) devtest.P {
 	return p
 }
 
-func runSysgo(ctx context.Context, stderr io.Writer, orch *sysgo.Orchestrator) error {
-	// Print available account.
+// getActor returns the address and private key for a given actor index
+func getActor(index uint32) (common.Address, any, error) {
 	hd, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	if err != nil {
-		return fmt.Errorf("new mnemonic dev keys: %w", err)
+		return common.Address{}, nil, fmt.Errorf("new mnemonic dev keys: %w", err)
 	}
-	const funderIndex = 10_000 // see sysgo/deployer.go.
-	funderUserKey := devkeys.UserKey(funderIndex)
-	funderAddress, err := hd.Address(funderUserKey)
+	userKey := devkeys.UserKey(index)
+	address, err := hd.Address(userKey)
 	if err != nil {
-		return fmt.Errorf("address: %w", err)
+		return common.Address{}, nil, fmt.Errorf("address: %w", err)
 	}
-	funderPrivKey, err := hd.Secret(funderUserKey)
+	privKey, err := hd.Secret(userKey)
 	if err != nil {
-		return fmt.Errorf("secret: %w", err)
+		return common.Address{}, nil, fmt.Errorf("secret: %w", err)
 	}
+	return address, privKey, nil
+}
 
-	fmt.Fprintf(stderr, "Test Account Address: %s\n", funderAddress)
-	fmt.Fprintf(stderr, "Test Account Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(funderPrivKey)))
-	fmt.Fprintf(stderr, "EL Node URL: %s\n", "http://localhost:8545")
+func runSysgo(ctx context.Context, stderr io.Writer, orch *sysgo.Orchestrator) error {
 
 	t := &testingT{
 		ctx:      ctx,

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -138,8 +138,8 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 	fmt.Fprintf(stderr, "L1 ProxyAdmin Owner Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(l1ProxyAdminPrivKeyAny.(*ecdsa.PrivateKey))))
 	fmt.Fprintf(stderr, "L2 ProxyAdmin Owner Address: %s\n", l2ProxyAdminOwner)
 	fmt.Fprintf(stderr, "L2 ProxyAdmin Owner Private Key: %s\n", "0x"+common.Bytes2Hex(crypto.FromECDSA(l2ProxyAdminPrivKeyAny.(*ecdsa.PrivateKey))))
-	fmt.Fprintf(stderr, "L1 Node URL: %s\n", "http://localhost:8544")
-	fmt.Fprintf(stderr, "L2 Node URL: %s\n", "http://localhost:8545")
+	fmt.Fprintf(stderr, "L1 Node URL: %s\n", "http://127.0.0.1:8544")
+	fmt.Fprintf(stderr, "L2 Node URL: %s\n", "http://127.0.0.1:8545")
 
 	ids := sysgo.NewDefaultMinimalSystemIDs(sysgo.DefaultL1ID, sysgo.DefaultL2AID)
 	opts := stack.Combine(

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -121,7 +121,7 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 	if err != nil {
 		return fmt.Errorf("get L1 proxy admin owner: %w", err)
 	}
-	l2ProxyAdminOwner, l2ProxyAdminPrivKeyAny, err := getActor(10002)
+	l2ProxyAdminOwner, l2ProxyAdminPrivKeyAny, err := getActor(10001)
 	if err != nil {
 		return fmt.Errorf("get L2 proxy admin owner: %w", err)
 	}


### PR DESCRIPTION
## Description

This PR enhances the developer experience for op-up by adding ProxyAdmin management capabilities and improving the development workflow with better logging and predictable network access.

### Key improvements:
  - Fixed L1 port: Set L1 geth to use port 8544 for predictable access (accessible via http://127.0.0.1:8544)
  - ProxyAdmin helper integration: Added WithL1ProxyAdminOwner and WithL2ProxyAdminOwner functions with deterministic key generation
  - Consolidated logging: All critical development information is now displayed on startup:
    - Test account address and private key
    - L1 ProxyAdmin owner address and private key
    - L2 ProxyAdmin owner address and private key
    - Ready-to-use URLs for both L1 and L2 nodes
  - Clean architecture: Refactored with getActor helper to centralize key generation logic

 ### Tests

  - Manual testing verified:
    - Successful compilation and execution of op-up
    - L1 network accessible on http://127.0.0.1:8544
    - L2 network accessible on http://127.0.0.1:8545
    - All generated private keys work correctly for transactions
    - ProxyAdmin owners have proper funding and functionality