### PR TITLE
fix: increase system owner funding to resolve insufficient funds error in operator fee tests

### DIFF
--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -29,7 +29,8 @@ func TestOperatorFee(gt *testing.T) {
 
 	operatorFee.CheckCompatibility()
 	systemOwner := operatorFee.GetSystemOwner()
-	sys.FunderL1.FundAtLeast(systemOwner, fundAmount)
+	// Use 1 ETH for L1 system owner to ensure sufficient funds for gas costs
+	sys.FunderL1.FundAtLeast(systemOwner, eth.Ether(1))
 
 	// First, ensure L2 is synced with current L1 state before starting tests
 	t.Log("Ensuring L2 is synced with current L1 state...")

--- a/op-acceptance-tests/tests/jovian/min_base_fee_test.go
+++ b/op-acceptance-tests/tests/jovian/min_base_fee_test.go
@@ -129,7 +129,8 @@ func TestMinBaseFee(gt *testing.T) {
 	minBaseFee.checkCompatibility(t)
 
 	systemOwner := minBaseFee.getSystemConfigOwner(t)
-	sys.FunderL1.FundAtLeast(systemOwner, eth.OneTenthEther)
+	// Use 1 ETH for L1 system owner to ensure sufficient funds for gas costs
+	sys.FunderL1.FundAtLeast(systemOwner, eth.Ether(1))
 
 	testCases := []struct {
 		name       string


### PR DESCRIPTION
## Problem
TestOperatorFeeDevstack fails with "insufficient funds for gas * price + value" error in Eris environment.

## Root Cause
System owner funding of 0.1 ETH is insufficient for L1 transaction costs (~0.024 ETH + gas price fluctuations).

## Solution
Increase system owner funding from `eth.OneTenthEther` (0.1 ETH) to `eth.Ether(1)` (1 ETH) in:
- `op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go`
- `op-acceptance-tests/tests/jovian/min_base_fee_test.go`

Fixes #17387