### PR TITLE
op-contracts: Allow arbitrary gas limit in DeployOPChain 

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -530,7 +530,7 @@ contract DeployOPChain is Script {
         require(systemConfig.basefeeScalar() == _doi.basefeeScalar(), "SYSCON-20");
         require(systemConfig.blobbasefeeScalar() == _doi.blobBaseFeeScalar(), "SYSCON-30");
         require(systemConfig.batcherHash() == bytes32(uint256(uint160(_doi.batcher()))), "SYSCON-40");
-        require(systemConfig.gasLimit() == uint64(60_000_000), "SYSCON-50");
+        require(systemConfig.gasLimit() == _doi.gasLimit(), "SYSCON-50");
         require(systemConfig.unsafeBlockSigner() == _doi.unsafeBlockSigner(), "SYSCON-60");
         require(systemConfig.scalar() >> 248 == 1, "SYSCON-70");
 


### PR DESCRIPTION
Cherry-picks commit `989bdeaba8e469d674f4c6b6f72b06843b41d321` from develop to allow `op-contracts/v3.0.0` to deploy a configurable gasLimit in `DeployOPChain.s.sol` instead of being forced to use the hardcoded 60Mgas/block limit.