### PR TITLE
opcm: Add new v2 dispute game implementation fields

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -216,6 +216,8 @@ interface IOPContractsManager {
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
         address mipsImpl;
+        address faultDisputeGameV2Impl;
+        address permissionedDisputeGameV2Impl;
     }
 
     /// @notice The input required to identify a chain for upgrading.

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerStandardValidator.sol
@@ -20,6 +20,8 @@ interface IOPContractsManagerStandardValidator {
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
         address mipsImpl;
+        address faultDisputeGameV2Impl;
+        address permissionedDisputeGameV2Impl;
     }
 
     struct ValidationInput {

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -137,7 +137,10 @@ contract DeployImplementations is Script {
             disputeGameFactoryImpl: address(_output.disputeGameFactoryImpl),
             anchorStateRegistryImpl: address(_output.anchorStateRegistryImpl),
             delayedWETHImpl: address(_output.delayedWETHImpl),
-            mipsImpl: address(_output.mipsSingleton)
+            mipsImpl: address(_output.mipsSingleton),
+            // TODO(#17257): Deploy the v2 contracts
+            faultDisputeGameV2Impl: address(0),
+            permissionedDisputeGameV2Impl: address(0)
         });
 
         deployOPCMBPImplsContainer(_input, _output, _blueprints, implementations);

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -530,6 +530,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Implementations",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerContractsContainer.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerContractsContainer.json
@@ -144,6 +144,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Implementations",
@@ -339,6 +349,16 @@
           {
             "internalType": "address",
             "name": "mipsImpl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
             "type": "address"
           }
         ],

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerDeployer.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerDeployer.json
@@ -428,6 +428,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Implementations",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerGameTypeAdder.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerGameTypeAdder.json
@@ -321,6 +321,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Implementations",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInteropMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerInteropMigrator.json
@@ -223,6 +223,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Implementations",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerStandardValidator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerStandardValidator.json
@@ -62,6 +62,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.Implementations",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUpgrader.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUpgrader.json
@@ -223,6 +223,16 @@
             "internalType": "address",
             "name": "mipsImpl",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "faultDisputeGameV2Impl",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "permissionedDisputeGameV2Impl",
+            "type": "address"
           }
         ],
         "internalType": "struct OPContractsManager.Implementations",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,12 +20,12 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0xe94325cd292ec3131cae7525eb1487abfea94c16aa4f000d594c1fd5a5bbbadd",
-    "sourceCodeHash": "0x144818d225cea78696e7ccdc486d79958b04ef6cd82d08e968db594ac2a571a3"
+    "initCodeHash": "0xb395215421b39f33c7a2f856e93dfcc9761d8a2e7581e8acc1cc0794dea0bc45",
+    "sourceCodeHash": "0x0a7ec5ab84321626319707ba3bac4ecc79dd3c9726770b7ab9074d61e0e33c3f"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xcc5dacb9e1c2b9395aa5f9c300f03c18af1ff5a9efd6a7ce4d5135dfbe7b1e2b",
-    "sourceCodeHash": "0x0c63dc35ccf59cc583fbbfc0f2251ba95d026c11540f08806a48cb3934e73ae4"
+    "initCodeHash": "0xdc0b4f1367e790f74aa6f34779e467d097f45e853e8963e2ef07e4f5d8414e28",
+    "sourceCodeHash": "0x9a9ab546c8d28c99f48eeb9d73bc456a445b7b1f5865123cfc4aafafebdb741e"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x8faaaf0aa74a8f7a98674e94009a516dddae7bb1feb687f4a6d43641c23efe45",

--- a/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerContractsContainer.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OPContractsManagerContractsContainer.json
@@ -7,7 +7,7 @@
     "type": "struct OPContractsManager.Blueprints"
   },
   {
-    "bytes": "448",
+    "bytes": "512",
     "label": "implementation",
     "offset": 0,
     "slot": "13",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1766,6 +1766,8 @@ contract OPContractsManager is ISemver {
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
         address mipsImpl;
+        address faultDisputeGameV2Impl;
+        address permissionedDisputeGameV2Impl;
     }
 
     /// @notice The input required to identify a chain for upgrading, along with new prestate hashes
@@ -1798,9 +1800,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 3.4.0
+    /// @custom:semver 3.5.0
     function version() public pure virtual returns (string memory) {
-        return "3.4.0";
+        return "3.5.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -38,8 +38,8 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 1.17.0
-    string public constant version = "1.17.0";
+    /// @custom:semver 1.18.0
+    string public constant version = "1.18.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -108,6 +108,8 @@ contract OPContractsManagerStandardValidator is ISemver {
         address anchorStateRegistryImpl;
         address delayedWETHImpl;
         address mipsImpl;
+        address faultDisputeGameV2Impl;
+        address permissionedDisputeGameV2Impl;
     }
 
     /// @notice Struct containing the input parameters for the validation process.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add implementation fields for new v2 dispute game contracts to `OPContractsManager` and  `OPContractsManagerStandardValidator`.

**Metadata**

Part of #17267
