### PR TITLE
tests: Skip Interop Acceptance Tests

### DIFF
--- a/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
+++ b/op-acceptance-tests/tests/interop/contract/interop_contract_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestRegularMessage checks that messages can be sent and relayed via L2ToL2CrossDomainMessenger
 func TestRegularMessage(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()

--- a/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
@@ -119,6 +119,7 @@ func (ie *InvalidExecMsgSpammer) Spam(t devtest.T) error {
 // executing messages are also spammed. The number of invalid messages spammed per slot is
 // configurable via NAT_INVALID_MPS (default: 1_000).
 func TestRelayWithInvalidMessagesSteady(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t, l2A, l2B := setupLoadTest(gt)
 
 	// Emit a valid initiating message.

--- a/op-acceptance-tests/tests/interop/loadtest/max_execute_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/max_execute_test.go
@@ -95,6 +95,7 @@ func (e *ExecMsgSpammer) Spam(t devtest.T) error {
 // executing messages emitted by one spammer become initiating messages for the other spammer. The
 // test aims to maximize load on the supervisor (indexing and access list checks).
 func TestMaxExecutingMessagesBurst(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t, l2A, l2B := setupLoadTest(gt)
 
 	// Initiate messages on both chains.

--- a/op-acceptance-tests/tests/interop/loadtest/relay_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/relay_test.go
@@ -55,6 +55,7 @@ func (r *RelaySpammer) Spam(t devtest.T) error {
 // spammer sends one initating message on the source chain and one corresponding executing message
 // on the destination chain.
 func TestRelaySteady(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t, l2A, l2B := setupLoadTest(gt)
 	s := NewSteady(l2B.EL.Escape().EthClient(), l2B.Config.ElasticityMultiplier(), l2B.BlockTime, WithAIMDObserver(aimdObserver{}))
 	s.Run(t, NewRelaySpammer(l2A, l2B))
@@ -63,6 +64,7 @@ func TestRelaySteady(gt *testing.T) {
 // TestRelayBurst runs the Relay spammer on a Burst schedule. See TestRelaySteady for more details
 // on the Relay spammer.
 func TestRelayBurst(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t, l2A, l2B := setupLoadTest(gt)
 	burst := NewBurst(l2B.BlockTime, WithAIMDObserver(aimdObserver{}))
 	burst.Run(t, NewRelaySpammer(l2A, l2B))

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -19,6 +19,7 @@ import (
 // included in two L2 chains and that the cross-safe ref for both of them progresses as expected beyond
 // the block number where the messages were included
 func TestInteropHappyTx(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 

--- a/op-acceptance-tests/tests/interop/message/interop_mon_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_mon_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestInteropMon is testing that the op-interop-mon metrics are correctly collected
 func TestInteropMon(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -31,6 +31,7 @@ import (
 
 // TestInitExecMsg tests basic interop messaging
 func TestInitExecMsg(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	rng := rand.New(rand.NewSource(1234))
@@ -48,6 +49,7 @@ func TestInitExecMsg(gt *testing.T) {
 
 // TestInitExecMsgWithDSL tests basic interop messaging with contract DSL
 func TestInitExecMsgWithDSL(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	rng := rand.New(rand.NewSource(1234))
@@ -123,6 +125,7 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 // TestRandomDirectedGraph tests below scenario:
 // Construct random directed graph of messages.
 func TestRandomDirectedGraph(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 
 	sys := presets.NewSimpleInterop(t)
@@ -245,6 +248,7 @@ func TestRandomDirectedGraph(gt *testing.T) {
 // TestInitExecMultipleMsg tests below scenario:
 // Transaction initiates and executes multiple messages of self
 func TestInitExecMultipleMsg(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()
@@ -290,6 +294,7 @@ func TestInitExecMultipleMsg(gt *testing.T) {
 // TestExecSameMsgTwice tests below scenario:
 // Transaction that executes the same message twice.
 func TestExecSameMsgTwice(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()
@@ -334,6 +339,7 @@ func TestExecSameMsgTwice(gt *testing.T) {
 // TestExecDifferentTopicCount tests below scenario:
 // Execute message that links with initiating message with: 0, 1, 2, 3, or 4 topics in it
 func TestExecDifferentTopicCount(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()
@@ -384,6 +390,7 @@ func TestExecDifferentTopicCount(gt *testing.T) {
 // TestExecMsgOpaqueData tests below scenario:
 // Execute message that links with initiating message with: 0, 10KB of opaque event data in it
 func TestExecMsgOpaqueData(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()
@@ -434,6 +441,7 @@ func TestExecMsgOpaqueData(gt *testing.T) {
 // TestExecMsgDifferEventIndexInSingleTx tests below scenario:
 // Execute message that links with initiating message with: first, random or last event of a tx.
 func TestExecMsgDifferEventIndexInSingleTx(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()
@@ -552,6 +560,7 @@ func executeIndexedFault(
 // TestExecMessageInvalidAttributes tests below scenario:
 // Execute message, but with one or more invalid attributes inside identifiers
 func TestExecMessageInvalidAttributes(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := sys.T.Require()

--- a/op-acceptance-tests/tests/interop/message/supervisor_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/message/supervisor_smoke_test.go
@@ -9,6 +9,7 @@ import (
 
 // TestInteropSystemSupervisor tests that the supervisor can provide finalized L1 block information
 func TestInteropSystemSupervisor(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 

--- a/op-acceptance-tests/tests/interop/prep/prep_test.go
+++ b/op-acceptance-tests/tests/interop/prep/prep_test.go
@@ -13,6 +13,7 @@ import (
 // before interop is scheduled with an actual hardfork time.
 // And then confirms we can finalize the chains.
 func TestUnscheduledInterop(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	t.Logger().Info("Checking that chain A and B can sync, even though interop is not scheduled")

--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestChallengerPlaysGame(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 	dsl.CheckAll(t,
@@ -38,6 +39,7 @@ func TestChallengerPlaysGame(gt *testing.T) {
 }
 
 func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 	dsl.CheckAll(t,
@@ -61,6 +63,7 @@ func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 }
 
 func TestChallengerRespondsToMultipleInvalidClaimsEOA(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 	dsl.CheckAll(t,

--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestProposer(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSuperRootWithdrawal(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	sys.L1Network.WaitForOnline()

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestSuperRootWithdrawal(gt *testing.T) {
-	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	sys.L1Network.WaitForOnline()

--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestReorgInitExecMsg(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	ctx := t.Ctx()
 

--- a/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/invalid_exec_msgs_test.go
@@ -26,6 +26,7 @@ import (
 // TestReorgInvalidExecMsgs tests that the supervisor reorgs the chain when an invalid exec msg is included
 // Each subtest runs a test with  a different invalid message, by modifying the message in the txModifierFn
 func TestReorgInvalidExecMsgs(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	gt.Run("invalid log index", func(gt *testing.T) {
 		testReorgInvalidExecMsg(gt, func(msg *suptypes.Message) {
 			msg.Identifier.LogIndex = 1024

--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -19,7 +19,7 @@ import (
 type checksFunc func(t devtest.T, sys *presets.SimpleInterop)
 
 func TestL2ReorgAfterL1Reorg(gt *testing.T) {
-	gt.Skip("TODO(#16972): skipping due to flakiness and impending op-node/supervisor refactor")
+	gt.Skip("Skipping Interop Acceptance Test")
 
 	gt.Run("unsafe reorg", func(gt *testing.T) {
 		var crossSafeRef, localSafeRef, unsafeRef eth.BlockID

--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -15,6 +15,7 @@ import (
 
 // TestReorgUnsafeHead starts an interop chain with an op-test-sequencer, which takes control over sequencing the L2 chain and introduces a reorg on the unsafe head
 func TestReorgUnsafeHead(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	ctx := t.Ctx()
 

--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -17,6 +17,7 @@ import (
 // the chain reorgs because of it, and that the chain then recovers.
 // This test can take 3 minutes to run.
 func TestSequencingWindowExpiry(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 
 	sys := presets.NewSimpleInterop(t)

--- a/op-acceptance-tests/tests/interop/smoke/interop_smoke_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/interop_smoke_test.go
@@ -13,12 +13,14 @@ import (
 )
 
 func TestInteropSystemNoop(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	_ = presets.NewMinimal(t)
 	t.Log("noop")
 }
 
 func TestSmokeTest(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	require := t.Require()
@@ -54,6 +56,7 @@ func TestSmokeTest(gt *testing.T) {
 }
 
 func TestSmokeTestFailure(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	require := t.Require()

--- a/op-acceptance-tests/tests/interop/smoke/smoke_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/smoke_test.go
@@ -18,6 +18,7 @@ import (
 // TestWrapETH checks WETH interactions, testing both reading and writing on the chain.
 // This demonstrates the usage of DSL for contract bindings
 func TestWrapETH(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	require := t.Require()
 	sys := presets.NewMinimal(t)

--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -15,6 +15,7 @@ import (
 // TestL2CLAheadOfSupervisor tests the below scenario:
 // L2CL ahead of supervisor, aka supervisor needs to reset the L2CL, to reproduce old data. Currently supervisor has only indexing mode implemented, so the supervisor will ask the L2CL to reset back.
 func TestL2CLAheadOfSupervisor(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 
 	sys := presets.NewMultiSupervisorInterop(t)
@@ -133,7 +134,7 @@ func TestL2CLAheadOfSupervisor(gt *testing.T) {
 // TestUnsafeChainKnownToL2CL tests the below scenario:
 // supervisor cross-safe ahead of L2CL cross-safe, aka L2CL can "skip" forward to match safety of supervisor.
 func TestUnsafeChainKnownToL2CL(gt *testing.T) {
-	gt.Skip("TODO(#16972): skipping due to flakiness and impending op-node/supervisor refactor")
+	gt.Skip("Skipping Interop Acceptance Test")
 
 	t := devtest.SerialT(gt)
 
@@ -204,7 +205,7 @@ func TestUnsafeChainKnownToL2CL(gt *testing.T) {
 // TestUnsafeChainUnknownToL2CL tests the below scenario:
 // supervisor unsafe ahead of L2CL unsafe, aka L2CL processes new blocks first.
 func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
-	gt.Skip("TODO(#16972): skipping due to flakiness and impending op-node/supervisor refactor")
+	gt.Skip("Skipping Interop Acceptance Test")
 
 	t := devtest.SerialT(gt)
 
@@ -246,6 +247,7 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 // TestL2CLSyncP2P checks that unsafe head is propagated from sequencer to verifier.
 // Tests started/restarted L2CL advances unsafe head via P2P connection.
 func TestL2CLSyncP2P(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 
 	sys := presets.NewMultiSupervisorInterop(t)

--- a/op-acceptance-tests/tests/interop/sync/simple_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/simple_interop/interop_sync_test.go
@@ -14,6 +14,7 @@ import (
 // TestL2CLResync checks that unsafe head advances after restarting L2CL.
 // Resync is only possible when supervisor and L2CL reconnects.
 func TestL2CLResync(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	logger := sys.Log.With("Test", "TestL2CLResync")

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestPostInbox(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSingleChainInterop(t)
 	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestPostInbox(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
@@ -42,6 +43,7 @@ func TestPostInbox(gt *testing.T) {
 }
 
 func TestPostInteropUpgradeComprehensive(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := t.Require()

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -26,6 +26,7 @@ import (
 // This test is known to be flaky
 // See: https://github.com/ethereum-optimism/optimism/issues/17298
 func TestPreNoInbox(gt *testing.T) {
+	gt.Skip("Skipping Interop Acceptance Test")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 	require := t.Require()


### PR DESCRIPTION
# Summary
Following PPS Decision to Skip Interop Acceptance Tests for their flakiness and lack of currently provided value in the production system, this PR skips all tests in the `op-acceptance-tests/tests/interop` directory.

Below is an AI generated table of all tests being skipped in this way.

Compare to insights at: https://app.circleci.com/insights/github/ethereum-optimism/optimism/workflows/acceptance-tests/tests?branch=develop

# Skips
File | Test Function | Package | Description
-- | -- | -- | --
upgrade/post_test.go | TestPostInbox | upgrade | Tests CrossL2Inbox implementation after interop upgrade
upgrade/post_test.go | TestPostInteropUpgradeComprehensive | upgrade | Comprehensive post-interop upgrade tests
upgrade/pre_test.go | TestPreNoInbox | upgrade | Tests that CrossL2Inbox is not available before upgrade
sync/simple_interop/interop_sync_test.go | TestL2CLResync | sync | Tests L2CL resync after restart
sync/multisupervisor_interop/interop_sync_test.go | TestL2CLAheadOfSupervisor | sync | Tests L2CL ahead of supervisor scenario
sync/multisupervisor_interop/interop_sync_test.go | TestUnsafeChainKnownToL2CL | sync | Tests supervisor cross-safe ahead of L2CL
sync/multisupervisor_interop/interop_sync_test.go | TestUnsafeChainUnknownToL2CL | sync | Tests supervisor unsafe ahead of L2CL
sync/multisupervisor_interop/interop_sync_test.go | TestL2CLSyncP2P | sync | Tests L2CL P2P sync propagation
smoke/interop_smoke_test.go | TestInteropSystemNoop | smoke | No-op interop system test
smoke/interop_smoke_test.go | TestSmokeTest | smoke | Basic WETH smoke test
smoke/interop_smoke_test.go | TestSmokeTestFailure | smoke | WETH failure smoke test
proofs/challenger_test.go | TestChallengerPlaysGame | proofs | Tests challenger playing dispute game
proofs/challenger_test.go | TestChallengerRespondsToMultipleInvalidClaims | proofs | Tests challenger response to multiple invalid claims
proofs/challenger_test.go | TestChallengerRespondsToMultipleInvalidClaimsEOA | proofs | Tests challenger response to multiple invalid claims (EOA)
message/supervisor_smoke_test.go | TestInteropSystemSupervisor | msg | Tests supervisor finalized L1 block information
loadtest/invalid_msg_test.go | TestRelayWithInvalidMessagesSteady | loadtest | Tests relay with invalid messages under steady load
smoke/smoke_test.go | TestWrapETH | smoke | Tests WETH interactions and DSL usage
reorgs/l2_reorgs_after_l1_reorg_test.go | TestL2ReorgAfterL1Reorg | reorgs | Tests L2 reorg after L1 reorg
message/interop_msg_test.go | TestInitExecMsg | msg | Tests basic interop messaging
message/interop_msg_test.go | TestInitExecMsgWithDSL | msg | Tests basic interop messaging with DSL
message/interop_msg_test.go | TestRandomDirectedGraph | msg | Tests random directed graph of messages
message/interop_msg_test.go | TestInitExecMultipleMsg | msg | Tests multiple message initiation and execution
message/interop_msg_test.go | TestExecSameMsgTwice | msg | Tests executing same message twice
message/interop_msg_test.go | TestExecDifferentTopicCount | msg | Tests messages with different topic counts
message/interop_msg_test.go | TestExecMsgOpaqueData | msg | Tests messages with opaque data
message/interop_msg_test.go | TestExecMsgDifferEventIndexInSingleTx | msg | Tests different event indices in single transaction
message/interop_msg_test.go | TestExecMessageInvalidAttributes | msg | Tests executing messages with invalid attributes
contract/interop_contract_test.go | TestRegularMessage | contract | Tests L2ToL2CrossDomainMessenger messaging
message/interop_mon_test.go | TestInteropMon | msg | Tests op-interop-mon metrics collection
message/interop_happy_tx_test.go | TestInteropHappyTx | msg | Tests valid init/exec message flow and cross-safe progression
seqwindow/expiry_test.go | TestSequencingWindowExpiry | seqwindow | Tests sequencing window expiry and recovery
reorgs/unsafe_head_test.go | TestReorgUnsafeHead | reorgs | Tests unsafe head reorg with test sequencer
reorgs/invalid_exec_msgs_test.go | TestReorgInvalidExecMsgs | reorgs | Tests supervisor reorgs with invalid exec messages
reorgs/init_exec_msg_test.go | TestReorgInitExecMsg | reorgs | Tests init/exec message reorg scenarios
loadtest/relay_test.go | TestRelaySteady | loadtest | Tests relay spammer on steady schedule
loadtest/relay_test.go | TestRelayBurst | loadtest | Tests relay spammer on burst schedule
loadtest/max_execute_test.go | TestMaxExecutingMessagesBurst | loadtest | Tests maximum executing messages load
proofs/proposer_test.go | TestProposer | proofs | Tests proposer functionality
upgrade-singlechain/crossl2inbox_test.go | TestPostInbox | upgrade | Tests post-inbox upgrade for single chain
prep/prep_test.go | TestUnscheduledInterop | msg | Tests unscheduled interop system

# Exempted:
File | Test Function | Package | Description
-- | -- | -- | --
proofs/withdrawal/withdrawal_test.go | TestSuperRootWithdrawal | withdrawal | Tests withdrawal with super roots
