### PR TITLE
feat: add safety checks for lockbox in setFeature

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -45,7 +45,7 @@
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
     "initCodeHash": "0x6e1e3cf76f08916bf6a3aed2b68772bd5ade935db4f0f876e682dc7a586334fb",
-    "sourceCodeHash": "0xf6f24113fe2ec36880ef554a1656eb363f673a39b00e559fe4727ab752c753d9"
+    "sourceCodeHash": "0x006e3560f8b2e17133eb10a116916798ddc4345a7b006f8504dab69e810adb1c"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -44,8 +44,8 @@
     "sourceCodeHash": "0xbf344c4369b8cb00ec7a3108f72795747f3bc59ab5b37ac18cf21e72e2979dbf"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x61d7234395adb2c91bd6714b2c5616bb5d5e5ba74e36b1a95d9f3e959eb41e50",
-    "sourceCodeHash": "0x53300cd4e69d0f6068fc47b8dc1ffcb566cb957eba9409226ee51e1b96c0afe3"
+    "initCodeHash": "0x6e1e3cf76f08916bf6a3aed2b68772bd5ade935db4f0f876e682dc7a586334fb",
+    "sourceCodeHash": "0xf6f24113fe2ec36880ef554a1656eb363f673a39b00e559fe4727ab752c753d9"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x9b664e3d84ad510091337b4aacaa494b142512e2f6f7fbcdb6210ed62ca9b885",

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -161,9 +161,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
-    /// @custom:semver 3.9.0
+    /// @custom:semver 3.10.0
     function version() public pure virtual returns (string memory) {
-        return "3.9.0";
+        return "3.10.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -509,6 +509,27 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         // disabling the feature if already disabled. This helps to prevent accidental misuse.
         if (_enabled == isFeatureEnabled[_feature]) {
             revert SystemConfig_InvalidFeatureState();
+        }
+
+        // Handle feature-specific safety logic here.
+        if (_feature == Features.ETH_LOCKBOX) {
+            // Lockbox shouldn't be unset if the ethLockbox address is still configured in the
+            // OptimismPortal2 contract. Doing so would cause the system to start keeping ETH in
+            // the portal. This check means there's no way to stop using ETHLockbox at the moment
+            // after it's been configured (which is expected).
+            if (
+                isFeatureEnabled[_feature] && !_enabled
+                    && address(IOptimismPortal2(payable(optimismPortal())).ethLockbox()) != address(0)
+            ) {
+                revert SystemConfig_InvalidFeatureState();
+            }
+
+            // Lockbox can't be set or unset if the system is currently paused because it would
+            // change the pause identifier which would potentially cause the system to become
+            // unpaused unexpectedly.
+            if (paused()) {
+                revert SystemConfig_InvalidFeatureState();
+            }
         }
 
         // Set the feature.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -513,6 +513,11 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
 
         // Handle feature-specific safety logic here.
         if (_feature == Features.ETH_LOCKBOX) {
+            // It would probably better to check that the ETHLockbox contract is set inside the
+            // OptimismPortal2 contract before you're allowed to enable the feature here, but the
+            // portal checks that the feature is set before allowing you to set the lockbox, so
+            // these checks are good enough.
+
             // Lockbox shouldn't be unset if the ethLockbox address is still configured in the
             // OptimismPortal2 contract. Doing so would cause the system to start keeping ETH in
             // the portal. This check means there's no way to stop using ETHLockbox at the moment


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds additional safety checks for setting the `ETHLockbox` feature in the `setFeature` function in the `SystemConfig`. 