### PR TITLE
[DO NOT MERGE] op-node: EL Sync concurrency experiment

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
+++ b/op-acceptance-tests/tests/sync_tester/hardforks_ext/hardforks_ext.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
 	"testing"
 
@@ -148,7 +147,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 		// To temporarily mitigate and stabilize tests, restrict runtime
 		// parallelism to 1 (no true concurrency). This masks the race;
 		// remove once the underlying issue is fixed.
-		runtime.GOMAXPROCS(1)
+		// runtime.GOMAXPROCS(1)
 	} else {
 		opt = stack.Combine(opt,
 			presets.WithSyncTesterELInitialState(eth.FCUState{

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -3,7 +3,6 @@ package sync_tester_ext_el
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -232,7 +231,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 		// To temporarily mitigate and stabilize tests, restrict runtime
 		// parallelism to 1 (no true concurrency). This masks the race;
 		// remove once the underlying issue is fixed.
-		runtime.GOMAXPROCS(1)
+		// runtime.GOMAXPROCS(1)
 	} else {
 		opt = stack.Combine(opt,
 			presets.WithSyncTesterELInitialState(eth.FCUState{

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -357,6 +357,11 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 	}
 	var finalizedRef eth.L2BlockRef
 	if e.finalizedHead == (eth.L2BlockRef{}) {
+		for i := range 20 {
+			fmt.Printf("### %d initializeUnknowns finalizedRef %s\n", i, e.finalizedHead)
+			time.Sleep(time.Microsecond)
+		}
+
 		var err error
 		finalizedRef, err = e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
 		if err != nil {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"runtime/debug"
 	gosync "sync"
 	"time"
 
@@ -493,6 +495,10 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		e.SetLocalSafeHead(ref)
 		e.SetSafeHead(ref)
 		e.onSafeUpdate(ctx, ref, ref)
+
+		// This must be placed before e.SetFinalizedHead
+		fmt.Fprintln(io.Discard, string(debug.Stack()))
+
 		e.SetFinalizedHead(ref)
 	}
 	logFn := e.logSyncProgressMaybe()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

```sh
cd op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext_granite
```

```
TAILSCALE_NETWORKING=true GOMAXPROCS=1 go test ./... -run ^TestSyncTesterHFS_Granite_ELSync$   -count=1 -v 
```
verses
```
TAILSCALE_NETWORKING=true GOMAXPROCS=2 go test ./... -run ^TestSyncTesterHFS_Granite_ELSync$   -count=1 -v 
```

