### PR TITLE
txmgr: fetch BlobBaseFee over RPC instead of computing from block header

### DIFF
--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -42,6 +42,7 @@ type L1TxAPI interface {
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
+	BlobBaseFee(ctx context.Context) (*big.Int, error)
 }
 
 type AltDAInputSetter interface {
@@ -375,7 +376,8 @@ func (s *L2Batcher) ActL2BatchSubmitRaw(t Testing, payload []byte, txOpts ...fun
 		sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&b})
 		require.NoError(t, err)
 		require.NotNil(t, pendingHeader.ExcessBlobGas, "need L1 header with 4844 properties")
-		blobBaseFee := eth.CalcBlobFeeDefault(pendingHeader)
+		blobBaseFee, err := s.l1.BlobBaseFee(t.Ctx())
+		require.NoError(t, err, "need blob base fee")
 		blobFeeCap := new(uint256.Int).Mul(uint256.NewInt(2), uint256.MustFromBig(blobBaseFee))
 		if blobFeeCap.Lt(uint256.NewInt(params.GWei)) { // ensure we meet 1 gwei geth tx-pool minimum
 			blobFeeCap = uint256.NewInt(params.GWei)
@@ -458,8 +460,8 @@ func (s *L2Batcher) ActL2BatchSubmitMultiBlob(t Testing, numBlobs int) {
 
 	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs)
 	require.NoError(t, err)
-	require.NotNil(t, pendingHeader.ExcessBlobGas, "need L1 header with 4844 properties")
-	blobBaseFee := eth.CalcBlobFeeDefault(pendingHeader)
+	blobBaseFee, err := s.l1.BlobBaseFee(t.Ctx())
+	require.NoError(t, err, "need blob base fee")
 	blobFeeCap := new(uint256.Int).Mul(uint256.NewInt(2), uint256.MustFromBig(blobBaseFee))
 	if blobFeeCap.Lt(uint256.NewInt(params.GWei)) { // ensure we meet 1 gwei geth tx-pool minimum
 		blobFeeCap = uint256.NewInt(params.GWei)

--- a/op-service/txmgr/estimator.go
+++ b/op-service/txmgr/estimator.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"math/big"
-
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type GasPriceEstimatorFn func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error)
@@ -24,9 +22,9 @@ func DefaultGasPriceEstimatorFn(ctx context.Context, backend ETHBackend) (*big.I
 		return nil, nil, nil, errors.New("txmgr does not support pre-london blocks that do not have a base fee")
 	}
 
-	var blobFee *big.Int
-	if head.ExcessBlobGas != nil {
-		blobFee = eth.CalcBlobFeeDefault(head)
+	blobFee, err := backend.BlobBaseFee(ctx)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	return tip, head.BaseFee, blobFee, nil

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -56,6 +56,10 @@ func (b *mockBackendWithNonce) NonceAt(ctx context.Context, account common.Addre
 	return uint64(len(b.minedTxs)), nil
 }
 
+func (b *mockBackendWithNonce) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
 func TestQueue_Send(t *testing.T) {
 	testCases := []struct {
 		name   string      // name of the test
@@ -298,6 +302,10 @@ func (b *mockBackendWithConfirmationDelay) MineAll() {
 	for hash, tx := range b.cachedTxs {
 		b.mine(&hash, tx.GasFeeCap(), nil)
 	}
+}
+
+func (b *mockBackendWithConfirmationDelay) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(0), nil
 }
 
 // Simple test that we can call q.Send() up to the maxPending limit without blocking.

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -817,13 +817,12 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 
 	m.metr.RecordBaseFee(tip.BaseFee)
 
-	blobFee, err := m.backend.BlobBaseFee(ctx)
-	if err != nil {
+	if blobFee, err := m.backend.BlobBaseFee(ctx); err != nil {
 		m.metr.RPCError()
-		m.l.Error("Unable to fetch blob base fee", "err", err)
-		return nil
+		m.l.Warn("Unable to fetch blob base fee", "err", err)
+	} else {
+		m.metr.RecordBlobBaseFee(blobFee)
 	}
-	m.metr.RecordBlobBaseFee(blobFee)
 
 	m.l.Debug("Transaction mined, checking confirmations", "tx", txHash,
 		"block", eth.ReceiptBlockID(receipt), "tip", eth.HeaderBlockID(tip),

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -119,6 +119,7 @@ type ETHBackend interface {
 	// TODO: Maybe need a generic interface to support different RPC providers
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+	BlobBaseFee(ctx context.Context) (*big.Int, error)
 	// NonceAt returns the account nonce of the given account.
 	// The block number can be nil, in which case the nonce is taken from the latest known block.
 	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
@@ -815,10 +816,14 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 	}
 
 	m.metr.RecordBaseFee(tip.BaseFee)
-	if tip.ExcessBlobGas != nil {
-		blobFee := eth.CalcBlobFeeDefault(tip)
-		m.metr.RecordBlobBaseFee(blobFee)
+
+	blobFee, err := m.backend.BlobBaseFee(ctx)
+	if err != nil {
+		m.metr.RPCError()
+		m.l.Error("Unable to fetch blob base fee", "err", err)
+		return nil
 	}
+	m.metr.RecordBlobBaseFee(blobFee)
 
 	m.l.Debug("Transaction mined, checking confirmations", "tx", txHash,
 		"block", eth.ReceiptBlockID(receipt), "tip", eth.HeaderBlockID(tip),

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -1020,11 +1020,10 @@ func TestManagerErrsOnZeroConfs(t *testing.T) {
 // first call but a success on the second call. This allows us to test that the
 // inner loop of WaitMined properly handles this case.
 type failingBackend struct {
-	returnSuccessBlockNumber bool
-	returnSuccessHeader      bool
-	returnSuccessReceipt     bool
-	baseFee, gasTip          *big.Int
-	excessBlobGas            *uint64
+	returnSuccessBlockNumber     bool
+	returnSuccessHeader          bool
+	returnSuccessReceipt         bool
+	baseFee, gasTip, blobBaseFee *big.Int
 }
 
 // BlockNumber for the failingBackend returns errRpcFailure on the first
@@ -1061,9 +1060,8 @@ func (b *failingBackend) HeaderByNumber(ctx context.Context, _ *big.Int) (*types
 	}
 
 	return &types.Header{
-		Number:        big.NewInt(1),
-		BaseFee:       b.baseFee,
-		ExcessBlobGas: b.excessBlobGas,
+		Number:  big.NewInt(1),
+		BaseFee: b.baseFee,
 	}, nil
 }
 
@@ -1099,7 +1097,7 @@ func (b *failingBackend) Close() {
 }
 
 func (b *failingBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
-	return nil, errors.New("unimplemented")
+	return b.blobBaseFee, nil
 }
 
 // TestWaitMinedReturnsReceiptAfterFailure asserts that WaitMined is able to
@@ -1323,12 +1321,10 @@ func testIncreaseGasPriceLimit(t *testing.T, lt gasPriceLimitTest) {
 
 	borkedTip := int64(10)
 	borkedFee := int64(45)
-	// simulate 100 excess blobs which yields a 50 wei blob base fee
-	borkedExcessBlobGas := uint64(100 * params.BlobTxBlobGasPerBlob)
 	borkedBackend := failingBackend{
 		gasTip:              big.NewInt(borkedTip),
 		baseFee:             big.NewInt(borkedFee),
-		excessBlobGas:       &borkedExcessBlobGas,
+		blobBaseFee:         big.NewInt(50),
 		returnSuccessHeader: true,
 	}
 

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -346,6 +346,10 @@ func (b *mockBackend) TransactionReceipt(ctx context.Context, txHash common.Hash
 func (b *mockBackend) Close() {
 }
 
+func (b *mockBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
 type testSendVariantsFn func(ctx context.Context, h *testHarness, tx TxCandidate) (*types.Receipt, error)
 
 func testSendVariants(t *testing.T, testFn func(t *testing.T, send testSendVariantsFn)) {
@@ -1092,6 +1096,10 @@ func (b *failingBackend) ChainID(ctx context.Context) (*big.Int, error) {
 }
 
 func (b *failingBackend) Close() {
+}
+
+func (b *failingBackend) BlobBaseFee(ctx context.Context) (*big.Int, error) {
+	return nil, errors.New("unimplemented")
 }
 
 // TestWaitMinedReturnsReceiptAfterFailure asserts that WaitMined is able to

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -131,7 +131,7 @@ type gasPricer struct {
 	mineAtEpoch   int64
 	baseGasTipFee *big.Int
 	baseBaseFee   *big.Int
-	excessBlobGas uint64
+	blobBaseFee   *big.Int
 	err           error
 	mu            sync.Mutex
 }
@@ -146,9 +146,7 @@ func newGasPricer(mineAtEpoch int64) *gasPricer {
 		mineAtEpoch:   mineAtEpoch,
 		baseGasTipFee: big.NewInt(baseGasTipFee),
 		baseBaseFee:   big.NewInt(baseBaseFee),
-		// Simulate 100 excess blobs, which results in a blobBaseFee of 50 wei.  This default means
-		// blob txs will be subject to the geth minimum blobgas fee of 1 gwei.
-		excessBlobGas: 100 * (params.BlobTxBlobGasPerBlob),
+		blobBaseFee:   big.NewInt(50),
 	}
 }
 
@@ -158,9 +156,8 @@ func (g *gasPricer) expGasFeeCap() *big.Int {
 }
 
 func (g *gasPricer) expBlobFeeCap() *big.Int {
-	_, _, excessBlobGas := g.feesForEpoch(g.mineAtEpoch)
-	// Needs to be adjusted when Prague gas pricing is needed.
-	return eth.CalcBlobFeeCancun(excessBlobGas)
+	_, _, blobBaseFee := g.feesForEpoch(g.mineAtEpoch)
+	return blobBaseFee
 }
 
 func (g *gasPricer) shouldMine(gasFeeCap *big.Int) bool {
@@ -171,13 +168,14 @@ func (g *gasPricer) shouldMineBlobTx(gasFeeCap, blobFeeCap *big.Int) bool {
 	return g.shouldMine(gasFeeCap) && g.expBlobFeeCap().Cmp(blobFeeCap) <= 0
 }
 
-func (g *gasPricer) feesForEpoch(epoch int64) (*big.Int, *big.Int, uint64) {
+func (g *gasPricer) feesForEpoch(epoch int64) (*big.Int, *big.Int, *big.Int) {
 	e := big.NewInt(epoch)
 	epochBaseFee := new(big.Int).Mul(g.baseBaseFee, e)
 	epochGasTipCap := new(big.Int).Mul(g.baseGasTipFee, e)
 	epochGasFeeCap := calcGasFeeCap(epochBaseFee, epochGasTipCap)
-	epochExcessBlobGas := g.excessBlobGas * uint64(epoch)
-	return epochGasTipCap, epochGasFeeCap, epochExcessBlobGas
+	epochBlobBaseFee := new(big.Int).Mul(g.blobBaseFee, new(big.Int).Exp(big.NewInt(2), e, nil))
+
+	return epochGasTipCap, epochGasFeeCap, epochBlobBaseFee
 }
 
 func (g *gasPricer) baseFee() *big.Int {
@@ -186,20 +184,14 @@ func (g *gasPricer) baseFee() *big.Int {
 	return new(big.Int).Mul(g.baseBaseFee, big.NewInt(g.epoch))
 }
 
-func (g *gasPricer) excessblobgas() uint64 {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.excessBlobGas * uint64(g.epoch)
-}
-
-func (g *gasPricer) sample() (*big.Int, *big.Int, uint64) {
+func (g *gasPricer) sample() (*big.Int, *big.Int, *big.Int) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
 	g.epoch++
-	epochGasTipCap, epochGasFeeCap, epochExcessBlobGas := g.feesForEpoch(g.epoch)
+	epochGasTipCap, epochGasFeeCap, epochBlobBaseFee := g.feesForEpoch(g.epoch)
 
-	return epochGasTipCap, epochGasFeeCap, epochExcessBlobGas
+	return epochGasTipCap, epochGasFeeCap, epochBlobBaseFee
 }
 
 type minedTxInfo struct {
@@ -274,11 +266,9 @@ func (b *mockBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*typ
 	if number != nil {
 		num.Set(number)
 	}
-	bg := b.g.excessblobgas()
 	return &types.Header{
-		Number:        num,
-		BaseFee:       b.g.baseFee(),
-		ExcessBlobGas: &bg,
+		Number:  num,
+		BaseFee: b.g.baseFee(),
 	}, nil
 }
 
@@ -515,9 +505,7 @@ func TestTxMgrConfirmsBlobTxAtHigherGasPrice(t *testing.T) {
 
 	h := newTestHarness(t)
 
-	gasTipCap, gasFeeCap, excessBlobGas := h.gasPricer.sample()
-	// Needs to be adjusted when testing with Prague activated on L1.
-	blobFeeCap := eth.CalcBlobFeeCancun(excessBlobGas)
+	gasTipCap, gasFeeCap, blobFeeCap := h.gasPricer.sample()
 	t.Log("Blob fee cap:", blobFeeCap, "gasFeeCap:", gasFeeCap)
 
 	tx := types.NewTx(&types.BlobTx{


### PR DESCRIPTION
This simplifies the transaction manager, meaning it does not need to understand the chain config of L1 in order to estimate fees properly (which, from Fusaka, it will otherwise need to do because the formula for computing the blob base fee from the excess blob gas changes frequently with BPO forks).

The `eth_blobBaseFee` method is part of the offical Ethereum JSON-RPC API. 