### PR TITLE
op-acceptance-tests: Bump attempts for CL Sync testing

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -94,7 +94,7 @@ func TestSyncTesterExtEL(gt *testing.T) {
 	blocksToSync := uint64(20)
 	sys, target := setupSystem(gt, t, blocksToSync)
 
-	attempts := 50
+	attempts := 500
 	if L2CLSyncMode == sync.ELSync {
 		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
 		attempts = 5


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes CL Sync testing using external data by allowing more attempts