### PR TITLE
txmgr: lock mutex when updating cachedTx map

### DIFF
--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -285,6 +285,8 @@ func newMockBackendWithConfirmationDelay(g *gasPricer, wg *sync.WaitGroup) *mock
 	b.g = g
 
 	sendTx := func(ctx context.Context, tx *types.Transaction) error {
+		b.mu.Lock()
+		defer b.mu.Unlock()
 		_, exists := b.cachedTxs[tx.Hash()]
 		if !exists {
 			b.cachedTxs[tx.Hash()] = tx


### PR DESCRIPTION
Closes #17554 

I confirmed the issue using 

```
go test -timeout 300s -run ^TestQueue_Send_MaxPendingMetrics$ github.com/ethereum-optimism/optimism/op-service/txmgr -race -count=100 
```

. The above command passes on this PR. 

