### PR TITLE
perf: explictly set compiler runs to 0 to reduce profiles

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -131,6 +131,7 @@ timeout = 300
 
 [profile.lite]
 optimizer = false
+optimizer_runs = 0
 
 # IMPORTANT:
 # See the info in the "DEFAULT" profile to understand this section.


### PR DESCRIPTION
**Description**

Explicitly set optimizer runs to 0 in the lite profile.  This reduces the number of compiler profiles we run when building with the lite profile from 5 to 4 and reduces compile time

**Tests**

N/A

**Additional context**


**Metadata**

