### PR TITLE
clean(op-acceptance-tests): cgt; use w3

### DIFF
--- a/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_l1_portal_introspection_test.go
@@ -2,17 +2,15 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
 )
 
 // TestCGT_L1PortalIntrospection checks that the L1 OptimismPortal exposes
@@ -31,24 +29,14 @@ func TestCGT_L1PortalIntrospection(gt *testing.T) {
 	defer cancel()
 
 	// Portal exposes systemConfig() -> address
-	const portalABI = `[
-	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
-	]`
-	pa, err := abi.JSON(strings.NewReader(portalABI))
-	if err != nil {
-		t.Require().Fail("parse portal ABI: %v", err)
-	}
-
-	data, _ := pa.Pack("systemConfig")
+	fnSystemConfig := w3.MustNewFunc("systemConfig()", "address")
+	data, _ := fnSystemConfig.EncodeArgs()
 	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("portal.systemConfig() call failed: %v", err)
 	}
-	vals, err := pa.Unpack("systemConfig", out)
-	if err != nil {
-		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
-	}
-	sysCfg := vals[0].(common.Address)
+	var sysCfg common.Address
+	t.Require().NoError(fnSystemConfig.DecodeReturns(out, &sysCfg))
 	if sysCfg == (common.Address{}) {
 		t.Require().Fail("portal.systemConfig() returned zero address")
 	}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_reverts_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_reverts_test.go
@@ -2,7 +2,6 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +12,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/lmittmann/w3"
 )
 
 // TestCGT_MessengerRejectsValue ensures that sending native value to the
@@ -48,22 +47,10 @@ func TestCGT_L2StandardBridge_LegacyWithdrawReverts(gt *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Ctx(), 30*time.Second)
 	defer cancel()
 
-	bridgeABIJSON := `[
-		{"inputs":[
-			{"internalType":"address","name":"_l2Token","type":"address"},
-			{"internalType":"uint256","name":"_amount","type":"uint256"},
-			{"internalType":"uint32","name":"_minGasLimit","type":"uint32"},
-			{"internalType":"bytes","name":"_extraData","type":"bytes"}
-		],
-		"name":"withdraw","outputs":[],"stateMutability":"payable","type":"function"}
-	]`
-	bridgeABI, err := abi.JSON(strings.NewReader(bridgeABIJSON))
-	if err != nil {
-		t.Require().Fail("%v", err)
-	}
+	fnWithdraw := w3.MustNewFunc("withdraw(address,uint256,uint32,bytes)", "")
 	// Any address is fine; the ETH-specific legacy path should be disabled under CGT.
 	anyAddress := l2XDMAddr
-	data, err := bridgeABI.Pack("withdraw", anyAddress, big.NewInt(1), uint32(100_000), []byte{})
+	data, err := fnWithdraw.EncodeArgs(anyAddress, big.NewInt(1), uint32(100_000), []byte{})
 	if err != nil {
 		t.Require().Fail("%v", err)
 	}

--- a/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
+++ b/op-acceptance-tests/tests/custom_gas_token/cgt_systemconfig_test.go
@@ -2,17 +2,15 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
 )
 
 // TestCGT_SystemConfigFlagOnL1 checks that the L1 SystemConfig contract reports
@@ -25,47 +23,32 @@ func TestCGT_SystemConfigFlagOnL1(gt *testing.T) {
 	l1c := sys.L1EL.EthClient()
 	portal := sys.L2Chain.DepositContractAddr()
 
-	portalABI := `[
-	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
-	]`
-	igasToken := `[
-	  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}
-	]`
-
-	pa, err := abi.JSON(strings.NewReader(portalABI))
-	if err != nil {
-		t.Require().Fail("%v", err)
-	}
+	fnSystemConfig := w3.MustNewFunc("systemConfig()", "address")
+	fnIsCGT := w3.MustNewFunc("isCustomGasToken()", "bool")
 	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
 	defer cancel()
 
 	// Resolve SystemConfig via Portal.systemConfig()
-	data, _ := pa.Pack("systemConfig")
+	data, _ := fnSystemConfig.EncodeArgs()
 	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("portal.systemConfig() call failed: %v", err)
 	}
-	vals, err := pa.Unpack("systemConfig", out)
-	if err != nil {
-		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
-	}
-	sysCfg := vals[0].(common.Address)
+	var sysCfg common.Address
+	t.Require().NoError(fnSystemConfig.DecodeReturns(out, &sysCfg))
 	if (sysCfg == common.Address{}) {
 		t.Require().Fail("portal.systemConfig() returned zero address")
 	}
 
 	// Ask SystemConfig whether CGT is enabled.
-	ga, _ := abi.JSON(strings.NewReader(igasToken))
-	data, _ = ga.Pack("isCustomGasToken")
+	data, _ = fnIsCGT.EncodeArgs()
 	out, err = l1c.Call(ctx, ethereum.CallMsg{To: &sysCfg, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("SystemConfig.isCustomGasToken() call failed: %v", err)
 	}
-	vals, err = ga.Unpack("isCustomGasToken", out)
-	if err != nil {
-		t.Require().Fail("unpack isCustomGasToken failed: %v", err)
-	}
-	if !vals[0].(bool) {
+	var flag bool
+	t.Require().NoError(fnIsCGT.DecodeReturns(out, &flag))
+	if !flag {
 		t.Skip("SystemConfig.isCustomGasToken() = false on this devnet; skipping")
 	}
 }
@@ -86,47 +69,25 @@ func TestCGT_SystemConfigFeatureFlag(gt *testing.T) {
 	defer cancel()
 
 	// Resolve SystemConfig via Portal.systemConfig()
-	const portalABI = `[
-	  {"inputs":[],"name":"systemConfig","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}
-	]`
-	pa, err := abi.JSON(strings.NewReader(portalABI))
-	if err != nil {
-		t.Require().Fail("parse portal ABI: %v", err)
-	}
-	data, _ := pa.Pack("systemConfig")
+	fnSystemConfig := w3.MustNewFunc("systemConfig()", "address")
+	data, _ := fnSystemConfig.EncodeArgs()
 	out, err := l1c.Call(ctx, ethereum.CallMsg{To: &portal, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("portal.systemConfig() call failed: %v", err)
 	}
-	vals, err := pa.Unpack("systemConfig", out)
-	if err != nil {
-		t.Require().Fail("unpack portal.systemConfig() failed: %v", err)
-	}
-	sysCfg := vals[0].(common.Address) // keep as interface; ABI unpack returns []interface{}
+	var sysCfg common.Address
+	t.Require().NoError(fnSystemConfig.DecodeReturns(out, &sysCfg))
 
 	// Query the CGT flag on SystemConfig via IGasToken.isCustomGasToken().
-	const igasTokenABI = `[
-	  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}
-	]`
-	ga, err := abi.JSON(strings.NewReader(igasTokenABI))
-	if err != nil {
-		t.Require().Fail("parse IGasToken ABI: %v", err)
-	}
-
-	// Build the call
-	data, _ = ga.Pack("isCustomGasToken")
-	out, err = l1c.Call(ctx, ethereum.CallMsg{
-		To:   &sysCfg,
-		Data: data,
-	}, rpc.LatestBlockNumber)
+	fnIsCGT := w3.MustNewFunc("isCustomGasToken()", "bool")
+	data, _ = fnIsCGT.EncodeArgs()
+	out, err = l1c.Call(ctx, ethereum.CallMsg{To: &sysCfg, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Require().Fail("SystemConfig.isCustomGasToken() call failed: %v", err)
 	}
-	flag, err := ga.Unpack("isCustomGasToken", out)
-	if err != nil {
-		t.Require().Fail("unpack isCustomGasToken failed: %v", err)
-	}
-	if !flag[0].(bool) {
+	var flag bool
+	t.Require().NoError(fnIsCGT.DecodeReturns(out, &flag))
+	if !flag {
 		t.Skip("SystemConfig.isCustomGasToken() = false on this devnet; skipping")
 	}
 }

--- a/op-acceptance-tests/tests/custom_gas_token/helpers.go
+++ b/op-acceptance-tests/tests/custom_gas_token/helpers.go
@@ -3,16 +3,15 @@ package custom_gas_token
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
 )
 
 var (
@@ -24,49 +23,44 @@ var (
 	l2BridgeAddr = common.HexToAddress("0x4200000000000000000000000000000000000010")
 )
 
-const igasTokenABI = `[
-  {"inputs":[],"name":"isCustomGasToken","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},
-  {"inputs":[],"name":"gasPayingTokenName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},
-  {"inputs":[],"name":"gasPayingTokenSymbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}
-]`
+var (
+	fnIsCustomGasToken     = w3.MustNewFunc("isCustomGasToken()", "bool")
+	fnGasPayingTokenName   = w3.MustNewFunc("gasPayingTokenName()", "string")
+	fnGasPayingTokenSymbol = w3.MustNewFunc("gasPayingTokenSymbol()", "string")
+)
 
 // ensureCGTOrSkip probes L2 L1Block for CGT mode. If not enabled, the test is skipped.
 // Returns (name, symbol).
 func ensureCGTOrSkip(t devtest.T, sys *presets.Minimal) (string, string) {
 	l2 := sys.L2EL.Escape().L2EthClient()
 
-	abiGT, err := abi.JSON(strings.NewReader(igasTokenABI))
-	t.Require().NoError(err)
-
 	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
 	defer cancel()
 
 	// isCustomGasToken()
-	data, _ := abiGT.Pack("isCustomGasToken")
+	data, _ := fnIsCustomGasToken.EncodeArgs()
 	out, err := l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
 		t.Skipf("CGT not enabled (isCustomGasToken() call failed): %v", err)
 	}
-	vals, err := abiGT.Unpack("isCustomGasToken", out)
-	t.Require().NoError(err)
-	if !vals[0].(bool) {
+	var isCGT bool
+	t.Require().NoError(fnIsCustomGasToken.DecodeReturns(out, &isCGT))
+	if !isCGT {
 		t.Skip("CGT disabled on this devnet (native ETH mode detected)")
 	}
 
 	// Read metadata (name/symbol)
-	data, _ = abiGT.Pack("gasPayingTokenName")
+	data, _ = fnGasPayingTokenName.EncodeArgs()
 	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	t.Require().NoError(err)
-	vn, err := abiGT.Unpack("gasPayingTokenName", out)
-	t.Require().NoError(err)
-	name := vn[0].(string)
+	var name string
+	t.Require().NoError(fnGasPayingTokenName.DecodeReturns(out, &name))
 
-	data, _ = abiGT.Pack("gasPayingTokenSymbol")
+	data, _ = fnGasPayingTokenSymbol.EncodeArgs()
 	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	t.Require().NoError(err)
-	vs, err := abiGT.Unpack("gasPayingTokenSymbol", out)
-	t.Require().NoError(err)
-	symbol := vs[0].(string)
+	var symbol string
+	t.Require().NoError(fnGasPayingTokenSymbol.DecodeReturns(out, &symbol))
 
 	return name, symbol
 }


### PR DESCRIPTION
## Description
Use w3 instead of manual ABI encoding/decoding; tidies the code a bit.

## Tests
Tested locally and all the CGT tests still pass.
