### PR TITLE
[backports] op-deployer: support custom gasLimit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250523163004-744d7764c475
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924135138-9c0c4dcf8822
 	github.com/ethereum/go-ethereum v1.15.3
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924135138-9c0c4dcf8822
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924204602-df4e953b384b
 	github.com/ethereum/go-ethereum v1.15.3
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101503.0-rc.2 h1:CHIF+1pENaamq7jq8LZOTQ1FVJ+U2EzNM9iVAr9Lgi8=
 github.com/ethereum-optimism/op-geth v1.101503.0-rc.2/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924135138-9c0c4dcf8822 h1:PfgErRy/eB+205VgNzP7Fz+d96+BMVO+Qf6yXlTVbZ4=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924135138-9c0c4dcf8822/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924204602-df4e953b384b h1:Z74yoEcb/0iKCPj0Fyg5X522by0DsBLTF6ozoB3yTjM=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924204602-df4e953b384b/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -196,14 +194,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101503.0-rc.2 h1:CHIF+1pENaamq7jq8LZOTQ1FVJ+U2EzNM9iVAr9Lgi8=
 github.com/ethereum-optimism/op-geth v1.101503.0-rc.2/go.mod h1:QUo3fn+45vWqJWzJW+rIzRHUV7NmhhHLPdI87mAn1M8=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250228185245-d4bb112dc979 h1:P37l7EFCz5KxE20+yPa3LWiH2Cg+xx6lQ4mOKYCZFPs=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250228185245-d4bb112dc979/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250307201638-7c3999db14c6 h1:EBEaI3oygl1npFpvdHghcWbKnhj2alEe4KqM2jG2XS8=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250307201638-7c3999db14c6/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64 h1:teDhU4h4ryaE8rSBl+vJJiwKHjxdnnHPkKZ9iNr2R8k=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250314162817-2c60e5723c64/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250523163004-744d7764c475 h1:rBsdEuZIiBUySD/36TvzkeKbSyiIT1/uTXxMRWrNEVs=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250523163004-744d7764c475/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924135138-9c0c4dcf8822 h1:PfgErRy/eB+205VgNzP7Fz+d96+BMVO+Qf6yXlTVbZ4=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250924135138-9c0c4dcf8822/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 const defaultL1ChainID uint64 = 77799777
+const testCustomGasLimit = uint64(60_000_000)
 
 type deployerKey struct{}
 
@@ -243,7 +244,6 @@ func TestGlobalOverrides(t *testing.T) {
 	defer cancel()
 
 	opts, intent, st := setupGenesisChain(t, defaultL1ChainID)
-	expectedGasLimit := strings.ToLower("0x1C9C380")
 	expectedBaseFeeVaultRecipient := common.HexToAddress("0x0000000000000000000000000000000000000001")
 	expectedL1FeeVaultRecipient := common.HexToAddress("0x0000000000000000000000000000000000000002")
 	expectedSequencerFeeVaultRecipient := common.HexToAddress("0x0000000000000000000000000000000000000003")
@@ -255,7 +255,6 @@ func TestGlobalOverrides(t *testing.T) {
 	expectedUseFaultProofs := false
 	intent.GlobalDeployOverrides = map[string]interface{}{
 		"l2BlockTime":                         float64(3),
-		"l2GenesisBlockGasLimit":              expectedGasLimit,
 		"baseFeeVaultRecipient":               expectedBaseFeeVaultRecipient,
 		"l1FeeVaultRecipient":                 expectedL1FeeVaultRecipient,
 		"sequencerFeeVaultRecipient":          expectedSequencerFeeVaultRecipient,
@@ -272,7 +271,6 @@ func TestGlobalOverrides(t *testing.T) {
 	cfg, err := state.CombineDeployConfig(intent, intent.Chains[0], st, st.Chains[0])
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), cfg.L2InitializationConfig.L2CoreDeployConfig.L2BlockTime, "L2 block time should be 3 seconds")
-	require.Equal(t, expectedGasLimit, strings.ToLower(cfg.L2InitializationConfig.L2GenesisBlockDeployConfig.L2GenesisBlockGasLimit.String()), "L2 Genesis Block Gas Limit should be 30_000_000")
 	require.Equal(t, expectedBaseFeeVaultRecipient, cfg.L2InitializationConfig.L2VaultsDeployConfig.BaseFeeVaultRecipient, "Base Fee Vault Recipient should be the expected address")
 	require.Equal(t, expectedL1FeeVaultRecipient, cfg.L2InitializationConfig.L2VaultsDeployConfig.L1FeeVaultRecipient, "L1 Fee Vault Recipient should be the expected address")
 	require.Equal(t, expectedSequencerFeeVaultRecipient, cfg.L2InitializationConfig.L2VaultsDeployConfig.SequencerFeeVaultRecipient, "Sequencer Fee Vault Recipient should be the expected address")
@@ -687,6 +685,7 @@ func newChainIntent(t *testing.T, dk *devkeys.MnemonicDevKeys, l1ChainID *big.In
 		Eip1559DenominatorCanyon:   standard.Eip1559DenominatorCanyon,
 		Eip1559Denominator:         standard.Eip1559Denominator,
 		Eip1559Elasticity:          standard.Eip1559Elasticity,
+		GasLimit:                   testCustomGasLimit,
 		Roles: state.ChainRoles{
 			L1ProxyAdminOwner: addrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainID)),
 			L2ProxyAdminOwner: addrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainID)),
@@ -820,6 +819,13 @@ func validateOPChainDeployment(t *testing.T, cg codeGetter, st *state.State, int
 			_, ok := alloc[predeploys.GovernanceTokenAddr]
 			require.False(t, ok, "governance token should not be deployed by default")
 		}
+
+		genesis, rollup, err := inspect.GenesisAndRollup(st, chainState.ID)
+		require.NoError(t, err)
+		require.Equal(t, rollup.Genesis.SystemConfig.GasLimit, testCustomGasLimit, "rollup gasLimit")
+		require.Equal(t, genesis.GasLimit, testCustomGasLimit, "genesis gasLimit")
+
+		require.Equal(t, chainIntent.GasLimit, testCustomGasLimit, "chainIntent gasLimit")
 
 		require.Equal(t, int(chainIntent.Eip1559Denominator), 50, "EIP1559Denominator should be set")
 		require.Equal(t, int(chainIntent.Eip1559Elasticity), 6, "EIP1559Elasticity should be set")

--- a/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
+++ b/op-deployer/pkg/deployer/opcm/read_superchain_deployment.go
@@ -29,13 +29,30 @@ type ReadSuperchainDeploymentOutput struct {
 	RequiredProtocolVersion    [32]byte
 }
 
+type OpcmImplementationsOutput struct {
+	SuperchainConfigImpl             common.Address `abi:"superchainConfigImpl"`
+	ProtocolVersionsImpl             common.Address `abi:"protocolVersionsImpl"`
+	L1ERC721BridgeImpl               common.Address `abi:"l1ERC721BridgeImpl"`
+	OptimismPortalImpl               common.Address `abi:"optimismPortalImpl"`
+	SystemConfigImpl                 common.Address `abi:"systemConfigImpl"`
+	OptimismMintableERC20FactoryImpl common.Address `abi:"optimismMintableERC20FactoryImpl"`
+	L1CrossDomainMessengerImpl       common.Address `abi:"l1CrossDomainMessengerImpl"`
+	L1StandardBridgeImpl             common.Address `abi:"l1StandardBridgeImpl"`
+	DisputeGameFactoryImpl           common.Address `abi:"disputeGameFactoryImpl"`
+	AnchorStateRegistryImpl          common.Address `abi:"anchorStateRegistryImpl"`
+	DelayedWETHImpl                  common.Address `abi:"delayedWETHImpl"`
+	MipsImpl                         common.Address `abi:"mipsImpl"`
+}
+
 // Function signatures
 var (
 	// OPContractsManager functions
 	funcProtocolVersions     = w3.MustNewFunc("protocolVersions()", "address")
 	funcSuperchainConfig     = w3.MustNewFunc("superchainConfig()", "address")
 	funcSuperchainProxyAdmin = w3.MustNewFunc("superchainProxyAdmin()", "address")
-
+	funcImplementations      = w3.MustNewFunc("implementations()",
+		"(address superchainConfigImpl,address protocolVersionsImpl,address l1ERC721BridgeImpl,address optimismPortalImpl,address systemConfigImpl,address optimismMintableERC20FactoryImpl,address l1CrossDomainMessengerImpl,address l1StandardBridgeImpl,address disputeGameFactoryImpl,address anchorStateRegistryImpl,address delayedWETHImpl,address mipsImpl)",
+	)
 	// Proxy functions
 	funcImplementation = w3.MustNewFunc("implementation()", "address")
 
@@ -59,20 +76,23 @@ func ReadSuperchainDeployment(ctx context.Context, rpcClient *rpc.Client, input 
 	defer w3Client.Close()
 
 	output := &ReadSuperchainDeploymentOutput{}
+	opcmImplementations := OpcmImplementationsOutput{}
 
-	// Step 1: Get proxy addresses from OPCM
+	// Step 1: Get addresses from OPCM
 	if err := w3Client.Call(
 		eth.CallFunc(input.OPCMAddress, funcProtocolVersions).Returns(&output.ProtocolVersionsProxy),
 		eth.CallFunc(input.OPCMAddress, funcSuperchainConfig).Returns(&output.SuperchainConfigProxy),
 		eth.CallFunc(input.OPCMAddress, funcSuperchainProxyAdmin).Returns(&output.SuperchainProxyAdmin),
+		eth.CallFunc(input.OPCMAddress, funcImplementations).Returns(&opcmImplementations),
 	); err != nil {
-		return nil, fmt.Errorf("failed to get proxy addresses: %w", err)
+		return nil, fmt.Errorf("failed to get addresses from opcm: %w", err)
 	}
+
+	output.SuperchainConfigImpl = opcmImplementations.SuperchainConfigImpl
 
 	// Step 2: Get implementation addresses from proxies
 	if err := w3Client.Call(
 		eth.CallFunc(output.ProtocolVersionsProxy, funcImplementation).Returns(&output.ProtocolVersionsImpl),
-		eth.CallFunc(output.SuperchainConfigProxy, funcImplementation).Returns(&output.SuperchainConfigImpl),
 	); err != nil {
 		return nil, fmt.Errorf("failed to get implementation addresses: %w", err)
 	}

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -99,7 +99,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		L2ChainId:                    chainID.Big(),
 		Opcm:                         st.ImplementationsDeployment.OpcmAddress,
 		SaltMixer:                    st.Create2Salt.String(), // passing through salt generated at state initialization
-		GasLimit:                     standard.GasLimit,
+		GasLimit:                     thisIntent.GasLimit,
 		DisputeGameType:              proofParams.DisputeGameType,
 		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
 		DisputeMaxGameDepth:          proofParams.DisputeMaxGameDepth,

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -88,7 +88,7 @@ var taggedReleases = map[string]TaggedRelease{
 		ContentHash:   common.HexToHash("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb"),
 	},
 	ContractsV301Tag: {
-		ArtifactsHash: common.HexToHash("33de11d9c1b60633b7b7603ca15bbc38d4fbdf4b5c79ccad5946f70240b06640"),
+		ArtifactsHash: common.HexToHash("b133236edd3828f245073b09c430cb471d7a7f42e6aa26f9ae265b94cdc2ef27"),
 		ContentHash:   common.HexToHash("1d87c33a13461b82baa1924c1a973521e350c65d3e19212caf262077695a2a1b"),
 	},
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -40,13 +40,14 @@ const (
 	ContractsV170Beta1L2Tag = "op-contracts/v1.7.0-beta.1+l2-contracts"
 	ContractsV200Tag        = "op-contracts/v2.0.0"
 	ContractsV300Tag        = "op-contracts/v3.0.0"
+	ContractsV301Tag        = "op-contracts/v3.0.1"
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
 
-var DefaultL1ContractsTag = ContractsV300Tag
+var DefaultL1ContractsTag = ContractsV301Tag
 
-var DefaultL2ContractsTag = ContractsV300Tag
+var DefaultL2ContractsTag = ContractsV301Tag
 
 type TaggedRelease struct {
 	ArtifactsHash common.Hash
@@ -86,16 +87,20 @@ var taggedReleases = map[string]TaggedRelease{
 		ArtifactsHash: common.HexToHash("40661d078e6efe7106b95d6fc5c4fda8db144487d85a47abd246cb3afcb41ab2"),
 		ContentHash:   common.HexToHash("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb"),
 	},
+	ContractsV301Tag: {
+		ArtifactsHash: common.HexToHash("33de11d9c1b60633b7b7603ca15bbc38d4fbdf4b5c79ccad5946f70240b06640"),
+		ContentHash:   common.HexToHash("1d87c33a13461b82baa1924c1a973521e350c65d3e19212caf262077695a2a1b"),
+	},
 }
 
 var _ embed.FS
 
 func IsSupportedL1Version(tag string) bool {
-	return tag == ContractsV300Tag
+	return tag == ContractsV301Tag
 }
 
 func IsSupportedL2Version(tag string) bool {
-	return tag == ContractsV300Tag
+	return tag == ContractsV301Tag
 }
 
 func L1VersionsFor(chainID uint64) (validation.Versions, error) {

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -26,7 +26,7 @@ func TestDefaultHardforkScheduleForTag(t *testing.T) {
 	require.NotNil(t, sched.HoloceneTime(0))
 	require.Nil(t, sched.IsthmusTime(0))
 
-	sched = DefaultHardforkScheduleForTag(ContractsV300Tag)
+	sched = DefaultHardforkScheduleForTag(ContractsV301Tag)
 	require.NotNil(t, sched.HoloceneTime(0))
 	require.Nil(t, sched.IsthmusTime(0))
 }

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -43,6 +43,7 @@ type ChainIntent struct {
 	Eip1559DenominatorCanyon   uint64                    `json:"eip1559DenominatorCanyon" toml:"eip1559DenominatorCanyon"`
 	Eip1559Denominator         uint64                    `json:"eip1559Denominator" toml:"eip1559Denominator"`
 	Eip1559Elasticity          uint64                    `json:"eip1559Elasticity" toml:"eip1559Elasticity"`
+	GasLimit                   uint64                    `json:"gasLimit" toml:"gasLimit"`
 	Roles                      ChainRoles                `json:"roles" toml:"roles"`
 	DeployOverrides            map[string]any            `json:"deployOverrides" toml:"deployOverrides"`
 	DangerousAltDAConfig       genesis.AltDADeployConfig `json:"dangerousAltDAConfig,omitempty" toml:"dangerousAltDAConfig,omitempty"`
@@ -63,6 +64,7 @@ type ChainRoles struct {
 
 var ErrChainRoleZeroAddress = fmt.Errorf("ChainRole is set to zero address")
 var ErrFeeVaultZeroAddress = fmt.Errorf("chain has a fee vault set to zero address")
+var ErrGasLimitZeroValue = fmt.Errorf("chain has a gas limit set to zero value")
 var ErrNonStandardValue = fmt.Errorf("chain contains non-standard config value")
 var ErrEip1559ZeroValue = fmt.Errorf("eip1559 param is set to zero value")
 var ErrIncompatibleValue = fmt.Errorf("chain contains incompatible config value")
@@ -81,6 +83,11 @@ func (c *ChainIntent) Check() error {
 		c.Eip1559Elasticity == 0 {
 		return fmt.Errorf("%w: chainId=%s", ErrEip1559ZeroValue, c.ID)
 	}
+
+	if c.GasLimit == 0 {
+		return fmt.Errorf("%w: chainId=%s", ErrGasLimitZeroValue, c.ID)
+	}
+
 	if c.BaseFeeVaultRecipient == emptyAddress ||
 		c.L1FeeVaultRecipient == emptyAddress ||
 		c.SequencerFeeVaultRecipient == emptyAddress {

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -46,7 +46,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 				FundDevAccounts: intent.FundDevAccounts,
 			},
 			L2GenesisBlockDeployConfig: genesis.L2GenesisBlockDeployConfig{
-				L2GenesisBlockGasLimit:      60_000_000,
+				L2GenesisBlockGasLimit:      hexutil.Uint64(chainIntent.GasLimit),
 				L2GenesisBlockBaseFeePerGas: &l2GenesisBlockBaseFeePerGas,
 			},
 			L2VaultsDeployConfig: genesis.L2VaultsDeployConfig{

--- a/op-deployer/pkg/deployer/state/deploy_config_test.go
+++ b/op-deployer/pkg/deployer/state/deploy_config_test.go
@@ -22,6 +22,7 @@ func TestCombineDeployConfig(t *testing.T) {
 	chainIntent := ChainIntent{
 		Eip1559Denominator:         1,
 		Eip1559Elasticity:          2,
+		GasLimit:                   standard.GasLimit,
 		BaseFeeVaultRecipient:      common.HexToAddress("0x123"),
 		L1FeeVaultRecipient:        common.HexToAddress("0x456"),
 		SequencerFeeVaultRecipient: common.HexToAddress("0x789"),

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -155,6 +155,9 @@ func (c *Intent) validateStandardValues() error {
 			chain.Eip1559Elasticity != standard.Eip1559Elasticity {
 			return fmt.Errorf("%w: chainId=%s", ErrNonStandardValue, chain.ID)
 		}
+		if chain.GasLimit != standard.GasLimit {
+			return fmt.Errorf("%w: chainId=%s", ErrNonStandardValue, chain.ID)
+		}
 		if len(chain.AdditionalDisputeGames) > 0 {
 			return fmt.Errorf("%w: chainId=%s additionalDisputeGames must be nil", ErrNonStandardValue, chain.ID)
 		}
@@ -297,7 +300,8 @@ func NewIntentCustom(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error)
 
 	for _, l2ChainID := range l2ChainIds {
 		intent.Chains = append(intent.Chains, &ChainIntent{
-			ID: l2ChainID,
+			ID:       l2ChainID,
+			GasLimit: standard.GasLimit,
 		})
 	}
 	return intent, nil
@@ -336,6 +340,7 @@ func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, erro
 			Eip1559DenominatorCanyon: standard.Eip1559DenominatorCanyon,
 			Eip1559Denominator:       standard.Eip1559Denominator,
 			Eip1559Elasticity:        standard.Eip1559Elasticity,
+			GasLimit:                 standard.GasLimit,
 			Roles: ChainRoles{
 				Challenger:        challenger,
 				L1ProxyAdminOwner: l1ProxyAdminOwner,

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
@@ -422,6 +423,7 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 				Eip1559Denominator:         250,
 				Eip1559DenominatorCanyon:   250,
 				Eip1559Elasticity:          6,
+				GasLimit:                   standard.GasLimit,
 				Roles: state.ChainRoles{
 					// Use deployer as L1PAO to deploy additional dispute impls
 					L1ProxyAdminOwner: deployer,


### PR DESCRIPTION
Add support for op-contracts/v3.0.1, which contains a single fix to DeployOPChain.s.sol to allow configurable gasLimit.

Also makes changes to op-deployer itself to support custom gasLimit value in the chainIntent, which eventually gets propagated as an input value to the DeployOPChain.s.sol script.