### PR TITLE
feat(ai-contracts-test): add devin API integration

### DIFF
--- a/ops/ai-eng/.gitignore
+++ b/ops/ai-eng/.gitignore
@@ -4,6 +4,9 @@
 */output/
 output/
 
+# Log file
+contracts-test-maintenance/log.jsonl
+
 # Python cache
 __pycache__/
 *.pyc

--- a/ops/ai-eng/contracts-test-maintenance/components/devin-api/devin_client.py
+++ b/ops/ai-eng/contracts-test-maintenance/components/devin-api/devin_client.py
@@ -1,0 +1,170 @@
+import os
+import json
+import time
+import urllib.request
+import glob
+from datetime import datetime
+
+# Load .env file
+if os.path.exists(".env"):
+    with open(".env") as f:
+        for line in f:
+            if "=" in line and not line.strip().startswith("#"):
+                key, value = line.strip().split("=", 1)
+                os.environ[key] = value.strip("\"'").strip()
+
+
+def find_prompt_file():
+    """Find the latest generated prompt file from the prompt renderer output."""
+    output_dir = "../prompt-renderer/output"
+    prompt_files = glob.glob(f"{output_dir}/*_prompt.md")
+
+    if not prompt_files:
+        raise FileNotFoundError(f"No prompt files found in {output_dir}")
+
+    if len(prompt_files) > 1:
+        raise ValueError(f"Multiple prompt files found in {output_dir}: {prompt_files}")
+
+    return prompt_files[0]
+
+
+def load_prompt_from_file(file_path):
+    """Load and return the contents of a prompt file."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def log_session(session_id, status, session_data):
+    """Log PR link and final status to JSONL file."""
+    # Extract run_id and selected files from existing data
+    try:
+        prompt_file = find_prompt_file()
+        run_id = os.path.basename(prompt_file).replace("_prompt.md", "")
+        run_time = datetime.strptime(run_id, "%Y%m%d_%H%M%S").strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+        ranking_file = f"../tests_ranker/output/{run_id}_ranking.json"
+        with open(ranking_file, "r") as f:
+            data = json.load(f)
+        selected_files = {
+            "test_path": data["entries"][0]["test_path"],
+            "contract_path": data["entries"][0]["contract_path"],
+        }
+    except Exception as e:
+        print(f"Error retrieving run data: {e}")
+        run_id = None
+        run_time = None
+        selected_files = {}
+
+    log_entry = {
+        "run_id": run_id,
+        "run_time": run_time,
+        "devin_session_id": session_id,
+        "selected_files": selected_files,
+        "status": status,
+    }
+
+    # Only add PR link if status is finished
+    if status == "finished" and session_data:
+        pr_url = session_data.get("pull_request", {}).get("url")
+        if pr_url:
+            log_entry["pull_request_url"] = pr_url
+
+    with open("../../log.jsonl", "a") as f:
+        f.write(json.dumps(log_entry) + "\n")
+
+
+def _make_request(url, headers, data=None, method="GET"):
+    """Make HTTP request to Devin API and return JSON response."""
+    try:
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except Exception as e:
+        print(f"Request failed: {method} {url}")
+        print(f"Error: {e}")
+        raise
+
+
+def _validate_environment():
+    """Validate required environment variables."""
+    api_key = os.getenv("DEVIN_API_KEY")
+    base_url = os.getenv("DEVIN_API_BASE_URL")
+
+    if not api_key:
+        raise ValueError("DEVIN_API_KEY environment variable not set")
+    if not base_url:
+        raise ValueError("DEVIN_API_BASE_URL environment variable not set")
+
+    return api_key, base_url
+
+
+def _create_headers(api_key, content_type=None):
+    """Create HTTP headers with authorization and optional content type."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+def create_session(prompt):
+    """Create a new Devin session with the given prompt."""
+    api_key, base_url = _validate_environment()
+
+    print(f"Creating session at: {base_url}/sessions")
+    headers = _create_headers(api_key, "application/json")
+    data = json.dumps({"prompt": prompt}).encode("utf-8")
+
+    response_data = _make_request(f"{base_url}/sessions", headers, data, "POST")
+    session_id = response_data["session_id"]
+
+    print(f"Created session: {session_id}")
+    return session_id
+
+
+def monitor_session(session_id):
+    """Monitor session status until completion."""
+    api_key, base_url = _validate_environment()
+    headers = _create_headers(api_key)
+    last_status = None
+
+    while True:
+        try:
+            status = _make_request(f"{base_url}/sessions/{session_id}", headers)
+            current_status = status.get("status_enum")
+
+            # Only print when status changes and is meaningful
+            if current_status and current_status != last_status:
+                print(f"Status: {current_status}")
+                last_status = current_status
+
+            # Stop monitoring for non-working statuses
+            if current_status in ["blocked", "expired", "finished"]:
+                print(f"Session finished with status: {current_status}")
+                log_session(session_id, current_status, status)
+                return
+
+            time.sleep(5)
+        except KeyboardInterrupt:
+            print(
+                f"\nSession {session_id} is still running. Check Devin web interface for progress."
+            )
+            return
+
+
+def send_prompt(prompt):
+    """Create a session and monitor it until completion."""
+    session_id = create_session(prompt)
+    monitor_session(session_id)
+
+
+if __name__ == "__main__":
+    try:
+        prompt_file = find_prompt_file()
+        prompt = load_prompt_from_file(prompt_file)
+        print(f"Using prompt from: {prompt_file}")
+        send_prompt(prompt)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}")
+        exit(1)

--- a/ops/ai-eng/contracts-test-maintenance/components/prompt-renderer/render.py
+++ b/ops/ai-eng/contracts-test-maintenance/components/prompt-renderer/render.py
@@ -9,18 +9,22 @@ from pathlib import Path
 
 
 def load_ranking_data():
-    """Load the ranking JSON file and return the first entry."""
-    ranking_file = (
-        Path(__file__).parent / "../tests_ranker" / "output" / "ranking.json"
-    )
+    """Load the ranking JSON file and return the first entry and run_id."""
+    ranking_dir = Path(__file__).parent / "../tests_ranker" / "output"
+
+    # Get the ranking file
+    ranking_file = next(ranking_dir.glob("*_ranking.json"))
+
+    # Extract run_id from filename
+    run_id = ranking_file.stem.replace("_ranking", "")
 
     with open(ranking_file, "r") as f:
         data = json.load(f)
 
     if not data.get("entries"):
-        raise ValueError("No entries found in ranking.json")
+        raise ValueError(f"No entries found in {ranking_file.name}")
 
-    return data["entries"][0]
+    return data["entries"][0], run_id
 
 
 def load_prompt_template():
@@ -38,18 +42,16 @@ def render_prompt(template, test_path, contract_path):
     )
 
 
-def save_prompt_instance(rendered_prompt, test_path, contract_path):
-    """Save the rendered prompt to the output folder with a descriptive name."""
+def save_prompt_instance(rendered_prompt, run_id):
+    """Save the rendered prompt to the output folder with run ID."""
     output_dir = Path(__file__).parent / "output"
     output_dir.mkdir(exist_ok=True)
 
-    # Extract test name and remove .t suffix if present
-    test_name = Path(test_path).stem
-    if test_name.endswith(".t"):
-        test_name = test_name[:-2]
+    # Remove old prompt files
+    for old_file in output_dir.glob("*_prompt.md"):
+        old_file.unlink()
 
-    # Create descriptive filename
-    filename = f"{test_name}_prompt.md"
+    filename = f"{run_id}_prompt.md"
     output_file = output_dir / filename
 
     with open(output_file, "w") as f:
@@ -61,12 +63,12 @@ def save_prompt_instance(rendered_prompt, test_path, contract_path):
 def main():
     """Main function to render and save the prompt instance."""
     try:
-        # Load the first entry from ranking
-        first_entry = load_ranking_data()
+        # Load ranking data and get run_id
+        first_entry, run_id = load_ranking_data()
         test_path = first_entry["test_path"]
         contract_path = first_entry["contract_path"]
 
-        print(f"Using first ranking entry:")
+        print(f"Using ranking from run {run_id}:")
         print(f"  Test path: {test_path}")
         print(f"  Contract path: {contract_path}")
 
@@ -77,7 +79,7 @@ def main():
         rendered_prompt = render_prompt(template, test_path, contract_path)
 
         # Save the rendered prompt
-        output_file = save_prompt_instance(rendered_prompt, test_path, contract_path)
+        output_file = save_prompt_instance(rendered_prompt, run_id)
 
         print(f"Prompt instance saved to: {output_file}")
 

--- a/ops/ai-eng/contracts-test-maintenance/components/prompt-renderer/render.py
+++ b/ops/ai-eng/contracts-test-maintenance/components/prompt-renderer/render.py
@@ -11,7 +11,7 @@ from pathlib import Path
 def load_ranking_data():
     """Load the ranking JSON file and return the first entry."""
     ranking_file = (
-        Path(__file__).parent.parent / "tests_ranker" / "output" / "ranking.json"
+        Path(__file__).parent / "../tests_ranker" / "output" / "ranking.json"
     )
 
     with open(ranking_file, "r") as f:
@@ -25,7 +25,7 @@ def load_ranking_data():
 
 def load_prompt_template():
     """Load the prompt template markdown file."""
-    prompt_file = Path(__file__).parent.parent / "prompt" / "prompt.md"
+    prompt_file = Path(__file__).parent.parent.parent / "prompt" / "prompt.md"
 
     with open(prompt_file, "r") as f:
         return f.read()

--- a/ops/ai-eng/contracts-test-maintenance/components/tests_ranker/test_ranker.py
+++ b/ops/ai-eng/contracts-test-maintenance/components/tests_ranker/test_ranker.py
@@ -249,19 +249,24 @@ def filter_excluded_files(
 
 
 def generate_ranking_json(
-    entries: list[dict[str, str | int | float | None]], output_dir: Path
+    entries: list[dict[str, str | int | float | None]], output_dir: Path, run_id: str
 ) -> Path:
     """Generate the ranking JSON file.
 
     Args:
         entries: List of test-to-contract mappings with scores.
         output_dir: Directory to write the output file.
+        run_id: Timestamp-based run identifier.
 
     Returns:
         Path to the generated JSON file.
     """
     # Ensure output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove old ranking files
+    for old_file in output_dir.glob("*_ranking.json"):
+        old_file.unlink()
 
     # Sort entries by score (descending), with None scores at the end
     sorted_entries = sorted(
@@ -270,12 +275,13 @@ def generate_ranking_json(
 
     # Create ranking JSON
     ranking = {
+        "run_id": run_id,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "entries": sorted_entries,
     }
 
-    # Write to output file
-    output_file = output_dir / "ranking.json"
+    # Write to output file with run_id
+    output_file = output_dir / f"{run_id}_ranking.json"
     with output_file.open("w") as f:
         json.dump(ranking, f, indent=2)
 
@@ -363,6 +369,10 @@ def collect_test_entries(
 def main() -> None:
     """Main function to generate test ranking JSON."""
     try:
+        # Generate unique run ID
+        run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        print(f"Starting ranking run: {run_id}")
+
         # Get base paths
         repo_root, contracts_bedrock, output_dir = get_base_paths()
 
@@ -374,10 +384,11 @@ def main() -> None:
             contracts_bedrock, excluded_dirs, excluded_files, repo_root
         )
 
-        # Generate ranking JSON
-        output_file = generate_ranking_json(entries, output_dir)
+        # Generate ranking JSON with run_id
+        output_file = generate_ranking_json(entries, output_dir, run_id)
 
         print(f"Generated {output_file} with {len(entries)} entries")
+        print(f"Run ID: {run_id}")
 
     except Exception as e:
         print(f"Error generating test ranking: {e}")

--- a/ops/ai-eng/contracts-test-maintenance/components/tests_ranker/test_ranker.py
+++ b/ops/ai-eng/contracts-test-maintenance/components/tests_ranker/test_ranker.py
@@ -106,7 +106,7 @@ def get_base_paths() -> tuple[Path, Path, Path]:
     Returns:
         Tuple of (repo_root, contracts_bedrock, output_dir) paths.
     """
-    repo_root = Path(__file__).parent.parent.parent.parent.parent
+    repo_root = Path(__file__).parent.parents[4]
     contracts_bedrock = repo_root / "packages" / "contracts-bedrock"
     output_dir = Path(__file__).parent / "output"
     return repo_root, contracts_bedrock, output_dir
@@ -161,7 +161,7 @@ def load_exclusions(contracts_bedrock: Path) -> tuple[list[Path], set[Path]]:
         FileNotFoundError: If exclusions.toml file is not found.
         tomllib.TOMLDecodeError: If TOML file is malformed.
     """
-    exclusions_file = Path(__file__).parent.parent / "exclusion.toml"
+    exclusions_file = Path(__file__).parent.parent.parent / "exclusion.toml"
 
     with exclusions_file.open("rb") as f:
         exclusions = tomllib.load(f)

--- a/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
+++ b/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
@@ -26,11 +26,12 @@ just render
 
 ### Test Ranking Output
 
-The `just rank` command generates `components/tests_ranker/output/ranking.json`:
+The `just rank` command generates `components/tests_ranker/output/{run_id}_ranking.json`:
 
 ```json
 {
-  "generated_at": "2025-09-19T16:49:56.517107+00:00",
+  "run_id": "20250922_143052",
+  "generated_at": "2025-09-22T14:30:52.517107+00:00",
   "entries": [
     {
       "test_path": "test/L1/ProtocolVersions.t.sol",
@@ -45,6 +46,9 @@ The `just rank` command generates `components/tests_ranker/output/ranking.json`:
 ```
 
 **Entry fields:**
+
+- `run_id` - Unique identifier for this ranking run (YYYYMMDD_HHMMSS format)
+- `generated_at` - ISO timestamp when the ranking was generated
 - `test_path` - Relative path to test file from contracts-bedrock
 - `contract_path` - Relative path to source contract from contracts-bedrock
 - `test_commit_ts` - Unix timestamp of test file's last commit
@@ -54,6 +58,6 @@ The `just rank` command generates `components/tests_ranker/output/ranking.json`:
 
 ### Prompt Renderer Output
 
-The `just render` command generates a markdown file in `components/prompt-renderer/output/` with the name format `{ContractName}_prompt.md`. This file contains the AI prompt template with the highest-priority test and contract paths filled in, ready to be used for test maintenance analysis.
+The `just render` command generates a markdown file in `components/prompt-renderer/output/` with the name format `{run_id}_prompt.md`. This file contains the AI prompt template with the highest-priority test and contract paths filled in, ready to be used for test maintenance analysis.
 
-For example, if the top-ranked test is `ProtocolVersions.t.sol`, the output file will be `ProtocolVersions_prompt.md`.
+For example, a run with ID `20250922_143052` will generate `20250922_143052_prompt.md`. The system automatically links prompts to their corresponding ranking runs through the shared run ID.

--- a/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
+++ b/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
@@ -10,16 +10,14 @@ The system uses a two-branch scoring algorithm: tests whose contracts have moved
 
 ```bash
 # From the ai-eng directory
+just ai-contracts-test
+```
 
-# Option 1: Run both steps in one command (recommended)
-just prompt
-
-# Option 2: Run steps individually
-# Step 1: Rank tests by staleness
-just rank
-
-# Step 2: Generate AI prompt for the highest-priority test
-just render
+Individual steps (for debugging):
+```bash
+just rank    # Rank tests by staleness
+just render  # Generate prompt for highest-priority test
+just devin   # Execute with Devin API
 ```
 
 ## Output
@@ -61,3 +59,42 @@ The `just rank` command generates `components/tests_ranker/output/{run_id}_ranki
 The `just render` command generates a markdown file in `components/prompt-renderer/output/` with the name format `{run_id}_prompt.md`. This file contains the AI prompt template with the highest-priority test and contract paths filled in, ready to be used for test maintenance analysis.
 
 For example, a run with ID `20250922_143052` will generate `20250922_143052_prompt.md`. The system automatically links prompts to their corresponding ranking runs through the shared run ID.
+
+### Devin API Client
+
+The Devin API client (`components/devin-api/devin_client.py`) automatically:
+
+1. **Finds the latest prompt** from the prompt renderer output
+2. **Creates a Devin session** with the generated prompt
+3. **Monitors the session** until completion ("blocked", "expired", or "finished")
+4. **Logs results** to `log.jsonl` in the project root
+
+#### Prerequisites
+
+Devin API credentials in `components/devin-api/.env`
+
+#### Session Logging
+
+All Devin sessions are automatically logged to `log.jsonl` with:
+
+```json
+{
+  "run_id": "20250924_160648",
+  "run_time": "2025-09-24 16:06:48",
+  "devin_session_id": "sess_abc123",
+  "selected_files": {
+    "test_path": "test/libraries/Storage.t.sol",
+    "contract_path": "src/libraries/Storage.sol"
+  },
+  "status": "finished",
+  "pull_request_url": "https://github.com/ethereum-optimism/optimism/pull/12345"
+}
+```
+
+**Log fields:**
+- `run_id` - Links to the ranking run that generated this session
+- `run_time` - Human-readable timestamp of the run
+- `devin_session_id` - Unique Devin session identifier
+- `selected_files` - The test-contract pair that was worked on
+- `status` - Final session status ("finished", "blocked", "expired")
+- `pull_request_url` - GitHub PR URL (only present if status is "finished")

--- a/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
+++ b/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
@@ -26,7 +26,7 @@ just render
 
 ### Test Ranking Output
 
-The `just rank` command generates `tests_ranker/output/ranking.json`:
+The `just rank` command generates `components/tests_ranker/output/ranking.json`:
 
 ```json
 {
@@ -54,6 +54,6 @@ The `just rank` command generates `tests_ranker/output/ranking.json`:
 
 ### Prompt Renderer Output
 
-The `just render` command generates a markdown file in `prompt-renderer/output/` with the name format `{ContractName}_prompt.md`. This file contains the AI prompt template with the highest-priority test and contract paths filled in, ready to be used for test maintenance analysis.
+The `just render` command generates a markdown file in `components/prompt-renderer/output/` with the name format `{ContractName}_prompt.md`. This file contains the AI prompt template with the highest-priority test and contract paths filled in, ready to be used for test maintenance analysis.
 
 For example, if the top-ranked test is `ProtocolVersions.t.sol`, the output file will be `ProtocolVersions_prompt.md`.

--- a/ops/ai-eng/justfile
+++ b/ops/ai-eng/justfile
@@ -14,3 +14,18 @@ render:
 prompt:
     just rank
     just render
+
+# Run the Devin client
+devin:
+    cd contracts-test-maintenance/components/devin-api && python3 devin_client.py
+
+# Run the complete cycle: rank, render, and send to Devin
+ai-contracts-test:
+    # Step 1: Rank tests
+    just rank
+
+    # Step 2: Render prompt
+    just render
+
+    # Step 3: Send to Devin
+    just devin

--- a/ops/ai-eng/justfile
+++ b/ops/ai-eng/justfile
@@ -4,11 +4,11 @@
 
 # Run the contract test ranking script
 rank:
-    cd contracts-test-maintenance/tests_ranker && python3 test_ranker.py
+    cd contracts-test-maintenance/components/tests_ranker && python3 test_ranker.py
 
 # Render prompt with the first ranked test and contract
 render:
-    cd contracts-test-maintenance/prompt-renderer && python3 render.py
+    cd contracts-test-maintenance/components/prompt-renderer && python3 render.py
 
 # Run ranking and render prompt in one command
 prompt:


### PR DESCRIPTION
This PR expands the AI Contract Test Maintenance System by adding **Devin API integration**, enabling fully automated test improvement workflows from ranking to PR creation.

## What's New

### Devin API Client
- Create and monitor Devin sessions with generated prompts
- Consumes prompt from renderer output
- Tracks sessions until completion ("finished", "blocked", "expired")
- Extracts GitHub PR URLs from successful runs

### Session Logging
- All sessions logged to `log.jsonl` with run IDs, timestamps, and outcomes
- Links ranking runs → prompts → Devin sessions → PRs

### Component Architecture
- Reorganized into `/components` structure for better modularity
- Added run ID system for linking pipeline stages
- Enhanced documentation with complete workflow instructions

## Result

The system now provides end-to-end automation:
**Tests Ranker** → **Prompt Generation** → **AI Improvement** → **PR Creation**