### PR TITLE
fix(challenger): reduce asterisc info logging frequency from 10M to 1…

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -49,7 +49,7 @@ const (
 	DefaultCannonSnapshotFreq   = uint(1_000_000_000)
 	DefaultCannonInfoFreq       = uint(10_000_000)
 	DefaultAsteriscSnapshotFreq = uint(1_000_000_000)
-	DefaultAsteriscInfoFreq     = uint(10_000_000)
+	DefaultAsteriscInfoFreq     = uint(1_000_000_000)
 	// DefaultGameWindow is the default maximum time duration in the past
 	// that the challenger will look for games to progress.
 	// The default value is 28 days. The worst case duration for a game is 16 days


### PR DESCRIPTION
While running long fault proof executions with asterisc trace type, I noticed the logs were getting quite verbose during extended runs. The current `DefaultAsteriscInfoFreq` is set to 10,000,000 steps, which generates processing logs like this:

```
level=INFO msg="processing" step=10000000 pc=00a1b2c0 insn=8c0a1bc0 ips=4532156.78 pages=1001 mem=10012KB name="main.execute"
level=INFO msg="processing" step=20000000 pc=01436580 insn=8c143580 ips=4621843.21 pages=2001 mem=20012KB name="main.execute"  
level=INFO msg="processing" step=30000000 pc=01e51840 insn=8c1e5840 ips=4698234.45 pages=3001 mem=30012KB name="main.execute"
level=INFO msg="processing" step=40000000 pc=0286cb00 insn=8c286b00 ips=4756891.32 pages=4001 mem=40012KB name="main.execute"
level=INFO msg="processing" step=50000000 pc=032883c0 insn=8c2873c0 ips=4802456.89 pages=5001 mem=50012KB name="main.execute"
```
this creates unnecessary log volume.

In high-performance scenarios, the original configuration could generate **5 logs per second** (300 logs per minute), which significantly impacts log readability and storage.