### PR TITLE
Signer: Add explicit HTTP client timeouts and avoid http.DefaultClient

### DIFF
--- a/op-service/signer/client.go
+++ b/op-service/signer/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -48,7 +49,9 @@ func NewSignerClient(logger log.Logger, endpoint string, headers http.Header, tl
 			return nil, err
 		}
 
+		// Configure HTTP client with sane timeouts to avoid indefinite hangs.
 		httpClient = &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					MinVersion: tls.VersionTLS13,
@@ -57,11 +60,28 @@ func NewSignerClient(logger log.Logger, endpoint string, headers http.Header, tl
 						return cm.GetCertificate(nil)
 					},
 				},
+				DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 20 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+				IdleConnTimeout:       90 * time.Second,
+				MaxIdleConns:          100,
 			},
 		}
 	} else {
 		logger.Info("no tlsConfig specified, using default http client")
-		httpClient = http.DefaultClient
+		// Avoid using http.DefaultClient to ensure explicit timeouts are always set.
+		httpClient = &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 20 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+				IdleConnTimeout:       90 * time.Second,
+				MaxIdleConns:          100,
+			},
+		}
 	}
 
 	rpcClient, err := rpc.DialOptions(context.Background(), endpoint, rpc.WithHTTPClient(httpClient), rpc.WithHeaders(headers))


### PR DESCRIPTION

- Summary: Ensure robust networking by setting explicit HTTP client and transport timeouts; stop using http.DefaultClient when TLS is disabled.
- Changes:
  - Add net import.
  - Configure http.Client Timeout (30s).
  - Configure http.Transport: Dial timeout (10s), TLS handshake (10s), response header (20s), expect-continue (1s), idle (90s), max idle conns (100).
  - Preserve TLS settings (TLS 1.3 min, RootCAs, dynamic client cert via certman).
- Motivation: Prevent indefinite hangs and resource leakage under network failures or slow peers.
- Impact: Safer, more predictable network behavior; no functional API change intended.
