### PR TITLE
op-acceptance-tests: Disable `TestSyncTesterELSync` tests for flakiness

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestSyncTesterELSync(gt *testing.T) {
+	// TODO(#17615) Root cause and re-enable tests
+	gt.Skip("Skip TestSyncTesterELSync")
+
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleWithSyncTester(t)
 	require := t.Require()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Temporally Disabling `TestSyncTesterELSync` for EL Sync test flakiness.

Re-enabling tracked at https://github.com/ethereum-optimism/optimism/issues/17615
