### PR TITLE
op-devstack: fix WaitForFinalization bug

### DIFF
--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -107,9 +107,12 @@ func (el *elNode) stackEL() stack.ELNode {
 	return el.inner
 }
 
+// WaitForFinalization waits for the current block height to be finalized. Note that it does not
+// ensure that the finalized block is the same as the current unsafe block (i.e., it is not
+// reorg-aware).
 func (el *elNode) WaitForFinalization() eth.BlockRef {
 	// Get current block and wait for it to be finalized
-	currentBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Finalized)
+	currentBlock, err := el.inner.EthClient().InfoByLabel(el.ctx, eth.Unsafe)
 	el.require.NoError(err, "Expected to get current block from execution client")
 
 	var finalizedBlock eth.BlockRef
@@ -119,7 +122,7 @@ func (el *elNode) WaitForFinalization() eth.BlockRef {
 		if err != nil {
 			return false
 		}
-		if block.NumberU64() > currentBlock.NumberU64() {
+		if block.NumberU64() >= currentBlock.NumberU64() {
 			finalizedBlock = eth.InfoToL1BlockRef(block)
 			return true
 		}


### PR DESCRIPTION
Previously, we waiting for the current finalized block to be finalized, while the expected behavior is to wait for the current unsafe block to be finalized. This is now documented as well.