### PR TITLE
txmgr: allow blobs to be sent with fusaka-compatible cell proofs (sidecar version 1) by configuration

### DIFF
--- a/op-chain-ops/cmd/check-ecotone/main.go
+++ b/op-chain-ops/cmd/check-ecotone/main.go
@@ -500,7 +500,8 @@ func checkBlobTxDenial(ctx context.Context, env *actionEnv) error {
 	for i := 0; i < 4096; i++ {
 		blob[32*i] &= 0b0011_1111
 	}
-	sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&blob})
+	// TODO add a test for cell proofs
+	sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&blob}, false)
 	if err != nil {
 		return fmt.Errorf("failed to make sidecar: %w", err)
 	}

--- a/op-chain-ops/cmd/check-ecotone/main.go
+++ b/op-chain-ops/cmd/check-ecotone/main.go
@@ -500,7 +500,6 @@ func checkBlobTxDenial(ctx context.Context, env *actionEnv) error {
 	for i := 0; i < 4096; i++ {
 		blob[32*i] &= 0b0011_1111
 	}
-	// TODO add a test for cell proofs
 	sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&blob}, false)
 	if err != nil {
 		return fmt.Errorf("failed to make sidecar: %w", err)

--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -372,7 +372,7 @@ func (s *L2Batcher) ActL2BatchSubmitRaw(t Testing, payload []byte, txOpts ...fun
 	} else if s.l2BatcherCfg.DataAvailabilityType == batcherFlags.BlobsType {
 		var b eth.Blob
 		require.NoError(t, b.FromData(payload), "must turn data into blob")
-		sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&b})
+		sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&b}, false) // TODO use cell proofs if configured to do so
 		require.NoError(t, err)
 		require.NotNil(t, pendingHeader.ExcessBlobGas, "need L1 header with 4844 properties")
 		blobBaseFee := eth.CalcBlobFeeDefault(pendingHeader)
@@ -456,7 +456,7 @@ func (s *L2Batcher) ActL2BatchSubmitMultiBlob(t Testing, numBlobs int) {
 	require.NoError(t, err, "need l1 pending header for gas price estimation")
 	gasFeeCap := new(big.Int).Add(gasTipCap, new(big.Int).Mul(pendingHeader.BaseFee, big.NewInt(2)))
 
-	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs)
+	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs, false) // TODO use cell proofs if configured to do so
 	require.NoError(t, err)
 	require.NotNil(t, pendingHeader.ExcessBlobGas, "need L1 header with 4844 properties")
 	blobBaseFee := eth.CalcBlobFeeDefault(pendingHeader)

--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -63,6 +63,8 @@ type BatcherCfg struct {
 
 	DataAvailabilityType batcherFlags.DataAvailabilityType
 	AltDA                AltDAInputSetter
+
+	EnableCellProofs bool
 }
 
 func DefaultBatcherCfg(dp *e2eutils.DeployParams) *BatcherCfg {
@@ -71,6 +73,7 @@ func DefaultBatcherCfg(dp *e2eutils.DeployParams) *BatcherCfg {
 		MaxL1TxSize:          128_000,
 		BatcherKey:           dp.Secrets.Batcher,
 		DataAvailabilityType: batcherFlags.CalldataType,
+		EnableCellProofs:     false, // TODO change to true when Osaka activates on L1
 	}
 }
 
@@ -372,7 +375,7 @@ func (s *L2Batcher) ActL2BatchSubmitRaw(t Testing, payload []byte, txOpts ...fun
 	} else if s.l2BatcherCfg.DataAvailabilityType == batcherFlags.BlobsType {
 		var b eth.Blob
 		require.NoError(t, b.FromData(payload), "must turn data into blob")
-		sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&b}, false) // TODO use cell proofs if configured to do so
+		sidecar, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{&b}, s.l2BatcherCfg.EnableCellProofs)
 		require.NoError(t, err)
 		require.NotNil(t, pendingHeader.ExcessBlobGas, "need L1 header with 4844 properties")
 		blobBaseFee := eth.CalcBlobFeeDefault(pendingHeader)
@@ -456,7 +459,7 @@ func (s *L2Batcher) ActL2BatchSubmitMultiBlob(t Testing, numBlobs int) {
 	require.NoError(t, err, "need l1 pending header for gas price estimation")
 	gasFeeCap := new(big.Int).Add(gasTipCap, new(big.Int).Mul(pendingHeader.BaseFee, big.NewInt(2)))
 
-	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs, false) // TODO use cell proofs if configured to do so
+	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs, s.l2BatcherCfg.EnableCellProofs)
 	require.NoError(t, err)
 	require.NotNil(t, pendingHeader.ExcessBlobGas, "need L1 header with 4844 properties")
 	blobBaseFee := eth.CalcBlobFeeDefault(pendingHeader)

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -472,7 +472,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	res.MinTipCap.Store(minTipCap)
 	res.MaxTipCap.Store(maxTipCap)
 	res.MinBlobTxFee.Store(defaultMinBlobTxFee)
-	res.EnableCellProofs.Store(cfg.EnableCellProofs)
+	res.EnableCellProofs = cfg.EnableCellProofs
 
 	return &res, nil
 }
@@ -513,7 +513,7 @@ type Config struct {
 
 	// EnableCellProofs determines whether to use cell proofs (Version1 sidecars)
 	// for Fusaka (EIP-7742) compatibility. If false, uses legacy blob proofs (Version0).
-	EnableCellProofs atomic.Bool
+	EnableCellProofs bool
 
 	// ChainID is the chain ID of the L1 chain.
 	ChainID *big.Int

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -77,6 +77,7 @@ type DefaultFlagValues struct {
 	TxSendTimeout             time.Duration
 	TxNotInMempoolTimeout     time.Duration
 	ReceiptQueryInterval      time.Duration
+	EnableCellProofs          bool
 }
 
 var (
@@ -95,6 +96,7 @@ var (
 		TxSendTimeout:             0, // Try sending txs indefinitely, to preserve tx ordering for Holocene
 		TxNotInMempoolTimeout:     2 * time.Minute,
 		ReceiptQueryInterval:      12 * time.Second,
+		EnableCellProofs:          false, // Ater Osaka activates on L1, this should be set to true
 	}
 	DefaultChallengerFlagValues = DefaultFlagValues{
 		NumConfirmations:          uint64(3),
@@ -242,7 +244,7 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 		&cli.BoolFlag{
 			Name:    EnableCellProofsFlagName,
 			Usage:   "Enable cell proofs in blob transactions for Fusaka (EIP-7742) compatibility",
-			Value:   true,
+			Value:   false,
 			EnvVars: prefixEnvVars("TXMGR_ENABLE_CELL_PROOFS"),
 		},
 	}, opsigner.CLIFlags(envPrefix, "")...)
@@ -293,7 +295,7 @@ func NewCLIConfig(l1RPCURL string, defaults DefaultFlagValues) CLIConfig {
 		TxSendTimeout:             defaults.TxSendTimeout,
 		TxNotInMempoolTimeout:     defaults.TxNotInMempoolTimeout,
 		ReceiptQueryInterval:      defaults.ReceiptQueryInterval,
-		EnableCellProofs:          true, // Enable cell proofs by default for Fusaka compatibility
+		EnableCellProofs:          defaults.EnableCellProofs,
 		SignerCLIConfig:           opsigner.NewCLIConfig(),
 	}
 }

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -44,6 +44,7 @@ const (
 	TxNotInMempoolTimeoutFlagName      = "txmgr.not-in-mempool-timeout"
 	ReceiptQueryIntervalFlagName       = "txmgr.receipt-query-interval"
 	AlreadyPublishedCustomErrsFlagName = "txmgr.already-published-custom-errs"
+	EnableCellProofsFlagName           = "txmgr.enable-cell-proofs"
 )
 
 var (
@@ -238,6 +239,12 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 			Usage:   "List of custom RPC error messages that indicate that a transaction has already been published.",
 			EnvVars: prefixEnvVars("TXMGR_ALREADY_PUBLISHED_CUSTOM_ERRS"),
 		},
+		&cli.BoolFlag{
+			Name:    EnableCellProofsFlagName,
+			Usage:   "Enable cell proofs in blob transactions for Fusaka (EIP-7742) compatibility",
+			Value:   true,
+			EnvVars: prefixEnvVars("TXMGR_ENABLE_CELL_PROOFS"),
+		},
 	}, opsigner.CLIFlags(envPrefix, "")...)
 }
 
@@ -266,6 +273,7 @@ type CLIConfig struct {
 	TxSendTimeout              time.Duration
 	TxNotInMempoolTimeout      time.Duration
 	AlreadyPublishedCustomErrs []string
+	EnableCellProofs           bool
 }
 
 func NewCLIConfig(l1RPCURL string, defaults DefaultFlagValues) CLIConfig {
@@ -285,6 +293,7 @@ func NewCLIConfig(l1RPCURL string, defaults DefaultFlagValues) CLIConfig {
 		TxSendTimeout:             defaults.TxSendTimeout,
 		TxNotInMempoolTimeout:     defaults.TxNotInMempoolTimeout,
 		ReceiptQueryInterval:      defaults.ReceiptQueryInterval,
+		EnableCellProofs:          true, // Enable cell proofs by default for Fusaka compatibility
 		SignerCLIConfig:           opsigner.NewCLIConfig(),
 	}
 }
@@ -460,6 +469,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	res.MinTipCap.Store(minTipCap)
 	res.MaxTipCap.Store(maxTipCap)
 	res.MinBlobTxFee.Store(defaultMinBlobTxFee)
+	res.EnableCellProofs.Store(cfg.EnableCellProofs)
 
 	return &res, nil
 }
@@ -497,6 +507,10 @@ type Config struct {
 	MaxTipCap atomic.Pointer[big.Int]
 
 	MinBlobTxFee atomic.Pointer[big.Int]
+
+	// EnableCellProofs determines whether to use cell proofs (Version1 sidecars)
+	// for Fusaka (EIP-7742) compatibility. If false, uses legacy blob proofs (Version0).
+	EnableCellProofs atomic.Bool
 
 	// ChainID is the chain ID of the L1 chain.
 	ChainID *big.Int

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -378,6 +378,7 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		TxSendTimeout:              ctx.Duration(TxSendTimeoutFlagName),
 		TxNotInMempoolTimeout:      ctx.Duration(TxNotInMempoolTimeoutFlagName),
 		AlreadyPublishedCustomErrs: ctx.StringSlice(AlreadyPublishedCustomErrsFlagName),
+		EnableCellProofs:           ctx.Bool(EnableCellProofsFlagName),
 	}
 }
 

--- a/op-service/txmgr/test_txmgr.go
+++ b/op-service/txmgr/test_txmgr.go
@@ -52,7 +52,7 @@ func (m *TestTxManager) makeStuckTx(ctx context.Context, candidate TxCandidate) 
 	var sidecar *types.BlobTxSidecar
 	var blobHashes []common.Hash
 	if len(candidate.Blobs) > 0 {
-		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs); err != nil {
+		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs, m.cfg.EnableCellProofs.Load()); err != nil {
 			return nil, err
 		}
 	}

--- a/op-service/txmgr/test_txmgr.go
+++ b/op-service/txmgr/test_txmgr.go
@@ -52,7 +52,7 @@ func (m *TestTxManager) makeStuckTx(ctx context.Context, candidate TxCandidate) 
 	var sidecar *types.BlobTxSidecar
 	var blobHashes []common.Hash
 	if len(candidate.Blobs) > 0 {
-		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs, m.cfg.EnableCellProofs.Load()); err != nil {
+		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs, m.cfg.EnableCellProofs); err != nil {
 			return nil, err
 		}
 	}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -363,7 +363,9 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		if candidate.To == nil {
 			return nil, errors.New("blob txs cannot deploy contracts")
 		}
-		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs); err != nil {
+		// Use configuration to determine whether to enable cell proofs
+		enableCellProofs := m.cfg.EnableCellProofs.Load()
+		if sidecar, blobHashes, err = MakeSidecarWithConfig(candidate.Blobs, enableCellProofs); err != nil {
 			return nil, fmt.Errorf("failed to make sidecar: %w", err)
 		}
 	}
@@ -491,10 +493,27 @@ func (m *SimpleTxManager) SetBumpFeeRetryTime(val time.Duration) {
 }
 
 // MakeSidecar builds & returns the BlobTxSidecar and corresponding blob hashes from the raw blob
-// data.
+// data. Creates Version1 sidecars with cell proofs for Fusaka (EIP-7742) compatibility by default.
 func MakeSidecar(blobs []*eth.Blob) (*types.BlobTxSidecar, []common.Hash, error) {
-	sidecar := &types.BlobTxSidecar{}
+	return MakeSidecarWithConfig(blobs, true) // Default to enabling cell proofs
+}
+
+// MakeSidecarWithConfig builds & returns the BlobTxSidecar and corresponding blob hashes from the raw blob
+// data with configurable cell proof support.
+func MakeSidecarWithConfig(blobs []*eth.Blob, enableCellProofs bool) (*types.BlobTxSidecar, []common.Hash, error) {
+	var sidecar *types.BlobTxSidecar
+	if enableCellProofs {
+		sidecar = &types.BlobTxSidecar{
+			Version: types.BlobSidecarVersion1, // Use Version1 for cell proofs (Fusaka compatibility)
+		}
+	} else {
+		sidecar = &types.BlobTxSidecar{
+			Version: types.BlobSidecarVersion0, // Use Version0 for legacy blob proofs
+		}
+	}
+
 	blobHashes := make([]common.Hash, 0, len(blobs))
+
 	for i, blob := range blobs {
 		rawBlob := blob.KZGBlob()
 		sidecar.Blobs = append(sidecar.Blobs, *rawBlob)
@@ -503,13 +522,34 @@ func MakeSidecar(blobs []*eth.Blob) (*types.BlobTxSidecar, []common.Hash, error)
 			return nil, nil, fmt.Errorf("cannot compute KZG commitment of blob %d in tx candidate: %w", i, err)
 		}
 		sidecar.Commitments = append(sidecar.Commitments, commitment)
-		proof, err := kzg4844.ComputeBlobProof(rawBlob, commitment)
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot compute KZG proof for fast commitment verification of blob %d in tx candidate: %w", i, err)
-		}
-		sidecar.Proofs = append(sidecar.Proofs, proof)
 		blobHashes = append(blobHashes, eth.KZGToVersionedHash(commitment))
 	}
+
+	// Compute proofs based on the sidecar version
+	if enableCellProofs {
+		// Version1: Use cell proofs for Fusaka compatibility
+		allCellProofs := make([]kzg4844.Proof, 0, len(blobs)*kzg4844.CellProofsPerBlob)
+		for i, blob := range blobs {
+			rawBlob := blob.KZGBlob()
+			cellProofs, err := kzg4844.ComputeCellProofs(rawBlob)
+			if err != nil {
+				return nil, nil, fmt.Errorf("cannot compute KZG cell proofs for blob %d in tx candidate: %w", i, err)
+			}
+			allCellProofs = append(allCellProofs, cellProofs...)
+		}
+		sidecar.Proofs = allCellProofs
+	} else {
+		// Version0: Use legacy blob proofs
+		for i, blob := range blobs {
+			rawBlob := blob.KZGBlob()
+			proof, err := kzg4844.ComputeBlobProof(rawBlob, sidecar.Commitments[i])
+			if err != nil {
+				return nil, nil, fmt.Errorf("cannot compute KZG proof for fast commitment verification of blob %d in tx candidate: %w", i, err)
+			}
+			sidecar.Proofs = append(sidecar.Proofs, proof)
+		}
+	}
+
 	return sidecar, blobHashes, nil
 }
 

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -516,25 +516,15 @@ func MakeSidecar(blobs []*eth.Blob, enableCellProofs bool) (*types.BlobTxSidecar
 		}
 		sidecar.Commitments = append(sidecar.Commitments, commitment)
 		blobHashes = append(blobHashes, eth.KZGToVersionedHash(commitment))
-	}
-
-	// Compute proofs based on the sidecar version
-	if enableCellProofs {
-		// Version1: Use cell proofs for Fusaka compatibility
-		allCellProofs := make([]kzg4844.Proof, 0, len(blobs)*kzg4844.CellProofsPerBlob)
-		for i, blob := range blobs {
-			rawBlob := blob.KZGBlob()
+		if enableCellProofs {
+			// Version1: Use cell proofs for Fusaka compatibility
 			cellProofs, err := kzg4844.ComputeCellProofs(rawBlob)
 			if err != nil {
 				return nil, nil, fmt.Errorf("cannot compute KZG cell proofs for blob %d in tx candidate: %w", i, err)
 			}
-			allCellProofs = append(allCellProofs, cellProofs...)
-		}
-		sidecar.Proofs = allCellProofs
-	} else {
-		// Version0: Use legacy blob proofs
-		for i, blob := range blobs {
-			rawBlob := blob.KZGBlob()
+			sidecar.Proofs = append(sidecar.Proofs, cellProofs...)
+		} else {
+			// Version0: Use legacy blob proofs
 			proof, err := kzg4844.ComputeBlobProof(rawBlob, sidecar.Commitments[i])
 			if err != nil {
 				return nil, nil, fmt.Errorf("cannot compute KZG proof for fast commitment verification of blob %d in tx candidate: %w", i, err)

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -497,10 +497,12 @@ func MakeSidecar(blobs []*eth.Blob, enableCellProofs bool) (*types.BlobTxSidecar
 	var sidecar *types.BlobTxSidecar
 	if enableCellProofs {
 		sidecar = &types.BlobTxSidecar{
+			Proofs:  make([]kzg4844.Proof, 0, len(blobs)*kzg4844.CellProofsPerBlob),
 			Version: types.BlobSidecarVersion1, // Use Version1 for cell proofs (Fusaka compatibility)
 		}
 	} else {
 		sidecar = &types.BlobTxSidecar{
+			Proofs:  make([]kzg4844.Proof, 0, len(blobs)),
 			Version: types.BlobSidecarVersion0, // Use Version0 for legacy blob proofs
 		}
 	}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -208,7 +208,7 @@ func (m *SimpleTxManager) Close() {
 }
 
 func (m *SimpleTxManager) txLogger(tx *types.Transaction, logGas bool) log.Logger {
-	fields := []any{"tx", tx.Hash(), "nonce", tx.Nonce()}
+	fields := []any{"tx", tx.Hash().Hex(), "nonce", tx.Nonce()}
 	if logGas {
 		fields = append(fields, "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap(), "gasLimit", tx.Gas())
 	}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -364,8 +364,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 			return nil, errors.New("blob txs cannot deploy contracts")
 		}
 		// Use configuration to determine whether to enable cell proofs
-		enableCellProofs := m.cfg.EnableCellProofs.Load()
-		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs, enableCellProofs); err != nil {
+		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs, m.cfg.EnableCellProofs); err != nil {
 			return nil, fmt.Errorf("failed to make sidecar: %w", err)
 		}
 	}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -365,7 +365,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		}
 		// Use configuration to determine whether to enable cell proofs
 		enableCellProofs := m.cfg.EnableCellProofs.Load()
-		if sidecar, blobHashes, err = MakeSidecarWithConfig(candidate.Blobs, enableCellProofs); err != nil {
+		if sidecar, blobHashes, err = MakeSidecar(candidate.Blobs, enableCellProofs); err != nil {
 			return nil, fmt.Errorf("failed to make sidecar: %w", err)
 		}
 	}
@@ -493,14 +493,8 @@ func (m *SimpleTxManager) SetBumpFeeRetryTime(val time.Duration) {
 }
 
 // MakeSidecar builds & returns the BlobTxSidecar and corresponding blob hashes from the raw blob
-// data. Creates Version1 sidecars with cell proofs for Fusaka (EIP-7742) compatibility by default.
-func MakeSidecar(blobs []*eth.Blob) (*types.BlobTxSidecar, []common.Hash, error) {
-	return MakeSidecarWithConfig(blobs, true) // Default to enabling cell proofs
-}
-
-// MakeSidecarWithConfig builds & returns the BlobTxSidecar and corresponding blob hashes from the raw blob
 // data with configurable cell proof support.
-func MakeSidecarWithConfig(blobs []*eth.Blob, enableCellProofs bool) (*types.BlobTxSidecar, []common.Hash, error) {
+func MakeSidecar(blobs []*eth.Blob, enableCellProofs bool) (*types.BlobTxSidecar, []common.Hash, error) {
 	var sidecar *types.BlobTxSidecar
 	if enableCellProofs {
 		sidecar = &types.BlobTxSidecar{

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -1736,7 +1736,22 @@ func TestMakeSidecar(t *testing.T) {
 	for i := 0; i < 4096; i++ {
 		blob[32*i] &= 0b0011_1111
 	}
-	sidecar, hashes, err := MakeSidecar([]*eth.Blob{&blob})
+
+	// Pre Fusaka, blob proof sidecar is Version0
+	sidecar, hashes, err := MakeSidecar([]*eth.Blob{&blob}, false)
+	require.NoError(t, err)
+	require.Equal(t, len(hashes), 1)
+	require.Equal(t, len(sidecar.Blobs), len(hashes))
+	require.Equal(t, len(sidecar.Proofs), len(hashes))
+	require.Equal(t, len(sidecar.Commitments), len(hashes))
+
+	for i, commit := range sidecar.Commitments {
+		require.NoError(t, eth.VerifyBlobProof((*eth.Blob)(&sidecar.Blobs[i]), commit, sidecar.Proofs[i]), "proof must be valid")
+		require.Equal(t, hashes[i], eth.KZGToVersionedHash(commit))
+	}
+
+	// Post Fusaka, blob proof sidecar is Version1
+	sidecar, hashes, err = MakeSidecar([]*eth.Blob{&blob}, true)
 	require.NoError(t, err)
 	require.Equal(t, len(hashes), 1)
 	require.Equal(t, len(sidecar.Blobs), len(hashes))

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -1755,11 +1755,11 @@ func TestMakeSidecar(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(hashes), 1)
 	require.Equal(t, len(sidecar.Blobs), len(hashes))
-	require.Equal(t, len(sidecar.Proofs), len(hashes))
+	require.Equal(t, len(sidecar.Proofs), len(hashes)*kzg4844.CellProofsPerBlob)
 	require.Equal(t, len(sidecar.Commitments), len(hashes))
 
+	require.NoError(t, kzg4844.VerifyCellProofs(sidecar.Blobs, sidecar.Commitments, sidecar.Proofs), "cell proof must be valid")
 	for i, commit := range sidecar.Commitments {
-		require.NoError(t, eth.VerifyBlobProof((*eth.Blob)(&sidecar.Blobs[i]), commit, sidecar.Proofs[i]), "proof must be valid")
 		require.Equal(t, hashes[i], eth.KZGToVersionedHash(commit))
 	}
 }


### PR DESCRIPTION
Closes #17472 

This fix requires a CLI flag update at the moment (or shortly after) of Fusaka activation on L2. Leaving automation / optimisation to make that unecessary to a future PR so that we can get this critical fix in place as soon as possible. 

I have manually confirmed that this code allows batcher blob transactions to be confirmed on Fusaka Devnet 3 (whereas before they would not be confirmed). 