### PR TITLE
op-dispute-mon: node endpoint error metrics

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -181,6 +181,8 @@ type Metricer interface {
 
 	RecordNodeEndpointErrors(count int)
 
+	RecordNodeEndpointErrorCount(count int)
+
 	RecordBondCollateral(addr common.Address, required, available *big.Int)
 
 	RecordL2Challenges(agreement bool, count int)
@@ -231,9 +233,10 @@ type Metrics struct {
 	failedGames                prometheus.Gauge
 	l2Challenges               prometheus.GaugeVec
 
-	requiredCollateral  prometheus.GaugeVec
-	nodeEndpointErrors  prometheus.Gauge
-	availableCollateral prometheus.GaugeVec
+	requiredCollateral     prometheus.GaugeVec
+	nodeEndpointErrors     prometheus.Gauge
+	nodeEndpointErrorCount prometheus.Gauge
+	availableCollateral    prometheus.GaugeVec
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -406,6 +409,11 @@ func NewMetrics() *Metrics {
 			Name:      "node_endpoint_errors",
 			Help:      "Number of rollup node RPC endpoints that returned at least one error other than \"not found\" in the last update cycle",
 		}),
+		nodeEndpointErrorCount: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "node_endpoint_error_count",
+			Help:      "Total number of individual endpoint error occurrences (other than \"not found\") across all rollup node endpoints in the last update cycle",
+		}),
 	}
 }
 
@@ -545,6 +553,10 @@ func (m *Metrics) RecordFailedGames(count int) {
 
 func (m *Metrics) RecordNodeEndpointErrors(count int) {
 	m.nodeEndpointErrors.Set(float64(count))
+}
+
+func (m *Metrics) RecordNodeEndpointErrorCount(count int) {
+	m.nodeEndpointErrorCount.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required, available *big.Int) {

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -179,6 +179,8 @@ type Metricer interface {
 
 	RecordIgnoredGames(count int)
 
+	RecordNodeEndpointErrors(count int)
+
 	RecordBondCollateral(addr common.Address, required, available *big.Int)
 
 	RecordL2Challenges(agreement bool, count int)
@@ -230,6 +232,7 @@ type Metrics struct {
 	l2Challenges               prometheus.GaugeVec
 
 	requiredCollateral  prometheus.GaugeVec
+	nodeEndpointErrors  prometheus.Gauge
 	availableCollateral prometheus.GaugeVec
 }
 
@@ -398,6 +401,11 @@ func NewMetrics() *Metrics {
 			// An l2 block number challenge with an agreement means the challenge was invalid.
 			"root_agreement",
 		}),
+		nodeEndpointErrors: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "node_endpoint_errors",
+			Help:      "Number of rollup node RPC endpoints that returned at least one error other than \"not found\" in the last update cycle",
+		}),
 	}
 }
 
@@ -533,6 +541,10 @@ func (m *Metrics) RecordIgnoredGames(count int) {
 
 func (m *Metrics) RecordFailedGames(count int) {
 	m.failedGames.Set(float64(count))
+}
+
+func (m *Metrics) RecordNodeEndpointErrors(count int) {
+	m.nodeEndpointErrors.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required, available *big.Int) {

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -185,6 +185,8 @@ type Metricer interface {
 
 	RecordMixedAvailabilityGames(count int)
 
+	RecordMixedSafetyGames(count int)
+
 	RecordBondCollateral(addr common.Address, required, available *big.Int)
 
 	RecordL2Challenges(agreement bool, count int)
@@ -240,6 +242,7 @@ type Metrics struct {
 	nodeEndpointErrors     prometheus.Gauge
 	nodeEndpointErrorCount prometheus.Gauge
 	mixedAvailabilityGames prometheus.Gauge
+	mixedSafetyGames       prometheus.Gauge
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -422,6 +425,11 @@ func NewMetrics() *Metrics {
 			Name:      "mixed_availability_games",
 			Help:      "Number of games where some rollup nodes reported \"not found\" while others successfully retrieved the block in the last update cycle",
 		}),
+		mixedSafetyGames: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "mixed_safety_games",
+			Help:      "Number of games where some rollup nodes reported the root as safe while others reported it as unsafe in the last update cycle",
+		}),
 	}
 }
 
@@ -569,6 +577,10 @@ func (m *Metrics) RecordNodeEndpointErrorCount(count int) {
 
 func (m *Metrics) RecordMixedAvailabilityGames(count int) {
 	m.mixedAvailabilityGames.Set(float64(count))
+}
+
+func (m *Metrics) RecordMixedSafetyGames(count int) {
+	m.mixedSafetyGames.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required, available *big.Int) {

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -183,6 +183,8 @@ type Metricer interface {
 
 	RecordNodeEndpointErrorCount(count int)
 
+	RecordMixedAvailabilityGames(count int)
+
 	RecordBondCollateral(addr common.Address, required, available *big.Int)
 
 	RecordL2Challenges(agreement bool, count int)
@@ -234,9 +236,10 @@ type Metrics struct {
 	l2Challenges               prometheus.GaugeVec
 
 	requiredCollateral     prometheus.GaugeVec
+	availableCollateral    prometheus.GaugeVec
 	nodeEndpointErrors     prometheus.Gauge
 	nodeEndpointErrorCount prometheus.Gauge
-	availableCollateral    prometheus.GaugeVec
+	mixedAvailabilityGames prometheus.Gauge
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -414,6 +417,11 @@ func NewMetrics() *Metrics {
 			Name:      "node_endpoint_error_count",
 			Help:      "Total number of individual endpoint error occurrences (other than \"not found\") across all rollup node endpoints in the last update cycle",
 		}),
+		mixedAvailabilityGames: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "mixed_availability_games",
+			Help:      "Number of games where some rollup nodes reported \"not found\" while others successfully retrieved the block in the last update cycle",
+		}),
 	}
 }
 
@@ -557,6 +565,10 @@ func (m *Metrics) RecordNodeEndpointErrors(count int) {
 
 func (m *Metrics) RecordNodeEndpointErrorCount(count int) {
 	m.nodeEndpointErrorCount.Set(float64(count))
+}
+
+func (m *Metrics) RecordMixedAvailabilityGames(count int) {
+	m.mixedAvailabilityGames.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required, available *big.Int) {

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -187,6 +187,8 @@ type Metricer interface {
 
 	RecordMixedSafetyGames(count int)
 
+	RecordDifferentOutputRootGames(count int)
+
 	RecordBondCollateral(addr common.Address, required, available *big.Int)
 
 	RecordL2Challenges(agreement bool, count int)
@@ -237,12 +239,13 @@ type Metrics struct {
 	failedGames                prometheus.Gauge
 	l2Challenges               prometheus.GaugeVec
 
-	requiredCollateral     prometheus.GaugeVec
-	availableCollateral    prometheus.GaugeVec
-	nodeEndpointErrors     prometheus.Gauge
-	nodeEndpointErrorCount prometheus.Gauge
-	mixedAvailabilityGames prometheus.Gauge
-	mixedSafetyGames       prometheus.Gauge
+	requiredCollateral       prometheus.GaugeVec
+	availableCollateral      prometheus.GaugeVec
+	nodeEndpointErrors       prometheus.Gauge
+	nodeEndpointErrorCount   prometheus.Gauge
+	mixedAvailabilityGames   prometheus.Gauge
+	mixedSafetyGames         prometheus.Gauge
+	differentOutputRootGames prometheus.Gauge
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -430,6 +433,11 @@ func NewMetrics() *Metrics {
 			Name:      "mixed_safety_games",
 			Help:      "Number of games where some rollup nodes reported the root as safe while others reported it as unsafe in the last update cycle",
 		}),
+		differentOutputRootGames: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "different_output_root_games",
+			Help:      "Number of games where rollup nodes returned different output roots for the same L2 block in the last update cycle",
+		}),
 	}
 }
 
@@ -581,6 +589,10 @@ func (m *Metrics) RecordMixedAvailabilityGames(count int) {
 
 func (m *Metrics) RecordMixedSafetyGames(count int) {
 	m.mixedSafetyGames.Set(float64(count))
+}
+
+func (m *Metrics) RecordDifferentOutputRootGames(count int) {
+	m.differentOutputRootGames.Set(float64(count))
 }
 
 func (m *Metrics) RecordBondCollateral(addr common.Address, required, available *big.Int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -57,3 +57,5 @@ func (*NoopMetricsImpl) RecordL2Challenges(_ bool, _ int) {}
 func (*NoopMetricsImpl) RecordNodeEndpointErrors(_ int) {}
 
 func (*NoopMetricsImpl) RecordNodeEndpointErrorCount(_ int) {}
+
+func (*NoopMetricsImpl) RecordMixedAvailabilityGames(_ int) {}

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -59,3 +59,5 @@ func (*NoopMetricsImpl) RecordNodeEndpointErrors(_ int) {}
 func (*NoopMetricsImpl) RecordNodeEndpointErrorCount(_ int) {}
 
 func (*NoopMetricsImpl) RecordMixedAvailabilityGames(_ int) {}
+
+func (*NoopMetricsImpl) RecordMixedSafetyGames(_ int) {}

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -55,3 +55,5 @@ func (*NoopMetricsImpl) RecordBondCollateral(_ common.Address, _, _ *big.Int) {}
 func (*NoopMetricsImpl) RecordL2Challenges(_ bool, _ int) {}
 
 func (*NoopMetricsImpl) RecordNodeEndpointErrors(_ int) {}
+
+func (*NoopMetricsImpl) RecordNodeEndpointErrorCount(_ int) {}

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -61,3 +61,5 @@ func (*NoopMetricsImpl) RecordNodeEndpointErrorCount(_ int) {}
 func (*NoopMetricsImpl) RecordMixedAvailabilityGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordMixedSafetyGames(_ int) {}
+
+func (*NoopMetricsImpl) RecordDifferentOutputRootGames(_ int) {}

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -53,3 +53,5 @@ func (*NoopMetricsImpl) RecordFailedGames(_ int) {}
 func (*NoopMetricsImpl) RecordBondCollateral(_ common.Address, _, _ *big.Int) {}
 
 func (*NoopMetricsImpl) RecordL2Challenges(_ bool, _ int) {}
+
+func (*NoopMetricsImpl) RecordNodeEndpointErrors(_ int) {}

--- a/op-dispute-mon/mon/different_output_roots.go
+++ b/op-dispute-mon/mon/different_output_roots.go
@@ -1,0 +1,41 @@
+package mon
+
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type DifferentOutputRootMetrics interface {
+	RecordDifferentOutputRootGames(count int)
+}
+
+type DifferentOutputRootMonitor struct {
+	logger  log.Logger
+	metrics DifferentOutputRootMetrics
+}
+
+func NewDifferentOutputRootMonitor(logger log.Logger, metrics DifferentOutputRootMetrics) *DifferentOutputRootMonitor {
+	return &DifferentOutputRootMonitor{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (m *DifferentOutputRootMonitor) CheckDifferentOutputRoots(games []*types.EnrichedGameData) {
+	count := 0
+	for _, game := range games {
+		if game.RollupEndpointDifferentOutputRoots {
+			count++
+			m.logger.Debug("Different output roots detected",
+				"game", game.Proxy,
+				"l2BlockNumber", game.L2BlockNumber,
+				"rootClaim", game.RootClaim)
+		}
+	}
+
+	m.metrics.RecordDifferentOutputRootGames(count)
+
+	if count > 0 {
+		m.logger.Info("Different output roots summary", "gamesWithDifferentOutputRoots", count, "totalGames", len(games))
+	}
+}

--- a/op-dispute-mon/mon/different_output_roots_test.go
+++ b/op-dispute-mon/mon/different_output_roots_test.go
@@ -1,0 +1,151 @@
+package mon
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckDifferentOutputRoots(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointDifferentOutputRoots: true,
+			L2BlockNumber:                      100,
+			RootClaim:                          common.HexToHash("0xaaa"),
+		},
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointDifferentOutputRoots: false, // No disagreement
+			L2BlockNumber:                      200,
+			RootClaim:                          common.HexToHash("0xbbb"),
+		},
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointDifferentOutputRoots: true,
+			L2BlockNumber:                      300,
+			RootClaim:                          common.HexToHash("0xccc"),
+		},
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x44}},
+			RollupEndpointDifferentOutputRoots: false, // No disagreement
+			L2BlockNumber:                      400,
+			RootClaim:                          common.HexToHash("0xddd"),
+		},
+	}
+	metrics := &stubDifferentOutputRootMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewDifferentOutputRootMonitor(logger, metrics)
+	monitor.CheckDifferentOutputRoots(games)
+	require.Equal(t, 2, metrics.recordedCount)
+
+	// Debug log for first game with different output roots
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("Different output roots detected")
+	logs := capturedLogs.FindLogs(levelFilter, messageFilter)
+	require.Len(t, logs, 2)
+
+	l := logs[0]
+	require.Equal(t, common.Address{0x11}, l.AttrValue("game"))
+	require.Equal(t, uint64(100), l.AttrValue("l2BlockNumber"))
+	require.Equal(t, common.HexToHash("0xaaa"), l.AttrValue("rootClaim"))
+
+	// Info log for summary
+	levelFilter = testlog.NewLevelFilter(log.LevelInfo)
+	messageFilter = testlog.NewMessageFilter("Different output roots summary")
+	l = capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(2), l.AttrValue("gamesWithDifferentOutputRoots"))
+	require.Equal(t, int64(4), l.AttrValue("totalGames"))
+}
+
+func TestCheckDifferentOutputRoots_NoDisagreements(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointDifferentOutputRoots: false,
+		},
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointDifferentOutputRoots: false,
+		},
+	}
+	metrics := &stubDifferentOutputRootMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewDifferentOutputRootMonitor(logger, metrics)
+	monitor.CheckDifferentOutputRoots(games)
+	require.Equal(t, 0, metrics.recordedCount)
+
+	// No info log should be present when count is 0
+	levelFilter := testlog.NewLevelFilter(log.LevelInfo)
+	messageFilter := testlog.NewMessageFilter("Different output roots summary")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.Nil(t, l)
+}
+
+func TestCheckDifferentOutputRoots_EmptyGamesList(t *testing.T) {
+	games := []*types.EnrichedGameData{}
+	metrics := &stubDifferentOutputRootMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewDifferentOutputRootMonitor(logger, metrics)
+	monitor.CheckDifferentOutputRoots(games)
+	require.Equal(t, 0, metrics.recordedCount)
+
+	// No log should be present when no games exist
+	levelFilter := testlog.NewLevelFilter(log.LevelInfo)
+	messageFilter := testlog.NewMessageFilter("Different output roots summary")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.Nil(t, l)
+}
+
+func TestCheckDifferentOutputRoots_AllGamesHaveDisagreements(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointDifferentOutputRoots: true,
+			L2BlockNumber:                      100,
+		},
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointDifferentOutputRoots: true,
+			L2BlockNumber:                      200,
+		},
+		{
+			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointDifferentOutputRoots: true,
+			L2BlockNumber:                      300,
+		},
+	}
+	metrics := &stubDifferentOutputRootMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewDifferentOutputRootMonitor(logger, metrics)
+	monitor.CheckDifferentOutputRoots(games)
+	require.Equal(t, 3, metrics.recordedCount)
+
+	// Debug logs for all games
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("Different output roots detected")
+	logs := capturedLogs.FindLogs(levelFilter, messageFilter)
+	require.Len(t, logs, 3)
+
+	// Info log for summary
+	levelFilter = testlog.NewLevelFilter(log.LevelInfo)
+	messageFilter = testlog.NewMessageFilter("Different output roots summary")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(3), l.AttrValue("gamesWithDifferentOutputRoots"))
+	require.Equal(t, int64(3), l.AttrValue("totalGames"))
+}
+
+type stubDifferentOutputRootMetrics struct {
+	recordedCount int
+}
+
+func (s *stubDifferentOutputRootMetrics) RecordDifferentOutputRootGames(count int) {
+	s.recordedCount = count
+}

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -149,18 +149,20 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		enrichedClaims[i] = monTypes.EnrichedClaim{Claim: claim}
 	}
 	enrichedGame := &monTypes.EnrichedGameData{
-		LastUpdateTime:           e.clock.Now(),
-		GameMetadata:             game,
-		L1Head:                   meta.L1Head,
-		L2BlockNumber:            meta.L2SequenceNum,
-		RootClaim:                meta.RootClaim,
-		Status:                   meta.Status,
-		MaxClockDuration:         meta.MaxClockDuration,
-		BlockNumberChallenged:    meta.L2BlockNumberChallenged,
-		BlockNumberChallenger:    meta.L2BlockNumberChallenger,
-		Claims:                   enrichedClaims,
-		RollupEndpointErrors:     make(map[string]bool),
-		RollupEndpointErrorCount: 0,
+		LastUpdateTime:              e.clock.Now(),
+		GameMetadata:                game,
+		L1Head:                      meta.L1Head,
+		L2BlockNumber:               meta.L2SequenceNum,
+		RootClaim:                   meta.RootClaim,
+		Status:                      meta.Status,
+		MaxClockDuration:            meta.MaxClockDuration,
+		BlockNumberChallenged:       meta.L2BlockNumberChallenged,
+		BlockNumberChallenger:       meta.L2BlockNumberChallenger,
+		Claims:                      enrichedClaims,
+		RollupEndpointErrors:        make(map[string]bool),
+		RollupEndpointErrorCount:    0,
+		RollupEndpointNotFoundCount: 0,
+		RollupEndpointTotalCount:    0,
 	}
 	if err := e.applyEnrichers(ctx, blockHash, caller, enrichedGame); err != nil {
 		return nil, fmt.Errorf("failed to enrich game: %w", err)

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -149,17 +149,18 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		enrichedClaims[i] = monTypes.EnrichedClaim{Claim: claim}
 	}
 	enrichedGame := &monTypes.EnrichedGameData{
-		LastUpdateTime:        e.clock.Now(),
-		GameMetadata:          game,
-		L1Head:                meta.L1Head,
-		L2BlockNumber:         meta.L2SequenceNum,
-		RootClaim:             meta.RootClaim,
-		Status:                meta.Status,
-		MaxClockDuration:      meta.MaxClockDuration,
-		BlockNumberChallenged: meta.L2BlockNumberChallenged,
-		BlockNumberChallenger: meta.L2BlockNumberChallenger,
-		Claims:                enrichedClaims,
-		RollupEndpointErrors:  make(map[string]bool),
+		LastUpdateTime:           e.clock.Now(),
+		GameMetadata:             game,
+		L1Head:                   meta.L1Head,
+		L2BlockNumber:            meta.L2SequenceNum,
+		RootClaim:                meta.RootClaim,
+		Status:                   meta.Status,
+		MaxClockDuration:         meta.MaxClockDuration,
+		BlockNumberChallenged:    meta.L2BlockNumberChallenged,
+		BlockNumberChallenger:    meta.L2BlockNumberChallenger,
+		Claims:                   enrichedClaims,
+		RollupEndpointErrors:     make(map[string]bool),
+		RollupEndpointErrorCount: 0,
 	}
 	if err := e.applyEnrichers(ctx, blockHash, caller, enrichedGame); err != nil {
 		return nil, fmt.Errorf("failed to enrich game: %w", err)

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -159,6 +159,7 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		BlockNumberChallenged: meta.L2BlockNumberChallenged,
 		BlockNumberChallenger: meta.L2BlockNumberChallenger,
 		Claims:                enrichedClaims,
+		RollupEndpointErrors:  make(map[string]bool),
 	}
 	if err := e.applyEnrichers(ctx, blockHash, caller, enrichedGame); err != nil {
 		return nil, fmt.Errorf("failed to enrich game: %w", err)

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -373,6 +373,17 @@ func (m *mockGameCaller) IsResolved(_ context.Context, _ rpcblock.Block, claims 
 	return resolved, nil
 }
 
+func TestExtractor_EnrichGameInitializesRollupEndpointErrorCount(t *testing.T) {
+	extractor, _, games, _, _ := setupExtractorTest(t)
+	games.games = []gameTypes.GameMetadata{{}}
+	enriched, ignored, failed, err := extractor.Extract(context.Background(), common.Hash{}, 0)
+	require.NoError(t, err)
+	require.Zero(t, ignored)
+	require.Zero(t, failed)
+	require.Len(t, enriched, 1)
+	require.Equal(t, 0, enriched[0].RollupEndpointErrorCount, "RollupEndpointErrorCount should be initialized to 0")
+}
+
 type mockEnricher struct {
 	err    error
 	calls  int

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -72,6 +72,8 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 		return nil
 	}
 
+	game.RollupEndpointTotalCount = len(o.clients)
+
 	results := make([]outputResult, len(o.clients))
 	var wg sync.WaitGroup
 	for i, client := range o.clients {
@@ -140,7 +142,9 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 
 		validResults = append(validResults, result)
 
-		if !result.notFound {
+		if result.notFound {
+			game.RollupEndpointNotFoundCount++
+		} else {
 			foundResults = append(foundResults, result)
 		}
 	}

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -129,9 +129,9 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	for idx, result := range results {
 		if result.err != nil {
 			o.log.Error("Failed to fetch output root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
-			// Record the endpoint that had an error (excluding "not found" errors)
 			endpointID := fmt.Sprintf("client-%d", idx)
 			game.RollupEndpointErrors[endpointID] = true
+			game.RollupEndpointErrorCount++
 			continue
 		}
 		if result.gameL1HeadUnprocessed {

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -182,6 +182,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 		for _, result := range foundResults[1:] {
 			if result.outputRoot != firstResult.outputRoot {
 				diverged = true
+				game.RollupEndpointDifferentOutputRoots = true
 				break
 			}
 		}

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -129,6 +129,9 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	for idx, result := range results {
 		if result.err != nil {
 			o.log.Error("Failed to fetch output root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
+			// Record the endpoint that had an error (excluding "not found" errors)
+			endpointID := fmt.Sprintf("client-%d", idx)
+			game.RollupEndpointErrors[endpointID] = true
 			continue
 		}
 		if result.gameL1HeadUnprocessed {

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -146,6 +146,14 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 			game.RollupEndpointNotFoundCount++
 		} else {
 			foundResults = append(foundResults, result)
+			// Track safety counts only for found results where the output root matches the game's root claim
+			if result.outputRoot == game.RootClaim {
+				if result.isSafe {
+					game.RollupEndpointSafeCount++
+				} else {
+					game.RollupEndpointUnsafeCount++
+				}
+			}
 		}
 	}
 

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -579,3 +579,139 @@ func (s *stubRollupClient) SafeHeadAtL1Block(_ context.Context, _ uint64) (*eth.
 		},
 	}, nil
 }
+
+func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CountsSafetyWhenOutputRootMatchesRootClaim", func(t *testing.T) {
+		rootClaim := common.HexToHash("0xabcd")
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// Client 0: safe (safeHeadNum >= l2BlockNumber)
+		clients[0].outputRoot = rootClaim
+		clients[0].safeHeadNum = 100
+
+		// Client 1: unsafe (safeHeadNum < l2BlockNumber)
+		clients[1].outputRoot = rootClaim
+		clients[1].safeHeadNum = 50
+
+		// Client 2: safe
+		clients[2].outputRoot = rootClaim
+		clients[2].safeHeadNum = 150
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                 200,
+			L2BlockNumber:             75,
+			RootClaim:                 rootClaim,
+			RollupEndpointErrors:      make(map[string]bool),
+			RollupEndpointSafeCount:   0,
+			RollupEndpointUnsafeCount: 0,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, game.RollupEndpointSafeCount, "Should count 2 safe endpoints")
+		require.Equal(t, 1, game.RollupEndpointUnsafeCount, "Should count 1 unsafe endpoint")
+		require.True(t, game.HasMixedSafety(), "Should have mixed safety")
+	})
+
+	t.Run("DoesNotCountSafetyWhenOutputRootDiffersFromRootClaim", func(t *testing.T) {
+		rootClaim := common.HexToHash("0xabcd")
+		differentRoot := common.HexToHash("0xdiff")
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// All clients return different root but have varying safety
+		for _, client := range clients {
+			client.outputRoot = differentRoot
+			client.safeHeadNum = 100 // All would be safe if checked
+		}
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                 200,
+			L2BlockNumber:             75,
+			RootClaim:                 rootClaim,
+			RollupEndpointErrors:      make(map[string]bool),
+			RollupEndpointSafeCount:   0,
+			RollupEndpointUnsafeCount: 0,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+
+		require.Equal(t, 0, game.RollupEndpointSafeCount, "Should not count safety when output root differs")
+		require.Equal(t, 0, game.RollupEndpointUnsafeCount, "Should not count safety when output root differs")
+		require.False(t, game.HasMixedSafety(), "Should not have mixed safety")
+	})
+
+	t.Run("DoesNotCountSafetyForNotFoundResults", func(t *testing.T) {
+		rootClaim := common.HexToHash("0xabcd")
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// Client 0: found and safe
+		clients[0].outputRoot = rootClaim
+		clients[0].safeHeadNum = 100
+
+		// Client 1: not found
+		clients[1].outputErr = errors.New("not found")
+
+		// Client 2: found and unsafe
+		clients[2].outputRoot = rootClaim
+		clients[2].safeHeadNum = 50
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                 200,
+			L2BlockNumber:             75,
+			RootClaim:                 rootClaim,
+			RollupEndpointErrors:      make(map[string]bool),
+			RollupEndpointSafeCount:   0,
+			RollupEndpointUnsafeCount: 0,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, game.RollupEndpointSafeCount, "Should count only found safe endpoints")
+		require.Equal(t, 1, game.RollupEndpointUnsafeCount, "Should count only found unsafe endpoints")
+		require.True(t, game.HasMixedSafety(), "Should have mixed safety")
+	})
+
+	t.Run("AllEndpointsSafeNoMixedSafety", func(t *testing.T) {
+		rootClaim := common.HexToHash("0xabcd")
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// All clients safe
+		for _, client := range clients {
+			client.outputRoot = rootClaim
+			client.safeHeadNum = 100
+		}
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                 200,
+			L2BlockNumber:             75,
+			RootClaim:                 rootClaim,
+			RollupEndpointErrors:      make(map[string]bool),
+			RollupEndpointSafeCount:   0,
+			RollupEndpointUnsafeCount: 0,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+
+		require.Equal(t, 3, game.RollupEndpointSafeCount, "Should count all safe endpoints")
+		require.Equal(t, 0, game.RollupEndpointUnsafeCount, "Should count no unsafe endpoints")
+		require.False(t, game.HasMixedSafety(), "Should not have mixed safety")
+	})
+}

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -409,6 +409,91 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		})
 
 	})
+
+	t.Run("RecordEndpointErrorCounts", func(t *testing.T) {
+		t.Run("SingleNodeErrorCount", func(t *testing.T) {
+			validator, client, _ := setupOutputValidatorTest(t)
+			client.outputErr = errors.New("connection failed")
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                200,
+				L2BlockNumber:            100,
+				RootClaim:                mockRootClaim,
+				RollupEndpointErrors:     make(map[string]bool),
+				RollupEndpointErrorCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.ErrorIs(t, err, ErrAllNodesUnavailable)
+			require.Equal(t, 1, game.RollupEndpointErrorCount)
+		})
+
+		t.Run("MultiNodeErrorCount", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 4)
+			clients[0].outputErr = errors.New("connection timeout")
+			clients[1].outputErr = errors.New("server error")
+			clients[2].outputErr = errors.New("another error")
+			// clients[3] will succeed
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                200,
+				L2BlockNumber:            100,
+				RootClaim:                mockRootClaim,
+				RollupEndpointErrors:     make(map[string]bool),
+				RollupEndpointErrorCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 3, game.RollupEndpointErrorCount)
+		})
+
+		t.Run("NotFoundErrorsNotCounted", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 3)
+			clients[0].outputErr = errors.New("not found")
+			clients[1].outputErr = errors.New("not found")
+			// clients[2] will succeed
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                200,
+				L2BlockNumber:            100,
+				RootClaim:                mockRootClaim,
+				RollupEndpointErrors:     make(map[string]bool),
+				RollupEndpointErrorCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 0, game.RollupEndpointErrorCount)
+		})
+
+		t.Run("MixedErrorTypes", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 4)
+			clients[0].outputErr = errors.New("not found")        // Should not be counted
+			clients[1].outputErr = errors.New("connection error") // Should be counted
+			clients[2].outputErr = errors.New("server error")     // Should be counted
+			// clients[3] will succeed
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                200,
+				L2BlockNumber:            100,
+				RootClaim:                mockRootClaim,
+				RollupEndpointErrors:     make(map[string]bool),
+				RollupEndpointErrorCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 2, game.RollupEndpointErrorCount)
+		})
+	})
 }
 
 // mockNotFoundRPCError creates a minimal rpc.Error that reports a "not found" message

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -392,7 +392,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 		t.Run("NotFoundErrorsNotRecorded", func(t *testing.T) {
 			validator, client, _ := setupOutputValidatorTest(t)
-			client.outputErr = errors.New("not found")
+			client.outputErr = mockNotFoundRPCError()
 			game := &types.EnrichedGameData{
 				GameMetadata: challengerTypes.GameMetadata{
 					GameType: 0,
@@ -453,8 +453,8 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 		t.Run("NotFoundErrorsNotCounted", func(t *testing.T) {
 			validator, clients, _ := setupMultiNodeTest(t, 3)
-			clients[0].outputErr = errors.New("not found")
-			clients[1].outputErr = errors.New("not found")
+			clients[0].outputErr = mockNotFoundRPCError()
+			clients[1].outputErr = mockNotFoundRPCError()
 			// clients[2] will succeed
 
 			game := &types.EnrichedGameData{
@@ -474,7 +474,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 		t.Run("MixedErrorTypes", func(t *testing.T) {
 			validator, clients, _ := setupMultiNodeTest(t, 4)
-			clients[0].outputErr = errors.New("not found")        // Should not be counted
+			clients[0].outputErr = mockNotFoundRPCError()         // Should not be counted
 			clients[1].outputErr = errors.New("connection error") // Should be counted
 			clients[2].outputErr = errors.New("server error")     // Should be counted
 			// clients[3] will succeed
@@ -770,7 +770,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		// Set up mixed availability: some found, some not found
 		clients[0].outputRoot = mockRootClaim
 		clients[1].outputRoot = mockRootClaim
-		clients[2].outputErr = errors.New("not found") // This client returns "not found"
+		clients[2].outputErr = mockNotFoundRPCError() // This client returns "not found"
 
 		game := &types.EnrichedGameData{
 			GameMetadata: challengerTypes.GameMetadata{

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -30,9 +30,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 0,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            200,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.ErrorIs(t, err, ErrRollupRpcRequired)
@@ -87,9 +88,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			client.outputErr = errors.New("boom")
 		}
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.Error(t, err)
@@ -105,9 +107,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			client.outputErr = mockNotFoundRPCError()
 		}
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -156,9 +159,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].outputErr = nil
 		clients[2].outputErr = nil
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -176,9 +180,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[3].outputRoot = mockRootClaim
 		clients[3].safeHeadNum = 100
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        50,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -194,9 +199,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].outputRoot = differentRoot
 		clients[2].outputRoot = differentRoot
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        50,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -212,9 +218,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].outputRoot = divergedRoot
 		clients[2].outputRoot = divergedRoot
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -229,9 +236,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].safeHeadNum = 99
 		clients[2].safeHeadNum = 101
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -246,9 +254,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].safeHeadErr = nil
 		clients[2].safeHeadErr = nil
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        0,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -263,9 +272,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].safeHeadNum = 60
 		clients[2].safeHeadNum = 70
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 80,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        80,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -283,9 +293,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		}
 
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 50, // Higher than all safe heads
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        50, // Higher than all safe heads
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
@@ -305,9 +316,10 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		}
 
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        50,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
@@ -323,15 +335,79 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		// without even making a request to the node.
 		rollup.outputErr = errors.New("should not have even requested the output root")
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: uint64(math.MaxInt64) + 1,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:            100,
+			L2BlockNumber:        uint64(math.MaxInt64) + 1,
+			RootClaim:            mockRootClaim,
+			RollupEndpointErrors: make(map[string]bool),
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
 		require.Equal(t, common.Hash{}, game.ExpectedRootClaim)
 		require.False(t, game.AgreeWithClaim)
 		require.Zero(t, metrics.fetchTime)
+	})
+
+	t.Run("RecordEndpointErrors", func(t *testing.T) {
+		t.Run("SingleNodeError", func(t *testing.T) {
+			validator, client, _ := setupOutputValidatorTest(t)
+			client.outputErr = errors.New("connection failed")
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:            200,
+				L2BlockNumber:        100,
+				RootClaim:            mockRootClaim,
+				RollupEndpointErrors: make(map[string]bool),
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.ErrorIs(t, err, ErrAllNodesUnavailable)
+			require.NotNil(t, game.RollupEndpointErrors)
+			require.Contains(t, game.RollupEndpointErrors, "client-0")
+		})
+
+		t.Run("MultiNodeErrors", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 3)
+			clients[0].outputErr = errors.New("connection timeout")
+			clients[2].outputErr = errors.New("server error")
+			// clients[1] will succeed
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:            200,
+				L2BlockNumber:        100,
+				RootClaim:            mockRootClaim,
+				RollupEndpointErrors: make(map[string]bool),
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.NotNil(t, game.RollupEndpointErrors)
+			require.Contains(t, game.RollupEndpointErrors, "client-0")
+			require.Contains(t, game.RollupEndpointErrors, "client-2")
+			require.NotContains(t, game.RollupEndpointErrors, "client-1")
+			require.Len(t, game.RollupEndpointErrors, 2)
+		})
+
+		t.Run("NotFoundErrorsNotRecorded", func(t *testing.T) {
+			validator, client, _ := setupOutputValidatorTest(t)
+			client.outputErr = errors.New("not found")
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:            200,
+				L2BlockNumber:        100,
+				RootClaim:            mockRootClaim,
+				RollupEndpointErrors: make(map[string]bool),
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.NotNil(t, game.RollupEndpointErrors)
+			require.Empty(t, game.RollupEndpointErrors)
+		})
+
 	})
 }
 

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -714,4 +714,127 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 		require.Equal(t, 0, game.RollupEndpointUnsafeCount, "Should count no unsafe endpoints")
 		require.False(t, game.HasMixedSafety(), "Should not have mixed safety")
 	})
+
+	t.Run("TracksDifferentOutputRootsWhenNodesDiverge", func(t *testing.T) {
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+		divergedRoot := common.HexToHash("0x5678")
+
+		// Set up different output roots
+		clients[0].outputRoot = mockRootClaim
+		clients[1].outputRoot = divergedRoot
+		clients[2].outputRoot = divergedRoot
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                          100,
+			L2BlockNumber:                      0,
+			RootClaim:                          mockRootClaim,
+			RollupEndpointErrors:               make(map[string]bool),
+			RollupEndpointDifferentOutputRoots: false,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.True(t, game.RollupEndpointDifferentOutputRoots, "Should track different output roots")
+	})
+
+	t.Run("DoesNotTrackDifferentOutputRootsWhenNodesAgree", func(t *testing.T) {
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// All clients return the same output root
+		for _, client := range clients {
+			client.outputRoot = mockRootClaim
+		}
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                          100,
+			L2BlockNumber:                      0,
+			RootClaim:                          mockRootClaim,
+			RollupEndpointErrors:               make(map[string]bool),
+			RollupEndpointDifferentOutputRoots: false,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.False(t, game.RollupEndpointDifferentOutputRoots, "Should not track different output roots when nodes agree")
+	})
+
+	t.Run("DoesNotTrackDifferentOutputRootsForMixedAvailability", func(t *testing.T) {
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// Set up mixed availability: some found, some not found
+		clients[0].outputRoot = mockRootClaim
+		clients[1].outputRoot = mockRootClaim
+		clients[2].outputErr = errors.New("not found") // This client returns "not found"
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                          100,
+			L2BlockNumber:                      0,
+			RootClaim:                          mockRootClaim,
+			RollupEndpointErrors:               make(map[string]bool),
+			RollupEndpointDifferentOutputRoots: false,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.False(t, game.RollupEndpointDifferentOutputRoots, "Should not track different output roots for mixed availability")
+		require.True(t, game.HasMixedAvailability(), "Should have mixed availability")
+	})
+
+	t.Run("TracksDifferentOutputRootsWithSingleDisagreeingNode", func(t *testing.T) {
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+		divergedRoot := common.HexToHash("0x9999")
+
+		// Two nodes agree, one disagrees
+		clients[0].outputRoot = mockRootClaim
+		clients[1].outputRoot = mockRootClaim
+		clients[2].outputRoot = divergedRoot
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                          100,
+			L2BlockNumber:                      0,
+			RootClaim:                          mockRootClaim,
+			RollupEndpointErrors:               make(map[string]bool),
+			RollupEndpointDifferentOutputRoots: false,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.NoError(t, err)
+		require.True(t, game.RollupEndpointDifferentOutputRoots, "Should track different output roots even with single disagreeing node")
+	})
+
+	t.Run("DoesNotTrackDifferentOutputRootsWithOnlyErrors", func(t *testing.T) {
+		enricher, clients, _ := setupMultiNodeTest(t, 3)
+
+		// All clients return errors (no successful results to compare)
+		for _, client := range clients {
+			client.outputErr = errors.New("rpc error")
+		}
+
+		game := &types.EnrichedGameData{
+			GameMetadata: challengerTypes.GameMetadata{
+				GameType: 0,
+			},
+			L1HeadNum:                          100,
+			L2BlockNumber:                      0,
+			RootClaim:                          mockRootClaim,
+			RollupEndpointErrors:               make(map[string]bool),
+			RollupEndpointDifferentOutputRoots: false,
+		}
+
+		err := enricher.Enrich(context.Background(), rpcblock.Latest, nil, game)
+		require.ErrorIs(t, err, ErrAllNodesUnavailable)
+		require.False(t, game.RollupEndpointDifferentOutputRoots, "Should not track different output roots when all nodes error")
+	})
 }

--- a/op-dispute-mon/mon/mixed_availability.go
+++ b/op-dispute-mon/mon/mixed_availability.go
@@ -37,6 +37,6 @@ func (m *MixedAvailability) CheckMixedAvailability(games []*types.EnrichedGameDa
 	m.metrics.RecordMixedAvailabilityGames(count)
 
 	if count > 0 {
-		m.logger.Info("Mixed availability summary", "gamesWithMixedAvailability", count, "totalGames", len(games))
+		m.logger.Warn("Mixed availability summary", "gamesWithMixedAvailability", count, "totalGames", len(games))
 	}
 }

--- a/op-dispute-mon/mon/mixed_availability.go
+++ b/op-dispute-mon/mon/mixed_availability.go
@@ -1,0 +1,42 @@
+package mon
+
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type MixedAvailabilityMetrics interface {
+	RecordMixedAvailabilityGames(count int)
+}
+
+type MixedAvailability struct {
+	logger  log.Logger
+	metrics MixedAvailabilityMetrics
+}
+
+func NewMixedAvailability(logger log.Logger, metrics MixedAvailabilityMetrics) *MixedAvailability {
+	return &MixedAvailability{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (m *MixedAvailability) CheckMixedAvailability(games []*types.EnrichedGameData) {
+	count := 0
+	for _, game := range games {
+		if game.HasMixedAvailability() {
+			count++
+			m.logger.Debug("Mixed availability detected",
+				"game", game.Proxy,
+				"totalEndpoints", game.RollupEndpointTotalCount,
+				"notFoundCount", game.RollupEndpointNotFoundCount,
+				"errorCount", game.RollupEndpointErrorCount)
+		}
+	}
+
+	m.metrics.RecordMixedAvailabilityGames(count)
+
+	if count > 0 {
+		m.logger.Info("Mixed availability summary", "gamesWithMixedAvailability", count, "totalGames", len(games))
+	}
+}

--- a/op-dispute-mon/mon/mixed_availability_test.go
+++ b/op-dispute-mon/mon/mixed_availability_test.go
@@ -1,0 +1,55 @@
+package mon
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckMixedAvailability(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, RollupEndpointTotalCount: 5, RollupEndpointNotFoundCount: 2, RollupEndpointErrorCount: 1}, // Mixed (2 successful)
+		{RollupEndpointTotalCount: 3, RollupEndpointNotFoundCount: 0, RollupEndpointErrorCount: 0},                                                                    // All successful
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, RollupEndpointTotalCount: 6, RollupEndpointNotFoundCount: 2, RollupEndpointErrorCount: 2}, // Mixed (2 successful)
+		{RollupEndpointTotalCount: 3, RollupEndpointNotFoundCount: 3, RollupEndpointErrorCount: 0},                                                                    // All not found
+		{RollupEndpointTotalCount: 2, RollupEndpointNotFoundCount: 0, RollupEndpointErrorCount: 2},                                                                    // All errors
+	}
+	metrics := &stubMixedAvailabilityMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewMixedAvailability(logger, metrics)
+	monitor.CheckMixedAvailability(games)
+	require.Equal(t, 2, metrics.recordedCount)
+
+	// Debug log for first mixed availability game
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("Mixed availability detected")
+	logs := capturedLogs.FindLogs(levelFilter, messageFilter)
+	require.Len(t, logs, 2)
+
+	l := logs[0]
+	require.Equal(t, common.Address{0x11}, l.AttrValue("game"))
+	require.Equal(t, int64(5), l.AttrValue("totalEndpoints"))
+	require.Equal(t, int64(2), l.AttrValue("notFoundCount"))
+	require.Equal(t, int64(1), l.AttrValue("errorCount"))
+
+	// Info log for summary
+	levelFilter = testlog.NewLevelFilter(log.LevelInfo)
+	messageFilter = testlog.NewMessageFilter("Mixed availability summary")
+	l = capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(2), l.AttrValue("gamesWithMixedAvailability"))
+	require.Equal(t, int64(5), l.AttrValue("totalGames"))
+}
+
+type stubMixedAvailabilityMetrics struct {
+	recordedCount int
+}
+
+func (s *stubMixedAvailabilityMetrics) RecordMixedAvailabilityGames(count int) {
+	s.recordedCount = count
+}

--- a/op-dispute-mon/mon/mixed_availability_test.go
+++ b/op-dispute-mon/mon/mixed_availability_test.go
@@ -37,8 +37,8 @@ func TestCheckMixedAvailability(t *testing.T) {
 	require.Equal(t, int64(2), l.AttrValue("notFoundCount"))
 	require.Equal(t, int64(1), l.AttrValue("errorCount"))
 
-	// Info log for summary
-	levelFilter = testlog.NewLevelFilter(log.LevelInfo)
+	// Warn log for summary
+	levelFilter = testlog.NewLevelFilter(log.LevelWarn)
 	messageFilter = testlog.NewMessageFilter("Mixed availability summary")
 	l = capturedLogs.FindLog(levelFilter, messageFilter)
 	require.NotNil(t, l)

--- a/op-dispute-mon/mon/mixed_safety.go
+++ b/op-dispute-mon/mon/mixed_safety.go
@@ -1,0 +1,41 @@
+package mon
+
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type MixedSafetyMetrics interface {
+	RecordMixedSafetyGames(count int)
+}
+
+type MixedSafetyMonitor struct {
+	logger  log.Logger
+	metrics MixedSafetyMetrics
+}
+
+func NewMixedSafetyMonitor(logger log.Logger, metrics MixedSafetyMetrics) *MixedSafetyMonitor {
+	return &MixedSafetyMonitor{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (m *MixedSafetyMonitor) CheckMixedSafety(games []*types.EnrichedGameData) {
+	count := 0
+	for _, game := range games {
+		if game.HasMixedSafety() {
+			count++
+			m.logger.Debug("Mixed safety detected",
+				"game", game.Proxy,
+				"safeCount", game.RollupEndpointSafeCount,
+				"unsafeCount", game.RollupEndpointUnsafeCount)
+		}
+	}
+
+	m.metrics.RecordMixedSafetyGames(count)
+
+	if count > 0 {
+		m.logger.Info("Mixed safety summary", "gamesWithMixedSafety", count, "totalGames", len(games))
+	}
+}

--- a/op-dispute-mon/mon/mixed_safety_test.go
+++ b/op-dispute-mon/mon/mixed_safety_test.go
@@ -1,0 +1,54 @@
+package mon
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckMixedSafety(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, RollupEndpointSafeCount: 2, RollupEndpointUnsafeCount: 1},
+		{RollupEndpointSafeCount: 3, RollupEndpointUnsafeCount: 0}, // All safe
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, RollupEndpointSafeCount: 1, RollupEndpointUnsafeCount: 4},
+		{RollupEndpointSafeCount: 0, RollupEndpointUnsafeCount: 2}, // All unsafe
+		{RollupEndpointSafeCount: 0, RollupEndpointUnsafeCount: 0}, // No safety checks
+	}
+	metrics := &stubMixedSafetyMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewMixedSafetyMonitor(logger, metrics)
+	monitor.CheckMixedSafety(games)
+	require.Equal(t, 2, metrics.recordedCount)
+
+	// Debug log for first mixed safety game
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("Mixed safety detected")
+	logs := capturedLogs.FindLogs(levelFilter, messageFilter)
+	require.Len(t, logs, 2)
+
+	l := logs[0]
+	require.Equal(t, common.Address{0x11}, l.AttrValue("game"))
+	require.Equal(t, int64(2), l.AttrValue("safeCount"))
+	require.Equal(t, int64(1), l.AttrValue("unsafeCount"))
+
+	// Info log for summary
+	levelFilter = testlog.NewLevelFilter(log.LevelInfo)
+	messageFilter = testlog.NewMessageFilter("Mixed safety summary")
+	l = capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(2), l.AttrValue("gamesWithMixedSafety"))
+	require.Equal(t, int64(5), l.AttrValue("totalGames"))
+}
+
+type stubMixedSafetyMetrics struct {
+	recordedCount int
+}
+
+func (s *stubMixedSafetyMetrics) RecordMixedSafetyGames(count int) {
+	s.recordedCount = count
+}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -205,3 +205,57 @@ func TestMonitor_NodeEndpointErrorsMonitorIntegration(t *testing.T) {
 		require.Equal(t, 3, nodeEndpointErrorsMetrics.recordedCount)
 	})
 }
+
+func TestMonitor_NodeEndpointErrorCountMonitorIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NodeEndpointErrorCountMonitorCalledWithGamesData", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games with endpoint error counts
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:             types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointErrorCount: 5, // First game has 5 errors
+			},
+			{
+				GameMetadata:             types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointErrorCount: 3, // Second game has 3 errors
+			},
+			{
+				GameMetadata:             types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointErrorCount: 0, // Third game has no errors
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		nodeEndpointErrorCountMetrics := &mockNodeEndpointErrorCountMetrics{}
+		nodeEndpointErrorCountMonitor := NewNodeEndpointErrorCountMonitor(logger, nodeEndpointErrorCountMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that NodeEndpointErrorCountMonitor was called and recorded the correct total
+		// Should sum all error counts: 5 + 3 + 0 = 8 total errors
+		require.Equal(t, 8, nodeEndpointErrorCountMetrics.recordedCount)
+	})
+}
+
+// mockNodeEndpointErrorCountMetrics for integration test
+type mockNodeEndpointErrorCountMetrics struct {
+	recordedCount int
+}
+
+func (m *mockNodeEndpointErrorCountMetrics) RecordNodeEndpointErrorCount(count int) {
+	m.recordedCount = count
+}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -259,3 +259,69 @@ type mockNodeEndpointErrorCountMetrics struct {
 func (m *mockNodeEndpointErrorCountMetrics) RecordNodeEndpointErrorCount(count int) {
 	m.recordedCount = count
 }
+
+func TestMonitor_MixedAvailabilityMonitorIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MixedAvailabilityMonitorCalledWithGamesData", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games with mixed availability scenarios
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:                types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointTotalCount:    3,
+				RollupEndpointNotFoundCount: 1, // Mixed availability: some found, some not found
+				RollupEndpointErrorCount:    0,
+			},
+			{
+				GameMetadata:                types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointTotalCount:    2,
+				RollupEndpointNotFoundCount: 2, // All endpoints not found - not mixed availability
+				RollupEndpointErrorCount:    0,
+			},
+			{
+				GameMetadata:                types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointTotalCount:    4,
+				RollupEndpointNotFoundCount: 2, // Mixed availability: some found, some not found
+				RollupEndpointErrorCount:    0,
+			},
+			{
+				GameMetadata:                types.GameMetadata{Proxy: common.Address{0x44}},
+				RollupEndpointTotalCount:    3,
+				RollupEndpointNotFoundCount: 0, // All endpoints found - not mixed availability
+				RollupEndpointErrorCount:    0,
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		mixedAvailabilityMetrics := &mockMixedAvailabilityMetrics{}
+		mixedAvailabilityMonitor := NewMixedAvailability(logger, mixedAvailabilityMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, mixedAvailabilityMonitor.CheckMixedAvailability)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that MixedAvailabilityMonitor was called and recorded the correct count
+		// Should count games with mixed availability: game 0x11 and 0x33 = 2 total
+		require.Equal(t, 2, mixedAvailabilityMetrics.recordedCount)
+	})
+}
+
+// mockMixedAvailabilityMetrics for integration test
+type mockMixedAvailabilityMetrics struct {
+	recordedCount int
+}
+
+func (m *mockMixedAvailabilityMetrics) RecordMixedAvailabilityGames(count int) {
+	m.recordedCount = count
+}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -468,3 +468,168 @@ type mockMixedSafetyMetrics struct {
 func (m *mockMixedSafetyMetrics) RecordMixedSafetyGames(count int) {
 	m.recordedCount = count
 }
+
+func TestMonitor_DifferentOutputRootMonitorIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DifferentOutputRootMonitorCalledWithGamesData", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games with different output root scenarios
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointDifferentOutputRoots: true, // Has different output roots
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointDifferentOutputRoots: false, // No disagreement
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointDifferentOutputRoots: true, // Has different output roots
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x44}},
+				RollupEndpointDifferentOutputRoots: false, // No disagreement
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
+		differentOutputRootMonitor := NewDifferentOutputRootMonitor(logger, differentOutputRootMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentOutputRoots)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that DifferentOutputRootMonitor was called and recorded the correct count
+		// Should count games with different output roots: game 0x11 and 0x33 = 2 total
+		require.Equal(t, 2, differentOutputRootMetrics.recordedCount)
+	})
+
+	t.Run("OnlyGamesWithDifferentOutputRootsAreCounted", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games without different output roots
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointDifferentOutputRoots: false, // No disagreement
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointDifferentOutputRoots: false, // No disagreement
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointDifferentOutputRoots: false, // No disagreement
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
+		differentOutputRootMonitor := NewDifferentOutputRootMonitor(logger, differentOutputRootMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentOutputRoots)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that no games were counted as having different output roots
+		require.Equal(t, 0, differentOutputRootMetrics.recordedCount)
+	})
+
+	t.Run("AllGamesHaveDifferentOutputRoots", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games where all have different output roots
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointDifferentOutputRoots: true,
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointDifferentOutputRoots: true,
+			},
+			{
+				GameMetadata:                       types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointDifferentOutputRoots: true,
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
+		differentOutputRootMonitor := NewDifferentOutputRootMonitor(logger, differentOutputRootMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentOutputRoots)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that all games were counted
+		require.Equal(t, 3, differentOutputRootMetrics.recordedCount)
+	})
+
+	t.Run("EmptyGamesListReturnsZero", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create empty games list
+		games := []*monTypes.EnrichedGameData{}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		differentOutputRootMetrics := &mockDifferentOutputRootMetrics{}
+		differentOutputRootMonitor := NewDifferentOutputRootMonitor(logger, differentOutputRootMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, differentOutputRootMonitor.CheckDifferentOutputRoots)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that count is zero
+		require.Equal(t, 0, differentOutputRootMetrics.recordedCount)
+	})
+}
+
+// mockDifferentOutputRootMetrics for integration test
+type mockDifferentOutputRootMetrics struct {
+	recordedCount int
+}
+
+func (m *mockDifferentOutputRootMetrics) RecordDifferentOutputRootGames(count int) {
+	m.recordedCount = count
+}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -158,3 +158,50 @@ func (m *mockExtractor) Extract(
 	}
 	return m.games, m.ignoredCount, m.failedCount, nil
 }
+
+func TestMonitor_NodeEndpointErrorsMonitorIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NodeEndpointErrorsMonitorCalledWithGamesData", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games with endpoint errors
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata: types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointErrors: map[string]bool{
+					"endpoint_1": true,
+					"endpoint_2": true,
+				},
+			},
+			{
+				GameMetadata: types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointErrors: map[string]bool{
+					"endpoint_2": true, // Overlapping with first game
+					"endpoint_3": true,
+				},
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		nodeEndpointErrorsMetrics := &stubNodeEndpointErrorsMetrics{}
+		nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(logger, nodeEndpointErrorsMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, nodeEndpointErrorsMonitor.CheckNodeEndpointErrors)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that NodeEndpointErrorsMonitor was called and recorded the correct count
+		// Should count unique endpoints: endpoint_1, endpoint_2, endpoint_3 = 3 total
+		require.Equal(t, 3, nodeEndpointErrorsMetrics.recordedCount)
+	})
+}

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -325,3 +325,146 @@ type mockMixedAvailabilityMetrics struct {
 func (m *mockMixedAvailabilityMetrics) RecordMixedAvailabilityGames(count int) {
 	m.recordedCount = count
 }
+
+func TestMonitor_MixedSafetyMonitorIntegration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MixedSafetyMonitorCalledWithGamesData", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games with mixed safety scenarios
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointSafeCount:   2, // Mixed safety: some safe, some unsafe
+				RollupEndpointUnsafeCount: 1,
+			},
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointSafeCount:   3, // All endpoints safe - not mixed safety
+				RollupEndpointUnsafeCount: 0,
+			},
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointSafeCount:   1, // Mixed safety: some safe, some unsafe
+				RollupEndpointUnsafeCount: 4,
+			},
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x44}},
+				RollupEndpointSafeCount:   0, // All endpoints unsafe - not mixed safety
+				RollupEndpointUnsafeCount: 2,
+			},
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x55}},
+				RollupEndpointSafeCount:   0, // No safety checks performed - not mixed safety
+				RollupEndpointUnsafeCount: 0,
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		mixedSafetyMetrics := &mockMixedSafetyMetrics{}
+		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, mixedSafetyMonitor.CheckMixedSafety)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that MixedSafetyMonitor was called and recorded the correct count
+		// Should count games with mixed safety: game 0x11 and 0x33 = 2 total
+		require.Equal(t, 2, mixedSafetyMetrics.recordedCount)
+	})
+
+	t.Run("OnlyGamesWithMixedSafetyAreCounted", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create games without mixed safety
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointSafeCount:   5, // All safe
+				RollupEndpointUnsafeCount: 0,
+			},
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x22}},
+				RollupEndpointSafeCount:   0, // All unsafe
+				RollupEndpointUnsafeCount: 3,
+			},
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x33}},
+				RollupEndpointSafeCount:   0, // No checks performed
+				RollupEndpointUnsafeCount: 0,
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		mixedSafetyMetrics := &mockMixedSafetyMetrics{}
+		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, mixedSafetyMonitor.CheckMixedSafety)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that no games were counted as having mixed safety
+		require.Equal(t, 0, mixedSafetyMetrics.recordedCount)
+	})
+
+	t.Run("EdgeCaseMinimalMixedSafety", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LvlDebug)
+		fetchHeadBlock := func(ctx context.Context) (eth.L1BlockRef, error) {
+			return eth.L1BlockRef{Number: 1, Hash: common.Hash{0xaa}}, nil
+		}
+		monitorInterval := 100 * time.Millisecond
+		cl := clock.NewAdvancingClock(10 * time.Millisecond)
+		cl.Start()
+
+		// Create a game with minimal mixed safety (1 safe, 1 unsafe)
+		games := []*monTypes.EnrichedGameData{
+			{
+				GameMetadata:              types.GameMetadata{Proxy: common.Address{0x11}},
+				RollupEndpointSafeCount:   1, // Minimal mixed safety
+				RollupEndpointUnsafeCount: 1,
+			},
+		}
+
+		extractor := &mockExtractor{games: games}
+		forecast := &mockForecast{}
+		mixedSafetyMetrics := &mockMixedSafetyMetrics{}
+		mixedSafetyMonitor := NewMixedSafetyMonitor(logger, mixedSafetyMetrics)
+
+		monitor := newGameMonitor(context.Background(), logger, cl, metrics.NoopMetrics, monitorInterval, 10*time.Second, fetchHeadBlock,
+			extractor.Extract, forecast.Forecast, mixedSafetyMonitor.CheckMixedSafety)
+
+		err := monitor.monitorGames()
+		require.NoError(t, err)
+
+		// Verify that the minimal mixed safety case is counted
+		require.Equal(t, 1, mixedSafetyMetrics.recordedCount)
+	})
+}
+
+// mockMixedSafetyMetrics for integration test
+type mockMixedSafetyMetrics struct {
+	recordedCount int
+}
+
+func (m *mockMixedSafetyMetrics) RecordMixedSafetyGames(count int) {
+	m.recordedCount = count
+}

--- a/op-dispute-mon/mon/node_endpoint_error_count.go
+++ b/op-dispute-mon/mon/node_endpoint_error_count.go
@@ -28,14 +28,6 @@ func (m *NodeEndpointErrorCountMonitor) CheckNodeEndpointErrorCount(games []*typ
 		totalErrors += game.RollupEndpointErrorCount
 	}
 
-	if totalErrors > 0 {
-		m.logger.Warn("Found rollup node endpoint errors",
-			"total_error_count", totalErrors,
-			"games_with_errors", countGamesWithErrors(games))
-	} else {
-		m.logger.Debug("No rollup node endpoint errors found")
-	}
-
 	m.metrics.RecordNodeEndpointErrorCount(totalErrors)
 }
 

--- a/op-dispute-mon/mon/node_endpoint_error_count.go
+++ b/op-dispute-mon/mon/node_endpoint_error_count.go
@@ -1,0 +1,51 @@
+package mon
+
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type NodeEndpointErrorCountMetrics interface {
+	RecordNodeEndpointErrorCount(count int)
+}
+
+type NodeEndpointErrorCountMonitor struct {
+	logger  log.Logger
+	metrics NodeEndpointErrorCountMetrics
+}
+
+func NewNodeEndpointErrorCountMonitor(logger log.Logger, metrics NodeEndpointErrorCountMetrics) *NodeEndpointErrorCountMonitor {
+	return &NodeEndpointErrorCountMonitor{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (m *NodeEndpointErrorCountMonitor) CheckNodeEndpointErrorCount(games []*types.EnrichedGameData) {
+	totalErrors := 0
+
+	for _, game := range games {
+		totalErrors += game.RollupEndpointErrorCount
+	}
+
+	if totalErrors > 0 {
+		m.logger.Warn("Found rollup node endpoint errors",
+			"total_error_count", totalErrors,
+			"games_with_errors", countGamesWithErrors(games))
+	} else {
+		m.logger.Debug("No rollup node endpoint errors found")
+	}
+
+	m.metrics.RecordNodeEndpointErrorCount(totalErrors)
+}
+
+// countGamesWithErrors returns the number of games that have at least one error
+func countGamesWithErrors(games []*types.EnrichedGameData) int {
+	count := 0
+	for _, game := range games {
+		if game.RollupEndpointErrorCount > 0 {
+			count++
+		}
+	}
+	return count
+}

--- a/op-dispute-mon/mon/node_endpoint_error_count_test.go
+++ b/op-dispute-mon/mon/node_endpoint_error_count_test.go
@@ -19,17 +19,12 @@ func TestCheckNodeEndpointErrorCount_NoErrors(t *testing.T) {
 	}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrorCount(games)
 
 	require.Equal(t, 0, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
-	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
 }
 
 func TestCheckNodeEndpointErrorCount_SingleGameWithErrors(t *testing.T) {
@@ -45,19 +40,12 @@ func TestCheckNodeEndpointErrorCount_SingleGameWithErrors(t *testing.T) {
 	}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrorCount(games)
 
 	require.Equal(t, 5, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
-	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
-	require.Equal(t, int64(5), l.AttrValue("total_error_count"))
-	require.Equal(t, int64(1), l.AttrValue("games_with_errors"))
 }
 
 func TestCheckNodeEndpointErrorCount_MultipleGamesWithErrors(t *testing.T) {
@@ -77,20 +65,13 @@ func TestCheckNodeEndpointErrorCount_MultipleGamesWithErrors(t *testing.T) {
 	}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrorCount(games)
 
 	// Should sum all error counts (3 + 7 + 2 = 12)
 	require.Equal(t, 12, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
-	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
-	require.Equal(t, int64(12), l.AttrValue("total_error_count"))
-	require.Equal(t, int64(3), l.AttrValue("games_with_errors"))
 }
 
 func TestCheckNodeEndpointErrorCount_MixedGamesWithAndWithoutErrors(t *testing.T) {
@@ -114,37 +95,25 @@ func TestCheckNodeEndpointErrorCount_MixedGamesWithAndWithoutErrors(t *testing.T
 	}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrorCount(games)
 
 	// Should sum only non-zero error counts (4 + 6 = 10)
 	require.Equal(t, 10, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
-	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
-	require.Equal(t, int64(10), l.AttrValue("total_error_count"))
-	require.Equal(t, int64(2), l.AttrValue("games_with_errors"))
 }
 
 func TestCheckNodeEndpointErrorCount_EmptyGamesList(t *testing.T) {
 	games := []*types.EnrichedGameData{}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrorCount(games)
 
 	require.Equal(t, 0, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
-	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
 }
 
 func TestCheckNodeEndpointErrorCount_HighVolumeErrors(t *testing.T) {
@@ -164,20 +133,13 @@ func TestCheckNodeEndpointErrorCount_HighVolumeErrors(t *testing.T) {
 	}
 
 	metrics := &stubNodeEndpointErrorCountMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrorCount(games)
 
 	// Should sum all error counts (100 + 250 + 75 = 425)
 	require.Equal(t, 425, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
-	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
-	require.Equal(t, int64(425), l.AttrValue("total_error_count"))
-	require.Equal(t, int64(3), l.AttrValue("games_with_errors"))
 }
 
 func TestCountGamesWithErrors(t *testing.T) {

--- a/op-dispute-mon/mon/node_endpoint_error_count_test.go
+++ b/op-dispute-mon/mon/node_endpoint_error_count_test.go
@@ -1,0 +1,237 @@
+package mon
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckNodeEndpointErrorCount_NoErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, RollupEndpointErrorCount: 0},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, RollupEndpointErrorCount: 0},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}, RollupEndpointErrorCount: 0},
+	}
+
+	metrics := &stubNodeEndpointErrorCountMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrorCount(games)
+
+	require.Equal(t, 0, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+}
+
+func TestCheckNodeEndpointErrorCount_SingleGameWithErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointErrorCount: 5,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointErrorCount: 0,
+		},
+	}
+
+	metrics := &stubNodeEndpointErrorCountMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrorCount(games)
+
+	require.Equal(t, 5, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(5), l.AttrValue("total_error_count"))
+	require.Equal(t, int64(1), l.AttrValue("games_with_errors"))
+}
+
+func TestCheckNodeEndpointErrorCount_MultipleGamesWithErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointErrorCount: 3,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointErrorCount: 7,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointErrorCount: 2,
+		},
+	}
+
+	metrics := &stubNodeEndpointErrorCountMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrorCount(games)
+
+	// Should sum all error counts (3 + 7 + 2 = 12)
+	require.Equal(t, 12, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(12), l.AttrValue("total_error_count"))
+	require.Equal(t, int64(3), l.AttrValue("games_with_errors"))
+}
+
+func TestCheckNodeEndpointErrorCount_MixedGamesWithAndWithoutErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointErrorCount: 0,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointErrorCount: 4,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointErrorCount: 0,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x44}},
+			RollupEndpointErrorCount: 6,
+		},
+	}
+
+	metrics := &stubNodeEndpointErrorCountMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrorCount(games)
+
+	// Should sum only non-zero error counts (4 + 6 = 10)
+	require.Equal(t, 10, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(10), l.AttrValue("total_error_count"))
+	require.Equal(t, int64(2), l.AttrValue("games_with_errors"))
+}
+
+func TestCheckNodeEndpointErrorCount_EmptyGamesList(t *testing.T) {
+	games := []*types.EnrichedGameData{}
+
+	metrics := &stubNodeEndpointErrorCountMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrorCount(games)
+
+	require.Equal(t, 0, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+}
+
+func TestCheckNodeEndpointErrorCount_HighVolumeErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointErrorCount: 100,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointErrorCount: 250,
+		},
+		{
+			GameMetadata:             gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointErrorCount: 75,
+		},
+	}
+
+	metrics := &stubNodeEndpointErrorCountMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorCountMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrorCount(games)
+
+	// Should sum all error counts (100 + 250 + 75 = 425)
+	require.Equal(t, 425, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(425), l.AttrValue("total_error_count"))
+	require.Equal(t, int64(3), l.AttrValue("games_with_errors"))
+}
+
+func TestCountGamesWithErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		games    []*types.EnrichedGameData
+		expected int
+	}{
+		{
+			name:     "no games",
+			games:    []*types.EnrichedGameData{},
+			expected: 0,
+		},
+		{
+			name: "no errors",
+			games: []*types.EnrichedGameData{
+				{RollupEndpointErrorCount: 0},
+				{RollupEndpointErrorCount: 0},
+			},
+			expected: 0,
+		},
+		{
+			name: "all games have errors",
+			games: []*types.EnrichedGameData{
+				{RollupEndpointErrorCount: 1},
+				{RollupEndpointErrorCount: 5},
+				{RollupEndpointErrorCount: 10},
+			},
+			expected: 3,
+		},
+		{
+			name: "mixed errors",
+			games: []*types.EnrichedGameData{
+				{RollupEndpointErrorCount: 0},
+				{RollupEndpointErrorCount: 3},
+				{RollupEndpointErrorCount: 0},
+				{RollupEndpointErrorCount: 7},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := countGamesWithErrors(tt.games)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+type stubNodeEndpointErrorCountMetrics struct {
+	recordedCount int
+}
+
+func (s *stubNodeEndpointErrorCountMetrics) RecordNodeEndpointErrorCount(count int) {
+	s.recordedCount = count
+}

--- a/op-dispute-mon/mon/node_endpoint_errors.go
+++ b/op-dispute-mon/mon/node_endpoint_errors.go
@@ -34,14 +34,6 @@ func (m *NodeEndpointErrorsMonitor) CheckNodeEndpointErrors(games []*types.Enric
 	}
 
 	errorCount := len(uniqueEndpointErrors)
-	if errorCount > 0 {
-		m.logger.Warn("Found rollup node endpoint errors",
-			"unique_endpoint_count", errorCount,
-			"endpoints", getEndpointList(uniqueEndpointErrors))
-	} else {
-		m.logger.Debug("No rollup node endpoint errors found")
-	}
-
 	m.metrics.RecordNodeEndpointErrors(errorCount)
 }
 

--- a/op-dispute-mon/mon/node_endpoint_errors.go
+++ b/op-dispute-mon/mon/node_endpoint_errors.go
@@ -1,0 +1,55 @@
+package mon
+
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type NodeEndpointErrorsMetrics interface {
+	RecordNodeEndpointErrors(count int)
+}
+
+type NodeEndpointErrorsMonitor struct {
+	logger  log.Logger
+	metrics NodeEndpointErrorsMetrics
+}
+
+func NewNodeEndpointErrorsMonitor(logger log.Logger, metrics NodeEndpointErrorsMetrics) *NodeEndpointErrorsMonitor {
+	return &NodeEndpointErrorsMonitor{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (m *NodeEndpointErrorsMonitor) CheckNodeEndpointErrors(games []*types.EnrichedGameData) {
+	// Use a set to track unique endpoint errors across all games
+	uniqueEndpointErrors := make(map[string]bool)
+
+	for _, game := range games {
+		if game.RollupEndpointErrors != nil {
+			for endpointID := range game.RollupEndpointErrors {
+				uniqueEndpointErrors[endpointID] = true
+			}
+		}
+	}
+
+	errorCount := len(uniqueEndpointErrors)
+	if errorCount > 0 {
+		m.logger.Warn("Found rollup node endpoint errors",
+			"unique_endpoint_count", errorCount,
+			"endpoints", getEndpointList(uniqueEndpointErrors))
+	} else {
+		m.logger.Debug("No rollup node endpoint errors found")
+	}
+
+	m.metrics.RecordNodeEndpointErrors(errorCount)
+}
+
+// getEndpointList converts the map keys to a slice for logging
+func getEndpointList(endpointErrors map[string]bool) []string {
+	endpoints := make([]string, 0, len(endpointErrors))
+	for endpointID := range endpointErrors {
+		endpoints = append(endpoints, endpointID)
+	}
+	return endpoints
+}

--- a/op-dispute-mon/mon/node_endpoint_errors.go
+++ b/op-dispute-mon/mon/node_endpoint_errors.go
@@ -36,12 +36,3 @@ func (m *NodeEndpointErrorsMonitor) CheckNodeEndpointErrors(games []*types.Enric
 	errorCount := len(uniqueEndpointErrors)
 	m.metrics.RecordNodeEndpointErrors(errorCount)
 }
-
-// getEndpointList converts the map keys to a slice for logging
-func getEndpointList(endpointErrors map[string]bool) []string {
-	endpoints := make([]string, 0, len(endpointErrors))
-	for endpointID := range endpointErrors {
-		endpoints = append(endpoints, endpointID)
-	}
-	return endpoints
-}

--- a/op-dispute-mon/mon/node_endpoint_errors.go
+++ b/op-dispute-mon/mon/node_endpoint_errors.go
@@ -26,7 +26,7 @@ func (m *NodeEndpointErrorsMonitor) CheckNodeEndpointErrors(games []*types.Enric
 	uniqueEndpointErrors := make(map[string]bool)
 
 	for _, game := range games {
-		if game.RollupEndpointErrors != nil {
+		if len(game.RollupEndpointErrors) != 0 {
 			for endpointID := range game.RollupEndpointErrors {
 				uniqueEndpointErrors[endpointID] = true
 			}

--- a/op-dispute-mon/mon/node_endpoint_errors_test.go
+++ b/op-dispute-mon/mon/node_endpoint_errors_test.go
@@ -19,17 +19,12 @@ func TestCheckNodeEndpointErrors_NoErrors(t *testing.T) {
 	}
 
 	metrics := &stubNodeEndpointErrorsMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrors(games)
 
 	require.Equal(t, 0, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
-	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
 }
 
 func TestCheckNodeEndpointErrors_SingleGameWithErrors(t *testing.T) {
@@ -45,22 +40,12 @@ func TestCheckNodeEndpointErrors_SingleGameWithErrors(t *testing.T) {
 	}
 
 	metrics := &stubNodeEndpointErrorsMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrors(games)
 
 	require.Equal(t, 2, metrics.recordedCount)
-
-	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
-	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
-	require.Equal(t, int64(2), l.AttrValue("unique_endpoint_count"))
-	endpoints := l.AttrValue("endpoints").([]string)
-	require.Len(t, endpoints, 2)
-	require.Contains(t, endpoints, "endpoint_1")
-	require.Contains(t, endpoints, "endpoint_2")
 }
 
 func TestCheckNodeEndpointErrors_MultipleGamesWithOverlappingErrors(t *testing.T) {
@@ -88,26 +73,13 @@ func TestCheckNodeEndpointErrors_MultipleGamesWithOverlappingErrors(t *testing.T
 	}
 
 	metrics := &stubNodeEndpointErrorsMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrors(games)
 
 	// Should count unique endpoints across all games (endpoint_1, endpoint_2, endpoint_3, endpoint_4)
 	require.Equal(t, 4, metrics.recordedCount)
-
-	// Check warn log for errors found
-	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
-	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
-	require.Equal(t, int64(4), l.AttrValue("unique_endpoint_count"))
-	endpoints := l.AttrValue("endpoints").([]string)
-	require.Len(t, endpoints, 4)
-	require.Contains(t, endpoints, "endpoint_1")
-	require.Contains(t, endpoints, "endpoint_2")
-	require.Contains(t, endpoints, "endpoint_3")
-	require.Contains(t, endpoints, "endpoint_4")
 }
 
 func TestCheckNodeEndpointErrors_MixedGamesWithAndWithoutErrors(t *testing.T) {
@@ -141,18 +113,12 @@ func TestCheckNodeEndpointErrors_EmptyGamesList(t *testing.T) {
 	games := []*types.EnrichedGameData{}
 
 	metrics := &stubNodeEndpointErrorsMetrics{}
-	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	logger := testlog.Logger(t, log.LvlDebug)
 	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
 
 	monitor.CheckNodeEndpointErrors(games)
 
 	require.Equal(t, 0, metrics.recordedCount)
-
-	// Check debug log for no errors
-	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
-	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
-	l := capturedLogs.FindLog(levelFilter, messageFilter)
-	require.NotNil(t, l)
 }
 
 type stubNodeEndpointErrorsMetrics struct {

--- a/op-dispute-mon/mon/node_endpoint_errors_test.go
+++ b/op-dispute-mon/mon/node_endpoint_errors_test.go
@@ -1,0 +1,164 @@
+package mon
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckNodeEndpointErrors_NoErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, RollupEndpointErrors: nil},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, RollupEndpointErrors: make(map[string]bool)},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}}, // No RollupEndpointErrors field set
+	}
+
+	metrics := &stubNodeEndpointErrorsMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrors(games)
+
+	require.Equal(t, 0, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+}
+
+func TestCheckNodeEndpointErrors_SingleGameWithErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointErrors: map[string]bool{
+				"endpoint_1": true,
+				"endpoint_2": true,
+			},
+		},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, RollupEndpointErrors: nil},
+	}
+
+	metrics := &stubNodeEndpointErrorsMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrors(games)
+
+	require.Equal(t, 2, metrics.recordedCount)
+
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(2), l.AttrValue("unique_endpoint_count"))
+	endpoints := l.AttrValue("endpoints").([]string)
+	require.Len(t, endpoints, 2)
+	require.Contains(t, endpoints, "endpoint_1")
+	require.Contains(t, endpoints, "endpoint_2")
+}
+
+func TestCheckNodeEndpointErrors_MultipleGamesWithOverlappingErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointErrors: map[string]bool{
+				"endpoint_1": true,
+				"endpoint_2": true,
+			},
+		},
+		{
+			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointErrors: map[string]bool{
+				"endpoint_2": true, // Overlapping with first game
+				"endpoint_3": true,
+			},
+		},
+		{
+			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointErrors: map[string]bool{
+				"endpoint_4": true,
+			},
+		},
+	}
+
+	metrics := &stubNodeEndpointErrorsMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrors(games)
+
+	// Should count unique endpoints across all games (endpoint_1, endpoint_2, endpoint_3, endpoint_4)
+	require.Equal(t, 4, metrics.recordedCount)
+
+	// Check warn log for errors found
+	levelFilter := testlog.NewLevelFilter(log.LevelWarn)
+	messageFilter := testlog.NewMessageFilter("Found rollup node endpoint errors")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+	require.Equal(t, int64(4), l.AttrValue("unique_endpoint_count"))
+	endpoints := l.AttrValue("endpoints").([]string)
+	require.Len(t, endpoints, 4)
+	require.Contains(t, endpoints, "endpoint_1")
+	require.Contains(t, endpoints, "endpoint_2")
+	require.Contains(t, endpoints, "endpoint_3")
+	require.Contains(t, endpoints, "endpoint_4")
+}
+
+func TestCheckNodeEndpointErrors_MixedGamesWithAndWithoutErrors(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, RollupEndpointErrors: nil},
+		{
+			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointErrors: map[string]bool{
+				"endpoint_1": true,
+			},
+		},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}, RollupEndpointErrors: make(map[string]bool)},
+		{
+			GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}},
+			RollupEndpointErrors: map[string]bool{
+				"endpoint_2": true,
+			},
+		},
+	}
+
+	metrics := &stubNodeEndpointErrorsMetrics{}
+	logger, _ := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrors(games)
+
+	require.Equal(t, 2, metrics.recordedCount)
+}
+
+func TestCheckNodeEndpointErrors_EmptyGamesList(t *testing.T) {
+	games := []*types.EnrichedGameData{}
+
+	metrics := &stubNodeEndpointErrorsMetrics{}
+	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
+	monitor := NewNodeEndpointErrorsMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointErrors(games)
+
+	require.Equal(t, 0, metrics.recordedCount)
+
+	// Check debug log for no errors
+	levelFilter := testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter := testlog.NewMessageFilter("No rollup node endpoint errors found")
+	l := capturedLogs.FindLog(levelFilter, messageFilter)
+	require.NotNil(t, l)
+}
+
+type stubNodeEndpointErrorsMetrics struct {
+	recordedCount int
+}
+
+func (s *stubNodeEndpointErrorsMetrics) RecordNodeEndpointErrors(count int) {
+	s.recordedCount = count
+}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -270,6 +270,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	l2ChallengesMonitor := NewL2ChallengesMonitor(s.logger, s.metrics)
 	updateTimeMonitor := NewUpdateTimeMonitor(s.cl, s.metrics)
 	nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(s.logger, s.metrics)
+	nodeEndpointErrorCountMonitor := NewNodeEndpointErrorCountMonitor(s.logger, s.metrics)
 	s.monitor = newGameMonitor(ctx, s.logger, s.cl, s.metrics, cfg.MonitorInterval, cfg.GameWindow, headBlockFetcher,
 		s.extractor.Extract,
 		s.forecast.Forecast,
@@ -279,7 +280,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.withdrawals.CheckWithdrawals,
 		l2ChallengesMonitor.CheckL2Challenges,
 		updateTimeMonitor.CheckUpdateTimes,
-		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors)
+		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
+		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -38,16 +38,7 @@ type Service struct {
 
 	cl clock.Clock
 
-	extractor           *extract.Extractor
-	forecast            *Forecast
-	bonds               *bonds.Bonds
 	game                *extract.GameCallerCreator
-	resolutions         *ResolutionMonitor
-	claims              *ClaimMonitor
-	withdrawals         *WithdrawalMonitor
-	mixedAvailability   *MixedAvailability
-	mixedSafety         *MixedSafetyMonitor
-	differentOutputRoot *DifferentOutputRootMonitor
 	rollupClients       []*sources.RollupClient
 	supervisorClients   []*sources.SupervisorClient
 
@@ -97,19 +88,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 		return fmt.Errorf("failed to init supervisor clients: %w", err)
 	}
 
-	s.initClaimMonitor(cfg)
-	s.initResolutionMonitor()
-	s.initWithdrawalMonitor()
-	s.initMixedAvailabilityMonitor()
-	s.initMixedSafetyMonitor()
-	s.initDifferentOutputRootMonitor()
-
 	s.initGameCallerCreator() // Must be called before initForecast
-
-	s.initExtractor(cfg)
-
-	s.initForecast(cfg)
-	s.initBonds()
 
 	s.initMonitor(ctx, cfg) // Monitor must be initialized last
 
@@ -117,30 +96,6 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.metrics.RecordUp()
 
 	return nil
-}
-
-func (s *Service) initClaimMonitor(cfg *config.Config) {
-	s.claims = NewClaimMonitor(s.logger, s.cl, s.honestActors, s.metrics)
-}
-
-func (s *Service) initResolutionMonitor() {
-	s.resolutions = NewResolutionMonitor(s.logger, s.metrics, s.cl)
-}
-
-func (s *Service) initWithdrawalMonitor() {
-	s.withdrawals = NewWithdrawalMonitor(s.logger, s.cl, s.metrics, s.honestActors)
-}
-
-func (s *Service) initMixedAvailabilityMonitor() {
-	s.mixedAvailability = NewMixedAvailability(s.logger, s.metrics)
-}
-
-func (s *Service) initMixedSafetyMonitor() {
-	s.mixedSafety = NewMixedSafetyMonitor(s.logger, s.metrics)
-}
-
-func (s *Service) initDifferentOutputRootMonitor() {
-	s.differentOutputRoot = NewDifferentOutputRootMonitor(s.logger, s.metrics)
 }
 
 func (s *Service) initGameCallerCreator() {
@@ -161,33 +116,6 @@ func (s *Service) asSuperRootProviders() []extract.SuperRootProvider {
 		clients[i] = client
 	}
 	return clients
-}
-
-func (s *Service) initExtractor(cfg *config.Config) {
-	s.extractor = extract.NewExtractor(
-		s.logger,
-		s.cl,
-		s.game.CreateContract,
-		s.factoryContract.GetGamesAtOrAfter,
-		cfg.IgnoredGames,
-		cfg.MaxConcurrency,
-		extract.NewClaimEnricher(),
-		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
-		extract.NewWithdrawalsEnricher(),
-		extract.NewBondEnricher(),
-		extract.NewBalanceEnricher(),
-		extract.NewL1HeadBlockNumEnricher(s.l1Client),
-		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
-		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
-	)
-}
-
-func (s *Service) initForecast(cfg *config.Config) {
-	s.forecast = NewForecast(s.logger, s.metrics)
-}
-
-func (s *Service) initBonds() {
-	s.bonds = bonds.NewBonds(s.logger, s.metrics, s.cl)
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {
@@ -285,24 +213,48 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	headBlockFetcher := func(ctx context.Context) (eth.L1BlockRef, error) {
 		return s.l1Client.L1BlockRefByLabel(ctx, "latest")
 	}
+	extractor := extract.NewExtractor(
+		s.logger,
+		s.cl,
+		s.game.CreateContract,
+		s.factoryContract.GetGamesAtOrAfter,
+		cfg.IgnoredGames,
+		cfg.MaxConcurrency,
+		extract.NewClaimEnricher(),
+		extract.NewRecipientEnricher(), // Must be called before WithdrawalsEnricher and BondEnricher
+		extract.NewWithdrawalsEnricher(),
+		extract.NewBondEnricher(),
+		extract.NewBalanceEnricher(),
+		extract.NewL1HeadBlockNumEnricher(s.l1Client),
+		extract.NewOutputAgreementEnricher(s.logger, s.metrics, s.outputRollupClients(), clock.SystemClock),
+		extract.NewSuperAgreementEnricher(s.logger, s.metrics, s.asSuperRootProviders(), clock.SystemClock),
+	)
+	forecast := NewForecast(s.logger, s.metrics)
+	bonds := bonds.NewBonds(s.logger, s.metrics, s.cl)
+	resolutions := NewResolutionMonitor(s.logger, s.metrics, s.cl)
+	claims := NewClaimMonitor(s.logger, s.cl, s.honestActors, s.metrics)
+	withdrawals := NewWithdrawalMonitor(s.logger, s.cl, s.metrics, s.honestActors)
 	l2ChallengesMonitor := NewL2ChallengesMonitor(s.logger, s.metrics)
 	updateTimeMonitor := NewUpdateTimeMonitor(s.cl, s.metrics)
 	nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(s.logger, s.metrics)
 	nodeEndpointErrorCountMonitor := NewNodeEndpointErrorCountMonitor(s.logger, s.metrics)
+	mixedAvailabilityMonitor := NewMixedAvailability(s.logger, s.metrics)
+	mixedSafetyMonitor := NewMixedSafetyMonitor(s.logger, s.metrics)
+	differentOutputRootMonitor := NewDifferentOutputRootMonitor(s.logger, s.metrics)
 	s.monitor = newGameMonitor(ctx, s.logger, s.cl, s.metrics, cfg.MonitorInterval, cfg.GameWindow, headBlockFetcher,
-		s.extractor.Extract,
-		s.forecast.Forecast,
-		s.bonds.CheckBonds,
-		s.resolutions.CheckResolutions,
-		s.claims.CheckClaims,
-		s.withdrawals.CheckWithdrawals,
+		extractor.Extract,
+		forecast.Forecast,
+		bonds.CheckBonds,
+		resolutions.CheckResolutions,
+		claims.CheckClaims,
+		withdrawals.CheckWithdrawals,
 		l2ChallengesMonitor.CheckL2Challenges,
 		updateTimeMonitor.CheckUpdateTimes,
 		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
 		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
-		s.mixedAvailability.CheckMixedAvailability,
-		s.mixedSafety.CheckMixedSafety,
-		s.differentOutputRoot.CheckDifferentOutputRoots)
+		mixedAvailabilityMonitor.CheckMixedAvailability,
+		mixedSafetyMonitor.CheckMixedSafety,
+		differentOutputRootMonitor.CheckDifferentOutputRoots)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -38,9 +38,9 @@ type Service struct {
 
 	cl clock.Clock
 
-	game                *extract.GameCallerCreator
-	rollupClients       []*sources.RollupClient
-	supervisorClients   []*sources.SupervisorClient
+	game              *extract.GameCallerCreator
+	rollupClients     []*sources.RollupClient
+	supervisorClients []*sources.SupervisorClient
 
 	l1RPC    rpcclient.RPC
 	l1Client *sources.L1Client

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -46,6 +46,7 @@ type Service struct {
 	claims            *ClaimMonitor
 	withdrawals       *WithdrawalMonitor
 	mixedAvailability *MixedAvailability
+	mixedSafety       *MixedSafetyMonitor
 	rollupClients     []*sources.RollupClient
 	supervisorClients []*sources.SupervisorClient
 
@@ -99,6 +100,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.initResolutionMonitor()
 	s.initWithdrawalMonitor()
 	s.initMixedAvailabilityMonitor()
+	s.initMixedSafetyMonitor()
 
 	s.initGameCallerCreator() // Must be called before initForecast
 
@@ -129,6 +131,10 @@ func (s *Service) initWithdrawalMonitor() {
 
 func (s *Service) initMixedAvailabilityMonitor() {
 	s.mixedAvailability = NewMixedAvailability(s.logger, s.metrics)
+}
+
+func (s *Service) initMixedSafetyMonitor() {
+	s.mixedSafety = NewMixedSafetyMonitor(s.logger, s.metrics)
 }
 
 func (s *Service) initGameCallerCreator() {
@@ -288,7 +294,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		updateTimeMonitor.CheckUpdateTimes,
 		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
 		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
-		s.mixedAvailability.CheckMixedAvailability)
+		s.mixedAvailability.CheckMixedAvailability,
+		s.mixedSafety.CheckMixedSafety)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -269,6 +269,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	}
 	l2ChallengesMonitor := NewL2ChallengesMonitor(s.logger, s.metrics)
 	updateTimeMonitor := NewUpdateTimeMonitor(s.cl, s.metrics)
+	nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(s.logger, s.metrics)
 	s.monitor = newGameMonitor(ctx, s.logger, s.cl, s.metrics, cfg.MonitorInterval, cfg.GameWindow, headBlockFetcher,
 		s.extractor.Extract,
 		s.forecast.Forecast,
@@ -277,7 +278,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		s.claims.CheckClaims,
 		s.withdrawals.CheckWithdrawals,
 		l2ChallengesMonitor.CheckL2Challenges,
-		updateTimeMonitor.CheckUpdateTimes)
+		updateTimeMonitor.CheckUpdateTimes,
+		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -45,6 +45,7 @@ type Service struct {
 	resolutions       *ResolutionMonitor
 	claims            *ClaimMonitor
 	withdrawals       *WithdrawalMonitor
+	mixedAvailability *MixedAvailability
 	rollupClients     []*sources.RollupClient
 	supervisorClients []*sources.SupervisorClient
 
@@ -97,6 +98,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.initClaimMonitor(cfg)
 	s.initResolutionMonitor()
 	s.initWithdrawalMonitor()
+	s.initMixedAvailabilityMonitor()
 
 	s.initGameCallerCreator() // Must be called before initForecast
 
@@ -123,6 +125,10 @@ func (s *Service) initResolutionMonitor() {
 
 func (s *Service) initWithdrawalMonitor() {
 	s.withdrawals = NewWithdrawalMonitor(s.logger, s.cl, s.metrics, s.honestActors)
+}
+
+func (s *Service) initMixedAvailabilityMonitor() {
+	s.mixedAvailability = NewMixedAvailability(s.logger, s.metrics)
 }
 
 func (s *Service) initGameCallerCreator() {
@@ -281,7 +287,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		l2ChallengesMonitor.CheckL2Challenges,
 		updateTimeMonitor.CheckUpdateTimes,
 		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
-		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount)
+		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
+		s.mixedAvailability.CheckMixedAvailability)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -38,17 +38,18 @@ type Service struct {
 
 	cl clock.Clock
 
-	extractor         *extract.Extractor
-	forecast          *Forecast
-	bonds             *bonds.Bonds
-	game              *extract.GameCallerCreator
-	resolutions       *ResolutionMonitor
-	claims            *ClaimMonitor
-	withdrawals       *WithdrawalMonitor
-	mixedAvailability *MixedAvailability
-	mixedSafety       *MixedSafetyMonitor
-	rollupClients     []*sources.RollupClient
-	supervisorClients []*sources.SupervisorClient
+	extractor           *extract.Extractor
+	forecast            *Forecast
+	bonds               *bonds.Bonds
+	game                *extract.GameCallerCreator
+	resolutions         *ResolutionMonitor
+	claims              *ClaimMonitor
+	withdrawals         *WithdrawalMonitor
+	mixedAvailability   *MixedAvailability
+	mixedSafety         *MixedSafetyMonitor
+	differentOutputRoot *DifferentOutputRootMonitor
+	rollupClients       []*sources.RollupClient
+	supervisorClients   []*sources.SupervisorClient
 
 	l1RPC    rpcclient.RPC
 	l1Client *sources.L1Client
@@ -101,6 +102,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	s.initWithdrawalMonitor()
 	s.initMixedAvailabilityMonitor()
 	s.initMixedSafetyMonitor()
+	s.initDifferentOutputRootMonitor()
 
 	s.initGameCallerCreator() // Must be called before initForecast
 
@@ -135,6 +137,10 @@ func (s *Service) initMixedAvailabilityMonitor() {
 
 func (s *Service) initMixedSafetyMonitor() {
 	s.mixedSafety = NewMixedSafetyMonitor(s.logger, s.metrics)
+}
+
+func (s *Service) initDifferentOutputRootMonitor() {
+	s.differentOutputRoot = NewDifferentOutputRootMonitor(s.logger, s.metrics)
 }
 
 func (s *Service) initGameCallerCreator() {
@@ -295,7 +301,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
 		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
 		s.mixedAvailability.CheckMixedAvailability,
-		s.mixedSafety.CheckMixedSafety)
+		s.mixedSafety.CheckMixedSafety,
+		s.differentOutputRoot.CheckDifferentOutputRoots)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -77,6 +77,9 @@ type EnrichedGameData struct {
 
 	// RollupEndpointUnsafeCount tracks the number of rollup endpoints that reported the root as unsafe.
 	RollupEndpointUnsafeCount int
+
+	// RollupEndpointDifferentOutputRoots tracks whether rollup endpoints returned different output roots for this game.
+	RollupEndpointDifferentOutputRoots bool
 }
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -59,6 +59,9 @@ type EnrichedGameData struct {
 	// This ETH balance will be used to pay out any bonds required by the games
 	// that use the same DelayedWETH contract.
 	ETHCollateral *big.Int
+
+	// RollupEndpointErrors stores endpoint IDs that returned errors other than "not found" for this game.
+	RollupEndpointErrors map[string]bool
 }
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -71,6 +71,12 @@ type EnrichedGameData struct {
 
 	// RollupEndpointTotalCount tracks the total number of rollup endpoints attempted for this game.
 	RollupEndpointTotalCount int
+
+	// RollupEndpointSafeCount tracks the number of rollup endpoints that reported the root as safe.
+	RollupEndpointSafeCount int
+
+	// RollupEndpointUnsafeCount tracks the number of rollup endpoints that reported the root as unsafe.
+	RollupEndpointUnsafeCount int
 }
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.
@@ -87,6 +93,12 @@ func (g EnrichedGameData) HasMixedAvailability() bool {
 
 	successfulEndpoints := g.RollupEndpointTotalCount - g.RollupEndpointErrorCount - g.RollupEndpointNotFoundCount
 	return g.RollupEndpointNotFoundCount > 0 && successfulEndpoints > 0
+}
+
+// HasMixedSafety returns true if some rollup endpoints reported the root as safe and others as unsafe
+// for this game. This indicates inconsistent safety assessment across the rollup node network.
+func (g EnrichedGameData) HasMixedSafety() bool {
+	return g.RollupEndpointSafeCount > 0 && g.RollupEndpointUnsafeCount > 0
 }
 
 // BidirectionalTree is a tree of claims represented as a flat list of claims.

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -65,11 +65,28 @@ type EnrichedGameData struct {
 
 	// RollupEndpointErrorCount tracks the total number of errors for this game across all endpoints.
 	RollupEndpointErrorCount int
+
+	// RollupEndpointNotFoundCount tracks the number of endpoints that returned "not found" for this game.
+	RollupEndpointNotFoundCount int
+
+	// RollupEndpointTotalCount tracks the total number of rollup endpoints attempted for this game.
+	RollupEndpointTotalCount int
 }
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.
 func (g EnrichedGameData) UsesOutputRoots() bool {
 	return slices.Contains(outputRootGameTypes, g.GameType)
+}
+
+// HasMixedAvailability returns true if some rollup endpoints returned "not found" while others succeeded
+// for this game. This indicates inconsistent block availability across the rollup node network.
+func (g EnrichedGameData) HasMixedAvailability() bool {
+	if g.RollupEndpointTotalCount == 0 {
+		return false
+	}
+
+	successfulEndpoints := g.RollupEndpointTotalCount - g.RollupEndpointErrorCount - g.RollupEndpointNotFoundCount
+	return g.RollupEndpointNotFoundCount > 0 && successfulEndpoints > 0
 }
 
 // BidirectionalTree is a tree of claims represented as a flat list of claims.

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -62,6 +62,9 @@ type EnrichedGameData struct {
 
 	// RollupEndpointErrors stores endpoint IDs that returned errors other than "not found" for this game.
 	RollupEndpointErrors map[string]bool
+
+	// RollupEndpointErrorCount tracks the total number of errors for this game across all endpoints.
+	RollupEndpointErrorCount int
 }
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -114,3 +114,66 @@ func TestEnrichedGameData_HasMixedAvailability(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichedGameData_HasMixedSafety(t *testing.T) {
+	tests := []struct {
+		name                      string
+		rollupEndpointSafeCount   int
+		rollupEndpointUnsafeCount int
+		expected                  bool
+	}{
+		{
+			name:                      "no safety assessments",
+			rollupEndpointSafeCount:   0,
+			rollupEndpointUnsafeCount: 0,
+			expected:                  false,
+		},
+		{
+			name:                      "all endpoints report safe",
+			rollupEndpointSafeCount:   3,
+			rollupEndpointUnsafeCount: 0,
+			expected:                  false,
+		},
+		{
+			name:                      "all endpoints report unsafe",
+			rollupEndpointSafeCount:   0,
+			rollupEndpointUnsafeCount: 3,
+			expected:                  false,
+		},
+		{
+			name:                      "mixed safety - some safe, some unsafe",
+			rollupEndpointSafeCount:   2,
+			rollupEndpointUnsafeCount: 1,
+			expected:                  true,
+		},
+		{
+			name:                      "mixed safety - minority safe",
+			rollupEndpointSafeCount:   1,
+			rollupEndpointUnsafeCount: 4,
+			expected:                  true,
+		},
+		{
+			name:                      "mixed safety - majority safe",
+			rollupEndpointSafeCount:   4,
+			rollupEndpointUnsafeCount: 1,
+			expected:                  true,
+		},
+		{
+			name:                      "mixed safety - equal split",
+			rollupEndpointSafeCount:   2,
+			rollupEndpointUnsafeCount: 2,
+			expected:                  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := EnrichedGameData{
+				RollupEndpointSafeCount:   test.rollupEndpointSafeCount,
+				RollupEndpointUnsafeCount: test.rollupEndpointUnsafeCount,
+			}
+			result := data.HasMixedSafety()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -30,3 +30,8 @@ func TestEnrichedGameData_UsesOutputRoots(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichedGameData_RollupEndpointErrorCountInitialization(t *testing.T) {
+	data := EnrichedGameData{}
+	require.Equal(t, 0, data.RollupEndpointErrorCount, "RollupEndpointErrorCount should default to 0")
+}

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -35,3 +35,82 @@ func TestEnrichedGameData_RollupEndpointErrorCountInitialization(t *testing.T) {
 	data := EnrichedGameData{}
 	require.Equal(t, 0, data.RollupEndpointErrorCount, "RollupEndpointErrorCount should default to 0")
 }
+
+func TestEnrichedGameData_HasMixedAvailability(t *testing.T) {
+	tests := []struct {
+		name                        string
+		rollupEndpointTotalCount    int
+		rollupEndpointErrorCount    int
+		rollupEndpointNotFoundCount int
+		expected                    bool
+	}{
+		{
+			name:                        "no endpoints attempted",
+			rollupEndpointTotalCount:    0,
+			rollupEndpointErrorCount:    0,
+			rollupEndpointNotFoundCount: 0,
+			expected:                    false,
+		},
+		{
+			name:                        "all endpoints successful",
+			rollupEndpointTotalCount:    3,
+			rollupEndpointErrorCount:    0,
+			rollupEndpointNotFoundCount: 0,
+			expected:                    false,
+		},
+		{
+			name:                        "all endpoints had errors",
+			rollupEndpointTotalCount:    3,
+			rollupEndpointErrorCount:    3,
+			rollupEndpointNotFoundCount: 0,
+			expected:                    false,
+		},
+		{
+			name:                        "all endpoints returned not found",
+			rollupEndpointTotalCount:    3,
+			rollupEndpointErrorCount:    0,
+			rollupEndpointNotFoundCount: 3,
+			expected:                    false,
+		},
+		{
+			name:                        "mixed availability - some not found, some successful",
+			rollupEndpointTotalCount:    3,
+			rollupEndpointErrorCount:    0,
+			rollupEndpointNotFoundCount: 1,
+			expected:                    true,
+		},
+		{
+			name:                        "mixed availability with errors - some not found, some successful, some errors",
+			rollupEndpointTotalCount:    5,
+			rollupEndpointErrorCount:    1,
+			rollupEndpointNotFoundCount: 2,
+			expected:                    true,
+		},
+		{
+			name:                        "mixed availability - majority not found",
+			rollupEndpointTotalCount:    4,
+			rollupEndpointErrorCount:    0,
+			rollupEndpointNotFoundCount: 3,
+			expected:                    true,
+		},
+		{
+			name:                        "no successful endpoints - only errors and not found",
+			rollupEndpointTotalCount:    4,
+			rollupEndpointErrorCount:    2,
+			rollupEndpointNotFoundCount: 2,
+			expected:                    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := EnrichedGameData{
+				RollupEndpointTotalCount:    test.rollupEndpointTotalCount,
+				RollupEndpointErrorCount:    test.rollupEndpointErrorCount,
+				RollupEndpointNotFoundCount: test.rollupEndpointNotFoundCount,
+			}
+			result := data.HasMixedAvailability()
+			require.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the following prometheus metrics to dispute-mon:

* Gauge of total number of endpoints that returned an error (other than not found) during the last update cycle - note this is the number of rpcs that had at least 1 failure, so if the same rpc gives an error on 10 games that still counts as 1.
* Gauge of total number of failures (other than not found) in the last update cycle. This counts each error from an rpc as a new event even if the rpc is the same (so one rpc giving 10 errors sets this to 10).
* Gauge of the total number of games where some nodes reported not found and others had the block in the last update cycle.
* Gauge of the total number of games where some nodes reported the output root as safe and others as unsafe in the last update cycle
* Gauge of the total number of games where nodes returned different expected output roots in the last update cycle

Reviewers might want to look at each commit separately, there's one for each metric.

Part of #11020. Super agreement enricher should be done before we close that, I'll do it in a separate PR.