### PR TITLE
op-sync-tester: Retry block fetching when processing newPayload

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/elsync_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func TestSyncTesterELSync(gt *testing.T) {
-	// TODO(#17615) Root cause and re-enable tests
-	gt.Skip("Skip TestSyncTesterELSync")
-
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleWithSyncTester(t)
 	require := t.Require()

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/metrics"
@@ -676,11 +677,27 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 	// Look up canonical block for relay comparison
 	block, err := s.elReader.GetBlockByHash(ctx, payload.BlockHash)
 	if err != nil {
-		// Do not know block hash included in payload is correct or not. Consider as a server error and make CL retry
-		if errors.Is(err, ethereum.NotFound) {
-			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("block not found", err))
+		if !errors.Is(err, ethereum.NotFound) {
+			// Do not retry when error did not occur because of Not found error
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to fetch block", err))
 		}
-		return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to fetch block", err))
+		// Not found error may be recovered when given payload is near the sequencer tip.
+		// Read only EL may not be ready yet. In this case, retry once more after waiting block time (2 seconds)
+		logger.Warn("Block not found while validating new payload. Retrying", "number", payload.BlockNumber, "hash", payload.BlockHash)
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			// Handle case when context cancelled while waiting.
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(fmt.Errorf("context done: %w", ctx.Err()))
+		}
+		block, err = s.elReader.GetBlockByHash(ctx, payload.BlockHash)
+		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("block not found after retry", err))
+			}
+			return &eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, engine.GenericServerError.With(wrapSyncTesterError("failed to fetch block after retry", err))
+		}
+		// Use block info fetched by retrying
 	}
 	// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/derivation.md#building-individual-payload-attributes
 	// Implicitly determine whether canyon is enabled by inspecting withdrawals from read only EL data


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`TestSyncTesterELSync` flaked because when sync tester receives `engine_newPayload`, it tries to validate the newpayload, comparing the payload from the payload generated by blockInfo fetched from the read only EL.

The race window happens when sync tester is processing the payload very near the unsafe chain tip. Read Only EL may temporally respond with `ethereum.NotFound` error. The maximum race window will be a single block time(2 second). 

So when the first try of fetching block failed with `ethereum.NotFound` error, we now gracefully retry to fetch the block once again after waiting single block time(2 second).

Note that validator may receive sequencer signed unsafe payload, before the sequencer controlled EL be queried that unsafe payload. 

Reenabling the sync test that was skipped.

**Tests**

All existing tests are passing

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17615
