### PR TITLE
contracts: Add new dispute game dev feature flags to bedrock test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1929,7 +1929,7 @@ workflows:
           dev_features: <<matrix.dev_features>>
           matrix:
             parameters:
-              dev_features: ["main", "OPTIMISM_PORTAL_INTEROP"]
+              dev_features: ["main", "OPTIMISM_PORTAL_INTEROP", "DEPLOY_V2_DISPUTE_GAMES"]
           # need this requires to ensure that all FFI JSONs exist
           requires:
             - contracts-bedrock-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1929,7 +1929,7 @@ workflows:
           dev_features: <<matrix.dev_features>>
           matrix:
             parameters:
-              dev_features: ["main", "OPTIMISM_PORTAL_INTEROP", "DEPLOY_V2_DISPUTE_GAMES"]
+              dev_features: ["main", "OPTIMISM_PORTAL_INTEROP", "CANNON_KONA,DEPLOY_V2_DISPUTE_GAMES"]
           # need this requires to ensure that all FFI JSONs exist
           requires:
             - contracts-bedrock-build

--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -245,4 +245,9 @@ library Config {
     function devFeatureCannonKona() internal view returns (bool) {
         return vm.envOr("DEV_FEATURE__CANNON_KONA", false);
     }
+
+    /// @notice Returns true if the development feature deploy_v2_dispute_games is enabled.
+    function devFeatureDeployV2DisputeGames() internal view returns (bool) {
+        return vm.envOr("DEV_FEATURE__DEPLOY_V2_DISPUTE_GAMES", false);
+    }
 }

--- a/packages/contracts-bedrock/test/setup/FeatureFlags.sol
+++ b/packages/contracts-bedrock/test/setup/FeatureFlags.sol
@@ -40,6 +40,10 @@ contract FeatureFlags {
             console.log("Setup: DEV_FEATURE__CANNON_KONA is enabled");
             devFeatureBitmap |= DevFeatures.CANNON_KONA;
         }
+        if (Config.devFeatureDeployV2DisputeGames()) {
+            console.log("Setup: DEV_FEATURE__DEPLOY_V2_DISPUTE_GAMES is enabled");
+            devFeatureBitmap |= DevFeatures.DEPLOY_V2_DISPUTE_GAMES;
+        }
     }
 
     /// @notice Enables a feature.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add `CANNON_KONA` and `DEPLOY_V2_DISPUTE_GAMES` feature flag to bedrock contracts test matrix.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/12421, and https://github.com/ethereum-optimism/optimism/issues/17285
