### PR TITLE
op-deployer: setup forge callers for apply deploy scripts

### DIFF
--- a/op-deployer/pkg/deployer/forge/client_test.go
+++ b/op-deployer/pkg/deployer/forge/client_test.go
@@ -45,7 +45,7 @@ func TestMinimalSources(t *testing.T) {
 	caller := NewScriptCaller(
 		cl,
 		"script/Test.s.sol:TestScript",
-		"runEncoded(bytes)",
+		"runWithBytes(bytes)",
 		&BytesScriptEncoder[ioStruct]{TypeName: "ioStruct"},
 		&BytesScriptDecoder[ioStruct]{TypeName: "ioStruct"},
 	)
@@ -100,7 +100,7 @@ func TestScriptCaller(t *testing.T) {
 	caller := NewScriptCaller(
 		cl,
 		"script/Test.s.sol:TestScript",
-		"runEncoded(bytes)",
+		"runWithBytes(bytes)",
 		&BytesScriptEncoder[ioStruct]{TypeName: "ioStruct"},
 		&BytesScriptDecoder[ioStruct]{TypeName: "ioStruct"},
 	)

--- a/op-deployer/pkg/deployer/forge/encoding.go
+++ b/op-deployer/pkg/deployer/forge/encoding.go
@@ -36,6 +36,18 @@ func GoTypeToABIType(goType reflect.Type) (string, error) {
 		goType = goType.Elem()
 	}
 
+	// non-standard go types (need to catch these first)
+	switch goType {
+	case reflect.TypeOf(common.Address{}):
+		return "address", nil
+	case reflect.TypeOf(common.Hash{}):
+		return "bytes32", nil
+	case reflect.TypeOf(params.ProtocolVersion{}):
+		return "bytes32", nil
+	case reflect.TypeOf(big.NewInt(0)).Elem():
+		return "uint256", nil
+	}
+
 	// standard go types
 	switch goType.Kind() {
 	case reflect.Slice:
@@ -84,18 +96,6 @@ func GoTypeToABIType(goType reflect.Type) (string, error) {
 		return "int32", nil
 	case reflect.Int64, reflect.Int:
 		return "int64", nil
-	}
-
-	// non-standard go types
-	switch goType {
-	case reflect.TypeOf(common.Address{}):
-		return "address", nil
-	case reflect.TypeOf(common.Hash{}):
-		return "bytes32", nil
-	case reflect.TypeOf(params.ProtocolVersion{}):
-		return "bytes32", nil
-	case reflect.TypeOf(big.NewInt(0)).Elem():
-		return "uint256", nil
 	}
 
 	return "", fmt.Errorf("unable to convert go type to abi type: %s", goType)

--- a/op-deployer/pkg/deployer/forge/testdata/testproject/script/Test.s.sol
+++ b/op-deployer/pkg/deployer/forge/testdata/testproject/script/Test.s.sol
@@ -20,7 +20,7 @@ contract TestScript {
         return Output({ id: 0x02, data: _input.data, slice: _input.slice, array: _input.array });
     }
 
-    function runEncoded(bytes memory _input) public pure returns (bytes memory) {
+    function runWithBytes(bytes memory _input) public pure returns (bytes memory) {
         Input memory input = abi.decode(_input, (Input));
         Output memory output = _run(input);
         return abi.encode(output);

--- a/op-deployer/pkg/deployer/opcm/implementations.go
+++ b/op-deployer/pkg/deployer/opcm/implementations.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -52,4 +53,14 @@ type DeployImplementationsScript script.DeployScriptWithOutput[DeployImplementat
 // NewDeployImplementationsScript loads and validates the DeployImplementations script contract
 func NewDeployImplementationsScript(host *script.Host) (DeployImplementationsScript, error) {
 	return script.NewDeployScriptWithOutputFromFile[DeployImplementationsInput, DeployImplementationsOutput](host, "DeployImplementations.s.sol", "DeployImplementations")
+}
+
+func NewDeployImplementationsForgeCaller(client *forge.Client) forge.ScriptCaller[DeployImplementationsInput, DeployImplementationsOutput] {
+	return forge.NewScriptCaller(
+		client,
+		"scripts/deploy/DeployImplementations.s.sol:DeployImplementations",
+		"runWithBytes(bytes)",
+		&forge.BytesScriptEncoder[DeployImplementationsInput]{TypeName: "DeployImplementationsInput"},
+		&forge.BytesScriptDecoder[DeployImplementationsOutput]{TypeName: "DeployImplementationsOutput"},
+	)
 }

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -83,6 +84,16 @@ func DeployOPChain(host *script.Host, input DeployOPChainInput) (DeployOPChainOu
 	return RunScriptSingle[DeployOPChainInput, DeployOPChainOutput](host, input, "DeployOPChain.s.sol", "DeployOPChain")
 }
 
+func NewDeployOPChainForgeCaller(client *forge.Client) forge.ScriptCaller[DeployOPChainInput, DeployOPChainOutput] {
+	return forge.NewScriptCaller(
+		client,
+		"scripts/deploy/DeployOPChain.s.sol:DeployOPChain",
+		"runWithBytes(bytes)",
+		&forge.BytesScriptEncoder[DeployOPChainInput]{TypeName: "DeployOPChainInput"},
+		&forge.BytesScriptDecoder[DeployOPChainOutput]{TypeName: "DeployOPChainOutput"},
+	)
+}
+
 type ReadImplementationAddressesInput struct {
 	AddressManager                    common.Address
 	L1ERC721BridgeProxy               common.Address
@@ -115,4 +126,14 @@ type ReadImplementationAddressesScript script.DeployScriptWithOutput[ReadImpleme
 // NewReadImplementationAddressesScript loads and validates the ReadImplementationAddresses script contract
 func NewReadImplementationAddressesScript(host *script.Host) (ReadImplementationAddressesScript, error) {
 	return script.NewDeployScriptWithOutputFromFile[ReadImplementationAddressesInput, ReadImplementationAddressesOutput](host, "ReadImplementationAddresses.s.sol", "ReadImplementationAddresses")
+}
+
+func NewReadImplementationAddressesForgeCaller(client *forge.Client) forge.ScriptCaller[ReadImplementationAddressesInput, ReadImplementationAddressesOutput] {
+	return forge.NewScriptCaller(
+		client,
+		"scripts/deploy/ReadImplementationAddresses.s.sol:ReadImplementationAddresses",
+		"runWithBytes(bytes)",
+		&forge.BytesScriptEncoder[ReadImplementationAddressesInput]{TypeName: "ReadImplementationAddressesInput"},
+		&forge.BytesScriptDecoder[ReadImplementationAddressesOutput]{TypeName: "ReadImplementationAddressesOutput"},
+	)
 }

--- a/op-deployer/pkg/deployer/opcm/superchain.go
+++ b/op-deployer/pkg/deployer/opcm/superchain.go
@@ -2,6 +2,7 @@ package opcm
 
 import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -28,4 +29,14 @@ type DeploySuperchainScript script.DeployScriptWithOutput[DeploySuperchainInput,
 // NewDeploySuperchainScript loads and validates the DeploySuperchain script contract
 func NewDeploySuperchainScript(host *script.Host) (DeploySuperchainScript, error) {
 	return script.NewDeployScriptWithOutputFromFile[DeploySuperchainInput, DeploySuperchainOutput](host, "DeploySuperchain.s.sol", "DeploySuperchain")
+}
+
+func NewDeploySuperchainForgeCaller(client *forge.Client) forge.ScriptCaller[DeploySuperchainInput, DeploySuperchainOutput] {
+	return forge.NewScriptCaller(
+		client,
+		"scripts/deploy/DeploySuperchain.s.sol:DeploySuperchain",
+		"runWithBytes(bytes)",
+		&forge.BytesScriptEncoder[DeploySuperchainInput]{TypeName: "DeploySuperchainInput"},
+		&forge.BytesScriptDecoder[DeploySuperchainOutput]{TypeName: "DeploySuperchainOutput"},
+	)
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -85,6 +85,12 @@ contract DeployImplementations is Script {
 
     // -------- Core Deployment Methods --------
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
+
     function run(Input memory _input) public returns (Output memory output_) {
         assertValidInput(_input);
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -357,6 +357,13 @@ contract DeployOPChainOutput is BaseDeployIO {
 contract DeployOPChain is Script {
     // -------- Core Deployment Methods --------
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        DeployOPChainInput _doi = abi.decode(_input, (DeployOPChainInput));
+        DeployOPChainOutput _doo;
+        run(_doi, _doo);
+        return abi.encode(_doo);
+    }
+
     function run(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
         IOPContractsManager opcm = _doi.opcm();
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -357,13 +357,6 @@ contract DeployOPChainOutput is BaseDeployIO {
 contract DeployOPChain is Script {
     // -------- Core Deployment Methods --------
 
-    function runWithBytes(bytes memory _input) public returns (bytes memory) {
-        DeployOPChainInput _doi = abi.decode(_input, (DeployOPChainInput));
-        DeployOPChainOutput _doo;
-        run(_doi, _doo);
-        return abi.encode(_doo);
-    }
-
     function run(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
         IOPContractsManager opcm = _doi.opcm();
 

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -56,6 +56,12 @@ contract DeploySuperchain is Script {
 
     // -------- Core Deployment Methods --------
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
+
     function run(Input memory _input) public returns (Output memory output_) {
         // Convert the external Input to InternalInput
         InternalInput memory internalInput = toInternalInput(_input);


### PR DESCRIPTION
Prepares the following forge scripts and the complementary go code to invoke the scripts via forge binary:

* DeploySuperchain.s.sol
* DeployImplementations.s.sol

Merging this setup code now, without using it in production code paths, will allow us to incrementally build tests on top until we are ready to switch over the production code paths to use the forge invokers.