### PR TITLE
feat(fusaka/proof): make kona-proof compatible with L1 chain config

### DIFF
--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -30,9 +30,10 @@ var (
 	ErrMissingBin    = errors.New("missing bin")
 	ErrMissingServer = errors.New("missing server")
 
-	ErrMissingRollupConfig = errors.New("missing network or rollup config path")
-	ErrMissingL2Genesis    = errors.New("missing network or l2 genesis path")
-	ErrNetworkUnknown      = errors.New("unknown network")
+	ErrMissingRollupConfig  = errors.New("missing network or rollup config path")
+	ErrMissingL1ChainConfig = errors.New("missing network or l1 chain config path")
+	ErrMissingL2Genesis     = errors.New("missing network or l2 genesis path")
+	ErrNetworkUnknown       = errors.New("unknown network")
 
 	ErrVMPanic = errors.New("vm exited with exit code 2 (panic)")
 )
@@ -57,6 +58,7 @@ type Config struct {
 	Networks          []string
 	L2Custom          bool
 	RollupConfigPaths []string
+	L1ConfigPaths     []string
 	L2GenesisPaths    []string
 	DepsetConfigPath  string
 }
@@ -79,6 +81,9 @@ func (c *Config) Check() error {
 	if len(c.Networks) == 0 {
 		if len(c.RollupConfigPaths) == 0 {
 			return ErrMissingRollupConfig
+		}
+		if len(c.L1ConfigPaths) == 0 {
+			return ErrMissingL1ChainConfig
 		}
 		if len(c.L2GenesisPaths) == 0 {
 			return ErrMissingL2Genesis

--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -23,8 +23,8 @@ func NewNativeKonaExecutor() *KonaExecutor {
 }
 
 func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.LocalGameInputs) ([]string, error) {
-	if len(cfg.L2s) != 1 || len(cfg.RollupConfigPaths) > 1 || len(cfg.Networks) > 1 {
-		return nil, errors.New("multiple L2s specified but only one supported")
+	if len(cfg.L2s) != 1 || len(cfg.RollupConfigPaths) > 1 || len(cfg.Networks) > 1 || len(cfg.L1ConfigPaths) > 1 {
+		return nil, errors.New("multiple L2s/L1s specified but only one supported")
 	}
 	args := []string{
 		cfg.Server,
@@ -55,6 +55,10 @@ func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.Lo
 
 		chainCfg := chaincfg.ChainByName(cfg.Networks[0])
 		args = append(args, "--l2-chain-id", strconv.FormatUint(chainCfg.ChainID, 10))
+	}
+
+	if len(cfg.L1ConfigPaths) > 0 {
+		args = append(args, "--l1-config-path", cfg.L1ConfigPaths[0])
 	}
 
 	return args, nil

--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
@@ -50,5 +50,9 @@ func (s *KonaSuperExecutor) OracleCommand(cfg Config, dataDir string, inputs uti
 		args = append(args, "--rollup-config-paths", strings.Join(cfg.RollupConfigPaths, ","))
 	}
 
+	if len(cfg.L1ConfigPaths) > 0 {
+		args = append(args, "--l1-config-paths", strings.Join(cfg.L1ConfigPaths, ","))
+	}
+
 	return args, nil
 }

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,10 +28,22 @@ func IsKonaConfigured() bool {
 	return konaHostPath != ""
 }
 
+func writeConfig[T any](t helpers.Testing, workDir string, name string, cfg []*T, cfgPaths []string) {
+	for i, cfg := range cfg {
+		cfgPath := filepath.Join(workDir, fmt.Sprintf("%s_%d.json", name, i))
+		ser, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(cfgPath, ser, fs.ModePerm))
+
+		cfgPaths[i] = cfgPath
+	}
+}
+
 func RunKonaNative(
 	t helpers.Testing,
 	workDir string,
 	rollupCfgs []*rollup.Config,
+	l1chainConfigs []*params.ChainConfig,
 	l1Rpc string,
 	l1BeaconRpc string,
 	l2Rpcs []string,
@@ -38,14 +51,11 @@ func RunKonaNative(
 ) error {
 	// Write rollup config to tempdir.
 	rollupCfgPaths := make([]string, len(rollupCfgs))
-	for i, cfg := range rollupCfgs {
-		rollupConfigPath := filepath.Join(workDir, fmt.Sprintf("rollup_%d.json", i))
-		ser, err := json.Marshal(cfg)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(rollupConfigPath, ser, fs.ModePerm))
+	writeConfig(t, workDir, "rollup", rollupCfgs, rollupCfgPaths)
 
-		rollupCfgPaths[i] = rollupConfigPath
-	}
+	// Write l1 chain config to tempdir.
+	l1chainConfigPaths := make([]string, len(l1chainConfigs))
+	writeConfig(t, workDir, "l1chain", l1chainConfigs, l1chainConfigPaths)
 
 	// Run the fault proof program from the state transition from L2 block L2Blocknumber - 1 -> L2BlockNumber.
 	vmCfg := vm.Config{
@@ -53,6 +63,7 @@ func RunKonaNative(
 		L1Beacon:          l1BeaconRpc,
 		L2s:               l2Rpcs,
 		RollupConfigPaths: rollupCfgPaths,
+		L1ConfigPaths:     l1chainConfigPaths,
 		Server:            konaHostPath,
 	}
 	inputs := utils.LocalGameInputs{

--- a/op-e2e/actions/proofs/helpers/runner.go
+++ b/op-e2e/actions/proofs/helpers/runner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,13 +84,15 @@ func RunFaultProofProgram(t helpers.Testing, logger log.Logger, l1 *helpers.L1Mi
 		defer fakeBeacon.Close()
 
 		rollupCfgs := make([]*rollup.Config, 0, len(fixtureInputs.L2Sources))
+		l1chainConfigs := make([]*params.ChainConfig, 0, len(fixtureInputs.L2Sources))
 		l2Endpoints := make([]string, 0, len(fixtureInputs.L2Sources))
 		for _, source := range fixtureInputs.L2Sources {
 			rollupCfgs = append(rollupCfgs, source.Node.RollupCfg)
+			l1chainConfigs = append(l1chainConfigs, source.Node.L1ChainConfig)
 			l2Endpoints = append(l2Endpoints, source.Engine.HTTPEndpoint())
 		}
 
-		err = RunKonaNative(t, workDir, rollupCfgs, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Endpoints, *fixtureInputs)
+		err = RunKonaNative(t, workDir, rollupCfgs, l1chainConfigs, l1.HTTPEndpoint(), fakeBeacon.BeaconAddr(), l2Endpoints, *fixtureInputs)
 		checkResult(t, err)
 	} else {
 		programCfg := NewOpProgramCfg(fixtureInputs)


### PR DESCRIPTION
## Description

In order to be compatible with the fusaka update, we need to ensure that we can provide explicit l1 chain configuration to kona-proof and op-program. This PR ensures the changes are implemented for kona-proof.

Rebased on top of #17568
