### PR TITLE
fix: have acceptance job skip building contract tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2587,6 +2587,7 @@ workflows:
       - stale-check:
           context:
             - circleci-repo-optimism
+
   scheduled-sync-test-op-node:
     when:
       or:
@@ -2598,6 +2599,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build: # needed for sysgo tests
+          build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -2621,6 +2623,7 @@ workflows:
             parameters:
               network_preset: ["op-sepolia", "base-sepolia", "unichain-sepolia", "op-mainnet", "base-mainnet"]
               l2_cl_syncmode: ["consensus-layer", "execution-layer"]
+
   # Acceptance tests (post-merge to develop)
   acceptance-tests:
     when:
@@ -2636,6 +2639,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build: # needed for sysgo tests
+          build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -2715,6 +2719,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build: # needed for sysgo tests
+          build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:


### PR DESCRIPTION
Skips building contract tests in the acceptance job which reduces the amount of memory used and decreases the chance of the job being killed. Also makes it faster.