### PR TITLE
refactor(test): standardize Unclassified to Uncategorized in test naming

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -190,9 +190,9 @@ func checkTestStructure(artifact *solc.ForgeArtifact) []error {
 	return errors
 }
 
-func checkTestMethodName(artifact *solc.ForgeArtifact, contractName string, functionName string, featureEnabledName string) []error {
+func checkTestMethodName(artifact *solc.ForgeArtifact, contractName string, functionName string, _ string) []error {
 	// Check for uncategorized test pattern
-	if functionName == "Uncategorized" || functionName == "Unclassified" {
+	if functionName == "Uncategorized" {
 		// Pattern: <ContractName>_Uncategorized_Test
 		return nil
 	}

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -643,9 +643,9 @@ contract ETHLockbox_MigrateLiquidity_Test is ETHLockbox_TestInit {
     }
 }
 
-/// @title ETHLockbox_Unclassified_Test
-/// @notice Contains unclassified tests related to ETHLockbox.
-contract ETHLockbox_Unclassified_Test is ETHLockbox_TestInit {
+/// @title ETHLockbox_Uncategorized_Test
+/// @notice Contains uncategorized tests related to ETHLockbox.
+contract ETHLockbox_Uncategorized_Test is ETHLockbox_TestInit {
     /// @notice Tests the proxy admin owner is correctly returned.
     function test_proxyProxyAdminOwner_succeeds() public view {
         assertEq(ethLockbox.proxyAdminOwner(), proxyAdminOwner);

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -323,7 +323,7 @@ contract L1CrossDomainMessenger_SendMessage_Test is L1CrossDomainMessenger_TestI
     }
 }
 
-/// @title L1CrossDomainMessenger_Unclassified_Test
+/// @title L1CrossDomainMessenger_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the L1CrossDomainMessenger
 ///         but are testing functionality of the CrossDomainMessenger contract that is inherited
 ///         from.

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -115,10 +115,10 @@ contract L2CrossDomainMessenger_SendMessage_Test is L2CrossDomainMessenger_TestI
     }
 }
 
-/// @title L2CrossDomainMessenger_Unclassified_Test
+/// @title L2CrossDomainMessenger_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `L2CrossDomainMessenger` contract.
-contract L2CrossDomainMessenger_Unclassified_Test is L2CrossDomainMessenger_TestInit {
+contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_TestInit {
     /// @notice Tests that `messageNonce` can be decoded correctly.
     function test_messageVersion_succeeds() external view {
         (, uint16 version) = Encoding.decodeVersionedNonce(l2CrossDomainMessenger.messageNonce());

--- a/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
@@ -397,10 +397,10 @@ contract L2StandardBridge_WithdrawTo_Test is L2StandardBridge_TestInit {
     }
 }
 
-/// @title L2StandardBridge_Unclassified_Test
+/// @title L2StandardBridge_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `L2StandardBridge`
 ///         contract.
-contract L2StandardBridge_Unclassified_Test is L2StandardBridge_TestInit {
+contract L2StandardBridge_Uncategorized_Test is L2StandardBridge_TestInit {
     /// @notice Ensures that the L2StandardBridge is always not paused. The pausability happens
     ///         on L1 and not L2.
     function test_paused_succeeds() external view {

--- a/packages/contracts-bedrock/test/L2/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismMintableERC721.t.sol
@@ -156,10 +156,10 @@ contract OptimismMintableERC721_SupportsInterface_Test is OptimismMintableERC721
     }
 }
 
-/// @title OptimismMintableERC721_Unclassified_Test
+/// @title OptimismMintableERC721_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `OptimismMintableERC721` contract.
-contract OptimismMintableERC721_Unclassified_Test is OptimismMintableERC721_TestInit {
+contract OptimismMintableERC721_Uncategorized_Test is OptimismMintableERC721_TestInit {
     /// @notice Tests that the `tokenURI` function returns the correct URI for a minted token.
     function test_tokenURI_succeeds() external {
         // Mint the token first.

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
@@ -300,10 +300,10 @@ contract OptimismSuperchainERC20_SupportsInterface_Test is OptimismSuperchainERC
     }
 }
 
-/// @title OptimismSuperchainERC20_Unclassified_Test
+/// @title OptimismSuperchainERC20_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `OptimismSuperchainERC20` contract.
-contract OptimismSuperchainERC20_Unclassified_Test is OptimismSuperchainERC20_TestInit {
+contract OptimismSuperchainERC20_Uncategorized_Test is OptimismSuperchainERC20_TestInit {
     /// @notice Tests that the allowance function returns the max uint256 value when the spender is
     ///         Permit.
     /// @param _randomCaller The address that will call the function - used to fuzz better since

--- a/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
@@ -49,10 +49,10 @@ contract MIPS64_TestInit is Test {
     }
 }
 
-/// @title MIPS64_Unclassified_Test
+/// @title MIPS64_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `MIPS64` contract or
 ///         are testing multiple functions at once.
-contract MIPS64_Unclassified_Test is MIPS64_TestInit {
+contract MIPS64_Uncategorized_Test is MIPS64_TestInit {
     /// @notice Test the we can deploy MIPS64 with a valid version parameter.
     function test_deploy_supportedVersions_succeeds() external {
         for (uint256 i = 0; i < validVersions.length; i++) {

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -1544,10 +1544,10 @@ contract PreimageOracle_SqueezeLPP_Test is PreimageOracle_TestInit {
     }
 }
 
-/// @title PreimageOracle_Unclassified_Test
+/// @title PreimageOracle_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `PreimageOracle`
 ///         contract or are testing multiple functions at once.
-contract PreimageOracle_Unclassified_Test is PreimageOracle_TestInit {
+contract PreimageOracle_Uncategorized_Test is PreimageOracle_TestInit {
     /// @notice Test the pre-image key computation with a known pre-image.
     function test_keccak256PreimageKey_succeeds() public pure {
         bytes memory preimage = hex"deadbeef";

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -806,10 +806,10 @@ contract DisputeGameFactory_FindLatestGames_Test is DisputeGameFactory_TestInit 
     }
 }
 
-/// @title DisputeGameFactory_Unclassified_Test
+/// @title DisputeGameFactory_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `DisputeGameFactory`
 ///         contract or are testing multiple functions at once.
-contract DisputeGameFactory_Unclassified_Test is DisputeGameFactory_TestInit {
+contract DisputeGameFactory_Uncategorized_Test is DisputeGameFactory_TestInit {
     /// @notice Tests that the `owner` function returns the correct address after deployment.
     function test_owner_succeeds() public view {
         assertEq(disputeGameFactory.owner(), address(this));

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -2641,10 +2641,10 @@ contract FaultDisputeGame_GetChallengerDuration_Test is FaultDisputeGame_TestIni
     }
 }
 
-/// @title FaultDisputeGame_Unclassified_Test
+/// @title FaultDisputeGame_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `FaultDisputeGame`
 ///         contract or are testing multiple functions at once.
-contract FaultDisputeGame_Unclassified_Test is FaultDisputeGame_TestInit {
+contract FaultDisputeGame_Uncategorized_Test is FaultDisputeGame_TestInit {
     /// @notice Tests that the game's starting timestamp is set correctly.
     function test_createdAt_succeeds() public view {
         assertEq(gameProxy.createdAt().raw(), block.timestamp);

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -189,10 +189,10 @@ contract PermissionedDisputeGame_Step_Test is PermissionedDisputeGame_TestInit {
     }
 }
 
-/// @title PermissionedDisputeGame_Unclassified_Test
+/// @title PermissionedDisputeGame_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `PermissionedDisputeGame` contract or are testing multiple functions at once.
-contract PermissionedDisputeGame_Unclassified_Test is PermissionedDisputeGame_TestInit {
+contract PermissionedDisputeGame_Uncategorized_Test is PermissionedDisputeGame_TestInit {
     /// @notice Tests that the proposer can create a permissioned dispute game.
     function test_createGame_proposer_succeeds() public {
         uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -2325,10 +2325,10 @@ contract SuperFaultDisputeGame_GetChallengerDuration_Test is SuperFaultDisputeGa
     }
 }
 
-/// @title SuperFaultDisputeGame_Unclassified_Test
+/// @title SuperFaultDisputeGame_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `SuperFaultDisputeGame`
 ///         contract or are testing multiple functions at once.
-contract SuperFaultDisputeGame_Unclassified_Test is SuperFaultDisputeGame_TestInit {
+contract SuperFaultDisputeGame_Uncategorized_Test is SuperFaultDisputeGame_TestInit {
     /// @notice Tests that the game's starting timestamp is set correctly.
     function test_createdAt_succeeds() public view {
         assertEq(gameProxy.createdAt().raw(), block.timestamp);

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -187,10 +187,10 @@ contract SuperPermissionedDisputeGame_Step_Test is SuperPermissionedDisputeGame_
     }
 }
 
-/// @title SuperPermissionedDisputeGame_Unclassified_Test
+/// @title SuperPermissionedDisputeGame_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `SuperPermissionedDisputeGame` contract or are testing multiple functions at once.
-contract SuperPermissionedDisputeGame_Unclassified_Test is SuperPermissionedDisputeGame_TestInit {
+contract SuperPermissionedDisputeGame_Uncategorized_Test is SuperPermissionedDisputeGame_TestInit {
     /// @notice Tests that the proposer can create a permissioned dispute game.
     function test_createGame_proposer_succeeds() public {
         uint256 bondAmount = disputeGameFactory.initBonds(GAME_TYPE);

--- a/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
@@ -213,10 +213,10 @@ contract LibPosition_Move_Test is LibPosition_TestInit {
     }
 }
 
-/// @title LibPosition_Unclassified_Test
+/// @title LibPosition_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `LibPosition` contract
 ///         or are testing multiple functions at once.
-contract LibPosition_Unclassified_Test is LibPosition_TestInit {
+contract LibPosition_Uncategorized_Test is LibPosition_TestInit {
     /// @notice A static unit test for the correctness of all gindicies, (depth, index) combos, and
     ///         the trace index in a tree of max depth = 4.
     function test_pos_correctness_succeeds() public pure {

--- a/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
@@ -2612,10 +2612,10 @@ contract FaultDisputeGameV2_GetChallengerDuration_Test is FaultDisputeGameV2_Tes
     }
 }
 
-/// @title FaultDisputeGame_Unclassified_Test
+/// @title FaultDisputeGame_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `FaultDisputeGame`
 ///         contract or are testing multiple functions at once.
-contract FaultDisputeGameV2_Unclassified_Test is FaultDisputeGameV2_TestInit {
+contract FaultDisputeGameV2_Uncategorized_Test is FaultDisputeGameV2_TestInit {
     /// @notice Tests that the game's starting timestamp is set correctly.
     function test_createdAt_succeeds() public view {
         assertEq(gameProxy.createdAt().raw(), block.timestamp);

--- a/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/FaultDisputeGameV2.t.sol
@@ -2612,7 +2612,7 @@ contract FaultDisputeGameV2_GetChallengerDuration_Test is FaultDisputeGameV2_Tes
     }
 }
 
-/// @title FaultDisputeGame_Uncategorized_Test
+/// @title FaultDisputeGameV2_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `FaultDisputeGame`
 ///         contract or are testing multiple functions at once.
 contract FaultDisputeGameV2_Uncategorized_Test is FaultDisputeGameV2_TestInit {

--- a/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
+++ b/packages/contracts-bedrock/test/dispute/v2/PermissionedDisputeGameV2.t.sol
@@ -332,10 +332,10 @@ contract PermissionedDisputeGameV2_Initialize_Test is PermissionedDisputeGameV2_
     }
 }
 
-/// @title PermissionedDisputeGameV2_Unclassified_Test
+/// @title PermissionedDisputeGameV2_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `PermissionedDisputeGame` contract or are testing multiple functions at once.
-contract PermissionedDisputeGameV2_Unclassified_Test is PermissionedDisputeGameV2_TestInit {
+contract PermissionedDisputeGameV2_Uncategorized_Test is PermissionedDisputeGameV2_TestInit {
     /// @notice Tests that the proposer can create a permissioned dispute game.
     function test_createGame_proposer_succeeds() public {
         vm.prank(PROPOSER, PROPOSER);

--- a/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
+++ b/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
@@ -58,10 +58,10 @@ contract GovernanceToken_Mint_Test is GovernanceToken_TestInit {
     }
 }
 
-/// @title GovernanceToken_Unclassified_Test
+/// @title GovernanceToken_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `GovernanceToken`
 ///         contract or are testing multiple functions at once.
-contract GovernanceToken_Unclassified_Test is GovernanceToken_TestInit {
+contract GovernanceToken_Uncategorized_Test is GovernanceToken_TestInit {
     /// @notice Tests that the owner can successfully call `burn`.
     function test_burn_succeeds() external {
         // Mint 100 tokens to rando.

--- a/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
@@ -206,10 +206,10 @@ contract L1ChugSplashProxy_GetImplementation_Test is L1ChugSplashProxy_TestInit 
     }
 }
 
-/// @title L1ChugSplashProxy_Unclassified_Test
+/// @title L1ChugSplashProxy_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `L1ChugSplashProxy`
 ///         contract or are testing multiple functions at once.
-contract L1ChugSplashProxy_Unclassified_Test is L1ChugSplashProxy_TestInit {
+contract L1ChugSplashProxy_Uncategorized_Test is L1ChugSplashProxy_TestInit {
     /// @notice Tests that when the caller is not the owner and the implementation is not set, all
     ///         calls reverts.
     function test_calls_whenNotOwnerNoImplementation_reverts() public {

--- a/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
@@ -237,10 +237,10 @@ contract Blueprint_BytesToUint_Test is Blueprint_TestInit {
     }
 }
 
-/// @title Blueprint_Unclassified_Test
+/// @title Blueprint_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Blueprint` library or
 ///         are testing multiple functions at once.
-contract Blueprint_Unclassified_Test is Blueprint_TestInit {
+contract Blueprint_Uncategorized_Test is Blueprint_TestInit {
     /// @dev Tests that a roundtrip from initcode to blueprint to initcode succeeds, ensuring the
     ///      invariant that `parseBlueprintPreamble(blueprintDeployerBytecode(x)) = x`.
     function testFuzz_roundtrip_succeeds(bytes memory _initcode) public {

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -303,10 +303,10 @@ contract Encoding_EncodeSuperRootProof_Test is Encoding_TestInit {
     }
 }
 
-/// @title Encoding_Unclassified_Test
+/// @title Encoding_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Encoding` contract or
 ///         are testing multiple functions at once.
-contract Encoding_Unclassified_Test is Encoding_TestInit {
+contract Encoding_Uncategorized_Test is Encoding_TestInit {
     /// @notice Tests encoding and decoding a nonce and version.
     function testFuzz_nonceVersioning_succeeds(uint240 _nonce, uint16 _version) external pure {
         (uint240 nonce, uint16 version) = Encoding.decodeVersionedNonce(Encoding.encodeVersionedNonce(_nonce, _version));

--- a/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
+++ b/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
@@ -116,10 +116,10 @@ contract GasPayingToken_Sanitize_Test is GasPayingToken_TestInit {
     }
 }
 
-/// @title GasPayingToken_Unclassified_Test
+/// @title GasPayingToken_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `GasPayingToken`
 ///         library or are testing multiple functions at once.
-contract GasPayingToken_Unclassified_Test is GasPayingToken_TestInit {
+contract GasPayingToken_Uncategorized_Test is GasPayingToken_TestInit {
     /// @notice Test that the gas paying token correctly sets values in storage when input name
     ///         and symbol are strings.
     function testFuzz_setGetWithSanitize_succeeds(

--- a/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
@@ -126,10 +126,10 @@ contract Predeploys_PredeployToCodeNamespace_Test is Predeploys_TestInit {
     }
 }
 
-/// @title Predeploys_Unclassified_Test
+/// @title Predeploys_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Predeploys` contract
 ///         or are testing multiple functions at once.
-contract Predeploys_Unclassified_Test is Predeploys_TestInit {
+contract Predeploys_Uncategorized_Test is Predeploys_TestInit {
     /// @notice Tests that the predeploy addresses are set correctly. They have code
     ///         and the proxied accounts have the correct admin.
     function test_predeploys_succeeds() external {
@@ -137,10 +137,10 @@ contract Predeploys_Unclassified_Test is Predeploys_TestInit {
     }
 }
 
-/// @title Predeploys_Interop_Unclassified_Test
+/// @title Predeploys_Interop_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Predeploys` contract
 ///         or are testing multiple functions at once, using interop mode.
-contract Predeploys_UnclassifiedInterop_Test is Predeploys_TestInit {
+contract Predeploys_UncategorizedInterop_Test is Predeploys_TestInit {
     /// @notice Test setup. Enabling interop to get all predeploys.
     function setUp() public virtual override {
         super.enableInterop();

--- a/packages/contracts-bedrock/test/libraries/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Preinstalls.t.sol
@@ -46,10 +46,10 @@ contract Preinstalls_GetPermit2Code_Test is Preinstalls_TestInit {
     }
 }
 
-/// @title Preinstalls_Unclassified_Test
+/// @title Preinstalls_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Preinstalls` contract
 ///         or are testing multiple functions at once.
-contract Preinstalls_Unclassified_Test is Preinstalls_TestInit {
+contract Preinstalls_Uncategorized_Test is Preinstalls_TestInit {
     /// @notice The domain separator commits to the chainid of the chain
     function test_preinstall_permit2DomainSeparator_works() external view {
         bytes32 domainSeparator = IEIP712(Preinstalls.Permit2).DOMAIN_SEPARATOR();

--- a/packages/contracts-bedrock/test/libraries/TransientContext.t.sol
+++ b/packages/contracts-bedrock/test/libraries/TransientContext.t.sol
@@ -170,10 +170,10 @@ contract TransientContext_ReentrantAware_Test is TransientContext_TestInit, Tran
     }
 }
 
-/// @title TransientContext_Unclassified_Test
+/// @title TransientContext_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `TransientContext`
 ///         contract or are testing multiple functions at once.
-contract TransientContext_Unclassified_Test is TransientContext_Set_Test {
+contract TransientContext_Uncategorized_Test is TransientContext_Set_Test {
     /// @notice Tests that `set()` and `get()` work together.
     /// @param _slot  Slot to test.
     /// @param _value Value to test.

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -67,10 +67,10 @@ contract TransferOnion_Constructor_Test is TransferOnion_TestInit {
     }
 }
 
-/// @title TransferOnion_Unclassified_Test
+/// @title TransferOnion_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `TransferOnion`
 ///         contract or are testing multiple functions at once.
-contract TransferOnion_Unclassified_Test is TransferOnion_TestInit {
+contract TransferOnion_Uncategorized_Test is TransferOnion_TestInit {
     /// @notice Tests unwrapping the onion.
     function test_unwrap_succeeds() external {
         // Commit to transferring tiny amounts of tokens

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
@@ -45,10 +45,10 @@ contract CheckBalanceLow_Check_Test is CheckBalanceLow_TestInit {
     }
 }
 
-/// @title CheckBalanceLow_Unclassified_Test
+/// @title CheckBalanceLow_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `CheckBalanceLow`
 ///         contract or are testing multiple functions at once.
-contract CheckBalanceLow_Unclassified_Test is CheckBalanceLow_TestInit {
+contract CheckBalanceLow_Uncategorized_Test is CheckBalanceLow_TestInit {
     /// @notice Test that the `name` function returns the correct value.
     function test_name_succeeds() external view {
         assertEq(c.name(), "CheckBalanceLow");

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
@@ -191,10 +191,10 @@ contract CheckSecrets_Reveal_Test is CheckSecrets_TestInit {
     }
 }
 
-/// @title CheckSecrets_Unclassified_Test
+/// @title CheckSecrets_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `CheckSecrets` contract
 ///         or are testing multiple functions at once.
-contract CheckSecrets_Unclassified_Test is CheckSecrets_TestInit {
+contract CheckSecrets_Uncategorized_Test is CheckSecrets_TestInit {
     /// @notice Test that the `name` function returns the correct value.
     function test_name_succeeds() external view {
         assertEq(c.name(), "CheckSecrets");

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
@@ -25,10 +25,10 @@ contract CheckTrue_Check_Test is CheckTrue_TestInit {
     }
 }
 
-/// @title CheckTrue_Unclassified_Test
+/// @title CheckTrue_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `CheckTrue` contract or
 ///         are testing multiple functions at once.
-contract CheckTrue_Unclassified_Test is CheckTrue_TestInit {
+contract CheckTrue_Uncategorized_Test is CheckTrue_TestInit {
     /// @notice Test that the `name` function returns the correct value.
     function test_name_succeeds() external view {
         assertEq(c.name(), "CheckTrue");

--- a/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
@@ -617,10 +617,10 @@ contract DeputyPauseModule_Pause_Test is DeputyPauseModule_TestInit {
     }
 }
 
-/// @title L1CrossDomainMessenger_Unclassified_Test
+/// @title L1CrossDomainMessenger_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `DeputyPauseModule`
 ///         contract or are testing multiple functions at once.
-contract DeputyPauseModule_Unclassified_Test is DeputyPauseModule_TestInit {
+contract DeputyPauseModule_Uncategorized_Test is DeputyPauseModule_TestInit {
     /// @notice Tests that the getters work.
     function test_getters_works() external view {
         assertEq(address(deputyPauseModule.guardianSafe()), address(guardianSafeInstance.safe));

--- a/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
@@ -617,7 +617,7 @@ contract DeputyPauseModule_Pause_Test is DeputyPauseModule_TestInit {
     }
 }
 
-/// @title L1CrossDomainMessenger_Uncategorized_Test
+/// @title DeputyPauseModule_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `DeputyPauseModule`
 ///         contract or are testing multiple functions at once.
 contract DeputyPauseModule_Uncategorized_Test is DeputyPauseModule_TestInit {

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -162,10 +162,10 @@ contract LivenessGuard_ShowLiveness_Test is LivenessGuard_TestInit {
     }
 }
 
-/// @title LivenessGuard_Unclassified_Test
+/// @title LivenessGuard_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `LivenessGuard`
 ///         contract or are testing multiple functions at once.
-contract LivenessGuard_Unclassified_Test is StdCheats, StdUtils, LivenessGuard_TestInit {
+contract LivenessGuard_Uncategorized_Test is StdCheats, StdUtils, LivenessGuard_TestInit {
     using SafeTestLib for SafeInstance;
 
     /// @notice Enumerates the possible owner management operations

--- a/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
@@ -603,10 +603,10 @@ contract LivenessModule_RemoveOwners_Test is LivenessModule_TestInit {
     }
 }
 
-/// @title LivenessModule_Unclassified_Test
+/// @title LivenessModule_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `LivenessModule`
 ///         contract or are testing multiple functions at once.
-contract LivenessModule_Unclassified_Test is LivenessModule_TestInit {
+contract LivenessModule_Uncategorized_Test is LivenessModule_TestInit {
     /// @notice Tests if the getters work correctly
     function test_getters_works() external view {
         assertEq(address(livenessModule.safe()), address(safeInstance.safe));

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
@@ -133,10 +133,10 @@ contract OptimismMintableERC20_Bridge_Test is OptimismMintableERC20_TestInit {
     }
 }
 
-/// @title OptimismMintableERC20_Unclassified_Test
+/// @title OptimismMintableERC20_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `OptimismMintableERC20`
 ///         contract.
-contract OptimismMintableERC20_Unclassified_Test is OptimismMintableERC20_TestInit {
+contract OptimismMintableERC20_Uncategorized_Test is OptimismMintableERC20_TestInit {
     function test_legacy_succeeds() external view {
         // Getters for the remote token
         assertEq(L2Token.REMOTE_TOKEN(), address(L1Token));

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -218,10 +218,10 @@ contract OptimismMintableERC20Factory_CreateStandardL2Token_Test is OptimismMint
     }
 }
 
-/// @title OptimismMintableERC20Factory_Unclassified_Test
+/// @title OptimismMintableERC20Factory_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the
 ///         `OptimismMintableERC20Factory` contract.
-contract OptimismMintableERC20Factory_Unclassified_Test is OptimismMintableERC20Factory_TestInit {
+contract OptimismMintableERC20Factory_Uncategorized_Test is OptimismMintableERC20Factory_TestInit {
     /// @notice Tests that the upgrade is successful.
     function test_upgrading_succeeds() external {
         IProxy proxy = IProxy(artifacts.mustGetAddress("OptimismMintableERC20FactoryProxy"));

--- a/packages/contracts-bedrock/test/universal/Proxy.t.sol
+++ b/packages/contracts-bedrock/test/universal/Proxy.t.sol
@@ -257,9 +257,9 @@ contract Proxy_Implementation_Test is Proxy_TestInit {
     }
 }
 
-/// @title Proxy_Unclassified_Test
+/// @title Proxy_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Proxy` contract.
-contract Proxy_Unclassified_Test is Proxy_TestInit {
+contract Proxy_Uncategorized_Test is Proxy_TestInit {
     function test_delegatesToImpl_succeeds() external {
         // Call the storage setter on the proxy
         Proxy_SimpleStorage_Harness(address(proxy)).set(1, 1);

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -291,10 +291,10 @@ contract ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_TestInit {
     }
 }
 
-/// @title ProxyAdmin_Unclassified_Test
+/// @title ProxyAdmin_Uncategorized_Test
 /// @notice General tests that are not testing any function directly or that test multiple
 ///         functions of the `ProxyAdmin` contract.
-contract ProxyAdmin_Unclassified_Test is ProxyAdmin_TestInit {
+contract ProxyAdmin_Uncategorized_Test is ProxyAdmin_TestInit {
     function test_owner_succeeds() external view {
         assertEq(admin.owner(), alice);
     }

--- a/packages/contracts-bedrock/test/universal/WETH98.t.sol
+++ b/packages/contracts-bedrock/test/universal/WETH98.t.sol
@@ -175,10 +175,10 @@ contract WETH98_TransferFrom_Test is WETH98_TestInit {
     }
 }
 
-/// @title WETH98_Unclassified_Test
+/// @title WETH98_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `WETH98` contract or
 ///         are testing multiple functions at once.
-contract WETH98_Unclassified_Test is WETH98_TestInit {
+contract WETH98_Uncategorized_Test is WETH98_TestInit {
     function test_getName_succeeds() public view {
         assertEq(weth.name(), "Wrapped Ether");
         assertEq(weth.symbol(), "WETH");

--- a/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
-/// @title AddressAliasHelper_Unclassified_Test
+/// @title AddressAliasHelper_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `AddressAliasHelper`
 ///         contract or are testing multiple functions at once.
-contract AddressAliasHelper_Unclassified_Test is Test {
+contract AddressAliasHelper_Uncategorized_Test is Test {
     /// @notice Tests that applying and then undoing an alias results in the original address.
     function testFuzz_applyAndUndo_succeeds(address _address) external pure {
         address aliased = AddressAliasHelper.applyL1ToL2Alias(_address);


### PR DESCRIPTION
This PR standardizes test contract naming across the codebase by replacing "Unclassified" with "Uncategorized" to ensure consistency.

## Changes

- Test contracts: Renamed all `*_Unclassified_Test` contracts to `*_Uncategorized_Test`
- Validation logic: Updated `checkTestMethodName` function to only check for "Uncategorized" pattern
- Documentation: Updated contract comments to use consistent "uncategorized" terminology
- Code cleanup: Removed unused parameter in validation function

This is a pure refactoring change that maintains all existing test functionality while establishing a consistent naming convention.