### PR TITLE
op-contracts: DeployOPChain.s.sol conform to input/output struct pattern

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -229,7 +229,12 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 
 	l1Host.SetTxOrigin(cfg.Deployer)
 
-	output, err := opcm.DeployOPChain(l1Host, opcm.DeployOPChainInput{
+	deployOPChainScript, err := opcm.NewDeployOPChainScript(l1Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployOPChain script: %w", err)
+	}
+
+	output, err := deployOPChainScript.Run(opcm.DeployOPChainInput{
 		OpChainProxyAdminOwner:       superCfg.ProxyAdminOwner,
 		SystemConfigOwner:            cfg.SystemConfigOwner,
 		Batcher:                      cfg.BatchSenderAddress,
@@ -244,8 +249,8 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 		GasLimit:                     cfg.GasLimit,
 		DisputeGameType:              cfg.DisputeGameType,
 		DisputeAbsolutePrestate:      cfg.DisputeAbsolutePrestate,
-		DisputeMaxGameDepth:          cfg.DisputeMaxGameDepth,
-		DisputeSplitDepth:            cfg.DisputeSplitDepth,
+		DisputeMaxGameDepth:          new(big.Int).SetUint64(cfg.DisputeMaxGameDepth),
+		DisputeSplitDepth:            new(big.Int).SetUint64(cfg.DisputeSplitDepth),
 		DisputeClockExtension:        cfg.DisputeClockExtension,
 		DisputeMaxClockDuration:      cfg.DisputeMaxClockDuration,
 		AllowCustomDisputeParameters: true,
@@ -258,7 +263,7 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 
 	// Collect deployment addresses
 	return &L2Deployment{
-		L2OpchainDeployment: L2OpchainDeployment(output),
+		L2OpchainDeployment: NewL2OPChainDeploymentFromDeployOPChainOutput(output),
 	}, nil
 }
 

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -1,6 +1,7 @@
 package interopgen
 
 import (
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -57,13 +58,34 @@ type L2OpchainDeployment struct {
 	L1CrossDomainMessengerProxy       common.Address `json:"L1CrossDomainMessengerProxy"`
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address `json:"OptimismPortalProxy"`
-	ETHLockboxProxy                    common.Address `json:"ETHLockboxProxy"`
+	EthLockboxProxy                    common.Address `json:"EthLockboxProxy"`
 	DisputeGameFactoryProxy            common.Address `json:"DisputeGameFactoryProxy"`
 	AnchorStateRegistryProxy           common.Address `json:"AnchorStateRegistryProxy"`
 	FaultDisputeGame                   common.Address `json:"FaultDisputeGame"`
 	PermissionedDisputeGame            common.Address `json:"PermissionedDisputeGame"`
 	DelayedWETHPermissionedGameProxy   common.Address `json:"DelayedWETHPermissionedGameProxy"`
 	DelayedWETHPermissionlessGameProxy common.Address `json:"DelayedWETHPermissionlessGameProxy"`
+}
+
+func NewL2OPChainDeploymentFromDeployOPChainOutput(output opcm.DeployOPChainOutput) L2OpchainDeployment {
+	return L2OpchainDeployment{
+		OpChainProxyAdmin:                 output.OpChainProxyAdmin,
+		AddressManager:                    output.AddressManager,
+		L1ERC721BridgeProxy:               output.L1ERC721BridgeProxy,
+		SystemConfigProxy:                 output.SystemConfigProxy,
+		OptimismMintableERC20FactoryProxy: output.OptimismMintableERC20FactoryProxy,
+		L1StandardBridgeProxy:             output.L1StandardBridgeProxy,
+		L1CrossDomainMessengerProxy:       output.L1CrossDomainMessengerProxy,
+		// Fault proof contracts below.
+		OptimismPortalProxy:                output.OptimismPortalProxy,
+		EthLockboxProxy:                    output.EthLockboxProxy,
+		DisputeGameFactoryProxy:            output.DisputeGameFactoryProxy,
+		AnchorStateRegistryProxy:           output.AnchorStateRegistryProxy,
+		FaultDisputeGame:                   output.FaultDisputeGame,
+		PermissionedDisputeGame:            output.PermissionedDisputeGame,
+		DelayedWETHPermissionedGameProxy:   output.DelayedWETHPermissionedGameProxy,
+		DelayedWETHPermissionlessGameProxy: output.DelayedWETHPermissionlessGameProxy,
+	}
 }
 
 type L2Deployment struct {

--- a/op-chain-ops/interopgen/deployments.go
+++ b/op-chain-ops/interopgen/deployments.go
@@ -58,7 +58,7 @@ type L2OpchainDeployment struct {
 	L1CrossDomainMessengerProxy       common.Address `json:"L1CrossDomainMessengerProxy"`
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address `json:"OptimismPortalProxy"`
-	EthLockboxProxy                    common.Address `json:"EthLockboxProxy"`
+	ETHLockboxProxy                    common.Address `json:"ETHLockboxProxy"`
 	DisputeGameFactoryProxy            common.Address `json:"DisputeGameFactoryProxy"`
 	AnchorStateRegistryProxy           common.Address `json:"AnchorStateRegistryProxy"`
 	FaultDisputeGame                   common.Address `json:"FaultDisputeGame"`
@@ -78,7 +78,7 @@ func NewL2OPChainDeploymentFromDeployOPChainOutput(output opcm.DeployOPChainOutp
 		L1CrossDomainMessengerProxy:       output.L1CrossDomainMessengerProxy,
 		// Fault proof contracts below.
 		OptimismPortalProxy:                output.OptimismPortalProxy,
-		EthLockboxProxy:                    output.EthLockboxProxy,
+		ETHLockboxProxy:                    output.EthLockboxProxy,
 		DisputeGameFactoryProxy:            output.DisputeGameFactoryProxy,
 		AnchorStateRegistryProxy:           output.AnchorStateRegistryProxy,
 		FaultDisputeGame:                   output.FaultDisputeGame,

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -35,22 +35,14 @@ type DeployOPChainInput struct {
 
 	DisputeGameType              uint32
 	DisputeAbsolutePrestate      common.Hash
-	DisputeMaxGameDepth          uint64
-	DisputeSplitDepth            uint64
+	DisputeMaxGameDepth          *big.Int
+	DisputeSplitDepth            *big.Int
 	DisputeClockExtension        uint64
 	DisputeMaxClockDuration      uint64
 	AllowCustomDisputeParameters bool
 
 	OperatorFeeScalar   uint32
 	OperatorFeeConstant uint64
-}
-
-func (input *DeployOPChainInput) InputSet() bool {
-	return true
-}
-
-func (input *DeployOPChainInput) StartingAnchorRoot() []byte {
-	return PermissionedGameStartingAnchorRoot
 }
 
 type DeployOPChainOutput struct {
@@ -63,7 +55,7 @@ type DeployOPChainOutput struct {
 	L1CrossDomainMessengerProxy       common.Address
 	// Fault proof contracts below.
 	OptimismPortalProxy                common.Address
-	ETHLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
+	EthLockboxProxy                    common.Address `evm:"ethLockboxProxy"`
 	DisputeGameFactoryProxy            common.Address
 	AnchorStateRegistryProxy           common.Address
 	FaultDisputeGame                   common.Address
@@ -72,16 +64,11 @@ type DeployOPChainOutput struct {
 	DelayedWETHPermissionlessGameProxy common.Address
 }
 
-func (output *DeployOPChainOutput) CheckOutput(input common.Address) error {
-	return nil
-}
+type DeployOPChainScript script.DeployScriptWithOutput[DeployOPChainInput, DeployOPChainOutput]
 
-type DeployOPChainScript struct {
-	Run func(input, output common.Address) error
-}
-
-func DeployOPChain(host *script.Host, input DeployOPChainInput) (DeployOPChainOutput, error) {
-	return RunScriptSingle[DeployOPChainInput, DeployOPChainOutput](host, input, "DeployOPChain.s.sol", "DeployOPChain")
+// NewDeployOPChainScript loads and validates the DeployOPChain script contract
+func NewDeployOPChainScript(host *script.Host) (DeployOPChainScript, error) {
+	return script.NewDeployScriptWithOutputFromFile[DeployOPChainInput, DeployOPChainOutput](host, "DeployOPChain.s.sol", "DeployOPChain")
 }
 
 func NewDeployOPChainForgeCaller(client *forge.Client) forge.ScriptCaller[DeployOPChainInput, DeployOPChainOutput] {

--- a/op-deployer/pkg/deployer/opcm/scripts.go
+++ b/op-deployer/pkg/deployer/opcm/scripts.go
@@ -17,6 +17,7 @@ type Scripts struct {
 	DeployPreimageOracle  DeployPreimageOracleScript
 	DeployProxy           DeployProxyScript
 	DeploySuperchain      DeploySuperchainScript
+	DeployOPChain         DeployOPChainScript
 }
 
 // NewScripts collects all the deployment scripts, raising exceptions if any of them
@@ -67,6 +68,11 @@ func NewScripts(host *script.Host) (*Scripts, error) {
 		return nil, fmt.Errorf("failed to load DeployProxy script: %w", err)
 	}
 
+	deployOPChain, err := NewDeployOPChainScript(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DeployOPChain script: %w", err)
+	}
+
 	return &Scripts{
 		DeployAlphabetVM:      deployAlphabetVM,
 		DeployAltDA:           deployAltDA,
@@ -77,5 +83,6 @@ func NewScripts(host *script.Host) (*Scripts, error) {
 		DeployProxy:           deployProxy,
 		DeployImplementations: deployImplementations,
 		DeploySuperchain:      deploySuperchain,
+		DeployOPChain:         deployOPChain,
 	}, nil
 }

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
@@ -33,7 +34,7 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 		return fmt.Errorf("error making deploy OP chain input: %w", err)
 	}
 
-	dco, err = opcm.DeployOPChain(env.L1ScriptHost, dci)
+	dco, err = env.Scripts.DeployOPChain.Run(dci)
 	if err != nil {
 		return fmt.Errorf("error deploying OP chain: %w", err)
 	}
@@ -110,8 +111,8 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		GasLimit:                     thisIntent.GasLimit,
 		DisputeGameType:              proofParams.DisputeGameType,
 		DisputeAbsolutePrestate:      proofParams.DisputeAbsolutePrestate,
-		DisputeMaxGameDepth:          proofParams.DisputeMaxGameDepth,
-		DisputeSplitDepth:            proofParams.DisputeSplitDepth,
+		DisputeMaxGameDepth:          new(big.Int).SetUint64(proofParams.DisputeMaxGameDepth),
+		DisputeSplitDepth:            new(big.Int).SetUint64(proofParams.DisputeSplitDepth),
 		DisputeClockExtension:        proofParams.DisputeClockExtension,   // 3 hours (input in seconds)
 		DisputeMaxClockDuration:      proofParams.DisputeMaxClockDuration, // 3.5 days (input in seconds)
 		AllowCustomDisputeParameters: proofParams.DangerouslyAllowCustomDisputeParameters,
@@ -130,7 +131,7 @@ func makeChainState(chainID common.Hash, dco opcm.DeployOPChainOutput) *state.Ch
 	opChainContracts.L1StandardBridgeProxy = dco.L1StandardBridgeProxy
 	opChainContracts.L1CrossDomainMessengerProxy = dco.L1CrossDomainMessengerProxy
 	opChainContracts.OptimismPortalProxy = dco.OptimismPortalProxy
-	opChainContracts.EthLockboxProxy = dco.ETHLockboxProxy
+	opChainContracts.EthLockboxProxy = dco.EthLockboxProxy
 	opChainContracts.DisputeGameFactoryProxy = dco.DisputeGameFactoryProxy
 	opChainContracts.AnchorStateRegistryProxy = dco.AnchorStateRegistryProxy
 	opChainContracts.FaultDisputeGameImpl = dco.FaultDisputeGame

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -55,6 +55,7 @@ library ChainAssertions {
     /// @notice Asserts that the SystemConfig is setup correctly
     function checkSystemConfigImpls(Types.ContractSet memory _contracts) internal view {
         ISystemConfig config = ISystemConfig(_contracts.SystemConfig);
+        console.log("Running chain assertions on the SystemConfig impl at %s", address(config));
 
         // Check that the contract is initialized
         DeployUtils.assertInitialized({ _contractAddress: address(config), _isProxy: false, _slot: 0, _offset: 0 });
@@ -95,6 +96,8 @@ library ChainAssertions {
         view
     {
         ISystemConfig config = ISystemConfig(_contracts.SystemConfig);
+        console.log("Running chain assertions on the SystemConfig proxy at %s", address(config));
+
         // Check that the contract is initialized
         DeployUtils.assertInitialized({ _contractAddress: address(config), _isProxy: true, _slot: 0, _offset: 0 });
 

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -7,7 +7,6 @@ import { console2 as console } from "forge-std/console2.sol";
 
 // Scripts
 import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
-import { DeployOPChainInput } from "scripts/deploy/DeployOPChain.s.sol";
 import { DeployImplementations } from "scripts/deploy/DeployImplementations.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
@@ -54,68 +53,70 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the SystemConfig is setup correctly
-    function checkSystemConfig(
+    function checkSystemConfigImpls(Types.ContractSet memory _contracts) internal view {
+        ISystemConfig config = ISystemConfig(_contracts.SystemConfig);
+
+        // Check that the contract is initialized
+        DeployUtils.assertInitialized({ _contractAddress: address(config), _isProxy: false, _slot: 0, _offset: 0 });
+
+        IResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
+
+        require(config.owner() == address(0), "CHECK-SCFG-220");
+        require(config.overhead() == 0, "CHECK-SCFG-230");
+        require(config.scalar() == 0, "CHECK-SCFG-240"); // version 1
+        require(config.basefeeScalar() == 0, "CHECK-SCFG-250");
+        require(config.blobbasefeeScalar() == 0, "CHECK-SCFG-260");
+        require(config.batcherHash() == bytes32(0), "CHECK-SCFG-270");
+        require(config.gasLimit() == 0, "CHECK-SCFG-280");
+        require(config.unsafeBlockSigner() == address(0), "CHECK-SCFG-290");
+        // Check _config
+        require(resourceConfig.maxResourceLimit == 0, "CHECK-SCFG-300");
+        require(resourceConfig.elasticityMultiplier == 0, "CHECK-SCFG-310");
+        require(resourceConfig.baseFeeMaxChangeDenominator == 0, "CHECK-SCFG-320");
+        require(resourceConfig.systemTxMaxGas == 0, "CHECK-SCFG-330");
+        require(resourceConfig.minimumBaseFee == 0, "CHECK-SCFG-340");
+        require(resourceConfig.maximumBaseFee == 0, "CHECK-SCFG-350");
+        // Check _addresses
+        require(config.startBlock() == type(uint256).max, "CHECK-SCFG-360");
+        require(config.batchInbox() == address(0), "CHECK-SCFG-370");
+        require(config.l1CrossDomainMessenger() == address(0), "CHECK-SCFG-380");
+        require(config.l1ERC721Bridge() == address(0), "CHECK-SCFG-390");
+        require(config.l1StandardBridge() == address(0), "CHECK-SCFG-400");
+        require(config.optimismPortal() == address(0), "CHECK-SCFG-420");
+        require(config.optimismMintableERC20Factory() == address(0), "CHECK-SCFG-430");
+    }
+
+    /// @notice Asserts that the SystemConfig is setup correctly
+    function checkSystemConfigProxies(
         Types.ContractSet memory _contracts,
-        DeployOPChainInput _doi,
-        bool _isProxy
+        Types.DeployOPChainInput memory _doi
     )
         internal
         view
     {
         ISystemConfig config = ISystemConfig(_contracts.SystemConfig);
-        console.log(
-            "Running chain assertions on the SystemConfig %s at %s",
-            _isProxy ? "proxy" : "implementation",
-            address(config)
-        );
-
         // Check that the contract is initialized
-        DeployUtils.assertInitialized({ _contractAddress: address(config), _isProxy: _isProxy, _slot: 0, _offset: 0 });
+        DeployUtils.assertInitialized({ _contractAddress: address(config), _isProxy: true, _slot: 0, _offset: 0 });
 
-        IResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
-
-        if (_isProxy) {
-            require(config.owner() == _doi.systemConfigOwner(), "CHECK-SCFG-10");
-            require(config.basefeeScalar() == _doi.basefeeScalar(), "CHECK-SCFG-20");
-            require(config.blobbasefeeScalar() == _doi.blobBaseFeeScalar(), "CHECK-SCFG-30");
-            require(config.batcherHash() == bytes32(uint256(uint160(_doi.batcher()))), "CHECK-SCFG-40");
-            require(config.gasLimit() == uint64(_doi.gasLimit()), "CHECK-SCFG-50");
-            require(config.unsafeBlockSigner() == _doi.unsafeBlockSigner(), "CHECK-SCFG-60");
-            require(config.scalar() >> 248 == 1, "CHECK-SCFG-70");
-            // Depends on start block being set to 0 in `initialize`
-            require(config.startBlock() == block.number, "CHECK-SCFG-140");
-            require(config.batchInbox() == _doi.opcm().chainIdToBatchInboxAddress(_doi.l2ChainId()), "CHECK-SCFG-150");
-            // Check _addresses
-            require(config.l1CrossDomainMessenger() == _contracts.L1CrossDomainMessenger, "CHECK-SCFG-160");
-            require(config.l1ERC721Bridge() == _contracts.L1ERC721Bridge, "CHECK-SCFG-170");
-            require(config.l1StandardBridge() == _contracts.L1StandardBridge, "CHECK-SCFG-180");
-            require(config.optimismPortal() == _contracts.OptimismPortal, "CHECK-SCFG-200");
-            require(config.optimismMintableERC20Factory() == _contracts.OptimismMintableERC20Factory, "CHECK-SCFG-210");
-        } else {
-            require(config.owner() == address(0), "CHECK-SCFG-220");
-            require(config.overhead() == 0, "CHECK-SCFG-230");
-            require(config.scalar() == 0, "CHECK-SCFG-240"); // version 1
-            require(config.basefeeScalar() == 0, "CHECK-SCFG-250");
-            require(config.blobbasefeeScalar() == 0, "CHECK-SCFG-260");
-            require(config.batcherHash() == bytes32(0), "CHECK-SCFG-270");
-            require(config.gasLimit() == 0, "CHECK-SCFG-280");
-            require(config.unsafeBlockSigner() == address(0), "CHECK-SCFG-290");
-            // Check _config
-            require(resourceConfig.maxResourceLimit == 0, "CHECK-SCFG-300");
-            require(resourceConfig.elasticityMultiplier == 0, "CHECK-SCFG-310");
-            require(resourceConfig.baseFeeMaxChangeDenominator == 0, "CHECK-SCFG-320");
-            require(resourceConfig.systemTxMaxGas == 0, "CHECK-SCFG-330");
-            require(resourceConfig.minimumBaseFee == 0, "CHECK-SCFG-340");
-            require(resourceConfig.maximumBaseFee == 0, "CHECK-SCFG-350");
-            // Check _addresses
-            require(config.startBlock() == type(uint256).max, "CHECK-SCFG-360");
-            require(config.batchInbox() == address(0), "CHECK-SCFG-370");
-            require(config.l1CrossDomainMessenger() == address(0), "CHECK-SCFG-380");
-            require(config.l1ERC721Bridge() == address(0), "CHECK-SCFG-390");
-            require(config.l1StandardBridge() == address(0), "CHECK-SCFG-400");
-            require(config.optimismPortal() == address(0), "CHECK-SCFG-420");
-            require(config.optimismMintableERC20Factory() == address(0), "CHECK-SCFG-430");
-        }
+        require(config.owner() == _doi.systemConfigOwner, "CHECK-SCFG-10");
+        require(config.basefeeScalar() == _doi.basefeeScalar, "CHECK-SCFG-20");
+        require(config.blobbasefeeScalar() == _doi.blobBaseFeeScalar, "CHECK-SCFG-30");
+        require(config.batcherHash() == bytes32(uint256(uint160(_doi.batcher))), "CHECK-SCFG-40");
+        require(config.gasLimit() == uint64(_doi.gasLimit), "CHECK-SCFG-50");
+        require(config.unsafeBlockSigner() == _doi.unsafeBlockSigner, "CHECK-SCFG-60");
+        require(config.scalar() >> 248 == 1, "CHECK-SCFG-70");
+        // Depends on start block being set to 0 in `initialize`
+        require(config.startBlock() == block.number, "CHECK-SCFG-140");
+        require(
+            config.batchInbox() == IOPContractsManager(_doi.opcm).chainIdToBatchInboxAddress(_doi.l2ChainId),
+            "CHECK-SCFG-150"
+        );
+        // Check _addresses
+        require(config.l1CrossDomainMessenger() == _contracts.L1CrossDomainMessenger, "CHECK-SCFG-160");
+        require(config.l1ERC721Bridge() == _contracts.L1ERC721Bridge, "CHECK-SCFG-170");
+        require(config.l1StandardBridge() == _contracts.L1StandardBridge, "CHECK-SCFG-180");
+        require(config.optimismPortal() == _contracts.OptimismPortal, "CHECK-SCFG-200");
+        require(config.optimismMintableERC20Factory() == _contracts.OptimismMintableERC20Factory, "CHECK-SCFG-210");
     }
 
     /// @notice Asserts that the L1CrossDomainMessenger is setup correctly
@@ -438,14 +439,12 @@ library ChainAssertions {
         );
     }
 
-    function checkAnchorStateRegistryProxy(
-        IAnchorStateRegistry _anchorStateRegistryProxy,
-        bool _isProxy
-    )
-        internal
-        view
-    {
-        // Then we check the proxy as ASR.
+    function checkAnchorStateRegistryProxy(IAnchorStateRegistry _anchorStateRegistryProxy, bool _isProxy) internal {
+        DeployUtils.assertValidContractAddress(address(_anchorStateRegistryProxy));
+        if (_isProxy) {
+            DeployUtils.assertERC1967ImplementationSet(address(_anchorStateRegistryProxy));
+        }
+
         DeployUtils.assertInitialized({
             _contractAddress: address(_anchorStateRegistryProxy),
             _isProxy: _isProxy,

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -9,7 +9,6 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Scripts
 import { Deployer } from "scripts/deploy/Deployer.sol";
-import { DeployOPChainInput } from "scripts/deploy/DeployOPChain.s.sol";
 import { Chains } from "scripts/libraries/Chains.sol";
 import { Config } from "scripts/libraries/Config.sol";
 import { StateDiff } from "scripts/libraries/StateDiff.sol";
@@ -327,7 +326,7 @@ contract Deploy is Deployer {
             _mips: IMIPS64(address(dio.mipsSingleton)),
             _superchainProxyAdmin: superchainProxyAdmin
         });
-        ChainAssertions.checkSystemConfig({ _doi: DeployOPChainInput(address(0)), _contracts: impls, _isProxy: false });
+        ChainAssertions.checkSystemConfigImpls(impls);
         ChainAssertions.checkAnchorStateRegistryProxy(IAnchorStateRegistry(impls.AnchorStateRegistry), false);
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -40,7 +40,6 @@ import { IOPContractsManagerStandardValidator } from "interfaces/L1/IOPContracts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { ChainAssertions } from "scripts/deploy/ChainAssertions.sol";
-import { DeployOPChainInput } from "scripts/deploy/DeployOPChain.s.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 contract DeployImplementations is Script {
@@ -701,7 +700,7 @@ contract DeployImplementations is Script {
         require(address(_input.upgradeController) != address(0), "DeployImplementations: upgradeController not set");
     }
 
-    function assertValidOutput(Input memory _input, Output memory _output) private view {
+    function assertValidOutput(Input memory _input, Output memory _output) private {
         // With 12 addresses, we'd get a stack too deep error if we tried to do this inline as a
         // single call to `Solarray.addresses`. So we split it into two calls.
         address[] memory addrs1 = Solarray.addresses(
@@ -781,8 +780,7 @@ contract DeployImplementations is Script {
             _isProxy: false
         });
         ChainAssertions.checkETHLockboxImpl(_output.ethLockboxImpl, _output.optimismPortalImpl);
-        // We can use DeployOPChainInput(address(0)) here because no method will be called on _doi when isProxy is false
-        ChainAssertions.checkSystemConfig(impls, DeployOPChainInput(address(0)), false);
+        ChainAssertions.checkSystemConfigImpls(impls);
         ChainAssertions.checkAnchorStateRegistryProxy(IAnchorStateRegistry(impls.AnchorStateRegistry), false);
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -5,7 +5,6 @@ import { Script } from "forge-std/Script.sol";
 
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
-
 import { ChainAssertions } from "scripts/deploy/ChainAssertions.sol";
 import { Constants as ScriptConstants } from "scripts/libraries/Constants.sol";
 import { Types } from "scripts/libraries/Types.sol";
@@ -18,7 +17,6 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
-
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
@@ -141,6 +139,11 @@ contract DeployOPChain is Script {
 
         require(_i.opcm != address(0), "DeployOPChainInput: opcm not set");
         DeployUtils.assertValidContractAddress(_i.opcm);
+
+        require(_i.disputeMaxGameDepth != 0, "DeployOPChainInput: disputeMaxGameDepth not set");
+        require(_i.disputeSplitDepth != 0, "DeployOPChainInput: disputeSplitDepth not set");
+        require(_i.disputeMaxClockDuration.raw() != 0, "DeployOPChainInput: disputeMaxClockDuration not set");
+        require(_i.disputeAbsolutePrestate.raw() != bytes32(0), "DeployOPChainInput: disputeAbsolutePrestate not set");
     }
 
     function checkOutput(Types.DeployOPChainInput memory _i, Output memory _o) public {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -31,135 +31,270 @@ import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
-contract DeployOPChainInput is BaseDeployIO {
-    address internal _opChainProxyAdminOwner;
-    address internal _systemConfigOwner;
-    address internal _batcher;
-    address internal _unsafeBlockSigner;
-    address internal _proposer;
-    address internal _challenger;
-
-    // TODO Add fault proofs inputs in a future PR.
-    uint32 internal _basefeeScalar;
-    uint32 internal _blobBaseFeeScalar;
-    uint256 internal _l2ChainId;
-    IOPContractsManager internal _opcm;
-    string internal _saltMixer;
-    uint64 internal _gasLimit;
-
-    // Configurable dispute game inputs
-    GameType internal _disputeGameType;
-    Claim internal _disputeAbsolutePrestate;
-    uint256 internal _disputeMaxGameDepth;
-    uint256 internal _disputeSplitDepth;
-    Duration internal _disputeClockExtension;
-    Duration internal _disputeMaxClockDuration;
-    bool internal _allowCustomDisputeParameters;
-
-    uint32 internal _operatorFeeScalar;
-    uint64 internal _operatorFeeConstant;
-
-    function set(bytes4 _sel, address _addr) public {
-        require(_addr != address(0), "DeployOPChainInput: cannot set zero address");
-        if (_sel == this.opChainProxyAdminOwner.selector) _opChainProxyAdminOwner = _addr;
-        else if (_sel == this.systemConfigOwner.selector) _systemConfigOwner = _addr;
-        else if (_sel == this.batcher.selector) _batcher = _addr;
-        else if (_sel == this.unsafeBlockSigner.selector) _unsafeBlockSigner = _addr;
-        else if (_sel == this.proposer.selector) _proposer = _addr;
-        else if (_sel == this.challenger.selector) _challenger = _addr;
-        else if (_sel == this.opcm.selector) _opcm = IOPContractsManager(_addr);
-        else revert("DeployOPChainInput: unknown selector");
+contract DeployOPChain is Script {
+    struct Output {
+        IProxyAdmin opChainProxyAdmin;
+        IAddressManager addressManager;
+        IL1ERC721Bridge l1ERC721BridgeProxy;
+        ISystemConfig systemConfigProxy;
+        IOptimismMintableERC20Factory optimismMintableERC20FactoryProxy;
+        IL1StandardBridge l1StandardBridgeProxy;
+        IL1CrossDomainMessenger l1CrossDomainMessengerProxy;
+        IOptimismPortal optimismPortalProxy;
+        IETHLockbox ethLockboxProxy;
+        IDisputeGameFactory disputeGameFactoryProxy;
+        IAnchorStateRegistry anchorStateRegistryProxy;
+        IFaultDisputeGame faultDisputeGame;
+        IPermissionedDisputeGame permissionedDisputeGame;
+        IDelayedWETH delayedWETHPermissionedGameProxy;
+        IDelayedWETH delayedWETHPermissionlessGameProxy;
     }
 
-    function set(bytes4 _sel, uint256 _value) public {
-        if (_sel == this.basefeeScalar.selector) {
-            _basefeeScalar = SafeCast.toUint32(_value);
-        } else if (_sel == this.blobBaseFeeScalar.selector) {
-            _blobBaseFeeScalar = SafeCast.toUint32(_value);
-        } else if (_sel == this.l2ChainId.selector) {
-            require(_value != 0 && _value != block.chainid, "DeployOPChainInput: invalid l2ChainId");
-            _l2ChainId = _value;
-        } else if (_sel == this.gasLimit.selector) {
-            _gasLimit = SafeCast.toUint64(_value);
-        } else if (_sel == this.disputeGameType.selector) {
-            _disputeGameType = GameType.wrap(SafeCast.toUint32(_value));
-        } else if (_sel == this.disputeMaxGameDepth.selector) {
-            _disputeMaxGameDepth = SafeCast.toUint64(_value);
-        } else if (_sel == this.disputeSplitDepth.selector) {
-            _disputeSplitDepth = SafeCast.toUint64(_value);
-        } else if (_sel == this.disputeClockExtension.selector) {
-            _disputeClockExtension = Duration.wrap(SafeCast.toUint64(_value));
-        } else if (_sel == this.disputeMaxClockDuration.selector) {
-            _disputeMaxClockDuration = Duration.wrap(SafeCast.toUint64(_value));
-        } else if (_sel == this.operatorFeeScalar.selector) {
-            _operatorFeeScalar = SafeCast.toUint32(_value);
-        } else if (_sel == this.operatorFeeConstant.selector) {
-            _operatorFeeConstant = SafeCast.toUint64(_value);
-        } else {
-            revert("DeployOPChainInput: unknown selector");
-        }
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Types.DeployOPChainInput memory input = abi.decode(_input, (Types.DeployOPChainInput));
+        Output memory output_ = run(input);
+        return abi.encode(output_);
     }
 
-    function set(bytes4 _sel, string memory _value) public {
-        require((bytes(_value).length != 0), "DeployImplementationsInput: cannot set empty string");
-        if (_sel == this.saltMixer.selector) _saltMixer = _value;
-        else revert("DeployOPChainInput: unknown selector");
+    function run(Types.DeployOPChainInput memory _input) public returns (Output memory output_) {
+        checkInput(_input);
+
+        IOPContractsManager opcm = IOPContractsManager(_input.opcm);
+
+        IOPContractsManager.Roles memory roles = IOPContractsManager.Roles({
+            opChainProxyAdminOwner: _input.opChainProxyAdminOwner,
+            systemConfigOwner: _input.systemConfigOwner,
+            batcher: _input.batcher,
+            unsafeBlockSigner: _input.unsafeBlockSigner,
+            proposer: _input.proposer,
+            challenger: _input.challenger
+        });
+        IOPContractsManager.DeployInput memory deployInput = IOPContractsManager.DeployInput({
+            roles: roles,
+            basefeeScalar: _input.basefeeScalar,
+            blobBasefeeScalar: _input.blobBaseFeeScalar,
+            l2ChainId: _input.l2ChainId,
+            startingAnchorRoot: startingAnchorRoot(),
+            saltMixer: _input.saltMixer,
+            gasLimit: _input.gasLimit,
+            disputeGameType: _input.disputeGameType,
+            disputeAbsolutePrestate: _input.disputeAbsolutePrestate,
+            disputeMaxGameDepth: _input.disputeMaxGameDepth,
+            disputeSplitDepth: _input.disputeSplitDepth,
+            disputeClockExtension: _input.disputeClockExtension,
+            disputeMaxClockDuration: _input.disputeMaxClockDuration
+        });
+
+        vm.broadcast(msg.sender);
+        IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
+
+        vm.label(address(deployOutput.opChainProxyAdmin), "opChainProxyAdmin");
+        vm.label(address(deployOutput.addressManager), "addressManager");
+        vm.label(address(deployOutput.l1ERC721BridgeProxy), "l1ERC721BridgeProxy");
+        vm.label(address(deployOutput.systemConfigProxy), "systemConfigProxy");
+        vm.label(address(deployOutput.optimismMintableERC20FactoryProxy), "optimismMintableERC20FactoryProxy");
+        vm.label(address(deployOutput.l1StandardBridgeProxy), "l1StandardBridgeProxy");
+        vm.label(address(deployOutput.l1CrossDomainMessengerProxy), "l1CrossDomainMessengerProxy");
+        vm.label(address(deployOutput.optimismPortalProxy), "optimismPortalProxy");
+        vm.label(address(deployOutput.ethLockboxProxy), "ethLockboxProxy");
+        vm.label(address(deployOutput.disputeGameFactoryProxy), "disputeGameFactoryProxy");
+        vm.label(address(deployOutput.anchorStateRegistryProxy), "anchorStateRegistryProxy");
+        vm.label(address(deployOutput.permissionedDisputeGame), "permissionedDisputeGame");
+        vm.label(address(deployOutput.delayedWETHPermissionedGameProxy), "delayedWETHPermissionedGameProxy");
+        // TODO: Eventually switch from Permissioned to Permissionless.
+        // vm.label(address(deployOutput.faultDisputeGame), "faultDisputeGame");
+        // vm.label(address(deployOutput.delayedWETHPermissionlessGameProxy), "delayedWETHPermissionlessGameProxy");
+
+        output_ = Output({
+            opChainProxyAdmin: deployOutput.opChainProxyAdmin,
+            addressManager: deployOutput.addressManager,
+            l1ERC721BridgeProxy: deployOutput.l1ERC721BridgeProxy,
+            systemConfigProxy: deployOutput.systemConfigProxy,
+            optimismMintableERC20FactoryProxy: deployOutput.optimismMintableERC20FactoryProxy,
+            l1StandardBridgeProxy: deployOutput.l1StandardBridgeProxy,
+            l1CrossDomainMessengerProxy: deployOutput.l1CrossDomainMessengerProxy,
+            optimismPortalProxy: deployOutput.optimismPortalProxy,
+            ethLockboxProxy: deployOutput.ethLockboxProxy,
+            disputeGameFactoryProxy: deployOutput.disputeGameFactoryProxy,
+            anchorStateRegistryProxy: deployOutput.anchorStateRegistryProxy,
+            faultDisputeGame: deployOutput.faultDisputeGame,
+            permissionedDisputeGame: deployOutput.permissionedDisputeGame,
+            delayedWETHPermissionedGameProxy: deployOutput.delayedWETHPermissionedGameProxy,
+            delayedWETHPermissionlessGameProxy: deployOutput.delayedWETHPermissionlessGameProxy
+        });
+
+        checkOutput(_input, output_);
     }
 
-    function set(bytes4 _sel, bytes32 _value) public {
-        if (_sel == this.disputeAbsolutePrestate.selector) _disputeAbsolutePrestate = Claim.wrap(_value);
-        else revert("DeployImplementationsInput: unknown selector");
+    // -------- Validations --------
+
+    function checkInput(Types.DeployOPChainInput memory _i) public view {
+        require(_i.opChainProxyAdminOwner != address(0), "DeployOPChainInput: opChainProxyAdminOwner not set");
+        require(_i.systemConfigOwner != address(0), "DeployOPChainInput: systemConfigOwner not set");
+        require(_i.batcher != address(0), "DeployOPChainInput: batcher not set");
+        require(_i.unsafeBlockSigner != address(0), "DeployOPChainInput: unsafeBlockSigner not set");
+        require(_i.proposer != address(0), "DeployOPChainInput: proposer not set");
+        require(_i.challenger != address(0), "DeployOPChainInput: challenger not set");
+
+        require(_i.blobBaseFeeScalar != 0, "DeployOPChainInput: blobBaseFeeScalar not set");
+        require(_i.basefeeScalar != 0, "DeployOPChainInput: basefeeScalar not set");
+        require(_i.gasLimit != 0, "DeployOPChainInput: gasLimit not set");
+
+        require(_i.l2ChainId != 0, "DeployOPChainInput: l2ChainId not set");
+        require(_i.l2ChainId != block.chainid, "DeployOPChainInput: l2ChainId matches block.chainid");
+
+        require(_i.opcm != address(0), "DeployOPChainInput: opcm not set");
+        DeployUtils.assertValidContractAddress(_i.opcm);
     }
 
-    function set(bytes4 _sel, bool _value) public {
-        if (_sel == this.allowCustomDisputeParameters.selector) _allowCustomDisputeParameters = _value;
-        else revert("DeployOPChainInput: unknown selector");
+    function checkOutput(Types.DeployOPChainInput memory _i, Output memory _o) public {
+        // With 16 addresses, we'd get a stack too deep error if we tried to do this inline as a
+        // single call to `Solarray.addresses`. So we split it into two calls.
+        address[] memory addrs1 = Solarray.addresses(
+            address(_o.opChainProxyAdmin),
+            address(_o.addressManager),
+            address(_o.l1ERC721BridgeProxy),
+            address(_o.systemConfigProxy),
+            address(_o.optimismMintableERC20FactoryProxy),
+            address(_o.l1StandardBridgeProxy),
+            address(_o.l1CrossDomainMessengerProxy)
+        );
+        address[] memory addrs2 = Solarray.addresses(
+            address(_o.optimismPortalProxy),
+            address(_o.disputeGameFactoryProxy),
+            address(_o.anchorStateRegistryProxy),
+            address(_o.permissionedDisputeGame),
+            address(_o.delayedWETHPermissionedGameProxy),
+            address(_o.ethLockboxProxy)
+        );
+        // TODO: Eventually switch from Permissioned to Permissionless. Add this address back in.
+        // address(_o.delayedWETHPermissionlessGameProxy)
+        // address(_o.faultDisputeGame()),
+
+        DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
+        _assertValidDeploy(_i, _o);
     }
 
-    function opChainProxyAdminOwner() public view returns (address) {
-        require(_opChainProxyAdminOwner != address(0), "DeployOPChainInput: not set");
-        return _opChainProxyAdminOwner;
+    function _assertValidDeploy(Types.DeployOPChainInput memory _i, Output memory _o) internal {
+        Types.ContractSet memory proxies = Types.ContractSet({
+            L1CrossDomainMessenger: address(_o.l1CrossDomainMessengerProxy),
+            L1StandardBridge: address(_o.l1StandardBridgeProxy),
+            L2OutputOracle: address(0),
+            DisputeGameFactory: address(_o.disputeGameFactoryProxy),
+            DelayedWETH: address(_o.delayedWETHPermissionlessGameProxy),
+            PermissionedDelayedWETH: address(_o.delayedWETHPermissionedGameProxy),
+            AnchorStateRegistry: address(_o.anchorStateRegistryProxy),
+            OptimismMintableERC20Factory: address(_o.optimismMintableERC20FactoryProxy),
+            OptimismPortal: address(_o.optimismPortalProxy),
+            ETHLockbox: address(_o.ethLockboxProxy),
+            SystemConfig: address(_o.systemConfigProxy),
+            L1ERC721Bridge: address(_o.l1ERC721BridgeProxy),
+            ProtocolVersions: address(0),
+            SuperchainConfig: address(0)
+        });
+
+        ChainAssertions.checkAnchorStateRegistryProxy(_o.anchorStateRegistryProxy, true);
+        ChainAssertions.checkDisputeGameFactory(
+            _o.disputeGameFactoryProxy, _i.opChainProxyAdminOwner, address(_o.permissionedDisputeGame), true
+        );
+        ChainAssertions.checkL1CrossDomainMessenger(_o.l1CrossDomainMessengerProxy, vm, true);
+        ChainAssertions.checkOptimismPortal2({
+            _contracts: proxies,
+            _superchainConfig: IOPContractsManager(_i.opcm).superchainConfig(),
+            _opChainProxyAdminOwner: _i.opChainProxyAdminOwner,
+            _isProxy: true
+        });
+        ChainAssertions.checkSystemConfigProxies(proxies, _i);
+
+        DeployUtils.assertValidContractAddress(address(_o.l1CrossDomainMessengerProxy));
+        DeployUtils.assertResolvedDelegateProxyImplementationSet("OVM_L1CrossDomainMessenger", _o.addressManager);
+
+        // Proxies initialized checks
+        DeployUtils.assertInitialized({
+            _contractAddress: address(_o.l1ERC721BridgeProxy),
+            _isProxy: true,
+            _slot: 0,
+            _offset: 0
+        });
+        DeployUtils.assertInitialized({
+            _contractAddress: address(_o.l1StandardBridgeProxy),
+            _isProxy: true,
+            _slot: 0,
+            _offset: 0
+        });
+        DeployUtils.assertInitialized({
+            _contractAddress: address(_o.optimismMintableERC20FactoryProxy),
+            _isProxy: true,
+            _slot: 0,
+            _offset: 0
+        });
+        DeployUtils.assertInitialized({
+            _contractAddress: address(_o.ethLockboxProxy),
+            _isProxy: true,
+            _slot: 0,
+            _offset: 0
+        });
+
+        require(_o.addressManager.owner() == address(_o.opChainProxyAdmin), "AM-10");
+        assertValidOPChainProxyAdmin(_i, _o);
     }
 
-    function systemConfigOwner() public view returns (address) {
-        require(_systemConfigOwner != address(0), "DeployOPChainInput: not set");
-        return _systemConfigOwner;
-    }
-
-    function batcher() public view returns (address) {
-        require(_batcher != address(0), "DeployOPChainInput: not set");
-        return _batcher;
-    }
-
-    function unsafeBlockSigner() public view returns (address) {
-        require(_unsafeBlockSigner != address(0), "DeployOPChainInput: not set");
-        return _unsafeBlockSigner;
-    }
-
-    function proposer() public view returns (address) {
-        require(_proposer != address(0), "DeployOPChainInput: not set");
-        return _proposer;
-    }
-
-    function challenger() public view returns (address) {
-        require(_challenger != address(0), "DeployOPChainInput: not set");
-        return _challenger;
-    }
-
-    function basefeeScalar() public view returns (uint32) {
-        require(_basefeeScalar != 0, "DeployOPChainInput: not set");
-        return _basefeeScalar;
-    }
-
-    function blobBaseFeeScalar() public view returns (uint32) {
-        require(_blobBaseFeeScalar != 0, "DeployOPChainInput: not set");
-        return _blobBaseFeeScalar;
-    }
-
-    function l2ChainId() public view returns (uint256) {
-        require(_l2ChainId != 0, "DeployOPChainInput: not set");
-        require(_l2ChainId != block.chainid, "DeployOPChainInput: invalid l2ChainId");
-        return _l2ChainId;
+    function assertValidOPChainProxyAdmin(Types.DeployOPChainInput memory _doi, Output memory _doo) internal {
+        IProxyAdmin admin = _doo.opChainProxyAdmin;
+        require(admin.owner() == _doi.opChainProxyAdminOwner, "OPCPA-10");
+        require(
+            admin.getProxyImplementation(address(_doo.l1CrossDomainMessengerProxy))
+                == DeployUtils.assertResolvedDelegateProxyImplementationSet(
+                    "OVM_L1CrossDomainMessenger", _doo.addressManager
+                ),
+            "OPCPA-20"
+        );
+        require(address(admin.addressManager()) == address(_doo.addressManager), "OPCPA-30");
+        require(
+            admin.getProxyImplementation(address(_doo.l1StandardBridgeProxy))
+                == DeployUtils.assertL1ChugSplashImplementationSet(address(_doo.l1StandardBridgeProxy)),
+            "OPCPA-40"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.l1ERC721BridgeProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.l1ERC721BridgeProxy)),
+            "OPCPA-50"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.optimismPortalProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.optimismPortalProxy)),
+            "OPCPA-60"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.systemConfigProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.systemConfigProxy)),
+            "OPCPA-70"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.optimismMintableERC20FactoryProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.optimismMintableERC20FactoryProxy)),
+            "OPCPA-80"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.disputeGameFactoryProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.disputeGameFactoryProxy)),
+            "OPCPA-90"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.delayedWETHPermissionedGameProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.delayedWETHPermissionedGameProxy)),
+            "OPCPA-100"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.anchorStateRegistryProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.anchorStateRegistryProxy)),
+            "OPCPA-110"
+        );
+        require(
+            admin.getProxyImplementation(address(_doo.ethLockboxProxy))
+                == DeployUtils.assertERC1967ImplementationSet(address(_doo.ethLockboxProxy)),
+            "OPCPA-120"
+        );
     }
 
     function startingAnchorRoot() public pure returns (bytes memory) {
@@ -177,420 +312,4 @@ contract DeployOPChainInput is BaseDeployIO {
         return abi.encode(ScriptConstants.DEFAULT_OUTPUT_ROOT());
     }
 
-    function opcm() public view returns (IOPContractsManager) {
-        require(address(_opcm) != address(0), "DeployOPChainInput: not set");
-        DeployUtils.assertValidContractAddress(address(_opcm));
-        return _opcm;
-    }
-
-    function saltMixer() public view returns (string memory) {
-        return _saltMixer;
-    }
-
-    function gasLimit() public view returns (uint64) {
-        return _gasLimit;
-    }
-
-    function disputeGameType() public view returns (GameType) {
-        return _disputeGameType;
-    }
-
-    function disputeAbsolutePrestate() public view returns (Claim) {
-        return _disputeAbsolutePrestate;
-    }
-
-    function disputeMaxGameDepth() public view returns (uint256) {
-        return _disputeMaxGameDepth;
-    }
-
-    function disputeSplitDepth() public view returns (uint256) {
-        return _disputeSplitDepth;
-    }
-
-    function disputeClockExtension() public view returns (Duration) {
-        return _disputeClockExtension;
-    }
-
-    function disputeMaxClockDuration() public view returns (Duration) {
-        return _disputeMaxClockDuration;
-    }
-
-    function allowCustomDisputeParameters() public view returns (bool) {
-        return _allowCustomDisputeParameters;
-    }
-
-    function operatorFeeScalar() public view returns (uint32) {
-        return _operatorFeeScalar;
-    }
-
-    function operatorFeeConstant() public view returns (uint64) {
-        return _operatorFeeConstant;
-    }
-}
-
-contract DeployOPChainOutput is BaseDeployIO {
-    IProxyAdmin internal _opChainProxyAdmin;
-    IAddressManager internal _addressManager;
-    IL1ERC721Bridge internal _l1ERC721BridgeProxy;
-    ISystemConfig internal _systemConfigProxy;
-    IOptimismMintableERC20Factory internal _optimismMintableERC20FactoryProxy;
-    IL1StandardBridge internal _l1StandardBridgeProxy;
-    IL1CrossDomainMessenger internal _l1CrossDomainMessengerProxy;
-    IOptimismPortal internal _optimismPortalProxy;
-    IETHLockbox internal _ethLockboxProxy;
-    IDisputeGameFactory internal _disputeGameFactoryProxy;
-    IAnchorStateRegistry internal _anchorStateRegistryProxy;
-    IFaultDisputeGame internal _faultDisputeGame;
-    IPermissionedDisputeGame internal _permissionedDisputeGame;
-    IDelayedWETH internal _delayedWETHPermissionedGameProxy;
-    IDelayedWETH internal _delayedWETHPermissionlessGameProxy;
-
-    function set(bytes4 _sel, address _addr) public virtual {
-        require(_addr != address(0), "DeployOPChainOutput: cannot set zero address");
-        // forgefmt: disable-start
-        if (_sel == this.opChainProxyAdmin.selector) _opChainProxyAdmin = IProxyAdmin(_addr) ;
-        else if (_sel == this.addressManager.selector) _addressManager = IAddressManager(_addr) ;
-        else if (_sel == this.l1ERC721BridgeProxy.selector) _l1ERC721BridgeProxy = IL1ERC721Bridge(_addr) ;
-        else if (_sel == this.systemConfigProxy.selector) _systemConfigProxy = ISystemConfig(_addr) ;
-        else if (_sel == this.optimismMintableERC20FactoryProxy.selector) _optimismMintableERC20FactoryProxy = IOptimismMintableERC20Factory(_addr) ;
-        else if (_sel == this.l1StandardBridgeProxy.selector) _l1StandardBridgeProxy = IL1StandardBridge(payable(_addr)) ;
-        else if (_sel == this.l1CrossDomainMessengerProxy.selector) _l1CrossDomainMessengerProxy = IL1CrossDomainMessenger(_addr) ;
-        else if (_sel == this.optimismPortalProxy.selector) _optimismPortalProxy = IOptimismPortal(payable(_addr)) ;
-        else if (_sel == this.ethLockboxProxy.selector) _ethLockboxProxy = IETHLockbox(payable(_addr)) ;
-        else if (_sel == this.disputeGameFactoryProxy.selector) _disputeGameFactoryProxy = IDisputeGameFactory(_addr) ;
-        else if (_sel == this.anchorStateRegistryProxy.selector) _anchorStateRegistryProxy = IAnchorStateRegistry(_addr) ;
-        else if (_sel == this.faultDisputeGame.selector) _faultDisputeGame = IFaultDisputeGame(_addr) ;
-        else if (_sel == this.permissionedDisputeGame.selector) _permissionedDisputeGame = IPermissionedDisputeGame(_addr) ;
-        else if (_sel == this.delayedWETHPermissionedGameProxy.selector) _delayedWETHPermissionedGameProxy = IDelayedWETH(payable(_addr)) ;
-        else if (_sel == this.delayedWETHPermissionlessGameProxy.selector) _delayedWETHPermissionlessGameProxy = IDelayedWETH(payable(_addr)) ;
-        else revert("DeployOPChainOutput: unknown selector");
-        // forgefmt: disable-end
-    }
-
-    function opChainProxyAdmin() public view returns (IProxyAdmin) {
-        DeployUtils.assertValidContractAddress(address(_opChainProxyAdmin));
-        return _opChainProxyAdmin;
-    }
-
-    function addressManager() public view returns (IAddressManager) {
-        DeployUtils.assertValidContractAddress(address(_addressManager));
-        return _addressManager;
-    }
-
-    function l1ERC721BridgeProxy() public returns (IL1ERC721Bridge) {
-        DeployUtils.assertValidContractAddress(address(_l1ERC721BridgeProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_l1ERC721BridgeProxy));
-        return _l1ERC721BridgeProxy;
-    }
-
-    function systemConfigProxy() public returns (ISystemConfig) {
-        DeployUtils.assertValidContractAddress(address(_systemConfigProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_systemConfigProxy));
-        return _systemConfigProxy;
-    }
-
-    function optimismMintableERC20FactoryProxy() public returns (IOptimismMintableERC20Factory) {
-        DeployUtils.assertValidContractAddress(address(_optimismMintableERC20FactoryProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_optimismMintableERC20FactoryProxy));
-        return _optimismMintableERC20FactoryProxy;
-    }
-
-    function l1StandardBridgeProxy() public returns (IL1StandardBridge) {
-        DeployUtils.assertValidContractAddress(address(_l1StandardBridgeProxy));
-        DeployUtils.assertL1ChugSplashImplementationSet(address(_l1StandardBridgeProxy));
-        return _l1StandardBridgeProxy;
-    }
-
-    function l1CrossDomainMessengerProxy() public view returns (IL1CrossDomainMessenger) {
-        DeployUtils.assertValidContractAddress(address(_l1CrossDomainMessengerProxy));
-        DeployUtils.assertResolvedDelegateProxyImplementationSet("OVM_L1CrossDomainMessenger", addressManager());
-        return _l1CrossDomainMessengerProxy;
-    }
-
-    function optimismPortalProxy() public returns (IOptimismPortal) {
-        DeployUtils.assertValidContractAddress(address(_optimismPortalProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_optimismPortalProxy));
-        return _optimismPortalProxy;
-    }
-
-    function ethLockboxProxy() public returns (IETHLockbox) {
-        DeployUtils.assertValidContractAddress(address(_ethLockboxProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_ethLockboxProxy));
-        return _ethLockboxProxy;
-    }
-
-    function disputeGameFactoryProxy() public returns (IDisputeGameFactory) {
-        DeployUtils.assertValidContractAddress(address(_disputeGameFactoryProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_disputeGameFactoryProxy));
-        return _disputeGameFactoryProxy;
-    }
-
-    function anchorStateRegistryProxy() public returns (IAnchorStateRegistry) {
-        DeployUtils.assertValidContractAddress(address(_anchorStateRegistryProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_anchorStateRegistryProxy));
-        return _anchorStateRegistryProxy;
-    }
-
-    function faultDisputeGame() public view returns (IFaultDisputeGame) {
-        DeployUtils.assertValidContractAddress(address(_faultDisputeGame));
-        return _faultDisputeGame;
-    }
-
-    function permissionedDisputeGame() public view returns (IPermissionedDisputeGame) {
-        DeployUtils.assertValidContractAddress(address(_permissionedDisputeGame));
-        return _permissionedDisputeGame;
-    }
-
-    function delayedWETHPermissionedGameProxy() public returns (IDelayedWETH) {
-        DeployUtils.assertValidContractAddress(address(_delayedWETHPermissionedGameProxy));
-        DeployUtils.assertERC1967ImplementationSet(address(_delayedWETHPermissionedGameProxy));
-        return _delayedWETHPermissionedGameProxy;
-    }
-
-    function delayedWETHPermissionlessGameProxy() public view returns (IDelayedWETH) {
-        // TODO: Eventually switch from Permissioned to Permissionless. Add this check back in.
-        // DeployUtils.assertValidContractAddress(address(_delayedWETHPermissionlessGameProxy));
-        return _delayedWETHPermissionlessGameProxy;
-    }
-}
-
-contract DeployOPChain is Script {
-    // -------- Core Deployment Methods --------
-
-    function run(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
-        IOPContractsManager opcm = _doi.opcm();
-
-        IOPContractsManager.Roles memory roles = IOPContractsManager.Roles({
-            opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
-            systemConfigOwner: _doi.systemConfigOwner(),
-            batcher: _doi.batcher(),
-            unsafeBlockSigner: _doi.unsafeBlockSigner(),
-            proposer: _doi.proposer(),
-            challenger: _doi.challenger()
-        });
-        IOPContractsManager.DeployInput memory deployInput = IOPContractsManager.DeployInput({
-            roles: roles,
-            basefeeScalar: _doi.basefeeScalar(),
-            blobBasefeeScalar: _doi.blobBaseFeeScalar(),
-            l2ChainId: _doi.l2ChainId(),
-            startingAnchorRoot: _doi.startingAnchorRoot(),
-            saltMixer: _doi.saltMixer(),
-            gasLimit: _doi.gasLimit(),
-            disputeGameType: _doi.disputeGameType(),
-            disputeAbsolutePrestate: _doi.disputeAbsolutePrestate(),
-            disputeMaxGameDepth: _doi.disputeMaxGameDepth(),
-            disputeSplitDepth: _doi.disputeSplitDepth(),
-            disputeClockExtension: _doi.disputeClockExtension(),
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration()
-        });
-
-        vm.broadcast(msg.sender);
-        IOPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
-
-        vm.label(address(deployOutput.opChainProxyAdmin), "opChainProxyAdmin");
-        vm.label(address(deployOutput.addressManager), "addressManager");
-        vm.label(address(deployOutput.l1ERC721BridgeProxy), "l1ERC721BridgeProxy");
-        vm.label(address(deployOutput.systemConfigProxy), "systemConfigProxy");
-        vm.label(address(deployOutput.optimismMintableERC20FactoryProxy), "optimismMintableERC20FactoryProxy");
-        vm.label(address(deployOutput.l1StandardBridgeProxy), "l1StandardBridgeProxy");
-        vm.label(address(deployOutput.l1CrossDomainMessengerProxy), "l1CrossDomainMessengerProxy");
-        vm.label(address(deployOutput.optimismPortalProxy), "optimismPortalProxy");
-        vm.label(address(deployOutput.ethLockboxProxy), "ethLockboxProxy");
-        vm.label(address(deployOutput.disputeGameFactoryProxy), "disputeGameFactoryProxy");
-        vm.label(address(deployOutput.anchorStateRegistryProxy), "anchorStateRegistryProxy");
-        // vm.label(address(deployOutput.faultDisputeGame), "faultDisputeGame");
-        vm.label(address(deployOutput.permissionedDisputeGame), "permissionedDisputeGame");
-        vm.label(address(deployOutput.delayedWETHPermissionedGameProxy), "delayedWETHPermissionedGameProxy");
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // vm.label(address(deployOutput.delayedWETHPermissionlessGameProxy), "delayedWETHPermissionlessGameProxy");
-
-        _doo.set(_doo.opChainProxyAdmin.selector, address(deployOutput.opChainProxyAdmin));
-        _doo.set(_doo.addressManager.selector, address(deployOutput.addressManager));
-        _doo.set(_doo.l1ERC721BridgeProxy.selector, address(deployOutput.l1ERC721BridgeProxy));
-        _doo.set(_doo.systemConfigProxy.selector, address(deployOutput.systemConfigProxy));
-        _doo.set(
-            _doo.optimismMintableERC20FactoryProxy.selector, address(deployOutput.optimismMintableERC20FactoryProxy)
-        );
-        _doo.set(_doo.l1StandardBridgeProxy.selector, address(deployOutput.l1StandardBridgeProxy));
-        _doo.set(_doo.l1CrossDomainMessengerProxy.selector, address(deployOutput.l1CrossDomainMessengerProxy));
-        _doo.set(_doo.optimismPortalProxy.selector, address(deployOutput.optimismPortalProxy));
-        _doo.set(_doo.ethLockboxProxy.selector, address(deployOutput.ethLockboxProxy));
-        _doo.set(_doo.disputeGameFactoryProxy.selector, address(deployOutput.disputeGameFactoryProxy));
-        _doo.set(_doo.anchorStateRegistryProxy.selector, address(deployOutput.anchorStateRegistryProxy));
-        // _doo.set(_doo.faultDisputeGame.selector, address(deployOutput.faultDisputeGame));
-        _doo.set(_doo.permissionedDisputeGame.selector, address(deployOutput.permissionedDisputeGame));
-        _doo.set(_doo.delayedWETHPermissionedGameProxy.selector, address(deployOutput.delayedWETHPermissionedGameProxy));
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // _doo.set(
-        //     _doo.delayedWETHPermissionlessGameProxy.selector,
-        // address(deployOutput.delayedWETHPermissionlessGameProxy)
-        // );
-
-        checkOutput(_doi, _doo);
-    }
-
-    function checkOutput(DeployOPChainInput _doi, DeployOPChainOutput _doo) public {
-        // With 16 addresses, we'd get a stack too deep error if we tried to do this inline as a
-        // single call to `Solarray.addresses`. So we split it into two calls.
-        address[] memory addrs1 = Solarray.addresses(
-            address(_doo.opChainProxyAdmin()),
-            address(_doo.addressManager()),
-            address(_doo.l1ERC721BridgeProxy()),
-            address(_doo.systemConfigProxy()),
-            address(_doo.optimismMintableERC20FactoryProxy()),
-            address(_doo.l1StandardBridgeProxy()),
-            address(_doo.l1CrossDomainMessengerProxy())
-        );
-        address[] memory addrs2 = Solarray.addresses(
-            address(_doo.optimismPortalProxy()),
-            address(_doo.disputeGameFactoryProxy()),
-            address(_doo.anchorStateRegistryProxy()),
-            address(_doo.permissionedDisputeGame()),
-            // address(_doo.faultDisputeGame()),
-            address(_doo.delayedWETHPermissionedGameProxy()),
-            address(_doo.ethLockboxProxy())
-        );
-        // TODO: Eventually switch from Permissioned to Permissionless. Add this address back in.
-        // address(_delayedWETHPermissionlessGameProxy)
-
-        DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
-        assertValidDeploy(_doi, _doo);
-    }
-
-    // -------- Deployment Assertions --------
-    function assertValidDeploy(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {
-        Types.ContractSet memory proxies = Types.ContractSet({
-            L1CrossDomainMessenger: address(_doo.l1CrossDomainMessengerProxy()),
-            L1StandardBridge: address(_doo.l1StandardBridgeProxy()),
-            L2OutputOracle: address(0),
-            DisputeGameFactory: address(_doo.disputeGameFactoryProxy()),
-            DelayedWETH: address(_doo.delayedWETHPermissionlessGameProxy()),
-            PermissionedDelayedWETH: address(_doo.delayedWETHPermissionedGameProxy()),
-            AnchorStateRegistry: address(_doo.anchorStateRegistryProxy()),
-            OptimismMintableERC20Factory: address(_doo.optimismMintableERC20FactoryProxy()),
-            OptimismPortal: address(_doo.optimismPortalProxy()),
-            ETHLockbox: address(_doo.ethLockboxProxy()),
-            SystemConfig: address(_doo.systemConfigProxy()),
-            L1ERC721Bridge: address(_doo.l1ERC721BridgeProxy()),
-            ProtocolVersions: address(0),
-            SuperchainConfig: address(0)
-        });
-
-        ChainAssertions.checkAnchorStateRegistryProxy(_doo.anchorStateRegistryProxy(), true);
-        ChainAssertions.checkDisputeGameFactory(
-            _doo.disputeGameFactoryProxy(),
-            address(_doi.opChainProxyAdminOwner()),
-            address(_doo.permissionedDisputeGame()),
-            true
-        );
-        ChainAssertions.checkL1CrossDomainMessenger(_doo.l1CrossDomainMessengerProxy(), vm, true);
-        DeployUtils.assertInitialized({
-            _contractAddress: address(_doo.l1ERC721BridgeProxy()),
-            _isProxy: true,
-            _slot: 0,
-            _offset: 0
-        });
-        DeployUtils.assertInitialized({
-            _contractAddress: address(_doo.l1StandardBridgeProxy()),
-            _isProxy: true,
-            _slot: 0,
-            _offset: 0
-        });
-        DeployUtils.assertInitialized({
-            _contractAddress: address(_doo.optimismMintableERC20FactoryProxy()),
-            _isProxy: true,
-            _slot: 0,
-            _offset: 0
-        });
-        ChainAssertions.checkOptimismPortal2({
-            _contracts: proxies,
-            _superchainConfig: _doi.opcm().superchainConfig(),
-            _opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
-            _isProxy: true
-        });
-        DeployUtils.assertInitialized({
-            _contractAddress: address(_doo.ethLockboxProxy()),
-            _isProxy: true,
-            _slot: 0,
-            _offset: 0
-        });
-        ChainAssertions.checkSystemConfig(proxies, _doi, true);
-        assertValidAddressManager(_doi, _doo);
-        assertValidOPChainProxyAdmin(_doi, _doo);
-    }
-
-    function assertValidAddressManager(DeployOPChainInput, DeployOPChainOutput _doo) internal view {
-        require(_doo.addressManager().owner() == address(_doo.opChainProxyAdmin()), "AM-10");
-    }
-
-    function assertValidOPChainProxyAdmin(DeployOPChainInput _doi, DeployOPChainOutput _doo) internal {
-        IProxyAdmin admin = _doo.opChainProxyAdmin();
-        require(admin.owner() == _doi.opChainProxyAdminOwner(), "OPCPA-10");
-        require(
-            admin.getProxyImplementation(address(_doo.l1CrossDomainMessengerProxy()))
-                == DeployUtils.assertResolvedDelegateProxyImplementationSet(
-                    "OVM_L1CrossDomainMessenger", _doo.addressManager()
-                ),
-            "OPCPA-20"
-        );
-        require(address(admin.addressManager()) == address(_doo.addressManager()), "OPCPA-30");
-        require(
-            admin.getProxyImplementation(address(_doo.l1StandardBridgeProxy()))
-                == DeployUtils.assertL1ChugSplashImplementationSet(address(_doo.l1StandardBridgeProxy())),
-            "OPCPA-40"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.l1ERC721BridgeProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.l1ERC721BridgeProxy())),
-            "OPCPA-50"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.optimismPortalProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.optimismPortalProxy())),
-            "OPCPA-60"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.systemConfigProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.systemConfigProxy())),
-            "OPCPA-70"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.optimismMintableERC20FactoryProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.optimismMintableERC20FactoryProxy())),
-            "OPCPA-80"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.disputeGameFactoryProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.disputeGameFactoryProxy())),
-            "OPCPA-90"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.delayedWETHPermissionedGameProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.delayedWETHPermissionedGameProxy())),
-            "OPCPA-100"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.anchorStateRegistryProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.anchorStateRegistryProxy())),
-            "OPCPA-110"
-        );
-        require(
-            admin.getProxyImplementation(address(_doo.ethLockboxProxy()))
-                == DeployUtils.assertERC1967ImplementationSet(address(_doo.ethLockboxProxy())),
-            "OPCPA-120"
-        );
-    }
-
-    // -------- Utilities --------
-
-    function etchIOContracts() public returns (DeployOPChainInput doi_, DeployOPChainOutput doo_) {
-        (doi_, doo_) = getIOContracts();
-        vm.etch(address(doi_), type(DeployOPChainInput).runtimeCode);
-        vm.etch(address(doo_), type(DeployOPChainOutput).runtimeCode);
-    }
-
-    function getIOContracts() public view returns (DeployOPChainInput doi_, DeployOPChainOutput doo_) {
-        doi_ = DeployOPChainInput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainInput"));
-        doo_ = DeployOPChainOutput(DeployUtils.toIOAddress(msg.sender, "optimism.DeployOPChainOutput"));
-    }
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -307,5 +307,4 @@ contract DeployOPChain is Script {
 
         return abi.encode(ScriptConstants.DEFAULT_OUTPUT_ROOT());
     }
-
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -3,11 +3,8 @@ pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
 
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
-import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 
 import { ChainAssertions } from "scripts/deploy/ChainAssertions.sol";
 import { Constants as ScriptConstants } from "scripts/libraries/Constants.sol";
@@ -21,7 +18,6 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
-import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
 
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";

--- a/packages/contracts-bedrock/scripts/libraries/Types.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Types.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
+
 library Types {
     /// @notice Represents a set of L1 contracts. Used to represent a set of proxies.
     /// This is not an exhaustive list of all contracts on L1, but rather a subset.
@@ -19,5 +21,33 @@ library Types {
         address L1ERC721Bridge;
         address ProtocolVersions;
         address SuperchainConfig;
+    }
+
+    struct DeployOPChainInput {
+        // Roles
+        address opChainProxyAdminOwner;
+        address systemConfigOwner;
+        address batcher;
+        address unsafeBlockSigner;
+        address proposer;
+        address challenger;
+        // TODO Add fault proofs inputs in a future PR.
+        uint32 basefeeScalar;
+        uint32 blobBaseFeeScalar;
+        uint256 l2ChainId;
+        address opcm;
+        string saltMixer;
+        uint64 gasLimit;
+        // Configurable dispute game inputs
+        GameType disputeGameType;
+        Claim disputeAbsolutePrestate;
+        uint256 disputeMaxGameDepth;
+        uint256 disputeSplitDepth;
+        Duration disputeClockExtension;
+        Duration disputeMaxClockDuration;
+        bool allowCustomDisputeParameters;
+        // Fee params
+        uint32 operatorFeeScalar;
+        uint64 operatorFeeConstant;
     }
 }

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1701,7 +1701,6 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
         internal
         returns (IOPContractsManager.DeployInput memory)
     {
-
         bytes memory startingAnchorRoot = new DeployOPChain().startingAnchorRoot();
         return IOPContractsManager.DeployInput({
             roles: IOPContractsManager.Roles({

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -9,11 +9,12 @@ import { DeployOPChain_TestBase } from "test/opcm/DeployOPChain.t.sol";
 import { DelegateCaller } from "test/mocks/Callers.sol";
 
 // Scripts
-import { DeployOPChainInput } from "scripts/deploy/DeployOPChain.s.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
 import { VerifyOPCM } from "scripts/deploy/VerifyOPCM.s.sol";
+import { DeployOPChain } from "scripts/deploy/DeployOPChain.s.sol";
 import { Config } from "scripts/libraries/Config.sol";
+import { Types } from "scripts/libraries/Types.sol";
 
 // Libraries
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
@@ -1694,79 +1695,58 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
 
     event Deployed(uint256 indexed l2ChainId, address indexed deployer, bytes deployOutput);
 
-    function setUp() public override {
-        DeployOPChain_TestBase.setUp();
-
-        doi.set(doi.opChainProxyAdminOwner.selector, opChainProxyAdminOwner);
-        doi.set(doi.systemConfigOwner.selector, systemConfigOwner);
-        doi.set(doi.batcher.selector, batcher);
-        doi.set(doi.unsafeBlockSigner.selector, unsafeBlockSigner);
-        doi.set(doi.proposer.selector, proposer);
-        doi.set(doi.challenger.selector, challenger);
-        doi.set(doi.basefeeScalar.selector, basefeeScalar);
-        doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
-        doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcm.selector, address(opcm));
-        doi.set(doi.gasLimit.selector, gasLimit);
-
-        doi.set(doi.disputeGameType.selector, disputeGameType);
-        doi.set(doi.disputeAbsolutePrestate.selector, disputeAbsolutePrestate);
-        doi.set(doi.disputeMaxGameDepth.selector, disputeMaxGameDepth);
-        doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
-        doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
-        doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
-    }
-
     // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol
     // to the input struct type defined in OPContractsManager.sol.
-    function toOPCMDeployInput(DeployOPChainInput _doi)
+    function toOPCMDeployInput(Types.DeployOPChainInput memory _doi)
         internal
-        view
         returns (IOPContractsManager.DeployInput memory)
     {
+
+        bytes memory startingAnchorRoot = new DeployOPChain().startingAnchorRoot();
         return IOPContractsManager.DeployInput({
             roles: IOPContractsManager.Roles({
-                opChainProxyAdminOwner: _doi.opChainProxyAdminOwner(),
-                systemConfigOwner: _doi.systemConfigOwner(),
-                batcher: _doi.batcher(),
-                unsafeBlockSigner: _doi.unsafeBlockSigner(),
-                proposer: _doi.proposer(),
-                challenger: _doi.challenger()
+                opChainProxyAdminOwner: _doi.opChainProxyAdminOwner,
+                systemConfigOwner: _doi.systemConfigOwner,
+                batcher: _doi.batcher,
+                unsafeBlockSigner: _doi.unsafeBlockSigner,
+                proposer: _doi.proposer,
+                challenger: _doi.challenger
             }),
-            basefeeScalar: _doi.basefeeScalar(),
-            blobBasefeeScalar: _doi.blobBaseFeeScalar(),
-            l2ChainId: _doi.l2ChainId(),
-            startingAnchorRoot: _doi.startingAnchorRoot(),
-            saltMixer: _doi.saltMixer(),
-            gasLimit: _doi.gasLimit(),
-            disputeGameType: _doi.disputeGameType(),
-            disputeAbsolutePrestate: _doi.disputeAbsolutePrestate(),
-            disputeMaxGameDepth: _doi.disputeMaxGameDepth(),
-            disputeSplitDepth: _doi.disputeSplitDepth(),
-            disputeClockExtension: _doi.disputeClockExtension(),
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration()
+            basefeeScalar: _doi.basefeeScalar,
+            blobBasefeeScalar: _doi.blobBaseFeeScalar,
+            l2ChainId: _doi.l2ChainId,
+            startingAnchorRoot: startingAnchorRoot,
+            saltMixer: _doi.saltMixer,
+            gasLimit: _doi.gasLimit,
+            disputeGameType: _doi.disputeGameType,
+            disputeAbsolutePrestate: _doi.disputeAbsolutePrestate,
+            disputeMaxGameDepth: _doi.disputeMaxGameDepth,
+            disputeSplitDepth: _doi.disputeSplitDepth,
+            disputeClockExtension: _doi.disputeClockExtension,
+            disputeMaxClockDuration: _doi.disputeMaxClockDuration
         });
     }
 
     function test_deploy_l2ChainIdEqualsZero_reverts() public {
-        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
-        deployInput.l2ChainId = 0;
+        IOPContractsManager.DeployInput memory input = toOPCMDeployInput(deployOPChainInput);
+        input.l2ChainId = 0;
+
         vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
-        opcm.deploy(deployInput);
+        opcm.deploy(input);
     }
 
     function test_deploy_l2ChainIdEqualsCurrentChainId_reverts() public {
-        IOPContractsManager.DeployInput memory deployInput = toOPCMDeployInput(doi);
-        deployInput.l2ChainId = block.chainid;
+        IOPContractsManager.DeployInput memory input = toOPCMDeployInput(deployOPChainInput);
+        input.l2ChainId = block.chainid;
 
         vm.expectRevert(IOPContractsManager.InvalidChainId.selector);
-        opcm.deploy(deployInput);
+        opcm.deploy(input);
     }
 
     function test_deploy_succeeds() public {
         vm.expectEmit(true, true, true, false); // TODO precompute the expected `deployOutput`.
-        emit Deployed(doi.l2ChainId(), address(this), bytes(""));
-        opcm.deploy(toOPCMDeployInput(doi));
+        emit Deployed(deployOPChainInput.l2ChainId, address(this), bytes(""));
+        opcm.deploy(toOPCMDeployInput(deployOPChainInput));
     }
 }
 

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -5,361 +5,84 @@ import { Test } from "forge-std/Test.sol";
 
 import { DeploySuperchain } from "scripts/deploy/DeploySuperchain.s.sol";
 import { DeployImplementations } from "scripts/deploy/DeployImplementations.s.sol";
-import { DeployOPChainInput, DeployOPChain, DeployOPChainOutput } from "scripts/deploy/DeployOPChain.s.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { DeployOPChain } from "scripts/deploy/DeployOPChain.s.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
+import { Types } from "scripts/libraries/Types.sol";
 
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
-import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
-import { IL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
-import { IResolvedDelegateProxy } from "interfaces/legacy/IResolvedDelegateProxy.sol";
-
-import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { IProxy } from "interfaces/universal/IProxy.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
+import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 
 import { Claim, Duration, GameType, GameTypes, Hash, Proposal } from "src/dispute/lib/Types.sol";
 
-contract DeployOPChainInput_Test is Test {
-    DeployOPChainInput doi;
+contract DeployOPChain_TestBase is Test {
+    DeploySuperchain deploySuperchain;
+    DeployImplementations deployImplementations;
+    DeployOPChain deployOPChain;
+    Types.DeployOPChainInput deployOPChainInput;
 
-    // Define defaults.
+    // DeploySuperchain default inputs.
+    address superchainProxyAdminOwner = makeAddr("superchainProxyAdminOwner");
+    address protocolVersionsOwner = makeAddr("protocolVersionsOwner");
+    address guardian = makeAddr("guardian");
+    bool paused = false;
+    bytes32 requiredProtocolVersion = bytes32(uint256(1));
+    bytes32 recommendedProtocolVersion = bytes32(uint256(2));
+
+    // DeployImplementations default inputs.
+    // - superchainConfigProxy and protocolVersionsProxy are set during `setUp` since they are
+    //   outputs of DeploySuperchain.
+    uint256 withdrawalDelaySeconds = 100;
+    uint256 minProposalSizeBytes = 200;
+    uint256 challengePeriodSeconds = 300;
+    uint256 proofMaturityDelaySeconds = 400;
+    uint256 disputeGameFinalityDelaySeconds = 500;
+
+    // DeployOPChain default inputs.
+    // - opcm is set during `setUp` since it is an output of DeployImplementations.
     address opChainProxyAdminOwner = makeAddr("opChainProxyAdminOwner");
     address systemConfigOwner = makeAddr("systemConfigOwner");
     address batcher = makeAddr("batcher");
     address unsafeBlockSigner = makeAddr("unsafeBlockSigner");
     address proposer = makeAddr("proposer");
     address challenger = makeAddr("challenger");
-    address opcm = makeAddr("opcm");
     uint32 basefeeScalar = 100;
     uint32 blobBaseFeeScalar = 200;
     uint256 l2ChainId = 300;
     string saltMixer = "saltMixer";
-
-    function setUp() public {
-        doi = new DeployOPChainInput();
-    }
-
-    function test_set_succeeds() public {
-        doi.set(doi.opChainProxyAdminOwner.selector, opChainProxyAdminOwner);
-        doi.set(doi.systemConfigOwner.selector, systemConfigOwner);
-        doi.set(doi.batcher.selector, batcher);
-        doi.set(doi.unsafeBlockSigner.selector, unsafeBlockSigner);
-        doi.set(doi.proposer.selector, proposer);
-        doi.set(doi.challenger.selector, challenger);
-        doi.set(doi.basefeeScalar.selector, basefeeScalar);
-        doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
-        doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.allowCustomDisputeParameters.selector, true);
-        doi.set(doi.opcm.selector, opcm);
-        vm.etch(opcm, hex"01");
-
-        // Compare the default inputs to the getter methods.
-        assertEq(opChainProxyAdminOwner, doi.opChainProxyAdminOwner(), "200");
-        assertEq(systemConfigOwner, doi.systemConfigOwner(), "300");
-        assertEq(batcher, doi.batcher(), "400");
-        assertEq(unsafeBlockSigner, doi.unsafeBlockSigner(), "500");
-        assertEq(proposer, doi.proposer(), "600");
-        assertEq(challenger, doi.challenger(), "700");
-        assertEq(basefeeScalar, doi.basefeeScalar(), "800");
-        assertEq(blobBaseFeeScalar, doi.blobBaseFeeScalar(), "900");
-        assertEq(l2ChainId, doi.l2ChainId(), "1000");
-        assertEq(opcm, address(doi.opcm()), "1100");
-        assertEq(true, doi.allowCustomDisputeParameters(), "1200");
-    }
-
-    function test_getters_whenNotSet_reverts() public {
-        bytes memory expectedErr = "DeployOPChainInput: not set";
-
-        vm.expectRevert(expectedErr);
-        doi.opChainProxyAdminOwner();
-
-        vm.expectRevert(expectedErr);
-        doi.systemConfigOwner();
-
-        vm.expectRevert(expectedErr);
-        doi.batcher();
-
-        vm.expectRevert(expectedErr);
-        doi.unsafeBlockSigner();
-
-        vm.expectRevert(expectedErr);
-        doi.proposer();
-
-        vm.expectRevert(expectedErr);
-        doi.challenger();
-
-        vm.expectRevert(expectedErr);
-        doi.basefeeScalar();
-
-        vm.expectRevert(expectedErr);
-        doi.blobBaseFeeScalar();
-
-        vm.expectRevert(expectedErr);
-        doi.l2ChainId();
-    }
-}
-
-contract DeployOPChainOutput_Test is Test {
-    DeployOPChainOutput doo;
-
-    // We set the non proxy contracts in storage because doing it locally in 'test_set_succeeds' function results in
-    // stack too deep.
-    IAddressManager addressManager = DeployUtils.buildAddressManager();
-    IProxyAdmin opChainProxyAdmin = IProxyAdmin(makeAddr("opChainProxyAdmin"));
-    IAnchorStateRegistry anchorStateRegistryImpl = IAnchorStateRegistry(makeAddr("anchorStateRegistryImpl"));
-    IFaultDisputeGame faultDisputeGame = IFaultDisputeGame(makeAddr("faultDisputeGame"));
-    IPermissionedDisputeGame permissionedDisputeGame = IPermissionedDisputeGame(makeAddr("permissionedDisputeGame"));
-
-    function setUp() public {
-        doo = new DeployOPChainOutput();
-    }
-
-    function test_set_succeeds() public {
-        vm.etch(address(opChainProxyAdmin), hex"01");
-        (IProxy l1ERC721BridgeProxy) = DeployUtils.buildERC1967ProxyWithImpl("l1ERC721BridgeProxy");
-        (IProxy systemConfigProxy) = DeployUtils.buildERC1967ProxyWithImpl("systemConfigProxy");
-        (IProxy optimismMintableERC20FactoryProxy) =
-            DeployUtils.buildERC1967ProxyWithImpl("optimismMintableERC20FactoryProxy");
-        (IL1ChugSplashProxy l1StandardBridgeProxy) = DeployUtils.buildL1ChugSplashProxyWithImpl("l1StandardBridgeProxy");
-        (IResolvedDelegateProxy l1CrossDomainMessengerProxy) =
-            DeployUtils.buildResolvedDelegateProxyWithImpl(addressManager, "OVM_L1CrossDomainMessenger");
-        (IProxy optimismPortalProxy) = DeployUtils.buildERC1967ProxyWithImpl("OptimismPortalProxy");
-        (IProxy disputeGameFactoryProxy) = DeployUtils.buildERC1967ProxyWithImpl("disputeGameFactoryProxy");
-        (IProxy anchorStateRegistryProxy) = DeployUtils.buildERC1967ProxyWithImpl("anchorStateRegistryProxy");
-        vm.etch(address(anchorStateRegistryImpl), hex"01");
-        vm.etch(address(faultDisputeGame), hex"01");
-        vm.etch(address(permissionedDisputeGame), hex"01");
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // (IProxy delayedWETHPermissionlessGameProxy) =
-        // DeployUtils.buildERC1967ProxyWithImpl("delayedWETHPermissionlessGameProxy");
-        (IProxy delayedWETHPermissionedGameProxy) =
-            DeployUtils.buildERC1967ProxyWithImpl("delayedWETHPermissionedGameProxy");
-
-        doo.set(doo.opChainProxyAdmin.selector, address(opChainProxyAdmin));
-        doo.set(doo.addressManager.selector, address(addressManager));
-        doo.set(doo.l1ERC721BridgeProxy.selector, address(l1ERC721BridgeProxy));
-        doo.set(doo.systemConfigProxy.selector, address(systemConfigProxy));
-        doo.set(doo.optimismMintableERC20FactoryProxy.selector, address(optimismMintableERC20FactoryProxy));
-        doo.set(doo.l1StandardBridgeProxy.selector, address(l1StandardBridgeProxy));
-        doo.set(doo.l1CrossDomainMessengerProxy.selector, address(l1CrossDomainMessengerProxy));
-        doo.set(doo.optimismPortalProxy.selector, address(optimismPortalProxy));
-        doo.set(doo.disputeGameFactoryProxy.selector, address(disputeGameFactoryProxy));
-        doo.set(doo.anchorStateRegistryProxy.selector, address(anchorStateRegistryProxy));
-        doo.set(doo.faultDisputeGame.selector, address(faultDisputeGame));
-        doo.set(doo.permissionedDisputeGame.selector, address(permissionedDisputeGame));
-        doo.set(doo.delayedWETHPermissionedGameProxy.selector, address(delayedWETHPermissionedGameProxy));
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // doo.set(doo.delayedWETHPermissionlessGameProxy.selector, address(delayedWETHPermissionlessGameProxy));
-
-        assertEq(address(opChainProxyAdmin), address(doo.opChainProxyAdmin()), "100");
-        assertEq(address(addressManager), address(doo.addressManager()), "200");
-        assertEq(address(l1ERC721BridgeProxy), address(doo.l1ERC721BridgeProxy()), "300");
-        assertEq(address(systemConfigProxy), address(doo.systemConfigProxy()), "400");
-        assertEq(address(optimismMintableERC20FactoryProxy), address(doo.optimismMintableERC20FactoryProxy()), "500");
-        assertEq(address(l1StandardBridgeProxy), address(doo.l1StandardBridgeProxy()), "600");
-        assertEq(address(l1CrossDomainMessengerProxy), address(doo.l1CrossDomainMessengerProxy()), "700");
-        assertEq(address(optimismPortalProxy), address(doo.optimismPortalProxy()), "800");
-        assertEq(address(disputeGameFactoryProxy), address(doo.disputeGameFactoryProxy()), "900");
-        assertEq(address(anchorStateRegistryProxy), address(doo.anchorStateRegistryProxy()), "1100");
-        assertEq(address(faultDisputeGame), address(doo.faultDisputeGame()), "1300");
-        assertEq(address(permissionedDisputeGame), address(doo.permissionedDisputeGame()), "1400");
-        assertEq(address(delayedWETHPermissionedGameProxy), address(doo.delayedWETHPermissionedGameProxy()), "1500");
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // assertEq(address(delayedWETHPermissionlessGameProxy), address(doo.delayedWETHPermissionlessGameProxy()),
-        // "1600");
-    }
-
-    function test_getters_whenNotSet_reverts() public {
-        bytes memory expectedErr = "DeployUtils: zero address";
-
-        vm.expectRevert(expectedErr);
-        doo.opChainProxyAdmin();
-
-        vm.expectRevert(expectedErr);
-        doo.addressManager();
-
-        vm.expectRevert(expectedErr);
-        doo.l1ERC721BridgeProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.systemConfigProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.optimismMintableERC20FactoryProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.l1StandardBridgeProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.l1CrossDomainMessengerProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.optimismPortalProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.disputeGameFactoryProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.anchorStateRegistryProxy();
-
-        vm.expectRevert(expectedErr);
-        doo.faultDisputeGame();
-
-        vm.expectRevert(expectedErr);
-        doo.permissionedDisputeGame();
-
-        vm.expectRevert(expectedErr);
-        doo.delayedWETHPermissionedGameProxy();
-
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // vm.expectRevert(expectedErr);
-        // doo.delayedWETHPermissionlessGameProxy();
-    }
-
-    function test_getters_whenAddrHasNoCode_reverts() public {
-        address emptyAddr = makeAddr("emptyAddr");
-        bytes memory expectedErr = bytes(string.concat("DeployUtils: no code at ", vm.toString(emptyAddr)));
-
-        doo.set(doo.opChainProxyAdmin.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.opChainProxyAdmin();
-
-        doo.set(doo.addressManager.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.addressManager();
-
-        doo.set(doo.l1ERC721BridgeProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.l1ERC721BridgeProxy();
-
-        doo.set(doo.systemConfigProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.systemConfigProxy();
-
-        doo.set(doo.optimismMintableERC20FactoryProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.optimismMintableERC20FactoryProxy();
-
-        doo.set(doo.l1StandardBridgeProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.l1StandardBridgeProxy();
-
-        doo.set(doo.l1CrossDomainMessengerProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.l1CrossDomainMessengerProxy();
-
-        doo.set(doo.optimismPortalProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.optimismPortalProxy();
-
-        doo.set(doo.disputeGameFactoryProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.disputeGameFactoryProxy();
-
-        doo.set(doo.anchorStateRegistryProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.anchorStateRegistryProxy();
-
-        doo.set(doo.faultDisputeGame.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.faultDisputeGame();
-
-        doo.set(doo.permissionedDisputeGame.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.permissionedDisputeGame();
-
-        doo.set(doo.delayedWETHPermissionedGameProxy.selector, emptyAddr);
-        vm.expectRevert(expectedErr);
-        doo.delayedWETHPermissionedGameProxy();
-
-        // TODO: Eventually switch from Permissioned to Permissionless.
-        // doo.set(doo.delayedWETHPermissionlessGameProxy.selector, emptyAddr);
-        // vm.expectRevert(expectedErr);
-        // doo.delayedWETHPermissionlessGameProxy();
-    }
-}
-
-// To mimic a production environment, we default to integration tests here that actually run the
-// DeploySuperchain and DeployImplementations scripts.
-contract DeployOPChain_TestBase is Test {
-    DeployOPChain deployOPChain;
-    DeployOPChainInput doi;
-    DeployOPChainOutput doo;
-
-    // Define default inputs for DeploySuperchain.
-    address superchainProxyAdminOwner = makeAddr("defaultSuperchainProxyAdminOwner");
-    address protocolVersionsOwner = makeAddr("defaultProtocolVersionsOwner");
-    address guardian = makeAddr("defaultGuardian");
-    bool paused = false;
-    ProtocolVersion requiredProtocolVersion = ProtocolVersion.wrap(1);
-    ProtocolVersion recommendedProtocolVersion = ProtocolVersion.wrap(2);
-
-    // Define default inputs for DeployImplementations.
-    // `superchainConfigProxy` and `protocolVersionsProxy` are set during `setUp` since they are
-    // outputs of the previous step.
-    uint256 withdrawalDelaySeconds = 100;
-    uint256 minProposalSizeBytes = 200;
-    uint256 challengePeriodSeconds = 300;
-    uint256 proofMaturityDelaySeconds = 400;
-    uint256 disputeGameFinalityDelaySeconds = 500;
-    string release = "dev-release"; // this means implementation contracts will be deployed
-    ISuperchainConfig superchainConfigProxy;
-    IProtocolVersions protocolVersionsProxy;
-    IProxyAdmin superchainProxyAdmin;
-    address upgradeController;
-    // Define default inputs for DeployOPChain.
-    // `opcm` is set during `setUp` since it is an output of the previous step.
-    address opChainProxyAdminOwner = makeAddr("defaultOPChainProxyAdminOwner");
-    address systemConfigOwner = makeAddr("defaultSystemConfigOwner");
-    address batcher = makeAddr("defaultBatcher");
-    address unsafeBlockSigner = makeAddr("defaultUnsafeBlockSigner");
-    address proposer = makeAddr("defaultProposer");
-    address challenger = makeAddr("defaultChallenger");
-    uint32 basefeeScalar = 100;
-    uint32 blobBaseFeeScalar = 200;
-    uint256 l2ChainId = 300;
-    Proposal startingAnchorRoot = Proposal({ root: Hash.wrap(keccak256("defaultOutputRoot")), l2SequenceNumber: 400 });
-    IOPContractsManager opcm = IOPContractsManager(address(0));
-    string saltMixer = "defaultSaltMixer";
     uint64 gasLimit = 60_000_000;
-    // Configurable dispute game parameters.
-    uint32 disputeGameType = GameType.unwrap(GameTypes.PERMISSIONED_CANNON);
-    bytes32 disputeAbsolutePrestate = hex"038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c";
+    GameType disputeGameType = GameTypes.PERMISSIONED_CANNON;
+    Claim disputeAbsolutePrestate = Claim.wrap(0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c);
     uint256 disputeMaxGameDepth = 73;
     uint256 disputeSplitDepth = 30;
-    uint64 disputeClockExtension = Duration.unwrap(Duration.wrap(3 hours));
-    uint64 disputeMaxClockDuration = Duration.unwrap(Duration.wrap(3.5 days));
+    Duration disputeClockExtension = Duration.wrap(3 hours);
+    Duration disputeMaxClockDuration = Duration.wrap(3.5 days);
+    IOPContractsManager opcm;
 
     function setUp() public virtual {
-        // Configure and deploy Superchain contracts
-        DeploySuperchain deploySuperchain = new DeploySuperchain();
+        deploySuperchain = new DeploySuperchain();
+        deployImplementations = new DeployImplementations();
+        deployOPChain = new DeployOPChain();
 
+        // 1) DeploySuperchain
         DeploySuperchain.Output memory dso = deploySuperchain.run(
             DeploySuperchain.Input({
                 superchainProxyAdminOwner: superchainProxyAdminOwner,
                 protocolVersionsOwner: protocolVersionsOwner,
                 guardian: guardian,
                 paused: paused,
-                requiredProtocolVersion: bytes32(ProtocolVersion.unwrap(requiredProtocolVersion)),
-                recommendedProtocolVersion: bytes32(ProtocolVersion.unwrap(recommendedProtocolVersion))
+                requiredProtocolVersion: requiredProtocolVersion,
+                recommendedProtocolVersion: recommendedProtocolVersion
             })
         );
 
-        // Populate the inputs for DeployImplementations based on the output of DeploySuperchain.
-        superchainConfigProxy = dso.superchainConfigProxy;
-        protocolVersionsProxy = dso.protocolVersionsProxy;
-        superchainProxyAdmin = dso.superchainProxyAdmin;
-        upgradeController = superchainProxyAdmin.owner();
-
-        // Configure and deploy Implementation contracts
-        DeployImplementations deployImplementations = new DeployImplementations();
-
+        // 2) DeployImplementations (produces OPCM)
         DeployImplementations.Output memory dio = deployImplementations.run(
             DeployImplementations.Input({
                 withdrawalDelaySeconds: withdrawalDelaySeconds,
@@ -372,21 +95,41 @@ contract DeployOPChain_TestBase is Test {
                 faultGameV2SplitDepth: 30,
                 faultGameV2ClockExtension: 10800,
                 faultGameV2MaxClockDuration: 302400,
-                superchainConfigProxy: superchainConfigProxy,
-                protocolVersionsProxy: protocolVersionsProxy,
-                superchainProxyAdmin: superchainProxyAdmin,
-                upgradeController: upgradeController,
+                superchainConfigProxy: dso.superchainConfigProxy,
+                protocolVersionsProxy: dso.protocolVersionsProxy,
+                superchainProxyAdmin: dso.superchainProxyAdmin,
+                upgradeController: dso.superchainProxyAdmin.owner(),
                 challenger: challenger,
                 devFeatureBitmap: bytes32(0)
             })
         );
-
-        // Set the OPContractsManager input for DeployOPChain.
         opcm = dio.opcm;
+        vm.label(address(opcm), "opcm");
 
-        // Deploy DeployOpChain, but defer populating the input values to the test suites inheriting this contract.
-        deployOPChain = new DeployOPChain();
-        (doi, doo) = deployOPChain.etchIOContracts();
+        // 3) Build DeployOPChainInput struct
+        deployOPChainInput = Types.DeployOPChainInput({
+            opChainProxyAdminOwner: opChainProxyAdminOwner,
+            systemConfigOwner: systemConfigOwner,
+            batcher: batcher,
+            unsafeBlockSigner: unsafeBlockSigner,
+            proposer: proposer,
+            challenger: challenger,
+            basefeeScalar: basefeeScalar,
+            blobBaseFeeScalar: blobBaseFeeScalar,
+            l2ChainId: l2ChainId,
+            opcm: address(opcm),
+            saltMixer: saltMixer,
+            gasLimit: gasLimit,
+            disputeGameType: disputeGameType,
+            disputeAbsolutePrestate: disputeAbsolutePrestate,
+            disputeMaxGameDepth: disputeMaxGameDepth,
+            disputeSplitDepth: disputeSplitDepth,
+            disputeClockExtension: disputeClockExtension,
+            disputeMaxClockDuration: disputeMaxClockDuration,
+            allowCustomDisputeParameters: false,
+            operatorFeeScalar: 0,
+            operatorFeeConstant: 0
+        });
     }
 }
 
@@ -395,120 +138,90 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         return keccak256(abi.encode(_seed, _i));
     }
 
+    function test_run_succeeds() public {
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+        // Basic non-zero and code checks are covered inside run->checkOutput.
+        // Additonal targeted assertions added below.
+
+        // Owners and roles propagated
+        assertEq(address(doo.opChainProxyAdmin.owner()), opChainProxyAdminOwner, "ProxyAdmin owner");
+        assertEq(address(doo.systemConfigProxy.owner()), systemConfigOwner, "SystemConfig owner");
+        assertEq(address(doo.systemConfigProxy.unsafeBlockSigner()), unsafeBlockSigner, "unsafeBlockSigner");
+        assertEq(address(uint160(uint256(doo.systemConfigProxy.batcherHash()))), batcher, "batcherHash");
+
+        // Dispute game roles/params propagated
+        assertEq(address(doo.permissionedDisputeGame.proposer()), proposer, "PDG proposer");
+        assertEq(address(doo.permissionedDisputeGame.challenger()), challenger, "PDG challenger");
+        assertEq(doo.permissionedDisputeGame.splitDepth(), disputeSplitDepth, "PDG splitDepth");
+        assertEq(doo.permissionedDisputeGame.maxGameDepth(), disputeMaxGameDepth, "PDG maxGameDepth");
+        assertEq(
+            Duration.unwrap(doo.permissionedDisputeGame.clockExtension()),
+            Duration.unwrap(disputeClockExtension),
+            "PDG clockExtension"
+        );
+        assertEq(
+            Duration.unwrap(doo.permissionedDisputeGame.maxClockDuration()),
+            Duration.unwrap(disputeMaxClockDuration),
+            "PDG maxClockDuration"
+        );
+        assertEq(
+            Claim.unwrap(doo.permissionedDisputeGame.absolutePrestate()),
+            Claim.unwrap(disputeAbsolutePrestate),
+            "PDG absolutePrestate"
+        );
+
+        (Hash actualRoot,) = doo.anchorStateRegistryProxy.anchors(GameTypes.PERMISSIONED_CANNON);
+        assertEq(Hash.unwrap(actualRoot), 0xdead000000000000000000000000000000000000000000000000000000000000, "ASR start root");
+    }
+
     function testFuzz_run_memory_succeeds(bytes32 _seed) public {
-        opChainProxyAdminOwner = address(uint160(uint256(hash(_seed, 0))));
-        systemConfigOwner = address(uint160(uint256(hash(_seed, 1))));
-        batcher = address(uint160(uint256(hash(_seed, 2))));
-        unsafeBlockSigner = address(uint160(uint256(hash(_seed, 3))));
-        proposer = address(uint160(uint256(hash(_seed, 4))));
-        challenger = address(uint160(uint256(hash(_seed, 5))));
-        basefeeScalar = uint32(uint256(hash(_seed, 6)));
-        blobBaseFeeScalar = uint32(uint256(hash(_seed, 7)));
-        l2ChainId = uint256(hash(_seed, 8));
+        deployOPChainInput.opChainProxyAdminOwner = address(uint160(uint256(hash(_seed, 0))));
+        deployOPChainInput.systemConfigOwner = address(uint160(uint256(hash(_seed, 1))));
+        deployOPChainInput.batcher = address(uint160(uint256(hash(_seed, 2))));
+        deployOPChainInput.unsafeBlockSigner = address(uint160(uint256(hash(_seed, 3))));
+        deployOPChainInput.proposer = address(uint160(uint256(hash(_seed, 4))));
+        deployOPChainInput.challenger = address(uint160(uint256(hash(_seed, 5))));
+        deployOPChainInput.basefeeScalar = uint32(uint256(hash(_seed, 6)));
+        deployOPChainInput.blobBaseFeeScalar = uint32(uint256(hash(_seed, 7)));
+        deployOPChainInput.l2ChainId = uint256(hash(_seed, 8));
 
-        doi.set(doi.opChainProxyAdminOwner.selector, opChainProxyAdminOwner);
-        doi.set(doi.systemConfigOwner.selector, systemConfigOwner);
-        doi.set(doi.batcher.selector, batcher);
-        doi.set(doi.unsafeBlockSigner.selector, unsafeBlockSigner);
-        doi.set(doi.proposer.selector, proposer);
-        doi.set(doi.challenger.selector, challenger);
-        doi.set(doi.basefeeScalar.selector, basefeeScalar);
-        doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
-        doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcm.selector, address(opcm));
-        doi.set(doi.saltMixer.selector, saltMixer);
-        doi.set(doi.gasLimit.selector, gasLimit);
-        doi.set(doi.disputeGameType.selector, disputeGameType);
-        doi.set(doi.disputeAbsolutePrestate.selector, disputeAbsolutePrestate);
-        doi.set(doi.disputeMaxGameDepth.selector, disputeMaxGameDepth);
-        doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
-        doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
-        doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
-
-        deployOPChain.run(doi, doo);
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
         // TODO Add fault proof contract assertions below once OPCM fully supports them.
 
-        // Assert that individual input fields were properly set based on the inputs.
-        assertEq(opChainProxyAdminOwner, doi.opChainProxyAdminOwner(), "100");
-        assertEq(systemConfigOwner, doi.systemConfigOwner(), "200");
-        assertEq(batcher, doi.batcher(), "300");
-        assertEq(unsafeBlockSigner, doi.unsafeBlockSigner(), "400");
-        assertEq(proposer, doi.proposer(), "500");
-        assertEq(challenger, doi.challenger(), "600");
-        assertEq(basefeeScalar, doi.basefeeScalar(), "700");
-        assertEq(blobBaseFeeScalar, doi.blobBaseFeeScalar(), "800");
-        assertEq(l2ChainId, doi.l2ChainId(), "900");
-        assertEq(saltMixer, doi.saltMixer(), "1000");
-        assertEq(gasLimit, doi.gasLimit(), "1100");
-        assertEq(disputeGameType, GameType.unwrap(doi.disputeGameType()), "1200");
-        assertEq(disputeAbsolutePrestate, Claim.unwrap(doi.disputeAbsolutePrestate()), "1300");
-        assertEq(disputeMaxGameDepth, doi.disputeMaxGameDepth(), "1400");
-        assertEq(disputeSplitDepth, doi.disputeSplitDepth(), "1500");
-        assertEq(disputeClockExtension, Duration.unwrap(doi.disputeClockExtension()), "1600");
-        assertEq(disputeMaxClockDuration, Duration.unwrap(doi.disputeMaxClockDuration()), "1700");
-
         // Assert inputs were properly passed through to the contract initializers.
-        assertEq(address(doo.opChainProxyAdmin().owner()), opChainProxyAdminOwner, "2100");
-        assertEq(address(doo.systemConfigProxy().owner()), systemConfigOwner, "2200");
-        address batcherActual = address(uint160(uint256(doo.systemConfigProxy().batcherHash())));
-        assertEq(batcherActual, batcher, "2300");
-        assertEq(address(doo.systemConfigProxy().unsafeBlockSigner()), unsafeBlockSigner, "2400");
-        assertEq(address(doo.permissionedDisputeGame().proposer()), proposer, "2500");
-        assertEq(address(doo.permissionedDisputeGame().challenger()), challenger, "2600");
+        assertEq(address(doo.opChainProxyAdmin.owner()), deployOPChainInput.opChainProxyAdminOwner, "2100");
+        assertEq(address(doo.systemConfigProxy.owner()), deployOPChainInput.systemConfigOwner, "2200");
+        address batcherActual = address(uint160(uint256(doo.systemConfigProxy.batcherHash())));
+        assertEq(batcherActual, deployOPChainInput.batcher, "2300");
+        assertEq(address(doo.systemConfigProxy.unsafeBlockSigner()), deployOPChainInput.unsafeBlockSigner, "2400");
+        assertEq(address(doo.permissionedDisputeGame.proposer()), deployOPChainInput.proposer, "2500");
+        assertEq(address(doo.permissionedDisputeGame.challenger()), deployOPChainInput.challenger, "2600");
 
         // TODO once we deploy the Permissionless Dispute Game
         // assertEq(address(doo.faultDisputeGame().proposer()), proposer, "2610");
         // assertEq(address(doo.faultDisputeGame().challenger()), challenger, "2620");
 
         // Verify that the initial bonds are zero.
-        assertEq(doo.disputeGameFactoryProxy().initBonds(GameTypes.CANNON), 0, "2700");
-        assertEq(doo.disputeGameFactoryProxy().initBonds(GameTypes.PERMISSIONED_CANNON), 0, "2800");
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "2700");
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.PERMISSIONED_CANNON), 0, "2800");
 
-        (Hash actualRoot,) = doo.anchorStateRegistryProxy().anchors(GameTypes.PERMISSIONED_CANNON);
-        assertEq(Hash.unwrap(actualRoot), 0xdead000000000000000000000000000000000000000000000000000000000000, "2900");
-        assertEq(doo.permissionedDisputeGame().l2BlockNumber(), 0, "3000");
+        assertEq(doo.permissionedDisputeGame.l2BlockNumber(), 0, "3000");
         assertEq(
-            Claim.unwrap(doo.permissionedDisputeGame().absolutePrestate()),
+            Claim.unwrap(doo.permissionedDisputeGame.absolutePrestate()),
             0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c,
             "3100"
         );
-        assertEq(Duration.unwrap(doo.permissionedDisputeGame().clockExtension()), 10800, "3200");
-        assertEq(Duration.unwrap(doo.permissionedDisputeGame().maxClockDuration()), 302400, "3300");
-        assertEq(doo.permissionedDisputeGame().splitDepth(), 30, "3400");
-        assertEq(doo.permissionedDisputeGame().maxGameDepth(), 73, "3500");
-
-        assertEq(address(doo.opChainProxyAdmin().addressManager().owner()), address(doo.opChainProxyAdmin()), "3600");
-        assertEq(address(doo.opChainProxyAdmin().addressManager()), address(doo.addressManager()), "3700");
-        assertEq(address(doo.opChainProxyAdmin().owner()), opChainProxyAdminOwner, "3800");
+        assertEq(Duration.unwrap(doo.permissionedDisputeGame.clockExtension()), 10800, "3200");
+        assertEq(Duration.unwrap(doo.permissionedDisputeGame.maxClockDuration()), 302400, "3300");
+        assertEq(doo.permissionedDisputeGame.splitDepth(), 30, "3400");
+        assertEq(doo.permissionedDisputeGame.maxGameDepth(), 73, "3500");
     }
 
     function test_customDisputeGame_customEnabled_succeeds() public {
-        setDOI();
-        doi.set(doi.allowCustomDisputeParameters.selector, true);
-        doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth + 1);
-        deployOPChain.run(doi, doo);
-        assertEq(doo.permissionedDisputeGame().splitDepth(), disputeSplitDepth + 1);
-    }
-
-    function setDOI() internal {
-        doi.set(doi.opChainProxyAdminOwner.selector, opChainProxyAdminOwner);
-        doi.set(doi.systemConfigOwner.selector, systemConfigOwner);
-        doi.set(doi.batcher.selector, batcher);
-        doi.set(doi.unsafeBlockSigner.selector, unsafeBlockSigner);
-        doi.set(doi.proposer.selector, proposer);
-        doi.set(doi.challenger.selector, challenger);
-        doi.set(doi.basefeeScalar.selector, basefeeScalar);
-        doi.set(doi.blobBaseFeeScalar.selector, blobBaseFeeScalar);
-        doi.set(doi.l2ChainId.selector, l2ChainId);
-        doi.set(doi.opcm.selector, address(opcm));
-        doi.set(doi.saltMixer.selector, saltMixer);
-        doi.set(doi.gasLimit.selector, gasLimit);
-        doi.set(doi.disputeGameType.selector, disputeGameType);
-        doi.set(doi.disputeAbsolutePrestate.selector, disputeAbsolutePrestate);
-        doi.set(doi.disputeMaxGameDepth.selector, disputeMaxGameDepth);
-        doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
-        doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
-        doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
+        deployOPChainInput.allowCustomDisputeParameters = true;
+        deployOPChainInput.disputeSplitDepth = disputeSplitDepth + 1;
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+        assertEq(doo.permissionedDisputeGame.splitDepth(), disputeSplitDepth + 1);
     }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -9,17 +9,8 @@ import { DeployOPChain } from "scripts/deploy/DeployOPChain.s.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
-import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
-import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
-import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
-
-import { Claim, Duration, GameType, GameTypes, Hash, Proposal } from "src/dispute/lib/Types.sol";
+import { Claim, Duration, GameType, GameTypes, Hash } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain_TestBase is Test {
     DeploySuperchain deploySuperchain;

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -10,7 +10,7 @@ import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
-import { Claim, Duration, GameType, GameTypes, Hash } from "src/dispute/lib/Types.sol";
+import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain_TestBase is Test {
     DeploySuperchain deploySuperchain;
@@ -134,13 +134,6 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         // Basic non-zero and code checks are covered inside run->checkOutput.
         // Additonal targeted assertions added below.
 
-        // Owners and roles propagated
-        assertEq(address(doo.opChainProxyAdmin.owner()), opChainProxyAdminOwner, "ProxyAdmin owner");
-        assertEq(address(doo.systemConfigProxy.owner()), systemConfigOwner, "SystemConfig owner");
-        assertEq(address(doo.systemConfigProxy.unsafeBlockSigner()), unsafeBlockSigner, "unsafeBlockSigner");
-        assertEq(address(uint160(uint256(doo.systemConfigProxy.batcherHash()))), batcher, "batcherHash");
-
-        // Dispute game roles/params propagated
         assertEq(address(doo.permissionedDisputeGame.proposer()), proposer, "PDG proposer");
         assertEq(address(doo.permissionedDisputeGame.challenger()), challenger, "PDG challenger");
         assertEq(doo.permissionedDisputeGame.splitDepth(), disputeSplitDepth, "PDG splitDepth");
@@ -160,9 +153,6 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
             Claim.unwrap(disputeAbsolutePrestate),
             "PDG absolutePrestate"
         );
-
-        (Hash actualRoot,) = doo.anchorStateRegistryProxy.anchors(GameTypes.PERMISSIONED_CANNON);
-        assertEq(Hash.unwrap(actualRoot), 0xdead000000000000000000000000000000000000000000000000000000000000, "ASR start root");
     }
 
     function testFuzz_run_memory_succeeds(bytes32 _seed) public {
@@ -177,21 +167,6 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         deployOPChainInput.l2ChainId = uint256(hash(_seed, 8));
 
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
-
-        // TODO Add fault proof contract assertions below once OPCM fully supports them.
-
-        // Assert inputs were properly passed through to the contract initializers.
-        assertEq(address(doo.opChainProxyAdmin.owner()), deployOPChainInput.opChainProxyAdminOwner, "2100");
-        assertEq(address(doo.systemConfigProxy.owner()), deployOPChainInput.systemConfigOwner, "2200");
-        address batcherActual = address(uint160(uint256(doo.systemConfigProxy.batcherHash())));
-        assertEq(batcherActual, deployOPChainInput.batcher, "2300");
-        assertEq(address(doo.systemConfigProxy.unsafeBlockSigner()), deployOPChainInput.unsafeBlockSigner, "2400");
-        assertEq(address(doo.permissionedDisputeGame.proposer()), deployOPChainInput.proposer, "2500");
-        assertEq(address(doo.permissionedDisputeGame.challenger()), deployOPChainInput.challenger, "2600");
-
-        // TODO once we deploy the Permissionless Dispute Game
-        // assertEq(address(doo.faultDisputeGame().proposer()), proposer, "2610");
-        // assertEq(address(doo.faultDisputeGame().challenger()), challenger, "2620");
 
         // Verify that the initial bonds are zero.
         assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "2700");


### PR DESCRIPTION
Refactors `DeployOPChain.s.sol` so that it has the following `run` function definition:
```
function run(Types.DeployOPChainInput memory _input) public returns (Output memory output_)
```
The main driver of this change is to make it easier to invoke this script via our op-deployer go code (which will shell out to forge binary). But the refactor also has the following additional advantages:
* consistency with other `Deploy*.s.sol.run()` functions (uses input/output structs)
* more intuitive = better maintainability: previous `run` method wrote input/output values to contract storage, which then had to be read onchain instead of just getting a return value