### PR TITLE
feat(op-deployer): customize etherscan URL from CLI and environment

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -24,6 +24,7 @@ const (
 	PrivateKeyFlagName       = "private-key"
 	IntentTypeFlagName       = "intent-type"
 	EtherscanAPIKeyFlagName  = "etherscan-api-key"
+	EtherscanUrlFlagName     = "etherscan-url"
 	InputFileFlagName        = "input-file"
 	ContractNameFlagName     = "contract-name"
 )
@@ -104,6 +105,12 @@ var (
 		EnvVars:  PrefixEnvVar("ETHERSCAN_API_KEY"),
 		Required: true,
 	}
+	EtherscanUrlFlag = &cli.StringFlag{
+		Name:     EtherscanUrlFlagName,
+		Usage:    "etherscan API URL for contract verification. when empty, default URLs are used.",
+		EnvVars:  PrefixEnvVar("ETHERSCAN_API_URL"),
+		Required: false,
+	}
 	InputFileFlag = &cli.StringFlag{
 		Name:    InputFileFlagName,
 		Usage:   "filepath of input file for command",
@@ -143,6 +150,7 @@ var VerifyFlags = []cli.Flag{
 	L1RPCURLFlag,
 	ArtifactsLocatorFlag,
 	EtherscanAPIKeyFlag,
+	EtherscanUrlFlag,
 	InputFileFlag,
 	ContractNameFlag,
 }

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -30,12 +30,17 @@ type Verifier struct {
 	numFailed   int
 }
 
-func NewVerifier(apiKey string, l1ChainID uint64, artifactsFS foundry.StatDirFs, l log.Logger, l1Client *ethclient.Client) (*Verifier, error) {
-	etherscanUrl, err := getAPIEndpoint(l1ChainID)
-	if err != nil {
-		return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
+func NewVerifier(apiKey string, l1ChainID uint64, artifactsFS foundry.StatDirFs, l log.Logger, l1Client *ethclient.Client, etherscanUrl string) (*Verifier, error) {
+	if len(etherscanUrl) == 0 {
+		var err error
+		etherscanUrl, err = getAPIEndpoint(l1ChainID)
+		if err != nil {
+			return nil, fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
+		}
+		l.Info("found etherscan url", "url", etherscanUrl)
+	} else {
+		l.Info("using provided etherscan url", "url", etherscanUrl)
 	}
-	l.Info("found etherscan url", "url", etherscanUrl)
 
 	etherscan := NewEtherscanClient(apiKey, etherscanUrl, rate.NewLimiter(rate.Limit(1), 1))
 
@@ -94,7 +99,8 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	}
 	l.Info("Downloaded artifacts", "path", artifactsFS)
 
-	v, err := NewVerifier(etherscanAPIKey, l1ChainId, artifactsFS, l, l1Client)
+	etherscanUrl := cliCtx.String(deployer.EtherscanUrlFlagName)
+	v, err := NewVerifier(etherscanAPIKey, l1ChainId, artifactsFS, l, l1Client, etherscanUrl)
 	if err != nil {
 		return fmt.Errorf("failed to create verifier: %w", err)
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This PR edits `op-deployer` code, adding the capability to chose a custom Etherscan API URL, either using the `--etherscan-url` CLI argument, or the `ETHERSCAN_API_URL` environment variable.

The new argument is optional and when empty, the behavior of chosing a default block explorer is preserved.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

Found no pre-existing tests for `NewVerifier` or any other component of `verifier.go`. Let me know if this in particular should be tested.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

Being able to verify source code for a local devnet deployment is very useful. Found no way to do so in the documentation and this seems like the easiest option. Let me know if I missed some doc article which mentions it.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

- Related to #14813, recent versions of Blockscout support etherscan-like APIs so as a side effect, this introduces support for Blockscout.
