### PR TITLE
chore: replace fmt.Errorf with errors.New for constant errors

### DIFF
--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -146,10 +147,10 @@ func (ch *Cheater) RunAndClose(fn HeadFn) error {
 	oldBody := rawdb.ReadBodyRLP(ch.DB, preID.Hash, preID.Number)
 	newKey := blockBodyKey(preID.Number, blockHash)
 	if err := batch.Delete(oldKey); err != nil {
-		return fmt.Errorf("error deleting old block body key")
+		return errors.New("error deleting old block body key")
 	}
 	if err := batch.Put(newKey, oldBody); err != nil {
-		return fmt.Errorf("error setting new block body key")
+		return errors.New("error setting new block body key")
 	}
 
 	// Flush the whole batch into the disk, exit the node if failed


### PR DESCRIPTION
**Description**

This swaps two constant-string fmt.Errorf calls in op-wheel/cheat/cheat.go for errors.New, avoiding unnecessary formatting overhead while keeping identical error values and call sites.
