### PR TITLE
feat(op-acceptance-tests): flake-shake auto-promotions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ parameters:
 orbs:
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
-  slack: circleci/slack@5.1.1
+  slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
   utils: ethereum-optimism/circleci-utils@1.0.20
@@ -356,6 +356,11 @@ jobs:
     resource_class: <<# parameters.use_circleci_runner >>xlarge<</ parameters.use_circleci_runner >><<^ parameters.use_circleci_runner >>ethereum-optimism/latitude-1<</ parameters.use_circleci_runner >>
     steps:
       - checkout-from-workspace
+      - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
       - run:
           name: Setup Kurtosis
           command: |
@@ -1454,6 +1459,11 @@ jobs:
           name: Download Go dependencies
           working_directory: op-acceptance-tests
           command: go mod download
+      - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
       # Persist schedule name into env var
       - run:
           name: Persist schedule name into env var
@@ -1550,6 +1560,11 @@ jobs:
           name: Download Go dependencies
           working_directory: op-acceptance-tests
           command: go mod download
+      - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
       # Prepare the test environment
       - run:
           name: Prepare test environment (compile tests and cache build results)
@@ -1636,27 +1651,14 @@ jobs:
           working_directory: op-acceptance-tests
           command: go mod download
       - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
+      - run:
           name: Calculate iterations for worker
           command: |
-            # Get total iterations and worker info from CircleCI parallelism
-            TOTAL_ITER=<< pipeline.parameters.flake-shake-iterations >>
-            WORKERS=${CIRCLE_NODE_TOTAL}
-            WORKER_ID=$((CIRCLE_NODE_INDEX + 1))
-
-            # Calculate how many iterations each worker should run
-            ITER_PER_WORKER=$((TOTAL_ITER / WORKERS))
-            REMAINDER=$((TOTAL_ITER % WORKERS))
-
-            # Distribute the remainder (first $REMAINDER workers get one extra iteration)
-            if [ $WORKER_ID -le $REMAINDER ]; then
-              ITER_COUNT=$((ITER_PER_WORKER + 1))
-            else
-              ITER_COUNT=$ITER_PER_WORKER
-            fi
-
-            echo "Worker $WORKER_ID running $ITER_COUNT of $TOTAL_ITER iterations"
-            echo "export FLAKE_SHAKE_ITERATIONS=$ITER_COUNT" >> $BASH_ENV
-            echo "export FLAKE_SHAKE_WORKER_ID=$WORKER_ID" >> $BASH_ENV
+            bash ./op-acceptance-tests/scripts/ci_flake_shake_calc_iterations.sh << pipeline.parameters.flake-shake-iterations >>
       - run:
           name: Run flake-shake iterations
           no_output_timeout: 2h
@@ -1664,7 +1666,6 @@ jobs:
           command: |
             OUTPUT_DIR="logs/flake-shake-results-worker-${FLAKE_SHAKE_WORKER_ID}"
             mkdir -p "$OUTPUT_DIR"
-
             op-acceptor \
               --validators ./acceptance-tests.yaml \
               --gate << parameters.gate >> \
@@ -1690,6 +1691,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
+      - run:
           name: Build flake-shake aggregator
           working_directory: op-acceptance-tests
           command: |
@@ -1706,67 +1712,84 @@ jobs:
       - run:
           name: Generate summary
           command: |
-            if [ -f final-report/flake-shake-report.json ]; then
-              echo "=== Flake-Shake Results ==="
-              STABLE=$(jq '[.tests[] | select(.recommendation == "STABLE")] | length' final-report/flake-shake-report.json)
-              UNSTABLE=$(jq '[.tests[] | select(.recommendation == "UNSTABLE")] | length' final-report/flake-shake-report.json)
-              echo "✅ STABLE: $STABLE tests"
-              echo "⚠️ UNSTABLE: $UNSTABLE tests"
-              if [ "$UNSTABLE" -gt 0 ]; then
-                echo "Unstable tests:"
-                jq -r '.tests[] | select(.recommendation == "UNSTABLE") | "  - \(.test_name) (\(.pass_rate)%)"' final-report/flake-shake-report.json
-              fi
-              # Write daily summary (include stable and unstable tests)
-              jq '{date, gate, total_runs, iterations,
-                   totals: {
-                     stable: ([.tests[] | select(.recommendation=="STABLE")] | length),
-                     unstable: ([.tests[] | select(.recommendation=="UNSTABLE")] | length)
-                   },
-                   stable_tests: [
-                     .tests[] | select(.recommendation=="STABLE") |
-                     {test_name, package, total_runs, pass_rate}
-                   ],
-                   unstable_tests: [
-                     .tests[] | select(.recommendation=="UNSTABLE") |
-                     {test_name, package, total_runs, passes, failures, pass_rate}
-                   ]
-                 }' final-report/flake-shake-report.json > final-report/daily-summary.json
-
-              # Write promotion readiness (100% pass)
-              jq '{ready: [.tests[] | select(.recommendation=="STABLE") | {test_name, package, total_runs, pass_rate, avg_duration, min_duration, max_duration}]}' final-report/flake-shake-report.json > final-report/promotion-ready.json
-
-              # Export UNSTABLE_COUNT for later steps
-              echo "export UNSTABLE_COUNT=$UNSTABLE" >> $BASH_ENV
-            else
-              echo "ERROR: No report found"
-              exit 1
-            fi
-      - run:
-          name: Prepare Discord owner mentions
-          command: |
-            # Build owner mentions for unstable tests
-            OWNERS_FILE=$(mktemp)
-            # Iterate over unstable tests and resolve owners from YAML metadata
-            jq -r '.tests[] | select(.recommendation=="UNSTABLE") | [.package, .test_name] | @tsv' final-report/flake-shake-report.json | while IFS=$'\t' read -r PKG NAME; do
-              OWNER=$(yq -r \
-                ".gates[] | select(.id==\"flake-shake\") | .tests[] | select(.package==\"${PKG}\" and ((.name // \"\")==\"${NAME}\")) | (.metadata.owner // \"\")" \
-                op-acceptance-tests/acceptance-tests.yaml)
-              if [ -n "$OWNER" ]; then echo "$OWNER" >> "$OWNERS_FILE"; fi
-            done
-            if [ -s "$OWNERS_FILE" ]; then
-              # unique list and prefix with @ for readability
-              OWNERS=$(sort -u "$OWNERS_FILE" | sed 's/^/@/')
-              echo "Resolved owners:" $OWNERS
-              echo "export EXTRA_DISCORD_MENTIONS=\"$OWNERS\"" >> $BASH_ENV
-            else
-              echo "No owners resolved"
-            fi
-      - discord-notification-failures-on-develop:
-          message: "Flake-Shake report is ready. See artifacts for details."
-          mentions: "$EXTRA_DISCORD_MENTIONS"
+            bash ./op-acceptance-tests/scripts/ci_flake_shake_generate_summary.sh final-report/flake-shake-report.json final-report
       - store_artifacts:
           path: ./final-report
           destination: flake-shake-report
+
+  op-acceptance-tests-flake-shake-promote:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: large
+    steps:
+      - checkout-from-workspace
+      - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
+      - run:
+          name: Build flake-shake promoter
+          working_directory: op-acceptance-tests
+          command: |
+            go mod download
+            go build -o ../flake-shake-promoter ./cmd/flake-shake-promoter/main.go
+      - run:
+          name: Set GH_TOKEN
+          command: |
+            if [ -n "${GITHUB_TOKEN_GOVERNANCE:-}" ]; then
+              echo "export GH_TOKEN=${GITHUB_TOKEN_GOVERNANCE}" >> "$BASH_ENV"
+            fi
+      - run:
+          name: Validate GH_TOKEN is present
+          command: |
+            if [ -z "${GH_TOKEN:-}" ]; then
+              echo "GH_TOKEN is required for PR creation" >&2
+              exit 1
+            fi
+      - run:
+          name: Run flake-shake promoter
+          command: |
+            ./flake-shake-promoter \
+              --org ethereum-optimism \
+              --repo optimism \
+              --branch "<< pipeline.git.branch >>" \
+              --workflow scheduled-flake-shake \
+              --report-job op-acceptance-tests-flake-shake-report \
+              --days 3 \
+              --gate flake-shake \
+              --min-runs 300 \
+              --max-failure-rate 0.01 \
+              --min-age-days 3 \
+              --dry-run=false \
+              --require-clean-24h \
+              --out ./final-promotion \
+              --verbose
+      - store_artifacts:
+          path: ./final-promotion
+          destination: flake-shake-promotion
+      - run:
+          name: Prepare Slack message (promotion candidates)
+          command: |
+            bash ./op-acceptance-tests/scripts/ci_flake_shake_prepare_slack.sh ./final-promotion/promotion-ready.json
+      - run:
+          name: Slack - Sending Notification
+          command: |
+            set -euo pipefail
+            # The Slack orb conditionals evaluate at compile time; guard at runtime instead.
+            if [ -z "${SLACK_BLOCKS_PAYLOAD:-}" ] || [ "${SLACK_BLOCKS_PAYLOAD}" = "[]" ]; then
+              echo "SLACK_BLOCKS is empty or doesn't exist. Skipping it..."
+              exit 0
+            fi
+            echo "$SLACK_BLOCKS_PAYLOAD" | jq '.' > /tmp/blocks.json
+            jq -c '{blocks: .}' /tmp/blocks.json > /tmp/slack_template.json
+            echo 'export SLACK_TEMPLATE=$(cat /tmp/slack_template.json)' >> $BASH_ENV
+      - slack/notify:
+          channel: notify-ci-failures
+          event: always
+          retries: 1
+          retry_delay: 3
+          template: SLACK_TEMPLATE
 
   sanitize-op-program:
     docker:
@@ -2953,6 +2976,14 @@ workflows:
       - op-acceptance-tests-flake-shake-report:
           requires:
             - op-acceptance-tests-flake-shake
+      - op-acceptance-tests-flake-shake-promote:
+          requires:
+            - op-acceptance-tests-flake-shake-report
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-optimism
+            - circleci-api-token
+            - slack
 
   scheduled-preimage-reproducibility:
     when:

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb
 	github.com/google/go-cmp v0.7.0
+	github.com/google/go-github/v55 v55.0.0
 	github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -67,6 +68,7 @@ require (
 	golang.org/x/crypto v0.36.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/mod v0.22.0
+	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync v0.14.0
 	golang.org/x/term v0.30.0
 	golang.org/x/text v0.25.0
@@ -82,6 +84,7 @@ require (
 	git.sr.ht/~sbinet/gg v0.6.0 // indirect
 	github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.2 // indirect
 	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect
@@ -97,6 +100,7 @@ require (
 	github.com/campoy/embedmd v1.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
@@ -144,6 +148,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20241009165004-a3522334989c // indirect
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
+github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
@@ -106,6 +108,7 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -136,6 +139,9 @@ github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
+github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
+github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f h1:otljaYPt5hWxV3MUfO5dFPFiOXg9CyG5/kCfayTqsJ4=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=
@@ -355,7 +361,11 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v55 v55.0.0 h1:4pp/1tNMB9X/LuAhs5i0KQAE40NmiR/y6prLNb9x9cg=
+github.com/google/go-github/v55 v55.0.0/go.mod h1:JLahOTA1DnXzhxEymmFF5PP2tSS9JVNj68mSZNDwskA=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8 h1:Ep/joEub9YwcjRY6ND3+Y/w0ncE540RtGatVhtZL0/Q=
 github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1056,6 +1066,8 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
+golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/op-acceptance-tests/README.md
+++ b/op-acceptance-tests/README.md
@@ -212,21 +212,14 @@ gates:
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/yourtest
         timeout: 10m
-        metadata:
-          target_gate: base  # Where to promote once stable
+        metatada:
+          owner: stefano
 ```
 
 ### Understanding Reports
 
-Flake-shake generates comprehensive reports in two formats:
-- **`flake-shake-report.json`**: Machine-readable results for automation
-- **`flake-shake-report.html`**: Human-friendly visualization with charts
-
-Reports include:
-- **Pass rate**: Percentage of successful runs per test
-- **Timing statistics**: Min/avg/max execution duration
-- **Failure patterns**: First few failure logs for debugging
-- **Stability recommendation**: STABLE or UNSTABLE classification
+Flake-shake stores a daily summary artifact per run:
+- **`final-report/daily-summary.json`**: Aggregated counts of stable/unstable tests and per-test pass/fail tallies.
 
 ### CI Integration
 
@@ -234,6 +227,25 @@ In CI, flake-shake runs tests across multiple parallel workers:
 - 10 workers each run 10 iterations (100 total by default)
 - Results are aggregated using the `flake-shake-aggregator` tool
 - Reports are stored as CircleCI artifacts
+
+### Automated Promotion (Promoter CLI)
+
+We provide a small CLI that aggregates the last N daily summaries from CircleCI and proposes YAML edits to promote stable tests out of the `flake-shake` gate:
+
+```bash
+export CIRCLE_API_TOKEN=...  # CircleCI API token (read artifacts)
+go build -o ./op-acceptance-tests/flake-shake-promoter ./op-acceptance-tests/cmd/flake-shake-promoter/main.go
+./op-acceptance-tests/flake-shake-promoter \
+  --org ethereum-optimism --repo optimism --branch develop \
+  --workflow scheduled-flake-shake --report-job op-acceptance-tests-flake-shake-report \
+  --days 3 --gate flake-shake --min-runs 300 --max-failure-rate 0.01 --min-age-days 3 \
+  --out ./final-promotion --dry-run
+```
+
+Outputs written to `--out`:
+- `aggregate.json`: Per-test aggregated totals across days
+- `promotion-ready.json`: Candidates and skip reasons
+- `promotion.yaml`: Proposed edits to `op-acceptance-tests/acceptance-tests.yaml`
 
 ### Promotion Criteria
 

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -5,36 +5,38 @@
 # base gate as well as any earlier fork gates.
 
 gates:
-  # New tests should be added here first with target_gate metadata.
-  # Once we're confident they're not flaky, they will be promoted.
+  # New tests should be added here first with an owner metadata.
+  # Once we're confident they're not flaky, a PR will be automatically created to remove them from this gate.
   # Example entry format:
   # - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/parallelism
   #   timeout: 10m
   #   metadata:
-  #     target_gate: base  # Will be promoted to base gate once stable
-  #     added_date: "2025-01-23"
   #     owner: "team-infra"
   - id: flake-shake
     description: "Quarantine gate for new and potentially flaky tests requiring stability validation."
     tests:
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/sync_tester_elsync
-        name: TestSyncTesterELSync
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext
+        name: TestSyncTesterHFS_Isthmus_ELSync
         timeout: 10m
         metadata:
-          target_gate: sync-test-op-node
           owner: "changwan,anton"
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/jovian
         name: TestMinBaseFee
         timeout: 10m
         metadata:
-          target_gate: jovian
           owner: "george"
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal
         name: TestWithdrawal
         timeout: 10m
         metadata:
-          target_gate: base
           owner: "stefano"
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base
+        name: TestDummyFlakyTest
+        timeout: 10m
+        metadata:
+          owner: "stefano"
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/osaka
+        owner: "josh"
 
   - id: isthmus
     description: "Isthmus network tests."

--- a/op-acceptance-tests/cmd/flake-shake-aggregator/main.go
+++ b/op-acceptance-tests/cmd/flake-shake-aggregator/main.go
@@ -3,12 +3,15 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"flag"
 	"fmt"
 	html_pkg "html"
+	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -78,6 +81,7 @@ func main() {
 }
 
 func run(inputPattern, outputDir string, verbose bool) error {
+	logger := log.New(os.Stdout, "[flake-shake-aggregator] ", log.LstdFlags)
 	// Create output directory
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
@@ -109,9 +113,9 @@ func run(inputPattern, outputDir string, verbose bool) error {
 	}
 
 	if verbose {
-		fmt.Printf("Found %d report files to aggregate:\n", len(reportFiles))
+		logger.Printf("Found %d report files to aggregate:", len(reportFiles))
 		for _, f := range reportFiles {
-			fmt.Printf("  - %s\n", f)
+			logger.Printf("  - %s", f)
 		}
 	}
 
@@ -123,18 +127,18 @@ func run(inputPattern, outputDir string, verbose bool) error {
 
 	for _, reportFile := range reportFiles {
 		if verbose {
-			fmt.Printf("Processing %s...\n", reportFile)
+			logger.Printf("Processing %s...", reportFile)
 		}
 
 		data, err := os.ReadFile(reportFile)
 		if err != nil {
-			fmt.Printf("Warning: failed to read %s: %v\n", reportFile, err)
+			logger.Printf("Warning: failed to read %s: %v", reportFile, err)
 			continue
 		}
 
 		var report FlakeShakeReport
 		if err := json.Unmarshal(data, &report); err != nil {
-			fmt.Printf("Warning: failed to parse %s: %v\n", reportFile, err)
+			logger.Printf("Warning: failed to parse %s: %v", reportFile, err)
 			continue
 		}
 
@@ -168,10 +172,10 @@ func run(inputPattern, outputDir string, verbose bool) error {
 				stats.durationSum += time.Duration(test.AvgDuration) * time.Duration(test.TotalRuns)
 				stats.durationCount += test.TotalRuns
 
-				// Merge failure logs (keep first 10)
+				// Merge failure logs (keep first 50)
 				stats.FailureLogs = append(stats.FailureLogs, test.FailureLogs...)
-				if len(stats.FailureLogs) > 10 {
-					stats.FailureLogs = stats.FailureLogs[:10]
+				if len(stats.FailureLogs) > 50 {
+					stats.FailureLogs = stats.FailureLogs[:50]
 				}
 
 				// Update last failure time
@@ -268,13 +272,13 @@ func run(inputPattern, outputDir string, verbose bool) error {
 		return fmt.Errorf("failed to write HTML report: %w", err)
 	}
 
-	fmt.Printf("✅ Aggregation complete!\n")
-	fmt.Printf("   - Processed %d worker reports\n", len(reportFiles))
-	fmt.Printf("   - Aggregated %d unique tests\n", len(finalTests))
-	fmt.Printf("   - Total iterations: %d\n", totalIterations)
-	fmt.Printf("   - Reports saved to:\n")
-	fmt.Printf("     • %s\n", jsonFile)
-	fmt.Printf("     • %s\n", htmlFile)
+	logger.Printf("✅ Aggregation complete!")
+	logger.Printf("   - Processed %d worker reports", len(reportFiles))
+	logger.Printf("   - Aggregated %d unique tests", len(finalTests))
+	logger.Printf("   - Total iterations: %d", totalIterations)
+	logger.Printf("   - Reports saved to:")
+	logger.Printf("     • %s", jsonFile)
+	logger.Printf("     • %s", htmlFile)
 
 	// Print summary statistics
 	stableCount := 0
@@ -287,22 +291,22 @@ func run(inputPattern, outputDir string, verbose bool) error {
 		}
 	}
 
-	fmt.Printf("\n📊 Test Stability Summary:\n")
+	logger.Printf("\n📊 Test Stability Summary:")
 	if len(finalTests) > 0 {
-		fmt.Printf("   - STABLE: %d tests (%.1f%%)\n", stableCount,
+		logger.Printf("   - STABLE: %d tests (%.1f%%)", stableCount,
 			float64(stableCount)/float64(len(finalTests))*100)
-		fmt.Printf("   - UNSTABLE: %d tests (%.1f%%)\n", unstableCount,
+		logger.Printf("   - UNSTABLE: %d tests (%.1f%%)", unstableCount,
 			float64(unstableCount)/float64(len(finalTests))*100)
 	} else {
-		fmt.Printf("   - No tests found\n")
+		logger.Printf("   - No tests found")
 	}
 
 	// List unstable tests if any
 	if unstableCount > 0 && verbose {
-		fmt.Printf("\n⚠️  Unstable tests:\n")
+		logger.Printf("\n⚠️  Unstable tests:")
 		for _, test := range finalTests {
 			if test.Recommendation == "UNSTABLE" {
-				fmt.Printf("   - %s (%.1f%% pass rate)\n",
+				logger.Printf("   - %s (%.1f%% pass rate)",
 					strings.TrimPrefix(test.TestName, test.Package+"::"),
 					test.PassRate)
 			}
@@ -450,6 +454,84 @@ func generateHTMLReport(report *FlakeShakeReport) string {
 	html.WriteString(`
             </tbody>
         </table>
+`)
+
+	// Append grouped failure details
+	html.WriteString(`
+        <h2>Failure Details</h2>
+`)
+
+	normalizer := regexp.MustCompile(`(?m)^\s*\[?\d{4}-\d{2}-\d{2}.*$|\bt=\d{4}-\d{2}-\d{2}.*$|\b(duration|elapsed|took)[:=].*$`)
+	classify := func(s string) string {
+		ls := strings.ToLower(s)
+		switch {
+		case strings.Contains(ls, "context deadline exceeded"):
+			return "context deadline"
+		case strings.Contains(ls, "deadline exceeded"):
+			return "deadline exceeded"
+		case strings.Contains(ls, "timeout"):
+			return "timeout"
+		case strings.Contains(ls, "connection refused"):
+			return "connection refused"
+		case strings.Contains(ls, "connection reset"):
+			return "connection reset"
+		case strings.Contains(ls, "rpc error") || strings.Contains(ls, "rpc call failed"):
+			return "rpc error"
+		case strings.Contains(ls, "assert") || strings.Contains(ls, "require"):
+			return "assertion"
+		default:
+			return "unknown"
+		}
+	}
+	for _, test := range report.Tests {
+		if len(test.FailureLogs) == 0 {
+			continue
+		}
+		html.WriteString(fmt.Sprintf(`<details><summary>%s — %s (failures: %d)</summary>`,
+			html_pkg.EscapeString(test.TestName), html_pkg.EscapeString(test.Package), test.Failures))
+
+		groups := map[string]struct {
+			Count  int
+			Sample string
+			Type   string
+		}{}
+		typeSummary := map[string]int{}
+		for _, raw := range test.FailureLogs {
+			norm := normalizer.ReplaceAllString(raw, "")
+			norm = strings.TrimSpace(norm)
+			sum := sha256.Sum256([]byte(norm))
+			key := fmt.Sprintf("%x", sum[:])
+			g := groups[key]
+			if g.Count == 0 {
+				g.Sample = norm
+				g.Type = classify(norm)
+			}
+			g.Count++
+			groups[key] = g
+		}
+		// Build type summary
+		for _, g := range groups {
+			typeSummary[g.Type] += g.Count
+		}
+		// Render summary
+		html.WriteString(`<div class="failure-group">`)
+		html.WriteString(`<strong>Summary:</strong><ul>`)
+		for t, c := range typeSummary {
+			html.WriteString(fmt.Sprintf(`<li>%s: %d</li>`, html_pkg.EscapeString(t), c))
+		}
+		html.WriteString(`</ul></div>`)
+		// Render groups
+		for _, g := range groups {
+			html.WriteString(`<div class="failure-group">`)
+			html.WriteString(fmt.Sprintf(`<div><strong>Type:</strong> %s</div>`, html_pkg.EscapeString(g.Type)))
+			html.WriteString(fmt.Sprintf(`<div><strong>Occurrences:</strong> %d</div>`, g.Count))
+			html.WriteString(`<pre>` + html_pkg.EscapeString(g.Sample) + `</pre>`)
+			html.WriteString(`</div>`)
+		}
+		html.WriteString(`</details>`)
+	}
+
+	html.WriteString(`
     </div>
 </body>
 </html>`)

--- a/op-acceptance-tests/cmd/flake-shake-aggregator/main_test.go
+++ b/op-acceptance-tests/cmd/flake-shake-aggregator/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeReport(t *testing.T, dir, name string, r FlakeShakeReport) string {
+	t.Helper()
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, b, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func TestRunAggregatesReports(t *testing.T) {
+	tmp := t.TempDir()
+	// create two worker reports
+	r1 := FlakeShakeReport{
+		Date:       "2025-01-01",
+		Gate:       "flake-shake",
+		Iterations: 10,
+		Tests: []FlakeShakeResult{{
+			TestName:    "pkg::T1",
+			Package:     "pkg",
+			TotalRuns:   10,
+			Passes:      9,
+			Failures:    1,
+			Skipped:     0,
+			AvgDuration: 100 * time.Millisecond,
+			MinDuration: 80 * time.Millisecond,
+			MaxDuration: 120 * time.Millisecond,
+		}},
+		GeneratedAt: time.Now(),
+		RunID:       "abc",
+	}
+	r2 := FlakeShakeReport{
+		Date:       "2025-01-01",
+		Gate:       "flake-shake",
+		Iterations: 5,
+		Tests: []FlakeShakeResult{{
+			TestName:    "pkg::T1",
+			Package:     "pkg",
+			TotalRuns:   5,
+			Passes:      5,
+			Failures:    0,
+			Skipped:     0,
+			AvgDuration: 90 * time.Millisecond,
+			MinDuration: 70 * time.Millisecond,
+			MaxDuration: 110 * time.Millisecond,
+		}},
+		GeneratedAt: time.Now(),
+		RunID:       "abc",
+	}
+	// Place files under pattern
+	d1 := filepath.Join(tmp, "flake-shake-results-worker-1")
+	d2 := filepath.Join(tmp, "flake-shake-results-worker-2")
+	if err := os.MkdirAll(d1, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(d2, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeReport(t, d1, "flake-shake-report.json", r1)
+	writeReport(t, d2, "flake-shake-report.json", r2)
+
+	out := filepath.Join(tmp, "final")
+	if err := run(filepath.Join(tmp, "flake-shake-results-worker-*/flake-shake-report.json"), out, false); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	// verify outputs exist
+	if _, err := os.Stat(filepath.Join(out, "flake-shake-report.json")); err != nil {
+		t.Fatalf("missing json report: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "flake-shake-report.html")); err != nil {
+		t.Fatalf("missing html report: %v", err)
+	}
+}
+
+func TestGenerateHTMLReportBasic(t *testing.T) {
+	r := &FlakeShakeReport{
+		Gate:       "flake-shake",
+		Iterations: 15,
+		Tests: []FlakeShakeResult{
+			{TestName: "pkg::T1", Package: "pkg", TotalRuns: 10, Passes: 10, Failures: 0, PassRate: 100},
+			{TestName: "pkg::T2", Package: "pkg", TotalRuns: 5, Passes: 4, Failures: 1, PassRate: 80},
+		},
+		GeneratedAt: time.Now(),
+	}
+	html := generateHTMLReport(r)
+	if len(html) == 0 {
+		t.Fatal("empty html")
+	}
+	if !strings.Contains(html, "Flake-Shake Report") {
+		t.Fatal("missing title")
+	}
+}

--- a/op-acceptance-tests/cmd/flake-shake-promoter/main.go
+++ b/op-acceptance-tests/cmd/flake-shake-promoter/main.go
@@ -1,0 +1,1117 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	github "github.com/google/go-github/v55/github" // newer version of Go is needed for the latest GitHub API
+	"golang.org/x/oauth2"
+	yaml "gopkg.in/yaml.v3"
+)
+
+var logger *log.Logger
+
+// CircleCI API models
+type pipelineList struct {
+	Items         []pipeline `json:"items"`
+	NextPageToken string     `json:"next_page_token"`
+}
+
+type pipeline struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type workflowList struct {
+	Items         []workflow `json:"items"`
+	NextPageToken string     `json:"next_page_token"`
+}
+
+type workflow struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type jobList struct {
+	Items         []job  `json:"items"`
+	NextPageToken string `json:"next_page_token"`
+}
+
+type job struct {
+	Name      string `json:"name"`
+	JobNumber int    `json:"job_number"`
+}
+
+type artifactsList struct {
+	Items []artifact `json:"items"`
+}
+
+type artifact struct {
+	URL  string `json:"url"`
+	Path string `json:"path"`
+}
+
+// Daily summary (as produced in CI job)
+type DailySummary struct {
+	Date       string `json:"date"`
+	Gate       string `json:"gate"`
+	TotalRuns  int    `json:"total_runs"`
+	Iterations int    `json:"iterations"`
+	Totals     struct {
+		Stable   int `json:"stable"`
+		Unstable int `json:"unstable"`
+	} `json:"totals"`
+	StableTests []struct {
+		TestName  string  `json:"test_name"`
+		Package   string  `json:"package"`
+		TotalRuns int     `json:"total_runs"`
+		PassRate  float64 `json:"pass_rate"`
+	} `json:"stable_tests"`
+	UnstableTests []struct {
+		TestName  string  `json:"test_name"`
+		Package   string  `json:"package"`
+		TotalRuns int     `json:"total_runs"`
+		Passes    int     `json:"passes"`
+		Failures  int     `json:"failures"`
+		PassRate  float64 `json:"pass_rate"`
+	} `json:"unstable_tests"`
+}
+
+// Acceptance tests YAML models
+type acceptanceYAML struct {
+	Gates []gateYAML `yaml:"gates"`
+}
+
+type gateYAML struct {
+	ID          string      `yaml:"id"`
+	Description string      `yaml:"description,omitempty"`
+	Inherits    []string    `yaml:"inherits,omitempty"`
+	Tests       []testEntry `yaml:"tests,omitempty"`
+}
+
+type testEntry struct {
+	Name     string                 `yaml:"name,omitempty"`
+	Package  string                 `yaml:"package"`
+	Timeout  string                 `yaml:"timeout,omitempty"`
+	Metadata map[string]interface{} `yaml:"metadata,omitempty"`
+}
+
+// Aggregated per test across days
+type aggStats struct {
+	Package       string     `json:"package"`
+	TestName      string     `json:"test_name"`
+	TotalRuns     int        `json:"total_runs"`
+	Passes        int        `json:"passes"`
+	Failures      int        `json:"failures"`
+	FirstSeenDay  string     `json:"first_seen_day"`
+	LastSeenDay   string     `json:"last_seen_day"`
+	LastFailureAt *time.Time `json:"last_failure_at,omitempty"`
+	DaysObserved  []string   `json:"days_observed"`
+}
+
+type promoteCandidate struct {
+	Package      string  `json:"package"`
+	TestName     string  `json:"test_name"`
+	TotalRuns    int     `json:"total_runs"`
+	PassRate     float64 `json:"pass_rate"`
+	Timeout      string  `json:"timeout"`
+	FirstSeenDay string  `json:"first_seen_day"`
+}
+
+// Map tests in flake-shake: key -> (timeout, name)
+type testInfo struct {
+	Timeout   string
+	Name      string
+	Meta      map[string]interface{}
+	GateIndex int
+	TestIndex int
+}
+
+func main() {
+	opts := parsePromoterFlags()
+
+	logger = log.New(os.Stdout, "[flake-shake-promoter] ", log.LstdFlags)
+	if opts.verbose {
+		logger.Printf("Flags: org=%s repo=%s branch=%s workflow=%s report_job=%s days=%d gate=%s min_runs=%d max_failure_rate=%.4f min_age_days=%d require_clean_24h=%t out=%s dry_run=%t",
+			opts.org, opts.repo, opts.branch, opts.workflowName, opts.reportJobName, opts.daysBack, opts.gateID, opts.minRuns, opts.maxFailureRate, opts.minAgeDays, opts.requireClean24h, opts.outDir, opts.dryRun,
+		)
+	}
+
+	token := requireEnv("CIRCLE_API_TOKEN")
+	if err := ensureDirExists(opts.outDir); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create out dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	now := time.Now().UTC()
+	since := now.AddDate(0, 0, -opts.daysBack)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	ctx := &apiCtx{client: client, token: token}
+
+	dailyReports, err := collectReports(ctx, opts.org, opts.repo, opts.branch, opts.workflowName, opts.reportJobName, since, opts.verbose)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collection failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	agg := aggregate(dailyReports)
+
+	logDailyReportSummary(dailyReports, opts.verbose)
+
+	// Load acceptance-tests.yaml
+	yamlPath := filepath.Join("op-acceptance-tests", "acceptance-tests.yaml")
+	cfg, err := readAcceptanceYAML(yamlPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed reading %s: %v\n", yamlPath, err)
+		os.Exit(1)
+	}
+
+	// Build indices for flake-shake tests and target gates
+	flakeTests, flakeGate, gateIndex := buildFlakeTests(&cfg, opts.gateID, yamlPath)
+	_ = gateIndex
+
+	// Select promotion candidates
+	candidates, reasons := selectPromotionCandidates(agg, flakeTests, opts.minRuns, opts.maxFailureRate, opts.requireClean24h, opts.minAgeDays, now)
+
+	// Write outputs
+	if err := writeJSON(filepath.Join(opts.outDir, "aggregate.json"), agg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed writing aggregate: %v\n", err)
+		os.Exit(1)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Package == candidates[j].Package {
+			return candidates[i].TestName < candidates[j].TestName
+		}
+		return candidates[i].Package < candidates[j].Package
+	})
+	if err := writeJSON(filepath.Join(opts.outDir, "promotion-ready.json"), map[string]interface{}{"candidates": candidates, "skipped": reasons}); err != nil {
+		fmt.Fprintf(os.Stderr, "failed writing promotion-ready: %v\n", err)
+		os.Exit(1)
+	}
+
+	if opts.verbose {
+		fmt.Printf("Promotion candidates: %d\n", len(candidates))
+		for _, c := range candidates {
+			name := c.TestName
+			if strings.TrimSpace(name) == "" {
+				name = "(package)"
+			}
+			fmt.Printf("  - %s %s (runs=%d pass=%.2f%%)\n", c.Package, name, c.TotalRuns, c.PassRate)
+		}
+	}
+
+	// Write metadata for downstream consumers (e.g., Slack)
+	meta := map[string]interface{}{
+		"date":             now.Format("2006-01-02"),
+		"candidates":       len(candidates),
+		"flake_gate_tests": len(flakeGate.Tests),
+	}
+	if err := writeJSON(filepath.Join(opts.outDir, "metadata.json"), meta); err != nil {
+		fmt.Fprintf(os.Stderr, "failed writing metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Generate updated YAML (proposal)
+	updated := computeUpdatedConfig(cfg, opts.gateID, candidates)
+
+	// Write proposed YAML
+	outYAML := filepath.Join(opts.outDir, "promotion.yaml")
+	if err := writeYAML(outYAML, &updated); err != nil {
+		fmt.Fprintf(os.Stderr, "failed writing promotion.yaml: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print short summary
+	if len(candidates) == 0 {
+		reason := buildNoCandidatesSummary(agg, flakeTests, opts.minAgeDays, opts.requireClean24h)
+		_ = os.WriteFile(filepath.Join(opts.outDir, "SUMMARY.txt"), []byte(reason+"\n"), 0o644)
+		logger.Println(reason)
+		return
+	}
+	var b bytes.Buffer
+	b.WriteString("Promotion candidates (dry-run):\n")
+	for _, c := range candidates {
+		b.WriteString(fmt.Sprintf("- %s %s (runs=%d, pass=%.2f%%)\n", c.Package, c.TestName, c.TotalRuns, c.PassRate))
+	}
+	_ = os.WriteFile(filepath.Join(opts.outDir, "SUMMARY.txt"), b.Bytes(), 0o644)
+	logger.Print(b.String())
+
+	if opts.dryRun {
+		logger.Println("Dry-run enabled; skipping branch creation, file update, and PR creation.")
+		return
+	}
+
+	// Prepare updated YAML content for PR by editing only the flake-shake gate in-place to preserve comments
+	var updatedYAMLBytes []byte
+
+	prBranch := fmt.Sprintf("ci/flake-shake-promote/%s", time.Now().UTC().Format("2006-01-02-150405"))
+
+	// Prepare commit message and PR body
+	title := "chore(op-acceptance-tests): flake-shake; test promotions"
+	var body bytes.Buffer
+	body.WriteString("## 🤖 Automated Flake-Shake Test Promotion\n\n")
+	body.WriteString(fmt.Sprintf("Promoting %d test(s) from gate `"+opts.gateID+"` based on stability criteria.\n\n", len(candidates)))
+	body.WriteString("### Tests Being Promoted\n\n")
+	body.WriteString("| Test | Package | Total Runs | Pass Rate |\n|---|---|---:|---:|\n")
+	for _, c := range candidates {
+		name := c.TestName
+		if strings.TrimSpace(name) == "" {
+			name = "(package)"
+		}
+		body.WriteString(fmt.Sprintf("| %s | %s | %d | %.2f%% |\n", name, c.Package, c.TotalRuns, c.PassRate))
+	}
+	body.WriteString("\nThis PR was auto-generated by flake-shake promoter.\n")
+
+	// Use GitHub API to create branch, update file, and open PR
+	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		fmt.Fprintln(os.Stderr, "GH_TOKEN is required for PR creation but not set")
+		os.Exit(1)
+	}
+	ghCtx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})
+	tc := oauth2.NewClient(ghCtx, ts)
+	ghc := github.NewClient(tc)
+
+	if opts.verbose {
+		logger.Printf("PR: starting creation process (base_branch=%s candidates=%d)", opts.branch, len(candidates))
+	}
+
+	// 1) Get base branch ref
+	baseRef, _, err := ghc.Git.GetRef(ghCtx, opts.org, opts.repo, "refs/heads/"+opts.branch)
+	if err != nil || baseRef.Object == nil || baseRef.Object.SHA == nil {
+		fmt.Fprintf(os.Stderr, "failed to get base ref: %v\n", err)
+		os.Exit(1)
+	}
+	if opts.verbose {
+		logger.Printf("PR: base ref resolved sha=%s", baseRef.GetObject().GetSHA())
+	}
+
+	// 2) Create new branch ref
+	newRef := &github.Reference{
+		Ref:    github.String("refs/heads/" + prBranch),
+		Object: &github.GitObject{SHA: baseRef.Object.SHA},
+	}
+	if _, _, err := ghc.Git.CreateRef(ghCtx, opts.org, opts.repo, newRef); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create ref: %v\n", err)
+		os.Exit(1)
+	}
+	if opts.verbose {
+		logger.Printf("PR: created branch %s", prBranch)
+	}
+
+	// 3) Read current file to fetch SHA (if exists) on base branch
+	path := yamlPath
+	var sha *string
+	var originalYAML []byte
+	if fileContent, _, resp, err := ghc.Repositories.GetContents(ghCtx, opts.org, opts.repo, path, &github.RepositoryContentGetOptions{Ref: opts.branch}); err == nil && fileContent != nil {
+		sha = fileContent.SHA
+		// Retrieve decoded file content via client helper
+		rawContent, gcErr := fileContent.GetContent()
+		if gcErr == nil && rawContent != "" {
+			originalYAML = []byte(rawContent)
+		}
+	} else if resp != nil && resp.StatusCode == 404 {
+		sha = nil
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get contents: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Build updated YAML by removing promoted tests only from flake-shake gate, preserving comments
+	promoteKeys := map[string]promoteCandidate{}
+	for _, c := range candidates {
+		promoteKeys[keyFor(c.Package, c.TestName)] = c
+	}
+	updatedYAMLBytes, err = updateFlakeShakeGateOnly(originalYAML, opts.gateID, promoteKeys)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to update YAML: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 4) Update file in new branch
+	commitMsg := title
+	if _, _, err = ghc.Repositories.UpdateFile(ghCtx, opts.org, opts.repo, path, &github.RepositoryContentFileOptions{
+		Message: github.String(commitMsg),
+		Content: updatedYAMLBytes,
+		Branch:  github.String(prBranch),
+		SHA:     sha,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to update file: %v\n", err)
+		os.Exit(1)
+	}
+	if opts.verbose {
+		logger.Printf("PR: updated file %s on branch %s", path, prBranch)
+	}
+
+	// 5) Create PR
+	prReq := &github.NewPullRequest{
+		Title: github.String(title),
+		Head:  github.String(prBranch),
+		Base:  github.String(opts.branch),
+		Body:  github.String(body.String()),
+	}
+	pr, _, err := ghc.PullRequests.Create(ghCtx, opts.org, opts.repo, prReq)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create PR: %v\n", err)
+		os.Exit(1)
+	}
+	logger.Printf("PR created: %s (number=%d)", pr.GetHTMLURL(), pr.GetNumber())
+
+	// Update metadata with PR details for downstream Slack notification
+	meta["pr_url"] = pr.GetHTMLURL()
+	meta["pr_number"] = pr.GetNumber()
+	if err := writeJSON(filepath.Join(opts.outDir, "metadata.json"), meta); err != nil {
+		fmt.Fprintf(os.Stderr, "failed updating metadata with PR info: %v\n", err)
+	}
+
+	// 6) Add labels
+	if _, _, err := ghc.Issues.AddLabelsToIssue(ghCtx, opts.org, opts.repo, pr.GetNumber(), []string{"M-ci", "A-acceptance-tests"}); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to add labels: %v\n", err)
+	}
+
+	// 7) Request reviewers (user and team slug)
+	if _, _, err := ghc.PullRequests.RequestReviewers(ghCtx, opts.org, opts.repo, pr.GetNumber(), github.ReviewersRequest{
+		Reviewers:     []string{"scharissis"},
+		TeamReviewers: []string{"platforms-team"},
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to request reviewers: %v\n", err)
+	}
+}
+
+// promoterOpts holds command-line options for the promoter tool.
+type promoterOpts struct {
+	org             string
+	repo            string
+	branch          string
+	workflowName    string
+	reportJobName   string
+	daysBack        int
+	gateID          string
+	minRuns         int
+	maxFailureRate  float64
+	minAgeDays      int
+	outDir          string
+	dryRun          bool
+	requireClean24h bool
+	verbose         bool
+}
+
+func parsePromoterFlags() promoterOpts {
+	var opts promoterOpts
+	flag.StringVar(&opts.org, "org", "ethereum-optimism", "GitHub org")
+	flag.StringVar(&opts.repo, "repo", "optimism", "GitHub repo")
+	flag.StringVar(&opts.branch, "branch", "develop", "Branch to scan")
+	flag.StringVar(&opts.workflowName, "workflow", "scheduled-flake-shake", "Workflow name")
+	flag.StringVar(&opts.reportJobName, "report-job", "op-acceptance-tests-flake-shake-report", "Report job name")
+	flag.IntVar(&opts.daysBack, "days", 3, "Number of days to aggregate")
+	flag.StringVar(&opts.gateID, "gate", "flake-shake", "Gate id in acceptance-tests.yaml")
+	flag.IntVar(&opts.minRuns, "min-runs", 300, "Minimum total runs required")
+	flag.Float64Var(&opts.maxFailureRate, "max-failure-rate", 0.01, "Maximum allowed failure rate")
+	flag.IntVar(&opts.minAgeDays, "min-age-days", 2, "Minimum age in days in flake-shake")
+	flag.StringVar(&opts.outDir, "out", "./promotion-output", "Output directory")
+	flag.BoolVar(&opts.dryRun, "dry-run", true, "Do not modify repo or open PRs")
+	flag.BoolVar(&opts.requireClean24h, "require-clean-24h", false, "Require no failures in the last 24 hours")
+	flag.BoolVar(&opts.verbose, "verbose", false, "Enable verbose debug logging")
+	flag.Parse()
+	// Validate interdependent options early to avoid confusing outcomes later
+	if opts.daysBack < opts.minAgeDays {
+		fmt.Fprintf(os.Stderr, "invalid flags: --days (%d) must be >= --min-age-days (%d)\n", opts.daysBack, opts.minAgeDays)
+		os.Exit(2)
+	}
+	if opts.requireClean24h && opts.daysBack < 2 {
+		fmt.Fprintf(os.Stderr, "invalid flags: --days (%d) must be >= 2 when --require-clean-24h is set to ensure >24h coverage\n", opts.daysBack)
+		os.Exit(2)
+	}
+	return opts
+}
+
+func requireEnv(name string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "%s is not set\n", name)
+		os.Exit(1)
+	}
+	return v
+}
+
+func ensureDirExists(dir string) error {
+	return os.MkdirAll(dir, 0o755)
+}
+
+func logDailyReportSummary(dailyReports map[string]DailySummary, verbose bool) {
+	if !verbose {
+		return
+	}
+	logger.Printf("Collected %d day(s) of summaries.", len(dailyReports))
+	totalTests := 0
+	for date, ds := range dailyReports {
+		n := len(ds.StableTests) + len(ds.UnstableTests)
+		totalTests += n
+		logger.Printf("  - %s: %d tests (stable=%d unstable=%d)", date, n, len(ds.StableTests), len(ds.UnstableTests))
+	}
+	logger.Printf("Total tests across days: %d", totalTests)
+}
+
+// buildFlakeTests returns a map of tests in the flake-shake gate and also returns
+// the flake gate reference and a gate index map for potential future use.
+func buildFlakeTests(cfg *acceptanceYAML, gateID, yamlPath string) (map[string]testInfo, *gateYAML, map[string]*gateYAML) {
+	flakeGate := findGate(cfg, gateID)
+	if flakeGate == nil {
+		fmt.Fprintf(os.Stderr, "gate %s not found in %s\n", gateID, yamlPath)
+		os.Exit(1)
+	}
+	gateIndex := map[string]*gateYAML{}
+	for i := range cfg.Gates {
+		gateIndex[cfg.Gates[i].ID] = &cfg.Gates[i]
+	}
+	flakeTests := map[string]testInfo{}
+	for ti, t := range flakeGate.Tests {
+		key := keyFor(t.Package, t.Name)
+		flakeTests[key] = testInfo{Timeout: t.Timeout, Name: t.Name, Meta: t.Metadata, GateIndex: indexOfGate(cfg, gateID), TestIndex: ti}
+	}
+	return flakeTests, flakeGate, gateIndex
+}
+
+func selectPromotionCandidates(agg map[string]*aggStats, flakeTests map[string]testInfo, minRuns int, maxFailureRate float64, requireClean24h bool, minAgeDays int, now time.Time) ([]promoteCandidate, map[string]string) {
+	candidates := []promoteCandidate{}
+	reasons := map[string]string{}
+	// Identify wildcard package entries (tests with empty name in the flake-shake gate)
+	wildcardPkgs := map[string]testInfo{}
+	for k, info := range flakeTests {
+		if strings.TrimSpace(info.Name) == "" && strings.HasSuffix(k, "::") {
+			pkg := strings.TrimSuffix(k, "::")
+			if pkg != "" {
+				wildcardPkgs[pkg] = info
+			}
+		}
+	}
+
+	// Produce package-level candidates for wildcard entries by aggregating all tests in the package
+	for pkg, info := range wildcardPkgs {
+		totalRuns := 0
+		totalPasses := 0
+		totalFailures := 0
+		earliest := ""
+		var lastFailureAt *time.Time
+		for _, s := range agg {
+			if s.Package != pkg {
+				continue
+			}
+			totalRuns += s.TotalRuns
+			totalPasses += s.Passes
+			totalFailures += s.Failures
+			if earliest == "" || (s.FirstSeenDay != "" && s.FirstSeenDay < earliest) {
+				earliest = s.FirstSeenDay
+			}
+			if s.LastFailureAt != nil {
+				if lastFailureAt == nil || s.LastFailureAt.After(*lastFailureAt) {
+					lastFailureAt = s.LastFailureAt
+				}
+			}
+		}
+		if totalRuns == 0 {
+			reasons[keyFor(pkg, "")] = "no runs observed for package"
+			continue
+		}
+		if totalRuns < minRuns {
+			reasons[keyFor(pkg, "")] = fmt.Sprintf("insufficient runs: %d < %d (pkg)", totalRuns, minRuns)
+			continue
+		}
+		failureRate := 0.0
+		if totalRuns > 0 {
+			failureRate = float64(totalFailures) / float64(totalRuns)
+		}
+		if failureRate > maxFailureRate {
+			reasons[keyFor(pkg, "")] = fmt.Sprintf("failure rate %.4f exceeds max %.4f (pkg)", failureRate, maxFailureRate)
+			continue
+		}
+		if requireClean24h && lastFailureAt != nil {
+			if time.Since(*lastFailureAt) < 24*time.Hour {
+				reasons[keyFor(pkg, "")] = "failure within last 24h (pkg)"
+				continue
+			}
+		}
+		if earliest == "" {
+			reasons[keyFor(pkg, "")] = "no age information (pkg)"
+			continue
+		}
+		firstDay, _ := time.Parse("2006-01-02", earliest)
+		daysInGate := int(now.Sub(firstDay).Hours()/24) + 1
+		if daysInGate < minAgeDays {
+			reasons[keyFor(pkg, "")] = fmt.Sprintf("min age %dd not met (have %dd) (pkg)", minAgeDays, daysInGate)
+			continue
+		}
+		passRate := 0.0
+		if totalRuns > 0 {
+			passRate = float64(totalPasses) / float64(totalRuns)
+		}
+		candidates = append(candidates, promoteCandidate{
+			Package:      pkg,
+			TestName:     "",
+			TotalRuns:    totalRuns,
+			PassRate:     passRate * 100.0,
+			Timeout:      info.Timeout,
+			FirstSeenDay: earliest,
+		})
+	}
+	for key, s := range agg {
+		// Skip per-test candidates for any package that is handled via wildcard aggregation
+		if _, hasWildcard := wildcardPkgs[s.Package]; hasWildcard {
+			continue
+		}
+		info, ok := flakeTests[key]
+		if !ok {
+			// Support wildcard package entries in the flake-shake gate where name is omitted.
+			// Treat a gate entry with empty name as a wildcard that matches all tests in that package.
+			if wi, wok := flakeTests[keyFor(s.Package, "")]; wok {
+				info = wi
+			} else {
+				continue
+			}
+		}
+		if s.TotalRuns < minRuns {
+			reasons[key] = fmt.Sprintf("insufficient runs: %d < %d", s.TotalRuns, minRuns)
+			continue
+		}
+		failureRate := 0.0
+		if s.TotalRuns > 0 {
+			failureRate = float64(s.Failures) / float64(s.TotalRuns)
+		}
+		if failureRate > maxFailureRate {
+			reasons[key] = fmt.Sprintf("failure rate %.4f exceeds max %.4f", failureRate, maxFailureRate)
+			continue
+		}
+		if requireClean24h && s.LastFailureAt != nil {
+			if time.Since(*s.LastFailureAt) < 24*time.Hour {
+				reasons[key] = "failure within last 24h"
+				continue
+			}
+		}
+		if s.FirstSeenDay == "" {
+			reasons[key] = "no age information"
+			continue
+		}
+		firstDay, _ := time.Parse("2006-01-02", s.FirstSeenDay)
+		daysInGate := int(now.Sub(firstDay).Hours()/24) + 1
+		if daysInGate < minAgeDays {
+			reasons[key] = fmt.Sprintf("min age %dd not met (have %dd)", minAgeDays, daysInGate)
+			continue
+		}
+		passRate := 0.0
+		if s.TotalRuns > 0 {
+			passRate = float64(s.Passes) / float64(s.TotalRuns)
+		}
+		candidates = append(candidates, promoteCandidate{
+			Package:      s.Package,
+			TestName:     s.TestName,
+			TotalRuns:    s.TotalRuns,
+			PassRate:     passRate * 100.0,
+			Timeout:      info.Timeout,
+			FirstSeenDay: s.FirstSeenDay,
+		})
+	}
+	return candidates, reasons
+}
+
+func computeUpdatedConfig(cfg acceptanceYAML, gateID string, candidates []promoteCandidate) acceptanceYAML {
+	updated := cfg
+	flakeIdx := indexOfGate(&updated, gateID)
+	if flakeIdx < 0 {
+		fmt.Fprintf(os.Stderr, "gate %s not found when updating\n", gateID)
+		os.Exit(1)
+	}
+	promoteKeys := map[string]promoteCandidate{}
+	for _, c := range candidates {
+		promoteKeys[keyFor(c.Package, c.TestName)] = c
+	}
+	newFlakeTests := make([]testEntry, 0, len(updated.Gates[flakeIdx].Tests))
+	for _, t := range updated.Gates[flakeIdx].Tests {
+		k := keyFor(t.Package, t.Name)
+		if _, ok := promoteKeys[k]; !ok {
+			newFlakeTests = append(newFlakeTests, t)
+		}
+	}
+	updated.Gates[flakeIdx].Tests = newFlakeTests
+	return updated
+}
+
+func buildNoCandidatesSummary(agg map[string]*aggStats, flakeTests map[string]testInfo, minAgeDays int, requireClean24h bool) string {
+	earliest := ""
+	totalRuns := 0
+	totalPass := 0
+	totalFail := 0
+	daySet := map[string]struct{}{}
+	for key, s := range agg {
+		if _, ok := flakeTests[key]; !ok {
+			continue
+		}
+		totalRuns += s.TotalRuns
+		totalPass += s.Passes
+		totalFail += s.Failures
+		if earliest == "" || (s.FirstSeenDay != "" && s.FirstSeenDay < earliest) {
+			earliest = s.FirstSeenDay
+		}
+		for _, d := range s.DaysObserved {
+			daySet[d] = struct{}{}
+		}
+	}
+	daysObserved := len(daySet)
+	return fmt.Sprintf(
+		"No promotion candidates. Reason: min_age_days=%d; earliest_observation=%s; days_observed=%d; require_clean_24h=%t; total_runs=%d; passes=%d; failures=%d.",
+		minAgeDays, earliest, daysObserved, requireClean24h, totalRuns, totalPass, totalFail,
+	)
+}
+
+// HTTP helper context
+type apiCtx struct {
+	client *http.Client
+	token  string
+}
+
+func (c *apiCtx) getJSON(u string, v interface{}) error {
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Circle-Token", c.token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GET %s: status %d body=%s", u, resp.StatusCode, string(body))
+	}
+	dec := json.NewDecoder(resp.Body)
+	return dec.Decode(v)
+}
+
+func (c *apiCtx) getBytes(u string) ([]byte, error) {
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Circle-Token", c.token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GET %s: status %d body=%s", u, resp.StatusCode, string(body))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// collectReports scans CircleCI pipelines for the given GitHub repo/branch,
+// locates the specified workflow and report job, and downloads/merges the
+// daily-summary.json artifacts into a map keyed by date (YYYY-MM-DD).
+// Only runs created at or after 'since' are considered. When multiple
+// summaries exist for the same day, totals are summed and test lists merged.
+func collectReports(ctx *apiCtx, org, repo, branch, workflowName, reportJobName string, since time.Time, verbose bool) (map[string]DailySummary, error) {
+	dailyByDay := map[string]DailySummary{}
+
+	basePipelines := fmt.Sprintf("https://circleci.com/api/v2/project/gh/%s/%s/pipeline?branch=%s", url.PathEscape(org), url.PathEscape(repo), url.QueryEscape(branch))
+	pageURL := basePipelines
+
+	for {
+		pl, nextToken, err := getPipelinesPage(ctx, pageURL)
+		if err != nil {
+			return nil, err
+		}
+		if verbose {
+			logger.Printf("Scanning pipelines page: %s", pageURL)
+		}
+
+		stop, err := processPipelines(ctx, pl, org, repo, workflowName, reportJobName, since, verbose, dailyByDay)
+		if err != nil {
+			return nil, err
+		}
+		if stop {
+			break
+		}
+		if nextToken == "" {
+			break
+		}
+		pageURL = basePipelines + "&page-token=" + url.QueryEscape(nextToken)
+	}
+	return dailyByDay, nil
+}
+
+// getPipelinesPage fetches a page of pipelines and returns the list along with the next page token.
+func getPipelinesPage(ctx *apiCtx, pageURL string) (pipelineList, string, error) {
+	var pl pipelineList
+	if err := ctx.getJSON(pageURL, &pl); err != nil {
+		return pipelineList{}, "", err
+	}
+	return pl, pl.NextPageToken, nil
+}
+
+// processPipelines iterates pipelines, filters by date/window, and merges daily summaries.
+// It returns stop=true when it encounters pipelines older than the provided 'since' time.
+func processPipelines(ctx *apiCtx, pl pipelineList, org, repo, workflowName, reportJobName string, since time.Time, verbose bool, dailyByDay map[string]DailySummary) (bool, error) {
+	for _, p := range pl.Items {
+		if verbose {
+			logger.Printf("  pipeline %s created_at=%s", p.ID, p.CreatedAt.Format(time.RFC3339))
+		}
+		if p.CreatedAt.Before(since) {
+			return true, nil
+		}
+
+		wfl, err := listWorkflows(ctx, p.ID)
+		if err != nil {
+			return false, err
+		}
+		for _, w := range wfl.Items {
+			if w.Name != workflowName {
+				continue
+			}
+			jl, err := listJobs(ctx, w.ID)
+			if err != nil {
+				return false, err
+			}
+			for _, j := range jl.Items {
+				if j.Name != reportJobName {
+					continue
+				}
+				al, err := listArtifacts(ctx, org, repo, j.JobNumber, verbose)
+				if err != nil {
+					return false, err
+				}
+				dailyURL := findDailySummaryArtifactURL(al)
+				if dailyURL == "" {
+					continue
+				}
+				if err := loadAndMergeDailySummary(ctx, dailyURL, dailyByDay, verbose); err != nil {
+					return false, err
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func listWorkflows(ctx *apiCtx, pipelineID string) (workflowList, error) {
+	wfURL := fmt.Sprintf("https://circleci.com/api/v2/pipeline/%s/workflow", pipelineID)
+	var wfl workflowList
+	if err := ctx.getJSON(wfURL, &wfl); err != nil {
+		return workflowList{}, err
+	}
+	return wfl, nil
+}
+
+func listJobs(ctx *apiCtx, workflowID string) (jobList, error) {
+	jobsURL := fmt.Sprintf("https://circleci.com/api/v2/workflow/%s/job", workflowID)
+	var jl jobList
+	if err := ctx.getJSON(jobsURL, &jl); err != nil {
+		return jobList{}, err
+	}
+	return jl, nil
+}
+
+func listArtifacts(ctx *apiCtx, org, repo string, jobNumber int, verbose bool) (artifactsList, error) {
+	artsURL := fmt.Sprintf("https://circleci.com/api/v2/project/gh/%s/%s/%d/artifacts", url.PathEscape(org), url.PathEscape(repo), jobNumber)
+	var al artifactsList
+	if err := ctx.getJSON(artsURL, &al); err != nil {
+		return artifactsList{}, err
+	}
+	if verbose {
+		logger.Printf("    job %d artifacts: %d", jobNumber, len(al.Items))
+		for _, a := range al.Items {
+			logger.Printf("      - %s", a.Path)
+		}
+	}
+	return al, nil
+}
+
+func findDailySummaryArtifactURL(al artifactsList) string {
+	for _, a := range al.Items {
+		// Accept any artifact path that ends with the filename, regardless of destination prefix
+		if strings.HasSuffix(a.Path, "daily-summary.json") {
+			return a.URL
+		}
+	}
+	return ""
+}
+
+func loadAndMergeDailySummary(ctx *apiCtx, dailyURL string, dailyByDay map[string]DailySummary, verbose bool) error {
+	data, err := ctx.getBytes(dailyURL)
+	if err != nil {
+		return err
+	}
+	var ds DailySummary
+	if json.Unmarshal(data, &ds) != nil || ds.Date == "" {
+		return nil
+	}
+	if prev, seen := dailyByDay[ds.Date]; !seen {
+		dailyByDay[ds.Date] = ds
+		if verbose {
+			logger.Printf("    loaded daily summary for %s (runs=%d iterations=%d)", ds.Date, ds.TotalRuns, ds.Iterations)
+		}
+		return nil
+	} else {
+		merged := prev
+		merged.TotalRuns += ds.TotalRuns
+		merged.Iterations += ds.Iterations
+		merged.StableTests = append(merged.StableTests, ds.StableTests...)
+		merged.UnstableTests = append(merged.UnstableTests, ds.UnstableTests...)
+		dailyByDay[ds.Date] = merged
+		if verbose {
+			logger.Printf("    merged another run for %s (+runs=%d +iters=%d) now runs=%d iters=%d", ds.Date, ds.TotalRuns, ds.Iterations, merged.TotalRuns, merged.Iterations)
+		}
+		return nil
+	}
+}
+
+// aggregate reduces per-day test summaries into a single map keyed by test,
+// summing runs/passes/failures and tracking which days each test appeared.
+// It also computes first/last seen day boundaries for each test.
+func aggregate(daily map[string]DailySummary) map[string]*aggStats {
+	result := map[string]*aggStats{}
+	// Collect all days
+	days := make([]string, 0, len(daily))
+	for d := range daily {
+		days = append(days, d)
+	}
+	sort.Strings(days)
+
+	for _, day := range days {
+		if ds, ok := daily[day]; ok {
+			for _, t := range ds.StableTests {
+				k := keyFor(t.Package, t.TestName)
+				s := ensureAgg(result, k, t.Package, t.TestName, day)
+				s.TotalRuns += t.TotalRuns
+				s.Passes += t.TotalRuns
+			}
+			for _, t := range ds.UnstableTests {
+				k := keyFor(t.Package, t.TestName)
+				s := ensureAgg(result, k, t.Package, t.TestName, day)
+				s.TotalRuns += t.TotalRuns
+				s.Passes += t.Passes
+				s.Failures += t.Failures
+				approx := parseDayEnd(day)
+				if s.LastFailureAt == nil || approx.After(*s.LastFailureAt) {
+					s.LastFailureAt = &approx
+				}
+			}
+		}
+	}
+	return result
+}
+
+// ensureAgg returns the aggregated stats bucket for the given test key, creating it
+// if it does not exist. It also records the provided day in DaysObserved (without
+// duplicates) and updates FirstSeenDay/LastSeenDay bounds accordingly.
+func ensureAgg(m map[string]*aggStats, key, pkg, name, day string) *aggStats {
+	s, ok := m[key]
+	if !ok {
+		s = &aggStats{Package: pkg, TestName: name, DaysObserved: []string{}, FirstSeenDay: day, LastSeenDay: day}
+		m[key] = s
+	}
+	// Append day if new
+	found := false
+	for _, d := range s.DaysObserved {
+		if d == day {
+			found = true
+			break
+		}
+	}
+	if !found {
+		s.DaysObserved = append(s.DaysObserved, day)
+		if s.FirstSeenDay == "" || day < s.FirstSeenDay {
+			s.FirstSeenDay = day
+		}
+		if s.LastSeenDay == "" || day > s.LastSeenDay {
+			s.LastSeenDay = day
+		}
+	}
+	return s
+}
+
+// parseDayEnd returns the exclusive end-of-day bound for the given date
+// (YYYY-MM-DD) in UTC. This is the start of the next day, suitable for
+// half-open intervals: [start, end).
+func parseDayEnd(day string) time.Time {
+	t, err := time.Parse("2006-01-02", day)
+	if err != nil {
+		return time.Now().UTC()
+	}
+	return t.UTC().Add(24 * time.Hour)
+}
+
+func keyFor(pkg, name string) string {
+	return pkg + "::" + strings.TrimSpace(name)
+}
+
+func readAcceptanceYAML(path string) (acceptanceYAML, error) {
+	var acc acceptanceYAML
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return acc, err
+	}
+	if err := yaml.Unmarshal(data, &acc); err != nil {
+		return acc, err
+	}
+	if len(acc.Gates) == 0 {
+		return acc, errors.New("no gates found")
+	}
+	return acc, nil
+}
+
+func findGate(acc *acceptanceYAML, id string) *gateYAML {
+	for i, gate := range acc.Gates {
+		if gate.ID == id {
+			return &acc.Gates[i]
+		}
+	}
+	return nil
+}
+
+func indexOfGate(acc *acceptanceYAML, id string) int {
+	for i := range acc.Gates {
+		if acc.Gates[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func writeJSON(path string, v interface{}) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func writeYAML(path string, v interface{}) error {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+	// Normalize line endings
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	return os.WriteFile(path, data, 0o644)
+}
+
+// updateFlakeShakeGateOnly updates only the flake-shake gate tests list in the original YAML bytes,
+// preserving all comments and formatting elsewhere. It removes any test entries matching promoteKeys.
+func updateFlakeShakeGateOnly(original []byte, gateID string, promoteKeys map[string]promoteCandidate) ([]byte, error) {
+	if len(original) == 0 {
+		// Fallback to structured marshal if original missing (should not happen in CI)
+		return yaml.Marshal(nil)
+	}
+	lines := strings.Split(string(original), "\n")
+	var out []string
+	inGates := false
+	inFlake := false
+	indentGate := ""
+	indentTests := ""
+	// simple state machine: copy all lines except tests under flake-shake that match promoteKeys
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		// Detect top-level 'gates:'
+		if strings.HasPrefix(trimmed, "gates:") {
+			inGates = true
+			out = append(out, line)
+			continue
+		}
+		if inGates && strings.HasPrefix(trimmed, "- id:") {
+			// Entering a gate block
+			// Determine indentation
+			indentGate = line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+			// Gate id value
+			id := strings.TrimSpace(strings.TrimPrefix(trimmed, "- id:"))
+			id = strings.Trim(id, "\"')")
+			inFlake = (id == gateID)
+			out = append(out, line)
+			continue
+		}
+		if !inFlake {
+			out = append(out, line)
+			continue
+		}
+		// Within flake-shake gate only
+		if strings.HasPrefix(strings.TrimSpace(line), "tests:") && indentTests == "" {
+			// Capture tests indent from next line if present
+			out = append(out, line)
+			// From here, filter list items until we leave tests list (deduce by indentation decrease or new key at gate level)
+			pos := i + 1
+			for ; pos < len(lines); pos++ {
+				cur := lines[pos]
+				curTrim := strings.TrimSpace(cur)
+				if curTrim == "" {
+					out = append(out, cur)
+					continue
+				}
+				// end of this gate block if next key aligns to indentGate and not list item
+				if !strings.HasPrefix(cur, indentGate+"  ") || strings.HasPrefix(strings.TrimSpace(cur), "- id:") {
+					// set i so that outer loop reprocesses this line next
+					i = pos - 1
+					break
+				}
+				// If this is a list item under tests: starts with indentGate + two spaces + two more (tests indent) + '- '
+				// We can't rely on exact spaces; detect package line to gather block
+				if strings.HasPrefix(strings.TrimSpace(cur), "- package:") {
+					// start of a test block; buffer until next '- package:' or gate-level boundary
+					block := []string{cur}
+					pkg := strings.TrimSpace(strings.TrimPrefix(curTrim, "- package:"))
+					name := ""
+					j := pos + 1
+					for ; j < len(lines); j++ {
+						nt := strings.TrimSpace(lines[j])
+						if nt == "" {
+							block = append(block, lines[j])
+							continue
+						}
+						// next test or end of tests
+						if strings.HasPrefix(nt, "- package:") || (!strings.HasPrefix(lines[j], indentGate+"  ")) {
+							j--
+							break
+						}
+						block = append(block, lines[j])
+						if strings.HasPrefix(nt, "name:") {
+							name = strings.TrimSpace(strings.TrimPrefix(nt, "name:"))
+						}
+					}
+					// Decide keep or drop
+					k := keyFor(pkg, name)
+					if _, toPromote := promoteKeys[k]; !toPromote {
+						out = append(out, block...)
+					}
+					pos = j
+					continue
+				}
+				// Non-test line under tests; keep
+				out = append(out, cur)
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+	return []byte(strings.Join(out, "\n")), nil
+}

--- a/op-acceptance-tests/cmd/flake-shake-promoter/main_test.go
+++ b/op-acceptance-tests/cmd/flake-shake-promoter/main_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"reflect"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestKeyFor(t *testing.T) {
+	if got := keyFor("pkg/a", ""); got != "pkg/a::" {
+		t.Fatalf("empty name => got %q", got)
+	}
+	if got := keyFor("pkg/a", "  TestFoo  "); got != "pkg/a::TestFoo" {
+		t.Fatalf("trim => got %q", got)
+	}
+}
+
+func TestParseDayEnd(t *testing.T) {
+	end := parseDayEnd("2025-01-02")
+	want := time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)
+	if !end.Equal(want) {
+		t.Fatalf("end != start-of-next-day: got %v want %v", end, want)
+	}
+}
+
+func TestEnsureAggAndAggregate(t *testing.T) {
+	// ensureAgg behavior
+	m := map[string]*aggStats{}
+	s := ensureAgg(m, "pkg::T1", "pkg", "T1", "2025-01-01")
+	if s.FirstSeenDay != "2025-01-01" || s.LastSeenDay != "2025-01-01" {
+		t.Fatalf("first/last not set")
+	}
+	s2 := ensureAgg(m, "pkg::T1", "pkg", "T1", "2025-01-02")
+	if s2 != s {
+		t.Fatalf("ensureAgg did not return same pointer for same key")
+	}
+	if !slices.Contains(s.DaysObserved, "2025-01-01") || !slices.Contains(s.DaysObserved, "2025-01-02") {
+		t.Fatalf("days observed missing: %v", s.DaysObserved)
+	}
+
+	// aggregate behavior across days
+	day1 := DailySummary{Date: "2025-01-01"}
+	day1.UnstableTests = append(day1.UnstableTests, struct {
+		TestName  string  `json:"test_name"`
+		Package   string  `json:"package"`
+		TotalRuns int     `json:"total_runs"`
+		Passes    int     `json:"passes"`
+		Failures  int     `json:"failures"`
+		PassRate  float64 `json:"pass_rate"`
+	}{TestName: "T1", Package: "pkg", TotalRuns: 10, Passes: 10, Failures: 0})
+
+	day2 := DailySummary{Date: "2025-01-02"}
+	day2.UnstableTests = append(day2.UnstableTests, struct {
+		TestName  string  `json:"test_name"`
+		Package   string  `json:"package"`
+		TotalRuns int     `json:"total_runs"`
+		Passes    int     `json:"passes"`
+		Failures  int     `json:"failures"`
+		PassRate  float64 `json:"pass_rate"`
+	}{TestName: "T1", Package: "pkg", TotalRuns: 5, Passes: 4, Failures: 1})
+
+	agg := aggregate(map[string]DailySummary{
+		day1.Date: day1,
+		day2.Date: day2,
+	})
+	a := agg["pkg::T1"]
+	if a == nil || a.TotalRuns != 15 || a.Passes != 14 || a.Failures != 1 {
+		t.Fatalf("bad aggregate: %+v", a)
+	}
+	// DaysObserved should be sorted and include both
+	wantDays := []string{"2025-01-01", "2025-01-02"}
+	gotDays := append([]string(nil), a.DaysObserved...)
+	sort.Strings(gotDays)
+	if !reflect.DeepEqual(gotDays, wantDays) {
+		t.Fatalf("days mismatch: got %v want %v", gotDays, wantDays)
+	}
+}
+
+func TestSelectPromotionCandidates(t *testing.T) {
+	now := time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)
+	flake := map[string]testInfo{"pkg::T1": {Timeout: "1m"}}
+	agg := map[string]*aggStats{
+		"pkg::T1": {
+			Package:      "pkg",
+			TestName:     "T1",
+			TotalRuns:    100,
+			Passes:       100,
+			Failures:     0,
+			FirstSeenDay: "2025-01-01",
+			DaysObserved: []string{"2025-01-01", "2025-01-02"},
+		},
+	}
+	cands, reasons := selectPromotionCandidates(agg, flake, 50, 0.01, true, 3, now)
+	if len(reasons) != 0 {
+		t.Fatalf("unexpected reasons: %v", reasons)
+	}
+	if len(cands) != 1 || cands[0].Package != "pkg" || cands[0].TestName != "T1" {
+		t.Fatalf("unexpected candidates: %+v", cands)
+	}
+}
+
+func TestComputeUpdatedConfig(t *testing.T) {
+	cfg := acceptanceYAML{Gates: []gateYAML{{ID: "flake-shake", Tests: []testEntry{{Package: "pkg", Name: "T1"}, {Package: "pkg", Name: "T2"}}}}}
+	cands := []promoteCandidate{{Package: "pkg", TestName: "T1"}}
+	updated := computeUpdatedConfig(cfg, "flake-shake", cands)
+	tests := updated.Gates[0].Tests
+	if len(tests) != 1 || tests[0].Name != "T2" {
+		t.Fatalf("expected only T2 to remain, got %+v", tests)
+	}
+}

--- a/op-acceptance-tests/cmd/main.go
+++ b/op-acceptance-tests/cmd/main.go
@@ -298,6 +298,11 @@ func runOpAcceptor(ctx context.Context, tracer trace.Tracer, config AcceptorConf
 		args = append(args, "--allow-skips")
 	}
 
+	// Exclude quarantined tests by default in all runs except when explicitly running the flake-shake gate
+	if config.Gate != "flake-shake" {
+		args = append(args, "--exclude-gates", "flake-shake")
+	}
+
 	acceptorCmd := exec.CommandContext(ctx, config.Acceptor, args...)
 	acceptorCmd.Env = env
 	acceptorCmd.Stdout = os.Stdout

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -95,6 +95,8 @@ acceptance-test devnet="" gate="base":
         CMD_ARGS=(
             "$BINARY_PATH"
             "--testdir" "{{REPO_ROOT}}/op-acceptance-tests/..."
+            "--validators" "./acceptance-tests.yaml"
+            "--exclude-gates" "flake-shake"
             "--allow-skips"
             "--timeout" "90m"
             "--default-timeout" "10m"
@@ -146,6 +148,7 @@ acceptance-test-docker devnet="simple" gate="base":
         --testdir "/go/src/github.com/ethereum-optimism/optimism" \
         --gate {{gate}} \
         --validators /acceptance-tests.yaml \
+        $( [[ "{{gate}}" != "flake-shake" ]] && echo --exclude-gates flake-shake ) \
         --log.level debug
 
 
@@ -153,3 +156,23 @@ acceptance-test-docker devnet="simple" gate="base":
 clean:
     kurtosis clean --all
     rm -rf tests/interop/loadtest/artifacts
+
+
+# Build, vet, lint and test Go code in ./cmd
+cmd-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    cd {{REPO_ROOT}}/op-acceptance-tests
+
+    echo "Downloading Go modules..."
+    go mod download
+
+    echo "Building ./cmd/..."
+    go build ./cmd/...
+
+    echo "Running go vet on ./cmd/..."
+    go vet ./cmd/...
+
+    echo "Running unit tests for ./cmd/..."
+    go test -v ./cmd/...

--- a/op-acceptance-tests/scripts/ci_flake_shake_calc_iterations.sh
+++ b/op-acceptance-tests/scripts/ci_flake_shake_calc_iterations.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci_flake_shake_calc_iterations.sh
+#
+# Purpose:
+#   Compute the number of iterations each CircleCI parallel worker should run
+#   and export FLAKE_SHAKE_ITERATIONS and FLAKE_SHAKE_WORKER_ID into $BASH_ENV.
+#
+# Usage:
+#   ci_flake_shake_calc_iterations.sh <TOTAL_ITER> [WORKERS] [WORKER_ID]
+#
+# Arguments:
+#   TOTAL_ITER (required): total iterations across all workers.
+#   WORKERS    (optional): number of parallel workers (defaults to $CIRCLE_NODE_TOTAL or 1).
+#   WORKER_ID  (optional): 1-based worker id (defaults to $((CIRCLE_NODE_INDEX+1)) or 1).
+#
+# Notes:
+#   - Remainder iterations are distributed one-by-one to the first N workers.
+
+TOTAL_ITER=${1:?TOTAL_ITER is required}
+WORKERS=${2:-${CIRCLE_NODE_TOTAL:-1}}
+WORKER_ID=${3:-$((${CIRCLE_NODE_INDEX:-0} + 1))}
+
+ITER_PER_WORKER=$(( TOTAL_ITER / WORKERS ))
+REMAINDER=$(( TOTAL_ITER % WORKERS ))
+
+# Distribute the remainder fairly: the first $REMAINDER workers get one extra iteration
+if [ "$WORKER_ID" -le "$REMAINDER" ] && [ "$REMAINDER" -ne 0 ]; then
+  ITER_COUNT=$(( ITER_PER_WORKER + 1 ))
+else
+  ITER_COUNT=$ITER_PER_WORKER
+fi
+
+echo "Worker $WORKER_ID running $ITER_COUNT of $TOTAL_ITER iterations"
+if [ -n "${BASH_ENV:-}" ]; then
+  echo "export FLAKE_SHAKE_ITERATIONS=$ITER_COUNT" >> "$BASH_ENV"
+  echo "export FLAKE_SHAKE_WORKER_ID=$WORKER_ID" >> "$BASH_ENV"
+fi
+
+exit 0
+
+

--- a/op-acceptance-tests/scripts/ci_flake_shake_generate_summary.sh
+++ b/op-acceptance-tests/scripts/ci_flake_shake_generate_summary.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci_flake_shake_generate_summary.sh
+#
+# Purpose:
+#   Used in CI by the flake-shake report job to transform the aggregated
+#   flake-shake report (JSON) into two derivative artifacts:
+#     1) daily-summary.json   – compact daily snapshot for downstream tooling
+#     2) promotion-ready.json – list of tests with 100% pass rate (promotion candidates)
+#
+# Usage: ci_flake_shake_generate_summary.sh [REPORT_JSON] [OUT_DIR]
+#   $1 REPORT_JSON (optional) – path to flake-shake aggregated report JSON
+#       Default: final-report/flake-shake-report.json
+#   $2 OUT_DIR (optional) – directory where outputs will be written
+#       Default: final-report
+#
+# Side-effects (env):
+#   Exports UNSTABLE_COUNT into $BASH_ENV for later CI steps (if available).
+#
+# Requirements:
+#   - jq must be available in PATH
+#
+# Notes:
+#   - This script is intentionally simple and idempotent; it does not mutate
+#     the input report and only writes to OUT_DIR.
+
+REPORT_JSON=${1:-final-report/flake-shake-report.json}
+OUT_DIR=${2:-final-report}
+
+if [ ! -f "$REPORT_JSON" ]; then
+  echo "ERROR: Report not found at $REPORT_JSON" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Print a short human-readable summary to the job logs
+echo "=== Flake-Shake Results ==="
+STABLE=$(jq '[.tests[] | select(.recommendation == "STABLE")] | length' "$REPORT_JSON")
+UNSTABLE=$(jq '[.tests[] | select(.recommendation == "UNSTABLE")] | length' "$REPORT_JSON")
+echo "✅ STABLE: $STABLE tests"
+echo "⚠️ UNSTABLE: $UNSTABLE tests"
+if [ "$UNSTABLE" -gt 0 ]; then
+  echo "Unstable tests:"
+  jq -r '.tests[] | select(.recommendation == "UNSTABLE") | "  - \(.test_name) (\(.pass_rate)%)"' "$REPORT_JSON"
+fi
+
+# Write daily summary JSON (compact per-day snapshot)
+jq '{date, gate, total_runs, iterations,
+     totals: {
+       stable: ([.tests[] | select(.recommendation=="STABLE")] | length),
+       unstable: ([.tests[] | select(.recommendation=="UNSTABLE")] | length)
+     },
+     stable_tests: [
+       .tests[] | select(.recommendation=="STABLE") |
+       {test_name, package, total_runs, pass_rate}
+     ],
+     unstable_tests: [
+       .tests[] | select(.recommendation=="UNSTABLE") |
+       {test_name, package, total_runs, passes, failures, pass_rate}
+     ]
+   }' "$REPORT_JSON" > "$OUT_DIR/daily-summary.json"
+
+# Write promotion readiness (100% pass) JSON
+jq '{ready: [.tests[] | select(.recommendation=="STABLE") | {test_name, package, total_runs, pass_rate, avg_duration, min_duration, max_duration}]}' "$REPORT_JSON" > "$OUT_DIR/promotion-ready.json"
+
+# Export UNSTABLE_COUNT for later CI steps (if BASH_ENV is present)
+if [ -n "${BASH_ENV:-}" ]; then
+  echo "export UNSTABLE_COUNT=$UNSTABLE" >> "$BASH_ENV"
+fi
+
+echo "Wrote: $OUT_DIR/daily-summary.json, $OUT_DIR/promotion-ready.json"
+

--- a/op-acceptance-tests/scripts/ci_flake_shake_prepare_slack.sh
+++ b/op-acceptance-tests/scripts/ci_flake_shake_prepare_slack.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci_flake_shake_prepare_slack.sh
+#
+# Purpose:
+#   Used in CI by the flake-shake promote job to parse the promoter output
+#   (`promotion-ready.json`) and prepare environment variables consumed by the
+#   Slack orb step.
+#
+# Inputs (positional):
+#   $1 PROMO_JSON – path to the promoter output `promotion-ready.json`.
+#       Default: ./final-promotion/promotion-ready.json
+#
+# Outputs (env):
+#   Exports into $BASH_ENV (for subsequent steps):
+#     - SLACK_BLOCKS_PAYLOAD: compact JSON array of Slack Block Kit blocks for the message body
+#
+# Requirements:
+#   - jq must be available in PATH
+#
+# Block count constraints:
+#   Slack allows max 50 blocks per message. Our layout uses:
+#     - 3 header/link/divider blocks
+#     - 4 blocks per candidate (2 sections + 1 context + 1 divider)
+#     - +1 optional overflow notice block
+#   This caps candidates at 11; if more, we add a final notice linking to the job.
+
+PROMO_JSON=${1:-./final-promotion/promotion-ready.json}
+
+SLACK_BLOCKS="[]"
+if [ -f "$PROMO_JSON" ]; then
+  # Build Block Kit blocks (header + link + divider + per-candidate sections)
+  SLACK_BLOCKS=$(jq -c \
+    --arg url "${CIRCLE_BUILD_URL:-}" \
+    --slurpfile meta "${PROMO_JSON%/*}/metadata.json" '
+    def name_or_pkg(t): (if ((t.test_name|tostring)|length) == 0 then "(package)" else t.test_name end);
+    def testblocks(t): [
+      {"type":"section","fields":[
+        {"type":"mrkdwn","text":"*Test:*\n\(name_or_pkg(t))"},
+        {"type":"mrkdwn","text":"*Package:*\n\(t.package)"}
+      ]},
+      {"type":"section","fields":[
+        {"type":"mrkdwn","text":"*Runs:*\n\(t.total_runs)"},
+        {"type":"mrkdwn","text":"*Pass Rate:*\n\((t.pass_rate|tostring))%"}
+      ]},
+      {"type":"context","elements":[{"type":"mrkdwn","text": t.package }]},
+      {"type":"divider"}
+    ];
+    . as $root |
+    ($meta | if length>0 then .[0] else {} end) as $meta |
+    ($meta.date // "") as $date |
+    ($meta.gate // "flake-shake") as $gate |
+    ($meta.pr_url // "") as $pr_url |
+    ( if (($meta.flake_gate_tests // 0) == 0) then
+        [
+          {"type":"header","text":{"type":"plain_text","text":":partywizard: Acceptance Tests: Flake-Shake — Gate Empty"}},
+          {"type":"section","text":{"type":"mrkdwn","text":"No tests in flake-shake gate; nothing to promote. Artifacts: <\($url)|CircleCI Job>"}}
+        ]
+      elif ($root.candidates|length) == 0 then
+        [
+          {"type":"header","text":{"type":"plain_text","text":":partywizard: Acceptance Tests: No Flake-Shake Promotion Candidates — \(if $date != "" then $date else (now|strftime("%Y-%m-%d")) end)"}},
+          {"type":"section","text":{"type":"mrkdwn","text":"No promotions today. Artifacts: <\($url)|CircleCI Job>"}}
+        ]
+      else
+        (
+          [
+            {"type":"header","text":{"type":"plain_text","text":":partywizard: Acceptance Tests: Flake-Shake Promotion Candidates (\($root.candidates|length)) — \(if $date != "" then $date else (now|strftime("%Y-%m-%d")) end)"}},
+            {"type":"section","text":{"type":"mrkdwn","text": (if $pr_url != "" then "PR: <\($pr_url)|Open PR>  •  Artifacts: <\($url)|CircleCI Job>" else "Artifacts: <\($url)|CircleCI Job>" end) }},
+            {"type":"divider"}
+          ]
+        )
+        + ( ($root.candidates[:11] | map(testblocks(.)) | add) )
+        + ( if ($root.candidates|length) > 11 then
+              [ {"type":"section","text":{"type":"mrkdwn","text":"Too many tests; see the report: <\($url)|CircleCI Job>"}} ]
+            else [] end )
+      end )
+  ' "$PROMO_JSON")
+fi
+
+echo "export SLACK_BLOCKS_PAYLOAD='$SLACK_BLOCKS'" >> "$BASH_ENV"
+
+echo "Prepared Slack env: blocks generated"
+
+echo "[debug] SLACK_BLOCKS: $SLACK_BLOCKS"

--- a/op-acceptance-tests/tests/base/dummy_flaky_test.go
+++ b/op-acceptance-tests/tests/base/dummy_flaky_test.go
@@ -1,0 +1,27 @@
+package base
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+)
+
+var dummyLogs = []string{
+	"rpc error: code = DeadlineExceeded desc = context deadline exceeded while waiting for L2 block",
+	"assertion failed: expected balance to increase after funding, but it did not",
+	"unexpected revert: contract call failed with error 'insufficient funds for gas * price + value'",
+}
+
+// This test only exists to be flaky, and is used to test the flake-shake system.
+func TestDummyFlakyTest(gt *testing.T) {
+	t := devtest.SerialT(gt)
+
+	t.Log("This test is flaky to test the flake-shake system")
+
+	if rand.Float64() < 0.05 {
+		// provide a dummy log, from a pool of three messages
+		t.Log(dummyLogs[rand.Intn(len(dummyLogs))])
+		t.Fail()
+	}
+}


### PR DESCRIPTION
## Description
Adds semi-automated promotions to our FlakeShake system, by:
- Reviewing the flake-shake results for promotion candidates
- Creating a PR for the promotion-ready tests
- Notifying us of this on Slack

<img width="614" height="568" alt="Screenshot 2025-10-04 at 19 33 28" src="https://github.com/user-attachments/assets/21c76667-c773-4ae3-88a6-8466aadd344d" />

Example PR it created: https://github.com/ethereum-optimism/optimism/pull/17723

## Testing
Manually via CI triggers. Most recent run: [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/102778/workflows/51139705-100e-438d-87cb-0fd272dcbe47)