### PR TITLE
op-acceptance-tests: test that unsafe chain is stalled when ReqResSync is disabled

### DIFF
--- a/op-acceptance-tests/tests/depreqres/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/depreqres_test.go
@@ -51,6 +51,6 @@ func TestUnsafeChainStalling_DisabledReqRespSync(gt *testing.T) {
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
-	l.Info("Confirm that the unsafe chain for L2CLB is stalled, since L2 batcher is stopped, even though ELSync is enabled on L2CLB")
+	l.Info("Confirm that the unsafe chain for L2CLB is stalled")
 	sys.L2CLB.NotAdvanced(types.LocalUnsafe, 10)
 }

--- a/op-acceptance-tests/tests/depreqres/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/depreqres_test.go
@@ -1,0 +1,56 @@
+package depreqres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestUnsafeChainStalling_DisabledReqRespSync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNode(t)
+	require := t.Require()
+	l := t.Logger()
+
+	l.Info("Confirm that the CL nodes are progressing the unsafe chain")
+	target := uint64(10)
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, target, 30),
+		sys.L2CLB.AdvancedFn(types.LocalUnsafe, target, 30),
+	)
+
+	l.Info("Stop the L2 batcher")
+	sys.L2Batcher.Stop()
+
+	l.Info("Disconnect L2CL from L2CLB, and vice versa")
+	sys.L2CLB.DisconnectPeer(sys.L2CL)
+	sys.L2CL.DisconnectPeer(sys.L2CLB)
+
+	ssA_before := sys.L2CL.SyncStatus()
+	ssB_before := sys.L2CLB.SyncStatus()
+
+	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
+	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
+
+	time.Sleep(20 * time.Second)
+
+	ssA_after := sys.L2CL.SyncStatus()
+	ssB_after := sys.L2CLB.SyncStatus()
+
+	l.Info("L2CL status after delay", "unsafeL2", ssA_after.UnsafeL2.ID(), "safeL2", ssA_after.SafeL2.ID())
+	l.Info("L2CLB status after delay", "unsafeL2", ssB_after.UnsafeL2.ID(), "safeL2", ssB_after.SafeL2.ID())
+
+	require.Greater(ssA_after.UnsafeL2.Number, ssA_before.UnsafeL2.Number, "unsafe chain for L2CL should have advanced")
+	require.Equal(ssB_after.UnsafeL2.Number, ssB_before.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
+
+	l.Info("Re-connect L2CL to L2CLB")
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2CL.ConnectPeer(sys.L2CLB)
+
+	l.Info("Confirm that the unsafe chain for L2CLB is stalled, since L2 batcher is stopped, even though ELSync is enabled on L2CLB")
+	sys.L2CLB.NotAdvanced(types.LocalUnsafe, 10)
+}

--- a/op-acceptance-tests/tests/depreqres/init_test.go
+++ b/op-acceptance-tests/tests/depreqres/init_test.go
@@ -1,0 +1,17 @@
+package depreqres
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		presets.WithSafeDBEnabled(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithReqRespSyncDisabled(),
+	)
+}

--- a/op-acceptance-tests/tests/depreqres/init_test.go
+++ b/op-acceptance-tests/tests/depreqres/init_test.go
@@ -10,7 +10,6 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSingleChainMultiNode(),
 		presets.WithExecutionLayerSyncOnVerifiers(),
-		presets.WithSafeDBEnabled(),
 		presets.WithCompatibleTypes(compat.SysGo),
 		presets.WithReqRespSyncDisabled(),
 	)

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -164,6 +164,29 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 	}
 }
 
+func (cl *L2CLNode) ReachedNodeFn(lvl types.SafetyLevel, cl2 *L2CLNode, attempts int) CheckFunc {
+	return func() error {
+		logger := cl.log.With("id", cl.inner.ID(), "chain", cl.ChainID(), "label", lvl)
+		logger.Info("Expecting " + cl.inner.ID().String() + " to reach " + lvl.String() + " same as " + cl2.inner.ID().String())
+		return retry.Do0(cl.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+			func() error {
+				head := cl.HeadBlockRef(lvl)
+
+				head2 := cl2.HeadBlockRef(lvl)
+				if head.Number == head2.Number {
+					logger.Info("Chain advanced as expected", "target", head.Number)
+					return nil
+				}
+				logger.Info("Chain sync status", "cl", head.Number, "cl2", head2.Number)
+				return fmt.Errorf("expected head to advance: %s", lvl)
+			})
+	}
+}
+
+func (cl *L2CLNode) ReachedNode(lvl types.SafetyLevel, cl2 *L2CLNode, attempts int) {
+	cl.require.NoError(cl.ReachedNodeFn(lvl, cl2, attempts)())
+}
+
 // ReachedFn returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) ReachedFn(lvl types.SafetyLevel, target uint64, attempts int) CheckFunc {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -164,29 +164,6 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 	}
 }
 
-func (cl *L2CLNode) ReachedNodeFn(lvl types.SafetyLevel, cl2 *L2CLNode, attempts int) CheckFunc {
-	return func() error {
-		logger := cl.log.With("id", cl.inner.ID(), "chain", cl.ChainID(), "label", lvl)
-		logger.Info("Expecting " + cl.inner.ID().String() + " to reach " + lvl.String() + " same as " + cl2.inner.ID().String())
-		return retry.Do0(cl.ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
-			func() error {
-				head := cl.HeadBlockRef(lvl)
-
-				head2 := cl2.HeadBlockRef(lvl)
-				if head.Number == head2.Number {
-					logger.Info("Chain advanced as expected", "target", head.Number)
-					return nil
-				}
-				logger.Info("Chain sync status", "cl", head.Number, "cl2", head2.Number)
-				return fmt.Errorf("expected head to advance: %s", lvl)
-			})
-	}
-}
-
-func (cl *L2CLNode) ReachedNode(lvl types.SafetyLevel, cl2 *L2CLNode, attempts int) {
-	cl.require.NoError(cl.ReachedNodeFn(lvl, cl2, attempts)())
-}
-
 // ReachedFn returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) ReachedFn(lvl types.SafetyLevel, target uint64, attempts int) CheckFunc {

--- a/op-devstack/presets/cl_config.go
+++ b/op-devstack/presets/cl_config.go
@@ -31,3 +31,11 @@ func WithSafeDBEnabled() stack.CommonOption {
 				cfg.SafeDBPath = p.TempDir()
 			})))
 }
+
+func WithReqRespSyncDisabled() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithGlobalL2CLOption(sysgo.L2CLOptionFn(
+			func(_ devtest.P, id stack.L2CLNodeID, cfg *sysgo.L2CLConfig) {
+				cfg.EnableReqRespSync = false
+			})))
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -27,6 +27,9 @@ type L2CLConfig struct {
 
 	IsSequencer  bool
 	IndexingMode bool
+
+	// EnableReqRespSync is the flag to enable/disable req-resp sync.
+	EnableReqRespSync bool
 }
 
 func L2CLSequencer() L2CLOption {
@@ -48,6 +51,7 @@ func DefaultL2CLConfig() *L2CLConfig {
 		SafeDBPath:        "",
 		IsSequencer:       false,
 		IndexingMode:      false,
+		EnableReqRespSync: true,
 	}
 }
 

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -241,6 +241,9 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			}
 		}
 
+		// Set the req-resp sync flag as per config
+		p2pConfig.EnableReqRespSync = cfg.EnableReqRespSync
+
 		// Get the L2 engine address from the EL node (which can be a regular EL node or a SyncTesterEL)
 		l2EngineAddr := l2EL.EngineRPC()
 


### PR DESCRIPTION
This PR is adding an acceptance test, which visualizes the current state of `syncing` within the `op-node` if we disable `ReqResSync` p2p protocol (which to be explicit we should not do, before we address the resulting behavior - i.e. the stalling of the `unsafe` chain)

In future PR we should amend the test when modifying the behavior.