### PR TITLE
chore: remove unused CrossL2Inbox ABI loader

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -28,9 +28,6 @@ var delayedWETH []byte
 //go:embed abi/SystemConfig.json
 var systemConfig []byte
 
-//go:embed abi/CrossL2Inbox.json
-var crossL2Inbox []byte
-
 func LoadDisputeGameFactoryABI() *abi.ABI {
 	return loadABI(disputeGameFactory)
 }
@@ -52,10 +49,6 @@ func LoadDelayedWETHABI() *abi.ABI {
 
 func LoadSystemConfigABI() *abi.ABI {
 	return loadABI(systemConfig)
-}
-
-func LoadCrossL2InboxABI() *abi.ABI {
-	return loadABI(crossL2Inbox)
 }
 
 func loadABI(json []byte) *abi.ABI {


### PR DESCRIPTION
- Delete dead CrossL2Inbox embed and accessor from snapshots ABI loader
- Confirm snapshots package remains healthy via go test ./packages/contracts-bedrock/snapshots