### PR TITLE
fix(op-deployer): avoid embedded artifacts recompilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,7 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: Build contracts
-          command: forge build <<parameters.build_args>>
+          command: just forge-build <<parameters.build_args>>
           environment:
             FOUNDRY_PROFILE: <<parameters.profile>>
           working_directory: packages/contracts-bedrock
@@ -572,7 +572,7 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: Build Kontrol summary files
-          command: forge build ./test/kontrol/proofs
+          command: just forge-build ./test/kontrol/proofs
           working_directory: packages/contracts-bedrock
       - notify-failures-on-develop
 

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -10,7 +10,12 @@ build-contracts:
 
 copy-contract-artifacts:
     rm -f ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz
-    tar -cvzf ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz -C ../packages/contracts-bedrock/forge-artifacts --exclude="*.t.sol" .
+    tar -cvzf ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz \
+        -C ../packages/contracts-bedrock \
+        --exclude="*.t.sol" \
+        --exclude="book/" \
+        --exclude="snapshots/" \
+        .
 
 _LDFLAGSSTRING := "'" + trim(
     "-X main.GitCommit=" + GITCOMMIT + " " + \

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -9,13 +9,13 @@ build-contracts:
   just ../packages/contracts-bedrock/forge-build
 
 copy-contract-artifacts:
-    rm -f ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz
-    tar -cvzf ./pkg/deployer/artifacts/forge-artifacts/artifacts.tgz \
-        -C ../packages/contracts-bedrock \
-        --exclude="*.t.sol" \
-        --exclude="book/" \
-        --exclude="snapshots/" \
-        .
+    #!/bin/bash
+    set -euo pipefail
+
+    rm -f ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst
+    go run ./pkg/deployer/artifacts/cmd/mktar \
+        -base ../packages/contracts-bedrock \
+        -out ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst
 
 _LDFLAGSSTRING := "'" + trim(
     "-X main.GitCommit=" + GITCOMMIT + " " + \

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -15,7 +15,8 @@ copy-contract-artifacts:
     rm -f ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst
     go run ./pkg/deployer/artifacts/cmd/mktar \
         -base ../packages/contracts-bedrock \
-        -out ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst
+        -out ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst \
+        --exclude="*.t.sol"
 
 _LDFLAGSSTRING := "'" + trim(
     "-X main.GitCommit=" + GITCOMMIT + " " + \

--- a/op-deployer/pkg/deployer/artifacts/cmd/mktar/main.go
+++ b/op-deployer/pkg/deployer/artifacts/cmd/mktar/main.go
@@ -6,22 +6,39 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
 )
 
+type multiFlag []string
+
+func (m *multiFlag) String() string {
+	return strings.Join(*m, ",")
+}
+
+func (m *multiFlag) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
 var (
 	baseDir = flag.String("base", "", "directory to archive")
 	outFile = flag.String("out", "", "path to output tzst")
+	exclude multiFlag
 )
+
+func init() {
+	flag.Var(&exclude, "exclude", "glob pattern to exclude (can be specified multiple times)")
+}
 
 // mktar creates a zstd-compressed tarball of the given base directory.
 // It excludes certain directories and files that are not needed for the
-// forge client.
+// forge client. Additional exclusions can be specified via --exclude.
 //
-// Usage: mktar -base DIR -out FILE
+// Usage: mktar -base DIR -out FILE [--exclude pattern]...
 //
 // Example: mktar -base ../packages/contracts-bedrock -out ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst
 //
@@ -147,6 +164,13 @@ func shouldExclude(rel string, d os.DirEntry) bool {
 
 	rel = filepath.ToSlash(rel)
 
+	for _, pattern := range exclude {
+		pattern = filepath.ToSlash(pattern)
+		if matchPattern(pattern, rel) {
+			return true
+		}
+	}
+
 	if strings.HasPrefix(rel, "book/") || rel == "book" {
 		return true
 	}
@@ -161,6 +185,25 @@ func shouldExclude(rel string, d os.DirEntry) bool {
 	}
 
 	return false
+}
+
+func matchPattern(pattern, rel string) bool {
+	matched, err := path.Match(pattern, rel)
+	if err != nil {
+		log.Fatalf("invalid --exclude pattern %q: %v", pattern, err)
+	}
+	if matched {
+		return true
+	}
+
+	if !strings.HasSuffix(pattern, "/") {
+		pattern = pattern + "/"
+	}
+	matched, err = path.Match(pattern+"*", rel+"/")
+	if err != nil {
+		log.Fatalf("invalid --exclude pattern %q: %v", pattern, err)
+	}
+	return matched
 }
 
 func linkTarget(path string, info os.FileInfo) string {

--- a/op-deployer/pkg/deployer/artifacts/cmd/mktar/main.go
+++ b/op-deployer/pkg/deployer/artifacts/cmd/mktar/main.go
@@ -17,6 +17,17 @@ var (
 	outFile = flag.String("out", "", "path to output tzst")
 )
 
+// mktar creates a zstd-compressed tarball of the given base directory.
+// It excludes certain directories and files that are not needed for the
+// forge client.
+//
+// Usage: mktar -base DIR -out FILE
+//
+// Example: mktar -base ../packages/contracts-bedrock -out ./pkg/deployer/artifacts/forge-artifacts/artifacts.tzst
+//
+// The output file will be a zstd-compressed tarball of the given base directory.
+// Do not confuse this script with the ops/publish-artifacts.sh script, which is
+// used to publish the tarball to GCS.
 func main() {
 	flag.Parse()
 

--- a/op-deployer/pkg/deployer/artifacts/cmd/mktar/main.go
+++ b/op-deployer/pkg/deployer/artifacts/cmd/mktar/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"archive/tar"
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+var (
+	baseDir = flag.String("base", "", "directory to archive")
+	outFile = flag.String("out", "", "path to output tzst")
+)
+
+func main() {
+	flag.Parse()
+
+	if *baseDir == "" || *outFile == "" {
+		log.Fatalf("usage: mktar -base DIR -out FILE")
+	}
+
+	absBase, err := filepath.Abs(*baseDir)
+	if err != nil {
+		log.Fatalf("resolve base: %v", err)
+	}
+
+	info, err := os.Stat(absBase)
+	if err != nil {
+		log.Fatalf("stat base: %v", err)
+	}
+	if !info.IsDir() {
+		log.Fatalf("base must be a directory: %s", absBase)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outFile), 0o755); err != nil {
+		log.Fatalf("create output directory: %v", err)
+	}
+
+	f, err := os.Create(*outFile)
+	if err != nil {
+		log.Fatalf("create output file: %v", err)
+	}
+	defer f.Close()
+
+	gz, err := zstd.NewWriter(f, zstd.WithEncoderLevel(zstd.SpeedBestCompression))
+	if err != nil {
+		log.Fatalf("create zstd writer: %v", err)
+	}
+	defer func() {
+		if err := gz.Close(); err != nil {
+			log.Fatalf("close zstd: %v", err)
+		}
+	}()
+
+	tw := tar.NewWriter(gz)
+	defer func() {
+		if err := tw.Close(); err != nil {
+			log.Fatalf("close tar: %v", err)
+		}
+	}()
+
+	if err := filepath.WalkDir(absBase, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		rel, err := filepath.Rel(absBase, path)
+		if err != nil {
+			return err
+		}
+
+		if shouldExclude(rel, d) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if rel == "." {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		hdr, err := tar.FileInfoHeader(info, linkTarget(path, info))
+		if err != nil {
+			return err
+		}
+
+		hdr.Name = filepath.ToSlash(rel)
+		hdr.ModTime = info.ModTime()
+		hdr.AccessTime = info.ModTime()
+
+		// tar-like progress output
+		log.Printf("a %s", hdr.Name)
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		if info.Mode().IsRegular() {
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			if _, err := io.Copy(tw, file); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		log.Fatalf("walk: %v", err)
+	}
+
+	if err := tw.Flush(); err != nil {
+		log.Fatalf("flush tar: %v", err)
+	}
+
+	log.Printf("wrote %s", *outFile)
+}
+
+func shouldExclude(rel string, d os.DirEntry) bool {
+	if rel == "." {
+		return false
+	}
+
+	rel = filepath.ToSlash(rel)
+
+	if strings.HasPrefix(rel, "book/") || rel == "book" {
+		return true
+	}
+	if strings.HasPrefix(rel, "snapshots/") || rel == "snapshots" {
+		return true
+	}
+
+	if !d.IsDir() {
+		if strings.HasSuffix(d.Name(), ".t.sol") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func linkTarget(path string, info os.FileInfo) string {
+	if info.Mode()&os.ModeSymlink == 0 {
+		return ""
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		log.Fatalf("readlink %s: %v", path, err)
+	}
+	return target
+}

--- a/op-deployer/pkg/deployer/artifacts/embedded.go
+++ b/op-deployer/pkg/deployer/artifacts/embedded.go
@@ -2,7 +2,6 @@ package artifacts
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"embed"
 	"fmt"
 	"io"
@@ -19,45 +18,22 @@ import (
 //go:embed forge-artifacts
 var embedDir embed.FS
 
-// Primary filenames for embedded artifacts. Prefer zstd (.tzst); support legacy gzip (.tgz).
+// Primary filename for embedded artifacts using zstd compression (.tzst).
 const embeddedArtifactsZstdShort = "artifacts.tzst"
-const embeddedArtifactsGzip = "artifacts.tgz"
 
 func ExtractEmbedded(destDir string) (foundry.StatDirFs, error) {
-	var (
-		f    io.ReadCloser
-		err  error
-		comp string
-	)
-	// Prefer zstd, fall back to gzip for legacy bundles
-	if rf, openErr := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsZstdShort)); openErr == nil {
-		f = rf
-		comp = "zstd"
-	} else if rf, openErr2 := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsGzip)); openErr2 == nil {
-		f = rf
-		comp = "gzip"
-	} else {
-		return nil, fmt.Errorf("could not open embedded artifacts: tried %q, %q", embeddedArtifactsZstdShort, embeddedArtifactsGzip)
+	f, err := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsZstdShort))
+	if err != nil {
+		return nil, fmt.Errorf("could not open embedded artifacts %q: %w", embeddedArtifactsZstdShort, err)
 	}
 	defer f.Close()
 
-	var reader io.ReadCloser
-	switch comp {
-	case "zstd":
-		zr, zerr := zstd.NewReader(f)
-		if zerr != nil {
-			return nil, fmt.Errorf("could not create zstd reader: %w", zerr)
-		}
-		reader = io.NopCloser(zr)
-		defer zr.Close()
-	default:
-		gzr, gerr := gzip.NewReader(f)
-		if gerr != nil {
-			return nil, fmt.Errorf("could not create gzip reader: %w", gerr)
-		}
-		reader = gzr
-		defer gzr.Close()
+	zr, zerr := zstd.NewReader(f)
+	if zerr != nil {
+		return nil, fmt.Errorf("could not create zstd reader: %w", zerr)
 	}
+	defer zr.Close()
+	reader := io.NopCloser(zr)
 
 	// Untar into a unique subdirectory to avoid collisions with pre-existing paths
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
@@ -88,22 +64,16 @@ func ExtractFromFile(destDir string, tarFilePath string) (foundry.StatDirFs, err
 	}
 	defer f.Close()
 
-	var reader io.ReadCloser
-	if strings.HasSuffix(tarFilePath, ".tar.zst") || strings.HasSuffix(tarFilePath, ".tzst") || strings.HasSuffix(tarFilePath, ".zst") {
-		zr, zerr := zstd.NewReader(f)
-		if zerr != nil {
-			return nil, fmt.Errorf("could not create zstd reader: %w", zerr)
-		}
-		reader = io.NopCloser(zr)
-		defer zr.Close()
-	} else {
-		gzr, gerr := gzip.NewReader(f)
-		if gerr != nil {
-			return nil, fmt.Errorf("could not create gzip reader: %w", gerr)
-		}
-		reader = gzr
-		defer gzr.Close()
+	if !strings.HasSuffix(tarFilePath, ".tzst") {
+		return nil, fmt.Errorf("unsupported file format: expected .tzst file, got %q", tarFilePath)
 	}
+
+	zr, zerr := zstd.NewReader(f)
+	if zerr != nil {
+		return nil, fmt.Errorf("could not create zstd reader: %w", zerr)
+	}
+	defer zr.Close()
+	reader := io.NopCloser(zr)
 
 	// Untar into a unique subdirectory to avoid collisions with pre-existing paths
 	if err := os.MkdirAll(destDir, 0o755); err != nil {

--- a/op-deployer/pkg/deployer/artifacts/embedded.go
+++ b/op-deployer/pkg/deployer/artifacts/embedded.go
@@ -17,7 +17,7 @@ var embedDir embed.FS
 
 const embeddedArtifactsFile = "artifacts.tgz"
 
-func ExtractEmbedded(dir string) (foundry.StatDirFs, error) {
+func ExtractEmbedded(destDir string) (foundry.StatDirFs, error) {
 	f, err := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsFile))
 	if err != nil {
 		return nil, fmt.Errorf("could not open embedded artifacts: %w", err)
@@ -31,9 +31,40 @@ func ExtractEmbedded(dir string) (foundry.StatDirFs, error) {
 	defer gzr.Close()
 
 	tr := tar.NewReader(gzr)
-	if err := ioutil.Untar(dir, tr); err != nil {
+	if err := ioutil.Untar(destDir, tr); err != nil {
 		return nil, fmt.Errorf("failed to untar embedded artifacts: %w", err)
 	}
 
-	return os.DirFS(dir).(foundry.StatDirFs), nil
+	forgeArtifactsDir := filepath.Join(destDir, "forge-artifacts")
+	if _, err := os.Stat(forgeArtifactsDir); err != nil {
+		return nil, fmt.Errorf("forge-artifacts directory not found within embedded artifacts: %w", err)
+	}
+
+	return os.DirFS(forgeArtifactsDir).(foundry.StatDirFs), nil
+}
+
+func ExtractFromFile(destDir string, tarFilePath string) (foundry.StatDirFs, error) {
+	f, err := os.Open(tarFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open tar file: %w", err)
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("could not create gzip reader: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	if err := ioutil.Untar(destDir, tr); err != nil {
+		return nil, fmt.Errorf("failed to untar embedded artifacts: %w", err)
+	}
+
+	forgeArtifactsDir := filepath.Join(destDir, "out")
+	if _, err := os.Stat(forgeArtifactsDir); err != nil {
+		return nil, fmt.Errorf("forge-artifacts directory not found within embedded artifacts: %w", err)
+	}
+
+	return os.DirFS(forgeArtifactsDir).(foundry.StatDirFs), nil
 }

--- a/op-deployer/pkg/deployer/artifacts/embedded.go
+++ b/op-deployer/pkg/deployer/artifacts/embedded.go
@@ -5,8 +5,12 @@ import (
 	"compress/gzip"
 	"embed"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -15,27 +19,61 @@ import (
 //go:embed forge-artifacts
 var embedDir embed.FS
 
-const embeddedArtifactsFile = "artifacts.tgz"
+// Primary filenames for embedded artifacts. Prefer zstd (.tzst); support legacy gzip (.tgz).
+const embeddedArtifactsZstdShort = "artifacts.tzst"
+const embeddedArtifactsGzip = "artifacts.tgz"
 
 func ExtractEmbedded(destDir string) (foundry.StatDirFs, error) {
-	f, err := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsFile))
-	if err != nil {
-		return nil, fmt.Errorf("could not open embedded artifacts: %w", err)
+	var (
+		f    io.ReadCloser
+		err  error
+		comp string
+	)
+	// Prefer zstd, fall back to gzip for legacy bundles
+	if rf, openErr := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsZstdShort)); openErr == nil {
+		f = rf
+		comp = "zstd"
+	} else if rf, openErr2 := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsGzip)); openErr2 == nil {
+		f = rf
+		comp = "gzip"
+	} else {
+		return nil, fmt.Errorf("could not open embedded artifacts: tried %q, %q", embeddedArtifactsZstdShort, embeddedArtifactsGzip)
 	}
 	defer f.Close()
 
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return nil, fmt.Errorf("could not create gzip reader: %w", err)
+	var reader io.ReadCloser
+	switch comp {
+	case "zstd":
+		zr, zerr := zstd.NewReader(f)
+		if zerr != nil {
+			return nil, fmt.Errorf("could not create zstd reader: %w", zerr)
+		}
+		reader = io.NopCloser(zr)
+		defer zr.Close()
+	default:
+		gzr, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return nil, fmt.Errorf("could not create gzip reader: %w", gerr)
+		}
+		reader = gzr
+		defer gzr.Close()
 	}
-	defer gzr.Close()
 
-	tr := tar.NewReader(gzr)
-	if err := ioutil.Untar(destDir, tr); err != nil {
+	// Untar into a unique subdirectory to avoid collisions with pre-existing paths
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to ensure destination dir: %w", err)
+	}
+	untarPath, err := os.MkdirTemp(destDir, "bundle-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp untar dir: %w", err)
+	}
+
+	tr := tar.NewReader(reader)
+	if err := ioutil.Untar(untarPath, tr); err != nil {
 		return nil, fmt.Errorf("failed to untar embedded artifacts: %w", err)
 	}
 
-	forgeArtifactsDir := filepath.Join(destDir, "forge-artifacts")
+	forgeArtifactsDir := filepath.Join(untarPath, "forge-artifacts")
 	if _, err := os.Stat(forgeArtifactsDir); err != nil {
 		return nil, fmt.Errorf("forge-artifacts directory not found within embedded artifacts: %w", err)
 	}
@@ -50,18 +88,38 @@ func ExtractFromFile(destDir string, tarFilePath string) (foundry.StatDirFs, err
 	}
 	defer f.Close()
 
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return nil, fmt.Errorf("could not create gzip reader: %w", err)
+	var reader io.ReadCloser
+	if strings.HasSuffix(tarFilePath, ".tar.zst") || strings.HasSuffix(tarFilePath, ".tzst") || strings.HasSuffix(tarFilePath, ".zst") {
+		zr, zerr := zstd.NewReader(f)
+		if zerr != nil {
+			return nil, fmt.Errorf("could not create zstd reader: %w", zerr)
+		}
+		reader = io.NopCloser(zr)
+		defer zr.Close()
+	} else {
+		gzr, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return nil, fmt.Errorf("could not create gzip reader: %w", gerr)
+		}
+		reader = gzr
+		defer gzr.Close()
 	}
-	defer gzr.Close()
 
-	tr := tar.NewReader(gzr)
-	if err := ioutil.Untar(destDir, tr); err != nil {
+	// Untar into a unique subdirectory to avoid collisions with pre-existing paths
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to ensure destination dir: %w", err)
+	}
+	untarPath, err := os.MkdirTemp(destDir, "bundle-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp untar dir: %w", err)
+	}
+
+	tr := tar.NewReader(reader)
+	if err := ioutil.Untar(untarPath, tr); err != nil {
 		return nil, fmt.Errorf("failed to untar embedded artifacts: %w", err)
 	}
 
-	forgeArtifactsDir := filepath.Join(destDir, "out")
+	forgeArtifactsDir := filepath.Join(untarPath, "out")
 	if _, err := os.Stat(forgeArtifactsDir); err != nil {
 		return nil, fmt.Errorf("forge-artifacts directory not found within embedded artifacts: %w", err)
 	}

--- a/op-deployer/pkg/deployer/forge/client.go
+++ b/op-deployer/pkg/deployer/forge/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -27,6 +28,22 @@ type Client struct {
 	Stdout io.Writer
 	Stderr io.Writer
 	Wd     string
+}
+
+func NewStandardClient(workdir string) (*Client, error) {
+	forgeBinary, err := NewStandardBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize forge binary: %w", err)
+	}
+	if err := forgeBinary.Ensure(context.Background()); err != nil {
+		return nil, fmt.Errorf("failed to ensure forge binary: %w", err)
+	}
+
+	forgeClient := NewClient(forgeBinary)
+	forgeClient.Wd = filepath.Dir(workdir)
+	fmt.Printf("Forge client working directory: %s\n", forgeClient.Wd)
+
+	return forgeClient, nil
 }
 
 func NewClient(binary Binary) *Client {

--- a/op-deployer/pkg/deployer/opcm/superchain_test.go
+++ b/op-deployer/pkg/deployer/opcm/superchain_test.go
@@ -1,9 +1,13 @@
 package opcm
 
 import (
+	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -34,4 +38,28 @@ func TestNewDeploySuperchainScript(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, output)
 	})
+}
+
+func TestNewDeploySuperchainScriptForge(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	embeddedArtifactsFS, err := artifacts.ExtractEmbedded(tmpDir)
+	require.NoError(t, err)
+
+	forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", embeddedArtifactsFS))
+	require.NoError(t, err)
+
+	deploySuperchain := NewDeploySuperchainForgeCaller(forgeClient)
+	output, recompiled, err := deploySuperchain(context.Background(), DeploySuperchainInput{
+		Guardian:                   common.BigToAddress(big.NewInt(1)),
+		ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
+		SuperchainProxyAdminOwner:  common.BigToAddress(big.NewInt(3)),
+		Paused:                     true,
+		RecommendedProtocolVersion: params.ProtocolVersion{1},
+		RequiredProtocolVersion:    params.ProtocolVersion{2},
+	})
+
+	require.NoError(t, err)
+	require.False(t, recompiled)
+	require.NotNil(t, output)
 }

--- a/op-deployer/pkg/deployer/verify/verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/verifier_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,8 +18,32 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
+
+func bootstrapContractAddresses() map[string]common.Address {
+	addrType := reflect.TypeOf(common.Address{})
+	structTypes := []reflect.Type{
+		reflect.TypeOf(opcm.DeploySuperchainOutput{}),
+		reflect.TypeOf(opcm.DeployImplementationsOutput{}),
+	}
+
+	addresses := make(map[string]common.Address)
+	index := int64(1)
+
+	for _, structType := range structTypes {
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			if field.Type == addrType {
+				addresses[field.Name] = common.BigToAddress(big.NewInt(index))
+				index++
+			}
+		}
+	}
+
+	return addresses
+}
 
 func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
 	testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
@@ -50,11 +76,9 @@ func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
 
 	verifier.etherscan = NewEtherscanClient(testAPIKey, fakeServer.URL, rate.NewLimiter(rate.Inf, 1))
 
+	bundle := bootstrapContractAddresses()
+
 	bundleFile := filepath.Join(testCacheDir, "contracts.json")
-	bundle := map[string]common.Address{
-		"SystemConfigProxy":   common.HexToAddress("0x02f909cf91c2134e70a67950b7f27db7c8ee55d6"),
-		"OptimismPortalProxy": common.HexToAddress("0x7bd8879acf1e74547455c7ddc07f5c3f4a3c133d"),
-	}
 	bundleData, err := json.Marshal(bundle)
 	require.NoError(t, err)
 	err = os.WriteFile(bundleFile, bundleData, 0o644)

--- a/op-deployer/pkg/deployer/verify/verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/verifier_test.go
@@ -25,8 +25,8 @@ import (
 func bootstrapContractAddresses() map[string]common.Address {
 	addrType := reflect.TypeOf(common.Address{})
 	structTypes := []reflect.Type{
-		reflect.TypeOf(opcm.DeploySuperchainOutput{}),
-		reflect.TypeOf(opcm.DeployImplementationsOutput{}),
+		reflect.TypeOf((*opcm.DeploySuperchainOutput)(nil)).Elem(),
+		reflect.TypeOf((*opcm.DeployImplementationsOutput)(nil)).Elem(),
 	}
 
 	addresses := make(map[string]common.Address)

--- a/op-deployer/pkg/deployer/verify/verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/verifier_test.go
@@ -1,0 +1,67 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
+	testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+
+	artifactsFS, err := artifacts.ExtractEmbedded(testCacheDir)
+	require.NoError(t, err, "embedded artifacts should be extracted successfully")
+
+	verifier, err := NewVerifier(testAPIKey, 1, artifactsFS, log.New(log.JSONHandler(io.Discard)), nil)
+	require.NoError(t, err, "verifier should be created successfully with embedded artifacts")
+	require.NotNil(t, verifier, "verifier should not be nil")
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.URL.Query().Get("action")
+
+		if action == "getabi" {
+			resp := EtherscanGenericResp{
+				Status:  "1",
+				Message: "OK",
+				Result:  "[]",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer fakeServer.Close()
+
+	verifier.etherscan = NewEtherscanClient(testAPIKey, fakeServer.URL, rate.NewLimiter(rate.Inf, 1))
+
+	bundleFile := filepath.Join(testCacheDir, "contracts.json")
+	bundle := map[string]common.Address{
+		"SystemConfigProxy":   common.HexToAddress("0x02f909cf91c2134e70a67950b7f27db7c8ee55d6"),
+		"OptimismPortalProxy": common.HexToAddress("0x7bd8879acf1e74547455c7ddc07f5c3f4a3c133d"),
+	}
+	bundleData, err := json.Marshal(bundle)
+	require.NoError(t, err)
+	err = os.WriteFile(bundleFile, bundleData, 0o644)
+	require.NoError(t, err)
+
+	err = verifier.verifyContractBundle(context.Background(), bundleFile, "")
+	require.NoError(t, err)
+	require.Equal(t, len(bundle), verifier.numSkipped, "all contracts should be skipped as already verified")
+	require.Equal(t, 0, verifier.numFailed)
+	require.Equal(t, 0, verifier.numVerified)
+}

--- a/op-deployer/pkg/deployer/verify/verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/verifier_test.go
@@ -87,6 +87,8 @@ func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
 	err = verifier.verifyContractBundle(context.Background(), bundleFile, "")
 	require.NoError(t, err)
 	require.Equal(t, len(bundle), verifier.numSkipped, "all contracts should be skipped as already verified")
+	// Ensure we actually have contracts to test with
+	require.Greater(t, len(bundle), 0, "contract bundle is empty")
 	require.Equal(t, 0, verifier.numFailed)
 	require.Equal(t, 0, verifier.numVerified)
 }

--- a/op-deployer/pkg/deployer/verify/verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/verifier_test.go
@@ -39,7 +39,8 @@ func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
 				Result:  "[]",
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(resp)
+			err := json.NewEncoder(w).Encode(resp)
+			require.NoError(t, err)
 			return
 		}
 

--- a/op-service/ioutil/tar.go
+++ b/op-service/ioutil/tar.go
@@ -29,16 +29,19 @@ func Untar(outDir string, tr *tar.Reader) error {
 			if err := os.MkdirAll(dst, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
+			if err := os.Chtimes(dst, hdr.AccessTime, hdr.ModTime); err != nil {
+				return fmt.Errorf("failed to set directory times: %w", err)
+			}
 			continue
 		}
 
-		if err := untarFile(dst, tr); err != nil {
+		if err := untarFile(dst, tr, hdr); err != nil {
 			return fmt.Errorf("failed to untar file: %w", err)
 		}
 	}
 }
 
-func untarFile(dst string, tr *tar.Reader) error {
+func untarFile(dst string, tr *tar.Reader, hdr *tar.Header) error {
 	f, err := os.Create(dst)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
@@ -51,6 +54,9 @@ func untarFile(dst string, tr *tar.Reader) error {
 	}
 	if err := buf.Flush(); err != nil {
 		return fmt.Errorf("failed to flush buffer: %w", err)
+	}
+	if err := os.Chtimes(dst, hdr.AccessTime, hdr.ModTime); err != nil {
+		return fmt.Errorf("failed to set file times: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Right now the artifacts get recompiled every time when using forge. This is an impediment to completing the forge migration.

- Downgrade forge to 1.1.0
- Avoid recompilation
- Custom tar files
- Switch compression method to zstd (10x reduction in filesize)

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
