### PR TITLE
opcm: Run isolated cannon-kona devfeature in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2117,7 +2117,7 @@ workflows:
           dev_features: <<matrix.dev_features>>
           matrix:
             parameters:
-              dev_features: ["main", "OPTIMISM_PORTAL_INTEROP", "CANNON_KONA,DEPLOY_V2_DISPUTE_GAMES"]
+              dev_features: ["main", "OPTIMISM_PORTAL_INTEROP","CANNON_KONA","CANNON_KONA,DEPLOY_V2_DISPUTE_GAMES"]
           # need this requires to ensure that all FFI JSONs exist
           requires:
             - contracts-bedrock-build


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Run an isolated `CANNON_KONA` devfeature flag in CI, since this feature is sequenced before the `DEPLOY_V2_DISPUTE_GAMES` feature.

**Metadata**

Relates to:
- https://github.com/ethereum-optimism/optimism/issues/17285
- https://github.com/ethereum-optimism/optimism/issues/12421
