### PR TITLE
fix(test) exclude foundry VM address from L2ToL2CrossDomainMessenger fuzz test

### DIFF
--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -775,8 +775,12 @@ contract L2ToL2CrossDomainMessenger_RelayMessage_Test is L2ToL2CrossDomainMessen
     )
         external
     {
-        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger
-        vm.assume(_target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER);
+        // Ensure that the target contract is not CrossL2Inbox or L2ToL2CrossDomainMessenger or the
+        // foundry VM
+        vm.assume(
+            _target != Predeploys.CROSS_L2_INBOX && _target != Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER
+                && _target != foundryVMAddress
+        );
 
         // Ensure that the target call is payable if value is sent
         if (_value > 0) assumePayable(_target);
@@ -785,7 +789,6 @@ contract L2ToL2CrossDomainMessenger_RelayMessage_Test is L2ToL2CrossDomainMessen
         vm.mockCallRevert({ callee: _target, msgValue: _value, data: _message, revertData: _revertData });
 
         // Construct the identifier -- using some hardcoded values for the block number, log index,
-
         // and time to avoid stack too deep errors.
         Identifier memory id = Identifier(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, 1, 1, 1, _source);
 


### PR DESCRIPTION
## Problem

During heavy fuzz testing on `L2ToL2CrossDomainMessenger.t.sol` test file, `testFuzz_relayMessage_targetCallFails_reverts` [intermittently failed](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/102599/workflows/855d8349-c419-43f4-a499-e4aac4cbd055/jobs/3926609) when the fuzzer generated `_target = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D` (Foundry's VM address). Calling this address caused Foundry to throw "unknown cheatcode with selector 0x00000000" instead of the expected revert.

## Solution

Exclude `foundryVMAddress` from fuzz inputs using `vm.assume()`, matching the pattern already used in other fuzz tests in this file.