### PR TITLE
fix: correct console.log format string in ManageDrippie script

### DIFF
--- a/packages/contracts-bedrock/scripts/periphery/drippie/ManageDrippie.s.sol
+++ b/packages/contracts-bedrock/scripts/periphery/drippie/ManageDrippie.s.sol
@@ -102,7 +102,7 @@ contract ManageDrippie is Script {
             console.log("%s already active", _name);
         } else {
             // TODO: Better way to handle this?
-            console.log("WARNING: % could not be activated", _name);
+            console.log("WARNING: %s could not be activated", _name);
         }
     }
 }


### PR DESCRIPTION

## Summary
Fixed incorrect format string in `ManageDrippie.s.sol` that was missing the `%s` specifier for proper variable interpolation.
Changed `"WARNING: % could not be activated"` to `"WARNING: %s could not be activated"`

## Impact
- Improves debugging experience by correctly displaying drip names in warning messages