### PR TITLE
fix(op-deployer): correct initial-bond parsing condition in AddGameTypeCLI

### DIFF
--- a/op-deployer/pkg/deployer/manage/add_game_type.go
+++ b/op-deployer/pkg/deployer/manage/add_game_type.go
@@ -151,7 +151,7 @@ func AddGameTypeCLI(cliCtx *cli.Context) error {
 	}
 
 	initialBond, err := cliutil.BigIntFlag(cliCtx, InitialBondFlag.Name)
-	if err != nil {
+	if err == nil {
 		cfg.InitialBond = initialBond
 	} else {
 		return fmt.Errorf("failed to parse initial bond: %w", err)


### PR DESCRIPTION
- Problem: The error handling after parsing the initial-bond flag was inverted. On successful parse, the code returned an error; on parse failure, it assigned the (nil/invalid) value. This caused valid inputs to be rejected and invalid inputs to proceed until failing later in config validation.
- Why fix: The bug breaks normal CLI usage, makes error messages misleading, and can lead to confusing runtime failures. Correct handling ensures valid bonds are accepted, invalid inputs are rejected early with a clear error, and downstream checks behave as intended.