### PR TITLE
op-challenger: Fix op-program executor argument for the l1 config

### DIFF
--- a/op-challenger/game/fault/trace/vm/op_program_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor.go
@@ -73,7 +73,7 @@ func (s *OpProgramServerExecutor) OracleCommand(cfg Config, dataDir string, inpu
 		args = append(args, "--l2.custom")
 	}
 	if cfg.L1GenesisPath != "" {
-		args = append(args, "--l1.config", cfg.L1GenesisPath)
+		args = append(args, "--l1.chainconfig", cfg.L1GenesisPath)
 	}
 	return args, nil
 }

--- a/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/op_program_server_executor_test.go
@@ -61,7 +61,7 @@ func TestOpProgramFillHostCommand(t *testing.T) {
 		require.Equal(t, inputs.L1Head.Hex(), pairs["--l1.head"])
 		require.Equal(t, inputs.L2Claim.Hex(), pairs["--l2.claim"])
 		require.Equal(t, inputs.L2SequenceNumber.String(), pairs["--l2.blocknumber"])
-		require.Equal(t, cfg.L1GenesisPath, pairs["--l1.config"])
+		require.Equal(t, cfg.L1GenesisPath, pairs["--l1.chainconfig"])
 		return pairs
 	}
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The cannon e2e tests in the `develop-fault-proofs` [workflow have been failing](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/102746/workflows/69bc3710-bc42-44e6-afae-179322f78f6f) in CI since the [l1 chain config PR](https://github.com/ethereum-optimism/optimism/pull/17568) was merged last week.  

This PR fixes a misconfiguration in the `op-challenger`'s op-program-host executor: we were passing a misspelled CLI arg for the [new l1 genesis config](https://github.com/ethereum-optimism/optimism/blob/47a1fe1bf04c7cb721a7116eb9db7d3503f5e59b/op-program/host/flags/flags.go#L37-L41). 

**Tests**

We should add a fast e2e test to catch these types of issues pre-merge.  See: https://github.com/ethereum-optimism/optimism/issues/17734.

**Metadata**

Relates to: https://github.com/ethereum-optimism/optimism/issues/17493
