### PR TITLE
op-acceptance-tests: fix test due to geth breakage

### DIFF
--- a/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
+++ b/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
@@ -157,9 +157,7 @@ func runBlockHistoryConsistencyTest(t devtest.T, l2EL *dsl.L2ELNode) {
 	l2Client := l2EL.Escape().EthClient()
 
 	// Get the latest block number
-	latestBlock, err := l2Client.InfoByLabel(t.Ctx(), eth.Unsafe)
-	require.NoError(err)
-	require.Greater(latestBlock.NumberU64(), uint64(1), "Need at least 2 blocks for history test")
+	latestBlock := l2EL.WaitForBlockNumber(2) // Need at least 2 blocks for history test.
 
 	// Get the block history contract code
 	code, err := l2Client.CodeAtHash(t.Ctx(), params.HistoryStorageAddress, latestBlock.Hash())

--- a/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
+++ b/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
@@ -167,7 +167,7 @@ func runBlockHistoryConsistencyTest(t devtest.T, l2EL *dsl.L2ELNode) {
 	require.NotEmpty(code, "Block history contract not deployed")
 
 	// Get the slot containing the parent block hash
-	parentHashSlotNum := (latestBlock.NumberU64() - 1) % (params.HistoryServeWindow - 1)
+	parentHashSlotNum := (latestBlock.NumberU64() - 1) % params.HistoryServeWindow
 
 	// Turn the uint64 into a 32-byte array
 	parentHashSlot := make([]byte, 32)

--- a/op-program/client/l2/fast_canon_test.go
+++ b/op-program/client/l2/fast_canon_test.go
@@ -233,7 +233,7 @@ func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
 		logger, _ := testlog.CaptureLogger(t, log.LvlInfo)
 		miner, backend := test.NewMiner(t, logger, 0)
 		stateOracle := &test.KvStateOracle{T: t, Source: backend.TrieDB().Disk()}
-		numBlocks := uint64(16384) // params.HistoryServeWindow * 2
+		numBlocks := uint64(16384) // params.HistoryServeWindow * 2 + 2
 		for i := uint64(0); i < numBlocks; i++ {
 			miner.Mine(t, nil)
 		}


### PR DESCRIPTION
geth changed the value of params.HistoryServeWindow and it broke the test. https://github.com/ethereum/go-ethereum/pull/32127
