### PR TITLE
op-stack: Interfaced CLI Context

### DIFF
--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 )
 
 // LoadSignerSetup loads a configuration for a Signer to be set up later
-func LoadSignerSetup(ctx *cli.Context, logger log.Logger) (p2p.SignerSetup, error) {
+func LoadSignerSetup(ctx cliiface.Context, logger log.Logger) (p2p.SignerSetup, error) {
 	key := ctx.String(flags.SequencerP2PKeyName)
 	signerCfg := opsigner.ReadCLIConfig(ctx)
 	if key != "" && signerCfg.Enabled() {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
@@ -51,7 +52,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*config.Config, error) {
 		return nil, err
 	}
 
-	depSet, err := NewDependencySetFromCLI(ctx)
+	depSet, err := NewDependencySetFromCLI(ctx, ctx.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*config.Config, error) {
 	return cfg, nil
 }
 
-func NewSupervisorEndpointConfig(ctx *cli.Context) *interop.Config {
+func NewSupervisorEndpointConfig(ctx cliiface.Context) *interop.Config {
 	return &interop.Config{
 		RPCAddr:          ctx.String(flags.InteropRPCAddr.Name),
 		RPCPort:          ctx.Int(flags.InteropRPCPort.Name),
@@ -156,7 +157,7 @@ func NewSupervisorEndpointConfig(ctx *cli.Context) *interop.Config {
 	}
 }
 
-func NewBeaconEndpointConfig(ctx *cli.Context) config.L1BeaconEndpointSetup {
+func NewBeaconEndpointConfig(ctx cliiface.Context) config.L1BeaconEndpointSetup {
 	return &config.L1BeaconEndpointConfig{
 		BeaconAddr:             ctx.String(flags.BeaconAddr.Name),
 		BeaconHeader:           ctx.String(flags.BeaconHeader.Name),
@@ -166,7 +167,7 @@ func NewBeaconEndpointConfig(ctx *cli.Context) config.L1BeaconEndpointSetup {
 	}
 }
 
-func NewL1EndpointConfig(ctx *cli.Context) *config.L1EndpointConfig {
+func NewL1EndpointConfig(ctx cliiface.Context) *config.L1EndpointConfig {
 	return &config.L1EndpointConfig{
 		L1NodeAddr:       ctx.String(flags.L1NodeAddr.Name),
 		L1TrustRPC:       ctx.Bool(flags.L1TrustRPC.Name),
@@ -179,7 +180,7 @@ func NewL1EndpointConfig(ctx *cli.Context) *config.L1EndpointConfig {
 	}
 }
 
-func NewL2EndpointConfig(ctx *cli.Context, logger log.Logger) (*config.L2EndpointConfig, error) {
+func NewL2EndpointConfig(ctx cliiface.Context, logger log.Logger) (*config.L2EndpointConfig, error) {
 	l2Addr := ctx.String(flags.L2EngineAddr.Name)
 	fileName := ctx.String(flags.L2EngineJWTSecret.Name)
 	secret, err := rpc.ObtainJWTSecret(logger, fileName, true)
@@ -194,7 +195,7 @@ func NewL2EndpointConfig(ctx *cli.Context, logger log.Logger) (*config.L2Endpoin
 	}, nil
 }
 
-func NewConfigPersistence(ctx *cli.Context) config.ConfigPersistence {
+func NewConfigPersistence(ctx cliiface.Context) config.ConfigPersistence {
 	stateFile := ctx.String(flags.RPCAdminPersistence.Name)
 	if stateFile == "" {
 		return config.DisabledConfigPersistence{}
@@ -202,7 +203,7 @@ func NewConfigPersistence(ctx *cli.Context) config.ConfigPersistence {
 	return config.NewConfigPersistence(stateFile)
 }
 
-func NewDriverConfig(ctx *cli.Context) *driver.Config {
+func NewDriverConfig(ctx cliiface.Context) *driver.Config {
 	return &driver.Config{
 		VerifierConfDepth:   ctx.Uint64(flags.VerifierL1Confs.Name),
 		SequencerConfDepth:  ctx.Uint64(flags.SequencerL1Confs.Name),
@@ -213,7 +214,7 @@ func NewDriverConfig(ctx *cli.Context) *driver.Config {
 	}
 }
 
-func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, error) {
+func NewRollupConfigFromCLI(log log.Logger, ctx cliiface.Context) (*rollup.Config, error) {
 	network := ctx.String(opflags.NetworkFlagName)
 	rollupConfigPath := ctx.String(opflags.RollupConfigFlagName)
 	if ctx.Bool(flags.BetaExtraNetworks.Name) {
@@ -257,7 +258,7 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	return &rollupConfig, nil
 }
 
-func applyOverrides(ctx *cli.Context, rollupConfig *rollup.Config) {
+func applyOverrides(ctx cliiface.Context, rollupConfig *rollup.Config) {
 	if ctx.IsSet(opflags.CanyonOverrideFlagName) {
 		canyon := ctx.Uint64(opflags.CanyonOverrideFlagName)
 		rollupConfig.CanyonTime = &canyon
@@ -300,7 +301,7 @@ func applyOverrides(ctx *cli.Context, rollupConfig *rollup.Config) {
 	}
 }
 
-func NewL1ChainConfig(chainId *big.Int, ctx *cli.Context, log log.Logger) (*params.ChainConfig, error) {
+func NewL1ChainConfig(chainId *big.Int, ctx cliiface.Context, log log.Logger) (*params.ChainConfig, error) {
 	if chainId == nil {
 		panic("l1 chain id is nil")
 	}
@@ -323,7 +324,7 @@ func NewL1ChainConfig(chainId *big.Int, ctx *cli.Context, log log.Logger) (*para
 	return cf, nil
 }
 
-func NewL1ChainConfigFromCLI(log log.Logger, ctx *cli.Context) (*params.ChainConfig, error) {
+func NewL1ChainConfigFromCLI(log log.Logger, ctx cliiface.Context) (*params.ChainConfig, error) {
 	l1ChainConfigPath := ctx.String(flags.L1ChainConfig.Name)
 	file, err := os.Open(l1ChainConfigPath)
 	if err != nil {
@@ -344,15 +345,15 @@ func NewL1ChainConfigFromCLI(log log.Logger, ctx *cli.Context) (*params.ChainCon
 	return jsonutil.LoadJSONFieldStrict[params.ChainConfig](l1ChainConfigPath, "config")
 }
 
-func NewDependencySetFromCLI(ctx *cli.Context) (depset.DependencySet, error) {
-	if !ctx.IsSet(flags.InteropDependencySet.Name) {
+func NewDependencySetFromCLI(cli cliiface.Context, ctx context.Context) (depset.DependencySet, error) {
+	if !cli.IsSet(flags.InteropDependencySet.Name) {
 		return nil, nil
 	}
-	loader := &depset.JSONDependencySetLoader{Path: ctx.Path(flags.InteropDependencySet.Name)}
-	return loader.LoadDependencySet(ctx.Context)
+	loader := &depset.JSONDependencySetLoader{Path: cli.Path(flags.InteropDependencySet.Name)}
+	return loader.LoadDependencySet(ctx)
 }
 
-func NewSyncConfig(ctx *cli.Context, log log.Logger) (*sync.Config, error) {
+func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 	if ctx.IsSet(flags.L2EngineSyncEnabled.Name) && ctx.IsSet(flags.SyncModeFlag.Name) {
 		return nil, errors.New("cannot set both --l2.engine-sync and --syncmode at the same time")
 	} else if ctx.IsSet(flags.L2EngineSyncEnabled.Name) {

--- a/op-service/cliiface/context.go
+++ b/op-service/cliiface/context.go
@@ -1,0 +1,21 @@
+package cliiface
+
+import (
+	"time"
+)
+
+// Context defines the minimal surface of urfave/cli.Context that our
+// configuration constructors depend on, across services.
+type Context interface {
+	String(name string) string
+	Bool(name string) bool
+	Int(name string) int
+	Uint(name string) uint
+	Uint64(name string) uint64
+	Float64(name string) float64
+	Duration(name string) time.Duration
+	StringSlice(name string) []string
+	IsSet(name string) bool
+	Path(name string) string
+	Generic(name string) any
+}

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -16,6 +16,7 @@ import (
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
 )
 
@@ -263,7 +264,7 @@ func DefaultCLIConfig() CLIConfig {
 	}
 }
 
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	cfg := DefaultCLIConfig()
 	cfg.Level = ctx.Generic(LevelFlagName).(*LevelFlagValue).Level()
 	cfg.Format = ctx.Generic(FormatFlagName).(*FormatFlagValue).FormatType()

--- a/op-service/metrics/cli.go
+++ b/op-service/metrics/cli.go
@@ -6,6 +6,7 @@ import (
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	"github.com/urfave/cli/v2"
 )
 
@@ -74,7 +75,7 @@ func (m CLIConfig) Check() error {
 	return nil
 }
 
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	return CLIConfig{
 		Enabled:    ctx.Bool(EnabledFlagName),
 		ListenAddr: ctx.String(ListenAddrFlagName),

--- a/op-service/oppprof/cli.go
+++ b/op-service/oppprof/cli.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	openum "github.com/ethereum-optimism/optimism/op-service/enum"
 	"github.com/ethereum-optimism/optimism/op-service/flags"
 	"github.com/urfave/cli/v2"
@@ -129,7 +130,7 @@ func (m CLIConfig) Check() error {
 	return nil
 }
 
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	profilePathFlag := ctx.Generic(ProfilePathFlagName).(*flags.PathFlag)
 	return CLIConfig{
 		ListenEnabled:   ctx.Bool(EnabledFlagName),

--- a/op-service/rpc/cli.go
+++ b/op-service/rpc/cli.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	"github.com/urfave/cli/v2"
 )
 
@@ -72,7 +73,7 @@ func (c CLIConfig) Check() error {
 	return nil
 }
 
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	return CLIConfig{
 		ListenAddr:  ctx.String(ListenAddrFlagName),
 		ListenPort:  ctx.Int(PortFlagName),

--- a/op-service/signer/cli.go
+++ b/op-service/signer/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	optls "github.com/ethereum-optimism/optimism/op-service/tls"
 )
 
@@ -70,7 +71,7 @@ func (c CLIConfig) Enabled() bool {
 	return c.Endpoint != "" && c.Address != ""
 }
 
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	var headers = http.Header{}
 	if ctx.StringSlice(HeadersFlagName) != nil {
 		for _, header := range ctx.StringSlice(HeadersFlagName) {
@@ -80,7 +81,6 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 			}
 		}
 	}
-
 	cfg := CLIConfig{
 		Endpoint:  ctx.String(EndpointFlagName),
 		Address:   ctx.String(AddressFlagName),

--- a/op-service/tls/cli.go
+++ b/op-service/tls/cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 )
 
 const (
@@ -101,7 +102,7 @@ func (c CLIConfig) TLSEnabled() bool {
 
 // ReadCLIConfigWithPrefix reads tls cli configs with flag prefix
 // Should be used for client TLS configs when different from server on the same process
-func ReadCLIConfigWithPrefix(ctx *cli.Context, flagPrefix string) CLIConfig {
+func ReadCLIConfigWithPrefix(ctx cliiface.Context, flagPrefix string) CLIConfig {
 	prefixFunc := func(flagName string) string {
 		return strings.Trim(fmt.Sprintf("%s.%s", flagPrefix, flagName), ".")
 	}

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
@@ -352,7 +353,7 @@ func (m CLIConfig) Check() error {
 	return nil
 }
 
-func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	return CLIConfig{
 		L1RPCURL:                   ctx.String(L1RPCFlagName),
 		Mnemonic:                   ctx.String(MnemonicFlagName),


### PR DESCRIPTION
## What
Currently, structures of the op-stack (node, conductor, batcher, etc) rely on a common collection of CLI configurations located throughout the codebase.

Because these configuration functions expected a concrete `urfave/v2` implementation of a `cli.Context`, there was no good way to get *identical* runtime behavior using a different CLI Context provider.

This PR Creates an interface called `cliiface`, in its own package under `op-service`. The interface defines exactly the required API surface area for all users of these common configuration functions.

The *only* change which was required beyond signature updates was that `LoadDependencySet` expected a `ctx.Context`, and interfaces don't support exported internals. However, this function was being called while the original CLI Context was still in scope, so I passed its `Context` into the function now. *ALL* other users of the CLI Context do so over a common API.

Now that we own the definition of the common CLI API used to configure components, we can add shims, wrappers, and alternative implementations. Especially useful in tests and other virtualization environments.

Additionally, the original `urfave/v2` cli.Context naturally satisfies the interface, so all callers can stay the same.

## Tests
- Just auto checks as this is a pure refactor