### PR TITLE
Add make gen-binding

### DIFF
--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -65,3 +65,13 @@ fuzz:
 		"go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzGethSolidity ./opgeth" \
 		"go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzCgo ./opgeth" \
 	| parallel -j 8 {}
+
+ifndef CONTRACT
+gen-binding:
+	$(error CONTRACT is required, usage: make gen-binding CONTRACT=OPContractsManager)
+else
+gen-binding:
+	cd ../packages/contracts-bedrock && just build
+	./scripts/gen-binding.sh $(CONTRACT)
+endif
+.PHONY: gen-binding

--- a/op-e2e/README.md
+++ b/op-e2e/README.md
@@ -39,6 +39,15 @@ make test-ws
 - `op-e2e/opgeth`: integration tests between test-mocks and op-geth execution-engine.
   - also includes upgrade-tests to ensure testing of op-stack Go components around a network upgrade.
 
+### Generating Binding
+
+Bindings for a contract can be generated (or updated) using
+
+```
+make gen-binding CONTRACT=OPContractsManager
+```
+
+
 ### `action`-tests
 
 Action tests are set up in a compositional way:

--- a/op-e2e/scripts/gen-binding.sh
+++ b/op-e2e/scripts/gen-binding.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 CONTRACT_NAME" >&2
+  exit 1
+fi
+
+CONTRACT="$1"
+ARTIFACT_DIR="packages/contracts-bedrock/forge-artifacts/${CONTRACT}.sol"
+ARTIFACT_PATH="${ARTIFACT_DIR}/${CONTRACT}.json"
+
+if [[ ! -f "${ARTIFACT_PATH}" ]]; then
+  echo "error: artifact not found at ${ARTIFACT_PATH}. Run the contracts build first." >&2
+  exit 1
+fi
+
+OUTPUT_BASENAME="$(echo "${CONTRACT}" | tr '[:upper:]' '[:lower:]')"
+OUTPUT_PATH="op-e2e/bindings/${OUTPUT_BASENAME}.go"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+ABI_PATH="${TMPDIR}/${CONTRACT}.abi.json"
+BIN_PATH="${TMPDIR}/${CONTRACT}.bin"
+
+jq '.abi' "${ARTIFACT_PATH}" > "${ABI_PATH}"
+jq -r '.bytecode.object' "${ARTIFACT_PATH}" > "${BIN_PATH}"
+
+abigen --pkg bindings --type "${CONTRACT}" --abi "${ABI_PATH}" --bin "${BIN_PATH}" --out "${OUTPUT_PATH}"
+gofmt -w "${OUTPUT_PATH}"


### PR DESCRIPTION
Adds a new script, and a `make gen-binding` command for generating or updating go bindings for a single contract.
Also includes documentation in the op-e2e README.
