### PR TITLE
sysext: correctly populate address configuration

### DIFF
--- a/devnet-sdk/descriptors/deployment.go
+++ b/devnet-sdk/descriptors/deployment.go
@@ -58,7 +58,6 @@ type Chain struct {
 
 type L2Chain struct {
 	*Chain
-	L1Addresses  AddressMap     `json:"l1_addresses,omitempty"`
 	L1Wallets    WalletMap      `json:"l1_wallets,omitempty"`
 	RollupConfig *rollup.Config `json:"rollup_config"`
 }

--- a/devnet-sdk/shell/env/env_test.go
+++ b/devnet-sdk/shell/env/env_test.go
@@ -138,9 +138,6 @@ func TestGetChain(t *testing.T) {
 							"deployer": common.HexToAddress("0x2345678901234567890123456789012345678901"),
 						},
 					},
-					L1Addresses: descriptors.AddressMap{
-						"deployer": common.HexToAddress("0x2345678901234567890123456789012345678901"),
-					},
 					L1Wallets: descriptors.WalletMap{
 						"deployer": &descriptors.Wallet{
 							Address:    common.HexToAddress("0x2345678901234567890123456789012345678901"),

--- a/devnet-sdk/system/chain.go
+++ b/devnet-sdk/system/chain.go
@@ -224,7 +224,7 @@ func newL2ChainFromDescriptor(d *descriptors.L2Chain) (*l2Chain, error) {
 	// TODO: handle incorrect descriptors better. We could panic here.
 
 	nodes := newNodesFromDescriptor(d.Chain)
-	c := newL2Chain(d.ID, nil, nil, d.Config, AddressMap(d.L1Addresses), AddressMap(d.Addresses), nodes) // Create chain first
+	c := newL2Chain(d.ID, nil, nil, d.Config, AddressMap(d.Addresses), nodes) // Create chain first
 
 	l2Wallets, err := newWalletMapFromDescriptorWalletMap(d.Wallets, c)
 	if err != nil {
@@ -241,23 +241,17 @@ func newL2ChainFromDescriptor(d *descriptors.L2Chain) (*l2Chain, error) {
 	return c, nil
 }
 
-func newL2Chain(chainID string, l1Wallets WalletMap, l2Wallets WalletMap, chainConfig *params.ChainConfig, l1Addresses AddressMap, l2Addresses AddressMap, nodes []Node) *l2Chain {
+func newL2Chain(chainID string, l1Wallets WalletMap, l2Wallets WalletMap, chainConfig *params.ChainConfig, l2Addresses AddressMap, nodes []Node) *l2Chain {
 	chain := &l2Chain{
-		chain:       newChain(chainID, l2Wallets, chainConfig, l2Addresses, nodes),
-		l1Addresses: l1Addresses,
-		l1Wallets:   l1Wallets,
+		chain:     newChain(chainID, l2Wallets, chainConfig, l2Addresses, nodes),
+		l1Wallets: l1Wallets,
 	}
 	return chain
 }
 
 type l2Chain struct {
 	*chain
-	l1Addresses AddressMap
-	l1Wallets   WalletMap
-}
-
-func (c *l2Chain) L1Addresses() AddressMap {
-	return c.l1Addresses
+	l1Wallets WalletMap
 }
 
 func (c *l2Chain) L1Wallets() WalletMap {

--- a/devnet-sdk/system/chain_test.go
+++ b/devnet-sdk/system/chain_test.go
@@ -111,9 +111,6 @@ func TestL2ChainFromDescriptor(t *testing.T) {
 				"user2": common.HexToAddress("0x1234567890123456789012345678901234567891"),
 			},
 		},
-		L1Addresses: descriptors.AddressMap{
-			"user1": common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		},
 		L1Wallets: descriptors.WalletMap{
 			"user1": &descriptors.Wallet{
 				PrivateKey: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",

--- a/devnet-sdk/system/interfaces.go
+++ b/devnet-sdk/system/interfaces.go
@@ -40,8 +40,7 @@ type Chain interface {
 type L2Chain interface {
 	Chain
 
-	// The wallets and addresses below are for use on the L1 chain that this L2Chain instance settles to.
-	L1Addresses() AddressMap
+	// The wallets below are for use on the L1 chain that this L2Chain instance settles to.
 	L1Wallets() WalletMap
 }
 

--- a/devnet-sdk/system/system_test.go
+++ b/devnet-sdk/system/system_test.go
@@ -71,9 +71,6 @@ func TestNewSystemFromEnv(t *testing.T) {
 						"defaultl2": common.HexToAddress("0x456"),
 					},
 				},
-				L1Addresses: descriptors.AddressMap{
-					"defaultl1": common.HexToAddress("0x123"),
-				},
 				L1Wallets: descriptors.WalletMap{
 					"default": &descriptors.Wallet{
 						Address:    common.HexToAddress("0x123"),
@@ -142,9 +139,6 @@ func TestSystemFromDevnet(t *testing.T) {
 								"default": testWallet,
 							},
 						},
-						L1Addresses: descriptors.AddressMap{
-							"defaultl1": common.HexToAddress("0x123"),
-						},
 						L1Wallets: descriptors.WalletMap{
 							"default": testWallet,
 						},
@@ -188,9 +182,6 @@ func TestSystemFromDevnet(t *testing.T) {
 									},
 								},
 							},
-						},
-						L1Addresses: descriptors.AddressMap{
-							"defaultl1": common.HexToAddress("0x123"),
 						},
 						L1Wallets: descriptors.WalletMap{
 							"default": testWallet,

--- a/kurtosis-devnet/pkg/kurtosis/kurtosis.go
+++ b/kurtosis-devnet/pkg/kurtosis/kurtosis.go
@@ -248,7 +248,6 @@ func (d *KurtosisDeployer) GetEnvironmentInfo(ctx context.Context, s *spec.Encla
 		// Add contract addresses if available
 		if deployerData.State != nil && deployerData.State.Deployments != nil {
 			if deployment, ok := deployerData.State.Deployments[chainSpec.NetworkID]; ok {
-				chain.L1Addresses = descriptors.AddressMap(deployment.L1Addresses)
 				chain.Addresses = descriptors.AddressMap(deployment.L2Addresses)
 				chain.Config = deployment.Config
 				chain.RollupConfig = deployment.RollupConfig

--- a/op-devstack/sysext/addrbook.go
+++ b/op-devstack/sysext/addrbook.go
@@ -12,9 +12,9 @@ const (
 	ProtocolVersionsAddressName = "ProtocolVersionsProxy"
 	SuperchainConfigAddressName = "SuperchainConfigProxy"
 
-	SystemConfigAddressName   = "SystemConfigProxy"
-	DisputeGameFactoryName    = "DisputeGameFactoryProxy"
-	L1StandardBridgeProxyName = "L1StandardBridgeProxy"
+	SystemConfigAddressName   = "systemConfigProxy"
+	DisputeGameFactoryName    = "disputeGameFactoryProxy"
+	L1StandardBridgeProxyName = "l1StandardBridgeProxy"
 )
 
 type l1AddressBook struct {
@@ -43,8 +43,7 @@ type l2AddressBook struct {
 	l1StandardBridge   common.Address
 }
 
-func newL2AddressBook(t devtest.T, l1Addresses descriptors.AddressMap) *l2AddressBook {
-	// TODO(#15817) op-devstack: sysext: fix address book
+func newL2AddressBook(l1Addresses descriptors.AddressMap) *l2AddressBook {
 	return &l2AddressBook{
 		systemConfig:       l1Addresses[SystemConfigAddressName],
 		disputeGameFactory: l1Addresses[DisputeGameFactoryName],

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -44,7 +44,7 @@ func (o *Orchestrator) hydrateL2(net *descriptors.L2Chain, system stack.Extensib
 		},
 		ID:           l2ID,
 		RollupConfig: net.RollupConfig,
-		Deployment:   newL2AddressBook(t, net.L1Addresses),
+		Deployment:   newL2AddressBook(net.Addresses),
 		Keys:         o.defineSystemKeys(t, net),
 		Superchain:   system.Superchain(stack.SuperchainID(env.Env.Name)),
 		L1:           l1,


### PR DESCRIPTION
sysext was previously using the L1Address field from the devnet-env.json, which netchef does not use. We remove this field to prevent future confusion and switch to the correct `Address` field.