### PR TITLE
op-deployer: Do not create cache directory on import

### DIFF
--- a/op-deployer/pkg/cli/app.go
+++ b/op-deployer/pkg/cli/app.go
@@ -20,6 +20,12 @@ func NewApp(versionWithMeta string) *cli.App {
 	app.Name = "op-deployer"
 	app.Usage = "Tool to configure and deploy OP Chains."
 	app.Flags = cliapp.ProtectFlags(deployer.GlobalFlags)
+	app.Before = func(context *cli.Context) error {
+		if err := deployer.EnsureDefaultCacheDir(); err != nil {
+			return err
+		}
+		return nil
+	}
 	app.Commands = []*cli.Command{
 		{
 			Name:   "init",

--- a/op-deployer/pkg/cli/app.go
+++ b/op-deployer/pkg/cli/app.go
@@ -21,7 +21,7 @@ func NewApp(versionWithMeta string) *cli.App {
 	app.Usage = "Tool to configure and deploy OP Chains."
 	app.Flags = cliapp.ProtectFlags(deployer.GlobalFlags)
 	app.Before = func(context *cli.Context) error {
-		if err := deployer.EnsureDefaultCacheDir(); err != nil {
+		if err := deployer.CreateCacheDir(context.String(deployer.CacheDirFlagName)); err != nil {
 			return err
 		}
 		return nil

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -48,7 +48,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   EnsureDefaultCacheDir(),
+		Value:   DefaultCacheDir(),
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,

--- a/op-deployer/pkg/deployer/utils.go
+++ b/op-deployer/pkg/deployer/utils.go
@@ -53,8 +53,7 @@ func DefaultCacheDir() string {
 	return cacheDir
 }
 
-func EnsureDefaultCacheDir() error {
-	cacheDir := DefaultCacheDir()
+func CreateCacheDir(cacheDir string) error {
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
 	}

--- a/op-deployer/pkg/deployer/utils.go
+++ b/op-deployer/pkg/deployer/utils.go
@@ -39,7 +39,7 @@ func cwd() string {
 	return dir
 }
 
-func EnsureDefaultCacheDir() string {
+func DefaultCacheDir() string {
 	var cacheDir string
 
 	homeDir, err := os.UserHomeDir()
@@ -50,9 +50,13 @@ func EnsureDefaultCacheDir() string {
 		cacheDir = path.Join(homeDir, ".op-deployer/cache")
 	}
 
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		panic(fmt.Sprintf("failed to create cache directory %s: %v", cacheDir, err))
-	}
-
 	return cacheDir
+}
+
+func EnsureDefaultCacheDir() error {
+	cacheDir := DefaultCacheDir()
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
+	}
+	return nil
 }

--- a/op-deployer/pkg/deployer/utils_test.go
+++ b/op-deployer/pkg/deployer/utils_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestEnsureDefaultCacheDir(t *testing.T) {
-	cacheDir := EnsureDefaultCacheDir()
+	cacheDir := DefaultCacheDir()
 	require.NotNil(t, cacheDir)
 }

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -88,7 +88,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse l1 contracts release locator: %w", err)
 	}
-	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.EnsureDefaultCacheDir())
+	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.DefaultCacheDir())
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}


### PR DESCRIPTION
This was causing things like the `op-node` (which imports `op-deployer` through `op-chain-ops`) to create the directory, which broke on certain cloud setups.