### PR TITLE
fix(circleci): always run contracts-bedrock-build before docker-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2547,6 +2547,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+            - contracts-bedrock-build
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2670,6 +2671,11 @@ workflows:
               only: /^(da-server|cannon|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
             branches:
               ignore: /.*/
+      - contracts-bedrock-build:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       # Standard (medium) cross-platform docker images go here
       - docker-build:
           matrix:
@@ -2704,6 +2710,7 @@ workflows:
             - oplabs-gcr-release
           requires:
             - initialize
+            - contracts-bedrock-build
       # Checks for cross-platform images go here
       - check-cross-platform:
           matrix:
@@ -2895,6 +2902,11 @@ workflows:
       - initialize:
           context:
             - circleci-repo-readonly-authenticated-github-token
+      - contracts-bedrock-build:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - docker-build:
           matrix:
             parameters:
@@ -2922,6 +2934,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+            - contracts-bedrock-build
       - check-cross-platform:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2913,6 +2913,7 @@ workflows:
               docker_name:
                 - op-node
                 - op-batcher
+                - op-deployer
                 - op-faucet
                 - op-program
                 - op-proposer
@@ -2941,6 +2942,7 @@ workflows:
               op_component:
                 - op-node
                 - op-batcher
+                - op-deployer
                 - op-faucet
                 - op-program
                 - op-proposer


### PR DESCRIPTION
Contract artifacts are expected to be embedded within the op-deployer binary, so we need to ensure that the `contracts-bedrock-build` job runs before any op-deployer `docker-build` job.

Since `contracts-bedrock-build` job includes steps to copy the contract artifacts to the correct op-deployer dir and persist them to the circleci workspace, subsequent `docker-build` jobs should have all the files they need.