### PR TITLE
fix(op-node): respect sequencer.max-safe-lag stall in onForkchoiceUpdate

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -458,17 +458,27 @@ func (d *Sequencer) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 		d.latest = BuildingState{}
 	}
 	if x.UnsafeL2Head.Number > d.latestHead.Number {
-		d.nextActionOK = true
-		now := d.timeNow()
-		blockTime := time.Duration(d.rollupCfg.BlockTime) * time.Second
-		payloadTime := time.Unix(int64(x.UnsafeL2Head.Time+d.rollupCfg.BlockTime), 0)
-		remainingTime := payloadTime.Sub(now)
-		if remainingTime > blockTime {
-			// if we have too much time, then wait before starting the build
-			d.nextAction = payloadTime.Add(-blockTime)
+		// Only enable next action if safe lag is within threshold
+		lagged := false
+		if maxSafeLag := d.maxSafeLag.Load(); maxSafeLag > 0 && x.SafeL2Head.Number+maxSafeLag <= x.UnsafeL2Head.Number {
+			lagged = true
+		}
+		if !lagged {
+			d.nextActionOK = true
+			now := d.timeNow()
+			blockTime := time.Duration(d.rollupCfg.BlockTime) * time.Second
+			payloadTime := time.Unix(int64(x.UnsafeL2Head.Time+d.rollupCfg.BlockTime), 0)
+			remainingTime := payloadTime.Sub(now)
+			if remainingTime > blockTime {
+				// if we have too much time, then wait before starting the build
+				d.nextAction = payloadTime.Add(-blockTime)
+			} else {
+				// otherwise start instantly
+				d.nextAction = now
+			}
 		} else {
-			// otherwise start instantly
-			d.nextAction = now
+			// keep stall active; do not change nextAction
+			d.nextActionOK = false
 		}
 	}
 	d.setLatestHead(x.UnsafeL2Head)


### PR DESCRIPTION
The sequencer’s safe-lag stall was ineffective. In onForkchoiceUpdate, when the safe head lagged beyond sequencer.max-safe-lag, we set nextActionOK=false to stall, but later unconditionally set nextActionOK=true when the unsafe head advanced, overwriting the stall. This contradicted the documented intent to “delay creating new blocks until the safe lag is below the threshold.”

This change ensures we only set nextActionOK=true and schedule the next action when the safe-to-unsafe lag is within the configured threshold. If the lag exceeds the threshold, we keep the stall active and do not modify nextAction. This aligns behavior with the flag’s semantics, prevents unnecessary block production when the chain is lagging, and is a minimal