### PR TITLE
Make contracts tests conditional to the contracts building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2351,6 +2351,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+            - contracts-bedrock-build
           check_changed_patterns: contracts-bedrock,op-node
       - contracts-bedrock-tests:
           # PreimageOracle test is slow, run it separately to unblock CI.
@@ -2360,6 +2361,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+            - contracts-bedrock-build
       - contracts-bedrock-tests:
           # Heavily fuzz any fuzz tests within added or modified test files.
           name: contracts-bedrock-tests-heavy-fuzz-modified
@@ -2370,6 +2372,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+            - contracts-bedrock-build
       - contracts-bedrock-coverage:
           # Generate coverage reports.
           name: contracts-bedrock-coverage <<matrix.dev_features>>
@@ -2396,6 +2399,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+            - contracts-bedrock-build
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build

--- a/packages/contracts-bedrock/src/BreakCI.sol
+++ b/packages/contracts-bedrock/src/BreakCI.sol
@@ -1,0 +1,1 @@
+contract BreakCI {

--- a/packages/contracts-bedrock/src/BreakCI.sol
+++ b/packages/contracts-bedrock/src/BreakCI.sol
@@ -1,1 +1,0 @@
-contract BreakCI {


### PR DESCRIPTION
**Description**

Include `requires: contracts-bedrock-build` for the tests in the `main` workflow that will fail if the contracts don't compile.

It cleans up the CI DevEx if you have such an issue.