### PR TITLE
fix(op-service): replace string-based error matching with errors.Is

### DIFF
--- a/op-service/txinclude/resubmitter.go
+++ b/op-service/txinclude/resubmitter.go
@@ -3,7 +3,6 @@ package txinclude
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core"
@@ -40,8 +39,8 @@ func NewResubmitter(inner Sender, blockTime time.Duration, opts ...ResubmitterOp
 		opt(cfg)
 	}
 	return &Resubmitter{
-		cfg:       cfg,
-		inner:     inner,
+		cfg: cfg,
+		inner: inner,
 		blockTime: blockTime,
 	}
 }
@@ -57,15 +56,15 @@ var fatalErrs = []error{
 	txpool.ErrReplaceUnderpriced,
 	txpool.ErrUnderpriced,
 
-	// Transaction limits.
+	// Transaction limits
 	txpool.ErrOversizedData,
 	core.ErrMaxInitCodeSizeExceeded,
 	legacypool.ErrAuthorityReserved,
 	legacypool.ErrFutureReplacePending,
 
-	// Validity.
+	// Validity
 	txpool.ErrInvalidSender,
-	txpool.ErrGasLimit, // This one could be transient, but in practice it's usually fatal.
+	txpool.ErrGasLimit,
 	txpool.ErrNegativeValue,
 	core.ErrInsufficientFunds,
 	core.ErrInsufficientFundsForTransfer,
@@ -79,33 +78,38 @@ var fatalErrs = []error{
 	core.ErrFeeCapTooLow,
 	core.ErrSenderNoEOA,
 	core.ErrTxTypeNotSupported,
-	// Blobs.
+
+	// Blobs
 	core.ErrBlobFeeCapTooLow,
 	core.ErrMissingBlobHashes,
 	core.ErrBlobTxCreate,
-	// 7702.
+
+	// 7702
 	core.ErrEmptyAuthList,
 	core.ErrSetCodeTxCreate,
-	// Interop.
+
+	// Interop
 	core.ErrTxFilteredOut,
 }
 
 var recognizedErrs = append([]error{
 	txpool.ErrAlreadyKnown,
 	legacypool.ErrTxPoolOverflow,
-	// Account limits.
+	// Account Limits
 	txpool.ErrAlreadyReserved,
 	txpool.ErrAccountLimitExceeded,
 	txpool.ErrInflightTxLimitReached,
 }, fatalErrs...)
 
+// tryToRecognizeError attempts to match the given error against known error types.
+// It uses errors.Is for proper error unwrapping and typ checking, which handles
+// wrapped errors correctly and is more performant than string comparisons.
 func tryToRecognizeError(err error) error {
 	if err == nil {
 		return nil
 	}
 	for _, recognizedErr := range recognizedErrs {
-		// TODO(13408): we should not need to use strings.Contains.
-		if strings.Contains(err.Error(), recognizedErr.Error()) {
+		if errors.Is(err, recognizedErr) {
 			return recognizedErr
 		}
 	}
@@ -113,7 +117,7 @@ func tryToRecognizeError(err error) error {
 }
 
 // SendTransaction implements Sender. It will continue resubmitting unless an error is hit
-// that the resubmitter considers unfixable with resubmissions alone (e.g., requiring modifications to tx)
+// that the resubmitter considers unfixable with resubmissions alone ( requiring modifications to tx)
 // See fatalErrs for the list of these errors.
 func (r *Resubmitter) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	for {

--- a/op-service/txinclude/resubmitter_test.go
+++ b/op-service/txinclude/resubmitter_test.go
@@ -2,11 +2,14 @@ package txinclude_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -54,4 +57,99 @@ func TestResubmitterFatalErrors(t *testing.T) {
 	for _, want := range inner.errs {
 		require.Equal(t, want, resubmitter.SendTransaction(context.Background(), types.NewTx(&types.DynamicFeeTx{})))
 	}
+}
+
+// TestResubmitterWrappedErrors verifies that wrapped errors are properly recognized
+// using errors.Is, which is the improvement over the previous string-based matching.
+func TestResubmitterWrappedErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		wrappedErr    error
+		expectedErr   error
+		shouldBeFatal bool
+	}{
+		{
+			name:          "wrapped nonce too low",
+			wrappedErr:    fmt.Errorf("transaction failed: %w", core.ErrNonceTooLow),
+			expectedErr:   core.ErrNonceTooLow,
+			shouldBeFatal: true,
+		},
+		{
+			name:          "wrapped insufficient funds",
+			wrappedErr:    fmt.Errorf("execution reverted: %w", core.ErrInsufficientFunds),
+			expectedErr:   core.ErrInsufficientFunds,
+			shouldBeFatal: true,
+		},
+		{
+			name:          "wrapped already known (non-fatal)",
+			wrappedErr:    fmt.Errorf("mempool error: %w", txpool.ErrAlreadyKnown),
+			expectedErr:   context.Canceled, // Should continue resubmitting until context canceled
+			shouldBeFatal: false,
+		},
+		{
+			name:          "wrapped replace underpriced",
+			wrappedErr:    fmt.Errorf("replacement transaction: %w", txpool.ErrReplaceUnderpriced),
+			expectedErr:   txpool.ErrReplaceUnderpriced,
+			shouldBeFatal: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &mockSender{
+				errs: []error{tc.wrappedErr},
+			}
+			resubmitter := txinclude.NewResubmitter(inner, time.Millisecond)
+
+			if tc.shouldBeFatal {
+				// Fatal errors should return immediately
+				err := resubmitter.SendTransaction(context.Background(), types.NewTx(&types.DynamicFeeTx{}))
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedErr)
+				require.Equal(t, uint64(1), inner.calls, "should only call inner sender once for fatal errors")
+			} else {
+				// Non-fatal errors should continue resubmitting
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				defer cancel()
+
+				err := resubmitter.SendTransaction(ctx, types.NewTx(&types.DynamicFeeTx{}))
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				require.Greater(t, inner.calls, uint64(1), "should call inner sender multiple times for non-fatal errors")
+			}
+		})
+	}
+}
+
+// TestResubmitterDoubleWrappedErrors tests deeply nested error wrapping
+func TestResubmitterDoubleWrappedErrors(t *testing.T) {
+	deeplyWrappedErr := fmt.Errorf("outer error: %w",
+		fmt.Errorf("middle error: %w",
+			fmt.Errorf("inner error: %w", core.ErrNonceTooLow)))
+
+	inner := &mockSender{
+		errs: []error{deeplyWrappedErr},
+	}
+	resubmitter := txinclude.NewResubmitter(inner, time.Millisecond)
+
+	err := resubmitter.SendTransaction(context.Background(), types.NewTx(&types.DynamicFeeTx{}))
+	require.Error(t, err)
+	require.ErrorIs(t, err, core.ErrNonceTooLow, "should recognize deeply wrapped errors")
+	require.Equal(t, uint64(1), inner.calls, "should only call inner sender once")
+}
+
+// TestResubmitterUnrecognizedError verifies behavior with unknown errors
+func TestResubmitterUnrecognizedError(t *testing.T) {
+	unknownErr := errors.New("some unknown network error")
+
+	inner := &mockSender{
+		errs: []error{unknownErr, unknownErr}, // Return same error twice
+	}
+	resubmitter := txinclude.NewResubmitter(inner, time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	err := resubmitter.SendTransaction(ctx, types.NewTx(&types.DynamicFeeTx{}))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Greater(t, inner.calls, uint64(1), "should retry on unrecognized errors")
 }


### PR DESCRIPTION
## Description
Replaces string-based error matching with Go's `errors.Is()` for proper error type checking in the transaction resubmitter.

Addresses TODO(13408) on line 107-108 of `op-service/txinclude/resubmitter.go`.

## Motivation
- **Performance**: `errors.Is()` is faster than string comparison
- **Correctness**: Properly handles wrapped errors (Go 1.13+ convention)
- **Maintainability**: Survives error message changes
- **Best Practice**: Aligns with Go error handling conventions

## Changes
- Replaced `strings.Contains(err.Error(), recognizedErr.Error())` with `errors.Is(err, recognizedErr)`
- Removed `strings` import as it's no longer needed
- Added comprehensive tests for wrapped errors, deeply nested errors, and unknown errors
- Updated function documentation to explain the improvement

## Related Issue
Fixes TODO(13408)

## Additional Notes
This is my first contribution to Optimism. I understand this may be considered a small change, but I wanted to learn the contribution process and address a legitimate technical improvement. Happy to expand this PR or take on additional tasks based on maintainer feedback.