### PR TITLE
[proposal/op-contracts/v4.1.0] op-deployer: add upgrade v4.1.0 command

### DIFF
--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -5,6 +5,7 @@ import (
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 	v300 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v3_0_0"
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
+	v410 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_1_0"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
@@ -50,5 +51,15 @@ var Commands = cli.Commands{
 			OverrideArtifactsURLFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v400.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "v4.1.0",
+		Usage: "upgrades a chain to version v4.1.0 (U16a)",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(v410.DefaultUpgrader),
 	},
 }

--- a/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
@@ -1,0 +1,25 @@
+// Package v4_1_0 implements the upgrade to v4.1.0 (U16a). The interface for the upgrade is identical
+// to the upgrade for v2.0.0 (U13), so all this package does is implement the Upgrader interface and
+// call into the v2.0.0 upgrade.
+package v4_1_0
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+)
+
+type Upgrader struct {
+}
+
+func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
+	return v200.DefaultUpgrader.Upgrade(host, input)
+}
+
+func (u *Upgrader) ArtifactsURL() string {
+	return "tag://" + standard.ContractsV410Tag
+}
+
+var DefaultUpgrader = new(Upgrader)


### PR DESCRIPTION
Adds the `op-deployer upgrade v4.1.0` command. It uses the same `UpgradeOPChain.s.sol` script as the previous contract version v4.0.0, so the command implementation is a copy of the `v4_0_0` package.