### PR TITLE
op-node: allow for L2 chain configs to be passed to NewL1ChainConfig

### DIFF
--- a/op-node/service.go
+++ b/op-node/service.go
@@ -317,7 +317,8 @@ func NewL1ChainConfig(chainId *big.Int, ctx *cli.Context, log log.Logger) (*para
 	if cf.ChainID.Cmp(chainId) != 0 {
 		return nil, fmt.Errorf("l1 chain config chain ID mismatch: %v != %v", cf.ChainID, chainId)
 	}
-	if cf.BlobScheduleConfig == nil {
+	if !cf.IsOptimism() && cf.BlobScheduleConfig == nil {
+		// No error if the chain config is an OP-Stack chain and doesn't have a blob schedule config
 		return nil, fmt.Errorf("L1 chain config does not have a blob schedule config")
 	}
 	return cf, nil

--- a/op-node/service_l1_chain_config_test.go
+++ b/op-node/service_l1_chain_config_test.go
@@ -50,6 +50,14 @@ func TestNewL1ChainConfig_CustomDirectAndEmbeddedAndNil(t *testing.T) {
 		BlobScheduleConfig: nil,
 	}
 
+	// Indicative of an L2 chain config
+	// Which is what L3 chains need to provide
+	customOPStack := &params.ChainConfig{
+		ChainID:            testChainID,
+		BlobScheduleConfig: nil,
+		Optimism:           &params.OptimismConfig{},
+	}
+
 	// Prepare temp dir
 	dir := t.TempDir()
 
@@ -75,6 +83,10 @@ func TestNewL1ChainConfig_CustomDirectAndEmbeddedAndNil(t *testing.T) {
 		Config *params.ChainConfig `json:"config"`
 	}
 	encode(embeddedPath, wrapper{Config: custom})
+
+	// Embedded JSON file that contains { "config": <ChainConfig> }
+	customOPStackPath := filepath.Join(dir, "optimism_chain.json")
+	encode(customOPStackPath, wrapper{Config: customOPStack})
 
 	// Helper to run the CLI with a given file path
 	runWithPath := func(path string) (*params.ChainConfig, error) {
@@ -115,7 +127,13 @@ func TestNewL1ChainConfig_CustomDirectAndEmbeddedAndNil(t *testing.T) {
 
 	t.Run("nil-blob-schedule-config-returns-error", func(t *testing.T) {
 		cfg, err := runWithPath(directFaultyPath)
-		require.Nil(t, cfg)
+		require.NotNil(t, cfg)
 		require.Error(t, err)
+	})
+
+	t.Run("nil-blob-schedule-config-returns-no-error-for-l2-chain-config", func(t *testing.T) {
+		cfg, err := runWithPath(customOPStackPath)
+		require.Nil(t, cfg)
+		require.NoError(t, err)
 	})
 }

--- a/op-node/service_l1_chain_config_test.go
+++ b/op-node/service_l1_chain_config_test.go
@@ -127,13 +127,13 @@ func TestNewL1ChainConfig_CustomDirectAndEmbeddedAndNil(t *testing.T) {
 
 	t.Run("nil-blob-schedule-config-returns-error", func(t *testing.T) {
 		cfg, err := runWithPath(directFaultyPath)
-		require.NotNil(t, cfg)
+		require.Nil(t, cfg)
 		require.Error(t, err)
 	})
 
 	t.Run("nil-blob-schedule-config-returns-no-error-for-l2-chain-config", func(t *testing.T) {
 		cfg, err := runWithPath(customOPStackPath)
-		require.Nil(t, cfg)
+		require.NotNil(t, cfg)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This should fix the problem where L3 nodes cannot start.

Closes https://github.com/ethereum-optimism/optimism/issues/17798