### PR TITLE
op-{sync-tester|devstack}: Support multiple EL Sync Runs

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync/init_test.go
@@ -11,7 +11,7 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithExecutionLayerSyncOnVerifiers(),
 		presets.WithSimpleWithSyncTester(),
-		presets.WithELSyncTarget(35),
+		presets.WithELSyncActive(),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/init_test.go
@@ -1,0 +1,24 @@
+package multi
+
+import (
+	"testing"
+
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		presets.WithSimpleWithSyncTester(),
+		presets.WithELSyncActive(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
+			// For stopping derivation, not to advance safe heads
+			cfg.Stopped = true
+		})),
+	)
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
@@ -1,0 +1,78 @@
+package multi
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestMultiELSync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleWithSyncTester(t)
+	require := t.Require()
+
+	// Stop L2CL2 to control SyncTesterL2EL manually
+	sys.L2CL2.Stop()
+
+	// Advance few blocks to make sure reference node advanced
+	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+
+	// Manually trigger multiple EL Syncs using the engine API
+	startNum := sys.SyncTesterL2EL.BlockRefByLabel(eth.Unsafe).Number
+
+	// Sync Tester will track all unsafe payloads which can not be appended to unsafe head
+	// Sync Tester will use the WindowSyncPolicy, and mocks completion of EL Sync when the consecutive
+	// payloads were previously observed
+
+	targetNum := startNum + 5
+	// Invoke consecutive FCU calls to mock L2CL2 behavior:
+	// L2CL2 will unsafe payloads from the sequencer and do newPayload, FCU call
+	// L2CL2 will push consecutive unsafe payloads, assuming sequencer sent payloads arrived in order
+
+	// First Run of EL Sync: Scenario: Mock op-node with consecutive newPayload + FCU calls
+	// Start with targetNum-2=startNum + 3 to trigger EL Sync. SyncTesterEL unsafe head=startNum
+	sys.SyncTesterL2EL.NewPayload(sys.L2EL, targetNum-2).IsSyncing()
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum-2, 0, 0, nil).IsSyncing()
+	// Window filled: [startNum+3]
+
+	sys.SyncTesterL2EL.NewPayload(sys.L2EL, targetNum-1).IsSyncing()
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum-1, 0, 0, nil).IsSyncing()
+	// Window filled: [startNum+3,startNum+4]
+
+	// Consecutive window size(two) payloads were FCUed
+	// Sync Tester will mock by advancing the non canonical chain to make the next newPayload return VALID
+	sys.SyncTesterL2EL.NewPayload(sys.L2EL, targetNum).IsValid()
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum, 0, 0, nil).IsValid()
+	// EL Sync Completed to targetNum
+
+	require.Equal(targetNum, sys.L2EL.BlockRefByHash(sys.SyncTesterL2EL.BlockRefByLabel(eth.Unsafe).Hash).Number)
+
+	// Second Run of EL Sync: Scenario: Manaul FCU, different with engine API pattern
+	// Start with targetNum-2=startNum+8 to trigger EL Sync. SyncTesterEL unsafe head=startNum+5
+	targetNum = startNum + 10
+	sys.SyncTesterL2EL.NewPayload(sys.L2EL, targetNum-2).IsSyncing()
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum-2, 0, 0, nil).IsSyncing()
+	// Window filled: [targetNum+8]
+
+	sys.SyncTesterL2EL.NewPayload(sys.L2EL, targetNum-1).IsSyncing()
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum-1, 0, 0, nil).IsSyncing()
+	// Window filled: [startNum+8,startNum+9]
+
+	// Consecutive window size(two) payloads were FCUed
+	// Sync Tester will mock by advancing the non canonical chain to make the next newPayload return VALID
+	// If we call FCU targeting startNum again, it will return VALID, canonicalizing
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum-1, 0, 0, nil).IsValid()
+
+	// Next call with newPayload, FCU will also VALID because the payload may be directly appended to the unsafe head
+	sys.SyncTesterL2EL.NewPayload(sys.L2EL, targetNum).IsValid()
+	sys.SyncTesterL2EL.ForkchoiceUpdate(sys.L2EL, targetNum, 0, 0, nil).IsValid()
+
+	require.Equal(targetNum, sys.L2EL.BlockRefByHash(sys.SyncTesterL2EL.BlockRefByLabel(eth.Unsafe).Hash).Number)
+
+	t.Cleanup(func() {
+		sys.L2CL2.Start()
+	})
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -98,7 +98,9 @@ func TestSyncTesterExtEL(gt *testing.T) {
 		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
 		attempts = 5
 		// Signal L2CL for triggering EL Sync
-		sys.L2CL.SignalTarget(sys.L2ELReadOnly, target)
+		for i := 2; i >= 0; i-- {
+			sys.L2CL.SignalTarget(sys.L2ELReadOnly, target-uint64(i))
+		}
 	}
 
 	// Test that we can get sync status from L2CL node

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -98,6 +98,7 @@ func TestSyncTesterExtEL(gt *testing.T) {
 		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
 		attempts = 5
 		// Signal L2CL for triggering EL Sync
+		// Must send consecutive three payloads due to default EL Sync policy
 		for i := 2; i >= 0; i-- {
 			sys.L2CL.SignalTarget(sys.L2ELReadOnly, target-uint64(i))
 		}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -219,7 +219,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 		}
 		opt = stack.Combine(opt,
 			presets.WithExecutionLayerSyncOnVerifiers(),
-			presets.WithELSyncTarget(target),
+			presets.WithELSyncActive(),
 			presets.WithSyncTesterELInitialState(eth.FCUState{
 				Latest: initial,
 				Safe:   0,

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -256,7 +256,9 @@ func hfsExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode sync.Mode) 
 		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
 		attempts = 5
 		// Signal L2CL for finishing EL Sync
-		sys.L2CL.SignalTarget(sys.L2ELReadOnly, targetBlock)
+		for i := 2; i >= 0; i-- {
+			sys.L2CL.SignalTarget(sys.L2ELReadOnly, targetBlock-uint64(i))
+		}
 	} else {
 		l2CLSyncStatus := sys.L2CL.WaitForNonZeroUnsafeTime(t.Ctx())
 		require.Less(l2CLSyncStatus.UnsafeL2.Time, *ft, "L2CL unsafe time should be less than fork timestamp before upgrade")

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -256,6 +256,7 @@ func hfsExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode sync.Mode) 
 		// After EL Sync is finished, the FCU state will advance to target immediately so less attempts
 		attempts = 5
 		// Signal L2CL for finishing EL Sync
+		// Must send consecutive three payloads due to default EL Sync policy
 		for i := 2; i >= 0; i-- {
 			sys.L2CL.SignalTarget(sys.L2ELReadOnly, targetBlock-uint64(i))
 		}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -191,7 +191,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 		}
 		opt = stack.Combine(opt,
 			presets.WithExecutionLayerSyncOnVerifiers(),
-			presets.WithELSyncTarget(targetBlock),
+			presets.WithELSyncActive(),
 			presets.WithSyncTesterELInitialState(eth.FCUState{
 				Latest: blk,
 				Safe:   0,

--- a/op-devstack/presets/sync_tester_config.go
+++ b/op-devstack/presets/sync_tester_config.go
@@ -15,11 +15,10 @@ func WithSyncTesterELInitialState(fcu eth.FCUState) stack.CommonOption {
 			})))
 }
 
-func WithELSyncTarget(elSyncTarget uint64) stack.CommonOption {
+func WithELSyncActive() stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithGlobalSyncTesterELOption(sysgo.SyncTesterELOptionFn(
 			func(_ devtest.P, id stack.L2ELNodeID, cfg *sysgo.SyncTesterELConfig) {
 				cfg.ELSyncActive = true
-				cfg.ELSyncTarget = elSyncTarget
 			})))
 }

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -94,6 +94,11 @@ func (n *SyncTesterEL) hydrate(system stack.ExtensibleSystem) {
 	require.NoError(err)
 	system.T().Cleanup(rpcCl.Close)
 
+	// Sync Tester EL is always writable, and needs no auth
+	engineCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), n.authRPC)
+	require.NoError(err)
+	system.T().Cleanup(engineCl.Close)
+
 	l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID()))
 	sysL2EL := shim.NewL2ELNode(shim.L2ELNodeConfig{
 		RollupCfg: l2Net.RollupConfig(),
@@ -102,7 +107,8 @@ func (n *SyncTesterEL) hydrate(system stack.ExtensibleSystem) {
 			Client:       rpcCl,
 			ChainID:      n.id.ChainID(),
 		},
-		ID: n.id,
+		EngineClient: engineCl,
+		ID:           n.id,
 	})
 	sysL2EL.SetLabel(match.LabelVendor, "sync-tester")
 	l2Net.(stack.ExtensibleL2Network).AddL2ELNode(sysL2EL)

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -38,13 +38,12 @@ type SyncTesterEL struct {
 type SyncTesterELConfig struct {
 	FCUState     eth.FCUState
 	ELSyncActive bool
-	ELSyncTarget uint64
 }
 
 func (cfg *SyncTesterELConfig) Path() string {
 	path := fmt.Sprintf("?latest=%d&safe=%d&finalized=%d", cfg.FCUState.Latest, cfg.FCUState.Safe, cfg.FCUState.Finalized)
 	if cfg.ELSyncActive {
-		path += fmt.Sprintf("&el_sync_target=%d", cfg.ELSyncTarget)
+		path += "&el_sync_active=true"
 	}
 	return path
 }
@@ -53,7 +52,6 @@ func DefaultSyncTesterELConfig() *SyncTesterELConfig {
 	return &SyncTesterELConfig{
 		FCUState:     eth.FCUState{Latest: 0, Safe: 0, Finalized: 0},
 		ELSyncActive: false,
-		ELSyncTarget: 0,
 	}
 }
 

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -11,6 +11,19 @@ type FCUState struct {
 	Finalized uint64 `json:"finalized"`
 }
 
+// ELSyncPolicy defines the policy for determining the synchronization status
+// of the execution layer (EL) during EL Sync, as triggered exclusively by
+// ForkchoiceUpdated (FCU) calls.
+//
+// In the EL Sync process, the consensus layer (CL) notifies the EL of the
+// current head via FCU. The EL then evaluates its internal sync state and
+// reports whether it is still syncing or fully in sync. An ELSyncPolicy
+// implementation encapsulates this decision logic.
+//
+// The purpose of this interface is to provide a configurable or mockable
+// strategy for how the EL responds to FCU-triggered sync checks—useful in
+// testing, simulation, or devnet environments where the real EL behavior
+// needs to be emulated.
 type ELSyncPolicy interface {
 	ELSyncStatus(num uint64) ExecutePayloadStatus
 }

--- a/op-service/eth/synctester_session.go
+++ b/op-service/eth/synctester_session.go
@@ -11,6 +11,10 @@ type FCUState struct {
 	Finalized uint64 `json:"finalized"`
 }
 
+type ELSyncPolicy interface {
+	ELSyncStatus(num uint64) ExecutePayloadStatus
+}
+
 type SyncTesterSession struct {
 	sync.Mutex
 
@@ -23,11 +27,10 @@ type SyncTesterSession struct {
 	// payloads
 	Payloads map[PayloadID]*ExecutionPayloadEnvelope `json:"-"`
 
-	ELSyncTarget uint64 `json:"el_sync_target"`
-	ELSyncActive bool   `json:"el_sync_active"`
+	ELSyncPolicy ELSyncPolicy `json:"-"`
+	ELSyncActive bool         `json:"el_sync_active"`
 
-	InitialState        FCUState `json:"initial_state"`
-	InitialELSyncActive bool     `json:"initial_el_sync_active"`
+	InitialState FCUState `json:"initial_state"`
 }
 
 func (s *SyncTesterSession) UpdateFCULatest(latest uint64) {
@@ -42,23 +45,17 @@ func (s *SyncTesterSession) UpdateFCUFinalized(finalized uint64) {
 	s.CurrentState.Finalized = finalized
 }
 
-func (s *SyncTesterSession) FinishELSync(target uint64) {
-	s.ELSyncActive = false
-	s.Validated = target
-}
-
-func (s *SyncTesterSession) IsELSyncFinished() bool {
-	return !s.ELSyncActive
-}
-
 func (s *SyncTesterSession) ResetSession() {
 	s.CurrentState = s.InitialState
 	s.Validated = s.InitialState.Latest
 	s.Payloads = make(map[PayloadID]*ExecutionPayloadEnvelope)
-	s.ELSyncActive = s.InitialELSyncActive
 }
 
-func NewSyncTesterSession(sessionID string, latest, safe, finalized, elSyncTarget uint64, elSyncActive bool) *SyncTesterSession {
+func (s *SyncTesterSession) IsELSyncActive() bool {
+	return s.ELSyncActive
+}
+
+func NewSyncTesterSession(sessionID string, latest, safe, finalized uint64, elSyncActive bool, elSyncState ELSyncPolicy) *SyncTesterSession {
 	return &SyncTesterSession{
 		SessionID: sessionID,
 		Validated: latest,
@@ -68,13 +65,12 @@ func NewSyncTesterSession(sessionID string, latest, safe, finalized, elSyncTarge
 			Finalized: finalized,
 		},
 		Payloads:     make(map[PayloadID]*ExecutionPayloadEnvelope),
-		ELSyncTarget: elSyncTarget,
 		ELSyncActive: elSyncActive,
+		ELSyncPolicy: elSyncState,
 		InitialState: FCUState{
 			Latest:    latest,
 			Safe:      safe,
 			Finalized: finalized,
 		},
-		InitialELSyncActive: elSyncActive,
 	}
 }

--- a/op-sync-tester/synctester/backend/el_sync.go
+++ b/op-sync-tester/synctester/backend/el_sync.go
@@ -1,0 +1,58 @@
+package backend
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var _ eth.ELSyncPolicy = (*WindowSyncPolicy)(nil)
+
+type WindowSyncPolicy struct {
+	cache   []uint64
+	cnt     int
+	maxSize int
+}
+
+func NewWindowSyncPolicy(cnt, maxSize int) *WindowSyncPolicy {
+	if cnt > maxSize {
+		panic(fmt.Sprintf("cache max size: %d less than window size: %d", maxSize, cnt))
+	}
+	return &WindowSyncPolicy{cnt: cnt, maxSize: maxSize}
+}
+
+func (e *WindowSyncPolicy) insertNum(num uint64) {
+	if len(e.cache) == 0 {
+		e.cache = append(e.cache, num)
+		return
+	}
+	maxNum := slices.Max(e.cache)
+	if maxNum >= num {
+		e.cache = slices.DeleteFunc(e.cache, func(v uint64) bool {
+			return v >= num
+		})
+	}
+	e.cache = append(e.cache, num)
+	slices.Sort(e.cache)
+	if e.maxSize < len(e.cache) {
+		e.cache = e.cache[1:]
+	}
+	// Invariant: cache is sorted, no duplicates and size not larger then maxSize
+}
+
+func (e *WindowSyncPolicy) ELSyncStatus(num uint64) eth.ExecutePayloadStatus {
+	e.insertNum(num)
+	if len(e.cache) < e.cnt {
+		return eth.ExecutionSyncing
+	}
+	if e.cache[len(e.cache)-1] != num {
+		return eth.ExecutionSyncing
+	}
+	for i := range e.cnt {
+		if e.cache[len(e.cache)-1-i] != num-uint64(i) {
+			return eth.ExecutionSyncing
+		}
+	}
+	return eth.ExecutionValid
+}

--- a/op-sync-tester/synctester/backend/elsync/el_sync.go
+++ b/op-sync-tester/synctester/backend/elsync/el_sync.go
@@ -1,4 +1,4 @@
-package backend
+package elsync
 
 import (
 	"fmt"
@@ -13,6 +13,10 @@ type WindowSyncPolicy struct {
 	cache   []uint64
 	cnt     int
 	maxSize int
+}
+
+func DefaultELSyncPolicy() eth.ELSyncPolicy {
+	return NewWindowSyncPolicy(2, 5)
 }
 
 func NewWindowSyncPolicy(cnt, maxSize int) *WindowSyncPolicy {

--- a/op-sync-tester/synctester/backend/elsync/el_sync.go
+++ b/op-sync-tester/synctester/backend/elsync/el_sync.go
@@ -9,17 +9,44 @@ import (
 
 var _ eth.ELSyncPolicy = (*WindowSyncPolicy)(nil)
 
+// WindowSyncPolicy implements eth.ELSyncPolicy by maintaining a sliding window
+// of recently observed payload numbers (block heights) and determining when the
+// execution layer (EL) should be considered fully synced.
+//
+// Conceptually, the policy tracks the most recent payload numbers in a sorted,
+// duplicate-free cache. When a new payload number is reported, it is inserted
+// into the cache while removing any entries greater than or equal to it -
+// simulating a reorg or an out-of-order unsafe payload insertion. The cache size
+// is capped by maxSize.
+//
+// The EL is considered SYNCING until the following conditions are met:
+//  1. At least cnt payload numbers have been observed, and
+//  2. The last cnt numbers in the cache form a consecutive sequence ending
+//     exactly at the most recent number.
+//
+// Once both conditions hold, ELSyncStatus(num) returns ExecutionValid.
+// Otherwise, it returns ExecutionSyncing.
+//
+// Example:
+//
+//	With cnt=3 and maxSize=5, the policy reports SYNCING until it has seen
+//	three consecutive payloads (for example 10, 11, 12). After that, it reports
+//	VALID for subsequent payloads unless a reorg or out-of-order insertion
+//	causes the cache to break the consecutive sequence.
 type WindowSyncPolicy struct {
 	cache   []uint64
-	cnt     int
-	maxSize int
+	cnt     uint64
+	maxSize uint64
 }
 
 func DefaultELSyncPolicy() eth.ELSyncPolicy {
 	return NewWindowSyncPolicy(2, 5)
 }
 
-func NewWindowSyncPolicy(cnt, maxSize int) *WindowSyncPolicy {
+func NewWindowSyncPolicy(cnt, maxSize uint64) *WindowSyncPolicy {
+	if cnt == 0 || maxSize == 0 {
+		panic(fmt.Sprintf("cache max size: %d or window size: %d is not positive", maxSize, cnt))
+	}
 	if cnt > maxSize {
 		panic(fmt.Sprintf("cache max size: %d less than window size: %d", maxSize, cnt))
 	}
@@ -39,22 +66,22 @@ func (e *WindowSyncPolicy) insertNum(num uint64) {
 	}
 	e.cache = append(e.cache, num)
 	slices.Sort(e.cache)
-	if e.maxSize < len(e.cache) {
+	if e.maxSize < uint64(len(e.cache)) {
 		e.cache = e.cache[1:]
 	}
-	// Invariant: cache is sorted, no duplicates and size not larger then maxSize
+	// Invariant: cache is sorted, no duplicates and size not larger than maxSize
 }
 
 func (e *WindowSyncPolicy) ELSyncStatus(num uint64) eth.ExecutePayloadStatus {
 	e.insertNum(num)
-	if len(e.cache) < e.cnt {
+	if uint64(len(e.cache)) < e.cnt {
 		return eth.ExecutionSyncing
 	}
 	if e.cache[len(e.cache)-1] != num {
 		return eth.ExecutionSyncing
 	}
 	for i := range e.cnt {
-		if e.cache[len(e.cache)-1-i] != num-uint64(i) {
+		if e.cache[uint64(len(e.cache))-1-i] != num-i {
 			return eth.ExecutionSyncing
 		}
 	}

--- a/op-sync-tester/synctester/backend/elsync/el_sync_test.go
+++ b/op-sync-tester/synctester/backend/elsync/el_sync_test.go
@@ -1,0 +1,171 @@
+package elsync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func runStatuses(p eth.ELSyncPolicy, nums ...uint64) []eth.ExecutePayloadStatus {
+	out := make([]eth.ExecutePayloadStatus, 0, len(nums))
+	for _, n := range nums {
+		out = append(out, p.ELSyncStatus(n))
+	}
+	return out
+}
+
+func TestWindowSyncPolicy_NewWindowSyncPolicy_PanicsOnInvalidArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		cnt           uint64
+		maxSize       uint64
+		wantSubstring string
+	}{
+		{
+			name:          "cnt greater than maxSize",
+			cnt:           uint64(3),
+			maxSize:       uint64(2),
+			wantSubstring: "less than window size",
+		},
+		{
+			name:          "cnt is zero",
+			cnt:           uint64(0),
+			maxSize:       uint64(5),
+			wantSubstring: "not positive",
+		},
+		{
+			name:          "maxSize is zero",
+			cnt:           uint64(2),
+			maxSize:       uint64(0),
+			wantSubstring: "not positive",
+		},
+		{
+			name:          "both zero",
+			cnt:           uint64(0),
+			maxSize:       uint64(0),
+			wantSubstring: "not positive",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				require.NotNil(t, r, "expected panic")
+				require.Contains(t, fmt.Sprint(r), tc.wantSubstring)
+			}()
+			NewWindowSyncPolicy(tc.cnt, tc.maxSize)
+		})
+	}
+}
+
+func TestWindowSyncPolicy_MonotonicConsecutive_DefaultCnt2(t *testing.T) {
+	p := DefaultELSyncPolicy()
+
+	// Need two consecutive observations ending at current num to become VALID.
+	got := runStatuses(p, 10, 11, 12)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionSyncing, // only 10 observed
+		eth.ExecutionValid,   // [10,11] consecutive window ending at 11
+		eth.ExecutionValid,   // [11,12] consecutive window ending at 12
+	}, got)
+}
+
+func TestWindowSyncPolicy_GapThenFill_Cnt3(t *testing.T) {
+	p := NewWindowSyncPolicy(3, 5)
+
+	// 10 -> SYNC, 12 -> SYNC (gap), 11 -> still SYNC (len < 3),
+	// 12 -> now have [10,11,12] ending at 12 => VALID
+	got := runStatuses(p, 10, 12, 11, 12)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionSyncing,
+		eth.ExecutionSyncing,
+		eth.ExecutionSyncing,
+		eth.ExecutionValid,
+	}, got)
+}
+
+func TestWindowSyncPolicy_Reorg_DropGreaterOrEqual_Current(t *testing.T) {
+	p := NewWindowSyncPolicy(2, 5)
+
+	// Build up to 12 => VALID, then reorg to 9 (drop >= 9) => SYNC,
+	// then 10 => VALID with window [9,10].
+	got := runStatuses(p, 10, 11, 12, 9, 10)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionSyncing, // 10
+		eth.ExecutionValid,   // 11
+		eth.ExecutionValid,   // 12
+		eth.ExecutionSyncing, // 9 (reorg down)
+		eth.ExecutionValid,   // 10 [9,10]
+	}, got)
+}
+
+func TestWindowSyncPolicy_Duplicates_DoNotAdvance(t *testing.T) {
+	p := NewWindowSyncPolicy(2, 5)
+
+	// Duplicate 10 should not create validity; need 11 next.
+	got := runStatuses(p, 10, 10, 11)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionSyncing,
+		eth.ExecutionSyncing, // duplicate doesn't satisfy window [9,10] or [10,11]
+		eth.ExecutionValid,   // 11 with prior 10
+	}, got)
+}
+
+func TestWindowSyncPolicy_MaxSizeTrimming_DoesNotBreakValidity(t *testing.T) {
+	p := NewWindowSyncPolicy(3, 3) // window == maxSize
+
+	// 5,6,7 => VALID at 7 (have [5,6,7])
+	// 8 => cache should trim oldest (effectively [6,7,8]), still VALID
+	got := runStatuses(p, 5, 6, 7, 8)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionSyncing, // 5
+		eth.ExecutionSyncing, // 6
+		eth.ExecutionValid,   // 7 (have 5,6,7)
+		eth.ExecutionValid,   // 8 (have 6,7,8 after trim)
+	}, got)
+}
+
+func TestWindowSyncPolicy_LongerRun_StabilityAcrossAdvances(t *testing.T) {
+	p := NewWindowSyncPolicy(3, 5)
+	seq := []uint64{100, 101, 102, 103, 104}
+	want := []eth.ExecutePayloadStatus{
+		eth.ExecutionSyncing, // 100
+		eth.ExecutionSyncing, // 101
+		eth.ExecutionValid,   // 102
+		eth.ExecutionValid,   // 103
+		eth.ExecutionValid,   // 104
+	}
+	require.Equal(t, want, runStatuses(p, seq...))
+}
+
+func TestWindowSyncPolicy_Cnt1_AlwaysValidAfterSingleObservation(t *testing.T) {
+	p := NewWindowSyncPolicy(1, 5)
+
+	// With cnt=1, a single observation of the current head is enough to be VALID,
+	// regardless of gaps or reorg-like regressions.
+	got := runStatuses(p, 10, 12, 11, 50, 49)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionValid, // 10
+		eth.ExecutionValid, // 12
+		eth.ExecutionValid, // 11
+		eth.ExecutionValid, // 50
+		eth.ExecutionValid, // 49
+	}, got)
+}
+
+func TestWindowSyncPolicy_MaxSize1_WithCnt1(t *testing.T) {
+	p := NewWindowSyncPolicy(1, 1)
+
+	// Cache can only hold the last number, but with cnt=1 that's sufficient.
+	got := runStatuses(p, 5, 6, 4, 4, 7)
+	require.Equal(t, []eth.ExecutePayloadStatus{
+		eth.ExecutionValid, // 5
+		eth.ExecutionValid, // 6
+		eth.ExecutionValid, // 4 (reorg-like; still VALID with cnt=1)
+		eth.ExecutionValid, // 4 (duplicate)
+		eth.ExecutionValid, // 7
+	}, got)
+}

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -357,12 +357,30 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 		// Consider as sync error if read only EL interaction fails because we cannot validate
 		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 	}
-	if candLatest.NumberU64() > session.Validated {
-		// Let CL backfill via newPayload
-		return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+	candLatestNum := candLatest.NumberU64()
+	if session.Validated < candLatestNum {
+		if !session.IsELSyncActive() {
+			// Let CL backfill via newPayload
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+		}
+		switch session.ELSyncPolicy.ELSyncStatus(candLatestNum) {
+		case eth.ExecutionValid:
+			// EL Sync complete so advance non canonical chain first
+			session.Validated = candLatestNum
+			logger.Info("Non canonical chain advanced because of EL Sync", "validated", session.Validated)
+			// Still early return here with SYNCING to mimic the asynchronous EL behavior
+			// The EL will eventually return VALID with the identical unsafe target with the next FCU call
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+		case eth.ExecutionSyncing:
+			logger.Trace("EL Sync on progress", "target", candLatestNum)
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
+		default:
+			logger.Warn("EL Sync failure", "target", candLatestNum)
+			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, fmt.Errorf("EL Sync failure with target block %d:%s", candLatest.NumberU64(), candLatest.Hash())
+		}
 	}
 	// Equivalent to SetCanonical
-	session.UpdateFCULatest(candLatest.NumberU64())
+	session.UpdateFCULatest(candLatestNum)
 	logger.Debug("Updated FCU State", "latest", session.CurrentState.Latest)
 	// Simulate db check for finalized head
 	if state.FinalizedBlockHash != (common.Hash{}) {
@@ -399,9 +417,8 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 	var id *engine.PayloadID
 	if attr != nil {
 		// attr is the ingredient for the block built after the head block
-		candNum := int64(candLatest.NumberU64())
 		// Query read only EL to fetch block which is desired to be produced from attr
-		newBlock, err := s.elReader.GetBlockByNumber(ctx, rpc.BlockNumber(candNum+1))
+		newBlock, err := s.elReader.GetBlockByNumber(ctx, rpc.BlockNumber(int64(candLatestNum)+1))
 		if err != nil {
 			// Consider as sync error if read only EL interaction fails because we cannot validate
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
@@ -723,31 +740,11 @@ func (s *SyncTester) newPayload(ctx context.Context, session *eth.SyncTesterSess
 			session.Validated += 1
 			logger.Debug("Advanced non canonical chain", "validated", session.Validated)
 		}
-		if !session.IsELSyncFinished() && session.Validated == session.ELSyncTarget {
-			// Can reach here when not doing EL Sync on CL side but session is configured for EL Sync
-			logger.Debug("Non canonical chain reached EL Sync target", "validated", session.Validated)
-			session.FinishELSync(session.Validated)
-		}
 		// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
 		// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
 		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &blockHash}, nil
-	} else if !session.IsELSyncFinished() {
-		if blockNumber == session.ELSyncTarget {
-			logger.Debug("Attempting to finish EL Sync on non canonical chain", "target", session.ELSyncTarget)
-			if status, err := s.validatePayload(logger, isCanyon, isIsthmus, block, payload, beaconRoot); status != nil {
-				return status, err
-			}
-			session.FinishELSync(blockNumber)
-			logger.Debug("Finished EL Sync by advancing non canonical chain", "validated", session.Validated)
-			// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#payload-validation
-			// Spec: If validation succeeds, the response MUST contain {status: VALID, latestValidHash: payload.blockHash}
-			return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &blockHash}, nil
-		} else if blockNumber < session.ELSyncTarget {
-			logger.Trace("EL Sync on progress", "target", blockNumber)
-		} else if blockNumber > session.ELSyncTarget {
-			// L2CL may never reach the EL Sync Target because the current number may keep increasing
-			logger.Warn("Received payload which has larger block number than EL Sync target", "current", blockNumber, "target", session.ELSyncTarget)
-		}
+	} else {
+		logger.Debug("Received payload which cannot be used to extend non canonical chain", "current", blockNumber, "validated", session.Validated)
 	}
 	// Block not available so mark as syncing
 	return &eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, nil

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -368,7 +368,10 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 			// EL Sync complete so advance non canonical chain first
 			session.Validated = candLatestNum
 			logger.Info("Non canonical chain advanced because of EL Sync", "validated", session.Validated)
-			// Still early return here with SYNCING to mimic the asynchronous EL behavior
+			// Equivalent to SetCanonical
+			session.UpdateFCULatest(session.Validated)
+			logger.Info("Canonical chain advanced because of EL Sync", "latest", session.CurrentState.Latest)
+			// Still return SYNCING to mimic the asynchronous EL behavior
 			// The EL will eventually return VALID with the identical unsafe target with the next FCU call
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 		case eth.ExecutionSyncing:

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	"github.com/google/uuid"
 )
 
 var ErrInvalidSessionIDFormat = errors.New("invalid UUID")
 var ErrInvalidParams = errors.New("invalid param")
-var ErrInvalidELSyncTarget = errors.New("invalid el sync target")
 
-const ELSyncTargetKey = "el_sync_target"
+const ELSyncActiveKey = "el_sync_active"
 
 func IsValidSessionID(sessionID string) error {
 	u, err := uuid.Parse(sessionID)
@@ -75,18 +75,9 @@ func parseSession(r *http.Request) (*http.Request, error) {
 		if err != nil {
 			return r, err
 		}
-		elSyncTarget, err := parseParam(ELSyncTargetKey)
-		if err != nil {
-			return r, err
-		}
-		elSyncActive := false
-		if elSyncTarget != 0 {
-			if elSyncTarget < latest {
-				return r, ErrInvalidELSyncTarget
-			}
-			elSyncActive = true
-		}
-		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncTarget, elSyncActive)
+		elSyncActive := query.Get(ELSyncActiveKey) == "true"
+		elSyncState := backend.NewWindowSyncPolicy(3, 5)
+		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncActive, elSyncState)
 		ctx := session.WithSyncTesterSession(r.Context(), sess)
 		// remove uuid path for routing
 		r.URL.Path = "/" + strings.Join(segments[:3], "/")

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -76,7 +76,7 @@ func parseSession(r *http.Request) (*http.Request, error) {
 			return r, err
 		}
 		elSyncActive := query.Get(ELSyncActiveKey) == "true"
-		elSyncState := backend.NewWindowSyncPolicy(3, 5)
+		elSyncState := backend.NewWindowSyncPolicy(2, 5)
 		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncActive, elSyncState)
 		ctx := session.WithSyncTesterSession(r.Context(), sess)
 		// remove uuid path for routing

--- a/op-sync-tester/synctester/middleware.go
+++ b/op-sync-tester/synctester/middleware.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend"
+	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/elsync"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	"github.com/google/uuid"
 )
@@ -76,7 +76,7 @@ func parseSession(r *http.Request) (*http.Request, error) {
 			return r, err
 		}
 		elSyncActive := query.Get(ELSyncActiveKey) == "true"
-		elSyncState := backend.NewWindowSyncPolicy(2, 5)
+		elSyncState := elsync.DefaultELSyncPolicy() // May be configurable
 		sess := eth.NewSyncTesterSession(sessionID, latest, safe, finalized, elSyncActive, elSyncState)
 		ctx := session.WithSyncTesterSession(r.Context(), sess)
 		// remove uuid path for routing

--- a/op-sync-tester/synctester/middleware_test.go
+++ b/op-sync-tester/synctester/middleware_test.go
@@ -3,7 +3,6 @@ package synctester
 import (
 	"net/http"
 	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -64,11 +63,11 @@ func TestParseSession_DefaultsToZero(t *testing.T) {
 	require.Equal(t, session.InitialState, session.CurrentState)
 }
 
-func TestParseSession_ELSyncTarget(t *testing.T) {
+func TestParseSession_ELSyncActive(t *testing.T) {
 	id := uuid.New().String()
 	query := url.Values{}
-	elSyncTarget := uint64(4)
-	query.Set(ELSyncTargetKey, strconv.Itoa(int(elSyncTarget)))
+	elSyncTarget := "true"
+	query.Set(ELSyncActiveKey, elSyncTarget)
 
 	req := newRequest("/chain/1/synctest/"+id, query)
 
@@ -86,7 +85,6 @@ func TestParseSession_ELSyncTarget(t *testing.T) {
 	require.Equal(t, session.InitialState.Latest, session.Validated)
 	require.Equal(t, session.InitialState, session.CurrentState)
 	require.True(t, session.ELSyncActive)
-	require.Equal(t, session.ELSyncTarget, elSyncTarget)
 }
 
 func TestParseSession_NoSessionInitialized(t *testing.T) {
@@ -114,17 +112,4 @@ func TestParseSession_InvalidQueryParam(t *testing.T) {
 	req := newRequest("/chain/1/synctest/"+id, query)
 	_, err := parseSession(req)
 	require.ErrorIs(t, err, ErrInvalidParams)
-}
-
-func TestParseSession_InvalidELSyncTarget(t *testing.T) {
-	id := uuid.New().String()
-	query := url.Values{}
-	latest := 4
-	elSyncTarget := latest - 1
-	query.Set(eth.Unsafe, strconv.Itoa(latest))
-	query.Set(ELSyncTargetKey, strconv.Itoa(elSyncTarget))
-
-	req := newRequest("/chain/1/synctest/"+id, query)
-	_, err := parseSession(req)
-	require.ErrorIs(t, err, ErrInvalidELSyncTarget)
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Makes Sync Tester support multiple rounds of EL Sync. The EL Sync typically occurs in following scenario.
- Some entity calls `engine_fcu` to the EL and the target does not build on top of unsafe head.
- EL asks its peers to fill in the gap to validate the target.
- Typically the CL will keep propagating the consecutive unsafe heads via `engine_FCU`, which payloads were sent from the sequencer CL.
- At some point, EL will catch up the speed of CL sending unsafe payloads. To explain the transition in detail
    - A) EL was poked `newPayload(unsafe head=N)`. It returns `SYNCING` and does not trigger EL Sync yet.
    - B) EL was poked `fcu(unsafe head=N)`. It returns `SYNCING`, and it finishes EL Syncing till block `N`.
        - At this point, if we send `fcu(unsafe head=N)`, it will immediately return `VALID`.
    - C) EL was poked `newPayload(unsafe head=N+1)`. It returns `VALID` because the canonical was advanced till `N`.
    - D) EL was poked `fcu(unsafe head=N+1)`. It returns `VALID`.
        - At this point, we can say the **EL Sync is complete** because the EL caught up the payload inserting speed from CL.

As we can see, step B behavior, only fcu triggering the EL Sync is validated at https://github.com/ethereum-optimism/optimism/pull/17752 and https://github.com/ethereum-optimism/optimism/pull/17802. The original sync tester implementation did not mirror this behavior, and instead triggered(mocked) EL Sync when newPayload was invoked. Changed that the FCU must maintain and control the EL Sync state.

Originally, `el_sync_target` was provided while initializing the sync tester session, and the sync tester returned `SYNCING` till the payload has reached to the `el_sync_target`. This only makes one iteration of EL Sync possible. This PR removes `el_sync_target`, and instead add `el_sync_active=true` to mock the EL Sync enabled(or peer attached) EL behavior. 

Added a `ELSyncPolicy` interface and `WindowSyncPolicy` implementation. We need a policy to mock or decide whether EL sync is in progress or completed. `ELSyncPolicy` decides when to return `VALID` or `SYNCING` while on EL Sync. An initial implementation is a `WindowSyncPolicy`. It maintains a sliding window of recently observed payload numbers (block heights) and determining when the EL should be considered fully synced. For example, if the sync tester notices consecutive targets 10, 11, 12 via FCU, it returns `SYNCING`, `SYNCING`, and eventually `VALID` because it mocked that the EL Sync is completed. Further `ELSyncPolicy` can be implemented.

**Tests**

Existing EL Sync tests are patched for considering the `WindowSyncPolicy`, sending consecutive unsafe payloads.

`TestMultiELSync` is added to demonstrate multiple EL Sync runs, by directly calling the engine APIs to the SyncTesterEL.

Validated the `scheduled-sync-test-op-node` all passes by manual trigger at https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/103607/workflows/683217e3-4a8f-4371-b308-cac0445b6bd7.

When we have support for op-node to do multiple EL Syncs(tracked at https://github.com/ethereum-optimism/optimism/issues/17627), not just initial EL Sync for boot strapping, the relevant tests may be added.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17695
