### PR TITLE
fix(circleci): ensure contracts-bedrock-build runs in release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2105,6 +2105,11 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+          filters:
+            tags:
+              only: /^(da-server|cannon|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
+            branches:
+              ignore: /.*/
       # Standard (medium) cross-platform docker images go here
       - docker-build:
           matrix:
@@ -2165,6 +2170,7 @@ workflows:
             - op-node-docker-release
             - op-batcher-docker-release
             - op-faucet-docker-release
+            - op-deployer-docker-release
             - op-proposer-docker-release
             - op-challenger-docker-release
             - op-dispute-mon-docker-release


### PR DESCRIPTION
Since the `release` workflow is triggered by tags, we must add a `filters` section for the `contracts-bedrock-build` job. Otherwise `contracts-bedrock-build` is always skipped