### PR TITLE
op-devstack: Error handle when direct FCU call errored

### DIFF
--- a/op-devstack/dsl/engine.go
+++ b/op-devstack/dsl/engine.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -64,6 +65,12 @@ func (r *ForkchoiceUpdateResult) WaitUntilValid(attempts int) *ForkchoiceUpdateR
 		func() error {
 			r.Refresh()
 			tryCnt += 1
+			if r.Err != nil {
+				return fmt.Errorf("forkchoice returned error: %w", r.Err)
+			}
+			if r.Result == nil {
+				return errors.New("forkchoice has empty result")
+			}
 			if r.Result.PayloadStatus.Status != eth.ExecutionValid {
 				r.T.Log("Wait for FCU to return valid", "status", r.Result.PayloadStatus.Status, "try_count", tryCnt)
 				return errors.New("still syncing")

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -230,7 +230,7 @@ func (el *L2ELNode) PayloadByNumber(number uint64) *eth.ExecutionPayloadEnvelope
 
 // NewPayload fetches payload for target number from the reference EL Node, and inserts the payload
 func (el *L2ELNode) NewPayload(refNode *L2ELNode, number uint64) *NewPayloadResult {
-	el.log.Info("NewPayload", "number", number, "refNode", refNode)
+	el.log.Info("NewPayload", "number", number, "node", el, "refNode", refNode)
 	payload := refNode.PayloadByNumber(number)
 	status, err := el.inner.L2EngineClient().NewPayload(el.ctx, payload.ExecutionPayload, payload.ParentBeaconBlockRoot)
 	return &NewPayloadResult{T: el.t, Status: status, Err: err}
@@ -240,7 +240,7 @@ func (el *L2ELNode) NewPayload(refNode *L2ELNode, number uint64) *NewPayloadResu
 func (el *L2ELNode) ForkchoiceUpdate(refNode *L2ELNode, unsafe, safe, finalized uint64, attr *eth.PayloadAttributes) *ForkchoiceUpdateResult {
 	result := &ForkchoiceUpdateResult{T: el.t}
 	refresh := func() {
-		el.log.Info("ForkchoiceUpdate", "unsafe", unsafe, "safe", safe, "finalized", finalized, "attr", attr, "refNode", refNode)
+		el.log.Info("ForkchoiceUpdate", "unsafe", unsafe, "safe", safe, "finalized", finalized, "attr", attr, "node", el, "refNode", refNode)
 		state := &eth.ForkchoiceState{
 			HeadBlockHash:      refNode.BlockRefByNumber(unsafe).Hash,
 			SafeBlockHash:      refNode.BlockRefByNumber(safe).Hash,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`TestL2ELP2PCanonicalChainAdvancedByFCU` flaked because it did not handle error case where direct FCU call for L2EL errored, causing nil point reference.

Adds more robust checking, and also enhances the log messages when devstack engine APIs invoked.

Example flake: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/103547/workflows/71d3d903-15b1-4d94-a8bf-dfb12760fd9c/jobs/3960419

Example flake logs:
```log
    sync_test.go:196:           INFO [10-09|22:14:04.913] Canonical chain advanced                 number=4
    l2_el.go:243:               INFO [10-09|22:14:04.914] ForkchoiceUpdate                         unsafe=6 safe=0 finalized=0 attr=<nil> refNode=L2ELNode-sequencer-901
t=2025-10-09T22:14:04.915+0000 lvl=info msg="Forkchoice requested sync to new head" number=6 hash=0xccbc07a639bde07ffb016cc003af602996dce6db6963bcdfd3d11a02158dbe4b finalized=unknown global=true
    l2_el.go:243:               INFO [10-09|22:14:04.915] ForkchoiceUpdate                         unsafe=6 safe=0 finalized=0 attr=<nil> refNode=L2ELNode-sequencer-901
t=2025-10-09T22:14:04.916+0000 lvl=info msg="Forkchoice requested sync to new head" number=6 hash=0xccbc07a639bde07ffb016cc003af602996dce6db6963bcdfd3d11a02158dbe4b finalized=unknown global=true
t=2025-10-09T22:14:04.915+0000 lvl=info msg="Restarting sync cycle" reason="chain gapped, head: 4, newHead: 6" global=true
t=2025-10-09T22:14:04.916+0000 lvl=warn msg="Served engine_forkchoiceUpdatedV3" reqid=15 duration=259.53µs err="beacon syncer reorging" global=true
t=2025-10-09T22:14:04.917+0000 lvl=info msg="Syncing beacon headers" downloaded=1 left=0 eta=0s global=true
t=2025-10-09T22:14:04.919+0000 lvl=info msg="Imported new chain segment" number=6 hash=0xccbc07a639bde07ffb016cc003af602996dce6db6963bcdfd3d11a02158dbe4b blocks=2 txs=2 mgas=0.092192 elapsed=1.698ms mgasps=54.28100571059826 triedirty="0.00 B" global=true
    engine_client.go:86:        WARN [10-09|22:14:04.920] Failed to share forkchoice-updated signal state="&{HeadBlockHash:0xccbc07a639bde07ffb016cc003af602996dce6db6963bcdfd3d11a02158dbe4b SafeBlockHash:0x885b0a23a9d0b1c1682e136f38e8d417742deccd1a496c93c4952365037f2355 FinalizedBlockHash:0x885b0a23a9d0b1c1682e136f38e8d417742deccd1a496c93c4952365037f2355}" err="beacon syncer reorging"
--- FAIL: TestL2ELP2PCanonicalChainAdvancedByFCU (23.07s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x21546fe]

goroutine 38999 [running]:
testing.tRunner.func1.2({0x2668fe0, 0x91696f0})
	/data/mise-data/installs/go/1.23.8/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
	/data/mise-data/installs/go/1.23.8/src/testing/testing.go:1635 +0x35e
panic({0x2668fe0?, 0x91696f0?})
	/data/mise-data/installs/go/1.23.8/src/runtime/panic.go:791 +0x132
github.com/ethereum-optimism/optimism/op-devstack/dsl.(*ForkchoiceUpdateResult).WaitUntilValid.func1()
	/var/opt/circleci/data/workdir/op-devstack/dsl/engine.go:67 +0x3e
github.com/ethereum-optimism/optimism/op-service/retry.Do0({0x79d2c28, 0xc00293e240}, 0x3, {0x79aec40, 0xc00126e698}, 0xc000f83c90)
	/var/opt/circleci/data/workdir/op-service/retry/operation.go:67 +0x16b
github.com/ethereum-optimism/optimism/op-devstack/dsl.(*ForkchoiceUpdateResult).WaitUntilValid(0xc0055142d0, 0x3)
	/var/opt/circleci/data/workdir/op-devstack/dsl/engine.go:63 +0xa5
github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync/elsync/gap_elp2p.TestL2ELP2PCanonicalChainAdvancedByFCU(0xc003c29ba0?)
	/var/opt/circleci/data/workdir/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go:205 +0xdfa
testing.tRunner(0xc003c29ba0, 0x769bce8)
	/data/mise-data/installs/go/1.23.8/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1
	/data/mise-data/installs/go/1.23.8/src/testing/testing.go:1743 +0x390
FAIL	github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync/elsync/gap_elp2p	27.605s
```

Some interesting behavior of L2EL shown, 
```
    engine_client.go:86:        WARN [10-09|22:14:04.920] Failed to share forkchoice-updated signal state="&{HeadBlockHash:0xccbc07a639bde07ffb016cc003af602996dce6db6963bcdfd3d11a02158dbe4b SafeBlockHash:0x885b0a23a9d0b1c1682e136f38e8d417742deccd1a496c93c4952365037f2355 FinalizedBlockHash:0x885b0a23a9d0b1c1682e136f38e8d417742deccd1a496c93c4952365037f2355}" err="beacon syncer reorging"
```
FCU may error when `beacon syncer is reorging`.

