### PR TITLE
acceptance-tests: force batcher to use cell proofs in osaka test

### DIFF
--- a/op-acceptance-tests/tests/osaka/osaka_test.go
+++ b/op-acceptance-tests/tests/osaka/osaka_test.go
@@ -86,6 +86,7 @@ func TestMain(m *testing.M) {
 		}),
 		sysgo.WithBatcherOption(func(_ stack.L2BatcherID, cfg *batcher.CLIConfig) {
 			cfg.DataAvailabilityType = flags.BlobsType
+			cfg.TxMgrConfig.CellProofTime = 0 // Force cell proofs to be used
 		}),
 	)))
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
