### PR TITLE
fix(circleci): ensure contracts-bedrock-build runs in release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2688,6 +2688,11 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
+          filters:
+            tags:
+              only: /^op-deployer.*/ # ensure contract artifacts are embedded in op-deployer binary
+            branches:
+              ignore: /.*/
       # Standard (medium) cross-platform docker images go here
       - docker-build:
           matrix:
@@ -2695,6 +2700,7 @@ workflows:
               docker_name:
                 - op-node
                 - op-batcher
+                - op-deployer
                 - op-faucet
                 - op-proposer
                 - op-challenger
@@ -2704,7 +2710,6 @@ workflows:
                 - op-ufm
                 - op-supervisor
                 - op-test-sequencer
-                - op-deployer
                 - cannon
                 - op-dripper
                 - op-interop-mon
@@ -2730,6 +2735,7 @@ workflows:
               op_component:
                 - op-node
                 - op-batcher
+                - op-deployer
                 - op-faucet
                 - op-proposer
                 - op-challenger
@@ -2747,6 +2753,7 @@ workflows:
           requires:
             - op-node-docker-release
             - op-batcher-docker-release
+            - op-deployer-docker-release
             - op-faucet-docker-release
             - op-proposer-docker-release
             - op-challenger-docker-release


### PR DESCRIPTION
We need to ensure the `contracts-bedrock-build` job runs before building op-deployer docker images since we expect the output of the contracts build (artifacts.tgz) to be embedded in the op-deployer go binary.

Ports the fix in [this pr](https://github.com/ethereum-optimism/optimism/pull/17806) from `proposal/op-contracts/v4.1.0` to `develop`