### PR TITLE
op-deployer: fix, support, test upgrades up to v4.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101603.1-rc.1 h1:qH+BM+AHrHFWPonJEpapmyo/LJhqj9/TGsRaWg4RCYg=
 github.com/ethereum-optimism/op-geth v1.101603.1-rc.1/go.mod h1:Ct2QjqZ2UKgvvgKLLYzoh/DBicJZB8DXsv45DgEjcco=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508 h1:A/3QVFt+Aa9ozpPVXxUTLui8honBjSusAaiCVRbafgs=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20250603144016-9c45ca7d4508/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af h1:WWz0gJM/boaUImtJnROecPirAerKCLpAU4m6Tx0ArOg=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -15,6 +15,10 @@ var schemeUnmarshalerDispatch = map[string]schemeUnmarshaler{
 	"https": unmarshalURL,
 }
 
+func CreateHttpLocator(contentHash string) string {
+	return fmt.Sprintf("https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-%s.tar.gz", contentHash)
+}
+
 const EmbeddedLocatorString = "embedded"
 
 var embeddedURL = &url.URL{
@@ -30,6 +34,10 @@ var DefaultL1ContractsLocator = EmbeddedLocator
 var DefaultL2ContractsLocator = EmbeddedLocator
 
 func NewLocatorFromURL(u string) (*Locator, error) {
+	if u == EmbeddedLocatorString {
+		return EmbeddedLocator, nil
+	}
+
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)

--- a/op-deployer/pkg/deployer/artifacts/locator_test.go
+++ b/op-deployer/pkg/deployer/artifacts/locator_test.go
@@ -39,6 +39,14 @@ func TestLocator_Marshaling(t *testing.T) {
 			err: false,
 		},
 		{
+			name: "deprecated tag URL",
+			in:   "tag://op-contracts/v4.1.0",
+			out: &Locator{
+				URL: parseUrl(t, "tag://op-contracts/v4.1.0"),
+			},
+			err: true,
+		},
+		{
 			name: "empty",
 			in:   "",
 			out:  nil,

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIUpgrade tests the upgrade CLI command for each standard opcm release
+// - forks sepolia at the block immediately after the opcm deployment block
+// - runs the upgrade CLI command using op-sepolia values to simulate its upgrade
+func TestCLIUpgrade(t *testing.T) {
+	lgr := testlog.Logger(t, slog.LevelDebug)
+
+	// op-sepolia values
+	l1ProxyAdminOwner := common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2")
+	systemConfigProxy := common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538")
+	proxyAdminImpl := common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc")
+
+	testCases := []struct {
+		contractTag string
+		version     string
+		forkBlock   uint64 // one block number past the opcm deployment block
+	}{
+		{
+			contractTag: standard.ContractsV200Tag,
+			version:     "v2.0.0",
+			forkBlock:   7792843,
+		},
+		//{
+		//contractTag: standard.ContractsV300Tag,
+		//version:     "v3.0.0",
+		//forkBlock:   7853303,
+		//},
+		{
+			contractTag: standard.ContractsV400Tag,
+			version:     "v4.0.0",
+			forkBlock:   8577263,
+		},
+		{
+			contractTag: standard.ContractsV410Tag,
+			version:     "v4.1.0",
+			forkBlock:   9165154,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.contractTag, func(t *testing.T) {
+			forkedL1, stopL1, err := devnet.NewForkedSepoliaFromBlock(lgr, tc.forkBlock)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, stopL1())
+			})
+
+			runner := NewCLITestRunnerWithNetwork(t, WithL1RPC(forkedL1.RPCUrl()))
+			workDir := runner.GetWorkDir()
+
+			opcm, err := standard.OPCMImplAddressFor(11155111, tc.contractTag)
+			require.NoError(t, err)
+
+			testConfig := v2_0_0.UpgradeOPChainInput{
+				Prank: l1ProxyAdminOwner,
+				Opcm:  opcm,
+				EncodedChainConfigs: []v2_0_0.OPChainConfig{
+					{
+						SystemConfigProxy: systemConfigProxy,
+						ProxyAdmin:        proxyAdminImpl,
+						AbsolutePrestate:  common.HexToHash("0x0abc"),
+					},
+				},
+			}
+
+			configFile := filepath.Join(workDir, "upgrade_config_"+tc.version+".json")
+			outputFile := filepath.Join(workDir, "upgrade_output_"+tc.version+".json")
+
+			configData, err := json.MarshalIndent(testConfig, "", "  ")
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(configFile, configData, 0644))
+
+			// Run full cli command to write calldata to outfile
+			output := runner.ExpectSuccess(t, []string{
+				"upgrade", tc.version,
+				"--config", configFile,
+				"--l1-rpc-url", runner.l1RPC,
+				"--outfile", outputFile,
+			}, nil)
+
+			t.Logf("Command output (logs):\n%s", output)
+
+			// Read and parse calldata from outfile
+			require.FileExists(t, outputFile)
+			data, err := os.ReadFile(outputFile)
+			require.NoError(t, err)
+
+			var dump []broadcaster.CalldataDump
+			require.NoError(t, json.Unmarshal(data, &dump))
+
+			t.Logf("Upgrade %s generated calldata: %s", tc.version, string(data))
+
+			// Verify the calldata
+			require.Len(t, dump, 1)
+			require.Equal(t, l1ProxyAdminOwner.Hex(), dump[0].To.Hex())
+			dataHex := hex.EncodeToString(dump[0].Data)
+			require.True(t, strings.HasPrefix(dataHex, "ff2dd5a1"),
+				"calldata should have opcm.upgrade fcn selector ff2dd5a1, got: %s", dataHex[:8])
+
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -41,7 +41,8 @@ const (
 	ContractsV200Tag        = "op-contracts/v2.0.0"
 	ContractsV300Tag        = "op-contracts/v3.0.0"
 	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
-	CurrentTag              = ContractsV400Tag
+	ContractsV410Tag        = "op-contracts/v4.1.0"
+	CurrentTag              = ContractsV410Tag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
@@ -180,7 +181,7 @@ func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployCon
 		return sched
 	case ContractsV180Tag, ContractsV200Tag, ContractsV300Tag:
 		sched.ActivateForkAtGenesis(rollup.Holocene)
-	case ContractsV400Tag:
+	case ContractsV400Tag, ContractsV410Tag:
 		sched.ActivateForkAtGenesis(rollup.Holocene)
 		sched.ActivateForkAtGenesis(rollup.Isthmus)
 	default:

--- a/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
@@ -1,7 +1,4 @@
-// Package v3_0_0 implements the upgrade to v3.0.0 (U14). The interface for the upgrade is identical
-// to the upgrade for v2.0.0 (U13), so all this package does is implement the Upgrader interface and
-// call into the v2.0.0 upgrade.
-package v3_0_0
+package embedded
 
 import (
 	"encoding/json"
@@ -19,7 +16,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return artifacts.CreateHttpLocator("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb")
+	return artifacts.EmbeddedLocatorString
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	embedded "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 	v300 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v3_0_0"
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
@@ -19,6 +20,11 @@ var (
 		Name:  "override-artifacts-url",
 		Usage: "override the artifacts URL",
 	}
+	OutfileFlag = &cli.StringFlag{
+		Name:  "outfile",
+		Usage: "path to write the output to, or - for stdout",
+		Value: "-",
+	}
 )
 
 var Commands = cli.Commands{
@@ -29,6 +35,7 @@ var Commands = cli.Commands{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v200.DefaultUpgrader),
 	},
@@ -39,16 +46,18 @@ var Commands = cli.Commands{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v300.DefaultUpgrader),
 	},
 	&cli.Command{
 		Name:  "v4.0.0",
-		Usage: "upgrades a chain to version v4.0.0",
+		Usage: "upgrades a chain to version v4.0.0 (U16)",
 		Flags: append([]cli.Flag{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v400.DefaultUpgrader),
 	},
@@ -59,7 +68,19 @@ var Commands = cli.Commands{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v410.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "embedded",
+		Usage: "upgrades a chain to version of contracts embedded in op-deployer",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+			OutfileFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(embedded.DefaultUpgrader),
 	},
 }

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -5,6 +5,7 @@ import (
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 	v300 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v3_0_0"
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
+	v410 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_1_0"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
@@ -50,5 +51,15 @@ var Commands = cli.Commands{
 			OverrideArtifactsURLFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v400.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "v4.1.0",
+		Usage: "upgrades a chain to version v4.1.0 (U16a)",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(v410.DefaultUpgrader),
 	},
 }

--- a/op-deployer/pkg/deployer/upgrade/v2_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v2_0_0/upgrade.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
@@ -53,7 +53,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return "tag://" + standard.ContractsV200Tag
+	return artifacts.CreateHttpLocator("1cec51ed629c0394b8fb17ff2c6fa45c406c30f94ebbd37d4c90ede6c29ad608")
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/v4_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v4_0_0/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 )
 
@@ -19,7 +19,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return "tag://" + standard.ContractsV400Tag
+	return artifacts.CreateHttpLocator("67966a2cb9945e1d9ab40e9c61f499e73cdb31d21b8d29a5a5c909b2b13ecd70")
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
@@ -1,0 +1,25 @@
+// Package v4_1_0 implements the upgrade to v4.1.0 (U16a). The interface for the upgrade is identical
+// to the upgrade for v2.0.0 (U13), so all this package does is implement the Upgrader interface and
+// call into the v2.0.0 upgrade.
+package v4_1_0
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+)
+
+type Upgrader struct {
+}
+
+func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
+	return v200.DefaultUpgrader.Upgrade(host, input)
+}
+
+func (u *Upgrader) ArtifactsURL() string {
+	return "tag://" + standard.ContractsV410Tag
+}
+
+var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 )
 
@@ -19,7 +19,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return "tag://" + standard.ContractsV410Tag
+	return artifacts.CreateHttpLocator("579f43b5bbb43e74216b7ed33125280567df86eaf00f7621f354e4a68c07323e")
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-service/testutils/devnet/anvil.go
+++ b/op-service/testutils/devnet/anvil.go
@@ -61,6 +61,12 @@ func WithChainID(id uint64) AnvilOption {
 	}
 }
 
+func WithForkBlockNumber(block uint64) AnvilOption {
+	return func(a *Anvil) {
+		a.args["--fork-block-number"] = strconv.FormatUint(block, 10)
+	}
+}
+
 func NewAnvil(logger log.Logger, opts ...AnvilOption) (*Anvil, error) {
 	if _, err := exec.LookPath("anvil"); err != nil {
 		return nil, fmt.Errorf("anvil not found in PATH: %w", err)

--- a/op-service/testutils/devnet/canned.go
+++ b/op-service/testutils/devnet/canned.go
@@ -46,3 +46,11 @@ func NewForkedSepolia(lgr log.Logger) (*Anvil, CleanupFunc, error) {
 	}
 	return NewForked(lgr, url)
 }
+
+func NewForkedSepoliaFromBlock(lgr log.Logger, block uint64) (*Anvil, CleanupFunc, error) {
+	url := os.Getenv("SEPOLIA_RPC_URL")
+	if url == "" {
+		return nil, nil, fmt.Errorf("SEPOLIA_RPC_URL not set")
+	}
+	return NewForked(lgr, url, WithForkBlockNumber(block))
+}


### PR DESCRIPTION
# Overview

* Updates the superchain-registry/validation package import so that it includes standard `op-contracts/v4.1.0` addresses.
* Ports support for `op-deployer upgrade v4.1.0` from [this pr](https://github.com/ethereum-optimism/optimism/pull/17790) that was made against `proposal/op-contracts/v4.1.0`
* Fixes bug in upgrade commands that use contracts `tag://`
* Adds CLI level integration tests for `upgrade` commands

# Tests

Uses existing cli runner to invoke `upgrade` commands via cli interface. Test implementation steps:
* target standard opcm address based on `op-contracts` tag
* fork sepolia at `blockNum = (opcmDeploymentBlock) + 1`
* using op-sepolia contract/role addresses, attempt `op-deployer upgrade`