### PR TITLE
chore: Remove redundant p2p private key path from quickstart

### DIFF
--- a/op-node/README.md
+++ b/op-node/README.md
@@ -64,7 +64,6 @@ just op-node
   --p2p.priv.path=opnode_p2p_priv.txt \
   --p2p.peerstore.path=opnode_peerstore_db \
   --p2p.discovery.path=opnode_discovery_db \
-  --p2p.priv.path=opnode_p2p_priv.txt
 ```
 
 ## Usage


### PR DESCRIPTION

Removes a redundant and duplicated line from the quickstart command, improving clarity and adherence to style.