### PR TITLE
proofs: Pass game type as a CWIA arg instead of a constructor arg

### DIFF
--- a/packages/contracts-bedrock/interfaces/dispute/v2/IFaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/IFaultDisputeGameV2.sol
@@ -72,7 +72,6 @@ interface IFaultDisputeGameV2 is IDisputeGame {
     error InvalidBondDistributionMode();
     error GameNotFinalized();
     error GameNotResolved();
-    error ReservedGameType();
     error GamePaused();
     event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
     event GameClosed(BondDistributionMode bondDistributionMode);

--- a/packages/contracts-bedrock/interfaces/dispute/v2/IFaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/IFaultDisputeGameV2.sol
@@ -6,7 +6,7 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 import { Types } from "src/libraries/Types.sol";
-import { GameType, Claim, Position, Clock, Hash, Duration, BondDistributionMode } from "src/dispute/lib/Types.sol";
+import { Claim, Position, Clock, Hash, Duration, BondDistributionMode } from "src/dispute/lib/Types.sol";
 
 interface IFaultDisputeGameV2 is IDisputeGame {
     struct ClaimData {
@@ -27,7 +27,6 @@ interface IFaultDisputeGameV2 is IDisputeGame {
     }
 
     struct GameConstructorParams {
-        GameType gameType;
         uint256 maxGameDepth;
         uint256 splitDepth;
         Duration clockExtension;

--- a/packages/contracts-bedrock/interfaces/dispute/v2/IPermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/IPermissionedDisputeGameV2.sol
@@ -67,7 +67,6 @@ interface IPermissionedDisputeGameV2 is IDisputeGame {
     error InvalidBondDistributionMode();
     error GameNotFinalized();
     error GameNotResolved();
-    error ReservedGameType();
     error GamePaused();
     event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
     event GameClosed(BondDistributionMode bondDistributionMode);

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -17,7 +17,7 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IFaultDisputeGameV2 } from "interfaces/dispute/v2/IFaultDisputeGameV2.sol";
 import { IPermissionedDisputeGameV2 } from "interfaces/dispute/v2/IPermissionedDisputeGameV2.sol";
-import { GameTypes, Duration } from "src/dispute/lib/Types.sol";
+import { Duration } from "src/dispute/lib/Types.sol";
 import {
     IOPContractsManager,
     IOPContractsManagerGameTypeAdder,
@@ -486,7 +486,6 @@ contract DeployImplementations is Script {
 
     function deployFaultDisputeGameV2Impl(Input memory _input, Output memory _output) private {
         IFaultDisputeGameV2.GameConstructorParams memory params;
-        params.gameType = GameTypes.CANNON;
         params.maxGameDepth = _input.faultGameV2MaxGameDepth;
         params.splitDepth = _input.faultGameV2SplitDepth;
         params.clockExtension = Duration.wrap(uint64(_input.faultGameV2ClockExtension));
@@ -505,7 +504,6 @@ contract DeployImplementations is Script {
 
     function deployPermissionedDisputeGameV2Impl(Input memory _input, Output memory _output) private {
         IFaultDisputeGameV2.GameConstructorParams memory params;
-        params.gameType = GameTypes.PERMISSIONED_CANNON;
         params.maxGameDepth = _input.faultGameV2MaxGameDepth;
         params.splitDepth = _input.faultGameV2SplitDepth;
         params.clockExtension = Duration.wrap(uint64(_input.faultGameV2ClockExtension));

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameV2.json
@@ -1158,11 +1158,6 @@
   },
   {
     "inputs": [],
-    "name": "ReservedGameType",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "UnexpectedList",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameV2.json
@@ -4,11 +4,6 @@
       {
         "components": [
           {
-            "internalType": "GameType",
-            "name": "gameType",
-            "type": "uint32"
-          },
-          {
             "internalType": "uint256",
             "name": "maxGameDepth",
             "type": "uint256"
@@ -377,7 +372,7 @@
         "type": "bytes"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -390,7 +385,7 @@
         "type": "uint32"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGameV2.json
@@ -1189,11 +1189,6 @@
   },
   {
     "inputs": [],
-    "name": "ReservedGameType",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "UnexpectedList",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/PermissionedDisputeGameV2.json
@@ -4,11 +4,6 @@
       {
         "components": [
           {
-            "internalType": "GameType",
-            "name": "gameType",
-            "type": "uint32"
-          },
-          {
             "internalType": "uint256",
             "name": "maxGameDepth",
             "type": "uint256"
@@ -390,7 +385,7 @@
         "type": "bytes"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -403,7 +398,7 @@
         "type": "uint32"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -156,8 +156,8 @@
     "sourceCodeHash": "0xdebf2ab3af4d5549c40e9dd9db6b2458af286f323b6891f3b0c4e89f3c8928db"
   },
   "src/dispute/DisputeGameFactory.sol:DisputeGameFactory": {
-    "initCodeHash": "0x41ea0025ffbbb7dabc45da9b8afe4bce6b8ec1f132b424f351cf8c7d3fe15579",
-    "sourceCodeHash": "0x81ffb8f29b29774847e8b699d8719aaf6c633070841b8e2c3a651105822ce9ea"
+    "initCodeHash": "0x820e876839f94564a9d5d1fa131781c40126aed76fbbd348f49f318ae3e12aae",
+    "sourceCodeHash": "0xf19216b7943479af87a01ab8935e68561853e8e333d09719c917228bc7a01a3a"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
     "initCodeHash": "0xe7d3c982532946d196d7efadb9e2576c76b8f9e0d1f885ac36977d6f3fb72a65",
@@ -176,12 +176,12 @@
     "sourceCodeHash": "0x8fdd69d4bcd33a3d8b49a73ff5b6855f9ad5f7e2b7393e67cd755973b127b1e8"
   },
   "src/dispute/v2/FaultDisputeGameV2.sol:FaultDisputeGameV2": {
-    "initCodeHash": "0xb5a7bfcbfcb445dc57fc88c07d7305191dc32cc0cf5580d50b4897229e4033c1",
-    "sourceCodeHash": "0x38fd8878a22564cd63e2bdc6af51edead373e2c4a90e631d2774078bbaa54ea6"
+    "initCodeHash": "0x3173e69aa244eec3d4e0b75ff817ea352a48e7a524077de55f2fdfcb1e450f79",
+    "sourceCodeHash": "0x99003aebdd2bed6caf5f38396457d20303dba2511584fe9411e6a88e5997adb2"
   },
   "src/dispute/v2/PermissionedDisputeGameV2.sol:PermissionedDisputeGameV2": {
-    "initCodeHash": "0xcff1406639ff8a83a4c948f412329956104bc7ee30eb8da169a2ba5ef6d8848f",
-    "sourceCodeHash": "0x53fdae5faf97beed5f23d4f285bed06766161ab15c88e3a388f84808471a73c3"
+    "initCodeHash": "0x0b7f811793005a2fa66c8341afdabf44c0a0c531bc6dd4fdfe49a7d4563bfd95",
+    "sourceCodeHash": "0xc0ff6e93b6e2b9111c11e81b5df8948ab71d02b9d2c4dfda982fcb615519f1f7"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x2e0ef4c341367eb59cc6c25190c64eff441d3fe130189da91d4d126f6bdbc9b5",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -176,11 +176,11 @@
     "sourceCodeHash": "0x8fdd69d4bcd33a3d8b49a73ff5b6855f9ad5f7e2b7393e67cd755973b127b1e8"
   },
   "src/dispute/v2/FaultDisputeGameV2.sol:FaultDisputeGameV2": {
-    "initCodeHash": "0x3173e69aa244eec3d4e0b75ff817ea352a48e7a524077de55f2fdfcb1e450f79",
-    "sourceCodeHash": "0x99003aebdd2bed6caf5f38396457d20303dba2511584fe9411e6a88e5997adb2"
+    "initCodeHash": "0x6fc59e2da083c9e2093e42b0fda705e8215cc216e4dcedbf728c08f69ec2d3bd",
+    "sourceCodeHash": "0x7fc97734c12e207f011c4f079fffe84f5bd11f4fb4a95dd56ad6a69df184584f"
   },
   "src/dispute/v2/PermissionedDisputeGameV2.sol:PermissionedDisputeGameV2": {
-    "initCodeHash": "0x0b7f811793005a2fa66c8341afdabf44c0a0c531bc6dd4fdfe49a7d4563bfd95",
+    "initCodeHash": "0x9896fd04e9a3f9fe4f1d6e93eb298b37a6bfa33424aa705e68cc58d0ba7f3f90",
     "sourceCodeHash": "0xc0ff6e93b6e2b9111c11e81b5df8948ab71d02b9d2c4dfda982fcb615519f1f7"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -56,8 +56,8 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.0
-    string public constant version = "1.3.0";
+    /// @custom:semver 1.4.0
+    string public constant version = "1.4.0";
 
     /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
     ///         `IDisputeGame` implementations.
@@ -165,21 +165,39 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         // Get the hash of the parent block.
         bytes32 parentHash = blockhash(block.number - 1);
 
-        // Clone the implementation contract and initialize it with the given parameters.
-        //
-        // CWIA Calldata Layout:
-        // ┌──────────────────────┬─────────────────────────────────────┐
-        // │        Bytes         │            Description              │
-        // ├──────────────────────┼─────────────────────────────────────┤
-        // │ [0, 20)              │ Game creator address                │
-        // │ [20, 52)             │ Root claim                          │
-        // │ [52, 84)             │ Parent block hash at creation time  │
-        // │ [84, 84 + n)         │ Extra data (opaque)                 │
-        // │ [84 + n, 84 + n + m) │ Implementation args (opaque)        │
-        // └──────────────────────┴─────────────────────────────────────┘
-        proxy_ = IDisputeGame(
-            address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData, gameArgs[_gameType]))
-        );
+        if (gameArgs[_gameType].length == 0) {
+            // Clone the implementation contract and initialize it with the given parameters.
+            //
+            // CWIA Calldata Layout:
+            // ┌──────────────────────┬─────────────────────────────────────┐
+            // │        Bytes         │            Description              │
+            // ├──────────────────────┼─────────────────────────────────────┤
+            // │ [0, 20)              │ Game creator address                │
+            // │ [20, 52)             │ Root claim                          │
+            // │ [52, 84)             │ Parent block hash at creation time  │
+            // │ [84, 84 + n)         │ Extra data (opaque)                 │
+            // └──────────────────────┴─────────────────────────────────────┘
+            proxy_ = IDisputeGame(address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData)));
+        } else {
+            // Clone the implementation contract and initialize it with the given parameters.
+            //
+            // CWIA Calldata Layout:
+            // ┌──────────────────────┬─────────────────────────────────────┐
+            // │        Bytes         │            Description              │
+            // ├──────────────────────┼─────────────────────────────────────┤
+            // │ [0, 20)              │ Game creator address                │
+            // │ [20, 52)             │ Root claim                          │
+            // │ [52, 84)             │ Parent block hash at creation time  │
+            // │ [84, 88)             │ Game type                           │
+            // │ [88, 88 + n)         │ Extra data (opaque)                 │
+            // │ [88 + n, 88 + n + m) │ Implementation args (opaque)        │
+            // └──────────────────────┴─────────────────────────────────────┘
+            proxy_ = IDisputeGame(
+                address(impl).clone(
+                    abi.encodePacked(msg.sender, _rootClaim, parentHash, _gameType, _extraData, gameArgs[_gameType])
+                )
+            );
+        }
         proxy_.initialize{ value: msg.value }();
 
         // Compute the unique identifier for the dispute game.

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -97,7 +97,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     /// @notice Parameters for creating a new FaultDisputeGame. We place this into a struct to
     ///         avoid stack-too-deep errors when compiling without the optimizer enabled.
     struct GameConstructorParams {
-        GameType gameType;
         uint256 maxGameDepth;
         uint256 splitDepth;
         Duration clockExtension;
@@ -135,9 +134,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     /// @notice The maximum duration that may accumulate on a team's chess clock before they may no longer respond.
     Duration internal immutable MAX_CLOCK_DURATION;
 
-    /// @notice The game type ID.
-    GameType internal immutable GAME_TYPE;
-
     /// @notice The duration of the clock extension. Will be doubled if the grandchild is the root claim of an execution
     ///         trace bisection subgame.
     Duration internal immutable CLOCK_EXTENSION;
@@ -151,9 +147,9 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.1.0
+    /// @custom:semver 2.2.0
     function version() public pure virtual returns (string memory) {
-        return "2.1.0";
+        return "2.2.0";
     }
 
     /// @notice The starting timestamp of the game
@@ -224,10 +220,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // The split depth cannot be 0 or 1 to stay in bounds of clock extension arithmetic.
         if (_params.splitDepth < 2) revert InvalidSplitDepth();
 
-        // Block type(uint32).max from being used as a game type so that it can be used in the
-        // OptimismPortal respected game type trick.
-        if (_params.gameType.raw() == type(uint32).max) revert ReservedGameType();
-
         // Validate clock extension bounds that don't require VM access.
         // The split depth extension is always clockExtension * 2.
         uint256 splitDepthExtension = uint256(_params.clockExtension.raw()) * 2;
@@ -239,7 +231,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         if (uint64(splitDepthExtension) > _params.maxClockDuration.raw()) revert InvalidClockExtension();
 
         // Set up initial game state.
-        GAME_TYPE = _params.gameType;
         MAX_GAME_DEPTH = _params.maxGameDepth;
         SPLIT_DEPTH = _params.splitDepth;
         CLOCK_EXTENSION = _params.clockExtension;
@@ -299,6 +290,10 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // The maximum clock extension may not be greater than the maximum clock duration.
         if (uint64(maxClockExtension) > MAX_CLOCK_DURATION.raw()) revert InvalidClockExtension();
 
+        // Block type(uint32).max from being used as a game type so that it can be used in the
+        // OptimismPortal respected game type trick.
+        if (gameType().raw() == type(uint32).max) revert ReservedGameType();
+
         // Set the root claim
         claimData.push(
             ClaimData({
@@ -324,7 +319,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
 
         // Set whether the game type was respected when the game was created.
         wasRespectedGameTypeWhenCreated =
-            GameType.unwrap(anchorStateRegistry().respectedGameType()) == GameType.unwrap(GAME_TYPE);
+            GameType.unwrap(anchorStateRegistry().respectedGameType()) == GameType.unwrap(gameType());
     }
 
     /// @notice Returns the expected calldata length for the initialize method
@@ -342,13 +337,14 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         // - 20 bytes: creator address
         // - 32 bytes: root claim
         // - 32 bytes: l1 head
+        // -  4 bytes: game type
         // - 32 bytes: extraData
         // - 32 bytes: absolutePrestate
         // - 20 bytes: vm address
         // - 20 bytes: anchorStateRegistry address
         // - 20 bytes: weth address
         // - 32 bytes: l2ChainId
-        return 240;
+        return 244;
     }
 
     ////////////////////////////////////////////////////////////////
@@ -637,7 +633,7 @@ contract FaultDisputeGameV2 is Clone, ISemver {
 
     /// @notice The l2BlockNumber of the disputed output root in the `L2OutputOracle`.
     function l2BlockNumber() public pure returns (uint256 l2BlockNumber_) {
-        l2BlockNumber_ = _getArgUint256(84);
+        l2BlockNumber_ = _getArgUint256(88);
     }
 
     /// @notice The l2SequenceNumber of the disputed output root in the `L2OutputOracle` (in this case - block number).
@@ -861,48 +857,55 @@ contract FaultDisputeGameV2 is Clone, ISemver {
         l1Head_ = Hash.wrap(_getArgBytes32(52));
     }
 
-    /// @notice Getter for the extra data.
+    /// @notice Getter for the game type.
     /// @dev `clones-with-immutable-args` argument #4
+    /// @return gameType_ The type of proof system being used.
+    function gameType() public pure returns (GameType gameType_) {
+        gameType_ = GameType.wrap(_getArgUint32(84));
+    }
+
+    /// @notice Getter for the extra data.
+    /// @dev `clones-with-immutable-args` argument #5
     /// @return extraData_ Any extra data supplied to the dispute game contract by the creator.
     function extraData() public pure returns (bytes memory extraData_) {
         // The extra data starts at the second word within the cwia calldata and
         // is 32 bytes long.
-        extraData_ = _getArgBytes(84, 32);
+        extraData_ = _getArgBytes(88, 32);
     }
 
     /// @notice Getter for the absolute prestate of the instruction trace.
-    /// @dev `clones-with-immutable-args` argument #5
+    /// @dev `clones-with-immutable-args` argument #6
     /// @return absolutePrestate_ The absolute prestate of the instruction trace.
     function absolutePrestate() public pure returns (Claim absolutePrestate_) {
-        absolutePrestate_ = Claim.wrap(_getArgBytes32(116));
+        absolutePrestate_ = Claim.wrap(_getArgBytes32(120));
     }
 
     /// @notice Getter for the VM implementation.
-    /// @dev `clones-with-immutable-args` argument #6
+    /// @dev `clones-with-immutable-args` argument #7
     /// @return vm_ The onchain VM implementation address.
     function vm() public pure returns (IBigStepper vm_) {
-        vm_ = IBigStepper(_getArgAddress(148));
+        vm_ = IBigStepper(_getArgAddress(152));
     }
 
     /// @notice Getter for the anchor state registry.
-    /// @dev `clones-with-immutable-args` argument #7
+    /// @dev `clones-with-immutable-args` argument #8
     /// @return registry_ The anchor state registry contract address.
     function anchorStateRegistry() public pure returns (IAnchorStateRegistry registry_) {
-        registry_ = IAnchorStateRegistry(_getArgAddress(168));
+        registry_ = IAnchorStateRegistry(_getArgAddress(172));
     }
 
     /// @notice Getter for the WETH contract.
-    /// @dev `clones-with-immutable-args` argument #8
+    /// @dev `clones-with-immutable-args` argument #9
     /// @return weth_ The WETH contract for holding ETH.
     function weth() public pure returns (IDelayedWETH weth_) {
-        weth_ = IDelayedWETH(payable(_getArgAddress(188)));
+        weth_ = IDelayedWETH(payable(_getArgAddress(192)));
     }
 
     /// @notice Getter for the L2 chain ID.
-    /// @dev `clones-with-immutable-args` argument #9
+    /// @dev `clones-with-immutable-args` argument #10
     /// @return l2ChainId_ The L2 chain ID.
     function l2ChainId() public pure returns (uint256 l2ChainId_) {
-        l2ChainId_ = _getArgUint256(208);
+        l2ChainId_ = _getArgUint256(212);
     }
 
     /// @notice A compliant implementation of this interface should return the components of the
@@ -912,18 +915,10 @@ contract FaultDisputeGameV2 is Clone, ISemver {
     /// @return gameType_ The type of proof system being used.
     /// @return rootClaim_ The root claim of the DisputeGame.
     /// @return extraData_ Any extra data supplied to the dispute game contract by the creator.
-    function gameData() external view returns (GameType gameType_, Claim rootClaim_, bytes memory extraData_) {
+    function gameData() external pure returns (GameType gameType_, Claim rootClaim_, bytes memory extraData_) {
         gameType_ = gameType();
         rootClaim_ = rootClaim();
         extraData_ = extraData();
-    }
-
-    /// @notice Getter for the game type.
-    /// @dev The reference impl should be entirely different depending on the type (fault, validity)
-    ///      i.e. The game type should indicate the security model.
-    /// @return gameType_ The type of proof system being used.
-    function gameType() public view returns (GameType gameType_) {
-        gameType_ = GAME_TYPE;
     }
 
     ////////////////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/FaultDisputeGameV2.sol
@@ -56,7 +56,6 @@ import {
     GameNotFinalized,
     InvalidBondDistributionMode,
     GameNotResolved,
-    ReservedGameType,
     GamePaused,
     BadExtraData
 } from "src/dispute/lib/Errors.sol";
@@ -289,10 +288,6 @@ contract FaultDisputeGameV2 is Clone, ISemver {
 
         // The maximum clock extension may not be greater than the maximum clock duration.
         if (uint64(maxClockExtension) > MAX_CLOCK_DURATION.raw()) revert InvalidClockExtension();
-
-        // Block type(uint32).max from being used as a game type so that it can be used in the
-        // OptimismPortal respected game type trick.
-        if (gameType().raw() == type(uint32).max) revert ReservedGameType();
 
         // Set the root claim
         claimData.push(

--- a/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/PermissionedDisputeGameV2.sol
@@ -26,9 +26,9 @@ contract PermissionedDisputeGameV2 is FaultDisputeGameV2 {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.1.0
+    /// @custom:semver 2.2.0
     function version() public pure override returns (string memory) {
-        return "2.1.0";
+        return "2.2.0";
     }
 
     /// @param _params Parameters for creating a new FaultDisputeGame.

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -104,13 +104,12 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
         });
     }
 
-    function _getGameConstructorParamsV2(GameType _gameType)
+    function _getGameConstructorParamsV2()
         internal
         pure
         returns (IFaultDisputeGameV2.GameConstructorParams memory params_)
     {
         return IFaultDisputeGameV2.GameConstructorParams({
-            gameType: _gameType,
             maxGameDepth: 2 ** 3,
             splitDepth: 2 ** 2,
             clockExtension: Duration.wrap(3 hours),
@@ -259,7 +258,7 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
         gameImpl_ = DeployUtils.create1({
             _name: "FaultDisputeGameV2",
             _args: DeployUtils.encodeConstructor(
-                abi.encodeCall(IFaultDisputeGameV2.__constructor__, (_getGameConstructorParamsV2(GameTypes.CANNON)))
+                abi.encodeCall(IFaultDisputeGameV2.__constructor__, (_getGameConstructorParamsV2()))
             )
         });
 
@@ -357,9 +356,7 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
         gameImpl_ = DeployUtils.create1({
             _name: "PermissionedDisputeGameV2",
             _args: DeployUtils.encodeConstructor(
-                abi.encodeCall(
-                    IPermissionedDisputeGameV2.__constructor__, (_getGameConstructorParamsV2(GameTypes.PERMISSIONED_CANNON))
-                )
+                abi.encodeCall(IPermissionedDisputeGameV2.__constructor__, (_getGameConstructorParamsV2()))
             )
         });
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -617,27 +617,6 @@ contract FaultDisputeGame_Initialize_Test is FaultDisputeGame_TestInit {
         );
     }
 
-    /// @notice Tests that the initialize of the `FaultDisputeGameV2` reverts when the `_gameType`
-    ///         parameter is set to the reserved `type(uint32).max` game type.
-    function test_initialize_reservedGameType_reverts() public {
-        // Game type is set and validated in the constructor of V1 dispute games.
-        skipIfDevFeatureDisabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
-        bytes memory extraData = abi.encode(validL2BlockNumber);
-
-        GameType gameType = GameType.wrap(type(uint32).max);
-        IDisputeGame gameImpl = disputeGameFactory.gameImpls(GAME_TYPE);
-        bytes memory implArgs = disputeGameFactory.gameArgs(GAME_TYPE);
-        vm.startPrank(disputeGameFactory.owner());
-        disputeGameFactory.setImplementation(gameType, gameImpl, implArgs);
-        vm.startPrank(disputeGameFactory.owner());
-        disputeGameFactory.setInitBond(gameType, initBond);
-
-        vm.expectRevert(ReservedGameType.selector);
-        gameProxy = IFaultDisputeGame(
-            payable(address(disputeGameFactory.create{ value: initBond }(gameType, arbitaryRootClaim, extraData)))
-        );
-    }
-
     /// @notice Tests that the proxy receives ETH from the dispute game factory.
     function test_initialize_receivesETH_succeeds() public {
         uint256 _value = disputeGameFactory.initBonds(GAME_TYPE);

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -509,7 +509,6 @@ contract FaultDisputeGameV2_Constructor_Test is FaultDisputeGame_TestInit {
                     IFaultDisputeGameV2.__constructor__,
                     (
                         IFaultDisputeGameV2.GameConstructorParams({
-                            gameType: GAME_TYPE,
                             maxGameDepth: _maxGameDepth,
                             splitDepth: _maxGameDepth + 1,
                             clockExtension: Duration.wrap(3 hours),
@@ -534,7 +533,6 @@ contract FaultDisputeGameV2_Constructor_Test is FaultDisputeGame_TestInit {
                     IFaultDisputeGameV2.__constructor__,
                     (
                         IFaultDisputeGameV2.GameConstructorParams({
-                            gameType: GAME_TYPE,
                             maxGameDepth: maxGameDepth,
                             splitDepth: _splitDepth,
                             clockExtension: Duration.wrap(3 hours),
@@ -559,7 +557,6 @@ contract FaultDisputeGameV2_Constructor_Test is FaultDisputeGame_TestInit {
                     IFaultDisputeGameV2.__constructor__,
                     (
                         IFaultDisputeGameV2.GameConstructorParams({
-                            gameType: GAME_TYPE,
                             maxGameDepth: 2 ** 3,
                             splitDepth: _splitDepth,
                             clockExtension: Duration.wrap(3 hours),
@@ -592,34 +589,10 @@ contract FaultDisputeGameV2_Constructor_Test is FaultDisputeGame_TestInit {
                     IFaultDisputeGameV2.__constructor__,
                     (
                         IFaultDisputeGameV2.GameConstructorParams({
-                            gameType: GAME_TYPE,
                             maxGameDepth: 16,
                             splitDepth: 8,
                             clockExtension: Duration.wrap(_clockExtension),
                             maxClockDuration: Duration.wrap(_maxClockDuration)
-                        })
-                    )
-                )
-            )
-        });
-    }
-
-    /// @notice Tests that the constructor of the `FaultDisputeGame` reverts when the `_gameType`
-    ///         parameter is set to the reserved `type(uint32).max` game type.
-    function test_constructor_reservedGameType_reverts() public {
-        vm.expectRevert(ReservedGameType.selector);
-        DeployUtils.create1({
-            _name: "FaultDisputeGameV2",
-            _args: DeployUtils.encodeConstructor(
-                abi.encodeCall(
-                    IFaultDisputeGameV2.__constructor__,
-                    (
-                        IFaultDisputeGameV2.GameConstructorParams({
-                            gameType: GameType.wrap(type(uint32).max),
-                            maxGameDepth: 16,
-                            splitDepth: 8,
-                            clockExtension: Duration.wrap(3 hours),
-                            maxClockDuration: Duration.wrap(3.5 days)
                         })
                     )
                 )
@@ -641,6 +614,27 @@ contract FaultDisputeGame_Initialize_Test is FaultDisputeGame_TestInit {
         vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, claim));
         gameProxy = IFaultDisputeGame(
             payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, claim, abi.encode(_blockNumber))))
+        );
+    }
+
+    /// @notice Tests that the initialize of the `FaultDisputeGameV2` reverts when the `_gameType`
+    ///         parameter is set to the reserved `type(uint32).max` game type.
+    function test_initialize_reservedGameType_reverts() public {
+        // Game type is set and validated in the constructor of V1 dispute games.
+        skipIfDevFeatureDisabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
+        bytes memory extraData = abi.encode(validL2BlockNumber);
+
+        GameType gameType = GameType.wrap(type(uint32).max);
+        IDisputeGame gameImpl = disputeGameFactory.gameImpls(GAME_TYPE);
+        bytes memory implArgs = disputeGameFactory.gameArgs(GAME_TYPE);
+        vm.startPrank(disputeGameFactory.owner());
+        disputeGameFactory.setImplementation(gameType, gameImpl, implArgs);
+        vm.startPrank(disputeGameFactory.owner());
+        disputeGameFactory.setInitBond(gameType, initBond);
+
+        vm.expectRevert(ReservedGameType.selector);
+        gameProxy = IFaultDisputeGame(
+            payable(address(disputeGameFactory.create{ value: initBond }(gameType, arbitaryRootClaim, extraData)))
         );
     }
 
@@ -2903,7 +2897,14 @@ contract FaultDisputeGame_Uncategorized_Test is FaultDisputeGame_TestInit {
         // Construct the expected CWIA data that the proxy will pass to the implementation,
         // alongside any extra calldata passed by the user.
         Hash l1Head = gameProxy.l1Head();
-        bytes memory cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+        bytes memory cwiaData;
+        if (isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
+            cwiaData = abi.encodePacked(
+                address(this), gameProxy.rootClaim(), l1Head, gameProxy.gameType(), gameProxy.extraData()
+            );
+        } else {
+            cwiaData = abi.encodePacked(address(this), gameProxy.rootClaim(), l1Head, gameProxy.extraData());
+        }
 
         // We expect a `ReceiveETH` event to be emitted when 0 bytes of calldata are sent; The
         // fallback is always reached *within the minimal proxy* in `LibClone`'s version of

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -9,7 +9,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Chains } from "scripts/libraries/Chains.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
-import { GameTypes } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -335,11 +334,6 @@ contract DeployImplementations_Test is Test {
         );
 
         // Validate constructor args for FaultDisputeGameV2
-        assertEq(
-            uint256(output.faultDisputeGameV2Impl.gameType().raw()),
-            uint256(GameTypes.CANNON.raw()),
-            "FaultDisputeGameV2 gameType incorrect"
-        );
         assertEq(output.faultDisputeGameV2Impl.maxGameDepth(), 73, "FaultDisputeGameV2 maxGameDepth incorrect");
         assertEq(output.faultDisputeGameV2Impl.splitDepth(), 30, "FaultDisputeGameV2 splitDepth incorrect");
         assertEq(
@@ -352,11 +346,6 @@ contract DeployImplementations_Test is Test {
         );
 
         // Validate constructor args for PermissionedDisputeGameV2
-        assertEq(
-            uint256(output.permissionedDisputeGameV2Impl.gameType().raw()),
-            uint256(GameTypes.PERMISSIONED_CANNON.raw()),
-            "PermissionedDisputeGameV2 gameType incorrect"
-        );
         assertEq(
             output.permissionedDisputeGameV2Impl.maxGameDepth(), 73, "PermissionedDisputeGameV2 maxGameDepth incorrect"
         );
@@ -476,11 +465,6 @@ contract DeployImplementations_Test is Test {
         );
 
         // Validate constructor args for FaultDisputeGameV2
-        assertEq(
-            uint256(output1.faultDisputeGameV2Impl.gameType().raw()),
-            uint256(GameTypes.CANNON.raw()),
-            "FaultDisputeGameV2 gameType incorrect"
-        );
         assertEq(output1.faultDisputeGameV2Impl.maxGameDepth(), 73, "FaultDisputeGameV2 maxGameDepth incorrect");
         assertEq(output1.faultDisputeGameV2Impl.splitDepth(), 30, "FaultDisputeGameV2 splitDepth incorrect");
         assertEq(
@@ -493,11 +477,6 @@ contract DeployImplementations_Test is Test {
         );
 
         // Validate constructor args for PermissionedDisputeGameV2
-        assertEq(
-            uint256(output1.permissionedDisputeGameV2Impl.gameType().raw()),
-            uint256(GameTypes.PERMISSIONED_CANNON.raw()),
-            "PermissionedDisputeGameV2 gameType incorrect"
-        );
         assertEq(
             output1.permissionedDisputeGameV2Impl.maxGameDepth(), 73, "PermissionedDisputeGameV2 maxGameDepth incorrect"
         );


### PR DESCRIPTION
**Description**

V2 fault dispute game contracts no longer take the game type as a constructor arg, allowing a single FaultDisputeGame deployment to be used for both cannon and cannon-kona.  DisputeGameFactory passes the game type as part of the CWIA args automatically.

The change is feature toggled with the game type only being passed through if the game args added in creator pattern are non-zero length.  So existing IDisputeGame implementations are unaffected.

**Tests**

Updated tests.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/17782

**Metadata**

#17260 