### PR TITLE
fix(op-service/signer): add default HTTP client timeout (30s) to prevent hangs

### DIFF
--- a/op-service/signer/client.go
+++ b/op-service/signer/client.go
@@ -64,6 +64,9 @@ func NewSignerClient(logger log.Logger, endpoint string, headers http.Header, tl
 		httpClient = http.DefaultClient
 	}
 
+	// Set a default timeout to avoid hanging requests if callers omit deadlines.
+	httpClient.Timeout = 30 * time.Second
+	
 	rpcClient, err := rpc.DialOptions(context.Background(), endpoint, rpc.WithHTTPClient(httpClient), rpc.WithHeaders(headers))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Overview
Sets a default `http.Client` timeout in `NewSignerClient` to prevent indefinite hangs when callers omit context deadlines.

## Rationale
- HTTP requests could hang indefinitely in TLS and non‑TLS paths.
- A default timeout provides a safe upper bound without affecting callers that already pass deadlines.

