### PR TITLE
fix: add context cancellation checks before network requests

### DIFF
--- a/op-node/cmd/batch_decoder/fetch/fetch.go
+++ b/op-node/cmd/batch_decoder/fetch/fetch.go
@@ -85,6 +85,12 @@ func fetchBatchesPerBlock(ctx context.Context, client *ethclient.Client, beacon 
 	invalidBatchCount := uint64(0)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
+
+	// Check if parent context was cancelled before making network request
+	if err := ctx.Err(); err != nil {
+		return 0, 0, err
+	}
+
 	block, err := client.BlockByNumber(ctx, new(big.Int).SetUint64(number))
 	if err != nil {
 		return 0, 0, err
@@ -122,6 +128,11 @@ func fetchBatchesPerBlock(ctx context.Context, client *ethclient.Client, beacon 
 					hashes = append(hashes, idh)
 					blobIndex += 1
 				}
+				// Check if context was cancelled before making beacon request
+				if err := ctx.Err(); err != nil {
+					return 0, 0, err
+				}
+
 				blobs, err := beacon.GetBlobs(ctx, eth.L1BlockRef{
 					Hash:       block.Hash(),
 					Number:     block.Number().Uint64(),


### PR DESCRIPTION
Add ctx.Err() checks before making network requests in fetchBatchesPerBlock to prevent unnecessary operations when parent context is cancelled. 

This ensures graceful handling of context cancellation during block fetching and blob retrieval operations.