### PR TITLE
chore(op-acceptance-tests): flake-shake; resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1638,7 +1638,7 @@ jobs:
         default: "flake-shake"
     machine:
       image: ubuntu-2404:current
-    resource_class: large
+    resource_class: xlarge
     parallelism: << pipeline.parameters.flake-shake-workers >>
     steps:
       - checkout-from-workspace
@@ -1661,7 +1661,7 @@ jobs:
             bash ./op-acceptance-tests/scripts/ci_flake_shake_calc_iterations.sh << pipeline.parameters.flake-shake-iterations >>
       - run:
           name: Run flake-shake iterations
-          no_output_timeout: 2h
+          no_output_timeout: 3h
           working_directory: op-acceptance-tests
           command: |
             OUTPUT_DIR="logs/flake-shake-results-worker-${FLAKE_SHAKE_WORKER_ID}"


### PR DESCRIPTION
A lot of flake-shake jobs have been failing with the mysterious "Infrastructure Failure" from CircleCI.
I'd like to try a larger resource class to get more CPUs to see if that remedies the issue.

<img width="1567" height="395" alt="Screenshot 2025-10-14 at 11 37 01" src="https://github.com/user-attachments/assets/4f6ac7e1-0ba2-4f1b-9c21-404a11a1b9c1" />
