### PR TITLE
op-deployer: fix upgrader.ArtifactsURLs

### DIFF
--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -15,6 +15,10 @@ var schemeUnmarshalerDispatch = map[string]schemeUnmarshaler{
 	"https": unmarshalURL,
 }
 
+func CreateHttpLocator(contentHash string) string {
+	return fmt.Sprintf("https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-%s.tar.gz", contentHash)
+}
+
 const EmbeddedLocatorString = "embedded"
 
 var embeddedURL = &url.URL{
@@ -30,6 +34,10 @@ var DefaultL1ContractsLocator = EmbeddedLocator
 var DefaultL2ContractsLocator = EmbeddedLocator
 
 func NewLocatorFromURL(u string) (*Locator, error) {
+	if u == EmbeddedLocatorString {
+		return EmbeddedLocator, nil
+	}
+
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)

--- a/op-deployer/pkg/deployer/artifacts/locator_test.go
+++ b/op-deployer/pkg/deployer/artifacts/locator_test.go
@@ -39,6 +39,14 @@ func TestLocator_Marshaling(t *testing.T) {
 			err: false,
 		},
 		{
+			name: "deprecated tag URL",
+			in:   "tag://op-contracts/v4.1.0",
+			out: &Locator{
+				URL: parseUrl(t, "tag://op-contracts/v4.1.0"),
+			},
+			err: true,
+		},
+		{
 			name: "empty",
 			in:   "",
 			out:  nil,

--- a/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/embedded/upgrade.go
@@ -1,7 +1,4 @@
-// Package v3_0_0 implements the upgrade to v3.0.0 (U14). The interface for the upgrade is identical
-// to the upgrade for v2.0.0 (U13), so all this package does is implement the Upgrader interface and
-// call into the v2.0.0 upgrade.
-package v3_0_0
+package embedded
 
 import (
 	"encoding/json"
@@ -19,7 +16,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return artifacts.CreateHttpLocator("147b9fae70608da2975a01be3d98948306f89ba1930af7c917eea41a54d87cdb")
+	return artifacts.EmbeddedLocatorString
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	embedded "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 	v300 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v3_0_0"
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
@@ -19,6 +20,11 @@ var (
 		Name:  "override-artifacts-url",
 		Usage: "override the artifacts URL",
 	}
+	OutfileFlag = &cli.StringFlag{
+		Name:  "outfile",
+		Usage: "path to write the output to, or - for stdout",
+		Value: "-",
+	}
 )
 
 var Commands = cli.Commands{
@@ -29,6 +35,7 @@ var Commands = cli.Commands{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v200.DefaultUpgrader),
 	},
@@ -39,16 +46,18 @@ var Commands = cli.Commands{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v300.DefaultUpgrader),
 	},
 	&cli.Command{
 		Name:  "v4.0.0",
-		Usage: "upgrades a chain to version v4.0.0",
+		Usage: "upgrades a chain to version v4.0.0 (U16)",
 		Flags: append([]cli.Flag{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v400.DefaultUpgrader),
 	},
@@ -59,7 +68,19 @@ var Commands = cli.Commands{
 			deployer.L1RPCURLFlag,
 			ConfigFlag,
 			OverrideArtifactsURLFlag,
+			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v410.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "embedded",
+		Usage: "upgrades a chain to version of contracts embedded in op-deployer",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+			OutfileFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(embedded.DefaultUpgrader),
 	},
 }

--- a/op-deployer/pkg/deployer/upgrade/upgrader.go
+++ b/op-deployer/pkg/deployer/upgrade/upgrader.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
@@ -57,7 +60,7 @@ func UpgradeCLI(upgrader Upgrader) func(*cli.Context) error {
 
 		artifactsFS, err := artifacts.Download(ctx, artifactsLocator, artifacts.BarProgressor(), cacheDir)
 		if err != nil {
-			return fmt.Errorf("failed to download L1 artifacts: %w", err)
+			return fmt.Errorf("failed to download L1 artifacts: %w, url: %s", err, artifactsLocator)
 		}
 
 		host, err := env.DefaultForkedScriptHost(
@@ -89,12 +92,12 @@ func UpgradeCLI(upgrader Upgrader) func(*cli.Context) error {
 			return fmt.Errorf("failed to dump calldata: %w", err)
 		}
 
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(dump); err != nil {
-			return fmt.Errorf("failed to encode calldata: %w", err)
+		outfile := cliCtx.String(OutfileFlag.Name)
+		if err := jsonutil.WriteJSON(dump, ioutil.ToStdOutOrFileOrNoop(outfile, 0o666)); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
 		}
 
+		lgr.Info("Success! opcm.upgrade calldata created")
 		return nil
 	}
 }

--- a/op-deployer/pkg/deployer/upgrade/v2_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v2_0_0/upgrade.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
@@ -53,7 +53,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return "tag://" + standard.ContractsV200Tag
+	return artifacts.CreateHttpLocator("1cec51ed629c0394b8fb17ff2c6fa45c406c30f94ebbd37d4c90ede6c29ad608")
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/v4_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v4_0_0/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 )
 
@@ -19,7 +19,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return "tag://" + standard.ContractsV400Tag
+	return artifacts.CreateHttpLocator("67966a2cb9945e1d9ab40e9c61f499e73cdb31d21b8d29a5a5c909b2b13ecd70")
 }
 
 var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v4_1_0/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
 )
 
@@ -19,7 +19,7 @@ func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
 }
 
 func (u *Upgrader) ArtifactsURL() string {
-	return "tag://" + standard.ContractsV410Tag
+	return artifacts.CreateHttpLocator("579f43b5bbb43e74216b7ed33125280567df86eaf00f7621f354e4a68c07323e")
 }
 
 var DefaultUpgrader = new(Upgrader)


### PR DESCRIPTION
Fixes upgrade commands which were broken due to removal of `tag://` locator types. Instead of using those locators for upgrade commands, we hardcode the exact tar file gcp url to download from for each version of contracts used for upgrades.

Cherry-picked commit a56ad8181b974059e208a5321a759dc22ef75c5c from https://github.com/ethereum-optimism/optimism/pull/17824