### PR TITLE
op-deployer: add cli tests

### DIFF
--- a/op-deployer/cmd/op-deployer/main.go
+++ b/op-deployer/cmd/op-deployer/main.go
@@ -4,20 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/clean"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
-
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/bootstrap"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/cli"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
-
-	"github.com/ethereum-optimism/optimism/op-service/cliapp"
-	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -29,57 +19,7 @@ var (
 var VersionWithMeta = opservice.FormatVersion(version.Version, GitCommit, GitDate, version.Meta)
 
 func main() {
-	app := cli.NewApp()
-	app.Version = VersionWithMeta
-	app.Name = "op-deployer"
-	app.Usage = "Tool to configure and deploy OP Chains."
-	app.Flags = cliapp.ProtectFlags(deployer.GlobalFlags)
-	app.Commands = []*cli.Command{
-		{
-			Name:   "init",
-			Usage:  "initializes a chain intent and state file",
-			Flags:  cliapp.ProtectFlags(deployer.InitFlags),
-			Action: deployer.InitCLI(),
-		},
-		{
-			Name:   "apply",
-			Usage:  "applies a chain intent to the chain",
-			Flags:  cliapp.ProtectFlags(deployer.ApplyFlags),
-			Action: deployer.ApplyCLI(),
-		},
-		{
-			Name:        "upgrade",
-			Usage:       "upgrades contracts by sending tx to OPCM.upgrade function",
-			Flags:       cliapp.ProtectFlags(deployer.UpgradeFlags),
-			Subcommands: upgrade.Commands,
-		},
-		{
-			Name:        "bootstrap",
-			Usage:       "bootstraps global contract instances",
-			Subcommands: bootstrap.Commands,
-		},
-		{
-			Name:        "inspect",
-			Usage:       "inspects the state of a deployment",
-			Subcommands: inspect.Commands,
-		},
-		{
-			Name:        "clean",
-			Usage:       "cleans up various things",
-			Subcommands: clean.Commands,
-		},
-		{
-			Name:   "verify",
-			Usage:  "verifies deployed contracts on Etherscan",
-			Flags:  cliapp.ProtectFlags(deployer.VerifyFlags),
-			Action: verify.VerifyCLI,
-		},
-		{
-			Name:        "manage",
-			Usage:       "manages the chain",
-			Subcommands: manage.Commands,
-		},
-	}
+	app := cli.NewApp(VersionWithMeta)
 	app.Writer = os.Stdout
 	app.ErrWriter = os.Stderr
 	err := app.Run(os.Args)

--- a/op-deployer/pkg/cli/app.go
+++ b/op-deployer/pkg/cli/app.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/bootstrap"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/clean"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
+
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/urfave/cli/v2"
+)
+
+// NewApp creates and configures a new CLI application
+func NewApp(versionWithMeta string) *cli.App {
+	app := cli.NewApp()
+	app.Version = versionWithMeta
+	app.Name = "op-deployer"
+	app.Usage = "Tool to configure and deploy OP Chains."
+	app.Flags = cliapp.ProtectFlags(deployer.GlobalFlags)
+	app.Before = func(context *cli.Context) error {
+		if err := deployer.CreateCacheDir(context.String(deployer.CacheDirFlagName)); err != nil {
+			return err
+		}
+		return nil
+	}
+	app.Commands = []*cli.Command{
+		{
+			Name:   "init",
+			Usage:  "initializes a chain intent and state file",
+			Flags:  cliapp.ProtectFlags(deployer.InitFlags),
+			Action: deployer.InitCLI(),
+		},
+		{
+			Name:   "apply",
+			Usage:  "applies a chain intent to the chain",
+			Flags:  cliapp.ProtectFlags(deployer.ApplyFlags),
+			Action: deployer.ApplyCLI(),
+		},
+		{
+			Name:        "upgrade",
+			Usage:       "upgrades contracts by sending tx to OPCM.upgrade function",
+			Flags:       cliapp.ProtectFlags(deployer.UpgradeFlags),
+			Subcommands: upgrade.Commands,
+		},
+		{
+			Name:        "bootstrap",
+			Usage:       "bootstraps global contract instances",
+			Subcommands: bootstrap.Commands,
+		},
+		{
+			Name:        "inspect",
+			Usage:       "inspects the state of a deployment",
+			Subcommands: inspect.Commands,
+		},
+		{
+			Name:        "clean",
+			Usage:       "cleans up various things",
+			Subcommands: clean.Commands,
+		},
+		{
+			Name:   "verify",
+			Usage:  "verifies deployed contracts on Etherscan",
+			Flags:  cliapp.ProtectFlags(deployer.VerifyFlags),
+			Action: verify.VerifyCLI,
+		},
+		{
+			Name:        "manage",
+			Usage:       "manages the chain",
+			Subcommands: manage.Commands,
+		},
+	}
+	return app
+}

--- a/op-deployer/pkg/deployer/artifacts/locator.go
+++ b/op-deployer/pkg/deployer/artifacts/locator.go
@@ -106,11 +106,29 @@ func (a *Locator) UnmarshalText(text []byte) error {
 }
 
 func (a *Locator) MarshalText() ([]byte, error) {
-	if a.URL.String() == embeddedURL.String() {
+	if a.URL.String() == embeddedURL.String() || a.URL.String() == "" {
 		return []byte("embedded"), nil
 	}
 
 	return []byte(a.URL.String()), nil
+}
+
+func (a *Locator) MarshalTOML() ([]byte, error) {
+	if a.URL.String() == embeddedURL.String() || a.URL.String() == "" {
+		return []byte(`"embedded"`), nil
+	}
+	return []byte(`"` + a.URL.String() + `"`), nil
+}
+
+func (a *Locator) UnmarshalTOML(i interface{}) error {
+	switch v := i.(type) {
+	case string:
+		return a.UnmarshalText([]byte(v))
+	case []byte:
+		return a.UnmarshalText(v)
+	default:
+		return fmt.Errorf("unsupported type for TOML unmarshaling: %T", i)
+	}
 }
 
 func (a *Locator) Equal(b *Locator) bool {

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -2,9 +2,6 @@ package deployer
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 
@@ -31,40 +28,6 @@ const (
 	ContractNameFlagName     = "contract-name"
 )
 
-type DeploymentTarget string
-
-const (
-	DeploymentTargetLive     DeploymentTarget = "live"
-	DeploymentTargetGenesis  DeploymentTarget = "genesis"
-	DeploymentTargetCalldata DeploymentTarget = "calldata"
-	DeploymentTargetNoop     DeploymentTarget = "noop"
-)
-
-func NewDeploymentTarget(s string) (DeploymentTarget, error) {
-	switch s {
-	case string(DeploymentTargetLive):
-		return DeploymentTargetLive, nil
-	case string(DeploymentTargetGenesis):
-		return DeploymentTargetGenesis, nil
-	case string(DeploymentTargetCalldata):
-		return DeploymentTargetCalldata, nil
-	case string(DeploymentTargetNoop):
-		return DeploymentTargetNoop, nil
-	default:
-		return "", fmt.Errorf("invalid deployment target: %s", s)
-	}
-}
-
-func GetDefaultCacheDir() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		fallbackDir := ".op-deployer/cache"
-		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, fallbackDir)
-		return fallbackDir
-	}
-	return path.Join(homeDir, ".op-deployer/cache")
-}
-
 var (
 	L1RPCURLFlag = &cli.StringFlag{
 		Name: L1RPCURLFlagName,
@@ -85,7 +48,7 @@ var (
 		Usage: "Cache directory. " +
 			"If set, the deployer will attempt to cache downloaded artifacts in the specified directory.",
 		EnvVars: PrefixEnvVar("CACHE_DIR"),
-		Value:   GetDefaultCacheDir(),
+		Value:   DefaultCacheDir(),
 	}
 	L1ChainIDFlag = &cli.Uint64Flag{
 		Name:    L1ChainIDFlagName,
@@ -186,12 +149,4 @@ var VerifyFlags = []cli.Flag{
 
 func PrefixEnvVar(name string) []string {
 	return op_service.PrefixEnvVar(EnvVarPrefix, name)
-}
-
-func cwd() string {
-	dir, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	return dir
 }

--- a/op-deployer/pkg/deployer/integration_test/cli/bootstrap_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/bootstrap_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIBootstrap tests the bootstrap commands via CLI
+func TestCLIBootstrap(t *testing.T) {
+	runner := NewCLITestRunnerWithNetwork(t)
+	workDir := runner.GetWorkDir()
+
+	// Use the same chain ID that anvil runs on
+	l1ChainID := uint64(devnet.DefaultChainID)
+	l1ChainIDBig := big.NewInt(int64(l1ChainID))
+
+	// Get dev keys for role addresses
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	// Get addresses for required roles
+	superchainProxyAdminOwner := shared.AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig))
+	protocolVersionsOwner := shared.AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainIDBig))
+	guardian := shared.AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig))
+	challenger := shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+	t.Run("bootstrap superchain", func(t *testing.T) {
+		superchainOutputFile := filepath.Join(workDir, "bootstrap_superchain.json")
+
+		// Run bootstrap superchain command
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+		}, nil)
+
+		t.Logf("Bootstrap superchain output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, superchainOutputFile)
+
+		// Parse and validate the output
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+	})
+
+	t.Run("bootstrap superchain with custom protocol versions", func(t *testing.T) {
+		superchainOutputFile := filepath.Join(workDir, "bootstrap_superchain_custom.json")
+
+		// Use a custom protocol version - create v1.0.0 with custom build
+		customVersion := params.ProtocolVersionV0{
+			Build:      [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+			Major:      1,
+			Minor:      0,
+			Patch:      0,
+			PreRelease: 0,
+		}.Encode()
+
+		// Run bootstrap superchain command with custom versions
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+			"--required-protocol-version", common.Hash(customVersion).Hex(),
+			"--recommended-protocol-version", common.Hash(customVersion).Hex(),
+		}, nil)
+
+		t.Logf("Bootstrap superchain (custom protocol versions) output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, superchainOutputFile)
+
+		// Parse and validate the output
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+	})
+
+	t.Run("bootstrap superchain paused", func(t *testing.T) {
+		superchainOutputFile := filepath.Join(workDir, "bootstrap_superchain_paused.json")
+
+		// Run bootstrap superchain command with paused flag
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+			"--paused",
+		}, nil)
+
+		t.Logf("Bootstrap superchain (paused) output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, superchainOutputFile)
+
+		// Parse and validate the output
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+	})
+
+	t.Run("bootstrap implementations", func(t *testing.T) {
+		// First, we need a superchain deployment
+		superchainOutputFile := filepath.Join(workDir, "bootstrap_superchain_for_impls.json")
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+		}, nil)
+
+		// Parse superchain output to get addresses
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+
+		implsOutputFile := filepath.Join(workDir, "bootstrap_implementations.json")
+
+		// Run bootstrap implementations command (use same key index as superchain deployment)
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "implementations",
+			"--outfile", implsOutputFile,
+			"--mips-version", strconv.Itoa(int(standard.MIPSVersion)),
+			"--protocol-versions-proxy", superchainOutput.ProtocolVersionsProxy.Hex(),
+			"--superchain-config-proxy", superchainOutput.SuperchainConfigProxy.Hex(),
+			"--upgrade-controller", superchainProxyAdminOwner.Hex(), // Use proxy admin owner as upgrade controller
+			"--superchain-proxy-admin", superchainOutput.SuperchainProxyAdmin.Hex(),
+			"--challenger", challenger.Hex(),
+		}, nil)
+
+		t.Logf("Bootstrap implementations output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, implsOutputFile)
+
+		// Parse and validate the output
+		var implsOutput opcm.DeployImplementationsOutput
+		data, err = os.ReadFile(implsOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &implsOutput)
+		require.NoError(t, err)
+
+		// We only check specific addresses that are always set
+		require.NotEqual(t, common.Address{}, implsOutput.Opcm, "Opcm should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.OpcmStandardValidator, "OpcmStandardValidator should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.DelayedWETHImpl, "DelayedWETHImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.OptimismPortalImpl, "OptimismPortalImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.ETHLockboxImpl, "ETHLockboxImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.PreimageOracleSingleton, "PreimageOracleSingleton should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.MipsSingleton, "MipsSingleton should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.SystemConfigImpl, "SystemConfigImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.L1CrossDomainMessengerImpl, "L1CrossDomainMessengerImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.L1ERC721BridgeImpl, "L1ERC721BridgeImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.L1StandardBridgeImpl, "L1StandardBridgeImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.OptimismMintableERC20FactoryImpl, "OptimismMintableERC20FactoryImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.DisputeGameFactoryImpl, "DisputeGameFactoryImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.AnchorStateRegistryImpl, "AnchorStateRegistryImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.SuperchainConfigImpl, "SuperchainConfigImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.ProtocolVersionsImpl, "ProtocolVersionsImpl should be set")
+	})
+
+	t.Run("bootstrap proxy", func(t *testing.T) {
+		proxyOutputFile := filepath.Join(workDir, "bootstrap_proxy.json")
+
+		// Run bootstrap proxy command
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "proxy",
+			"--proxy-owner", superchainProxyAdminOwner.Hex(),
+			"--outfile", proxyOutputFile,
+		}, nil)
+
+		t.Logf("Bootstrap proxy output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, proxyOutputFile)
+
+		// Parse and validate the output
+		var proxyOutput opcm.DeployProxyOutput
+		data, err := os.ReadFile(proxyOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &proxyOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(proxyOutput))
+	})
+
+	t.Run("bootstrap with stdout output", func(t *testing.T) {
+		// Test that stdout output works (no --outfile flag)
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "proxy",
+			"--proxy-owner", superchainProxyAdminOwner.Hex(),
+			"--outfile", "-", // stdout
+		}, nil)
+
+		t.Logf("Bootstrap proxy (stdout) output:\n%s", output)
+	})
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/cli_runner.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/cli_runner.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/stretchr/testify/require"
+)
+
+// CLITestRunner provides utilities for running op-deployer CLI commands in tests
+type CLITestRunner struct {
+	workDir       string
+	l1RPC         string
+	privateKeyHex string
+}
+
+// CLITestRunnerOption is a functional option for configuring CLITestRunner
+type CLITestRunnerOption func(*CLITestRunner)
+
+func WithL1RPC(rpcURL string) CLITestRunnerOption {
+	return func(r *CLITestRunner) {
+		r.l1RPC = rpcURL
+	}
+}
+
+func WithPrivateKey(pkHex string) CLITestRunnerOption {
+	return func(r *CLITestRunner) {
+		r.privateKeyHex = pkHex
+	}
+}
+
+func NewCLITestRunner(t *testing.T, opts ...CLITestRunnerOption) *CLITestRunner {
+	workDir := t.TempDir()
+	return &CLITestRunner{
+		workDir: workDir,
+	}
+}
+
+// NewCLITestRunnerWithNetwork creates a new CLI test runner with default network setup.
+// Defaults can be overridden using functional options.
+func NewCLITestRunnerWithNetwork(t *testing.T, opts ...CLITestRunnerOption) *CLITestRunner {
+	workDir := t.TempDir()
+
+	// Set up defaults
+	lgr := testlog.Logger(t, slog.LevelDebug)
+	l1RPC, _ := devnet.DefaultAnvilRPC(t, lgr)
+	pkHex, _, _ := shared.DefaultPrivkey(t)
+
+	runner := &CLITestRunner{
+		workDir:       workDir,
+		l1RPC:         l1RPC,
+		privateKeyHex: pkHex,
+	}
+
+	// Apply options to override defaults
+	for _, opt := range opts {
+		opt(runner)
+	}
+
+	return runner
+}
+
+// GetWorkDir returns the working directory for this test runner
+func (r *CLITestRunner) GetWorkDir() string {
+	return r.workDir
+}
+
+// captureOutputWriter captures output written to it for testing
+type captureOutputWriter struct {
+	buf *bytes.Buffer
+}
+
+func (w *captureOutputWriter) Write(p []byte) (n int, err error) {
+	return w.buf.Write(p)
+}
+
+func newCaptureOutputWriter() *captureOutputWriter {
+	return &captureOutputWriter{buf: &bytes.Buffer{}}
+}
+
+// Run executes a CLI command and returns the output
+func (r *CLITestRunner) Run(ctx context.Context, args []string, env map[string]string) (string, error) {
+	// Set up environment variables
+	for key, value := range env {
+		os.Setenv(key, value)
+		defer os.Unsetenv(key)
+	}
+
+	// Change to the working directory for the test
+	originalDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = os.Chdir(originalDir)
+	}()
+
+	if err := os.Chdir(r.workDir); err != nil {
+		return "", err
+	}
+
+	// Capture output
+	stdout := newCaptureOutputWriter()
+	stderr := newCaptureOutputWriter()
+
+	// Add "op-deployer" as the first argument if not already present
+	fullArgs := args
+	if len(args) == 0 || args[0] != "op-deployer" {
+		fullArgs = append([]string{"op-deployer"}, args...)
+	}
+
+	// Run the CLI command using the testable interface
+	err = RunCLI(ctx, stdout, stderr, fullArgs)
+	output := stdout.buf.String() + stderr.buf.String()
+	if err != nil {
+		return output, err
+	}
+
+	return output, nil
+}
+
+// RunWithNetwork executes a CLI command with network parameters if available
+func (r *CLITestRunner) RunWithNetwork(ctx context.Context, args []string, env map[string]string) (string, error) {
+	if r.l1RPC != "" {
+		args = append(args, "--l1-rpc-url", r.l1RPC)
+	}
+	if r.privateKeyHex != "" {
+		args = append(args, "--private-key", r.privateKeyHex)
+	}
+
+	return r.Run(ctx, args, env)
+}
+
+// ExpectSuccess runs a command expecting it to succeed
+func (r *CLITestRunner) ExpectSuccess(t *testing.T, args []string, env map[string]string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	output, err := r.Run(ctx, args, env)
+	require.NoError(t, err, "Command failed: %s", output)
+	return output
+}
+
+// ExpectSuccessWithNetwork runs a command with network parameters expecting it to succeed
+func (r *CLITestRunner) ExpectSuccessWithNetwork(t *testing.T, args []string, env map[string]string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	output, err := r.RunWithNetwork(ctx, args, env)
+	require.NoError(t, err, "Command failed: %s", output)
+	return output
+}
+
+// ExpectErrorContains runs a command expecting it to fail with specific error text
+func (r *CLITestRunner) ExpectErrorContains(t *testing.T, args []string, env map[string]string, contains string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	output, err := r.Run(ctx, args, env)
+	require.Error(t, err, "Expected command to fail but it succeeded")
+	require.Contains(t, output, contains, "Error message should contain expected text")
+	return output
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/cli_runner_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/cli_runner_test.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLITestRunnerSmoke tests the CLITestRunner itself
+func TestCLITestRunnerSmoke(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	require.DirExists(t, runner.GetWorkDir())
+
+	// Test basic command execution
+	runner.ExpectSuccess(t, []string{"--help"}, nil)
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/cli_testable.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/cli_testable.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/cli"
+)
+
+// RunCLI provides a testable interface for running the op-deployer CLI
+func RunCLI(ctx context.Context, w io.Writer, ew io.Writer, args []string) error {
+	app := cli.NewApp("v0.0.0-test")
+	app.Writer = w
+	app.ErrWriter = ew
+	err := app.RunContext(ctx, args)
+	if err != nil {
+		_, _ = fmt.Fprintf(ew, "Application failed: %v\n", err)
+	}
+	return err
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/command_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/command_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitCommandFlagValidation(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectError    bool
+		expectContains []string
+	}{
+		{
+			name:           "valid init command",
+			args:           []string{"init", "--l1-chain-id", "11155111", "--l2-chain-ids", "123"},
+			expectError:    false,
+			expectContains: []string{}, // Success is validated by lack of error
+		},
+		{
+			name:           "missing required l2-chain-ids",
+			args:           []string{"init", "--l1-chain-id", "11155111"},
+			expectError:    true,
+			expectContains: []string{"must specify at least one L2 chain ID"},
+		},
+		{
+			name:           "invalid l1-chain-id format",
+			args:           []string{"init", "--l1-chain-id", "invalid", "--l2-chain-ids", "123"},
+			expectError:    true,
+			expectContains: []string{"invalid value \"invalid\" for flag -l1-chain-id: parse error"},
+		},
+		{
+			name:           "invalid intent-type",
+			args:           []string{"init", "--l1-chain-id", "11155111", "--l2-chain-ids", "123", "--intent-type", "invalid"},
+			expectError:    true,
+			expectContains: []string{"intent type not supported: invalid"},
+		},
+		{
+			name:           "valid intent-type custom",
+			args:           []string{"init", "--l1-chain-id", "11155111", "--l2-chain-ids", "123", "--intent-type", "custom"},
+			expectError:    false,
+			expectContains: []string{}, // Success is validated by lack of error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := runner.GetWorkDir()
+			args := append(tt.args, "--workdir", workDir)
+
+			if tt.expectError {
+				runner.ExpectErrorContains(t, args, nil, strings.Join(tt.expectContains, " "))
+			} else {
+				runner.ExpectSuccess(t, args, nil)
+				// For successful cases, validate output if expectContains is not empty
+				if len(tt.expectContains) > 0 {
+					output := runner.ExpectSuccess(t, args, nil)
+					for _, expected := range tt.expectContains {
+						require.Contains(t, output, expected, "Output should contain expected string: %s", expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestApplyCommandFlagValidation(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectError    bool
+		expectContains []string
+	}{
+		{
+			name:           "invalid deployment target",
+			args:           []string{"apply", "--deployment-target", "invalid"},
+			expectError:    true,
+			expectContains: []string{"failed to parse deployment target: invalid deployment target: invalid"},
+		},
+		{
+			name:           "valid deployment targets",
+			args:           []string{"apply", "--deployment-target", "live"},
+			expectError:    true, // Will fail because no RPC URL, but tests flag parsing
+			expectContains: []string{"l1 RPC URL must be specified"},
+		},
+		{
+			name:           "valid noop deployment target",
+			args:           []string{"apply", "--deployment-target", "noop"},
+			expectError:    true, // Will fail because no intent file, but tests flag parsing
+			expectContains: []string{"failed to read intent file"},
+		},
+		{
+			name:           "valid calldata deployment target",
+			args:           []string{"apply", "--deployment-target", "calldata"},
+			expectError:    true, // Will fail because no intent file, but tests flag parsing
+			expectContains: []string{"failed to read intent file"},
+		},
+		{
+			name:           "valid genesis deployment target",
+			args:           []string{"apply", "--deployment-target", "genesis"},
+			expectError:    true, // Will fail because no intent file, but tests flag parsing
+			expectContains: []string{"failed to read intent file"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := runner.GetWorkDir()
+			args := append(tt.args, "--workdir", workDir)
+
+			if tt.expectError {
+				runner.ExpectErrorContains(t, args, nil, strings.Join(tt.expectContains, " "))
+			} else {
+				runner.ExpectSuccess(t, args, nil)
+				// For successful cases, validate output if expectContains is not empty
+				if len(tt.expectContains) > 0 {
+					output := runner.ExpectSuccess(t, args, nil)
+					for _, expected := range tt.expectContains {
+						require.Contains(t, output, expected, "Output should contain expected string: %s", expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGlobalFlagValidation(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectError    bool
+		expectContains []string
+	}{
+		{
+			name:           "invalid global flag",
+			args:           []string{"--invalid-global-flag", "init", "--l1-chain-id", "11155111", "--l2-chain-ids", "123"},
+			expectError:    true,
+			expectContains: []string{"flag provided but not defined: -invalid-global-flag"},
+		},
+		{
+			name:           "valid cache dir flag",
+			args:           []string{"--cache-dir", "/tmp/cache", "init", "--l1-chain-id", "11155111", "--l2-chain-ids", "123"},
+			expectError:    false,
+			expectContains: []string{}, // Success is validated by lack of error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := runner.GetWorkDir()
+			args := append(tt.args, "--workdir", workDir)
+
+			if tt.expectError {
+				runner.ExpectErrorContains(t, args, nil, strings.Join(tt.expectContains, " "))
+			} else {
+				runner.ExpectSuccess(t, args, nil)
+				// For successful cases, validate output if expectContains is not empty
+				if len(tt.expectContains) > 0 {
+					output := runner.ExpectSuccess(t, args, nil)
+					for _, expected := range tt.expectContains {
+						require.Contains(t, output, expected, "Output should contain expected string: %s", expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCommandParsing(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectError    bool
+		expectContains []string
+	}{
+		{
+			name:           "help command",
+			args:           []string{"--help"},
+			expectError:    false,
+			expectContains: []string{"op-deployer", "Tool to configure and deploy OP Chains"}, // From cli/app.go app.Usage
+		},
+		{
+			name:           "version command",
+			args:           []string{"--version"},
+			expectError:    false,
+			expectContains: []string{"op-deployer", "v0.0.0"}, // Version should contain app name and version format
+		},
+		{
+			name:           "no command",
+			args:           []string{},
+			expectError:    false,                                                             // Shows help
+			expectContains: []string{"op-deployer", "Tool to configure and deploy OP Chains"}, // From cli/app.go app.Usage
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectError {
+				runner.ExpectErrorContains(t, tt.args, nil, strings.Join(tt.expectContains, " "))
+			} else {
+				output := runner.ExpectSuccess(t, tt.args, nil)
+				// Verify expected content in output
+				for _, expected := range tt.expectContains {
+					require.Contains(t, output, expected, "Output should contain expected string: %s", expected)
+				}
+			}
+		})
+	}
+}
+
+// TestCLIApplyMissingIntent tests apply when intent.toml is missing (uses real CLI binary)
+func TestCLIApplyMissingIntent(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	workDir := runner.GetWorkDir()
+
+	runner.ExpectErrorContains(t, []string{
+		"apply",
+		"--deployment-target", "noop",
+		"--workdir", workDir,
+	}, nil, "failed to read intent file")
+}
+
+// TestCLIApplyMissingState tests apply when state.json is missing (uses real CLI binary)
+func TestCLIApplyMissingState(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	workDir := runner.GetWorkDir()
+
+	// Create intent.toml but not state.json
+	intent := &state.Intent{
+		ConfigType: state.IntentTypeCustom,
+		L1ChainID:  11155111,
+	}
+	require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
+
+	runner.ExpectErrorContains(t, []string{
+		"apply",
+		"--deployment-target", "noop",
+		"--workdir", workDir,
+	}, nil, "failed to read state file")
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/e2e_apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/e2e_apply_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIEndToEndApply tests the full end-to-end apply workflow via CLI
+func TestCLIEndToEndApply(t *testing.T) {
+	runner := NewCLITestRunnerWithNetwork(t)
+
+	workDir := runner.GetWorkDir()
+	// Use the same chain ID that anvil runs on
+	l1ChainID := uint64(devnet.DefaultChainID)
+	l2ChainID1 := uint256.NewInt(1)
+	l2ChainID2 := uint256.NewInt(2)
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	t.Run("two chains one after another", func(t *testing.T) {
+		intent, _ := cliInitIntent(t, runner, l1ChainID, []common.Hash{l2ChainID1.Bytes32()})
+
+		if intent.SuperchainRoles == nil {
+			t.Log("SuperchainRoles is nil, initializing...")
+			intent.SuperchainRoles = &addresses.SuperchainRoles{}
+		}
+
+		l1ChainIDBig := big.NewInt(int64(l1ChainID))
+		intent.SuperchainRoles.SuperchainProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig))
+		intent.SuperchainRoles.SuperchainGuardian = shared.AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig))
+		intent.SuperchainRoles.ProtocolVersionsOwner = shared.AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainIDBig))
+		intent.SuperchainRoles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+		for _, chain := range intent.Chains {
+			chain.Roles.L1ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+			chain.Roles.L2ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+			chain.Roles.SystemConfigOwner = shared.AddrFor(t, dk, devkeys.SystemConfigOwner.Key(l1ChainIDBig))
+			chain.Roles.UnsafeBlockSigner = shared.AddrFor(t, dk, devkeys.SequencerP2PRole.Key(l1ChainIDBig))
+			chain.Roles.Batcher = shared.AddrFor(t, dk, devkeys.BatcherRole.Key(l1ChainIDBig))
+			chain.Roles.Proposer = shared.AddrFor(t, dk, devkeys.ProposerRole.Key(l1ChainIDBig))
+			chain.Roles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+			chain.BaseFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.BaseFeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.L1FeeVaultRecipient = shared.AddrFor(t, dk, devkeys.L1FeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.SequencerFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainIDBig))
+
+			chain.Eip1559DenominatorCanyon = standard.Eip1559DenominatorCanyon
+			chain.Eip1559Denominator = standard.Eip1559Denominator
+			chain.Eip1559Elasticity = standard.Eip1559Elasticity
+		}
+		require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
+
+		// Apply first chain with live deployment
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"apply",
+			"--deployment-target", "live",
+			"--workdir", workDir,
+		}, nil)
+
+		// Add second chain to intent
+		intent, err := pipeline.ReadIntent(workDir)
+		require.NoError(t, err)
+
+		secondChain := shared.NewChainIntent(t, dk, new(big.Int).SetUint64(l1ChainID), l2ChainID2, 60_000_000)
+		secondChain.Eip1559DenominatorCanyon = standard.Eip1559DenominatorCanyon
+		secondChain.Eip1559Denominator = standard.Eip1559Denominator
+		secondChain.Eip1559Elasticity = standard.Eip1559Elasticity
+		intent.Chains = append(intent.Chains, secondChain)
+
+		require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
+
+		// Apply again with both chains
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"apply",
+			"--deployment-target", "live",
+			"--workdir", workDir,
+		}, nil)
+
+		// Verify final state
+		finalState, err := pipeline.ReadState(workDir)
+		require.NoError(t, err)
+		require.Len(t, finalState.Chains, 2)
+		require.Equal(t, common.Hash(l2ChainID1.Bytes32()), finalState.Chains[0].ID)
+		require.Equal(t, common.Hash(l2ChainID2.Bytes32()), finalState.Chains[1].ID)
+
+		require.NotNil(t, finalState.AppliedIntent)
+	})
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/init_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/init_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIInit tests basic init command and file creation
+func TestCLIInit(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	workDir := runner.GetWorkDir()
+
+	runner.ExpectSuccess(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1",
+		"--workdir", workDir,
+	}, nil)
+
+	// Verify intent.toml was created and has correct content
+	intent, err := pipeline.ReadIntent(workDir)
+	require.NoError(t, err)
+	require.Equal(t, uint64(11155111), intent.L1ChainID)
+	require.Len(t, intent.Chains, 1)
+	require.Equal(t, common.Hash(uint256.NewInt(1).Bytes32()), intent.Chains[0].ID)
+
+	// Verify state.json was created (chains get populated during apply, not init)
+	st, err := pipeline.ReadState(workDir)
+	require.NoError(t, err)
+	// State starts empty and gets populated during apply
+	require.Len(t, st.Chains, 0)
+}
+
+// TestCLIInitMultipleChains tests init with multiple L2 chain IDs
+func TestCLIInitMultipleChains(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	workDir := runner.GetWorkDir()
+
+	runner.ExpectSuccess(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1,2",
+		"--workdir", workDir,
+	}, nil)
+
+	intent, err := pipeline.ReadIntent(workDir)
+	require.NoError(t, err)
+	require.Equal(t, uint64(11155111), intent.L1ChainID)
+	require.Len(t, intent.Chains, 2)
+	require.Equal(t, common.Hash(uint256.NewInt(1).Bytes32()), intent.Chains[0].ID)
+	require.Equal(t, common.Hash(uint256.NewInt(2).Bytes32()), intent.Chains[1].ID)
+
+	// State starts empty and gets populated during apply
+	st, err := pipeline.ReadState(workDir)
+	require.NoError(t, err)
+	require.Len(t, st.Chains, 0)
+}
+
+// TestCLIInitCustomIntentType tests init with custom intent type
+func TestCLIInitCustomIntentType(t *testing.T) {
+	runner := NewCLITestRunner(t)
+
+	workDir := runner.GetWorkDir()
+
+	runner.ExpectSuccess(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1",
+		"--intent-type", "custom",
+		"--workdir", workDir,
+	}, nil)
+
+	intent, err := pipeline.ReadIntent(workDir)
+	require.NoError(t, err)
+	require.Equal(t, state.IntentTypeCustom, intent.ConfigType)
+	require.Equal(t, uint64(11155111), intent.L1ChainID)
+	require.Len(t, intent.Chains, 1)
+
+	// State starts empty and gets populated during apply
+	st, err := pipeline.ReadState(workDir)
+	require.NoError(t, err)
+	require.Len(t, st.Chains, 0)
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/noop_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/noop_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIApplyNoOp tests apply with noop target
+func TestCLIApplyNoOp(t *testing.T) {
+	runner := NewCLITestRunnerWithNetwork(t)
+
+	workDir := runner.GetWorkDir()
+
+	intent, _ := cliInitIntent(t, runner, devnet.DefaultChainID, []common.Hash{uint256.NewInt(1).Bytes32()})
+
+	if intent.SuperchainRoles == nil {
+		t.Log("SuperchainRoles is nil, initializing...")
+		intent.SuperchainRoles = &addresses.SuperchainRoles{}
+	}
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	l1ChainIDBig := big.NewInt(devnet.DefaultChainID)
+	intent.SuperchainRoles.SuperchainProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig))
+	intent.SuperchainRoles.SuperchainGuardian = shared.AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig))
+	intent.SuperchainRoles.ProtocolVersionsOwner = shared.AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainIDBig))
+	intent.SuperchainRoles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+	// Set chain-specific addresses
+	for _, chain := range intent.Chains {
+		chain.Roles.L1ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+		chain.Roles.L2ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+		chain.Roles.SystemConfigOwner = shared.AddrFor(t, dk, devkeys.SystemConfigOwner.Key(l1ChainIDBig))
+		chain.Roles.UnsafeBlockSigner = shared.AddrFor(t, dk, devkeys.SequencerP2PRole.Key(l1ChainIDBig))
+		chain.Roles.Batcher = shared.AddrFor(t, dk, devkeys.BatcherRole.Key(l1ChainIDBig))
+		chain.Roles.Proposer = shared.AddrFor(t, dk, devkeys.ProposerRole.Key(l1ChainIDBig))
+		chain.Roles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+		chain.BaseFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.BaseFeeVaultRecipientRole.Key(l1ChainIDBig))
+		chain.L1FeeVaultRecipient = shared.AddrFor(t, dk, devkeys.L1FeeVaultRecipientRole.Key(l1ChainIDBig))
+		chain.SequencerFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainIDBig))
+
+		chain.Eip1559DenominatorCanyon = standard.Eip1559DenominatorCanyon
+		chain.Eip1559Denominator = standard.Eip1559Denominator
+		chain.Eip1559Elasticity = standard.Eip1559Elasticity
+	}
+	require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
+
+	runner.ExpectSuccessWithNetwork(t, []string{
+		"apply",
+		"--deployment-target", "noop",
+		"--workdir", workDir,
+	}, nil)
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/shared.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/shared.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// cliInitIntent creates an intent using the CLI init command
+func cliInitIntent(t *testing.T, runner *CLITestRunner, l1ChainID uint64, l2ChainIDs []common.Hash) (*state.Intent, *state.State) {
+	workDir := runner.GetWorkDir()
+
+	chainIDStrings := make([]string, len(l2ChainIDs))
+	for i, id := range l2ChainIDs {
+		chainIDStrings[i] = new(uint256.Int).SetBytes32(id[:]).String()
+	}
+	l2ChainIDsStr := strings.Join(chainIDStrings, ",")
+
+	runner.ExpectSuccess(t, []string{
+		"init",
+		"--l1-chain-id", fmt.Sprintf("%d", l1ChainID),
+		"--l2-chain-ids", l2ChainIDsStr,
+		"--intent-type", "custom",
+		"--workdir", workDir,
+	}, nil)
+
+	intent, err := pipeline.ReadIntent(workDir)
+	require.NoError(t, err)
+
+	st, err := pipeline.ReadState(workDir)
+	require.NoError(t, err)
+
+	return intent, st
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIUpgrade tests the upgrade CLI command for each standard opcm release
+// - forks sepolia at the block immediately after the opcm deployment block
+// - runs the upgrade CLI command using op-sepolia values to simulate its upgrade
+func TestCLIUpgrade(t *testing.T) {
+	lgr := testlog.Logger(t, slog.LevelDebug)
+
+	// op-sepolia values
+	l1ProxyAdminOwner := common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2")
+	systemConfigProxy := common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538")
+	proxyAdminImpl := common.HexToAddress("0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc")
+
+	testCases := []struct {
+		contractTag string
+		version     string
+		forkBlock   uint64 // one block number past the opcm deployment block
+	}{
+		{
+			contractTag: standard.ContractsV200Tag,
+			version:     "v2.0.0",
+			forkBlock:   7792843,
+		},
+		//{
+		//contractTag: standard.ContractsV300Tag,
+		//version:     "v3.0.0",
+		//forkBlock:   7853303,
+		//},
+		{
+			contractTag: standard.ContractsV400Tag,
+			version:     "v4.0.0",
+			forkBlock:   8577263,
+		},
+		{
+			contractTag: standard.ContractsV410Tag,
+			version:     "v4.1.0",
+			forkBlock:   9165154,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.contractTag, func(t *testing.T) {
+			forkedL1, stopL1, err := devnet.NewForkedSepoliaFromBlock(lgr, tc.forkBlock)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, stopL1())
+			})
+
+			runner := NewCLITestRunnerWithNetwork(t, WithL1RPC(forkedL1.RPCUrl()))
+			workDir := runner.GetWorkDir()
+
+			opcm, err := standard.OPCMImplAddressFor(11155111, tc.contractTag)
+			require.NoError(t, err)
+
+			testConfig := v2_0_0.UpgradeOPChainInput{
+				Prank: l1ProxyAdminOwner,
+				Opcm:  opcm,
+				EncodedChainConfigs: []v2_0_0.OPChainConfig{
+					{
+						SystemConfigProxy: systemConfigProxy,
+						ProxyAdmin:        proxyAdminImpl,
+						AbsolutePrestate:  common.HexToHash("0x0abc"),
+					},
+				},
+			}
+
+			configFile := filepath.Join(workDir, "upgrade_config_"+tc.version+".json")
+			outputFile := filepath.Join(workDir, "upgrade_output_"+tc.version+".json")
+
+			configData, err := json.MarshalIndent(testConfig, "", "  ")
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(configFile, configData, 0644))
+
+			// Run full cli command to write calldata to outfile
+			output := runner.ExpectSuccess(t, []string{
+				"upgrade", tc.version,
+				"--config", configFile,
+				"--l1-rpc-url", runner.l1RPC,
+				"--outfile", outputFile,
+			}, nil)
+
+			t.Logf("Command output (logs):\n%s", output)
+
+			// Read and parse calldata from outfile
+			require.FileExists(t, outputFile)
+			data, err := os.ReadFile(outputFile)
+			require.NoError(t, err)
+
+			var dump []broadcaster.CalldataDump
+			require.NoError(t, json.Unmarshal(data, &dump))
+
+			t.Logf("Upgrade %s generated calldata: %s", tc.version, string(data))
+
+			// Verify the calldata
+			require.Len(t, dump, 1)
+			require.Equal(t, l1ProxyAdminOwner.Hex(), dump[0].To.Hex())
+			dataHex := hex.EncodeToString(dump[0].Data)
+			require.True(t, strings.HasPrefix(dataHex, "ff2dd5a1"),
+				"calldata should have opcm.upgrade fcn selector ff2dd5a1, got: %s", dataHex[:8])
+
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // TestCLIUpgrade tests the upgrade CLI command for each standard opcm release
-// - forks sepolia at the block immediately after the opcm deployment block
+// - forks sepolia at a block before op-sepolia was upgraded
 // - runs the upgrade CLI command using op-sepolia values to simulate its upgrade
 func TestCLIUpgrade(t *testing.T) {
 	lgr := testlog.Logger(t, slog.LevelDebug)
@@ -32,27 +32,27 @@ func TestCLIUpgrade(t *testing.T) {
 	testCases := []struct {
 		contractTag string
 		version     string
-		forkBlock   uint64 // one block number past the opcm deployment block
+		forkBlock   uint64
 	}{
 		{
 			contractTag: standard.ContractsV200Tag,
 			version:     "v2.0.0",
-			forkBlock:   7792843,
+			forkBlock:   7792843, // one block past the opcm deployment block
 		},
-		//{
-		//contractTag: standard.ContractsV300Tag,
-		//version:     "v3.0.0",
-		//forkBlock:   7853303,
-		//},
+		{
+			contractTag: standard.ContractsV300Tag,
+			version:     "v3.0.0",
+			forkBlock:   8092886, // one block before op-sepolia was upgraded
+		},
 		{
 			contractTag: standard.ContractsV400Tag,
 			version:     "v4.0.0",
-			forkBlock:   8577263,
+			forkBlock:   8577263, // one block past the opcm deployment block
 		},
 		{
 			contractTag: standard.ContractsV410Tag,
 			version:     "v4.1.0",
-			forkBlock:   9165154,
+			forkBlock:   9165154, // one block past the opcm deployment block
 		},
 	}
 

--- a/op-deployer/pkg/deployer/integration_test/shared/shared.go
+++ b/op-deployer/pkg/deployer/integration_test/shared/shared.go
@@ -1,0 +1,89 @@
+package shared
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// AddrFor generates an address for a given role
+func AddrFor(t *testing.T, dk *devkeys.MnemonicDevKeys, key devkeys.Key) common.Address {
+	addr, err := dk.Address(key)
+	require.NoError(t, err)
+	return addr
+}
+
+func NewChainIntent(t *testing.T, dk *devkeys.MnemonicDevKeys, l1ChainID *big.Int, l2ChainID *uint256.Int, gasLimit uint64) *state.ChainIntent {
+	return &state.ChainIntent{
+		ID:                         l2ChainID.Bytes32(),
+		BaseFeeVaultRecipient:      AddrFor(t, dk, devkeys.BaseFeeVaultRecipientRole.Key(l1ChainID)),
+		L1FeeVaultRecipient:        AddrFor(t, dk, devkeys.L1FeeVaultRecipientRole.Key(l1ChainID)),
+		SequencerFeeVaultRecipient: AddrFor(t, dk, devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainID)),
+		Eip1559DenominatorCanyon:   standard.Eip1559DenominatorCanyon,
+		Eip1559Denominator:         standard.Eip1559Denominator,
+		Eip1559Elasticity:          standard.Eip1559Elasticity,
+		GasLimit:                   gasLimit,
+		Roles: state.ChainRoles{
+			L1ProxyAdminOwner: AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainID)),
+			L2ProxyAdminOwner: AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainID)),
+			SystemConfigOwner: AddrFor(t, dk, devkeys.SystemConfigOwner.Key(l1ChainID)),
+			UnsafeBlockSigner: AddrFor(t, dk, devkeys.SequencerP2PRole.Key(l1ChainID)),
+			Batcher:           AddrFor(t, dk, devkeys.BatcherRole.Key(l1ChainID)),
+			Proposer:          AddrFor(t, dk, devkeys.ProposerRole.Key(l1ChainID)),
+			Challenger:        AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainID)),
+		},
+	}
+}
+
+func NewIntent(
+	t *testing.T,
+	l1ChainID *big.Int,
+	dk *devkeys.MnemonicDevKeys,
+	l2ChainID *uint256.Int,
+	l1Loc *artifacts.Locator,
+	l2Loc *artifacts.Locator,
+	gasLimit uint64,
+) (*state.Intent, *state.State) {
+	intent := &state.Intent{
+		ConfigType: state.IntentTypeCustom,
+		L1ChainID:  l1ChainID.Uint64(),
+		SuperchainRoles: &addresses.SuperchainRoles{
+			SuperchainProxyAdminOwner: AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainID)),
+			ProtocolVersionsOwner:     AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainID)),
+			SuperchainGuardian:        AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainID)),
+			Challenger:                AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainID)),
+		},
+		FundDevAccounts:    false,
+		L1ContractsLocator: l1Loc,
+		L2ContractsLocator: l2Loc,
+		Chains: []*state.ChainIntent{
+			NewChainIntent(t, dk, l1ChainID, l2ChainID, gasLimit),
+		},
+	}
+	st := &state.State{
+		Version: 1,
+	}
+	return intent, st
+}
+
+// DefaultPrivkey returns the default private key for testing
+func DefaultPrivkey(t *testing.T) (string, *ecdsa.PrivateKey, *devkeys.MnemonicDevKeys) {
+	pkHex := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	pk, err := crypto.HexToECDSA(pkHex)
+	require.NoError(t, err)
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	return pkHex, pk, dk
+}

--- a/op-deployer/pkg/deployer/utils.go
+++ b/op-deployer/pkg/deployer/utils.go
@@ -1,0 +1,61 @@
+package deployer
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+type DeploymentTarget string
+
+const (
+	DeploymentTargetLive     DeploymentTarget = "live"
+	DeploymentTargetGenesis  DeploymentTarget = "genesis"
+	DeploymentTargetCalldata DeploymentTarget = "calldata"
+	DeploymentTargetNoop     DeploymentTarget = "noop"
+)
+
+func NewDeploymentTarget(s string) (DeploymentTarget, error) {
+	switch s {
+	case string(DeploymentTargetLive):
+		return DeploymentTargetLive, nil
+	case string(DeploymentTargetGenesis):
+		return DeploymentTargetGenesis, nil
+	case string(DeploymentTargetCalldata):
+		return DeploymentTargetCalldata, nil
+	case string(DeploymentTargetNoop):
+		return DeploymentTargetNoop, nil
+	default:
+		return "", fmt.Errorf("invalid deployment target: %s", s)
+	}
+}
+
+func cwd() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return dir
+}
+
+func DefaultCacheDir() string {
+	var cacheDir string
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		cacheDir = ".op-deployer/cache"
+		log.Printf("error getting user home directory: %v, using fallback directory: %s\n", err, cacheDir)
+	} else {
+		cacheDir = path.Join(homeDir, ".op-deployer/cache")
+	}
+
+	return cacheDir
+}
+
+func CreateCacheDir(cacheDir string) error {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
+	}
+	return nil
+}

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -88,7 +88,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse l1 contracts release locator: %w", err)
 	}
-	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.GetDefaultCacheDir())
+	artifactsFS, err := artifacts.Download(ctx, locator, nil, deployer.DefaultCacheDir())
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}

--- a/op-service/testutils/devnet/anvil.go
+++ b/op-service/testutils/devnet/anvil.go
@@ -61,6 +61,12 @@ func WithChainID(id uint64) AnvilOption {
 	}
 }
 
+func WithForkBlockNumber(block uint64) AnvilOption {
+	return func(a *Anvil) {
+		a.args["--fork-block-number"] = strconv.FormatUint(block, 10)
+	}
+}
+
 func NewAnvil(logger log.Logger, opts ...AnvilOption) (*Anvil, error) {
 	if _, err := exec.LookPath("anvil"); err != nil {
 		return nil, fmt.Errorf("anvil not found in PATH: %w", err)

--- a/op-service/testutils/devnet/canned.go
+++ b/op-service/testutils/devnet/canned.go
@@ -46,3 +46,11 @@ func NewForkedSepolia(lgr log.Logger) (*Anvil, CleanupFunc, error) {
 	}
 	return NewForked(lgr, url)
 }
+
+func NewForkedSepoliaFromBlock(lgr log.Logger, block uint64) (*Anvil, CleanupFunc, error) {
+	url := os.Getenv("SEPOLIA_RPC_URL")
+	if url == "" {
+		return nil, nil, fmt.Errorf("SEPOLIA_RPC_URL not set")
+	}
+	return NewForked(lgr, url, WithForkBlockNumber(block))
+}


### PR DESCRIPTION
Ports op-deployer cli level integration_tests from `develop` onto `proposal/op-contracts/v4.1.0`. All of this code replicates the code currently on the latest `develop` commit`. 

In order to run the cli tests we needed to include the following:
* cli runner
* refactor `cmd/op-deployer/main.go` for improved testability
* entire `integration_test/cli` package, which includes all cli tests
* `op-service/testutils/devnet` updates to allow cli tests to create an anvil env from a fork sepolia at a specific blockNum