### PR TITLE
chore(op-acceptance-tests): flake-shake; tweaked default workers.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,10 @@ parameters:
     default: false
   flake-shake-iterations:
     type: integer
-    default: 400
+    default: 300
   flake-shake-workers:
     type: integer
-    default: 20
+    default: 50
 
 orbs:
   go: circleci/go@1.8.0

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -22,7 +22,7 @@ gates:
           owner: "axel,mofi"
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/proofs
         name: TestChallengerPlaysGame
-        timeout: 30m
+        timeout: 60m
         metadata:
           owner: "axel,mofi"
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/osaka


### PR DESCRIPTION
This should reduce the chance of CircleCI timeouts.
