### PR TITLE
op-acceptance-tests: Target non-existing hash while FCU and Reorg

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/init_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/init_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithNewSingleChainMultiNodeWithTestSeq(),
+	presets.DoMain(m,
+		presets.WithNewSingleChainMultiNodeWithTestSeq(),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/init_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/init_test.go
@@ -1,0 +1,14 @@
+package reorg_elp2p
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/init_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/init_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+	presets.DoMain(m, presets.WithNewSingleChainMultiNodeWithTestSeq(),
 		presets.WithCompatibleTypes(compat.SysGo),
 	)
 }

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
@@ -15,115 +15,381 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func TestSafeReorg(gt *testing.T) {
+func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
 	require := t.Require()
 	logger := t.Logger()
 	ctx := t.Ctx()
 
-	// sys.L2CL.DisconnectPeer(sys.L2CLB)
+	logger = logger.With("###", "###")
 
 	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
 	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	// Pass the L1 genesis
 	sys.L1Network.WaitForBlock()
+
+	// Stop auto advancing L1
 	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
 
-	for i := range 12 {
-		parent := common.Hash{}
-		// parent[0] = byte(i)
-		_ = i
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
-		// must send empty hash to seq. why?
-		require.NoError(ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
-		require.NoError(ts.Next(t.Ctx()))
-		l1Unsafe := sys.L1EL.BlockRefByLabel(eth.Unsafe)
-		logger.Info("### L1", "unsafe", l1Unsafe, "time", l1Unsafe.Time)
+	require.Eventually(func() bool {
+		// Advance single L1 block
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		l2Safe := sys.L2EL.BlockRefByLabel(eth.Safe)
+		logger.Info("l1 info", "l1_head", l1head, "l1_origin", l2Safe.L1Origin, "l2Safe", l2Safe)
+		// Wait until safe L2 block has L1 origin point after the startL1Block
+		return l2Safe.Number > 0 && l2Safe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
 
-		sys.L2Chain.WaitForBlock()
-		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
-		logger.Info("### L2", "unsafe", l2Unsafe, "time", l2Unsafe.Time, "l1Origin", l2Unsafe.L1Origin)
-	}
+	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Safe)
+	logger.Info("Target L2 Block to reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
 
-	n := 10
-	require.GreaterOrEqual(12, n)
-	// select a divergence block to reorg from
-	var divergence eth.L1BlockRef
-	{
-		tip := sys.L1EL.BlockRefByLabel(eth.Unsafe)
-		require.Greater(tip.Number, uint64(n), "n is larger than L1 tip, cannot reorg out block number `tip-n`")
+	// Make sure verifier safe head is also advanced from reorgL2Block or matched
+	sys.L2ELB.Reached(eth.Safe, l2BlockBeforeReorg.Number, 3)
 
-		divergence = sys.L1EL.BlockRefByNumber(tip.Number - uint64(n))
-		logger.Info("### L1 Divergence", "div", divergence)
-	}
+	// Disconnect CLP2P
+	sys.L2CLB.DisconnectPeer(sys.L2CL)
+	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
-	tipL2_preReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	// Stop verifier CL
+	sys.L2CLB.Stop()
 
-	logger.Info("### tipL2_preReorg", "number", tipL2_preReorg.Number)
+	// Reorg L1 block which safe block L1 Origin points to
+	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
+	logger.Info("Triggering L1 reorg", "l1", l1BlockBeforeReorg)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1BlockBeforeReorg.ParentHash}))
+	require.NoError(ts.Next(ctx))
 
-	logger.Info("### L1 Div", "unsafe", sys.L1EL.BlockRefByLabel(eth.Unsafe))
-	// reorg the L1 chain -- sequence an alternative L1 block from divergence block parent
-	require.NoError(ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: divergence.ParentHash}))
-	require.NoError(ts.Next(t.Ctx()))
-	logger.Info("### L1 Div", "unsafe", sys.L1EL.BlockRefByLabel(eth.Unsafe))
-
+	// Start advancing L1
 	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
 
-	sys.L1EL.ReorgTriggered(divergence, 5)
+	// Make sure L1 reorged
+	sys.L1EL.WaitForBlockNumber(l1BlockBeforeReorg.Number)
+	l1BlockAfterReorg := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
+	logger.Info("Triggered L1 reorg", "l1", l1BlockAfterReorg)
+	require.NotEqual(l1BlockAfterReorg.Hash, l1BlockBeforeReorg.Hash)
 
-	sys.L2CL.Reached(types.CrossSafe, tipL2_preReorg.Number, 50)
+	// Need to poll until the L2CL detects L1 Reorg and trigger L2 Reorg
+	// What happens:
+	//  L2CL detects L1 Reorg and reset the pipeline. op-node example logs: "reset: detected L1 reorg"
+	//  L2EL detects L2 Reorg and reorgs. op-geth example logs: "Chain reorg detected"
+	sys.L2EL.ReorgTriggered(l2BlockBeforeReorg, 30)
+	l2BlockAfterReorg := sys.L2EL.BlockRefByNumber(l2BlockBeforeReorg.Number)
+	require.NotEqual(l2BlockAfterReorg.Hash, l2BlockBeforeReorg.Hash)
+	logger.Info("Triggered L2 reorg", "l2", l2BlockAfterReorg)
+	//  Batcher re-submits batch using updated L1 view
+	sys.L2EL.Reached(eth.Safe, l2BlockAfterReorg.Number, 30)
+	require.GreaterOrEqual(sys.L1EL.BlockRefByNumber(l2BlockAfterReorg.L1Origin.Number).Number, l1BlockAfterReorg.Number)
 
-	reorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
-	logger.Info("### Reorg", "unsafe", reorg)
-	logger.Info("### Reorg", "unsafe", sys.L2ELB.BlockRefByNumber(reorg.Number))
+	// Check the divergence before restarting verifier L2CLB
+	verUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Unsafe heads", "seq", seqUnsafe, "ver", verUnsafe)
+	// Verifier unsafe head cannot advance yet because L2CLB is down
+	require.Greater(seqUnsafe.Number, verUnsafe.Number)
+	// Verifier unsafe head diverged
+	canonicalFromSeq := sys.L2EL.BlockRefByNumber(verUnsafe.Number)
+	require.NotEqual(canonicalFromSeq.Hash, verUnsafe.Hash)
+	logger.Info("Verifer unsafe head diverged", "verUnsafe", verUnsafe, "canonical", canonicalFromSeq)
+	var rewindTo eth.L2BlockRef
+	for i := verUnsafe.Number; i > 0; i-- {
+		ver := sys.L2ELB.BlockRefByNumber(i)
+		seq := sys.L2EL.BlockRefByNumber(i)
+		if ver.Hash == seq.Hash {
+			rewindTo = ver
+			break
+		}
+	}
+	logger.Info("Verifier diverged", "rewindTo", rewindTo)
+	require.Greater(l1BlockAfterReorg.Number, rewindTo.L1Origin.Number)
+
+	// Restart verifier L2CL. CLP2P disabled
+	sys.L2CLB.Start()
+
+	// Safe block reorged. Verifier L2CL will read the new L1 and reorg the safe chain
+	// Unsafe head will also be updated because safe chain reorged
+	sys.L2ELB.ReorgTriggered(l2BlockBeforeReorg, 10)
+	logger.Info("Triggered L2 safe reorg at verifier", "l2", l2BlockAfterReorg)
+
+	sys.L2ELB.Matched(sys.L2EL, eth.Safe, 5)
+
+	// L2CLB has no P2P connection, so unsafe gap always exists
+	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Verifier unsafe gap", "gap", seqUnsafe.Number-verUnsafe.Number, "seqUnsafe", seqUnsafe.Number, "verUnsafe", verUnsafe.Number)
+
+	// Reenable CLP2P
+	// L2CL will receive unsafe payloads from sequencer
+	// Unsafe gap will be observed by the L2CLB, and it will be smart enough to close the gap,
+	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2CL.ConnectPeer(sys.L2CLB)
+
+	// Unsafe gap is closed
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+
+	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Verifier unsafe gap closed", "gap", seqUnsafe.Number-verUnsafe.Number, "seqUnsafe", seqUnsafe.Number, "verUnsafe", verUnsafe.Number)
+
+	gt.Cleanup(func() {
+		sys.L2CLB.Start()
+		sys.L2CLB.ConnectPeer(sys.L2CL)
+		sys.L2CL.ConnectPeer(sys.L2CLB)
+	})
+}
+
+func TestUnsafeGapFillAfterUnsafeReorg_RestartOpNode(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	logger = logger.With("###", "###")
+
+	// Stop the batcher not to advance safe head
+	sys.L2Batcher.Stop()
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	// Pass the L1 genesis
+	sys.L1Network.WaitForBlock()
+
+	// Stop auto advancing L1
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 
 	require.Eventually(func() bool {
-		unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		// Advance single L1 block
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		logger.Info("l1 info", "l1_head", l1head, "l1_origin", l2Unsafe.L1Origin, "l2Unsafe", l2Unsafe)
+		// Wait until unsafe L2 block has L1 origin point after the startL1Block
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
 
-		block, err := sys.L1EL.Escape().EthClient().InfoByNumber(ctx, unsafe.L1Origin.Number)
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+
+	// Pick reorg block
+	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Target L2 Block to reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
+
+	// Make few more unsafe blocks which will be reorged out
+	sys.L2EL.Advanced(eth.Unsafe, 4)
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+
+	// Stop Verifier CL
+	sys.L2CLB.Stop()
+
+	// Reorg L1 block which unsafe block L1 Origin points to
+	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
+	logger.Info("Triggering L1 reorg", "l1", l1BlockBeforeReorg)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1BlockBeforeReorg.ParentHash}))
+	require.NoError(ts.Next(ctx))
+
+	// Start advancing L1
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	// Make sure L1 reorged
+	sys.L1EL.WaitForBlockNumber(l1BlockBeforeReorg.Number)
+	l1BlockAfterReorg := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
+	logger.Info("Triggered L1 reorg", "l1", l1BlockAfterReorg)
+	require.NotEqual(l1BlockAfterReorg.Hash, l1BlockBeforeReorg.Hash)
+
+	// Need to poll until the L2CL detects L1 Reorg and trigger L2 Reorg
+	// What happens:
+	//  L2CL detects L1 Reorg and reset the pipeline. op-node example logs: "reset: detected L1 reorg"
+	//  L2EL detects L2 Reorg and reorgs. op-geth example logs: "Chain reorg detected"
+	sys.L2EL.ReorgTriggered(l2BlockBeforeReorg, 30)
+	l2BlockAfterReorg := sys.L2EL.BlockRefByNumber(l2BlockBeforeReorg.Number)
+	require.NotEqual(l2BlockAfterReorg.Hash, l2BlockBeforeReorg.Hash)
+	logger.Info("Triggered L2 reorg", "l2", l2BlockAfterReorg)
+
+	// Check the divergence before restarting verifier L2CLB
+	verUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Unsafe heads", "seq", seqUnsafe, "ver", verUnsafe)
+	// Verifier unsafe head cannot advance yet because L2CLB is down
+	require.Greater(seqUnsafe.Number, verUnsafe.Number)
+	// Verifier unsafe head diverged
+	canonicalFromSeq := sys.L2EL.BlockRefByNumber(verUnsafe.Number)
+	require.NotEqual(canonicalFromSeq.Hash, verUnsafe.Hash)
+	logger.Info("Verifer unsafe head diverged", "verUnsafe", verUnsafe, "canonical", canonicalFromSeq)
+	var rewindTo eth.L2BlockRef
+	for i := verUnsafe.Number; i > 0; i-- {
+		ver := sys.L2ELB.BlockRefByNumber(i)
+		seq := sys.L2EL.BlockRefByNumber(i)
+		if ver.Hash == seq.Hash {
+			rewindTo = ver
+			break
+		}
+	}
+	logger.Info("Verifier diverged", "rewindTo", rewindTo)
+	require.Greater(l1BlockAfterReorg.Number, rewindTo.L1Origin.Number)
+
+	// Restart verifier L2CL
+	// L2CL walks back. op-node example logs "walking sync start"
+	// Dropping L2 blocks which has invalid L1 origin, until we reach rewindTo
+	sys.L2CLB.Start()
+
+	// Make sure CLP2P is connected
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2CL.ConnectPeer(sys.L2CLB)
+
+	// Unsafe gap is closed
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+
+	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Verifier unsafe gap closed", "gap", seqUnsafe.Number-verUnsafe.Number, "seqUnsafe", seqUnsafe.Number, "verUnsafe", verUnsafe.Number)
+
+	gt.Cleanup(func() {
+		sys.L2Batcher.Start()
+		sys.L2CLB.Start()
+		sys.L2CLB.ConnectPeer(sys.L2CL)
+		sys.L2CL.ConnectPeer(sys.L2CLB)
+	})
+}
+
+func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	logger = logger.With("###", "###")
+
+	// Stop the batcher not to advance safe head
+	sys.L2Batcher.Stop()
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	// Pass the L1 genesis
+	sys.L1Network.WaitForBlock()
+
+	// Stop auto advancing L1
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+
+	require.Eventually(func() bool {
+		// Advance single L1 block
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l1head := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		logger.Info("l1 info", "l1_head", l1head, "l1_origin", l2Unsafe.L1Origin, "l2Unsafe", l2Unsafe)
+		// Wait until unsafe L2 block has L1 origin point after the startL1Block
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+
+	// Pick reorg block
+	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Target L2 Block to reorg", "l2", l2BlockBeforeReorg, "l1_origin", l2BlockBeforeReorg.L1Origin)
+
+	// Make few more unsafe blocks which will be reorged out
+	sys.L2EL.Advanced(eth.Unsafe, 4)
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+
+	// Disconnect CLP2P
+	sys.L2CLB.DisconnectPeer(sys.L2CL)
+	sys.L2CL.DisconnectPeer(sys.L2CLB)
+
+	// verUnsafe will eventually reorged out
+	verUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+
+	// Reorg L1 block which unsafe block L1 Origin points to
+	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
+	logger.Info("Triggering L1 reorg", "l1", l1BlockBeforeReorg)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1BlockBeforeReorg.ParentHash}))
+	require.NoError(ts.Next(ctx))
+
+	// Start advancing L1
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	// Make sure L1 reorged
+	sys.L1EL.WaitForBlockNumber(l1BlockBeforeReorg.Number)
+	l1BlockAfterReorg := sys.L1EL.BlockRefByNumber(l1BlockBeforeReorg.Number)
+	logger.Info("Triggered L1 reorg", "l1", l1BlockAfterReorg)
+	require.NotEqual(l1BlockAfterReorg.Hash, l1BlockBeforeReorg.Hash)
+
+	// Need to poll until the L2CL detects L1 Reorg and trigger L2 Reorg
+	// What happens:
+	//  L2CL detects L1 Reorg and reset the pipeline. op-node example logs: "reset: detected L1 reorg"
+	//  L2EL detects L2 Reorg and reorgs. op-geth example logs: "Chain reorg detected"
+	sys.L2EL.ReorgTriggered(l2BlockBeforeReorg, 30)
+	l2BlockAfterReorg := sys.L2EL.BlockRefByNumber(l2BlockBeforeReorg.Number)
+	require.NotEqual(l2BlockAfterReorg.Hash, l2BlockBeforeReorg.Hash)
+	logger.Info("Triggered L2 reorg", "l2", l2BlockAfterReorg)
+
+	// L2CLB is still up but only have access to L1 to update canonical view
+	// verifier cannot advance unsafe head, but only reorging out blocks
+	// Test can still independently find rewindTo
+	rewindTo := sys.L2ELB.BlockRefByNumber(0)
+	for i := verUnsafe.Number; i > 0; i-- {
+		ref, err := sys.L2ELB.Escape().L2EthClient().L2BlockRefByNumber(ctx, i)
 		if err != nil {
-			sys.Log.Warn("failed to get L1 block info by number", "number", unsafe.L1Origin.Number, "err", err)
-			return false
+			// May be not found since verifier EL reorging
+			continue
 		}
-
-		sys.Log.Info("current unsafe ref", "tip", unsafe, "tip_origin", unsafe.L1Origin, "l1blk", eth.InfoToL1BlockRef(block))
-
-		// print the chains so we have information to debug if the test fails
-		sys.L2Chain.PrintChain()
-		sys.L1Network.PrintChain()
-
-		return block.Hash() == unsafe.L1Origin.Hash
-	}, 120*time.Second, 7*time.Second, "L1 block origin hash should match hash of block on L1 at that number. If not, it means there was a reorg, and L2 blocks L1Origin field is referencing a reorged block.")
-
-	// confirm all L1Origin fields point to canonical blocks
-	require.Eventually(func() bool {
-		ref := sys.L2EL.BlockRefByLabel(eth.Unsafe)
-		var err error
-
-		// wait until L2 chains' L1Origin points to a L1 block after the one that was reorged
-		if ref.L1Origin.Number < divergence.Number {
-			return false
+		if ref.L1Origin.Number < l1BlockAfterReorg.Number {
+			rewindTo = ref
+			break
 		}
+	}
+	logger.Info("Verifier diverged", "rewindTo", rewindTo)
 
-		sys.Log.Info("L2 chain progressed, pointing to newer L1 block", "ref", ref, "ref_origin", ref.L1Origin, "divergence", divergence)
+	// TODO: will verifier automatically detect L1 reorg and drop blocks?
+	//	 It reorgs
+	// t=2025-10-16T17:32:29.039+0900 lvl=info msg="Chain reorg detected" number=7 hash=0x6708f85e055b90d77e23344bfb226d5229b0d536558286388fbda24d25c3fa08 drop=14 dropfrom=0x5f3bbd8450231da1e87bb6e32c418be72655185167500c909cd4b6325c23748a add=1 addfrom=0x11f6667c2d60dbc970bb511bbb6c44cfdb960b851b006b92088ae24f446cd14c global=true
+	// but why does block ref by label still returns 12? Find out
 
-		for i := ref.Number; i > 0 && ref.L1Origin.Number >= divergence.Number; i-- {
-			ref, err = sys.L2EL.Escape().L2EthClient().L2BlockRefByNumber(ctx, i)
-			if err != nil {
-				return false
-			}
+	// Wait until verifier reset and dropped all reorg blocks
+	// require.NoError(retry.Do0(ctx, 30, &retry.FixedStrategy{Dur: 2 * time.Second},
+	// 	func() error {
+	// 		unsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	// 		logger.Info("Node Status", "unsafe", unsafe)
+	// 		if unsafe.Hash == rewindTo.Hash {
+	// 			return nil
+	// 		}
+	// 		return errors.New("still resetting")
+	// 	}))
 
-			if !sys.L1EL.IsCanonical(ref.L1Origin) {
-				return false
-			}
-		}
+	// "reset: detected L1 reorg"
+	//  "walking sync start"
 
-		return true
-	}, 120*time.Second, 5*time.Second, "all L1Origin fields should point to canonical L1 blocks")
+	// lets try to enable p2p. does this trigger rewind?
+	// logger.Info("Before ConnectPeer")
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2CL.ConnectPeer(sys.L2CLB)
+	// logger.Info("After ConnectPeer")
 
+	// Unsafe gap is closed
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+
+	gt.Cleanup(func() {
+		sys.L2Batcher.Start()
+		sys.L2CLB.ConnectPeer(sys.L2CL)
+		sys.L2CL.ConnectPeer(sys.L2CLB)
+	})
 }
 
 func TestUnsafeReorgToSafe(gt *testing.T) {
+	// We may do not need this test
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
 	require := t.Require()
@@ -177,4 +443,9 @@ func TestUnsafeReorgToSafe(gt *testing.T) {
 	//  t=2025-10-15T00:40:26.803+0900 lvl=debug msg="Fetching batch of headers" id=dabe984226b4e6ab1e1debfd4dd94d669aba83288d3e95038fef7df26e2d0f16 conn=staticdial count=1 fromhash=0x84da371982ce4edcc1eb2fe7cbf2f886265619637645e64a25e13898275b9a30 skip=0 reverse=false global=true
 	//  t=2025-10-15T00:40:26.803+0900 lvl=warn msg="Could not retrieve unknown head from peers" global=true
 	sys.L2ELB.ForkchoiceUpdateRaw(targetHash, targetHash, genesis.Hash, nil).IsSyncing() // WaitUntilValid(10)
+
+	gt.Cleanup(func() {
+		sys.L2ELB.PeerWith(sys.L2EL)
+		sys.L2CLB.Start()
+	})
 }

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
@@ -2,13 +2,118 @@ package reorg_elp2p
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
 )
+
+func TestSafeReorg(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	// logger := t.Logger()
+	ctx := t.Ctx()
+
+	sys.L2CL.DisconnectPeer(sys.L2CLB)
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+	sys.L1Network.WaitForBlock()
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	for i := range 12 {
+		parent := common.Hash{}
+		// parent[0] = byte(i)
+		_ = i
+
+		// must send empty hash to seq. why?
+		require.NoError(ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
+		require.NoError(ts.Next(t.Ctx()))
+
+		sys.L2Chain.WaitForBlock()
+		sys.L2Chain.WaitForBlock()
+	}
+
+	n := 10
+	require.GreaterOrEqual(12, n)
+	// select a divergence block to reorg from
+	var divergence eth.L1BlockRef
+	{
+		tip := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		require.Greater(tip.Number, uint64(n), "n is larger than L1 tip, cannot reorg out block number `tip-n`")
+
+		divergence = sys.L1EL.BlockRefByNumber(tip.Number - uint64(n))
+	}
+
+	// print the chains before sequencing an alternative L1 block
+	sys.L2Chain.PrintChain()
+	sys.L1Network.PrintChain()
+
+	tipL2_preReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+
+	// reorg the L1 chain -- sequence an alternative L1 block from divergence block parent
+	require.NoError(ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: divergence.ParentHash}))
+	require.NoError(ts.Next(t.Ctx()))
+
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	sys.L1EL.ReorgTriggered(divergence, 5)
+
+	sys.L2CL.Reached(types.CrossSafe, tipL2_preReorg.Number, 50)
+
+	require.Eventually(func() bool {
+		unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+
+		block, err := sys.L1EL.Escape().EthClient().InfoByNumber(ctx, unsafe.L1Origin.Number)
+		if err != nil {
+			sys.Log.Warn("failed to get L1 block info by number", "number", unsafe.L1Origin.Number, "err", err)
+			return false
+		}
+
+		sys.Log.Info("current unsafe ref", "tip", unsafe, "tip_origin", unsafe.L1Origin, "l1blk", eth.InfoToL1BlockRef(block))
+
+		// print the chains so we have information to debug if the test fails
+		sys.L2Chain.PrintChain()
+		sys.L1Network.PrintChain()
+
+		return block.Hash() == unsafe.L1Origin.Hash
+	}, 120*time.Second, 7*time.Second, "L1 block origin hash should match hash of block on L1 at that number. If not, it means there was a reorg, and L2 blocks L1Origin field is referencing a reorged block.")
+
+	// confirm all L1Origin fields point to canonical blocks
+	require.Eventually(func() bool {
+		ref := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		var err error
+
+		// wait until L2 chains' L1Origin points to a L1 block after the one that was reorged
+		if ref.L1Origin.Number < divergence.Number {
+			return false
+		}
+
+		sys.Log.Info("L2 chain progressed, pointing to newer L1 block", "ref", ref, "ref_origin", ref.L1Origin, "divergence", divergence)
+
+		for i := ref.Number; i > 0 && ref.L1Origin.Number >= divergence.Number; i-- {
+			ref, err = sys.L2EL.Escape().L2EthClient().L2BlockRefByNumber(ctx, i)
+			if err != nil {
+				return false
+			}
+
+			if !sys.L1EL.IsCanonical(ref.L1Origin) {
+				return false
+			}
+		}
+
+		return true
+	}, 120*time.Second, 5*time.Second, "all L1Origin fields should point to canonical L1 blocks")
+
+}
 
 func TestUnsafeReorgToSafe(gt *testing.T) {
 	t := devtest.SerialT(gt)
@@ -31,7 +136,7 @@ func TestUnsafeReorgToSafe(gt *testing.T) {
 	require.GreaterOrEqual(unsafe.Number, safe.Number)
 
 	// Make unsafe head diff between sequencer EL and verifier EL
-	sys.L2CL.AdvancedFn(types.LocalUnsafe, 3, 30)
+	sys.L2CL.Advanced(types.LocalUnsafe, 3, 30)
 
 	logger.Info("Unsafe blocks exists which not yet promoted to safe", "unsafe", unsafe.Number, "safe", safe.Number)
 
@@ -53,6 +158,7 @@ func TestUnsafeReorgToSafe(gt *testing.T) {
 	// Peer again for EL Sync preparation
 	sys.L2ELB.PeerWith(sys.L2EL)
 
+	require.GreaterOrEqual(sys.L2EL.BlockRefByLabel(eth.Unsafe).Number, unsafe.Number+1)
 	// Trigger EL Sync to fill in the gap
 	target := sys.L2EL.BlockRefByNumber(unsafe.Number + 1)
 	targetHash := target.Hash
@@ -62,5 +168,5 @@ func TestUnsafeReorgToSafe(gt *testing.T) {
 	//  t=2025-10-15T00:40:26.803+0900 lvl=debug msg="Attempting to retrieve sync target" peer=dabe984226b4e6ab1e1debfd4dd94d669aba83288d3e95038fef7df26e2d0f16 hash=0x84da371982ce4edcc1eb2fe7cbf2f886265619637645e64a25e13898275b9a30 global=true
 	//  t=2025-10-15T00:40:26.803+0900 lvl=debug msg="Fetching batch of headers" id=dabe984226b4e6ab1e1debfd4dd94d669aba83288d3e95038fef7df26e2d0f16 conn=staticdial count=1 fromhash=0x84da371982ce4edcc1eb2fe7cbf2f886265619637645e64a25e13898275b9a30 skip=0 reverse=false global=true
 	//  t=2025-10-15T00:40:26.803+0900 lvl=warn msg="Could not retrieve unknown head from peers" global=true
-	sys.L2ELB.ForkchoiceUpdateRaw(targetHash, targetHash, genesis.Hash, nil).WaitUntilValid(10)
+	sys.L2ELB.ForkchoiceUpdateRaw(targetHash, targetHash, genesis.Hash, nil).IsSyncing() // WaitUntilValid(10)
 }

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
@@ -19,10 +19,10 @@ func TestSafeReorg(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
 	require := t.Require()
-	// logger := t.Logger()
+	logger := t.Logger()
 	ctx := t.Ctx()
 
-	sys.L2CL.DisconnectPeer(sys.L2CLB)
+	// sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
 	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
@@ -37,9 +37,12 @@ func TestSafeReorg(gt *testing.T) {
 		// must send empty hash to seq. why?
 		require.NoError(ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
 		require.NoError(ts.Next(t.Ctx()))
+		l1Unsafe := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		logger.Info("### L1", "unsafe", l1Unsafe, "time", l1Unsafe.Time)
 
 		sys.L2Chain.WaitForBlock()
-		sys.L2Chain.WaitForBlock()
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		logger.Info("### L2", "unsafe", l2Unsafe, "time", l2Unsafe.Time, "l1Origin", l2Unsafe.L1Origin)
 	}
 
 	n := 10
@@ -51,23 +54,28 @@ func TestSafeReorg(gt *testing.T) {
 		require.Greater(tip.Number, uint64(n), "n is larger than L1 tip, cannot reorg out block number `tip-n`")
 
 		divergence = sys.L1EL.BlockRefByNumber(tip.Number - uint64(n))
+		logger.Info("### L1 Divergence", "div", divergence)
 	}
-
-	// print the chains before sequencing an alternative L1 block
-	sys.L2Chain.PrintChain()
-	sys.L1Network.PrintChain()
 
 	tipL2_preReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 
+	logger.Info("### tipL2_preReorg", "number", tipL2_preReorg.Number)
+
+	logger.Info("### L1 Div", "unsafe", sys.L1EL.BlockRefByLabel(eth.Unsafe))
 	// reorg the L1 chain -- sequence an alternative L1 block from divergence block parent
 	require.NoError(ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: divergence.ParentHash}))
 	require.NoError(ts.Next(t.Ctx()))
+	logger.Info("### L1 Div", "unsafe", sys.L1EL.BlockRefByLabel(eth.Unsafe))
 
 	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
 
 	sys.L1EL.ReorgTriggered(divergence, 5)
 
 	sys.L2CL.Reached(types.CrossSafe, tipL2_preReorg.Number, 50)
+
+	reorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	logger.Info("### Reorg", "unsafe", reorg)
+	logger.Info("### Reorg", "unsafe", sys.L2ELB.BlockRefByNumber(reorg.Number))
 
 	require.Eventually(func() bool {
 		unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
@@ -353,33 +353,20 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	}
 	logger.Info("Verifier diverged", "rewindTo", rewindTo)
 
-	// TODO: will verifier automatically detect L1 reorg and drop blocks?
-	//	 It reorgs
-	// t=2025-10-16T17:32:29.039+0900 lvl=info msg="Chain reorg detected" number=7 hash=0x6708f85e055b90d77e23344bfb226d5229b0d536558286388fbda24d25c3fa08 drop=14 dropfrom=0x5f3bbd8450231da1e87bb6e32c418be72655185167500c909cd4b6325c23748a add=1 addfrom=0x11f6667c2d60dbc970bb511bbb6c44cfdb960b851b006b92088ae24f446cd14c global=true
-	// but why does block ref by label still returns 12? Find out
-
 	// Wait until verifier reset and dropped all reorg blocks
-	// require.NoError(retry.Do0(ctx, 30, &retry.FixedStrategy{Dur: 2 * time.Second},
-	// 	func() error {
-	// 		unsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
-	// 		logger.Info("Node Status", "unsafe", unsafe)
-	// 		if unsafe.Hash == rewindTo.Hash {
-	// 			return nil
-	// 		}
-	// 		return errors.New("still resetting")
-	// 	}))
+	sys.L2CLB.Reset(types.LocalUnsafe, rewindTo)
+	logger.Info("Verifier rewind done", "rewindTo", rewindTo)
 
-	// "reset: detected L1 reorg"
-	//  "walking sync start"
-
-	// lets try to enable p2p. does this trigger rewind?
-	// logger.Info("Before ConnectPeer")
+	// Make sure CLP2P is connected
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
-	// logger.Info("After ConnectPeer")
 
 	// Unsafe gap is closed
 	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+
+	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	logger.Info("Verifier unsafe gap closed", "gap", seqUnsafe.Number-verUnsafe.Number, "seqUnsafe", seqUnsafe.Number, "verUnsafe", verUnsafe.Number)
 
 	gt.Cleanup(func() {
 		sys.L2Batcher.Start()

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
@@ -1,0 +1,66 @@
+package reorg_elp2p
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestUnsafeReorgToSafe(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+	require := t.Require()
+	logger := t.Logger()
+
+	delta := uint64(10)
+	dsl.CheckAll(t,
+		sys.L2CLB.AdvancedFn(types.LocalUnsafe, delta, 30),
+		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30),
+	)
+
+	sys.L2CLB.Stop()
+	sys.L2ELB.DisconnectPeerWith(sys.L2EL)
+
+	genesis := sys.L2ELB.BlockRefByNumber(0)
+	unsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	safe := sys.L2ELB.BlockRefByLabel(eth.Safe)
+	require.GreaterOrEqual(unsafe.Number, safe.Number)
+
+	// Make unsafe head diff between sequencer EL and verifier EL
+	sys.L2CL.AdvancedFn(types.LocalUnsafe, 3, 30)
+
+	logger.Info("Unsafe blocks exists which not yet promoted to safe", "unsafe", unsafe.Number, "safe", safe.Number)
+
+	// Trigger Reorg to block diverged from sequencer
+	res := sys.L2ELB.NewPayloadWithFault(sys.L2EL, safe.Number).IsValid()
+	sys.L2ELB.ForkchoiceUpdateRaw(res.BlockHash, res.BlockHash, genesis.Hash, nil).IsValid()
+
+	require.Equal(safe.Number, sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number)
+	require.Equal(safe.Number, sys.L2ELB.BlockRefByLabel(eth.Safe).Number)
+	require.NotEqual(safe.Hash, sys.L2ELB.BlockRefByLabel(eth.Safe).Hash)
+
+	// Trigger Reorg to sequencer produced block
+	sys.L2ELB.NewPayload(sys.L2EL, safe.Number).IsValid()
+	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, safe.Number, safe.Number, 0, nil).IsValid()
+	require.Equal(safe.Number, sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number)
+	require.Equal(safe.Number, sys.L2ELB.BlockRefByLabel(eth.Safe).Number)
+	require.Equal(safe.Hash, sys.L2ELB.BlockRefByLabel(eth.Safe).Hash)
+
+	// Peer again for EL Sync preparation
+	sys.L2ELB.PeerWith(sys.L2EL)
+
+	// Trigger EL Sync to fill in the gap
+	target := sys.L2EL.BlockRefByNumber(unsafe.Number + 1)
+	targetHash := target.Hash
+	targetHash[0] = targetHash[0] + 1 // inject fault
+	// op-geth logs
+	// 	t=2025-10-15T00:40:26.803+0900 lvl=warn msg="Fetching the unknown forkchoice head from network" hash=0x84da371982ce4edcc1eb2fe7cbf2f886265619637645e64a25e13898275b9a30 global=true
+	//  t=2025-10-15T00:40:26.803+0900 lvl=debug msg="Attempting to retrieve sync target" peer=dabe984226b4e6ab1e1debfd4dd94d669aba83288d3e95038fef7df26e2d0f16 hash=0x84da371982ce4edcc1eb2fe7cbf2f886265619637645e64a25e13898275b9a30 global=true
+	//  t=2025-10-15T00:40:26.803+0900 lvl=debug msg="Fetching batch of headers" id=dabe984226b4e6ab1e1debfd4dd94d669aba83288d3e95038fef7df26e2d0f16 conn=staticdial count=1 fromhash=0x84da371982ce4edcc1eb2fe7cbf2f886265619637645e64a25e13898275b9a30 skip=0 reverse=false global=true
+	//  t=2025-10-15T00:40:26.803+0900 lvl=warn msg="Could not retrieve unknown head from peers" global=true
+	sys.L2ELB.ForkchoiceUpdateRaw(targetHash, targetHash, genesis.Hash, nil).WaitUntilValid(10)
+}

--- a/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg_elp2p/sync_test.go
@@ -22,8 +22,6 @@ func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 	logger := t.Logger()
 	ctx := t.Ctx()
 
-	logger = logger.With("###", "###")
-
 	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
 	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
 
@@ -124,7 +122,7 @@ func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 	logger.Info("Verifier unsafe gap", "gap", seqUnsafe.Number-verUnsafe.Number, "seqUnsafe", seqUnsafe.Number, "verUnsafe", verUnsafe.Number)
 
 	// Reenable CLP2P
-	// L2CL will receive unsafe payloads from sequencer
+	// L2CLB will receive unsafe payloads from sequencer
 	// Unsafe gap will be observed by the L2CLB, and it will be smart enough to close the gap,
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 	sys.L2CLB.ConnectPeer(sys.L2CL)
@@ -150,8 +148,6 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartOpNode(gt *testing.T) {
 	require := t.Require()
 	logger := t.Logger()
 	ctx := t.Ctx()
-
-	logger = logger.With("###", "###")
 
 	// Stop the batcher not to advance safe head
 	sys.L2Batcher.Stop()
@@ -246,6 +242,10 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartOpNode(gt *testing.T) {
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
+	// L2CLB will receive unsafe payloads from sequencer
+	// Unsafe gap will be observed by the L2CLB, and it will be smart enough to close the gap,
+	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
+
 	// Unsafe gap is closed
 	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
 
@@ -267,8 +267,6 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	require := t.Require()
 	logger := t.Logger()
 	ctx := t.Ctx()
-
-	logger = logger.With("###", "###")
 
 	// Stop the batcher not to advance safe head
 	sys.L2Batcher.Stop()
@@ -360,6 +358,10 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	// Make sure CLP2P is connected
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
+
+	// L2CLB will receive unsafe payloads from sequencer
+	// Unsafe gap will be observed by the L2CLB, and it will be smart enough to close the gap,
+	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Unsafe gap is closed
 	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)

--- a/op-devstack/dsl/engine.go
+++ b/op-devstack/dsl/engine.go
@@ -8,12 +8,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type NewPayloadResult struct {
-	T      devtest.T
-	Status *eth.PayloadStatusV1
-	Err    error
+	T         devtest.T
+	Status    *eth.PayloadStatusV1
+	BlockHash common.Hash
+	Err       error
 }
 
 func (r *NewPayloadResult) IsPayloadStatus(status eth.ExecutePayloadStatus) *NewPayloadResult {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -375,3 +375,15 @@ func (cl *L2CLNode) SignalTarget(el *L2ELNode, targetNum uint64) {
 	})
 	cl.require.NoErrorf(err, "failed to post unsafe payload via admin API: target %d", targetNum)
 }
+
+func (cl *L2CLNode) Reset(lvl types.SafetyLevel, target eth.L2BlockRef) {
+	cl.require.NoError(retry.Do0(cl.ctx, 5, &retry.FixedStrategy{Dur: 2 * time.Second},
+		func() error {
+			res := cl.HeadBlockRef(lvl)
+			cl.log.Info("Chain sync Status", lvl, res)
+			if res.Hash == target.Hash {
+				return nil
+			}
+			return errors.New("waiting to reset")
+		}))
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -286,4 +288,28 @@ func (el *L2ELNode) ForkchoiceUpdateRaw(unsafe, safe, finalized common.Hash, att
 	result.Refresh = refresh
 	result.Refresh()
 	return result
+}
+
+func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) eth.BlockID {
+	el.require.Equal(chainID, el.inner.ID().ChainID(), "chain ID mismatch")
+	var blockRef eth.L2BlockRef
+	switch lvl {
+	case types.Finalized:
+		blockRef = el.BlockRefByLabel(eth.Finalized)
+	case types.CrossSafe, types.LocalSafe:
+		blockRef = el.BlockRefByLabel(eth.Safe)
+	case types.CrossUnsafe, types.LocalUnsafe:
+		blockRef = el.BlockRefByLabel(eth.Unsafe)
+	default:
+		el.require.NoError(errors.New("invalid safety level"))
+	}
+	return blockRef.ID()
+}
+
+func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
+	return MatchedFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
+}
+
+func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
+	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -233,7 +233,22 @@ func (el *L2ELNode) NewPayload(refNode *L2ELNode, number uint64) *NewPayloadResu
 	el.log.Info("NewPayload", "number", number, "node", el, "refNode", refNode)
 	payload := refNode.PayloadByNumber(number)
 	status, err := el.inner.L2EngineClient().NewPayload(el.ctx, payload.ExecutionPayload, payload.ParentBeaconBlockRoot)
-	return &NewPayloadResult{T: el.t, Status: status, Err: err}
+	return &NewPayloadResult{T: el.t, Status: status, BlockHash: payload.ExecutionPayload.BlockHash, Err: err}
+}
+
+func (el *L2ELNode) NewPayloadWithFault(refNode *L2ELNode, number uint64) *NewPayloadResult {
+	el.log.Info("NewPayloadWithFault", "number", number, "node", el, "refNode", refNode)
+	payload := refNode.PayloadByNumber(number)
+	_, ok := payload.CheckBlockHash()
+	el.require.True(ok)
+	payload.ExecutionPayload.FeeRecipient = common.MaxAddress
+	newBlockHash, ok := payload.CheckBlockHash()
+	el.require.False(ok)
+	payload.ExecutionPayload.BlockHash = newBlockHash
+	_, ok = payload.CheckBlockHash()
+	el.require.True(ok)
+	status, err := el.inner.L2EngineClient().NewPayload(el.ctx, payload.ExecutionPayload, payload.ParentBeaconBlockRoot)
+	return &NewPayloadResult{T: el.t, Status: status, BlockHash: payload.ExecutionPayload.BlockHash, Err: err}
 }
 
 // ForkchoiceUpdate fetches FCU target hashes from the reference EL node, and FCU update with attributes
@@ -245,6 +260,24 @@ func (el *L2ELNode) ForkchoiceUpdate(refNode *L2ELNode, unsafe, safe, finalized 
 			HeadBlockHash:      refNode.BlockRefByNumber(unsafe).Hash,
 			SafeBlockHash:      refNode.BlockRefByNumber(safe).Hash,
 			FinalizedBlockHash: refNode.BlockRefByNumber(finalized).Hash,
+		}
+		res, err := el.inner.L2EngineClient().ForkchoiceUpdate(el.ctx, state, attr)
+		result.Result = res
+		result.Err = err
+	}
+	result.Refresh = refresh
+	result.Refresh()
+	return result
+}
+
+func (el *L2ELNode) ForkchoiceUpdateRaw(unsafe, safe, finalized common.Hash, attr *eth.PayloadAttributes) *ForkchoiceUpdateResult {
+	result := &ForkchoiceUpdateResult{T: el.t}
+	refresh := func() {
+		el.log.Info("ForkchoiceUpdateRaw", "unsafe", unsafe, "safe", safe, "finalized", finalized, "attr", attr, "node", el)
+		state := &eth.ForkchoiceState{
+			HeadBlockHash:      unsafe,
+			SafeBlockHash:      safe,
+			FinalizedBlockHash: finalized,
 		}
 		res, err := el.inner.L2EngineClient().ForkchoiceUpdate(el.ctx, state, attr)
 		result.Result = res

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -226,6 +226,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			}
 			p2pConfig, err = p2pcli.NewConfig(cliCtx, l2Net.rollupCfg.BlockTime)
 			require.NoError(err, "failed to load p2p config")
+			p2pConfig.NoDiscovery = true
 		}
 
 		// specify interop config, but do not configure anything, to disable indexing mode


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
