### PR TITLE
op-acceptance-tests: Integration test for op-deployer add-game-type

### DIFF
--- a/op-acceptance-tests/tests/base/disputegame_v2/init_test.go
+++ b/op-acceptance-tests/tests/base/disputegame_v2/init_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestMain(m *testing.M) {
 	// TODO(#17810): Use the new v2 dispute game flag via presets.WithDisputeGameV2()
-	//presets.DoMain(m, presets.WithMinimal(), presets.WithDisputeGameV2())
-	presets.DoMain(m, presets.WithMinimal())
+	//presets.DoMain(m, presets.WithProofs(), presets.WithDisputeGameV2())
+	presets.DoMain(m, presets.WithProofs())
 }

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -83,3 +83,8 @@ func WithDisputeGameFinalityDelaySeconds(seconds uint64) stack.CommonOption {
 		sysgo.WithDisputeGameFinalityDelaySeconds(seconds),
 	))
 }
+
+// WithProofs enables a minimal system with permissionless proofs enabled
+func WithProofs() stack.CommonOption {
+	return stack.MakeCommon(sysgo.ProofSystem(&sysgo.DefaultMinimalSystemIDs{}))
+}

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -16,83 +16,88 @@ import (
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func WithGameTypeAdded(l1ChainID eth.ChainID, l2ChainID eth.ChainID, l1ELID stack.L1ELNodeID) stack.Option[*Orchestrator] {
+func WithCannonGameTypeAdded(l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) stack.Option[*Orchestrator] {
 	return stack.FnOption[*Orchestrator]{
 		FinallyFn: func(o *Orchestrator) {
-			t := o.P()
-			require := t.Require()
-			require.NotNil(o.wb, "must have a world builder")
-
-			opcmAddr := o.wb.output.ImplementationsDeployment.OpcmImpl
-
-			l1EL, ok := o.l1ELs.Get(l1ELID)
-			require.True(ok, "l1El must exist")
-
-			rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
-			require.NoError(err)
-			client := ethclient.NewClient(rpcClient)
-
-			l1PAO, err := o.keys.Address(devkeys.ChainOperatorKeys(l1ChainID.ToBig())(devkeys.L1ProxyAdminOwnerRole))
-			require.NoError(err, "failed to get l1 proxy admin owner address")
-
-			artifactsLocator := LocalArtifacts(t)
-			absolutePrestate := getAbsolutePrestate(t, "op-program/bin/prestate-proof-mt64.json")
-
-			cfg := manage.AddGameTypeConfig{
-				L1RPCUrl:                l1EL.UserRPC(),
-				Logger:                  t.Logger(),
-				ArtifactsLocator:        artifactsLocator,
-				CacheDir:                t.TempDir(),
-				L1ProxyAdminOwner:       l1PAO,
-				OPCMImpl:                opcmAddr,
-				SystemConfigProxy:       o.wb.outL2Deployment[l2ChainID].SystemConfigProxyAddr(),
-				OPChainProxyAdmin:       o.wb.outL2Deployment[l2ChainID].ProxyAdminAddr(),
-				DelayedWETHProxy:        o.wb.outL2Deployment[l2ChainID].PermissionlessDelayedWETHProxyAddr(),
-				DisputeGameType:         0, // CANNON
-				DisputeAbsolutePrestate: absolutePrestate,
-				DisputeMaxGameDepth:     big.NewInt(73),
-				DisputeSplitDepth:       big.NewInt(30),
-				DisputeClockExtension:   10800,
-				DisputeMaxClockDuration: 302400,
-				InitialBond:             eth.GWei(80_000_000).ToBig(), // 0.08 ETH
-				VM:                      o.wb.output.ImplementationsDeployment.MipsImpl,
-				Permissionless:          true,
-				SaltMixer:               fmt.Sprintf("devstack-%s-%s", l2ChainID, absolutePrestate.Hex()),
-			}
-
-			_, addGameTypeCalldata, err := manage.AddGameType(t.Ctx(), cfg)
-			require.NoError(err, "failed to create add game type calldata")
-			require.Len(addGameTypeCalldata, 1, "calldata must contain one entry")
-
-			chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
-			l1PAOKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
-			require.NoError(err, "failed to get l1 proxy admin owner key")
-			transactOpts, err := bind.NewKeyedTransactorWithChainID(l1PAOKey, l1ChainID.ToBig())
-			require.NoError(err, "must have transact opts")
-			transactOpts.Context = t.Ctx()
-
-			t.Log("Deploying delegate call proxy contract")
-			delegateCallProxy, proxyContract := deployDelegateCallProxy(t, transactOpts, client, l1PAO)
-			// transfer ownership to the proxy so that we can delegatecall the opcm
-			transferOwnership(t, l1PAOKey, client, cfg.OPChainProxyAdmin, delegateCallProxy)
-			dgf := o.wb.outL2Deployment[l2ChainID].DisputeGameFactoryProxyAddr()
-			transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
-
-			t.Log("sending opcm.addGameType transaction")
-			tx, err := proxyContract.ExecuteDelegateCall(transactOpts, opcmAddr, addGameTypeCalldata[0].Data)
-			require.NoError(err, "failed to send add game type tx")
-			_, err = wait.ForReceiptOK(t.Ctx(), client, tx.Hash())
-			require.NoError(err, "failed to wait for add game type receipt")
-
-			// reset ProxyAdmin ownership transfers
-			transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, cfg.OPChainProxyAdmin, l1PAO)
-			transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, dgf, l1PAO)
+			// TODO(#17867): Rebuild the op-program prestate using the newly minted L2 chain configs before using it.
+			absolutePrestate := getAbsolutePrestate(o.P(), "op-program/bin/prestate-proof-mt64.json")
+			addGameType(o, absolutePrestate, 0 /* CANNON */, l1ELID, l2ChainID)
 		},
 	}
+}
+
+func addGameType(o *Orchestrator, absolutePrestate common.Hash, gameType uint32, l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) {
+	t := o.P()
+	require := t.Require()
+	require.NotNil(o.wb, "must have a world builder")
+	l1ChainID := l1ELID.ChainID()
+
+	opcmAddr := o.wb.output.ImplementationsDeployment.OpcmImpl
+
+	l1EL, ok := o.l1ELs.Get(l1ELID)
+	require.True(ok, "l1El must exist")
+
+	rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
+	require.NoError(err)
+	client := ethclient.NewClient(rpcClient)
+
+	l1PAO, err := o.keys.Address(devkeys.ChainOperatorKeys(l1ChainID.ToBig())(devkeys.L1ProxyAdminOwnerRole))
+	require.NoError(err, "failed to get l1 proxy admin owner address")
+
+	cfg := manage.AddGameTypeConfig{
+		L1RPCUrl:                l1EL.UserRPC(),
+		Logger:                  t.Logger(),
+		ArtifactsLocator:        LocalArtifacts(t),
+		CacheDir:                t.TempDir(),
+		L1ProxyAdminOwner:       l1PAO,
+		OPCMImpl:                opcmAddr,
+		SystemConfigProxy:       o.wb.outL2Deployment[l2ChainID].SystemConfigProxyAddr(),
+		OPChainProxyAdmin:       o.wb.outL2Deployment[l2ChainID].ProxyAdminAddr(),
+		DelayedWETHProxy:        o.wb.outL2Deployment[l2ChainID].PermissionlessDelayedWETHProxyAddr(),
+		DisputeGameType:         gameType,
+		DisputeAbsolutePrestate: absolutePrestate,
+		DisputeMaxGameDepth:     big.NewInt(73),
+		DisputeSplitDepth:       big.NewInt(30),
+		DisputeClockExtension:   10800,
+		DisputeMaxClockDuration: 302400,
+		InitialBond:             eth.GWei(80_000_000).ToBig(), // 0.08 ETH
+		VM:                      o.wb.output.ImplementationsDeployment.MipsImpl,
+		Permissionless:          true,
+		SaltMixer:               fmt.Sprintf("devstack-%s-%s", l2ChainID, absolutePrestate.Hex()),
+	}
+
+	_, addGameTypeCalldata, err := manage.AddGameType(t.Ctx(), cfg)
+	require.NoError(err, "failed to create add game type calldata")
+	require.Len(addGameTypeCalldata, 1, "calldata must contain one entry")
+
+	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
+	l1PAOKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
+	require.NoError(err, "failed to get l1 proxy admin owner key")
+	transactOpts, err := bind.NewKeyedTransactorWithChainID(l1PAOKey, l1ChainID.ToBig())
+	require.NoError(err, "must have transact opts")
+	transactOpts.Context = t.Ctx()
+
+	t.Log("Deploying delegate call proxy contract")
+	delegateCallProxy, proxyContract := deployDelegateCallProxy(t, transactOpts, client, l1PAO)
+	// transfer ownership to the proxy so that we can delegatecall the opcm
+	transferOwnership(t, l1PAOKey, client, cfg.OPChainProxyAdmin, delegateCallProxy)
+	dgf := o.wb.outL2Deployment[l2ChainID].DisputeGameFactoryProxyAddr()
+	transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
+
+	t.Log("sending opcm.addGameType transaction")
+	tx, err := proxyContract.ExecuteDelegateCall(transactOpts, opcmAddr, addGameTypeCalldata[0].Data)
+	require.NoError(err, "failed to send add game type tx")
+	_, err = wait.ForReceiptOK(t.Ctx(), client, tx.Hash())
+	require.NoError(err, "failed to wait for add game type receipt")
+
+	// reset ProxyAdmin ownership transfers
+	transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, cfg.OPChainProxyAdmin, l1PAO)
+	transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, dgf, l1PAO)
 }
 
 func LocalArtifacts(t devtest.P) *artifacts.Locator {

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -1,0 +1,111 @@
+package sysgo
+
+import (
+	"fmt"
+	"math/big"
+	"net/url"
+	"path"
+	"runtime"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func WithGameTypeAdded(l1ChainID eth.ChainID, l2ChainID eth.ChainID, l1ELID stack.L1ELNodeID) stack.Option[*Orchestrator] {
+	return stack.FnOption[*Orchestrator]{
+		FinallyFn: func(o *Orchestrator) {
+			t := o.P()
+			require := t.Require()
+			require.NotNil(o.wb, "must have a world builder")
+
+			opcmAddr := o.wb.output.ImplementationsDeployment.OpcmImpl
+
+			l1EL, ok := o.l1ELs.Get(l1ELID)
+			require.True(ok, "l1El must exist")
+
+			rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
+			require.NoError(err)
+			client := ethclient.NewClient(rpcClient)
+
+			l1PAO, err := o.keys.Address(devkeys.ChainOperatorKeys(l1ChainID.ToBig())(devkeys.L1ProxyAdminOwnerRole))
+			require.NoError(err, "failed to get l1 proxy admin owner address")
+
+			artifactsLocator := LocalArtifacts(t)
+			absolutePrestate := getAbsolutePrestate(t, "op-program/bin/prestate-proof-mt64.json")
+
+			cfg := manage.AddGameTypeConfig{
+				L1RPCUrl:                l1EL.UserRPC(),
+				Logger:                  t.Logger(),
+				ArtifactsLocator:        artifactsLocator,
+				CacheDir:                t.TempDir(),
+				L1ProxyAdminOwner:       l1PAO,
+				OPCMImpl:                opcmAddr,
+				SystemConfigProxy:       o.wb.outL2Deployment[l2ChainID].SystemConfigProxyAddr(),
+				OPChainProxyAdmin:       o.wb.outL2Deployment[l2ChainID].ProxyAdminAddr(),
+				DelayedWETHProxy:        o.wb.outL2Deployment[l2ChainID].PermissionlessDelayedWETHProxyAddr(),
+				DisputeGameType:         0, // CANNON
+				DisputeAbsolutePrestate: absolutePrestate,
+				DisputeMaxGameDepth:     big.NewInt(73),
+				DisputeSplitDepth:       big.NewInt(30),
+				DisputeClockExtension:   10800,
+				DisputeMaxClockDuration: 302400,
+				InitialBond:             eth.GWei(80_000_000).ToBig(), // 0.08 ETH
+				VM:                      o.wb.output.ImplementationsDeployment.MipsImpl,
+				Permissionless:          true,
+				SaltMixer:               fmt.Sprintf("devstack-%s-%s", l2ChainID, absolutePrestate.Hex()),
+			}
+
+			_, addGameTypeCalldata, err := manage.AddGameType(t.Ctx(), cfg)
+			require.NoError(err, "failed to create add game type calldata")
+			require.Len(addGameTypeCalldata, 1, "calldata must contain one entry")
+
+			chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
+			l1PAOKey, err := o.keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
+			require.NoError(err, "failed to get l1 proxy admin owner key")
+			transactOpts, err := bind.NewKeyedTransactorWithChainID(l1PAOKey, l1ChainID.ToBig())
+			require.NoError(err, "must have transact opts")
+			transactOpts.Context = t.Ctx()
+
+			t.Log("Deploying delegate call proxy contract")
+			delegateCallProxy, proxyContract := deployDelegateCallProxy(t, transactOpts, client, l1PAO)
+			// transfer ownership to the proxy so that we can delegatecall the opcm
+			transferOwnership(t, l1PAOKey, client, cfg.OPChainProxyAdmin, delegateCallProxy)
+			dgf := o.wb.outL2Deployment[l2ChainID].DisputeGameFactoryProxyAddr()
+			transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
+
+			t.Log("sending opcm.addGameType transaction")
+			tx, err := proxyContract.ExecuteDelegateCall(transactOpts, opcmAddr, addGameTypeCalldata[0].Data)
+			require.NoError(err, "failed to send add game type tx")
+			_, err = wait.ForReceiptOK(t.Ctx(), client, tx.Hash())
+			require.NoError(err, "failed to wait for add game type receipt")
+
+			// reset ProxyAdmin ownership transfers
+			transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, cfg.OPChainProxyAdmin, l1PAO)
+			transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, dgf, l1PAO)
+		},
+	}
+}
+
+func LocalArtifacts(t devtest.P) *artifacts.Locator {
+	require := t.Require()
+	_, testFilename, _, ok := runtime.Caller(0)
+	require.Truef(ok, "failed to get test filename")
+	monorepoDir, err := op_service.FindMonorepoRoot(testFilename)
+	require.NoError(err, "failed to find monorepo root")
+	artifactsDir := path.Join(monorepoDir, "packages", "contracts-bedrock", "forge-artifacts")
+	artifactsURL, err := url.Parse(fmt.Sprintf("file://%s", artifactsDir))
+	require.NoError(err, "failed to parse artifacts dir url")
+	loc := &artifacts.Locator{
+		URL: artifactsURL,
+	}
+	return loc
+}

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -134,9 +134,11 @@ func WithDeployer() stack.Option[*Orchestrator] {
 }
 
 type L2Deployment struct {
-	systemConfigProxyAddr   common.Address
-	disputeGameFactoryProxy common.Address
-	l1StandardBridgeProxy   common.Address
+	systemConfigProxyAddr          common.Address
+	disputeGameFactoryProxy        common.Address
+	l1StandardBridgeProxy          common.Address
+	proxyAdmin                     common.Address
+	permissionlessDelayedWETHProxy common.Address
 }
 
 var _ stack.L2Deployment = &L2Deployment{}
@@ -151,6 +153,14 @@ func (d *L2Deployment) DisputeGameFactoryProxyAddr() common.Address {
 
 func (d *L2Deployment) L1StandardBridgeProxyAddr() common.Address {
 	return d.l1StandardBridgeProxy
+}
+
+func (d *L2Deployment) ProxyAdminAddr() common.Address {
+	return d.proxyAdmin
+}
+
+func (d *L2Deployment) PermissionlessDelayedWETHProxyAddr() common.Address {
+	return d.permissionlessDelayedWETHProxy
 }
 
 type InteropMigration struct {
@@ -384,9 +394,11 @@ func (wb *worldBuilder) buildL2DeploymentOutputs() {
 	for _, ch := range wb.output.Chains {
 		chainID := eth.ChainIDFromBytes32(ch.ID)
 		wb.outL2Deployment[chainID] = &L2Deployment{
-			systemConfigProxyAddr:   ch.SystemConfigProxy,
-			disputeGameFactoryProxy: ch.DisputeGameFactoryProxy,
-			l1StandardBridgeProxy:   ch.L1StandardBridgeProxy,
+			systemConfigProxyAddr:          ch.SystemConfigProxy,
+			disputeGameFactoryProxy:        ch.DisputeGameFactoryProxy,
+			l1StandardBridgeProxy:          ch.L1StandardBridgeProxy,
+			proxyAdmin:                     ch.OpChainProxyAdminImpl,
+			permissionlessDelayedWETHProxy: ch.DelayedWethPermissionlessGameProxy,
 		}
 	}
 	wb.outSuperchainDeployment = &SuperchainDeployment{

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -208,9 +208,13 @@ func getSuperRoot(t devtest.CommonT, o *Orchestrator, timestamp uint64, supervis
 }
 
 func getInteropAbsolutePrestate(t devtest.CommonT) common.Hash {
-	root, err := findMonorepoRoot("op-program/bin/prestate-proof-interop.json")
+	return getAbsolutePrestate(t, "op-program/bin/prestate-proof-interop.json")
+}
+
+func getAbsolutePrestate(t devtest.CommonT, prestatePath string) common.Hash {
+	root, err := findMonorepoRoot(prestatePath)
 	t.Require().NoError(err)
-	p := path.Join(root, "op-program/bin/prestate-proof-interop.json")
+	p := path.Join(root, prestatePath)
 	file, err := os.Open(p)
 	t.Require().NoError(err)
 	decoder := json.NewDecoder(file)

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -432,6 +432,6 @@ func MultiSupervisorInteropSystem(dest *MultiSupervisorInteropSystemIDs) stack.O
 func ProofSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestrator] {
 	ids := NewDefaultMinimalSystemIDs(DefaultL1ID, DefaultL2AID)
 	opt := defaultMinimalSystemOpts(&ids, dest)
-	opt.Add(WithGameTypeAdded(ids.L1.ChainID(), ids.L2.ChainID(), ids.L1EL))
+	opt.Add(WithCannonGameTypeAdded(ids.L1EL, ids.L2.ChainID()))
 	return opt
 }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -47,7 +47,10 @@ func NewDefaultMinimalSystemIDs(l1ID, l2ID eth.ChainID) DefaultMinimalSystemIDs 
 
 func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestrator] {
 	ids := NewDefaultMinimalSystemIDs(DefaultL1ID, DefaultL2AID)
+	return defaultMinimalSystemOpts(&ids, dest)
+}
 
+func defaultMinimalSystemOpts(ids *DefaultMinimalSystemIDs, dest *DefaultMinimalSystemIDs) stack.CombinedOption[*Orchestrator] {
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
 		o.P().Logger().Info("Setting up")
@@ -80,7 +83,7 @@ func DefaultMinimalSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestra
 	}))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
-		*dest = ids
+		*dest = *ids
 	}))
 
 	return opt
@@ -423,5 +426,12 @@ func MultiSupervisorInteropSystem(dest *MultiSupervisorInteropSystemIDs) stack.O
 		*dest = ids
 	}))
 
+	return opt
+}
+
+func ProofSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestrator] {
+	ids := NewDefaultMinimalSystemIDs(DefaultL1ID, DefaultL2AID)
+	opt := defaultMinimalSystemOpts(&ids, dest)
+	opt.Add(WithGameTypeAdded(ids.L1.ChainID(), ids.L2.ChainID(), ids.L1EL))
 	return opt
 }


### PR DESCRIPTION
This patch enables devstack to use op-deployer’s add-game-type functionality. This allows us to run acceptance tests for the creator pattern via `opcm.addGameType`.

While this feature could also be implemented as an integration test in op-deployer, doing it at the acceptance-test level avoids the need for a live RPC endpoint that would be required by a full integration test.

This patch also fixes the absolute prestate that's used for FDG deployments. Previously, we stubbed the absolute prestate since it's not defined at L2 genesis. With the new `WithGameTypeAdded` devstack option, we can correct the prestate stub once the chain genesis is available.