### PR TITLE
feat: reduce lite profile fuzz runs

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -134,6 +134,13 @@ timeout = 300
 optimizer = false
 optimizer_runs = 0
 
+[profile.lite.fuzz]
+runs = 8
+
+[profile.lite.invariant]
+runs = 8
+depth = 8
+
 # IMPORTANT:
 # See the info in the "DEFAULT" profile to understand this section.
 additional_compiler_profiles = [


### PR DESCRIPTION
Reduces lite profile fuzz and invariant runs to 8 across the board. We now run heavier fuzz runs in CI, so it's generally nicer and easier if we run significantly reduced runs locally.