### PR TITLE
op-conductor: use op-service HTTP Server for Flashblocks ; fix test flake

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -325,8 +325,8 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 
 // initFlashblocksHandler initializes the flashblocks handler
 func (c *OpConductor) initFlashblocksHandler(ctx context.Context) error {
-	if c.cfg.RollupBoostWsURL == "" || c.cfg.WebsocketServerPort <= 0 {
-		c.log.Info("flashblocks handler disabled, no rollup boost URL or websocket server port configured")
+	if c.cfg.RollupBoostWsURL == "" {
+		c.log.Info("flashblocks handler disabled, no rollup boost URL configured")
 		return nil
 	}
 

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -1077,12 +1077,13 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 
 	// Start the conductor, which should initialize and start the flashblocks handler
 	s.hmon.EXPECT().Start(mock.Anything).Return(nil)
+
+	s.NotNil(conductor.flashblocksHandler, "flashblocks handler should be initialized before starting the conductor")
 	err = conductor.Start(s.ctx)
 	s.NoError(err)
 
-	// Wait for handler readiness and capture bound port
-	s.NotNil(conductor.flashblocksHandler, "flashblocks handler should be initialized")
 	boundPort := conductor.flashblocksHandler.BoundPort()
+	s.NotZero(boundPort, "bound port should be non-zero")
 
 	// Wait for rollup boost server connection (event-driven, not time-based)
 	select {

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -1082,12 +1082,6 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 
 	// Wait for handler readiness and capture bound port
 	s.NotNil(conductor.flashblocksHandler, "flashblocks handler should be initialized")
-	select {
-	case <-conductor.flashblocksHandler.Ready():
-		// ready
-	case <-time.After(5 * time.Second):
-		s.Fail("Timeout waiting for WebSocket server readiness")
-	}
 	boundPort := conductor.flashblocksHandler.BoundPort()
 
 	// Wait for rollup boost server connection (event-driven, not time-based)

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -984,11 +983,6 @@ func (s *OpConductorTestSuite) TestSupervisorConnectionDown() {
 
 // TestFlashblocksHandlerIntegration tests that the flashblocks handler is properly initialized and started
 func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
-	// Use a random available port to avoid conflicts
-	listener, err := net.Listen("tcp", "localhost:0")
-	s.NoError(err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
 
 	// Channels for coordination without timing dependencies
 	testCtx, testCancel := context.WithCancel(context.Background())
@@ -1070,7 +1064,8 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 	// Create a copy of the config to avoid modifying the shared config object
 	testCfg := s.cfg
 	testCfg.RollupBoostWsURL = rollupBoostWsURL
-	testCfg.WebsocketServerPort = port
+	// Bind port dynamically via handler (use port 0)
+	testCfg.WebsocketServerPort = 0
 
 	// Create a new conductor with the updated config
 	conductor, err := NewOpConductor(s.ctx, &testCfg, s.log, s.metrics, s.version, s.ctrl, s.cons, s.hmon)
@@ -1085,8 +1080,15 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 	err = conductor.Start(s.ctx)
 	s.NoError(err)
 
-	// Wait for conductor to be ready using its internal state
+	// Wait for handler readiness and capture bound port
 	s.NotNil(conductor.flashblocksHandler, "flashblocks handler should be initialized")
+	select {
+	case <-conductor.flashblocksHandler.Ready():
+		// ready
+	case <-time.After(5 * time.Second):
+		s.Fail("Timeout waiting for WebSocket server readiness")
+	}
+	boundPort := conductor.flashblocksHandler.BoundPort()
 
 	// Wait for rollup boost server connection (event-driven, not time-based)
 	select {
@@ -1097,10 +1099,10 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 	}
 
 	// Connect to the WebSocket server BEFORE messages are sent
-	wsURL := fmt.Sprintf("ws://localhost:%d/ws", testCfg.WebsocketServerPort)
+	wsURL := fmt.Sprintf("ws://127.0.0.1:%d/ws", boundPort)
 
 	// Create connection context
-	connCtx, connCancel := context.WithTimeout(testCtx, 3*time.Second)
+	connCtx, connCancel := context.WithTimeout(testCtx, 10*time.Second)
 	defer connCancel()
 
 	var client *websocket.Conn
@@ -1123,7 +1125,7 @@ func (s *OpConductorTestSuite) TestFlashblocksHandlerIntegration() {
 			select {
 			case <-connCtx.Done():
 				s.Failf("Failed to connect to WebSocket server", "Last error: %v", err)
-			case <-time.After(10 * time.Millisecond):
+			case <-time.After(25 * time.Millisecond):
 				// Continue loop
 			}
 		}
@@ -1148,7 +1150,7 @@ connected:
 	receivedMessages := make([]string, 0, len(expectedMessages))
 
 	// Read messages with timeout
-	readCtx, readCancel := context.WithTimeout(testCtx, 3*time.Second)
+	readCtx, readCancel := context.WithTimeout(testCtx, 10*time.Second)
 	defer readCancel()
 
 	for len(receivedMessages) < len(expectedMessages) {

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
 	"github.com/coder/websocket"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -38,8 +38,6 @@ type FlashblockHandler interface {
 	BroadcastMessage(message []byte)
 	// BoundPort returns the actual TCP port the server is bound to
 	BoundPort() int
-	// Ready is closed once the server listener is bound and ready to accept connections
-	Ready() <-chan struct{}
 }
 
 // Config contains configuration for the flashblocks handler
@@ -59,10 +57,8 @@ type Handler struct {
 	rollupBoostConn     *websocket.Conn
 	rollupBoostCtx      context.Context
 	rollupBoostWsCancel context.CancelFunc
-	server              *http.Server
-	listener            net.Listener
+	httpServer          *httputil.HTTPServer
 	hub                 *Hub
-	ready               chan struct{}
 	boundPort           int
 }
 
@@ -83,7 +79,6 @@ func NewHandler(cfg Config, log log.Logger, isLeaderFn func(context.Context) boo
 		log:        log,
 		isLeaderFn: isLeaderFn,
 		metrics:    m,
-		ready:      make(chan struct{}),
 	}
 
 	// Try to establish initial connection to rollup boost WebSocket
@@ -141,13 +136,11 @@ func (h *Handler) Stop() {
 	}
 
 	// Close the HTTP server if it's running
-	if h.server != nil {
+	if h.httpServer != nil {
 		h.log.Info("closing WebSocket server")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-
-		err := h.server.Shutdown(ctx)
-		if err != nil {
+		if err := h.httpServer.Stop(ctx); err != nil {
 			h.log.Error("Error shutting down WebSocket server", "err", err)
 		}
 		h.log.Info("WebSocket server closed")
@@ -170,29 +163,21 @@ func (h *Handler) startWebSocketServer(_ context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", h.handleWebSocket)
 
-	// Bind listener (supports port=0 for dynamic assignment)
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", h.cfg.WebsocketServerPort))
+	// Start HTTP server using reusable httputil server (supports port=0 and exposes Port())
+	addr := fmt.Sprintf(":%d", h.cfg.WebsocketServerPort)
+	srv, err := httputil.StartHTTPServer(addr, mux)
 	if err != nil {
 		return err
 	}
-	h.listener = ln
-	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
-		h.boundPort = tcpAddr.Port
+	h.httpServer = srv
+	// Determine bound port
+	if port, err := h.httpServer.Port(); err == nil {
+		h.boundPort = port
 	} else {
-		panic("ln.Addr() is not a TCPAddr")
+		h.log.Warn("failed to determine bound port", "err", err)
 	}
 
-	// Start HTTP server on bound listener
-	h.server = &http.Server{Handler: mux}
-
 	h.log.Info("starting WebSocket server", "port", h.boundPort)
-	// Signal readiness as soon as the listener is bound
-	close(h.ready)
-	go func() {
-		if err := h.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			h.log.Error("WebSocket server error", "err", err)
-		}
-	}()
 
 	return nil
 }
@@ -200,11 +185,6 @@ func (h *Handler) startWebSocketServer(_ context.Context) error {
 // BoundPort returns the actual TCP port the server is bound to.
 func (h *Handler) BoundPort() int {
 	return h.boundPort
-}
-
-// Ready returns a channel that is closed when the server listener is bound.
-func (h *Handler) Ready() <-chan struct{} {
-	return h.ready
 }
 
 // handleWebSocket handles WebSocket upgrade requests

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -174,7 +174,8 @@ func (h *Handler) startWebSocketServer(_ context.Context) error {
 	if port, err := h.httpServer.Port(); err == nil {
 		h.boundPort = port
 	} else {
-		h.log.Warn("failed to determine bound port", "err", err)
+		h.log.Error("failed to determine bound port", "err", err)
+		panic(err)
 	}
 
 	h.log.Info("starting WebSocket server", "port", h.boundPort)

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -174,8 +174,7 @@ func (h *Handler) startWebSocketServer(_ context.Context) error {
 	if port, err := h.httpServer.Port(); err == nil {
 		h.boundPort = port
 	} else {
-		h.log.Error("failed to determine bound port", "err", err)
-		panic(err)
+		return fmt.Errorf("failed to determine bound port: %w", err)
 	}
 
 	h.log.Info("starting WebSocket server", "port", h.boundPort)

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -35,6 +36,10 @@ type FlashblockHandler interface {
 	Stop()
 	// BroadcastMessage sends a message to all connected WebSocket clients
 	BroadcastMessage(message []byte)
+	// BoundPort returns the actual TCP port the server is bound to
+	BoundPort() int
+	// Ready is closed once the server listener is bound and ready to accept connections
+	Ready() <-chan struct{}
 }
 
 // Config contains configuration for the flashblocks handler
@@ -55,15 +60,18 @@ type Handler struct {
 	rollupBoostCtx      context.Context
 	rollupBoostWsCancel context.CancelFunc
 	server              *http.Server
+	listener            net.Listener
 	hub                 *Hub
+	ready               chan struct{}
+	boundPort           int
 }
 
 // NewHandler creates a new flashblocks handler
 func NewHandler(cfg Config, log log.Logger, isLeaderFn func(context.Context) bool, m metrics.Metricer) (FlashblockHandler, error) {
 	// Validate configuration
-	if cfg.RollupBoostWsURL == "" || cfg.WebsocketServerPort <= 0 {
-		log.Error("rollup boost WebSocket URL or websocket server port not configured")
-		return nil, errors.New("rollup boost WebSocket URL or websocket server port not configured")
+	if cfg.RollupBoostWsURL == "" {
+		log.Error("rollup boost WebSocket URL not configured")
+		return nil, errors.New("rollup boost WebSocket URL not configured")
 	}
 
 	// Initialize the handler
@@ -72,6 +80,7 @@ func NewHandler(cfg Config, log log.Logger, isLeaderFn func(context.Context) boo
 		log:        log,
 		isLeaderFn: isLeaderFn,
 		metrics:    m,
+		ready:      make(chan struct{}),
 	}
 
 	// Try to establish initial connection to rollup boost WebSocket
@@ -148,10 +157,6 @@ func (h *Handler) BroadcastMessage(message []byte) {
 }
 
 func (h *Handler) startWebSocketServer(_ context.Context) error {
-	if h.cfg.WebsocketServerPort <= 0 {
-		return fmt.Errorf("WebSocket server port not configured or invalid: %d", h.cfg.WebsocketServerPort)
-	}
-
 	h.hub = newHub(h.metrics)
 	go h.hub.run()
 
@@ -159,20 +164,39 @@ func (h *Handler) startWebSocketServer(_ context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", h.handleWebSocket)
 
-	// Start HTTP server
-	h.server = &http.Server{
-		Addr:    fmt.Sprintf(":%d", h.cfg.WebsocketServerPort),
-		Handler: mux,
+	// Bind listener (supports port=0 for dynamic assignment)
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", h.cfg.WebsocketServerPort))
+	if err != nil {
+		return err
+	}
+	h.listener = ln
+	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
+		h.boundPort = tcpAddr.Port
 	}
 
-	h.log.Info("starting WebSocket server", "port", h.cfg.WebsocketServerPort)
+	// Start HTTP server on bound listener
+	h.server = &http.Server{Handler: mux}
+
+	h.log.Info("starting WebSocket server", "port", h.boundPort)
+	// Signal readiness as soon as the listener is bound
+	close(h.ready)
 	go func() {
-		if err := h.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := h.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			h.log.Error("WebSocket server error", "err", err)
 		}
 	}()
 
 	return nil
+}
+
+// BoundPort returns the actual TCP port the server is bound to.
+func (h *Handler) BoundPort() int {
+	return h.boundPort
+}
+
+// Ready returns a channel that is closed when the server listener is bound.
+func (h *Handler) Ready() <-chan struct{} {
+	return h.ready
 }
 
 // handleWebSocket handles WebSocket upgrade requests

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -73,6 +73,9 @@ func NewHandler(cfg Config, log log.Logger, isLeaderFn func(context.Context) boo
 		log.Error("rollup boost WebSocket URL not configured")
 		return nil, errors.New("rollup boost WebSocket URL not configured")
 	}
+	if cfg.WebsocketServerPort < 0 {
+		return nil, fmt.Errorf("WebSocket server port invalid: %d", cfg.WebsocketServerPort)
+	}
 
 	// Initialize the handler
 	handler := &Handler{
@@ -157,6 +160,9 @@ func (h *Handler) BroadcastMessage(message []byte) {
 }
 
 func (h *Handler) startWebSocketServer(_ context.Context) error {
+	if h.cfg.WebsocketServerPort < 0 {
+		return fmt.Errorf("WebSocket server port invalid: %d", h.cfg.WebsocketServerPort)
+	}
 	h.hub = newHub(h.metrics)
 	go h.hub.run()
 
@@ -172,6 +178,8 @@ func (h *Handler) startWebSocketServer(_ context.Context) error {
 	h.listener = ln
 	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
 		h.boundPort = tcpAddr.Port
+	} else {
+		panic("ln.Addr() is not a TCPAddr")
 	}
 
 	// Start HTTP server on bound listener


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/17879

- Replaces direct golang http server with `op-service` utility version, which contains bound port exposing
- Removes logic which directs `port=0` to semantically mean disable the feature. Port 0 is used for auto assignment.
- Retains checks for invalid port numbers (negative)
- Updates test to await bound port as part of test procedure. This fixes flakes where port contention during CI leads to failures.