### PR TITLE
fix(acceptance-tests/op-reth): fix acceptance tests for op-reth

### DIFF
--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -187,10 +187,10 @@ func (el *L2ELNode) VerifyWithdrawalHashChangedIn(blockHash common.Hash) {
 	parentBlockInfo, err := l2Client.InfoByHash(el.ctx, postBlockWithdrawalInfo.ParentHash())
 	el.require.NoError(err, "failed to get parent block info")
 
-	postProof, err := l2Client.GetProof(el.ctx, predeploys.L2ToL1MessagePasserAddr, nil, blockHash.String())
+	postProof, err := l2Client.GetProof(el.ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{}, blockHash.String())
 	el.require.NoError(err, "failed to get post-withdrawal storage proof")
 
-	parentProof, err := l2Client.GetProof(el.ctx, predeploys.L2ToL1MessagePasserAddr, nil, postBlockWithdrawalInfo.ParentHash().String())
+	parentProof, err := l2Client.GetProof(el.ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{}, postBlockWithdrawalInfo.ParentHash().String())
 	el.require.NoError(err, "failed to get parent storage proof")
 
 	el.require.NotEqual(parentProof.StorageHash, postProof.StorageHash, "withdrawal hash should have changed between parent and current block")

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -217,6 +217,7 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 			"--ipcdisable",
 			"--authrpc.addr=127.0.0.1",
 			"--authrpc.port=0",
+			"--rpc.eth-proof-window=30",
 			"--authrpc.jwtsecret=" + jwtPath,
 			"--txpool.minimum-priority-fee=1",
 			"--txpool.nolocals",


### PR DESCRIPTION
## Description

Small PR to fix acceptance tests for op-reth

Issues:
- The proof generation window was too short which was making the `withdrawals_root` test fail
- The `getProof` arguments in the `withdrawals_root` test were not properly serialized (it seems that `jsonrpsee` doesn't deserialize `null` as empty vector)