### PR TITLE
feat: Only allow transactions to be scheduled by Safe owners

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -873,6 +873,11 @@
   },
   {
     "inputs": [],
+    "name": "TimelockGuard_NotOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "TimelockGuard_TransactionAlreadyCancelled",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,7 +208,7 @@
     "sourceCodeHash": "0x950725f8b9ad9bb3b6b5e836f67e18db824a7864bac547ee0eeba88ada3de0e9"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x22730f6ebe10e0d78b23b3e0f3d58f867f420039981455b09a508755e512c127",
+    "initCodeHash": "0x2773b3a98145b82b42ef5ea9ee088f5ff7bc13ba34925c8b7350151149a7d95a",
     "sourceCodeHash": "0xe3d2fd50724baf6d5e83e2c9d89fcfcbc678d966187bd38e2d9a840716bcafa3"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x950725f8b9ad9bb3b6b5e836f67e18db824a7864bac547ee0eeba88ada3de0e9"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x2773b3a98145b82b42ef5ea9ee088f5ff7bc13ba34925c8b7350151149a7d95a",
-    "sourceCodeHash": "0xe3d2fd50724baf6d5e83e2c9d89fcfcbc678d966187bd38e2d9a840716bcafa3"
+    "initCodeHash": "0xd9268a8659162881e242921b7d133ed139fbbe1017e02789abc0af48e8407300",
+    "sourceCodeHash": "0x9d76fa66c0bd1261ab3f6c32892a0942ce4c10a5dfa169c012985dd43ea1cdde"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -22,8 +22,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      functionality is not desired, then there is no need to enable or configure it.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -149,6 +149,9 @@ abstract contract TimelockGuard is IGuard {
     /// @notice Error for when the contract is not at least version 1.3.0
     error TimelockGuard_InvalidVersion();
 
+    /// @notice Error for when the caller is not an owner of the Safe
+    error TimelockGuard_NotOwner();
+
     /// @notice Emitted when a Safe configures the guard
     /// @param safe The Safe whose guard is configured.
     /// @param timelockDelay The timelock delay in seconds.
@@ -471,6 +474,13 @@ abstract contract TimelockGuard is IGuard {
     )
         external
     {
+        // Limit submission of transactions to owners of the Safe only.
+        // Restrict scheduling to Safe owners for increased security. This ensures that an attacker
+        // cannot simply collect valid signatures, but must also control a private key.
+        if(!_safe.isOwner(tx.origin)){
+            revert TimelockGuard_NotOwner();
+        }
+
         // Check that this guard is enabled on the calling Safe
         if (!_isGuardEnabled(_safe)) {
             revert TimelockGuard_GuardNotEnabled();

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -477,7 +477,7 @@ abstract contract TimelockGuard is IGuard {
         // Limit submission of transactions to owners of the Safe only.
         // Restrict scheduling to Safe owners for increased security. This ensures that an attacker
         // cannot simply collect valid signatures, but must also control a private key.
-        if(!_safe.isOwner(tx.origin)){
+        if (!_safe.isOwner(tx.origin)) {
             revert TimelockGuard_NotOwner();
         }
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -86,13 +86,7 @@ library TransactionBuilder {
     }
 
     /// @notice Schedules the transaction with the supplied TimelockGuard instance, using a specified owner.
-    function scheduleTransaction(
-        Transaction memory _tx,
-        TimelockGuard _timelockGuard,
-        address _owner
-    )
-        internal
-    {
+    function scheduleTransaction(Transaction memory _tx, TimelockGuard _timelockGuard, address _owner) internal {
         // Prank as the specified owner to satisfy the tx.origin check
         Vm(VM_ADDR).prank(_owner, _owner);
         _timelockGuard.scheduleTransaction(_tx.safeInstance.safe, _tx.nonce, _tx.params, _tx.signatures);
@@ -869,8 +863,9 @@ contract TimelockGuard_Integration_Test is TimelockGuard_TestInit {
         TransactionBuilder.Transaction memory cancellationTx = dummyTx.makeCancellationTransaction(timelockGuard);
         timelockGuard.cancelTransaction(safeInstance.safe, dummyTx.hash, dummyTx.nonce, cancellationTx.signatures);
 
+        address owner = safeInstance.safe.getOwners()[0];
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
-        dummyTx.scheduleTransaction(timelockGuard);
+        dummyTx.scheduleTransaction(timelockGuard, owner);
     }
 
     /// @notice Test that the guard can be reset while still enabled, and then can be disabled

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -79,6 +79,22 @@ library TransactionBuilder {
 
     /// @notice Schedules the transaction with the supplied TimelockGuard instance.
     function scheduleTransaction(Transaction memory _tx, TimelockGuard _timelockGuard) internal {
+        // Prank as an owner (use the first owner) to satisfy the tx.origin check
+        address owner = _tx.safeInstance.safe.getOwners()[0];
+        Vm(VM_ADDR).prank(owner, owner);
+        _timelockGuard.scheduleTransaction(_tx.safeInstance.safe, _tx.nonce, _tx.params, _tx.signatures);
+    }
+
+    /// @notice Schedules the transaction with the supplied TimelockGuard instance, using a specified owner.
+    function scheduleTransaction(
+        Transaction memory _tx,
+        TimelockGuard _timelockGuard,
+        address _owner
+    )
+        internal
+    {
+        // Prank as the specified owner to satisfy the tx.origin check
+        Vm(VM_ADDR).prank(_owner, _owner);
         _timelockGuard.scheduleTransaction(_tx.safeInstance.safe, _tx.nonce, _tx.params, _tx.signatures);
     }
 
@@ -416,17 +432,21 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         assertEq(timelockGuard.timelockConfiguration(unguardedSafe.safe), 0);
 
         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(unguardedSafe);
+        address owner = unguardedSafe.safe.getOwners()[0];
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
-        dummyTx.scheduleTransaction(timelockGuard);
+        dummyTx.scheduleTransaction(timelockGuard, owner);
     }
 
     /// @notice Verifies rescheduling an identical pending transaction reverts.
     function test_scheduleTransaction_reschedulingIdenticalTransaction_reverts() external {
         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
 
+        address owner = safeInstance.safe.getOwners()[0];
+        vm.prank(owner, owner);
         timelockGuard.scheduleTransaction(safeInstance.safe, dummyTx.nonce, dummyTx.params, dummyTx.signatures);
 
         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyScheduled.selector);
+        vm.prank(owner, owner);
         timelockGuard.scheduleTransaction(dummyTx.safeInstance.safe, dummyTx.nonce, dummyTx.params, dummyTx.signatures);
     }
 
@@ -437,8 +457,21 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
         _enableGuard(unguardedSafe);
         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(unguardedSafe);
 
+        address owner = unguardedSafe.safe.getOwners()[0];
         vm.expectRevert(TimelockGuard.TimelockGuard_GuardNotConfigured.selector);
-        dummyTx.scheduleTransaction(timelockGuard);
+        dummyTx.scheduleTransaction(timelockGuard, owner);
+    }
+
+    /// @notice Verifies non-owners cannot schedule transactions even with valid signatures.
+    function test_scheduleTransaction_notOwner_reverts() external {
+        TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
+
+        // Create a non-owner address
+        address nonOwner = makeAddr("nonOwner");
+
+        // Attempt to schedule as a non-owner (using tx.origin)
+        vm.expectRevert(TimelockGuard.TimelockGuard_NotOwner.selector);
+        dummyTx.scheduleTransaction(timelockGuard, nonOwner);
     }
 
     /// @notice Demonstrates identical payloads can be scheduled with distinct nonces.
@@ -454,6 +487,8 @@ contract TimelockGuard_ScheduleTransaction_Test is TimelockGuard_TestInit {
 
         vm.expectEmit(true, true, true, true);
         emit TransactionScheduled(safe, newTx.hash, INIT_TIME + TIMELOCK_DELAY);
+        address owner = safeInstance.safe.getOwners()[0];
+        vm.prank(owner, owner);
         timelockGuard.scheduleTransaction(safeInstance.safe, newTx.nonce, newTx.params, newTx.signatures);
     }
 }


### PR DESCRIPTION
**Description**

This gives us an extra layer of defense because now an attacker also needs a private key to execute, and just phishing signatures is not sufficient.

Should be merged after #17808, in order to get the semver progression right.