### PR TITLE
make all _TestInit contracts abstract

### DIFF
--- a/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
+++ b/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
@@ -13,7 +13,7 @@ import { Preinstalls } from "src/libraries/Preinstalls.sol";
 
 /// @title DataAvailabilityChallenge Test Init
 /// @notice Test initialization for DataAvailabilityChallenge tests.
-contract DataAvailabilityChallenge_TestInit is CommonTest {
+abstract contract DataAvailabilityChallenge_TestInit is CommonTest {
     function setUp() public virtual override {
         super.enableAltDA();
         super.setUp();

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -20,7 +20,7 @@ import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 /// @title ETHLockbox_TestInit
 /// @notice Base contract that sets up the testing environment for ETHLockbox tests.
-contract ETHLockbox_TestInit is CommonTest {
+abstract contract ETHLockbox_TestInit is CommonTest {
     error InvalidInitialization();
 
     event ETHLocked(IOptimismPortal2 indexed portal, uint256 amount);

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -40,7 +40,7 @@ contract L1CrossDomainMessenger_Encoding_Harness {
 
 /// @title L1CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for L1CrossDomainMessenger tests.
-contract L1CrossDomainMessenger_TestInit is CommonTest {
+abstract contract L1CrossDomainMessenger_TestInit is CommonTest {
     /// @dev The receiver address
     address recipient = address(0xabbaacdc);
 

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -30,7 +30,7 @@ contract L1ERC721Bridge_TestERC721_Harness is ERC721 {
 
 /// @title L1ERC721Bridge_TestInit
 /// @notice Test contract for L1ERC721Bridge initialization and setup.
-contract L1ERC721Bridge_TestInit is CommonTest {
+abstract contract L1ERC721Bridge_TestInit is CommonTest {
     L1ERC721Bridge_TestERC721_Harness internal localToken;
     L1ERC721Bridge_TestERC721_Harness internal remoteToken;
     uint256 internal constant tokenId = 1;

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -25,7 +25,7 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
 /// @title L1StandardBridge_TestInit
 /// @notice Reusable test initialization for `L1StandardBridge` tests.
-contract L1StandardBridge_TestInit is CommonTest {
+abstract contract L1StandardBridge_TestInit is CommonTest {
     /// @notice Asserts the expected calls and events for bridging ETH depending on whether the
     ///         bridge call is legacy or not.
     function _preBridgeETH(bool isLegacy, uint256 value) internal {

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -316,7 +316,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
 
 /// @title OPContractsManager_TestInit
 /// @notice Reusable test initialization for `OPContractsManager` tests.
-contract OPContractsManager_TestInit is CommonTest {
+abstract contract OPContractsManager_TestInit is CommonTest {
     event GameTypeAdded(
         uint256 indexed l2ChainId, GameType indexed gameType, IDisputeGame newDisputeGame, IDisputeGame oldDisputeGame
     );

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -77,7 +77,7 @@ contract BadDisputeGameFactoryReturner {
 
 /// @title OPContractsManagerStandardValidator_TestInit
 /// @notice Base contract for `OPContractsManagerStandardValidator` tests, handles common setup.
-contract OPContractsManagerStandardValidator_TestInit is CommonTest {
+abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
     /// @notice Deploy input that was used to deploy the contracts being tested.
     IOPContractsManager.DeployInput deployInput;
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -34,7 +34,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
-contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
+abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     address depositor;
 
     Types.WithdrawalTransaction _defaultTx;

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -11,7 +11,7 @@ import { IProtocolVersions, ProtocolVersion } from "interfaces/L1/IProtocolVersi
 
 /// @title ProtocolVersions Test Init
 /// @notice Test initialization for ProtocolVersions tests.
-contract ProtocolVersions_TestInit is CommonTest {
+abstract contract ProtocolVersions_TestInit is CommonTest {
     event ConfigUpdate(uint256 indexed version, IProtocolVersions.UpdateType indexed updateType, bytes data);
 
     ProtocolVersion required;

--- a/packages/contracts-bedrock/test/L1/ProxyAdminOwnedBase.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProxyAdminOwnedBase.t.sol
@@ -50,7 +50,7 @@ contract ProxyAdminOwnedBase_Harness is ProxyAdminOwnedBase {
     }
 }
 
-contract ProxyAdminOwnedBase_TestInit is CommonTest {
+abstract contract ProxyAdminOwnedBase_TestInit is CommonTest {
     /// @notice Harness for the `ProxyAdminOwnedBase` contract.
     ProxyAdminOwnedBase_Harness public harness;
 

--- a/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
@@ -92,7 +92,7 @@ contract CustomMeterUser is ResourceMetering {
 
 /// @title ResourceMetering_TestInit
 /// @notice Reusable test initialization for `ResourceMetering` tests.
-contract ResourceMetering_TestInit is Test {
+abstract contract ResourceMetering_TestInit is Test {
     MeterUser internal meter;
     uint64 initialBlockNum;
 

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -15,7 +15,7 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
 /// @title SuperchainConfig_TestInit
 /// @notice Initialization contract for SuperchainConfig tests.
-contract SuperchainConfig_TestInit is CommonTest {
+abstract contract SuperchainConfig_TestInit is CommonTest {
     function setUp() public virtual override {
         super.setUp();
         skipIfForkTest("SuperchainConfig_TestInit: cannot test initialization on forked network");

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -20,7 +20,7 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
 /// @title SystemConfig Test Init
 /// @notice Reusable test initialization for SystemConfig tests.
-contract SystemConfig_TestInit is CommonTest {
+abstract contract SystemConfig_TestInit is CommonTest {
     event ConfigUpdate(uint256 indexed version, ISystemConfig.UpdateType indexed updateType, bytes data);
 
     bytes32 public constant EXAMPLE_FEATURE = "EXAMPLE_FEATURE";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
@@ -27,7 +27,7 @@ contract XDomainSetter is CrossDomainOwnable {
 
 /// @title CrossDomainOwnable_TestInit
 /// @notice Reusable test initialization for `CrossDomainOwnable` tests.
-contract CrossDomainOwnable_TestInit is Test {
+abstract contract CrossDomainOwnable_TestInit is Test {
     XDomainSetter setter;
 
     function setUp() public virtual {

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable2.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable2.t.sol
@@ -27,7 +27,7 @@ contract XDomainSetter2 is CrossDomainOwnable2 {
 
 /// @title CrossDomainOwnable2_TestInit
 /// @notice Reusable test initialization for `CrossDomainOwnable2` tests.
-contract CrossDomainOwnable2_TestInit is CommonTest {
+abstract contract CrossDomainOwnable2_TestInit is CommonTest {
     XDomainSetter2 setter;
 
     function setUp() public virtual override {

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable3.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable3.t.sol
@@ -27,7 +27,7 @@ contract XDomainSetter3 is CrossDomainOwnable3 {
 
 /// @title CrossDomainOwnable3_TestInit
 /// @notice Reusable test initialization for `CrossDomainOwnable3` tests.
-contract CrossDomainOwnable3_TestInit is CommonTest {
+abstract contract CrossDomainOwnable3_TestInit is CommonTest {
     XDomainSetter3 setter;
 
     /// @notice CrossDomainOwnable3.sol transferOwnership event

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -41,7 +41,7 @@ contract CrossL2Inbox_ValidateMessageRelayer_Harness is Test {
 
 /// @title CrossL2Inbox_Test_Init
 /// @notice Reusable test initialization for `CrossL2Inbox` tests.
-contract CrossL2Inbox_TestInit is CommonTest {
+abstract contract CrossL2Inbox_TestInit is CommonTest {
     event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
 
     CrossL2Inbox_ValidateMessageRelayer_Harness public validateMessageRelayer;

--- a/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
@@ -10,7 +10,7 @@ import { InvalidAmount } from "src/libraries/errors/CommonErrors.sol";
 
 /// @title ETHLiquidity_TestInit
 /// @notice Reusable test initialization for `ETHLiquidity` tests.
-contract ETHLiquidity_TestInit is CommonTest {
+abstract contract ETHLiquidity_TestInit is CommonTest {
     /// @notice Emitted when an address burns ETH liquidity.
     event LiquidityBurned(address indexed caller, uint256 value);
 

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -11,7 +11,7 @@ import "src/libraries/L1BlockErrors.sol";
 
 /// @title L1Block_ TestInit
 /// @notice Reusable test initialization for `L1Block` tests.
-contract L1Block_TestInit is CommonTest {
+abstract contract L1Block_TestInit is CommonTest {
     address depositor;
 
     /// @notice Sets up the test suite.

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -20,7 +20,7 @@ import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 
 /// @title L2CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for `L2CrossDomainMessenger` tests.
-contract L2CrossDomainMessenger_TestInit is CommonTest {
+abstract contract L2CrossDomainMessenger_TestInit is CommonTest {
     /// @notice Receiver address for testing
     address recipient = address(0xabbaacdc);
 }

--- a/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
@@ -67,7 +67,7 @@ contract L2ERC721Bridge_NonCompliantERC721_Harness {
 
 /// @title L2ERC721Bridge_TestInit
 /// @notice Reusable test initialization for `L2ERC721Bridge` tests.
-contract L2ERC721Bridge_TestInit is CommonTest {
+abstract contract L2ERC721Bridge_TestInit is CommonTest {
     L2ERC721Bridge_TestMintableERC721_Harness internal localToken;
     L2ERC721Bridge_TestERC721_Harness internal remoteToken;
     uint256 internal constant tokenId = 1;

--- a/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
@@ -23,7 +23,7 @@ import { IL2StandardBridge } from "interfaces/L2/IL2StandardBridge.sol";
 
 /// @title L2StandardBridge_TestInit
 /// @notice Reusable test initialization for `L2StandardBridge` tests.
-contract L2StandardBridge_TestInit is CommonTest {
+abstract contract L2StandardBridge_TestInit is CommonTest {
     /// @notice Sets up expected calls and emits for a successful ERC20 withdrawal.
     function _preBridgeERC20(bool _isLegacy, address _l2Token) internal {
         // Alice has 100 L2Token

--- a/packages/contracts-bedrock/test/L2/L2StandardBridgeInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridgeInterop.t.sol
@@ -15,7 +15,7 @@ import { IOptimismERC20Factory } from "interfaces/L2/IOptimismERC20Factory.sol";
 
 /// @title L2StandardBridgeInterop_TestInit
 /// @notice Reusable test initialization for `L2StandardBridgeInterop` tests.
-contract L2StandardBridgeInterop_TestInit is CommonTest {
+abstract contract L2StandardBridgeInterop_TestInit is CommonTest {
     /// @notice Emitted when a conversion is made.
     event Converted(address indexed from, address indexed to, address indexed caller, uint256 amount);
 

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -63,7 +63,7 @@ contract L2ToL2CrossDomainMessenger_WithModifiableTransientStorage_Harness is L2
 
 /// @title L2ToL2CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for `L2ToL2CrossDomainMessenger` tests.
-contract L2ToL2CrossDomainMessenger_TestInit is Test {
+abstract contract L2ToL2CrossDomainMessenger_TestInit is Test {
     address internal foundryVMAddress = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
 
     /// @notice L2ToL2CrossDomainMessenger contract instance with modifiable transient storage.

--- a/packages/contracts-bedrock/test/L2/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismMintableERC721.t.sol
@@ -10,7 +10,7 @@ import { OptimismMintableERC721, IOptimismMintableERC721 } from "src/L2/Optimism
 
 /// @title OptimismMintableERC721_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC721` tests.
-contract OptimismMintableERC721_TestInit is CommonTest {
+abstract contract OptimismMintableERC721_TestInit is CommonTest {
     ERC721 internal L1NFT;
     OptimismMintableERC721 internal L2NFT;
 

--- a/packages/contracts-bedrock/test/L2/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismMintableERC721Factory.t.sol
@@ -6,7 +6,7 @@ import { OptimismMintableERC721 } from "src/L2/OptimismMintableERC721.sol";
 
 /// @title OptimismMintableERC721Factory_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC721Factory` tests.
-contract OptimismMintableERC721Factory_TestInit is CommonTest {
+abstract contract OptimismMintableERC721Factory_TestInit is CommonTest {
     event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     function calculateTokenAddress(

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
@@ -23,7 +23,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title OptimismSuperchainERC20_TestInit
 /// @notice Reusable test initialization for `OptimismSuperchainERC20` tests.
-contract OptimismSuperchainERC20_TestInit is Test {
+abstract contract OptimismSuperchainERC20_TestInit is Test {
     address internal constant ZERO_ADDRESS = address(0);
     address internal constant REMOTE_TOKEN = address(0x123);
     string internal constant NAME = "OptimismSuperchainERC20";

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Beacon.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Beacon.t.sol
@@ -10,7 +10,7 @@ import { IBeacon } from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 
 /// @title OptimismSuperchainERC20Beacon_TestInit
 /// @notice Reusable test initialization for `OptimismSuperchainERC20Beacon` tests.
-contract OptimismSuperchainERC20Beacon_TestInit is CommonTest {
+abstract contract OptimismSuperchainERC20Beacon_TestInit is CommonTest {
     /// @notice Sets up the test suite.
     function setUp() public override {
         // Skip the test until OptimismSuperchainERC20Beacon is integrated again

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Factory.t.sol
@@ -13,7 +13,7 @@ import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadat
 
 /// @title OptimismSuperchainERC20Factory_TestInit
 /// @notice Reusable test initialization for `OptimismSuperchainERC20Factory` tests.
-contract OptimismSuperchainERC20Factory_TestInit is CommonTest {
+abstract contract OptimismSuperchainERC20Factory_TestInit is CommonTest {
     using Bytes32AddressLib for bytes32;
 
     event OptimismSuperchainERC20Created(

--- a/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
@@ -17,7 +17,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title SequencerFeeVault_TestInit
 /// @notice Reusable test initialization for `SequencerFeeVault` tests.
-contract SequencerFeeVault_TestInit is CommonTest {
+abstract contract SequencerFeeVault_TestInit is CommonTest {
     address recipient;
 
     /// @dev Sets up the test suite.

--- a/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
@@ -16,7 +16,7 @@ import { MockSuperchainERC20Implementation } from "test/mocks/SuperchainERC20Imp
 
 /// @title SuperchainERC20_TestInit
 /// @notice Reusable test initialization for `SuperchainERC20` tests.
-contract SuperchainERC20_TestInit is Test {
+abstract contract SuperchainERC20_TestInit is Test {
     address internal constant ZERO_ADDRESS = address(0);
     address internal constant SUPERCHAIN_TOKEN_BRIDGE = Predeploys.SUPERCHAIN_TOKEN_BRIDGE;
     address internal constant MESSENGER = Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER;

--- a/packages/contracts-bedrock/test/L2/SuperchainETHBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainETHBridge.t.sol
@@ -15,7 +15,7 @@ import { IL2ToL2CrossDomainMessenger } from "interfaces/L2/IL2ToL2CrossDomainMes
 
 /// @title SuperchainETHBridge_TestInit
 /// @notice Reusable test initialization for `SuperchainETHBridge` tests.
-contract SuperchainETHBridge_TestInit is CommonTest {
+abstract contract SuperchainETHBridge_TestInit is CommonTest {
     event SendETH(address indexed from, address indexed to, uint256 amount, uint256 destination);
 
     event RelayETH(address indexed from, address indexed to, uint256 amount, uint256 source);

--- a/packages/contracts-bedrock/test/L2/SuperchainTokenBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainTokenBridge.t.sol
@@ -18,7 +18,7 @@ import { MockSuperchainERC20Implementation } from "test/mocks/SuperchainERC20Imp
 
 /// @title SuperchainTokenBridge_TestInit
 /// @notice Reusable test initialization for `SuperchainTokenBridge` tests.
-contract SuperchainTokenBridge_TestInit is Test {
+abstract contract SuperchainTokenBridge_TestInit is Test {
     address internal constant ZERO_ADDRESS = address(0);
     string internal constant NAME = "SuperchainERC20";
     string internal constant SYMBOL = "OSE";

--- a/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
@@ -10,7 +10,7 @@ import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 
 /// @title MIPS64_TestInit
 /// @notice Reusable test initialization for `MIPS64` tests.
-contract MIPS64_TestInit is Test {
+abstract contract MIPS64_TestInit is Test {
     IPreimageOracle oracle;
 
     // Store some data about acceptable versions

--- a/packages/contracts-bedrock/test/cannon/MIPS64Memory.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64Memory.t.sol
@@ -39,7 +39,7 @@ contract MIPS64MemoryWithCalldata {
 
 /// @title MIPS64Memory_TestInit
 /// @notice Reusable test initialization for `MIPS64Memory` tests.
-contract MIPS64Memory_TestInit is CommonTest {
+abstract contract MIPS64Memory_TestInit is CommonTest {
     MIPS64MemoryWithCalldata mem;
 
     error InvalidAddress();

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -38,7 +38,7 @@ function precompilePreimageKey(address _precompile, uint64 _gas, bytes memory _i
 
 /// @title PreimageOracle_TestInit
 /// @notice Reusable test initialization for `PreimageOracle` tests.
-contract PreimageOracle_TestInit is Test {
+abstract contract PreimageOracle_TestInit is Test {
     /// @notice The PreimageOracle contract to test.
     IPreimageOracle internal oracle;
 

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -16,7 +16,7 @@ import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
 
 /// @title AnchorStateRegistry_TestInit
 /// @notice Reusable test initialization for `AnchorStateRegistry` tests.
-contract AnchorStateRegistry_TestInit is BaseFaultDisputeGame_TestInit {
+abstract contract AnchorStateRegistry_TestInit is BaseFaultDisputeGame_TestInit {
     /// @dev A valid l2BlockNumber that comes after the current anchor root block.
     uint256 validL2BlockNumber;
 

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -53,7 +53,7 @@ contract DelayedWETH_FallbackReverter_Harness {
 
 /// @title DelayedWETH_TestInit
 /// @notice Reusable test initialization for `DelayedWETH` tests.
-contract DelayedWETH_TestInit is CommonTest {
+abstract contract DelayedWETH_TestInit is CommonTest {
     event Approval(address indexed src, address indexed guy, uint256 wad);
     event Transfer(address indexed src, address indexed dst, uint256 wad);
     event Deposit(address indexed dst, uint256 wad);

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -48,7 +48,7 @@ contract DisputeGameFactory_FakeClone_Harness {
 
 /// @title DisputeGameFactory_TestInit
 /// @notice Reusable test initialization for `DisputeGameFactory` tests.
-contract DisputeGameFactory_TestInit is CommonTest {
+abstract contract DisputeGameFactory_TestInit is CommonTest {
     DisputeGameFactory_FakeClone_Harness fakeClone;
 
     event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -66,7 +66,7 @@ function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim 
 
 /// @title BaseFaultDisputeGame_TestInit
 /// @notice Base test initializer that can be used by other contracts outside of this test suite.
-contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
+abstract contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @dev The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.CANNON;
 
@@ -143,7 +143,7 @@ contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
 
 /// @title FaultDisputeGame_TestInit
 /// @notice Reusable test initialization for `FaultDisputeGame` tests.
-contract FaultDisputeGame_TestInit is BaseFaultDisputeGame_TestInit {
+abstract contract FaultDisputeGame_TestInit is BaseFaultDisputeGame_TestInit {
     /// @dev The root claim of the game.
     Claim internal ROOT_CLAIM;
     /// @dev An arbitrary root claim for testing.

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -16,7 +16,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 
 /// @title PermissionedDisputeGame_TestInit
 /// @notice Reusable test initialization for `PermissionedDisputeGame` tests.
-contract PermissionedDisputeGame_TestInit is DisputeGameFactory_TestInit {
+abstract contract PermissionedDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @notice The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.PERMISSIONED_CANNON;
     /// @notice Mock proposer key

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -58,7 +58,7 @@ contract ClaimCreditReenter {
 
 /// @title BaseSuperFaultDisputeGame_TestInit
 /// @notice Base test initializer that can be used by other contracts outside of this test suite.
-contract BaseSuperFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
+abstract contract BaseSuperFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @dev The type of the game being tested.
     GameType internal immutable GAME_TYPE = GameTypes.SUPER_CANNON;
 
@@ -127,7 +127,7 @@ contract BaseSuperFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
 
 /// @title SuperFaultDisputeGame_TestInit
 /// @notice Reusable test initialization for `SuperFaultDisputeGame` tests.
-contract SuperFaultDisputeGame_TestInit is BaseSuperFaultDisputeGame_TestInit {
+abstract contract SuperFaultDisputeGame_TestInit is BaseSuperFaultDisputeGame_TestInit {
     /// @dev The root claim of the game.
     Claim internal ROOT_CLAIM;
 

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -14,7 +14,7 @@ import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisput
 
 /// @title SuperPermissionedDisputeGame_TestInit
 /// @notice Reusable test initialization for `SuperPermissionedDisputeGame` tests.
-contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_TestInit {
+abstract contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_TestInit {
     /// @notice The type of the game being tested.
     GameType internal constant GAME_TYPE = GameType.wrap(5);
     /// @notice Mock proposer key

--- a/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
@@ -7,7 +7,7 @@ import "src/dispute/lib/Types.sol";
 
 /// @title LibPosition_TestInit
 /// @notice Reusable test initialization for `LibPosition` tests.
-contract LibPosition_TestInit is Test {
+abstract contract LibPosition_TestInit is Test {
     /// @dev Assumes a MAX depth of 126 for the Position type. Any greater depth can cause
     ///      overflows.
     /// @dev At the lowest level of the tree, this allows for 2 ** 126 leaves. In reality, the max

--- a/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
+++ b/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
@@ -6,7 +6,7 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 
 /// @title GovernanceToken_TestInit
 /// @notice Reusable test initialization for `GovernanceToken` tests.
-contract GovernanceToken_TestInit is CommonTest {
+abstract contract GovernanceToken_TestInit is CommonTest {
     address owner;
     address rando;
 

--- a/packages/contracts-bedrock/test/governance/MintManager.t.sol
+++ b/packages/contracts-bedrock/test/governance/MintManager.t.sol
@@ -11,7 +11,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title MintManager_TestInit
 /// @notice Reusable test initialization for `MintManager` tests.
-contract MintManager_TestInit is CommonTest {
+abstract contract MintManager_TestInit is CommonTest {
     address constant owner = address(0x1234);
     address constant rando = address(0x5678);
     IGovernanceToken internal gov;

--- a/packages/contracts-bedrock/test/integration/EventLogger.t.sol
+++ b/packages/contracts-bedrock/test/integration/EventLogger.t.sol
@@ -15,7 +15,7 @@ import { CrossL2Inbox } from "src/L2/CrossL2Inbox.sol";
 
 /// @title EventLogger_TestInit
 /// @notice Reusable test initialization for `EventLogger` tests.
-contract EventLogger_TestInit is Test {
+abstract contract EventLogger_TestInit is Test {
     event ExecutingMessage(bytes32 indexed msgHash, ImplIdentifier id);
 
     EventLogger eventLogger;

--- a/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
@@ -10,7 +10,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title DeployerWhitelist_TestInit
 /// @notice Reusable test initialization for `DeployerWhitelist` tests.
-contract DeployerWhitelist_TestInit is Test {
+abstract contract DeployerWhitelist_TestInit is Test {
     IDeployerWhitelist list;
     address owner = address(12345);
 

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -14,7 +14,7 @@ import { IL1Block } from "interfaces/L2/IL1Block.sol";
 
 /// @title L1BlockNumber_TestInit
 /// @notice Reusable test initialization for `L1BlockNumber` tests.
-contract L1BlockNumber_TestInit is Test {
+abstract contract L1BlockNumber_TestInit is Test {
     IL1Block lb;
     IL1BlockNumber bn;
 

--- a/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
@@ -47,7 +47,7 @@ contract L1ChugSplashProxy_Implementation_Harness {
 
 /// @title L1ChugSplashProxy_TestInit
 /// @notice Reusable test initialization for `L1ChugSplashProxy` tests.
-contract L1ChugSplashProxy_TestInit is Test {
+abstract contract L1ChugSplashProxy_TestInit is Test {
     IL1ChugSplashProxy proxy;
     address impl;
     address owner = makeAddr("owner");

--- a/packages/contracts-bedrock/test/legacy/LegacyMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/legacy/LegacyMintableERC20.t.sol
@@ -9,7 +9,7 @@ import { ILegacyMintableERC20 } from "interfaces/legacy/ILegacyMintableERC20.sol
 
 /// @title LegacyMintableERC20_TestInit
 /// @notice Reusable test initialization for `LegacyMintableERC20` tests.
-contract LegacyMintableERC20_TestInit is CommonTest {
+abstract contract LegacyMintableERC20_TestInit is CommonTest {
     LegacyMintableERC20 legacyMintableERC20;
 
     function setUp() public override {

--- a/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
@@ -23,7 +23,7 @@ contract ResolvedDelegateProxy_SimpleImplementation_Harness {
 
 /// @title ResolvedDelegateProxy_TestInit
 /// @notice Reusable test initialization for `ResolvedDelegateProxy` tests.
-contract ResolvedDelegateProxy_TestInit is Test {
+abstract contract ResolvedDelegateProxy_TestInit is Test {
     IAddressManager internal addressManager;
     ResolvedDelegateProxy_SimpleImplementation_Harness internal impl;
     ResolvedDelegateProxy_SimpleImplementation_Harness internal proxy;

--- a/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
@@ -42,7 +42,7 @@ contract BlueprintHarness {
 
 /// @title Blueprint_TestInit
 /// @notice Reusable test initialization for `Blueprint` tests.
-contract Blueprint_TestInit is Test {
+abstract contract Blueprint_TestInit is Test {
     BlueprintHarness blueprint;
 
     function setUp() public {

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -15,7 +15,7 @@ contract Bytes_Harness {
 
 /// @title Bytes_TestInit
 /// @notice Reusable test initialization for `Bytes` tests.
-contract Bytes_TestInit is Test {
+abstract contract Bytes_TestInit is Test {
     Bytes_Harness harness;
 
     /// @notice Manually checks equality of two dynamic `bytes` arrays in memory.

--- a/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
@@ -10,7 +10,7 @@ import { Solarray } from "scripts/libraries/Solarray.sol";
 
 /// @title DeployUtils_TestInit
 /// @notice Reusable test initialization for `DeployUtils` tests.
-contract DeployUtils_TestInit is Test {
+abstract contract DeployUtils_TestInit is Test {
     /// @notice Helper function to test the revert message of assertUniqueAddresses with duplicate
     ///         addresses.
     /// @dev This function only exists because expectRevert only accepts a calldata argument but

--- a/packages/contracts-bedrock/test/libraries/EOA.t.sol
+++ b/packages/contracts-bedrock/test/libraries/EOA.t.sol
@@ -19,7 +19,7 @@ contract EOA_Harness {
 
 /// @title EOA_TestInit
 /// @notice Reusable test initialization for `EOA` tests.
-contract EOA_TestInit is Test {
+abstract contract EOA_TestInit is Test {
     EOA_Harness harness;
 
     /// @notice Sets up the test.

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -32,7 +32,7 @@ contract Encoding_Harness {
 
 /// @title Encoding_TestInit
 /// @notice Reusable test initialization for `Encoding` tests.
-contract Encoding_TestInit is CommonTest {
+abstract contract Encoding_TestInit is CommonTest {
     Encoding_Harness encoding;
 
     function setUp() public override {

--- a/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
+++ b/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
@@ -15,7 +15,7 @@ contract GasPayingToken_Harness {
 
 /// @title GasPayingToken_TestInit
 /// @notice Reusable test initialization for `GasPayingToken` tests.
-contract GasPayingToken_TestInit is Test {
+abstract contract GasPayingToken_TestInit is Test {
     GasPayingToken_Harness harness;
 
     function setUp() public {

--- a/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
@@ -12,7 +12,7 @@ import { Fork } from "scripts/libraries/Config.sol";
 
 /// @title Predeploys_TestInit
 /// @notice Reusable test initialization for `Predeploys` tests.
-contract Predeploys_TestInit is CommonTest {
+abstract contract Predeploys_TestInit is CommonTest {
     //////////////////////////////////////////////////////
     /// Internal helpers
     //////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/test/libraries/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Preinstalls.t.sol
@@ -8,7 +8,7 @@ import { IEIP712 } from "interfaces/universal/IEIP712.sol";
 
 /// @title Preinstalls_TestInit
 /// @notice Reusable test initialization for `Preinstalls` tests.
-contract Preinstalls_TestInit is CommonTest {
+abstract contract Preinstalls_TestInit is CommonTest {
     function assertPreinstall(address _addr, bytes memory _code) internal view {
         assertNotEq(_code.length, 0, "must have code");
         assertNotEq(_addr.code.length, 0, "deployed preinstall account must have code");

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -31,7 +31,7 @@ contract SimpleSafeCaller {
 
 /// @title SafeCall_TestInit
 /// @notice Reusable test initialization for `SafeCall` tests.
-contract SafeCall_TestInit is Test {
+abstract contract SafeCall_TestInit is Test {
     /// @notice Helper function to deduplicate code. Makes all assumptions required for these
     ///         tests.
     function assumeNot(address _addr) internal {

--- a/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
@@ -26,7 +26,7 @@ contract SemverComp_Harness {
 
 /// @title SemverComp_TestInit
 /// @notice Reusable test initialization for `SemverComp` tests.
-contract SemverComp_TestInit is Test {
+abstract contract SemverComp_TestInit is Test {
     SemverComp_Harness internal harness;
 
     /// @notice Sets up the test environment.

--- a/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
+++ b/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
@@ -10,7 +10,7 @@ import { StaticConfig } from "src/libraries/StaticConfig.sol";
 
 /// @title StaticConfig_TestInit
 /// @notice Reusable test initialization for `StaticConfig` tests.
-contract StaticConfig_TestInit is Test {
+abstract contract StaticConfig_TestInit is Test {
     FFIInterface constant ffi = FFIInterface(address(uint160(uint256(keccak256(abi.encode("optimism.ffi"))))));
 
     function setUp() public {

--- a/packages/contracts-bedrock/test/libraries/Storage.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Storage.t.sol
@@ -7,7 +7,7 @@ import { Test } from "forge-std/Test.sol";
 
 /// @title Storage_TestInit
 /// @notice Reusable test initialization for `Storage` tests.
-contract Storage_TestInit is Test {
+abstract contract Storage_TestInit is Test {
     StorageSetter setter;
 
     function setUp() public {

--- a/packages/contracts-bedrock/test/libraries/TransientContext.t.sol
+++ b/packages/contracts-bedrock/test/libraries/TransientContext.t.sol
@@ -10,7 +10,7 @@ import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
 
 /// @title TransientContext_TestInit
 /// @notice Reusable test initialization for `TransientContext` tests.
-contract TransientContext_TestInit is Test {
+abstract contract TransientContext_TestInit is Test {
     /// @notice Slot for call depth.
     bytes32 internal callDepthSlot = bytes32(uint256(keccak256("transient.calldepth")) - 1);
 }

--- a/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
@@ -15,7 +15,7 @@ contract MerkleTrie_Harness {
 
 /// @title MerkleTrie_TestInit
 /// @notice Reusable test initialization for `MerkleTrie` tests.
-contract MerkleTrie_TestInit is Test {
+abstract contract MerkleTrie_TestInit is Test {
     FFIInterface constant ffi = FFIInterface(address(uint160(uint256(keccak256(abi.encode("optimism.ffi"))))));
     MerkleTrie_Harness harness;
 

--- a/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
@@ -9,7 +9,7 @@ import { AssetReceiver } from "src/periphery/AssetReceiver.sol";
 
 /// @title AssetReceiver_TestInit
 /// @notice Reusable test initialization for `AssetReceiver` tests.
-contract AssetReceiver_TestInit is Test {
+abstract contract AssetReceiver_TestInit is Test {
     address alice = address(128);
     address bob = address(256);
 

--- a/packages/contracts-bedrock/test/periphery/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/periphery/Transactor.t.sol
@@ -8,7 +8,7 @@ import { Transactor } from "src/periphery/Transactor.sol";
 
 /// @title Transactor_TestInit
 /// @notice Reusable test initialization for `Transactor` tests.
-contract Transactor_TestInit is Test {
+abstract contract Transactor_TestInit is Test {
     address alice = address(128);
     address bob = address(256);
 

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -10,7 +10,7 @@ import { TransferOnion } from "src/periphery/TransferOnion.sol";
 
 /// @title TransferOnion_TestInit
 /// @notice Reusable test initialization for `TransferOnion` tests.
-contract TransferOnion_TestInit is Test {
+abstract contract TransferOnion_TestInit is Test {
     /// @notice TransferOnion
     TransferOnion internal onion;
 

--- a/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
@@ -38,7 +38,7 @@ contract Drippie_Test_Harness is Drippie {
 
 /// @title Drippie_TestInit
 /// @notice Reusable test initialization for `Drippie` tests.
-contract Drippie_TestInit is Test {
+abstract contract Drippie_TestInit is Test {
     /// @notice Emitted when a drip is executed.
     event DripExecuted(string indexed nameref, string name, address executor, uint256 timestamp);
 

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
@@ -6,7 +6,7 @@ import { CheckBalanceLow } from "src/periphery/drippie/dripchecks/CheckBalanceLo
 
 /// @title CheckBalanceLow_TestInit
 /// @notice Reusable test initialization for `CheckBalanceLow` tests.
-contract CheckBalanceLow_TestInit is Test {
+abstract contract CheckBalanceLow_TestInit is Test {
     /// @notice An instance of the CheckBalanceLow contract.
     CheckBalanceLow c;
 

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
@@ -6,7 +6,7 @@ import { CheckSecrets } from "src/periphery/drippie/dripchecks/CheckSecrets.sol"
 
 /// @title CheckSecrets_TestInit
 /// @notice Reusable test initialization for `CheckSecrets` tests.
-contract CheckSecrets_TestInit is Test {
+abstract contract CheckSecrets_TestInit is Test {
     /// @notice Event emitted when a secret is revealed.
     event SecretRevealed(bytes32 indexed secretHash, bytes secret);
 

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
@@ -6,7 +6,7 @@ import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";
 
 /// @title CheckTrue_TestInit
 /// @notice Reusable test initialization for `CheckTrue` tests.
-contract CheckTrue_TestInit is Test {
+abstract contract CheckTrue_TestInit is Test {
     /// @notice An instance of the CheckTrue contract.
     CheckTrue c;
 

--- a/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
@@ -8,7 +8,7 @@ import { FaucetHelper } from "test/mocks/FaucetHelper.sol";
 
 /// @title Faucet_TestInit
 /// @notice Reusable test initialization for `Faucet` tests.
-contract Faucet_TestInit is Test {
+abstract contract Faucet_TestInit is Test {
     event Drip(string indexed authModule, bytes32 indexed userId, uint256 amount, address indexed recipient);
 
     address internal faucetContractAdmin;

--- a/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
@@ -8,7 +8,7 @@ import { FaucetHelper } from "test/mocks/FaucetHelper.sol";
 
 /// @title AdminFaucetAuthModule_TestInit
 /// @notice Reusable test initialization for `AdminFaucetAuthModule` tests.
-contract AdminFaucetAuthModule_TestInit is Test {
+abstract contract AdminFaucetAuthModule_TestInit is Test {
     /// @notice The admin of the `AdminFaucetAuthModule` contract.
     address internal admin;
 

--- a/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
+++ b/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
@@ -12,7 +12,7 @@ import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 
 /// @title DisputeMonitorHelper_TestInit
 /// @notice Reusable test initialization for `DisputeMonitorHelper` tests.
-contract DisputeMonitorHelper_TestInit is DisputeGameFactory_TestInit {
+abstract contract DisputeMonitorHelper_TestInit is DisputeGameFactory_TestInit {
     DisputeMonitorHelper helper;
 
     function setUp() public override {

--- a/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
@@ -14,7 +14,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 /// @title DeputyPauseModule_TestInit
 /// @notice Reusable test initialization for `DeputyPauseModule` tests.
-contract DeputyPauseModule_TestInit is CommonTest, SafeTestTools {
+abstract contract DeputyPauseModule_TestInit is CommonTest, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
     event ExecutionFromModuleSuccess(address indexed module);

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -25,7 +25,7 @@ contract LivenessGuard_WrappedGuard_Harness is LivenessGuard {
 
 /// @title LivenessGuard_TestInit
 /// @notice Reusable test initialization for `LivenessGuard` tests.
-contract LivenessGuard_TestInit is Test, SafeTestTools {
+abstract contract LivenessGuard_TestInit is Test, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
     event OwnerRecorded(address owner);

--- a/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
@@ -11,7 +11,7 @@ import { LivenessGuard } from "src/safe/LivenessGuard.sol";
 
 /// @title LivenessModule_TestInit
 /// @notice Reusable test initialization for `LivenessModule` tests.
-contract LivenessModule_TestInit is Test, SafeTestTools {
+abstract contract LivenessModule_TestInit is Test, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
     error OwnerRemovalFailed(string reason);

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -10,7 +10,7 @@ import { SaferSafes } from "src/safe/SaferSafes.sol";
 
 /// @title LivenessModule2_TestInit
 /// @notice Reusable test initialization for `LivenessModule2` tests.
-contract LivenessModule2_TestInit is Test, SafeTestTools {
+abstract contract LivenessModule2_TestInit is Test, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
     // Events

--- a/packages/contracts-bedrock/test/safe/SafeSigners.t.sol
+++ b/packages/contracts-bedrock/test/safe/SafeSigners.t.sol
@@ -7,7 +7,7 @@ import "test/safe-tools/SafeTestTools.sol";
 
 /// @title SafeSigners_TestInit
 /// @notice Reusable test initialization for `SafeSigners` tests.
-contract SafeSigners_TestInit is Test {
+abstract contract SafeSigners_TestInit is Test {
     bytes4 internal constant EIP1271_MAGIC_VALUE = 0x20c13b0b;
 
     enum SigTypes {

--- a/packages/contracts-bedrock/test/safe/SaferSafes.t.sol
+++ b/packages/contracts-bedrock/test/safe/SaferSafes.t.sol
@@ -9,7 +9,7 @@ import { LivenessModule2 } from "src/safe/LivenessModule2.sol";
 
 /// @title SaferSafes_TestInit
 /// @notice Reusable test initialization for `SaferSafes` tests.
-contract SaferSafes_TestInit is Test, SafeTestTools {
+abstract contract SaferSafes_TestInit is Test, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
     // Events

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -142,7 +142,7 @@ library TransactionBuilder {
 
 /// @title TimelockGuard_TestInit
 /// @notice Reusable test initialization for `TimelockGuard` tests.
-contract TimelockGuard_TestInit is Test, SafeTestTools {
+abstract contract TimelockGuard_TestInit is Test, SafeTestTools {
     // Events
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -18,7 +18,7 @@ import { IGasPriceOracle } from "interfaces/L2/IGasPriceOracle.sol";
 
 /// @title L2Genesis_TestInit
 /// @notice Reusable test initialization for `L2Genesis` tests.
-contract L2Genesis_TestInit is Test {
+abstract contract L2Genesis_TestInit is Test {
     L2Genesis.Input internal input;
 
     L2Genesis internal genesis;

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -61,7 +61,7 @@ contract VerifyOPCM_Harness is VerifyOPCM {
 
 /// @title VerifyOPCM_TestInit
 /// @notice Reusable test initialization for `VerifyOPCM` tests.
-contract VerifyOPCM_TestInit is OPContractsManager_TestInit {
+abstract contract VerifyOPCM_TestInit is OPContractsManager_TestInit {
     VerifyOPCM_Harness internal harness;
 
     function setUp() public virtual override {

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -24,7 +24,7 @@ import { ILegacyMintableERC20Full } from "interfaces/legacy/ILegacyMintableERC20
 
 /// @title CommonTest
 /// @dev An extension to `Test` that sets up the optimism smart contracts.
-contract CommonTest is Test, Setup, Events {
+abstract contract CommonTest is Test, Setup, Events {
     address alice;
     address bob;
 

--- a/packages/contracts-bedrock/test/setup/Events.sol
+++ b/packages/contracts-bedrock/test/setup/Events.sol
@@ -12,7 +12,7 @@ import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 /// @dev Contains various events that are tested against. This contract needs to
 ///      exist until we either modularize the implementations or use a newer version of
 ///      solc that allows for referencing events from other contracts.
-contract Events {
+abstract contract Events {
     /// @dev OpenZeppelin Ownable.sol transferOwnership event
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData);

--- a/packages/contracts-bedrock/test/setup/FeatureFlags.sol
+++ b/packages/contracts-bedrock/test/setup/FeatureFlags.sol
@@ -14,7 +14,7 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
 /// @notice FeatureFlags manages the feature bitmap by either direct user input or via environment
 ///         variables.
-contract FeatureFlags {
+abstract contract FeatureFlags {
     /// @notice The address of the foundry Vm contract.
     Vm private constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -68,7 +68,7 @@ import { ICrossL2Inbox } from "interfaces/L2/ICrossL2Inbox.sol";
 ///      sets the L2 contracts directly at the predeploy addresses instead of setting them
 ///      up behind proxies. In the future we will migrate to importing the genesis JSON
 ///      file that is created to set up the L2 contracts instead of setting them up manually.
-contract Setup is FeatureFlags {
+abstract contract Setup is FeatureFlags {
     using ForkUtils for Fork;
 
     /// @notice The address of the foundry Vm contract.

--- a/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
@@ -85,7 +85,7 @@ contract CrossDomainMessenger_ExternalRelay_Harness is Test {
 
 /// @title CrossDomainMessenger_TestInit
 /// @notice Reusable test initialization for `CrossDomainMessenger` tests.
-contract CrossDomainMessenger_TestInit is CommonTest {
+abstract contract CrossDomainMessenger_TestInit is CommonTest {
     // Storage slot of the l2Sender
     uint256 constant senderSlotIndex = 50;
 

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
@@ -8,7 +8,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 
 /// @title OptimismMintableERC20_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC20` tests.
-contract OptimismMintableERC20_TestInit is CommonTest {
+abstract contract OptimismMintableERC20_TestInit is CommonTest {
     event Mint(address indexed account, uint256 amount);
     event Burn(address indexed account, uint256 amount);
 }

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -16,7 +16,7 @@ import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMin
 
 /// @title OptimismMintableERC20Factory_TestInit
 /// @notice Reusable test initialization for `OptimismMintableERC20Factory` tests.
-contract OptimismMintableERC20Factory_TestInit is CommonTest {
+abstract contract OptimismMintableERC20Factory_TestInit is CommonTest {
     event StandardL2TokenCreated(address indexed remoteToken, address indexed localToken);
     event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
 

--- a/packages/contracts-bedrock/test/universal/Proxy.t.sol
+++ b/packages/contracts-bedrock/test/universal/Proxy.t.sol
@@ -26,7 +26,7 @@ contract Proxy_Clasher_Harness {
 
 /// @title Proxy_TestInit
 /// @notice Reusable test initialization for `Proxy` tests.
-contract Proxy_TestInit is Test {
+abstract contract Proxy_TestInit is Test {
     event Upgraded(address indexed implementation);
     event AdminChanged(address previousAdmin, address newAdmin);
 

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -16,7 +16,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title ProxyAdmin_TestInit
 /// @notice Reusable test initialization for `ProxyAdmin` tests.
-contract ProxyAdmin_TestInit is Test {
+abstract contract ProxyAdmin_TestInit is Test {
     address alice = address(64);
 
     IProxy proxy;

--- a/packages/contracts-bedrock/test/universal/StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/universal/StandardBridge.t.sol
@@ -52,7 +52,7 @@ contract LegacyMintable is ERC20 {
 /// @notice Reusable test initialization for `StandardBridge` tests.
 /// @dev This setup is primarily for tests focusing on internal stateless logic or default states
 ///      of the `StandardBridge` contract.
-contract StandardBridge_TestInit is CommonTest {
+abstract contract StandardBridge_TestInit is CommonTest {
     StandardBridgeTester internal bridge;
     OptimismMintableERC20 internal mintable;
     ERC20 internal erc20;

--- a/packages/contracts-bedrock/test/universal/WETH98.t.sol
+++ b/packages/contracts-bedrock/test/universal/WETH98.t.sol
@@ -10,7 +10,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title WETH98_TestInit
 /// @notice Reusable test initialization for `WETH98` tests.
-contract WETH98_TestInit is Test {
+abstract contract WETH98_TestInit is Test {
     event Approval(address indexed src, address indexed guy, uint256 wad);
     event Transfer(address indexed src, address indexed dst, uint256 wad);
     event Deposit(address indexed dst, uint256 wad);


### PR DESCRIPTION
These contracts don't need to run, so they can all be abstract. Local testing suggests this saves about 30 seconds during the build.
