### PR TITLE
interop: validate PendingProgress equals number of chains during consolidation

### DIFF
--- a/op-program/client/interop/interop.go
+++ b/op-program/client/interop/interop.go
@@ -107,9 +107,9 @@ func stateTransition(logger log.Logger, bootInfo *boot.BootInfoInterop, l1Preima
 		expectedPendingProgress = append(expectedPendingProgress, block)
 	} else if transitionState.Step == ConsolidateStep {
 		logger.Info("Running consolidate step")
-		// sanity check
-		if len(transitionState.PendingProgress) > ConsolidateStep {
-			return common.Hash{}, fmt.Errorf("%w: pending progress length does not match the expected step", ErrInvalidPrestate)
+		// sanity check: ensure pending progress aligns with number of chains
+		if len(transitionState.PendingProgress) != len(superRoot.Chains) {
+			return common.Hash{}, fmt.Errorf("%w: pending progress length %d does not match number of chains %d", ErrInvalidPrestate, len(transitionState.PendingProgress), len(superRoot.Chains))
 		}
 		expectedSuperRoot, err := RunConsolidation(
 			logger, bootInfo, l1PreimageOracle, l2PreimageOracle, transitionState, superRoot, tasks)


### PR DESCRIPTION
Problem: Consolidation assumed a 1:1 mapping between superRoot.Chains and transitionState.PendingProgress but only checked len(PendingProgress) > ConsolidateStep (127). This allowed inconsistent lengths, risking out-of-range access or silent misalignment during consolidation where PendingProgress[i] is indexed per chain.

Fix: Replace the check with len(transitionState.PendingProgress) == len(superRoot.Chains) and emit a precise error message including both lengths. This enforces the actual invariant required by RunConsolidation and related logic.