### PR TITLE
op-acceptance-tests: Retry FCU for triggering EL Sync

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -184,10 +184,10 @@ func TestL2ELP2PCanonicalChainAdvancedByFCU(gt *testing.T) {
 	attempts := 3
 
 	// FCU to target block which can be eventually validated, because ELP2P enabled
-	// Example logs from L2EL(geth)
-	//  New skeleton head announced
-	//  Backfilling with the network
 	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, targetNum, 0, 0, nil).IsSyncing()
+	// In rare cases, EL is not ready to trigger EL Sync even though peers attached
+	// Retry a few times until the first EL Sync is complete
+	sys.L2ELB.FinishedELSync(sys.L2EL, targetNum, 0, 0)
 
 	// Wait until L2EL finishes EL Sync and canonicalizes until targetNum
 	sys.L2ELB.Reached(eth.Unsafe, targetNum, 3)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`TestL2ELP2PCanonicalChainAdvancedByFCU` flaked because verifier EL did not trigger EL sync even it received FCU. Do not know the exact reason, but this may be occur since there is too less delay between peering and calling FCU. 

We retry multiple FCUs after the peer is established to deflake.

Note that this test was inserted to flake-shake, and it got 100% pass on the 400 trials. Ref: https://github.com/ethereum-optimism/optimism/pull/17875, so this is a very rare case.
