### PR TITLE
op-acceptance-tests: ELP2P down but payload appendable till chain tip

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -63,6 +63,10 @@ func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
 
 	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
 
+	// batcher down so safe not advanced
+	require.Equal(uint64(0), sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
+	require.Equal(uint64(0), sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
+
 	trial := 0
 	require.NoError(
 		retry.Do0(ctx, 200, &retry.FixedStrategy{Dur: 250 * time.Millisecond}, func() error {

--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -54,14 +54,9 @@ func TestSyncAfterInitialELSync(gt *testing.T) {
 func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
-	require := t.Require()
 	logger := t.Logger()
 
 	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
-
-	// batcher down so safe not advanced
-	require.Equal(uint64(0), sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
-	require.Equal(uint64(0), sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
 
 	// First make verifier reach unsafe tip
 	logger.Info("Initial trial for appending payload until tip")

--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -1,11 +1,14 @@
 package gap_clp2p
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -19,33 +22,59 @@ func TestSyncAfterInitialELSync(gt *testing.T) {
 	// batcher down so safe not advanced
 	require.Equal(uint64(0), sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
 	require.Equal(uint64(0), sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
-	// verifier not advanced unsafe head
-	require.Equal(uint64(0), sys.L2CLB.HeadBlockRef(types.LocalUnsafe).Number)
+
+	startNum := sys.L2CLB.HeadBlockRef(types.LocalUnsafe).Number
 
 	// Finish EL sync by supplying the first block
-	// EL Sync finished because underlying EL has states to validate the payload for block 1
-	sys.L2CLB.SignalTarget(sys.L2EL, 1)
+	// EL Sync finished because underlying EL has states to validate the payload for block startNum+1
+	sys.L2CLB.SignalTarget(sys.L2EL, startNum+1)
 
-	// Send payloads for block 3, 4, 5, 7 which will fill in unsafe payload queue, block 2 missed
+	// Send payloads for block startNum+3, startNum+4, startNum+5, startNum+7 which will fill in unsafe payload queue, block startNum+2 missed
 	// Non-canonical payloads will be not sent to L2EL
 	// Order does not matter
-	for _, target := range []uint64{5, 3, 4, 7} {
+	for _, delta := range []uint64{5, 3, 4, 7} {
+		target := startNum + delta
 		sys.L2CLB.SignalTarget(sys.L2EL, target)
 		// Canonical unsafe head never advances because of the gap
-		require.Equal(uint64(1), sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number)
+		require.Equal(startNum+1, sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number)
 	}
 
-	// Send missing gap, payload 2, still not sending FCU since unsafe gap exists
-	sys.L2CLB.SignalTarget(sys.L2EL, 2)
+	// Send missing gap, payload startNum+2, still not sending FCU since unsafe gap exists
+	sys.L2CLB.SignalTarget(sys.L2EL, startNum+2)
 
 	retries := 2
-	// Gap filled and payload 2, 3, 4, 5 became canonical by relaying to ELB.
-	// Payload 7 is still in the unsafe payload queue because of unsafe gap
-	sys.L2ELB.Reached(eth.Unsafe, 5, retries)
+	// Gap filled and payload startNum+2, startNum+3, startNum+4, startNum+5 became canonical by relaying to ELB.
+	// Payload startNum+7 is still in the unsafe payload queue because of unsafe gap
+	sys.L2ELB.Reached(eth.Unsafe, startNum+5, retries)
 
-	// Send missing gap, payload 6
-	sys.L2CLB.SignalTarget(sys.L2EL, 6)
+	// Send missing gap, payload startNum+6
+	sys.L2CLB.SignalTarget(sys.L2EL, startNum+6)
 
-	// Gap filled and block 6, 7 became canonical by relaying to ELB.
-	sys.L2ELB.Reached(eth.Unsafe, 7, retries)
+	// Gap filled and block startNum+6, startNum+7 became canonical by relaying to ELB.
+	sys.L2ELB.Reached(eth.Unsafe, startNum+7, retries)
+}
+
+func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+
+	trial := 0
+	require.NoError(
+		retry.Do0(ctx, 200, &retry.FixedStrategy{Dur: 250 * time.Millisecond}, func() error {
+			verUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+			seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+			gap := seqUnsafe.Number - verUnsafe.Number
+			logger.Info("Filling in the gap by appending unsafe payload", "gap", gap, "ver", verUnsafe, "seq", seqUnsafe, "trial", trial)
+			if gap == 0 {
+				return nil
+			}
+			trial += 1
+			sys.L2CLB.SignalTarget(sys.L2EL, verUnsafe.Number+1)
+			return fmt.Errorf("gap yet filled: %d", gap)
+		}))
 }

--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -1,14 +1,11 @@
 package gap_clp2p
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -59,7 +56,6 @@ func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
 	require := t.Require()
 	logger := t.Logger()
-	ctx := t.Ctx()
 
 	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
 
@@ -67,18 +63,13 @@ func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
 	require.Equal(uint64(0), sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
 	require.Equal(uint64(0), sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
 
-	trial := 0
-	require.NoError(
-		retry.Do0(ctx, 200, &retry.FixedStrategy{Dur: 250 * time.Millisecond}, func() error {
-			verUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
-			seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
-			gap := seqUnsafe.Number - verUnsafe.Number
-			logger.Info("Filling in the gap by appending unsafe payload", "gap", gap, "ver", verUnsafe, "seq", seqUnsafe, "trial", trial)
-			if gap == 0 {
-				return nil
-			}
-			trial += 1
-			sys.L2CLB.SignalTarget(sys.L2EL, verUnsafe.Number+1)
-			return fmt.Errorf("gap yet filled: %d", gap)
-		}))
+	// First make verifier reach unsafe tip
+	logger.Info("Initial trial for appending payload until tip")
+	sys.L2CLB.AppendUnsafePayloadUntilTip(sys.L2ELB, sys.L2EL, 400)
+
+	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+
+	// Try once more to check that filling in the gap works again
+	logger.Info("Second trial for appending payload until tip")
+	sys.L2CLB.AppendUnsafePayloadUntilTip(sys.L2ELB, sys.L2EL, 400)
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -401,6 +401,6 @@ func (cl *L2CLNode) AppendUnsafePayloadUntilTip(verEL, seqEL *L2ELNode, maxAttem
 			}
 			trial += 1
 			cl.SignalTarget(seqEL, verUnsafe.Number+1)
-			return fmt.Errorf("gap yet filled: %d", gap)
+			return fmt.Errorf("unsafe gap with size %d still exists", gap)
 		}))
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -387,3 +387,20 @@ func (cl *L2CLNode) Reset(lvl types.SafetyLevel, target eth.L2BlockRef) {
 			return errors.New("waiting to reset")
 		}))
 }
+
+func (cl *L2CLNode) AppendUnsafePayloadUntilTip(verEL, seqEL *L2ELNode, maxAttempts int) {
+	trial := 0
+	cl.require.NoError(
+		retry.Do0(cl.ctx, 200, &retry.FixedStrategy{Dur: 250 * time.Millisecond}, func() error {
+			verUnsafe := verEL.BlockRefByLabel(eth.Unsafe)
+			seqUnsafe := seqEL.BlockRefByLabel(eth.Unsafe)
+			gap := seqUnsafe.Number - verUnsafe.Number
+			cl.log.Info("Filling in the gap by appending unsafe payload", "gap", gap, "ver", verUnsafe, "seq", seqUnsafe, "trial", trial)
+			if gap == 0 {
+				return nil
+			}
+			trial += 1
+			cl.SignalTarget(seqEL, verUnsafe.Number+1)
+			return fmt.Errorf("gap yet filled: %d", gap)
+		}))
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds `TestReachUnsafeTipByAppendingUnsafePayload` which demonstrates below scenario:
- ELP2P down, but chain still advancing since the unsafe payloads build on top of the unsafe head. This scenario happens after verifier at least reached once the tip of the chain.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/17694
