### PR TITLE
op-devstack: do not filter logs below level info

### DIFF
--- a/op-devstack/presets/orchestrator.go
+++ b/op-devstack/presets/orchestrator.go
@@ -64,7 +64,6 @@ func DoMain(m TestingM, opts ...stack.CommonOption) {
 		cfg := flags.ReadTestConfig()
 		logHandler := oplog.NewLogHandler(os.Stdout, cfg.LogConfig)
 		logHandler = logfilter.WrapFilterHandler(logHandler)
-		logHandler.(logfilter.FilterHandler).Set(logfilter.DefaultMute(logfilter.Level(log.LevelInfo).Show()))
 		logHandler = logfilter.WrapContextHandler(logHandler)
 		// The default can be changed using the WithLogFilters option which replaces this default
 		logger := log.NewLogger(logHandler)


### PR DESCRIPTION
This PR is removing the filtering of logs below log level `INFO`.

Without this change it is not possible to enable TRACE or DEBUG lines when running tests, for example the following command does not enable TRACE logs, but it should:

```
LOG_LEVEL=trace go test -v -count=1 -timeout 600s -run TestName .
```