### PR TITLE
op-node: revive async block processing timing log

### DIFF
--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type PayloadSuccessEvent struct {
@@ -51,5 +52,42 @@ func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucce
 	err := e.tryUpdateEngineInternal(ctx)
 	if err != nil {
 		e.log.Error("Failed to update engine", "error", err)
+	} else {
+		updateEngineFinish := time.Now()
+		e.logBlockProcessingMetrics(updateEngineFinish, ev)
 	}
+}
+
+func (e *EngineController) logBlockProcessingMetrics(updateEngineFinish time.Time, ev PayloadSuccessEvent) {
+	// Protect against nil pointer dereferences
+	if ev.Envelope == nil || ev.Envelope.ExecutionPayload == nil {
+		e.log.Debug("Envelope.ExecutionPayload not found, skipping block processing metrics")
+		return
+	}
+
+	buildTime := ev.InsertStarted.Sub(ev.BuildStarted)
+	insertTime := updateEngineFinish.Sub(ev.InsertStarted)
+
+	var totalTime time.Duration
+	if !ev.BuildStarted.IsZero() {
+		totalTime = updateEngineFinish.Sub(ev.BuildStarted)
+	} else {
+		totalTime = insertTime
+	}
+
+	// Protect against divide-by-zero
+	var mgasps float64
+	if totalTime > 0 {
+		mgasps = float64(ev.Envelope.ExecutionPayload.GasUsed) * 1000 / float64(totalTime)
+	}
+
+	e.log.Info("Inserted new L2 unsafe block",
+		"hash", ev.Envelope.ExecutionPayload.BlockHash,
+		"number", uint64(ev.Envelope.ExecutionPayload.BlockNumber),
+		"build_time", common.PrettyDuration(buildTime),
+		"insert_time", common.PrettyDuration(insertTime),
+		"total_time", common.PrettyDuration(totalTime),
+		"mgas", float64(ev.Envelope.ExecutionPayload.GasUsed)/1000000,
+		"mgasps", mgasps,
+	)
 }

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -61,24 +61,29 @@ func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucce
 func (e *EngineController) logBlockProcessingMetrics(updateEngineFinish time.Time, ev PayloadSuccessEvent) {
 	// Protect against nil pointer dereferences
 	if ev.Envelope == nil || ev.Envelope.ExecutionPayload == nil {
-		e.log.Debug("Envelope.ExecutionPayload not found, skipping block processing metrics")
+		e.log.Info("Envelope.ExecutionPayload not found, skipping block processing metrics")
 		return
 	}
 
-	buildTime := ev.InsertStarted.Sub(ev.BuildStarted)
+	mgas := float64(ev.Envelope.ExecutionPayload.GasUsed) / 1e6
+	buildTime := time.Duration(0)
 	insertTime := updateEngineFinish.Sub(ev.InsertStarted)
+	totalTime := insertTime
 
-	var totalTime time.Duration
+	// BuildStarted may be zero if sequencer already built + gossiped a block, but failed during
+	// insertion and needed a retry of the insertion. In that case we use the default values above,
+	// otherwise we calculate buildTime and totalTime below
 	if !ev.BuildStarted.IsZero() {
+		buildTime = ev.InsertStarted.Sub(ev.BuildStarted)
 		totalTime = updateEngineFinish.Sub(ev.BuildStarted)
-	} else {
-		totalTime = insertTime
 	}
 
 	// Protect against divide-by-zero
-	var mgasps float64
+	var mgasps float64 // Mgas/s
 	if totalTime > 0 {
-		mgasps = float64(ev.Envelope.ExecutionPayload.GasUsed) * 1000 / float64(totalTime)
+		// Calculate "block-processing" Mgas/s.
+		// NOTE: "realtime" mgasps (chain throughput) is a different calculation: (GasUsed / blockPeriod)
+		mgasps = mgas / totalTime.Seconds()
 	}
 
 	e.log.Info("Inserted new L2 unsafe block",
@@ -87,7 +92,7 @@ func (e *EngineController) logBlockProcessingMetrics(updateEngineFinish time.Tim
 		"build_time", common.PrettyDuration(buildTime),
 		"insert_time", common.PrettyDuration(insertTime),
 		"total_time", common.PrettyDuration(totalTime),
-		"mgas", float64(ev.Envelope.ExecutionPayload.GasUsed)/1000000,
+		"mgas", mgas,
 		"mgasps", mgasps,
 	)
 }


### PR DESCRIPTION
# Overview
To provide more visibility into block processing performance (useful for benchmarking execution clients), it's useful to log the time it takes to execute all 4 engineApi calls `op-node` makes to its execution client as part of the block processing lifecycle. 

# Additional context
Last year we merged [this pr](https://github.com/ethereum-optimism/optimism/pull/12907), which updated both code paths to log the block processing durations. [This pr](https://github.com/ethereum-optimism/optimism/pull/17015) from ~2 months ago removed the log from the async code path. It would also be good to add some metrics for some of the logged data field, but can do that in a follow-up pr.

# Open questions
1. Previously, there were two code paths the engine could take: a synchronous path, and an async/event-based path. Are both of those paths going to be supported going forward or will the synchronous path be deprecated? We no longer see the sync block processing logs in our grafana dashboard for production nodes, which makes me think the [sync path](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/engine/engine_controller.go#L581-L588) is currently dead code