### PR TITLE
fix(op-deployer): remove superchainRoles standard value check

### DIFF
--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -142,10 +142,6 @@ func (c *Intent) validateStandardValues() error {
 		return ErrIncompatibleValue
 	}
 
-	if c.SuperchainRoles != nil {
-		return ErrIncompatibleValue
-	}
-
 	standardOPCM, err := standard.OPCMImplAddressFor(c.L1ChainID, standard.CurrentTag)
 	if err != nil {
 		return fmt.Errorf("error getting OPCM address: %w", err)

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -78,15 +78,6 @@ func TestValidateStandardValues(t *testing.T) {
 			},
 			ErrNonStandardValue,
 		},
-		{
-			"SuperchainRoles",
-			func(intent *Intent) {
-				intent.SuperchainRoles = &addresses.SuperchainRoles{
-					SuperchainGuardian: common.HexToAddress("0x9999"),
-				}
-			},
-			ErrIncompatibleValue,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Inconsistency between standard chain validation and genesis deployment requirements in `op-deployer`. The standard intent type (`configType = "standard"`) validation rejects superchain roles, but the genesis deployment target requires them. This makes it impossible to deploy a standard chain using the genesis target.

**Steps to Reproduce**

1. Install op-deployer following the guide: [`op-deployer/book/src/user-guide/installation.md`](https://github.com/ethereum-optimism/optimism/blob/develop/op-deployer/book/src/user-guide/installation.md)

2. Initialize a standard chain configuration.

   e.g:

   ```bash
   op-deployer init \
   --l1-chain-id 1 \
   --l2-chain-ids 10 \
   --outdir ./test-standard \
   --intent-type standard
   ```

3. Specify configuration on `./test-standard/intent.toml`.

   e.g:

   ```toml
   configType = "standard"
   l1ChainID = 1
   opcmAddress = "0x8123739C1368C2DEDc8C564255bc417FEEeBFF9D"
   fundDevAccounts = false
   l1ContractsLocator = "embedded"
   l2ContractsLocator = "embedded"

    [[chains]]
    id = "0x000000000000000000000000000000000000000000000000000000000000000a"
    baseFeeVaultRecipient = "0x0000000000000000000000000000000000000005"
    l1FeeVaultRecipient = "0x0000000000000000000000000000000000000006"
    sequencerFeeVaultRecipient = "0x0000000000000000000000000000000000000007"
    eip1559DenominatorCanyon = 250
    eip1559Denominator = 50
    eip1559Elasticity = 6
    gasLimit = 60000000
    operatorFeeScalar = 0
    operatorFeeConstant = 0
    minBaseFee = 0
    [chains.roles]
    l1ProxyAdminOwner = "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a"
    l2ProxyAdminOwner = "0x6b1bae59d09fccbddb6c6cceb07b7279367c4e3b"
    systemConfigOwner = "0x0000000000000000000000000000000000000001"
    unsafeBlockSigner = "0x0000000000000000000000000000000000000002"
    batcher = "0x0000000000000000000000000000000000000003"
    proposer = "0x0000000000000000000000000000000000000004"
    challenger = "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a"

   ```

4. Attempt to deploy using genesis target:

   ```bash
   op-deployer apply --workdir ./test-standard --deployment-target genesis
   ```

5. Observe error: "superchain roles must be set for genesis strategy"

6. Add superchain roles to intent.toml:

   ```toml
   [superchainRoles]
   SuperchainProxyAdminOwner = "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a"
   SuperchainGuardian = "0x0000000000000000000000000000000000000009"
   ProtocolVersionsOwner = "0x000000000000000000000000000000000000000b"
   Challenger = "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a"
   ```

7. Observe new error: "chain contains incompatible config value"

**Expected behavior**

Should be able to deploy a standard chain using the genesis target without configuration conflicts. The validation rules should be consistent between deployment targets and intent types.

**Additional context**

The issue stems from conflicting validations in:

1. [`pipeline/init.go`](https://github.com/ethereum-optimism/optimism/blob/96b920867c086b8568156d98b092246f5eccbb9d/op-deployer/pkg/deployer/pipeline/init.go#L115-#L117): `InitGenesisStrategy` requires superchain roles for genesis deployment.

   ```go
   if intent.SuperchainRoles == nil {
       return fmt.Errorf("superchain roles must be set for genesis strategy")
   }
   ```

2. [`state/intent.go`](https://github.com/ethereum-optimism/optimism/blob/96b920867c086b8568156d98b092246f5eccbb9d/op-deployer/pkg/deployer/state/intent.go#L145-#L147): `validateStandardValues` rejects superchain roles for standard intent type.

   ```go
   if c.SuperchainRoles != nil {
       return ErrIncompatibleValue
   }
   ```

**Proposed Solution**

Remove the superchain roles validation for standard intent type in `state/intent.go`.

The `pipeline/init.go` check remains as the superchain roles are required for executing `DeploySuperchain` function.

**Note**: This change only affects the genesis deployment target. The live deployment target (`InitLiveStrategy`) is unaffected because:

1.  For standard intent type, `validateStandardValues` requires OPCM address to be set.

2.  When OPCM address is set, [`InitLiveStrategy`](https://github.com/ethereum-optimism/optimism/blob/55150e4898ccf845735de83e98a76871922e0ef0/op-deployer/pkg/deployer/pipeline/init.go#L36) requires SuperchainRoles to be set too:

```go
if hasPredeployedOPCM {
   //...
   if intent.SuperchainRoles != nil {
   return fmt.Errorf("cannot set superchain roles for predeployed OPCM")
   }
}
```


