### PR TITLE
fix(op-devstack): correct EnableReqRespSync default to false

### DIFF
--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -54,7 +54,7 @@ func DefaultL2CLConfig() *L2CLConfig {
 		SafeDBPath:        "",
 		IsSequencer:       false,
 		IndexingMode:      false,
-		EnableReqRespSync: true,
+		EnableReqRespSync: false, // Changed to false: tests explicitly enable when needed
 		NoDiscovery:       false,
 	}
 }


### PR DESCRIPTION
found this issue from https://github.com/ethereum-optimism/optimism/pull/17496 ([CI checks failed](https://circleci.com/gh/ethereum-optimism/optimism/3987093))

Fixes test failure by correcting the default value introduced in 3f2bf2853 - req-resp sync should be opt-in, not opt-out.

cc @nonsense