### PR TITLE
op-acceptance-tests: disable discovery for test

### DIFF
--- a/op-acceptance-tests/tests/depreqres/init_test.go
+++ b/op-acceptance-tests/tests/depreqres/init_test.go
@@ -12,5 +12,6 @@ func TestMain(m *testing.M) {
 		presets.WithExecutionLayerSyncOnVerifiers(),
 		presets.WithCompatibleTypes(compat.SysGo),
 		presets.WithReqRespSyncDisabled(),
+		presets.WithNoDiscovery(),
 	)
 }


### PR DESCRIPTION
Discovery should be disabled for test, as we are disconnecting peers, and don't want to have discovery mechanism connect them...

This is fixed in https://github.com/ethereum-optimism/optimism/pull/17751 , but the test is already triggering flakes on `develop` which is annoying.