### PR TITLE
feat(op-up): add custom config intent 

### DIFF
--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -244,6 +244,59 @@ func WithCommons(l1ChainID eth.ChainID) DeployerOption {
 	}
 }
 
+func WithCustomIntent(intent *state.Intent) DeployerOption {
+	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
+		if intent == nil {
+			return
+		}
+		if intent.L1ContractsLocator != nil {
+			builder.WithL1ContractsLocator(intent.L1ContractsLocator)
+		}
+		if intent.L2ContractsLocator != nil {
+			builder.WithL2ContractsLocator(intent.L2ContractsLocator)
+		}
+
+		if intent.GlobalDeployOverrides["devFeatureBitmap"] != nil {
+			builder.WithGlobalOverride("devFeatureBitmap", intent.GlobalDeployOverrides["devFeatureBitmap"])
+		}
+
+		for _, chainIntent := range intent.Chains {
+			l2ChainID := eth.ChainIDFromBytes32(chainIntent.ID)
+			var l2Config intentbuilder.L2Configurator
+			for _, l2 := range builder.L2s() {
+				if l2.ChainID() == l2ChainID {
+					l2Config = l2
+					break
+				}
+			}
+
+			l2Config.WithBaseFeeVaultRecipient(chainIntent.BaseFeeVaultRecipient)
+			l2Config.WithSequencerFeeVaultRecipient(chainIntent.SequencerFeeVaultRecipient)
+			l2Config.WithL1FeeVaultRecipient(chainIntent.L1FeeVaultRecipient)
+
+			l2Config.WithL1ProxyAdminOwner(chainIntent.Roles.L1ProxyAdminOwner)
+			l2Config.WithL2ProxyAdminOwner(chainIntent.Roles.L2ProxyAdminOwner)
+			l2Config.WithSystemConfigOwner(chainIntent.Roles.SystemConfigOwner)
+			l2Config.WithUnsafeBlockSigner(chainIntent.Roles.UnsafeBlockSigner)
+			l2Config.WithBatcher(chainIntent.Roles.Batcher)
+			l2Config.WithProposer(chainIntent.Roles.Proposer)
+			l2Config.WithChallenger(chainIntent.Roles.Challenger)
+
+			l2Config.WithEIP1559DenominatorCanyon(chainIntent.Eip1559DenominatorCanyon)
+			l2Config.WithEIP1559Denominator(chainIntent.Eip1559Denominator)
+			l2Config.WithEIP1559Elasticity(chainIntent.Eip1559Elasticity)
+			l2Config.WithOperatorFeeScalar(uint64(chainIntent.OperatorFeeScalar))
+			l2Config.WithOperatorFeeConstant(chainIntent.OperatorFeeConstant)
+
+			if chainIntent.L2DevGenesisParams != nil {
+				for addr, balance := range chainIntent.L2DevGenesisParams.Prefund {
+					l2Config.WithPrefundedAccount(addr, uint256.Int(*balance))
+				}
+			}
+		}
+	}
+}
+
 func WithGuardianMatchL1PAO() DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
 		_, superCfg := builder.WithSuperchain()

--- a/op-up/example.intent.toml
+++ b/op-up/example.intent.toml
@@ -1,0 +1,34 @@
+configType = "standard"
+l1ChainID = 1
+opcmAddress = "0x8123739C1368C2DEDc8C564255bc417FEEeBFF9D"
+fundDevAccounts = false
+l1ContractsLocator = "embedded"
+l2ContractsLocator = "embedded"
+
+
+[[chains]]
+id = "0x000000000000000000000000000000000000000000000000000000000000000a"
+baseFeeVaultRecipient = "0x0000000000000000000000000000000000000005"
+l1FeeVaultRecipient = "0x0000000000000000000000000000000000000006"
+sequencerFeeVaultRecipient = "0x0000000000000000000000000000000000000007"
+eip1559DenominatorCanyon = 250
+eip1559Denominator = 50
+eip1559Elasticity = 6
+gasLimit = 60000000
+operatorFeeScalar = 0
+operatorFeeConstant = 0
+minBaseFee = 0
+[chains.roles]
+l1ProxyAdminOwner = "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a"
+l2ProxyAdminOwner = "0x6b1bae59d09fccbddb6c6cceb07b7279367c4e3b"
+systemConfigOwner = "0x0000000000000000000000000000000000000001"
+unsafeBlockSigner = "0x0000000000000000000000000000000000000002"
+batcher = "0x0000000000000000000000000000000000000003"
+proposer = "0x0000000000000000000000000000000000000004"
+challenger = "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a"
+
+[superchainRoles]
+SuperchainProxyAdminOwner = "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a"
+SuperchainGuardian = "0x0000000000000000000000000000000000000009"
+ProtocolVersionsOwner = "0x000000000000000000000000000000000000000b"
+Challenger = "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a"

--- a/op-up/justfile
+++ b/op-up/justfile
@@ -18,3 +18,11 @@ artifacts:
 
 clean:
     rm -f {{ BINARY }}
+
+run INTENT="":
+    #!/usr/bin/env bash
+    if [ -n "{{ INTENT }}" ]; then
+        ./bin/op-up --intent {{ INTENT }}
+    else
+        ./bin/op-up
+    fi

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -27,6 +28,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
 	"github.com/ethereum-optimism/optimism/op-service/testreq"
@@ -65,6 +67,11 @@ var (
 			return filepath.Join(parentDir, ".op-up")
 		}(),
 	}
+	intentFlag = &cli.PathFlag{
+		Name:    "intent",
+		Usage:   "the path to a custom intent.toml file. If not specified, a default intent will be generated.",
+		EnvVars: opservice.PrefixEnvVar(envPrefix, "INTENT"),
+	}
 )
 
 func main() {
@@ -83,7 +90,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	app.Version = opservice.FormatVersion(Version, GitCommit, GitDate, VersionMeta)
 	app.Name = "op-up"
 	app.Usage = "deploys an in-memory OP Stack devnet."
-	app.Flags = cliapp.ProtectFlags([]cli.Flag{dirFlag})
+	app.Flags = cliapp.ProtectFlags([]cli.Flag{dirFlag, intentFlag})
 	// The default OnUsageError behavior will print the error twice: once in the cli package and
 	// once in our main function.
 	// The function below prints help and returns the error for further handling/error messages.
@@ -94,12 +101,12 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	app.Action = func(cliCtx *cli.Context) error {
-		return runOpUp(cliCtx.Context, cliCtx.App.ErrWriter, cliCtx.String(dirFlag.Name))
+		return runOpUp(cliCtx.Context, cliCtx.App.ErrWriter, cliCtx.String(dirFlag.Name), cliCtx.String(intentFlag.Name))
 	}
 	return app.RunContext(ctx, args)
 }
 
-func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
+func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string, intentPath string) error {
 	fmt.Fprintf(stderr, "%s\n", asciiArt)
 
 	if err := os.MkdirAll(opUpDir, 0o755); err != nil {
@@ -115,7 +122,29 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 	p := newP(ctx, stderr)
 	defer p.Close()
 
-	ids := sysgo.NewDefaultMinimalSystemIDs(sysgo.DefaultL1ID, sysgo.DefaultL2AID)
+	var l1ChainID, l2ChainID eth.ChainID
+	var intent *state.Intent
+	if intentPath != "" {
+		// Load intent from file
+		var err error
+		intent, err = jsonutil.LoadTOML[state.Intent](intentPath)
+		if err != nil {
+			return fmt.Errorf("failed to load intent: %w", err)
+		}
+		if len(intent.Chains) == 0 {
+			return fmt.Errorf("intent must have at least one chain")
+		}
+		// Load ids from custom intent
+		l1ChainID = eth.ChainIDFromUInt64(intent.L1ChainID)
+		l2ChainID = eth.ChainIDFromBytes32([32]byte(intent.Chains[0].ID))
+	} else {
+		// Use sysgo default ids
+		l1ChainID = sysgo.DefaultL1ID
+		l2ChainID = sysgo.DefaultL2AID
+	}
+
+	ids := sysgo.NewDefaultMinimalSystemIDs(l1ChainID, l2ChainID)
+
 	opts := stack.Combine(
 		sysgo.WithMnemonicKeys(devkeys.TestMnemonic),
 
@@ -124,6 +153,7 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 			sysgo.WithEmbeddedContractSources(),
 			sysgo.WithCommons(ids.L1.ChainID()),
 			sysgo.WithPrefundedL2(ids.L1.ChainID(), ids.L2.ChainID()),
+			sysgo.WithCustomIntent(intent),
 		),
 		sysgo.WithDeployerPipelineOption(sysgo.WithDeployerCacheDir(deployerCacheDir)),
 

--- a/op-up/main_test.go
+++ b/op-up/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"io"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
@@ -42,6 +45,47 @@ func TestRun(t *testing.T) {
 				continue
 			}
 			require.Equal(t, sysgo.DefaultL2AID.ToBig(), chainID)
+			return
+		}
+	}
+}
+
+func TestRunWithIntent(t *testing.T) {
+	// Load intent to get expected chain ID
+	intent, err := jsonutil.LoadTOML[state.Intent]("example.intent.toml")
+	require.NoError(t, err)
+	require.NotEmpty(t, intent.Chains)
+	expectedChainID := new(big.Int).SetBytes(intent.Chains[0].ID[:])
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(errCh)
+		if err := run(ctx, []string{"op-up", "--dir", t.TempDir(), "--intent", "example.intent.toml"}, io.Discard, io.Discard); err != nil {
+			errCh <- err
+		}
+	}()
+
+	client, err := ethclient.DialContext(ctx, "http://localhost:8545")
+	require.NoError(t, err)
+	ticker := time.NewTicker(time.Millisecond * 250)
+	for {
+		select {
+		case e := <-errCh:
+			require.NoError(t, e)
+		case <-ticker.C:
+			chainID, err := client.ChainID(ctx)
+			if err != nil {
+				t.Logf("error while querying chain ID, will retry: %s", err)
+				continue
+			}
+			require.Equal(t, expectedChainID, chainID)
 			return
 		}
 	}


### PR DESCRIPTION
**Description**

Adds support for custom intent configuration files in op-up, allowing users to specify custom L1/L2 chain IDs, roles, fee parameters and other settings via a TOML file.

**Changes include**

- Added `--intent` CLI flag to op-up for specifying a custom intent TOML file path.
- Implemented `WithCustomIntent` deployer option in `op-devstack/sysgo/deployer.go` that applies custom intent settings.
- Added `example.intent.toml` demonstrating the intent file format.
- Updated `op-up/justfile` with a run command that accepts an optional intent file path.
- Modified `op-up/main.go` to load intent from file when provided, defaulting to standard behavior when not specified.

Intent files can be generated using op-deployer `init` command (see https://docs.optimism.io/builders/chain-operators/tools/op-deployer#init-command) and then passed to op-up via the `--intent` flag.

**Tests**

- Added `TestRunWithIntent` that loads the example intent file and verifies the devnet starts with the correct chain ID.

**Additional context**

This enables more flexible local development and testing scenarios where developers need specific chain configurations, custom roles, or non-default fee parameters without modifying code. Can also be used to for testing enabling/disabling devfeatures easily.

**Note**

The `L2DevGenesisParams.Prefund` map (for custom prefunded accounts) is currently handled in the code but cannot be specified in the TOML file. The TOML decoder cannot handle `map[common.Address]\*hexutil.U256` because `common.Address` is not a string type, it's a byte array. Alternative approaches to enable this functionality include: (1) adding a custom TOML unmarshaler for the `L2DevGenesisParams` type, or (2) using JSON format instead of TOML for the intent file.
