### PR TITLE
fix(op-chain-ops): use correct file permissions for debug_witness.json

### DIFF
--- a/op-chain-ops/cmd/op-run-block/main.go
+++ b/op-chain-ops/cmd/op-run-block/main.go
@@ -166,7 +166,7 @@ func mainAction(c *cli.Context) error {
 			logger.Error("failed to encode witness", "err", err)
 			return
 		}
-		if err := os.WriteFile("debug_witness.json", out, 0755); err != nil {
+		if err := os.WriteFile("debug_witness.json", out, 0644); err != nil {
 			logger.Error("Failed to write witness", "err", err)
 		}
 	}()


### PR DESCRIPTION


## Description
The `debug_witness.json` file was being created with executable permissions (`0755`) instead of standard read-write permissions for data files.

### Solution
Changed file permissions from `0755` to `0644` when writing the debug witness JSON file.

