### PR TITLE
op-node: Fix gossip validation for Jovian blocks

### DIFF
--- a/op-service/ptr/ptr.go
+++ b/op-service/ptr/ptr.go
@@ -1,0 +1,15 @@
+// Package ptr provides helper functions for working with pointers.
+package ptr
+
+import "fmt"
+
+func New[T any](v T) *T {
+	return &v
+}
+
+func Str[T any](v *T) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *v)
+}


### PR DESCRIPTION

**Description**
Jovian blocks can have a non-zero blobGasUsed value, as the DA footprint is stored in it.

**Tests**

Added case to the block validator unit test.
