### PR TITLE
op-acceptance-tests: various improvements to the Fusaka acceptance test

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ svm-rs = "0.5.19"
 
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
-"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.16.4" # Osaka release.
+"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.16.4" # Osaka testnet release.
 "go:gotest.tools/gotestsum" = "1.12.1"
 "go:github.com/vektra/mockery/v2" = "2.46.0"
 "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.64.8"

--- a/op-acceptance-tests/tests/fusaka/fusaka_test.go
+++ b/op-acceptance-tests/tests/fusaka/fusaka_test.go
@@ -1,4 +1,4 @@
-package osaka
+package fusaka
 
 import (
 	"context"

--- a/op-acceptance-tests/tests/fusaka/fusaka_test.go
+++ b/op-acceptance-tests/tests/fusaka/fusaka_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
@@ -83,13 +86,21 @@ func TestBlobBaseFeeIsCorrectAfterBPOFork(gt *testing.T) {
 	t.Require().NoError(err)
 	l1BlobBaseFee := calcBlobBaseFee(l1ChainConfig, l1OriginInfo)
 
-	// Get the L2 blob base fee from the system deposit tx.
-	info, txs, err := sys.L2EL.Escape().EthClient().InfoAndTxsByHash(t.Ctx(), l2UnsafeRef.Hash)
+	l2Info, l2Txs, err := sys.L2EL.Escape().EthClient().InfoAndTxsByHash(t.Ctx(), l2UnsafeRef.Hash)
 	t.Require().NoError(err)
-	blockInfo, err := derive.L1BlockInfoFromBytes(sys.L2Chain.Escape().RollupConfig(), info.Time(), txs[0].Data())
+
+	// Check the L1 blob base fee in the system deposit tx.
+	blockInfo, err := derive.L1BlockInfoFromBytes(sys.L2Chain.Escape().RollupConfig(), l2Info.Time(), l2Txs[0].Data())
 	t.Require().NoError(err)
 	l2BlobBaseFee := blockInfo.BlobBaseFee
+	t.Require().Equal(l1BlobBaseFee, l2BlobBaseFee)
 
+	// Check the L1 Blob base fee in the L1Block contract.
+	l1Block := bindings.NewL1Block(bindings.WithClient(sys.L2EL.Escape().EthClient()), bindings.WithTo(predeploys.L1BlockAddr))
+	l2BlobBaseFee, err = contractio.Read(l1Block.BlobBaseFee(), t.Ctx(), func(tx *txplan.PlannedTx) {
+		tx.AgainstBlock.Set(l2Info)
+	})
+	t.Require().NoError(err)
 	t.Require().Equal(l1BlobBaseFee, l2BlobBaseFee)
 }
 

--- a/op-acceptance-tests/tests/fusaka/fusaka_test.go
+++ b/op-acceptance-tests/tests/fusaka/fusaka_test.go
@@ -3,6 +3,7 @@ package fusaka
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"math/big"
 	"sync"
 	"testing"
@@ -18,10 +19,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestSafeHeadAdvancesAfterOsaka(gt *testing.T) {
@@ -50,30 +51,10 @@ func TestBlobBaseFeeIsCorrectAfterBPOFork(gt *testing.T) {
 	sys.L1EL.WaitForTime(*sys.L1Network.Escape().ChainConfig().BPO1Time)
 	t.Log("BPO1 activated")
 
-	sys.L1EL.WaitForBlock()
-	l1BlockTime := sys.L1EL.EstimateBlockTime()
-	l1ChainConfig := sys.L1Network.Escape().ChainConfig()
-
 	spamBlobs(t, sys) // Raise the blob base fee to make blob parameter changes visible.
 
-	// Wait for the blob base fee to rise above 1 so the blob parameter changes will be visible.
-	for range time.Tick(l1BlockTime) {
-		info, _, err := sys.L1EL.EthClient().InfoAndTxsByLabel(t.Ctx(), eth.Unsafe)
-		t.Require().NoError(err)
-		if calcBlobBaseFee(l1ChainConfig, info).Cmp(big.NewInt(1)) > 0 {
-			break
-		}
-		t.Logf("Waiting for blob base fee to rise above 1")
-	}
-
-	l2UnsafeRef := sys.L2CL.SyncStatus().UnsafeL2
-
-	// Get the L1 blob base fee.
-	l1OriginInfo, err := sys.L1EL.EthClient().InfoByHash(t.Ctx(), l2UnsafeRef.L1Origin.Hash)
-	t.Require().NoError(err)
-	l1BlobBaseFee := calcBlobBaseFee(l1ChainConfig, l1OriginInfo)
-
-	l2Info, l2Txs, err := sys.L2EL.Escape().EthClient().InfoAndTxsByHash(t.Ctx(), l2UnsafeRef.Hash)
+	l2UnsafeHash, l1BlobBaseFee := waitForNonTrivialBPO1Block(t, sys)
+	l2Info, l2Txs, err := sys.L2EL.Escape().EthClient().InfoAndTxsByHash(t.Ctx(), l2UnsafeHash)
 	t.Require().NoError(err)
 
 	// Check the L1 blob base fee in the system deposit tx.
@@ -89,6 +70,45 @@ func TestBlobBaseFeeIsCorrectAfterBPOFork(gt *testing.T) {
 	})
 	t.Require().NoError(err)
 	t.Require().Equal(l1BlobBaseFee, l2BlobBaseFee)
+}
+
+// waitForNonTrivialBPO1Block will return an L1 blob base fee that can only be calculated using the
+// correct BPO1 parameters (i.e., the Osaka parameters result in a different value). It also
+// returns an L2 block hash from the same epoch.
+func waitForNonTrivialBPO1Block(t devtest.T, sys *presets.Minimal) (common.Hash, *big.Int) {
+	l1ChainConfig := sys.L1Network.Escape().ChainConfig()
+	l1BlockTime := sys.L1EL.EstimateBlockTime()
+	for {
+		l2UnsafeRef := sys.L2CL.SyncStatus().UnsafeL2
+
+		l1Info, _, err := sys.L1EL.EthClient().InfoAndTxsByHash(t.Ctx(), l2UnsafeRef.L1Origin.Hash)
+		if errors.Is(err, ethereum.NotFound) { // Possible reorg, try again.
+			continue
+		}
+		t.Require().NoError(err)
+
+		// Calculate expected blob base fee with old Osaka parameters.
+		osakaBlobBaseFee := eip4844.CalcBlobFee(l1ChainConfig, &types.Header{
+			Time:          *l1ChainConfig.OsakaTime,
+			ExcessBlobGas: l1Info.ExcessBlobGas(),
+		})
+
+		// Calculate expected blob base fee with new BPO1 parameters.
+		bpo1BlobBaseFee := eip4844.CalcBlobFee(l1ChainConfig, &types.Header{
+			Time:          l1Info.Time(),
+			ExcessBlobGas: l1Info.ExcessBlobGas(),
+		})
+
+		if bpo1BlobBaseFee.Cmp(osakaBlobBaseFee) != 0 {
+			return l2UnsafeRef.Hash, bpo1BlobBaseFee
+		}
+
+		select {
+		case <-t.Ctx().Done():
+			t.Require().Fail("context canceled before finding a block with a divergent base fee")
+		case <-time.After(l1BlockTime):
+		}
+	}
 }
 
 func spamBlobs(t devtest.T, sys *presets.Minimal) {
@@ -133,13 +153,4 @@ func spamBlobs(t devtest.T, sys *presets.Minimal) {
 		defer wg.Done()
 		schedule.Run(t.WithCtx(ctx), spammer)
 	}()
-}
-
-func calcBlobBaseFee(cfg *params.ChainConfig, info eth.BlockInfo) *big.Int {
-	return eip4844.CalcBlobFee(cfg, &types.Header{
-		// It's unfortunate that we can't build a proper header from a BlockInfo.
-		// We do our best to work around deficiencies in the BlockInfo implementation here.
-		Time:          info.Time(),
-		ExcessBlobGas: info.ExcessBlobGas(),
-	})
 }

--- a/op-acceptance-tests/tests/fusaka/fusaka_test.go
+++ b/op-acceptance-tests/tests/fusaka/fusaka_test.go
@@ -24,32 +24,19 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// TestBatcherSafeHeadAdvancesAfterOsaka waits for the first unsafe head after the Osaka hardfork
-// to be promoted to safe. This indicates that the batcher is able to include blob txs after Osaka.
-// Note that as of this comment, Geth automatically converts pre-EIP7594 blob txs, but it not all
-// ELs do this.
-func TestBatcherSafeHeadAdvancesAfterOsaka(gt *testing.T) {
+func TestSafeHeadAdvancesAfterOsaka(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
+	l1Config := sys.L1Network.Escape().ChainConfig()
 	t.Log("Waiting for Osaka to activate")
-	t.Require().NotNil(sys.L1Network.Escape().ChainConfig().OsakaTime)
-	sys.L1EL.WaitForTime(*sys.L1Network.Escape().ChainConfig().OsakaTime)
+	t.Require().NotNil(l1Config.OsakaTime)
+	sys.L1EL.WaitForTime(*l1Config.OsakaTime)
 	t.Log("Osaka activated")
 
-	// 1. Wait for the sequencer to build a block after Osaka is activated. This avoids a race
-	//    condition where the unsafe head has been posted as part of a blob, but has not been
-	//    marked as "safe" yet.
-	sys.L2EL.WaitForBlock()
-
-	// 2. Wait for the safe head to advance to the latest unsafe head.
-	target := sys.L2EL.BlockRefByLabel(eth.Unsafe)
-	blockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
-	for range time.Tick(blockTime) {
-		if sys.L2EL.BlockRefByLabel(eth.Safe).Number >= target.Number {
-			// If the safe head is ahead of the target height and the target block is part of the
-			// canonical chain, then the target block is safe.
-			_, err := sys.L2EL.Escape().EthClient().BlockRefByHash(t.Ctx(), target.Hash)
-			t.Require().NoError(err)
+	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
+	for range time.Tick(l2BlockTime) {
+		l2SafeRef := sys.L2EL.BlockRefByLabel(eth.Safe)
+		if l1Config.IsOsaka(new(big.Int).SetUint64(l2SafeRef.Number), l2SafeRef.Time) {
 			return
 		}
 	}

--- a/op-acceptance-tests/tests/fusaka/fusaka_test.go
+++ b/op-acceptance-tests/tests/fusaka/fusaka_test.go
@@ -35,10 +35,16 @@ func TestSafeHeadAdvancesAfterOsaka(gt *testing.T) {
 	t.Log("Osaka activated")
 
 	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
-	for range time.Tick(l2BlockTime) {
+	for {
 		l2SafeRef := sys.L2EL.BlockRefByLabel(eth.Safe)
 		if l1Config.IsOsaka(new(big.Int).SetUint64(l2SafeRef.Number), l2SafeRef.Time) {
 			return
+		}
+		t.Log("L2 safe head predates Osaka activation on L1, waiting for it to advance...")
+		select {
+		case <-time.After(l2BlockTime):
+		case <-t.Ctx().Done():
+			t.Require().Fail("Never found a safe L2 block after Osaka activated on L1")
 		}
 	}
 }

--- a/op-acceptance-tests/tests/fusaka/init_test.go
+++ b/op-acceptance-tests/tests/fusaka/init_test.go
@@ -63,7 +63,9 @@ func TestMain(m *testing.M) {
 		sysgo.WithDeployerOptions(func(_ devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
 			_, l1Config := builder.WithL1(sysgo.DefaultL1ID)
 			l1Config.WithOsakaOffset(0)
-			l1Config.WithBPO1Offset(0)
+			// Make the BPO fork happen after Osaka so we can easily use geth's eip4844.CalcBlobFee
+			// to calculate the blob base fee using the Osaka parameters.
+			l1Config.WithBPO1Offset(1)
 			l1Config.WithL1BlobSchedule(&params.BlobScheduleConfig{
 				Cancun: params.DefaultCancunBlobConfig,
 				Osaka:  params.DefaultOsakaBlobConfig,

--- a/op-acceptance-tests/tests/fusaka/init_test.go
+++ b/op-acceptance-tests/tests/fusaka/init_test.go
@@ -1,4 +1,4 @@
-package osaka
+package fusaka
 
 import (
 	"bytes"

--- a/op-acceptance-tests/tests/osaka/init_test.go
+++ b/op-acceptance-tests/tests/osaka/init_test.go
@@ -1,0 +1,79 @@
+package osaka
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// configureDevstackEnvVars sets the appropriate env vars to use a mise-installed geth binary for
+// the L1 EL. This is useful in Osaka acceptance tests since op-geth does not include full Osaka
+// support. This is meant to run before presets.DoMain in a TestMain function. It will log to
+// stdout. ResetDevstackEnvVars should be used to reset the environment variables when TestMain
+// exits.
+//
+// Note that this is a no-op if either [sysgo.DevstackL1ELKindVar] or [sysgo.GethExecPathEnvVar]
+// are set.
+//
+// The returned callback resets any modified environment variables.
+func configureDevstackEnvVars() func() {
+	if _, ok := os.LookupEnv(sysgo.DevstackL1ELKindEnvVar); ok {
+		return func() {}
+	}
+	if _, ok := os.LookupEnv(sysgo.GethExecPathEnvVar); ok {
+		return func() {}
+	}
+
+	cmd := exec.Command("mise", "which", "geth")
+	buf := bytes.NewBuffer([]byte{})
+	cmd.Stdout = buf
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Failed to find mise-installed geth: %v\n", err)
+		return func() {}
+	}
+	execPath := strings.TrimSpace(buf.String())
+	fmt.Println("Found mise-installed geth:", execPath)
+	_ = os.Setenv(sysgo.GethExecPathEnvVar, execPath)
+	_ = os.Setenv(sysgo.DevstackL1ELKindEnvVar, "geth")
+	return func() {
+		_ = os.Unsetenv(sysgo.GethExecPathEnvVar)
+		_ = os.Unsetenv(sysgo.DevstackL1ELKindEnvVar)
+	}
+}
+
+func TestMain(m *testing.M) {
+	resetEnvVars := configureDevstackEnvVars()
+	defer resetEnvVars()
+
+	presets.DoMain(m, stack.MakeCommon(stack.Combine[*sysgo.Orchestrator](
+		sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{}),
+		sysgo.WithDeployerOptions(func(_ devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
+			_, l1Config := builder.WithL1(sysgo.DefaultL1ID)
+			l1Config.WithOsakaOffset(0)
+			l1Config.WithBPO1Offset(0)
+			l1Config.WithL1BlobSchedule(&params.BlobScheduleConfig{
+				Cancun: params.DefaultCancunBlobConfig,
+				Osaka:  params.DefaultOsakaBlobConfig,
+				Prague: params.DefaultPragueBlobConfig,
+				BPO1:   params.DefaultBPO1BlobConfig,
+			})
+		}),
+		sysgo.WithBatcherOption(func(_ stack.L2BatcherID, cfg *batcher.CLIConfig) {
+			cfg.DataAvailabilityType = flags.BlobsType
+			cfg.TxMgrConfig.CellProofTime = 0 // Force cell proofs to be used
+		}),
+	)))
+}

--- a/op-acceptance-tests/tests/osaka/osaka_test.go
+++ b/op-acceptance-tests/tests/osaka/osaka_test.go
@@ -1,27 +1,16 @@
 package osaka
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
-	"fmt"
 	"math/big"
-	"os"
-	"os/exec"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
-	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
-	"github.com/ethereum-optimism/optimism/op-batcher/flags"
-	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
@@ -31,65 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
-
-// configureDevstackEnvVars sets the appropriate env vars to use a mise-installed geth binary for
-// the L1 EL. This is useful in Osaka acceptance tests since op-geth does not include full Osaka
-// support. This is meant to run before presets.DoMain in a TestMain function. It will log to
-// stdout. ResetDevstackEnvVars should be used to reset the environment variables when TestMain
-// exits.
-//
-// Note that this is a no-op if either [sysgo.DevstackL1ELKindVar] or [sysgo.GethExecPathEnvVar]
-// are set.
-//
-// The returned callback resets any modified environment variables.
-func configureDevstackEnvVars() func() {
-	if _, ok := os.LookupEnv(sysgo.DevstackL1ELKindEnvVar); ok {
-		return func() {}
-	}
-	if _, ok := os.LookupEnv(sysgo.GethExecPathEnvVar); ok {
-		return func() {}
-	}
-
-	cmd := exec.Command("mise", "which", "geth")
-	buf := bytes.NewBuffer([]byte{})
-	cmd.Stdout = buf
-	if err := cmd.Run(); err != nil {
-		fmt.Printf("Failed to find mise-installed geth: %v\n", err)
-		return func() {}
-	}
-	execPath := strings.TrimSpace(buf.String())
-	fmt.Println("Found mise-installed geth:", execPath)
-	_ = os.Setenv(sysgo.GethExecPathEnvVar, execPath)
-	_ = os.Setenv(sysgo.DevstackL1ELKindEnvVar, "geth")
-	return func() {
-		_ = os.Unsetenv(sysgo.GethExecPathEnvVar)
-		_ = os.Unsetenv(sysgo.DevstackL1ELKindEnvVar)
-	}
-}
-
-func TestMain(m *testing.M) {
-	resetEnvVars := configureDevstackEnvVars()
-	defer resetEnvVars()
-
-	presets.DoMain(m, stack.MakeCommon(stack.Combine[*sysgo.Orchestrator](
-		sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{}),
-		sysgo.WithDeployerOptions(func(_ devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
-			_, l1Config := builder.WithL1(sysgo.DefaultL1ID)
-			l1Config.WithOsakaOffset(0)
-			l1Config.WithBPO1Offset(0)
-			l1Config.WithL1BlobSchedule(&params.BlobScheduleConfig{
-				Cancun: params.DefaultCancunBlobConfig,
-				Osaka:  params.DefaultOsakaBlobConfig,
-				Prague: params.DefaultPragueBlobConfig,
-				BPO1:   params.DefaultBPO1BlobConfig,
-			})
-		}),
-		sysgo.WithBatcherOption(func(_ stack.L2BatcherID, cfg *batcher.CLIConfig) {
-			cfg.DataAvailabilityType = flags.BlobsType
-			cfg.TxMgrConfig.CellProofTime = 0 // Force cell proofs to be used
-		}),
-	)))
-}
 
 func TestBatcherUsesNewSidecarFormatAfterOsaka(gt *testing.T) {
 	t := devtest.SerialT(gt)

--- a/op-acceptance-tests/tests/osaka/osaka_test.go
+++ b/op-acceptance-tests/tests/osaka/osaka_test.go
@@ -21,7 +21,11 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func TestBatcherUsesNewSidecarFormatAfterOsaka(gt *testing.T) {
+// TestBatcherSafeHeadAdvancesAfterOsaka waits for the first unsafe head after the Osaka hardfork
+// to be promoted to safe. This indicates that the batcher is able to include blob txs after Osaka.
+// Note that as of this comment, Geth automatically converts pre-EIP7594 blob txs, but it not all
+// ELs do this.
+func TestBatcherSafeHeadAdvancesAfterOsaka(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	t.Log("Waiting for Osaka to activate")
@@ -34,9 +38,7 @@ func TestBatcherUsesNewSidecarFormatAfterOsaka(gt *testing.T) {
 	//    marked as "safe" yet.
 	sys.L2EL.WaitForBlock()
 
-	// 2. Wait for the batcher to include target in a batch and post it to L1. Because the batch is
-	//    posted after Osaka has activated, it means the batcher must have successfully used the
-	//    new format.
+	// 2. Wait for the safe head to advance to the latest unsafe head.
 	target := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	blockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
 	for range time.Tick(blockTime) {

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -396,8 +396,11 @@ func WithBlobs(blobs []*eth.Blob, config *params.ChainConfig) Option {
 			return uint256.MustFromBig(tx.AgainstBlock.Value().BlobBaseFee(config)), nil
 		})
 		var blobHashes []common.Hash
+		tx.Sidecar.DependOn(&tx.AgainstBlock)
 		tx.Sidecar.Fn(func(_ context.Context) (*types.BlobTxSidecar, error) {
-			sidecar, hashes, err := txmgr.MakeSidecar(blobs, true)
+			againstBlock := tx.AgainstBlock.Value()
+			useCellProofs := config.IsOsaka(new(big.Int).SetUint64(againstBlock.NumberU64()), againstBlock.Time())
+			sidecar, hashes, err := txmgr.MakeSidecar(blobs, useCellProofs)
 			if err != nil {
 				return nil, fmt.Errorf("make blob tx sidecar: %w", err)
 			}


### PR DESCRIPTION
This is a follow-up to https://github.com/ethereum-optimism/optimism/pull/17529, which merged with nits due to time pressure.