### PR TITLE
fix(op-alt-da): ensure HTTP response bodies are closed in error cases

### DIFF
--- a/op-alt-da/daclient.go
+++ b/op-alt-da/daclient.go
@@ -47,13 +47,13 @@ func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get preimage: %v", resp.StatusCode)
 	}
-	defer resp.Body.Close()
 	input, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Summary

Fixes a resource leak in `op-alt-da/daclient.go` by ensuring HTTP response bodies are properly closed in all error scenarios.

## Problem

The `GetInput` method in `DAClient` was not closing HTTP response bodies when returning early due to error status codes (404, non-200). This can lead to:
- Resource leaks and file descriptor exhaustion
- Performance degradation due to inability to reuse connections
- Potential connection pool exhaustion under load

## Solution

Moved `defer resp.Body.Close()` immediately after the `client.Do(req)` call to guarantee response body closure in all execution paths, including error cases.

