### PR TITLE
opcm: Support v2 games for updatePrestate

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
     "initCodeHash": "0x1a1de93a1e15a32fd621b572211bd1ceccf82d5d2b936e0aa337ea7593c1ce19",
-    "sourceCodeHash": "0xa4b62dc245c7ea89253f5f46ace5659a1789047db4f0ede5f0bd0378aa2e7a28"
+    "sourceCodeHash": "0xbe7ceb48b39fc1d6c311b9d6dd9095ee72fa5cf82f72d27ec4511c97c01b02aa"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x2eaa345ba05582c67b40a1eb7ec9d54823aa08468e697e2d6c04bb74cc574abc",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x02af0627bee699be308b7d83ceb41655c38ae6856ed3842246917ae696475d64",
-    "sourceCodeHash": "0x76f8991025c5346053444d50c4c0b63faa1739deebdbad99360fe37ca068ed15"
+    "initCodeHash": "0x1a1de93a1e15a32fd621b572211bd1ceccf82d5d2b936e0aa337ea7593c1ce19",
+    "sourceCodeHash": "0xa4b62dc245c7ea89253f5f46ace5659a1789047db4f0ede5f0bd0378aa2e7a28"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x2eaa345ba05582c67b40a1eb7ec9d54823aa08468e697e2d6c04bb74cc574abc",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -462,6 +462,24 @@ abstract contract OPContractsManagerBase {
         }
     }
 
+    /// @notice Retrieves the BigStepper VM for a given v1 or v2 game
+    function getVM(
+        IDisputeGameFactory _disputeGameFactory,
+        IDisputeGame _disputeGame,
+        GameType _gameType
+    )
+        internal
+        view
+        returns (IBigStepper)
+    {
+        bytes memory gameArgsBytes = _disputeGameFactory.gameArgs(_gameType);
+        if (gameArgsBytes.length == 0) {
+            return IFaultDisputeGame(address(_disputeGame)).vm();
+        } else {
+            return IBigStepper(LibGameArgs.decode(gameArgsBytes).vm);
+        }
+    }
+
     /// @notice Sets a game implementation on the dispute game factory
     /// @param _dgf The dispute game factory
     /// @param _gameType The game type
@@ -804,23 +822,20 @@ contract OPContractsManagerGameTypeAdder is OPContractsManagerBase {
                     revert OPContractsManager.PrestateRequired();
                 }
 
-                // Grab the existing game constructor params and init bond.
-                IFaultDisputeGame.GameConstructorParams memory gameParams = getGameConstructorParams(existingGame);
-
                 // Create a new game input with the updated prestate.
                 OPContractsManager.AddGameInput memory input = OPContractsManager.AddGameInput({
                     disputeAbsolutePrestate: prestate,
                     saltMixer: reusableSaltMixer(_prestateUpdateInputs[i].systemConfigProxy),
                     systemConfig: _prestateUpdateInputs[i].systemConfigProxy,
                     proxyAdmin: _prestateUpdateInputs[i].systemConfigProxy.proxyAdmin(),
-                    delayedWETH: IDelayedWETH(payable(address(gameParams.weth))),
-                    disputeGameType: gameParams.gameType,
-                    disputeMaxGameDepth: gameParams.maxGameDepth,
-                    disputeSplitDepth: gameParams.splitDepth,
-                    disputeClockExtension: gameParams.clockExtension,
-                    disputeMaxClockDuration: gameParams.maxClockDuration,
+                    delayedWETH: getWETH(dgf, existingGame, gameType),
+                    disputeGameType: gameType,
+                    disputeMaxGameDepth: existingGame.maxGameDepth(),
+                    disputeSplitDepth: existingGame.splitDepth(),
+                    disputeClockExtension: existingGame.clockExtension(),
+                    disputeMaxClockDuration: existingGame.maxClockDuration(),
                     initialBond: dgf.initBonds(gameType),
-                    vm: gameParams.vm,
+                    vm: getVM(dgf, existingGame, gameType),
                     permissioned: gameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()
                         || gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
                 });
@@ -993,7 +1008,7 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
         if (!isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
             // Update the PermissionedDisputeGame.
             // We're reusing the same DelayedWETH and ASR contracts.
-            deployAndSetNewGameImpl({
+            deployAndSetNewGameImplV1({
                 _l2ChainId: _l2ChainId,
                 _disputeGame: permissionedDisputeGame,
                 _newDelayedWeth: getWETHV1(IFaultDisputeGame(address(permissionedDisputeGame))),
@@ -1008,7 +1023,7 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
             // If it exists, replace its implementation.
             // We're reusing the same DelayedWETH and ASR contracts.
             if (address(permissionlessDisputeGame) != address(0)) {
-                deployAndSetNewGameImpl({
+                deployAndSetNewGameImplV1({
                     _l2ChainId: _l2ChainId,
                     _disputeGame: permissionlessDisputeGame,
                     _newDelayedWeth: getWETHV1(IFaultDisputeGame(address(permissionlessDisputeGame))),
@@ -1087,14 +1102,14 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
         assertValidContractAddress(address(_config.proxyAdmin));
     }
 
-    /// @notice Deploys and sets a new dispute game implementation
+    /// @notice Deploys and sets a new v1 dispute game implementation
     /// @param _l2ChainId The L2 chain ID
     /// @param _disputeGame The current dispute game implementation
     /// @param _newDelayedWeth The new delayed WETH implementation
     /// @param _newAnchorStateRegistryProxy The new anchor state registry proxy
     /// @param _gameType The type of game to deploy
     /// @param _opChainConfig The OP chain configuration
-    function deployAndSetNewGameImpl(
+    function deployAndSetNewGameImplV1(
         uint256 _l2ChainId,
         IDisputeGame _disputeGame,
         IDelayedWETH _newDelayedWeth,
@@ -2138,9 +2153,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 4.5.0
+    /// @custom:semver 4.6.0
     function version() public pure virtual returns (string memory) {
-        return "4.5.0";
+        return "4.6.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -706,8 +706,8 @@ contract OPContractsManagerGameTypeAdder is OPContractsManagerBase {
                             getAnchorStateRegistry(gameConfig.systemConfig),
                             gameL2ChainId
                         ),
-                        getProposerV1(IPermissionedDisputeGame(address(existingGame))),
-                        getChallengerV1(IPermissionedDisputeGame(address(existingGame)))
+                        getProposer(dgf, IPermissionedDisputeGame(address(existingGame)), gameConfig.disputeGameType),
+                        getChallenger(dgf, IPermissionedDisputeGame(address(existingGame)), gameConfig.disputeGameType)
                     );
                 } else {
                     constructorData = encodePermissionlessFDGConstructor(

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1088,6 +1088,42 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
         }
     }
 
+    /// @notice Mocks the existence of a previous SuperPermissionedDisputeGame so we can add a real
+    /// SuperPermissionedDisputeGame implementation by calling opcm.updatePrestate.
+    function _mockSuperPermissionedGame() internal {
+        // If this feature flag is set then OPContractsManager_TestInit deployed a V2 game
+        // Mock gameArgs accordingly for the v2 deployed game
+        if (isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
+            vm.mockCall(
+                address(chainDeployOutput1.disputeGameFactoryProxy),
+                abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+                abi.encode(opcm.implementations().permissionedDisputeGameV2Impl)
+            );
+            // It suffices to mock the proposer and challenger gameArgs
+            vm.mockCall(
+                address(chainDeployOutput1.disputeGameFactoryProxy),
+                abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+                abi.encodePacked(bytes32(0), address(0), address(0), address(0), uint256(0), proposer, challenger)
+            );
+            vm.mockCall(
+                address(opcm.implementations().permissionedDisputeGameV2Impl),
+                abi.encodeCall(IDisputeGame.gameType, ()),
+                abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
+            );
+        } else {
+            vm.mockCall(
+                address(chainDeployOutput1.disputeGameFactoryProxy),
+                abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+                abi.encode(chainDeployOutput1.permissionedDisputeGame)
+            );
+            vm.mockCall(
+                address(chainDeployOutput1.permissionedDisputeGame),
+                abi.encodeCall(IDisputeGame.gameType, ()),
+                abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
+            );
+        }
+    }
+
     /// @notice Tests that we can update the prestate when only the PermissionedDisputeGame exists.
     function test_updatePrestate_pdgOnlyWithValidInput_succeeds() public {
         Claim prestate = Claim.wrap(bytes32(hex"ABBA"));
@@ -1120,21 +1156,7 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     ///         shouldn't matter because the function is independent of other game types that
     ///         exist.
     function test_updatePrestate_withSuperGame_succeeds() public {
-        // TODO(#17972): Remove skip once dispute-game v2 supports the Super DG.
-        skipIfDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
-
-        // Mock out the existence of a previous SuperPermissionedDisputeGame so we can add a real
-        // SuperPermissionedDisputeGame implementation.
-        vm.mockCall(
-            address(chainDeployOutput1.disputeGameFactoryProxy),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
-            abi.encode(chainDeployOutput1.permissionedDisputeGame)
-        );
-        vm.mockCall(
-            address(chainDeployOutput1.permissionedDisputeGame),
-            abi.encodeCall(IDisputeGame.gameType, ()),
-            abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
-        );
+        _mockSuperPermissionedGame();
 
         // Add a SuperPermissionedDisputeGame implementation via addGameType.
         IOPContractsManager.AddGameInput memory input1 = newGameInputFactory(GameTypes.SUPER_PERMISSIONED_CANNON);
@@ -1262,23 +1284,9 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     }
 
     function test_updatePrestate_cannonKonaWithSuperGame_succeeds() public {
-        // TODO(#17972): Remove skip if DEPLOY_V2_DISPUTE_GAMES is enabled once dispute-game v2 supports the Super DG.
-        skipIfDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
-
         skipIfDevFeatureDisabled(DevFeatures.CANNON_KONA);
-        // Mock out the existence of a previous SuperPermissionedDisputeGame so we can add a real
-        // SuperPermissionedDisputeGame implementation.
-        vm.mockCall(
-            address(chainDeployOutput1.disputeGameFactoryProxy),
-            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
-            abi.encode(chainDeployOutput1.permissionedDisputeGame)
-        );
-        vm.mockCall(
-            address(chainDeployOutput1.permissionedDisputeGame),
-            abi.encodeCall(IDisputeGame.gameType, ()),
-            abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
-        );
 
+        _mockSuperPermissionedGame();
         // Add a SuperPermissionedDisputeGame implementation via addGameType.
         IOPContractsManager.AddGameInput memory input1 = newGameInputFactory(GameTypes.SUPER_PERMISSIONED_CANNON);
         addGameType(input1);

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -948,12 +948,6 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
 
     function setUp() public virtual override {
         super.setUp();
-
-        // Skip UpdatePrestate tests when V2 dispute games enabled
-        // UpdatePrestate feature not yet implemented for V2
-        // TODO(#17261): Remove skip when V2 dispute game support for updatePrestate implemented
-        skipIfDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
-
         prestateUpdater = opcm;
     }
 
@@ -961,6 +955,55 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     /// @param _input The input to the OPCM updatePrestate function.
     function _runUpdatePrestateAndChecks(IOPContractsManager.UpdatePrestateInput memory _input) internal {
         _runUpdatePrestateAndChecks(_input, bytes(""));
+    }
+
+    /// @notice Returns the game args of a v1 or v2 game.
+    function _getGameArgs(
+        IDisputeGameFactory _dgf,
+        GameType _gameType
+    )
+        internal
+        view
+        returns (LibGameArgs.GameArgs memory gameArgs_)
+    {
+        bytes memory args = _dgf.gameArgs(_gameType);
+        if (args.length == 0) {
+            IPermissionedDisputeGame game = IPermissionedDisputeGame(address(_dgf.gameImpls(_gameType)));
+            gameArgs_.absolutePrestate = game.absolutePrestate().raw();
+            gameArgs_.vm = address(game.vm());
+            gameArgs_.anchorStateRegistry = address(game.anchorStateRegistry());
+            gameArgs_.weth = address(game.weth());
+            gameArgs_.l2ChainId = game.l2ChainId();
+            if (
+                game.gameType().raw() == GameTypes.PERMISSIONED_CANNON.raw()
+                    || game.gameType().raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw()
+            ) {
+                gameArgs_.proposer = game.proposer();
+                gameArgs_.challenger = game.challenger();
+            }
+            return gameArgs_;
+        } else {
+            return LibGameArgs.decode(args);
+        }
+    }
+
+    function _assertGameArgsEqual(
+        LibGameArgs.GameArgs memory a,
+        LibGameArgs.GameArgs memory b,
+        bool _skipPrestateCheck
+    )
+        internal
+        pure
+    {
+        if (!_skipPrestateCheck) {
+            assertEq(a.absolutePrestate, b.absolutePrestate, "absolutePrestate mismatch");
+        }
+        assertEq(a.vm, b.vm, "vm mismatch");
+        assertEq(a.anchorStateRegistry, b.anchorStateRegistry, "anchorStateRegistry mismatch");
+        assertEq(a.weth, b.weth, "weth mismatch");
+        assertEq(a.l2ChainId, b.l2ChainId, "l2ChainId mismatch");
+        assertEq(a.proposer, b.proposer, "proposer mismatch");
+        assertEq(a.challenger, b.challenger, "challenger mismatch");
     }
 
     /// @notice Runs the OPCM updatePrestate function and checks the results.
@@ -980,6 +1023,18 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
                 GameTypes.CANNON_KONA
             )
         ) != address(0);
+
+        // Retrieve current game args before updatePrestate
+        IDisputeGameFactory dgf = IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory());
+        LibGameArgs.GameArgs memory pdgArgsBefore = _getGameArgs(dgf, GameTypes.PERMISSIONED_CANNON);
+        LibGameArgs.GameArgs memory cannonArgsBefore;
+        LibGameArgs.GameArgs memory cannonKonaArgsBefore;
+        if (expectCannonUpdated) {
+            cannonArgsBefore = _getGameArgs(dgf, GameTypes.CANNON);
+        }
+        if (expectCannonKonaUpdated) {
+            cannonKonaArgsBefore = _getGameArgs(dgf, GameTypes.CANNON_KONA);
+        }
 
         // Turn the ProxyAdmin owner into a DelegateCaller.
         address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
@@ -1002,62 +1057,34 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
             return;
         }
 
-        // Grab the PermissionedDisputeGame.
-        IPermissionedDisputeGame pdg = IPermissionedDisputeGame(
-            address(
-                IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory()).gameImpls(
-                    GameTypes.PERMISSIONED_CANNON
-                )
-            )
-        );
-        assertEq(pdg.absolutePrestate().raw(), _input.cannonPrestate.raw(), "permissioned game prestate mismatch");
+        LibGameArgs.GameArgs memory pdgArgsAfter = _getGameArgs(dgf, GameTypes.PERMISSIONED_CANNON);
+        _assertGameArgsEqual(pdgArgsBefore, pdgArgsAfter, true);
+        assertEq(pdgArgsAfter.absolutePrestate, _input.cannonPrestate.raw(), "permissioned game prestate mismatch");
         // Ensure that the WETH contracts are not reverting
-        pdg.weth().balanceOf(address(0));
+        IDelayedWETH(payable(pdgArgsAfter.weth)).balanceOf(address(0));
 
         if (expectCannonUpdated) {
-            IPermissionedDisputeGame game = IPermissionedDisputeGame(
-                address(
-                    IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory()).gameImpls(
-                        GameTypes.CANNON
-                    )
-                )
-            );
-            assertEq(game.absolutePrestate().raw(), _input.cannonPrestate.raw(), "cannon game prestate mismatch");
+            LibGameArgs.GameArgs memory cannonArgsAfter = _getGameArgs(dgf, GameTypes.CANNON);
+            _assertGameArgsEqual(cannonArgsBefore, cannonArgsAfter, true);
+            assertEq(cannonArgsAfter.absolutePrestate, _input.cannonPrestate.raw(), "cannon game prestate mismatch");
             // Ensure that the WETH contracts are not reverting
-            game.weth().balanceOf(address(0));
+            IDelayedWETH(payable(cannonArgsAfter.weth)).balanceOf(address(0));
         } else {
-            assertEq(
-                address(
-                    IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory()).gameImpls(
-                        GameTypes.CANNON
-                    )
-                ),
-                (address(0)),
-                "cannon game should not exist"
-            );
+            assertEq(address(dgf.gameImpls(GameTypes.CANNON)), (address(0)), "cannon game should not exist");
         }
 
         if (expectCannonKonaUpdated) {
-            IPermissionedDisputeGame game = IPermissionedDisputeGame(
-                address(
-                    IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory()).gameImpls(
-                        GameTypes.CANNON_KONA
-                    )
-                )
-            );
-            assertEq(game.absolutePrestate().raw(), _input.cannonKonaPrestate.raw(), "cannon game prestate mismatch");
-            // Ensure that the WETH contracts are not reverting
-            game.weth().balanceOf(address(0));
-        } else {
+            LibGameArgs.GameArgs memory cannonKonaArgsAfter = _getGameArgs(dgf, GameTypes.CANNON_KONA);
+            _assertGameArgsEqual(cannonKonaArgsBefore, cannonKonaArgsAfter, true);
             assertEq(
-                address(
-                    IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory()).gameImpls(
-                        GameTypes.CANNON_KONA
-                    )
-                ),
-                (address(0)),
-                "cannon_kona game should not exist"
+                cannonKonaArgsAfter.absolutePrestate,
+                _input.cannonKonaPrestate.raw(),
+                "cannon-kona game prestate mismatch"
             );
+            // Ensure that the WETH contracts are not reverting
+            IDelayedWETH(payable(cannonKonaArgsAfter.weth)).balanceOf(address(0));
+        } else {
+            assertEq(address(dgf.gameImpls(GameTypes.CANNON_KONA)), (address(0)), "cannon_kona game should not exist");
         }
     }
 
@@ -1093,6 +1120,9 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     ///         shouldn't matter because the function is independent of other game types that
     ///         exist.
     function test_updatePrestate_withSuperGame_succeeds() public {
+        // TODO(#17972): Remove skip once dispute-game v2 supports the Super DG.
+        skipIfDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
+
         // Mock out the existence of a previous SuperPermissionedDisputeGame so we can add a real
         // SuperPermissionedDisputeGame implementation.
         vm.mockCall(
@@ -1232,6 +1262,9 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     }
 
     function test_updatePrestate_cannonKonaWithSuperGame_succeeds() public {
+        // TODO(#17972): Remove skip if DEPLOY_V2_DISPUTE_GAMES is enabled once dispute-game v2 supports the Super DG.
+        skipIfDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES);
+
         skipIfDevFeatureDisabled(DevFeatures.CANNON_KONA);
         // Mock out the existence of a previous SuperPermissionedDisputeGame so we can add a real
         // SuperPermissionedDisputeGame implementation.

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1091,37 +1091,26 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
     /// @notice Mocks the existence of a previous SuperPermissionedDisputeGame so we can add a real
     /// SuperPermissionedDisputeGame implementation by calling opcm.updatePrestate.
     function _mockSuperPermissionedGame() internal {
-        // If this feature flag is set then OPContractsManager_TestInit deployed a V2 game
-        // Mock gameArgs accordingly for the v2 deployed game
-        if (isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
-            vm.mockCall(
-                address(chainDeployOutput1.disputeGameFactoryProxy),
-                abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
-                abi.encode(opcm.implementations().permissionedDisputeGameV2Impl)
-            );
-            // It suffices to mock the proposer and challenger gameArgs
-            vm.mockCall(
-                address(chainDeployOutput1.disputeGameFactoryProxy),
-                abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.SUPER_PERMISSIONED_CANNON)),
-                abi.encodePacked(bytes32(0), address(0), address(0), address(0), uint256(0), proposer, challenger)
-            );
-            vm.mockCall(
-                address(opcm.implementations().permissionedDisputeGameV2Impl),
-                abi.encodeCall(IDisputeGame.gameType, ()),
-                abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
-            );
-        } else {
-            vm.mockCall(
-                address(chainDeployOutput1.disputeGameFactoryProxy),
-                abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
-                abi.encode(chainDeployOutput1.permissionedDisputeGame)
-            );
-            vm.mockCall(
-                address(chainDeployOutput1.permissionedDisputeGame),
-                abi.encodeCall(IDisputeGame.gameType, ()),
-                abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
-            );
-        }
+        vm.mockCall(
+            address(chainDeployOutput1.disputeGameFactoryProxy),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED_CANNON)),
+            abi.encode(chainDeployOutput1.permissionedDisputeGame)
+        );
+        vm.mockCall(
+            address(chainDeployOutput1.permissionedDisputeGame),
+            abi.encodeCall(IDisputeGame.gameType, ()),
+            abi.encode(GameTypes.SUPER_PERMISSIONED_CANNON)
+        );
+        vm.mockCall(
+            address(chainDeployOutput1.permissionedDisputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.proposer, ()),
+            abi.encode(proposer)
+        );
+        vm.mockCall(
+            address(chainDeployOutput1.permissionedDisputeGame),
+            abi.encodeCall(IPermissionedDisputeGame.challenger, ()),
+            abi.encode(challenger)
+        );
     }
 
     /// @notice Tests that we can update the prestate when only the PermissionedDisputeGame exists.


### PR DESCRIPTION
Updates the `OPContractsManager_UpdatePrestate_Test` test to ensure that disputegame-v2 game parameters are setup correctly when the `DEPLOY_V2_DISPUTE_GAMES` feature flag is enabled.

Once `opcm.addGameType` supports disputegame-v2, we can follow up to remove the `vm.skip` call for that feature flag.

fixes https://github.com/ethereum-optimism/optimism/issues/17261